### PR TITLE
jsonnet: Wait for leader zone to be ready when scaling up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,7 @@
 * [ENHANCEMENT] Multi-zone: Make config validation exclusions configurable via `multi_zone_config_validation_excluded_args` and `multi_zone_config_validation_excluded_env_vars`, and add validation for multi-zone distributor deployments. #13728
 * [ENHANCEMENT] Overrides-exporter: Include query configuration so that query limit defaults are reported accurately. #13850
 * [ENHANCEMENT] Expose pod termination grace period for alertmanagers, ingesters, query-frontends, rulers and store-gateways. #13852
+* [ENHANCEMENT] Store-gateways configured in multi-zone deployment will only scale up once the preceding zones replicas are all ready. #13879
 * [BUGFIX] Ingester: Fix `$._config.ingest_storage_ingester_autoscaling_max_owned_series_threshold` default value, to compute it based on the configured `$._config.ingester_instance_limits.max_series`. #13448
 
 ### Documentation

--- a/operations/mimir-tests/test-automated-downscale-generated.yaml
+++ b/operations/mimir-tests/test-automated-downscale-generated.yaml
@@ -2164,6 +2164,7 @@ metadata:
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "80"
     grafana.com/rollout-downscale-leader: store-gateway-zone-a
+    grafana.com/rollout-upscale-only-when-leader-ready: "true"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/min-time-between-zones-downscale: 15m
@@ -2306,6 +2307,7 @@ metadata:
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "80"
     grafana.com/rollout-downscale-leader: store-gateway-zone-b
+    grafana.com/rollout-upscale-only-when-leader-ready: "true"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/min-time-between-zones-downscale: 15m

--- a/operations/mimir-tests/test-automated-downscale-v2-generated.yaml
+++ b/operations/mimir-tests/test-automated-downscale-v2-generated.yaml
@@ -2237,6 +2237,7 @@ metadata:
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "80"
     grafana.com/rollout-downscale-leader: store-gateway-zone-a
+    grafana.com/rollout-upscale-only-when-leader-ready: "true"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/min-time-between-zones-downscale: 15m
@@ -2379,6 +2380,7 @@ metadata:
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: "80"
     grafana.com/rollout-downscale-leader: store-gateway-zone-b
+    grafana.com/rollout-upscale-only-when-leader-ready: "true"
     rollout-max-unavailable: "50"
   labels:
     grafana.com/min-time-between-zones-downscale: 15m

--- a/operations/mimir/store-gateway-automated-downscale.libsonnet
+++ b/operations/mimir/store-gateway-automated-downscale.libsonnet
@@ -51,6 +51,7 @@
       $.removeReplicasFromSpec +
       statefulSet.mixin.metadata.withAnnotationsMixin({
         'grafana.com/rollout-downscale-leader': 'store-gateway-zone-a',
+        'grafana.com/rollout-upscale-only-when-leader-ready': 'true',
       }),
   ),
 
@@ -61,6 +62,7 @@
       $.removeReplicasFromSpec +
       statefulSet.mixin.metadata.withAnnotationsMixin({
         'grafana.com/rollout-downscale-leader': 'store-gateway-zone-b',
+        'grafana.com/rollout-upscale-only-when-leader-ready': 'true',
       }),
   ),
 


### PR DESCRIPTION
#### What this PR does

When scaling up store-gateways, wait for the leader zone to be ready. This upstreams a configuration we've been using in Grafana Cloud for a while.

#### Which issue(s) this PR fixes or relates to

Related #9024

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces upscale gating for multi-zone store-gateways so later zones only scale up once the preceding zone is ready.
> 
> - Adds `grafana.com/rollout-upscale-only-when-leader-ready: "true"` to store-gateway `StatefulSet` annotations for zones B and C in generated tests (`test-automated-downscale*.yaml`)
> - Updates `operations/mimir/store-gateway-automated-downscale.libsonnet` to include the new annotation for zones B and C when multi-zone automated downscale is enabled
> - Updates `CHANGELOG.md` with an enhancement entry describing the new multi-zone upscale behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb161ca7b923896949b5f1c4cb912a1b1ebd2739. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->