### PR TITLE
store-gateway: add metric to track per-tenant disk utilisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@
 * [ENHANCEMENT] Querier: `-querier.active-series-results-max-size-bytes` is now stable and no longer experimental. #13110
 * [ENHANCEMENT] API: The `/api/v1/cardinality/active_series` endpoint is now stable and no longer experimental. #13111
 * [ENHANCEMENT] Querier: Default to streaming active series responses to query-frontends via `querier.response-streaming-enabled`. #13883
-* [ENHANCEMENT] Store-gateway: Add `cortex_bucket_store_blocks_size_bytes` metric to track per-tenant disk utilization. #13891
+* [ENHANCEMENT] Store-gateway: Add `cortex_bucket_store_blocks_loaded_size_bytes` metric to track per-tenant disk utilization. #13891
 * [BUGFIX] Distributor: Fix issue where distributors didn't send custom values of native histograms. #13849
 * [BUGFIX] Compactor: Fix potential concurrent map writes. #13053
 * [BUGFIX] Query-frontend: Fix issue where queries sometimes fail with `failed to receive query result stream message: rpc error: code = Canceled desc = context canceled` if remote execution is enabled. #13084


### PR DESCRIPTION
#### What this PR does

The PR adds a new metric to the store-gateway, that tracks per-tenant disk usage. This data should be handy in the investigations of the `MimirPersistentVolumeFillingUp` alerts. That is, today, when receive the page, we have to connect to a store-gateway's pod and check which tenant consumed the disk space, and maybe needed its sharding to be adjusted. Having this data per-instance-per-tenant will make such an investigation simpler.

#### Which issue(s) this PR fixes or relates to

Relates to https://github.com/grafana/mimir-squad/issues/3397

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
