### PR TITLE
MQE: refactor plan decoding

### DIFF
--- a/pkg/frontend/v2/remoteexec_test.go
+++ b/pkg/frontend/v2/remoteexec_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/promql/parser/posrange"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 	"golang.org/x/sync/errgroup"
@@ -1046,7 +1047,7 @@ func TestRemoteExecutor_CorrectlyPassesQueriedTimeRangeAndUpdatesQueryStats(t *t
 	stats, ctx := stats.ContextWithEmptyStats(context.Background())
 	stats.AddRemoteExecutionRequests(12)
 	node := &core.VectorSelector{VectorSelectorDetails: &core.VectorSelectorDetails{}}
-	_, err := executor.startExecution(ctx, &planning.QueryPlan{}, node, timeRange, false, 1)
+	_, err := executor.startExecution(ctx, &planning.QueryParameters{}, node, timeRange, false, 1)
 	require.NoError(t, err)
 
 	require.Equal(t, startT.Add(-cfg.LookBackDelta+time.Millisecond), frontendMock.minT)
@@ -1073,31 +1074,89 @@ func TestRemoteExecutor_SendsQueryPlanVersion(t *testing.T) {
 	timeRange := types.NewInstantQueryTimeRange(time.Now())
 
 	node := &nodeWithOverriddenVersion{
-		Node: &nodeWithOverriddenVersion{
-			Node:    &core.NumberLiteral{NumberLiteralDetails: &core.NumberLiteralDetails{Value: 1234}},
+		child: &nodeWithOverriddenVersion{
+			child:   &core.NumberLiteral{NumberLiteralDetails: &core.NumberLiteralDetails{Value: 1234}},
 			version: 55,
 		},
 		version: 44,
 	}
 
-	fullPlan := &planning.QueryPlan{Version: 66}
-
-	_, err := executor.startExecution(ctx, fullPlan, node, timeRange, false, 1)
+	_, err := executor.startExecution(ctx, &planning.QueryParameters{}, node, timeRange, false, 1)
 	require.NoError(t, err)
 
 	require.NotNil(t, frontendMock.request)
 	require.IsType(t, &querierpb.EvaluateQueryRequest{}, frontendMock.request)
 	request := frontendMock.request.(*querierpb.EvaluateQueryRequest)
-	require.Equal(t, planning.QueryPlanVersion(66), request.Plan.Version, "should set request plan version to match the original plan version")
+	require.Equal(t, planning.QueryPlanVersion(55), request.Plan.Version, "should set request plan version to match the highest version required by all nodes")
 }
 
 type nodeWithOverriddenVersion struct {
-	planning.Node
 	version planning.QueryPlanVersion
+	child   planning.Node
 }
 
 func (n *nodeWithOverriddenVersion) MinimumRequiredPlanVersion() planning.QueryPlanVersion {
 	return n.version
+}
+
+func (n *nodeWithOverriddenVersion) Details() proto.Message {
+	return &core.StringLiteralDetails{Value: "nodeWithOverriddenVersion dummy value"}
+}
+
+func (n *nodeWithOverriddenVersion) NodeType() planning.NodeType {
+	return planning.NODE_TYPE_TEST
+}
+
+func (n *nodeWithOverriddenVersion) Child(idx int) planning.Node {
+	if idx != 0 {
+		panic("invalid child index")
+	}
+
+	return n.child
+}
+
+func (n *nodeWithOverriddenVersion) ChildCount() int {
+	return 1
+}
+
+func (n *nodeWithOverriddenVersion) SetChildren(children []planning.Node) error {
+	panic("not supported")
+}
+
+func (n *nodeWithOverriddenVersion) ReplaceChild(idx int, child planning.Node) error {
+	panic("not supported")
+}
+
+func (n *nodeWithOverriddenVersion) EquivalentToIgnoringHintsAndChildren(other planning.Node) bool {
+	panic("not supported")
+}
+
+func (n *nodeWithOverriddenVersion) MergeHints(other planning.Node) error {
+	panic("not supported")
+}
+
+func (n *nodeWithOverriddenVersion) Describe() string {
+	panic("not supported")
+}
+
+func (n *nodeWithOverriddenVersion) ChildrenLabels() []string {
+	panic("not supported")
+}
+
+func (n *nodeWithOverriddenVersion) ChildrenTimeRange(timeRange types.QueryTimeRange) types.QueryTimeRange {
+	return n.child.ChildrenTimeRange(timeRange)
+}
+
+func (n *nodeWithOverriddenVersion) ResultType() (parser.ValueType, error) {
+	panic("not supported")
+}
+
+func (n *nodeWithOverriddenVersion) QueriedTimeRange(queryTimeRange types.QueryTimeRange, lookbackDelta time.Duration) planning.QueriedTimeRange {
+	return n.child.QueriedTimeRange(queryTimeRange, lookbackDelta)
+}
+
+func (n *nodeWithOverriddenVersion) ExpressionPosition() posrange.PositionRange {
+	panic("not supported")
 }
 
 type requestCapturingFrontendMock struct {

--- a/pkg/querier/dispatcher.go
+++ b/pkg/querier/dispatcher.go
@@ -139,7 +139,7 @@ func (d *Dispatcher) evaluateQuery(ctx context.Context, body []byte, resp *query
 		nodeIndices = append(nodeIndices, node.NodeIndex)
 	}
 
-	plan, nodes, err := req.Plan.ToDecodedPlan(nodeIndices...)
+	nodes, err := req.Plan.DecodeNodes(nodeIndices...)
 	if err != nil {
 		resp.WriteError(ctx, apierror.TypeBadData, fmt.Errorf("could not decode plan: %w", err))
 		return
@@ -170,7 +170,7 @@ func (d *Dispatcher) evaluateQuery(ctx context.Context, body []byte, resp *query
 	}
 
 	opts := promql.NewPrometheusQueryOpts(false, 0)
-	e, err := d.engine.NewEvaluator(ctx, d.queryable, opts, plan, nodeRequests)
+	e, err := d.engine.NewEvaluator(ctx, d.queryable, opts, req.Plan.DecodeParameters(), nodeRequests)
 	if err != nil {
 		resp.WriteError(ctx, apierror.TypeBadData, fmt.Errorf("could not materialize query: %w", err))
 		return

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -1877,7 +1877,7 @@ func TestEvaluator_ReportsMemoryConsumptionLimit(t *testing.T) {
 	plan, err := planner.NewQueryPlan(ctx, expr, types.NewInstantQueryTimeRange(timestamp.Time(0)), NoopPlanningObserver{})
 	require.NoError(t, err)
 
-	evaluator, err := engine.NewEvaluator(ctx, storage, nil, plan, []NodeEvaluationRequest{{Node: plan.Root, TimeRange: plan.TimeRange}})
+	evaluator, err := engine.NewEvaluator(ctx, storage, nil, plan.Parameters, []NodeEvaluationRequest{{Node: plan.Root, TimeRange: plan.Parameters.TimeRange}})
 	require.NoError(t, err)
 
 	err = evaluator.Evaluate(ctx, noopEvaluationObserver{})

--- a/pkg/streamingpromql/operators/binops/vector_scalar_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/vector_scalar_binary_operation.go
@@ -69,7 +69,7 @@ func NewVectorScalarBinaryOperation(
 		Op:                       op,
 		ReturnBool:               returnBool,
 		MemoryConsumptionTracker: opParams.MemoryConsumptionTracker,
-		EnableDelayedNameRemoval: opParams.EnableDelayedNameRemoval,
+		EnableDelayedNameRemoval: opParams.QueryParameters.EnableDelayedNameRemoval,
 
 		timeRange:          timeRange,
 		annotations:        opParams.Annotations,

--- a/pkg/streamingpromql/operators/functions/factories.go
+++ b/pkg/streamingpromql/operators/functions/factories.go
@@ -44,7 +44,7 @@ func SingleInputVectorFunctionOperatorFactory(name string, f FunctionOverInstant
 			return nil, fmt.Errorf("expected an instant vector argument for %s, got %T", name, args[0])
 		}
 
-		return NewFunctionOverInstantVector(inner, nil, opParams.MemoryConsumptionTracker, f, expressionPosition, timeRange, opParams.EnableDelayedNameRemoval), nil
+		return NewFunctionOverInstantVector(inner, nil, opParams.MemoryConsumptionTracker, f, expressionPosition, timeRange, opParams.QueryParameters.EnableDelayedNameRemoval), nil
 	}
 }
 
@@ -87,7 +87,7 @@ func TimeTransformationFunctionOperatorFactory(name string, seriesDataFunc Insta
 			return nil, fmt.Errorf("expected 0 or 1 argument for %s, got %v", name, len(args))
 		}
 
-		return NewFunctionOverInstantVector(inner, nil, opParams.MemoryConsumptionTracker, f, expressionPosition, timeRange, opParams.EnableDelayedNameRemoval), nil
+		return NewFunctionOverInstantVector(inner, nil, opParams.MemoryConsumptionTracker, f, expressionPosition, timeRange, opParams.QueryParameters.EnableDelayedNameRemoval), nil
 	}
 }
 
@@ -130,7 +130,7 @@ func FunctionOverRangeVectorOperatorFactory(
 			return nil, fmt.Errorf("expected a range vector argument for %s, got %T", name, args[0])
 		}
 
-		return NewFunctionOverRangeVector(inner, nil, opParams.MemoryConsumptionTracker, f, opParams.Annotations, expressionPosition, timeRange, opParams.EnableDelayedNameRemoval), nil
+		return NewFunctionOverRangeVector(inner, nil, opParams.MemoryConsumptionTracker, f, opParams.Annotations, expressionPosition, timeRange, opParams.QueryParameters.EnableDelayedNameRemoval), nil
 	}
 }
 
@@ -154,7 +154,7 @@ func PredictLinearFactory(args []types.Operator, _ labels.Labels, opParams *plan
 		return nil, fmt.Errorf("expected second argument for predict_linear to be a scalar, got %T", args[1])
 	}
 
-	var o types.InstantVectorOperator = NewFunctionOverRangeVector(inner, []types.ScalarOperator{arg}, opParams.MemoryConsumptionTracker, f, opParams.Annotations, expressionPosition, timeRange, opParams.EnableDelayedNameRemoval)
+	var o types.InstantVectorOperator = NewFunctionOverRangeVector(inner, []types.ScalarOperator{arg}, opParams.MemoryConsumptionTracker, f, opParams.Annotations, expressionPosition, timeRange, opParams.QueryParameters.EnableDelayedNameRemoval)
 
 	return o, nil
 }
