### PR TITLE
Async usage tracking for users far from limits (#13427)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,8 @@
   * `-common.storage.gcs.max-retries`
   * `-ruler-storage.gcs.max-retries`
 * [ENHANCEMENT] Usage-tracker: Improve first snapshot loading & rehash speed. #13284
-* [ENHANCEMENT] Ruler: Implemented `OperatorControllableErrorClassifier` for rule evaluation, allowing differentiation between operator-controllable errors (e.g., storage failures, 5xx errors, rate limiting) and user-controllable errors (e.g., bad queries, validation errors, 4xx errors). This change affects the rule evaluation failure metric `prometheus_rule_evaluation_failures_total`, which now includes a `reason` label with values `operator` or `user` to distinguish between them. #13313
+* [ENHANCEMENT] Usage-tracker, distributor: Make usage-tracker calls asynchronous for users who are far enough from the series limits. #13427
+* [ENHANCEMENT] Ruler: Implemented `OperatorControllableErrorClassifier` for rule evaluation, allowing differentiation between operator-controllable errors (e.g., storage failures, 5xx errors, rate limiting) and user-controllable errors (e.g., bad queries, validation errors, 4xx errors). This change affects the rule evaluation failure metric `prometheus_rule_evaluation_failures_total`, which now includes a `reason` label with values `operator` or `user` to distinguish between them. #13313, #13470
 * [BUGFIX] Compactor: Fix potential concurrent map writes. #13053
 * [BUGFIX] Query-frontend: Fix issue where queries sometimes fail with `failed to receive query result stream message: rpc error: code = Canceled desc = context canceled` if remote execution is enabled. #13084
 * [BUGFIX] Query-frontend: Fix issue where query stats, such as series read, did not include the parameters to the `histogram_quantile` and `histogram_fraction` functions if remote execution was enabled. #13084

--- a/go.mod
+++ b/go.mod
@@ -25,9 +25,9 @@ require (
 	github.com/minio/minio-go/v7 v7.0.97
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/oklog/ulid v1.3.1 // indirect
-	github.com/opentracing-contrib/go-grpc v0.1.2 // indirect
+	github.com/opentracing-contrib/go-grpc v0.1.2
 	github.com/opentracing-contrib/go-stdlib v1.1.0 // indirect
-	github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b // indirect
+	github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/alertmanager v0.28.1
 	github.com/prometheus/client_golang v1.23.2

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -103,6 +103,7 @@ const (
 type usageTrackerGenericClient interface {
 	services.Service
 	TrackSeries(ctx context.Context, userID string, series []uint64) ([]uint64, error)
+	CanTrackAsync(userID string) bool
 }
 
 // Distributor forwards appends and queries to individual ingesters.
@@ -163,6 +164,10 @@ type Distributor struct {
 
 	// Metric for silently dropped native histogram samples
 	droppedNativeHistograms *prometheus.CounterVec
+
+	// Metrics for async usage tracking.
+	asyncUsageTrackerCalls                   *prometheus.CounterVec
+	asyncUsageTrackerCallsWithRejectedSeries *prometheus.CounterVec
 
 	// Metrics for data rejected for hitting per-tenant limits
 	discardedSamplesTooManyHaClusters  *prometheus.CounterVec
@@ -520,6 +525,15 @@ func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Ove
 			Help: "The total number of native histograms that were silently dropped because native histograms ingestion is disabled.",
 		}, []string{"user"}),
 
+		asyncUsageTrackerCalls: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "cortex_distributor_async_usage_tracker_calls_total",
+			Help: "The total number of asynchronous usage-tracker calls performed per user.",
+		}, []string{"user"}),
+		asyncUsageTrackerCallsWithRejectedSeries: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "cortex_distributor_async_usage_tracker_calls_with_rejected_series_total",
+			Help: "The total number of asynchronous usage-tracker calls that rejected series per user.",
+		}, []string{"user"}),
+
 		discardedSamplesTooManyHaClusters:  validation.DiscardedSamplesCounter(reg, reasonTooManyHAClusters),
 		discardedSamplesPerUserSeriesLimit: validation.DiscardedSamplesCounter(reg, reasonPerUserActiveSeriesLimit),
 		discardedSamplesRateLimited:        validation.DiscardedSamplesCounter(reg, reasonRateLimited),
@@ -673,7 +687,7 @@ func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Ove
 			return nil, errors.New("usage-tracker instance ring is required")
 		}
 
-		d.usageTrackerClient = usagetrackerclient.NewUsageTrackerClient("distributor", d.cfg.UsageTrackerClient, usageTrackerPartitionRing, usageTrackerInstanceRing, log, reg)
+		d.usageTrackerClient = usagetrackerclient.NewUsageTrackerClient("distributor", d.cfg.UsageTrackerClient, usageTrackerPartitionRing, usageTrackerInstanceRing, d.limits, log, reg)
 		subservices = append(subservices, d.usageTrackerClient)
 	}
 
@@ -802,6 +816,8 @@ func (d *Distributor) cleanupInactiveUser(userID string) {
 	d.PushMetrics.deleteUserMetrics(userID)
 
 	d.droppedNativeHistograms.DeleteLabelValues(userID)
+	d.asyncUsageTrackerCalls.DeleteLabelValues(userID)
+	d.asyncUsageTrackerCallsWithRejectedSeries.DeleteLabelValues(userID)
 
 	filter := prometheus.Labels{"user": userID}
 	d.incomingRequests.DeletePartialMatch(filter)
@@ -1541,40 +1557,23 @@ func (d *Distributor) prePushMaxSeriesLimitMiddleware(next PushFunc) PushFunc {
 		}
 
 		// Track the series and check if anyone should be rejected because over the limit.
+		// For users that are far from their limits, we can do this asynchronously.
+		if d.usageTrackerClient.CanTrackAsync(userID) {
+			// User is far from limit.
+			// We can perform the track call in parallel with the metrics ingestion hoping that no series would be rejected.
+			cleanup := d.parallelUsageTrackerClientTrackSeriesCall(ctx, userID, seriesHashes)
+			pushReq.AddCleanup(cleanup)
+			return next(ctx, pushReq)
+		}
+
+		// User is close to limit, track synchronously.
 		rejectedHashes, err := d.usageTrackerClient.TrackSeries(ctx, userID, seriesHashes)
 		if err != nil {
 			return errors.Wrap(err, "failed to enforce max series limit")
 		}
 
 		if len(rejectedHashes) > 0 {
-			// Build a map of rejected hashes so that it's easier to lookup.
-			rejectedHashesMap := make(map[uint64]struct{}, len(rejectedHashes))
-			for _, hash := range rejectedHashes {
-				rejectedHashesMap[hash] = struct{}{}
-			}
-
-			// Filter out rejected series.
-			discardedSamples := 0
-			o := 0
-			for i := 0; i < len(req.Timeseries); i++ {
-				seriesHash := seriesHashes[i]
-
-				if _, rejected := rejectedHashesMap[seriesHash]; !rejected {
-					// Keep this series.
-					req.Timeseries[o] = req.Timeseries[i]
-					o++
-					continue
-				}
-
-				// Keep track of the discarded samples and histograms.
-				discardedSamples += len(req.Timeseries[i].Samples) + len(req.Timeseries[i].Histograms)
-
-				// This series has been rejected and filtered out from the WriteRequest. We can reuse its memory.
-				mimirpb.ReusePreallocTimeseries(&req.Timeseries[i])
-			}
-
-			req.Timeseries = req.Timeseries[:o]
-
+			discardedSamples := filterOutRejectedSeries(req, seriesHashes, rejectedHashes)
 			d.discardedSamplesPerUserSeriesLimit.WithLabelValues(userID, pushReq.group).Add(float64(discardedSamples))
 		}
 
@@ -1594,6 +1593,79 @@ func (d *Distributor) prePushMaxSeriesLimitMiddleware(next PushFunc) PushFunc {
 
 		return nil
 	}
+}
+
+func (d *Distributor) parallelUsageTrackerClientTrackSeriesCall(ctx context.Context, userID string, seriesHashes []uint64) func() {
+	d.asyncUsageTrackerCalls.WithLabelValues(userID).Inc()
+	done := make(chan struct{}, 1)
+	t0 := time.Now()
+	asyncTrackingCtx, cancelAsyncTracking := context.WithCancelCause(ctx)
+	go func() {
+		defer close(done)
+		rejected, err := d.usageTrackerClient.TrackSeries(asyncTrackingCtx, userID, seriesHashes)
+		if err != nil {
+			level.Error(d.log).Log("msg", "failed to track series asynchronously", "err", err, "user", userID, "series", len(seriesHashes))
+		}
+		if len(rejected) > 0 {
+			level.Warn(d.log).Log("msg", "ingested some series that should have been rejected, because they were tracked asynchronously", "user", userID, "rejected", len(rejected))
+			d.asyncUsageTrackerCallsWithRejectedSeries.WithLabelValues(userID).Inc()
+		}
+	}()
+
+	// Add a cleanup function that will wait for the async tracking to complete.
+	return func() {
+		defer cancelAsyncTracking(nil)
+
+		tCleanup := time.Now()
+		select {
+		case <-done:
+			// No need to wait.
+			return
+		default:
+		}
+
+		select {
+		case <-done:
+			level.Info(d.log).Log("msg", "async tracking call took longer than ingestion", "user", userID, "series", len(seriesHashes), "tracking_time", time.Since(t0), "time_since_cleanup", time.Since(tCleanup))
+		case <-time.After(d.cfg.UsageTrackerClient.MaxTimeToWaitForAsyncTrackingResponseAfterIngestion):
+			level.Warn(d.log).Log("msg", "async tracking call took too long, canceling", "user", userID, "series", len(seriesHashes), "tracking_time", time.Since(t0), "time_since_cleanup", time.Since(tCleanup))
+			cancelAsyncTracking(errors.New("async tracking call took too long"))
+		}
+	}
+}
+
+// filterOutRejectedSeries filters out time series from the WriteRequest based on rejected hashes and returns discarded samples count.
+// It updates the WriteRequest in place and optimizes memory by reusing preallocated time series.
+// seriesHashes should contain the hashes of req.Timeseries in the same order.
+func filterOutRejectedSeries(req *mimirpb.WriteRequest, seriesHashes []uint64, rejectedHashes []uint64) int {
+	// Build a map of rejected hashes so that it's easier to lookup.
+	rejectedHashesMap := make(map[uint64]struct{}, len(rejectedHashes))
+	for _, hash := range rejectedHashes {
+		rejectedHashesMap[hash] = struct{}{}
+	}
+
+	// Filter out rejected series.
+	discardedSamples := 0
+	o := 0
+	for i := 0; i < len(req.Timeseries); i++ {
+		seriesHash := seriesHashes[i]
+
+		if _, rejected := rejectedHashesMap[seriesHash]; !rejected {
+			// Keep this series.
+			req.Timeseries[o] = req.Timeseries[i]
+			o++
+			continue
+		}
+
+		// Keep track of the discarded samples and histograms.
+		discardedSamples += len(req.Timeseries[i].Samples) + len(req.Timeseries[i].Histograms)
+
+		// This series has been rejected and filtered out from the WriteRequest. We can reuse its memory.
+		mimirpb.ReusePreallocTimeseries(&req.Timeseries[i])
+	}
+
+	req.Timeseries = req.Timeseries[:o]
+	return discardedSamples
 }
 
 // metricsMiddleware updates metrics which are expected to account for all received data,

