### PR TITLE
Jsonnet: add store_gateway_shard_size_per_zone_defaults_enabled and store_gateway_shard_size_per_zone_overrides_enabled config options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,7 +197,10 @@
 * [CHANGE] Zone pod disruption budget: Remove `multi_zone_zpdb_enabled` and replace it with `multi_zone_ingester_zpdb_enabled` and `multi_zone_store_gateway_zpdb_enabled` to allow to selectively enable the zone pod disruption budget on a per-component basis. #13813
 * [FEATURE] Add multi-zone support for read path components (memcached, querier, query-frontend, query-scheduler, ruler, and ruler remote evaluation stack). Add multi-AZ support for ingester and store-gateway multi-zone deployments. Add memberlist-bridge support for zone-aware memberlist routing. #13559 #13628 #13636 #13915
 * [FEATURE] Add deletion protection support for ingesters and store-gateways StatefulSet. It can be enabled by setting `ingester_deletion_protection_enabled` and `store_gateway_deletion_protection_enabled` in the `_config` block. #13819
-* [FEATURE] Shuffle sharding: Add `$._config.shuffle_sharding.store_gateway_shard_size_per_zone_enabled` configuration option to enable the experimental per-zone store-gateway shard size. #13908
+* [FEATURE] Shuffle sharding: Add the following configuration options to enable the experimental per-zone store-gateway shard size: #13908 #13941
+  * `$._config.shuffle_sharding.store_gateway_shard_size_per_zone_enabled`
+  * `$._config.shuffle_sharding.store_gateway_shard_size_per_zone_defaults_enabled` (takes precedence over `store_gateway_shard_size_per_zone_enabled`)
+  * `$._config.shuffle_sharding.store_gateway_shard_size_per_zone_overrides_enabled` (takes precedence over `store_gateway_shard_size_per_zone_enabled`)
 * [ENHANCEMENT] Ruler querier and query-frontend: Add support for newly-introduced querier ring, which is used when performing query planning in query-frontends and distributing portions of the plan to queriers for execution. #13017
 * [ENHANCEMENT] Ingester: Increase `$._config.ingester_tsdb_head_early_compaction_min_in_memory_series` default when Mimir is running with the ingest storage architecture. #13450
 * [ENHANCEMENT] Memberlist bridge: Add `memberlist_bridge_replicas_per_zone` configuration option (default: 2). #13727

--- a/operations/mimir/shuffle-sharding.libsonnet
+++ b/operations/mimir/shuffle-sharding.libsonnet
@@ -14,6 +14,8 @@
       // Enables store-gateway per-zone shard size configuration
       // (when enabled it takes precedence over the global shard size).
       store_gateway_shard_size_per_zone_enabled: false,
+      store_gateway_shard_size_per_zone_defaults_enabled: $._config.shuffle_sharding.store_gateway_shard_size_per_zone_enabled,
+      store_gateway_shard_size_per_zone_overrides_enabled: $._config.shuffle_sharding.store_gateway_shard_size_per_zone_enabled,
 
       // Default shard sizes. We want the shard size to be divisible by the number of zones.
       // We typically run 3 zones
@@ -93,7 +95,7 @@
         ingestion_tenant_shard_size: ingesterTenantShardSize(series),
         ingestion_partitions_tenant_shard_size: ingesterPartitionsTenantShardSize(series),
         store_gateway_tenant_shard_size: std.max(3, $._config.shuffle_sharding.store_gateway_shard_size),
-        store_gateway_tenant_shard_size_per_zone: if $._config.shuffle_sharding.store_gateway_shard_size_per_zone_enabled then std.ceil(self.store_gateway_tenant_shard_size / 3) else null,
+        store_gateway_tenant_shard_size_per_zone: if $._config.shuffle_sharding.store_gateway_shard_size_per_zone_overrides_enabled then std.ceil(self.store_gateway_tenant_shard_size / 3) else null,
         ruler_tenant_shard_size: std.max(2, $._config.shuffle_sharding.ruler_shard_size),
       }),
 
@@ -104,7 +106,7 @@
         ingestion_tenant_shard_size: ingesterTenantShardSize(series),
         ingestion_partitions_tenant_shard_size: ingesterPartitionsTenantShardSize(series),
         store_gateway_tenant_shard_size: std.max(6, $._config.shuffle_sharding.store_gateway_shard_size),
-        store_gateway_tenant_shard_size_per_zone: if $._config.shuffle_sharding.store_gateway_shard_size_per_zone_enabled then std.ceil(self.store_gateway_tenant_shard_size / 3) else null,
+        store_gateway_tenant_shard_size_per_zone: if $._config.shuffle_sharding.store_gateway_shard_size_per_zone_overrides_enabled then std.ceil(self.store_gateway_tenant_shard_size / 3) else null,
         ruler_tenant_shard_size: std.max(2, $._config.shuffle_sharding.ruler_shard_size),
       }),
 
