### PR TITLE
Makefile: Add rule to regenerate .pb.go.expdiff files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -627,6 +627,18 @@ check-helm-tests: build-helm-tests helm-conftest-test
 
 endif
 
+%.pb.go.expdiff: ## Regenerates expected diff files from the current content of .pb.go files.
+%.pb.go.expdiff: %.pb.go
+	@echo "Regenerating $@"
+	$(eval PBGO_FILE := $(patsubst %.pb.go.expdiff,%.pb.go,$@))
+	$(eval PROTO_FILE := $(patsubst %.pb.go.expdiff,%.proto,$@))
+	@cp $(PBGO_FILE) $(PBGO_FILE).bak
+	@touch $(PROTO_FILE)
+	@$(MAKE) -B $(PBGO_FILE)
+	@git diff --no-index $(PBGO_FILE).bak $(PBGO_FILE) | sed 's/.pb.go.bak/.pb.go/g' > $@ || true
+	@rm $(PBGO_FILE).bak
+	@./tools/apply-expected-diffs.sh $(PBGO_FILE)
+
 .PHONY: check-makefiles
 check-makefiles: ## Check the makefiles format.
 check-makefiles: format-makefiles


### PR DESCRIPTION
#### What this PR does

Adds a build rule to the Makefile to make it easy to update .expdiff (expected diff) files:

1. Make the changes on the .pb.go files.
2. Run `make path/to/file.pb.go.expdiff` for the corresponding .expdiff files.

Tested on https://github.com/grafana/mimir/pull/13609

#### Which issue(s) this PR fixes or relates to

—

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a helper Makefile rule to quickly update expected diffs for protobuf-generated Go files.
> 
> - New pattern rule `%.pb.go.expdiff: %.pb.go` backs up the current `.pb.go`, forces regeneration, diffs against backup, writes the result to the corresponding `.expdiff`, cleans up, and runs `tools/apply-expected-diffs.sh`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2db905ff0a3431cd1b62d948ecd95dfe232db7a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->