### PR TITLE
usage-tracker: remove the `cortex_usage_tracker_active_series_current_limit` metrics

### DIFF
--- a/pkg/usagetracker/tracker_store_collector.go
+++ b/pkg/usagetracker/tracker_store_collector.go
@@ -8,23 +8,14 @@ var _ prometheus.Collector = &trackerStore{}
 
 const activeSeriesMetricName = "cortex_usage_tracker_active_series"
 
-const currentActiveSeriesLimit = "cortex_usage_tracker_active_series_current_limit"
-
 var activeSeriesMetricDesc = prometheus.NewDesc(
 	activeSeriesMetricName,
 	"Number of active series tracker for each user.",
 	[]string{"user"}, nil,
 )
 
-var currentLimitMetricDesc = prometheus.NewDesc(
-	currentActiveSeriesLimit,
-	"Current active series limit for each user.",
-	[]string{"user"}, nil,
-)
-
 func (t *trackerStore) Describe(descs chan<- *prometheus.Desc) {
 	descs <- activeSeriesMetricDesc
-	descs <- currentLimitMetricDesc
 }
 
 func (t *trackerStore) Collect(metrics chan<- prometheus.Metric) {
@@ -33,6 +24,5 @@ func (t *trackerStore) Collect(metrics chan<- prometheus.Metric) {
 	for _, tenantID := range t.sortedTenants {
 		tenant := t.tenants[tenantID]
 		metrics <- prometheus.MustNewConstMetric(activeSeriesMetricDesc, prometheus.GaugeValue, float64(tenant.series.Load()), tenantID)
-		metrics <- prometheus.MustNewConstMetric(currentLimitMetricDesc, prometheus.GaugeValue, float64(tenant.currentLimit.Load()), tenantID)
 	}
 }


### PR DESCRIPTION
#### What this PR does

We should reduce the amount of series we expose that have tenants*partitions cardinality, as we've seen scraping being quite expensive. This metric was meant more as a development insight, and I don't expect the operators to use it, so let's remove it and reduce the amount of these metrics by 50%.

Not updating the CHANGELOG since this service is still experimental and this metric is not documented.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the high-cardinality `cortex_usage_tracker_active_series_current_limit` metric from the usage tracker Prometheus collector to reduce scrape load.
> 
> - Deletes `currentActiveSeriesLimit` constant and `currentLimitMetricDesc`; drops emission in `Describe` and `Collect`
> - Retains `cortex_usage_tracker_active_series` metric unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8fd2bae9cbb6f1f113bb00522e9167a63e7e1a58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->