### PR TITLE
Query-frontend: add support for range() duration expression.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@
 * [ENHANCEMENT] Querier: Default to streaming active series responses to query-frontends via `querier.response-streaming-enabled`. #13883
 * [ENHANCEMENT] Store-gateway: Add `cortex_bucket_store_blocks_loaded_size_bytes` metric to track per-tenant disk utilization. #13891
 * [ENHANCEMENT] Compactor: If compaction fails because the result block would have a postings offsets table larger than the 4GB limit, mark input blocks for no-compaction to avoid blocking future compactor runs. #13876
+* [ENHANCEMENT] Query-frontend: add support for `range()` duration expression. #13931
 * [BUGFIX] Distributor: Fix issue where distributors didn't send custom values of native histograms. #13849
 * [BUGFIX] Compactor: Fix potential concurrent map writes. #13053
 * [BUGFIX] Query-frontend: Fix issue where queries sometimes fail with `failed to receive query result stream message: rpc error: code = Canceled desc = context canceled` if remote execution is enabled. #13084

--- a/pkg/frontend/querymiddleware/durations.go
+++ b/pkg/frontend/querymiddleware/durations.go
@@ -162,6 +162,8 @@ func checkDuration(expr parser.Expr) error {
 		switch n.Op {
 		case parser.STEP:
 			return nil
+		case parser.RANGE:
+			return nil
 		case parser.MIN:
 			return nil
 		case parser.MAX:

--- a/pkg/frontend/querymiddleware/durations_test.go
+++ b/pkg/frontend/querymiddleware/durations_test.go
@@ -48,6 +48,11 @@ func TestDurationMiddleware(t *testing.T) {
 			expectInstant: "rate(http_requests_total[5m])",
 			expectRange:   "rate(http_requests_total[6m])",
 		},
+		"valid duration expression with range() should be rewritten": {
+			query:         "rate(http_requests_total[range() + 30s])",
+			expectInstant: "rate(http_requests_total[30s])",
+			expectRange:   "rate(http_requests_total[31s])",
+		},
 	}
 	for name, tc := range testCases {
 		for _, instant := range []bool{false, true} {


### PR DESCRIPTION
The [range()](https://github.com/prometheus/prometheus/pull/17670) operator in duration expressions was not explicitly handled in the checkDuration function, which would cause queries using it to be rejected. This adds the missing case and includes a test to verify that range() expressions are properly evaluated and rewritten.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### Checklist

- [x] Tests updated.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables `range()` in duration expressions for the query-frontend by updating duration validation and tests.
> 
> - Accept `parser.RANGE` in `checkDuration` to prevent rejecting `range()`
> - Add test case verifying evaluation and rewrite with `range()` in `durations_test.go`
> - Update `CHANGELOG.md` with an enhancement entry
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 957e889060aa0341bee10a91cabb1088aa9e28c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->