### PR TITLE
chore(renovate): Add custom manager for Docker images in Jsonnet files

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -4,6 +4,17 @@
     'config:recommended',
     'schedule:daily'
   ],
+  customManagers: [
+    {
+      customType: 'regex',
+      description: 'Update Docker images in Jsonnet files',
+      managerFilePatterns: ['\\.jsonnet$'],
+      matchStrings: [
+        "image:\\s*'(?<depName>.+):(?<currentValue>[^'/@]+)'",
+      ],
+      datasourceTemplate: 'docker',
+    },
+  ],
   baseBranchPatterns: [
     'main',
     'release-3.0',


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

The microservices development environment uses Jsonnet files as the source of truth for docker-compose configuration. Renovate was not updating these files, causing Prometheus versions to fall behind.

This adds a custom regex manager to detect and update Docker image references in .jsonnet files.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Renovate custom regex manager to update Docker image tags in `.jsonnet` files.
> 
> - Extends `renovate.json5` with `customManagers` using a regex to match `image: '<name>:<tag>'` and `docker` datasource
> - No other config behavior changed (schedules, package rules, limits retained)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 348023fceb9805b33daf51c757200b2a30c7bd0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->