### PR TITLE
demonstrate memory leak

### DIFF
--- a/pkg/mimirpb/compat_rw2.go
+++ b/pkg/mimirpb/compat_rw2.go
@@ -57,6 +57,19 @@ func (ps *rw2PagedSymbols) releasePages() {
 	ps.count = 0
 }
 
+// releasePagesFixed is the fixed version that clears string references
+func (ps *rw2PagedSymbols) releasePagesFixed() {
+	for _, page := range ps.pages {
+		for i := range *page {
+			(*page)[i] = ""
+		}
+		*page = (*page)[:0]
+		rw2PagedSymbolsPool.Put(page)
+	}
+	ps.pages = nil
+	ps.count = 0
+}
+
 func (ps *rw2PagedSymbols) get(ref uint32) (string, error) {
 	// RW2.0 Spec: The first element of the symbols table MUST be an empty string.
 	if ref == 0 {

--- a/pkg/mimirpb/compat_rw2_leak_test.go
+++ b/pkg/mimirpb/compat_rw2_leak_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package mimirpb
+
+import (
+	"runtime"
+	"testing"
+)
+
+// TestRW2SymbolsMemoryLeak demonstrates the difference between the buggy and fixed releasePages().
+func TestRW2SymbolsMemoryLeak(t *testing.T) {
+	bufferSize := 10 * 1024 * 1024 // 10MB
+
+	// Test 1: Buggy version (current releasePages)
+	t.Run("buggy version", func(t *testing.T) {
+		buffer := make([]byte, bufferSize)
+		for i := range buffer {
+			buffer[i] = byte(i % 256)
+		}
+
+		ps := &rw2PagedSymbols{}
+		numSymbols := 1000
+		symbolSize := bufferSize / numSymbols
+		for i := 0; i < numSymbols; i++ {
+			start := i * symbolSize
+			end := start + symbolSize
+			if end > bufferSize {
+				end = bufferSize
+			}
+			ps.append(yoloString(buffer[start:end]))
+		}
+
+		buffer = nil
+
+		runtime.GC()
+		var m1 runtime.MemStats
+		runtime.ReadMemStats(&m1)
+		t.Logf("Heap with yoloStrings referenced: %.2f MB", float64(m1.HeapAlloc)/(1024*1024))
+
+		// Call the BUGGY releasePages()
+		ps.releasePages()
+
+		runtime.GC()
+		var m2 runtime.MemStats
+		runtime.ReadMemStats(&m2)
+
+		freed := int64(m1.HeapAlloc) - int64(m2.HeapAlloc)
+		t.Logf("Memory freed by buggy releasePages(): %d bytes (%.2f MB)", freed, float64(freed)/(1024*1024))
+
+		// The buggy version should NOT free the buffer
+		if freed < int64(bufferSize/2) {
+			t.Logf("✓ Confirmed: Buggy version did NOT free the buffer (freed only %.2f MB)", float64(freed)/(1024*1024))
+		} else {
+			t.Logf("✗ Unexpected: Buggy version freed %.2f MB", float64(freed)/(1024*1024))
+		}
+	})
+
+	// Test 2: Fixed version
+	t.Run("fixed version", func(t *testing.T) {
+		buffer := make([]byte, bufferSize)
+		for i := range buffer {
+			buffer[i] = byte(i % 256)
+		}
+
+		ps := &rw2PagedSymbols{}
+		numSymbols := 1000
+		symbolSize := bufferSize / numSymbols
+		for i := 0; i < numSymbols; i++ {
+			start := i * symbolSize
+			end := start + symbolSize
+			if end > bufferSize {
+				end = bufferSize
+			}
+			ps.append(yoloString(buffer[start:end]))
+		}
+
+		buffer = nil
+
+		runtime.GC()
+		var m1 runtime.MemStats
+		runtime.ReadMemStats(&m1)
+		t.Logf("Heap with yoloStrings referenced: %.2f MB", float64(m1.HeapAlloc)/(1024*1024))
+
+		// Call the FIXED releasePages()
+		ps.releasePagesFixed()
+
+		runtime.GC()
+		var m2 runtime.MemStats
+		runtime.ReadMemStats(&m2)
+
+		freed := int64(m1.HeapAlloc) - int64(m2.HeapAlloc)
+		t.Logf("Memory freed by fixed releasePages(): %d bytes (%.2f MB)", freed, float64(freed)/(1024*1024))
+
+		// The fixed version should free the buffer
+		minExpectedFreed := int64(bufferSize * 9 / 10)
+		if freed >= minExpectedFreed {
+			t.Logf("✓ Confirmed: Fixed version freed the buffer (%.2f MB)", float64(freed)/(1024*1024))
+		} else {
+			t.Logf("✗ Unexpected: Fixed version only freed %.2f MB", float64(freed)/(1024*1024))
+		}
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `releasePagesFixed` to zero string references before pooling pages and a test demonstrating the leak in `releasePages` vs the fixed method.
> 
> - **pkg/mimirpb**:
>   - **Memory management**: Introduces `releasePagesFixed()` in `pkg/mimirpb/compat_rw2.go` to clear string entries in `rw2PagedSymbols` pages before returning them to `rw2PagedSymbolsPool`.
>   - **Tests**: Adds `pkg/mimirpb/compat_rw2_leak_test.go` demonstrating memory retention with `releasePages()` and improved GC with `releasePagesFixed()` using `runtime.MemStats`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d9390dade38963897889c250f02a0bb831fd6e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->