### PR TITLE
Fix duplicate label validation bypass when label value exceeds length limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,7 @@
 * [BUGFIX] Store-gateway: Fix blocks being incorrectly dropped during shutdown when the store-gateway is terminated while fetching an updated bucket index. #14113
 * [BUGFIX] Ingester: Defensive correctness fix for buffer reference counting in pkg/mimirpb. #14108
 * [BUGFIX] Ingester: Add timeouts to wait for instance state on startup and deferred shutdown of tasks on failure. #14134
+* [BUGFIX] Distributor: Fix duplicate label validation bypass when label value exceeds length limit and is handled by Truncate or Drop strategy. #14131
 
 ### Mixin
 

--- a/pkg/distributor/validate.go
+++ b/pkg/distributor/validate.go
@@ -586,12 +586,15 @@ func validateLabels(m *sampleValidationMetrics, cfg labelValidationConfig, userI
 			default:
 				panic(fmt.Errorf("unexpected value: %v", labelValueLengthOverLimitStrategy))
 			}
-		} else if lastLabelName == l.Name {
+		}
+
+		// Duplicate check moved outside else-if chain so it always runs,
+		// even when value-too-long handling (Truncate/Drop) modified the label.
+		if lastLabelName == l.Name {
 			cat.IncrementDiscardedSamples(ls, 1, reasonDuplicateLabelNames, ts)
 			m.duplicateLabelNames.WithLabelValues(userID, group).Inc()
 			return fmt.Errorf(duplicateLabelMsgFormat, l.Name, mimirpb.FromLabelAdaptersToString(ls))
 		}
-
 		lastLabelName = l.Name
 	}
 


### PR DESCRIPTION
#### What this PR does

Fixes a bug where duplicate label validation was bypassed when a label's value exceeded `maxLabelValueLength` and was handled by the `Truncate` or `Drop` strategy.

The duplicate label check was part of an `else if` chain:

```go
} else if len(l.Value) > maxLabelValueLength {
    switch labelValueLengthOverLimitStrategy {
    case ...Truncate:
        // truncate, no return
    case ...Drop:
        // drop, no return
    }
} else if lastLabelName == l.Name {
    // duplicate check - SKIPPED when above branch taken
}
```

When the value-too-long branch was taken (and didn't return early for Truncate/Drop), the duplicate check was skipped entirely.

The fix moves the duplicate check outside the `else if` chain so it always runs.

#### Which issue(s) this PR fixes or relates to

<!--Fixes #<issue number>-->

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Bugfix: duplicate label validation**
> 
> - Move duplicate-label check in `validateLabels` so it always runs, even after `Truncate`/`Drop` handling of over-length values in `pkg/distributor/validate.go`.
> - Add targeted tests validating duplicates are detected with over-length values under both strategies in `validate_test.go`.
> - Update `CHANGELOG.md` with the distributor bugfix entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3fa2945416e53519366379fc81db1a49ded740c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->