### PR TITLE
workflows: push-mimir-build-image use new app token when comitting update build image

### DIFF
--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -51,9 +51,9 @@ jobs:
             APP_ID=mimir-github-bot:app_id
             PRIVATE_KEY=mimir-github-bot:private_key
 
-      - name: Generate GitHub App Token
+      - name: Generate GitHub App Token for Membership
         if: steps.check_dockerfile.outputs.modified == 'true'
-        id: app-token
+        id: app-token-for-membership
         uses: actions/create-github-app-token@7e473efe3cb98aa54f8d4bac15400b15fad77d94 # v2
         with:
           app-id: ${{ env.APP_ID }}
@@ -81,7 +81,7 @@ jobs:
             echo "✗ User ${PR_AUTHOR} is not a Grafana organization member (HTTP $status_code)"
           fi
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-token-for-membership.outputs.token }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
 
       # We want to allow running github actions for all contributors, but don't want all contributors to be able to
@@ -191,6 +191,17 @@ jobs:
             echo "Built tag is different from the one in Makefile"
             echo "isDifferent=true" >> $GITHUB_OUTPUT
           fi
+          
+      # Tokens expire after 1h. Since building the image can take a long time, we create a fresh App Token for the last
+      # step of the build. (https://github.com/actions/create-github-app-token/issues/121#issuecomment-2027574184)
+      - name: Generate GitHub App Token
+        if: steps.check_dockerfile.outputs.modified == 'true'
+        id: app-token-for-commit
+        uses: actions/create-github-app-token@7e473efe3cb98aa54f8d4bac15400b15fad77d94 # v2
+        with:
+          app-id: ${{ env.APP_ID }}
+          private-key: ${{ env.PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       # This step uses "Mimir bot" token (generated at the start of the workflow) instead of
       # "github-actions bot" (secrets.GITHUB_TOKEN) because any events triggered by the latter
@@ -215,7 +226,7 @@ jobs:
             git push origin HEAD
           fi
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-token-for-commit.outputs.token }}
           GITHUB_LOGIN: ${{ github.event.pull_request.user.login }}
           TAG: ${{ steps.compute_hash.outputs.tag }}
           MAIN_TAG: ${{ steps.prepare.outputs.main_image_tag }}


### PR DESCRIPTION
#### What this PR does

Fetches a new app token for the commit step because the old token might be expired.
https://github.com/actions/create-github-app-token/issues/121#issuecomment-2027574184

#### Which issue(s) this PR fixes or relates to

Fixes workflow runs like: https://github.com/grafana/mimir/actions/runs/19657663117

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Generates a fresh GitHub App token for the commit/push step and renames/updates the membership token step and references.
> 
> - **Workflow**: `.github/workflows/push-mimir-build-image.yml`
>   - **Auth tokens**:
>     - Add `Generate GitHub App Token` step (`id: app-token-for-commit`) before committing/pushing; use `steps.app-token-for-commit.outputs.token` for `git push`.
>     - Rename membership token step to `Generate GitHub App Token for Membership` (`id: app-token-for-membership`) and update `GITHUB_TOKEN` references in membership check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19cbdc3d963c4285a5ea6c071d30f2f39f8f281f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->