### PR TITLE
index planning: define local Statistics interface

### DIFF
--- a/pkg/ingester/lookupplan/branch_and_bound.go
+++ b/pkg/ingester/lookupplan/branch_and_bound.go
@@ -9,7 +9,6 @@ import (
 	"math"
 
 	"github.com/prometheus/prometheus/model/labels"
-	"github.com/prometheus/prometheus/tsdb/index"
 
 	"github.com/grafana/mimir/pkg/storage/sharding"
 )
@@ -64,7 +63,7 @@ func (pq plans) Iterator() iter.Seq[plan] {
 
 // generatePlansBranchAndBound uses branch-and-bound to explore the space of possible plans.
 // It prunes branches that cannot possibly lead to a better plan than the current best.
-func (p CostBasedPlanner) generatePlansBranchAndBound(ctx context.Context, statistics index.Statistics, matchers []*labels.Matcher, pools *costBasedPlannerPools, shard *sharding.ShardSelector) iter.Seq[plan] {
+func (p CostBasedPlanner) generatePlansBranchAndBound(ctx context.Context, statistics Statistics, matchers []*labels.Matcher, pools *costBasedPlannerPools, shard *sharding.ShardSelector) iter.Seq[plan] {
 	// Initialize priority queue with the root plan (all predicates undecided)
 	prospectPlans := pools.GetPlans(maxPlansForPlanning)
 

--- a/pkg/ingester/lookupplan/mock_statistics_test.go
+++ b/pkg/ingester/lookupplan/mock_statistics_test.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 )
 
-// mockStatistics implements the index.Statistics interface with hardcoded data for testing
+// mockStatistics implements the Statistics interface with hardcoded data for testing
 type mockStatistics struct {
 	// seriesPerValue maps label name -> label value -> number of series
 	seriesPerValue map[string]map[string]uint64

--- a/pkg/ingester/lookupplan/plan.go
+++ b/pkg/ingester/lookupplan/plan.go
@@ -7,7 +7,6 @@ import (
 	"slices"
 
 	"github.com/prometheus/prometheus/model/labels"
-	"github.com/prometheus/prometheus/tsdb/index"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
@@ -38,7 +37,7 @@ type plan struct {
 }
 
 // newScanOnlyPlan returns a plan in which all predicates would be used to scan and none to reach from the index.
-func newScanOnlyPlan(ctx context.Context, stats index.Statistics, config CostConfig, matchers []*labels.Matcher, predicatesPool *pool.SlabPool[bool], shard *sharding.ShardSelector) plan {
+func newScanOnlyPlan(ctx context.Context, stats Statistics, config CostConfig, matchers []*labels.Matcher, predicatesPool *pool.SlabPool[bool], shard *sharding.ShardSelector) plan {
 	p := plan{
 		predicates:          make([]planPredicate, 0, len(matchers)),
 		indexPredicate:      make([]bool, 0, len(matchers)),
@@ -58,7 +57,7 @@ func newScanOnlyPlan(ctx context.Context, stats index.Statistics, config CostCon
 	return p
 }
 
-func newIndexOnlyPlan(ctx context.Context, stats index.Statistics, config CostConfig, matchers []*labels.Matcher, predicatesPool *pool.SlabPool[bool], shard *sharding.ShardSelector) plan {
+func newIndexOnlyPlan(ctx context.Context, stats Statistics, config CostConfig, matchers []*labels.Matcher, predicatesPool *pool.SlabPool[bool], shard *sharding.ShardSelector) plan {
 	p := newScanOnlyPlan(ctx, stats, config, matchers, predicatesPool, shard)
 	for i := range p.indexPredicate {
 		p.indexPredicate[i] = true

--- a/pkg/ingester/lookupplan/planner.go
+++ b/pkg/ingester/lookupplan/planner.go
@@ -70,11 +70,11 @@ func (p *costBasedPlannerPools) Release() {
 
 type CostBasedPlanner struct {
 	config  CostConfig
-	stats   index.Statistics
+	stats   Statistics
 	metrics Metrics
 }
 
-func NewCostBasedPlanner(metrics Metrics, statistics index.Statistics, config CostConfig) *CostBasedPlanner {
+func NewCostBasedPlanner(metrics Metrics, statistics Statistics, config CostConfig) *CostBasedPlanner {
 	return &CostBasedPlanner{
 		config:  config,
 		metrics: metrics,

--- a/pkg/ingester/lookupplan/statistics.go
+++ b/pkg/ingester/lookupplan/statistics.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package lookupplan
+
+import "context"
+
+// Statistics provides cardinality information about a TSDB component for query planning.
+type Statistics interface {
+	// TotalSeries returns the number of series in the TSDB component.
+	TotalSeries() uint64
+
+	// LabelValuesCount returns the number of values for a label name. If the given label name does not exist,
+	// it is valid to return 0.
+	LabelValuesCount(ctx context.Context, name string) uint64
+
+	// LabelValuesCardinality returns the cardinality of a given label name (i.e., the number of series which
+	// contain that label name). If values are provided, it returns the combined cardinality of all given values;
+	// otherwise, it returns the total cardinality across all values for the label name. If the label name does not exist,
+	// it returns 0.
+	LabelValuesCardinality(ctx context.Context, name string, values ...string) uint64
+}

--- a/pkg/ingester/lookupplan/stats.go
+++ b/pkg/ingester/lookupplan/stats.go
@@ -50,7 +50,7 @@ func setCountMinEpsilon(smallLabelCardinalityThreshold, largeLabelCardinalityThr
 }
 
 // Stats creates statistics using count-min sketches
-func (g StatisticsGenerator) Stats(meta tsdb.BlockMeta, r tsdb.IndexReader, smallLabelCardinalityThreshold, largeLabelCardinalityThreshold uint64) (retStats index.Statistics, retErr error) {
+func (g StatisticsGenerator) Stats(meta tsdb.BlockMeta, r tsdb.IndexReader, smallLabelCardinalityThreshold, largeLabelCardinalityThreshold uint64) (retStats Statistics, retErr error) {
 	ctx := context.Background()
 
 	defer func(startTime time.Time) {
@@ -136,7 +136,7 @@ func (g StatisticsGenerator) Stats(meta tsdb.BlockMeta, r tsdb.IndexReader, smal
 }
 
 // BlockStatistics contains count-min sketches of the values for each label name in a TSDB block.
-// It implements index.Statistics, which can be used to inform query plan generation.
+// It implements Statistics, which can be used to inform query plan generation.
 type BlockStatistics struct {
 	totalSeries uint64
 	labelNames  map[string]*LabelValuesSketch


### PR DESCRIPTION
## What

Define a local `Statistics` interface in the lookupplan package instead of relying on `index.Statistics` from Prometheus TSDB.

## Why

The stats were moved in this repo with https://github.com/grafana/mimir/pull/12607 so there's no need to be referring to the interface from mimir-prometheus

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a local `Statistics` interface in `lookupplan` and migrate planner, predicates, and stats generator to use it instead of `tsdb/index.Statistics`.
> 
> - **Core API**:
>   - Add `lookupplan.Statistics` interface (`pkg/ingester/lookupplan/statistics.go`).
>   - Replace all usages of `index.Statistics` with `lookupplan.Statistics` in planner, plan construction, and predicates.
> - **Planner/Plans**:
>   - Update `CostBasedPlanner` to hold `Statistics` and adjust constructors/signatures (`planner.go`).
>   - Update plan generation (`generatePlansBranchAndBound`), `newScanOnlyPlan`, `newIndexOnlyPlan`, and predicate creation to accept `Statistics` (in `branch_and_bound.go`, `plan.go`, `predicate.go`).
> - **Stats generation**:
>   - `StatisticsGenerator.Stats` now returns `lookupplan.Statistics` and `BlockStatistics` documents implementation of this interface (`stats.go`).
> - **Tests**:
>   - Convert mock to implement `lookupplan.Statistics` (`mock_statistics_test.go`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9069fab799a8d7357dfbe2c88a5ebfd966501903. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->