### PR TITLE
fix(benchmark): Align expected error message with received one in distributor push benchmark

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -2319,7 +2319,7 @@ func BenchmarkDistributor_Push(b *testing.B) {
 
 				return metrics, samples
 			},
-			expectedErr: "received a series whose label value length exceeds the limit",
+			expectedErr: "received a series whose label value length of 204 exceeds the limit of 200",
 		},
 		"timestamp too new": {
 			prepareConfig: func(limits *validation.Limits) {


### PR DESCRIPTION
change introduced by PR #12583

#### What this PR does

Fix benchmark failure

#### Which issue(s) this PR fixes or relates to

Fixes distributor benchmark to run them for #13665

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the expected error string for max label value length to include actual (204) and limit (200) values in `BenchmarkDistributor_Push`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 743cb98b23069708d0d5cf8e5748aedc207aa8c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->