### PR TITLE
Jsonnet: export newStatefulSetDeletionProtectionPolicy()

### DIFF
--- a/operations/mimir/deletion-protection.libsonnet
+++ b/operations/mimir/deletion-protection.libsonnet
@@ -11,7 +11,7 @@
 
   // Helper function to create a deletion protection policy for StatefulSets.
   // The policy blocks deletion of StatefulSets whose name starts with the given name.
-  local newStatefulSetDeletionProtectionPolicy(name) = {
+  newStatefulSetDeletionProtectionPolicy(name):: {
     local policyName = '%s-%s-deletion-protection' % [$._config.namespace, name],
 
     policy:
@@ -39,12 +39,12 @@
   },
 
   // Ingester deletion protection
-  local ingesterProtection = newStatefulSetDeletionProtectionPolicy('ingester'),
+  local ingesterProtection = $.newStatefulSetDeletionProtectionPolicy('ingester'),
   ingester_deletion_protection_policy: if !$._config.ingester_deletion_protection_enabled then null else ingesterProtection.policy,
   ingester_deletion_protection_policy_binding: if !$._config.ingester_deletion_protection_enabled then null else ingesterProtection.binding,
 
   // Store-gateway deletion protection
-  local storeGatewayProtection = newStatefulSetDeletionProtectionPolicy('store-gateway'),
+  local storeGatewayProtection = $.newStatefulSetDeletionProtectionPolicy('store-gateway'),
   store_gateway_deletion_protection_policy: if !$._config.store_gateway_deletion_protection_enabled then null else storeGatewayProtection.policy,
   store_gateway_deletion_protection_policy_binding: if !$._config.store_gateway_deletion_protection_enabled then null else storeGatewayProtection.binding,
 }


### PR DESCRIPTION
#### What this PR does

Follow up of https://github.com/grafana/mimir/pull/13819, where I've forgot to export `newStatefulSetDeletionProtectionPolicy()` (I need in a downstream project too).

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Exports the StatefulSet deletion-protection helper and updates internal references to use the exported symbol.
> 
> - **Libsonnet (deletion protection)**:
>   - Export `newStatefulSetDeletionProtectionPolicy(name)` using `::`.
>   - Update usages to reference `$.newStatefulSetDeletionProtectionPolicy` for `ingester` and `store-gateway` policies.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96cf380e06d752e67f32fa644a1781e645edfd78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->