@@ -179,7 +179,7 @@ func QuantileOverTimeFactory(args []types.Operator, _ labels.Labels, opParams *p
 		return nil, fmt.Errorf("expected second argument for quantile_over_time to be a range vector, got %T", args[0])
 	}
 
-	var o types.InstantVectorOperator = NewFunctionOverRangeVector(inner, []types.ScalarOperator{arg}, opParams.MemoryConsumptionTracker, f, opParams.Annotations, expressionPosition, timeRange, opParams.EnableDelayedNameRemoval)
+	var o types.InstantVectorOperator = NewFunctionOverRangeVector(inner, []types.ScalarOperator{arg}, opParams.MemoryConsumptionTracker, f, opParams.Annotations, expressionPosition, timeRange, opParams.QueryParameters.EnableDelayedNameRemoval)
 
 	return o, nil
 }
@@ -241,7 +241,7 @@ func LabelJoinFunctionOperatorFactory(args []types.Operator, _ labels.Labels, op
 		},
 	}
 
-	return NewFunctionOverInstantVector(inner, nil, opParams.MemoryConsumptionTracker, f, expressionPosition, timeRange, opParams.EnableDelayedNameRemoval), nil
+	return NewFunctionOverInstantVector(inner, nil, opParams.MemoryConsumptionTracker, f, expressionPosition, timeRange, opParams.QueryParameters.EnableDelayedNameRemoval), nil
 }
 
 func LabelReplaceFunctionOperatorFactory(args []types.Operator, _ labels.Labels, opParams *planning.OperatorParameters, expressionPosition posrange.PositionRange, timeRange types.QueryTimeRange) (types.Operator, error) {
@@ -287,7 +287,7 @@ func LabelReplaceFunctionOperatorFactory(args []types.Operator, _ labels.Labels,
 		},
 	}
 
