### PR TITLE
Jsonnet: refactor multi-zone distributor ScaledObject definition

### DIFF
--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -747,47 +747,21 @@
       }
     ),
 
-  local isDistributorSingleZoneEnabled = $._config.single_zone_distributor_enabled,
-  local isDistributorMultiZoneEnabled = $._config.multi_zone_distributor_enabled,
-  local isDistributorAutoscalingEnabled = $._config.autoscaling_distributor_enabled,
-  local isDistributorAutoscalingSingleZoneEnabled = isDistributorSingleZoneEnabled && isDistributorAutoscalingEnabled,
-  local isDistributorAutoscalingZoneAEnabled = isDistributorMultiZoneEnabled && isDistributorAutoscalingEnabled && std.length($._config.multi_zone_availability_zones) >= 1,
-  local isDistributorAutoscalingZoneBEnabled = isDistributorMultiZoneEnabled && isDistributorAutoscalingEnabled && std.length($._config.multi_zone_availability_zones) >= 2,
-  local isDistributorAutoscalingZoneCEnabled = isDistributorMultiZoneEnabled && isDistributorAutoscalingEnabled && std.length($._config.multi_zone_availability_zones) >= 3,
+  //
+  // Distributors
+  //
 
-  distributor_scaled_object: if !isDistributorAutoscalingSingleZoneEnabled then null else
-    // When both single-zone and multi-zone coexists, the single-zone scaling metrics shouldn't
-    // match the multi-zone pods.
-    $.newDistributorScaledObject('distributor', extra_matchers=(if isDistributorMultiZoneEnabled then 'pod!~"distributor-zone.*"' else '')),
+  distributor_scaled_object: if !$._config.autoscaling_distributor_enabled then null else
+    $.newDistributorScaledObject('distributor'),
 
   distributor_deployment: overrideSuperIfExists(
     'distributor_deployment',
-    if !isDistributorAutoscalingSingleZoneEnabled then {} else $.removeReplicasFromSpec
+    if !$._config.autoscaling_distributor_enabled then {} else $.removeReplicasFromSpec
   ),
 
