### PR TITLE
Usage-tracker: update development/mimir-ingest-storage config

### DIFF
--- a/development/mimir-ingest-storage/config/mimir.yaml
+++ b/development/mimir-ingest-storage/config/mimir.yaml
@@ -104,6 +104,9 @@ overrides_exporter:
 
 usage_tracker:
   enabled: false
+  idle_timeout: 20m
+  partitions: 16
+  max_partitions_to_create_per_reconcile: 16
   snapshots_storage:
     s3:
       bucket_name: usage-tracker-snapshots
@@ -111,7 +114,7 @@ usage_tracker:
     address: kafka_1:9092
     topic: usage-tracker-events
     auto_create_topic_enabled: true
-    auto_create_topic_default_partitions: 64
+    auto_create_topic_default_partitions: 16
   events_storage_reader:
     address: kafka_1:9092
     topic: usage-tracker-events
@@ -119,10 +122,18 @@ usage_tracker:
     address: kafka_1:9092
     topic: usage-tracker-snapshots-metadata
     auto_create_topic_enabled: true
-    auto_create_topic_default_partitions: 64
+    auto_create_topic_default_partitions: 16
   snapshots_metadata_reader:
     address: kafka_1:9092
     topic: usage-tracker-snapshots-metadata
+  instance_ring:
+    kvstore:
+      prefix: ''
+    heartbeat_period: 30s
+    heartbeat_timeout: 2m
+  partition_ring:
+    kvstore:
+      prefix: ''
 
 limits:
   native_histograms_ingestion_enabled: true


### PR DESCRIPTION
#### What this PR does

Updating the config to make it easier to just flip the 'enabled' flag to start using it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands `usage_tracker` configuration and tunes Kafka topic defaults for easier enablement and local scalability.
> 
> - Adds `usage_tracker` settings: `idle_timeout`, `partitions`, `max_partitions_to_create_per_reconcile`
> - Introduces `instance_ring` and `partition_ring` configs with `kvstore` prefixes and heartbeat settings
> - Lowers `auto_create_topic_default_partitions` from 64 to 16 for `events_storage_writer` and `snapshots_metadata_writer`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4768e9f4d35c2e49afed8aad8a4a12e8c61c76c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->