### PR TITLE
Remove the experimental conditional artificial delay config options

### DIFF
--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -516,62 +516,6 @@ func TestDistributorIngestionArtificialDelay(t *testing.T) {
 			},
 			expectedDelay: time.Second,
 		},
-		"should apply delay based on 'max series less than' condition if tenant max series is < the threshold": {
-			tenantID: "tenant-a",
-			tenantLimits: func(l *Limits) {
-				l.IngestionArtificialDelayConditionForTenantsWithLessThanMaxSeries = 15001
-				l.IngestionArtificialDelayDurationForTenantsWithLessThanMaxSeries = model.Duration(time.Second)
-				l.MaxGlobalSeriesPerUser = 15000
-			},
-			expectedDelay: time.Second,
-		},
-		"should not apply delay based on 'max series less than' condition if tenant max series is >= the threshold": {
-			tenantID: "tenant-a",
-			tenantLimits: func(l *Limits) {
-				l.IngestionArtificialDelayConditionForTenantsWithLessThanMaxSeries = 15001
-				l.IngestionArtificialDelayDurationForTenantsWithLessThanMaxSeries = model.Duration(time.Second)
-				l.MaxGlobalSeriesPerUser = 15001
-			},
-			expectedDelay: 0,
-		},
-		"should apply delay based on 'tenant ID greater than' condition if tenant ID is numeric and > the condition": {
-			tenantID: "12346",
-			tenantLimits: func(l *Limits) {
-				l.IngestionArtificialDelayConditionForTenantsWithIDGreaterThan = 12345
-				l.IngestionArtificialDelayDurationForTenantsWithIDGreaterThan = model.Duration(time.Second)
-			},
-			expectedDelay: time.Second,
-		},
-		"should not apply delay based on 'tenant ID greater than' condition if tenant ID is numeric and <= the condition": {
-			tenantID: "12345",
-			tenantLimits: func(l *Limits) {
-				l.IngestionArtificialDelayConditionForTenantsWithIDGreaterThan = 12345
-				l.IngestionArtificialDelayDurationForTenantsWithIDGreaterThan = model.Duration(time.Second)
-			},
-			expectedDelay: 0,
-		},
-		"should not apply delay based on 'tenant ID greater than' condition if tenant ID is not numeric": {
-			tenantID: "tenant-123456",
-			tenantLimits: func(l *Limits) {
-				l.IngestionArtificialDelayConditionForTenantsWithIDGreaterThan = 12345
-				l.IngestionArtificialDelayDurationForTenantsWithIDGreaterThan = model.Duration(time.Second)
-			},
-			expectedDelay: 0,
-		},
-		"should apply the highest delay among matching conditions": {
-			tenantID: "12346",
-			tenantLimits: func(l *Limits) {
-				l.IngestionArtificialDelay = model.Duration(300 * time.Millisecond)
-
-				l.IngestionArtificialDelayConditionForTenantsWithLessThanMaxSeries = 15001
-				l.IngestionArtificialDelayDurationForTenantsWithLessThanMaxSeries = model.Duration(200 * time.Millisecond)
-				l.MaxGlobalSeriesPerUser = 15000
-
-				l.IngestionArtificialDelayConditionForTenantsWithIDGreaterThan = 12345
-				l.IngestionArtificialDelayDurationForTenantsWithIDGreaterThan = model.Duration(100 * time.Millisecond)
-			},
-			expectedDelay: 300 * time.Millisecond,
-		},
 	}
 
 	for testName, testData := range tests {


### PR DESCRIPTION
#### What this PR does

Removing the following experimental flags, that were never used and not even announced (e.g. not in the CHANGELOG):

- `-distributor.ingestion-artificial-delay-condition-for-tenants-with-less-than-max-series`
- `-distributor.ingestion-artificial-delay-duration-for-tenants-with-less-than-max-series`
- `-distributor.ingestion-artificial-delay-condition-for-tenants-with-id-greater-than`
- `-distributor.ingestion-artificial-delay-duration-for-tenants-with-id-greater-than`

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the conditional artificial delay flags/fields and tests, simplifying ingestion delay to a single per-tenant `ingestion_artificial_delay`.
> 
> - **Validation limits**:
>   - Remove conditional delay fields and CLI flags from `pkg/util/validation/limits.go` (`IngestionArtificialDelayConditionForTenantsWithLessThanMaxSeries`, `IngestionArtificialDelayDurationForTenantsWithLessThanMaxSeries`, `IngestionArtificialDelayConditionForTenantsWithIDGreaterThan`, `IngestionArtificialDelayDurationForTenantsWithIDGreaterThan`).
>   - Simplify `Overrides.DistributorIngestionArtificialDelay()` to return only `IngestionArtificialDelay`.
>   - Drop now-unused import `strconv`.
> - **Tests**:
>   - Delete test cases covering the removed conditional delay options in `pkg/util/validation/limits_test.go`; keep and validate only the plain delay behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12500a05689ee17026bef55251c971747c2b449c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->