-  distributor_zone_a_scaled_object: if !isDistributorAutoscalingZoneAEnabled then null else
-    $.newDistributorScaledObject('distributor-zone-a', 'pod=~"distributor-zone-a.*"'),
-
-  distributor_zone_a_deployment: overrideSuperIfExists(
-    'distributor_zone_a_deployment',
-    if !isDistributorAutoscalingZoneAEnabled then {} else $.removeReplicasFromSpec
-  ),
-
-  distributor_zone_b_scaled_object: if !isDistributorAutoscalingZoneBEnabled then null else
-    $.newDistributorScaledObject('distributor-zone-b', 'pod=~"distributor-zone-b.*"'),
-
-  distributor_zone_b_deployment: overrideSuperIfExists(
-    'distributor_zone_b_deployment',
-    if !isDistributorAutoscalingZoneBEnabled then {} else $.removeReplicasFromSpec
-  ),
-
-  distributor_zone_c_scaled_object: if !isDistributorAutoscalingZoneCEnabled then null else
-    $.newDistributorScaledObject('distributor-zone-c', 'pod=~"distributor-zone-c.*"'),
-
-  distributor_zone_c_deployment: overrideSuperIfExists(
-    'distributor_zone_c_deployment',
-    if !isDistributorAutoscalingZoneCEnabled then {} else $.removeReplicasFromSpec
-  ),
+  //
+  // Rulers
+  //
 
   newRulerScaledObject(name, extra_matchers='')::
     $.newResourceScaledObject(

--- a/operations/mimir/mimir.libsonnet
+++ b/operations/mimir/mimir.libsonnet
@@ -28,15 +28,13 @@
 (import 'ruler-remote-evaluation.libsonnet') +
 (import 'continuous-test.libsonnet') +
 
-// Multi-zone write path support.
-(import 'multi-zone-distributor.libsonnet') +
-
 // Import autoscaling after other features because it overrides deployments,
 // but before multi-zone deployments because they build on this.
 (import 'autoscaling.libsonnet') +
 
 // Multi-zone support.
 (import 'multi-zone-common.libsonnet') +
+(import 'multi-zone-distributor.libsonnet') +
 (import 'multi-zone-ingester.libsonnet') +
 (import 'multi-zone-store-gateway.libsonnet') +
 (import 'multi-zone-memcached.libsonnet') +

--- a/operations/mimir/multi-zone-distributor.libsonnet
+++ b/operations/mimir/multi-zone-distributor.libsonnet
@@ -16,6 +16,11 @@
   local isZoneAEnabled = isMultiZoneEnabled && std.length($._config.multi_zone_availability_zones) >= 1,
   local isZoneBEnabled = isMultiZoneEnabled && std.length($._config.multi_zone_availability_zones) >= 2,
   local isZoneCEnabled = isMultiZoneEnabled && std.length($._config.multi_zone_availability_zones) >= 3,
+  local isAutoscalingEnabled = $._config.autoscaling_distributor_enabled,
+  local isAutoscalingSingleZoneEnabled = isSingleZoneEnabled && isAutoscalingEnabled,
+  local isAutoscalingZoneAEnabled = isZoneAEnabled && isAutoscalingEnabled,
+  local isAutoscalingZoneBEnabled = isZoneBEnabled && isAutoscalingEnabled,
+  local isAutoscalingZoneCEnabled = isZoneCEnabled && isAutoscalingEnabled,
 
   distributor_zone_a_args:: $.distributor_args,
   distributor_zone_b_args:: $.distributor_args,
@@ -39,13 +44,16 @@
     $.newDistributorZoneContainer('c', $.distributor_zone_c_args, $.distributor_zone_c_env_map),
 
   distributor_zone_a_deployment: if !isZoneAEnabled then null else
-    $.newDistributorZoneDeployment('a', $.distributor_zone_a_container, $.distributor_zone_a_node_affinity_matchers),
+    $.newDistributorZoneDeployment('a', $.distributor_zone_a_container, $.distributor_zone_a_node_affinity_matchers) +
+    (if !isAutoscalingZoneAEnabled then {} else $.removeReplicasFromSpec),
 
   distributor_zone_b_deployment: if !isZoneBEnabled then null else
-    $.newDistributorZoneDeployment('b', $.distributor_zone_b_container, $.distributor_zone_b_node_affinity_matchers),
+    $.newDistributorZoneDeployment('b', $.distributor_zone_b_container, $.distributor_zone_b_node_affinity_matchers) +
+    (if !isAutoscalingZoneBEnabled then {} else $.removeReplicasFromSpec),
 
   distributor_zone_c_deployment: if !isZoneCEnabled then null else
-    $.newDistributorZoneDeployment('c', $.distributor_zone_c_container, $.distributor_zone_c_node_affinity_matchers),
+    $.newDistributorZoneDeployment('c', $.distributor_zone_c_container, $.distributor_zone_c_node_affinity_matchers) +
+    (if !isAutoscalingZoneCEnabled then {} else $.removeReplicasFromSpec),
 
   distributor_zone_a_service: if !isZoneAEnabled then null else
     $.util.serviceFor($.distributor_zone_a_deployment, $._config.service_ignored_labels) +
@@ -81,8 +89,23 @@
     deployment.spec.template.spec.withTolerationsMixin($.newMimirMultiZoneToleration()),
 
   // Remove single-zone deployment when multi-zone is enabled.
-  distributor_deployment: if !isSingleZoneEnabled then null else super.distributor_deployment,
+  distributor_deployment: if !isSingleZoneEnabled then null else
+    super.distributor_deployment + (if !isAutoscalingSingleZoneEnabled then {} else $.removeReplicasFromSpec),
   distributor_service: if !isSingleZoneEnabled then null else super.distributor_service,
   distributor_pdb: if !isSingleZoneEnabled then null else super.distributor_pdb,
-  distributor_scaled_object: if !isSingleZoneEnabled then null else super.distributor_scaled_object,
+
+  // Autoscaling.
+  distributor_scaled_object:
+    if !isAutoscalingSingleZoneEnabled then
+      null
+    else if isMultiZoneEnabled then
+      // When both single-zone and multi-zone coexists, the single-zone scaling metrics shouldn't
+      // match the multi-zone pods.
+      $.newDistributorScaledObject('distributor', extra_matchers='pod!~"distributor-zone.*"')
+    else
+      super.distributor_scaled_object,
+
+  distributor_zone_a_scaled_object: if !isAutoscalingZoneAEnabled then null else $.newDistributorScaledObject('distributor-zone-a', 'pod=~"distributor-zone-a.*"'),
+  distributor_zone_b_scaled_object: if !isAutoscalingZoneBEnabled then null else $.newDistributorScaledObject('distributor-zone-b', 'pod=~"distributor-zone-b.*"'),
+  distributor_zone_c_scaled_object: if !isAutoscalingZoneCEnabled then null else $.newDistributorScaledObject('distributor-zone-c', 'pod=~"distributor-zone-c.*"'),
 }


### PR DESCRIPTION
#### What this PR does

In https://github.com/grafana/mimir/pull/13559 I've upstreamed multi-zone jsonnet support for read path components, and imported the new `multi-zone-*.libsonnet` files after the `autoscaling.libsonnet` import. However, `multi-zone-distributor.libsonnet` was still imported before `autoscaling.libsonnet` because jsonnet used for distributors has a design different than other `multi-zone-*.libsonnet` (multi-zone distributor ScaledObject was configured in `autoscaling.libsonnet` instead of `multi-zone-distributor.libsonnet`).

In this PR I'm moving multi-zone distributor ScaledObject from `autoscaling.libsonnet` to `multi-zone-distributor.libsonnet`, following the design used for other multi-zone Mimir components.

This PR is expected to be a no-op (no changes to jsonnet tests output).

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves distributor ScaledObject logic from autoscaling.libsonnet into multi-zone-distributor.libsonnet, adds per-zone/single-zone autoscaling handling, and reorders imports accordingly.
> 
> - **Autoscaling (`operations/mimir/autoscaling.libsonnet`)**:
>   - **Distributors**: Simplify to a single `distributor_scaled_object` gate by `autozscaling_distributor_enabled` and remove zone-specific logic; `distributor_deployment` drops `replicas` when autoscaling is enabled.
> - **Multi-zone Distributor (`operations/mimir/multi-zone-distributor.libsonnet`)**:
>   - Add autoscaling flags and conditions for single-zone and zones A/B/C.
>   - Create `ScaledObject`s: `distributor` (with matcher excluding `distributor-zone.*` when multi-zone coexists), and per-zone `distributor-zone-{a,b,c}`.
>   - Remove `replicas` from zone deployments and single-zone deployment when respective autoscaling is enabled.
> - **Root (`operations/mimir/mimir.libsonnet`)**:
>   - Reorder imports: include `autoscaling.libsonnet` before multi-zone files and move `multi-zone-distributor.libsonnet` into the multi-zone block.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e68368d5da107a341ae8594808c3560a7438498. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->