@@ -115,7 +117,7 @@
         ingestion_tenant_shard_size: ingesterTenantShardSize(series),
         ingestion_partitions_tenant_shard_size: ingesterPartitionsTenantShardSize(series),
         store_gateway_tenant_shard_size: std.max(9, $._config.shuffle_sharding.store_gateway_shard_size),
-        store_gateway_tenant_shard_size_per_zone: if $._config.shuffle_sharding.store_gateway_shard_size_per_zone_enabled then std.ceil(self.store_gateway_tenant_shard_size / 3) else null,
+        store_gateway_tenant_shard_size_per_zone: if $._config.shuffle_sharding.store_gateway_shard_size_per_zone_overrides_enabled then std.ceil(self.store_gateway_tenant_shard_size / 3) else null,
         ruler_tenant_shard_size: std.max(2, $._config.shuffle_sharding.ruler_shard_size),
       }),
 
@@ -126,7 +128,7 @@
         ingestion_tenant_shard_size: ingesterTenantShardSize(series),
         ingestion_partitions_tenant_shard_size: ingesterPartitionsTenantShardSize(series),
         store_gateway_tenant_shard_size: std.max(12, $._config.shuffle_sharding.store_gateway_shard_size),
-        store_gateway_tenant_shard_size_per_zone: if $._config.shuffle_sharding.store_gateway_shard_size_per_zone_enabled then std.ceil(self.store_gateway_tenant_shard_size / 3) else null,
+        store_gateway_tenant_shard_size_per_zone: if $._config.shuffle_sharding.store_gateway_shard_size_per_zone_overrides_enabled then std.ceil(self.store_gateway_tenant_shard_size / 3) else null,
         ruler_tenant_shard_size: std.max(3, $._config.shuffle_sharding.ruler_shard_size),
       }),
 
@@ -137,7 +139,7 @@
         ingestion_tenant_shard_size: ingesterTenantShardSize(series),
         ingestion_partitions_tenant_shard_size: ingesterPartitionsTenantShardSize(series),
         store_gateway_tenant_shard_size: std.max(18, $._config.shuffle_sharding.store_gateway_shard_size),
-        store_gateway_tenant_shard_size_per_zone: if $._config.shuffle_sharding.store_gateway_shard_size_per_zone_enabled then std.ceil(self.store_gateway_tenant_shard_size / 3) else null,
+        store_gateway_tenant_shard_size_per_zone: if $._config.shuffle_sharding.store_gateway_shard_size_per_zone_overrides_enabled then std.ceil(self.store_gateway_tenant_shard_size / 3) else null,
         ruler_tenant_shard_size: std.max(6, $._config.shuffle_sharding.ruler_shard_size),
       }),
 
@@ -148,7 +150,7 @@
         ingestion_tenant_shard_size: ingesterTenantShardSize(series),
         ingestion_partitions_tenant_shard_size: ingesterPartitionsTenantShardSize(series),
         store_gateway_tenant_shard_size: std.max(24, $._config.shuffle_sharding.store_gateway_shard_size),
-        store_gateway_tenant_shard_size_per_zone: if $._config.shuffle_sharding.store_gateway_shard_size_per_zone_enabled then std.ceil(self.store_gateway_tenant_shard_size / 3) else null,
+        store_gateway_tenant_shard_size_per_zone: if $._config.shuffle_sharding.store_gateway_shard_size_per_zone_overrides_enabled then std.ceil(self.store_gateway_tenant_shard_size / 3) else null,
         ruler_tenant_shard_size: std.max(8, $._config.shuffle_sharding.ruler_shard_size),
       }),
 
@@ -159,7 +161,7 @@
         ingestion_tenant_shard_size: ingesterTenantShardSize(series),
         ingestion_partitions_tenant_shard_size: ingesterPartitionsTenantShardSize(series),
         store_gateway_tenant_shard_size: std.max(30, $._config.shuffle_sharding.store_gateway_shard_size),
-        store_gateway_tenant_shard_size_per_zone: if $._config.shuffle_sharding.store_gateway_shard_size_per_zone_enabled then std.ceil(self.store_gateway_tenant_shard_size / 3) else null,
+        store_gateway_tenant_shard_size_per_zone: if $._config.shuffle_sharding.store_gateway_shard_size_per_zone_overrides_enabled then std.ceil(self.store_gateway_tenant_shard_size / 3) else null,
         ruler_tenant_shard_size: std.max(8, $._config.shuffle_sharding.ruler_shard_size),
       }),
 
