### PR TITLE
mixin: Add MimirMemberlistZoneAwareRoutingAutoFailover alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@
 * [ENHANCEMENT] Dashboards: Add variable to compactor and object store dashboards to switch between classic and native latencies. Use native histogram `thanos_objstore_bucket_operation_duration_seconds`. #12137
 * [ENHANCEMENT] Recording rules: Add native histogram version of histogram recording rules. #13553
 * [ENHANCEMENT] Alerts: Add `MimirMemberlistBridgeZoneUnavailable` alert. #13647
+* [ENHANCEMENT] Alerts: Add `MimirMemberlistZoneAwareRoutingAutoFailover` alert that fires when memberlist zone-aware routing auto-failover triggers due to missing memberlist bridges. #13726
 * [ENHANCEMENT] Dashboards and recording rules: Add usage-tracker rows to writes, writes-networking, writes-resources dashboards if the config.usage_tracker_enabled var is set. Add usage-tracker client latency recording rules. #13639 #13652
 * [ENHANCEMENT] Recording rules and dashboards: Add `stage` label to `cortex_ingester_queried_series` recording rules and filter Queries dashboard "Series per query" panel to show only `stage=merged_blocks`. #13666
 * [BUGFIX] Dashboards: Fix issue where throughput dashboard panels would group all gRPC requests that resulted in a status containing an underscore into one series with no name. #13184

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -1128,6 +1128,21 @@ How to **investigate**:
   }
   ```
 
+### MimirMemberlistZoneAwareRoutingAutoFailover
+
+This alert fires when memberlist zone-aware routing auto-failover triggers because it detects missing memberlist bridges in any of the zones where members are running.
+
+How it **works**:
+
+- When memberlist zone-aware routing is enabled and a zone has no healthy memberlist-bridge pods, the memberlist client automatically temporarily disables zone-aware routing to reduce the likelihood of network partitioning.
+- When the failover triggers, inter-AZ data transfer will occur. Inter-AZ data transfer is billed in most cloud providers.
+- This alert triggers when the auto-failover mechanism is actively skipping nodes due to missing bridges.
+
+How to **investigate**:
+
+- Ensure memberlist-bridge is running in every zone where Mimir is running.
+- Refer to the [MimirMemberlistBridgeZoneUnavailable](#mimirmemberlistbridgezoneunavailable) runbook for detailed investigation steps.
+
 ### MimirAlertmanagerSyncConfigsFailing
 
 How it **works**:

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -762,6 +762,15 @@ spec:
             for: 10m
             labels:
               severity: critical
+          - alert: MimirMemberlistZoneAwareRoutingAutoFailover
+            annotations:
+              message: Mimir memberlist in {{ $labels.cluster }}/{{ $labels.namespace }} has automatically temporarily disabled zone-aware routing because it detected missing memberlist bridges.
+              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirmemberlistzoneawareroutingautofailover
+            expr: |
+              sum by (cluster, namespace) (rate(memberlist_client_zone_aware_routing_select_nodes_skipped_total[1m])) > 0
+            for: 10m
+            labels:
+              severity: warning
       - name: golang_alerts
         rules:
           - alert: MimirGoThreadsTooHigh

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -740,6 +740,15 @@ groups:
           for: 10m
           labels:
             severity: critical
+        - alert: MimirMemberlistZoneAwareRoutingAutoFailover
+          annotations:
+            message: Mimir memberlist in {{ $labels.cluster }}/{{ $labels.namespace }} has automatically temporarily disabled zone-aware routing because it detected missing memberlist bridges.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirmemberlistzoneawareroutingautofailover
+          expr: |
+            sum by (cluster, namespace) (rate(memberlist_client_zone_aware_routing_select_nodes_skipped_total[1m])) > 0
+          for: 10m
+          labels:
+            severity: warning
     - name: golang_alerts
       rules:
         - alert: MimirGoThreadsTooHigh

--- a/operations/mimir-mixin-compiled-gem/alerts.yaml
+++ b/operations/mimir-mixin-compiled-gem/alerts.yaml
@@ -750,6 +750,15 @@ groups:
           for: 10m
           labels:
             severity: critical
+        - alert: MimirMemberlistZoneAwareRoutingAutoFailover
+          annotations:
+            message: GEM memberlist in {{ $labels.cluster }}/{{ $labels.namespace }} has automatically temporarily disabled zone-aware routing because it detected missing memberlist bridges.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirmemberlistzoneawareroutingautofailover
+          expr: |
+            sum by (cluster, namespace) (rate(memberlist_client_zone_aware_routing_select_nodes_skipped_total[1m])) > 0
+          for: 10m
+          labels:
+            severity: warning
     - name: golang_alerts
       rules:
         - alert: MimirGoThreadsTooHigh

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -750,6 +750,15 @@ groups:
           for: 10m
           labels:
             severity: critical
+        - alert: MimirMemberlistZoneAwareRoutingAutoFailover
+          annotations:
+            message: Mimir memberlist in {{ $labels.cluster }}/{{ $labels.namespace }} has automatically temporarily disabled zone-aware routing because it detected missing memberlist bridges.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirmemberlistzoneawareroutingautofailover
+          expr: |
+            sum by (cluster, namespace) (rate(memberlist_client_zone_aware_routing_select_nodes_skipped_total[1m])) > 0
+          for: 10m
+          labels:
+            severity: warning
     - name: golang_alerts
       rules:
         - alert: MimirGoThreadsTooHigh

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -1045,6 +1045,19 @@ local utils = import 'mixin-utils/utils.libsonnet';
             message: '%(product)s memberlist-bridge in %(alert_aggregation_variables)s {{ $labels.zone }} has no available pods.' % $._config,
           },
         },
+        {
+          alert: $.alertName('MemberlistZoneAwareRoutingAutoFailover'),
+          expr: |||
+            sum by (%(alert_aggregation_labels)s) (rate(memberlist_client_zone_aware_routing_select_nodes_skipped_total[1m])) > 0
+          ||| % $._config,
+          'for': '10m',
+          labels: {
+            severity: 'warning',
+          },
+          annotations: {
+            message: '%(product)s memberlist in %(alert_aggregation_variables)s has automatically temporarily disabled zone-aware routing because it detected missing memberlist bridges.' % $._config,
+          },
+        },
       ],
     },
     {


### PR DESCRIPTION
#### What this PR does

Adds a new `MimirMemberlistZoneAwareRoutingAutoFailover` alert that fires when memberlist zone-aware routing auto-failover triggers due to missing memberlist bridges in zones where members are running.

When the failover triggers, zone-aware routing is temporarily disabled, which causes inter-AZ data transfer (billed in most cloud providers).

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new alert to detect memberlist zone-aware routing auto-failover due to missing bridges, with runbook docs and regenerated compiled/Helm outputs.
> 
> - **Alerts (mixin/libsonnet)**:
>   - Add `MimirMemberlistZoneAwareRoutingAutoFailover` (warning) detecting zone-aware routing auto-failover via `memberlist_client_zone_aware_routing_select_nodes_skipped_total`.
> - **Compiled outputs**:
>   - Include the new alert in `operations/mimir-mixin-compiled*.yaml` and Helm test `metamonitoring/mixin-alerts.yaml` (messages/runbook URLs adjusted for Mimir/GEM/baremetal).
> - **Documentation**:
>   - Add runbook section for `MimirMemberlistZoneAwareRoutingAutoFailover` explaining behavior and investigation steps.
> - **Changelog**:
>   - Note enhancement adding this alert.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1dcf77aac4aeab6cb7a3cbc01c46423ec151144. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->