### PR TITLE
[r366][cost attribution]: fix panic when metrics are configured with invali…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * [BUGFIX] Query-frontend: Fix issue where queriers may receive a `rpc error: code = Internal desc = cardinality violation: expected <EOF> for non server-streaming RPCs, but received another message` error while sending a query result to a query-frontend if remote execution is enabled. #13147
 * [BUGFIX] Querier: Fix issue where evaluation metrics and logs aren't emitted if remote execution is enabled. #13207
 * [BUGFIX] Query-frontend: Fix issue where queries containing subqueries could fail with `slice capacity must be a power of two, but is X` if remote execution is enabled. #13211
+* [BUGFIX] Cost attribution: Fix panic when metrics are created with invalid labels. #13273
 
 ### Mixin
 

--- a/pkg/costattribution/active_tracker.go
+++ b/pkg/costattribution/active_tracker.go
@@ -28,10 +28,10 @@ type counters struct {
 
 type ActiveSeriesTracker struct {
 	userID                                         string
-	activeSeriesPerUserAttribution                 *prometheus.Desc
-	attributedOverflowLabels                       *prometheus.Desc
-	activeNativeHistogramSeriesPerUserAttribution  *prometheus.Desc
-	activeNativeHistogramBucketsPerUserAttribution *prometheus.Desc
+	activeSeriesPerUserAttribution                 *descriptor
+	attributedOverflowLabels                       *descriptor
+	activeNativeHistogramSeriesPerUserAttribution  *descriptor
+	activeNativeHistogramBucketsPerUserAttribution *descriptor
 	logger                                         log.Logger
 
 	labels         []costattributionmodel.Label
@@ -49,15 +49,14 @@ type ActiveSeriesTracker struct {
 	overflowCounter counters
 }
 
-func NewActiveSeriesTracker(userID string, trackedLabels []costattributionmodel.Label, limit int, cooldownDuration time.Duration, logger log.Logger) *ActiveSeriesTracker {
+func NewActiveSeriesTracker(userID string, trackedLabels []costattributionmodel.Label, limit int, cooldownDuration time.Duration, logger log.Logger) (*ActiveSeriesTracker, error) {
 	// Create a map for overflow labels to export when overflow happens
-	overflowLabels := make([]string, len(trackedLabels)+2)
+	overflowLabels := make([]string, len(trackedLabels)+1)
 	for i := range trackedLabels {
 		overflowLabels[i] = overflowValue
 	}
 
 	overflowLabels[len(trackedLabels)] = userID
-	overflowLabels[len(trackedLabels)+1] = overflowValue
 
 	ast := &ActiveSeriesTracker{
 		userID:           userID,
@@ -69,25 +68,39 @@ func NewActiveSeriesTracker(userID string, trackedLabels []costattributionmodel.
 		cooldownDuration: cooldownDuration,
 	}
 
-	variableLabels := make([]string, 0, len(trackedLabels)+2)
-	for _, label := range trackedLabels {
-		variableLabels = append(variableLabels, label.OutputLabel())
+	if err := ast.createAndValidateDescriptors(trackedLabels); err != nil {
+		return nil, fmt.Errorf("failed to create an active series tracker for tenant %s: %w", userID, err)
 	}
-	variableLabels = append(variableLabels, tenantLabel, "reason")
+	return ast, nil
+}
 
-	ast.activeSeriesPerUserAttribution = prometheus.NewDesc("cortex_ingester_attributed_active_series",
-		"The total number of active series per user and attribution.", variableLabels[:len(variableLabels)-1],
-		prometheus.Labels{trackerLabel: defaultTrackerName})
-	ast.attributedOverflowLabels = prometheus.NewDesc("cortex_attributed_series_overflow_labels",
-		"The overflow labels for this tenant. This metric is always 1 for tenants with active series, it is only used to have the overflow labels available in the recording rules without knowing their names.", variableLabels[:len(variableLabels)-1],
-		prometheus.Labels{trackerLabel: defaultTrackerName})
-	ast.activeNativeHistogramSeriesPerUserAttribution = prometheus.NewDesc("cortex_ingester_attributed_active_native_histogram_series",
-		"The total number of active native histogram series per user and attribution.", variableLabels[:len(variableLabels)-1],
-		prometheus.Labels{trackerLabel: defaultTrackerName})
-	ast.activeNativeHistogramBucketsPerUserAttribution = prometheus.NewDesc("cortex_ingester_attributed_active_native_histogram_buckets",
-		"The total number of active native histogram buckets per user and attribution.", variableLabels[:len(variableLabels)-1],
-		prometheus.Labels{trackerLabel: defaultTrackerName})
-	return ast
+func (at *ActiveSeriesTracker) createAndValidateDescriptors(trackedLabels []costattributionmodel.Label) error {
+	variableLabels := make([]string, 0, len(trackedLabels)+1)
+	variableLabels = append(variableLabels, costattributionmodel.FromCostAttributionLabelsToOutputLabels(trackedLabels)...)
+	variableLabels = append(variableLabels, tenantLabel)
+
+	var err error
+	if at.activeSeriesPerUserAttribution, err = newDescriptor("cortex_ingester_attributed_active_series",
+		"The total number of active series per user and attribution.", variableLabels,
+		prometheus.Labels{trackerLabel: defaultTrackerName}); err != nil {
+		return err
+	}
+	if at.attributedOverflowLabels, err = newDescriptor("cortex_attributed_series_overflow_labels",
+		"The overflow labels for this tenant. This metric is always 1 for tenants with active series, it is only used to have the overflow labels available in the recording rules without knowing their names.", variableLabels,
+		prometheus.Labels{trackerLabel: defaultTrackerName}); err != nil {
+		return err
+	}
+	if at.activeNativeHistogramSeriesPerUserAttribution, err = newDescriptor("cortex_ingester_attributed_active_native_histogram_series",
+		"The total number of active native histogram series per user and attribution.", variableLabels,
+		prometheus.Labels{trackerLabel: defaultTrackerName}); err != nil {
+		return err
+	}
+	if at.activeNativeHistogramBucketsPerUserAttribution, err = newDescriptor("cortex_ingester_attributed_active_native_histogram_buckets",
+		"The total number of active native histogram buckets per user and attribution.", variableLabels,
+		prometheus.Labels{trackerLabel: defaultTrackerName}); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (at *ActiveSeriesTracker) hasSameLabels(labels []costattributionmodel.Label) bool {
@@ -217,7 +230,7 @@ func (at *ActiveSeriesTracker) Decrement(lbls labels.Labels, nativeHistogramBuck
 }
 
 func (at *ActiveSeriesTracker) Collect(out chan<- prometheus.Metric) {
-	out <- prometheus.MustNewConstMetric(at.attributedOverflowLabels, prometheus.GaugeValue, 1, at.overflowLabels[:len(at.overflowLabels)-1]...)
+	out <- at.attributedOverflowLabels.gauge(1, at.overflowLabels...)
 
 	at.observedMtx.RLock()
 	if !at.overflowSince.IsZero() {
@@ -230,13 +243,13 @@ func (at *ActiveSeriesTracker) Collect(out chan<- prometheus.Metric) {
 			nhBucketNum += c.nativeHistogramBuckets.Load()
 		}
 		at.observedMtx.RUnlock()
-		out <- prometheus.MustNewConstMetric(at.activeSeriesPerUserAttribution, prometheus.GaugeValue, float64(activeSeries+at.overflowCounter.activeSeries.Load()), at.overflowLabels[:len(at.overflowLabels)-1]...)
+		out <- at.activeSeriesPerUserAttribution.gauge(float64(activeSeries+at.overflowCounter.activeSeries.Load()), at.overflowLabels...)
 
 		if nhcounter := float64(nativeHistogram + at.overflowCounter.nativeHistograms.Load()); nhcounter > 0 {
-			out <- prometheus.MustNewConstMetric(at.activeNativeHistogramSeriesPerUserAttribution, prometheus.GaugeValue, nhcounter, at.overflowLabels[:len(at.overflowLabels)-1]...)
+			out <- at.activeNativeHistogramSeriesPerUserAttribution.gauge(nhcounter, at.overflowLabels...)
 		}
 		if bcounter := float64(nhBucketNum + at.overflowCounter.nativeHistogramBuckets.Load()); bcounter > 0 {
-			out <- prometheus.MustNewConstMetric(at.activeNativeHistogramBucketsPerUserAttribution, prometheus.GaugeValue, bcounter, at.overflowLabels[:len(at.overflowLabels)-1]...)
+			out <- at.activeNativeHistogramBucketsPerUserAttribution.gauge(bcounter, at.overflowLabels...)
 		}
 		return
 	}
@@ -245,18 +258,12 @@ func (at *ActiveSeriesTracker) Collect(out chan<- prometheus.Metric) {
 	for key, c := range at.observed {
 		keys := strings.Split(key, string(sep))
 		keys = append(keys, at.userID)
-		prometheusMetrics = append(prometheusMetrics,
-			prometheus.MustNewConstMetric(at.activeSeriesPerUserAttribution, prometheus.GaugeValue, float64(c.activeSeries.Load()), keys...),
-		)
+		prometheusMetrics = append(prometheusMetrics, at.activeSeriesPerUserAttribution.gauge(float64(c.activeSeries.Load()), keys...))
 		if nhcounter := c.nativeHistograms.Load(); nhcounter > 0 {
-			prometheusMetrics = append(prometheusMetrics,
-				prometheus.MustNewConstMetric(at.activeNativeHistogramSeriesPerUserAttribution, prometheus.GaugeValue, float64(nhcounter), keys...),
-			)
+			prometheusMetrics = append(prometheusMetrics, at.activeNativeHistogramSeriesPerUserAttribution.gauge(float64(nhcounter), keys...))
 		}
 		if nbcounter := c.nativeHistogramBuckets.Load(); nbcounter > 0 {
-			prometheusMetrics = append(prometheusMetrics,
-				prometheus.MustNewConstMetric(at.activeNativeHistogramBucketsPerUserAttribution, prometheus.GaugeValue, float64(nbcounter), keys...),
-			)
+			prometheusMetrics = append(prometheusMetrics, at.activeNativeHistogramBucketsPerUserAttribution.gauge(float64(nbcounter), keys...))
 		}
 	}
 	at.observedMtx.RUnlock()

--- a/pkg/costattribution/active_tracker_test.go
+++ b/pkg/costattribution/active_tracker_test.go
@@ -3,17 +3,64 @@
 package costattribution
 
 import (
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/costattribution/costattributionmodel"
 )
+
+func TestNewActiveTracker(t *testing.T) {
+	testCases := map[string]struct {
+		costAttributionLabels []costattributionmodel.Label
+		expectedErr           error
+	}{
+		"happy case single label": {
+			costAttributionLabels: []costattributionmodel.Label{{Input: "good_label", Output: "good_label"}},
+			expectedErr:           nil,
+		},
+		"happy case multiple labels": {
+			costAttributionLabels: []costattributionmodel.Label{
+				{Input: "good_label", Output: "good_label"},
+				{Input: "another_good_label", Output: "another_good_label"},
+			},
+			expectedErr: nil,
+		},
+		"incorrect label name causes an error single label": {
+			costAttributionLabels: []costattributionmodel.Label{{Input: "__bad_label__", Output: "__bad_label__"}},
+			expectedErr:           fmt.Errorf(`failed to create an active series tracker for tenant tenant-1: descriptor Desc{fqName: "cortex_ingester_attributed_active_series", help: "The total number of active series per user and attribution.", constLabels: {}, variableLabels: {__bad_label__,tenant}} is invalid: "__bad_label__" is not a valid label name for metric "cortex_ingester_attributed_active_series"`),
+		},
+		"incorrect label name causes an error multiple labels": {
+			costAttributionLabels: []costattributionmodel.Label{
+				{Input: "good_label", Output: "good_label"},
+				{Input: "__bad_label__", Output: "__bad_label__"},
+			},
+			expectedErr: fmt.Errorf(`failed to create an active series tracker for tenant tenant-1: descriptor Desc{fqName: "cortex_ingester_attributed_active_series", help: "The total number of active series per user and attribution.", constLabels: {}, variableLabels: {good_label,__bad_label__,tenant}} is invalid: "__bad_label__" is not a valid label name for metric "cortex_ingester_attributed_active_series"`),
+		},
+	}
+
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			ast, astErr := NewActiveSeriesTracker("tenant-1", testCase.costAttributionLabels, 10, 1*time.Minute, log.NewNopLogger())
+			if testCase.expectedErr == nil {
+				require.NoError(t, astErr)
+				require.NotNil(t, ast)
+			} else {
+				require.Error(t, astErr)
+				require.EqualError(t, astErr, testCase.expectedErr.Error())
+				require.Nil(t, ast)
+			}
+		})
+	}
+}
 
 func TestActiveTracker_hasSameLabels(t *testing.T) {
 	manager, _, _ := newTestManager()

--- a/pkg/costattribution/costattributionmodel/labels.go
+++ b/pkg/costattribution/costattributionmodel/labels.go
@@ -69,3 +69,11 @@ func ParseCostAttributionLabels(labelStrings []string) []Label {
 
 	return output
 }
+
+func FromCostAttributionLabelsToOutputLabels(labels []Label) []string {
+	res := make([]string, 0, len(labels))
+	for _, label := range labels {
+		res = append(res, label.OutputLabel())
+	}
+	return res
+}

--- a/pkg/costattribution/costattributionmodel/labels_test.go
+++ b/pkg/costattribution/costattributionmodel/labels_test.go
@@ -105,3 +105,32 @@ func TestLabel_Validate(t *testing.T) {
 		})
 	}
 }
+
+func TestFromCostAttributionLabelsToOutputLabels(t *testing.T) {
+	tc := map[string]struct {
+		input    []Label
+		expected []string
+	}{
+		"no labels": {
+			input:    []Label{},
+			expected: []string{},
+		},
+		"single": {
+			input:    []Label{{Input: "team", Output: "my_team"}},
+			expected: []string{"my_team"},
+		},
+		"regular list": {
+			input: []Label{
+				{Input: "team", Output: "my_team"},
+				{Input: "service", Output: "my_service"},
+			},
+			expected: []string{"my_team", "my_service"},
+		},
+	}
+	for name, tt := range tc {
+		t.Run(name, func(t *testing.T) {
+			result := FromCostAttributionLabelsToOutputLabels(tt.input)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/costattribution/manager_test.go
+++ b/pkg/costattribution/manager_test.go
@@ -427,3 +427,193 @@ func TestManager_OutputLabels(t *testing.T) {
 		"cortex_ingester_attributed_active_native_histogram_buckets",
 	))
 }
+
+func TestManager_InvalidTrackers(t *testing.T) {
+	manager, reg, costAttributionReg := newTestManager()
+
+	t.Run("Tracker existence and attributes", func(t *testing.T) {
+		user1SampleTracker := manager.SampleTracker("user1")
+		assert.NotNil(t, user1SampleTracker)
+		assert.True(t, user1SampleTracker.hasSameLabels([]costattributionmodel.Label{{Input: "team", Output: ""}}))
+		assert.Equal(t, 5, user1SampleTracker.maxCardinality)
+
+		assert.Nil(t, manager.SampleTracker("user2"))
+
+		user3ActiveTracker := manager.ActiveSeriesTracker("user3")
+		assert.NotNil(t, user3ActiveTracker)
+		assert.True(t, user3ActiveTracker.hasSameLabels([]costattributionmodel.Label{{Input: "department", Output: ""}, {Input: "service", Output: ""}}))
+		assert.Equal(t, 2, user3ActiveTracker.maxCardinality)
+	})
+
+	t.Run("Metrics tracking", func(t *testing.T) {
+		manager.SampleTracker("user1").IncrementDiscardedSamples([]mimirpb.LabelAdapter{{Name: "team", Value: "bar"}}, 1, "invalid-metrics-name", time.Unix(6, 0))
+		manager.SampleTracker("user1").IncrementDiscardedSamples([]mimirpb.LabelAdapter{{Name: "team", Value: "foo"}}, 1, "invalid-metrics-name", time.Unix(12, 0))
+		manager.SampleTracker("user3").IncrementReceivedSamples(testutils.CreateRequest([]testutils.Series{{LabelValues: []string{"department", "foo", "service", "dodo"}, SamplesCount: 1}}), time.Unix(20, 0))
+		manager.ActiveSeriesTracker("user1").Increment(labels.FromStrings("team", "bar"), time.Unix(10, 0), 50)
+		manager.ActiveSeriesTracker("user1").Increment(labels.FromStrings("team", "bar"), time.Unix(10, 0), -1)
+		manager.ActiveSeriesTracker("user3").Increment(labels.FromStrings("department", "foo", "service", "dodo"), time.Unix(10, 0), 2)
+
+		expectedMetrics := `
+		# HELP cortex_discarded_attributed_samples_total The total number of samples that were discarded per attribution.
+		# TYPE cortex_discarded_attributed_samples_total counter
+		cortex_discarded_attributed_samples_total{reason="invalid-metrics-name",team="bar",tenant="user1",tracker="cost-attribution"} 1
+		cortex_discarded_attributed_samples_total{reason="invalid-metrics-name",team="foo",tenant="user1",tracker="cost-attribution"} 1
+		# HELP cortex_distributor_received_attributed_samples_total The total number of samples that were received per attribution.
+		# TYPE cortex_distributor_received_attributed_samples_total counter
+		cortex_distributor_received_attributed_samples_total{department="foo",service="dodo",tenant="user3",tracker="cost-attribution"} 1
+		# HELP cortex_ingester_attributed_active_native_histogram_buckets The total number of active native histogram buckets per user and attribution.
+        # TYPE cortex_ingester_attributed_active_native_histogram_buckets gauge
+        cortex_ingester_attributed_active_native_histogram_buckets{team="bar",tenant="user1",tracker="cost-attribution"} 50
+        cortex_ingester_attributed_active_native_histogram_buckets{department="foo",service="dodo",tenant="user3",tracker="cost-attribution"} 2
+        # HELP cortex_ingester_attributed_active_native_histogram_series The total number of active native histogram series per user and attribution.
+        # TYPE cortex_ingester_attributed_active_native_histogram_series gauge
+        cortex_ingester_attributed_active_native_histogram_series{team="bar",tenant="user1",tracker="cost-attribution"} 1
+        cortex_ingester_attributed_active_native_histogram_series{department="foo",service="dodo",tenant="user3",tracker="cost-attribution"} 1
+		# HELP cortex_ingester_attributed_active_series The total number of active series per user and attribution.
+        # TYPE cortex_ingester_attributed_active_series gauge
+        cortex_ingester_attributed_active_series{team="bar",tenant="user1",tracker="cost-attribution"} 2
+        cortex_ingester_attributed_active_series{department="foo",service="dodo",tenant="user3",tracker="cost-attribution"} 1
+		# HELP cortex_attributed_series_overflow_labels The overflow labels for this tenant. This metric is always 1 for tenants with active series, it is only used to have the overflow labels available in the recording rules without knowing their names.
+		# TYPE cortex_attributed_series_overflow_labels gauge
+		cortex_attributed_series_overflow_labels{team="__overflow__",tenant="user1",tracker="cost-attribution"} 1
+		cortex_attributed_series_overflow_labels{department="__overflow__",service="__overflow__",tenant="user3",tracker="cost-attribution"} 1
+		`
+		assert.NoError(t, testutil.GatherAndCompare(costAttributionReg,
+			strings.NewReader(expectedMetrics),
+			"cortex_discarded_attributed_samples_total",
+			"cortex_distributor_received_attributed_samples_total",
+			"cortex_ingester_attributed_active_series",
+			"cortex_ingester_attributed_active_native_histogram_series",
+			"cortex_ingester_attributed_active_native_histogram_buckets",
+			"cortex_attributed_series_overflow_labels",
+		))
+
+		expectedMetrics = `
+		# HELP cortex_cost_attribution_active_series_tracker_cardinality The cardinality of a cost attribution active series tracker for each user.
+		# TYPE cortex_cost_attribution_active_series_tracker_cardinality gauge
+		cortex_cost_attribution_active_series_tracker_cardinality{tracker="cost-attribution",user="user1"} 1
+		cortex_cost_attribution_active_series_tracker_cardinality{tracker="cost-attribution",user="user3"} 1
+		# HELP cortex_cost_attribution_sample_tracker_cardinality The cardinality of a cost attribution sample tracker for each user.
+		# TYPE cortex_cost_attribution_sample_tracker_cardinality gauge
+		cortex_cost_attribution_sample_tracker_cardinality{tracker="cost-attribution",user="user1"} 2
+		cortex_cost_attribution_sample_tracker_cardinality{tracker="cost-attribution",user="user3"} 1
+		`
+		assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expectedMetrics),
+			"cortex_cost_attribution_sample_tracker_cardinality",
+			"cortex_cost_attribution_sample_tracker_overflown",
+			"cortex_cost_attribution_active_series_tracker_cardinality",
+			"cortex_cost_attribution_active_series_tracker_overflown",
+			"cortex_cost_attribution_tracker_creation_errors_total",
+		))
+	})
+
+	t.Run("Update cost attribution labels with a bad label name", func(t *testing.T) {
+		manager.limits = testutils.NewMockCostAttributionLimits(0, []string{"user1", "__team__"})
+		manager.purgeInactiveAttributionsUntil(time.Unix(11, 0).Add(manager.inactiveTimeout))
+
+		expectedMetrics := `
+		# HELP cortex_distributor_received_attributed_samples_total The total number of samples that were received per attribution.
+		# TYPE cortex_distributor_received_attributed_samples_total counter
+		cortex_distributor_received_attributed_samples_total{department="foo",service="dodo",tenant="user3",tracker="cost-attribution"} 1
+		# HELP cortex_ingester_attributed_active_native_histogram_buckets The total number of active native histogram buckets per user and attribution.
+        # TYPE cortex_ingester_attributed_active_native_histogram_buckets gauge
+        cortex_ingester_attributed_active_native_histogram_buckets{department="foo",service="dodo",tenant="user3",tracker="cost-attribution"} 2
+        # HELP cortex_ingester_attributed_active_native_histogram_series The total number of active native histogram series per user and attribution.
+        # TYPE cortex_ingester_attributed_active_native_histogram_series gauge
+        cortex_ingester_attributed_active_native_histogram_series{department="foo",service="dodo",tenant="user3",tracker="cost-attribution"} 1
+		# HELP cortex_ingester_attributed_active_series The total number of active series per user and attribution.
+        # TYPE cortex_ingester_attributed_active_series gauge
+        cortex_ingester_attributed_active_series{department="foo",service="dodo",tenant="user3",tracker="cost-attribution"} 1
+		# HELP cortex_attributed_series_overflow_labels The overflow labels for this tenant. This metric is always 1 for tenants with active series, it is only used to have the overflow labels available in the recording rules without knowing their names.
+		# TYPE cortex_attributed_series_overflow_labels gauge
+		cortex_attributed_series_overflow_labels{department="__overflow__",service="__overflow__",tenant="user3",tracker="cost-attribution"} 1
+		`
+		assert.NoError(t, testutil.GatherAndCompare(costAttributionReg,
+			strings.NewReader(expectedMetrics),
+			"cortex_discarded_attributed_samples_total",
+			"cortex_distributor_received_attributed_samples_total",
+			"cortex_ingester_attributed_active_series",
+			"cortex_ingester_attributed_active_native_histogram_series",
+			"cortex_ingester_attributed_active_native_histogram_buckets",
+			"cortex_attributed_series_overflow_labels",
+		))
+
+		expectedMetrics = `
+		# HELP cortex_cost_attribution_active_series_tracker_cardinality The cardinality of a cost attribution active series tracker for each user.
+		# TYPE cortex_cost_attribution_active_series_tracker_cardinality gauge
+		cortex_cost_attribution_active_series_tracker_cardinality{tracker="cost-attribution",user="user3"} 1
+		# HELP cortex_cost_attribution_sample_tracker_cardinality The cardinality of a cost attribution sample tracker for each user.
+		# TYPE cortex_cost_attribution_sample_tracker_cardinality gauge
+		cortex_cost_attribution_sample_tracker_cardinality{tracker="cost-attribution",user="user3"} 1
+        # HELP cortex_cost_attribution_tracker_creation_errors_total The total number of errors creating cost attribution trackers for each user.
+        # TYPE cortex_cost_attribution_tracker_creation_errors_total counter
+        cortex_cost_attribution_tracker_creation_errors_total{tracker="active-series",user="user1"} 1
+        cortex_cost_attribution_tracker_creation_errors_total{tracker="samples",user="user1"} 1
+		`
+		assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expectedMetrics),
+			"cortex_cost_attribution_sample_tracker_cardinality",
+			"cortex_cost_attribution_sample_tracker_overflown",
+			"cortex_cost_attribution_active_series_tracker_cardinality",
+			"cortex_cost_attribution_active_series_tracker_overflown",
+			"cortex_cost_attribution_tracker_creation_errors_total",
+		))
+	})
+
+	t.Run("Update cost attribution labels with a good label name", func(t *testing.T) {
+		manager.limits = testutils.NewMockCostAttributionLimits(0, []string{"user1", "team"})
+		manager.purgeInactiveAttributionsUntil(time.Unix(11, 0).Add(manager.inactiveTimeout))
+		manager.ActiveSeriesTracker("user1").Increment(labels.FromStrings("team", "bar"), time.Unix(10, 0), 50)
+
+		expectedMetrics := `
+		# HELP cortex_distributor_received_attributed_samples_total The total number of samples that were received per attribution.
+		# TYPE cortex_distributor_received_attributed_samples_total counter
+		cortex_distributor_received_attributed_samples_total{department="foo",service="dodo",tenant="user3",tracker="cost-attribution"} 1
+		# HELP cortex_ingester_attributed_active_native_histogram_buckets The total number of active native histogram buckets per user and attribution.
+        # TYPE cortex_ingester_attributed_active_native_histogram_buckets gauge
+        cortex_ingester_attributed_active_native_histogram_buckets{team="bar",tenant="user1",tracker="cost-attribution"} 50
+        cortex_ingester_attributed_active_native_histogram_buckets{department="foo",service="dodo",tenant="user3",tracker="cost-attribution"} 2
+        # HELP cortex_ingester_attributed_active_native_histogram_series The total number of active native histogram series per user and attribution.
+        # TYPE cortex_ingester_attributed_active_native_histogram_series gauge
+        cortex_ingester_attributed_active_native_histogram_series{team="bar",tenant="user1",tracker="cost-attribution"} 1
+        cortex_ingester_attributed_active_native_histogram_series{department="foo",service="dodo",tenant="user3",tracker="cost-attribution"} 1
+		# HELP cortex_ingester_attributed_active_series The total number of active series per user and attribution.
+        # TYPE cortex_ingester_attributed_active_series gauge
+        cortex_ingester_attributed_active_series{team="bar",tenant="user1",tracker="cost-attribution"} 1
+        cortex_ingester_attributed_active_series{department="foo",service="dodo",tenant="user3",tracker="cost-attribution"} 1
+		# HELP cortex_attributed_series_overflow_labels The overflow labels for this tenant. This metric is always 1 for tenants with active series, it is only used to have the overflow labels available in the recording rules without knowing their names.
+		# TYPE cortex_attributed_series_overflow_labels gauge
+        cortex_attributed_series_overflow_labels{team="__overflow__",tenant="user1",tracker="cost-attribution"} 1
+		cortex_attributed_series_overflow_labels{department="__overflow__",service="__overflow__",tenant="user3",tracker="cost-attribution"} 1
+		`
+		assert.NoError(t, testutil.GatherAndCompare(costAttributionReg,
+			strings.NewReader(expectedMetrics),
+			"cortex_discarded_attributed_samples_total",
+			"cortex_distributor_received_attributed_samples_total",
+			"cortex_ingester_attributed_active_series",
+			"cortex_ingester_attributed_active_native_histogram_series",
+			"cortex_ingester_attributed_active_native_histogram_buckets",
+			"cortex_attributed_series_overflow_labels",
+		))
+
+		expectedMetrics = `
+		# HELP cortex_cost_attribution_active_series_tracker_cardinality The cardinality of a cost attribution active series tracker for each user.
+		# TYPE cortex_cost_attribution_active_series_tracker_cardinality gauge
+        cortex_cost_attribution_active_series_tracker_cardinality{tracker="cost-attribution",user="user1"} 1
+		cortex_cost_attribution_active_series_tracker_cardinality{tracker="cost-attribution",user="user3"} 1
+		# HELP cortex_cost_attribution_sample_tracker_cardinality The cardinality of a cost attribution sample tracker for each user.
+		# TYPE cortex_cost_attribution_sample_tracker_cardinality gauge
+        cortex_cost_attribution_sample_tracker_cardinality{tracker="cost-attribution",user="user3"} 1
+        # HELP cortex_cost_attribution_tracker_creation_errors_total The total number of errors creating cost attribution trackers for each user.
+        # TYPE cortex_cost_attribution_tracker_creation_errors_total counter
+        cortex_cost_attribution_tracker_creation_errors_total{tracker="active-series",user="user1"} 1
+        cortex_cost_attribution_tracker_creation_errors_total{tracker="samples",user="user1"} 1
+		`
+		assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expectedMetrics),
+			"cortex_cost_attribution_sample_tracker_cardinality",
+			"cortex_cost_attribution_sample_tracker_overflown",
+			"cortex_cost_attribution_active_series_tracker_cardinality",
+			"cortex_cost_attribution_active_series_tracker_overflown",
+			"cortex_cost_attribution_tracker_creation_errors_total",
+		))
+	})
+}

