### PR TITLE
Refactoring: lookup ingesters' Zones() and healthy instances from ring client instead of ring Lifecycler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/golang/snappy v1.0.0
 	github.com/google/gopacket v1.1.19
 	github.com/gorilla/mux v1.8.1
-	github.com/grafana/dskit v0.0.0-20260114164011-87ad61f7d273
+	github.com/grafana/dskit v0.0.0-20260115150232-8daf14154064
 	github.com/grafana/e2e v0.1.2-0.20251205060319-9884d3ffb1bf
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/influxdata/influxdb/v2 v2.8.0

--- a/go.sum
+++ b/go.sum
@@ -587,8 +587,8 @@ github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc h1:PXZQA2WCxe85T
 github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc/go.mod h1:AHHlOEv1+GGQ3ktHMlhuTUwo3zljV3QJbC0+8o2kn+4=
 github.com/grafana/alerting v0.0.0-20251002141545-d513d62d3210 h1:R4+ks/StOXvv+j8U7J+WQXqpa0e5bLZKFac9y20xeck=
 github.com/grafana/alerting v0.0.0-20251002141545-d513d62d3210/go.mod h1:VGjS5gDwWEADPP6pF/drqLxEImgeuHlEW5u8E5EfIrM=
-github.com/grafana/dskit v0.0.0-20260114164011-87ad61f7d273 h1:f3hZ/N5imFIMNEv2E5eDw7gzNLoCCj9jBRP6ibyECIo=
-github.com/grafana/dskit v0.0.0-20260114164011-87ad61f7d273/go.mod h1:tvSZnwqSdgyFwEZorNAD/fFAiVM3CSzXun4BhkYl8Jk=
+github.com/grafana/dskit v0.0.0-20260115150232-8daf14154064 h1:mQkgeOFuC2upBot2QeViEpYVpcFEFTm3maHZZZxDSu8=
+github.com/grafana/dskit v0.0.0-20260115150232-8daf14154064/go.mod h1:tvSZnwqSdgyFwEZorNAD/fFAiVM3CSzXun4BhkYl8Jk=
 github.com/grafana/e2e v0.1.2-0.20251205060319-9884d3ffb1bf h1:YYTHGOeRDG0NHHZlx8MwftSTiBbezySKEacB2B3UWKs=
 github.com/grafana/e2e v0.1.2-0.20251205060319-9884d3ffb1bf/go.mod h1:yJTKLGWYlRYj0m/LGP41Od7lTC5SRBlxbEampIOonAA=
 github.com/grafana/goautoneg v0.0.0-20240607115440-f335c04c58ce h1:WI1olbgS+sEl77qxEYbmt9TgRUz7iLqmjh8lYPpGlKQ=

--- a/pkg/ingester/circuitbreaker_test.go
+++ b/pkg/ingester/circuitbreaker_test.go
@@ -621,7 +621,7 @@ func TestIngester_IngestStorage_PushToStorageAndReleaseRequest_CircuitBreaker(t 
 
 				// Wait until the ingester is healthy
 				test.Poll(t, 100*time.Millisecond, 1, func() interface{} {
-					return i.lifecycler.HealthyInstancesCount()
+					return healthyInstancesCount(i.ring)
 				})
 
 				// the first request is successful

--- a/vendor/github.com/grafana/dskit/ring/basic_lifecycler_metrics.go
+++ b/vendor/github.com/grafana/dskit/ring/basic_lifecycler_metrics.go
@@ -9,6 +9,7 @@ type BasicLifecyclerMetrics struct {
 	heartbeats  prometheus.Counter
 	tokensOwned prometheus.Gauge
 	tokensToOwn prometheus.Gauge
+	readOnly    prometheus.Gauge
 }
 
 func NewBasicLifecyclerMetrics(ringName string, reg prometheus.Registerer) *BasicLifecyclerMetrics {
@@ -26,6 +27,11 @@ func NewBasicLifecyclerMetrics(ringName string, reg prometheus.Registerer) *Basi
 		tokensToOwn: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Name:        "ring_member_tokens_to_own",
 			Help:        "The number of tokens to own in the ring.",
+			ConstLabels: prometheus.Labels{"name": ringName},
+		}),
+		readOnly: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Name:        "lifecycler_read_only",
+			Help:        "Set to 1 if this lifecycler's instance entry is in read-only state.",
 			ConstLabels: prometheus.Labels{"name": ringName},
 		}),
 	}

