### PR TITLE
fix blocks store queryable logging blank retryable error

### DIFF
--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -854,12 +854,12 @@ func (q *blocksStoreQuerier) fetchSeriesFromStores(ctx context.Context, sp *stor
 					util.CloseAndExhaust[*storepb.SeriesResponse](stream) //nolint:errcheck
 					break
 				}
-				if err != nil {
-					return err
-				}
 				if shouldRetry {
 					level.Warn(clientSpanLog).Log("msg", "failed to receive series", "remote", c.RemoteAddress(), "err", err)
 					return nil
+				}
+				if err != nil {
+					return err
 				}
 
 				if isEOS {
@@ -980,7 +980,7 @@ func (q *blocksStoreQuerier) receiveMessage(c BlocksStoreClient, stream storegat
 		}
 
 		if shouldRetry(err) {
-			return myWarnings, myQueriedBlocks, myStreamingSeriesLabels, indexBytesFetched, false, true, nil
+			return myWarnings, myQueriedBlocks, myStreamingSeriesLabels, indexBytesFetched, false, true, err
 		}
 
 		return myWarnings, myQueriedBlocks, myStreamingSeriesLabels, indexBytesFetched, false, false, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Currently the logic swallows retryable errors down in `receiveMessage` and returns a `shouldRetry` boolean instead.
The caller, `fetchSeriesFromStores` then attempts to log a warning about this before retrying but the actual error in the log is blank because it's already been swallowed.
This results in log messages like this:

> ts=2025-11-19T09:05:46.778294291Z caller=blocks_store_queryable.go:861 method=blocksStoreQuerier.fetchSeriesFromStores level=warn msg="failed to receive series" **err=null**

---
The change here does two things:
1. Eliminates the extra boolean flag and just returns the error up to the caller.
The caller handles the `shouldRetry` check so the error is still available to be logged.

2. Moves the logic to not retry on limit errors _from_ the special boolean flag set by the `if limitErr := queryLimiter.AddSeries(ls); limitErr != nil` conditional branch _to_ the `shouldRetry` func which is already used and tested for all other cases.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Preserves and propagates retryable errors from `receiveMessage` so callers can log them while still triggering retries, and adjusts error-handling order in streaming loop.
> 
> - **Querier (blocks store streaming)**:
>   - Propagates retryable errors from `receiveMessage` instead of swallowing them (`shouldRetry=true` now returns the original `err`).
>   - Reorders error handling in `fetchSeriesFromStores` streaming loop to check `shouldRetry` before generic error handling, enabling non-empty warning logs and proper retry behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb051e474662c5f2e0b2c96a9677904ef228cb7b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->