--- a/pkg/costattribution/metrics.go
+++ b/pkg/costattribution/metrics.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package costattribution
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"google.golang.org/protobuf/proto"
+)
+
+// descriptor wraps a prometheus.Desc with additional metadata for metric validation and creation.
+// This wrapper is needed because prometheus.Desc doesn't expose important information about the
+// descriptor itself, such as metric name, label names, and a possible error obtained during the
+// descriptor construction. The first two are accessible via the name and labels fields, while
+// construction error can be obtained by calling validate().
+type descriptor struct {
+	desc   *prometheus.Desc
+	name   string
+	labels []string
+}
+
+// newDescriptor creates a new descriptor with the specified metric name, help text, variable labels, and constant labels.
+// It returns an error if a creation of the underlying prometheus.Desc is not successful, for example when the metric name
+// or any of the label names don't conform to Prometheus naming conventions.
+func newDescriptor(name string, help string, labels []string, constLabels prometheus.Labels) (*descriptor, error) {
+	desc := &descriptor{
+		desc:   prometheus.NewDesc(name, help, labels, constLabels),
+		name:   name,
+		labels: labels,
+	}
+	if err := desc.validate(); err != nil {
+		return nil, err
+	}
+	return desc, nil
+}
+
+// validate checks whether the underlying prometheus.Desc is valid.
+//
+// A prometheus.Desc may contain an internal error if created with invalid
+// metric or label names. Since this error is unexported, validate detects
+// such cases and returns the underlying error if present. Otherwise, it
+// returns nil.
+func (d *descriptor) validate() error {
+	reg := prometheus.NewRegistry()
+	if err := reg.Register(d); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Describe implements the prometheus.Collector interface by sending this descriptor to the provided channel.
+func (d *descriptor) Describe(ch chan<- *prometheus.Desc) {
+	ch <- d.desc
+}
+
+// Collect implements the prometheus.Collector interface with an empty implementation since we only need Describe for validation.
+func (d *descriptor) Collect(_ chan<- prometheus.Metric) {
+	// Empty implementation - we only need Describe for validation
+}
+
+// gauge creates a new gauge metric with the specified value and label values.
+// This has the same effect as calling prometheus.NewConstMetric with value type prometheus.GaugeValue
+// but without any validation.
+func (d *descriptor) gauge(v float64, labelValues ...string) prometheus.Metric {
+	return &constMetric{
+		desc: d.desc,
+		metric: dto.Metric{
+			Label: prometheus.MakeLabelPairs(d.desc, labelValues),
+			Gauge: &dto.Gauge{Value: proto.Float64(v)},
+		},
+	}
+}
+
+// counter creates a new counter metric with the specified value and label values.
+// This has the same effect as calling prometheus.NewConstMetric with value type prometheus.CounterValue
+// but without any validation.
+func (d *descriptor) counter(v float64, labelValues ...string) prometheus.Metric {
+	return &constMetric{
+		desc: d.desc,
+		metric: dto.Metric{
+			Label:   prometheus.MakeLabelPairs(d.desc, labelValues),
+			Counter: &dto.Counter{Value: proto.Float64(v)},
+		},
+	}
+}
+
+// constMetric represents a constant metric that implements the prometheus.Metric interface.
+// It corresponds to prometheus.constMetric, which is not exported.
+type constMetric struct {
+	desc   *prometheus.Desc
+	metric dto.Metric
+}
+
+func (m *constMetric) Desc() *prometheus.Desc {
+	return m.desc
+}
+
+func (m *constMetric) Write(out *dto.Metric) error {
+	out.Label = m.metric.Label
+	out.Counter = m.metric.Counter
+	out.Gauge = m.metric.Gauge
+	out.Untyped = m.metric.Untyped
+	return nil
+}

--- a/pkg/costattribution/metrics_test.go
+++ b/pkg/costattribution/metrics_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package costattribution
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDescriptor(t *testing.T) {
+	testCases := map[string]struct {
+		metricName  string
+		help        string
+		labels      []string
+		constLabels prometheus.Labels
+		expectedErr error
+	}{
+		"metric with valid labels and without constLabels": {
+			metricName:  "test_metric_with_labels",
+			help:        "A test metric with labels",
+			labels:      []string{"label1", "label2"},
+			constLabels: nil,
+			expectedErr: nil,
+		},
+		"metric with valid labels and const labels": {
+			metricName:  "test_metric_with_both_labels",
+			help:        "A test metric with both label types",
+			labels:      []string{"var_label"},
+			constLabels: prometheus.Labels{"const_label": "value"},
+			expectedErr: nil,
+		},
+		"metric with invalid label": {
+			metricName:  "test_metric",
+			help:        "Metric with invalid label",
+			labels:      []string{"__bad_label__"},
+			constLabels: nil,
+			expectedErr: fmt.Errorf(`descriptor Desc{fqName: "test_metric", help: "Metric with invalid label", constLabels: {}, variableLabels: {__bad_label__}} is invalid: "__bad_label__" is not a valid label name for metric "test_metric"`),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			desc, err := newDescriptor(tc.metricName, tc.help, tc.labels, tc.constLabels)
+			if tc.expectedErr != nil {
+				require.Error(t, err)
+				require.EqualError(t, err, tc.expectedErr.Error())
+				require.Nil(t, desc)
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, desc.desc)
+				assert.Equal(t, tc.metricName, desc.name)
+				assert.Equal(t, tc.labels, desc.labels)
+			}
+		})
+	}
+}

