### PR TITLE
Usage-tracker: serialize metrics gathering to reduce tail latency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@
 * [ENHANCEMENT] Ingester: Make sharded active-series requests matching all series faster. #13491
 * [ENHANCEMENT] Ingester: New `-blocks-storage.tsdb.close-idle-tsdb-when-shipping-disabled` flag to enforce closing of idle TSDBs when block shipping is disabled. #13862
 * [ENHANCEMENT] Partitions ring: Add support to forcefully lock a partition state through the web UI. #13811
+* [ENHANCEMENT] Usage-tracker: Serialize metrics gathering to reduce tail latency when running many partitions on a single instance. #13886
 * [ENHANCEMENT] API: The `/api/v1/user_limits` endpoint is now stable and no longer experimental. #13218
 * [ENHANCEMENT] Ingester: limiting CPU and memory utilized by the read path (`-ingester.read-path-cpu-utilization-limit` and `-ingester.read-path-memory-utilization-limit`) is now considered stable. #13167
 * [ENHANCEMENT] Querier: `-querier.max-estimated-fetched-chunks-per-query-multiplier` is now stable and no longer experimental. #13120

--- a/pkg/usagetracker/tracker_store_collector.go
+++ b/pkg/usagetracker/tracker_store_collector.go
@@ -2,7 +2,9 @@
 
 package usagetracker
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 var _ prometheus.Collector = &trackerStore{}
 
@@ -28,6 +30,8 @@ func (t *trackerStore) Describe(descs chan<- *prometheus.Desc) {
 }
 
 func (t *trackerStore) Collect(metrics chan<- prometheus.Metric) {
+	trackerStoreCollectTestHook()
+
 	t.mtx.RLock()
 	defer t.mtx.RUnlock()
 	for _, tenantID := range t.sortedTenants {
@@ -36,3 +40,5 @@ func (t *trackerStore) Collect(metrics chan<- prometheus.Metric) {
 		metrics <- prometheus.MustNewConstMetric(currentLimitMetricDesc, prometheus.GaugeValue, float64(tenant.currentLimit.Load()), tenantID)
 	}
 }
+
+var trackerStoreCollectTestHook = func() {}

--- a/pkg/usagetracker/tracker_test.go
+++ b/pkg/usagetracker/tracker_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -642,8 +643,8 @@ func stopAllTrackers(t *testing.T, trackers map[string]*UsageTracker) {
 	}
 }
 
