### PR TITLE
Fix flaky `TestMaxQueryParallelismWithRemoteExecution`

### DIFF
--- a/pkg/frontend/v2/frontend_test.go
+++ b/pkg/frontend/v2/frontend_test.go
@@ -166,7 +166,7 @@ func sendStreamingResponse(t testing.TB, f *Frontend, userID string, queryID uin
 	require.NoError(t, sendStreamingResponseWithErrorCapture(f, userID, queryID, nil, resp...))
 }
 
-func sendStreamingResponseWithErrorCapture(f *Frontend, userID string, queryID uint64, afterLastMessageSent func(), resp ...*frontendv2pb.QueryResultStreamRequest) error {
+func sendStreamingResponseWithErrorCapture(f *Frontend, userID string, queryID uint64, beforeLastMessageSent func(), resp ...*frontendv2pb.QueryResultStreamRequest) error {
 	for _, m := range resp {
 		m.QueryID = queryID
 	}
@@ -191,7 +191,11 @@ func sendStreamingResponseWithErrorCapture(f *Frontend, userID string, queryID u
 		return err
 	}
 
-	for _, m := range resp {
+	for idx, m := range resp {
+		if idx == len(resp)-1 && beforeLastMessageSent != nil {
+			beforeLastMessageSent()
+		}
+
 		if err := stream.Send(m); err != nil {
 			if errors.Is(err, io.EOF) {
 				// If Send returns EOF, then we need to call RecvMsg to get that error.
@@ -206,10 +210,6 @@ func sendStreamingResponseWithErrorCapture(f *Frontend, userID string, queryID u
 
 			return err
 		}
-	}
-
-	if afterLastMessageSent != nil {
-		afterLastMessageSent()
 	}
 
 	_, err = stream.CloseAndRecv()


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue where `TestMaxQueryParallelismWithRemoteExecution` can be flaky.

#### Which issue(s) this PR fixes or relates to

Fixes #12982

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Change streaming test helper to invoke a callback before sending the last message and update the remote execution parallelism test to use it, reducing flakiness.
> 
> - **Tests**:
>   - Adjust `sendStreamingResponseWithErrorCapture` in `pkg/frontend/v2/frontend_test.go` to accept `beforeLastMessageSent` and invoke it right before sending the final stream message; remove the post-send callback.
>   - Update `TestMaxQueryParallelismWithRemoteExecution` in `pkg/frontend/v2/remoteexec_test.go` to use the new pre-send hook for decrementing concurrency, improving stability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1048c1e62511084e03307fa6396e41b4b69f4941. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->