### PR TITLE
usage-tracker: remove do-not-apply-series-limits config

### DIFF
--- a/pkg/usagetracker/tracker_test.go
+++ b/pkg/usagetracker/tracker_test.go
@@ -102,27 +102,6 @@ func TestUsageTracker_Tracking(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, resp.RejectedSeriesHashes, 2)
 	})
-
-	t.Run("service dry-run does not reject series", func(t *testing.T) {
-		t.Parallel()
-
-		tracker := newReadyTestUsageTracker(t, map[string]*validation.Limits{
-			"tenant": {
-				MaxActiveSeriesPerUser: testPartitionsCount,     // one series per partition.
-				MaxGlobalSeriesPerUser: testPartitionsCount * 2, // two series per partition
-			},
-		}, func(cfg *Config) {
-			cfg.DoNotApplySeriesLimits = true
-		})
-
-		resp, err := tracker.TrackSeries(t.Context(), &usagetrackerpb.TrackSeriesRequest{
-			UserID:       "tenant",
-			Partition:    0,
-			SeriesHashes: []uint64{0, 1, 2, 3, 4, 5, 6, 7},
-		})
-		require.NoError(t, err)
-		require.Equal(t, &usagetrackerpb.TrackSeriesResponse{RejectedSeriesHashes: nil}, resp)
-	})
 }
 
 func TestUsageTracker_PartitionAssignment(t *testing.T) {


### PR DESCRIPTION
#### What this PR does

This configuration is harmful as it removes the tracker store's ability to create tenant shard maps of correct capacity, leading to unnecessary rehashing and poor performance.

Not updating the changelog because this is an experimental undocumented flag on an experimental non-documented component. This would be a CHANGE otherwise, but I think it would only make noise at this point.

#### Which issue(s) this PR fixes or relates to

Fixes an internal issue.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the dry-run series-limits option and unlimited limiter, always enforcing series limits and updating partition handler wiring and tests accordingly.
> 
> - **Usage Tracker**:
>   - Remove `usage-tracker.do-not-apply-series-limits` flag registration and dry-run behavior; series limits are always enforced.
>   - Delete `unlimitedSeriesLimiter` and related logic; `newPartitionHandler` now always receives `t` as the limiter.
> - **Tests**:
>   - Remove test case that verified dry-run mode (`service dry-run does not reject series`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 851b0dd17144cf7661323f9cc37365a0a685eac1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->