-	return NewFunctionOverInstantVector(inner, nil, opParams.MemoryConsumptionTracker, f, expressionPosition, timeRange, opParams.EnableDelayedNameRemoval), nil
+	return NewFunctionOverInstantVector(inner, nil, opParams.MemoryConsumptionTracker, f, expressionPosition, timeRange, opParams.QueryParameters.EnableDelayedNameRemoval), nil
 }
 
 func AbsentOperatorFactory(args []types.Operator, labels labels.Labels, opParams *planning.OperatorParameters, expressionPosition posrange.PositionRange, timeRange types.QueryTimeRange) (types.Operator, error) {
@@ -345,7 +345,7 @@ func ClampFunctionOperatorFactory(args []types.Operator, _ labels.Labels, opPara
 		SeriesMetadataFunction: DropSeriesName,
 	}
 
-	return NewFunctionOverInstantVector(inner, []types.ScalarOperator{min, max}, opParams.MemoryConsumptionTracker, f, expressionPosition, timeRange, opParams.EnableDelayedNameRemoval), nil
+	return NewFunctionOverInstantVector(inner, []types.ScalarOperator{min, max}, opParams.MemoryConsumptionTracker, f, expressionPosition, timeRange, opParams.QueryParameters.EnableDelayedNameRemoval), nil
 }
 
 func ClampMinMaxFunctionOperatorFactory(functionName string, isMin bool) FunctionOperatorFactory {
@@ -372,7 +372,7 @@ func ClampMinMaxFunctionOperatorFactory(functionName string, isMin bool) Functio
 			SeriesMetadataFunction: DropSeriesName,
 		}
 
-		return NewFunctionOverInstantVector(inner, []types.ScalarOperator{clampTo}, opParams.MemoryConsumptionTracker, f, expressionPosition, timeRange, opParams.EnableDelayedNameRemoval), nil
+		return NewFunctionOverInstantVector(inner, []types.ScalarOperator{clampTo}, opParams.MemoryConsumptionTracker, f, expressionPosition, timeRange, opParams.QueryParameters.EnableDelayedNameRemoval), nil
 	}
 }
 
@@ -404,7 +404,7 @@ func RoundFunctionOperatorFactory(args []types.Operator, _ labels.Labels, opPara
 		SeriesMetadataFunction: DropSeriesName,
 	}
 
