### PR TITLE
[r378] ingester: fix race condition in closeAllTSDB during shutdown (#14094) #14126  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,7 @@
 * [BUGFIX] Ingester: Query all ingesters when shuffle sharding is disabled. #14041
 * [BUGFIX] Store-gateway: Fix blocks being incorrectly dropped during shutdown when the store-gateway is terminated while fetching an updated bucket index. #14113
 * [BUGFIX] Ingester: Defensive correctness fix for buffer reference counting in pkg/mimirpb. #14108
+* [BUGFIX] Ingester: Fix race condition during shutdown where TSDBs could be closed while appends are still in progress. #14094 #14127
 
 ### Mixin
 

--- a/pkg/ingester/user_tsdb.go
+++ b/pkg/ingester/user_tsdb.go
@@ -257,6 +257,20 @@ func (u *userTSDB) changeStateToForcedCompaction(from tsdbState, forcedCompactio
 	})
 }
 
+// setClosingState unconditionally sets the TSDB state to closing.
+// This is used during ingester shutdown to prevent new appends from starting.
+// Unlike changeState, this doesn't require a specific "from" state since during
+// shutdown we need to close regardless of the current state.
+func (u *userTSDB) setClosingState() {
+	u.stateMtx.Lock()
+	defer u.stateMtx.Unlock()
+
+	// Only transition if not already closing or closed
+	if u.state != closing && u.state != closed {
+		u.state = closing
+	}
+}
+
 // compactHead triggers a forced compaction of the TSDB Head. This function compacts the in-order Head
 // block with the specified block duration and the OOO Head block at the chunk range duration, to avoid
 // having huge blocks.


### PR DESCRIPTION
#### What this PR does
Backport https://github.com/grafana/mimir/commit/5b86c5f9f8dfd3719effc66afb2273b83e643bf9 from #14094 to r378.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves ingester shutdown safety by preventing TSDB closure while appends are in progress.
> 
> - Update `Ingester.closeAllTSDB` to first set all user `TSDB`s to `closing`, wait for `inFlightAppends`, then close concurrently
> - Add `userTSDB.setClosingState()` to force transition to `closing` unless already `closing`/`closed`
> - New test `TestIngester_closeAllTSDB_waitsForInFlightAppends` verifies shutdown blocks until append lock is released
> - Update `CHANGELOG.md` with a `[BUGFIX]` entry for the ingester shutdown race
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59ed568e2d7ccdfdc5a838970104a5ec3fcb7333. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->