### PR TITLE
chore: remove experimental querier.response-streaming-enabled flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [CHANGE] Querier: Renamed experimental flag `-querier.prefer-availability-zone` to `-querier.prefer-availability-zones` and changed it to accept a comma-separated list of availability zones. All zones in the list are given equal priority when querying ingesters and store-gateways. #13756 #13758
 * [CHANGE] Ingester: Stabilize experimental flag `-ingest-storage.write-logs-fsync-before-kafka-commit-concurrency` to fsync write logs before the offset is committed to Kafka. Remove `-ingest-storage.write-logs-fsync-before-kafka-commit-enabled` since this is always enabled now. #13591
 * [CHANGE] Ingester: Remove metric `cortex_ingester_owned_target_info_series`; if needed this is better done as a custom active series tracker. #13831
+* [CHANGE] Querier: Remove experimental flag `-querier.response-streaming-enabled`, active series responses are now always streamed to query-frontends. #14095
 * [CHANGE] Store-gateway: Warn when loading index headers based on TSDB blocks that use v1 of the index file format. #13834
 * [CHANGE] Cache: Remove the experimental setting `-<prefix>.memcached.dns-ignore-startup-failures` that allowed failure to discover Memcached servers to be a soft error and always consider failure to discover Memcached servers a hard error. #14038
 * [CHANGE] Ruler: Add path traversal checks when parsing namespaces and groups, which prevents namespace and group name from containing non-local paths. #14052

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -7444,17 +7444,6 @@
           ],
           "fieldValue": null,
           "fieldDefaultValue": null
-        },
-        {
-          "kind": "field",
-          "name": "response_streaming_enabled",
-          "required": false,
-          "desc": "Enables streaming of responses from querier to query-frontend for response types that support it (currently only `active_series` responses do).",
-          "fieldValue": null,
-          "fieldDefaultValue": true,
-          "fieldFlag": "querier.response-streaming-enabled",
-          "fieldType": "boolean",
-          "fieldCategory": "experimental"
         }
       ],
       "fieldValue": null,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2177,8 +2177,6 @@ Usage of ./cmd/mimir/mimir:
     	Maximum lookback beyond which queries are not sent to ingester. 0 means all queries are sent to ingester. (default 13h)
   -querier.query-store-after duration
     	The time after which a metric should be queried from storage and not just ingesters. 0 means all queries are sent to store. If this option is enabled, the time range of the query sent to the store-gateway will be manipulated to ensure the query end is not more recent than 'now - query-store-after'. (default 12h0m0s)
-  -querier.response-streaming-enabled
-    	[experimental] Enables streaming of responses from querier to query-frontend for response types that support it (currently only `active_series` responses do). (default true)
   -querier.ring.auto-forget-unhealthy-periods int
     	Number of consecutive timeout periods after which Mimir automatically removes an unhealthy instance in the ring. Set to 0 to disable auto-forget. (default 10)
   -querier.ring.consul.acl-token string

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -194,7 +194,6 @@ The following features are currently experimental:
     - `-blocks-storage.tsdb.index-lookup-planning-comparison-portion`
 - Querier
   - Max concurrency for tenant federated queries (`-tenant-federation.max-concurrent`)
-  - Allow streaming of `/active_series` responses to the frontend (`-querier.response-streaming-enabled`)
   - [Mimir query engine](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/mimir-query-engine) (`-querier.query-engine` and `-querier.enable-query-engine-fallback`, and all flags beginning with `-querier.mimir-query-engine`)
   - Maximum estimated memory consumption per query limit (`-querier.max-estimated-memory-consumption-per-query`)
   - Enable the experimental Prometheus feature for delayed name removal (`-querier.enable-delayed-name-removal`)

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -3590,12 +3590,6 @@ grpc_client_config:
 # query-scheduler.
 # The CLI flags prefix for this block configuration is: querier.scheduler-client
 [query_scheduler_grpc_client_config: <grpc_client>]
