### PR TITLE
Add owned and active series panels to writes dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [FEATURE] Continuous test: Add `prometheus2` option `-tests.write-protocol` flag to select Prometheus Remote-Write 2.0 as a protocol. #13659
 * [FEATURE] Continuous test: Write metrics metadata along with samples. #13659 #13732 #13796
 * [FEATURE] Store-gateway: Add experimental per-zone shard size `-store-gateway.tenant-shard-size-per-zone`. When set, the total shard size is computed as this value multiplied by the number of zones. This option takes precedence over `-store-gateway.tenant-shard-size`. #13835
+* [ENHANCEMENT] Dashboards: Add "Owned series" and "Active series" panels to the writes dashboard Headlines row. #13894
 * [ENHANCEMENT] Compactor, Store-gateway: Remove experimental setting `-compactor.upload-sparse-index-headers` and always upload sparse index-headers. This improves lazy loading performance in the store-gateway. #13089 #13882
 * [ENHANCEMENT] Store-gateway: Verify CRC32 checksums for 1 out of every 128 chunks read from object storage and the chunks cache to detect corruption. #13151
 * [ENHANCEMENT] Ingester: the per-tenant postings for matchers cache is now stable. Use the following configuration options: #13101

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes.json
@@ -290,7 +290,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Exemplars in ingesters\nNumber of TSDB exemplars currently in ingesters' storage.\nWith classic storage we the sum of exemplars from all ingesters is divided by the replication factor.\nWith ingest storage we take the maximum exemplars of each ingest partition.\n\n",
+                  "description": "### Owned series\nThe number of owned series across all ingesters.\nOwned series are the subset of in-memory series that currently map to the ingester in the ring.\nWith classic storage the sum of series from all ingesters is divided by the replication factor.\nWith ingest storage we take the maximum series of each ingest partition.\n\n",
                   "fill": 1,
                   "format": "short",
                   "id": 5,
@@ -314,6 +314,158 @@
                   "seriesOverrides": [ ],
                   "spaceLength": 10,
                   "span": 2,
+                  "stack": false,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "( # Classic storage\n  sum by (cluster, namespace, ) (\n    sum without (user) (cortex_ingester_owned_series{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir))\"}) unless on (job)\n    cortex_partition_ring_partitions{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir))\"}\n  )\n  / on (cluster, namespace) group_left()\n  max by (cluster, namespace) (cortex_distributor_replication_factor{cluster=~\"$cluster\", job=~\"($namespace)/((distributor.*|cortex|mimir))\"})\n)\nor\n( # Ingest storage\n  sum by (cluster, namespace, ) (\n    max by (ingester_id, cluster, namespace, ) (\n      label_replace(\n        sum without (user) (cortex_ingester_owned_series{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir))\"}),\n        \"ingester_id\", \"$1\", \"instance\", \".*-([0-9]+)$\"\n      )\n    )\n  )\n)\n",
+                        "format": "time_series",
+                        "instant": true,
+                        "refId": "A"
+                     }
+                  ],
+                  "thresholds": "70,80",
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Owned series",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "singlestat",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
+               },
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "description": "### Active series\nThe number of active series across all ingesters.\nActive series are series that have received a sample within the active series window (configured via -ingester.active-series-metrics-idle-timeout).\nWith classic storage the sum of series from all ingesters is divided by the replication factor.\nWith ingest storage we take the maximum series of each ingest partition.\n\n",
+                  "fill": 1,
+                  "format": "short",
+                  "id": 6,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 2,
+                  "stack": false,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "( # Classic storage\n  sum by (cluster, namespace, ) (\n    sum without (user) (cortex_ingester_active_series{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir))\"}) unless on (job)\n    cortex_partition_ring_partitions{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir))\"}\n  )\n  / on (cluster, namespace) group_left()\n  max by (cluster, namespace) (cortex_distributor_replication_factor{cluster=~\"$cluster\", job=~\"($namespace)/((distributor.*|cortex|mimir))\"})\n)\nor\n( # Ingest storage\n  sum by (cluster, namespace, ) (\n    max by (ingester_id, cluster, namespace, ) (\n      label_replace(\n        sum without (user) (cortex_ingester_active_series{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir))\"}),\n        \"ingester_id\", \"$1\", \"instance\", \".*-([0-9]+)$\"\n      )\n    )\n  )\n)\n",
+                        "format": "time_series",
+                        "instant": true,
+                        "refId": "A"
+                     }
+                  ],
+                  "thresholds": "70,80",
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Active series",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "singlestat",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
+               },
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "description": "### Exemplars in ingesters\nNumber of TSDB exemplars currently in ingesters' storage.\nWith classic storage we the sum of exemplars from all ingesters is divided by the replication factor.\nWith ingest storage we take the maximum exemplars of each ingest partition.\n\n",
+                  "fill": 1,
+                  "format": "short",
+                  "id": 7,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 1,
                   "stack": false,
                   "steppedLine": false,
                   "targets": [
@@ -368,7 +520,7 @@
                   "datasource": "$datasource",
                   "fill": 1,
                   "format": "short",
-                  "id": 6,
+                  "id": 8,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -388,7 +540,7 @@
                   "renderer": "flot",
                   "seriesOverrides": [ ],
                   "spaceLength": 10,
-                  "span": 2,
+                  "span": 1,
                   "stack": false,
                   "steppedLine": false,
                   "targets": [
@@ -624,7 +776,7 @@
                         }
                      ]
                   },
