### PR TITLE
development/mimir-ingest-storage: fix kafka health check

### DIFF
--- a/development/mimir-ingest-storage/docker-compose.jsonnet
+++ b/development/mimir-ingest-storage/docker-compose.jsonnet
@@ -247,7 +247,7 @@ std.manifestYamlDoc({
         '29092:29092',
       ],
       healthcheck: {
-        test: 'nc -z localhost 9092 || exit -1',
+        test: 'kafka-broker-api-versions --bootstrap-server localhost:9092 || exit 1',
         start_period: '1s',
         interval: '1s',
         timeout: '1s',
@@ -267,7 +267,7 @@ std.manifestYamlDoc({
         '29093:29093',
       ],
       healthcheck: {
-        test: 'nc -z localhost 9092 || exit -1',
+        test: 'kafka-broker-api-versions --bootstrap-server localhost:9092 || exit 1',
         start_period: '1s',
         interval: '1s',
         timeout: '1s',
@@ -287,7 +287,7 @@ std.manifestYamlDoc({
         '29094:29094',
       ],
       healthcheck: {
-        test: 'nc -z localhost 9092 || exit -1',
+        test: 'kafka-broker-api-versions --bootstrap-server localhost:9092 || exit 1',
         start_period: '1s',
         interval: '1s',
         timeout: '1s',

--- a/development/mimir-ingest-storage/docker-compose.yml
+++ b/development/mimir-ingest-storage/docker-compose.yml
@@ -219,7 +219,7 @@
       "interval": "1s"
       "retries": "30"
       "start_period": "1s"
-      "test": "nc -z localhost 9092 || exit -1"
+      "test": "kafka-broker-api-versions --bootstrap-server localhost:9092 || exit 1"
       "timeout": "1s"
     "image": "confluentinc/cp-kafka:latest"
     "ports":
@@ -243,7 +243,7 @@
       "interval": "1s"
       "retries": "30"
       "start_period": "1s"
-      "test": "nc -z localhost 9092 || exit -1"
+      "test": "kafka-broker-api-versions --bootstrap-server localhost:9092 || exit 1"
       "timeout": "1s"
     "image": "confluentinc/cp-kafka:latest"
     "ports":
@@ -267,7 +267,7 @@
       "interval": "1s"
       "retries": "30"
       "start_period": "1s"
-      "test": "nc -z localhost 9092 || exit -1"
+      "test": "kafka-broker-api-versions --bootstrap-server localhost:9092 || exit 1"
       "timeout": "1s"
     "image": "confluentinc/cp-kafka:latest"
     "ports":


### PR DESCRIPTION
#### What this PR does

There's no 'nc' in the image anymore, but there's a handy binary that can communicate with Kafka itself.

#### Which issue(s) this PR fixes or relates to

Fixes dev env.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Kafka broker health checks in the dev environment to use Kafka’s own CLI.
> 
> - Replace `nc`-based healthcheck with `kafka-broker-api-versions --bootstrap-server localhost:9092` for `kafka_1`, `kafka_2`, and `kafka_3` in both `docker-compose.jsonnet` and `docker-compose.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 780950d879490c642217a57bfcf6a5bec8fe02d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->