### PR TITLE
storegateway: bubble up error when listing owned users fail

### DIFF
--- a/pkg/storegateway/bucket_stores.go
+++ b/pkg/storegateway/bucket_stores.go
@@ -234,6 +234,7 @@ func (u *BucketStores) syncUsersBlocksWithRetries(ctx context.Context, f func(co
 	for retries.Ongoing() {
 		userIDs, err := u.ownedUsers(ctx)
 		if err != nil {
+			lastErr = fmt.Errorf("list owned users: %w", err)
 			retries.Wait()
 			continue
 		}


### PR DESCRIPTION
#### What this PR does

The changes improve the store-gateway's logging by making sure the errors, that occur while listing for owned users, are bubble up.

#### Which issue(s) this PR fixes or relates to

Fixes #12864

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
