### PR TITLE
[release-2.17] mimirpb: copy custom values and ensure via exhaustruct

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,6 +25,7 @@ linters:
     - misspell
     - revive
     - staticcheck
+    - exhaustruct
   settings:
     # path to a file containing a list of functions to exclude from checking
     # see https://github.com/kisielk/errcheck#excluding-functions for details
@@ -77,6 +78,9 @@ linters:
     staticcheck:
       checks:
         - ST1016
+    exhaustruct:
+      exclude:
+        - .*
   exclusions:
     presets:
       - comments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.17.x / unreleased
 
 * [BUGFIX] Distributor: Calculate `WriteResponseStats` before validation and `PushWrappers`. This prevents clients using Remote-Write 2.0 from seeing a diff in written samples, histograms and exemplars. #12682 #14144
+* [BUGFIX] Distributor: Fix issue where distributors didn't send custom values of native histograms. #13849 #14145
 
 ## 2.17.4
 

--- a/pkg/mimirpb/timeseries.go
+++ b/pkg/mimirpb/timeseries.go
@@ -766,6 +766,7 @@ func copyHistogram(src Histogram) Histogram {
 		dstZeroCount = &Histogram_ZeroCountFloat{ZeroCountFloat: src.GetZeroCountFloat()}
 	}
 
+	//exhaustruct:enforce
 	return Histogram{
 		Count:          dstCount,
 		Sum:            src.Sum,
@@ -780,6 +781,7 @@ func copyHistogram(src Histogram) Histogram {
 		PositiveCounts: slices.Clone(src.PositiveCounts),
 		ResetHint:      src.ResetHint,
 		Timestamp:      src.Timestamp,
+		CustomValues:   slices.Clone(src.CustomValues),
 	}
 }
 

--- a/pkg/mimirpb/timeseries_test.go
+++ b/pkg/mimirpb/timeseries_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -123,16 +124,20 @@ func TestDeepCopyTimeseries(t *testing.T) {
 			},
 			Histograms: []Histogram{
 				{
-					Timestamp:      4*time.Minute.Milliseconds() - 1,
 					Count:          &Histogram_CountInt{CountInt: 35},
 					Sum:            108,
-					ZeroCount:      &Histogram_ZeroCountInt{ZeroCountInt: 2},
+					Schema:         histogram.CustomBucketsSchema,
 					ZeroThreshold:  0.01,
+					ZeroCount:      &Histogram_ZeroCountInt{ZeroCountInt: 2},
 					NegativeSpans:  []BucketSpan{{Offset: -1, Length: 1}, {Offset: -2, Length: 1}},
 					NegativeDeltas: []int64{7, 3},
+					NegativeCounts: []float64{8, 9},
 					PositiveSpans:  []BucketSpan{{Offset: 0, Length: 1}, {Offset: 2, Length: 1}},
 					PositiveDeltas: []int64{2, 21},
+					PositiveCounts: []float64{6, 7},
 					ResetHint:      Histogram_UNKNOWN,
+					Timestamp:      4*time.Minute.Milliseconds() - 1,
+					CustomValues:   []float64{3, 4},
 				},
 			},
 			Exemplars: []Exemplar{{
@@ -208,6 +213,14 @@ func TestDeepCopyTimeseries(t *testing.T) {
 		assert.NotEqual(t,
 			// Ignore deprecation warning for now
 			//nolint:staticcheck
+			(*reflect.SliceHeader)(unsafe.Pointer(&src.Histograms[histogramIdx].NegativeCounts)).Data,
+			// Ignore deprecation warning for now
+			//nolint:staticcheck
+			(*reflect.SliceHeader)(unsafe.Pointer(&dst.Histograms[histogramIdx].NegativeCounts)).Data,
+		)
+		assert.NotEqual(t,
+			// Ignore deprecation warning for now
+			//nolint:staticcheck
 			(*reflect.SliceHeader)(unsafe.Pointer(&src.Histograms[histogramIdx].PositiveSpans)).Data,
 			// Ignore deprecation warning for now
 			//nolint:staticcheck
@@ -220,6 +233,22 @@ func TestDeepCopyTimeseries(t *testing.T) {
 			// Ignore deprecation warning for now
 			//nolint:staticcheck
 			(*reflect.SliceHeader)(unsafe.Pointer(&dst.Histograms[histogramIdx].PositiveDeltas)).Data,
+		)
+		assert.NotEqual(t,
+			// Ignore deprecation warning for now
+			//nolint:staticcheck
+			(*reflect.SliceHeader)(unsafe.Pointer(&src.Histograms[histogramIdx].PositiveCounts)).Data,
+			// Ignore deprecation warning for now
+			//nolint:staticcheck
+			(*reflect.SliceHeader)(unsafe.Pointer(&dst.Histograms[histogramIdx].PositiveCounts)).Data,
+		)
+		assert.NotEqual(t,
+			// Ignore deprecation warning for now
+			//nolint:staticcheck
+			(*reflect.SliceHeader)(unsafe.Pointer(&src.Histograms[histogramIdx].CustomValues)).Data,
+			// Ignore deprecation warning for now
+			//nolint:staticcheck
+			(*reflect.SliceHeader)(unsafe.Pointer(&dst.Histograms[histogramIdx].CustomValues)).Data,
 		)
 	}
 


### PR DESCRIPTION
Backport of #13849 . No code conflicts, only changelog and golangcilint.

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [N/A] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [N/A] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Backports a bugfix ensuring native histogram custom values are preserved and validated across code and tests.
> 
> - Update `Histogram` clone in `timeseries.go` to copy `CustomValues` and add `//exhaustruct:enforce`
> - Extend histogram tests to cover custom buckets schema and verify deep copies for counts and `CustomValues`
> - Enable/configure `exhaustruct` in `.golangci.yml`
> - Add `[BUGFIX]` entry to `CHANGELOG.md` for distributors not sending custom histogram values
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e4f60a0802026cb586e353e4a3e13629306fd32. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->