### PR TITLE
Jsonnet: add ingester_priority_class config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,6 +233,7 @@
   * `multi_zone_read_path_enabled`
   * `multi_zone_read_path_multi_az_enabled`
 * [ENHANCEMENT] Overrides-exporter: Add `overrides_exporter_exported_limits` config option to specify the limits exposed by the exporter. The default list of limits has not been changed compared to the previous version. #13912
+* [ENHANCEMENT] Ingester: Add `ingester_priority_class` config option to customise the ingester priority class. By default no explicit priority class is configured, and the Kubernetes default class is used. #14093
 * [BUGFIX] Ingester: Fix `$._config.ingest_storage_ingester_autoscaling_max_owned_series_threshold` default value, to compute it based on the configured `$._config.ingester_instance_limits.max_series`. #13448
 
 ### Documentation

--- a/operations/mimir-tests/test-all-components-with-deletion-protection-and-custom-priority-classes-generated.yaml
+++ b/operations/mimir-tests/test-all-components-with-deletion-protection-and-custom-priority-classes-generated.yaml
@@ -1184,6 +1184,7 @@ spec:
           name: ingester-data
         - mountPath: /etc/mimir
           name: overrides
+      priorityClassName: high-nonpreempting
       securityContext:
         runAsUser: 0
       terminationGracePeriodSeconds: 1200

--- a/operations/mimir-tests/test-all-components-with-deletion-protection-and-custom-priority-classes.jsonnet
+++ b/operations/mimir-tests/test-all-components-with-deletion-protection-and-custom-priority-classes.jsonnet
@@ -3,5 +3,7 @@
   _config+:: {
     ingester_deletion_protection_enabled: true,
     store_gateway_deletion_protection_enabled: true,
+
+    ingester_priority_class: 'high-nonpreempting',
   },
 }

--- a/operations/mimir/ingester.libsonnet
+++ b/operations/mimir/ingester.libsonnet
@@ -4,6 +4,11 @@
   local statefulSet = $.apps.v1.statefulSet,
   local volumeMount = $.core.v1.volumeMount,
 
+  _config+:: {
+    // Priority class for ingester pods.
+    ingester_priority_class: '',
+  },
+
   ingester_args::
     $._config.commonConfig +
     $._config.usageStatsConfig +
@@ -104,7 +109,7 @@
     $.newMimirNodeAffinityMatchers(nodeAffinityMatchers) +
     statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds($.ingester_termination_grace_period_seconds) +
     $.mimirVolumeMounts +
-    $.util.podPriority('high') +
+    (if $._config.ingester_priority_class != '' then statefulSet.spec.template.spec.withPriorityClassName($._config.ingester_priority_class) else {}) +
     (if withAntiAffinity then $.util.antiAffinity else {}),
 
   ingester_statefulset:


### PR DESCRIPTION
#### What this PR does

Add `ingester_priority_class` config option to customise the ingester priority class. By default no explicit priority class is configured, and the Kubernetes default class is used.

```diff
diff operations/mimir-tests/test-all-components-generated.yaml operations/mimir-tests/test-all-components-with-deletion-protection-and-custom-priority-classes-generated.yaml

1186a1187
>       priorityClassName: high-nonpreempting
1571a1573,1650
> ---
> apiVersion: admissionregistration.k8s.io/v1
> kind: ValidatingAdmissionPolicy
> metadata:
>   name: default-ingester-deletion-protection
>   namespace: default
> spec:
>   failurePolicy: Fail
>   matchConstraints:
>     resourceRules:
>     - apiGroups:
>       - apps
>       apiVersions:
>       - v1
>       operations:
>       - DELETE
>       resources:
>       - statefulsets
>   validations:
>   - expression: '!oldObject.metadata.name.startsWith("ingester")'
>     messageExpression: '"Deleting " + oldObject.metadata.name + " StatefulSet is forbidden
>       because it is highly destructive. If you must proceed, consult the ''Mimir components
>       deletion protection'' runbook to understand the consequences and how to unblock
>       the deletion."'
>     reason: Forbidden
> ---
> apiVersion: admissionregistration.k8s.io/v1
> kind: ValidatingAdmissionPolicy
> metadata:
>   name: default-store-gateway-deletion-protection
>   namespace: default
> spec:
>   failurePolicy: Fail
>   matchConstraints:
>     resourceRules:
>     - apiGroups:
>       - apps
>       apiVersions:
>       - v1
>       operations:
>       - DELETE
>       resources:
>       - statefulsets
>   validations:
>   - expression: '!oldObject.metadata.name.startsWith("store-gateway")'
>     messageExpression: '"Deleting " + oldObject.metadata.name + " StatefulSet is forbidden
>       because it is highly destructive. If you must proceed, consult the ''Mimir components
>       deletion protection'' runbook to understand the consequences and how to unblock
>       the deletion."'
>     reason: Forbidden
> ---
> apiVersion: admissionregistration.k8s.io/v1
> kind: ValidatingAdmissionPolicyBinding
> metadata:
>   name: default-ingester-deletion-protection
>   namespace: default
> spec:
>   matchResources:
>     namespaceSelector:
>       matchLabels:
>         kubernetes.io/metadata.name: default
>   policyName: default-ingester-deletion-protection
>   validationActions:
>   - Deny
> ---
> apiVersion: admissionregistration.k8s.io/v1
> kind: ValidatingAdmissionPolicyBinding
> metadata:
>   name: default-store-gateway-deletion-protection
>   namespace: default
> spec:
>   matchResources:
>     namespaceSelector:
>       matchLabels:
>         kubernetes.io/metadata.name: default
>   policyName: default-store-gateway-deletion-protection
>   validationActions:
>   - Deny
```

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a configurable priority class for ingester pods and applies it in generated manifests.
> 
> - Adds `_config.ingester_priority_class` (default empty) and sets `priorityClassName` on ingester StatefulSet when provided, replacing the prior hardcoded `util.podPriority('high')`
> - Updates test fixture (`test-all-components-with-deletion-protection-and-custom-priority-classes*`) to set `ingester_priority_class: 'high-nonpreempting'` and reflect `priorityClassName` in YAML
> - Updates `CHANGELOG.md` with the enhancement
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9194a70906a7ffd2da386dbe3bcbfbdc815a2505. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->