### PR TITLE
docs: remove reference to Grafana Agent

### DIFF
--- a/docs/sources/mimir/_index.md
+++ b/docs/sources/mimir/_index.md
@@ -41,7 +41,7 @@ cards:
       height: 24
     - title: Send metric data
       href: ./send/
-      description: Configure your data sources to write data to Grafana Mimir. These include such sources as Prometheus, the OpenTelemetry Collector, and Grafana Agent.
+      description: Configure your data sources to write data to Grafana Mimir. These include such sources as Prometheus, the OpenTelemetry Collector, and Grafana Alloy.
       height: 24
     - title: Manage
       href: ./manage/

--- a/docs/sources/mimir/configure/configure-out-of-order-samples-ingestion.md
+++ b/docs/sources/mimir/configure/configure-out-of-order-samples-ingestion.md
@@ -70,7 +70,7 @@ The moment that a new series sample arrives, Mimir needs to determine if the ser
 The experimental out-of-order ingestion helps fix both the issues.
 
 {{< admonition type="note" >}}
-If you're writing metrics using Prometheus remote write or Grafana Agent, then you shouldn't expect out-of-order samples.
+If you're writing metrics using Prometheus remote write or Grafana Alloy, then you shouldn't expect out-of-order samples.
 
-Prometheus and Grafana Agent guarantee that samples are written in-order for the same series.
+Prometheus and Grafana Alloy guarantee that samples are written in-order for the same series.
 {{< /admonition >}}

--- a/docs/sources/mimir/manage/use-exemplars/before-you-begin.md
+++ b/docs/sources/mimir/manage/use-exemplars/before-you-begin.md
@@ -18,10 +18,10 @@ Follow the checklist to ensure that your application is generating metrics, trac
   - For histograms, use the `ObserveWithExemplar` method to emit the trace ID along with a value for the histogram. These functions are from the Go library but you can find similar functions in the other libraries.
   - For counters, use the `AddWithExemplar` method to emit the trace ID along with a counter increment.
 - Verify that metrics are being generated with exemplars by running the following command in a shell: `curl -H "Accept: application/openmetrics-text" http://<your application>/metrics | grep -i "traceid"`.
-- Configure your Prometheus server or Grafana Agent to store and send exemplars.
-  - To configure Grafana Agent to send exemplars:
-    1. Confirm that the Agent is scraping exemplars by verifying that the `prometheus_remote_storage_exemplars_total` metric is a non-zero value.
-    1. Add the option `send_exemplars: true` under the `remote_write` configuration block in the Grafana Agent configuration file.
+- Configure your Prometheus server or Grafana Alloy to store and send exemplars.
+  - To configure Grafana Alloy to send exemplars:
+    1. Confirm that Alloy is scraping exemplars by verifying that the `prometheus_remote_storage_exemplars_total` metric is a non-zero value.
+    1. In Alloy, set `send_exemplars: true` under the `prometheus.remote_write` configuration block. For details, refer to the [Grafana Alloy documentation](https://grafana.com/docs/alloy/latest/).
   - To configure a Prometheus server to send exemplars:
     1. Run Prometheus with the `--enable-feature=exemplar-storage` flag.
     1. Confirm that Prometheus is scraping exemplars by verifying that the `prometheus_remote_storage_exemplars_total` metric is a non-zero value.

--- a/docs/sources/mimir/set-up/migrate/migrate-from-thanos-to-mimir-with-thanos-sidecar.md
+++ b/docs/sources/mimir/set-up/migrate/migrate-from-thanos-to-mimir-with-thanos-sidecar.md
@@ -13,7 +13,7 @@ As an operator, you can migrate a deployment of Thanos to Grafana Mimir by using
 
 ## Overview
 
-An option when migrating is to allow Thanos to query Mimir. This way you retain historical data via your existing Thanos deployment while pointing all of your Prometheus servers (or grafana agents and other metric sources) to Mimir.
+An option when migrating is to allow Thanos to query Mimir. This way you retain historical data via your existing Thanos deployment while pointing all of your Prometheus servers (or Grafana Alloy and other metric sources) to Mimir.
 
 The overall setup consists of setting up Thanos Sidecar alongside Mimir and then pointing Thanos Query to the sidecar as if it was just a normal sidecar.
 


### PR DESCRIPTION
This pull request updates references in the documentation to replace "Grafana Agent" with "Grafana Alloy" across multiple Mimir docs. The changes ensure consistency with the current naming and clarify configuration steps for users migrating or setting up metric ingestion and exemplar support.

Documentation updates for Grafana Alloy:

* Updated references from "Grafana Agent" to "Grafana Alloy" in the migration guide, configuration instructions, and summary cards to reflect the new product name and usage. [[1]](diffhunk://#diff-183ed38899d993f2f15470fb262dabb82b694f30b5060ee2c08aa58b87853298L16-R16) [[2]](diffhunk://#diff-a06adcadfc0b8b436a717964d8131b049fe4f9e633bbbfd1cd5c46f84d86d1e1L44-R44) [[3]](diffhunk://#diff-e3cadb89850ca214889f33f5ff398f67156d63d3f08c8bd4e35262b922e8542cL73-R75) [[4]](diffhunk://#diff-a187a83046baf0e7830fbace4174fbbfa56ffe9bc36835314f3ea3e701528291L21-R24)

Configuration instructions:

* Revised exemplar configuration steps to show how to enable and verify exemplar support in Grafana Alloy, including a link to the official documentation.

Consistency and clarity improvements:

* Ensured all mentions of metric sources, ingestion, and out-of-order sample handling reference Grafana Alloy instead of the deprecated Grafana Agent. [[1]](diffhunk://#diff-e3cadb89850ca214889f33f5ff398f67156d63d3f08c8bd4e35262b922e8542cL73-R75) [[2]](diffhunk://#diff-183ed38899d993f2f15470fb262dabb82b694f30b5060ee2c08aa58b87853298L16-R16) [[3]](diffhunk://#diff-a187a83046baf0e7830fbace4174fbbfa56ffe9bc36835314f3ea3e701528291L21-R24)

Fixes https://github.com/grafana/mimir-squad/issues/3352