### PR TITLE
MQE: only keep a fixed number of spans in memory in tests

### DIFF
--- a/pkg/streamingpromql/engine_fuzz_test.go
+++ b/pkg/streamingpromql/engine_fuzz_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/querier/stats"
-	"github.com/grafana/mimir/pkg/streamingpromql/testutils"
+	mqetest "github.com/grafana/mimir/pkg/streamingpromql/testutils"
 )
 
 const (
@@ -113,7 +113,6 @@ func fixUpAndAssertPostingErrors(t *testing.T, prom, mqe *promql.Result) {
 
 // testInstantQueries executes the given query against both engines and asserts that the results match
 func testInstantQueries(t *testing.T, startT time.Time, query string, testEnvironment *fuzzTestEnvironment) {
-
 	prometheusQuery, prometheusError := testEnvironment.prometheus.NewInstantQuery(context.Background(), testEnvironment.queryable, nil, query, startT)
 	mqeQuery, mqeError := testEnvironment.mqe.NewInstantQuery(context.Background(), testEnvironment.queryable, nil, query, startT)
 
@@ -161,7 +160,7 @@ func executeQueriesAndCompareResults(t *testing.T, testEnvironment fuzzTestEnvir
 	fixUpAndAssertPostingErrors(t, prom, mqe)
 
 	// Assert that the results match exactly. Note that annotations comparison will be ignored if the query is in the given ignore map
-	testutils.RequireEqualResults(t, query, prom, mqe, testEnvironment.ignoreAnnotations[query])
+	mqetest.RequireEqualResults(t, query, prom, mqe, testEnvironment.ignoreAnnotations[query])
 }
 
 // FuzzQuery is a test function which invokes a set of queries against the Prometheus and MQE query engines and validates that their responses are identical.
@@ -172,7 +171,6 @@ func executeQueriesAndCompareResults(t *testing.T, testEnvironment fuzzTestEnvir
 // * Add additional step sizes or time ranges to consider
 // When the Go Fuzzer is used, it will randomize the inputs of query string, start time, end time and step size.
 func FuzzQuery(f *testing.F) {
-
 	steps := []time.Duration{
 		time.Second,
 		time.Second * 2,

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -44,7 +44,7 @@ import (
 	"github.com/grafana/mimir/pkg/storage/lazyquery"
 	"github.com/grafana/mimir/pkg/streamingpromql/compat"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning"
-	"github.com/grafana/mimir/pkg/streamingpromql/testutils"
+	mqetest "github.com/grafana/mimir/pkg/streamingpromql/testutils"
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
 	"github.com/grafana/mimir/pkg/util/globalerror"
 	"github.com/grafana/mimir/pkg/util/limiter"
@@ -52,7 +52,10 @@ import (
 )
 
 var (
-	spanExporter = tracetest.NewInMemoryExporter()
+	// We use an in-memory span exporter since we test that things are instrumented
+	// correctly in unit tests, but it only retains a fixed number of spans to avoid
+	// using an excessive amount of memory.
+	spanExporter = mqetest.NewFixedInMemoryExporter(1024)
 )
 
 func init() {
@@ -176,7 +179,7 @@ func TestNewInstantQuery_Strings(t *testing.T) {
 	prometheus := q.Exec(context.Background())
 	defer q.Close()
 
-	testutils.RequireEqualResults(t, expr, prometheus, mimir, false)
+	mqetest.RequireEqualResults(t, expr, prometheus, mimir, false)
 }
 
 // This test runs the test cases defined upstream in https://github.com/prometheus/prometheus/tree/main/promql/testdata and copied to testdata/upstream.
@@ -1338,7 +1341,7 @@ func TestSubqueries(t *testing.T) {
 				require.NoError(t, err)
 
 				res := qry.Exec(context.Background())
-				testutils.RequireEqualResults(t, testCase.Query, &testCase.Result, res, false)
+				mqetest.RequireEqualResults(t, testCase.Query, &testCase.Result, res, false)
 				qry.Close()
 			}
 
@@ -2277,7 +2280,7 @@ func runAnnotationTests(t *testing.T, testCases map[string]annotationTestCase) {
 					if len(results) == 2 {
 						// We do this extra comparison to ensure that we don't skip a series that may be outputted during a warning
 						// or vice-versa where no result may be expected etc.
-						testutils.RequireEqualResults(t, testCase.expr, results[0], results[1], false)
+						mqetest.RequireEqualResults(t, testCase.expr, results[0], results[1], false)
 					}
 				})
 			}
@@ -3303,7 +3306,7 @@ func runMixedMetricsTests(t *testing.T, expressions []string, pointsPerSeries in
 			mimirQuery, err := mimirEngine.NewRangeQuery(context.Background(), storage, nil, expr, start, end, tr.interval)
 			require.NoError(t, err)
 			mimirResults := mimirQuery.Exec(context.Background())
-			testutils.RequireEqualResults(t, expr, prometheusResults, mimirResults, skipAnnotationComparison)
+			mqetest.RequireEqualResults(t, expr, prometheusResults, mimirResults, skipAnnotationComparison)
 
 			prometheusQuery.Close()
 			mimirQuery.Close()
@@ -3317,9 +3320,9 @@ func TestCompareVariousMixedMetricsFunctions(t *testing.T) {
 	labelsToUse, pointsPerSeries, seriesData := getMixedMetricsForTests(true)
 
 	// Test each label individually to catch edge cases in with single series
-	labelCombinations := testutils.Combinations(labelsToUse, 1)
+	labelCombinations := mqetest.Combinations(labelsToUse, 1)
 	// Generate combinations of 2 labels. (e.g., "a,b", "e,f" etc)
-	labelCombinations = append(labelCombinations, testutils.Combinations(labelsToUse, 2)...)
+	labelCombinations = append(labelCombinations, mqetest.Combinations(labelsToUse, 2)...)
 
 	expressions := []string{}
 
@@ -3348,8 +3351,8 @@ func TestCompareVariousMixedMetricsBinaryOperations(t *testing.T) {
 	labelsToUse, pointsPerSeries, seriesData := getMixedMetricsForTests(false)
 
 	// Generate combinations of 2 and 3 labels. (e.g., "a,b", "e,f", "c,d,e" etc)
-	labelCombinations := testutils.Combinations(labelsToUse, 2)
-	labelCombinations = append(labelCombinations, testutils.Combinations(labelsToUse, 3)...)
+	labelCombinations := mqetest.Combinations(labelsToUse, 2)
+	labelCombinations = append(labelCombinations, mqetest.Combinations(labelsToUse, 3)...)
 
 	expressions := []string{}
 
@@ -3404,10 +3407,10 @@ func TestCompareVariousMixedMetricsAggregations(t *testing.T) {
 	labelsToUse, pointsPerSeries, seriesData := getMixedMetricsForTests(true)
 
 	// Test each label individually to catch edge cases in with single series
-	labelCombinations := testutils.Combinations(labelsToUse, 1)
+	labelCombinations := mqetest.Combinations(labelsToUse, 1)
 	// Generate combinations of 2 and 3 labels. (e.g., "a,b", "e,f", "c,d,e", "a,b,c,d", "c,d,e,f" etc)
-	labelCombinations = append(labelCombinations, testutils.Combinations(labelsToUse, 2)...)
-	labelCombinations = append(labelCombinations, testutils.Combinations(labelsToUse, 3)...)
+	labelCombinations = append(labelCombinations, mqetest.Combinations(labelsToUse, 2)...)
+	labelCombinations = append(labelCombinations, mqetest.Combinations(labelsToUse, 3)...)
 
 	expressions := []string{}
 
@@ -3435,7 +3438,7 @@ func TestCompareVariousMixedMetricsVectorSelectors(t *testing.T) {
 	expressions := []string{}
 
 	// Test each label individually to catch edge cases in with single series
-	labelCombinations := testutils.Combinations(labelsToUse, 1)
+	labelCombinations := mqetest.Combinations(labelsToUse, 1)
 
 	// We tried to have this test with 2 labels, but it was failing due to the inconsistent ordering of prometheus processing matchers that result in multiples series, e.g series{label=~"(c|e)"}.
 	// Prometheus might process series c first or e first which will trigger different validation errors for second and third parameter of double_exponential_smoothing.
@@ -3446,7 +3449,7 @@ func TestCompareVariousMixedMetricsVectorSelectors(t *testing.T) {
 	}
 
 	// Generate combinations of 2 labels. (e.g., "a,b", "e,f" etc)
-	labelCombinations = append(labelCombinations, testutils.Combinations(labelsToUse, 2)...)
+	labelCombinations = append(labelCombinations, mqetest.Combinations(labelsToUse, 2)...)
 
 	for _, labels := range labelCombinations {
 		labelRegex := strings.Join(labels, "|")
@@ -3471,9 +3474,9 @@ func TestCompareVariousMixedMetricsComparisonOps(t *testing.T) {
 	labelsToUse, pointsPerSeries, seriesData := getMixedMetricsForTests(true)
 
 	// Test each label individually to catch edge cases in with single series
-	labelCombinations := testutils.Combinations(labelsToUse, 1)
+	labelCombinations := mqetest.Combinations(labelsToUse, 1)
 	// Generate combinations of 2 labels. (e.g., "a,b", "e,f", etc)
-	labelCombinations = append(labelCombinations, testutils.Combinations(labelsToUse, 2)...)
+	labelCombinations = append(labelCombinations, mqetest.Combinations(labelsToUse, 2)...)
 
 	expressions := []string{}
 
@@ -4259,7 +4262,7 @@ func TestEagerLoadSelectors(t *testing.T) {
 			require.NoError(t, eagerLoadingResult.Err)
 			defer q.Close()
 
-			testutils.RequireEqualResults(t, expr, baselineResult, eagerLoadingResult, false)
+			mqetest.RequireEqualResults(t, expr, baselineResult, eagerLoadingResult, false)
 			require.True(t, synchronisingStorage.sawExpectedSelectCalls)
 		})
 	}
@@ -4367,7 +4370,7 @@ func TestInstantQueryDurationExpression(t *testing.T) {
 	require.NoError(t, mimirResult.Err)
 	t.Cleanup(mimirQuery.Close)
 
-	testutils.RequireEqualResults(t, expr, prometheusResult, mimirResult, false)
+	mqetest.RequireEqualResults(t, expr, prometheusResult, mimirResult, false)
 }
 
 func TestEngine_RegisterNodeMaterializer(t *testing.T) {

--- a/pkg/streamingpromql/testutils/span_exporter.go
+++ b/pkg/streamingpromql/testutils/span_exporter.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package testutils
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// NewFixedInMemoryExporter creates a SpanExporter that keeps a fixed number of
+// exported spans in memory. Useful for tests that assert that particular spans
+// were emitted.
+func NewFixedInMemoryExporter(cap int) *FixedInMemoryExporter {
+	return &FixedInMemoryExporter{
+		stubs: make([]tracetest.SpanStub, cap),
+		idx:   0,
+	}
+}
+
+type FixedInMemoryExporter struct {
+	mtx   sync.Mutex
+	stubs []tracetest.SpanStub
+	idx   int
+}
+
+func (e *FixedInMemoryExporter) ExportSpans(_ context.Context, spans []trace.ReadOnlySpan) error {
+	stubs := tracetest.SpanStubsFromReadOnlySpans(spans)
+
+	e.mtx.Lock()
+	defer e.mtx.Unlock()
+
+	l := cap(e.stubs)
+	for _, s := range stubs {
+		e.stubs[e.idx%l] = s
+		e.idx++
+	}
+
+	return nil
+}
+
+func (e *FixedInMemoryExporter) Shutdown(context.Context) error {
+	e.Reset()
+	return nil
+}
+
+func (e *FixedInMemoryExporter) Reset() {
+	e.mtx.Lock()
+	defer e.mtx.Unlock()
+
+	e.idx = 0
+}
+
+func (e *FixedInMemoryExporter) GetSpans() tracetest.SpanStubs {
+	e.mtx.Lock()
+	defer e.mtx.Unlock()
+
+	var ret tracetest.SpanStubs
+	l := cap(e.stubs)
+
+	// We keep track of the number of items written. If we've written more
+	// than the capacity of the underlying slice, return every element. If
+	// we haven't written more than the capacity of the underlying slice,
+	// return from index 0 (start) up to the index that we've written to.
+	start := 0
+	if e.idx > l {
+		start = e.idx - l
+	}
+
+	for i := start; i < e.idx; i++ {
+		ret = append(ret, e.stubs[i%l])
+	}
+
+	return ret
+}

--- a/pkg/streamingpromql/testutils/span_exporter_test.go
+++ b/pkg/streamingpromql/testutils/span_exporter_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package testutils
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestFixedInMemoryExporter(t *testing.T) {
+	t.Run("exporter has room", func(t *testing.T) {
+		stub := tracetest.SpanStub{Name: "test 1"}
+		span := stub.Snapshot()
+
+		exporter := NewFixedInMemoryExporter(4)
+
+		require.NoError(t, exporter.ExportSpans(context.Background(), []trace.ReadOnlySpan{span}))
+		exported := exporter.GetSpans()
+		require.Len(t, exported, 1)
+		require.Equal(t, exported[0], stub)
+	})
+
+	t.Run("exporter wraps around", func(t *testing.T) {
+		var stubs []tracetest.SpanStub
+		var spans []trace.ReadOnlySpan
+
+		for i := 0; i < 6; i++ {
+			stub := tracetest.SpanStub{Name: fmt.Sprintf("test %d", i+1)}
+			stubs = append(stubs, stub)
+			spans = append(spans, stub.Snapshot())
+		}
+
+		exporter := NewFixedInMemoryExporter(4)
+
+		require.NoError(t, exporter.ExportSpans(context.Background(), spans))
+		exported := exporter.GetSpans()
+		require.Len(t, exported, 4)
+		require.Equal(t, exported[0], stubs[2])
+		require.Equal(t, exported[1], stubs[3])
+		require.Equal(t, exported[2], stubs[4])
+		require.Equal(t, exported[3], stubs[5])
+	})
+
+	t.Run("reset", func(t *testing.T) {
+		stub := tracetest.SpanStub{Name: "test 1"}
+		span := stub.Snapshot()
+
+		exporter := NewFixedInMemoryExporter(4)
+
+		require.NoError(t, exporter.ExportSpans(context.Background(), []trace.ReadOnlySpan{span}))
+		exported := exporter.GetSpans()
+		require.Len(t, exported, 1)
+
+		exporter.Reset()
+		exported = exporter.GetSpans()
+		require.Empty(t, exported)
+	})
+}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Change the OTEL `SpanExporter` implementation used during unit tests to only keep a fixed number of spans in memory instead of all of them. This prevents unit tests from taking an execessive amount of memory to run.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reduces test memory usage and standardizes test utilities.
> 
> - Adds `testutils.FixedInMemoryExporter` with a ring buffer and unit tests; used in `engine_test.go` via `mqetest.NewFixedInMemoryExporter(1024)` to cap retained spans
> - Replaces `tracetest.NewInMemoryExporter` with the new exporter in tracer setup while preserving span assertions via `GetSpans()`
> - Refactors test imports to `mqetest` alias and updates calls to `RequireEqualResults`, `Combinations`, etc., across tests
> - Minor cleanup in fuzz/engine tests; no production code changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7bdeac65869239a3ce3ce6471acb2481a799cc9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->