### PR TITLE
update-vendored-mimir-prometheus: Update to Go 1.25.4

### DIFF
--- a/.github/workflows/update-vendored-mimir-prometheus.yml
+++ b/.github/workflows/update-vendored-mimir-prometheus.yml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
         with:
           # We only use this to run `go mod` commands, so it doesn't need to follow the version used in the Dockerfile.
-          go-version: "1.25.2"
+          go-version: "1.25.4"
 
       # This job uses "mimir-vendoring bot" instead of "github-actions bot" (secrets.GITHUB_TOKEN)
       # because any events triggered by the later don't spawn GitHub actions.


### PR DESCRIPTION
#### What this PR does

Mimir recently updated to Go 1.25.4: https://github.com/grafana/mimir/pull/13691

The update-vendored-mimir-prometheus workflow uses its own go installation, separate from the build container, to run `go mod` commands, so this workflow now breaks: https://github.com/grafana/mimir/actions/runs/19910672992/job/57078299265

This PR bumps accordingly to fix that workflow.

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update the Go version in `.github/workflows/update-vendored-mimir-prometheus.yml` from 1.25.2 to 1.25.4.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 310ad509ca0c016299445a334e226d12b6951aea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->