### PR TITLE
Update MQE team members tagged when Prometheus vendoring PR fails `pkg/streamingpromql` tests

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -199,7 +199,7 @@ jobs:
           ${{ env.FAILED_PACKAGES }}
           \`\`\`
               
-          cc @charleskorn @56quarters @lamida @zenador @Konstantinov-Innokentii 
+          cc @charleskorn @56quarters @lamida @zenador @tcp13equals2
               
           Please review the [test logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) and push fixes to this PR."
           fi


### PR DESCRIPTION
#### What this PR does

This PR updates the list of people tagged in a comment like [this one](https://github.com/grafana/mimir/pull/13784#issuecomment-3629128759) when a Prometheus vendoring PR fails unit tests in the `pkg/streamingpromql` package.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the CI workflow to change who is @-mentioned when `pkg/streamingpromql` tests fail on vendored Prometheus PRs.
> 
> - **CI (GitHub Actions)**:
>   - Update `test` job failure comment in `.github/workflows/test-build-deploy.yml` to replace `@Konstantinov-Innokentii` with `@tcp13equals2` in the `pkg/streamingpromql` failure notification.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4625180090ddeeb49e043f708c0421cac092f993. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->