### PR TITLE
WIP: test illustrating query stats issues with subqueries and CSE

### DIFF
--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -3762,6 +3762,21 @@ func TestQueryStats(t *testing.T) {
 			expectedTotalSamplesWithMQE:        1,
 			expectedTotalSamplesPerStepWithMQE: []int64{1},
 		},
+		"common subexpression elimination inside subquery, instant query": {
+			expr:                               `sum_over_time((sum(dense_series))[5m:1m]) + sum_over_time((count(dense_series))[5m:1m])`,
+			isInstantQuery:                     true,
+			expectedTotalSamples:               10,
+			expectedTotalSamplesPerStep:        []int64{10},
+			expectedTotalSamplesWithMQE:        5,
+			expectedTotalSamplesPerStepWithMQE: []int64{5},
+		},
+		"common subexpression elimination inside subquery, range query": {
+			expr:                               `sum_over_time((sum(dense_series))[5m:1m]) + sum_over_time((count(dense_series))[5m:1m])`,
+			expectedTotalSamples:               90,
+			expectedTotalSamplesPerStep:        []int64{2, 4, 6, 8, 10, 10, 10, 10, 10, 10, 10},
+			expectedTotalSamplesWithMQE:        45,
+			expectedTotalSamplesPerStepWithMQE: []int64{1, 2, 3, 4, 5, 5, 5, 5, 5, 5, 5},
+		},
 		// Three tests below cover PQE bug: sample counting is incorrect when subqueries with range vector selectors are wrapped in functions.
 		// In MQE it's fixed, so that's why cases have a skipCompareWithPrometheus set.
 		// See this for details: https://github.com/prometheus/prometheus/issues/16638


### PR DESCRIPTION
#### What this PR does

This is a WIP PR demonstrating some issues with query stats from subqueries when CSE applies to a query.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
