### PR TITLE
Alerts: Compactor, Update Alerts For Different Execution Modes

### DIFF
--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -1093,7 +1093,7 @@ spec:
                 (time() - cortex_compactor_last_successful_run_timestamp_seconds > 60 * 60 * 24)
                 and
                 (cortex_compactor_last_successful_run_timestamp_seconds > 0)
-                and
+                and ignoring(mode)
                 (cortex_compactor_info{mode="standalone"} == 1)
               )
             for: 1h
@@ -1109,7 +1109,7 @@ spec:
               # so this alert correctly doesn't fire if compactor has nothing to do.
               (
                 (cortex_compactor_last_successful_run_timestamp_seconds == 0)
-                and
+                and ignoring(mode)
                 (cortex_compactor_info{mode="standalone"} == 1)
               )
             for: 24h
@@ -1125,7 +1125,7 @@ spec:
                 (time() - cortex_compactor_scheduler_last_contact_timestamp_seconds > 900)
                 and
                 (cortex_compactor_scheduler_last_contact_timestamp_seconds > 0)
-                and
+                and ignoring(mode)
                 (cortex_compactor_info{mode="scheduler"} == 1)
               )
             for: 5m
@@ -1139,7 +1139,7 @@ spec:
             expr: |
               (
                 (cortex_compactor_scheduler_last_contact_timestamp_seconds == 0)
-                and
+                and ignoring(mode)
                 (cortex_compactor_info{mode="scheduler"} == 1)
               )
             for: 15m
@@ -1155,7 +1155,7 @@ spec:
                 (time() - cortex_compactor_last_successful_group_compaction_timestamp_seconds > 60 * 60 * 24)
                 and
                 (cortex_compactor_last_successful_group_compaction_timestamp_seconds > 0)
-                and
+                and ignoring(mode)
                 (cortex_compactor_info{mode="scheduler"} == 1)
               )
             for: 1h
@@ -1169,7 +1169,7 @@ spec:
             expr: |
               (
                 (cortex_compactor_last_successful_group_compaction_timestamp_seconds == 0)
-                and
+                and ignoring(mode)
                 (cortex_compactor_info{mode="scheduler"} == 1)
               )
             for: 24h
@@ -1183,7 +1183,7 @@ spec:
             expr: |
               (
                 increase(cortex_compactor_runs_failed_total{reason!="shutdown"}[2h]) >= 2
-                and
+                and ignoring(mode)
                 (cortex_compactor_info{mode="standalone"} == 1)
               )
             labels:

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -1067,7 +1067,7 @@ groups:
               (time() - cortex_compactor_last_successful_run_timestamp_seconds > 60 * 60 * 24)
               and
               (cortex_compactor_last_successful_run_timestamp_seconds > 0)
-              and
+              and ignoring(mode)
               (cortex_compactor_info{mode="standalone"} == 1)
             )
           for: 1h
@@ -1083,7 +1083,7 @@ groups:
             # so this alert correctly doesn't fire if compactor has nothing to do.
             (
               (cortex_compactor_last_successful_run_timestamp_seconds == 0)
-              and
+              and ignoring(mode)
               (cortex_compactor_info{mode="standalone"} == 1)
             )
           for: 24h
@@ -1099,7 +1099,7 @@ groups:
               (time() - cortex_compactor_scheduler_last_contact_timestamp_seconds > 900)
               and
               (cortex_compactor_scheduler_last_contact_timestamp_seconds > 0)
-              and
+              and ignoring(mode)
               (cortex_compactor_info{mode="scheduler"} == 1)
             )
           for: 5m
@@ -1113,7 +1113,7 @@ groups:
           expr: |
             (
               (cortex_compactor_scheduler_last_contact_timestamp_seconds == 0)
-              and
+              and ignoring(mode)
               (cortex_compactor_info{mode="scheduler"} == 1)
             )
           for: 15m
@@ -1129,7 +1129,7 @@ groups:
               (time() - cortex_compactor_last_successful_group_compaction_timestamp_seconds > 60 * 60 * 24)
               and
               (cortex_compactor_last_successful_group_compaction_timestamp_seconds > 0)
-              and
+              and ignoring(mode)
               (cortex_compactor_info{mode="scheduler"} == 1)
             )
           for: 1h
@@ -1143,7 +1143,7 @@ groups:
           expr: |
             (
               (cortex_compactor_last_successful_group_compaction_timestamp_seconds == 0)
-              and
+              and ignoring(mode)
               (cortex_compactor_info{mode="scheduler"} == 1)
             )
           for: 24h
