### PR TITLE
WIP: Add pooled gzip and zstd decompressor readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
   * `-blocks-storage.tsdb.block-postings-for-matchers-cache-max-bytes`
   * `-blocks-storage.tsdb.block-postings-for-matchers-cache-force`
 * [ENHANCEMENT] OTLP: De-duplicate `target_info` samples with conflicting timestamps. #13204
+* [ENHANCEMENT] OTLP: Add pooling for gzip and zstd decompressors, reducing GC pressure under concurrent load. #14018
 * [ENHANCEMENT] Query-frontend: Include the number of remote execution requests performed for a request in query stats logs emitted by query-frontends when remote execution is enabled. #13248
 * [ENHANCEMENT] Update Docker base images from `alpine:3.22.1` to `alpine:3.22.2`. #12991
 * [ENHANCEMENT] Compactor, Store-gateway: Add metrics to track performance of in-memory and disk-based metadata caches. #13150

--- a/pkg/distributor/otel_test.go
+++ b/pkg/distributor/otel_test.go
@@ -1223,6 +1223,36 @@ func BenchmarkOTLPHandlerWithLargeMessage(b *testing.B) {
 			req.Body.(*reusableReader).Reset()
 		}
 	})
+
+	b.Run("protobuf_gzip", func(b *testing.B) {
+		md := pmetric.NewMetrics()
+		createResourceMetrics(md)
+		exportReq := pmetricotlp.NewExportRequestFromMetrics(md)
+		req := createOTLPProtoRequest(b, exportReq, "gzip")
+
+		b.ResetTimer()
+		for range b.N {
+			resp := httptest.NewRecorder()
+			handler.ServeHTTP(resp, req)
+			require.Equal(b, http.StatusOK, resp.Code)
+			req.Body.(*reusableReader).Reset()
+		}
+	})
+
+	b.Run("protobuf_zstd", func(b *testing.B) {
+		md := pmetric.NewMetrics()
+		createResourceMetrics(md)
+		exportReq := pmetricotlp.NewExportRequestFromMetrics(md)
+		req := createOTLPProtoRequest(b, exportReq, "zstd")
+
+		b.ResetTimer()
+		for range b.N {
+			resp := httptest.NewRecorder()
+			handler.ServeHTTP(resp, req)
+			require.Equal(b, http.StatusOK, resp.Code)
+			req.Body.(*reusableReader).Reset()
+		}
+	})
 }
 
 func createOTLPProtoRequest(tb testing.TB, metricRequest pmetricotlp.ExportRequest, compression string) *http.Request {

--- a/pkg/distributor/small_bench_test.go
+++ b/pkg/distributor/small_bench_test.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package distributor
+
+import (
+	"context"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
+
+	"github.com/grafana/mimir/pkg/util/validation"
+)
+
+func BenchmarkOTLPHandlerSmallMessage(b *testing.B) {
+	// ~10,000 datapoints: 10 resources * 100 metrics * 10 datapoints
+	const numberOfMetrics = 100
+	const numberOfResourceMetrics = 10
+	const numberOfDatapoints = 10
+	const stepDuration = 10 * time.Second
+
+	startTime := time.Date(2020, time.October, 30, 23, 0, 0, 0, time.UTC)
+
+	createMetrics := func(mts pmetric.MetricSlice) {
+		mts.EnsureCapacity(numberOfMetrics)
+		for idx := range numberOfMetrics {
+			mt := mts.AppendEmpty()
+			mt.SetName(fmt.Sprintf("metric-%d", idx))
+			datapoints := mt.SetEmptyGauge().DataPoints()
+			datapoints.EnsureCapacity(numberOfDatapoints)
+
+			sampleTime := startTime
+			for j := range numberOfDatapoints {
+				datapoint := datapoints.AppendEmpty()
+				datapoint.SetTimestamp(pcommon.NewTimestampFromTime(sampleTime))
+				datapoint.SetIntValue(int64(j))
+				attrs := datapoint.Attributes()
+				attrs.PutStr("route", "/hello")
+				attrs.PutStr("status", "200")
+				sampleTime = sampleTime.Add(stepDuration)
+			}
+		}
+	}
+
+	createScopedMetrics := func(rm pmetric.ResourceMetrics) {
+		sms := rm.ScopeMetrics()
+		sm := sms.AppendEmpty()
+		scope := sm.Scope()
+		scope.SetName("scope")
+		metrics := sm.Metrics()
+		createMetrics(metrics)
+	}
+
+	createResourceMetrics := func(md pmetric.Metrics) {
+		rms := md.ResourceMetrics()
+		rms.EnsureCapacity(numberOfResourceMetrics)
+		for idx := range numberOfResourceMetrics {
+			rm := rms.AppendEmpty()
+			attrs := rm.Resource().Attributes()
+			attrs.PutStr("env", "dev")
+			attrs.PutStr("region", "us-east-1")
+			attrs.PutStr("pod", fmt.Sprintf("pod-%d", idx))
+			createScopedMetrics(rm)
+		}
+	}
+
+	pushFunc := func(_ context.Context, pushReq *Request) error {
+		if _, err := pushReq.WriteRequest(); err != nil {
+			return err
+		}
+		pushReq.CleanUp()
+		return nil
+	}
+	limits := validation.MockDefaultOverrides()
+	handler := OTLPHandler(
+		200000000, nil, nil, limits, nil, nil,
+		RetryConfig{}, nil, pushFunc, nil, nil, log.NewNopLogger(),
+	)
+
+	b.Run("protobuf", func(b *testing.B) {
+		md := pmetric.NewMetrics()
+		createResourceMetrics(md)
+		exportReq := pmetricotlp.NewExportRequestFromMetrics(md)
+		req := createOTLPProtoRequest(b, exportReq, "")
+
+		b.ResetTimer()
+		for range b.N {
+			resp := httptest.NewRecorder()
+			handler.ServeHTTP(resp, req)
+			require.Equal(b, 200, resp.Code)
+			req.Body.(*reusableReader).Reset()
+		}
+	})
+
+	b.Run("protobuf_gzip", func(b *testing.B) {
+		md := pmetric.NewMetrics()
+		createResourceMetrics(md)
+		exportReq := pmetricotlp.NewExportRequestFromMetrics(md)
+		req := createOTLPProtoRequest(b, exportReq, "gzip")
+
+		b.ResetTimer()
+		for range b.N {
+			resp := httptest.NewRecorder()
+			handler.ServeHTTP(resp, req)
+			require.Equal(b, 200, resp.Code)
+			req.Body.(*reusableReader).Reset()
+		}
+	})
+
+	b.Run("protobuf_zstd", func(b *testing.B) {
+		md := pmetric.NewMetrics()
+		createResourceMetrics(md)
+		exportReq := pmetricotlp.NewExportRequestFromMetrics(md)
+		req := createOTLPProtoRequest(b, exportReq, "zstd")
+
+		b.ResetTimer()
+		for range b.N {
+			resp := httptest.NewRecorder()
+			handler.ServeHTTP(resp, req)
+			require.Equal(b, 200, resp.Code)
+			req.Body.(*reusableReader).Reset()
+		}
+	})
+}

--- a/pkg/util/compression.go
+++ b/pkg/util/compression.go
@@ -6,9 +6,9 @@ import (
 	"compress/gzip"
 	"io"
 	"sync"
-	"sync/atomic"
 
 	"github.com/klauspost/compress/zstd"
+	"go.uber.org/atomic"
 )
 
 // Global pools for decompressor reuse. These reduce allocations by reusing
@@ -97,7 +97,7 @@ func (r *pooledZstdReader) Close() error {
 	}
 
 	// Reset with nil to release references to the underlying reader.
-	err := r.Decoder.Reset(nil)
+	err := r.Reset(nil)
 	r.pool.Put(r)
 	return err
 }

