### PR TITLE
Jsonnet: split querier rings into per-zone rings when multi-zone read path is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,7 +134,7 @@
 * [CHANGE] Store-gateway: The store-gateway disk class now honors the one configured via `$._config.store_gateway_data_disk_class` and doesn't replace `fast` with `fast-dont-retain`. #13152
 * [CHANGE] Rollout-operator: Vendor jsonnet from rollout-operator repository. #13245 #13317
 * [CHANGE] Ruler: Set default memory ballast to 1GiB to reduce GC pressure during startup. #13376
-* [FEATURE] Add multi-zone support for read path components (memcached, querier, query-frontend, query-scheduler, ruler, and ruler remote evaluation stack). Add multi-AZ support for ingester and store-gateway multi-zone deployments. Add memberlist-bridge support for zone-aware memberlist routing. #13559
+* [FEATURE] Add multi-zone support for read path components (memcached, querier, query-frontend, query-scheduler, ruler, and ruler remote evaluation stack). Add multi-AZ support for ingester and store-gateway multi-zone deployments. Add memberlist-bridge support for zone-aware memberlist routing. #13559 #13628
 * [ENHANCEMENT] Ruler querier and query-frontend: Add support for newly-introduced querier ring, which is used when performing query planning in query-frontends and distributing portions of the plan to queriers for execution. #13017
 * [ENHANCEMENT] Ingester: Increase `$._config.ingester_tsdb_head_early_compaction_min_in_memory_series` default when Mimir is running with the ingest storage architecture. #13450
 * [ENHANCEMENT] Update the list of OTel resource attributes used for tracing. #13469

--- a/operations/mimir-tests/test-multi-az-read-path-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-generated.yaml
@@ -1611,6 +1611,7 @@ spec:
         - -querier.max-concurrent=8
         - -querier.max-partial-query-length=768h
         - -querier.prefer-availability-zone=zone-a
+        - -querier.ring.prefix=querier-zone-a/
         - -querier.store-gateway-client.grpc-max-recv-msg-size=209715200
         - -query-scheduler.ring.prefix=query-scheduler-zone-a/
         - -query-scheduler.ring.store=memberlist
@@ -1728,6 +1729,7 @@ spec:
         - -querier.max-concurrent=8
         - -querier.max-partial-query-length=768h
         - -querier.prefer-availability-zone=zone-b
+        - -querier.ring.prefix=querier-zone-b/
         - -querier.store-gateway-client.grpc-max-recv-msg-size=209715200
         - -query-scheduler.ring.prefix=query-scheduler-zone-b/
         - -query-scheduler.ring.store=memberlist
@@ -1826,6 +1828,7 @@ spec:
         - -memberlist.zone-aware-routing.enabled=true
         - -memberlist.zone-aware-routing.instance-availability-zone=zone-a
         - -memberlist.zone-aware-routing.role=member
+        - -querier.ring.prefix=querier-zone-a/
         - -query-frontend.cache-results=true
         - -query-frontend.max-cache-freshness=10m
         - -query-frontend.max-total-query-length=12000h
@@ -1925,6 +1928,7 @@ spec:
         - -memberlist.zone-aware-routing.enabled=true
         - -memberlist.zone-aware-routing.instance-availability-zone=zone-b
         - -memberlist.zone-aware-routing.role=member
+        - -querier.ring.prefix=querier-zone-b/
         - -query-frontend.cache-results=true
         - -query-frontend.max-cache-freshness=10m
         - -query-frontend.max-total-query-length=12000h
@@ -2270,7 +2274,7 @@ spec:
         - -querier.max-concurrent=8
         - -querier.max-partial-query-length=768h
         - -querier.prefer-availability-zone=zone-a
-        - -querier.ring.prefix=ruler-querier/
+        - -querier.ring.prefix=ruler-querier-zone-a/
         - -querier.store-gateway-client.grpc-max-recv-msg-size=209715200
         - -query-scheduler.ring.prefix=ruler-query-scheduler-zone-a/
         - -query-scheduler.ring.store=memberlist
@@ -2386,7 +2390,7 @@ spec:
         - -querier.max-concurrent=8
         - -querier.max-partial-query-length=768h
         - -querier.prefer-availability-zone=zone-b
-        - -querier.ring.prefix=ruler-querier/
+        - -querier.ring.prefix=ruler-querier-zone-b/
         - -querier.store-gateway-client.grpc-max-recv-msg-size=209715200
         - -query-scheduler.ring.prefix=ruler-query-scheduler-zone-b/
         - -query-scheduler.ring.store=memberlist
