### PR TITLE
[r369] Do not apply sharding inside MQE to intermediate expressions used by subquery spin-off 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
 * [BUGFIX] Query-frontend: Fix incorrect query results when evaluating some sharded aggregations with `without` when running sharding inside MQE. #13484
 * [BUGFIX]: Ingester: Panic when push and read reactive limiters are enabled with prioritization. #13482
 * [BUGFIX] Query-frontend: Fix excessive CPU and memory consumption when running sharding inside MQE. #13580
+* [BUGFIX] Query-frontend: Fix incorrect query results when running sharding inside MQE is enabled and the query contains a subquery eligible for subquery spin-off wrapped in a shardable aggregation. #13619
 
 ### Mixin
 

--- a/pkg/frontend/querymiddleware/astmapper/embedded.go
+++ b/pkg/frontend/querymiddleware/astmapper/embedded.go
@@ -8,6 +8,7 @@ package astmapper
 import (
 	"encoding/json"
 
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 )
@@ -120,7 +121,10 @@ func (s *embeddedQueriesSquasher) Squash(exprs ...EmbeddedQuery) (parser.Expr, e
 	}
 
 	return &parser.VectorSelector{
-		Name:          EmbeddedQueriesMetricName,
-		LabelMatchers: []*labels.Matcher{embeddedQuery},
+		Name: EmbeddedQueriesMetricName,
+		LabelMatchers: []*labels.Matcher{
+			labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, EmbeddedQueriesMetricName),
+			embeddedQuery,
+		},
 	}, nil
 }

--- a/pkg/frontend/querymiddleware/astmapper/subquery_spin_off.go
+++ b/pkg/frontend/querymiddleware/astmapper/subquery_spin_off.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/pkg/errors"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 )
@@ -68,6 +69,7 @@ func (m *subquerySpinOffMapper) MapExpr(ctx context.Context, expr parser.Expr) (
 		selector := &parser.VectorSelector{
 			Name: DownstreamQueryMetricName,
 			LabelMatchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, DownstreamQueryMetricName),
 				labels.MustNewMatcher(labels.MatchEqual, DownstreamQueryLabelName, expr.String()),
 			},
 		}
@@ -109,6 +111,7 @@ func (m *subquerySpinOffMapper) MapExpr(ctx context.Context, expr parser.Expr) (
 			selector := &parser.VectorSelector{
 				Name: SubqueryMetricName,
 				LabelMatchers: []*labels.Matcher{
+					labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, SubqueryMetricName),
 					labels.MustNewMatcher(labels.MatchEqual, SubqueryQueryLabelName, sq.Expr.String()),
 					labels.MustNewMatcher(labels.MatchEqual, SubqueryRangeLabelName, sq.Range.String()),
 					labels.MustNewMatcher(labels.MatchEqual, SubqueryStepLabelName, step.String()),

--- a/pkg/streamingpromql/optimize/ast/sharding/optimization_pass_test.go
+++ b/pkg/streamingpromql/optimize/ast/sharding/optimization_pass_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/frontend/querymiddleware"
+	"github.com/grafana/mimir/pkg/frontend/querymiddleware/astmapper"
 )
 
 func TestOptimizationPass(t *testing.T) {
@@ -63,6 +64,11 @@ func TestOptimizationPass(t *testing.T) {
 			},
 			expectedOutput: `sum(__sharded_concat__(sum(foo{__query_shard__="1_of_2"}), sum(foo{__query_shard__="2_of_2"})))`,
 		},
+		"shardable expression eligible for subquery spin-off": {
+			input: `sum(sum_over_time(sum(foo)[5h:30s]))`,
+			// We should not rewrite the expression, because it's not valid to try to shard the __subquery_spinoff__ selector.
+			expectedOutput: `sum(sum_over_time(__subquery_spinoff__{__query__="sum(foo)",__range__="5h0m0s",__step__="30s"}[5h]))`,
+		},
 	}
 
 	for name, testCase := range testCases {
@@ -76,12 +82,12 @@ func TestOptimizationPass(t *testing.T) {
 			}
 			pass := NewOptimizationPass(limits, seriesPerShard, reg, logger)
 
-			expr, err := parser.ParseExpr(testCase.input)
+			ctx := user.InjectOrgID(context.Background(), "tenant-1")
+			afterRewrite, err := rewriteForSubquerySpinoff(ctx, testCase.input)
 			require.NoError(t, err)
 
-			ctx := user.InjectOrgID(context.Background(), "tenant-1")
 			ctx = querymiddleware.ContextWithRequestHintsAndOptions(ctx, testCase.hints, testCase.options)
-			output, err := pass.Apply(ctx, expr)
+			output, err := pass.Apply(ctx, afterRewrite)
 			require.NoError(t, err)
 			require.Equal(t, testCase.expectedOutput, output.String())
 		})
@@ -109,4 +115,25 @@ func (m *mockLimits) QueryShardingMaxShardedQueries(userID string) int {
 
 func (m *mockLimits) CompactorSplitAndMergeShards(userID string) int {
 	return m.splitAndMergeShards
+}
+
+func rewriteForSubquerySpinoff(ctx context.Context, expr string) (parser.Expr, error) {
+	stats := astmapper.NewSubquerySpinOffMapperStats()
+	defaultStepFunc := func(rangeMillis int64) int64 { return 1000 }
+	mapper := astmapper.NewSubquerySpinOffMapper(defaultStepFunc, log.NewNopLogger(), stats)
+	ast, err := parser.ParseExpr(expr)
+	if err != nil {
+		return nil, err
+	}
+
+	rewrittenQuery, err := mapper.Map(ctx, ast)
+	if err != nil {
+		return nil, err
+	}
+
+	if stats.SpunOffSubqueries() == 0 {
+		return ast, nil
+	}
+
+	return rewrittenQuery, nil
 }


### PR DESCRIPTION
Manually backporting https://github.com/grafana/mimir/pull/13619 to r369 due to merge conflict

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents sharding when a spun‑off subquery is present and adds explicit metric name matchers to fake selectors, fixing incorrect results when MQE sharding and subquery spin‑off interact.
> 
> - **Sharding Optimization (streamingpromql)**:
>   - Skip sharding when the AST contains a spun‑off subquery (`__subquery_spinoff__`).
>   - Add helper `containsSpunOffSubquery()`; wire into `Apply()` early return.
> - **AST Mappers (query-frontend)**:
>   - Add `__name__` label matcher to fake selectors in `embedded.go` and `subquery_spin_off.go` for `__embedded_queries__`, `__downstream_query__`, and `__subquery_spinoff__`.
> - **Tests**:
>   - Update sharding pass tests to rewrite for subquery spin‑off and add case ensuring no sharding of `__subquery_spinoff__` selectors.
> - **Changelog**:
>   - Note bug fix for incorrect results when MQE sharding interacts with subquery spin‑off (#13619).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 087838bcc4486214f64e15628858c88ed02d2c84. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->