### PR TITLE
[r369] Remote execution: fix issue where eager loading of response can consume a large amount of memory and CPU time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
 * [BUGFIX] Query-frontend: Fix incorrect annotation position information when running sharding inside MQE. #13484
 * [BUGFIX] Query-frontend: Fix incorrect query results when evaluating some sharded aggregations with `without` when running sharding inside MQE. #13484
 * [BUGFIX]: Ingester: Panic when push and read reactive limiters are enabled with prioritization. #13482
+* [BUGFIX] Query-frontend: Fix excessive CPU and memory consumption when running sharding inside MQE. #13580
 
 ### Mixin
 

--- a/pkg/frontend/v2/frontend.go
+++ b/pkg/frontend/v2/frontend.go
@@ -57,6 +57,7 @@ var errExecutingQueryRoundTripFinished = cancellation.NewErrorf("executing query
 var errFinishedReceivingResponse = cancellation.NewErrorf("finished receiving response from querier")
 var errStreamClosed = cancellation.NewErrorf("stream closed")
 var errUnexpectedHTTPResponse = errors.New("unexpected HTTP response to non-HTTP request")
+var errEndOfStream = errors.New("end of stream reached")
 
 // Config for a Frontend.
 type Config struct {
@@ -551,6 +552,8 @@ func (s *ProtobufResponseStream) Next(ctx context.Context) (*frontendv2pb.QueryR
 			if err := s.shouldAbortReading(ctx); err != nil {
 				return nil, err
 			}
+
+			return nil, errEndOfStream
 		}
 
 		if resp.err != nil {

--- a/pkg/frontend/v2/frontend_test.go
+++ b/pkg/frontend/v2/frontend_test.go
@@ -302,7 +302,7 @@ func TestFrontend_Protobuf_HappyPath(t *testing.T) {
 
 	// Response stream exhausted.
 	msg, err = resp.Next(ctx)
-	require.NoError(t, err)
+	require.EqualError(t, err, "end of stream reached")
 	require.Nil(t, msg)
 }
 
@@ -352,7 +352,7 @@ func TestFrontend_Protobuf_ShouldNotCancelRequestAfterSuccess(t *testing.T) {
 				if exhaustStream {
 					// Response stream exhausted.
 					msg, err = resp.Next(ctx)
-					require.NoError(t, err)
+					require.EqualError(t, err, "end of stream reached")
 					require.Nil(t, msg)
 				}
 
@@ -407,7 +407,7 @@ func TestFrontend_Protobuf_QuerierResponseReceivedBeforeSchedulerResponse(t *tes
 
 	// Response stream exhausted.
 	msg, err = resp.Next(ctx)
-	require.NoError(t, err)
+	require.EqualError(t, err, "end of stream reached")
 	require.Nil(t, msg)
 
 	close(responseRead)
@@ -751,7 +751,7 @@ func TestFrontend_Protobuf_ReadingResponseAfterAllMessagesReceived(t *testing.T)
 	require.Equal(t, expectedMessages[2], msg, "should still be able to read last message after stream has been completely read")
 
 	msg, err = resp.Next(ctx)
-	require.NoError(t, err)
+	require.EqualError(t, err, "end of stream reached")
 	require.Nil(t, msg)
 }
 
@@ -1312,7 +1312,7 @@ func TestFrontend_Protobuf_ResponseSentTwice(t *testing.T) {
 
 	// Response stream exhausted.
 	msg, err = resp.Next(ctx)
-	require.NoError(t, err)
+	require.EqualError(t, err, "end of stream reached")
 	require.Nil(t, msg)
 
 	// Wait for both responses to be sent off, then confirm one failed in the way we expect.

--- a/pkg/frontend/v2/remoteexec.go
+++ b/pkg/frontend/v2/remoteexec.go
@@ -118,10 +118,8 @@ func (r *RemoteExecutor) startExecution(
 
 type responseStream interface {
 	// Next returns the next message in the stream, or an error if the stream has ended or failed.
-	// Next must not be called concurrently with Close.
 	Next(ctx context.Context) (*frontendv2pb.QueryResultStreamRequest, error)
 	// Close closes the stream.
-	// Close must not be called concurrently with Next.
 	Close()
 }
 
@@ -658,7 +656,7 @@ type bufferedMessage struct {
 
 func (b *responseStreamBuffer) Push(msg bufferedMessage) {
 	if b.length == cap(b.msgs) {
-		newCap := max(len(b.msgs)*2, 1)
+		newCap := max(cap(b.msgs)*2, 1)
 		newMsgs := responseMessageSlicePool.Get(newCap)
 		newMsgs = newMsgs[:newCap]
 		headSize := cap(b.msgs) - b.startIndex


### PR DESCRIPTION
Manually backporting #13580 to r369 due to merge conflict

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce explicit end-of-stream error for protobuf response streams and fix response buffer growth to reduce CPU/memory during MQE sharding.
> 
> - **Query-frontend (v2)**:
>   - Add `errEndOfStream` and make `ProtobufResponseStream.Next()` return it at stream exhaustion; adjust call sites and tests accordingly (`pkg/frontend/v2/frontend.go`, `frontend_test.go`).
> - **Remote execution**:
>   - Fix ring buffer growth to use `cap(b.msgs)` when resizing in `responseStreamBuffer.Push()` to prevent inefficient reallocations (`pkg/frontend/v2/remoteexec.go`).
>   - Minor cleanup of `responseStream` interface comments.
> - **Changelog**:
>   - Add bugfix entry: reduce excessive CPU/memory when running sharding inside MQE.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c614507251364f287cb87ffcfc0594c11e7e364. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->