### PR TITLE
docs: Etcd and Consul are not deprecated for HA tracker

### DIFF
--- a/docs/sources/mimir/configure/configure-high-availability-deduplication.md
+++ b/docs/sources/mimir/configure/configure-high-availability-deduplication.md
@@ -108,11 +108,7 @@ Alternatively, you can enable the HA tracker only on a per-tenant basis, keeping
 The HA tracker requires a key-value (KV) store to coordinate which replica is currently elected.
 Starting from Mimir 3.0, `memberlist` is the recommended and default KV store backend for the HA tracker.
 
-{{< admonition type="note" >}}
-The `consul` and `etcd` backends are deprecated as of Mimir 3.0. If you're currently using `consul` or `etcd` for the HA tracker, refer to the migration guide for instructions on migrating to `memberlist`.
-{{< /admonition >}}
-
-To migrate from Consul or etcd to memberlist without downtime, see [Migrate HA tracker from Consul or etcd to memberlist](migrate-ha-tracker-to-memberlist/).
+To migrate from Consul or etcd to memberlist without downtime, see [Migrate HA tracker from Consul or etcd to memberlist](../migrate-ha-tracker-to-memberlist/).
 
 The following CLI flags (and their respective YAML configuration options) are available for configuring the HA tracker KV store:
 

--- a/docs/sources/mimir/configure/migrate-ha-tracker-to-memberlist.md
+++ b/docs/sources/mimir/configure/migrate-ha-tracker-to-memberlist.md
@@ -7,7 +7,7 @@ weight: 55
 
 # Migrate HA tracker from Consul or etcd to memberlist without downtime
 
-Since Grafana Mimir 2.17, the HA tracker supports memberlist as a key-value (KV) store backend. Memberlist is the recommended KV store for the HA tracker. The `consul` and `etcd` backends are deprecated.
+Since Grafana Mimir 2.17, the HA tracker supports memberlist as a key-value (KV) store backend. Memberlist is the recommended KV store for the HA tracker.
 
 Follow this guidance to migrate your HA tracker configuration from Consul or etcd to memberlist without any downtime.
 


### PR DESCRIPTION
#### What this PR does

Per https://github.com/grafana/mimir/issues/12010#issuecomment-3416314251 using Etcd or Consul for the HA tracker is not deprecated but Memberlist is recommended. This also fixes a link to the migration guide.

#### Which issue(s) this PR fixes or relates to

Related #12010

#### Checklist

- [ ] Tests updated.
- [X] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies HA tracker docs to recommend memberlist without deprecating Consul/etcd and fixes the migration guide link.
> 
> - **Docs (Mimir HA tracker)**:
>   - Clarify KV backend guidance: memberlist remains recommended/default; remove statements deprecating `consul`/`etcd`.
>   - Fix migration guide link in `configure-high-availability-deduplication.md` to `../migrate-ha-tracker-to-memberlist/`.
> - **Migration doc**:
>   - Remove deprecation note for `consul`/`etcd`; keep memberlist as recommended backend.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d43a33b2cd7f34c1bf114883f9fdc78a9d5216d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->