### PR TITLE
benchmark: add benchmark processing large OTLP messages

### DIFF
--- a/pkg/distributor/otel_test.go
+++ b/pkg/distributor/otel_test.go
@@ -7,6 +7,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -1132,6 +1133,88 @@ func BenchmarkOTLPHandler(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
+			resp := httptest.NewRecorder()
+			handler.ServeHTTP(resp, req)
+			require.Equal(b, http.StatusOK, resp.Code)
+			req.Body.(*reusableReader).Reset()
+		}
+	})
+}
+
+func BenchmarkOTLPHandlerWithLargeMessage(b *testing.B) {
+	const numberOfMetrics = 150
+	const numberOfResourceMetrics = 300
+	const numberOfDatapoints = 4
+	const stepDuration = 10 * time.Second
+
+	startTime := time.Date(2020, time.October, 30, 23, 0, 0, 0, time.UTC)
+
+	createMetrics := func(mts pmetric.MetricSlice) {
+		mts.EnsureCapacity(numberOfMetrics)
+		for idx := range numberOfMetrics {
+			mt := mts.AppendEmpty()
+			mt.SetName(fmt.Sprintf("metric-%d", idx))
+			datapoints := mt.SetEmptyGauge().DataPoints()
+			datapoints.EnsureCapacity(numberOfDatapoints)
+
+			sampleTime := startTime
+			for j := range numberOfDatapoints {
+				datapoint := datapoints.AppendEmpty()
+				datapoint.SetTimestamp(pcommon.NewTimestampFromTime(sampleTime))
+				datapoint.SetIntValue(int64(j))
+				attrs := datapoint.Attributes()
+				attrs.PutStr("route", "/hello")
+				attrs.PutStr("status", "200")
+				sampleTime = sampleTime.Add(stepDuration)
+			}
+		}
+	}
+
+	createScopedMetrics := func(rm pmetric.ResourceMetrics) {
+		sms := rm.ScopeMetrics()
+
+		sm := sms.AppendEmpty()
+		scope := sm.Scope()
+		scope.SetName("scope")
+		metrics := sm.Metrics()
+		createMetrics(metrics)
+	}
+
+	createResourceMetrics := func(md pmetric.Metrics) {
+		rms := md.ResourceMetrics()
+		rms.EnsureCapacity(numberOfResourceMetrics)
+		for idx := range numberOfResourceMetrics {
+			rm := rms.AppendEmpty()
+			attrs := rm.Resource().Attributes()
+			attrs.PutStr("env", "dev")
+			attrs.PutStr("region", "us-east-1")
+			attrs.PutStr("pod", fmt.Sprintf("pod-%d", idx))
+			createScopedMetrics(rm)
+		}
+	}
+
+	pushFunc := func(_ context.Context, pushReq *Request) error {
+		if _, err := pushReq.WriteRequest(); err != nil {
+			return err
+		}
+
+		pushReq.CleanUp()
+		return nil
+	}
+	limits := validation.MockDefaultOverrides()
+	handler := OTLPHandler(
+		200000000, nil, nil, limits, nil, nil,
+		RetryConfig{}, nil, pushFunc, nil, nil, log.NewNopLogger(),
+	)
+
+	b.Run("protobuf", func(b *testing.B) {
+		md := pmetric.NewMetrics()
+		createResourceMetrics(md)
+		exportReq := pmetricotlp.NewExportRequestFromMetrics(md)
+		req := createOTLPProtoRequest(b, exportReq, "")
+
+		b.ResetTimer()
+		for range b.N {
 			resp := httptest.NewRecorder()
 			handler.ServeHTTP(resp, req)
 			require.Equal(b, http.StatusOK, resp.Code)


### PR DESCRIPTION
#### What this PR does

This add a benchmark that tests the processing of a large OTLP message marshaled to protobuf.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [X] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a protobuf benchmark that measures OTLP handler performance on a very large, generated metrics payload.
> 
> - **Tests/Benchmarks**:
>   - Add `BenchmarkOTLPHandlerWithLargeMessage` in `pkg/distributor/otel_test.go` to generate a large OTLP metrics payload (many resource metrics, metrics, datapoints) and benchmark the protobuf path through `OTLPHandler`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c950de6b634dee49708c38e0293fa150c8b7b0ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->