### PR TITLE
[DO NOT REVIEW] Compactor: Keep bucket index update progress across failed cleanUser() runs

### DIFF
--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -535,7 +535,7 @@ func (c *MultitenantCompactor) starting(ctx context.Context) error {
 		GetDeletionMarkersConcurrency: defaultGetDeletionMarkersConcurrency,
 		UpdateBlocksConcurrency:       c.compactorCfg.UpdateBlocksConcurrency,
 		CompactionBlockRanges:         c.compactorCfg.BlockRanges,
-	}, c.bucketClient, c.shardingStrategy.blocksCleanerOwnsUser, c.cfgProvider, c.parentLogger, c.registerer)
+	}, c.bucketClient, c.shardingStrategy.blocksCleanerOwnsUser, c.cfgProvider, c.compactorCfg.DataDir, c.parentLogger, c.registerer)
 
 	// Start blocks cleaner asynchronously, don't wait until initial cleanup is finished.
 	if err := c.blocksCleaner.StartAsync(ctx); err != nil {

--- a/pkg/storage/tsdb/bucketindex/local_cache.go
+++ b/pkg/storage/tsdb/bucketindex/local_cache.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package bucketindex
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/runutil"
+
+	"github.com/grafana/mimir/pkg/util/atomicfs"
+)
+
+const (
+	inProgressIndexFilename = "in-progress-index.json.gz"
+	cleanerCacheDir         = "cleaner-cache"
+)
+
+// InProgressIndex stores an in-progress bucket index along with metadata
+// needed to determine if it's still valid to use.
+type InProgressIndex struct {
+	// The in-progress bucket index.
+	Index *Index `json:"index"`
+
+	// BaseUpdatedAt is the UpdatedAt timestamp of the bucket index that was read
+	// from object storage before running UpdateIndex(). This is used to detect
+	// if another compactor updated the bucket index while we were working.
+	// If 0, it means we started from scratch (no index existed in object storage).
+	BaseUpdatedAt int64 `json:"base_updated_at"`
+
+	// CreatedAt is a unix timestamp (seconds precision) of when this in-progress
+	// index was saved.
+	CreatedAt int64 `json:"created_at"`
+}
+
+// inProgressIndexPath returns the path to the in-progress index file for a user.
+func inProgressIndexPath(dataDir, userID string) string {
+	return filepath.Join(dataDir, cleanerCacheDir, userID, inProgressIndexFilename)
+}
+
+// WriteInProgressIndex writes the in-progress index to disk atomically.
+// The file is written to a temporary location and then renamed to ensure
+// atomicity. If dataDir is empty, this function returns nil without doing anything.
+func WriteInProgressIndex(dataDir, userID string, idx *InProgressIndex, logger log.Logger) error {
+	if dataDir == "" {
+		return nil
+	}
+
+	path := inProgressIndexPath(dataDir, userID)
+
+	// Ensure directory exists.
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+
+	// Marshal the index to JSON.
+	content, err := json.Marshal(idx)
+	if err != nil {
+		return err
+	}
+
+	// Compress it.
+	var gzipContent bytes.Buffer
+	gzipWriter := gzip.NewWriter(&gzipContent)
+	gzipWriter.Name = inProgressIndexFilename
+
+	if _, err := gzipWriter.Write(content); err != nil {
+		return err
+	}
+	if err := gzipWriter.Close(); err != nil {
+		return err
+	}
+
+	// Write atomically using atomicfs.
+	if err := atomicfs.CreateFile(path, bytes.NewReader(gzipContent.Bytes())); err != nil {
+		return err
+	}
+
+	level.Debug(logger).Log("msg", "wrote in-progress index to disk", "path", path, "created_at", time.Unix(idx.CreatedAt, 0))
+	return nil
+}
+
+// ReadInProgressIndex reads the in-progress index from disk.
+// Returns (nil, nil) if the file doesn't exist.
+// If dataDir is empty, returns (nil, nil).
+func ReadInProgressIndex(dataDir, userID string, logger log.Logger) (*InProgressIndex, error) {
+	if dataDir == "" {
+		return nil, nil
+	}
+
+	path := inProgressIndexPath(dataDir, userID)
+
+	f, err := os.Open(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer runutil.CloseWithLogOnErr(logger, f, "close in-progress index file")
+
+	gzipReader, err := gzip.NewReader(f)
+	if err != nil {
+		return nil, err
+	}
+	defer runutil.CloseWithLogOnErr(logger, gzipReader, "close in-progress index gzip reader")
+
+	var idx InProgressIndex
+	if err := json.NewDecoder(gzipReader).Decode(&idx); err != nil {
+		return nil, err
+	}
+
+	level.Debug(logger).Log("msg", "read in-progress index from disk", "path", path, "created_at", time.Unix(idx.CreatedAt, 0), "base_updated_at", idx.BaseUpdatedAt)
+	return &idx, nil
+}
+
+// DeleteInProgressIndex removes the in-progress index file.
+// It's a no-op if the file doesn't exist or dataDir is empty.
+func DeleteInProgressIndex(dataDir, userID string, logger log.Logger) error {
+	if dataDir == "" {
+		return nil
+	}
+
+	path := inProgressIndexPath(dataDir, userID)
+	err := os.Remove(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err == nil {
+		level.Debug(logger).Log("msg", "deleted in-progress index file", "path", path)
+	}
+	return err
+}

--- a/pkg/storage/tsdb/bucketindex/local_cache_test.go
+++ b/pkg/storage/tsdb/bucketindex/local_cache_test.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package bucketindex
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInProgressIndex_WriteAndRead(t *testing.T) {
+	logger := log.NewNopLogger()
+	tmpDir := t.TempDir()
+	userID := "test-user"
+
+	idx := &Index{
+		Version:   IndexVersion2,
+		UpdatedAt: time.Now().Unix(),
+		Blocks: []*Block{
+			{
+				ID:      ulid.MustNew(1, nil),
+				MinTime: 1000,
+				MaxTime: 2000,
+			},
+		},
+		BlockDeletionMarks: []*BlockDeletionMark{
+			{
+				ID:           ulid.MustNew(2, nil),
+				DeletionTime: time.Now().Unix(),
+			},
+		},
+	}
+
+	inProgressIdx := &InProgressIndex{
+		Index:         idx,
+		BaseUpdatedAt: 12345,
+		CreatedAt:     time.Now().Unix(),
+	}
+
+	// Write the index.
+	err := WriteInProgressIndex(tmpDir, userID, inProgressIdx, logger)
+	require.NoError(t, err)
+
+	// Verify the file exists.
+	path := inProgressIndexPath(tmpDir, userID)
+	_, err = os.Stat(path)
+	require.NoError(t, err)
+
+	// Read the index back.
+	readIdx, err := ReadInProgressIndex(tmpDir, userID, logger)
+	require.NoError(t, err)
+	require.NotNil(t, readIdx)
+
+	// Verify the content.
+	assert.Equal(t, inProgressIdx.BaseUpdatedAt, readIdx.BaseUpdatedAt)
+	assert.Equal(t, inProgressIdx.CreatedAt, readIdx.CreatedAt)
+	assert.Equal(t, len(inProgressIdx.Index.Blocks), len(readIdx.Index.Blocks))
+	assert.Equal(t, len(inProgressIdx.Index.BlockDeletionMarks), len(readIdx.Index.BlockDeletionMarks))
+	assert.Equal(t, inProgressIdx.Index.Version, readIdx.Index.Version)
+}
+
+func TestInProgressIndex_ReadNonExistent(t *testing.T) {
+	logger := log.NewNopLogger()
+	tmpDir := t.TempDir()
+	userID := "test-user"
+
+	// Read a non-existent index.
+	readIdx, err := ReadInProgressIndex(tmpDir, userID, logger)
+	require.NoError(t, err)
+	assert.Nil(t, readIdx)
+}
+
+func TestInProgressIndex_Delete(t *testing.T) {
+	logger := log.NewNopLogger()
+	tmpDir := t.TempDir()
+	userID := "test-user"
+
+	idx := &Index{
+		Version:   IndexVersion2,
+		UpdatedAt: time.Now().Unix(),
+	}
+
+	inProgressIdx := &InProgressIndex{
+		Index:         idx,
+		BaseUpdatedAt: 12345,
+		CreatedAt:     time.Now().Unix(),
+	}
+
+	// Write the index.
+	err := WriteInProgressIndex(tmpDir, userID, inProgressIdx, logger)
+	require.NoError(t, err)
+
+	// Verify it exists.
+	path := inProgressIndexPath(tmpDir, userID)
+	_, err = os.Stat(path)
+	require.NoError(t, err)
+
+	// Delete it.
+	err = DeleteInProgressIndex(tmpDir, userID, logger)
+	require.NoError(t, err)
+
+	// Verify it's gone.
+	_, err = os.Stat(path)
+	require.True(t, os.IsNotExist(err))
+
+	// Deleting again should not error.
+	err = DeleteInProgressIndex(tmpDir, userID, logger)
+	require.NoError(t, err)
+}
+
+func TestInProgressIndex_EmptyDataDir(t *testing.T) {
+	logger := log.NewNopLogger()
+	userID := "test-user"
+
+	idx := &Index{
+		Version:   IndexVersion2,
+		UpdatedAt: time.Now().Unix(),
+	}
+
+	inProgressIdx := &InProgressIndex{
+		Index:         idx,
+		BaseUpdatedAt: 12345,
+		CreatedAt:     time.Now().Unix(),
+	}
+
+	// Write with empty dataDir should succeed but do nothing.
+	err := WriteInProgressIndex("", userID, inProgressIdx, logger)
+	require.NoError(t, err)
+
+	// Read with empty dataDir should return nil.
+	readIdx, err := ReadInProgressIndex("", userID, logger)
+	require.NoError(t, err)
+	assert.Nil(t, readIdx)
+
+	// Delete with empty dataDir should succeed but do nothing.
+	err = DeleteInProgressIndex("", userID, logger)
+	require.NoError(t, err)
+}
+
+func TestInProgressIndex_CorruptedFile(t *testing.T) {
+	logger := log.NewNopLogger()
+	tmpDir := t.TempDir()
+	userID := "test-user"
+
+	// Create a corrupted file.
+	path := inProgressIndexPath(tmpDir, userID)
+	err := os.MkdirAll(filepath.Dir(path), 0755)
+	require.NoError(t, err)
+
+	err = os.WriteFile(path, []byte("corrupted data"), 0644)
+	require.NoError(t, err)
+
+	// Reading the corrupted file should return an error.
+	readIdx, err := ReadInProgressIndex(tmpDir, userID, logger)
+	require.Error(t, err)
+	assert.Nil(t, readIdx)
+}
+
+func TestInProgressIndex_AtomicWrite(t *testing.T) {
+	logger := log.NewNopLogger()
+	tmpDir := t.TempDir()
+	userID := "test-user"
+
+	idx := &Index{
+		Version:   IndexVersion2,
+		UpdatedAt: time.Now().Unix(),
+	}
+
+	inProgressIdx := &InProgressIndex{
+		Index:         idx,
+		BaseUpdatedAt: 12345,
+		CreatedAt:     time.Now().Unix(),
+	}
+
+	// Write the index.
+	err := WriteInProgressIndex(tmpDir, userID, inProgressIdx, logger)
+	require.NoError(t, err)
+
+	// Verify the temporary file was cleaned up.
+	path := inProgressIndexPath(tmpDir, userID)
+	tmpPath := path + ".tmp"
+	_, err = os.Stat(tmpPath)
+	require.True(t, os.IsNotExist(err), "temporary file should be cleaned up")
+
+	// Verify the final file exists.
+	_, err = os.Stat(path)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
# ⚠️ DO NOT REVIEW - Work in Progress

This PR is not ready for review yet. It's a draft to track progress on implementing a fix for https://github.com/grafana/pir-actions/issues/402.

---

## What this PR does

This PR implements caching of in-progress bucket index updates in the compactor's BlocksCleaner. When `cleanUser()` fails after successfully updating the bucket index, the updated index is now saved to local disk. On the next run, this cached index is loaded and validated, allowing cleanup to resume from where it left off instead of starting from scratch.

**Key changes:**
- New `local_cache.go` in `pkg/storage/tsdb/bucketindex/` with functions to read/write/delete in-progress index cache
- Modified `cleanUser()` in `blocks_cleaner.go` to:
  - Load cached in-progress index at startup (if available)
  - Validate cache staleness by comparing with object storage index
  - Save in-progress index on failure (via defer)
  - Delete cache on successful completion
- Updated `NewBlocksCleaner()` to accept `dataDir` parameter
- Added comprehensive unit tests for cache operations

**Benefits:**
- Reduces duplicated work (re-listing blocks, re-fetching meta.json) for long-running cleanup jobs
- Increases likelihood of completing cleanup for tenants with large block counts
- Cache is automatically invalidated if another compactor updates the index

## Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/pir-actions/issues/402

## Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

## TODO before marking ready for review

- [ ] Add CHANGELOG entry
- [ ] Add integration test for cache behavior
- [ ] Update documentation if needed
- [ ] Run full test suite
- [ ] Address any feedback from initial review