### PR TITLE
Merge release-2.17 to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,7 +125,6 @@
 * [BUGFIX] Query-scheduler: Fix issue where queries executed with remote execution could time out rather than fail immediately if the querier evaluating the request crashes after receiving the query from the query-scheduler. #13742
 * [BUGFIX] Query-frontend: Fix silent panic when executing a remote read API request if the request has no matchers. #13745
 * [BUGFIX] Ruler: Fixed `-ruler.max-rule-groups-per-tenant-by-namespace` to only count rule groups in the specified namespace instead of all namespaces. #13743
-* [BUGFIX] Update to Go v1.25.5 to address [CVE-2025-61729](https://pkg.go.dev/vuln/GO-2025-4155). #13755
 * [BUGFIX] Query-frontend: Fix race condition that could sometimes cause unnecessary resharding of queriers if querier shuffle sharding and remote execution is enabled. #13794 #13838
 
 ### Mixin
@@ -413,6 +412,12 @@
 
 * [CHANGE] If you configure multiple secondary backends and enable comparisons, query-tee reports comparison results of the preferred backend against each of the secondaries. #13022
 * [CHANGE] Add backend configuration options for request proportion sampling and time-based query filtering. #13037
+
+## 2.17.4-rc.0
+
+### Grafana Mimir
+
+* [BUGFIX] Update to Go v1.25.5 to address [CVE-2025-61729](https://pkg.go.dev/vuln/GO-2025-4155), [CVE-2025-61727](https://pkg.go.dev/vuln/GO-2025-4175). #13755, #13896
 
 ## 2.17.3
 


### PR DESCRIPTION
In this PR I'm merging the release-2.17 branch to main branch. Please merge this PR using a **merge commit** or by using `tools/release/merge-approved-pr-branch-to-main.sh` script.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `CHANGELOG.md` for the upcoming release.
> 
> - Adds **2.17.4-rc.0** section with a bugfix noting upgrade to `Go 1.25.5` addressing CVEs `GO-2025-4155`/`CVE-2025-61729` and `GO-2025-4175`/`CVE-2025-61727`
> - Removes the prior standalone Go upgrade bugfix entry from the earlier section to avoid duplication
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37b402d1e3b44d39b63ad9b6fd70de6bbe9d9cca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->