### PR TITLE
Give special rights to Grafana Cloud Hosted Metrics engineers in GOVE…

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -30,7 +30,7 @@ Each project must have a [`MAINTAINERS.md`][maintainers] file with at least one 
 
 Team member status may be given to those who have made ongoing contributions to the Mimir project for at least 3 months. This is usually in the form of code improvements and/or notable work on documentation, but organizing events or user support could also be taken into account.
 
-- For Grafana Cloud Hosted Metrics engineers, an engineer is automatically added as a team member as soon as they join the on-call rotation without being proposed.
+- For Grafana Cloud Hosted Metrics engineers, an engineer is automatically added as a team member as soon as they join the on-call rotation.
 - For other people, they may be proposed by any existing member by email to the [team mailing list][team]. It is highly desirable to reach consensus about acceptance of a new member. However, the proposal is ultimately voted on by a formal [supermajority vote](#supermajority-vote).
 
 If the new member proposal is accepted, the proposed team member should be contacted privately via email to confirm or deny their acceptance of team membership. This email will also be CC'd to the [team mailing list][team] for record-keeping purposes.


### PR DESCRIPTION
Another version of https://github.com/grafana/mimir/pull/14033

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates governance to reflect special handling for Grafana Cloud Hosted Metrics engineers.
> 
> - **Team members**: Automatically added when engineers join the on-call rotation; others still proposed via email and decided by supermajority vote
> - **Maintainers**: Automatically granted when engineers join the on-call rotation; others decided by rough consensus after announcement
> - **Offboarding**: Engineers who leave the role or Grafana Labs are assumed to have retired/resigned unless they state otherwise
> - Documentation-only change in `GOVERNANCE.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4fafd3b948e12ee9b696a114e7dc3ba83e7a1570. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->