### PR TITLE
jsonnet: include query config in overrides-exporter args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,7 @@
 * [ENHANCEMENT] Ingester: Set `-ingester.partition-ring.delete-inactive-partition-after` based on  `-querier.query-ingesters-within`. #13550
 * [ENHANCEMENT] Add extra, **experimental**, KEDA ScaledObject trigger to prevent from down-scaling during OOM kills, if memory trigger is disabled and `$._config.autoscaling_oom_protection_enabled` is true. #13509
 * [ENHANCEMENT] Multi-zone: Make config validation exclusions configurable via `multi_zone_config_validation_excluded_args` and `multi_zone_config_validation_excluded_env_vars`, and add validation for multi-zone distributor deployments. #13728
+* [ENHANCEMENT] Overrides-exporter: Include query configuration so that query limit defaults are reported accurately. #13850
 * [BUGFIX] Ingester: Fix `$._config.ingest_storage_ingester_autoscaling_max_owned_series_threshold` default value, to compute it based on the configured `$._config.ingester_instance_limits.max_series`. #13448
 
 ### Documentation

--- a/operations/mimir-tests/test-helm-parity.jsonnet
+++ b/operations/mimir-tests/test-helm-parity.jsonnet
@@ -33,6 +33,10 @@ mimir {
   // We unset them all here so the default values are used like in Helm.
   // At that point there will likely be less deviation between components.
   // See the tracking issue: https://github.com/grafana/mimir/issues/2749
+  overrides_exporter_args+:: {
+    'querier.max-partial-query-length': null,
+  },
+
   querier_args+:: {
     'querier.max-partial-query-length': null,
   },

--- a/operations/mimir/overrides-exporter.libsonnet
+++ b/operations/mimir/overrides-exporter.libsonnet
@@ -28,6 +28,7 @@
   overrides_exporter_args::
     $._config.commonConfig +
     $._config.limitsConfig +
+    $._config.queryConfig +
     $._config.overridesExporterRingConfig +
     $.mimirRuntimeConfigFile +
     {


### PR DESCRIPTION
#### What this PR does

The overrides exporter needs the configuration used for queriers to accurately report all limits and their default values.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Include query configuration in overrides-exporter args, add test parity override, and update the changelog.
> 
> - **Jsonnet**:
>   - `operations/mimir/overrides-exporter.libsonnet`: Include `$._config.queryConfig` in `overrides_exporter_args` so query-related limits are exported.
> - **Tests**:
>   - `operations/mimir-tests/test-helm-parity.jsonnet`: Add `overrides_exporter_args` parity override (`'querier.max-partial-query-length': null`).
> - **Changelog**:
>   - Add enhancement entry noting overrides-exporter now includes query configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4257fb8deb5875a44cea236b08f60b83de0e5e3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->