### PR TITLE
docs: pick less ambiguous example values for CPU limiting

### DIFF
--- a/docs/sources/mimir/configure/configure-resource-utilization-based-ingester-read-path-limiting.md
+++ b/docs/sources/mimir/configure/configure-resource-utilization-based-ingester-read-path-limiting.md
@@ -29,8 +29,8 @@ Alternatively, you may configure the ingester via YAML, as in the following snip
 
 ```yaml
 ingester:
-  # Configure ingester to reject read requests when average CPU utilization is >= 0.8 cores
-  read_path_cpu_utilization_limit: 0.8
+  # Configure ingester to reject read requests when average CPU utilization is >= 3.5 cores
+  read_path_cpu_utilization_limit: 3.5
   # Configure ingester to reject read requests when memory utilization is >= 16 GiB
   read_path_memory_utilization_limit: 17179869184
 ```


### PR DESCRIPTION
#### What this PR does

Pick a CPU resource utilization limit that is less ambiguous to make it clear that the setting is a number of cores, not any sort of percentage of cores used.

#### Which issue(s) this PR fixes or relates to

Clarifying based on a question in community slack.

#### Checklist

- [ ] Tests updated.
- [X] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies the docs by using a 3.5 cores example for `read_path_cpu_utilization_limit` in the ingester read-path limiting YAML.
> 
> - **Documentation**:
>   - Update example YAML in `docs/sources/mimir/configure/configure-resource-utilization-based-ingester-read-path-limiting.md`:
>     - Change `read_path_cpu_utilization_limit` from `0.8` to `3.5` and adjust the comment to emphasize the value is in CPU cores.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3aadcbe90c30e7bd043219f0638028cb146f8d72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->