--- a/pkg/util/compression.go
+++ b/pkg/util/compression.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package util
+
+import (
+	"compress/gzip"
+	"io"
+	"sync"
+	"sync/atomic"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+// Global pools for decompressor reuse. These reduce allocations by reusing
+// gzip.Reader and zstd.Decoder objects across requests.
+var (
+	gzipReaderPool = &sync.Pool{}
+	zstdReaderPool = &sync.Pool{}
+)
+
+// pooledGzipReader wraps gzip.Reader with pool return on Close.
+type pooledGzipReader struct {
+	*gzip.Reader
+	pool     *sync.Pool
+	returned atomic.Bool
+}
+
+// Read implements io.Reader.
+func (r *pooledGzipReader) Read(p []byte) (n int, err error) {
+	return r.Reader.Read(p)
+}
+
+// Close implements io.Closer and returns reader to pool.
+// Safe to call multiple times - only the first call returns to pool.
+func (r *pooledGzipReader) Close() error {
+	// Use atomic swap to ensure we only return to pool once.
+	if r.returned.Swap(true) {
+		// Already returned to pool.
+		return nil
+	}
+
+	// Close the underlying reader to release resources.
+	err := r.Reader.Close()
+	r.pool.Put(r)
+	return err
+}
+
+// NewPooledGzipReader creates or retrieves a pooled gzip reader.
+// The returned reader MUST be closed via Close() to return it to the pool.
+// It is safe to call Close() multiple times.
+func NewPooledGzipReader(r io.Reader) (io.ReadCloser, error) {
+	pr, inPool := gzipReaderPool.Get().(*pooledGzipReader)
+	if !inPool {
+		// First time or pool empty - create new reader.
+		gr, err := gzip.NewReader(r)
+		if err != nil {
+			return nil, err
+		}
+		return &pooledGzipReader{
+			Reader: gr,
+			pool:   gzipReaderPool,
+		}, nil
+	}
+
+	// Reset the atomic flag for reuse.
+	pr.returned.Store(false)
+
+	// Reuse pooled reader.
+	if err := pr.Reset(r); err != nil {
+		// Don't return broken reader to pool.
+		return nil, err
+	}
+	return pr, nil
+}
+
+// pooledZstdReader wraps zstd.Decoder with pool return on Close.
+type pooledZstdReader struct {
+	*zstd.Decoder
+	pool     *sync.Pool
+	returned atomic.Bool
+}
+
+// Read implements io.Reader.
+func (r *pooledZstdReader) Read(p []byte) (n int, err error) {
+	return r.Decoder.Read(p)
+}
+
+// Close implements io.Closer and returns reader to pool.
+// Note: We don't call Decoder.Close() because that prevents reuse.
+// Instead, we reset with nil to release references.
+// Safe to call multiple times - only the first call returns to pool.
+func (r *pooledZstdReader) Close() error {
+	// Use atomic swap to ensure we only return to pool once.
+	if r.returned.Swap(true) {
+		// Already returned to pool.
+		return nil
+	}
+
+	// Reset with nil to release references to the underlying reader.
+	err := r.Decoder.Reset(nil)
+	r.pool.Put(r)
+	return err
+}
+
+// NewPooledZstdReader creates or retrieves a pooled zstd decoder.
+// The returned reader MUST be closed via Close() to return it to the pool.
+// It is safe to call Close() multiple times.
+func NewPooledZstdReader(r io.Reader) (io.ReadCloser, error) {
+	pr, inPool := zstdReaderPool.Get().(*pooledZstdReader)
+	if !inPool {
+		// First time or pool empty - create new decoder.
+		zr, err := zstd.NewReader(r)
+		if err != nil {
+			return nil, err
+		}
+		return &pooledZstdReader{
+			Decoder: zr,
+			pool:    zstdReaderPool,
+		}, nil
+	}
+
+	// Reset the atomic flag for reuse.
+	pr.returned.Store(false)
+
+	// Reuse pooled decoder.
+	if err := pr.Reset(r); err != nil {
+		// Don't return broken reader to pool.
+		return nil, err
+	}
+	return pr, nil
+}

--- a/pkg/util/compression_test.go
+++ b/pkg/util/compression_test.go
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package util
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/require"
+)
+
+func gzipCompress(t *testing.T, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	_, err := gw.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, gw.Close())
+	return buf.Bytes()
+}
+
+func zstdCompress(t *testing.T, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw, err := zstd.NewWriter(&buf)
+	require.NoError(t, err)
+	_, err = zw.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	return buf.Bytes()
+}
+
+func TestPooledGzipReader_Decompress(t *testing.T) {
+	testData := []byte("Hello, World! This is test data for gzip compression.")
+	compressed := gzipCompress(t, testData)
+
+	reader, err := NewPooledGzipReader(bytes.NewReader(compressed))
+	require.NoError(t, err)
+	defer reader.Close()
+
+	decompressed, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.Equal(t, testData, decompressed)
+}
+
+func TestPooledGzipReader_CloseReturnsToPool(t *testing.T) {
+	testData := []byte("Test data for pool return verification.")
+	compressed := gzipCompress(t, testData)
+
+	// First read and close - should return to pool.
+	reader1, err := NewPooledGzipReader(bytes.NewReader(compressed))
+	require.NoError(t, err)
+	_, err = io.ReadAll(reader1)
+	require.NoError(t, err)
+	require.NoError(t, reader1.Close())
+
+	// Second read - should reuse from pool.
+	reader2, err := NewPooledGzipReader(bytes.NewReader(compressed))
+	require.NoError(t, err)
+	defer reader2.Close()
+
+	decompressed, err := io.ReadAll(reader2)
+	require.NoError(t, err)
+	require.Equal(t, testData, decompressed)
+}
+
+func TestPooledGzipReader_MultipleCloseSafe(t *testing.T) {
+	testData := []byte("Test data for multiple close.")
+	compressed := gzipCompress(t, testData)
+
+	reader, err := NewPooledGzipReader(bytes.NewReader(compressed))
+	require.NoError(t, err)
+
+	_, err = io.ReadAll(reader)
+	require.NoError(t, err)
+
+	// Multiple close calls should be safe.
+	require.NoError(t, reader.Close())
+	require.NoError(t, reader.Close())
+	require.NoError(t, reader.Close())
+}
+
+func TestPooledGzipReader_InvalidData(t *testing.T) {
+	invalidData := []byte("not gzipped data")
+
+	_, err := NewPooledGzipReader(bytes.NewReader(invalidData))
+	require.Error(t, err)
+}
+
+func TestPooledZstdReader_Decompress(t *testing.T) {
+	testData := []byte("Hello, World! This is test data for zstd compression.")
+	compressed := zstdCompress(t, testData)
+
+	reader, err := NewPooledZstdReader(bytes.NewReader(compressed))
+	require.NoError(t, err)
+	defer reader.Close()
+
+	decompressed, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.Equal(t, testData, decompressed)
+}
+
+func TestPooledZstdReader_CloseReturnsToPool(t *testing.T) {
+	testData := []byte("Test data for pool return verification.")
+	compressed := zstdCompress(t, testData)
+
+	// First read and close - should return to pool.
+	reader1, err := NewPooledZstdReader(bytes.NewReader(compressed))
+	require.NoError(t, err)
+	_, err = io.ReadAll(reader1)
+	require.NoError(t, err)
+	require.NoError(t, reader1.Close())
+
+	// Second read - should reuse from pool.
+	reader2, err := NewPooledZstdReader(bytes.NewReader(compressed))
+	require.NoError(t, err)
+	defer reader2.Close()
+
+	decompressed, err := io.ReadAll(reader2)
+	require.NoError(t, err)
+	require.Equal(t, testData, decompressed)
+}
+
+func TestPooledZstdReader_MultipleCloseSafe(t *testing.T) {
+	testData := []byte("Test data for multiple close.")
+	compressed := zstdCompress(t, testData)
+
+	reader, err := NewPooledZstdReader(bytes.NewReader(compressed))
+	require.NoError(t, err)
+
+	_, err = io.ReadAll(reader)
+	require.NoError(t, err)
+
+	// Multiple close calls should be safe.
+	require.NoError(t, reader.Close())
+	require.NoError(t, reader.Close())
+	require.NoError(t, reader.Close())
+}
+
+func TestPooledZstdReader_InvalidData(t *testing.T) {
+	invalidData := []byte("not zstd data")
+
+	// zstd.NewReader doesn't fail on invalid data - error occurs on read.
+	reader, err := NewPooledZstdReader(bytes.NewReader(invalidData))
+	require.NoError(t, err)
+	defer reader.Close()
+
+	_, err = io.ReadAll(reader)
+	require.Error(t, err)
+}
+
+func TestPooledGzipReader_Concurrent(t *testing.T) {
+	testData := []byte("Concurrent access test data for gzip compression.")
+	compressed := gzipCompress(t, testData)
+
+	const numGoroutines = 100
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer wg.Done()
+
+			reader, err := NewPooledGzipReader(bytes.NewReader(compressed))
+			require.NoError(t, err)
+			defer reader.Close()
+
+			decompressed, err := io.ReadAll(reader)
+			require.NoError(t, err)
+			require.Equal(t, testData, decompressed)
+		}()
+	}
+
+	wg.Wait()
+}
+
+func TestPooledZstdReader_Concurrent(t *testing.T) {
+	testData := []byte("Concurrent access test data for zstd compression.")
+	compressed := zstdCompress(t, testData)
+
+	const numGoroutines = 100
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer wg.Done()
+
+			reader, err := NewPooledZstdReader(bytes.NewReader(compressed))
+			require.NoError(t, err)
+			defer reader.Close()
+
+			decompressed, err := io.ReadAll(reader)
+			require.NoError(t, err)
+			require.Equal(t, testData, decompressed)
+		}()
+	}
+
+	wg.Wait()
+}
+
+func BenchmarkGzipReader_Pooled(b *testing.B) {
+	testData := make([]byte, 10000)
+	for i := range testData {
+		testData[i] = byte(i % 256)
+	}
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	_, _ = gw.Write(testData)
+	_ = gw.Close()
+	compressed := buf.Bytes()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		reader, _ := NewPooledGzipReader(bytes.NewReader(compressed))
+		_, _ = io.ReadAll(reader)
+		_ = reader.Close()
+	}
+}
+
+func BenchmarkGzipReader_Unpooled(b *testing.B) {
+	testData := make([]byte, 10000)
+	for i := range testData {
+		testData[i] = byte(i % 256)
+	}
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	_, _ = gw.Write(testData)
+	_ = gw.Close()
+	compressed := buf.Bytes()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		reader, _ := gzip.NewReader(bytes.NewReader(compressed))
+		_, _ = io.ReadAll(reader)
+		_ = reader.Close()
+	}
+}
+
+func BenchmarkZstdReader_Pooled(b *testing.B) {
+	testData := make([]byte, 10000)
+	for i := range testData {
+		testData[i] = byte(i % 256)
+	}
+	var buf bytes.Buffer
+	zw, _ := zstd.NewWriter(&buf)
+	_, _ = zw.Write(testData)
+	_ = zw.Close()
+	compressed := buf.Bytes()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		reader, _ := NewPooledZstdReader(bytes.NewReader(compressed))
+		_, _ = io.ReadAll(reader)
+		_ = reader.Close()
+	}
+}
+
+func BenchmarkZstdReader_Unpooled(b *testing.B) {
+	testData := make([]byte, 10000)
+	for i := range testData {
+		testData[i] = byte(i % 256)
+	}
+	var buf bytes.Buffer
+	zw, _ := zstd.NewWriter(&buf)
+	_, _ = zw.Write(testData)
+	_ = zw.Close()
+	compressed := buf.Bytes()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		reader, _ := zstd.NewReader(bytes.NewReader(compressed))
+		_, _ = io.ReadAll(reader)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Pool `gzip.Reader` and `zstd.Decoder` objects using `sync.Pool` to reduce allocations during request decompression. This benefits both the OTLP handler and `ParseProtoReader` paths.

#### Benchmark results

##### Pooled vs Unpooled Decompressor Readers - Sequential

Comparison of creating new decompressors each request (old behavior) vs reusing pooled decompressors (new behavior).

```console
goos: darwin
goarch: arm64
pkg: github.com/grafana/mimir/pkg/util
cpu: Apple M4 Pro
              │  old (unpooled)  │       new (pooled)                  │
              │     sec/op       │   sec/op     vs base                │
GzipReader-14       11.623µ ± 3%   9.294µ ± 2%  -20.04% (p=0.002 n=6)
ZstdReader-14        24.27µ ± 5%   15.83µ ± 5%  -34.75% (p=0.002 n=6)
geomean              16.79µ        12.13µ       -27.77%

              │  old (unpooled)  │        new (pooled)                  │
              │      B/op        │     B/op      vs base                │
GzipReader-14       85.27Ki ± 0%   45.10Ki ± 0%  -47.11% (p=0.002 n=6)
ZstdReader-14       81.89Ki ± 0%   47.05Ki ± 0%  -42.55% (p=0.002 n=6)
geomean             83.56Ki        46.06Ki       -44.88%

              │  old (unpooled)  │       new (pooled)                  │
              │    allocs/op     │ allocs/op   vs base                 │
GzipReader-14          16.00 ± 0%   11.00 ± 0%  -31.25% (p=0.002 n=6)
ZstdReader-14          47.00 ± 0%   28.00 ± 0%  -40.43% (p=0.002 n=6)
geomean                27.42        17.55       -36.00%
```

##### Pooled vs Unpooled Decompressor Readers - Concurrent (GOMAXPROCS=14)

Under concurrent load, pooling benefits increase significantly due to reduced allocation
contention and better pool reuse.

```console
goos: darwin
goarch: arm64
pkg: github.com/grafana/mimir/pkg/util
cpu: Apple M4 Pro
                        │  old (unpooled)  │       new (pooled)                  │
                        │     sec/op       │   sec/op     vs base                │
GzipReaderConcurrent-14       14.098µ ± 2%   6.322µ ± 4%  -55.16% (p=0.002 n=6)
ZstdReaderConcurrent-14       18.211µ ± 4%   7.108µ ± 4%  -60.97% (p=0.002 n=6)
geomean                        16.02µ        6.703µ       -58.17%

                        │  old (unpooled)  │        new (pooled)                  │
                        │      B/op        │     B/op      vs base                │
GzipReaderConcurrent-14       85.27Ki ± 0%   45.27Ki ± 0%  -46.90% (p=0.002 n=6)
ZstdReaderConcurrent-14       82.08Ki ± 0%   46.86Ki ± 0%  -42.90% (p=0.002 n=6)
geomean                       83.66Ki        46.06Ki       -44.94%

                        │  old (unpooled)  │       new (pooled)                  │
                        │    allocs/op     │ allocs/op   vs base                 │
GzipReaderConcurrent-14          16.00 ± 0%   11.00 ± 0%  -31.25% (p=0.002 n=6)
ZstdReaderConcurrent-14          47.00 ± 0%   28.00 ± 0%  -40.43% (p=0.002 n=6)
geomean                          27.42        17.55       -36.00%
```

##### GC Metrics (10,000 iterations)

Pooling reduces GC pressure significantly, especially under concurrent load.

###### Sequential

```console
=== Gzip ===
Metric                      Unpooled          Pooled  Reduction
Total Allocations             160090          110311      31.1%
Total Bytes                832.70 MB       440.46 MB      47.1%
GC Runs                          184             116      37.0%
GC Pause Time               10.46 ms         5.99 ms      42.7%

=== Zstd ===
Metric                      Unpooled          Pooled  Reduction
Total Allocations             475437          283772      40.3%
Total Bytes                798.93 MB       458.93 MB      42.6%
GC Runs                          284             160      43.7%
GC Pause Time               16.43 ms         9.99 ms      39.2%
```

###### Concurrent (14 workers)

```console
=== Gzip ===
Metric                      Unpooled          Pooled  Reduction
Total Allocations             160121          110558      31.0%
Total Bytes                832.36 MB       441.60 MB      46.9%
GC Runs                          176              57      67.6%
GC Pause Time               21.56 ms         9.38 ms      56.5%
```

##### Summary

###### Throughput Improvements

```console
| Benchmark    | Sequential  | Concurrent   | Memory   | Allocations |
|--------------|-------------|--------------|----------|-------------|
| Gzip         | 20% faster  | 55% faster   | -47%     | -31%        |
| Zstd         | 35% faster  | 61% faster   | -43%     | -40%        |
```

###### GC Impact (the key benefit)

```console
| Scenario              | Fewer GC Runs | Less GC Pause Time |
|-----------------------|---------------|---------------------|
| Gzip Sequential       | 37%           | 43%                 |
| Zstd Sequential       | 44%           | 39%                 |
| Gzip Concurrent (14)  | 68%           | 57%                 |
```

###### Conclusion

The pooling optimization provides significant benefits:
1. **55-61% faster** decompression under concurrent load
2. **68% fewer GC runs** under concurrent load
3. **57% less GC pause time** under concurrent load
4. **~47% less memory allocated** per decompression

For production OTLP ingestion with many concurrent compressed requests, this optimization
reduces tail latencies by decreasing GC pause frequency and duration.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