-                  "id": 7,
+                  "id": 9,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -678,7 +830,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 8,
+                  "id": 10,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -757,7 +909,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 9,
+                  "id": 11,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -843,7 +995,7 @@
                         }
                      ]
                   },
-                  "id": 10,
+                  "id": 12,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -898,7 +1050,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 11,
+                  "id": 13,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1128,7 +1280,7 @@
                         }
                      ]
                   },
-                  "id": 12,
+                  "id": 14,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1182,7 +1334,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 13,
+                  "id": 15,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -1261,7 +1413,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 14,
+                  "id": 16,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1377,7 +1529,7 @@
                         }
                      ]
                   },
-                  "id": 15,
+                  "id": 17,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1439,7 +1591,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 16,
+                  "id": 18,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1496,7 +1648,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 17,
+                  "id": 19,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1563,7 +1715,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 18,
+                  "id": 20,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1664,7 +1816,7 @@
                         }
                      ]
                   },
-                  "id": 19,
+                  "id": 21,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1725,7 +1877,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 20,
+                  "id": 22,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1792,7 +1944,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 21,
+                  "id": 23,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1859,7 +2011,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 22,
+                  "id": 24,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1910,7 +2062,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 23,
+                  "id": 25,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2020,7 +2172,7 @@
                         }
                      ]
                   },
-                  "id": 24,
+                  "id": 26,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2075,7 +2227,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 25,
+                  "id": 27,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2203,7 +2355,7 @@
                         }
                      ]
                   },
-                  "id": 26,
+                  "id": 28,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2264,7 +2416,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 27,
+                  "id": 29,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2313,7 +2465,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 28,
+                  "id": 30,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2362,7 +2514,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 29,
+                  "id": 31,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2573,7 +2725,7 @@
                         }
                      ]
                   },
-                  "id": 30,
+                  "id": 32,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2627,7 +2779,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 31,
+                  "id": 33,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -2887,7 +3039,7 @@
                         }
                      ]
                   },
-                  "id": 32,
+                  "id": 34,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2941,7 +3093,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 33,
+                  "id": 35,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -3201,7 +3353,7 @@
                         }
                      ]
                   },
-                  "id": 34,
+                  "id": 36,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3255,7 +3407,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 35,
+                  "id": 37,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -3396,7 +3548,7 @@
                         }
                      ]
                   },
-                  "id": 36,
+                  "id": 38,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3451,7 +3603,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 37,
+                  "id": 39,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -3592,7 +3744,7 @@
                         }
                      ]
                   },
-                  "id": 38,
+                  "id": 40,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3647,7 +3799,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 39,
+                  "id": 41,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -3788,7 +3940,7 @@
                         }
                      ]
                   },
-                  "id": 40,
+                  "id": 42,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3874,7 +4026,7 @@
                         }
                      ]
                   },
-                  "id": 41,
+                  "id": 43,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3930,7 +4082,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 42,
+                  "id": 44,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -4010,7 +4162,7 @@
                         }
                      ]
                   },
