### PR TITLE
Jsonnet: allow to selectively configure ZPDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,7 @@
 * [CHANGE] Store-gateway: The store-gateway disk class now honors the one configured via `$._config.store_gateway_data_disk_class` and doesn't replace `fast` with `fast-dont-retain`. #13152
 * [CHANGE] Rollout-operator: Vendor jsonnet from rollout-operator repository. #13245 #13317 #13793 #13799
 * [CHANGE] Ruler: Set default memory ballast to 1GiB to reduce GC pressure during startup. #13376
+* [CHANGE] Zone pod disruption budget: Remove `multi_zone_zpdb_enabled` and replace it with `multi_zone_ingester_zpdb_enabled` and `multi_zone_store_gateway_zpdb_enabled` to allow to selectively enable the zone pod disruption budget on a per-component basis. #13813
 * [FEATURE] Add multi-zone support for read path components (memcached, querier, query-frontend, query-scheduler, ruler, and ruler remote evaluation stack). Add multi-AZ support for ingester and store-gateway multi-zone deployments. Add memberlist-bridge support for zone-aware memberlist routing. #13559 #13628 #13636
 * [ENHANCEMENT] Ruler querier and query-frontend: Add support for newly-introduced querier ring, which is used when performing query planning in query-frontends and distributing portions of the plan to queriers for execution. #13017
 * [ENHANCEMENT] Ingester: Increase `$._config.ingester_tsdb_head_early_compaction_min_in_memory_series` default when Mimir is running with the ingest storage architecture. #13450

--- a/operations/mimir/multi-zone-common.libsonnet
+++ b/operations/mimir/multi-zone-common.libsonnet
@@ -2,9 +2,6 @@ local jsonpath = import 'github.com/jsonnet-libs/xtd/jsonpath.libsonnet';
 
 {
   _config+: {
-    // Use a zone aware pod disruption budget for ingester and/or store-gateways
-    multi_zone_zpdb_enabled: $._config.multi_zone_ingester_enabled || $._config.multi_zone_store_gateway_enabled,
-
     // Ordered list of availability zones where multi-zone components should be deployed to.
     // Mimir zone-a deployments are scheduled to the first AZ in the list, zone-b deployment to the second AZ,
     // and zone-c deployments to the third AZ. Maximum 3 AZs are supported.
@@ -36,7 +33,6 @@ local jsonpath = import 'github.com/jsonnet-libs/xtd/jsonpath.libsonnet';
     ],
   },
 
-  assert !$._config.multi_zone_zpdb_enabled || $._config.rollout_operator_webhooks_enabled : 'zpdb configuration requires rollout_operator_webhooks_enabled=true',
   assert std.length($._config.multi_zone_availability_zones) <= 3 : 'Mimir jsonnet supports a maximum of 3 availability zones',
 
   //


### PR DESCRIPTION
#### What this PR does

In this PR I'm proposing a jsonnet change to allow to selectively configure ZPDB on a per-component basis: remove `multi_zone_zpdb_enabled` and replace it with `multi_zone_ingester_zpdb_enabled` and `multi_zone_store_gateway_zpdb_enabled`.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make ZPDB selectable per component by replacing the global flag with `multi_zone_ingester_zpdb_enabled` and `multi_zone_store_gateway_zpdb_enabled` and updating PDB logic accordingly.
> 
> - **Jsonnet (multi-zone)**:
>   - Introduce per-component ZPDB toggles: `multi_zone_ingester_zpdb_enabled` and `multi_zone_store_gateway_zpdb_enabled` (default to their component enablement).
>   - Replace uses of global `multi_zone_zpdb_enabled`; update assertions to check `rollout_operator_webhooks_enabled` per component.
>   - Update rollout PDB creation to conditionally use `$.newZPDB(...)` based on the new per-component flags.
>   - Remove obsolete assertion and config related to the global ZPDB flag in `operations/mimir/multi-zone-common.libsonnet`.
> - **Docs**:
>   - Update `CHANGELOG.md` with the config change and rationale.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16e039032d397c5ec70f0ceaef347e9a206fd591. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->