### PR TITLE
index planning: Add virtual predicate support to plan struct

### DIFF
--- a/pkg/ingester/lookupplan/plan.go
+++ b/pkg/ingester/lookupplan/plan.go
@@ -132,8 +132,8 @@ func (p plan) TotalCost() float64 {
 func (p plan) indexLookupCost() float64 {
 	cost := 0.0
 	for i := range p.predicates {
-		pr, ok := p.virtualPredicate(i)
-		if !ok {
+		pr, isIndex := p.virtualPredicate(i)
+		if !isIndex {
 			continue
 		}
 
@@ -147,8 +147,8 @@ func (p plan) indexLookupCost() float64 {
 func (p plan) intersectionCost() float64 {
 	iteratedPostings := uint64(0)
 	for i := range p.predicates {
-		pred, ok := p.virtualPredicate(i)
-		if !ok {
+		pred, isIndex := p.virtualPredicate(i)
+		if !isIndex {
 			continue
 		}
 
@@ -173,8 +173,8 @@ func (p plan) filterCost() float64 {
 	for i := range p.predicates {
 		// In reality, we will apply all the predicates for each series and stop once one predicate doesn't match.
 		// But we calculate for the worst case where we have to run all predicates for all series.
-		pred, ok := p.virtualPredicate(i)
-		if ok {
+		pred, isIndex := p.virtualPredicate(i)
+		if isIndex {
 			continue
 		}
 
@@ -190,8 +190,8 @@ func (p plan) numSelectedPostingsInOurShard() uint64 {
 func (p plan) NumSelectedPostings() uint64 {
 	finalSelectivity := 1.0
 	for i := range p.predicates {
-		pred, ok := p.virtualPredicate(i)
-		if !ok {
+		pred, isIndex := p.virtualPredicate(i)
+		if !isIndex {
 			continue
 		}
 


### PR DESCRIPTION
Add support for lower bound cost estimation through virtual predicates in the plan struct.

This allows branch-and-bound planning to compute cost lower bounds without duplicating cost calculation logic.

The `numDecidedPredicates` field tracks which predicates have been decided, and the `virtualPredicate()` method returns actual predicates for decided indices and minimal-cost virtual predicates for undecided ones.

This is a precursor to https://github.com/grafana/mimir/pull/13568; 

related to https://github.com/grafana/mimir/issues/11921


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `numDecidedPredicates` and `virtualPredicate()` to enable lower-bound cost estimation and updates cost calculations to use them.
> 
> - **Lookup plan (`pkg/ingester/lookupplan/plan.go`)**:
>   - Add `numDecidedPredicates` and `virtualPredicate()` to model undecided predicates (first undecided treated as index; others as minimal-cost scans).
>   - Update cost functions to use `virtualPredicate()`: `indexLookupCost()`, `intersectionCost()`, `filterCost()`, and `NumSelectedPostings()`.
>   - Initialize `numDecidedPredicates` in `newScanOnlyPlan()` so all predicates are decided for scan-only plans.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc8571e133d5ab41584b132ce6f5b3b100c47e58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->