### PR TITLE
Usage-tracker: fall back to global series limit instead of using it

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1619,7 +1619,7 @@ func (d *Distributor) prePushMaxSeriesLimitMiddleware(next PushFunc) PushFunc {
 
 		if len(req.Timeseries) == 0 {
 			// All series have been rejected, no need to talk to ingesters.
-			return newActiveSeriesLimitedError(totalTimeseries, len(rejectedHashes), d.limits.MaxActiveSeriesPerUser(userID))
+			return newActiveSeriesLimitedError(totalTimeseries, len(rejectedHashes), d.limits.MaxActiveOrGlobalSeriesPerUser(userID))
 		}
 
 		// If there's an error coming from the ingesters, prioritize that one.
@@ -1628,7 +1628,7 @@ func (d *Distributor) prePushMaxSeriesLimitMiddleware(next PushFunc) PushFunc {
 		}
 
 		if len(rejectedHashes) > 0 {
-			return newActiveSeriesLimitedError(totalTimeseries, len(rejectedHashes), d.limits.MaxActiveSeriesPerUser(userID))
+			return newActiveSeriesLimitedError(totalTimeseries, len(rejectedHashes), d.limits.MaxActiveOrGlobalSeriesPerUser(userID))
 		}
 
 		return nil

--- a/pkg/usagetracker/tracker_test.go
+++ b/pkg/usagetracker/tracker_test.go
@@ -83,16 +83,14 @@ func TestUsageTracker_Tracking(t *testing.T) {
 		require.ErrorContains(t, err, "partition handler 0 is not running (state: Terminated)")
 	})
 
-	t.Run("applies global series limit when configured", func(t *testing.T) {
+	t.Run("applies global series limit when active series limit is not configured", func(t *testing.T) {
 		t.Parallel()
 
 		tracker := newReadyTestUsageTracker(t, map[string]*validation.Limits{
 			"tenant": {
-				MaxActiveSeriesPerUser: testPartitionsCount,     // one series per partition.
+				MaxActiveSeriesPerUser: 0,                       // unset
 				MaxGlobalSeriesPerUser: testPartitionsCount * 2, // two series per partition
 			},
-		}, func(cfg *Config) {
-			cfg.UseGlobalSeriesLimits = true
 		})
 
 		resp, err := tracker.TrackSeries(t.Context(), &usagetrackerpb.TrackSeriesRequest{

--- a/pkg/usagetracker/usagetrackerclient/client.go
+++ b/pkg/usagetracker/usagetrackerclient/client.go
@@ -34,7 +34,7 @@ var (
 
 // limitsProvider provides access to user limits.
 type limitsProvider interface {
-	MaxActiveSeriesPerUser(userID string) int
+	MaxActiveOrGlobalSeriesPerUser(userID string) int
 }
 
 type Config struct {
@@ -481,7 +481,7 @@ func (c *UsageTrackerClient) selectRandomPartition() (int32, ring.ReplicationSet
 func (c *UsageTrackerClient) CanTrackAsync(userID string) bool {
 	// Check if user's limit is below the minimum threshold for async tracking.
 	if c.cfg.MinSeriesLimitForAsyncTracking > 0 {
-		userLimit := c.limits.MaxActiveSeriesPerUser(userID)
+		userLimit := c.limits.MaxActiveOrGlobalSeriesPerUser(userID)
 		if userLimit > 0 && userLimit < c.cfg.MinSeriesLimitForAsyncTracking {
 			// User's limit is too low, must track synchronously.
 			return false

--- a/pkg/usagetracker/usagetrackerclient/client_test.go
+++ b/pkg/usagetracker/usagetrackerclient/client_test.go
@@ -40,7 +40,7 @@ func newMockLimitsProvider() *mockLimitsProvider {
 	}
 }
 
-func (m *mockLimitsProvider) MaxActiveSeriesPerUser(userID string) int {
+func (m *mockLimitsProvider) MaxActiveOrGlobalSeriesPerUser(userID string) int {
 	if limit, ok := m.limits[userID]; ok {
 		return limit
 	}

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -866,9 +866,22 @@ func (o *Overrides) PastGracePeriod(userID string) time.Duration {
 	return time.Duration(o.getOverridesForUser(userID).PastGracePeriod)
 }
 
-// MaxActiveSeriesPerUser returns the maximum number of active series a user is allowed to store across the cluster.
-func (o *Overrides) MaxActiveSeriesPerUser(userID string) int {
-	return o.getOverridesForUser(userID).MaxActiveSeriesPerUser
+// MaxActiveOrGlobalSeriesPerUser returns the maximum number of active series a user is allowed to store across the cluster.
+// It will automatically fall back to the MaxGlobalSeriesPerUser setting if MaxActiveSeriesPerUser is unset.
+// This means that for users who have any overrides defined, the fallback order is:
+// - Tenant's MaxActiveSeriesPerUser
+// - Default MaxActiveSeriesPerUser
+// - Tenant's MaxGlobalSeriesPerUser
+// - Default MaxGlobalSeriesPerUser
+// And for tenants without overrides it's just:
+// - Default MaxActiveSeriesPerUser
+// - Default MaxGlobalSeriesPerUser
+func (o *Overrides) MaxActiveOrGlobalSeriesPerUser(userID string) int {
+	overrides := o.getOverridesForUser(userID)
+	if maxActive := overrides.MaxActiveSeriesPerUser; maxActive > 0 {
+		return maxActive
+	}
+	return overrides.MaxGlobalSeriesPerUser
 }
 
 // MaxGlobalSeriesPerUser returns the maximum number of series a user is allowed to store across the cluster.


### PR DESCRIPTION
#### What this PR does

Instead of using active-series limit OR global-series limit, we'll use active-series limit when available, and fall back to global series limit if it's not defined.

Marking the previous flag as deprecated instead of removing it to simplify the migration of the internal deployments. 

Not updating the CHANGELOG.md because this is still an experimental component.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements an automatic fallback from `MaxActiveSeriesPerUser` to `MaxGlobalSeriesPerUser` and propagates it across components.
> 
> - Adds `Overrides.MaxActiveOrGlobalSeriesPerUser()` and switches callers in `distributor` and `usagetrackerclient` to use it
> - Updates limit enforcement errors in `distributor` to report the new combined limit
> - Changes `UsageTracker.localSeriesLimit()` to use the combined limit and divide by configured `partitions` (not active partitions)
> - Deprecates `-usage-tracker.use-global-series-limits` via `flagext.DeprecatedFlag`
> - Updates interfaces/tests: replaces `MaxActiveSeriesPerUser` with `MaxActiveOrGlobalSeriesPerUser`, adjusts test to validate fallback behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0df062f41372b535a518d7724b6aba1699589951. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->