### PR TITLE
Docs: update unit tests instructions

### DIFF
--- a/docs/internal/contributing/README.md
+++ b/docs/internal/contributing/README.md
@@ -49,7 +49,7 @@ The mount options can be adjusted with `CONTAINER_MOUNT_OPTIONS`.)
 To run the unit tests suite:
 
 ```
-make test ./...
+make test
 ```
 
 To run the integration tests suite please see "[How integration tests work](./how-integration-tests-work.md)".


### PR DESCRIPTION
This pull request updates the documentation to reflect the correct command for running the unit test suite. The change replaces the previous `go test ./...` command with the `make test ./...` command in the contributing guide.

* Updated the unit test suite instructions in `docs/internal/contributing/README.md` to use `make test ./...` instead of `go test ./...`.

Fixes https://github.com/grafana/mimir/issues/11051


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update contributing guide to use `make test` for running unit tests instead of `go test ./...`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ff36cfefa347d8c3d1429385d13796a3b082d68. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->