@@ -170,7 +172,7 @@
         ingestion_tenant_shard_size: ingesterTenantShardSize(series),
         ingestion_partitions_tenant_shard_size: ingesterPartitionsTenantShardSize(series),
         store_gateway_tenant_shard_size: std.max(42, $._config.shuffle_sharding.store_gateway_shard_size),
-        store_gateway_tenant_shard_size_per_zone: if $._config.shuffle_sharding.store_gateway_shard_size_per_zone_enabled then std.ceil(self.store_gateway_tenant_shard_size / 3) else null,
+        store_gateway_tenant_shard_size_per_zone: if $._config.shuffle_sharding.store_gateway_shard_size_per_zone_overrides_enabled then std.ceil(self.store_gateway_tenant_shard_size / 3) else null,
         ruler_tenant_shard_size: std.max(12, $._config.shuffle_sharding.ruler_shard_size),
       }),
     },
@@ -202,7 +204,7 @@
       'store-gateway.tenant-shard-size': $._config.shuffle_sharding.store_gateway_shard_size,
     }
   ) + (
-    if !$._config.shuffle_sharding.store_gateway_enabled || !$._config.shuffle_sharding.store_gateway_shard_size_per_zone_enabled then {} else {
+    if !$._config.shuffle_sharding.store_gateway_enabled || !$._config.shuffle_sharding.store_gateway_shard_size_per_zone_defaults_enabled then {} else {
       'store-gateway.tenant-shard-size-per-zone': $._config.shuffle_sharding.store_gateway_shard_size_per_zone,
     }
   ) + (
@@ -223,7 +225,7 @@
       'store-gateway.tenant-shard-size': $._config.shuffle_sharding.store_gateway_shard_size,
     }
   ) + (
-    if !$._config.shuffle_sharding.store_gateway_enabled || !$._config.shuffle_sharding.store_gateway_shard_size_per_zone_enabled then {} else {
+    if !$._config.shuffle_sharding.store_gateway_enabled || !$._config.shuffle_sharding.store_gateway_shard_size_per_zone_defaults_enabled then {} else {
       'store-gateway.tenant-shard-size-per-zone': $._config.shuffle_sharding.store_gateway_shard_size_per_zone,
     }
   ),
@@ -255,7 +257,7 @@
       'store-gateway.tenant-shard-size': $._config.shuffle_sharding.store_gateway_shard_size,
     }
   ) + (
-    if !$._config.shuffle_sharding.store_gateway_enabled || !$._config.shuffle_sharding.store_gateway_shard_size_per_zone_enabled then {} else {
+    if !$._config.shuffle_sharding.store_gateway_enabled || !$._config.shuffle_sharding.store_gateway_shard_size_per_zone_defaults_enabled then {} else {
       'store-gateway.tenant-shard-size-per-zone': $._config.shuffle_sharding.store_gateway_shard_size_per_zone,
     }
   ),
@@ -265,7 +267,7 @@
       'store-gateway.tenant-shard-size': $._config.shuffle_sharding.store_gateway_shard_size,
     }
   ) + (
-    if !$._config.shuffle_sharding.store_gateway_enabled || !$._config.shuffle_sharding.store_gateway_shard_size_per_zone_enabled then {} else {
+    if !$._config.shuffle_sharding.store_gateway_enabled || !$._config.shuffle_sharding.store_gateway_shard_size_per_zone_defaults_enabled then {} else {
       'store-gateway.tenant-shard-size-per-zone': $._config.shuffle_sharding.store_gateway_shard_size_per_zone,
     }
   ),


### PR DESCRIPTION
#### What this PR does

This PR is a follow up of #13908. In this PR I'm adding two more config options to selectively enable the store-gateway per-zone shard size for overrides and/or defaults. This is required during migrations to per-zone shard size, because first we need to enable it for overrides, and then change the default in a second step.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces selective enablement for per-zone store-gateway shard size.
> 
> - Adds `$._config.shuffle_sharding.store_gateway_shard_size_per_zone_defaults_enabled` and `$._config.shuffle_sharding.store_gateway_shard_size_per_zone_overrides_enabled` (both take precedence over `store_gateway_shard_size_per_zone_enabled`)
> - Defaults new flags to `store_gateway_shard_size_per_zone_enabled`
> - Gates `store-gateway.tenant-shard-size-per-zone` args on `...defaults_enabled`
> - Computes per-user `store_gateway_tenant_shard_size_per_zone` based on `...overrides_enabled`
> - Updates CHANGELOG entry to list the new options and precedence
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a35913395f7a5413e21bbe2df48ab82002ee5af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->