@@ -1157,7 +1157,7 @@ groups:
           expr: |
             (
               increase(cortex_compactor_runs_failed_total{reason!="shutdown"}[2h]) >= 2
-              and
+              and ignoring(mode)
               (cortex_compactor_info{mode="standalone"} == 1)
             )
           labels:

--- a/operations/mimir-mixin-compiled-gem/alerts.yaml
+++ b/operations/mimir-mixin-compiled-gem/alerts.yaml
@@ -1081,7 +1081,7 @@ groups:
               (time() - cortex_compactor_last_successful_run_timestamp_seconds > 60 * 60 * 24)
               and
               (cortex_compactor_last_successful_run_timestamp_seconds > 0)
-              and
+              and ignoring(mode)
               (cortex_compactor_info{mode="standalone"} == 1)
             )
           for: 1h
@@ -1097,7 +1097,7 @@ groups:
             # so this alert correctly doesn't fire if compactor has nothing to do.
             (
               (cortex_compactor_last_successful_run_timestamp_seconds == 0)
-              and
+              and ignoring(mode)
               (cortex_compactor_info{mode="standalone"} == 1)
             )
           for: 24h
@@ -1113,7 +1113,7 @@ groups:
               (time() - cortex_compactor_scheduler_last_contact_timestamp_seconds > 900)
               and
               (cortex_compactor_scheduler_last_contact_timestamp_seconds > 0)
-              and
+              and ignoring(mode)
               (cortex_compactor_info{mode="scheduler"} == 1)
             )
           for: 5m
@@ -1127,7 +1127,7 @@ groups:
           expr: |
             (
               (cortex_compactor_scheduler_last_contact_timestamp_seconds == 0)
-              and
+              and ignoring(mode)
               (cortex_compactor_info{mode="scheduler"} == 1)
             )
           for: 15m
@@ -1143,7 +1143,7 @@ groups:
               (time() - cortex_compactor_last_successful_group_compaction_timestamp_seconds > 60 * 60 * 24)
               and
               (cortex_compactor_last_successful_group_compaction_timestamp_seconds > 0)
-              and
+              and ignoring(mode)
               (cortex_compactor_info{mode="scheduler"} == 1)
             )
           for: 1h
@@ -1157,7 +1157,7 @@ groups:
           expr: |
             (
               (cortex_compactor_last_successful_group_compaction_timestamp_seconds == 0)
-              and
+              and ignoring(mode)
               (cortex_compactor_info{mode="scheduler"} == 1)
             )
           for: 24h
@@ -1171,7 +1171,7 @@ groups:
           expr: |
             (
               increase(cortex_compactor_runs_failed_total{reason!="shutdown"}[2h]) >= 2
-              and
+              and ignoring(mode)
               (cortex_compactor_info{mode="standalone"} == 1)
             )
           labels:

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -1081,7 +1081,7 @@ groups:
               (time() - cortex_compactor_last_successful_run_timestamp_seconds > 60 * 60 * 24)
               and
               (cortex_compactor_last_successful_run_timestamp_seconds > 0)
-              and
+              and ignoring(mode)
               (cortex_compactor_info{mode="standalone"} == 1)
             )
           for: 1h
@@ -1097,7 +1097,7 @@ groups:
             # so this alert correctly doesn't fire if compactor has nothing to do.
             (
               (cortex_compactor_last_successful_run_timestamp_seconds == 0)
-              and
+              and ignoring(mode)
               (cortex_compactor_info{mode="standalone"} == 1)
             )
           for: 24h
@@ -1113,7 +1113,7 @@ groups:
               (time() - cortex_compactor_scheduler_last_contact_timestamp_seconds > 900)
               and
               (cortex_compactor_scheduler_last_contact_timestamp_seconds > 0)
-              and
+              and ignoring(mode)
               (cortex_compactor_info{mode="scheduler"} == 1)
             )
           for: 5m
@@ -1127,7 +1127,7 @@ groups:
           expr: |
             (
               (cortex_compactor_scheduler_last_contact_timestamp_seconds == 0)
-              and
+              and ignoring(mode)
               (cortex_compactor_info{mode="scheduler"} == 1)
             )
           for: 15m
@@ -1143,7 +1143,7 @@ groups:
               (time() - cortex_compactor_last_successful_group_compaction_timestamp_seconds > 60 * 60 * 24)
               and
               (cortex_compactor_last_successful_group_compaction_timestamp_seconds > 0)
-              and
+              and ignoring(mode)
               (cortex_compactor_info{mode="scheduler"} == 1)
             )
           for: 1h