--- a/vendor/github.com/grafana/dskit/ring/ring.go
+++ b/vendor/github.com/grafana/dskit/ring/ring.go
@@ -145,6 +145,10 @@ type ReadRing interface {
 
 	// ZonesCount returns the number of zones for which there's at least 1 instance registered in the ring.
 	ZonesCount() int
+
+	// Zones returns the list of zones for which there's at least 1 instance registered in the ring.
+	// The returned slice is sorted alphabetically.
+	Zones() []string
 }
 
 var (
@@ -1474,6 +1478,15 @@ func (r *Ring) ZonesCount() int {
 	defer r.mtx.RUnlock()
 
 	return len(r.ringZones)
+}
+
+// Zones returns the list of zones for which there's at least 1 instance registered in the ring.
+// The returned slice is sorted alphabetically.
+func (r *Ring) Zones() []string {
+	r.mtx.RLock()
+	defer r.mtx.RUnlock()
+
+	return slices.Clone(r.ringZones)
 }
 
 // readOnlyInstanceCount returns the number of read only instances in the ring.

--- a/vendor/github.com/grafana/dskit/services/README.md
+++ b/vendor/github.com/grafana/dskit/services/README.md
@@ -1,90 +1,94 @@
 # Services
 
-This is a Go implementation of [services model](https://github.com/google/guava/wiki/ServiceExplained) from [Google Guava](https://github.com/google/guava) library.
+This is a Go implementation of the [services model](https://github.com/google/guava/wiki/ServiceExplained) from the [Google Guava](https://github.com/google/guava) library.
 
-It provides `Service` interface (with implementation in `BasicService` type) and `Manager` for managing group of services at once.
+It provides a `Service` interface (with implementation in the `BasicService` type) and a `Manager` for managing a group of services at once.
 
-Main benefits of this model are:
+The main benefits of this model are:
 
-- Services have well-defined explicit states. Services are not supposed to start any work until they are started, and they are supposed to enter Running state only if they have successfully done all initialization in Starting state.
-- States are observable by clients. Client can not only see the state, but also wait for Running or Terminated state.
+- Services have well-defined explicit states. Services don't start any work until they are started and only enter the `Running` state if they have successfully done all initialization in the `Starting` state.
+- States are observable by clients. A client can see the state and also wait for `Running` or `Terminated` states.
 - If more observability is needed, clients can register state listeners.
-- Service startup and shutdown is done asynchronously. This allows for nice parallelization of startup or shutdown of multiple services.
-- Services that depend on each other can simply wait for other service to be in correct state before using it.
+- Service startup and shutdown are done asynchronously. This allows for nice parallelization of startup or shutdown of multiple services.
+- Services that depend on each other can simply wait for other services to be in the correct state before using them.
 
 ## Service interface
 
-As the user of the service, here is what you need to know:
-Each service starts in New state.
-In this state, service is not yet doing anything. It is only instantiated, and ready to be started.
+As a user of the service, here is what you need to know.
 
-Service is started by calling its `StartAsync` method. This will make service transition to `Starting` state, and eventually to `Running` state, if starting is successful.
-Starting is done asynchronously, so that client can do other work while service is starting, for example start more services.
+Each service starts in the `New` state.
+In this state, the service is only instantiated and ready to be started.
 
-Service spends most of its time in `Running` state, in which it provides it services to the clients. What exactly it does depends on service itself. Typical examples include responding to HTTP requests, running periodic background tasks, etc.
+Start a service by calling its `StartAsync` method. This makes the service transition to the `Starting` state, and eventually to the `Running` state, if starting is successful.
+Starting is done asynchronously, so that a client can do other work while the service is starting, for example, starting more services.
 
-Clients can stop the service by calling `StopAsync`, which tells service to stop. `Service` will transition to `Stopping` state (in which it does the necessary cleanup) and eventually `Terminated` state.
-If service fails in its `Starting`, `Running` or `Stopping` state, it will end up in `Failed` state instead of Terminated.
+A service spends most of its time in the `Running` state, in which it provides its services to the clients. What exactly it does depends on the service itself. Typical examples include responding to HTTP requests, running periodic background tasks, etc.
 
-Once service is in `Terminated` or `Failed` state, it cannot be restarted, these states are terminal.
+Clients can stop the service by calling `StopAsync`, which tells the service to stop. The service transitions to the `Stopping` state to perform necessary cleanup, and then to the `Terminated` state.
+If a service fails in its `Starting`, `Running`, or `Stopping` state, it ends up in the `Failed` state instead of `Terminated`.
+
+Once a service is in a `Terminated` or `Failed` state, it cannot be restarted; these states are terminal.
 
 Full state diagram:
 
-```text
-   ┌────────────────────────────────────────────────────────────────────┐
-   │                                                                    │
-   │                                                                    ▼
-┌─────┐      ┌──────────┐      ┌─────────┐     ┌──────────┐      ┌────────────┐
-│ New │─────▶│ Starting │─────▶│ Running │────▶│ Stopping │───┬─▶│ Terminated │
-└─────┘      └──────────┘      └─────────┘     └──────────┘   │  └────────────┘
-                   │                                          │
-                   │                                          │
-                   │                                          │   ┌────────┐
-                   └──────────────────────────────────────────┴──▶│ Failed │
-                                                                  └────────┘
+
+```mermaid
+flowchart LR
+  new[New]
+  starting[Starting]
+  running[Running]
+  stopping[Stopping]
+  terminated[Terminated]
+  failed[Failed]
+  new --> starting --> running --> stopping --> terminated
+  new --> terminated
+  starting --> failed
+  running --> failed
+  stopping --> failed
+	
 ```
 
-API and states and semantics are implemented to correspond to [Service class](https://guava.dev/releases/snapshot/api/docs/com/google/common/util/concurrent/Service.html) in Guava library.
+The API, states, and semantics are implemented to correspond to the [Service class](https://guava.dev/releases/snapshot/api/docs/com/google/common/util/concurrent/Service.html) in the Guava library.
 
 ## Manager
 
-Multiple services can be managed via `Manager` (corresponds to [ServiceManager](https://guava.dev/releases/snapshot/api/docs/com/google/common/util/concurrent/ServiceManager.html) in Guava library).
-Manager is initialized with list of New services.
-It can start the services, and wait until all services are running (= "Healthy" state).
-Manager can also be stopped – which triggers stopping of all its services.
-When all services are in their terminal states (Terminated or Final), manager is said to be Stopped.
+Multiple services can be managed via a `Manager` (corresponds to the [ServiceManager](https://guava.dev/releases/snapshot/api/docs/com/google/common/util/concurrent/ServiceManager.html) in Guava library).
+A `Manager` is initialized with a list of `New` services.
+It can start the services and wait until all services are running (= "Healthy" state).
+A `Manager` can also be stopped, which also stops all of its services.
+When all services are in their `Terminated` or `Failed` states, the `Manager` is said to be "stopped."
 
-## Implementing custom Service
+## Implementing a custom service
 
 As a developer who wants to implement your own service, there are several possibilities.
 
 ### Using `NewService`
 
-The easiest possible way to create a service is using `NewService` function with three functions called `StartingFn`, `RunningFn` and `StoppingFn`.
-Returned service will be in `New` state.
-When it transitions to `Starting` state (by calling `StartAsync`), `StartingFn` is called.
-When `StartingFn` finishes with no error, service transitions to `Running` state and `RunningFn` is called.
-When `RunningFn` finishes, services transitions to `Stopping` state, and `StoppingFn` is called.
-After `StoppingFn` is done, service ends in `Terminated` state (if none of the functions returned error), or `Failed` state, if there were errors.
+The easiest possible way to create a service is using the `NewService` function with three functions as arguments called `StartingFn`, `RunningFn` and `StoppingFn`.
+The returned service is in the `New` state.
+When it transitions to the `Starting` state (by calling `StartAsync`), `StartingFn` is called.
+When `StartingFn` finishes with no error, the service transitions to the `Running` state and `RunningFn` is called.
+When `RunningFn` finishes, services transition to the `Stopping` state, and `StoppingFn` is called.
+After `StoppingFn` is done, the service ends in `Terminated` state (if none of the functions returned an error), or the `Failed` state, if there were errors.
 
-Any of the functions can be `nil`, in which case service simply moves to the next state.
+Any of the functions can be `nil`, in which case the service simply moves to the next state.
 
 ### Using `NewIdleService`
 
-"Idle" service is a service which needs to run custom code during `Starting` or `Stopping` state, but not in `Running` state.
-Service will remain in `Running` state until explicitly stopped via `StopAsync`.
+This "idle" service needs to run custom code during `Starting` or `Stopping` states, but not in the `Running` state.
+The service remains in the `Running` state until explicitly stopped using `StopAsync`.
 
 Example usage is a service that registers some HTTP or gRPC handlers.
 
 ### Using `NewTimerService`
 
-Timer service runs supplied function on every tick. If this function returns error, service will fail.
-Otherwise service will continue calling supplied function until stopped via `StopAsync`.
+This service runs a supplied function once every tick interval, defined by a `time.Duration` argument. If this function returns an error, the service fails.
+Otherwise, the service continues calling the supplied function until stopped using `StopAsync`.
 
 ### Using `BasicService` struct
 
-All previous options use `BasicService` type internally, and it is `BasicService` which implements semantics of `Service` interface.
-This struct can also be embedded into custom struct, and then initialized with starting/running/stopping functions via `InitBasicService`:
+All previous options use the `BasicService` type internally, and it is `BasicService` that implements the semantics of the `Service` interface.
+This struct can also be embedded into a custom struct, and then initialized with starting/running/stopping functions via `InitBasicService`:
 
 ```go
 type exampleService struct {
@@ -98,11 +102,12 @@ func newExampleServ() *exampleService {
 	s := &exampleService{
 		ch: make(chan string),
 	}
-    s.BasicService = NewBasicService(nil, s.collect, nil) // StartingFn, RunningFn, StoppingFn
+    s.BasicService = NewBasicService(nil, s.collect, nil) // `StartingFn`, `RunningFn`, `StoppingFn`
 	return s
 }
 
-// used as Running function. When service is stopped, context is canceled, so we react on it.
+// This is used as the `RunningFn` function. When the service is stopped,
+// the context is canceled, so we can react to it.
 func (s *exampleService) collect(ctx context.Context) error {
 	for {
 		select {
@@ -114,42 +119,42 @@ func (s *exampleService) collect(ctx context.Context) error {
 	}
 }
 
-// External method called by clients of the Service.
+// External method called by clients of the service.
 func (s *exampleService) Send(msg string) bool {
-	ctx := s.ServiceContext() // provided by BasicService. Not part of Service interface.
+	ctx := s.ServiceContext() // provided by `BasicService`, not part of the `Service` interface.
 	if ctx == nil {
-		// Service is not yet started
+		// `Service` is not yet started.
 		return false
 	}
 	select {
 	case s.ch <- msg:
 		return true
 	case <-ctx.Done():
-		// Service is not running anymore.
+		// `Service` is not running anymore.
 		return false
 	}
 }
 ```
 
-Now `exampleService` is a service that can be started, observed for state changes, or stopped. As long as service is in Running state, clients can call its `Send` method:
+Now `exampleService` is a service that can be started, observed for state changes, or stopped. As long as the service is in the `Running` state, clients can call its `Send` method:
 
 ```go
 s := newExampleServ()
 s.StartAsync(context.Background())
 s.AwaitRunning(context.Background())
-// now collect() is running
+// Now collect() is running.
 s.Send("A")
 s.Send("B")
 s.Send("C")
 s.StopAsync()
 s.AwaitTerminated(context.Background())
-// now service is finished, and we can access s.log
+// Now the service is finished, and we can access s.log.
 ```
 
-After service is stopped (in Terminated or Failed state, although here the "running" function doesn't return error, so only Terminated state is possible), all collected messages can be read from `log` field.
-Notice that no further synchronization is necessary in this case... when service is stopped and client has observed that via `AwaitTerminated`, any access to `log` is safe.
+After a service is stopped, i.e. in the `Terminated` or `Failed` state, all collected messages can be read from the `log` field. However in this case the `RunningFn` function doesn't return an error, so only the `Terminated` state is possible.
+Notice that no further synchronization is necessary in this case; when the service is stopped and a client has observed that via `AwaitTerminated`, any access to `log` is safe.
 
-(This example is adapted from unit tests in basic_service_test.go)
+(This example is adapted from the unit tests in `basic_service_test.go`)
 
 This may seem like a lot of extra code, and for such a simple usage it probably is.
-Real benefit comes when one starts combining multiple services into a manager, observe them as a group, or let services depend on each other via Await methods.
+The real benefit comes when one starts combining multiple services into a `Manager`, observes them as a group, or lets services depend on each other via `Await` methods.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -795,7 +795,7 @@ github.com/grafana/alerting/receivers/wecom/v1
 github.com/grafana/alerting/templates
 github.com/grafana/alerting/templates/gomplate
 github.com/grafana/alerting/templates/mimir
-# github.com/grafana/dskit v0.0.0-20260114164011-87ad61f7d273
+# github.com/grafana/dskit v0.0.0-20260115150232-8daf14154064
 ## explicit; go 1.24.0
 github.com/grafana/dskit/backoff
 github.com/grafana/dskit/ballast


### PR DESCRIPTION
#### What this PR does

This is a refactoring to make https://github.com/grafana/mimir/pull/14024 easier to review. In this PR I expect no functional change:

1. Lookup ingester ring `Zones()` from the ring client instead of the `Lifecycler`. Why? Because in https://github.com/grafana/mimir/pull/14024 I will introduce `BasicLifecycler` that doesn't have a way to lookup `Zones()`
2. Count the number of healthy instances from ring client instead of the `Lifecycler` (this count is only used in tests). Why? Because in https://github.com/grafana/mimir/pull/14024 I will introduce `BasicLifecycler` that doesn't have a way to count the number of healthy instances
3. Introduce `IngesterRingName` const instead of the `"ingester"` hardcoded string in few places
4. Rename `Ingester.shipperIngesterID` to `Ingester.ingesterID`

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes ingester ring interactions and aligns with newer dskit APIs.
> 
> - Switches zone lookup and healthy instance counting from `lifecycler` to the ring client (`ReadRing`), storing `ring` on `Ingester` and updating tests to use `healthyInstancesCount()` and `ring.Zones()`
> - Introduces `IngesterRingName` and uses it when creating rings/lifecycler (replacing hardcoded "ingester")
> - Renames `Ingester.shipperIngesterID` to `Ingester.ingesterID`
> - Bumps `github.com/grafana/dskit` and vendors changes: adds `ReadRing.Zones()`, a `lifecycler_read_only` gauge (and updates on register/unregister/state change), minor README wording updates
> - Updates helpers and test code accordingly, without intended functional changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf5cb147226a4dd20a30a25690ffc6f093f40b3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->