--- a/pkg/distributor/distributor_max_series_limit_test.go
+++ b/pkg/distributor/distributor_max_series_limit_test.go
@@ -3,6 +3,7 @@
 package distributor
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -53,23 +54,53 @@ func TestDistributor_Push_ShouldEnforceMaxSeriesLimits(t *testing.T) {
 	series5Hash := labels.StableHash(mimirpb.FromLabelAdaptersToLabels(sampleReq.Timeseries[4].Labels))
 
 	testCases := map[string]struct {
-		trackSeriesRejectedHashes []uint64
-		trackSeriesErr            error
-		expectedAcceptedSeries    []string
+		trackSeriesRejectedHashes             []uint64
+		trackSeriesErr                        error
+		expectedAcceptedSeries                []string
+		expectedResourceExhaustedErrorCode    bool
+		expectedFailedToEnforceSeriesLimitErr bool
+		canTrackAsync                         bool
 	}{
 		"no series rejected": {
-			expectedAcceptedSeries: []string{"series_1", "series_2", "series_3", "series_4", "series_5"},
+			expectedAcceptedSeries:             []string{"series_1", "series_2", "series_3", "series_4", "series_5"},
+			expectedResourceExhaustedErrorCode: false,
+			canTrackAsync:                      false,
 		},
 		"some series rejected": {
-			trackSeriesRejectedHashes: []uint64{series4Hash, series2Hash}, // Rejected hashes in different order than series in the request.
-			expectedAcceptedSeries:    []string{"series_1", "series_3", "series_5"},
+			trackSeriesRejectedHashes:          []uint64{series4Hash, series2Hash}, // Rejected hashes in different order than series in the request.
+			expectedAcceptedSeries:             []string{"series_1", "series_3", "series_5"},
+			expectedResourceExhaustedErrorCode: true,
+			canTrackAsync:                      false,
 		},
 		"all series rejected": {
-			trackSeriesRejectedHashes: []uint64{series1Hash, series2Hash, series3Hash, series4Hash, series5Hash},
-			expectedAcceptedSeries:    []string{},
+			trackSeriesRejectedHashes:          []uint64{series1Hash, series2Hash, series3Hash, series4Hash, series5Hash},
+			expectedAcceptedSeries:             []string{},
+			expectedResourceExhaustedErrorCode: true,
+			canTrackAsync:                      false,
 		},
 		"failed to track series via usage-tracker": {
-			trackSeriesErr: errors.New("usage-tracker service is unavailable"),
+			trackSeriesErr:                        errors.New("usage-tracker service is unavailable"),
+			expectedFailedToEnforceSeriesLimitErr: true,
+			canTrackAsync:                         false,
+		},
+
+		"async: no series rejected": {
+			expectedAcceptedSeries:             []string{"series_1", "series_2", "series_3", "series_4", "series_5"},
+			expectedResourceExhaustedErrorCode: false,
+			canTrackAsync:                      true,
+		},
+		"async: some series rejected": {
+			trackSeriesRejectedHashes:          []uint64{series4Hash, series2Hash}, // Rejected asynchronously so they're still ingested.
+			expectedAcceptedSeries:             []string{"series_1", "series_2", "series_3", "series_4", "series_5"},
+			expectedResourceExhaustedErrorCode: false,
+			canTrackAsync:                      true,
+		},
+		"async: failed to track series via usage-tracker": {
+			trackSeriesErr:                        errors.New("usage-tracker service is unavailable"), // Failed asynchronously, so series are still ingested.
+			expectedAcceptedSeries:                []string{"series_1", "series_2", "series_3", "series_4", "series_5"},
+			expectedResourceExhaustedErrorCode:    false,
+			expectedFailedToEnforceSeriesLimitErr: false,
+			canTrackAsync:                         true,
 		},
 	}
 
@@ -97,6 +128,7 @@ func TestDistributor_Push_ShouldEnforceMaxSeriesLimits(t *testing.T) {
 
 			// Enable the usage-tracker using a client mock.
 			usageTracker := &usageTrackerClientMock{}
+			usageTracker.On("CanTrackAsync", userID).Return(testData.canTrackAsync)
 			usageTracker.On("TrackSeries", mock.Anything, userID, mock.Anything).Return(testData.trackSeriesRejectedHashes, testData.trackSeriesErr)
 
 			distributors[0].cfg.UsageTrackerEnabled = true
@@ -105,8 +137,11 @@ func TestDistributor_Push_ShouldEnforceMaxSeriesLimits(t *testing.T) {
 			// Send write request.
 			ctx := user.InjectOrgID(context.Background(), userID)
 			res, err := distributors[0].Push(ctx, createWriteRequest())
-			if testData.trackSeriesErr == nil {
-				if len(testData.trackSeriesRejectedHashes) > 0 {
+			if testData.expectedFailedToEnforceSeriesLimitErr {
+				require.ErrorContains(t, err, "failed to enforce max series limit")
+				require.Nil(t, res)
+			} else {
+				if testData.expectedResourceExhaustedErrorCode {
 					require.NotNil(t, err)
 					st, ok := grpcutil.ErrorToStatus(err)
 					require.True(t, ok, "Expected error to be a gRPC status error")
@@ -115,9 +150,6 @@ func TestDistributor_Push_ShouldEnforceMaxSeriesLimits(t *testing.T) {
 					require.NoError(t, err)
 					require.NotNil(t, res)
 				}
-			} else {
-				require.ErrorContains(t, err, "failed to enforce max series limit")
-				require.Nil(t, res)
 			}
 
 			// We expect TrackSeries() has been called with all input series hashes, in the same order.
@@ -133,14 +165,36 @@ func TestDistributor_Push_ShouldEnforceMaxSeriesLimits(t *testing.T) {
 			}
 
 			// Ensure the number of discarded samples has been correctly tracked.
-			if expectedDiscardedSamples := len(testData.trackSeriesRejectedHashes); expectedDiscardedSamples > 0 {
+			if testData.expectedResourceExhaustedErrorCode {
 				require.NoError(t, testutil.GatherAndCompare(regs[0], strings.NewReader(fmt.Sprintf(`
 					# HELP cortex_discarded_samples_total The total number of samples that were discarded.
 					# TYPE cortex_discarded_samples_total counter
 					cortex_discarded_samples_total{group="",reason="per_user_active_series_limit",user="user-1"} %d
-				`, expectedDiscardedSamples)), "cortex_discarded_samples_total"))
+				`, len(testData.trackSeriesRejectedHashes))), "cortex_discarded_samples_total"))
 			} else {
 				require.NoError(t, testutil.GatherAndCompare(regs[0], strings.NewReader(""), "cortex_discarded_samples_total"))
+			}
+
+			if testData.canTrackAsync {
+				require.NoError(t, testutil.GatherAndCompare(regs[0], strings.NewReader(`
+					# HELP cortex_distributor_async_usage_tracker_calls_total The total number of asynchronous usage-tracker calls performed per user.
+					# TYPE cortex_distributor_async_usage_tracker_calls_total counter
+					cortex_distributor_async_usage_tracker_calls_total{user="user-1"} 1
+				`), "cortex_distributor_async_usage_tracker_calls_total"))
+				if len(testData.trackSeriesRejectedHashes) > 0 {
+					require.NoError(t, testutil.GatherAndCompare(regs[0], strings.NewReader(`
+						# HELP cortex_distributor_async_usage_tracker_calls_with_rejected_series_total The total number of asynchronous usage-tracker calls that rejected series per user.
+						# TYPE cortex_distributor_async_usage_tracker_calls_with_rejected_series_total counter
+						cortex_distributor_async_usage_tracker_calls_with_rejected_series_total{user="user-1"} 1
+					`), "cortex_distributor_async_usage_tracker_calls_with_rejected_series_total"))
+				} else {
+					require.NoError(t, testutil.GatherAndCompare(regs[0], &bytes.Buffer{}, "cortex_distributor_async_usage_tracker_calls_with_rejected_series_total"))
+				}
+			} else {
+				require.NoError(t, testutil.GatherAndCompare(regs[0], &bytes.Buffer{},
+					"cortex_distributor_async_usage_tracker_calls_total",
+					"cortex_distributor_async_usage_tracker_calls_with_rejected_series_total",
+				))
 			}
 		})
 	}
@@ -239,6 +293,11 @@ func (m *usageTrackerClientMock) TrackSeries(ctx context.Context, userID string,
 	return args.Get(0).([]uint64), args.Error(1)
 }
 
+func (m *usageTrackerClientMock) CanTrackAsync(userID string) bool {
+	args := m.Called(userID)
+	return args.Bool(0)
+}
+
 type usageTrackerClientRejectionMock struct {
 	services.Service
 
@@ -258,4 +317,9 @@ func (m *usageTrackerClientRejectionMock) TrackSeries(_ context.Context, _ strin
 	copy(rejected, series[len(series)-len(rejected):])
 
 	return rejected, nil
+}
+
+func (m *usageTrackerClientRejectionMock) CanTrackAsync(_ string) bool {
+	// For testing purposes, we force all users to be tracked synchronously.
+	return false
 }

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -935,6 +935,7 @@ func New(cfg Config, reg prometheus.Registerer) (*Mimir, error) {
 			"/schedulerpb.SchedulerForFrontend/FrontendLoop",
 			"/schedulerpb.SchedulerForQuerier/QuerierLoop",
 			"/schedulerpb.SchedulerForQuerier/NotifyQuerierShutdown",
+			"/usagetrackerpb.UsageTracker/GetUsersCloseToLimit",
 		})
 
 	// Do not allow to configure potentially unsafe options until we've properly tested them in Mimir.

--- a/pkg/usagetracker/partition_handler.go
+++ b/pkg/usagetracker/partition_handler.go
@@ -105,6 +105,8 @@ type partitionHandler struct {
 
 	// Testing
 	onConsumeEvent func(eventType string)
+
+	forceUpdateLimitsForTests chan chan struct{}
 }
 
 func newPartitionHandler(
@@ -170,6 +172,8 @@ func newPartitionHandler(
 		}),
 
 		instanceIDBytes: []byte(cfg.InstanceRing.InstanceID),
+
+		forceUpdateLimitsForTests: make(chan chan struct{}),
 	}
 
 	// In the partition ring lifecycler one owner can only have one partition, so we create a sub-owner for this partition, because we (may) own multiple partitions.
@@ -197,7 +201,7 @@ func newPartitionHandler(
 	}
 
 	eventsPublisher := chanEventsPublisher{events: p.pendingCreatedSeriesMarshaledEvents, logger: logger}
-	p.store = newTrackerStore(cfg.IdleTimeout, logger, lim, eventsPublisher)
+	p.store = newTrackerStore(cfg.IdleTimeout, cfg.UserCloseToLimitPercentageThreshold, logger, lim, eventsPublisher)
 	p.Service = services.NewBasicService(p.start, p.run, p.stop)
 	return p, nil
 }
@@ -503,6 +507,9 @@ func (p *partitionHandler) run(ctx context.Context) error {
 			p.store.cleanup(now)
 		case <-updateLimits.C:
 			p.store.updateLimits()
+		case done := <-p.forceUpdateLimitsForTests:
+			p.store.updateLimits()
+			close(done)
 		case <-ctx.Done():
 			return nil
 		case err := <-p.subservicesWatcher.Chan():

--- a/pkg/usagetracker/tracker_store_bench_test.go
+++ b/pkg/usagetracker/tracker_store_bench_test.go
@@ -51,7 +51,7 @@ func BenchmarkTrackerStoreTrackSeries(b *testing.B) {
 func benckmarkTrackerStoreTrackSeries(b *testing.B, seriesRefs []uint64, seriesPerRequest, tenantsCount int, cleanupsEnabled bool) {
 	nowSeconds := atomic.NewInt64(0)
 	now := func() time.Time { return time.Unix(nowSeconds.Load(), 0) }
-	t := newTrackerStore(testIdleTimeout, log.NewNopLogger(), limiterMock{}, noopEvents{})
+	t := newTrackerStore(testIdleTimeout, 85, log.NewNopLogger(), limiterMock{}, noopEvents{})
 
 	seriesPerTenant := len(seriesRefs) / tenantsCount
 	// Warmup each tenant.
@@ -110,7 +110,7 @@ func BenchmarkTrackerStoreLoadSnapshot(b *testing.B) {
 
 	b.Run("concurrency=1", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			t := newTrackerStore(testIdleTimeout, log.NewNopLogger(), lim, noopEvents{})
+			t := newTrackerStore(testIdleTimeout, 85, log.NewNopLogger(), lim, noopEvents{})
 			for _, d := range snapshots {
 				require.NoError(b, t.loadSnapshot(d, now, true))
 			}
@@ -119,7 +119,7 @@ func BenchmarkTrackerStoreLoadSnapshot(b *testing.B) {
 
 	b.Run("concurrency=shards", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			t := newTrackerStore(testIdleTimeout, log.NewNopLogger(), lim, noopEvents{})
+			t := newTrackerStore(testIdleTimeout, 85, log.NewNopLogger(), lim, noopEvents{})
 			wg := &sync.WaitGroup{}
 			wg.Add(len(snapshots))
 			for _, d := range snapshots {
@@ -144,7 +144,7 @@ func generateSnapshot(b *testing.B, tenantsCount int, totalSeries int, now time.
 	}
 	seriesPerTenantPerMinute := seriesPerTenant / int(testIdleTimeout.Minutes())
 
-	t := newTrackerStore(testIdleTimeout, log.NewNopLogger(), lim, noopEvents{})
+	t := newTrackerStore(testIdleTimeout, 85, log.NewNopLogger(), lim, noopEvents{})
 	deterministicRand := rand.New(rand.NewSource(0))
 	for timestamp := now.Add(-testIdleTimeout); timestamp.Before(now); timestamp = timestamp.Add(time.Minute) {
 		for i := 0; i < tenantsCount; i++ {

--- a/pkg/usagetracker/tracker_store_collector.go
+++ b/pkg/usagetracker/tracker_store_collector.go
@@ -30,7 +30,8 @@ func (t *trackerStore) Describe(descs chan<- *prometheus.Desc) {
 func (t *trackerStore) Collect(metrics chan<- prometheus.Metric) {
 	t.mtx.RLock()
 	defer t.mtx.RUnlock()
-	for tenantID, tenant := range t.tenants {
+	for _, tenantID := range t.sortedTenants {
+		tenant := t.tenants[tenantID]
 		metrics <- prometheus.MustNewConstMetric(activeSeriesMetricDesc, prometheus.GaugeValue, float64(tenant.series.Load()), tenantID)
 		metrics <- prometheus.MustNewConstMetric(currentLimitMetricDesc, prometheus.GaugeValue, float64(tenant.currentLimit.Load()), tenantID)
 	}

--- a/pkg/usagetracker/tracker_store_test.go
+++ b/pkg/usagetracker/tracker_store_test.go
@@ -31,7 +31,7 @@ func TestTrackerStore_HappyCase(t *testing.T) {
 
 	now := time.Date(2020, 1, 1, 1, 2, 3, 0, time.UTC)
 
-	tracker := newTrackerStore(idleTimeout, log.NewNopLogger(), limits, noopEvents{})
+	tracker := newTrackerStore(idleTimeout, 85, log.NewNopLogger(), limits, noopEvents{})
 
 	{
 		// Push 2 series, both are accepted.
@@ -83,7 +83,7 @@ func TestTrackerStore_SeriesCreationRateLimit(t *testing.T) {
 	limits := limiterMock{testUser1: 10}
 
 	now := time.Date(2020, 1, 1, 1, 2, 3, 0, time.UTC)
-	tracker := newTrackerStore(idleTimeout, log.NewNopLogger(), limits, noopEvents{})
+	tracker := newTrackerStore(idleTimeout, 85, log.NewNopLogger(), limits, noopEvents{})
 
 	{
 		// Push 10 series, 5 of them are rejected because current limit is 5.
@@ -151,9 +151,9 @@ func TestTrackerStore_CreatedSeriesCommunication(t *testing.T) {
 	now := time.Date(2020, 1, 1, 1, 2, 3, 0, time.UTC)
 
 	tracker1Events := eventsPipe{}
-	tracker1 := newTrackerStore(idleTimeout, log.NewNopLogger(), limits, &tracker1Events)
+	tracker1 := newTrackerStore(idleTimeout, 85, log.NewNopLogger(), limits, &tracker1Events)
 	tracker2Events := eventsPipe{}
-	tracker2 := newTrackerStore(idleTimeout, log.NewNopLogger(), limits, &tracker2Events)
+	tracker2 := newTrackerStore(idleTimeout, 85, log.NewNopLogger(), limits, &tracker2Events)
 	tracker1Events.listeners = []*trackerStore{tracker2}
 	tracker2Events.listeners = []*trackerStore{tracker1}
 
@@ -230,7 +230,7 @@ func TestTrackerStore_Snapshot_E2E(t *testing.T) {
 	const testUser2 = "user2"
 	now := time.Date(2020, 1, 1, 1, 2, 3, 0, time.UTC)
 
-	tracker1 := newTrackerStore(idleTimeoutMinutes*time.Minute, log.NewNopLogger(), limiterMock{}, noopEvents{})
+	tracker1 := newTrackerStore(idleTimeoutMinutes*time.Minute, 85, log.NewNopLogger(), limiterMock{}, noopEvents{})
 
 	for i := 0; i < 60; i++ {
 		rejected, err := tracker1.trackSeries(context.Background(), testUser1, []uint64{uint64(i)}, now)
@@ -252,7 +252,7 @@ func TestTrackerStore_Snapshot_E2E(t *testing.T) {
 		testUser2: 2 * idleTimeoutMinutes,
 	}, tracker1.seriesCountsForTests())
 
-	tracker2 := newTrackerStore(idleTimeoutMinutes*time.Minute, log.NewNopLogger(), limiterMock{}, noopEvents{})
+	tracker2 := newTrackerStore(idleTimeoutMinutes*time.Minute, 85, log.NewNopLogger(), limiterMock{}, noopEvents{})
 
 	var data []byte
 	for shard := uint8(0); shard < shards; shard++ {
@@ -294,7 +294,7 @@ func TestTrackerStore_Snapshot_Size(t *testing.T) {
 	totalSeriesCountForAllUsers := 1_000_000
 	usersCount := 1_000
 	seriesPerUser := totalSeriesCountForAllUsers / usersCount
-	tr := newTrackerStore(idleTimeoutMinutes*time.Minute, log.NewNopLogger(), limiterMock{}, noopEvents{})
+	tr := newTrackerStore(idleTimeoutMinutes*time.Minute, 85, log.NewNopLogger(), limiterMock{}, noopEvents{})
 
 	for u := 0; u < usersCount; u++ {
 		userID := strconv.Itoa(int(r.Int63() % (1 << 16)))
@@ -323,7 +323,7 @@ func TestTrackerStore_Cleanup_OffByOneError(t *testing.T) {
 	const testUser1 = "user1"
 
 	now := time.Date(2020, 1, 1, 1, 2, 3, 0, time.UTC)
-	tracker := newTrackerStore(time.Minute, log.NewNopLogger(), limiterMock{}, noopEvents{})
+	tracker := newTrackerStore(time.Minute, 85, log.NewNopLogger(), limiterMock{}, noopEvents{})
 
 	rejected, err := tracker.trackSeries(context.Background(), testUser1, []uint64{1}, now)
 	require.Empty(t, rejected)
@@ -349,7 +349,7 @@ func TestTrackerStore_Cleanup_Tenants(t *testing.T) {
 
 	now := time.Date(2020, 1, 1, 1, 2, 3, 0, time.UTC)
 
-	tracker := newTrackerStore(defaultIdleTimeout, log.NewNopLogger(), limits, noopEvents{})
+	tracker := newTrackerStore(defaultIdleTimeout, 85, log.NewNopLogger(), limits, noopEvents{})
 
 	// Push 2 series to testUser1, both are accepted.
 	rejected, err := tracker.trackSeries(context.Background(), testUser1, []uint64{1, 2}, now)
@@ -403,7 +403,7 @@ func TestTrackerStore_Cleanup_Concurrency(t *testing.T) {
 	now := func() time.Time { return time.Unix(nowUnixMinutes.Load()*60, 0) }
 
 	createdSeries := createdSeriesCounter{count: atomic.NewUint64(0)}
-	tracker := newTrackerStore(idleTimeoutMinutes*time.Minute, log.NewNopLogger(), limiterMock{}, createdSeries)
+	tracker := newTrackerStore(idleTimeoutMinutes*time.Minute, 85, log.NewNopLogger(), limiterMock{}, createdSeries)
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)
@@ -461,7 +461,7 @@ func TestTrackerStore_PrometheusCollector(t *testing.T) {
 
 	now := time.Date(2020, 1, 1, 1, 2, 3, 0, time.UTC)
 
-	tracker := newTrackerStore(defaultIdleTimeout, log.NewNopLogger(), limiterMock{}, noopEvents{})
+	tracker := newTrackerStore(defaultIdleTimeout, 85, log.NewNopLogger(), limiterMock{}, noopEvents{})
 
 	reg := prometheus.NewRegistry()
 	require.NoError(t, reg.Register(tracker))

--- a/pkg/usagetracker/usagetrackerclient/client.go
+++ b/pkg/usagetracker/usagetrackerclient/client.go
@@ -6,11 +6,13 @@ import (
 	"context"
 	"flag"
 	"math/rand/v2"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/concurrency"
 	"github.com/grafana/dskit/crypto/tls"
 	"github.com/grafana/dskit/grpcclient"
@@ -30,6 +32,11 @@ var (
 	TrackSeriesOp = ring.NewOp([]ring.InstanceState{ring.ACTIVE}, nil)
 )
 
+// limitsProvider provides access to user limits.
+type limitsProvider interface {
+	MaxActiveSeriesPerUser(userID string) int
+}
+
 type Config struct {
 	IgnoreRejectedSeries bool `yaml:"ignore_rejected_series" category:"experimental"`
 	IgnoreErrors         bool `yaml:"ignore_errors" category:"experimental"`
@@ -42,6 +49,16 @@ type Config struct {
 
 	TLSEnabled bool             `yaml:"tls_enabled" category:"advanced"`
 	TLS        tls.ClientConfig `yaml:",inline"`
+
+	UsersCloseToLimitPollInterval        time.Duration `yaml:"users_close_to_limit_poll_interval" category:"advanced"`
+	UsersCloseToLimitCacheStartupRetries int           `yaml:"users_close_to_limit_cache_startup_retries" category:"advanced"`
+
+	MaxTimeToWaitForAsyncTrackingResponseAfterIngestion time.Duration `yaml:"max_time_to_wait_for_async_tracking_response_after_ingestion" category:"advanced"`
+
+	// MinSeriesLimitForAsyncTracking is the minimum series limit for a user to be eligible for async tracking.
+	// Users with a series limit below this threshold will always be tracked synchronously.
+	// Set to 0 to disable this check (all users eligible for async tracking based on proximity to limit).
+	MinSeriesLimitForAsyncTracking int `yaml:"min_series_limit_for_async_tracking" category:"advanced"`
 
 	// Allow to inject custom client factory in tests.
 	ClientFactory client.PoolFactory `yaml:"-"`
@@ -58,6 +75,11 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.StringVar(&cfg.PreferAvailabilityZone, prefix+"prefer-availability-zone", "", "Preferred availability zone to query usage-trackers.")
 	f.DurationVar(&cfg.RequestsHedgingDelay, prefix+"requests-hedging-delay", 100*time.Millisecond, "Delay before initiating requests to further usage-trackers (e.g. in other zones).")
 	f.IntVar(&cfg.ReusableWorkers, prefix+"reusable-workers", 500, "Number of pre-allocated workers used to send requests to usage-trackers. If 0, no workers pool will be used and a new goroutine will be spawned for each request.")
+	f.DurationVar(&cfg.UsersCloseToLimitPollInterval, prefix+"users-close-to-limit-poll-interval", time.Second, "Interval to poll usage-tracker instances for the list of users close to their series limit. This list is used to determine whether to track series synchronously or asynchronously.")
+	f.IntVar(&cfg.UsersCloseToLimitCacheStartupRetries, prefix+"users-close-to-limit-cache-startup-retries", 3, "Number of retries to populate the users close to limit cache at startup. If all retries fail, the client will start with an empty cache.")
+
+	f.DurationVar(&cfg.MaxTimeToWaitForAsyncTrackingResponseAfterIngestion, prefix+"max-time-to-wait-for-async-tracking-response-after-ingestion", 250*time.Millisecond, "Maximum time to wait for an asynchronous tracking response after ingestion request is completed.")
+	f.IntVar(&cfg.MinSeriesLimitForAsyncTracking, prefix+"min-series-limit-for-async-tracking", 0, "Minimum series limit for a user to be eligible for async tracking. Users with a series limit below this threshold will always be tracked synchronously. Set to 0 to disable this check.")
 
 	cfg.GRPCClientConfig.RegisterFlagsWithPrefix(prefix+"grpc-client-config", f)
 }
@@ -67,6 +89,7 @@ type UsageTrackerClient struct {
 
 	cfg    Config
 	logger log.Logger
+	limits limitsProvider
 
 	partitionRing *ring.MultiPartitionInstanceRing
 
@@ -75,14 +98,23 @@ type UsageTrackerClient struct {
 	// trackSeriesWorkersPool is the pool of workers used to send requests to usage-tracker instances.
 	trackSeriesWorkersPool *concurrency.ReusableGoroutinesPool
 
+	// Cache for users close to their limits.
+	usersCloseToLimitsMtx   sync.RWMutex
+	usersCloseToLimit       []string
+	usersCloseToLimitLoaded bool
+
 	// Metrics.
-	trackSeriesDuration *prometheus.HistogramVec
+	trackSeriesDuration                *prometheus.HistogramVec
+	usersCloseToLimitCount             prometheus.Gauge
+	usersCloseToLimitLastUpdateSeconds prometheus.Gauge
+	usersCloseToLimitUpdateFailures    prometheus.Counter
 }
 
-func NewUsageTrackerClient(clientName string, clientCfg Config, partitionRing *ring.MultiPartitionInstanceRing, instanceRing ring.ReadRing, logger log.Logger, registerer prometheus.Registerer) *UsageTrackerClient {
+func NewUsageTrackerClient(clientName string, clientCfg Config, partitionRing *ring.MultiPartitionInstanceRing, instanceRing ring.ReadRing, limits limitsProvider, logger log.Logger, registerer prometheus.Registerer) *UsageTrackerClient {
 	c := &UsageTrackerClient{
 		cfg:                    clientCfg,
 		logger:                 logger,
+		limits:                 limits,
 		partitionRing:          partitionRing,
 		clientsPool:            newUsageTrackerClientPool(client.NewRingServiceDiscovery(instanceRing), clientName, clientCfg, logger, registerer),
 		trackSeriesWorkersPool: concurrency.NewReusableGoroutinesPool(clientCfg.ReusableWorkers),
@@ -94,16 +126,74 @@ func NewUsageTrackerClient(clientName string, clientCfg Config, partitionRing *r
 			NativeHistogramMinResetDuration: 1 * time.Hour,
 			Buckets:                         prometheus.DefBuckets,
 		}, []string{"status_code"}),
+		usersCloseToLimitCount: promauto.With(registerer).NewGauge(prometheus.GaugeOpts{
+			Name: "cortex_usage_tracker_client_users_close_to_limit_count",
+			Help: "Number of users that are close to their series limit.",
+		}),
+		usersCloseToLimitLastUpdateSeconds: promauto.With(registerer).NewGauge(prometheus.GaugeOpts{
+			Name: "cortex_usage_tracker_client_users_close_to_limit_last_update_timestamp_seconds",
+			Help: "Unix timestamp of the last update to the users close to limit cache.",
+		}),
+		usersCloseToLimitUpdateFailures: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
+			Name: "cortex_usage_tracker_client_users_close_to_limit_update_failures_total",
+			Help: "Total number of failed attempts to update the users close to limit cache.",
+		}),
 	}
 
-	c.Service = services.NewIdleService(nil, c.stop)
+	c.Service = services.NewBasicService(c.starting, c.running, c.stopping)
 	return c
 }
 
-// stop implements services.StoppingFn.
-func (c *UsageTrackerClient) stop(_ error) error {
-	c.trackSeriesWorkersPool.Close()
+// starting implements services.StartingFn.
+func (c *UsageTrackerClient) starting(ctx context.Context) error {
+	// Try to populate the cache at startup with retries.
+	// If all retries fail, we still start with an empty cache.
+	maxRetries := c.cfg.UsersCloseToLimitCacheStartupRetries
+	if maxRetries <= 0 {
+		maxRetries = 1 // At least try once
+	}
 
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		if attempt > 0 {
+			level.Warn(c.logger).Log("msg", "retrying users close to limit cache population at startup", "attempt", attempt+1, "max_retries", maxRetries)
+		}
+
+		c.updateUsersCloseToLimitCache(ctx)
+
+		// Check if the cache was successfully populated.
+		c.usersCloseToLimitsMtx.Lock()
+		count := len(c.usersCloseToLimit)
+		loaded := c.usersCloseToLimitLoaded
+		c.usersCloseToLimitsMtx.Unlock()
+		if loaded {
+			level.Info(c.logger).Log("msg", "successfully populated users close to limit cache at startup", "user_count", count, "attempt", attempt+1)
+			return nil
+		}
+	}
+
+	// All retries failed, but we still start with an empty cache.
+	level.Warn(c.logger).Log("msg", "failed to populate users close to limit cache at startup after all retries, starting with empty cache", "max_retries", maxRetries)
+	return nil
+}
+
+// running implements services.RunningFn.
+func (c *UsageTrackerClient) running(ctx context.Context) error {
+	ticker := time.NewTicker(c.cfg.UsersCloseToLimitPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			c.updateUsersCloseToLimitCache(ctx)
+		}
+	}
+}
+
+// stopping implements services.StoppingFn.
+func (c *UsageTrackerClient) stopping(_ error) error {
+	c.trackSeriesWorkersPool.Close()
 	return nil
 }
 
@@ -224,11 +314,6 @@ func (c *UsageTrackerClient) trackSeriesPerPartition(ctx context.Context, userID
 	}
 
 	res, err := ring.DoUntilQuorum[[]uint64](ctx, set, cfg, func(ctx context.Context, instance *ring.InstanceDesc) ([]uint64, error) {
-		if instance == nil {
-			// This should never happen.
-			return nil, errors.New("instance is nil")
-		}
-
 		poolClient, err := c.clientsPool.GetClientForInstance(*instance)
 		if err != nil {
 			return nil, errors.Errorf("usage-tracker instance %s (%s)", instance.Id, instance.Addr)
@@ -280,4 +365,109 @@ func (c *UsageTrackerClient) sortZones(zones []string) []string {
 	}
 
 	return zones
+}
+
+// updateUsersCloseToLimitCache polls a random usage-tracker partition for the list of users
+// close to their series limit and updates the local cache.
+func (c *UsageTrackerClient) updateUsersCloseToLimitCache(ctx context.Context) (ok bool) {
+	partitionID, set, ok := c.selectRandomPartition()
+	if !ok {
+		c.usersCloseToLimitUpdateFailures.Inc()
+		return false
+	}
+
+	cfg := ring.DoUntilQuorumConfig{
+		Logger: spanlogger.FromContext(ctx, c.logger),
+
+		MinimizeRequests: true,
+		HedgingDelay:     c.cfg.RequestsHedgingDelay,
+
+		// Give precedence to the client's zone.
+		ZoneSorter: c.sortZones,
+
+		// No error is a terminal error, and a failing request should be retried on another usage-tracker
+		// replica for the same partition (if available).
+		IsTerminalError: func(_ error) bool { return false },
+	}
+
+	_, err := ring.DoUntilQuorum[[]string](ctx, set, cfg, func(ctx context.Context, instance *ring.InstanceDesc) ([]string, error) {
+		poolClient, err := c.clientsPool.GetClientForInstance(*instance)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get client for usage-tracker instance %s (%s)", instance.Id, instance.Addr)
+		}
+
+		trackerClient := poolClient.(usagetrackerpb.UsageTrackerClient)
+		resp, err := trackerClient.GetUsersCloseToLimit(ctx, &usagetrackerpb.GetUsersCloseToLimitRequest{Partition: partitionID})
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get users close to limit from partition %d", partitionID)
+		}
+
+		c.usersCloseToLimitsMtx.Lock()
+		first := !c.usersCloseToLimitLoaded
+		c.usersCloseToLimit = slices.Clone(resp.SortedUserIds)
+		c.usersCloseToLimitLoaded = true
+		c.usersCloseToLimitsMtx.Unlock()
+
+		// Update metrics.
+		c.usersCloseToLimitCount.Set(float64(len(resp.SortedUserIds)))
+		c.usersCloseToLimitLastUpdateSeconds.Set(float64(time.Now().Unix()))
+
+		lvl := level.Debug
+		if first {
+			lvl = level.Info
+		}
+		lvl(c.logger).Log("msg", "updated users close to limit cache", "partition", resp.Partition, "user_count", len(resp.SortedUserIds))
+		return nil, nil
+	}, func([]string) {})
+
+	if err != nil {
+		c.usersCloseToLimitUpdateFailures.Inc()
+		level.Error(c.logger).Log("msg", "failed to get users close to limit from usage-tracker", "err", err)
+		return false
+	}
+
+	return true
+}
+
+func (c *UsageTrackerClient) selectRandomPartition() (int32, ring.ReplicationSet, bool) {
+	partitions := c.partitionRing.PartitionRing().ActivePartitionIDs()
+	if len(partitions) == 0 {
+		level.Error(c.logger).Log("msg", "no partitions available in ring for users close to limit poll")
+		return 0, ring.ReplicationSet{}, false
+	}
+	partitionID := partitions[rand.IntN(len(partitions))]
+	set, err := c.partitionRing.GetReplicationSetForPartitionAndOperation(partitionID, TrackSeriesOp)
+	if err != nil {
+		level.Error(c.logger).Log("msg", "failed to get replication set for partition", "partition", partitionID, "err", err)
+		return 0, ring.ReplicationSet{}, false
+	}
+
+	return partitionID, set, true
+}
+
+// CanTrackAsync returns true if the user can be tracked asynchronously.
+// A user can be tracked async if:
+// 1. The user is NOT in the cache of users close to their limit, AND
+// 2. The user's series limit is >= MinSeriesLimitForAsyncTracking (if configured)
+func (c *UsageTrackerClient) CanTrackAsync(userID string) bool {
+	// Check if user's limit is below the minimum threshold for async tracking.
+	if c.cfg.MinSeriesLimitForAsyncTracking > 0 {
+		userLimit := c.limits.MaxActiveSeriesPerUser(userID)
+		if userLimit > 0 && userLimit < c.cfg.MinSeriesLimitForAsyncTracking {
+			// User's limit is too low, must track synchronously.
+			return false
+		}
+	}
+
+	// Check if user is close to their limit.
+	c.usersCloseToLimitsMtx.RLock()
+	defer c.usersCloseToLimitsMtx.RUnlock()
+	if !c.usersCloseToLimitLoaded {
+		// Can't do async if we don't really know.
+		return false
+	}
+
+	// Can track async if it's not in the list of users close to their limit.
+	_, found := slices.BinarySearch(c.usersCloseToLimit, userID)
+	return !found
 }

--- a/pkg/usagetracker/usagetrackerclient/client_test.go
+++ b/pkg/usagetracker/usagetrackerclient/client_test.go
@@ -29,6 +29,97 @@ import (
 	"github.com/grafana/mimir/pkg/usagetracker/usagetrackerpb"
 )
 
+// mockLimitsProvider is a mock implementation of usagetrackerclient.limitsProvider.
+type mockLimitsProvider struct {
+	limits map[string]int
+}
+
+func newMockLimitsProvider() *mockLimitsProvider {
+	return &mockLimitsProvider{
+		limits: make(map[string]int),
+	}
+}
+
+func (m *mockLimitsProvider) MaxActiveSeriesPerUser(userID string) int {
+	if limit, ok := m.limits[userID]; ok {
+		return limit
+	}
+	return 0 // No limit
+}
+
+// prepareTestRings is a helper function that sets up the rings needed for testing.
+func prepareTestRings(t *testing.T, ctx context.Context) (*ring.MultiPartitionInstanceRing, *ring.Ring, prometheus.Registerer) {
+	logger := log.NewNopLogger()
+	registerer := prometheus.NewPedanticRegistry()
+
+	consulConfig := consul.Config{
+		MaxCasRetries: 100,
+		CasRetryDelay: 10 * time.Millisecond,
+	}
+
+	// Setup the in-memory KV store used for the ring.
+	instanceRingStore, instanceRingCloser := consul.NewInMemoryClientWithConfig(ring.GetCodec(), consulConfig, log.NewNopLogger(), nil)
+	t.Cleanup(func() { assert.NoError(t, instanceRingCloser.Close()) })
+
+	partitionRingStore, partitionRingCloser := consul.NewInMemoryClientWithConfig(ring.GetPartitionRingCodec(), consulConfig, log.NewNopLogger(), nil)
+	t.Cleanup(func() { assert.NoError(t, partitionRingCloser.Close()) })
+
+	// Add few usage-tracker instances to the instance ring.
+	require.NoError(t, instanceRingStore.CAS(ctx, usagetracker.InstanceRingKey, func(interface{}) (interface{}, bool, error) {
+		d := ring.NewDesc()
+		d.AddIngester("usage-tracker-zone-a-1", "1.1.1.1", "zone-a", []uint32{1}, ring.ACTIVE, time.Now(), false, time.Time{}, nil)
+		d.AddIngester("usage-tracker-zone-a-2", "2.2.2.2", "zone-a", []uint32{2}, ring.ACTIVE, time.Now(), false, time.Time{}, nil)
+		d.AddIngester("usage-tracker-zone-b-1", "3.3.3.3", "zone-b", []uint32{3}, ring.ACTIVE, time.Now(), false, time.Time{}, nil)
+		d.AddIngester("usage-tracker-zone-b-2", "4.4.4.4", "zone-b", []uint32{4}, ring.ACTIVE, time.Now(), false, time.Time{}, nil)
+
+		return d, true, nil
+	}))
+
+	// Add partitions to the partition ring.
+	require.NoError(t, partitionRingStore.CAS(ctx, usagetracker.PartitionRingKey, func(interface{}) (interface{}, bool, error) {
+		d := ring.NewPartitionRingDesc()
+		d.AddPartition(1, ring.PartitionActive, time.Now())
+		d.AddPartition(2, ring.PartitionActive, time.Now())
+		d.AddOrUpdateOwner("usage-tracker-zone-a-1", ring.OwnerActive, 1, time.Now())
+		d.AddOrUpdateOwner("usage-tracker-zone-a-2", ring.OwnerActive, 2, time.Now())
+		d.AddOrUpdateOwner("usage-tracker-zone-b-1", ring.OwnerActive, 1, time.Now())
+		d.AddOrUpdateOwner("usage-tracker-zone-b-2", ring.OwnerActive, 2, time.Now())
+
+		return d, true, nil
+	}))
+
+	serverCfg := createTestServerConfig()
+	serverCfg.InstanceRing.KVStore.Mock = instanceRingStore
+	serverCfg.PartitionRing.KVStore.Mock = partitionRingStore
+
+	// Create the instance ring.
+	instanceRing, err := usagetracker.NewInstanceRingClient(serverCfg.InstanceRing, logger, registerer)
+	require.NoError(t, err)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, instanceRing))
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, instanceRing))
+	})
+
+	// Pre-condition check: all instances should be healthy.
+	set, err := instanceRing.GetAllHealthy(usagetrackerclient.TrackSeriesOp)
+	require.NoError(t, err)
+	require.Len(t, set.Instances, 4)
+
+	// Create the partition ring.
+	partitionRingWatcher := usagetracker.NewPartitionRingWatcher(partitionRingStore, logger, registerer)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, partitionRingWatcher))
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, partitionRingWatcher))
+	})
+
+	partitionRing := ring.NewMultiPartitionInstanceRing(partitionRingWatcher, instanceRing, serverCfg.InstanceRing.HeartbeatTimeout)
+
+	// Pre-condition check: all partitions should be active.
+	require.Equal(t, []int32{1, 2}, partitionRingWatcher.PartitionRing().ActivePartitionIDs())
+
+	return partitionRing, instanceRing, registerer
+}
+
 func TestUsageTrackerClient_TrackSeries(t *testing.T) {
 	var (
 		ctx    = context.Background()
@@ -37,74 +128,7 @@ func TestUsageTrackerClient_TrackSeries(t *testing.T) {
 	)
 
 	prepareTest := func() (*ring.MultiPartitionInstanceRing, *ring.Ring, prometheus.Registerer) {
-		registerer := prometheus.NewPedanticRegistry()
-
-		consulConfig := consul.Config{
-			MaxCasRetries: 100,
-			CasRetryDelay: 10 * time.Millisecond,
-		}
-
-		// Setup the in-memory KV store used for the ring.
-		instanceRingStore, instanceRingCloser := consul.NewInMemoryClientWithConfig(ring.GetCodec(), consulConfig, log.NewNopLogger(), nil)
-		t.Cleanup(func() { assert.NoError(t, instanceRingCloser.Close()) })
-
-		partitionRingStore, partitionRingCloser := consul.NewInMemoryClientWithConfig(ring.GetPartitionRingCodec(), consulConfig, log.NewNopLogger(), nil)
-		t.Cleanup(func() { assert.NoError(t, partitionRingCloser.Close()) })
-
-		// Add few usage-tracker instances to the instance ring.
-		require.NoError(t, instanceRingStore.CAS(ctx, usagetracker.InstanceRingKey, func(interface{}) (interface{}, bool, error) {
-			d := ring.NewDesc()
-			d.AddIngester("usage-tracker-zone-a-1", "1.1.1.1", "zone-a", []uint32{1}, ring.ACTIVE, time.Now(), false, time.Time{}, nil)
-			d.AddIngester("usage-tracker-zone-a-2", "2.2.2.2", "zone-a", []uint32{2}, ring.ACTIVE, time.Now(), false, time.Time{}, nil)
-			d.AddIngester("usage-tracker-zone-b-1", "3.3.3.3", "zone-b", []uint32{3}, ring.ACTIVE, time.Now(), false, time.Time{}, nil)
-			d.AddIngester("usage-tracker-zone-b-2", "4.4.4.4", "zone-b", []uint32{4}, ring.ACTIVE, time.Now(), false, time.Time{}, nil)
-
-			return d, true, nil
-		}))
-
-		// Add partitions to the partition ring.
-		require.NoError(t, partitionRingStore.CAS(ctx, usagetracker.PartitionRingKey, func(interface{}) (interface{}, bool, error) {
-			d := ring.NewPartitionRingDesc()
-			d.AddPartition(1, ring.PartitionActive, time.Now())
-			d.AddPartition(2, ring.PartitionActive, time.Now())
-			d.AddOrUpdateOwner("usage-tracker-zone-a-1", ring.OwnerActive, 1, time.Now())
-			d.AddOrUpdateOwner("usage-tracker-zone-a-2", ring.OwnerActive, 2, time.Now())
-			d.AddOrUpdateOwner("usage-tracker-zone-b-1", ring.OwnerActive, 1, time.Now())
-			d.AddOrUpdateOwner("usage-tracker-zone-b-2", ring.OwnerActive, 2, time.Now())
-
-			return d, true, nil
-		}))
-
-		serverCfg := createTestServerConfig()
-		serverCfg.InstanceRing.KVStore.Mock = instanceRingStore
-		serverCfg.PartitionRing.KVStore.Mock = partitionRingStore
-
-		// Create the instance ring.
-		instanceRing, err := usagetracker.NewInstanceRingClient(serverCfg.InstanceRing, logger, registerer)
-		require.NoError(t, err)
-		require.NoError(t, services.StartAndAwaitRunning(ctx, instanceRing))
-		t.Cleanup(func() {
-			require.NoError(t, services.StopAndAwaitTerminated(ctx, instanceRing))
-		})
-
-		// Pre-condition check: all instances should be healthy.
-		set, err := instanceRing.GetAllHealthy(usagetrackerclient.TrackSeriesOp)
-		require.NoError(t, err)
-		require.Len(t, set.Instances, 4)
-
-		// Create the partition ring.
-		partitionRingWatcher := usagetracker.NewPartitionRingWatcher(partitionRingStore, logger, registerer)
-		require.NoError(t, services.StartAndAwaitRunning(ctx, partitionRingWatcher))
-		t.Cleanup(func() {
-			require.NoError(t, services.StopAndAwaitTerminated(ctx, partitionRingWatcher))
-		})
-
-		partitionRing := ring.NewMultiPartitionInstanceRing(partitionRingWatcher, instanceRing, serverCfg.InstanceRing.HeartbeatTimeout)
-
-		// Pre-condition check: all partitions should be active.
-		require.Equal(t, []int32{1, 2}, partitionRingWatcher.PartitionRing().ActivePartitionIDs())
-
-		return partitionRing, instanceRing, registerer
+		return prepareTestRings(t, ctx)
 	}
 
 	t.Run("should track series to usage-trackers running in the preferred zone if available (series are sharded to 2 partitions)", func(t *testing.T) {
@@ -132,7 +156,7 @@ func TestUsageTrackerClient_TrackSeries(t *testing.T) {
 			return nil, fmt.Errorf("usage-tracker with ID %s not found", instance.Id)
 		})
 
-		c := usagetrackerclient.NewUsageTrackerClient("test", clientCfg, partitionRing, instanceRing, logger, registerer)
+		c := usagetrackerclient.NewUsageTrackerClient("test", clientCfg, partitionRing, instanceRing, newMockLimitsProvider(), logger, registerer)
 		require.NoError(t, services.StartAndAwaitRunning(ctx, c))
 		t.Cleanup(func() {
 			require.NoError(t, services.StopAndAwaitTerminated(ctx, c))
@@ -196,7 +220,7 @@ func TestUsageTrackerClient_TrackSeries(t *testing.T) {
 			return nil, fmt.Errorf("usage-tracker with ID %s not found", instance.Id)
 		})
 
-		c := usagetrackerclient.NewUsageTrackerClient("test", clientCfg, partitionRing, instanceRing, logger, registerer)
+		c := usagetrackerclient.NewUsageTrackerClient("test", clientCfg, partitionRing, instanceRing, newMockLimitsProvider(), logger, registerer)
 		require.NoError(t, services.StartAndAwaitRunning(ctx, c))
 		t.Cleanup(func() {
 			require.NoError(t, services.StopAndAwaitTerminated(ctx, c))
@@ -254,7 +278,7 @@ func TestUsageTrackerClient_TrackSeries(t *testing.T) {
 			return nil, fmt.Errorf("usage-tracker with ID %s not found", instance.Id)
 		})
 
-		c := usagetrackerclient.NewUsageTrackerClient("test", clientCfg, partitionRing, instanceRing, logger, registerer)
+		c := usagetrackerclient.NewUsageTrackerClient("test", clientCfg, partitionRing, instanceRing, newMockLimitsProvider(), logger, registerer)
 		require.NoError(t, services.StartAndAwaitRunning(ctx, c))
 		t.Cleanup(func() {
 			require.NoError(t, services.StopAndAwaitTerminated(ctx, c))
@@ -346,7 +370,7 @@ func TestUsageTrackerClient_TrackSeries(t *testing.T) {
 				return nil, fmt.Errorf("usage-tracker with ID %s not found", instance.Id)
 			})
 
-			c := usagetrackerclient.NewUsageTrackerClient("test", clientCfg, partitionRing, instanceRing, logger, registerer)
+			c := usagetrackerclient.NewUsageTrackerClient("test", clientCfg, partitionRing, instanceRing, newMockLimitsProvider(), logger, registerer)
 			require.NoError(t, services.StartAndAwaitRunning(ctx, c))
 			t.Cleanup(func() {
 				require.NoError(t, services.StopAndAwaitTerminated(ctx, c))
@@ -418,7 +442,7 @@ func TestUsageTrackerClient_TrackSeries(t *testing.T) {
 			return nil, fmt.Errorf("usage-tracker with ID %s not found", instance.Id)
 		})
 
-		c := usagetrackerclient.NewUsageTrackerClient("test", clientCfg, partitionRing, instanceRing, logger, registerer)
+		c := usagetrackerclient.NewUsageTrackerClient("test", clientCfg, partitionRing, instanceRing, newMockLimitsProvider(), logger, registerer)
 		require.NoError(t, services.StartAndAwaitRunning(ctx, c))
 		t.Cleanup(func() {
 			require.NoError(t, services.StopAndAwaitTerminated(ctx, c))
@@ -474,7 +498,7 @@ func TestUsageTrackerClient_TrackSeries(t *testing.T) {
 			return nil, fmt.Errorf("usage-tracker with ID %s not found", instance.Id)
 		})
 
-		c := usagetrackerclient.NewUsageTrackerClient("test", clientCfg, partitionRing, instanceRing, logger, registerer)
+		c := usagetrackerclient.NewUsageTrackerClient("test", clientCfg, partitionRing, instanceRing, newMockLimitsProvider(), logger, registerer)
 		require.NoError(t, services.StartAndAwaitRunning(ctx, c))
 		t.Cleanup(func() {
 			require.NoError(t, services.StopAndAwaitTerminated(ctx, c))
@@ -511,7 +535,7 @@ func TestUsageTrackerClient_TrackSeries(t *testing.T) {
 			return nil, fmt.Errorf("usage-tracker with ID %s not found", instance.Id)
 		})
 
-		c := usagetrackerclient.NewUsageTrackerClient("test", clientCfg, partitionRing, instanceRing, logger, registerer)
+		c := usagetrackerclient.NewUsageTrackerClient("test", clientCfg, partitionRing, instanceRing, newMockLimitsProvider(), logger, registerer)
 		require.NoError(t, services.StartAndAwaitRunning(ctx, c))
 		t.Cleanup(func() {
 			require.NoError(t, services.StopAndAwaitTerminated(ctx, c))
@@ -596,6 +620,168 @@ func (m *usageTrackerMock) TrackSeries(ctx context.Context, req *usagetrackerpb.
 	return nil, args.Error(1)
 }
 
+func (m *usageTrackerMock) GetUsersCloseToLimit(ctx context.Context, req *usagetrackerpb.GetUsersCloseToLimitRequest, _ ...grpc.CallOption) (*usagetrackerpb.GetUsersCloseToLimitResponse, error) {
+	// Check if there's a configured expectation
+	if len(m.ExpectedCalls) > 0 {
+		for _, call := range m.ExpectedCalls {
+			if call.Method == "GetUsersCloseToLimit" {
+				args := m.Called(ctx, req)
+				if args.Get(0) != nil {
+					return args.Get(0).(*usagetrackerpb.GetUsersCloseToLimitResponse), args.Error(1)
+				}
+				return &usagetrackerpb.GetUsersCloseToLimitResponse{
+					SortedUserIds: []string{},
+					Partition:     req.Partition,
+				}, args.Error(1)
+			}
+		}
+	}
+
+	// Return empty list by default for tests that don't need to check async tracking behavior
+	return &usagetrackerpb.GetUsersCloseToLimitResponse{
+		SortedUserIds: []string{},
+		Partition:     req.Partition,
+	}, nil
+}
+
 func (m *usageTrackerMock) Close() error {
 	return nil
+}
+
+func TestUsageTrackerClient_CanTrackAsync(t *testing.T) {
+	tests := []struct {
+		name                           string
+		userID                         string
+		usersCloseToLimit              []string
+		userLimit                      int
+		minSeriesLimitForAsyncTracking int
+		expectedCanTrackAsync          bool
+	}{
+		{
+			name:                           "user not in close to limit list, no min limit check",
+			userID:                         "user-1",
+			usersCloseToLimit:              []string{"user-2", "user-3"},
+			userLimit:                      100000,
+			minSeriesLimitForAsyncTracking: 0,
+			expectedCanTrackAsync:          true,
+		},
+		{
+			name:                           "user in close to limit list",
+			userID:                         "user-2",
+			usersCloseToLimit:              []string{"user-1", "user-2", "user-3"},
+			userLimit:                      100000,
+			minSeriesLimitForAsyncTracking: 0,
+			expectedCanTrackAsync:          false,
+		},
+		{
+			name:                           "user with limit below min threshold",
+			userID:                         "user-1",
+			usersCloseToLimit:              []string{},
+			userLimit:                      50000,
+			minSeriesLimitForAsyncTracking: 100000,
+			expectedCanTrackAsync:          false,
+		},
+		{
+			name:                           "user with limit at min threshold",
+			userID:                         "user-1",
+			usersCloseToLimit:              []string{},
+			userLimit:                      100000,
+			minSeriesLimitForAsyncTracking: 100000,
+			expectedCanTrackAsync:          true,
+		},
+		{
+			name:                           "user with limit above min threshold",
+			userID:                         "user-1",
+			usersCloseToLimit:              []string{},
+			userLimit:                      150000,
+			minSeriesLimitForAsyncTracking: 100000,
+			expectedCanTrackAsync:          true,
+		},
+		{
+			name:                           "user with no limit (0) and min threshold set",
+			userID:                         "user-1",
+			usersCloseToLimit:              []string{},
+			userLimit:                      0,
+			minSeriesLimitForAsyncTracking: 100000,
+			expectedCanTrackAsync:          true,
+		},
+		{
+			name:                           "user below min threshold and in close to limit list",
+			userID:                         "user-1",
+			usersCloseToLimit:              []string{"user-1", "user-2"},
+			userLimit:                      50000,
+			minSeriesLimitForAsyncTracking: 100000,
+			expectedCanTrackAsync:          false,
+		},
+		{
+			name:                           "empty close to limit list",
+			userID:                         "user-1",
+			usersCloseToLimit:              []string{},
+			userLimit:                      100000,
+			minSeriesLimitForAsyncTracking: 0,
+			expectedCanTrackAsync:          true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				ctx    = context.Background()
+				logger = log.NewNopLogger()
+			)
+
+			partitionRing, instanceRing, registerer := prepareTestRings(t, ctx)
+
+			// Create mock limits provider
+			limitsProvider := newMockLimitsProvider()
+			limitsProvider.limits[tt.userID] = tt.userLimit
+
+			// Mock the usage-tracker server to return the users close to limit
+			instances := map[string]*usageTrackerMock{
+				"usage-tracker-zone-a-1": newUsageTrackerMockWithUsersCloseToLimit(tt.usersCloseToLimit),
+				"usage-tracker-zone-a-2": newUsageTrackerMockWithUsersCloseToLimit(tt.usersCloseToLimit),
+				"usage-tracker-zone-b-1": newUsageTrackerMockWithUsersCloseToLimit(tt.usersCloseToLimit),
+				"usage-tracker-zone-b-2": newUsageTrackerMockWithUsersCloseToLimit(tt.usersCloseToLimit),
+			}
+
+			clientCfg := createTestClientConfig()
+			clientCfg.MinSeriesLimitForAsyncTracking = tt.minSeriesLimitForAsyncTracking
+
+			clientCfg.ClientFactory = ring_client.PoolInstFunc(func(instance ring.InstanceDesc) (ring_client.PoolClient, error) {
+				mock, ok := instances[instance.Id]
+				if ok {
+					return mock, nil
+				}
+				return nil, fmt.Errorf("usage-tracker with ID %s not found", instance.Id)
+			})
+
+			// Create and start the client
+			// StartAndAwaitRunning ensures that starting() has completed, which populates the cache
+			c := usagetrackerclient.NewUsageTrackerClient("test", clientCfg, partitionRing, instanceRing, limitsProvider, logger, registerer)
+			require.NoError(t, services.StartAndAwaitRunning(ctx, c))
+			t.Cleanup(func() {
+				require.NoError(t, services.StopAndAwaitTerminated(ctx, c))
+			})
+
+			// Test CanTrackAsync
+			result := c.CanTrackAsync(tt.userID)
+			assert.Equal(t, tt.expectedCanTrackAsync, result)
+		})
+	}
+}
+
+// newUsageTrackerMockWithUsersCloseToLimit creates a mock that returns a specific list of users close to limit.
+func newUsageTrackerMockWithUsersCloseToLimit(userIDs []string) *usageTrackerMock {
+	m := &usageTrackerMock{}
+	m.On("TrackSeries", mock.Anything, mock.Anything).Return(&usagetrackerpb.TrackSeriesResponse{}, nil)
+
+	// Clone and sort the user IDs since CanTrackAsync expects a sorted list for binary search
+	sortedUserIDs := slices.Clone(userIDs)
+	slices.Sort(sortedUserIDs)
+
+	m.On("GetUsersCloseToLimit", mock.Anything, mock.Anything).Return(&usagetrackerpb.GetUsersCloseToLimitResponse{
+		SortedUserIds: sortedUserIDs,
+		Partition:     1,
+	}, nil)
+	return m
 }

--- a/pkg/usagetracker/usagetrackerpb/usagetracker.pb.go
+++ b/pkg/usagetracker/usagetrackerpb/usagetracker.pb.go
@@ -359,6 +359,104 @@ func (m *SnapshotFile) GetData() [][]byte {
 	return nil
 }
 
+type GetUsersCloseToLimitRequest struct {
+	// Optional partition to query. If not specified or -1, a random partition will be selected.
+	Partition int32 `protobuf:"varint,1,opt,name=partition,proto3" json:"partition,omitempty"`
+}
+
+func (m *GetUsersCloseToLimitRequest) Reset()      { *m = GetUsersCloseToLimitRequest{} }
+func (*GetUsersCloseToLimitRequest) ProtoMessage() {}
+func (*GetUsersCloseToLimitRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_24aa1621a7eb7fd6, []int{6}
+}
+func (m *GetUsersCloseToLimitRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *GetUsersCloseToLimitRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_GetUsersCloseToLimitRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *GetUsersCloseToLimitRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetUsersCloseToLimitRequest.Merge(m, src)
+}
+func (m *GetUsersCloseToLimitRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *GetUsersCloseToLimitRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetUsersCloseToLimitRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GetUsersCloseToLimitRequest proto.InternalMessageInfo
+
+func (m *GetUsersCloseToLimitRequest) GetPartition() int32 {
+	if m != nil {
+		return m.Partition
+	}
+	return 0
+}
+
+type GetUsersCloseToLimitResponse struct {
+	// The list of user IDs that are close to their series limit.
+	// This list is sorted.
+	SortedUserIds []string `protobuf:"bytes,1,rep,name=sorted_user_ids,json=sortedUserIds,proto3" json:"sorted_user_ids,omitempty"`
+	// The partition that was queried.
+	Partition int32 `protobuf:"varint,2,opt,name=partition,proto3" json:"partition,omitempty"`
+}
+
+func (m *GetUsersCloseToLimitResponse) Reset()      { *m = GetUsersCloseToLimitResponse{} }
+func (*GetUsersCloseToLimitResponse) ProtoMessage() {}
+func (*GetUsersCloseToLimitResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_24aa1621a7eb7fd6, []int{7}
+}
+func (m *GetUsersCloseToLimitResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *GetUsersCloseToLimitResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_GetUsersCloseToLimitResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *GetUsersCloseToLimitResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetUsersCloseToLimitResponse.Merge(m, src)
+}
+func (m *GetUsersCloseToLimitResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *GetUsersCloseToLimitResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetUsersCloseToLimitResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GetUsersCloseToLimitResponse proto.InternalMessageInfo
+
+func (m *GetUsersCloseToLimitResponse) GetSortedUserIds() []string {
+	if m != nil {
+		return m.SortedUserIds
+	}
+	return nil
+}
+
+func (m *GetUsersCloseToLimitResponse) GetPartition() int32 {
+	if m != nil {
+		return m.Partition
+	}
+	return 0
+}
+
 func init() {
 	proto.RegisterType((*TrackSeriesRequest)(nil), "usagetrackerpb.TrackSeriesRequest")
 	proto.RegisterType((*TrackSeriesResponse)(nil), "usagetrackerpb.TrackSeriesResponse")
@@ -366,40 +464,47 @@ func init() {
 	proto.RegisterType((*SnapshotRecord)(nil), "usagetrackerpb.SnapshotRecord")
 	proto.RegisterType((*SnapshotEvent)(nil), "usagetrackerpb.SnapshotEvent")
 	proto.RegisterType((*SnapshotFile)(nil), "usagetrackerpb.SnapshotFile")
+	proto.RegisterType((*GetUsersCloseToLimitRequest)(nil), "usagetrackerpb.GetUsersCloseToLimitRequest")
+	proto.RegisterType((*GetUsersCloseToLimitResponse)(nil), "usagetrackerpb.GetUsersCloseToLimitResponse")
 }
 
 func init() { proto.RegisterFile("usagetracker.proto", fileDescriptor_24aa1621a7eb7fd6) }
 
 var fileDescriptor_24aa1621a7eb7fd6 = []byte{
-	// 433 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x53, 0x41, 0x6f, 0xd3, 0x30,
-	0x18, 0x8d, 0x97, 0x32, 0x91, 0x8f, 0xb2, 0x83, 0x99, 0x20, 0xaa, 0x26, 0x2b, 0x0a, 0x12, 0xca,
-	0xa9, 0x48, 0xe3, 0xc2, 0x79, 0x0c, 0x44, 0x4f, 0x20, 0x77, 0xec, 0xc0, 0xcd, 0x6d, 0xbe, 0xb4,
-	0x81, 0x34, 0x0e, 0xb6, 0xc3, 0x99, 0x9f, 0xc0, 0xcf, 0xe0, 0xa7, 0x70, 0xec, 0x71, 0x27, 0x44,
-	0xd3, 0x0b, 0xc7, 0xfd, 0x04, 0x14, 0x87, 0xd0, 0x64, 0xc0, 0xd8, 0xcd, 0xef, 0x7d, 0x2f, 0xcf,
-	0xcf, 0xf1, 0x33, 0xd0, 0x52, 0x8b, 0x05, 0x1a, 0x25, 0xe6, 0xef, 0x51, 0x8d, 0x0b, 0x25, 0x8d,
-	0xa4, 0x07, 0x5d, 0xae, 0x98, 0x8d, 0x0e, 0x17, 0x72, 0x21, 0xed, 0xe8, 0x71, 0xbd, 0x6a, 0x54,
-	0x61, 0x0e, 0xf4, 0xac, 0x96, 0x4c, 0x51, 0xa5, 0xa8, 0x39, 0x7e, 0x28, 0x51, 0x1b, 0x7a, 0x1f,
-	0xf6, 0x4b, 0x8d, 0x6a, 0x72, 0xea, 0x93, 0x80, 0x44, 0x1e, 0xff, 0x85, 0xe8, 0x11, 0x78, 0x85,
-	0x50, 0x26, 0x35, 0xa9, 0xcc, 0xfd, 0xbd, 0x80, 0x44, 0xb7, 0xf8, 0x8e, 0xa0, 0x21, 0x0c, 0xb5,
-	0xb5, 0x79, 0x29, 0xf4, 0x12, 0xb5, 0xef, 0x06, 0x6e, 0x34, 0xe0, 0x3d, 0x2e, 0x9c, 0xc0, 0xbd,
-	0xde, 0x7e, 0xba, 0x90, 0xb9, 0x46, 0x7a, 0x0c, 0x87, 0x0a, 0xdf, 0xe1, 0xdc, 0x60, 0x3c, 0xed,
-	0x5a, 0x10, 0x6b, 0xf1, 0xd7, 0x59, 0x1d, 0xbd, 0xc1, 0xcf, 0x14, 0x0a, 0x83, 0xf1, 0xf3, 0x8f,
-	0x98, 0x5f, 0x1b, 0xdd, 0xa4, 0x2b, 0xd4, 0x46, 0xac, 0x0a, 0x1b, 0xdd, 0xe5, 0x3b, 0xe2, 0x46,
-	0xd1, 0xbf, 0x11, 0x38, 0x98, 0xe6, 0xa2, 0xd0, 0x4b, 0x69, 0x38, 0xce, 0xa5, 0x8a, 0xfb, 0xa6,
-	0xe4, 0xaa, 0xe9, 0x11, 0x78, 0x49, 0x9a, 0x61, 0x2e, 0x56, 0xa8, 0xfd, 0xbd, 0xc0, 0x8d, 0x3c,
-	0xbe, 0x23, 0xe8, 0x39, 0x3c, 0xca, 0x84, 0x36, 0x36, 0xf5, 0xab, 0x24, 0xd1, 0x68, 0x5e, 0x97,
-	0xb3, 0x2c, 0xd5, 0x4b, 0x8c, 0x4f, 0x30, 0x91, 0x0a, 0xdb, 0xbd, 0x7c, 0xd7, 0x1a, 0xdf, 0x50,
-	0x4d, 0x9f, 0xc2, 0x83, 0x5a, 0xd9, 0xe2, 0xce, 0x17, 0xfe, 0xc0, 0x1a, 0xfd, 0x6b, 0x1c, 0x4e,
-	0xe0, 0x6e, 0x8f, 0xfe, 0xcf, 0xf1, 0x46, 0x70, 0xbb, 0x3d, 0x8d, 0xfd, 0xa1, 0x1e, 0xff, 0x8d,
-	0xc3, 0x10, 0x86, 0xad, 0xd5, 0x8b, 0x34, 0x43, 0x4a, 0x61, 0x10, 0x0b, 0x23, 0xec, 0x7d, 0x0e,
-	0xb9, 0x5d, 0x1f, 0x27, 0x30, 0x7c, 0x53, 0x57, 0xf4, 0xac, 0xa9, 0x28, 0x3d, 0x87, 0x3b, 0x9d,
-	0x6a, 0xd0, 0x70, 0xdc, 0x2f, 0xf0, 0xf8, 0xcf, 0x9e, 0x8e, 0x1e, 0x5e, 0xab, 0x69, 0xba, 0x75,
-	0x72, 0xba, 0xde, 0x30, 0xe7, 0x62, 0xc3, 0x9c, 0xcb, 0x0d, 0x23, 0x9f, 0x2a, 0x46, 0xbe, 0x54,
-	0x8c, 0x7c, 0xad, 0x18, 0x59, 0x57, 0x8c, 0x7c, 0xaf, 0x18, 0xf9, 0x51, 0x31, 0xe7, 0xb2, 0x62,
-	0xe4, 0xf3, 0x96, 0x39, 0xeb, 0x2d, 0x73, 0x2e, 0xb6, 0xcc, 0x79, 0x7b, 0xe5, 0xf9, 0xcc, 0xf6,
-	0xed, 0x7b, 0x79, 0xf2, 0x33, 0x00, 0x00, 0xff, 0xff, 0x55, 0xf3, 0x20, 0x6a, 0x6b, 0x03, 0x00,
-	0x00,
+	// 520 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x54, 0xcf, 0x8e, 0x12, 0x4f,
+	0x10, 0x9e, 0x5e, 0xf8, 0x6d, 0x7e, 0x53, 0xb2, 0x6b, 0xd2, 0x12, 0x9d, 0x20, 0xe9, 0x90, 0x31,
+	0xd9, 0x90, 0x68, 0x30, 0x59, 0x2f, 0x26, 0xde, 0x76, 0xd7, 0x3f, 0x24, 0x26, 0x9a, 0x81, 0xdd,
+	0x83, 0x97, 0x4d, 0xc3, 0x14, 0xd0, 0x0a, 0xd3, 0xb3, 0xdd, 0x8d, 0x67, 0x1f, 0xc1, 0xc7, 0xf0,
+	0x51, 0x3c, 0x72, 0x5c, 0x2f, 0x46, 0x86, 0x8b, 0xc7, 0x7d, 0x04, 0x33, 0x3d, 0x20, 0x0c, 0x22,
+	0x72, 0xeb, 0xfa, 0xba, 0xea, 0xeb, 0xaf, 0xba, 0xbf, 0x6a, 0xa0, 0x63, 0xcd, 0xfb, 0x68, 0x14,
+	0xef, 0x7e, 0x40, 0xd5, 0x88, 0x95, 0x34, 0x92, 0x1e, 0xae, 0x62, 0x71, 0xa7, 0x52, 0xee, 0xcb,
+	0xbe, 0xb4, 0x5b, 0x8f, 0xd3, 0x55, 0x96, 0xe5, 0x47, 0x40, 0xdb, 0x69, 0x4a, 0x0b, 0x95, 0x40,
+	0x1d, 0xe0, 0xd5, 0x18, 0xb5, 0xa1, 0x77, 0x61, 0x7f, 0xac, 0x51, 0x35, 0xcf, 0x3c, 0x52, 0x23,
+	0x75, 0x37, 0x98, 0x47, 0xb4, 0x0a, 0x6e, 0xcc, 0x95, 0x11, 0x46, 0xc8, 0xc8, 0xdb, 0xab, 0x91,
+	0xfa, 0x7f, 0xc1, 0x12, 0xa0, 0x3e, 0x94, 0xb4, 0xa5, 0x79, 0xc5, 0xf5, 0x00, 0xb5, 0x57, 0xa8,
+	0x15, 0xea, 0xc5, 0x20, 0x87, 0xf9, 0x4d, 0xb8, 0x93, 0x3b, 0x4f, 0xc7, 0x32, 0xd2, 0x48, 0x8f,
+	0xa1, 0xac, 0xf0, 0x3d, 0x76, 0x0d, 0x86, 0xad, 0x55, 0x0a, 0x62, 0x29, 0x36, 0xee, 0xa5, 0xd2,
+	0xb3, 0xf8, 0x54, 0x21, 0x37, 0x18, 0x3e, 0xff, 0x88, 0xd1, 0x56, 0xe9, 0x46, 0x8c, 0x50, 0x1b,
+	0x3e, 0x8a, 0xad, 0xf4, 0x42, 0xb0, 0x04, 0x76, 0x92, 0xfe, 0x9d, 0xc0, 0x61, 0x2b, 0xe2, 0xb1,
+	0x1e, 0x48, 0x13, 0x60, 0x57, 0xaa, 0x30, 0x4f, 0x4a, 0xd6, 0x49, 0xab, 0xe0, 0xf6, 0xc4, 0x10,
+	0x23, 0x3e, 0x42, 0xed, 0xed, 0xd5, 0x0a, 0x75, 0x37, 0x58, 0x02, 0xf4, 0x02, 0x8e, 0x86, 0x5c,
+	0x1b, 0xab, 0xfa, 0x4d, 0xaf, 0xa7, 0xd1, 0xbc, 0x1d, 0x77, 0x86, 0x42, 0x0f, 0x30, 0x3c, 0xc1,
+	0x9e, 0x54, 0xb8, 0x38, 0xcb, 0x2b, 0x58, 0xe2, 0x1d, 0xb3, 0xe9, 0x53, 0xb8, 0x97, 0x66, 0x2e,
+	0xe2, 0x95, 0x0a, 0xaf, 0x68, 0x89, 0xfe, 0xb6, 0xed, 0x37, 0xe1, 0x20, 0x07, 0xff, 0xa3, 0xbd,
+	0x0a, 0xfc, 0xbf, 0xe8, 0xc6, 0x5e, 0xa8, 0x1b, 0xfc, 0x8e, 0x7d, 0x1f, 0x4a, 0x0b, 0xaa, 0x17,
+	0x62, 0x88, 0x94, 0x42, 0x31, 0xe4, 0x86, 0xdb, 0xf7, 0x2c, 0x05, 0x76, 0xed, 0x3f, 0x83, 0xfb,
+	0x2f, 0xd1, 0x9c, 0x6b, 0x54, 0xfa, 0x74, 0x28, 0x35, 0xb6, 0xe5, 0x6b, 0x31, 0x12, 0x66, 0xe1,
+	0xc1, 0x9c, 0xd7, 0xc8, 0x9a, 0xd7, 0xfc, 0x10, 0xaa, 0x9b, 0x8b, 0xe7, 0x86, 0x3a, 0x82, 0xdb,
+	0x5a, 0x2a, 0x83, 0xe1, 0x65, 0xfa, 0xfe, 0x97, 0x22, 0xcc, 0xbc, 0xe4, 0x06, 0x07, 0x19, 0x9c,
+	0x56, 0x36, 0x43, 0xbd, 0xdd, 0xd1, 0xc7, 0xdf, 0x08, 0x94, 0xce, 0xd3, 0x31, 0x6a, 0x67, 0x63,
+	0x44, 0x2f, 0xe0, 0xd6, 0x8a, 0x7d, 0xa9, 0xdf, 0xc8, 0x0f, 0x59, 0xe3, 0xcf, 0x59, 0xaa, 0x3c,
+	0xd8, 0x9a, 0x33, 0x97, 0x7b, 0x05, 0xe5, 0x4d, 0xed, 0xd0, 0x87, 0xeb, 0xc5, 0x5b, 0x6e, 0xac,
+	0xf2, 0x68, 0xb7, 0xe4, 0xec, 0xc8, 0x93, 0xb3, 0xc9, 0x94, 0x39, 0xd7, 0x53, 0xe6, 0xdc, 0x4c,
+	0x19, 0xf9, 0x94, 0x30, 0xf2, 0x25, 0x61, 0xe4, 0x6b, 0xc2, 0xc8, 0x24, 0x61, 0xe4, 0x47, 0xc2,
+	0xc8, 0xcf, 0x84, 0x39, 0x37, 0x09, 0x23, 0x9f, 0x67, 0xcc, 0x99, 0xcc, 0x98, 0x73, 0x3d, 0x63,
+	0xce, 0xbb, 0xb5, 0x5f, 0xa5, 0xb3, 0x6f, 0xbf, 0x91, 0x27, 0xbf, 0x02, 0x00, 0x00, 0xff, 0xff,
+	0xd4, 0x83, 0x94, 0xa7, 0x82, 0x04, 0x00, 0x00,
 }
 
 func (this *TrackSeriesRequest) Equal(that interface{}) bool {
@@ -595,6 +700,62 @@ func (this *SnapshotFile) Equal(that interface{}) bool {
 	}
 	return true
 }
+func (this *GetUsersCloseToLimitRequest) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*GetUsersCloseToLimitRequest)
+	if !ok {
+		that2, ok := that.(GetUsersCloseToLimitRequest)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.Partition != that1.Partition {
+		return false
+	}
+	return true
+}
+func (this *GetUsersCloseToLimitResponse) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*GetUsersCloseToLimitResponse)
+	if !ok {
+		that2, ok := that.(GetUsersCloseToLimitResponse)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if len(this.SortedUserIds) != len(that1.SortedUserIds) {
+		return false
+	}
+	for i := range this.SortedUserIds {
+		if this.SortedUserIds[i] != that1.SortedUserIds[i] {
+			return false
+		}
+	}
+	if this.Partition != that1.Partition {
+		return false
+	}
+	return true
+}
 func (this *TrackSeriesRequest) GoString() string {
 	if this == nil {
 		return "nil"
@@ -663,6 +824,27 @@ func (this *SnapshotFile) GoString() string {
 	s = append(s, "}")
 	return strings.Join(s, "")
 }
+func (this *GetUsersCloseToLimitRequest) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 5)
+	s = append(s, "&usagetrackerpb.GetUsersCloseToLimitRequest{")
+	s = append(s, "Partition: "+fmt.Sprintf("%#v", this.Partition)+",\n")
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *GetUsersCloseToLimitResponse) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 6)
+	s = append(s, "&usagetrackerpb.GetUsersCloseToLimitResponse{")
+	s = append(s, "SortedUserIds: "+fmt.Sprintf("%#v", this.SortedUserIds)+",\n")
+	s = append(s, "Partition: "+fmt.Sprintf("%#v", this.Partition)+",\n")
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
 func valueToGoStringUsagetracker(v interface{}, typ string) string {
 	rv := reflect.ValueOf(v)
 	if rv.IsNil() {
@@ -685,6 +867,7 @@ const _ = grpc.SupportPackageIsVersion4
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type UsageTrackerClient interface {
 	TrackSeries(ctx context.Context, in *TrackSeriesRequest, opts ...grpc.CallOption) (*TrackSeriesResponse, error)
+	GetUsersCloseToLimit(ctx context.Context, in *GetUsersCloseToLimitRequest, opts ...grpc.CallOption) (*GetUsersCloseToLimitResponse, error)
 }
 
 type usageTrackerClient struct {
@@ -704,9 +887,19 @@ func (c *usageTrackerClient) TrackSeries(ctx context.Context, in *TrackSeriesReq
 	return out, nil
 }
 
+func (c *usageTrackerClient) GetUsersCloseToLimit(ctx context.Context, in *GetUsersCloseToLimitRequest, opts ...grpc.CallOption) (*GetUsersCloseToLimitResponse, error) {
+	out := new(GetUsersCloseToLimitResponse)
+	err := c.cc.Invoke(ctx, "/usagetrackerpb.UsageTracker/GetUsersCloseToLimit", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // UsageTrackerServer is the server API for UsageTracker service.
 type UsageTrackerServer interface {
 	TrackSeries(context.Context, *TrackSeriesRequest) (*TrackSeriesResponse, error)
+	GetUsersCloseToLimit(context.Context, *GetUsersCloseToLimitRequest) (*GetUsersCloseToLimitResponse, error)
 }
 
 // UnimplementedUsageTrackerServer can be embedded to have forward compatible implementations.
@@ -715,6 +908,9 @@ type UnimplementedUsageTrackerServer struct {
 
 func (*UnimplementedUsageTrackerServer) TrackSeries(ctx context.Context, req *TrackSeriesRequest) (*TrackSeriesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method TrackSeries not implemented")
+}
+func (*UnimplementedUsageTrackerServer) GetUsersCloseToLimit(ctx context.Context, req *GetUsersCloseToLimitRequest) (*GetUsersCloseToLimitResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetUsersCloseToLimit not implemented")
 }
 
 func RegisterUsageTrackerServer(s *grpc.Server, srv UsageTrackerServer) {
@@ -739,6 +935,24 @@ func _UsageTracker_TrackSeries_Handler(srv interface{}, ctx context.Context, dec
 	return interceptor(ctx, in, info, handler)
 }
 
+func _UsageTracker_GetUsersCloseToLimit_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetUsersCloseToLimitRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(UsageTrackerServer).GetUsersCloseToLimit(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/usagetrackerpb.UsageTracker/GetUsersCloseToLimit",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(UsageTrackerServer).GetUsersCloseToLimit(ctx, req.(*GetUsersCloseToLimitRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _UsageTracker_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "usagetrackerpb.UsageTracker",
 	HandlerType: (*UsageTrackerServer)(nil),
@@ -746,6 +960,10 @@ var _UsageTracker_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "TrackSeries",
 			Handler:    _UsageTracker_TrackSeries_Handler,
+		},
+		{
+			MethodName: "GetUsersCloseToLimit",
+			Handler:    _UsageTracker_GetUsersCloseToLimit_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -1013,6 +1231,71 @@ func (m *SnapshotFile) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *GetUsersCloseToLimitRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetUsersCloseToLimitRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *GetUsersCloseToLimitRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Partition != 0 {
+		i = encodeVarintUsagetracker(dAtA, i, uint64(m.Partition))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *GetUsersCloseToLimitResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetUsersCloseToLimitResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *GetUsersCloseToLimitResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Partition != 0 {
+		i = encodeVarintUsagetracker(dAtA, i, uint64(m.Partition))
+		i--
+		dAtA[i] = 0x10
+	}
+	if len(m.SortedUserIds) > 0 {
+		for iNdEx := len(m.SortedUserIds) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.SortedUserIds[iNdEx])
+			copy(dAtA[i:], m.SortedUserIds[iNdEx])
+			i = encodeVarintUsagetracker(dAtA, i, uint64(len(m.SortedUserIds[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintUsagetracker(dAtA []byte, offset int, v uint64) int {
 	offset -= sovUsagetracker(v)
 	base := offset
@@ -1141,6 +1424,36 @@ func (m *SnapshotFile) Size() (n int) {
 	return n
 }
 
+func (m *GetUsersCloseToLimitRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Partition != 0 {
+		n += 1 + sovUsagetracker(uint64(m.Partition))
+	}
+	return n
+}
+
+func (m *GetUsersCloseToLimitResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.SortedUserIds) > 0 {
+		for _, s := range m.SortedUserIds {
+			l = len(s)
+			n += 1 + l + sovUsagetracker(uint64(l))
+		}
+	}
+	if m.Partition != 0 {
+		n += 1 + sovUsagetracker(uint64(m.Partition))
+	}
+	return n
+}
+
 func sovUsagetracker(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
@@ -1211,6 +1524,27 @@ func (this *SnapshotFile) String() string {
 	}
 	s := strings.Join([]string{`&SnapshotFile{`,
 		`Data:` + fmt.Sprintf("%v", this.Data) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *GetUsersCloseToLimitRequest) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&GetUsersCloseToLimitRequest{`,
+		`Partition:` + fmt.Sprintf("%v", this.Partition) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *GetUsersCloseToLimitResponse) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&GetUsersCloseToLimitResponse{`,
+		`SortedUserIds:` + fmt.Sprintf("%v", this.SortedUserIds) + `,`,
+		`Partition:` + fmt.Sprintf("%v", this.Partition) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -2004,6 +2338,176 @@ func (m *SnapshotFile) Unmarshal(dAtA []byte) error {
 			m.Data = append(m.Data, make([]byte, postIndex-iNdEx))
 			copy(m.Data[len(m.Data)-1], dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipUsagetracker(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthUsagetracker
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetUsersCloseToLimitRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowUsagetracker
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetUsersCloseToLimitRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetUsersCloseToLimitRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Partition", wireType)
+			}
+			m.Partition = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowUsagetracker
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Partition |= int32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := skipUsagetracker(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthUsagetracker
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetUsersCloseToLimitResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowUsagetracker
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetUsersCloseToLimitResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetUsersCloseToLimitResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SortedUserIds", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowUsagetracker
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthUsagetracker
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthUsagetracker
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.SortedUserIds = append(m.SortedUserIds, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Partition", wireType)
+			}
+			m.Partition = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowUsagetracker
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Partition |= int32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := skipUsagetracker(dAtA[iNdEx:])

--- a/pkg/usagetracker/usagetrackerpb/usagetracker.proto
+++ b/pkg/usagetracker/usagetrackerpb/usagetracker.proto
@@ -12,6 +12,7 @@ option (gogoproto.unmarshaler_all) = true;
 
 service UsageTracker {
   rpc TrackSeries(TrackSeriesRequest) returns (TrackSeriesResponse);
+  rpc GetUsersCloseToLimit(GetUsersCloseToLimitRequest) returns (GetUsersCloseToLimitResponse);
 }
 
 message TrackSeriesRequest {
@@ -56,4 +57,18 @@ message SnapshotEvent {
 
 message SnapshotFile {
   repeated bytes data = 1;
+}
+
+message GetUsersCloseToLimitRequest {
+  // Optional partition to query. If not specified or -1, a random partition will be selected.
+  int32 partition = 1;
+}
+
+message GetUsersCloseToLimitResponse {
+  // The list of user IDs that are close to their series limit.
+  // This list is sorted.
+  repeated string sorted_user_ids = 1;
+
+  // The partition that was queried.
+  int32 partition = 2;
 }

--- a/tools/usage-tracker-load-generator/main.go
+++ b/tools/usage-tracker-load-generator/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/grafana/mimir/pkg/usagetracker"
 	"github.com/grafana/mimir/pkg/usagetracker/usagetrackerclient"
 	"github.com/grafana/mimir/pkg/util"
+	"github.com/grafana/mimir/pkg/util/validation"
 )
 
 type Config struct {
@@ -116,7 +117,8 @@ func main() {
 	}()
 
 	// Create the usage-tracker client.
-	client := usagetrackerclient.NewUsageTrackerClient("load-generator", cfg.Client, partitionRing, instanceRing, logger, prometheus.DefaultRegisterer)
+	stubLimits := validation.NewOverrides(validation.Limits{}, validation.NewMockTenantLimits(nil))
+	client := usagetrackerclient.NewUsageTrackerClient("load-generator", cfg.Client, partitionRing, instanceRing, stubLimits, logger, prometheus.DefaultRegisterer)
 
 	// Compute the number of workers assuming each TrackSeries() request 100ms on average (we consider this a worst case scenario).
 	numRequestsPerScrapeInterval := cfg.SimulatedTotalSeries / cfg.SimulatedSeriesPerWriteRequest


### PR DESCRIPTION
Backporting #13427 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables async series tracking for tenants far from limits by adding a users-close-to-limit RPC and client cache, integrating it in the distributor, and adding related configs, metrics, and tests.
> 
> - **Distributor**:
>   - Add async path for usage tracking when `CanTrackAsync(user)` is true; waits briefly post-ingestion and cancels if slow.
>   - New metrics: `cortex_distributor_async_usage_tracker_calls_total` and `_with_rejected_series_total`.
>   - Refactor series rejection filtering into `filterOutRejectedSeries()`.
>   - Wire updated client ctor (passes limits) and metric cleanup.
> - **Usage-tracker Service**:
>   - New RPC `GetUsersCloseToLimit` and auth bypass for it; add proto/messages.
>   - Track and expose sorted users-close-to-limit based on new threshold; maintain `sortedTenants` and periodic `updateLimits()` logic.
>   - Config: `usage-tracker.user-close-to-limit-percentage-threshold`.
>   - Partition handler: test hook to force limit updates.
> - **Usage-tracker Client**:
>   - Background poll of a random partition for users-close-to-limit; cache + metrics (`*_users_close_to_limit_*`).
>   - New `CanTrackAsync(user)`; constructor now requires limits provider.
>   - Config: poll interval, startup retries, max wait after ingestion, min series limit for async.
>   - gRPC instrumentation excludes auth header for new method.
> - **Other**:
>   - Docs: distributor/usage-tracker interaction updated for async path.
>   - Tests updated/added across distributor, tracker, client; load generator adapted.
>   - CHANGELOG and go.mod (opentracing deps) updated.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8924525ac2d663615ae4fe8eaad7553393ee2fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->