-                  "id": 43,
+                  "id": 45,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -4077,7 +4229,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 44,
+                  "id": 46,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -4126,7 +4278,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 45,
+                  "id": 47,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -4175,7 +4327,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 46,
+                  "id": 48,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -4224,7 +4376,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 47,
+                  "id": 49,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -4284,7 +4436,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 48,
+                  "id": 50,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -4332,7 +4484,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 49,
+                  "id": 51,
                   "links": [ ],
                   "options": {
                      "legend": {

--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-writes.json
@@ -291,7 +291,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Exemplars in ingesters\nNumber of TSDB exemplars currently in ingesters' storage.\nWith classic storage we the sum of exemplars from all ingesters is divided by the replication factor.\nWith ingest storage we take the maximum exemplars of each ingest partition.\n\n",
+                  "description": "### Owned series\nThe number of owned series across all ingesters.\nOwned series are the subset of in-memory series that currently map to the ingester in the ring.\nWith classic storage the sum of series from all ingesters is divided by the replication factor.\nWith ingest storage we take the maximum series of each ingest partition.\n\n",
                   "fill": 1,
                   "format": "short",
                   "id": 5,
@@ -315,6 +315,158 @@
                   "seriesOverrides": [ ],
                   "spaceLength": 10,
                   "span": 2,
+                  "stack": false,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "( # Classic storage\n  sum by (cluster, namespace, ) (\n    sum without (user) (cortex_ingester_owned_series{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir))\"}) unless on (job)\n    cortex_partition_ring_partitions{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir))\"}\n  )\n  / on (cluster, namespace) group_left()\n  max by (cluster, namespace) (cortex_distributor_replication_factor{cluster=~\"$cluster\", job=~\"($namespace)/((distributor.*|cortex|mimir))\"})\n)\nor\n( # Ingest storage\n  sum by (cluster, namespace, ) (\n    max by (ingester_id, cluster, namespace, ) (\n      label_replace(\n        sum without (user) (cortex_ingester_owned_series{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir))\"}),\n        \"ingester_id\", \"$1\", \"pod\", \".*-([0-9]+)$\"\n      )\n    )\n  )\n)\n",
+                        "format": "time_series",
+                        "instant": true,
+                        "refId": "A"
+                     }
+                  ],
+                  "thresholds": "70,80",
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Owned series",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "singlestat",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
+               },
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "description": "### Active series\nThe number of active series across all ingesters.\nActive series are series that have received a sample within the active series window (configured via -ingester.active-series-metrics-idle-timeout).\nWith classic storage the sum of series from all ingesters is divided by the replication factor.\nWith ingest storage we take the maximum series of each ingest partition.\n\n",
+                  "fill": 1,
+                  "format": "short",
+                  "id": 6,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 1,
+                  "stack": false,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "( # Classic storage\n  sum by (cluster, namespace, ) (\n    sum without (user) (cortex_ingester_active_series{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir))\"}) unless on (job)\n    cortex_partition_ring_partitions{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir))\"}\n  )\n  / on (cluster, namespace) group_left()\n  max by (cluster, namespace) (cortex_distributor_replication_factor{cluster=~\"$cluster\", job=~\"($namespace)/((distributor.*|cortex|mimir))\"})\n)\nor\n( # Ingest storage\n  sum by (cluster, namespace, ) (\n    max by (ingester_id, cluster, namespace, ) (\n      label_replace(\n        sum without (user) (cortex_ingester_active_series{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir))\"}),\n        \"ingester_id\", \"$1\", \"pod\", \".*-([0-9]+)$\"\n      )\n    )\n  )\n)\n",
+                        "format": "time_series",
+                        "instant": true,
+                        "refId": "A"
+                     }
+                  ],
+                  "thresholds": "70,80",
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Active series",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "singlestat",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
+               },
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "description": "### Exemplars in ingesters\nNumber of TSDB exemplars currently in ingesters' storage.\nWith classic storage we the sum of exemplars from all ingesters is divided by the replication factor.\nWith ingest storage we take the maximum exemplars of each ingest partition.\n\n",
+                  "fill": 1,
+                  "format": "short",
+                  "id": 7,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 1,
                   "stack": false,
                   "steppedLine": false,
                   "targets": [
@@ -369,7 +521,7 @@
                   "datasource": "$datasource",
                   "fill": 1,
                   "format": "short",
-                  "id": 6,
+                  "id": 8,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -389,7 +541,7 @@
                   "renderer": "flot",
                   "seriesOverrides": [ ],
                   "spaceLength": 10,
-                  "span": 2,
+                  "span": 1,
                   "stack": false,
                   "steppedLine": false,
                   "targets": [
@@ -444,7 +596,7 @@
                   "datasource": "$datasource",
                   "fill": 1,
                   "format": "reqps",
-                  "id": 7,
+                  "id": 9,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -464,7 +616,7 @@
                   "renderer": "flot",
                   "seriesOverrides": [ ],
                   "spaceLength": 10,
-                  "span": 2,
+                  "span": 1,
                   "stack": false,
                   "steppedLine": false,
                   "targets": [
@@ -705,7 +857,7 @@
                         }
                      ]
                   },
