### PR TITLE
Mixin: add missing matchers for usage-tracker client latency panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,7 +128,7 @@
 * [ENHANCEMENT] Dashboards: Add variable to compactor and object store dashboards to switch between classic and native latencies. Use native histogram `thanos_objstore_bucket_operation_duration_seconds`. #12137
 * [ENHANCEMENT] Recording rules: Add native histogram version of histogram recording rules. #13553
 * [ENHANCEMENT] Alerts: Add `MimirMemberlistBridgeZoneUnavailable` alert. #13647
-* [ENHANCEMENT] Dashboards and recording rules: Add usage-tracker rows to writes, writes-networking, writes-resources dashboards if the config.usage_tracker_enabled var is set. Add usage-tracker client latency recording rules. #13639
+* [ENHANCEMENT] Dashboards and recording rules: Add usage-tracker rows to writes, writes-networking, writes-resources dashboards if the config.usage_tracker_enabled var is set. Add usage-tracker client latency recording rules. #13639 #13652
 * [BUGFIX] Dashboards: Fix issue where throughput dashboard panels would group all gRPC requests that resulted in a status containing an underscore into one series with no name. #13184
 * [BUGFIX] Dashboards: Filter out 0s from `max_series` limit on Writes Resources > Ingester > In-memory series panel. #13419
 

--- a/operations/mimir-mixin/dashboards/writes.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes.libsonnet
@@ -267,7 +267,7 @@ local filename = 'mimir-writes.json';
       .addPanel(
         local title = 'Client latency';
         $.timeseriesPanel(title) +
-        $.latencyRecordingRulePanelNativeHistogram($.queries.usage_tracker.clientRequestsPerSecondMetric, []) +
+        $.latencyRecordingRulePanelNativeHistogram($.queries.usage_tracker.clientRequestsPerSecondMetric, $.jobSelector(std.set($._config.job_names.distributor + $._config.job_names.ruler))) +
         $.panelDescription(
           title,
           |||
@@ -277,7 +277,7 @@ local filename = 'mimir-writes.json';
       )
       .addPanel(
         $.timeseriesPanel('Client per %s p99 latency' % $._config.per_instance_label) +
-        $.perInstanceLatencyPanelNativeHistogram('0.99', $.queries.usage_tracker.clientRequestsPerSecondMetric, [])
+        $.perInstanceLatencyPanelNativeHistogram('0.99', $.queries.usage_tracker.clientRequestsPerSecondMetric, $.jobSelector(std.set($._config.job_names.distributor + $._config.job_names.ruler)))
       )
     )
     .addRowIf(


### PR DESCRIPTION
These panels weren't selecting job or namespace.

Signed-off-by: Oleg Zaytsev <mail@olegzaytsev.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add missing job/namespace matchers to Usage Tracker client latency panels in the Writes dashboard and update the changelog reference.
> 
> - **Mixin Dashboards (Writes)**:
>   - Update Usage Tracker client panels to include job/namespace matchers:
>     - `Client latency`: use `$.latencyRecordingRulePanelNativeHistogram(..., $.jobSelector(std.set($._config.job_names.distributor + $._config.job_names.ruler)))`.
>     - `Client per <instance> p99 latency`: use `$.perInstanceLatencyPanelNativeHistogram('0.99', ..., $.jobSelector(std.set($._config.job_names.distributor + $._config.job_names.ruler)))`.
> - **Changelog**:
>   - Add reference `#13652` to the existing enhancement entry for usage-tracker dashboards/recording rules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 756eb4ffb6441d4571adb79275e448c674906d58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->