### PR TITLE
Mimir 2.17 release notes: Note specifically which experimental features are disabled by default

### DIFF
--- a/docs/sources/mimir/release-notes/v2.17.md
+++ b/docs/sources/mimir/release-notes/v2.17.md
@@ -66,7 +66,7 @@ Use these features with caution and report any issues that you encounter:
 - Promoting OTel scope metadata, including name, version, schema URL, and attributes, to metric labels, prefixed with `otel_scope_`. Enable this feature through the `-distributor.otel-promote-scope-metadata` flag.
 - Allowing primitive delta metrics ingestion through the OTLP endpoint with the `-distributor.otel-native-delta-ingestion` option.
 - Support for `sort_by_label` and `sort_by_label_desc` PromQL functions. Enable this feature through the `-query-frontend.enabled-promql-experimental-functions` flag.
-- Support for cluster validation in HTTP calls. When enabled, the HTTP server verifies if a request coming from an HTTP client comes from an expected cluster. Disabled by default, you can configure this validation with the following options:
+- Support for cluster validation in HTTP calls. When enabled, the HTTP server verifies if a request coming from an HTTP client comes from an expected cluster. Disabled by default. You can configure this validation with the following options:
   - `-server.cluster-validation.label`
   - `-server.cluster-validation.http.enabled`
   - `-server.cluster-validation.http.soft-validation`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

The Mimir 2.17 release notes say that all experimental features are disabled by default, which isn't the case for Prometheus Remote-Write 2.0 protocol and PromQL duration expressions. Fix by stating which need enabling.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies experimental feature defaults and enablement details in the Mimir 2.17 release notes.
> 
> - **Docs** (`docs/sources/mimir/release-notes/v2.17.md`):
>   - **Experimental features**:
>     - Remove blanket statement that all experimental features are disabled by default.
>     - Note enablement flag for `sort_by_label`/`sort_by_label_desc` PromQL functions via `-query-frontend.enabled-promql-experimental-functions`.
>     - State cluster validation in HTTP is disabled by default and clarify its configuration options.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76187e1630f86c28881aa61f2287309acfa457d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->