### PR TITLE
Add Grafana Labs temporary team members to governance

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -28,6 +28,8 @@ Each project must have a [`MAINTAINERS.md`][maintainers] file with at least one 
 
 ### Team members
 
+#### Regular team members
+
 Team member status may be given to those who have made ongoing contributions to the Mimir project for at least 3 months. This is usually in the form of code improvements and/or notable work on documentation, but organizing events or user support could also be taken into account.
 
 New members may be proposed by any existing member by email to the [team mailing list][team]. It is highly desirable to reach consensus about acceptance of a new member. However, the proposal is ultimately voted on by a formal [supermajority vote](#supermajority-vote).
@@ -46,7 +48,17 @@ Upon death of a member, they leave the team automatically.
 
 In case a member leaves, the [offboarding](#offboarding) procedure is applied.
 
-The current team members are:
+#### Grafana Labs temporary team members
+
+Grafana Labs temporary team members are a subset of team members who interact with the Mimir project as part of their employment at Grafana Labs. They are expected to follow this governance document and participate in decision making as described herein.
+
+New Grafana Labs temporary team members are added without a public vote by a team member working at Grafana Labs who is not temporary. They appear in the list of team members with a note indicating their temporary status.
+
+Upon leaving the Mimir team at Grafana Labs or death of a member, a regular team member working at Grafana Labs will remove them from the list of team members.
+
+Grafana Labs temporary team members may become regular team members under the same condition as contributors who do not work at Grafana Labs.
+
+#### Current team members
 
 - Andrew Hall [@tcp13equals2](https://github.com/tcp13equals2) ([Grafana Labs](https://grafana.com/))
 - Andy Asp [@andyasp](https://github.com/andyasp) ([Grafana Labs](https://grafana.com/))
@@ -81,7 +93,7 @@ The current team members are:
 - Ying-jeanne Wang [@ying-jeanne](https://github.com/ying-jeanne) ([Grafana Labs](https://grafana.com/))
 - Đurica Yuri Nikolić [@duricanikolic](https://github.com/duricanikolic) ([Grafana Labs](https://grafana.com/))
 
-Previous team members:
+#### Previous team members
 
 - Goutham Veeramachaneni — [@gouthamve](https://github.com/gouthamve)
 - Jacob Lisi — [@jtlisi](https://github.com/jtlisi)


### PR DESCRIPTION
This change introduces a “Grafana Labs temporary team members” class under the team members section. It clarifies that these members are a subset of team members tied to Grafana Labs employment, how they are added and removed, and that they can transition to regular team members under the same criteria as other contributors. The update keeps existing governance structure intact while documenting the temporary status and its lifecycle.

**Reasoning**
We want a minimal, explicit way to cover Grafana Labs employees who must be team members for their role (e.g. being on-call for Grafana Mimir deployments) while leaving room for long‑term contributors to remain regular team members even if they later leave Grafana Labs. This change documents that distinction without altering the existing membership or maintainer processes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a documented class of `Grafana Labs temporary team members` and clarifies team member categorization.
> 
> - New subsection defines temporary members, expectations, and how they’re added (no public vote), removed, and can transition to regular members
> - Restructures the team members section with explicit `Regular team members`, `Current team members`, and `Previous team members` headings
> - No changes to maintainership or voting processes beyond these clarifications
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2cb4722203ad9e1fbdacedc49d78c8655cf02878. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->