### PR TITLE
Jsonnet: Add config options to enable store-gateway multi-AZ deployments on a per-zone basis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,6 +238,10 @@
   * `multi_zone_read_path_multi_az_enabled`
 * [ENHANCEMENT] Overrides-exporter: Add `overrides_exporter_exported_limits` config option to specify the limits exposed by the exporter. The default list of limits has not been changed compared to the previous version. #13912
 * [ENHANCEMENT] Ingester: Add `ingester_priority_class` config option to customise the ingester priority class. By default no explicit priority class is configured, and the Kubernetes default class is used. #14093
+* [ENHANCEMENT] Store-gateway: Add config options to enable store-gateway multi-AZ deployments on a per-zone basis. #14111
+  * `multi_zone_store_gateway_zone_a_multi_az_enabled`
+  * `multi_zone_store_gateway_zone_b_multi_az_enabled`
+  * `multi_zone_store_gateway_zone_c_multi_az_enabled`
 * [BUGFIX] Ingester: Fix `$._config.ingest_storage_ingester_autoscaling_max_owned_series_threshold` default value, to compute it based on the configured `$._config.ingester_instance_limits.max_series`. #13448
 
 ### Documentation

--- a/operations/mimir/multi-zone-memberlist-bridge.libsonnet
+++ b/operations/mimir/multi-zone-memberlist-bridge.libsonnet
@@ -196,8 +196,8 @@
   // Store-gateways get split in "virtual" zones, that could eventually be mapped to different AZs.
   // If multi-AZ deployment is enabled, then we apply the zone-specific memberlist config, otherwise the zone-a one.
   store_gateway_zone_a_args+:: $.memberlist_zone_a_args,
-  store_gateway_zone_b_args+:: if $._config.multi_zone_store_gateway_multi_az_enabled && isZoneBAvailable then $.memberlist_zone_b_args else $.memberlist_zone_a_args,
-  store_gateway_zone_c_args+:: if $._config.multi_zone_store_gateway_multi_az_enabled && isZoneCAvailable then $.memberlist_zone_c_args else $.memberlist_zone_a_args,
+  store_gateway_zone_b_args+:: if $._config.multi_zone_store_gateway_zone_b_multi_az_enabled && isZoneBAvailable then $.memberlist_zone_b_args else $.memberlist_zone_a_args,
+  store_gateway_zone_c_args+:: if $._config.multi_zone_store_gateway_zone_c_multi_az_enabled && isZoneCAvailable then $.memberlist_zone_c_args else $.memberlist_zone_a_args,
 
   // Other components only deployed to zone-a.
   compactor_args+:: $.memberlist_zone_a_args,

--- a/operations/mimir/multi-zone-store-gateway.libsonnet
+++ b/operations/mimir/multi-zone-store-gateway.libsonnet
@@ -14,6 +14,9 @@
 
     // Controls whether the multi (virtual) zone store-gateway should also be deployed multi-AZ.
     multi_zone_store_gateway_multi_az_enabled: $._config.multi_zone_read_path_multi_az_enabled,
+    multi_zone_store_gateway_zone_a_multi_az_enabled: $._config.multi_zone_store_gateway_multi_az_enabled,
+    multi_zone_store_gateway_zone_b_multi_az_enabled: $._config.multi_zone_store_gateway_multi_az_enabled,
+    multi_zone_store_gateway_zone_c_multi_az_enabled: $._config.multi_zone_store_gateway_multi_az_enabled,
   },
 
   local container = $.core.v1.container,
@@ -23,10 +26,10 @@
   local servicePort = $.core.v1.servicePort,
   local podAntiAffinity = $.apps.v1.deployment.mixin.spec.template.spec.affinity.podAntiAffinity,
 
-  local isMultiAZEnabled = $._config.multi_zone_store_gateway_multi_az_enabled,
-  local isZoneAEnabled = isMultiAZEnabled && std.length($._config.multi_zone_availability_zones) >= 1,
-  local isZoneBEnabled = isMultiAZEnabled && std.length($._config.multi_zone_availability_zones) >= 2,
-  local isZoneCEnabled = isMultiAZEnabled && std.length($._config.multi_zone_availability_zones) >= 3,
+  local isMultiAZEnabled = $._config.multi_zone_store_gateway_zone_a_multi_az_enabled || $._config.multi_zone_store_gateway_zone_b_multi_az_enabled || $._config.multi_zone_store_gateway_zone_c_multi_az_enabled,
+  local isZoneAEnabled = $._config.multi_zone_store_gateway_zone_a_multi_az_enabled && std.length($._config.multi_zone_availability_zones) >= 1,
+  local isZoneBEnabled = $._config.multi_zone_store_gateway_zone_b_multi_az_enabled && std.length($._config.multi_zone_availability_zones) >= 2,
+  local isZoneCEnabled = $._config.multi_zone_store_gateway_zone_c_multi_az_enabled && std.length($._config.multi_zone_availability_zones) >= 3,
 
   assert !isMultiAZEnabled || $._config.multi_zone_store_gateway_enabled : 'store-gateway multi-AZ deployment requires store-gateway multi-zone to be enabled',
   assert !isMultiAZEnabled || $._config.multi_zone_memcached_enabled : 'store-gateway multi-AZ deployment requires memcached multi-zone to be enabled',


### PR DESCRIPTION
#### What this PR does

Add config options to enable store-gateway multi-AZ deployments on a per-zone basis. This gives us a better control during migrations.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces per-zone control for store-gateway multi-AZ deployments and wires it through Jsonnet configs.
> 
> - Adds `multi_zone_store_gateway_zone_a_multi_az_enabled`, `multi_zone_store_gateway_zone_b_multi_az_enabled`, `multi_zone_store_gateway_zone_c_multi_az_enabled` (default to the previous global flag)
> - Updates `multi-zone-store-gateway.libsonnet` to compute `isMultiAZEnabled` and zone enablement from per-zone flags
> - Switches `multi-zone-memberlist-bridge.libsonnet` to use per-zone flags for store-gateway zone B/C memberlist args
> - Updates `CHANGELOG.md` with the new enhancement and config options
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9692efb030e08cdf28c62d68b30c1bde0414aa3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->