### PR TITLE
Dedupe `msg` field in logs

### DIFF
--- a/pkg/querier/dispatcher.go
+++ b/pkg/querier/dispatcher.go
@@ -292,15 +292,15 @@ func (w *queryResponseWriter) Write(ctx context.Context, r querierpb.EvaluateQue
 
 func (w *queryResponseWriter) WriteError(ctx context.Context, fallbackType apierror.Type, err error) {
 	typ := errorTypeForError(err, fallbackType)
-	msg := err.Error()
+	errMsg := err.Error()
 
 	if typ == mimirpb.QUERY_ERROR_TYPE_CANCELED {
-		level.Debug(w.logger).Log("msg", "returning cancelled status", "type", typ.String(), "err", msg)
+		level.Debug(w.logger).Log("msg", "returning cancelled status", "type", typ.String(), "err", errMsg)
 	} else {
 		span := trace.SpanFromContext(ctx)
-		span.SetStatus(codes.Error, msg)
+		span.SetStatus(codes.Error, errMsg)
 
-		level.Warn(w.logger).Log("msg", "returning error", "type", typ.String(), "err", msg)
+		level.Warn(w.logger).Log("msg", "returning error", "type", typ.String(), "err", errMsg)
 	}
 
 	w.status = "ERROR_" + strings.TrimPrefix(typ.String(), "QUERY_ERROR_TYPE_")
@@ -309,16 +309,16 @@ func (w *queryResponseWriter) WriteError(ctx context.Context, fallbackType apier
 		Data: &frontendv2pb.QueryResultStreamRequest_Error{
 			Error: &querierpb.Error{
 				Type:    typ,
-				Message: msg,
+				Message: errMsg,
 			},
 		},
 	}
 
 	if err := w.write(ctx, resp); err != nil {
 		if grpcutil.IsCanceled(err) {
-			level.Debug(w.logger).Log("msg", "failed to write error to query-frontend stream because the request was canceled", "writeErr", err, "originalErr", msg)
+			level.Debug(w.logger).Log("msg", "failed to write error to query-frontend stream because the request was canceled", "writeErr", err, "originalErr", errMsg)
 		} else {
-			level.Warn(w.logger).Log("msg", "failed to write error to query-frontend stream", "writeErr", err, "originalErr", msg)
+			level.Warn(w.logger).Log("msg", "failed to write error to query-frontend stream", "writeErr", err, "originalErr", errMsg)
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Logging two `msg` fields breaks log parsing the value of the second `msg` in LogQL. This renames the second `msg` field, which contains an error string, to `err`

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Deduplicates log fields in error paths to improve log parsing.
> 
> - In `pkg/querier/dispatcher.go` `WriteError`, replace local `msg` with `errMsg` and log key `msg` with `err` for the error string
> - Use `errMsg` for span status and `Error.Message`, and for `originalErr` in write-failure logs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 001c72736bc47edb4480b14214d0109fc333e010. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->