-	return NewFunctionOverInstantVector(inner, []types.ScalarOperator{toNearest}, opParams.MemoryConsumptionTracker, f, expressionPosition, timeRange, opParams.EnableDelayedNameRemoval), nil
+	return NewFunctionOverInstantVector(inner, []types.ScalarOperator{toNearest}, opParams.MemoryConsumptionTracker, f, expressionPosition, timeRange, opParams.QueryParameters.EnableDelayedNameRemoval), nil
 }
 
 func HistogramQuantileFunctionOperatorFactory(args []types.Operator, _ labels.Labels, opParams *planning.OperatorParameters, expressionPosition posrange.PositionRange, timeRange types.QueryTimeRange) (types.Operator, error) {
@@ -425,7 +425,7 @@ func HistogramQuantileFunctionOperatorFactory(args []types.Operator, _ labels.La
 		return nil, fmt.Errorf("expected an instant vector for 2nd argument for histogram_quantile, got %T", args[1])
 	}
 
-	return NewHistogramQuantileFunction(ph, inner, opParams.MemoryConsumptionTracker, opParams.Annotations, expressionPosition, timeRange, opParams.EnableDelayedNameRemoval), nil
+	return NewHistogramQuantileFunction(ph, inner, opParams.MemoryConsumptionTracker, opParams.Annotations, expressionPosition, timeRange, opParams.QueryParameters.EnableDelayedNameRemoval), nil
 }
 
 func HistogramFractionFunctionOperatorFactory(args []types.Operator, _ labels.Labels, opParams *planning.OperatorParameters, expressionPosition posrange.PositionRange, timeRange types.QueryTimeRange) (types.Operator, error) {
@@ -452,7 +452,7 @@ func HistogramFractionFunctionOperatorFactory(args []types.Operator, _ labels.La
 		return nil, fmt.Errorf("expected an instant vector for 3rd argument for histogram_fraction, got %T", args[2])
 	}
 
-	return NewHistogramFractionFunction(lower, upper, inner, opParams.MemoryConsumptionTracker, opParams.Annotations, expressionPosition, timeRange, opParams.EnableDelayedNameRemoval), nil
+	return NewHistogramFractionFunction(lower, upper, inner, opParams.MemoryConsumptionTracker, opParams.Annotations, expressionPosition, timeRange, opParams.QueryParameters.EnableDelayedNameRemoval), nil
 }
 
 func TimestampFunctionOperatorFactory(args []types.Operator, _ labels.Labels, opParams *planning.OperatorParameters, expressionPosition posrange.PositionRange, timeRange types.QueryTimeRange) (types.Operator, error) {
@@ -475,7 +475,7 @@ func TimestampFunctionOperatorFactory(args []types.Operator, _ labels.Labels, op
 		f.SeriesDataFunc = PassthroughData
 	}
 
-	o := NewFunctionOverInstantVector(inner, nil, opParams.MemoryConsumptionTracker, f, expressionPosition, timeRange, opParams.EnableDelayedNameRemoval)
+	o := NewFunctionOverInstantVector(inner, nil, opParams.MemoryConsumptionTracker, f, expressionPosition, timeRange, opParams.QueryParameters.EnableDelayedNameRemoval)
 	return o, nil
 }
 
@@ -541,7 +541,7 @@ func SortOperatorFactory(descending bool) FunctionOperatorFactory {
 		if timeRange.StepCount != 1 {
 			// If this is a range query, sort / sort_desc does not reorder series, but does drop all histograms like it would for an instant query.
 			f := FunctionOverInstantVectorDefinition{SeriesDataFunc: DropHistograms}
-			return NewFunctionOverInstantVector(inner, nil, opParams.MemoryConsumptionTracker, f, expressionPosition, timeRange, opParams.EnableDelayedNameRemoval), nil
+			return NewFunctionOverInstantVector(inner, nil, opParams.MemoryConsumptionTracker, f, expressionPosition, timeRange, opParams.QueryParameters.EnableDelayedNameRemoval), nil
 		}
 
 		return NewSort(inner, descending, opParams.MemoryConsumptionTracker, expressionPosition), nil
@@ -618,7 +618,7 @@ func UnaryNegationOfInstantVectorOperatorFactory(inner types.InstantVectorOperat
 		SeriesMetadataFunction: DropSeriesName,
 	}
 
-	o := NewFunctionOverInstantVector(inner, nil, opParams.MemoryConsumptionTracker, f, expressionPosition, timeRange, opParams.EnableDelayedNameRemoval)
+	o := NewFunctionOverInstantVector(inner, nil, opParams.MemoryConsumptionTracker, f, expressionPosition, timeRange, opParams.QueryParameters.EnableDelayedNameRemoval)
 	return o
 }
 
@@ -648,7 +648,7 @@ func DoubleExponentialSmoothingFunctionOperatorFactory(args []types.Operator, _ 
 		return nil, fmt.Errorf("expected third argument for %s to be a scalar, got %T", functionName, args[2])
 	}
 
