### PR TITLE
Backport #14041 (Query all ingesters when shuffle sharding is disabled) to 2.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [BUGFIX] Distributor: Calculate `WriteResponseStats` before validation and `PushWrappers`. This prevents clients using Remote-Write 2.0 from seeing a diff in written samples, histograms and exemplars. #12682 #14144
 * [BUGFIX] Distributor: Fix issue where distributors didn't send custom values of native histograms. #13849 #14145
 * [BUGFIX] Distributor: Fix metric metadata of type Unknown being silently dropped from RW2 requests. #12461 #14150
+* [BUGFIX] Ingester: Query all ingesters when shuffle sharding is disabled. #14041
 
 ## 2.17.4
 

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -141,7 +141,11 @@ func (d *Distributor) getIngesterReplicationSetsForQuery(ctx context.Context) ([
 	// Lookup ingesters ring because ingest storage is disabled.
 	shardSize := d.limits.IngestionTenantShardSize(userID)
 	r := d.ingestersRing
-	r = r.ShuffleShardWithLookback(userID, shardSize, d.cfg.ShuffleShardingLookbackPeriod, time.Now())
+
+	// If tenant uses shuffle sharding, we should only query ingesters which are part of the tenant's subring.
+	if lookbackPeriod := d.cfg.ShuffleShardingLookbackPeriod; lookbackPeriod > 0 {
+		r = r.ShuffleShardWithLookback(userID, shardSize, lookbackPeriod, time.Now())
+	}
 
 	replicationSet, err := r.GetReplicationSetForOperation(readNoExtend)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Backports #14041 to release-2.17 by cherry-picking [0f097e3](https://github.com/grafana/mimir/commit/0f097e30f3daaa8582177b8c14462abd17b2f84a).

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Distributor write path:** Compute and record `WriteResponseStats` (samples/histograms/exemplars) before validation and `PushWrappers`; include histograms in `incomingSamples` and tracing attributes; refactor `updateReceivedMetrics` (remove ctx, no longer updates response stats) and adjust callers.
> - **Query routing:** Only apply `ShuffleShardWithLookback` when lookback > 0, ensuring all ingesters are queried when shuffle sharding is disabled. New tests cover this.
> - **RW2 compatibility:** Adjust RW2 metadata unmarshalling to map all metric types correctly and ignore duplicates after fully parsing fields. Add tests for type mapping.
> - **Histograms:** Ensure `Histogram` deep copy includes `CustomValues`; expand tests to verify cloning of counts and custom values.
> - **Tooling/deps:** Enable `exhaustruct` linter (globally excluded), update Puppeteer-related packages in lockfile, and update `CHANGELOG.md` with related bugfixes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ad5cc65f1424c5425c67652271dac7a312d3554. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->