### PR TITLE
Fix flaky TestUsageTracker_GetUsersCloseToLimit

### DIFF
--- a/pkg/usagetracker/tracker_test.go
+++ b/pkg/usagetracker/tracker_test.go
@@ -687,7 +687,7 @@ func newReadyTestUsageTracker(t *testing.T, limits map[string]*validation.Limits
 	require.NoError(t, tracker.reconcilePartitions(t.Context()))
 
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		require.Len(t, getPartitionRing(t, pkv).ActivePartitionIDs(), testPartitionsCount)
+		require.Equal(t, testPartitionsCount, tracker.partitionRing.PartitionRing().ActivePartitionsCount())
 	}, 5*time.Second, 100*time.Millisecond, "All partitions should be active now.")
 
 	return tracker


### PR DESCRIPTION
#### What this PR does

Fixes a race condition in `TestUsageTracker_GetUsersCloseToLimit` that caused flaky test failures.

The test was checking the KV store directly to verify all partitions were active, but the production code uses the tracker's internal partition ring cache which is synced asynchronously by a watcher.

This timing difference caused inconsistent limit calculations:
- With 16 partitions synced: threshold = 900 → test passes ✓
- With 15 partitions synced: threshold = 959 → test fails ✗

**Fix:** Wait for the tracker's internal partition ring cache to sync instead of checking the KV store directly. This ensures the test validates the same state that the production code uses.

#### Which issue(s) this PR fixes or relates to

Fixes #13776

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update test to wait on the tracker's internal partition ring cache being fully active instead of reading KV directly, removing a race.
> 
> - **Tests**:
>   - In `newReadyTestUsageTracker`, assert `tracker.partitionRing.PartitionRing().ActivePartitionsCount()` equals `testPartitionsCount` instead of checking `getPartitionRing(...).ActivePartitionIDs()`, aligning with production behavior and eliminating the race in `TestUsageTracker_GetUsersCloseToLimit`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5106613747be0ebc05e7a2a3b1b1b0eebf1d2bcb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->