### PR TITLE
Runbooks: Add postings offsets table exceeds maximum size scenario to `MimirCompactorNotRunningCompaction`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,7 @@
 * [ENHANCEMENT] Add Azure object store workload identity example configuration. #13135
 * [ENHANCEMENT] Ruler: clarify that internal distributor applies to both operational modes. #13300
 * [ENHANCEMENT] Native histograms: Set expectations on querying classic histograms versus NHCBs. #13689
+* [ENHANCEMENT] Add a scenario to the MimirCompactorNotRunningCompaction runbook. #13874
 
 ### Tools
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Add TSDB block index postings offsets table exceeds maximum size scenario to runbook `MimirCompactorNotRunningCompaction`.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new runbook scenario for compactor failures when the postings offsets table exceeds maximum size, with detection and mitigation steps; updates changelog.
> 
> - **Documentation**:
>   - Update `docs/sources/mimir/manage/mimir-runbooks/_index.md` to add a new scenario: result block index postings offsets table exceeds maximum size.
>     - Detection: search logs for `length size exceeds`.
>     - Cause: extremely high label cardinality; consider increasing `compactor_split_and_merge_shards`.
>     - Mitigation: mark source blocks `no-compact` (example `./tools/mark-blocks` GCS command) and double `compactor_split_and_merge_shards` for affected tenant.
> - **Changelog**:
>   - Add `[ENHANCEMENT]` entry noting the new runbook scenario in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44e5b4c4e864c1ca3b37e1790ef4bce2582d6eca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->