### PR TITLE
helm: set minReadySeconds for cache statefulsets

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -33,6 +33,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Add Support to customize gossip ring k8s service annotations. #12718
 * [ENHANCEMENT] Ruler querier and query-frontend: Add support for newly-introduced querier ring, which is used when performing query planning in query-frontends and distributing portions of the plan to queriers for execution. #13017
 * [ENHANCEMENT] Upgrade rollout-operator chart to [0.37.0](https://github.com/grafana/helm-charts/blob/main/charts/rollout-operator/README.md#upgrade-of-grafana-rollout-operator). Note required actions for upgrading the rollout-operator chart. #13245
+* [ENHANCEMENT] Set `minReadySeconds` for Memcached statefulsets to slow down rollouts. #13495
 * [BUGFIX] Fix missing newline for custom pod labels. #13325
 * [BUGFIX] Upgrade rollout-operator chart to 0.37.1, which fixes server-tls.self-signed-cert.dns-name to use the full release name instead of always being set to `rollout-operator.NAMESPACE.svc`. If upgrading from 6.0.0 or 6.0.1, delete the `certificate` secret created by the rollout-operator pod and recreate the rollout-operator pod. #13357
 * [BUGFIX] Delete gateway's serviceMonitor #13481

--- a/operations/helm/charts/mimir-distributed/large.yaml
+++ b/operations/helm/charts/mimir-distributed/large.yaml
@@ -80,10 +80,6 @@ ingester:
   zoneAwareReplication:
     topologyKey: "kubernetes.io/hostname"
 
-admin-cache:
-  enabled: true
-  replicas: 3
-
 chunks-cache:
   enabled: true
   replicas: 3

--- a/operations/helm/charts/mimir-distributed/small.yaml
+++ b/operations/helm/charts/mimir-distributed/small.yaml
@@ -81,10 +81,6 @@ ingester:
   zoneAwareReplication:
     topologyKey: "kubernetes.io/hostname"
 
-admin-cache:
-  enabled: true
-  replicas: 3
-
 chunks-cache:
   enabled: true
   replicas: 3

--- a/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-statefulset.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-statefulset.tpl
@@ -15,6 +15,7 @@ metadata:
   namespace: {{ $.ctx.Release.Namespace | quote }}
 spec:
   podManagementPolicy: {{ .podManagementPolicy }}
+  minReadySeconds: {{ .minReadySeconds }}
   replicas: {{ .replicas }}
   selector:
     matchLabels:

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -2531,6 +2531,9 @@ chunks-cache:
   # -- Specifies whether memcached based chunks-cache should be enabled
   enabled: false
 
+  # -- How long each pod must be ready for before the next one is started/restarted
+  minReadySeconds: 60
+
   # -- Total number of chunks-cache replicas
   replicas: 1
 
@@ -2632,6 +2635,9 @@ chunks-cache:
 index-cache:
   # -- Specifies whether memcached based index-cache should be enabled
   enabled: false
+
+  # -- How long each pod must be ready for before the next one is started/restarted
+  minReadySeconds: 60
 
   # -- Total number of index-cache replicas
   replicas: 1
@@ -2735,6 +2741,9 @@ metadata-cache:
   # -- Specifies whether memcached based metadata-cache should be enabled
   enabled: false
 
+  # -- How long each pod must be ready for before the next one is started/restarted
+  minReadySeconds: 60
+
   # -- Total number of metadata-cache replicas
   replicas: 1
 
@@ -2836,6 +2845,9 @@ metadata-cache:
 results-cache:
   # -- Specifies whether memcached based results-cache should be enabled
   enabled: false
+
+  # -- How long each pod must be ready for before the next one is started/restarted
+  minReadySeconds: 60
 
   # -- Total number of results-cache replicas
   replicas: 1

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -14,6 +14,7 @@ metadata:
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -14,6 +14,7 @@ metadata:
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -14,6 +14,7 @@ metadata:
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -14,6 +14,7 @@ metadata:
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -14,6 +14,7 @@ metadata:
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -14,6 +14,7 @@ metadata:
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -14,6 +14,7 @@ metadata:
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -14,6 +14,7 @@ metadata:
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
+  minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -14,6 +14,7 @@ metadata:
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
+  minReadySeconds: 60
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -14,6 +14,7 @@ metadata:
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
+  minReadySeconds: 60
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -14,6 +14,7 @@ metadata:
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
+  minReadySeconds: 60
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -14,6 +14,7 @@ metadata:
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
+  minReadySeconds: 60
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -14,6 +14,7 @@ metadata:
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
+  minReadySeconds: 60
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -14,6 +14,7 @@ metadata:
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
+  minReadySeconds: 60
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -14,6 +14,7 @@ metadata:
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
+  minReadySeconds: 60
   replicas: 1
   selector:
     matchLabels:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -14,6 +14,7 @@ metadata:
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
+  minReadySeconds: 60
   replicas: 1
   selector:
     matchLabels:


### PR DESCRIPTION
#### What this PR does

Set the `minReadySeconds` field for cache statefulsets to require that each pod is ready for 60 seconds by default before moving on to the next pod. This slows down rollouts of cache servers to avoid invaliding the entire cache at nearly the same time.

#### Which issue(s) this PR fixes or relates to

Related #12938

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets minReadySeconds (default 60s) on all memcached cache StatefulSets, updates values/tests, and removes admin-cache from sizing plans.
> 
> - **Helm (mimir-distributed)**
>   - **Memcached caches**:
>     - Add `minReadySeconds` to StatefulSets via `templates/memcached/_memcached-statefulset.tpl`.
>     - Expose `*.minReadySeconds` (default `60`) in `values.yaml` for `chunks-cache`, `index-cache`, `metadata-cache`, `results-cache`.
>     - Update generated manifests/tests to include `minReadySeconds: 60`.
>   - **Sizing plans**:
>     - Remove `admin-cache` from `large.yaml` and `small.yaml`.
>   - **Changelog**:
>     - Add enhancement entry noting `minReadySeconds` for Memcached statefulsets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b79255dfe50392fb37ac7339b0c178a2bc810dec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->