### PR TITLE
chore(mixin): update jsonnet-libs dependency

### DIFF
--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -280,8 +280,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
       },
     },
 
-  ncLatencyPanel(metricName, selector, multiplier='1e3')::
-    super.latencyPanelNativeHistogram(metricName, selector, multiplier),
+  ncLatencyPanel(metricName, selector, multiplier='1e3', quantile=[99, 50])::
+    super.latencyPanelNativeHistogram(metricName, selector, multiplier, quantile),
 
   // hiddenLegendQueryPanel adds on to 'timeseriesPanel', not the deprecated 'panel'.
   // It is a standard query panel designed to handle a large number of series.  it hides the legend, doesn't fill the series and

--- a/operations/mimir-mixin/jsonnetfile.lock.json
+++ b/operations/mimir-mixin/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "grafana-builder"
         }
       },
-      "version": "a64f0ca4b1c285d615fd0cbbf5870ae291b6914e",
-      "sum": "d8iL8gbyQxspZJ8mDGsqHRR/JF3cu+YOaV50vao93Nw="
+      "version": "86f29cfec63cccf41928146e1f9ce5e9526eb210",
+      "sum": "eBzW/FD3PIyReZGRMdOpbHEh3uk8k8G0CIy+djUbrfA="
     },
     {
       "source": {
@@ -18,7 +18,7 @@
           "subdir": "mixin-utils"
         }
       },
-      "version": "a64f0ca4b1c285d615fd0cbbf5870ae291b6914e",
+      "version": "86f29cfec63cccf41928146e1f9ce5e9526eb210",
       "sum": "juQsRDtnqZWgCRDgl8abH7ZmIuJnrSu9vM+vUjGT/0g="
     },
     {


### PR DESCRIPTION
No-op.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps jsonnet-libs dependencies and extends `ncLatencyPanel` to accept configurable quantiles (default `[99, 50]`).
> 
> - **Dashboards**:
>   - `operations/mimir-mixin/dashboards/dashboard-utils.libsonnet`:
>     - Extend `ncLatencyPanel(metricName, selector, multiplier, quantile=[99, 50])` and pass `quantile` to `latencyPanelNativeHistogram`.
> - **Dependencies**:
>   - Update `grafana-builder` and `mixin-utils` versions in `operations/mimir-mixin/jsonnetfile.lock.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f618b1c75440e7f94ec5cafa50bff6aa0721b810. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->