### PR TITLE
[r369] Query-frontend: fix silent panic in remote read API if there's no matcher #13747

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@
 * [BUGFIX]: Ingester: Panic when push and read reactive limiters are enabled with prioritization. #13482
 * [BUGFIX] Query-frontend: Fix excessive CPU and memory consumption when running sharding inside MQE. #13580
 * [BUGFIX] Query-frontend: Fix incorrect query results when running sharding inside MQE is enabled and the query contains a subquery eligible for subquery spin-off wrapped in a shardable aggregation. #13619
+* [BUGFIX] Query-frontend: Fix silent panic when executing a remote read API request if the request has no matchers. #13745
 
 ### Mixin
 

--- a/pkg/frontend/querymiddleware/block_internal_functions.go
+++ b/pkg/frontend/querymiddleware/block_internal_functions.go
@@ -29,7 +29,7 @@ func newBlockInternalFunctionsMiddleware(functionsToBlock FunctionNamesSet, logg
 }
 
 func (b *blockInternalFunctionsMiddleware) Do(ctx context.Context, request MetricsQueryRequest) (Response, error) {
-	expr, err := astmapper.CloneExpr(request.GetParsedQuery())
+	expr, err := request.GetClonedParsedQuery()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/frontend/querymiddleware/codec.go
+++ b/pkg/frontend/querymiddleware/codec.go
@@ -51,6 +51,7 @@ var (
 	errEndBeforeStart = apierror.New(apierror.TypeBadData, `invalid parameter "end": end timestamp must not be before start time`)
 	errNegativeStep   = apierror.New(apierror.TypeBadData, `invalid parameter "step": zero or negative query resolution step widths are not accepted. Try a positive integer`)
 	errStepTooSmall   = apierror.New(apierror.TypeBadData, "exceeded maximum resolution of 11,000 points per timeseries. Try decreasing the query resolution (?step=XX)")
+	errRequestNoQuery = apierror.New(apierror.TypeBadData, "the request has no query")
 	allFormats        = []string{formatJSON, formatProtobuf}
 
 	// List of HTTP headers to propagate when a Prometheus request is encoded into a HTTP request.
@@ -100,8 +101,12 @@ type MetricsQueryRequest interface {
 	GetStep() int64
 	// GetQuery returns the query of the request.
 	GetQuery() string
-	// GetParsedQuery returns the query, parsed into an AST.
-	GetParsedQuery() parser.Expr
+	// GetClonedParsedQuery returns the query, parsed into an AST. The returned query is a clone, so
+	// it's safe to manipulate the returned expression without affecting the expression stored in the
+	// request itself.
+	//
+	// This function returns an error if the query is invalid or the request has no query.
+	GetClonedParsedQuery() (parser.Expr, error)
 	// GetMinT returns the minimum timestamp in milliseconds of data to be queried,
 	// as determined from the start timestamp and any range vector or offset in the query.
 	GetMinT() int64

--- a/pkg/frontend/querymiddleware/durations.go
+++ b/pkg/frontend/querymiddleware/durations.go
@@ -13,7 +13,6 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 
 	apierror "github.com/grafana/mimir/pkg/api/error"
-	"github.com/grafana/mimir/pkg/frontend/querymiddleware/astmapper"
 	"github.com/grafana/mimir/pkg/util/spanlogger"
 )
 
@@ -56,7 +55,7 @@ func (d *durationsMiddleware) rewriteIfNeeded(ctx context.Context, req MetricsQu
 	defer spanLog.Finish()
 
 	origQuery := req.GetQuery()
-	expr, err := astmapper.CloneExpr(req.GetParsedQuery())
+	expr, err := req.GetClonedParsedQuery()
 	if err != nil {
 		// This middleware focuses on duration expressions, so if the query is
 		// not valid, we just fall through to the next handler.

--- a/pkg/frontend/querymiddleware/experimental_functions.go
+++ b/pkg/frontend/querymiddleware/experimental_functions.go
@@ -12,7 +12,6 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 
 	apierror "github.com/grafana/mimir/pkg/api/error"
-	"github.com/grafana/mimir/pkg/frontend/querymiddleware/astmapper"
 )
 
 const (
@@ -59,7 +58,7 @@ func (m *experimentalFunctionsMiddleware) Do(ctx context.Context, req MetricsQue
 		return m.next.Do(ctx, req)
 	}
 
-	expr, err := astmapper.CloneExpr(req.GetParsedQuery())
+	expr, err := req.GetClonedParsedQuery()
 	if err != nil {
 		return nil, apierror.New(apierror.TypeBadData, DecorateWithParamName(err, "query").Error())
 	}

--- a/pkg/frontend/querymiddleware/experimental_functions_test.go
+++ b/pkg/frontend/querymiddleware/experimental_functions_test.go
@@ -3,8 +3,13 @@
 package querymiddleware
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/user"
+	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/stretchr/testify/require"
 )
@@ -61,4 +66,21 @@ func TestContainedExperimentalFunctions(t *testing.T) {
 			require.ElementsMatch(t, tc.expect, enabled)
 		})
 	}
+}
+
+func TestExperimentalFunctionsMiddleware_ShouldNotPanicOnNilQueryExpression(t *testing.T) {
+	inner := mockHandlerWith(nil, nil)
+	middleware := newExperimentalFunctionsMiddleware(mockLimits{}, log.NewNopLogger())
+	handler := middleware.Wrap(inner)
+
+	// Create a request with a nil queryExpr to simulate a failed parse.
+	req := NewPrometheusInstantQueryRequest("/", nil, timestamp.FromTime(time.Now()), 5*time.Minute, nil, Options{}, nil, "")
+
+	ctx := user.InjectOrgID(context.Background(), "test")
+
+	require.NotPanics(t, func() {
+		resp, err := handler.Do(ctx, req)
+		require.ErrorContains(t, err, errRequestNoQuery.Error())
+		require.Nil(t, resp)
+	})
 }