-                  "id": 8,
+                  "id": 10,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -759,7 +911,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 9,
+                  "id": 11,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -838,7 +990,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 10,
+                  "id": 12,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1058,7 +1210,7 @@
                         }
                      ]
                   },
-                  "id": 11,
+                  "id": 13,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1112,7 +1264,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 12,
+                  "id": 14,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -1191,7 +1343,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 13,
+                  "id": 15,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1411,7 +1563,7 @@
                         }
                      ]
                   },
-                  "id": 14,
+                  "id": 16,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1465,7 +1617,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 15,
+                  "id": 17,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -1544,7 +1696,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 16,
+                  "id": 18,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1764,7 +1916,7 @@
                         }
                      ]
                   },
-                  "id": 17,
+                  "id": 19,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1818,7 +1970,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 18,
+                  "id": 20,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -1897,7 +2049,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 19,
+                  "id": 21,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1967,7 +2119,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 20,
+                  "id": 22,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2197,7 +2349,7 @@
                         }
                      ]
                   },
-                  "id": 21,
+                  "id": 23,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2251,7 +2403,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 22,
+                  "id": 24,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -2330,7 +2482,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 23,
+                  "id": 25,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2416,7 +2568,7 @@
                         }
                      ]
                   },
-                  "id": 24,
+                  "id": 26,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2471,7 +2623,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 25,
+                  "id": 27,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2701,7 +2853,7 @@
                         }
                      ]
                   },
-                  "id": 26,
+                  "id": 28,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2755,7 +2907,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 27,
+                  "id": 29,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -2834,7 +2986,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 28,
+                  "id": 30,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2950,7 +3102,7 @@
                         }
                      ]
                   },
-                  "id": 29,
+                  "id": 31,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3012,7 +3164,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 30,
+                  "id": 32,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3069,7 +3221,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 31,
+                  "id": 33,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3136,7 +3288,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 32,
+                  "id": 34,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3237,7 +3389,7 @@
                         }
                      ]
                   },
-                  "id": 33,
+                  "id": 35,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3298,7 +3450,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 34,
+                  "id": 36,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3365,7 +3517,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 35,
+                  "id": 37,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3432,7 +3584,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 36,
+                  "id": 38,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3483,7 +3635,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 37,
+                  "id": 39,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3593,7 +3745,7 @@
                         }
                      ]
                   },
-                  "id": 38,
+                  "id": 40,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3648,7 +3800,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 39,
+                  "id": 41,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3776,7 +3928,7 @@
                         }
                      ]
                   },
-                  "id": 40,
+                  "id": 42,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3837,7 +3989,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 41,
+                  "id": 43,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3886,7 +4038,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 42,
+                  "id": 44,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3935,7 +4087,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 43,
+                  "id": 45,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -4146,7 +4298,7 @@
                         }
                      ]
                   },
-                  "id": 44,
+                  "id": 46,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -4200,7 +4352,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 45,
+                  "id": 47,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -4460,7 +4612,7 @@
                         }
                      ]
                   },
-                  "id": 46,
+                  "id": 48,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -4514,7 +4666,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 47,
+                  "id": 49,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -4774,7 +4926,7 @@
                         }
                      ]
                   },
-                  "id": 48,
+                  "id": 50,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -4828,7 +4980,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 49,
+                  "id": 51,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -4969,7 +5121,7 @@
                         }
                      ]
                   },
-                  "id": 50,
+                  "id": 52,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -5024,7 +5176,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 51,
+                  "id": 53,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -5165,7 +5317,7 @@
                         }
                      ]
                   },