-func waitUntilAllTrackersSeeAllInstancesInTheirZones(t *testing.T, trackers map[string]*UsageTracker) {
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
+func waitUntilAllTrackersSeeAllInstancesInTheirZones(tb testing.TB, trackers map[string]*UsageTracker) {
+	require.EventuallyWithT(tb, func(t *assert.CollectT) {
 		trackersPerZone := map[string]int{}
 		for _, ut := range trackers {
 			trackersPerZone[ut.cfg.InstanceRing.InstanceZone]++
@@ -664,16 +665,16 @@ func reconcileAllTrackersPartitionCountTimes(t require.TestingT, trackers map[st
 	}
 }
 
-func prepareKVStoreAndKafkaMocks(t *testing.T) (*consul.Client, *consul.Client, *kfake.Cluster) {
+func prepareKVStoreAndKafkaMocks(tb testing.TB) (*consul.Client, *consul.Client, *kfake.Cluster) {
 	consulConfig := consul.Config{
 		MaxCasRetries: 100,
 		CasRetryDelay: 50 * time.Millisecond,
 	}
 	ikv, instanceKVCloser := consul.NewInMemoryClientWithConfig(ring.GetCodec(), consulConfig, log.NewNopLogger(), nil)
-	t.Cleanup(func() { assert.NoError(t, instanceKVCloser.Close()) })
+	tb.Cleanup(func() { assert.NoError(tb, instanceKVCloser.Close()) })
 	pkv, partitionKVCloser := consul.NewInMemoryClientWithConfig(ring.GetPartitionRingCodec(), consulConfig, log.NewNopLogger(), nil)
-	t.Cleanup(func() { assert.NoError(t, partitionKVCloser.Close()) })
-	cluster := fakeKafkaCluster(t)
+	tb.Cleanup(func() { assert.NoError(tb, partitionKVCloser.Close()) })
+	cluster := fakeKafkaCluster(tb)
 	return ikv, pkv, cluster
 }
 
@@ -682,7 +683,7 @@ func newReadyTestUsageTracker(t *testing.T, limits map[string]*validation.Limits
 		cfg.MaxPartitionsToCreatePerReconcile = testPartitionsCount // create all partitions in one reconcile.
 	})
 	ikv, pkv, cluster := prepareKVStoreAndKafkaMocks(t)
-	tracker := newTestUsageTrackerWithTenantLimits(t, 0, "zone-a", ikv, pkv, cluster, validation.NewMockTenantLimits(limits), options...)
+	tracker := newTestUsageTrackerWithDeps(t, 0, "zone-a", ikv, pkv, cluster, newUsageTrackerDeps{tenantLimits: validation.NewMockTenantLimits(limits)}, options...)
 	waitUntilAllTrackersSeeAllInstancesInTheirZones(t, map[string]*UsageTracker{"a0": tracker})
 	require.NoError(t, tracker.reconcilePartitions(t.Context()))
 
@@ -694,52 +695,64 @@ func newReadyTestUsageTracker(t *testing.T, limits map[string]*validation.Limits
 }
 
 func newTestUsageTracker(t *testing.T, index int, zone string, ikv, pkv kv.Client, cluster *kfake.Cluster, options ...func(cfg *Config)) *UsageTracker {
-	return newTestUsageTrackerWithTenantLimits(t, index, zone, ikv, pkv, cluster, nil, options...)
+	return newTestUsageTrackerWithDeps(t, index, zone, ikv, pkv, cluster, newUsageTrackerDeps{}, options...)
 }
 
-func newTestUsageTrackerWithTenantLimits(t *testing.T, index int, zone string, ikv, pkv kv.Client, cluster *kfake.Cluster, tenantLimits validation.TenantLimits, options ...func(cfg *Config)) *UsageTracker {
+type newUsageTrackerDeps struct {
+	registry     *prometheus.Registry
+	logger       log.Logger
+	tenantLimits validation.TenantLimits
+}
+
+func newTestUsageTrackerWithDeps(tb testing.TB, index int, zone string, ikv, pkv kv.Client, cluster *kfake.Cluster, deps newUsageTrackerDeps, options ...func(cfg *Config)) *UsageTracker {
 	instanceID := fmt.Sprintf("usage-tracker-%s-%d", zone, index)
-	cfg := newTestUsageTrackerConfig(t, instanceID, zone, ikv, pkv, cluster)
+	cfg := newTestUsageTrackerConfig(tb, instanceID, zone, ikv, pkv, cluster)
 	for _, option := range options {
 		option(&cfg)
 	}
-	reg := prometheus.NewPedanticRegistry()
-	logger := utiltest.NewTestingLogger(t)
+	logger := deps.logger
+	if logger == nil {
+		logger = utiltest.NewTestingLogger(tb)
+	}
+	reg := deps.registry
+	if reg == nil {
+		reg = prometheus.NewPedanticRegistry()
+	}
+	overrides := validation.NewOverrides(validation.Limits{}, deps.tenantLimits)
+
 	instanceRing, err := NewInstanceRingClient(cfg.InstanceRing, logger, reg)
-	require.NoError(t, err)
-	startServiceAndStopOnCleanup(t, instanceRing)
+	require.NoError(tb, err)
+	startServiceAndStopOnCleanup(tb, instanceRing)
 
 	partitionRingWatcher := NewPartitionRingWatcher(pkv, logger, reg)
 	partitionRing := ring.NewMultiPartitionInstanceRing(partitionRingWatcher, instanceRing, cfg.InstanceRing.HeartbeatTimeout)
-	startServiceAndStopOnCleanup(t, partitionRingWatcher)
-
-	overrides := validation.NewOverrides(validation.Limits{}, tenantLimits)
+	startServiceAndStopOnCleanup(tb, partitionRingWatcher)
 
 	ut, err := NewUsageTracker(cfg, instanceRing, partitionRing, overrides, logger, reg)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
-	startServiceAndStopOnCleanup(t, ut)
+	startServiceAndStopOnCleanup(tb, ut)
 	return ut
 }
 
-func startServiceAndStopOnCleanup(t *testing.T, svc services.Service) {
-	t.Helper()
-	require.NoError(t, services.StartAndAwaitRunning(context.Background(), svc))
-	t.Cleanup(func() { stopService(t, svc) })
+func startServiceAndStopOnCleanup(tb testing.TB, svc services.Service) {
+	tb.Helper()
+	require.NoError(tb, services.StartAndAwaitRunning(context.Background(), svc))
+	tb.Cleanup(func() { stopService(tb, svc) })
 }
 
-func stopService(t *testing.T, svc services.Service) {
+func stopService(tb testing.TB, svc services.Service) {
 	err := services.StopAndAwaitTerminated(context.Background(), svc)
 	if err != nil && !errors.Is(err, context.Canceled) {
-		t.Errorf("Unexpected error stopping service %T: %s", svc, err)
+		tb.Errorf("Unexpected error stopping service %T: %s", svc, err)
 	}
 }
 
-func newTestUsageTrackerConfig(t *testing.T, instanceID, zone string, ikv, pkv kv.Client, cluster *kfake.Cluster) Config {
+func newTestUsageTrackerConfig(tb testing.TB, instanceID, zone string, ikv, pkv kv.Client, cluster *kfake.Cluster) Config {
 	var cfg Config
 	fs := flag.NewFlagSet("usage-tracker", flag.PanicOnError)
 	cfg.RegisterFlags(fs, log.NewNopLogger())
-	require.NoError(t, fs.Parse(nil))
+	require.NoError(tb, fs.Parse(nil))
 	cfg.Enabled = true
 
 	cfg.Partitions = testPartitionsCount
@@ -767,17 +780,17 @@ func newTestUsageTrackerConfig(t *testing.T, instanceID, zone string, ikv, pkv k
 
 	cfg.PartitionReconcileInterval = time.Hour // we do reconciliation manually
 
-	cfg.SnapshotsStorage.Filesystem.Directory = t.TempDir()
+	cfg.SnapshotsStorage.Filesystem.Directory = tb.TempDir()
 
-	require.NoError(t, cfg.ValidateForUsageTracker())
+	require.NoError(tb, cfg.ValidateForUsageTracker())
 	return cfg
 }
 
-func fakeKafkaCluster(t *testing.T, topicsToSeed ...string) *kfake.Cluster {
-	t.Helper()
+func fakeKafkaCluster(tb testing.TB, topicsToSeed ...string) *kfake.Cluster {
+	tb.Helper()
 	cluster, err := kfake.NewCluster(kfake.NumBrokers(1), kfake.SeedTopics(testPartitionsCount, topicsToSeed...))
-	require.NoError(t, err)
-	t.Cleanup(cluster.Close)
+	require.NoError(tb, err)
+	tb.Cleanup(cluster.Close)
 	return cluster
 }
 
@@ -983,4 +996,86 @@ func TestUsageTracker_CleanupSnapshots(t *testing.T) {
 		}))
 		require.Len(t, remaining, 1)
 	})
+}
+
+// TestMetricsGatheringIsNotConcurrent makes sure that metrics collection from usage-tracker is not made concurrently.
+// Sometimes we run all 64 partitions on a single instance, serving thousands of tenants.
+// When that happens, the default behaviour of the prometheus.Registry.Gather() is to launch a goroutine for each one of the collectors registered.
+// Since each partition is a collector, it launches 64 quite-heavy goroutines, overwhelming the scheduler and increasing the tail latency.
+func TestMetricsGatheringIsNotConcurrent(t *testing.T) {
+	counter := 0
+	trackerStoreCollectTestHook = func() {
+		// If metrics gathering is concurrent, race detector should complain here.
+		counter++
+		require.Equal(t, 1, counter)
+		counter--
+	}
+	t.Cleanup(func() { trackerStoreCollectTestHook = func() {} })
+
+	const partitions = 64
+	reg := prometheus.NewRegistry()
+	logger := log.NewNopLogger()
+
+	ikv, pkv, cluster := prepareKVStoreAndKafkaMocks(t)
+	tracker := newTestUsageTrackerWithDeps(t, 0, "zone-a", ikv, pkv, cluster, newUsageTrackerDeps{registry: reg, logger: logger}, func(cfg *Config) {
+		cfg.Partitions = partitions
+		cfg.MaxPartitionsToCreatePerReconcile = partitions
+		cfg.EventsStorageWriter.AutoCreateTopicDefaultPartitions = partitions
+		cfg.SnapshotsMetadataWriter.AutoCreateTopicDefaultPartitions = partitions
+	})
+	waitUntilAllTrackersSeeAllInstancesInTheirZones(t, map[string]*UsageTracker{"a0": tracker})
+	require.NoError(t, tracker.reconcilePartitions(t.Context()))
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		require.Equal(t, partitions, tracker.partitionRing.PartitionRing().ActivePartitionsCount())
+	}, 5*time.Second, 100*time.Millisecond, "All partitions should be active now.")
+
+	_, err := reg.Gather()
+	require.NoError(t, err)
+}
+
+func BenchmarkMetricsGathering(b *testing.B) {
+	const partitions = 64
+
+	for _, tenants := range []int{1, 10, 100, 1000, 10000} {
+		b.Run(fmt.Sprintf("tenants=%d", tenants), func(b *testing.B) {
+			reg := prometheus.NewRegistry()
+			logger := log.NewNopLogger()
+
+			ikv, pkv, cluster := prepareKVStoreAndKafkaMocks(b)
+			tracker := newTestUsageTrackerWithDeps(b, 0, "zone-a", ikv, pkv, cluster, newUsageTrackerDeps{registry: reg, logger: logger}, func(cfg *Config) {
+				cfg.Partitions = partitions
+				cfg.MaxPartitionsToCreatePerReconcile = partitions
+				cfg.EventsStorageWriter.AutoCreateTopicDefaultPartitions = partitions
+				cfg.SnapshotsMetadataWriter.AutoCreateTopicDefaultPartitions = partitions
+			})
+			waitUntilAllTrackersSeeAllInstancesInTheirZones(b, map[string]*UsageTracker{"a0": tracker})
+			require.NoError(b, tracker.reconcilePartitions(b.Context()))
+
+			require.EventuallyWithT(b, func(t *assert.CollectT) {
+				require.Equal(t, partitions, tracker.partitionRing.PartitionRing().ActivePartitionsCount())
+			}, 5*time.Second, 100*time.Millisecond, "All partitions should be active now.")
+
+			for tenant := 0; tenant < tenants; tenant++ {
+				userID := strconv.Itoa(tenant)
+				for partition := int32(0); partition < partitions; partition++ {
+					resp, err := tracker.TrackSeries(b.Context(), &usagetrackerpb.TrackSeriesRequest{
+						UserID:       userID,
+						Partition:    partition,
+						SeriesHashes: []uint64{0, 1},
+					})
+					require.NoError(b, err)
+					require.Empty(b, resp.RejectedSeriesHashes)
+				}
+			}
+
+			b.Run("gather", func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					metrics, err := reg.Gather()
+					require.NoError(b, err)
+					require.NotEmpty(b, metrics)
+				}
+			})
+		})
+	}
 }


### PR DESCRIPTION
## Summary

When running all 64 partitions on a single instance serving thousands of tenants, Prometheus's default `Gather()` behavior launches a goroutine per collector (one per partition). This overwhelms the scheduler and increases tail latency.

This change wraps all usage-tracker metrics in a single collector to serialize gathering, preventing concurrent collection across partitions.

I checked that the new test fails without this change.

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/mimir/pkg/usagetracker
cpu: Apple M3 Pro
                                        │   concurrent   │               sequential                │
                                        │     sec/op     │     sec/op      vs base                 │
MetricsGathering/tenants=1/gather         25.18m ±  3%     22.21m ±  3%    -11.80% (p=0.002 n=6)
MetricsGathering/tenants=1/gather-12      4.211m ±  0%     4.186m ±  0%     -0.59% (p=0.026 n=6)
MetricsGathering/tenants=10/gather        17.92m ±  2%     22.59m ±  4%    +26.10% (p=0.002 n=6)
MetricsGathering/tenants=10/gather-12     5.181m ±  1%     5.010m ±  1%     -3.30% (p=0.002 n=6)
MetricsGathering/tenants=100/gather       50.91m ±  5%     51.95m ±  4%          ~ (p=0.699 n=6)
MetricsGathering/tenants=100/gather-12    19.11m ±  1%     17.06m ±  1%    -10.72% (p=0.002 n=6)
MetricsGathering/tenants=1000/gather      411.2m ± 21%     405.6m ± 32%          ~ (p=0.937 n=6)
MetricsGathering/tenants=1000/gather-12   192.8m ±  2%     155.3m ±  1%    -19.43% (p=0.002 n=6)
MetricsGathering/tenants=10000/gather      2.791 ±   ∞ ¹    1.950 ±   ∞ ¹        ~ (p=1.000 n=1) ²
geomean                                   50.45m           47.12m           -6.60%
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves metrics collection performance by avoiding concurrent gathers across partitions.
> 
> - Wraps all usage-tracker metrics under a single collector in `NewUsageTracker`, registering a dedicated `prometheus.Registry` to serialize gathering
> - Adds a test hook in `trackerStore.Collect()` to detect concurrent collection and a new `TestMetricsGatheringIsNotConcurrent`
> - Introduces `BenchmarkMetricsGathering` to measure gather performance at scale
> - Refactors test helpers to use `testing.TB`, supports dependency injection for `logger`/`registry`, and minor test utilities cleanup
> - Updates `CHANGELOG.md` with the enhancement entry
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4d368a05e0bd82628690f6bbf9e5f7a0db060c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->