### PR TITLE
fix(docs): Fix Thanos sidecar migration doc

### DIFF
--- a/docs/sources/mimir/set-up/migrate/migrate-from-thanos-to-mimir-with-thanos-sidecar.md
+++ b/docs/sources/mimir/set-up/migrate/migrate-from-thanos-to-mimir-with-thanos-sidecar.md
@@ -25,7 +25,7 @@ This is not so much of a guide as it is a collection of configurations that have
 
 There are very few obstacles to get this working properly. Thanos Sidecar is designed to work with the Prometheus API which Mimir (almost) implements. There are only 2 endpoints that are not implemented that we need to "spoof" to get Thanos sidecar to believe it is connecting to a Prometheus server: `/api/v1/status/buildinfo` and `/api/v1/status/config`. We spoof these endpoints using NGINX (more details later).
 
-In addition the `/metrics` endpoint of the Prometheus server needs to be handled via NGINX configuration. Since Thanos version `v0.37.0` the sidecar evaluates the `prometheus_tsdb_lowest_timestamp_seconds` to get the lowest timestamp in the tsdb database (see https://github.com/thanos-io/thanos/pull/7820).
+In addition, you need to handle the `/metrics` endpoint of the Prometheus server through NGINX configuration. Since Thanos version `v0.37.0`, the sidecar evaluates the `prometheus_tsdb_lowest_timestamp_seconds` to get the lowest timestamp in the TSDB database. Refer to https://github.com/thanos-io/thanos/pull/7820.
 
 The only other roadblock is the requirement for requests to Mimir to contain the `X-Scope-Org-Id` header to identify the Tenant. We inject this header using another NGINX container sitting in between Thanos Sidecar and Mimir.
 


### PR DESCRIPTION
Since Thanos version `v0.37.0` the documentation is broken due to https://github.com/thanos-io/thanos/pull/7820. Update the documentation accordingly.

#### What this PR does

Updates the "Migrate from Thanos to Mimir using Thanos sidecar" documentation.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add NGINX `/prometheus/metrics` spoofing to the Thanos sidecar migration doc to support Thanos ≥ v0.37.0.
> 
> - **Docs (Mimir migration via Thanos sidecar)**:
>   - Add requirement and NGINX config to spoof `GET /prometheus/metrics`, returning `prometheus_tsdb_lowest_timestamp_seconds 0` (gzip/plaintext), to satisfy Thanos >= `v0.37.0`.
>   - Update technical details to mention `/metrics` handling alongside existing spoofed endpoints `.../status/config` and `.../status/buildinfo`.
>   - Reflect the new `/prometheus/metrics` location in the full Mimir distributed NGINX example.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f65b37ae451567651ab000cbb2e3fabe12898e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->