@@ -1157,7 +1157,7 @@ groups:
           expr: |
             (
               (cortex_compactor_last_successful_group_compaction_timestamp_seconds == 0)
-              and
+              and ignoring(mode)
               (cortex_compactor_info{mode="scheduler"} == 1)
             )
           for: 24h
@@ -1171,7 +1171,7 @@ groups:
           expr: |
             (
               increase(cortex_compactor_runs_failed_total{reason!="shutdown"}[2h]) >= 2
-              and
+              and ignoring(mode)
               (cortex_compactor_info{mode="standalone"} == 1)
             )
           labels:

--- a/operations/mimir-mixin/alerts/compactor.libsonnet
+++ b/operations/mimir-mixin/alerts/compactor.libsonnet
@@ -30,7 +30,7 @@
               (time() - cortex_compactor_last_successful_run_timestamp_seconds > 60 * 60 * 24)
               and
               (cortex_compactor_last_successful_run_timestamp_seconds > 0)
-              and
+              and ignoring(mode)
               (cortex_compactor_info{mode="standalone"} == 1)
             )
           |||,
@@ -51,7 +51,7 @@
             # so this alert correctly doesn't fire if compactor has nothing to do.
             (
               (cortex_compactor_last_successful_run_timestamp_seconds == 0)
-              and
+              and ignoring(mode)
               (cortex_compactor_info{mode="standalone"} == 1)
             )
           |||,
@@ -72,7 +72,7 @@
               (time() - cortex_compactor_scheduler_last_contact_timestamp_seconds > 900)
               and
               (cortex_compactor_scheduler_last_contact_timestamp_seconds > 0)
-              and
+              and ignoring(mode)
               (cortex_compactor_info{mode="scheduler"} == 1)
             )
           |||,
@@ -91,7 +91,7 @@
           expr: |||
             (
               (cortex_compactor_scheduler_last_contact_timestamp_seconds == 0)
-              and
+              and ignoring(mode)
               (cortex_compactor_info{mode="scheduler"} == 1)
             )
           |||,
@@ -112,7 +112,7 @@
               (time() - cortex_compactor_last_successful_group_compaction_timestamp_seconds > 60 * 60 * 24)
               and
               (cortex_compactor_last_successful_group_compaction_timestamp_seconds > 0)
-              and
+              and ignoring(mode)
               (cortex_compactor_info{mode="scheduler"} == 1)
             )
           |||,
@@ -131,7 +131,7 @@
           expr: |||
             (
               (cortex_compactor_last_successful_group_compaction_timestamp_seconds == 0)
-              and
+              and ignoring(mode)
               (cortex_compactor_info{mode="scheduler"} == 1)
             )
           |||,
@@ -149,7 +149,7 @@
           expr: |||
             (
               increase(cortex_compactor_runs_failed_total{reason!="shutdown"}[2h]) >= 2
-              and
+              and ignoring(mode)
               (cortex_compactor_info{mode="standalone"} == 1)
             )
           |||,


### PR DESCRIPTION
#### What this PR does

This PR updates select compactor-related:

1. Update certain alerts to be support unique conditions  for`"standalone"` and `"scheduler"` modes.

- Current `CompactorNotRunningCompaction` variants that would erroneously fire under "scheduler" mode updated to include a `(cortex_compactor_info{mode="standalone"} == 1)` clause 

2. Add several new alerts.

- `CompactorNotRunningCompaction` &mdash; New scheduler mode variants, use `cortex_compactor_scheduler_last_contact_timestamp_seconds`. Alert fires when a compactor hasn't communicated with the scheduler in a set (default: 15m) interval.
- `CompactorNotRunningCompaction` &mdash; New scheduler mode variants.  Alert fires when a compactor hasn't completed a compaction job in a set (default: 24h) interval.
                                                                                                                                         

#### Which issue(s) this PR fixes or relates to

See: https://github.com/grafana/mimir/issues/13943

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes compactor alerts mode-aware and adds scheduler-specific coverage.
> 
> - Gate existing `CompactorNotRunningCompaction` and consecutive-failure checks to `standalone` via `ignoring(mode)` + `cortex_compactor_info{mode="standalone"} == 1`
> - Add new `scheduler`-mode alerts: no scheduler contact (last 15m and since startup) and no successful group compactions (last 24h and since startup)
> - Update source `alerts/compactor.libsonnet` and regenerate compiled outputs (`mimir-mixin-compiled*`, Helm metamonitoring)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5924b3b6593319f6cf2e50022e24a6bed36132b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->