### PR TITLE
Fixes flaky TestSchedulerShutdown_QuerierLoop

### DIFF
--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/grafana/dskit/cancellation"
 	"github.com/grafana/dskit/flagext"
+	"github.com/grafana/dskit/grpcutil"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/services"
@@ -53,7 +54,8 @@ import (
 const testMaxOutstandingPerTenant = 5
 
 var (
-	spanExporter = tracetest.NewInMemoryExporter()
+	spanExporter              = tracetest.NewInMemoryExporter()
+	drainingCancellationError = cancellation.NewError(errors.New("draining"))
 )
 
 func init() {
@@ -129,7 +131,7 @@ func drainScheduler(t *testing.T, s *Scheduler) {
 	for key := range s.schedulerInflightRequests {
 		req := s.schedulerInflightRequests[key]
 		if req != nil {
-			req.CancelFunc(cancellation.NewError(errors.New("draining")))
+			req.CancelFunc(drainingCancellationError)
 		}
 
 		delete(s.schedulerInflightRequests, key)
@@ -497,9 +499,11 @@ func TestSchedulerShutdown_QuerierLoop(t *testing.T) {
 		require.ErrorIs(t, err, io.EOF)
 	}
 
-	// This should return with error, since scheduler has terminated.
+	// This should return with error, since scheduler has cancelled any outstanding dequeue requests.
 	_, err = querierLoop.Recv()
-	require.Error(t, err)
+	status, valid := grpcutil.ErrorToStatus(err)
+	require.True(t, valid)
+	require.Equal(t, status.Message(), drainingCancellationError.Error())
 }
 
 func TestSchedulerShutdown_PendingRequests(t *testing.T) {


### PR DESCRIPTION
This PR fixes an occasional TestSchedulerShutdown_QuerierLoop failure where the scheduler completely terminates before the test querier sends its polling/unblock request (intentional) and the gRPC connection returns an io.EOF error (not originally handled).

#### Which issue(s) this PR fixes or relates to
Fixes #14077

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves reliability of scheduler shutdown tests and clarifies expected cancellation behavior.
> 
> - Introduces shared `drainingCancellationError` and uses it in `drainScheduler()`
> - Updates `TestSchedulerShutdown_QuerierLoop` to handle `io.EOF` when the scheduler exits and to assert the cancelled dequeue via `grpcutil.ErrorToStatus` matching `drainingCancellationError`
> - Adds `grpcutil` import in tests
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47e79e47d9c0c5a2727a1ac473200e9a9764ced5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->