@@ -2483,7 +2487,7 @@ spec:
         - -memberlist.zone-aware-routing.enabled=true
         - -memberlist.zone-aware-routing.instance-availability-zone=zone-a
         - -memberlist.zone-aware-routing.role=member
-        - -querier.ring.prefix=ruler-querier/
+        - -querier.ring.prefix=ruler-querier-zone-a/
         - -query-frontend.cache-results=false
         - -query-frontend.max-cache-freshness=10m
         - -query-frontend.max-total-query-length=12000h
@@ -2588,7 +2592,7 @@ spec:
         - -memberlist.zone-aware-routing.enabled=true
         - -memberlist.zone-aware-routing.instance-availability-zone=zone-b
         - -memberlist.zone-aware-routing.role=member
-        - -querier.ring.prefix=ruler-querier/
+        - -querier.ring.prefix=ruler-querier-zone-b/
         - -query-frontend.cache-results=false
         - -query-frontend.max-cache-freshness=10m
         - -query-frontend.max-total-query-length=12000h

--- a/operations/mimir-tests/test-multi-az-read-path-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-generated.yaml
@@ -2123,6 +2123,7 @@ spec:
         - -querier.max-concurrent=8
         - -querier.max-partial-query-length=768h
         - -querier.prefer-availability-zone=zone-a
+        - -querier.ring.prefix=querier-zone-a/
         - -querier.store-gateway-client.grpc-max-recv-msg-size=209715200
         - -query-scheduler.ring.prefix=query-scheduler-zone-a/
         - -query-scheduler.ring.store=memberlist
@@ -2240,6 +2241,7 @@ spec:
         - -querier.max-concurrent=8
         - -querier.max-partial-query-length=768h
         - -querier.prefer-availability-zone=zone-b
+        - -querier.ring.prefix=querier-zone-b/
         - -querier.store-gateway-client.grpc-max-recv-msg-size=209715200
         - -query-scheduler.ring.prefix=query-scheduler-zone-b/
         - -query-scheduler.ring.store=memberlist
@@ -2423,6 +2425,7 @@ spec:
         - -memberlist.zone-aware-routing.enabled=true
         - -memberlist.zone-aware-routing.instance-availability-zone=zone-a
         - -memberlist.zone-aware-routing.role=member
+        - -querier.ring.prefix=querier-zone-a/
         - -query-frontend.cache-results=true
         - -query-frontend.max-cache-freshness=10m
         - -query-frontend.max-total-query-length=12000h
@@ -2522,6 +2525,7 @@ spec:
         - -memberlist.zone-aware-routing.enabled=true
         - -memberlist.zone-aware-routing.instance-availability-zone=zone-b
         - -memberlist.zone-aware-routing.role=member
+        - -querier.ring.prefix=querier-zone-b/
         - -query-frontend.cache-results=true
         - -query-frontend.max-cache-freshness=10m
         - -query-frontend.max-total-query-length=12000h
@@ -3150,7 +3154,7 @@ spec:
         - -querier.max-concurrent=8
         - -querier.max-partial-query-length=768h
         - -querier.prefer-availability-zone=zone-a
-        - -querier.ring.prefix=ruler-querier/
+        - -querier.ring.prefix=ruler-querier-zone-a/
         - -querier.store-gateway-client.grpc-max-recv-msg-size=209715200
         - -query-scheduler.ring.prefix=ruler-query-scheduler-zone-a/
         - -query-scheduler.ring.store=memberlist
@@ -3266,7 +3270,7 @@ spec:
         - -querier.max-concurrent=8
         - -querier.max-partial-query-length=768h
         - -querier.prefer-availability-zone=zone-b
-        - -querier.ring.prefix=ruler-querier/
+        - -querier.ring.prefix=ruler-querier-zone-b/
         - -querier.store-gateway-client.grpc-max-recv-msg-size=209715200
         - -query-scheduler.ring.prefix=ruler-query-scheduler-zone-b/
         - -query-scheduler.ring.store=memberlist
@@ -3454,7 +3458,7 @@ spec:
         - -memberlist.zone-aware-routing.enabled=true
         - -memberlist.zone-aware-routing.instance-availability-zone=zone-a
         - -memberlist.zone-aware-routing.role=member
-        - -querier.ring.prefix=ruler-querier/
+        - -querier.ring.prefix=ruler-querier-zone-a/
         - -query-frontend.cache-results=false
         - -query-frontend.max-cache-freshness=10m
         - -query-frontend.max-total-query-length=12000h
@@ -3559,7 +3563,7 @@ spec:
         - -memberlist.zone-aware-routing.enabled=true
         - -memberlist.zone-aware-routing.instance-availability-zone=zone-b
         - -memberlist.zone-aware-routing.role=member
