### PR TITLE
mimirpb: copy custom values and ensure via exhaustruct

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,6 +25,7 @@ linters:
     - misspell
     - revive
     - staticcheck
+    - exhaustruct
   settings:
     # path to a file containing a list of functions to exclude from checking
     # see https://github.com/kisielk/errcheck#excluding-functions for details
@@ -83,6 +84,9 @@ linters:
         - -ST1020
         - -ST1021
         - -ST1022
+    exhaustruct:
+      exclude:
+        - .*
   exclusions:
     presets:
       - comments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@
 * [ENHANCEMENT] Query-frontend: query blocking (configured with `blocked_queries` limit) is now stable and no longer experimental. #13107
 * [ENHANCEMENT] Querier: `-querier.active-series-results-max-size-bytes` is now stable and no longer experimental. #13110
 * [ENHANCEMENT] API: The `/api/v1/cardinality/active_series` endpoint is now stable and no longer experimental. #13111
+* [BUGFIX] Distributor: Fix issue where distributors didn't send custom values of native histograms. #13849
 * [BUGFIX] Compactor: Fix potential concurrent map writes. #13053
 * [BUGFIX] Query-frontend: Fix issue where queries sometimes fail with `failed to receive query result stream message: rpc error: code = Canceled desc = context canceled` if remote execution is enabled. #13084
 * [BUGFIX] Query-frontend: Fix issue where query stats, such as series read, did not include the parameters to the `histogram_quantile` and `histogram_fraction` functions if remote execution was enabled. #13084

--- a/pkg/mimirpb/timeseries.go
+++ b/pkg/mimirpb/timeseries.go
@@ -798,6 +798,7 @@ func copyHistogram(src Histogram) Histogram {
 		dstZeroCount = &Histogram_ZeroCountFloat{ZeroCountFloat: src.GetZeroCountFloat()}
 	}
 
+	//exhaustruct:enforce
 	return Histogram{
 		Count:          dstCount,
 		Sum:            src.Sum,
@@ -812,6 +813,7 @@ func copyHistogram(src Histogram) Histogram {
 		PositiveCounts: slices.Clone(src.PositiveCounts),
 		ResetHint:      src.ResetHint,
 		Timestamp:      src.Timestamp,
+		CustomValues:   slices.Clone(src.CustomValues),
 	}
 }
 

--- a/pkg/mimirpb/timeseries_test.go
+++ b/pkg/mimirpb/timeseries_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -124,16 +125,20 @@ func TestDeepCopyTimeseries(t *testing.T) {
 			},
 			Histograms: []Histogram{
 				{
-					Timestamp:      4*time.Minute.Milliseconds() - 1,
 					Count:          &Histogram_CountInt{CountInt: 35},
 					Sum:            108,
-					ZeroCount:      &Histogram_ZeroCountInt{ZeroCountInt: 2},
+					Schema:         histogram.CustomBucketsSchema,
 					ZeroThreshold:  0.01,
+					ZeroCount:      &Histogram_ZeroCountInt{ZeroCountInt: 2},
 					NegativeSpans:  []BucketSpan{{Offset: -1, Length: 1}, {Offset: -2, Length: 1}},
 					NegativeDeltas: []int64{7, 3},
+					NegativeCounts: []float64{8, 9},
 					PositiveSpans:  []BucketSpan{{Offset: 0, Length: 1}, {Offset: 2, Length: 1}},
 					PositiveDeltas: []int64{2, 21},
+					PositiveCounts: []float64{6, 7},
 					ResetHint:      Histogram_UNKNOWN,
+					Timestamp:      4*time.Minute.Milliseconds() - 1,
+					CustomValues:   []float64{3, 4},
 				},
 			},
 			Exemplars: []Exemplar{{
@@ -209,6 +214,14 @@ func TestDeepCopyTimeseries(t *testing.T) {
 		assert.NotEqual(t,
 			// Ignore deprecation warning for now
 			//nolint:staticcheck
+			(*reflect.SliceHeader)(unsafe.Pointer(&src.Histograms[histogramIdx].NegativeCounts)).Data,
+			// Ignore deprecation warning for now
+			//nolint:staticcheck
+			(*reflect.SliceHeader)(unsafe.Pointer(&dst.Histograms[histogramIdx].NegativeCounts)).Data,
+		)
+		assert.NotEqual(t,
+			// Ignore deprecation warning for now
+			//nolint:staticcheck
 			(*reflect.SliceHeader)(unsafe.Pointer(&src.Histograms[histogramIdx].PositiveSpans)).Data,
 			// Ignore deprecation warning for now
 			//nolint:staticcheck
@@ -221,6 +234,22 @@ func TestDeepCopyTimeseries(t *testing.T) {
 			// Ignore deprecation warning for now
 			//nolint:staticcheck
 			(*reflect.SliceHeader)(unsafe.Pointer(&dst.Histograms[histogramIdx].PositiveDeltas)).Data,
+		)
+		assert.NotEqual(t,
+			// Ignore deprecation warning for now
+			//nolint:staticcheck
+			(*reflect.SliceHeader)(unsafe.Pointer(&src.Histograms[histogramIdx].PositiveCounts)).Data,
+			// Ignore deprecation warning for now
+			//nolint:staticcheck
+			(*reflect.SliceHeader)(unsafe.Pointer(&dst.Histograms[histogramIdx].PositiveCounts)).Data,
+		)
+		assert.NotEqual(t,
+			// Ignore deprecation warning for now
+			//nolint:staticcheck
+			(*reflect.SliceHeader)(unsafe.Pointer(&src.Histograms[histogramIdx].CustomValues)).Data,
+			// Ignore deprecation warning for now
+			//nolint:staticcheck
+			(*reflect.SliceHeader)(unsafe.Pointer(&dst.Histograms[histogramIdx].CustomValues)).Data,
 		)
 	}
 


### PR DESCRIPTION
#### What this PR does

This PR correctly copies custom values in `mimirpb` package and ensures that via lints.

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures `Histogram.CustomValues` are cloned in deep copies and adds `exhaustruct` linting; tests and changelog updated accordingly.
> 
> - **mimirpb**:
>   - `copyHistogram()`: also clones `Histogram.CustomValues`; add `//exhaustruct:enforce` to ensure struct fields are exhaustively set.
> - **Tests**:
>   - Extend `DeepCopyTimeseries` tests to cover `NegativeCounts`, `PositiveCounts`, and `CustomValues`; set `Schema` via Prometheus `histogram.CustomBucketsSchema`.
> - **Linting**:
>   - Enable `exhaustruct` in `.golangci.yml` with a global exclude pattern.
> - **Changelog**:
>   - Add bugfix entry about distributors not sending native histogram custom values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00173d73a96591657297def3086feb1923582c43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->