### PR TITLE
docs: clarify backfill visibility delay and add examples

### DIFF
--- a/docs/sources/mimir/manage/tools/mimirtool.md
+++ b/docs/sources/mimir/manage/tools/mimirtool.md
@@ -1195,7 +1195,7 @@ INFO[0001] finished uploading blocks                already_exists=1 failed=0 su
 ```
 
 {{< admonition type="note" >}}
-Backfilled data visibility depends on the sample timestamps in the uploaded blocks. Sometimes data can appear more than 12 hours after upload
+Backfilled data visibility depends on the sample timestamps in the uploaded blocks. Sometimes data can appear more than 12 hours after upload.
 {{< /admonition >}}
 
 ## License


### PR DESCRIPTION
This pull request adds a note to the documentation to clarify how backfilled data appears after uploading blocks. The note explains that data visibility can be delayed and may show up more than 12 hours after upload, depending on sample timestamps.

Documentation improvement:

* Added an admonition note to `docs/sources/mimir/manage/tools/mimirtool.md` explaining that backfilled data visibility depends on sample timestamps, and data may appear more than 12 hours after upload.

Fixes https://github.com/grafana/support-escalations/issues/15003

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a note to `docs/sources/mimir/manage/tools/mimirtool.md` stating backfilled data visibility depends on sample timestamps and may appear more than 12 hours after upload.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09b58fe16a8fdc3b51e6359d8ab86fec77b3c700. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->