-                  "id": 52,
+                  "id": 54,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -5220,7 +5372,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 53,
+                  "id": 55,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -5361,7 +5513,7 @@
                         }
                      ]
                   },
-                  "id": 54,
+                  "id": 56,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -5447,7 +5599,7 @@
                         }
                      ]
                   },
-                  "id": 55,
+                  "id": 57,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -5503,7 +5655,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 56,
+                  "id": 58,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -5583,7 +5735,7 @@
                         }
                      ]
                   },
-                  "id": 57,
+                  "id": 59,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -5650,7 +5802,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 58,
+                  "id": 60,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -5699,7 +5851,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 59,
+                  "id": 61,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -5748,7 +5900,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 60,
+                  "id": 62,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -5797,7 +5949,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 61,
+                  "id": 63,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -5857,7 +6009,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 62,
+                  "id": 64,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -5905,7 +6057,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 63,
+                  "id": 65,
                   "links": [ ],
                   "options": {
                      "legend": {

--- a/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-writes.json
@@ -290,7 +290,7 @@
                   "dashLength": 10,
                   "dashes": false,
                   "datasource": "$datasource",
-                  "description": "### Exemplars in ingesters\nNumber of TSDB exemplars currently in ingesters' storage.\nWith classic storage we the sum of exemplars from all ingesters is divided by the replication factor.\nWith ingest storage we take the maximum exemplars of each ingest partition.\n\n",
+                  "description": "### Owned series\nThe number of owned series across all ingesters.\nOwned series are the subset of in-memory series that currently map to the ingester in the ring.\nWith classic storage the sum of series from all ingesters is divided by the replication factor.\nWith ingest storage we take the maximum series of each ingest partition.\n\n",
                   "fill": 1,
                   "format": "short",
                   "id": 5,
@@ -314,6 +314,158 @@
                   "seriesOverrides": [ ],
                   "spaceLength": 10,
                   "span": 2,
+                  "stack": false,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "( # Classic storage\n  sum by (cluster, namespace, ) (\n    sum without (user) (cortex_ingester_owned_series{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir))\"}) unless on (job)\n    cortex_partition_ring_partitions{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir))\"}\n  )\n  / on (cluster, namespace) group_left()\n  max by (cluster, namespace) (cortex_distributor_replication_factor{cluster=~\"$cluster\", job=~\"($namespace)/((distributor.*|cortex|mimir))\"})\n)\nor\n( # Ingest storage\n  sum by (cluster, namespace, ) (\n    max by (ingester_id, cluster, namespace, ) (\n      label_replace(\n        sum without (user) (cortex_ingester_owned_series{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir))\"}),\n        \"ingester_id\", \"$1\", \"pod\", \".*-([0-9]+)$\"\n      )\n    )\n  )\n)\n",
+                        "format": "time_series",
+                        "instant": true,
+                        "refId": "A"
+                     }
+                  ],
+                  "thresholds": "70,80",
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Owned series",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "singlestat",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
+               },
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "description": "### Active series\nThe number of active series across all ingesters.\nActive series are series that have received a sample within the active series window (configured via -ingester.active-series-metrics-idle-timeout).\nWith classic storage the sum of series from all ingesters is divided by the replication factor.\nWith ingest storage we take the maximum series of each ingest partition.\n\n",
+                  "fill": 1,
+                  "format": "short",
+                  "id": 6,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 2,
+                  "stack": false,
+                  "steppedLine": false,
+                  "targets": [
+                     {
+                        "expr": "( # Classic storage\n  sum by (cluster, namespace, ) (\n    sum without (user) (cortex_ingester_active_series{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir))\"}) unless on (job)\n    cortex_partition_ring_partitions{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir))\"}\n  )\n  / on (cluster, namespace) group_left()\n  max by (cluster, namespace) (cortex_distributor_replication_factor{cluster=~\"$cluster\", job=~\"($namespace)/((distributor.*|cortex|mimir))\"})\n)\nor\n( # Ingest storage\n  sum by (cluster, namespace, ) (\n    max by (ingester_id, cluster, namespace, ) (\n      label_replace(\n        sum without (user) (cortex_ingester_active_series{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir))\"}),\n        \"ingester_id\", \"$1\", \"pod\", \".*-([0-9]+)$\"\n      )\n    )\n  )\n)\n",
+                        "format": "time_series",
+                        "instant": true,
+                        "refId": "A"
+                     }
+                  ],
+                  "thresholds": "70,80",
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Active series",
+                  "tooltip": {
+                     "shared": false,
+                     "sort": 0,
+                     "value_type": "individual"
+                  },
+                  "type": "singlestat",
+                  "xaxis": {
+                     "buckets": null,
+                     "mode": "time",
+                     "name": null,
+                     "show": true,
+                     "values": [ ]
+                  },
+                  "yaxes": [
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                     },
+                     {
+                        "format": "short",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": null,
+                        "show": false
+                     }
+                  ]
+               },
+               {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "description": "### Exemplars in ingesters\nNumber of TSDB exemplars currently in ingesters' storage.\nWith classic storage we the sum of exemplars from all ingesters is divided by the replication factor.\nWith ingest storage we take the maximum exemplars of each ingest partition.\n\n",
+                  "fill": 1,
+                  "format": "short",
+                  "id": 7,
+                  "legend": {
+                     "avg": false,
+                     "current": false,
+                     "max": false,
+                     "min": false,
+                     "show": true,
+                     "total": false,
+                     "values": false
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [ ],
+                  "nullPointMode": "null as zero",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 1,
                   "stack": false,
                   "steppedLine": false,
                   "targets": [
@@ -368,7 +520,7 @@
                   "datasource": "$datasource",
                   "fill": 1,
                   "format": "short",
-                  "id": 6,
+                  "id": 8,
                   "legend": {
                      "avg": false,
                      "current": false,
@@ -388,7 +540,7 @@
                   "renderer": "flot",
                   "seriesOverrides": [ ],
                   "spaceLength": 10,
-                  "span": 2,
+                  "span": 1,
                   "stack": false,
                   "steppedLine": false,
                   "targets": [
@@ -624,7 +776,7 @@
                         }
                      ]
                   },
-                  "id": 7,
+                  "id": 9,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -678,7 +830,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 8,
+                  "id": 10,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -757,7 +909,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 9,
+                  "id": 11,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -843,7 +995,7 @@
                         }
                      ]
                   },
