### PR TITLE
docs: add note to play with mimir for classic architecture

### DIFF
--- a/docs/sources/mimir/get-started/play-with-grafana-mimir/index.md
+++ b/docs/sources/mimir/get-started/play-with-grafana-mimir/index.md
@@ -49,11 +49,11 @@ In this tutorial, you'll:
 - Run Prometheus to scrape some metrics and remote write to Grafana Mimir
 - Run Grafana to explore Grafana Mimir dashboards
 - Configure a testing recording rule and alert in Grafana Mimir
- 
+
 {{< admonition type="note" >}}
 This tutorial runs Grafana Mimir using classic architecture. For more information about the supported architectures in Grafana Mimir, refer to [Grafana Mimir architecture](https://grafana.com/docs/mimir/<MIMIR_VERSION>/get-started/about-grafana-mimir-architecture/).
 {{< /admonition >}}
- 
+
 <!-- INTERACTIVE ignore START -->
 
 ## Prerequisites


### PR DESCRIPTION
This pull request adds a note to clarify the architecture used in the Grafana Mimir tutorial. The note informs users that the tutorial runs Grafana Mimir using the classic architecture and provides a link to further documentation for more details.

- **Documentation clarity:**
  * Added an admonition to the tutorial indicating it uses the classic architecture and included a link to the official Grafana Mimir architecture documentation for further reference.

Fixes https://github.com/grafana/mimir-squad/issues/3294

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies the architecture context of the tutorial.
> 
> - Adds a `note` admonition in `docs/sources/mimir/get-started/play-with-grafana-mimir/index.md` stating the tutorial runs Grafana Mimir using classic architecture and links to the architecture docs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26d5e29afc4666db1ad424756366b4fb8b35618e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->