### PR TITLE
Query-frontend: fix step() duration expression returning 1000x larger value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@
 * [BUGFIX] Query-frontend: Fix silent panic when executing a remote read API request if the request has no matchers. #13745
 * [BUGFIX] Ruler: Fixed `-ruler.max-rule-groups-per-tenant-by-namespace` to only count rule groups in the specified namespace instead of all namespaces. #13743
 * [BUGFIX] Query-frontend: Fix race condition that could sometimes cause unnecessary resharding of queriers if querier shuffle sharding and remote execution is enabled. #13794 #13838
+* [BUGFIX] Query-frontend: Fix `step()` duration expression returning 1000x larger value. #13920
 
 ### Mixin
 

--- a/pkg/frontend/querymiddleware/durations.go
+++ b/pkg/frontend/querymiddleware/durations.go
@@ -62,7 +62,7 @@ func (d *durationsMiddleware) rewriteIfNeeded(ctx context.Context, req MetricsQu
 		return req, nil
 	}
 
-	expr, err = promql.PreprocessExpr(expr, time.UnixMilli(req.GetStart()), time.UnixMilli(req.GetEnd()), time.Duration(req.GetStep())*time.Second)
+	expr, err = promql.PreprocessExpr(expr, time.UnixMilli(req.GetStart()), time.UnixMilli(req.GetEnd()), time.Duration(req.GetStep())*time.Millisecond)
 	if err != nil {
 		level.Warn(spanLog).Log("msg", "failed to evaluate duration expressions in query", "err", err)
 		return nil, apierror.New(apierror.TypeBadData, DecorateWithParamName(err, "query").Error())

--- a/pkg/frontend/querymiddleware/durations_test.go
+++ b/pkg/frontend/querymiddleware/durations_test.go
@@ -72,7 +72,7 @@ func TestDurationMiddleware(t *testing.T) {
 						nil,
 						2000,
 						3000,
-						60,
+						60000,
 						0,
 						expr,
 						Options{},


### PR DESCRIPTION
The durationsMiddleware incorrectly multiplied req.GetStep() by time.Second instead of time.Millisecond. Since GetStep() returns the step in milliseconds, this caused step() to return a value 1000x larger than the actual query step. For example, a 60-second step would cause step() to evaluate to 60000 seconds (~16.7 hours) instead of 60 seconds.

This fix makes the conversion consistent with how GetStep() is used everywhere else in the codebase (stats.go, limits.go, querysharding.go).

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### Checklist

- [x] Tests updated.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes incorrect unit handling in duration evaluation that caused `step()` to be 1000x larger than the query step.
> 
> - In `durations.go`, use `time.Duration(req.GetStep()) * time.Millisecond` when calling `promql.PreprocessExpr`
> - Update tests in `durations_test.go` to provide step values in milliseconds
> - Add `[BUGFIX]` entry to `CHANGELOG.md` for query-frontend `step()` duration fix
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69a697981ed54c61da46cd979ec6bb3669d60c41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->