-                  "id": 10,
+                  "id": 12,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -898,7 +1050,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 11,
+                  "id": 13,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1128,7 +1280,7 @@
                         }
                      ]
                   },
-                  "id": 12,
+                  "id": 14,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1182,7 +1334,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 13,
+                  "id": 15,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -1261,7 +1413,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 14,
+                  "id": 16,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1377,7 +1529,7 @@
                         }
                      ]
                   },
-                  "id": 15,
+                  "id": 17,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1439,7 +1591,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 16,
+                  "id": 18,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1496,7 +1648,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 17,
+                  "id": 19,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1563,7 +1715,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 18,
+                  "id": 20,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1664,7 +1816,7 @@
                         }
                      ]
                   },
-                  "id": 19,
+                  "id": 21,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1725,7 +1877,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 20,
+                  "id": 22,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1792,7 +1944,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 21,
+                  "id": 23,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1859,7 +2011,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 22,
+                  "id": 24,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -1910,7 +2062,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 23,
+                  "id": 25,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2020,7 +2172,7 @@
                         }
                      ]
                   },
-                  "id": 24,
+                  "id": 26,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2075,7 +2227,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 25,
+                  "id": 27,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2203,7 +2355,7 @@
                         }
                      ]
                   },
-                  "id": 26,
+                  "id": 28,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2264,7 +2416,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 27,
+                  "id": 29,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2313,7 +2465,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 28,
+                  "id": 30,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2362,7 +2514,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 29,
+                  "id": 31,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2573,7 +2725,7 @@
                         }
                      ]
                   },
-                  "id": 30,
+                  "id": 32,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2627,7 +2779,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 31,
+                  "id": 33,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -2887,7 +3039,7 @@
                         }
                      ]
                   },
-                  "id": 32,
+                  "id": 34,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -2941,7 +3093,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 33,
+                  "id": 35,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -3201,7 +3353,7 @@
                         }
                      ]
                   },
-                  "id": 34,
+                  "id": 36,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3255,7 +3407,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 35,
+                  "id": 37,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -3396,7 +3548,7 @@
                         }
                      ]
                   },
-                  "id": 36,
+                  "id": 38,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3451,7 +3603,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 37,
+                  "id": 39,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -3592,7 +3744,7 @@
                         }
                      ]
                   },
