### PR TITLE
Fix `tools/upload-block` to work when run from any directory

### DIFF
--- a/development/tools/upload-block/upload-block.sh
+++ b/development/tools/upload-block/upload-block.sh
@@ -24,7 +24,7 @@ function main() {
   fi
 
   BLOCK_ULID="$(basename "$BLOCK_DIR")"
-  if ! go run "$SCRIPT_DIR/../../../tools/ulidtime" "$BLOCK_ULID" >/dev/null 2>&1; then
+  if ! go run -C "$SCRIPT_DIR/../../../tools/ulidtime" . "$BLOCK_ULID" >/dev/null 2>&1; then
     echo "'$BLOCK_ULID' is not a valid ULID." >/dev/stderr
     exit 1
   fi
@@ -45,7 +45,7 @@ function main() {
 }
 
 function mark_blocks() {
-  go run "$SCRIPT_DIR/../../../tools/mark-blocks" \
+  go run -C "$SCRIPT_DIR/../../../tools/mark-blocks" . \
     -backend="s3" \
     -s3.access-key-id="$AWS_ACCESS_KEY_ID" \
     -s3.secret-access-key="$AWS_SECRET_ACCESS_KEY" \


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue running `tools/upload-block/upload-block.sh` from outside a Mimir repo clone, where `go run` complains that it can't find a `go.mod` file.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures `development/tools/upload-block/upload-block.sh` works when executed from any directory by running Go helper tools from their module dirs.
> 
> - Update `go run` for ULID validation to use `-C "$SCRIPT_DIR/../../../tools/ulidtime" . "$BLOCK_ULID"`
> - Update `go run` in `mark_blocks` to use `-C "$SCRIPT_DIR/../../../tools/mark-blocks" .`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77395eeb86370613bf48aadbf4f96ebaef915fc0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->