### PR TITLE
CHANGELOG: Downgrade some CHANGEs to ENHANCEMENTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,6 @@
 * [ENHANCEMENT] Server: The `/metrics` endpoint now supports metrics filtering by providing one or more `name[]` query parameters. #13746
 * [ENHANCEMENT] Ingester: Make sharded active-series requests matching all series faster. #13491
 * [ENHANCEMENT] Partitions ring: Add support to forcefully lock a partition state through the web UI. #13811
-* [ENHANCEMENT] Build: Upgrade Go to 1.25.4. #13691
 * [ENHANCEMENT] API: The `/api/v1/user_limits` endpoint is now stable and no longer experimental. #13218
 * [ENHANCEMENT] Ingester: limiting CPU and memory utilized by the read path (`-ingester.read-path-cpu-utilization-limit` and `-ingester.read-path-memory-utilization-limit`) is now considered stable. #13167
 * [ENHANCEMENT] Querier: `-querier.max-estimated-fetched-chunks-per-query-multiplier` is now stable and no longer experimental. #13120


### PR DESCRIPTION
#### What this PR does

Where a change was purely updating a feature from experimental to stable (or "advanced"), don't list it as a CHANGE.

CHANGE is supposed to be for breaking changes, that an admin must know about before upgrading.

The Go 1.25.4 update line is removed, since there is already a line for Go 1.25.5.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reclassifies multiple items from CHANGE to ENHANCEMENT (features promoted from experimental to stable) and removes the unreleased Go 1.25.4 build entry.
> 
> - **Changelog (main/unreleased)**:
>   - **Reclassified to `ENHANCEMENT`** (from `CHANGE`):
>     - API: `/api/v1/user_limits`, `/api/v1/cardinality/active_series` now stable.
>     - Ingester: read-path utilization limits; out-of-order ingestion support stable.
>     - Querier: max estimated fetched chunks multiplier; active-series results size limit stable.
>     - Query-frontend: query blocking stable.
>     - Ruler: `align_evaluation_time_on_interval` stable.
>     - Alertmanager: UTF-8 strict mode stable.
>     - Logging: rate-limiting config stable.
>   - **Removed**: unreleased `Build: Upgrade Go to 1.25.4` entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7ad6505b51a31fa6ef719044ce20567cb16580f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->