-                  "id": 38,
+                  "id": 40,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3647,7 +3799,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 39,
+                  "id": 41,
                   "links": [ ],
                   "nullPointMode": "null as zero",
                   "options": {
@@ -3788,7 +3940,7 @@
                         }
                      ]
                   },
-                  "id": 40,
+                  "id": 42,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3874,7 +4026,7 @@
                         }
                      ]
                   },
-                  "id": 41,
+                  "id": 43,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -3930,7 +4082,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 42,
+                  "id": 44,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -4010,7 +4162,7 @@
                         }
                      ]
                   },
-                  "id": 43,
+                  "id": 45,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -4077,7 +4229,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 44,
+                  "id": 46,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -4126,7 +4278,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 45,
+                  "id": 47,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -4175,7 +4327,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 46,
+                  "id": 48,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -4224,7 +4376,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 47,
+                  "id": 49,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -4284,7 +4436,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 48,
+                  "id": 50,
                   "links": [ ],
                   "options": {
                      "legend": {
@@ -4332,7 +4484,7 @@
                      },
                      "overrides": [ ]
                   },
-                  "id": 49,
+                  "id": 51,
                   "links": [ ],
                   "options": {
                      "legend": {

--- a/operations/mimir-mixin/dashboards/writes.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes.libsonnet
@@ -38,6 +38,7 @@ local filename = 'mimir-writes.json';
          height: '100px',
          showTitle: false,
        })
+      .justifyPanels()  // Make sure panels use all width even if 12 columns are not divisible by the number of panels.
       .addPanel(
         $.panel('Samples / sec') +
         $.statPanel(
@@ -71,6 +72,40 @@ local filename = 'mimir-writes.json';
           |||
             The number of series not yet flushed to object storage that are held in ingester memory.
             With classic storage we the sum of series from all ingesters is divided by the replication factor.
+            With ingest storage we take the maximum series of each ingest partition.
+          |||
+        ),
+      )
+      .addPanel(
+        local title = 'Owned series';
+        $.panel(title) +
+        $.statPanel(
+          $.queries.ingester.ingestOrClassicDeduplicatedQuery('sum without (user) (cortex_ingester_owned_series{%s})' % [$.jobMatcher($._config.job_names.ingester)]),
+          format='short'
+        ) +
+        $.panelDescription(
+          title,
+          |||
+            The number of owned series across all ingesters.
+            Owned series are the subset of in-memory series that currently map to the ingester in the ring.
+            With classic storage the sum of series from all ingesters is divided by the replication factor.
+            With ingest storage we take the maximum series of each ingest partition.
+          |||
+        ),
+      )
+      .addPanel(
+        local title = 'Active series';
+        $.panel(title) +
+        $.statPanel(
+          $.queries.ingester.ingestOrClassicDeduplicatedQuery('sum without (user) (cortex_ingester_active_series{%s})' % [$.jobMatcher($._config.job_names.ingester)]),
+          format='short'
+        ) +
+        $.panelDescription(
+          title,
+          |||
+            The number of active series across all ingesters.
+            Active series are series that have received a sample within the active series window (configured via -ingester.active-series-metrics-idle-timeout).
+            With classic storage the sum of series from all ingesters is divided by the replication factor.
             With ingest storage we take the maximum series of each ingest partition.
           |||
         ),


### PR DESCRIPTION
This adds two new stat panels to the Headlines row on the writes dashboard:

- **Owned series**: Shows the subset of in-memory series that currently map to ingesters in the ring
- **Active series**: Shows series that have received samples within the active series window

These metrics provide better visibility into the ingester series state alongside the existing "In-memory series" panel.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds visibility into ingester series state directly in the writes dashboard headlines.
> 
> - New `Owned series` and `Active series` singlestats with deduplicated queries for classic vs ingest storage (`cortex_ingester_owned_series`, `cortex_ingester_active_series`)
> - Previously headline `Exemplars in ingesters` moved/retained; panel layout adjusted (IDs/spans) and `.justifyPanels()` applied
> - Updated panel descriptions to explain semantics and replication-factor handling
> - Compiled dashboards updated for baremetal, gem, and default; CHANGELOG entry added under enhancements
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4e54357ff08b3d056a972e3c6462b830d124980. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->