-
-# (experimental) Enables streaming of responses from querier to query-frontend
-# for response types that support it (currently only `active_series` responses
-# do).
-# CLI flag: -querier.response-streaming-enabled
-[response_streaming_enabled: <boolean> | default = true]
 ```
 
 ### etcd

--- a/integration/query_frontend_active_series_test.go
+++ b/integration/query_frontend_active_series_test.go
@@ -33,11 +33,7 @@ func TestActiveSeriesWithQuerySharding(t *testing.T) {
 			shardActiveSeriesQueries:    tc.shardingEnabled,
 			querySchedulerDiscoveryMode: "ring",
 			setup: func(t *testing.T, s *e2e.Scenario) (string, map[string]string) {
-				flags := mergeFlags(BlocksStorageFlags(), BlocksStorageS3Flags(),
-					map[string]string{
-						"-querier.response-streaming-enabled": "true",
-					},
-				)
+				flags := mergeFlags(BlocksStorageFlags(), BlocksStorageS3Flags())
 				minio := e2edb.NewMinio(9000, flags["-blocks-storage.s3.bucket-name"])
 				require.NoError(t, s.StartAndWaitReady(minio))
 

--- a/operations/mimir/mimir-flags-defaults.json
+++ b/operations/mimir/mimir-flags-defaults.json
@@ -512,7 +512,6 @@
   "querier.scheduler-client.connect-backoff-base-delay": 1000000000,
   "querier.scheduler-client.connect-backoff-max-delay": 5000000000,
   "querier.scheduler-client.cluster-validation.label": "",
-  "querier.response-streaming-enabled": true,
   "query-frontend.log-queries-longer-than": 0,
   "query-frontend.log-query-request-headers": "",
   "query-frontend.max-body-size": 10485760,

--- a/pkg/querier/worker/scheduler_processor.go
+++ b/pkg/querier/worker/scheduler_processor.go
@@ -71,14 +71,13 @@ var (
 
 func newSchedulerProcessor(cfg Config, httpHandler RequestHandler, protobufHandler ProtobufRequestHandler, log log.Logger, reg prometheus.Registerer) (*schedulerProcessor, []services.Service) {
 	p := &schedulerProcessor{
-		log:              log,
-		httpHandler:      httpHandler,
-		protobufHandler:  protobufHandler,
-		streamResponse:   streamResponse,
-		maxMessageSize:   cfg.QueryFrontendGRPCClientConfig.MaxSendMsgSize,
-		querierID:        cfg.QuerierID,
-		grpcConfig:       cfg.QueryFrontendGRPCClientConfig.Config,
-		streamingEnabled: cfg.ResponseStreamingEnabled,
+		log:             log,
+		httpHandler:     httpHandler,
+		protobufHandler: protobufHandler,
+		streamResponse:  streamResponse,
+		maxMessageSize:  cfg.QueryFrontendGRPCClientConfig.MaxSendMsgSize,
+		querierID:       cfg.QuerierID,
+		grpcConfig:      cfg.QueryFrontendGRPCClientConfig.Config,
 
 		schedulerClientFactory: func(conn *grpc.ClientConn) schedulerpb.SchedulerForQuerierClient {
 			return schedulerpb.NewSchedulerForQuerierClient(conn)
@@ -120,14 +119,13 @@ type frontendResponseStreamer func(
 
 // Handles incoming queries from query-scheduler.
 type schedulerProcessor struct {
-	log              log.Logger
-	httpHandler      RequestHandler
-	protobufHandler  ProtobufRequestHandler
-	streamResponse   frontendResponseStreamer
-	grpcConfig       grpcclient.Config
-	maxMessageSize   int
-	querierID        string
-	streamingEnabled bool
+	log             log.Logger
+	httpHandler     RequestHandler
+	protobufHandler ProtobufRequestHandler
+	streamResponse  frontendResponseStreamer
+	grpcConfig      grpcclient.Config
+	maxMessageSize  int
+	querierID       string
 
 	frontendPool                  *client.Pool
 	frontendClientRequestDuration *prometheus.HistogramVec
@@ -368,7 +366,7 @@ func (sp *schedulerProcessor) runHttpRequest(ctx context.Context, logger log.Log
 
 	var hasStreamHeader bool
 	response.Headers, hasStreamHeader = removeStreamingHeader(response.Headers)
-	shouldStream := hasStreamHeader && sp.streamingEnabled && len(response.Body) > responseStreamingBodyChunkSizeBytes
+	shouldStream := hasStreamHeader && len(response.Body) > responseStreamingBodyChunkSizeBytes
 
 	// Protect against not-yet-exited querier handler goroutines that could
 	// still be incrementing stats when sent for marshaling below.

--- a/pkg/querier/worker/scheduler_processor_test.go
+++ b/pkg/querier/worker/scheduler_processor_test.go
@@ -571,8 +571,6 @@ func TestSchedulerProcessor_ResponseStream(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			reqProcessor, processClient, httpRequestHandler, _, frontend := prepareSchedulerProcessor(t, true)
-			// enable response streaming
-			reqProcessor.streamingEnabled = true
 			// make sure responses don't get rejected as too large
 			reqProcessor.maxMessageSize = 5 * responseStreamingBodyChunkSizeBytes
 
@@ -611,7 +609,6 @@ func TestSchedulerProcessor_ResponseStream(t *testing.T) {
 
 	t.Run("should abort streaming if query is cancelled", func(t *testing.T) {
 		sp, loopClient, httpRequestHandler, _, frontend := prepareSchedulerProcessor(t, true)
-		sp.streamingEnabled = true
 		sp.maxMessageSize = 5 * responseStreamingBodyChunkSizeBytes
 
 		recvCount := atomic.NewInt64(0)
@@ -657,7 +654,6 @@ func TestSchedulerProcessor_ResponseStream(t *testing.T) {
 
 	t.Run("should finish streaming if worker context is canceled", func(t *testing.T) {
 		sp, loopClient, httpRequestHandler, _, frontend := prepareSchedulerProcessor(t, true)
-		sp.streamingEnabled = true
 		sp.maxMessageSize = 5 * responseStreamingBodyChunkSizeBytes
 
 		recvCount := atomic.NewInt64(0)
@@ -700,7 +696,6 @@ func TestSchedulerProcessor_ResponseStream(t *testing.T) {
 
 	t.Run("should finish streaming if scheduler client returns a non-cancellation error", func(t *testing.T) {
 		sp, loopClient, httpRequestHandler, _, frontend := prepareSchedulerProcessor(t, true)
-		sp.streamingEnabled = true
 		sp.maxMessageSize = 5 * responseStreamingBodyChunkSizeBytes
 
 		recvCount := atomic.NewInt64(0)
@@ -744,8 +739,6 @@ func TestSchedulerProcessor_ResponseStream(t *testing.T) {
 
 	t.Run("should retry streamed responses", func(t *testing.T) {
 		reqProcessor, processClient, httpRequestHandler, _, frontend := prepareSchedulerProcessor(t, true)
-		// enable response streaming
-		reqProcessor.streamingEnabled = true
 		// make sure responses don't get rejected as too large
 		reqProcessor.maxMessageSize = 5 * responseStreamingBodyChunkSizeBytes
 

--- a/pkg/querier/worker/worker.go
+++ b/pkg/querier/worker/worker.go
@@ -37,7 +37,6 @@ type Config struct {
 	QuerierID                      string                    `yaml:"id" category:"advanced"`
 	QueryFrontendGRPCClientConfig  QueryFrontendClientConfig `yaml:"grpc_client_config" doc:"description=Configures the gRPC client used to communicate between the querier and the query-frontend."`
 	QuerySchedulerGRPCClientConfig grpcclient.Config         `yaml:"query_scheduler_grpc_client_config" doc:"description=Configures the gRPC client used to communicate between the querier and the query-scheduler."`
-	ResponseStreamingEnabled       bool                      `yaml:"response_streaming_enabled" category:"experimental"`
 
 	// This configuration is injected internally.
 	MaxConcurrentRequests   int                       `yaml:"-"` // Must be same as passed to PromQL Engine.
@@ -48,7 +47,6 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.SchedulerAddress, "querier.scheduler-address", "", fmt.Sprintf("Address of the query-scheduler component, in host:port format. The host should resolve to all query-scheduler instances. This option should be set only when query-scheduler component is in use and -%s is set to '%s'.", schedulerdiscovery.ModeFlagName, schedulerdiscovery.ModeDNS))
 	f.DurationVar(&cfg.DNSLookupPeriod, "querier.dns-lookup-period", 10*time.Second, "How often to query DNS for query-frontend or query-scheduler address.")
 	f.StringVar(&cfg.QuerierID, "querier.id", "", "Querier ID, sent to the query-frontend to identify requests from the same querier. Defaults to hostname.")
-	f.BoolVar(&cfg.ResponseStreamingEnabled, "querier.response-streaming-enabled", true, "Enables streaming of responses from querier to query-frontend for response types that support it (currently only `active_series` responses do).")
 
 	cfg.QueryFrontendGRPCClientConfig.CustomCompressors = []string{s2.Name}
 	cfg.QueryFrontendGRPCClientConfig.RegisterFlagsWithPrefix("querier.frontend-client", f)


### PR DESCRIPTION
#### What this PR does

This has been enabled for months in Grafana Cloud without issue and the default was previously changed to `true` (enabled) in #13883

#### Which issue(s) this PR fixes or relates to

Related  #13883

#### Checklist

- [X] Tests updated.
- [X] Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [X] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the experimental `-querier.response-streaming-enabled` flag and makes streaming of `active_series` responses always on.
> 
> - Deletes flag from config (`Config` struct and `RegisterFlags`), config descriptor, defaults JSON, CLI help, and docs
> - Simplifies worker logic by removing `streamingEnabled` gating; streaming now determined solely by response headers/body size
> - Updates tests and integration setup to no longer set or rely on the flag
> - Adds CHANGELOG entry documenting the removal
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7afa3dd9a6591f89b4cbc4b0ce490ef5ff0abe6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->