### PR TITLE
continuous-test: Standardize time format in logs

### DIFF
--- a/pkg/continuoustest/write_read_series.go
+++ b/pkg/continuoustest/write_read_series.go
@@ -190,7 +190,7 @@ func (t *WriteReadSeriesTest) RunInner(ctx context.Context, now time.Time, write
 func (t *WriteReadSeriesTest) writeSamples(ctx context.Context, typeLabel string, timestamp time.Time, series []prompb.TimeSeries, metricName string, metadata []prompb.MetricMetadata, records *MetricHistory) error {
 	sp, ctx := spanlogger.New(ctx, t.logger, tracer, "WriteReadSeriesTest.writeSamples")
 	defer sp.Finish()
-	logger := log.With(sp, "timestamp", timestamp.String(), "num_series", t.cfg.NumSeries, "metric_name", metricName, "protocol", t.client.Protocol())
+	logger := log.With(sp, "timestamp", timestamp.UnixMilli(), "num_series", t.cfg.NumSeries, "metric_name", metricName, "protocol", t.client.Protocol())
 
 	start := time.Now()
 	statusCode, err := t.client.WriteSeries(ctx, series, metadata)


### PR DESCRIPTION
#### What this PR does

This is an extremely tiny change that fixes a pain point operating continuous test.

Right now the remote write logs use ISO 8601 time, e.g.
```
test=write-read-series method=WriteReadSeriesTest.writeSamples level=info timestamp="2026-01-15 21:38:20 +0000 UTC" num_series=5000 metric_name=mimir_continuous_test_sine_wave_v2 protocol=otlp-http msg="Remote write series succeeded"
```

But all failure logs contain the time in unix milliseconds format.
When comparing a failure log against its remote write log, operators have to convert between the two, which is just extra toil.

#### Which issue(s) this PR fixes or relates to

n/a
#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies log timestamp format for continuous test remote writes.
> 
> - In `write_read_series.go`, changes `timestamp` logging in `WriteReadSeriesTest.writeSamples` from `timestamp.String()` to `timestamp.UnixMilli()` to match failure logs and ease correlation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2d85ed4648dee1f628039fba97bb6866cc1bc86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->