### PR TITLE
usage-tracker: refactor/rename some tenantshard implementation details

### DIFF
--- a/pkg/usagetracker/tenantshard/map.go
+++ b/pkg/usagetracker/tenantshard/map.go
@@ -88,7 +88,7 @@ func (m *Map) Put(key uint64, value clock.Minutes, series, limit *atomic.Uint64,
 	pfx, sfx := splitHash(key)
 	i := probeStart(sfx, len(m.index))
 	for { // inlined find loop
-		matches := metaMatchH2(&m.index[i], pfx)
+		matches := m.index[i].match(pfx)
 		for matches != 0 {
 			j := nextMatch(&matches)
 			if key == m.keys[i][j] { // found
@@ -101,7 +101,7 @@ func (m *Map) Put(key uint64, value clock.Minutes, series, limit *atomic.Uint64,
 		}
 		// |key| is not in group |i|,
 		// stop probing if we see an empty slot
-		matches = metaMatchEmpty(&m.index[i])
+		matches = m.index[i].matchEmpty()
 		if matches != 0 { // insert
 			// Only check limit if we're tracking series.
 			// We don't check limit for Load events.
@@ -154,7 +154,7 @@ func (m *Map) load(key uint64, value clock.Minutes) {
 	looped := false
 	for {
 		// Find an empty slot and insert without checking if it already exists.
-		matches := metaMatchEmpty(&m.index[i])
+		matches := m.index[i].matchEmpty()
 		if matches != 0 { // insert
 			m.insert(key, pfx, value, i, matches)
 			return

--- a/pkg/usagetracker/tenantshard/map_nonsimd.go
+++ b/pkg/usagetracker/tenantshard/map_nonsimd.go
@@ -21,8 +21,8 @@ const (
 
 type bitset uint64
 
-// metaMatchH2 searches the given index for whole bytes that match the given prefix.
-func metaMatchH2(m *index, p prefix) bitset {
+// match searches the given index for whole bytes that match the given prefix.
+func (m *index) match(p prefix) bitset {
 	// See: https://graphics.stanford.edu/~seander/bithacks.html##ValueInWord
 	// e.g.,
 	// if m = 0x123456c9c9777777 and p = 0xc9, then:
@@ -32,7 +32,7 @@ func metaMatchH2(m *index, p prefix) bitset {
 	return findZeroBytes(castUint64(m) ^ (loBits * uint64(p)))
 }
 
-func metaMatchEmpty(m *index) bitset {
+func (m *index) matchEmpty() bitset {
 	return findZeroBytes(castUint64(m))
 }
 

--- a/pkg/usagetracker/tenantshard/map_nonsimd_test.go
+++ b/pkg/usagetracker/tenantshard/map_nonsimd_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMetaMatchH2(t *testing.T) {
+func TestIndex_Match(t *testing.T) {
 	m := &index{0x12, 0x34, 0x56, 0xc9, 0xc9, 0x77, 0x77, 0x77}
 	p := prefix(0xc9)
-	require.Equal(t, bitset(0x0000008080000000), metaMatchH2(m, p))
+	require.Equal(t, bitset(0x0000008080000000), m.match(p))
 }
 
 func TestFindZeroBytes(t *testing.T) {


### PR DESCRIPTION
#### What this PR does

Follow up on https://github.com/grafana/mimir/pull/13594

I'm removing the word 'meta' because we don't call it that way in our implementation, we call it index. And H2 is 'prefix' in our impl, and if we make this method a receiver, we don't need to be so verbose in the name because the signature of index.match(prefix) already tells what it's doing.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames metaMatchH2/metaMatchEmpty into index receiver methods (match/matchEmpty) and updates map probing logic and tests accordingly.
> 
> - **tenantshard**:
>   - **Index helpers refactor**: Rename `metaMatchH2` -> `index.match` and `metaMatchEmpty` -> `index.matchEmpty`.
>   - **Map probing updates**: Replace calls in `pkg/usagetracker/tenantshard/map.go` (`Put`, `load`) to use `index.match`/`index.matchEmpty`.
>   - **Tests**: Rename `TestMetaMatchH2` to `TestIndex_Match` and update assertions to call `m.match`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d75da6dc58502e7eaf4cacc986aafbd25dc687a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->