### PR TITLE
Mimir 3.0 release notes: Note specifically which experimental features are disabled by default

### DIFF
--- a/docs/sources/mimir/release-notes/v3.0.md
+++ b/docs/sources/mimir/release-notes/v3.0.md
@@ -48,12 +48,12 @@ Grafana Mimir 3.0 introduces several updates that change default behavior and co
 
 ## Experimental features
 
-Grafana Mimir 3.0 includes some features that are experimental and disabled by default. Use these features with caution and report any issues that you encounter:
+Grafana Mimir 3.0 includes some features that are experimental. Use these features with caution and report any issues that you encounter:
 
 - Prometheus Remote-Write 2.0 protocol
 - PromQL duration expressions that allow simple arithmetic in range or offset values
-- Cluster validation for HTTP requests (`-server.cluster-validation.*` flags)
-- Native OTLP delta metric ingestion (`-distributor.otel-native-delta-ingestion`)
+- Cluster validation for HTTP requests (disabled by default, enable through `-server.cluster-validation.*` flags)
+- Native OTLP delta metric ingestion (disabled by default, enable through `-distributor.otel-native-delta-ingestion`)
 
 ## Bug fixes
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

The Mimir 3.0 release notes say that all experimental features are disabled by default, which isn't the case for Prometheus Remote-Write 2.0 protocol and PromQL duration expressions. Fix by stating which are disabled.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies which experimental features are disabled by default in `docs/sources/mimir/release-notes/v3.0.md` and updates wording accordingly.
> 
> - **Docs**:
>   - **Release notes (`docs/sources/mimir/release-notes/v3.0.md`)**:
>     - Refine “Experimental features” intro to remove blanket "disabled by default" claim.
>     - Specify which features are disabled by default:
>       - Cluster validation for HTTP requests (enable via `-server.cluster-validation.*`).
>       - Native OTLP delta metric ingestion (enable via `-distributor.otel-native-delta-ingestion`).
>     - Keep Prometheus Remote-Write 2.0 and PromQL duration expressions listed as experimental without default-disable note.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44df2cdfc2e04c0f4f54f6964b07b0320c4c6727. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->