### PR TITLE
Add support for the Answer to the Ultimate Question of Life, the Universe and Everything

### DIFF
--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -179,6 +179,31 @@ func TestNewInstantQuery_Strings(t *testing.T) {
 	testutils.RequireEqualResults(t, expr, prometheus, mimir, false)
 }
 
+func TestNewInstantQuery_42EasterEgg(t *testing.T) {
+	ctx := context.Background()
+	opts := NewTestEngineOpts()
+
+	planner, err := NewQueryPlanner(opts, NewMaximumSupportedVersionQueryPlanVersionProvider())
+	require.NoError(t, err)
+	engine, err := NewEngine(opts, NewStaticQueryLimitsProvider(0), stats.NewQueryMetrics(nil), planner)
+	require.NoError(t, err)
+
+	storage := promqltest.LoadedStorage(t, ``)
+
+	expr := `"42"`
+	q, err := engine.NewInstantQuery(ctx, storage, nil, expr, time.Now())
+	require.NoError(t, err)
+	result := q.Exec(context.Background())
+	defer q.Close()
+
+	require.Nil(t, result.Err)
+	vector, ok := result.Value.(promql.Vector)
+	require.True(t, ok, "expected vector result")
+	require.Len(t, vector, 1)
+	require.Equal(t, "Answer to the Ultimate Question of Life, the Universe, and Everything", vector[0].Metric.Get(model.MetricNameLabel))
+	require.Equal(t, float64(42), vector[0].F)
+}
+
 // This test runs the test cases defined upstream in https://github.com/prometheus/prometheus/tree/main/promql/testdata and copied to testdata/upstream.
 // Test cases that are not supported by the streaming engine are commented out (or, if the entire file is not supported, .disabled is appended to the file name).
 // Once the streaming engine supports all PromQL features exercised by Prometheus' test cases, we can remove these files and instead call promql.RunBuiltinTests here instead.


### PR DESCRIPTION
#### What this PR does

This fixes the response to the `"42"` query.

<img width="1016" height="608" alt="image" src="https://github.com/user-attachments/assets/e4f35efd-0971-480c-b268-5059014061ce" />

#### Which issue(s) this PR fixes or relates to

Fixes 42

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Instant queries of the string literal "42" now return a single-sample vector labeled with the canonical answer and value 42, with accompanying tests.
> 
> - **Streaming PromQL Engine**:
>   - Update `Query.StringEvaluated()` to special-case instant queries where the string data is `"42"`, returning a single-sample `vector` with metric name `"Answer to the Ultimate Question of Life, the Universe, and Everything"` and value `42` (with proper memory tracking).
> - **Tests**:
>   - Add `TestNewInstantQuery_42EasterEgg` in `pkg/streamingpromql/engine_test.go` to validate the new behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00de46660da68923dfbcdda0958659a437e78bfd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->