### PR TITLE
compactor: verify that TSDB uploads use index format v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [CHANGE] Limits: removed the experimental `cost_attribution_labels` configuration option. Use `cost_attribution_labels_structured` instead. #13286
 * [CHANGE] Ingester: Renamed `cortex_ingest_storage_writer_buffered_produce_bytes` metric to `cortex_ingest_storage_writer_buffered_produce_bytes_distribution` (Prometheus summary), and added `cortex_ingest_storage_writer_buffered_produce_bytes` metric that exports the buffer size as a Prometheus Gauge. #13414
 * [CHANGE] Querier and query-frontend: Removed support for per-step stats when MQE is enabled. #13582
+* [CHANGE] Compactor: Require that uploaded TSDB blocks use v2 of the index file format. #13815
 * [CHANGE] Query-frontend: Removed support for calculating 'cache-adjusted samples processed' query statistic. The `-query-frontend.cache-samples-processed-stats` CLI flag has been deprecated and will be removed in a future release. Setting it has now no effect. #13582
 * [CHANGE] Querier: Renamed experimental flag `-querier.prefer-availability-zone` to `-querier.prefer-availability-zones` and changed it to accept a comma-separated list of availability zones. All zones in the list are given equal priority when querying ingesters and store-gateways. #13756 #13758
 * [CHANGE] Ingester: Stabilize experimental flag `-ingest-storage.write-logs-fsync-before-kafka-commit-concurrency` to fsync write logs before the offset is committed to Kafka. Remove `-ingest-storage.write-logs-fsync-before-kafka-commit-enabled` since this is always enabled now. #13591


### PR DESCRIPTION
#### What this PR does

Verify that the TSDB block index file uses v2 for the file format, not v1. The v1 format was only used for Prometheus 2.0 and 2.1 as far as I can tell. It hasn't been the default format for new blocks since Prometheus 2.2 and has never been the default for Mimir.

#### Which issue(s) this PR fixes or relates to

Part of #13808

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces v2 TSDB index format on uploaded blocks by validating index version during health checks, adds tests, and updates the changelog.
> 
> - **Compactor / TSDB index validation**:
>   - Add `HealthStats.IndexFormat` and `UnsupportedIndexFormat()`; only `v2` (`index.FormatV2`) is accepted via `SupportedIndexFormats`.
>   - `GatherBlockHealthStats()` records index file version; `AnyErr()` now fails on unsupported formats.
>   - Tests cover new validation and existing error paths (`TestHealthStats_AnyErr`).
> - **Docs**:
>   - Update `CHANGELOG.md`: require uploaded TSDB blocks to use v2 index format.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2477fd9fd076c6657512d2f0d82760f37f6e0a31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->