### PR TITLE
Enable debug logging in TestSingleBinaryWithMemberlistScaling

### DIFF
--- a/integration/integration_memberlist_single_binary_test.go
+++ b/integration/integration_memberlist_single_binary_test.go
@@ -182,6 +182,9 @@ func TestSingleBinaryWithMemberlistScaling(t *testing.T) {
 	flags := map[string]string{
 		"-memberlist.packet-dial-timeout":  "10s",
 		"-memberlist.packet-write-timeout": "10s",
+		// Debug logging for https://github.com/grafana/mimir/issues/13287
+		"-log.level":                  "debug",
+		"-memberlist.transport-debug": "true",
 	}
 
 	// Start the 1st instance. This will provide the initial state to other members.


### PR DESCRIPTION
Relates to https://github.com/grafana/mimir/issues/13287

The `TestSingleBinaryWithMemberlistScaling` test occasionally renders the "nil pointer dereference" panic, that stems from a memberlist's TCP connection. So far we cannot figure how this happens.

 Observed panic:

  ```
  mimir-1: panic: runtime error: invalid memory address or nil pointer dereference
  mimir-1: [signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x153c7db]
  mimir-1: goroutine 1609 [running]:
  mimir-1: github.com/hashicorp/memberlist.(*Memberlist).handleConn.func1()
  mimir-1: /__w/mimir/mimir/vendor/github.com/hashicorp/memberlist/net.go:238 +0x3b
  mimir-1: github.com/hashicorp/memberlist.(*Memberlist).handleConn(0xc000ade160, {0x0, 0x0})
  mimir-1: /__w/mimir/mimir/vendor/github.com/hashicorp/memberlist/net.go:347 +0x6ea
```