### PR TITLE
Include more information in `bucket index corrupted` errors

### DIFF
--- a/pkg/querier/blocks_finder_bucket_index_test.go
+++ b/pkg/querier/blocks_finder_bucket_index_test.go
@@ -163,7 +163,7 @@ func TestBucketIndexBlocksFinder_GetBlocks_BucketIndexIsCorrupted(t *testing.T) 
 	require.NoError(t, bkt.Upload(ctx, path.Join(userID, bucketindex.IndexCompressedFilename), strings.NewReader("invalid}!")))
 
 	_, err := finder.GetBlocks(ctx, userID, 10, 20)
-	require.Equal(t, bucketindex.ErrIndexCorrupted, err)
+	require.ErrorIs(t, err, bucketindex.ErrIndexCorrupted)
 }
 
 func TestBucketIndexBlocksFinder_GetBlocks_BucketIndexIsTooOld(t *testing.T) {

--- a/pkg/storage/tsdb/bucketindex/loader_test.go
+++ b/pkg/storage/tsdb/bucketindex/loader_test.go
@@ -112,7 +112,7 @@ func TestLoader_GetIndex_ShouldCacheError(t *testing.T) {
 	// Request the index multiple times.
 	for i := 0; i < 10; i++ {
 		_, err := loader.GetIndex(ctx, "user-1")
-		require.Equal(t, ErrIndexCorrupted, err)
+		require.ErrorIs(t, err, ErrIndexCorrupted)
 	}
 
 	// Ensure metrics have been updated accordingly.
@@ -328,7 +328,7 @@ func TestLoader_ShouldUpdateIndexInBackgroundOnPreviousLoadFailure(t *testing.T)
 	})
 
 	_, err := loader.GetIndex(ctx, "user-1")
-	assert.Equal(t, ErrIndexCorrupted, err)
+	assert.ErrorIs(t, err, ErrIndexCorrupted)
 
 	// Upload the bucket index.
 	idx := &Index{

--- a/pkg/storage/tsdb/bucketindex/storage.go
+++ b/pkg/storage/tsdb/bucketindex/storage.go
@@ -10,6 +10,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/go-kit/log"
@@ -47,7 +48,7 @@ func ReadIndex(ctx context.Context, bkt objstore.Bucket, userID string, cfgProvi
 	// Read all the content.
 	gzipReader, err := gzip.NewReader(reader)
 	if err != nil {
-		return nil, ErrIndexCorrupted
+		return nil, fmt.Errorf("%w: %w", ErrIndexCorrupted, err)
 	}
 	defer runutil.CloseWithLogOnErr(logger, gzipReader, "close bucket index gzip reader")
 
@@ -55,7 +56,7 @@ func ReadIndex(ctx context.Context, bkt objstore.Bucket, userID string, cfgProvi
 	index := &Index{}
 	d := json.NewDecoder(gzipReader)
 	if err := d.Decode(index); err != nil {
-		return nil, ErrIndexCorrupted
+		return nil, fmt.Errorf("%w: %w", ErrIndexCorrupted, err)
 	}
 
 	return index, nil

--- a/pkg/storage/tsdb/bucketindex/storage_test.go
+++ b/pkg/storage/tsdb/bucketindex/storage_test.go
@@ -37,7 +37,7 @@ func TestReadIndex_ShouldReturnErrorIfIndexIsCorrupted(t *testing.T) {
 	require.NoError(t, bkt.Upload(ctx, path.Join(userID, IndexCompressedFilename), strings.NewReader("invalid!}")))
 
 	idx, err := ReadIndex(ctx, bkt, userID, nil, log.NewNopLogger())
-	require.Equal(t, ErrIndexCorrupted, err)
+	require.ErrorIs(t, err, ErrIndexCorrupted)
 	require.Nil(t, idx)
 }
 


### PR DESCRIPTION
#### What this PR does

This PR adds more information to errors returned when the bucket index can't be decoded.

At present, if the bucket index can't be decoded for any reason, then a `bucket index corrupted` error is returned, but this doesn't include any information about what has gone wrong. (In the case I was investigating, I suspect the context was cancelled, and so the bucket index was not actually corrupted.)

I've chosen not to add a changelog entry given this is a minor change to an error message.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wrap `ErrIndexCorrupted` with the underlying gzip/JSON error in `ReadIndex` and update tests to assert with `ErrorIs`.
> 
> - **Storage (bucket index)**:
>   - `ReadIndex` now wraps decode/open failures as `ErrIndexCorrupted` with the underlying error (`fmt.Errorf("%w: %w", ...)`).
>   - Add `fmt` import.
> - **Tests**:
>   - Update assertions to use `require.ErrorIs`/`assert.ErrorIs` for `ErrIndexCorrupted` in `pkg/querier/blocks_finder_bucket_index_test.go`, `pkg/storage/tsdb/bucketindex/loader_test.go`, and `pkg/storage/tsdb/bucketindex/storage_test.go`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34d3610fc214683f0dfb4516b4bff98ea18948ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->