### PR TITLE
fix(test): flaky TestRulerRemoteEvaluationErrorClassification wait until distributor has updated the ring before pushing series

### DIFF
--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -1364,6 +1364,10 @@ func TestRulerRemoteEvaluationErrorClassification(t *testing.T) {
 	require.NoError(t, s.WaitReady(queryFrontend))
 	require.NoError(t, s.StartAndWaitReady(ruler))
 
+	// Wait until both the distributor and ruler have updated the ring.
+	// The distributor should have 512 tokens for the ingester ring and 1 for the distributor ring
+	require.NoError(t, distributor.WaitSumMetrics(e2e.Equals(512+1), "cortex_ring_tokens_total"))
+	// Ruler will see 512 tokens from ingester, and 128 tokens from itself.
 	require.NoError(t, ruler.WaitSumMetrics(e2e.Equals(512+128), "cortex_ring_tokens_total"))
 
 	const user = "user"


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

There were two occurrences of ⬇️ while trying to push series through the distributor. I located the error in dskit ([ref](https://github.com/grafana/dskit/blob/82cb21a782bc12be66d5ad6e1c1d597dba7b9047/ring/batch.go#L119)
). From what I understand, this means that there were no ingesters available in the ring at that time. I believe there is a race condition where we attempt to push series before the ingester becomes available in the distributor ring.

> distributor: ts=2026-01-02T09:05:31.435618945Z caller=push.go:260 level=error user=user msg="detected an error while ingesting Prometheus remote-write request (the request may have been partially ingested)" httpCode=500 err="send data to ingesters: DoBatch: InstancesCount <= 0"


I solve this by waiting until the distributor updates its ring with the ingesters

#### Which issue(s) this PR fixes or relates to

Fixes #13918

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves stability of `TestRulerRemoteEvaluationErrorClassification` by waiting for ring readiness before writes.
> 
> - Adds wait for `distributor` to reach expected `cortex_ring_tokens_total` (ingester 512 + distributor 1) before pushing series
> - Keeps existing wait for `ruler` ring tokens (ingester 512 + ruler 128)
> 
> No production code changes; test-only flake fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ecea1025410f10a505c60214d8fa1f65103efff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->