### PR TITLE
Chore: remove unused PUSH_MULTIARCH_TARGET_CONTINUOUS_TEST

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -37,7 +37,6 @@ runs:
         make \
           BUILD_IN_CONTAINER=false \
           PUSH_MULTIARCH_TARGET="type=oci,dest=$OUTPUT_DIR/$NAME.oci" \
-          PUSH_MULTIARCH_TARGET_CONTINUOUS_TEST="type=oci,dest=$OUTPUT_DIR/$NAME\-continuous\-test.oci" \
           push-multiarch-$TARGET
       env:
         TARGET: ${{ inputs.target }}

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,6 @@ SED ?= $(shell which gsed 2>/dev/null || which sed)
 # Other options are documented in https://docs.docker.com/engine/reference/commandline/buildx_build/#output.
 # CI workflow uses PUSH_MULTIARCH_TARGET="type=oci,dest=file.oci" to store images locally for next steps in the pipeline.
 PUSH_MULTIARCH_TARGET ?= type=registry
-PUSH_MULTIARCH_TARGET_CONTINUOUS_TEST ?= type=registry
 
 # This target compiles mimir for linux/amd64 and linux/arm64 and then builds and pushes a multiarch image to the target repository.
 # We don't do separate building of single-platform and multiplatform images here (as we do for push-multiarch-build-image), as


### PR DESCRIPTION
#### What this PR does

Remove unused `PUSH_MULTIARCH_TARGET_CONTINUOUS_TEST` variable from Makefile given we're not building the continuous-test image anymore since https://github.com/grafana/mimir/pull/13097

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the unused `PUSH_MULTIARCH_TARGET_CONTINUOUS_TEST` variable from the Makefile and its usage in the build-image GitHub Action.
> 
> - **Build system**:
>   - **Makefile**: Remove `PUSH_MULTIARCH_TARGET_CONTINUOUS_TEST` default and all references.
>   - **CI Action**: In `.github/actions/build-image/action.yml`, stop passing `PUSH_MULTIARCH_TARGET_CONTINUOUS_TEST` to `make` and only use `PUSH_MULTIARCH_TARGET`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18e95cf7ee25efe35d0bbc941ca82afca9422657. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->