### PR TITLE
Fix for running promql benchmarks

### DIFF
--- a/pkg/streamingpromql/benchmarks/benchmarks.go
+++ b/pkg/streamingpromql/benchmarks/benchmarks.go
@@ -8,7 +8,6 @@ package benchmarks
 import (
 	"context"
 	"fmt"
-	"github.com/grafana/mimir/pkg/util/limiter"
 	"strconv"
 	"strings"
 	"testing"
@@ -49,11 +48,6 @@ func (c BenchCase) Name() string {
 func (c BenchCase) Run(ctx context.Context, t testing.TB, start, end time.Time, interval time.Duration, engine promql.QueryEngine, q storage.Queryable) (*promql.Result, func()) {
 	var qry promql.Query
 	var err error
-
-	promqlEngine, ok := engine.(*promql.Engine)
-	if ok {
-		engine = limiter.NewUnlimitedMemoryTrackerPromQLEngine(promqlEngine)
-	}
 
 	if c.Steps == 0 {
 		qry, err = engine.NewInstantQuery(ctx, q, nil, c.Expr, start)

--- a/pkg/streamingpromql/benchmarks/comparison_test.go
+++ b/pkg/streamingpromql/benchmarks/comparison_test.go
@@ -43,7 +43,7 @@ func BenchmarkQuery(b *testing.B) {
 	cases := TestCases(MetricSizes)
 
 	opts := streamingpromql.NewTestEngineOpts()
-	prometheusEngine := promql.NewEngine(opts.CommonOpts)
+	prometheusEngine := limiter.NewUnlimitedMemoryTrackerPromQLEngine(promql.NewEngine(opts.CommonOpts))
 	planner, err := streamingpromql.NewQueryPlanner(opts, streamingpromql.NewMaximumSupportedVersionQueryPlanVersionProvider())
 	require.NoError(b, err)
 	mimirEngine, err := streamingpromql.NewEngine(opts, streamingpromql.NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner)


### PR DESCRIPTION
#### What this PR does

For the running the MQE/PromQL benchmarks.

In order for the promql.Engine to be used it requires a MemoryTracker to be available in the context.

#### Which issue(s) this PR fixes or relates to


#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wraps the Prometheus PromQL engine in benchmarks with an unlimited memory-tracked engine to satisfy required MemoryTracker usage.
> 
> - **Benchmarks**:
>   - In `pkg/streamingpromql/benchmarks/comparison_test.go`, initialize `prometheusEngine` via `limiter.NewUnlimitedMemoryTrackerPromQLEngine(promql.NewEngine(opts.CommonOpts))` to ensure a MemoryTracker is present during benchmark runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 866db40f932c221b5f8c3c92bff87938dd56de1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->