### PR TITLE
backport - r378 - fix(ingester): add timeouts to wait for instance state on startup and deferred shutdown tasks on failure (#14134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,7 @@
 * [BUGFIX] Store-gateway: Fix blocks being incorrectly dropped during shutdown when the store-gateway is terminated while fetching an updated bucket index. #14113
 * [BUGFIX] Ingester: Defensive correctness fix for buffer reference counting in pkg/mimirpb. #14108
 * [BUGFIX] Ingester: Fix race condition during shutdown where TSDBs could be closed while appends are still in progress. #14094 #14127
+* [BUGFIX] Ingester: Add timeouts to wait for instance state on startup and deferred shutdown of tasks on failure. #14134
 
 ### Mixin
 

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/golang/snappy v1.0.0
 	github.com/google/gopacket v1.1.19
 	github.com/gorilla/mux v1.8.1
-	github.com/grafana/dskit v0.0.0-20260115221100-0ee97c59102f
+	github.com/grafana/dskit v0.0.0-20260123032120-fb7d1aad51e6
 	github.com/grafana/e2e v0.1.2-0.20251205060319-9884d3ffb1bf
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/influxdata/influxdb/v2 v2.8.0

--- a/go.sum
+++ b/go.sum
@@ -587,8 +587,8 @@ github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc h1:PXZQA2WCxe85T
 github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc/go.mod h1:AHHlOEv1+GGQ3ktHMlhuTUwo3zljV3QJbC0+8o2kn+4=
 github.com/grafana/alerting v0.0.0-20251002141545-d513d62d3210 h1:R4+ks/StOXvv+j8U7J+WQXqpa0e5bLZKFac9y20xeck=
 github.com/grafana/alerting v0.0.0-20251002141545-d513d62d3210/go.mod h1:VGjS5gDwWEADPP6pF/drqLxEImgeuHlEW5u8E5EfIrM=
-github.com/grafana/dskit v0.0.0-20260115221100-0ee97c59102f h1:NB0Ze2DrKKafmmAfo9G53BvhFZZCwDlyMyV/U9wB5sg=
-github.com/grafana/dskit v0.0.0-20260115221100-0ee97c59102f/go.mod h1:tvSZnwqSdgyFwEZorNAD/fFAiVM3CSzXun4BhkYl8Jk=
+github.com/grafana/dskit v0.0.0-20260123032120-fb7d1aad51e6 h1:dgEou9fvuaSAQi4Eoas9qoFcRNOCYjbq0m5o0UlXP0s=
+github.com/grafana/dskit v0.0.0-20260123032120-fb7d1aad51e6/go.mod h1:iHZFIKfU//1Uto0gmgmGBB1oVUBcTiepUFslatTkrAs=
 github.com/grafana/e2e v0.1.2-0.20251205060319-9884d3ffb1bf h1:YYTHGOeRDG0NHHZlx8MwftSTiBbezySKEacB2B3UWKs=
 github.com/grafana/e2e v0.1.2-0.20251205060319-9884d3ffb1bf/go.mod h1:yJTKLGWYlRYj0m/LGP41Od7lTC5SRBlxbEampIOonAA=
 github.com/grafana/goautoneg v0.0.0-20240607115440-f335c04c58ce h1:WI1olbgS+sEl77qxEYbmt9TgRUz7iLqmjh8lYPpGlKQ=

--- a/vendor/github.com/grafana/dskit/ring/lifecycler.go
+++ b/vendor/github.com/grafana/dskit/ring/lifecycler.go
@@ -623,7 +623,8 @@ func (i *Lifecycler) stopping(runningError error) error {
 	if runningError != nil {
 		// previously lifecycler just called os.Exit (from loop method)...
 		// now it stops more gracefully, but also without doing any cleanup
-		return nil
+		level.Error(i.logger).Log("msg", "lifecycler loop() exited with error", "err", runningError)
+		return runningError
 	}
 
 	heartbeatTickerStop, heartbeatTickerChan := newDisableableTicker(i.cfg.HeartbeatPeriod)

--- a/vendor/github.com/grafana/dskit/ring/partition_ring.go
+++ b/vendor/github.com/grafana/dskit/ring/partition_ring.go
@@ -41,6 +41,9 @@ type PartitionRing struct {
 
 	// activePartitionsCount is a saved count of active partitions to avoid recomputing it.
 	activePartitionsCount int
+
+	// opts is used to propagate the options to sub rings when shuffle sharding.
+	opts PartitionRingOptions
 }
 
 // PartitionRingOptions holds optional configuration parameters for creating a PartitionRing.
@@ -77,6 +80,7 @@ func NewPartitionRingWithOptions(desc PartitionRingDesc, opts PartitionRingOptio
 		ownersByPartition:     desc.ownersByPartition(),
 		activePartitionsCount: desc.activePartitionsCount(),
 		shuffleShardCache:     shuffleShardCache,
+		opts:                  opts,
 	}, nil
 }
 
@@ -281,7 +285,7 @@ func (r *PartitionRing) shuffleShard(identifier string, size int, lookbackPeriod
 		}
 	}
 
-	return NewPartitionRing(r.desc.WithPartitions(result))
+	return NewPartitionRingWithOptions(r.desc.WithPartitions(result), r.opts)
 }
 
 // PartitionsCount returns the number of partitions in the ring.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -795,7 +795,7 @@ github.com/grafana/alerting/receivers/wecom/v1
 github.com/grafana/alerting/templates
 github.com/grafana/alerting/templates/gomplate
 github.com/grafana/alerting/templates/mimir
-# github.com/grafana/dskit v0.0.0-20260115221100-0ee97c59102f
+# github.com/grafana/dskit v0.0.0-20260123032120-fb7d1aad51e6
 ## explicit; go 1.24.0
 github.com/grafana/dskit/backoff
 github.com/grafana/dskit/ballast


### PR DESCRIPTION
Ingester - add timeouts to wait for instance state on startup and deferred shutdown tasks on failure.

Brings in additional logging from dskit.

Fixes #<issue number>

- [ ] Tests updated.
- [ ] Documentation added.
- [x ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Bugfix and resiliency improvements**
> 
> - Ingester: `starting()` now uses a 7m timeout when waiting for `ring.ACTIVE` and a 3m shutdown context to stop subservices on startup failure.
> - Vendor/deps: Bump `github.com/grafana/dskit` bringing:
>   - `lifecycler`: `stopping()` logs and returns loop errors instead of swallowing them.
>   - Partition ring: propagate `PartitionRingOptions` to subrings and watcher (`NewPartitionRingWatcherWithOptions`).
> - `CHANGELOG.md`: add corresponding [BUGFIX] entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5544bb802a2284d0d708bec64a36a771a1850c86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->