### PR TITLE
Make BufferHolder.FreeBuffer() panic on double-free

### DIFF
--- a/pkg/mimirpb/custom.go
+++ b/pkg/mimirpb/custom.go
@@ -212,6 +212,7 @@ type MessageWithBufferRef interface {
 // BufferHolder is a base type for protobuf messages that keep unsafe references to the unmarshalling buffer.
 type BufferHolder struct {
 	buffer mem.Buffer
+	freed  bool
 }
 
 func (m *BufferHolder) Buffer() mem.Buffer {
@@ -223,10 +224,17 @@ func (m *BufferHolder) SetBuffer(buf mem.Buffer) {
 }
 
 func (m *BufferHolder) FreeBuffer() {
-	if m.buffer != nil {
-		m.buffer.Free()
-		m.buffer = nil
+	if m.buffer == nil {
+		if !m.freed {
+			return // Never had a buffer, no-op.
+		}
+
+		panic("BufferHolder.FreeBuffer called on already-freed buffer")
 	}
+
+	m.buffer.Free()
+	m.buffer = nil
+	m.freed = true
 }
 
 var _ MessageWithBufferRef = &BufferHolder{}


### PR DESCRIPTION
#### What this PR does

Makes `BufferHolder.FreeBuffer()` panic when called on an already-freed buffer, rather than silently succeeding. This helps catch lifetime management bugs during testing.

The change distinguishes between:
- **Never had a buffer**: no-op (legitimate, e.g., freshly created struct)
- **Had a buffer, already freed**: panic (bug in caller's lifetime management)

This is consistent with grpc's `mem.Buffer.Free()` which also panics on double-free.

#### Rationale

Idempotent `FreeBuffer()` can mask bugs where callers don't properly track buffer ownership. Failing fast makes these bugs visible during testing rather than silently corrupting state in production.

Analysis of all callers confirmed none depend on idempotent behavior:
- Direct call sites use single-call patterns (`defer`, loops over unique objects)
- Wrapper methods (`SeriesChunksStreamReader.FreeBuffer()`, `storeGatewayStreamReader.FreeBuffer()`) have their own nil-checks that prevent double-calling the underlying method

#### Which issue(s) this PR fixes or relates to

Follow-up to #13888 buffer reference counting changes.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces stricter buffer lifetime enforcement and updates tests.
> 
> - **Change `BufferHolder` semantics**: track `freed` state and make `FreeBuffer()` panic on double-free; remains a no-op if it never held a buffer. Adds internal state `freed` and preserves buffer ref-counting behavior.
> - **Tests updated**: replace idempotency test with explicit double-free panic and "never had buffer" no-op tests; adjust `WriteRequest.FreeBuffer` tests and `AddSourceBufferHolder` deduplication by underlying buffer.
> - Minor: import `grpc/mem` in tests and small test cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f17ecff2f499ce173725dacfc3b6d5ff6207221d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->