### PR TITLE
[r378] Fix blocks being incorrectly dropped during shutdown when the store-gateway is terminated while fetching an updated bucket index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,7 @@
 * [BUGFIX] MQE: Map remote execution storage errors correctly. #13944
 * [BUGFIX] Ingester: Fix race condition where new partition could reach Active partition ring state for a before its ingester instances reached Active ring state. #14025
 * [BUGFIX] Ingester: Query all ingesters when shuffle sharding is disabled. #14041
+* [BUGFIX] Store-gateway: Fix blocks being incorrectly dropped during shutdown when the store-gateway is terminated while fetching an updated bucket index. #14113
 
 ### Mixin
 


### PR DESCRIPTION
manual backport of #14113

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves error handling when reading the bucket index and adds coverage, plus a changelog entry for a related store-gateway bugfix.
> 
> - In `pkg/storage/tsdb/bucketindex/storage.go`, `ReadIndex` now wraps only non-context errors as `ErrIndexCorrupted` via a new `wrapCorruptedError`, ensuring `context.Canceled`/`DeadlineExceeded` propagate unchanged
> - Adds tests in `storage_test.go` to verify context errors aren’t misreported as corruption, including a custom reader to simulate mid-read failures
> - Updates `CHANGELOG.md` with a [BUGFIX] for store-gateway blocks being incorrectly dropped during shutdown while fetching an updated bucket index
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e673383156421a6a994597044c09b70e7a5c8576. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->