--- a/pkg/frontend/querymiddleware/model_extra.go
+++ b/pkg/frontend/querymiddleware/model_extra.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/grafana/mimir/pkg/frontend/querymiddleware/astmapper"
 	"github.com/grafana/mimir/pkg/mimirpb"
 )
 
@@ -138,8 +139,12 @@ func (r *PrometheusRangeQueryRequest) GetQuery() string {
 	return ""
 }
 
-func (r *PrometheusRangeQueryRequest) GetParsedQuery() parser.Expr {
-	return r.queryExpr
+func (r *PrometheusRangeQueryRequest) GetClonedParsedQuery() (parser.Expr, error) {
+	if r.queryExpr == nil {
+		return nil, errRequestNoQuery
+	}
+
+	return astmapper.CloneExpr(r.queryExpr)
 }
 
 // GetMinT returns the minimum timestamp in milliseconds of data to be queried,
@@ -343,8 +348,12 @@ func (r *PrometheusInstantQueryRequest) GetQuery() string {
 	return ""
 }
 
-func (r *PrometheusInstantQueryRequest) GetParsedQuery() parser.Expr {
-	return r.queryExpr
+func (r *PrometheusInstantQueryRequest) GetClonedParsedQuery() (parser.Expr, error) {
+	if r.queryExpr == nil {
+		return nil, errRequestNoQuery
+	}
+
+	return astmapper.CloneExpr(r.queryExpr)
 }
 
 func (r *PrometheusInstantQueryRequest) GetStart() int64 {

--- a/pkg/frontend/querymiddleware/querysharding.go
+++ b/pkg/frontend/querymiddleware/querysharding.go
@@ -99,7 +99,7 @@ func (s *querySharding) Do(ctx context.Context, r MetricsQueryRequest) (Response
 		return s.next.Do(ctx, r)
 	}
 
-	queryExpr, err := astmapper.CloneExpr(r.GetParsedQuery())
+	queryExpr, err := r.GetClonedParsedQuery()
 	if err != nil {
 		return nil, apierror.New(apierror.TypeBadData, DecorateWithParamName(err, "query").Error())
 	}

--- a/pkg/frontend/querymiddleware/remote_read.go
+++ b/pkg/frontend/querymiddleware/remote_read.go
@@ -282,14 +282,12 @@ func (r *remoteReadQueryRequest) GetQuery() string {
 	return r.promQuery
 }
 
-func (r *remoteReadQueryRequest) GetParsedQuery() parser.Expr {
-	if r.promQuery != "" {
-		expr, err := parser.ParseExpr(r.promQuery)
-		if err == nil {
-			return expr
-		}
+func (r *remoteReadQueryRequest) GetClonedParsedQuery() (parser.Expr, error) {
+	if r.promQuery == "" {
+		return nil, errRequestNoQuery
 	}
-	return nil
+
+	return parser.ParseExpr(r.promQuery)
 }
 
 func (r *remoteReadQueryRequest) GetHeaders() []*PrometheusHeader {

--- a/pkg/frontend/querymiddleware/rewrite.go
+++ b/pkg/frontend/querymiddleware/rewrite.go
@@ -12,7 +12,6 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 
 	apierror "github.com/grafana/mimir/pkg/api/error"
-	"github.com/grafana/mimir/pkg/frontend/querymiddleware/astmapper"
 	"github.com/grafana/mimir/pkg/streamingpromql/optimize/ast"
 	"github.com/grafana/mimir/pkg/util/spanlogger"
 )
@@ -70,7 +69,7 @@ func newRewriteMiddleware(
 func (m *rewriteMiddleware) Do(ctx context.Context, r MetricsQueryRequest) (Response, error) {
 	log := spanlogger.FromContext(ctx, m.logger)
 
-	rewrittenQuery, success, err := m.rewriteQuery(ctx, r.GetParsedQuery())
+	rewrittenQuery, success, err := m.rewriteRequestQuery(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -90,11 +89,12 @@ func (m *rewriteMiddleware) Do(ctx context.Context, r MetricsQueryRequest) (Resp
 	return m.next.Do(ctx, updatedReq)
 }
 
-func (m *rewriteMiddleware) rewriteQuery(ctx context.Context, expr parser.Expr) (parser.Expr, bool, error) {
-	rewrittenQuery, err := astmapper.CloneExpr(expr)
+func (m *rewriteMiddleware) rewriteRequestQuery(ctx context.Context, r MetricsQueryRequest) (parser.Expr, bool, error) {
+	rewrittenQuery, err := r.GetClonedParsedQuery()
 	if err != nil {
 		return nil, false, apierror.New(apierror.TypeBadData, DecorateWithParamName(err, "query").Error())
 	}
+
 	changed := false
 
 	if m.cfg.RewriteQueriesHistogram {

--- a/pkg/frontend/querymiddleware/roundtrip_test.go
+++ b/pkg/frontend/querymiddleware/roundtrip_test.go
@@ -761,7 +761,21 @@ func TestTripperware_RemoteRead(t *testing.T) {
 		expectAPIError      bool
 		expectErrorContains string
 	}{
-		"valid query": {
+		"request without matchers": {
+			makeRequest: func() *http.Request {
+				return makeTestHTTPRequestFromRemoteRead(&prompb.ReadRequest{
+					Queries: []*prompb.Query{
+						{
+							Matchers:         nil,
+							StartTimestampMs: 0,
+							EndTimestampMs:   42,
+						},
+					},
+				})
+			},
+			limits: mockLimits{},
+		},
+		"request with matchers": {
 			makeRequest: func() *http.Request {
 				return makeTestHTTPRequestFromRemoteRead(makeTestRemoteReadRequest())
 			},

--- a/pkg/frontend/querymiddleware/spin_off_subqueries.go
+++ b/pkg/frontend/querymiddleware/spin_off_subqueries.go
@@ -140,7 +140,7 @@ func (s *spinOffSubqueriesMiddleware) Do(ctx context.Context, req MetricsQueryRe
 	defer cancel()
 	mapper := astmapper.NewSubquerySpinOffMapper(s.defaultStepFunc, spanLog, mapperStats)
 
-	expr, err := astmapper.CloneExpr(req.GetParsedQuery())
+	expr, err := req.GetClonedParsedQuery()
 	if err != nil {
 		level.Warn(spanLog).Log("msg", "failed to parse query", "err", err)
 		s.metrics.spinOffSkipped.WithLabelValues(subquerySpinoffSkippedReasonParsingFailed).Inc()

--- a/pkg/frontend/querymiddleware/split_and_cache.go
+++ b/pkg/frontend/querymiddleware/split_and_cache.go
@@ -25,7 +25,6 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	apierror "github.com/grafana/mimir/pkg/api/error"
-	"github.com/grafana/mimir/pkg/frontend/querymiddleware/astmapper"
 	"github.com/grafana/mimir/pkg/querier/stats"
 	"github.com/grafana/mimir/pkg/util/spanlogger"
 	"github.com/grafana/mimir/pkg/util/validation"
@@ -671,7 +670,7 @@ func doRequests(ctx context.Context, downstream MetricsQueryHandler, reqs []Metr
 func splitQueryByInterval(req MetricsQueryRequest, interval time.Duration) ([]MetricsQueryRequest, error) {
 	// Replace @ modifier function to their respective constant values in the query.
 	// This way subqueries will be evaluated at the same time as the parent query.
-	query, err := astmapper.CloneExpr(req.GetParsedQuery())
+	query, err := req.GetClonedParsedQuery()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/frontend/querymiddleware/stats.go
+++ b/pkg/frontend/querymiddleware/stats.go
@@ -13,7 +13,6 @@ import (
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
 
-	"github.com/grafana/mimir/pkg/frontend/querymiddleware/astmapper"
 	"github.com/grafana/mimir/pkg/querier/api"
 	"github.com/grafana/mimir/pkg/querier/stats"
 	"github.com/grafana/mimir/pkg/streamingpromql"
@@ -72,7 +71,7 @@ func (s queryStatsMiddleware) Do(ctx context.Context, req MetricsQueryRequest) (
 }
 
 func (s queryStatsMiddleware) trackRegexpMatchers(req MetricsQueryRequest) {
-	expr, err := astmapper.CloneExpr(req.GetParsedQuery())
+	expr, err := req.GetClonedParsedQuery()
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Backport 8db242818980866f74ea6d85b8394b5fe3d06774 from #13745

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevent panics by introducing a cloned-parse query API and validating missing queries across middlewares and remote read, with tests and a changelog entry.
> 
> - **Query-frontend (middlewares/API)**:
>   - Introduce `MetricsQueryRequest.GetClonedParsedQuery()` returning a cloned AST and error; replace all `GetParsedQuery()` usages.
>   - Add `errRequestNoQuery` and update middlewares (`durations`, `rewrite`, `querysharding`, `spin_off_subqueries`, `experimental_functions`, `block_internal_functions`, `split_and_cache`, `stats`) to safely handle missing/invalid queries.
>   - Remote read: validate/parse PromQL from matchers via `GetClonedParsedQuery()`; return `errRequestNoQuery` when empty; avoid silent panic.
> - **Tests**:
>   - Add no-panic tests for nil query expressions across affected middlewares and query sharding; extend roundtrip tests to cover remote read requests without matchers.
> - **Docs/Changelog**:
>   - Add bugfix entry: remote read no-matchers could cause a silent panic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d99254b5106266a21808621d5bedfb5ee254b9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->