### PR TITLE
storegateway: fix bucket index discovery logging

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1222,12 +1222,11 @@ func (s *BucketStore) recordBucketIndexDiscoveryDiff(ctx context.Context) {
 	meta := s.bucketIndexMeta.Metadata()
 	diff := meta.UpdatedAt - reqUpdatedAt
 
-	logger := log.With(s.logger, "ours", meta.UpdatedAt, "requested", reqUpdatedAt, "diff", diff)
-
+	logger := log.With(spanlogger.FromContext(ctx, s.logger), "ours", meta.UpdatedAt, "requested", reqUpdatedAt, "diff", diff)
 	if diff < 0 {
-		level.Warn(spanlogger.FromContext(ctx, logger)).Log("msg", "bucket index version (updated_at) is older than requested")
+		level.Warn(logger).Log("msg", "bucket index version (updated_at) is older than requested")
 	} else {
-		level.Debug(spanlogger.FromContext(ctx, logger)).Log("msg", "bucket index versions (updated_at)")
+		level.Debug(logger).Log("msg", "bucket index versions (updated_at)")
 	}
 }
 


### PR DESCRIPTION
#### What this PR does

Following https://github.com/grafana/mimir/pull/13942

The PR fixes the bucket index discovery logging. In the previous one, I've missed that the fields added to the `With` are only applied to the fallback logger. So we don't see these fields in practice 🤦 

I've noticed this only now because in one of the cells, where the changes were deployed we do see quite a fair bit of these warnings:

<img width="1462" height="225" alt="Screenshot 2026-01-15 at 18 05 53" src="https://github.com/user-attachments/assets/f84144d4-0f67-4b06-a6b0-b15c23ce3ea0" />

#### Which issue(s) this PR fixes or relates to

Relates to https://github.com/grafana/mimir-squad/issues/3373

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
