### PR TITLE
usage-tracker: tenantshard.Map.Cleanup(): continue outer on empty slot

### DIFF
--- a/pkg/usagetracker/tenantshard/map.go
+++ b/pkg/usagetracker/tenantshard/map.go
@@ -177,11 +177,12 @@ func (m *Map) Count() int {
 
 func (m *Map) Cleanup(watermark clock.Minutes) int {
 	removed := 0
+outer:
 	for i := range m.data {
 		for j, xor := range m.data[i] {
 			if xor == 0 {
-				// There's nothing here.
-				continue
+				// There's nothing here, hence nothing in the next slots.
+				continue outer
 			}
 			if value := ^xor; watermark.GreaterOrEqualThan(value) {
 				m.index[i][j] = tombstone


### PR DESCRIPTION
#### What this PR does

If a slot is empty in a group, next slots will be empty too, there's no need to check them.

Since our load target is 50%, this should reduce the amount of slots checked by 50%.

Benchmark shows a 12% reduction in cleanup time.

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> `Cleanup` now `continue`s the outer loop on an empty slot, skipping remaining slots in the group.
> 
> - **`pkg/usagetracker/tenantshard/map.go`**:
>   - **`Map.Cleanup`**: add labeled `outer` loop and `continue outer` when encountering `xor == 0`, skipping subsequent slots in the current group; update comment accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e90e769ab9fd3b1d751d1ddec2b8053a9991037b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->