### PR TITLE
Update Go version to 1.25.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/mimir
 
-go 1.25.1
+go 1.25.4
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.3


### PR DESCRIPTION
Updates the minimum required Go version in go.mod from 1.25.1 to 1.25.4. This is part of the Go 1.25.4 upgrade process.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the minimum required Go version in `go.mod` from `1.25.1` to `1.25.4`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fffb0b64a0e608ba5c2033200ac71e19b4d309be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->