### PR TITLE
indexheader: inject block id into LazyBinaryReader logs

### DIFF
--- a/pkg/storage/indexheader/lazy_binary_reader.go
+++ b/pkg/storage/indexheader/lazy_binary_reader.go
@@ -147,6 +147,8 @@ func NewLazyBinaryReader(
 		_ = df.Close()
 	}
 
+	logger = log.With(logger, "id", id)
+
 	g := errgroup.Group{}
 	g.Go(func() error {
 		return ensureIndexHeaderOnDisk(ctx, logger, bkt, id, indexHeaderPath)


### PR DESCRIPTION
#### What this PR does

The PR injects the block identifier into the `LazyBinaryReader` logs. This is so we had more context regarding the logs, especially those related to sparse-header.

E.g. today we have these,

```
ts=2025-11-15T14:15:13.979450834Z caller=stream_binary_reader.go:249 level=info user=9960 msg="downloaded sparse index-header from bucket"
```

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
