### PR TITLE
Update minor versions in backward compatibility test

### DIFF
--- a/integration/backward_compatibility.go
+++ b/integration/backward_compatibility.go
@@ -11,11 +11,11 @@ var DefaultPreviousVersionImages = map[string]e2emimir.FlagMapper{
 		removePartitionRingFlags,
 		removeQuerierRingFlags,
 	),
-	"grafana/mimir:2.17.3": e2emimir.ChainFlagMappers(
+	"grafana/mimir:2.17.4": e2emimir.ChainFlagMappers(
 		removePartitionRingFlags,
 		removeQuerierRingFlags,
 	),
-	"grafana/mimir:3.0.1": e2emimir.ChainFlagMappers(
+	"grafana/mimir:3.0.2": e2emimir.ChainFlagMappers(
 		removePartitionRingFlags,
 		removeQuerierRingFlags,
 	),


### PR DESCRIPTION
#### What this PR does

See title

#### Which issue(s) this PR fixes or relates to

Part of https://github.com/grafana/mimir/issues/13063

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refreshes image tags used for backward compatibility testing.
> 
> - In `integration/backward_compatibility.go`, update `DefaultPreviousVersionImages` to `grafana/mimir:2.17.4` and `grafana/mimir:3.0.2` (keeping `2.16.2`), maintaining the same flag mappers (`removePartitionRingFlags`, `removeQuerierRingFlags`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a5ae164debcd4b9f8c81464eed367ed537810ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->