### PR TITLE
[r377] ingester: fix race condition in closeAllTSDB during shutdown (#14094)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,7 @@
 * [BUGFIX] Query-frontend: Fix `step()` duration expression returning 1000x larger value. #13920
 * [BUGFIX] Store-gateway: Fix parent-child relationship in LabelNames and LabelValues trace spans. #13932
 * [BUGFIX] MQE: Map remote execution storage errors correctly. #13944
+* [BUGFIX] Ingester: Fix race condition during shutdown where TSDBs could be closed while appends are still in progress. #14094 #14126
 
 ### Mixin
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -2827,6 +2827,18 @@ func (i *Ingester) createBlockChunkQuerier(userID string, b tsdb.BlockReader, mi
 func (i *Ingester) closeAllTSDB() {
 	i.tsdbsMtx.Lock()
 
+	// First, mark all TSDBs as closing to prevent new appends from starting.
+	// We try to transition from any active state to closing.
+	for _, userDB := range i.tsdbs {
+		userDB.setClosingState()
+	}
+
+	// Now wait for all in-flight appends to complete before closing.
+	// This prevents closing TSDBs while appenders are still writing to them.
+	for _, userDB := range i.tsdbs {
+		userDB.inFlightAppends.Wait()
+	}
+
 	wg := &sync.WaitGroup{}
 	wg.Add(len(i.tsdbs))
 

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -8185,6 +8185,56 @@ func TestIngester_CloseTSDBsOnShutdown(t *testing.T) {
 	require.Nil(t, db)
 }
 
+func TestIngester_closeAllTSDB_waitsForInFlightAppends(t *testing.T) {
+	cfg := defaultIngesterTestConfig(t)
+
+	// Create ingester
+	i, r, err := prepareIngesterWithBlocksStorage(t, cfg, nil, nil)
+	require.NoError(t, err)
+	startAndWaitHealthy(t, i, r)
+
+	// Push some data to create a TSDB.
+	pushSingleSampleWithMetadata(t, i)
+
+	db := i.getTSDB(userID)
+	require.NotNil(t, db)
+
+	// Simulate an in-flight append by acquiring the append lock.
+	state, err := db.acquireAppendLock(0)
+	require.NoError(t, err)
+	require.Equal(t, active, state)
+
+	// Call closeAllTSDB in a goroutine - it should block waiting for in-flight appends.
+	closeAllDone := make(chan struct{})
+	go func() {
+		i.closeAllTSDB()
+		close(closeAllDone)
+	}()
+
+	// Wait for closeAllTSDB to set the closing state.
+	test.Poll(t, 1*time.Second, closing, func() any {
+		db.stateMtx.RLock()
+		defer db.stateMtx.RUnlock()
+		return db.state
+	})
+
+	// Verify closeAllTSDB is still blocked waiting for in-flight appends.
+	select {
+	case <-closeAllDone:
+		t.Fatal("closeAllTSDB should be blocked waiting for in-flight appends")
+	default:
+	}
+
+	// Release the in-flight append lock.
+	db.releaseAppendLock(state)
+
+	// Wait for closeAllTSDB to complete.
+	<-closeAllDone
+
+	// Verify the TSDB was closed.
+	require.Nil(t, i.getTSDB(userID))
+}
+
 func TestIngesterNotDeleteUnshippedBlocks(t *testing.T) {
 	chunkRange := 2 * time.Hour
 	chunkRangeMilliSec := chunkRange.Milliseconds()

--- a/pkg/ingester/user_tsdb.go
+++ b/pkg/ingester/user_tsdb.go
@@ -257,6 +257,20 @@ func (u *userTSDB) changeStateToForcedCompaction(from tsdbState, forcedCompactio
 	})
 }
 
+// setClosingState unconditionally sets the TSDB state to closing.
+// This is used during ingester shutdown to prevent new appends from starting.
+// Unlike changeState, this doesn't require a specific "from" state since during
+// shutdown we need to close regardless of the current state.
+func (u *userTSDB) setClosingState() {
+	u.stateMtx.Lock()
+	defer u.stateMtx.Unlock()
+
+	// Only transition if not already closing or closed
+	if u.state != closing && u.state != closed {
+		u.state = closing
+	}
+}
+
 // compactHead triggers a forced compaction of the TSDB Head. This function compacts the in-order Head
 // block with the specified block duration and the OOO Head block at the chunk range duration, to avoid
 // having huge blocks.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Backport https://github.com/grafana/mimir/commit/5b86c5f9f8dfd3719effc66afb2273b83e643bf9 from #14094 to r377.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures safe ingester shutdown by coordinating TSDB state and append lifecycle.
> 
> - In `Ingester.closeAllTSDB()`, set all user TSDBs to `closing`, wait for `inFlightAppends`, then close TSDBs concurrently
> - Add `userTSDB.setClosingState()` to transition to `closing` without CAS during shutdown
> - New test `TestIngester_closeAllTSDB_waitsForInFlightAppends` verifies blocking until append lock is released
> - Update `CHANGELOG.md` with a bugfix entry for the shutdown race
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b7958b726018aadeec512a508824fae5a7334a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->