### PR TITLE
SoftAppendErrorProcessor field order

### DIFF
--- a/pkg/storage/soft_append_error_processor.go
+++ b/pkg/storage/soft_append_error_processor.go
@@ -23,10 +23,10 @@ type SoftAppendErrorProcessor struct {
 	sampleTooFarInFuture           func(int64, []mimirpb.LabelAdapter)
 	errDuplicateSampleForTimestamp func(string, int64, []mimirpb.LabelAdapter)
 	maxSeriesPerUser               func(labels []mimirpb.LabelAdapter)
-	maxSeriesPerMetric             func(labels []mimirpb.LabelAdapter)
-	errLabelsNotSorted             func([]mimirpb.LabelAdapter)
+	maxSeriesPerMetric func(labels []mimirpb.LabelAdapter)
 	// Native histogram errors.
-	errHistogram func(error, int64, []mimirpb.LabelAdapter) bool
+	errHistogram       func(error, int64, []mimirpb.LabelAdapter) bool
+	errLabelsNotSorted func([]mimirpb.LabelAdapter)
 }
 
 func NewSoftAppendErrorProcessor(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors `SoftAppendErrorProcessor` to normalize field and constructor parameter ordering and grouping.
> 
> - Reorders struct fields to group native histogram handling (`errHistogram`, `errLabelsNotSorted`) and places `maxSeriesPerMetric` with related quota callbacks
> - Updates constructor signature and returned struct initialization to match the new order
> - No logic changes to `ProcessErr` or callbacks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a400d9d85872608cfd931fbf6427fb89ff9285f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->