### PR TITLE
[release-2.17] distributor: calculate write response stats early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.17.x / unreleased
+
+* [BUGFIX] Distributor: Calculate `WriteResponseStats` before validation and `PushWrappers`. This prevents clients using Remote-Write 2.0 from seeing a diff in written samples, histograms and exemplars. #12682 #14144
+
 ## 2.17.4
 
 ### Grafana Mimir

--- a/integration/distributor_test.go
+++ b/integration/distributor_test.go
@@ -929,7 +929,11 @@ func testDistributorWithCachingUnmarshalData(t *testing.T, cachingUnmarshalDataE
 				{
 					Samples:    1,
 					Histograms: 0,
-					Exemplars:  0,
+					// Mimir may silently drop outdated samples/histograms/exemplars during aggregation, due to age or
+					// other middlewares running in distributors. Mimir can't differentiate if a data point was dropped
+					// deliberately or accidentally. Hence, to avoid confusing clients we count every sample, histogram
+					// and exemplar that was received, even if we didn't ingest it.
+					Exemplars: 1,
 				},
 			},
 		},


### PR DESCRIPTION
#### What this PR does

Backport #12682 . No conflict other than the CHANGELOG.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [N/A] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [N/A] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Backports correction to Remote-Write 2.0 stats accounting and related metrics.
> 
> - Calculate `WriteResponseStats` early in distributor middleware (before validation and `PushWrappers`) via `updateWriteResponseStatsCtx(...)`
> - Count histograms separately (`numHistograms`) and include them with samples for incoming metrics and trace attrs (`write.samples` now `samples + histograms`)
> - Simplify `updateReceivedMetrics` signature (remove `ctx`) and stop updating write response stats there
> - Update test to expect exemplars counted as received (even if not ingested) and add explanatory comment
> - Add `[BUGFIX]` entry to `CHANGELOG.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5188b44bd40f1d4f2cebe5c4757d8b6f091dd0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->