### PR TITLE
Add how to opt out of rollout-operator to v5 -> v6 docs

### DIFF
--- a/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-helm-chart-5.x-to-6.0.md
+++ b/docs/sources/helm-charts/mimir-distributed/migration-guides/migrate-helm-chart-5.x-to-6.0.md
@@ -29,7 +29,9 @@ Follow the [Migrate to unified proxy deployment](https://grafana.com/docs/helm-c
 
 ### Account for the rollout-operator
 
-#### If using, install CRDs
+If your deployment uses the rollout-operator, you must ensure that the required CustomResourceDefinitions (CRDs) are installed. If you don't use the rollout-operator, you must explicitly disable it in your values file to avoid unnecessary components and issues with subsequent rollouts.
+
+#### Install CRDs if using the rollout-operator
 
 If you're using the rollout-operator, install the CRDs from the rollout-operator chart:
 
@@ -38,9 +40,9 @@ kubectl apply -f https://raw.githubusercontent.com/grafana/helm-charts/main/char
 kubectl apply -f https://raw.githubusercontent.com/grafana/helm-charts/main/charts/rollout-operator/crds/zone-aware-pod-disruption-budget-custom-resource-definition.yaml
 ```
 
-#### If not using, disable webhooks
+#### Disable the rollout-operator if not in use
 
-If you've opted not to use the rollout-operator, disable it in your values file:
+If you don't use the rollout-operator, disable it in your values file to prevent the installation of related webhooks which will interfere with subsequent rollouts:
 
 ```yaml
 rollout_operator:


### PR DESCRIPTION
Upgrading without this leads to a mimir deployment that can no longer be modified (e.g. https://github.com/grafana/mimir/issues/13928).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the 5.x→6.0 Helm chart migration guide to clarify rollout-operator handling.
> 
> - Renames the rollout-operator section to "Account for the rollout-operator"
> - Adds explicit opt-out instructions with `rollout_operator.enabled: false` to avoid webhook interference during rollouts
> - Retains/clarifies CRD install commands when rollout-operator is used
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0217cbb5b78b385f9db2cba076065773dc9b1d1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->