### PR TITLE
fix(ingester): keep INACTIVE state for partition when any number of compactions are in progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@
 * [BUGFIX] Query-frontend: Fix `step()` duration expression returning 1000x larger value. #13920
 * [BUGFIX] Store-gateway: Fix parent-child relationship in LabelNames and LabelValues trace spans. #13932
 * [BUGFIX] MQE: Map remote execution storage errors correctly. #13944
+* [BUGFIX] Ingester: Fix issue where partitions can exit INACTIVE state during idle compactions, resulting in write errors. #13964
 
 ### Mixin
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This was fixed previously for classic architecture with https://github.com/grafana/mimir/issues/11850. In this PR we extend the fix to the Ingest Storage and the partitions

With this a partition will not be able to change in ACTIVE state from INACTIVE if there is any compaction in progress, which can cause writes to fail

#### Which issue(s) this PR fixes or relates to

Fixes #11850 for ingest storage archtiecture

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents partitions from leaving `INACTIVE` during compaction and adds coverage.
> 
> - In `PreparePartitionDownscaleHandler` (`DELETE`), if partition is `INACTIVE` and `numCompactionsInProgress` > 0, log a warning, return `409 Conflict`, and keep state `INACTIVE`
> - Adds test validating `DELETE` fails and partition remains `INACTIVE` when a compaction is in progress
> - Updates `CHANGELOG.md` with the ingester bugfix entry
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bbc10a0af1b82e8c4156e94ecd3668ae6f0f2351. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->