### PR TITLE
dashboards: fix aliasColors in dashboard-utils

### DIFF
--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -1608,7 +1608,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     fieldConfig+: {
       // Take existing field overrides and extend them with the new ones. Let new ones take
       // precedence over already existing ones.
-      overrides: std.sort(std.setDiff(super.overrides, newOverrides, byName) + newOverrides, byName),
+      overrides: std.sort(std.setDiff(if 'overrides' in super then super.overrides else [], newOverrides, byName) + newOverrides, byName),
     },
   },
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Make `aliasColors` merge resilient by handling missing `fieldConfig.overrides` when extending overrides.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 338e6bb1feb7d650a569da4ccbd2adaf3151f9c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->