### PR TITLE
usage-tracker: store xorData instead of XOR'd clock.Minutes

### DIFF
--- a/pkg/usagetracker/tenantshard/map.go
+++ b/pkg/usagetracker/tenantshard/map.go
@@ -47,8 +47,7 @@ type index [groupSize]prefix
 
 type keys [groupSize]uint64
 
-// data is a group of groupSize data/value entries.
-// Each entry is the keyMasked key and valueMasked value.
+// data is a group of groupSize xorData entries.
 type data [groupSize]xorData
 
 // xorData is what we store in data, which is xor-ed clock.Minutes value.


### PR DESCRIPTION
#### What this PR does

This defines a new type, xorData, which is stored in data, instead of manually mangling with ^clock.Minutes in every method. This adds more safety. OTOH, load() now takes xorData as entry, which improves the rehash performance as it doesn't need to XOR in order to XOR again.

```
$ benchstat main xorData
goos: darwin
goarch: arm64
pkg: github.com/grafana/mimir/pkg/usagetracker/tenantshard
cpu: Apple M3 Pro
                           │    main     │              xorData               │
                           │   sec/op    │   sec/op     vs base               │
MapRehash/size=1000000-12    10.96m ± 1%   10.85m ± 2%  -0.97% (p=0.004 n=15)
MapRehash/size=10000000-12   110.6m ± 2%   109.5m ± 0%  -1.03% (p=0.000 n=15)
geomean                      34.81m        34.47m       -1.00%
```

#### Which issue(s) this PR fixes or relates to

Fixes implementation details.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces raw XOR usage with a new xorData type for map storage and updates related methods to use helpers and pass pre-xored entries.
> 
> - **tenantshard/map.go**:
>   - Introduce `xorData` type with helpers `xor(clock.Minutes)` and `xorData.clockMinutes()`.
>   - Change `data` storage to `[]xorData` and adjust insertion/update logic.
>   - Update `Put`, `insert`, `Load`, `load`, `Cleanup`, `rehash`, and `Items` to use `xorData` and convert via helpers.
>   - `rehash`/`load` now pass pre-xored entries to avoid repeated XOR operations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e67840f30e7fadb5dd6336537d5694587bd034fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->