-        - -querier.ring.prefix=ruler-querier/
+        - -querier.ring.prefix=ruler-querier-zone-b/
         - -query-frontend.cache-results=false
         - -query-frontend.max-cache-freshness=10m
         - -query-frontend.max-total-query-length=12000h

--- a/operations/mimir/multi-zone-querier.libsonnet
+++ b/operations/mimir/multi-zone-querier.libsonnet
@@ -27,9 +27,14 @@
     'querier.prefer-availability-zone': 'zone-%s' % zone,
   },
 
-  querier_zone_a_args:: $.querier_args + $.querier_only_args + $.blocks_metadata_zone_a_caching_config + $.querySchedulerClientZoneArgs('a') + querierZoneArgs('a'),
-  querier_zone_b_args:: $.querier_args + $.querier_only_args + $.blocks_metadata_zone_b_caching_config + $.querySchedulerClientZoneArgs('b') + querierZoneArgs('b'),
-  querier_zone_c_args:: $.querier_args + $.querier_only_args + $.blocks_metadata_zone_c_caching_config + $.querySchedulerClientZoneArgs('c') + querierZoneArgs('c'),
+  querierClientZoneArgs(zone):: {
+    // The querier runs on a dedicated ring per zone.
+    'querier.ring.prefix': 'querier-zone-%s/' % zone,
+  },
+
+  querier_zone_a_args:: $.querier_args + $.querier_only_args + $.blocks_metadata_zone_a_caching_config + $.querySchedulerClientZoneArgs('a') + $.querierClientZoneArgs('a') + querierZoneArgs('a'),
+  querier_zone_b_args:: $.querier_args + $.querier_only_args + $.blocks_metadata_zone_b_caching_config + $.querySchedulerClientZoneArgs('b') + $.querierClientZoneArgs('b') + querierZoneArgs('b'),
+  querier_zone_c_args:: $.querier_args + $.querier_only_args + $.blocks_metadata_zone_c_caching_config + $.querySchedulerClientZoneArgs('c') + $.querierClientZoneArgs('c') + querierZoneArgs('c'),
 
   querier_zone_a_env_map:: {},
   querier_zone_b_env_map:: {},

--- a/operations/mimir/multi-zone-query-frontend.libsonnet
+++ b/operations/mimir/multi-zone-query-frontend.libsonnet
@@ -22,9 +22,9 @@
 
   assert !isMultiZoneEnabled || $._config.multi_zone_memcached_enabled : 'query-frontend multi-zone deployment requires memcached multi-zone to be enabled',
 
-  query_frontend_zone_a_args:: $.query_frontend_args + $.query_frontend_only_args + $.query_frontend_zone_a_caching_config + $.querySchedulerClientZoneArgs('a'),
-  query_frontend_zone_b_args:: $.query_frontend_args + $.query_frontend_only_args + $.query_frontend_zone_b_caching_config + $.querySchedulerClientZoneArgs('b'),
-  query_frontend_zone_c_args:: $.query_frontend_args + $.query_frontend_only_args + $.query_frontend_zone_c_caching_config + $.querySchedulerClientZoneArgs('c'),
+  query_frontend_zone_a_args:: $.query_frontend_args + $.query_frontend_only_args + $.query_frontend_zone_a_caching_config + $.querySchedulerClientZoneArgs('a') + $.querierClientZoneArgs('a'),
+  query_frontend_zone_b_args:: $.query_frontend_args + $.query_frontend_only_args + $.query_frontend_zone_b_caching_config + $.querySchedulerClientZoneArgs('b') + $.querierClientZoneArgs('b'),
+  query_frontend_zone_c_args:: $.query_frontend_args + $.query_frontend_only_args + $.query_frontend_zone_c_caching_config + $.querySchedulerClientZoneArgs('c') + $.querierClientZoneArgs('c'),
 
   query_frontend_zone_a_env_map:: {},
   query_frontend_zone_b_env_map:: {},

--- a/operations/mimir/multi-zone-ruler-remote-evaluation.libsonnet
+++ b/operations/mimir/multi-zone-ruler-remote-evaluation.libsonnet
@@ -33,9 +33,14 @@
     'querier.prefer-availability-zone': 'zone-%s' % zone,
   },
 
