### PR TITLE
feat(docs): document classic vs NHCB query result expectations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,7 +164,7 @@
 
 * [ENHANCEMENT] Add Azure object store workload identity example configuration. #13135
 * [ENHANCEMENT] Ruler: clarify that internal distributor applies to both operational modes. #13300
-* [ENHANCEMENT] Native histograms: set expectations on querying classic histograms versus NHCBs. #13689
+* [ENHANCEMENT] Native histograms: Set expectations on querying classic histograms versus NHCBs. #13689
 
 ### Tools
 

--- a/docs/sources/mimir/send/native-histograms/_custom_buckets.md
+++ b/docs/sources/mimir/send/native-histograms/_custom_buckets.md
@@ -46,12 +46,12 @@ There are advantages and disadvantages of using NHCBs compared to classic Promet
 
 ## Query result equivalence
 
-NHCBs contain the same information as classic histograms, however that doesn't mean that all queries return exactly the same result. Here are some edge cases when query results may be different.
+NHCBs contain the same information as classic histograms. However, this doesn't mean that all queries return exactly the same result. Here are some edge cases when query results may be different:
 
-- Classic histograms are stored in independent series which might be lost or delayed independently from each other, whereas NHCBs are stored in a single series. This means that a classic histogram might be inconsistent compared to an NHCB and query results will be different.
-- In a normal case when classic histograms series are not lot or delayed, the bucket counts, overall count and sum of observation will be equal between the classic histograms and NHCBs.
-- Rate, increase, and delta calculation results might differ even when both the classic histograms and NHCBs are in sync. This occurs when the rate interval overlaps with one or more buckets transitioning from being empty to being in use, which can happen if the series just came into existence or when buckets transition from 0 value to some positive value. The reason is that the PromQL function [`rate`](https://prometheus.io/docs/prometheus/latest/querying/functions/#rate) and related functions use extrapolation that is applied to classic histograms series independently resulting in potentially different 0 points and slope being calculated. For NHCBs the extrapolation is consistent across all buckets.
-- In general the PromQL warning "input to histogram_quantile needed to be fixed for monotonicity" that sometimes happens for classic histograms should not happen for NHCBs as NHCBs are atomic, self consistent and extrapolated consistently.
+- Classic histograms are stored in independent series which might be lost or delayed independently from each other, whereas NHCBs are stored in a single series. This means that a classic histogram might be inconsistent compared to an NHCB and query results might differ.
+- In a normal case when classic histograms series are not lost or delayed, the bucket counts, overall count, and sum of observations are equal between the classic histograms and NHCBs.
+- Rate, increase, and delta calculation results might differ, even when both the classic histograms and NHCBs are in sync. This occurs when the rate interval overlaps with one or more buckets transitioning from being empty to being in use. This can happen if the series just came into existence or when buckets transition from a value of `0` to a positive value. The reason is that the PromQL function [`rate`](https://prometheus.io/docs/prometheus/latest/querying/functions/#rate) and related functions use extrapolation that is applied to classic histograms series independently resulting in potentially different calculations for `0` points and slopes. For NHCBs, the extrapolation is consistent across all buckets.
+- In general, the PromQL warning "input to histogram_quantile needed to be fixed for monotonicity" that sometimes happens for classic histograms should not happen for NHCBs, as NHCBs are atomic, self-consistent, and extrapolated consistently.
 
 ## Instrumentation
 


### PR DESCRIPTION
#### What this PR does

Set expectations on classic histograms vs NHCBs when it comes to query results.

#### Which issue(s) this PR fixes or relates to

Related to #7154

#### Checklist

- [N/A] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [N/A] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds documentation detailing when query results may differ between classic histograms and NHCBs, and updates the changelog accordingly.
> 
> - **Documentation**:
>   - **Native histograms (NHCBs)**: Add “Query result equivalence” section in `docs/sources/mimir/send/native-histograms/_custom_buckets.md` explaining edge cases where results can differ from classic histograms (inconsistent series, extrapolation effects, monotonicity warning avoidance).
>   - Update `CHANGELOG.md` with enhancement entry: expectations on querying classic histograms vs NHCBs (#13689).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c9de43010336baec78063871007d6ec92940636. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->