### PR TITLE
LabelsAreUniqueSorted empty test

### DIFF
--- a/pkg/mimirpb/validate_test.go
+++ b/pkg/mimirpb/validate_test.go
@@ -43,8 +43,6 @@ func TestLabelsAreSorted(t *testing.T) {
 	})
 
 	t.Run("empty is ok", func(t *testing.T) {
-		assert.True(t, LabelsAreUniqueSorted([]LabelAdapter{
-			{Name: "a", Value: "z"},
-		}))
+		assert.True(t, LabelsAreUniqueSorted([]LabelAdapter{}))
 	})
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Corrects the `empty is ok` test in `pkg/mimirpb/validate_test.go` to pass an empty `[]LabelAdapter{}` to `LabelsAreUniqueSorted`, ensuring the empty-labels case is validated. No production code changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e1357f9006c4d2861b321735f357285f7ed75de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->