### PR TITLE
usage-tracker: ensure tenant shards have enough capacity when loading a snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
   * `-ruler-storage.gcs.max-retries`
 * [ENHANCEMENT] Usage-tracker: Improve first snapshot loading & rehash speed. #13284
 * [ENHANCEMENT] Usage-tracker, distributor: Make usage-tracker calls asynchronous for users who are far enough from the series limits. #13427
+* [ENHANCEMENT] Usage-tracker: Ensure tenant shards have enough capacity when loading a snapshot. #13607
 * [ENHANCEMENT] Ruler: Implemented `OperatorControllableErrorClassifier` for rule evaluation, allowing differentiation between operator-controllable errors (e.g., storage failures, 5xx errors, rate limiting) and user-controllable errors (e.g., bad queries, validation errors, 4xx errors). This change affects the rule evaluation failure metric `prometheus_rule_evaluation_failures_total`, which now includes a `reason` label with values `operator` or `user` to distinguish between them. #13313, #13470
 * [ENHANCEMENT] Store-gateway: Added `cortex_bucket_store_block_discovery_latency_seconds` metric to track time from block creation to discovery by store-gateway. #13489 #13552
 * [ENHANCEMENT] Querier: Added experimental `-querier.frontend-health-check-grace-period` CLI flag to configure a grace period for query-frontend health checks. The default value of 0 preserves the existing behaviour of immediately removing query-frontend connections that have failed a health check. #13521

--- a/pkg/usagetracker/tenantshard/map.go
+++ b/pkg/usagetracker/tenantshard/map.go
@@ -196,6 +196,15 @@ func (m *Map) Cleanup(watermark clock.Minutes, series *atomic.Uint64) {
 	}
 }
 
+// EnsureCapacity ensure that the map has enough capacity to store |n| elements.
+// This does not mean that the map will have n empty slots, there might be already n elements in the map and 0 spare capacity.
+// If there's no enough capacity, the map is rehashed to accommodate at least |n| elements.
+func (m *Map) EnsureCapacity(n uint32) {
+	if groups := numGroups(n); len(m.index) < int(groups) {
+		m.rehash(groups)
+	}
+}
+
 func (m *Map) nextSize() (n uint32) {
 	n = uint32(len(m.index)) * 2
 	if m.dead >= (m.resident / 2) {

--- a/pkg/usagetracker/tracker_store_snapshot.go
+++ b/pkg/usagetracker/tracker_store_snapshot.go
@@ -120,6 +120,9 @@ func (t *trackerStore) loadSnapshot(data []byte, now time.Time) error {
 		tenant := t.getOrCreateTenant(tenantID)
 		m := tenant.shards[shard]
 		m.Lock()
+		// Ensure the shard has enough capacity for this snapshot to minimize the number of rehashes.
+		m.EnsureCapacity(uint32(len(refs)))
+
 		// Check if the shard is empty. If it is, we can use the faster Load() method
 		// which doesn't check for duplicates. Otherwise, use Put() which handles
 		// concurrent loads and deduplication.


### PR DESCRIPTION
#### What this PR does

When we're loading a snapshot, all its elements will end up in the tenant shard. In order to minimize the number of rehashes, we can make sure (and rehash if needed) that the map has enough capacity to allocate the elements.

#### Which issue(s) this PR fixes or relates to

Fixes an observed behavior.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pre-sizes tenant shard maps when loading snapshots by adding Map.EnsureCapacity() and invoking it in loadSnapshot(), reducing rehashes; updates CHANGELOG.
> 
> - **Usage-tracker**:
>   - Add `tenantshard.Map.EnsureCapacity(n)` to pre-size the open-addressing map.
>   - In `tracker_store_snapshot.loadSnapshot()`, call `m.EnsureCapacity(len(refs))` before bulk inserts to minimize rehashes.
> - **Docs**:
>   - Update `CHANGELOG.md` with the enhancement entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4d1baae065cf1c744d0b6c5beb7e04e098d1872. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->