-  ruler_querier_zone_a_args:: $.ruler_querier_args + $.blocks_metadata_zone_a_caching_config + $.rulerQuerySchedulerClientZoneArgs('a') + rulerQuerierZoneArgs('a'),
-  ruler_querier_zone_b_args:: $.ruler_querier_args + $.blocks_metadata_zone_b_caching_config + $.rulerQuerySchedulerClientZoneArgs('b') + rulerQuerierZoneArgs('b'),
-  ruler_querier_zone_c_args:: $.ruler_querier_args + $.blocks_metadata_zone_c_caching_config + $.rulerQuerySchedulerClientZoneArgs('c') + rulerQuerierZoneArgs('c'),
+  rulerQuerierClientZoneArgs(zone):: {
+    // The ruler-querier runs on a dedicated ring per zone.
+    'querier.ring.prefix': 'ruler-querier-zone-%s/' % zone,
+  },
+
+  ruler_querier_zone_a_args:: $.ruler_querier_args + $.blocks_metadata_zone_a_caching_config + $.rulerQuerySchedulerClientZoneArgs('a') + $.rulerQuerierClientZoneArgs('a') + rulerQuerierZoneArgs('a'),
+  ruler_querier_zone_b_args:: $.ruler_querier_args + $.blocks_metadata_zone_b_caching_config + $.rulerQuerySchedulerClientZoneArgs('b') + $.rulerQuerierClientZoneArgs('b') + rulerQuerierZoneArgs('b'),
+  ruler_querier_zone_c_args:: $.ruler_querier_args + $.blocks_metadata_zone_c_caching_config + $.rulerQuerySchedulerClientZoneArgs('c') + $.rulerQuerierClientZoneArgs('c') + rulerQuerierZoneArgs('c'),
 
   ruler_querier_zone_a_env_map:: {},
   ruler_querier_zone_b_env_map:: {},
@@ -133,9 +138,9 @@
   local isRulerQueryFrontendAutoscalingZoneBEnabled = isZoneBEnabled && $._config.autoscaling_ruler_query_frontend_enabled,
   local isRulerQueryFrontendAutoscalingZoneCEnabled = isZoneCEnabled && $._config.autoscaling_ruler_query_frontend_enabled,
 
-  ruler_query_frontend_zone_a_args:: $.ruler_query_frontend_args + $.query_frontend_zone_a_caching_config + $.rulerQuerySchedulerClientZoneArgs('a'),
-  ruler_query_frontend_zone_b_args:: $.ruler_query_frontend_args + $.query_frontend_zone_b_caching_config + $.rulerQuerySchedulerClientZoneArgs('b'),
-  ruler_query_frontend_zone_c_args:: $.ruler_query_frontend_args + $.query_frontend_zone_c_caching_config + $.rulerQuerySchedulerClientZoneArgs('c'),
+  ruler_query_frontend_zone_a_args:: $.ruler_query_frontend_args + $.query_frontend_zone_a_caching_config + $.rulerQuerySchedulerClientZoneArgs('a') + $.rulerQuerierClientZoneArgs('a'),
+  ruler_query_frontend_zone_b_args:: $.ruler_query_frontend_args + $.query_frontend_zone_b_caching_config + $.rulerQuerySchedulerClientZoneArgs('b') + $.rulerQuerierClientZoneArgs('b'),
+  ruler_query_frontend_zone_c_args:: $.ruler_query_frontend_args + $.query_frontend_zone_c_caching_config + $.rulerQuerySchedulerClientZoneArgs('c') + $.rulerQuerierClientZoneArgs('c'),
 
   ruler_query_frontend_zone_a_env_map:: {},
   ruler_query_frontend_zone_b_env_map:: {},


### PR DESCRIPTION
#### What this PR does

Follow up of https://github.com/grafana/mimir/pull/13559. In this PR I'm splitting querier rings into per-zone rings when multi-zone read path is enabled. This change is already applied in Grafana Cloud, and I'm just upstreaming it to OSS too.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce zone-scoped querier rings and wire query-frontends and ruler-queriers to their zone-specific rings; update generated manifests and changelog.
> 
> - **Jsonnet**:
>   - **Querier (multi-zone)**: Add `querier.ring.prefix` per zone via `querierClientZoneArgs()` (`querier-zone-a/`, `querier-zone-b/`, `querier-zone-c/`).
>   - **Query-frontend (multi-zone)**: Target zone-specific querier rings by adding `$.querierClientZoneArgs('a'|'b'|'c')`.
>   - **Ruler remote evaluation (multi-zone)**: Add `ruler-querier.ring.prefix` per zone via `rulerQuerierClientZoneArgs()` and propagate to ruler-query-frontend.
> - **Generated manifests (tests)**:
>   - Set `-querier.ring.prefix=querier-zone-a/|querier-zone-b/` for zonal queriers and query-frontends.
>   - Rename ruler-querier ring prefixes to `ruler-querier-zone-a/|zone-b/` and update ruler-query-frontends accordingly.
> - **Changelog**: Append reference `#13628` to multi-zone read path feature entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1688a6e85997a97233e07891c707e1eab8d397e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->