### PR TITLE
[release-2.17] rw2: Do not silently drop metric metadata of type Unknown (#12461)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [BUGFIX] Distributor: Calculate `WriteResponseStats` before validation and `PushWrappers`. This prevents clients using Remote-Write 2.0 from seeing a diff in written samples, histograms and exemplars. #12682 #14144
 * [BUGFIX] Distributor: Fix issue where distributors didn't send custom values of native histograms. #13849 #14145
+* [BUGFIX] Distributor: Fix metric metadata of type Unknown being silently dropped from RW2 requests. #12461 #14150
 
 ## 2.17.4
 

--- a/pkg/mimirpb/mimir.pb.go
+++ b/pkg/mimirpb/mimir.pb.go
@@ -11668,13 +11668,6 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata 
 					break
 				}
 			}
-			normalizeMetricName, _ = getMetricName(metricName, metricType)
-			if _, ok := metadata[normalizeMetricName]; ok {
-				// Already have metadata for this metric familiy name.
-				// Since we cannot have multiple definitions of the same
-				// metric family name, we ignore this metadata.
-				return nil
-			}
 		case 3:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field HelpRef", wireType)
@@ -11740,9 +11733,17 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata 
 	if iNdEx > l {
 		return io.ErrUnexpectedEOF
 	}
+	normalizeMetricName, _ = getMetricName(metricName, metricType)
 	if len(normalizeMetricName) == 0 {
 		return nil
 	}
+	if _, ok := metadata[normalizeMetricName]; ok {
+		// Already have metadata for this metric familiy name.
+		// Since we cannot have multiple definitions of the same
+		// metric family name, we ignore this metadata.
+		return nil
+	}
+	
 	if len(unit) > 0 || len(help) > 0 || metricType != 0 {
 		metadata[normalizeMetricName] = &MetricMetadata{
 			MetricFamilyName: normalizeMetricName,

--- a/pkg/mimirpb/mimir.pb.go.expdiff
+++ b/pkg/mimirpb/mimir.pb.go.expdiff
@@ -1,5 +1,5 @@
 diff --git a/pkg/mimirpb/mimir.pb.go b/pkg/mimirpb/mimir.pb.go
-index c4d0bfb6f..de8364cdb 100644
+index 4dac3b5315..de8364cdbc 100644
 --- a/pkg/mimirpb/mimir.pb.go
 +++ b/pkg/mimirpb/mimir.pb.go
 @@ -275,9 +275,6 @@ func (MetadataRW2_MetricType) EnumDescriptor() ([]byte, []int) {
@@ -371,7 +371,7 @@ index c4d0bfb6f..de8364cdb 100644
  			for shift := uint(0); ; shift += 7 {
  				if shift >= 64 {
  					return ErrIntOverflowMimir
-@@ -11663,23 +11584,16 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
+@@ -11663,7 +11584,7 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
  				}
  				b := dAtA[iNdEx]
  				iNdEx++
@@ -380,15 +380,7 @@ index c4d0bfb6f..de8364cdb 100644
  				if b < 0x80 {
  					break
  				}
- 			}
--			normalizeMetricName, _ = getMetricName(metricName, metricType)
--			if _, ok := metadata[normalizeMetricName]; ok {
--				// Already have metadata for this metric familiy name.
--				// Since we cannot have multiple definitions of the same
--				// metric family name, we ignore this metadata.
--				return nil
--			}
- 		case 3:
+@@ -11672,7 +11593,7 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
  			if wireType != 0 {
  				return fmt.Errorf("proto: wrong wireType = %d for field HelpRef", wireType)
  			}
@@ -397,7 +389,7 @@ index c4d0bfb6f..de8364cdb 100644
  			for shift := uint(0); ; shift += 7 {
  				if shift >= 64 {
  					return ErrIntOverflowMimir
-@@ -11689,20 +11603,16 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
+@@ -11682,20 +11603,16 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
  				}
  				b := dAtA[iNdEx]
  				iNdEx++
@@ -420,7 +412,7 @@ index c4d0bfb6f..de8364cdb 100644
  			for shift := uint(0); ; shift += 7 {
  				if shift >= 64 {
  					return ErrIntOverflowMimir
-@@ -11712,15 +11622,11 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
+@@ -11705,15 +11622,11 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
  				}
  				b := dAtA[iNdEx]
  				iNdEx++
@@ -437,13 +429,21 @@ index c4d0bfb6f..de8364cdb 100644
  		default:
  			iNdEx = preIndex
  			skippy, err := skipMimir(dAtA[iNdEx:])
-@@ -11740,18 +11646,6 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
+@@ -11733,26 +11646,6 @@ func MetricMetadataUnmarshalRW2(dAtA []byte, symbols *rw2PagedSymbols, metadata
  	if iNdEx > l {
  		return io.ErrUnexpectedEOF
  	}
+-	normalizeMetricName, _ = getMetricName(metricName, metricType)
 -	if len(normalizeMetricName) == 0 {
 -		return nil
 -	}
+-	if _, ok := metadata[normalizeMetricName]; ok {
+-		// Already have metadata for this metric familiy name.
+-		// Since we cannot have multiple definitions of the same
+-		// metric family name, we ignore this metadata.
+-		return nil
+-	}
+-	
 -	if len(unit) > 0 || len(help) > 0 || metricType != 0 {
 -		metadata[normalizeMetricName] = &MetricMetadata{
 -			MetricFamilyName: normalizeMetricName,


### PR DESCRIPTION
#### What this PR does

Backport of #12461.
 git cherry-pick -x 590b184a50eac11e0c0c299f261bb6217f4ce7e6

Conflicts:
- CHANGELOG.md - as expected, I fixed it by hand.
- pkg/mimirpb/mimir.pb.go.expdiff - expected as we're skipping a couple of changes on upstream, I've regenerated it.
- pkg/mimirpb/prealloc_rw2_test.go - this is because this test and associated feature doesn't exist in this release, I've deleted it.



Fixes a bug where we silently drop a metric metadata, if the type is `UNKNOWN`. Such metadata might still contain help/unit text that we want to store. This affects both the Remote Write 2.0 push API and ingest-storage V2 record format.

This happens because we normalize the metric name at the moment we parse the type. Since `UNKNOWN` is the default metric type, Proto often chooses to save a few bytes and never send the field at all. That means we also never parse the `type` field, thus we never normalize the name, thus the value of `normalizeMetricName` is always empty string. The parser now thinks the metric name is empty and drops the metadata as it maps to no series.

The fix simply normalizes the metric name a little later, outside of the `metricType` parsing branch.

#### Which issue(s) this PR fixes or relates to

Contrib https://github.com/grafana/mimir-squad/issues/2253

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

(cherry picked from commit 590b184a50eac11e0c0c299f261bb6217f4ce7e6)

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