-	return NewFunctionOverRangeVector(inner, []types.ScalarOperator{smoothingFactor, trendFactor}, opParams.MemoryConsumptionTracker, f, opParams.Annotations, expressionPosition, timeRange, opParams.EnableDelayedNameRemoval), nil
+	return NewFunctionOverRangeVector(inner, []types.ScalarOperator{smoothingFactor, trendFactor}, opParams.MemoryConsumptionTracker, f, opParams.Annotations, expressionPosition, timeRange, opParams.QueryParameters.EnableDelayedNameRemoval), nil
 }
 
 func init() {

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/optimization_pass.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/optimization_pass.go
@@ -90,7 +90,7 @@ func (e *OptimizationPass) accumulatePaths(plan *planning.QueryPlan) []path {
 		{
 			node:       plan.Root,
 			childIndex: 0,
-			timeRange:  plan.TimeRange,
+			timeRange:  plan.Parameters.TimeRange,
 		},
 	})
 }

--- a/pkg/streamingpromql/optimize/plan/remoteexec/executor.go
+++ b/pkg/streamingpromql/optimize/plan/remoteexec/executor.go
@@ -15,13 +15,13 @@ import (
 
 type RemoteExecutor interface {
 	// StartScalarExecution submits a request to remotely evaluate an expression that produces a scalar.
-	StartScalarExecution(ctx context.Context, plan *planning.QueryPlan, node planning.Node, timeRange types.QueryTimeRange, memoryConsumptionTracker *limiter.MemoryConsumptionTracker, eagerLoad bool) (ScalarRemoteExecutionResponse, error)
+	StartScalarExecution(ctx context.Context, params *planning.QueryParameters, node planning.Node, timeRange types.QueryTimeRange, memoryConsumptionTracker *limiter.MemoryConsumptionTracker, eagerLoad bool) (ScalarRemoteExecutionResponse, error)
 
 	// StartInstantVectorExecution submits a request to remotely evaluate an expression that produces an instant vector.
-	StartInstantVectorExecution(ctx context.Context, plan *planning.QueryPlan, node planning.Node, timeRange types.QueryTimeRange, memoryConsumptionTracker *limiter.MemoryConsumptionTracker, eagerLoad bool) (InstantVectorRemoteExecutionResponse, error)
+	StartInstantVectorExecution(ctx context.Context, params *planning.QueryParameters, node planning.Node, timeRange types.QueryTimeRange, memoryConsumptionTracker *limiter.MemoryConsumptionTracker, eagerLoad bool) (InstantVectorRemoteExecutionResponse, error)
 
 	// StartRangeVectorExecution submits a request to remotely evaluate an expression that produces a range vector.
-	StartRangeVectorExecution(ctx context.Context, plan *planning.QueryPlan, node planning.Node, timeRange types.QueryTimeRange, memoryConsumptionTracker *limiter.MemoryConsumptionTracker, eagerLoad bool) (RangeVectorRemoteExecutionResponse, error)
+	StartRangeVectorExecution(ctx context.Context, params *planning.QueryParameters, node planning.Node, timeRange types.QueryTimeRange, memoryConsumptionTracker *limiter.MemoryConsumptionTracker, eagerLoad bool) (RangeVectorRemoteExecutionResponse, error)
 }
 
 type ScalarRemoteExecutionResponse interface {

--- a/pkg/streamingpromql/optimize/plan/remoteexec/instant_vector_operator.go
+++ b/pkg/streamingpromql/optimize/plan/remoteexec/instant_vector_operator.go
@@ -14,7 +14,7 @@ import (
 )
 
 type InstantVectorRemoteExec struct {
-	RootPlan                 *planning.QueryPlan
+	QueryParameters          *planning.QueryParameters
 	Node                     planning.Node
 	TimeRange                types.QueryTimeRange
 	RemoteExecutor           RemoteExecutor
@@ -31,7 +31,7 @@ var _ types.InstantVectorOperator = &InstantVectorRemoteExec{}
 
 func (r *InstantVectorRemoteExec) Prepare(ctx context.Context, params *types.PrepareParams) error {
 	var err error
-	r.resp, err = r.RemoteExecutor.StartInstantVectorExecution(ctx, r.RootPlan, r.Node, r.TimeRange, r.MemoryConsumptionTracker, r.EagerLoad)
+	r.resp, err = r.RemoteExecutor.StartInstantVectorExecution(ctx, r.QueryParameters, r.Node, r.TimeRange, r.MemoryConsumptionTracker, r.EagerLoad)
 	return err
 }
 

--- a/pkg/streamingpromql/optimize/plan/remoteexec/node.go
+++ b/pkg/streamingpromql/optimize/plan/remoteexec/node.go
@@ -140,7 +140,7 @@ func (m *RemoteExecutionMaterializer) Materialize(n planning.Node, materializer 
 	switch resultType {
 	case parser.ValueTypeScalar:
 		return planning.NewSingleUseOperatorFactory(&ScalarRemoteExec{
-			RootPlan:                 params.Plan,
+			QueryParameters:          params.QueryParameters,
 			Node:                     r.Inner,
 			TimeRange:                timeRange,
 			RemoteExecutor:           m.executor,
@@ -152,7 +152,7 @@ func (m *RemoteExecutionMaterializer) Materialize(n planning.Node, materializer 
 
 	case parser.ValueTypeVector:
 		return planning.NewSingleUseOperatorFactory(&InstantVectorRemoteExec{
-			RootPlan:                 params.Plan,
+			QueryParameters:          params.QueryParameters,
 			Node:                     r.Inner,
 			TimeRange:                timeRange,
 			RemoteExecutor:           m.executor,
@@ -164,7 +164,7 @@ func (m *RemoteExecutionMaterializer) Materialize(n planning.Node, materializer 
 
 	case parser.ValueTypeMatrix:
 		return planning.NewSingleUseOperatorFactory(&RangeVectorRemoteExec{
-			RootPlan:                 params.Plan,
+			QueryParameters:          params.QueryParameters,
 			Node:                     r.Inner,
 			TimeRange:                timeRange,
 			RemoteExecutor:           m.executor,

--- a/pkg/streamingpromql/optimize/plan/remoteexec/range_vector_operator.go
+++ b/pkg/streamingpromql/optimize/plan/remoteexec/range_vector_operator.go
@@ -14,7 +14,7 @@ import (
 )
 
 type RangeVectorRemoteExec struct {
-	RootPlan                 *planning.QueryPlan
+	QueryParameters          *planning.QueryParameters
 	Node                     planning.Node
 	TimeRange                types.QueryTimeRange
 	RemoteExecutor           RemoteExecutor
@@ -32,7 +32,7 @@ var _ types.RangeVectorOperator = &RangeVectorRemoteExec{}
 
 func (r *RangeVectorRemoteExec) Prepare(ctx context.Context, params *types.PrepareParams) error {
 	var err error
-	r.resp, err = r.RemoteExecutor.StartRangeVectorExecution(ctx, r.RootPlan, r.Node, r.TimeRange, r.MemoryConsumptionTracker, r.EagerLoad)
+	r.resp, err = r.RemoteExecutor.StartRangeVectorExecution(ctx, r.QueryParameters, r.Node, r.TimeRange, r.MemoryConsumptionTracker, r.EagerLoad)
 	return err
 }
 

--- a/pkg/streamingpromql/optimize/plan/remoteexec/scalar_operator.go
+++ b/pkg/streamingpromql/optimize/plan/remoteexec/scalar_operator.go
@@ -14,7 +14,7 @@ import (
 )
 
 type ScalarRemoteExec struct {
-	RootPlan                 *planning.QueryPlan
+	QueryParameters          *planning.QueryParameters
 	Node                     planning.Node
 	TimeRange                types.QueryTimeRange
 	RemoteExecutor           RemoteExecutor
@@ -31,7 +31,7 @@ var _ types.ScalarOperator = &ScalarRemoteExec{}
 
 func (s *ScalarRemoteExec) Prepare(ctx context.Context, params *types.PrepareParams) error {
 	var err error
-	s.resp, err = s.RemoteExecutor.StartScalarExecution(ctx, s.RootPlan, s.Node, s.TimeRange, s.MemoryConsumptionTracker, s.EagerLoad)
+	s.resp, err = s.RemoteExecutor.StartScalarExecution(ctx, s.QueryParameters, s.Node, s.TimeRange, s.MemoryConsumptionTracker, s.EagerLoad)
 	return err
 }
 

--- a/pkg/streamingpromql/planning.go
+++ b/pkg/streamingpromql/planning.go
@@ -230,11 +230,12 @@ func (p *QueryPlanner) NewQueryPlan(ctx context.Context, qs string, timeRange ty
 		}
 
 		plan := &planning.QueryPlan{
-			TimeRange: timeRange,
-			Root:      root,
-
-			OriginalExpression:       qs,
-			EnableDelayedNameRemoval: p.enableDelayedNameRemoval,
+			Root: root,
+			Parameters: &planning.QueryParameters{
+				TimeRange:                timeRange,
+				OriginalExpression:       qs,
+				EnableDelayedNameRemoval: p.enableDelayedNameRemoval,
+			},
 		}
 
 		return plan, nil

--- a/pkg/streamingpromql/planning/plan.go
+++ b/pkg/streamingpromql/planning/plan.go
@@ -50,17 +50,20 @@ const QueryPlanV2 = QueryPlanVersion(2)
 const QueryPlanV3 = QueryPlanVersion(3)
 
 type QueryPlan struct {
-	TimeRange types.QueryTimeRange
-	Root      Node
-
-	OriginalExpression       string
-	EnableDelayedNameRemoval bool
+	Root       Node
+	Parameters *QueryParameters
 
 	// The version of this query plan.
 	//
 	// Queriers use this to ensure they do not attempt to execute a query plan that contains features they
 	// cannot safely or correctly execute (eg. new nodes or new meaning for existing node details).
 	Version QueryPlanVersion
+}
+
+type QueryParameters struct {
+	OriginalExpression       string
+	TimeRange                types.QueryTimeRange
+	EnableDelayedNameRemoval bool
 }
 
 // Node represents a node in the query plan graph.
@@ -217,8 +220,7 @@ type OperatorParameters struct {
 	QueryStats               *types.QueryStats
 	LookbackDelta            time.Duration
 	EagerLoadSelectors       bool
-	Plan                     *QueryPlan
-	EnableDelayedNameRemoval bool
+	QueryParameters          *QueryParameters
 	Logger                   log.Logger
 }
 
@@ -237,9 +239,9 @@ func (p *QueryPlan) ToEncodedPlan(includeDescriptions bool, includeDetails bool,
 	encoder := newQueryPlanEncoder(includeDescriptions, includeDetails)
 
 	encoded := &EncodedQueryPlan{
-		TimeRange:                toEncodedTimeRange(p.TimeRange),
-		OriginalExpression:       p.OriginalExpression,
-		EnableDelayedNameRemoval: p.EnableDelayedNameRemoval,
+		TimeRange:                ToEncodedTimeRange(p.Parameters.TimeRange),
+		OriginalExpression:       p.Parameters.OriginalExpression,
+		EnableDelayedNameRemoval: p.Parameters.EnableDelayedNameRemoval,
 		Version:                  p.Version,
 	}
 
@@ -287,7 +289,7 @@ func (p *QueryPlan) maxMinimumRequiredPlanVersion(node Node) QueryPlanVersion {
 	return maxVersion
 }
 
-func toEncodedTimeRange(t types.QueryTimeRange) EncodedQueryTimeRange {
+func ToEncodedTimeRange(t types.QueryTimeRange) EncodedQueryTimeRange {
 	return EncodedQueryTimeRange{
 		StartT:               t.StartT,
 		EndT:                 t.EndT,
@@ -373,40 +375,32 @@ func NodeTypeName(n Node) string {
 	return reflect.TypeOf(n).Elem().Name()
 }
 
-// ToDecodedPlan converts this encoded plan to its decoded form.
-// It returns references to the specified nodeIndices.
-func (p *EncodedQueryPlan) ToDecodedPlan(nodeIndices ...int64) (*QueryPlan, []Node, error) {
+// DecodeNodes decodes nodes for the provided nodeIndices from the encoded plan.
+func (p *EncodedQueryPlan) DecodeNodes(nodeIndices ...int64) ([]Node, error) {
 	if p.Version > MaximumSupportedQueryPlanVersion {
-		return nil, nil, apierror.Newf(apierror.TypeBadData, "query plan has version %v, but the maximum supported query plan version is %v", p.Version, MaximumSupportedQueryPlanVersion)
-	}
-
-	if p.RootNode < 0 || p.RootNode >= int64(len(p.Nodes)) {
-		return nil, nil, apierror.Newf(apierror.TypeBadData, "root node index %v out of range with %v nodes in plan", p.RootNode, len(p.Nodes))
+		return nil, apierror.Newf(apierror.TypeBadData, "query plan has version %v, but the maximum supported query plan version is %v", p.Version, MaximumSupportedQueryPlanVersion)
 	}
 
 	decoder := newQueryPlanDecoder(p.Nodes)
-	root, err := decoder.decodeNode(p.RootNode)
-
-	if err != nil {
-		return nil, nil, err
-	}
 
 	nodes := make([]Node, 0, len(nodeIndices))
 	for _, idx := range nodeIndices {
 		n, err := decoder.decodeNode(idx)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		nodes = append(nodes, n)
 	}
 
-	return &QueryPlan{
-		TimeRange:                p.TimeRange.ToDecodedTimeRange(),
-		Root:                     root,
+	return nodes, nil
+}
+
+func (p *EncodedQueryPlan) DecodeParameters() *QueryParameters {
+	return &QueryParameters{
 		OriginalExpression:       p.OriginalExpression,
+		TimeRange:                p.TimeRange.ToDecodedTimeRange(),
 		EnableDelayedNameRemoval: p.EnableDelayedNameRemoval,
-		Version:                  p.Version,
-	}, nodes, nil
+	}
 }
 
 type queryPlanDecoder struct {

--- a/pkg/streamingpromql/planning_test.go
+++ b/pkg/streamingpromql/planning_test.go
@@ -1407,15 +1407,18 @@ func TestPlanCreationEncodingAndDecoding(t *testing.T) {
 			require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expectedMetrics), "cortex_mimir_query_engine_plans_generated_total"))
 
 			// Encode plan, confirm it matches what we expect
-			encoded, nodes, err := originalPlan.ToEncodedPlan(true, true)
+			encoded, nodeIndices, err := originalPlan.ToEncodedPlan(true, true)
 			require.NoError(t, err)
 			require.Equal(t, testCase.expectedPlan, encoded)
-			require.Equal(t, []int64{testCase.expectedPlan.RootNode}, nodes)
+			require.Equal(t, []int64{testCase.expectedPlan.RootNode}, nodeIndices)
 
-			// Decode plan, confirm it matches the original plan
-			decodedPlan, _, err := encoded.ToDecodedPlan()
+			// Decode plan tree from root node, confirm it matches the original plan
+			nodes, err := encoded.DecodeNodes(encoded.RootNode)
 			require.NoError(t, err)
-			require.Equal(t, originalPlan, decodedPlan)
+			require.Len(t, nodes, 1)
+			require.Equal(t, originalPlan.Root, nodes[0])
+
+			require.Equal(t, originalPlan.Parameters, encoded.DecodeParameters())
 		})
 	}
 }
@@ -1494,9 +1497,11 @@ func TestPlanVersioning(t *testing.T) {
 
 	// Plan has a node which has a min required plan version of 9000
 	plan := &planning.QueryPlan{
-		TimeRange:          types.NewInstantQueryTimeRange(time.Now()),
-		Root:               newTestNode(9000),
-		OriginalExpression: "123",
+		Root: newTestNode(9000),
+		Parameters: &planning.QueryParameters{
+			TimeRange:          types.NewInstantQueryTimeRange(time.Now()),
+			OriginalExpression: "123",
+		},
 	}
 
 	err := plan.DeterminePlanVersion()
@@ -1506,9 +1511,12 @@ func TestPlanVersioning(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, planning.QueryPlanVersion(9000), encoded.Version)
 
-	decoded, _, err := encoded.ToDecodedPlan()
+	nodes, err := encoded.DecodeNodes(encoded.RootNode)
 	require.NoError(t, err)
-	require.Equal(t, plan, decoded)
+	require.Len(t, nodes, 1)
+	require.Equal(t, plan.Root, nodes[0])
+
+	require.Equal(t, plan.Parameters, encoded.DecodeParameters())
 }
 
 func TestDeduplicateAndMergePlanning(t *testing.T) {
@@ -1704,7 +1712,7 @@ func BenchmarkPlanEncodingAndDecoding(b *testing.B) {
 						require.NoError(b, err)
 					}
 
-					_, _, err = unmarshalled.ToDecodedPlan()
+					_, err = unmarshalled.DecodeNodes(unmarshalled.RootNode)
 					if err != nil {
 						require.NoError(b, err)
 					}
@@ -1764,7 +1772,7 @@ func TestDecodingInvalidPlan(t *testing.T) {
 					},
 				},
 			},
-			expectedError: "root node index 1 out of range with 1 nodes in plan",
+			expectedError: "node index 1 out of range with 1 nodes in plan",
 		},
 		"negative root node index": {
 			input: &planning.EncodedQueryPlan{
@@ -1779,7 +1787,7 @@ func TestDecodingInvalidPlan(t *testing.T) {
 					},
 				},
 			},
-			expectedError: "root node index -1 out of range with 1 nodes in plan",
+			expectedError: "node index -1 out of range with 1 nodes in plan",
 		},
 		"child node index out of range": {
 			input: &planning.EncodedQueryPlan{
@@ -1888,9 +1896,8 @@ func TestDecodingInvalidPlan(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			output, _, err := testCase.input.ToDecodedPlan()
+			_, err := testCase.input.DecodeNodes(testCase.input.RootNode)
 			require.EqualError(t, err, testCase.expectedError)
-			require.Nil(t, output)
 		})
 	}
 }


### PR DESCRIPTION
#### What this PR does

This PR refactors query plan decoding in MQE. Specifically, it replaces the `EncodedQueryPlan.ToDecodedPlan()` method with `DecodeNodes` and `DecodeParameters` methods. 

A full query plan doesn't make sense in the context of a querier receiving a remote execution request, and so this change removes this awkwardness in the model.

I've chosen not to add a changelog entry given this is a user-invisible refactoring.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/pull/13685#discussion_r2574950442

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces full plan decoding with node/parameter decoding and propagates QueryParameters throughout executor, engine, dispatcher, operators, and tests.
> 
> - **Planning/Encoding**:
>   - Add `planning.QueryParameters` and move `TimeRange`, `OriginalExpression`, and `EnableDelayedNameRemoval` into it.
>   - Replace `EncodedQueryPlan.ToDecodedPlan()` with `DecodeNodes()` and `DecodeParameters()`; export `ToEncodedTimeRange`.
>   - `QueryPlan.ToEncodedPlan()` now returns node indices (supports partial-node encoding); `DeterminePlanVersion()` used more broadly.
> - **Frontend/Remote Exec**:
>   - `RemoteExecutor` methods now accept `*planning.QueryParameters` instead of full `QueryPlan`.
>   - Frontend builds a subset `QueryPlan` with `Parameters`, determines version, encodes specific `node` indices, and sends per-node `TimeRange`.
> - **Querier/Engine**:
>   - Dispatcher decodes requested nodes via `DecodeNodes()` and materializes using `DecodeParameters()`.
>   - Engine/materializer APIs accept `QueryParameters`; `OperatorParameters` stores `QueryParameters` instead of `Plan`.
>   - Use `plan.Parameters.*` throughout (eg. statement time range).
> - **Operators/Functions**:
>   - Use `opParams.QueryParameters.EnableDelayedNameRemoval` instead of `opParams.EnableDelayedNameRemoval`.
> - **Optimization**:
>   - CSE pass reads `plan.Parameters.TimeRange`.
> - **Tests**:
>   - Updated to new APIs, assertions (including error messages) and plan version logic; added coverage for highest node-required version propagation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2aa44563b495f39fd09e46dd2deccc6cb1dc0707. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->