--- a/pkg/costattribution/sample_tracker.go
+++ b/pkg/costattribution/sample_tracker.go
@@ -4,6 +4,7 @@ package costattribution
 
 import (
 	"bytes"
+	"fmt"
 	"slices"
 	"strings"
 	"sync"
@@ -29,8 +30,8 @@ type observation struct {
 
 type SampleTracker struct {
 	userID                     string
-	receivedSamplesAttribution *prometheus.Desc
-	discardedSampleAttribution *prometheus.Desc
+	receivedSamplesAttribution *descriptor
+	discardedSampleAttribution *descriptor
 	logger                     log.Logger
 
 	labels         []costattributionmodel.Label
@@ -46,7 +47,7 @@ type SampleTracker struct {
 	overflowCounter observation
 }
 
-func newSampleTracker(userID string, trackedLabels []costattributionmodel.Label, limit int, cooldown time.Duration, logger log.Logger) *SampleTracker {
+func newSampleTracker(userID string, trackedLabels []costattributionmodel.Label, limit int, cooldown time.Duration, logger log.Logger) (*SampleTracker, error) {
 	// Create a map for overflow labels to export when overflow happens
 	overflowLabels := make([]string, len(trackedLabels)+2)
 	for i := range trackedLabels {
@@ -67,22 +68,35 @@ func newSampleTracker(userID string, trackedLabels []costattributionmodel.Label,
 		overflowCounter:  observation{},
 	}
 
+	if err := tracker.createAndValidateDescriptors(trackedLabels); err != nil {
+		return nil, fmt.Errorf("failed to create a sample tracker for tenant %s: %w", userID, err)
+	}
+
+	return tracker, nil
+}
+
+func (st *SampleTracker) createAndValidateDescriptors(trackedLabels []costattributionmodel.Label) error {
 	variableLabels := make([]string, 0, len(trackedLabels)+2)
 	for _, label := range trackedLabels {
 		variableLabels = append(variableLabels, label.OutputLabel())
 	}
-	variableLabels = append(variableLabels, tenantLabel, "reason")
+	variableLabels = append(variableLabels, tenantLabel, reasonLabel)
 
-	tracker.discardedSampleAttribution = prometheus.NewDesc("cortex_discarded_attributed_samples_total",
-		"The total number of samples that were discarded per attribution.",
-		variableLabels,
-		prometheus.Labels{trackerLabel: defaultTrackerName})
-
-	tracker.receivedSamplesAttribution = prometheus.NewDesc("cortex_distributor_received_attributed_samples_total",
+	var err error
+	if st.receivedSamplesAttribution, err = newDescriptor("cortex_distributor_received_attributed_samples_total",
 		"The total number of samples that were received per attribution.",
 		variableLabels[:len(variableLabels)-1],
-		prometheus.Labels{trackerLabel: defaultTrackerName})
-	return tracker
+		prometheus.Labels{trackerLabel: defaultTrackerName}); err != nil {
+		return err
+	}
+
+	if st.discardedSampleAttribution, err = newDescriptor("cortex_discarded_attributed_samples_total",
+		"The total number of samples that were discarded per attribution.",
+		variableLabels,
+		prometheus.Labels{trackerLabel: defaultTrackerName}); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (st *SampleTracker) hasSameLabels(labels []costattributionmodel.Label) bool {
@@ -102,8 +116,8 @@ func (st *SampleTracker) collectCostAttribution(out chan<- prometheus.Metric) {
 
 	if !st.overflowSince.IsZero() {
 		st.observedMtx.RUnlock()
-		out <- prometheus.MustNewConstMetric(st.receivedSamplesAttribution, prometheus.CounterValue, st.overflowCounter.receivedSample.Load(), st.overflowLabels[:len(st.overflowLabels)-1]...)
-		out <- prometheus.MustNewConstMetric(st.discardedSampleAttribution, prometheus.CounterValue, st.overflowCounter.totalDiscarded.Load(), st.overflowLabels...)
+		out <- st.receivedSamplesAttribution.counter(st.overflowCounter.receivedSample.Load(), st.overflowLabels[:len(st.overflowLabels)-1]...)
+		out <- st.discardedSampleAttribution.counter(st.overflowCounter.totalDiscarded.Load(), st.overflowLabels...)
 		return
 	}
 
@@ -111,11 +125,11 @@ func (st *SampleTracker) collectCostAttribution(out chan<- prometheus.Metric) {
 		keys := strings.Split(key, string(sep))
 		keys = append(keys, st.userID)
 		if o.receivedSample.Load() > 0 {
-			prometheusMetrics = append(prometheusMetrics, prometheus.MustNewConstMetric(st.receivedSamplesAttribution, prometheus.CounterValue, o.receivedSample.Load(), keys...))
+			prometheusMetrics = append(prometheusMetrics, st.receivedSamplesAttribution.counter(o.receivedSample.Load(), keys...))
 		}
 		o.discardedSampleMtx.RLock()
 		for reason, discarded := range o.discardedSample {
-			prometheusMetrics = append(prometheusMetrics, prometheus.MustNewConstMetric(st.discardedSampleAttribution, prometheus.CounterValue, discarded.Load(), append(keys, reason)...))
+			prometheusMetrics = append(prometheusMetrics, st.discardedSampleAttribution.counter(discarded.Load(), append(keys, reason)...))
 		}
 		o.discardedSampleMtx.RUnlock()
 	}

--- a/pkg/costattribution/sample_tracker_test.go
+++ b/pkg/costattribution/sample_tracker_test.go
@@ -3,11 +3,13 @@
 package costattribution
 
 import (
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,6 +18,50 @@ import (
 	"github.com/grafana/mimir/pkg/costattribution/testutils"
 	"github.com/grafana/mimir/pkg/mimirpb"
 )
+
+func TestNewSampleTracker(t *testing.T) {
+	testCases := map[string]struct {
+		costAttributionLabels []costattributionmodel.Label
+		expectedErr           error
+	}{
+		"happy case single label": {
+			costAttributionLabels: []costattributionmodel.Label{{Input: "good_label", Output: "good_label"}},
+			expectedErr:           nil,
+		},
+		"happy case multiple labels": {
+			costAttributionLabels: []costattributionmodel.Label{
+				{Input: "good_label", Output: "good_label"},
+				{Input: "another_good_label", Output: "another_good_label"},
+			},
+			expectedErr: nil,
+		},
+		"incorrect label name causes an error single label": {
+			costAttributionLabels: []costattributionmodel.Label{{Input: "__bad_label__", Output: "__bad_label__"}},
+			expectedErr:           fmt.Errorf(`failed to create a sample tracker for tenant tenant-1: descriptor Desc{fqName: "cortex_distributor_received_attributed_samples_total", help: "The total number of samples that were received per attribution.", constLabels: {}, variableLabels: {__bad_label__,tenant}} is invalid: "__bad_label__" is not a valid label name for metric "cortex_distributor_received_attributed_samples_total"`),
+		},
+		"incorrect label name causes an error multiple labels": {
+			costAttributionLabels: []costattributionmodel.Label{
+				{Input: "good_label", Output: "good_label"},
+				{Input: "__bad_label__", Output: "__bad_label__"},
+			},
+			expectedErr: fmt.Errorf(`failed to create a sample tracker for tenant tenant-1: descriptor Desc{fqName: "cortex_distributor_received_attributed_samples_total", help: "The total number of samples that were received per attribution.", constLabels: {}, variableLabels: {good_label,__bad_label__,tenant}} is invalid: "__bad_label__" is not a valid label name for metric "cortex_distributor_received_attributed_samples_total"`),
+		},
+	}
+
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			st, stErr := newSampleTracker("tenant-1", testCase.costAttributionLabels, 10, 1*time.Minute, log.NewNopLogger())
+			if testCase.expectedErr == nil {
+				require.NoError(t, stErr)
+				require.NotNil(t, st)
+			} else {
+				require.Error(t, stErr)
+				require.EqualError(t, stErr, testCase.expectedErr.Error())
+				require.Nil(t, st)
+			}
+		})
+	}
+}
 
 func TestSampleTracker_hasSameLabels(t *testing.T) {
 	manager, _, _ := newTestManager()

--- a/pkg/ingester/activeseries/active_series_test.go
+++ b/pkg/ingester/activeseries/active_series_test.go
@@ -1028,7 +1028,8 @@ func TestActiveSeries_ReloadCostAttributionTrackers(t *testing.T) {
 	assert.True(t, valid)
 
 	// Change the cost attribution tracker, and make sure it's reloaded, purge result not valid.
-	cat := costattribution.NewActiveSeriesTracker("a", []costattributionmodel.Label{{Input: "a"}, {Input: "b"}}, 4, 5*time.Minute, log.NewNopLogger())
+	cat, err := costattribution.NewActiveSeriesTracker("a", []costattributionmodel.Label{{Input: "a"}, {Input: "b"}}, 4, 5*time.Minute, log.NewNopLogger())
+	assert.NoError(t, err)
 	c.ReloadMatchersAndTrackers(asm, cat, currentTime)
 	valid = c.Purge(currentTime, nil)
 	assert.False(t, valid)
@@ -1041,7 +1042,8 @@ func TestActiveSeries_ReloadCostAttributionTrackers(t *testing.T) {
 	assert.True(t, valid)
 	assert.NotNil(t, c.cat)
 
-	cat = costattribution.NewActiveSeriesTracker("a", []costattributionmodel.Label{{Input: "a"}}, 4, 5*time.Minute, log.NewNopLogger())
+	cat, err = costattribution.NewActiveSeriesTracker("a", []costattributionmodel.Label{{Input: "a"}}, 4, 5*time.Minute, log.NewNopLogger())
+	assert.NoError(t, err)
 	c.ReloadMatchersAndTrackers(asm, cat, currentTime)
 	valid = c.Purge(currentTime, nil)
 	assert.False(t, valid)
@@ -1128,7 +1130,8 @@ func TestActiveSeries_ReloadSeriesMatchers_LessMatchers(t *testing.T) {
 		"bar": `{a=~.+}`,
 	}))
 
-	cat := costattribution.NewActiveSeriesTracker("a", []costattributionmodel.Label{{Input: "a"}, {Input: "b"}}, 4, 5*time.Minute, log.NewNopLogger())
+	cat, err := costattribution.NewActiveSeriesTracker("a", []costattributionmodel.Label{{Input: "a"}, {Input: "b"}}, 4, 5*time.Minute, log.NewNopLogger())
+	assert.NoError(t, err)
 	currentTime := time.Now()
 	c := NewActiveSeries(asm, DefaultTimeout, cat)
 	valid := c.Purge(currentTime, nil)


### PR DESCRIPTION
Backport https://github.com/grafana/mimir/pull/13273

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Validate and guard cost attribution metrics by introducing a descriptor layer, returning constructor errors on invalid labels, tracking creation failures, and updating collectors/tests to prevent panics.
> 
> - **Cost attribution (backend)**:
>   - Introduce `descriptor` wrapper (`pkg/costattribution/metrics.go`) to validate metric names/labels and create const metrics without runtime validation.
>   - Update `ActiveSeriesTracker` and `SampleTracker` to use validated descriptors; constructors now return errors on invalid labels and export metrics via new helpers.
>   - Manager handles tracker creation failures, increments `cortex_cost_attribution_tracker_creation_errors_total`, and safely skips invalid trackers; refresh logic updated accordingly.
>   - Add `reason` label constant; adjust overflow label handling; helper `FromCostAttributionLabelsToOutputLabels` added.
>   - Extensive tests added/updated across trackers, manager, labels, metrics, and ingester active-series to cover error cases and behavior.
> - **Changelog**: Add bugfix entry for cost attribution panic on invalid labels.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 739d242c347c9dd590af75c1028806444b92b999. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->