### PR TITLE
Prepare mimir-distributed 6.0.4 release

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -27,6 +27,10 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the Pull Request that introduced the change.
 
+## 6.0.4
+
+* [CHANGE] Upgrade Mimir to [3.0.1](https://github.com/grafana/mimir/blob/main/CHANGELOG.md#301). #13702
+
 ## 6.0.3
 
 * [BUGFIX] Fix missing newline for custom pod labels. #13325

--- a/operations/helm/charts/mimir-distributed/Chart.yaml
+++ b/operations/helm/charts/mimir-distributed/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-version: 6.0.3
-appVersion: 3.0.0
+version: 6.0.4
+appVersion: 3.0.1
 description: "Grafana Mimir"
 home: https://grafana.com/docs/helm-charts/mimir-distributed/latest/
 icon: https://grafana.com/static/img/logos/logo-mimir.svg

--- a/operations/helm/charts/mimir-distributed/README.md
+++ b/operations/helm/charts/mimir-distributed/README.md
@@ -4,7 +4,7 @@ Helm chart for deploying [Grafana Mimir](https://grafana.com/docs/mimir/latest/)
 
 For the full documentation, visit [Grafana mimir-distributed Helm chart documentation](https://grafana.com/docs/helm-charts/mimir-distributed/latest/).
 
-> **Note:** The documentation version is derived from the Helm chart version which is 6.0.3.
+> **Note:** The documentation version is derived from the Helm chart version which is 6.0.4.
 
 When upgrading from Helm chart version 4.X, please see [Migrate the Helm chart from version 4.x to 5.0](https://grafana.com/docs/helm-charts/mimir-distributed/latest/migration-guides/migrate-helm-chart-4.x-to-5.0/).
 When upgrading from Helm chart version 3.x, please see [Migrate from single zone to zone-aware replication with Helm](https://grafana.com/docs/helm-charts/mimir-distributed/latest/migration-guides/migrate-from-single-zone-with-helm/).
@@ -14,7 +14,7 @@ When upgrading from Helm chart version 2.1, please see [Upgrade the Grafana Mimi
 
 # mimir-distributed
 
-![Version: 6.0.3](https://img.shields.io/badge/Version-6.0.3-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
+![Version: 6.0.4](https://img.shields.io/badge/Version-6.0.4-informational?style=flat-square) ![AppVersion: 3.0.1](https://img.shields.io/badge/AppVersion-3.0.1-informational?style=flat-square)
 
 Grafana Mimir
 

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -31,7 +31,7 @@ image:
   # -- Grafana Mimir container image repository
   repository: grafana/mimir
   # -- Grafana Mimir container image tag
-  tag: 3.0.0
+  tag: 3.0.1
   # -- Container pull policy
   pullPolicy: IfNotPresent
   # -- Optionally specify an array of imagePullSecrets


### PR DESCRIPTION
Upgrade Mimir to 3.0.1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps the Helm chart to 6.0.4 and upgrades Mimir to 3.0.1, updating defaults, docs, and changelog.
> 
> - **Chart release**
>   - Update `Chart.yaml` `version` to `6.0.4` and `appVersion` to `3.0.1`.
>   - Set default image `tag` to `3.0.1` in `values.yaml`.
>   - Refresh `README.md` badges/note to `6.0.4` / `3.0.1`.
>   - Add `CHANGELOG.md` entry `6.0.4` noting upgrade to Mimir `3.0.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30ef07805c2d45dfc77bb7d7d2e95d2d6740b579. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->