### PR TITLE
Fix issue where utilization-based limiter always fails to start

### DIFF
--- a/pkg/util/limiter/utilization.go
+++ b/pkg/util/limiter/utilization.go
@@ -132,7 +132,11 @@ func (l *UtilizationBasedLimiter) LimitingReason() string {
 func (l *UtilizationBasedLimiter) starting(_ context.Context) error {
 	var err error
 	l.utilizationScanner, err = newCombinedScanner()
-	return fmt.Errorf("unable to detect CPU/memory utilization, unsupported platform. Please disable utilization based limiting: %w", err)
+	if err != nil {
+		return fmt.Errorf("unable to detect CPU/memory utilization, unsupported platform. Please disable utilization based limiting: %w", err)
+	}
+
+	return nil
 }
 
 func (l *UtilizationBasedLimiter) update(_ context.Context) error {


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue introduced in https://github.com/grafana/mimir/pull/13408 where the utilization-based limiter always fails to start with `unable to detect CPU/memory utilization, unsupported platform. Please disable utilization based limiting: %!w(<nil>)`

I've chosen not to add a changelog entry given #13408 does not have a changelog entry and this change has not been part of a numbered release yet.

#### Which issue(s) this PR fixes or relates to

#13408

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
