### PR TITLE
WIP: Add /api/v1/info_labels endpoint for PromQL info() autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * [FEATURE] Ingest storage: Add `-ingest-storage.kafka.sasl-mechanism` flag supporting more ways to authenticate with Kafka. #14307 #14344 #14540
 * [FEATURE] Ingest storage: Add `-ingest-storage.kafka.tls*` flags to connect to Kafka using TLS. #14550
 * [FEATURE] MQE: Add experimental support for splitting and caching intermediate results for functions over range vectors in instant queries. #13472 #14479 #14506 #14499 #14517 #14536
+* [FEATURE] Querier: Add `/api/v1/info_labels` endpoint for PromQL `info()` function autocomplete. Returns data labels from info metrics (like `target_info`) for use in autocomplete suggestions. #14168
 * [ENHANCEMENT] Memberlist: Add experimental propagation delay tracker to measure gossip propagation delay across the memberlist cluster. Enable with `-memberlist.propagation-delay-tracker.enabled=true`. #14312 #14406
 * [ENHANCEMENT] Compactor: Add 0-100% jitter to the first compaction interval to spread compactions when multiple compactors start simultaneously. #14280
 * [ENHANCEMENT] Compactor, Store-gateway: Remove experimental setting `-compactor.upload-sparse-index-headers` and always upload sparse index-headers. This improves lazy loading performance in the store-gateway. #13089 #13882

--- a/go.mod
+++ b/go.mod
@@ -362,7 +362,7 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20260225105904-7c22e95a1b6f
+replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20260310150936-1bf6b94cbd54
 
 // Replace memberlist with our fork which includes some changes that haven't been
 // merged upstream yet for years and we don't expect to change anytime soon.

--- a/go.sum
+++ b/go.sum
@@ -609,8 +609,8 @@ github.com/grafana/memberlist v0.3.1-0.20251126142931-6f9f62ab6f86 h1:aTwfQuroOm
 github.com/grafana/memberlist v0.3.1-0.20251126142931-6f9f62ab6f86/go.mod h1:h60o12SZn/ua/j0B6iKAZezA4eDaGsIuPO70eOaJ6WE=
 github.com/grafana/mimir-otlptranslator v0.0.0-20251017074411-ea1e8f863e1d h1:k4NIVPYPP0sLJoGNzGwoQs2MpnWTvTcgbWPCzfdX66c=
 github.com/grafana/mimir-otlptranslator v0.0.0-20251017074411-ea1e8f863e1d/go.mod h1:vRYWnXvI6aWGpsdY/mOT/cbeVRBlPWtBNDb7kGR3uKM=
-github.com/grafana/mimir-prometheus v1.8.2-0.20260225105904-7c22e95a1b6f h1:kRG9PEIdSnoFpv16FeSjn9JheN/8wzoMCHoVH1RLAsA=
-github.com/grafana/mimir-prometheus v1.8.2-0.20260225105904-7c22e95a1b6f/go.mod h1:BAiocBzCS2Jcm1iSrDLW3u1OP25FOPd4VE9m/T7xXYY=
+github.com/grafana/mimir-prometheus v1.8.2-0.20260310150936-1bf6b94cbd54 h1:78FUEgxFaKDNhe1zwi6gcVV42OdTAMqhcW/6MNFquHE=
+github.com/grafana/mimir-prometheus v1.8.2-0.20260310150936-1bf6b94cbd54/go.mod h1:BAiocBzCS2Jcm1iSrDLW3u1OP25FOPd4VE9m/T7xXYY=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956 h1:em1oddjXL8c1tL0iFdtVtPloq2hRPen2MJQKoAWpxu0=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
 github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF3YH66t4qL8=

--- a/integration/querier_info_labels_test.go
+++ b/integration/querier_info_labels_test.go
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//go:build requires_docker
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/grafana/e2e"
+	e2edb "github.com/grafana/e2e/db"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/prompb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/integration/e2emimir"
+)
+
+func TestQuerierInfoLabels(t *testing.T) {
+	s, err := e2e.NewScenario(networkName)
+	require.NoError(t, err)
+	defer s.Close()
+
+	// Start dependencies.
+	consul := e2edb.NewConsul()
+	require.NoError(t, s.StartAndWaitReady(consul))
+
+	flags := mergeFlags(BlocksStorageFlags(), BlocksStorageS3Flags(), map[string]string{})
+
+	// Start minio.
+	minio := e2edb.NewMinio(9000, flags["-blocks-storage.s3.bucket-name"])
+	require.NoError(t, s.StartAndWaitReady(minio))
+
+	// Start Mimir components.
+	distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags)
+	ingester := e2emimir.NewIngester("ingester", consul.NetworkHTTPEndpoint(), flags)
+	querier := e2emimir.NewQuerier("querier", consul.NetworkHTTPEndpoint(), flags)
+	require.NoError(t, s.StartAndWaitReady(distributor, ingester, querier))
+
+	// Wait until distributor and querier have updated the ring.
+	require.NoError(t, distributor.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
+		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+	require.NoError(t, querier.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
+		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+
+	// Create client for pushing and querying.
+	client, err := e2emimir.NewClient(distributor.HTTPEndpoint(), querier.HTTPEndpoint(), "", "", userID)
+	require.NoError(t, err)
+
+	now := time.Now()
+
+	// Push target_info metrics with data labels.
+	// target_info is the standard info metric that contains identifying labels (job, instance)
+	// and data labels (version, commit, etc.) that describe the target.
+	targetInfoSeries := []prompb.TimeSeries{
+		{
+			Labels: []prompb.Label{
+				{Name: "__name__", Value: "target_info"},
+				{Name: "job", Value: "prometheus"},
+				{Name: "instance", Value: "localhost:9090"},
+				{Name: "version", Value: "2.45.0"},
+				{Name: "commit", Value: "abc123"},
+			},
+			Samples: []prompb.Sample{{Value: 1, Timestamp: now.UnixMilli()}},
+		},
+		{
+			Labels: []prompb.Label{
+				{Name: "__name__", Value: "target_info"},
+				{Name: "job", Value: "prometheus"},
+				{Name: "instance", Value: "localhost:9091"},
+				{Name: "version", Value: "2.44.0"},
+				{Name: "commit", Value: "def456"},
+			},
+			Samples: []prompb.Sample{{Value: 1, Timestamp: now.UnixMilli()}},
+		},
+		{
+			Labels: []prompb.Label{
+				{Name: "__name__", Value: "target_info"},
+				{Name: "job", Value: "grafana"},
+				{Name: "instance", Value: "localhost:3000"},
+				{Name: "version", Value: "10.0.0"},
+				{Name: "edition", Value: "oss"},
+			},
+			Samples: []prompb.Sample{{Value: 1, Timestamp: now.UnixMilli()}},
+		},
+	}
+
+	// Also push a build_info metric to test metric_match parameter.
+	buildInfoSeries := []prompb.TimeSeries{
+		{
+			Labels: []prompb.Label{
+				{Name: "__name__", Value: "build_info"},
+				{Name: "job", Value: "mimir"},
+				{Name: "instance", Value: "localhost:8080"},
+				{Name: "branch", Value: "main"},
+				{Name: "goversion", Value: "go1.21.0"},
+			},
+			Samples: []prompb.Sample{{Value: 1, Timestamp: now.UnixMilli()}},
+		},
+	}
+
+	// Push all series.
+	res, err := client.Push(targetInfoSeries)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	res, err = client.Push(buildInfoSeries)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	t.Run("basic info_labels query returns data labels from target_info", func(t *testing.T) {
+		result, err := queryInfoLabels(client, querier.HTTPEndpoint(), nil)
+		require.NoError(t, err)
+
+		// Should return data labels from target_info (excludes identifying labels like job, instance, __name__)
+		// Data labels are: version, commit, edition
+		assert.Contains(t, result, "version")
+		assert.Contains(t, result, "commit")
+		assert.Contains(t, result, "edition")
+
+		// Verify values are sorted and correct
+		sort.Strings(result["version"])
+		assert.Equal(t, []string{"10.0.0", "2.44.0", "2.45.0"}, result["version"])
+	})
+
+	t.Run("info_labels with metric_match returns data labels from specified info metric", func(t *testing.T) {
+		result, err := queryInfoLabels(client, querier.HTTPEndpoint(), map[string]string{
+			"metric_match": "build_info",
+		})
+		require.NoError(t, err)
+
+		// Should return data labels from build_info
+		assert.Contains(t, result, "branch")
+		assert.Contains(t, result, "goversion")
+		assert.Equal(t, []string{"main"}, result["branch"])
+		assert.Equal(t, []string{"go1.21.0"}, result["goversion"])
+
+		// Should NOT contain target_info labels
+		assert.NotContains(t, result, "version")
+		assert.NotContains(t, result, "commit")
+	})
+
+	t.Run("info_labels with match[] filters to base metrics", func(t *testing.T) {
+		result, err := queryInfoLabels(client, querier.HTTPEndpoint(), map[string]string{
+			"match[]": `{job="prometheus"}`,
+		})
+		require.NoError(t, err)
+
+		// Should only return labels from target_info series where job=prometheus
+		assert.Contains(t, result, "version")
+		assert.Contains(t, result, "commit")
+
+		// Should have prometheus versions only
+		sort.Strings(result["version"])
+		assert.Equal(t, []string{"2.44.0", "2.45.0"}, result["version"])
+
+		// Should NOT have grafana-specific labels
+		assert.NotContains(t, result, "edition")
+	})
+
+	t.Run("info_labels with limit truncates values", func(t *testing.T) {
+		result, err := queryInfoLabels(client, querier.HTTPEndpoint(), map[string]string{
+			"limit": "1",
+		})
+		require.NoError(t, err)
+
+		// Each label should have at most 1 value due to limit
+		for labelName, values := range result {
+			assert.LessOrEqual(t, len(values), 1, "label %s should have at most 1 value", labelName)
+		}
+	})
+
+	t.Run("info_labels with time range", func(t *testing.T) {
+		// Query with a time range that includes our data
+		start := now.Add(-1 * time.Hour)
+		end := now.Add(1 * time.Hour)
+		result, err := queryInfoLabels(client, querier.HTTPEndpoint(), map[string]string{
+			"start": fmt.Sprintf("%d", start.Unix()),
+			"end":   fmt.Sprintf("%d", end.Unix()),
+		})
+		require.NoError(t, err)
+
+		// Should return data
+		assert.NotEmpty(t, result)
+		assert.Contains(t, result, "version")
+	})
+}
+
+// infoLabelsResponse represents the API response from /api/v1/info_labels.
+type infoLabelsResponse struct {
+	Status string              `json:"status"`
+	Data   map[string][]string `json:"data"`
+}
+
+// queryInfoLabels queries the /api/v1/info_labels endpoint with optional parameters.
+func queryInfoLabels(client *e2emimir.Client, querierAddress string, params map[string]string) (map[string][]string, error) {
+	u, err := url.Parse(fmt.Sprintf("http://%s/prometheus/api/v1/info_labels", querierAddress))
+	if err != nil {
+		return nil, err
+	}
+
+	q := u.Query()
+	for k, v := range params {
+		q.Set(k, v)
+	}
+	u.RawQuery = q.Encode()
+
+	resp, body, err := client.DoGetBody(u.String())
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	var result infoLabelsResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w, body: %s", err, string(body))
+	}
+
+	if result.Status != "success" {
+		return nil, fmt.Errorf("unexpected status: %s", result.Status)
+	}
+
+	return result.Data, nil
+}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -479,6 +479,7 @@ func (a *API) RegisterQueryAPI(handler http.Handler, buildInfoHandler http.Handl
 	a.RegisterRoute(path.Join(a.cfg.PrometheusHTTPPrefix, "/api/v1/query_exemplars"), handler, true, true, "GET", "POST")
 	a.RegisterRoute(path.Join(a.cfg.PrometheusHTTPPrefix, "/api/v1/labels"), handler, true, true, "GET", "POST")
 	a.RegisterRoute(path.Join(a.cfg.PrometheusHTTPPrefix, "/api/v1/label/{name}/values"), handler, true, true, "GET")
+	a.RegisterRoute(path.Join(a.cfg.PrometheusHTTPPrefix, "/api/v1/info_labels"), handler, true, true, "GET", "POST")
 	a.RegisterRoute(path.Join(a.cfg.PrometheusHTTPPrefix, "/api/v1/series"), handler, true, true, "GET", "POST", "DELETE")
 	a.RegisterRoute(path.Join(a.cfg.PrometheusHTTPPrefix, "/api/v1/status/buildinfo"), buildInfoHandler, false, true, "GET")
 	a.RegisterRoute(path.Join(a.cfg.PrometheusHTTPPrefix, "/api/v1/metadata"), handler, true, true, "GET")

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -328,6 +328,7 @@ func NewQuerierHandler(
 	router.Path(path.Join(promPrefix, "/query_exemplars")).Methods("GET", "POST").Handler(exemplarsQueryStats.Wrap(promRouter))
 	router.Path(path.Join(promPrefix, "/labels")).Methods("GET", "POST").Handler(labelsQueryStats.Wrap(promRouter))
 	router.Path(path.Join(promPrefix, "/label/{name}/values")).Methods("GET").Handler(labelsQueryStats.Wrap(promRouter))
+	router.Path(path.Join(promPrefix, "/info_labels")).Methods("GET", "POST").Handler(labelsQueryStats.Wrap(unlimitedMemoryTrackerMiddleware.Wrap(promRouter)))
 	router.Path(path.Join(promPrefix, "/series")).Methods("GET", "POST", "DELETE").Handler(seriesQueryStats.Wrap(unlimitedMemoryTrackerMiddleware.Wrap(promRouter)))
 	router.Path(path.Join(promPrefix, "/metadata")).Methods("GET").Handler(metadataQueryStats.Wrap(querier.NewMetadataHandler(metadataSupplier)))
 	router.Path(path.Join(promPrefix, "/cardinality/label_names")).Methods("GET", "POST").Handler(cardinalityQueryStats.Wrap(querier.LabelNamesCardinalityHandler(distributor, limits)))

--- a/pkg/frontend/querymiddleware/codec.go
+++ b/pkg/frontend/querymiddleware/codec.go
@@ -482,7 +482,7 @@ func (Codec) DecodeLabelsSeriesQueryRequest(_ context.Context, r *http.Request) 
 			Limit:            limit,
 		}, nil
 	}
-	if IsLabelNamesQuery(r.URL.Path) {
+	if IsLabelNamesQuery(r.URL.Path) || IsInfoLabelsQuery(r.URL.Path) {
 		return &PrometheusLabelNamesQueryRequest{
 			Path:             r.URL.Path,
 			Headers:          headers,

--- a/pkg/frontend/querymiddleware/codec_test.go
+++ b/pkg/frontend/querymiddleware/codec_test.go
@@ -831,6 +831,38 @@ func TestCodec_DecodeEncodeLabelsQueryRequest(t *testing.T) {
 			expectedGetStartOrDefault: 1708502400 * 1e3,
 			expectedGetEndOrDefault:   1708588800 * 1e3,
 		},
+		{
+			name:        "info_labels with start and end timestamps, no matcher sets",
+			url:         "/api/v1/info_labels?end=1708588800&start=1708502400",
+			expectedURL: "/api/v1/info_labels?end=1708588800&start=1708502400",
+			expectedStruct: &PrometheusLabelNamesQueryRequest{
+				Path:             "/api/v1/info_labels",
+				Start:            1708502400 * 1e3,
+				End:              1708588800 * 1e3,
+				LabelMatcherSets: nil,
+			},
+			expectedGetLabelName:      "",
+			expectedGetStartOrDefault: 1708502400 * 1e3,
+			expectedGetEndOrDefault:   1708588800 * 1e3,
+		},
+		{
+			name:        "info_labels with matcher sets and limit",
+			url:         "/api/v1/info_labels?end=1708588800&limit=10&match%5B%5D=up%7Bjob%3D%22prometheus%22%7D&start=1708502400",
+			expectedURL: "/api/v1/info_labels?end=1708588800&limit=10&match%5B%5D=up%7Bjob%3D%22prometheus%22%7D&start=1708502400",
+			expectedStruct: &PrometheusLabelNamesQueryRequest{
+				Path:  "/api/v1/info_labels",
+				Start: 1708502400 * 1e3,
+				End:   1708588800 * 1e3,
+				Limit: 10,
+				LabelMatcherSets: []string{
+					`up{job="prometheus"}`,
+				},
+			},
+			expectedGetLabelName:      "",
+			expectedLimit:             10,
+			expectedGetStartOrDefault: 1708502400 * 1e3,
+			expectedGetEndOrDefault:   1708588800 * 1e3,
+		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			for _, reqMethod := range []string{http.MethodGet, http.MethodPost} {

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -39,6 +39,7 @@ const (
 	cardinalityActiveSeriesPathSuffix                 = "/api/v1/cardinality/active_series"
 	cardinalityActiveNativeHistogramMetricsPathSuffix = "/api/v1/cardinality/active_native_histogram_metrics"
 	labelNamesPathSuffix                              = "/api/v1/labels"
+	infoLabelsPathSuffix                              = "/api/v1/info_labels"
 	remoteReadPathSuffix                              = "/api/v1/read"
 	seriesPathSuffix                                  = "/api/v1/series"
 
@@ -667,8 +668,12 @@ func IsLabelValuesQuery(path string) bool {
 	return labelValuesPathSuffix.MatchString(path)
 }
 
+func IsInfoLabelsQuery(path string) bool {
+	return strings.HasSuffix(path, infoLabelsPathSuffix)
+}
+
 func IsLabelsQuery(path string) bool {
-	return IsLabelNamesQuery(path) || IsLabelValuesQuery(path)
+	return IsLabelNamesQuery(path) || IsLabelValuesQuery(path) || IsInfoLabelsQuery(path)
 }
 
 func IsSeriesQuery(path string) bool {

--- a/pkg/frontend/querymiddleware/roundtrip_test.go
+++ b/pkg/frontend/querymiddleware/roundtrip_test.go
@@ -745,12 +745,54 @@ func TestIsLabelsQuery(t *testing.T) {
 		}, {
 			path:     "/prometheus/api/v1/label/test/unknown/values",
 			expected: false,
+		}, {
+			path:     "/api/v1/info_labels",
+			expected: true,
+		}, {
+			path:     "/prometheus/api/v1/info_labels",
+			expected: true,
+		}, {
+			path:     "/info_labels",
+			expected: false,
+		}, {
+			path:     "/api/v1/info_labels/unknown",
+			expected: false,
 		},
 	}
 
 	for _, testData := range tests {
 		t.Run(testData.path, func(t *testing.T) {
 			assert.Equal(t, testData.expected, IsLabelsQuery(testData.path))
+		})
+	}
+}
+
+func TestIsInfoLabelsQuery(t *testing.T) {
+	tests := []struct {
+		path     string
+		expected bool
+	}{
+		{
+			path:     "/api/v1/info_labels",
+			expected: true,
+		}, {
+			path:     "/prometheus/api/v1/info_labels",
+			expected: true,
+		}, {
+			path:     "/info_labels",
+			expected: false,
+		}, {
+			path:     "/api/v1/info_labels/unknown",
+			expected: false,
+		}, {
+			path:     "/api/v1/labels",
+			expected: false,
+		},
+	}
+
+	for _, testData := range tests {
+		t.Run(testData.path, func(t *testing.T) {
+			assert.Equal(t, testData.expected, IsInfoLabelsQuery(testData.path))
 		})
 	}
 }

--- a/vendor/github.com/prometheus/prometheus/promql/info.go
+++ b/vendor/github.com/prometheus/prometheus/promql/info.go
@@ -18,22 +18,15 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
 
-	"github.com/grafana/regexp"
 	"github.com/prometheus/common/model"
 
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/infohelper"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/util/annotations"
 )
-
-const targetInfo = "target_info"
-
-// identifyingLabels are the labels we consider as identifying for info metrics.
-// Currently hard coded, so we don't need knowledge of individual info metrics.
-var identifyingLabels = []string{"instance", "job"}
 
 // evalInfo implements the info PromQL function.
 func (ev *evaluator) evalInfo(ctx context.Context, args parser.Expressions) (parser.Value, annotations.Annotations) {
@@ -52,7 +45,7 @@ func (ev *evaluator) evalInfo(ctx context.Context, args parser.Expressions) (par
 			}
 		}
 	} else {
-		infoNameMatchers = []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, targetInfo)}
+		infoNameMatchers = []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, infohelper.DefaultInfoMetricName)}
 	}
 
 	// Don't try to enrich info series.
@@ -149,7 +142,7 @@ func (ev *evaluator) fetchInfoSeries(ctx context.Context, mat Matrix, ignoreSeri
 		}
 
 		// Register relevant values per identifying label for this series.
-		for _, l := range identifyingLabels {
+		for _, l := range infohelper.DefaultIdentifyingLabels {
 			val := s.Metric.Get(l)
 			if val == "" {
 				continue
@@ -171,24 +164,9 @@ func (ev *evaluator) fetchInfoSeries(ctx context.Context, mat Matrix, ignoreSeri
 	}
 
 	// Generate regexps for every interesting value per identifying label.
-	var sb strings.Builder
-	idLblRegexps := make(map[string]string, len(idLblValues))
-	for name, vals := range idLblValues {
-		sb.Reset()
-		i := 0
-		for v := range vals {
-			if i > 0 {
-				sb.WriteRune('|')
-			}
-			sb.WriteString(regexp.QuoteMeta(v))
-			i++
-		}
-		idLblRegexps[name] = sb.String()
-	}
-
 	var infoLabelMatchers []*labels.Matcher
-	for name, re := range idLblRegexps {
-		infoLabelMatchers = append(infoLabelMatchers, labels.MustNewMatcher(labels.MatchRegexp, name, re))
+	for name, vals := range idLblValues {
+		infoLabelMatchers = append(infoLabelMatchers, labels.MustNewMatcher(labels.MatchRegexp, name, infohelper.BuildRegexpAlternation(vals)))
 	}
 	hasNameMatcher := false
 	for _, ms := range dataLabelMatchers {
@@ -202,7 +180,7 @@ func (ev *evaluator) fetchInfoSeries(ctx context.Context, mat Matrix, ignoreSeri
 	removeNameFromDataLabelMatchers()
 	if !hasNameMatcher {
 		// Default to using the target_info metric.
-		infoLabelMatchers = append([]*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, targetInfo)}, infoLabelMatchers...)
+		infoLabelMatchers = append([]*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, infohelper.DefaultInfoMetricName)}, infoLabelMatchers...)
 	}
 
 	infoIt := ev.querier.Select(ctx, false, &selectHints, infoLabelMatchers...)
@@ -223,7 +201,7 @@ func (ev *evaluator) combineWithInfoSeries(ctx context.Context, mat, infoMat Mat
 		return func(lset labels.Labels) string {
 			lb.Reset()
 			lb.Add(model.MetricNameLabel, name)
-			lset.MatchLabels(true, identifyingLabels...).Range(func(l labels.Label) {
+			lset.MatchLabels(true, infohelper.DefaultIdentifyingLabels...).Range(func(l labels.Label) {
 				lb.Add(l.Name, l.Value)
 			})
 			lb.Sort()

--- a/vendor/github.com/prometheus/prometheus/promql/infohelper/infohelper.go
+++ b/vendor/github.com/prometheus/prometheus/promql/infohelper/infohelper.go
@@ -1,0 +1,254 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package infohelper provides utilities for extracting data labels from info metrics.
+// Info metrics (like target_info) contain metadata labels that can be used to enrich
+// other time series via identifying labels like "job" and "instance".
+package infohelper
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/grafana/regexp"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/util/annotations"
+)
+
+// InfoLabelsResult is the structured result of ExtractDataLabels.
+// Labels is the map of label names to their unique sorted values.
+// LabelOrder preserves the ordering of label names — alphabetical when no
+// search is given, relevance-ranked otherwise.
+type InfoLabelsResult struct {
+	Labels     map[string][]string `json:"labels"`
+	LabelOrder []string            `json:"labelOrder"`
+}
+
+// DefaultIdentifyingLabels are the standard labels used to match base metrics to info metrics.
+// These are the default identifying labels for Prometheus info metrics.
+var DefaultIdentifyingLabels = []string{"instance", "job"}
+
+// DefaultInfoMetricName is the default info metric name when none is specified.
+const DefaultInfoMetricName = "target_info"
+
+// Config controls behavior of info label extraction.
+type Config struct {
+	// IdentifyingLabels are the labels used to match base metrics to info metrics.
+	// These labels are excluded from the data labels returned.
+	IdentifyingLabels []string
+
+	// DefaultInfoMetric is the default info metric to query when none is specified.
+	DefaultInfoMetric string
+}
+
+// DefaultConfig returns the standard config for Prometheus info metrics.
+func DefaultConfig() Config {
+	return Config{
+		IdentifyingLabels: DefaultIdentifyingLabels,
+		DefaultInfoMetric: DefaultInfoMetricName,
+	}
+}
+
+// InfoLabelExtractor extracts data labels from info metrics.
+type InfoLabelExtractor struct {
+	config Config
+}
+
+// New creates an InfoLabelExtractor with the given config.
+func New(config Config) *InfoLabelExtractor {
+	return &InfoLabelExtractor{config: config}
+}
+
+// NewWithDefaults creates an InfoLabelExtractor with default config.
+func NewWithDefaults() *InfoLabelExtractor {
+	return New(DefaultConfig())
+}
+
+// ExtractDataLabels queries info metrics and returns label names and their values.
+// Data labels are all labels on the info metric except for __name__ and identifying labels.
+//
+// Parameters:
+//   - ctx: Context for cancellation
+//   - querier: Storage querier to use for fetching series
+//   - infoMetricMatcher: Matcher for the info metric __name__ (e.g., MatchEqual "target_info" or MatchRegexp ".*_info")
+//   - identifyingLabelValues: If provided, only info metrics matching these identifying label values
+//     are considered. The map keys are identifying label names (e.g., "job", "instance") and values
+//     are sets of label values. If nil or empty, all info metrics are returned.
+//   - hints: Select hints for the storage layer
+//   - search: If non-empty, only label names containing this substring (case-insensitive) are
+//     included, and LabelOrder is sorted by relevance. If empty, all labels are returned with
+//     LabelOrder in alphabetical order.
+//
+// Returns an InfoLabelsResult with labels map and ordered label names.
+func (e *InfoLabelExtractor) ExtractDataLabels(
+	ctx context.Context,
+	querier storage.Querier,
+	infoMetricMatcher *labels.Matcher,
+	identifyingLabelValues map[string]map[string]struct{},
+	hints *storage.SelectHints,
+	search string,
+) (InfoLabelsResult, annotations.Annotations, error) {
+	var warnings annotations.Annotations
+
+	// Build matchers for the info metric query
+	infoMatchers := []*labels.Matcher{infoMetricMatcher}
+
+	// If identifying label values are provided, filter info metrics by those values
+	if len(identifyingLabelValues) > 0 {
+		// Add regex matchers for identifying labels
+		for name, vals := range identifyingLabelValues {
+			infoMatchers = append(infoMatchers, labels.MustNewMatcher(labels.MatchRegexp, name, BuildRegexpAlternation(vals)))
+		}
+	}
+
+	// Query info metrics
+	infoSet := querier.Select(ctx, false, hints, infoMatchers...)
+	warnings.Merge(infoSet.Warnings())
+
+	searchLower := strings.ToLower(search)
+
+	// Collect data labels from info series
+	dataLabels := make(map[string]map[string]struct{})
+
+	for infoSet.Next() {
+		// Check for context cancellation periodically
+		if ctx.Err() != nil {
+			return InfoLabelsResult{}, warnings, ctx.Err()
+		}
+
+		series := infoSet.At()
+		lbls := series.Labels()
+
+		lbls.Range(func(lbl labels.Label) {
+			// Skip __name__
+			if lbl.Name == labels.MetricName {
+				return
+			}
+
+			// Skip identifying labels
+			if slices.Contains(e.config.IdentifyingLabels, lbl.Name) {
+				return
+			}
+
+			// If search is provided, skip labels that don't match
+			if search != "" && !strings.Contains(strings.ToLower(lbl.Name), searchLower) {
+				return
+			}
+
+			// Add to data labels
+			if dataLabels[lbl.Name] == nil {
+				dataLabels[lbl.Name] = make(map[string]struct{})
+			}
+			dataLabels[lbl.Name][lbl.Value] = struct{}{}
+		})
+	}
+
+	if err := infoSet.Err(); err != nil {
+		return InfoLabelsResult{}, warnings, err
+	}
+
+	// Convert to sorted slices
+	labelsMap := make(map[string][]string, len(dataLabels))
+	for name, vals := range dataLabels {
+		valList := make([]string, 0, len(vals))
+		for v := range vals {
+			valList = append(valList, v)
+		}
+		slices.Sort(valList)
+		labelsMap[name] = valList
+	}
+
+	// Build ordered label names. Ensure non-nil slice for consistent JSON serialization.
+	labelOrder := make([]string, 0, len(labelsMap))
+	for name := range labelsMap {
+		labelOrder = append(labelOrder, name)
+	}
+	if search != "" {
+		rankLabels(labelOrder, searchLower)
+	} else {
+		slices.Sort(labelOrder)
+	}
+
+	return InfoLabelsResult{Labels: labelsMap, LabelOrder: labelOrder}, warnings, nil
+}
+
+// rankLabels sorts label names by relevance to a lowercase search string.
+// Ordering: exact match first, then prefix match, then by substring position,
+// with alphabetical tie-breaking.
+// TODO: Consider Jaro-Winkler or similar fuzzy matching for improved relevance.
+func rankLabels(names []string, searchLower string) {
+	keys := make(map[string]string, len(names))
+	for _, n := range names {
+		keys[n] = labelRelevance(n, searchLower)
+	}
+	slices.SortFunc(names, func(a, b string) int {
+		return strings.Compare(keys[a], keys[b])
+	})
+}
+
+// labelRelevance returns a sort key for a label name given a lowercase search.
+// Lower values = more relevant. The key encodes: match type (exact=0, prefix=1,
+// contains=2+position) and alphabetical order as tie-breaker.
+func labelRelevance(name, searchLower string) string {
+	lower := strings.ToLower(name)
+	var prefix string
+	switch {
+	case lower == searchLower:
+		prefix = "0"
+	case strings.HasPrefix(lower, searchLower):
+		prefix = "1"
+	default:
+		pos := strings.Index(lower, searchLower)
+		// Encode position as a zero-padded 4-digit number so earlier positions sort first.
+		prefix = fmt.Sprintf("2%04d", pos)
+	}
+	return prefix + ":" + lower
+}
+
+// IdentifyingLabels returns the identifying labels configured for this extractor.
+func (e *InfoLabelExtractor) IdentifyingLabels() []string {
+	return e.config.IdentifyingLabels
+}
+
+// DefaultInfoMetric returns the default info metric configured for this extractor.
+func (e *InfoLabelExtractor) DefaultInfoMetric() string {
+	return e.config.DefaultInfoMetric
+}
+
+// BuildRegexpAlternation creates a regex pattern that matches any of the provided values.
+// Values are escaped for use in regular expressions and joined with the '|' alternation operator.
+// The values are sorted to ensure deterministic output.
+// For example: {"foo": {}, "bar": {}, "baz": {}} -> "bar|baz|foo"
+// Special regex characters in values are escaped: {"a.b": {}, "c*d": {}} -> "a\\.b|c\\*d"
+//
+// This is used to build efficient regex matchers for filtering info metrics by
+// identifying label values extracted from base metrics.
+func BuildRegexpAlternation(values map[string]struct{}) string {
+	if len(values) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	for i, v := range slices.Sorted(maps.Keys(values)) {
+		if i > 0 {
+			sb.WriteRune('|')
+		}
+		sb.WriteString(regexp.QuoteMeta(v))
+	}
+	return sb.String()
+}

--- a/vendor/github.com/prometheus/prometheus/web/api/v1/openapi.go
+++ b/vendor/github.com/prometheus/prometheus/web/api/v1/openapi.go
@@ -272,6 +272,7 @@ func (b *OpenAPIBuilder) getAllPathDefinitions() *orderedmap.Map[string, *v3.Pat
 	// Label endpoints.
 	paths.Set("/labels", b.labelsPath())
 	paths.Set("/label/{name}/values", b.labelValuesPath())
+	paths.Set("/info_labels", b.infoLabelsPath())
 
 	// Series endpoints.
 	paths.Set("/series", b.seriesPath())

--- a/vendor/github.com/prometheus/prometheus/web/api/v1/openapi_examples.go
+++ b/vendor/github.com/prometheus/prometheus/web/api/v1/openapi_examples.go
@@ -534,6 +534,72 @@ func labelValuesResponseExamples() *orderedmap.Map[string, *base.Example] {
 	return examples
 }
 
+// infoLabelsResponseExamples returns examples for /info_labels response.
+func infoLabelsResponseExamples() *orderedmap.Map[string, *base.Example] {
+	examples := orderedmap.New[string, *base.Example]()
+
+	examples.Set("infoLabels", &base.Example{
+		Summary: "All info labels (no search filter)",
+		Value: createYAMLNode(map[string]any{
+			"status": "success",
+			"data": map[string]any{
+				"labels": map[string][]string{
+					"version":    {"1.0.0", "2.0.0"},
+					"commit":     {"abc123"},
+					"go_version": {"go1.21.0"},
+				},
+				"labelOrder": []string{"commit", "go_version", "version"},
+			},
+		}),
+	})
+
+	examples.Set("infoLabelsWithSearch", &base.Example{
+		Summary: "Info labels filtered by search (search=ver)",
+		Value: createYAMLNode(map[string]any{
+			"status": "success",
+			"data": map[string]any{
+				"labels": map[string][]string{
+					"version":    {"1.0.0", "2.0.0"},
+					"go_version": {"go1.21.0"},
+				},
+				"labelOrder": []string{"version", "go_version"},
+			},
+		}),
+	})
+
+	return examples
+}
+
+// infoLabelsPostExamples returns examples for POST /info_labels endpoint.
+func infoLabelsPostExamples() *orderedmap.Map[string, *base.Example] {
+	examples := orderedmap.New[string, *base.Example]()
+
+	examples.Set("simpleQuery", &base.Example{
+		Summary: "Simple info labels query",
+		Value: createYAMLNode(map[string]any{
+			"metric_match": "target_info",
+		}),
+	})
+
+	examples.Set("queryWithExpr", &base.Example{
+		Summary: "Info labels query with expression",
+		Value: createYAMLNode(map[string]any{
+			"expr":         "up{job=\"prometheus\"}",
+			"metric_match": "target_info",
+		}),
+	})
+
+	examples.Set("queryWithSearch", &base.Example{
+		Summary: "Info labels query with search filter",
+		Value: createYAMLNode(map[string]any{
+			"metric_match": "target_info",
+			"search":       "env",
+		}),
+	})
+
+	return examples
+}
+
 // metadataResponseExamples returns examples for /metadata response.
 func metadataResponseExamples() *orderedmap.Map[string, *base.Example] {
 	examples := orderedmap.New[string, *base.Example]()

--- a/vendor/github.com/prometheus/prometheus/web/api/v1/openapi_paths.go
+++ b/vendor/github.com/prometheus/prometheus/web/api/v1/openapi_paths.go
@@ -199,6 +199,35 @@ func (*OpenAPIBuilder) labelValuesPath() *v3.PathItem {
 	}
 }
 
+func (*OpenAPIBuilder) infoLabelsPath() *v3.PathItem {
+	params := []*v3.Parameter{
+		queryParamWithExample("start", "Start timestamp for info labels query.", false, timestampSchema(), timestampExamples(exampleTime.Add(-1*time.Hour))),
+		queryParamWithExample("end", "End timestamp for info labels query.", false, timestampSchema(), timestampExamples(exampleTime)),
+		queryParamWithExample("expr", "PromQL expression to extract identifying labels from.", false, stringSchema(), []example{{"example", "up{job=\"prometheus\"}"}}),
+		queryParamWithExample("metric_match", "Matcher for the info metric name (default: target_info).", false, stringSchema(), []example{{"example", "target_info"}}),
+		queryParamWithExample("search", "Filter label names by substring match (case-insensitive). When provided, response includes a labelOrder array sorted by relevance.", false, stringSchema(), []example{{"example", "env"}}),
+		queryParamWithExample("limit", "Maximum number of values per label to return.", false, integerSchema(), []example{{"example", 100}}),
+	}
+	return &v3.PathItem{
+		Get: &v3.Operation{
+			OperationId: "info-labels",
+			Summary:     "Get info metric labels",
+			Description: "Returns a map of data label names to their values from info metrics.",
+			Tags:        []string{"labels"},
+			Parameters:  params,
+			Responses:   responsesWithErrorExamples("InfoLabelsOutputBody", infoLabelsResponseExamples(), errorResponseExamples(), "Info labels retrieved successfully.", "Error retrieving info labels."),
+		},
+		Post: &v3.Operation{
+			OperationId: "info-labels-post",
+			Summary:     "Get info metric labels",
+			Description: "Returns a map of data label names to their values from info metrics.",
+			Tags:        []string{"labels"},
+			RequestBody: formRequestBodyWithExamples("InfoLabelsPostInputBody", infoLabelsPostExamples(), "Submit an info labels query."),
+			Responses:   responsesWithErrorExamples("InfoLabelsOutputBody", infoLabelsResponseExamples(), errorResponseExamples(), "Info labels retrieved successfully via POST.", "Error retrieving info labels via POST."),
+		},
+	}
+}
+
 func (*OpenAPIBuilder) seriesPath() *v3.PathItem {
 	params := []*v3.Parameter{
 		queryParamWithExample("start", "Start timestamp for series query.", false, timestampSchema(), timestampExamples(exampleTime.Add(-1*time.Hour))),

--- a/vendor/github.com/prometheus/prometheus/web/api/v1/openapi_schemas.go
+++ b/vendor/github.com/prometheus/prometheus/web/api/v1/openapi_schemas.go
@@ -54,6 +54,8 @@ func (b *OpenAPIBuilder) buildComponents() *v3.Components {
 	schemas.Set("LabelsOutputBody", b.stringArrayResponseBodySchema())
 	schemas.Set("LabelsPostInputBody", b.labelsPostInputBodySchema())
 	schemas.Set("LabelValuesOutputBody", b.stringArrayResponseBodySchema())
+	schemas.Set("InfoLabelsOutputBody", b.infoLabelsOutputBodySchema())
+	schemas.Set("InfoLabelsPostInputBody", b.infoLabelsPostInputBodySchema())
 
 	// Series schemas.
 	schemas.Set("SeriesOutputBody", b.labelsArrayResponseBodySchema())
@@ -714,6 +716,63 @@ func (*OpenAPIBuilder) labelsPostInputBodySchema() *base.SchemaProxy {
 	return base.CreateSchemaProxy(&base.Schema{
 		Type:                 []string{"object"},
 		Description:          "POST request body for labels query.",
+		AdditionalProperties: &base.DynamicValue[*base.SchemaProxy, bool]{N: 1, B: false},
+		Properties:           props,
+	})
+}
+
+func (*OpenAPIBuilder) infoLabelsOutputBodySchema() *base.SchemaProxy {
+	// Data is an InfoLabelsResult with labels map and labelOrder array.
+	dataProps := orderedmap.New[string, *base.SchemaProxy]()
+	dataProps.Set("labels", base.CreateSchemaProxy(&base.Schema{
+		Type:        []string{"object"},
+		Description: "Map of label names to their possible values from info metrics.",
+		AdditionalProperties: &base.DynamicValue[*base.SchemaProxy, bool]{
+			A: base.CreateSchemaProxy(&base.Schema{
+				Type:  []string{"array"},
+				Items: &base.DynamicValue[*base.SchemaProxy, bool]{A: stringSchema()},
+			}),
+		},
+	}))
+	dataProps.Set("labelOrder", base.CreateSchemaProxy(&base.Schema{
+		Type:        []string{"array"},
+		Description: "Ordered list of label names. Without search, alphabetical. With search, sorted by relevance (exact > prefix > earlier substring position > alphabetical).",
+		Items:       &base.DynamicValue[*base.SchemaProxy, bool]{A: stringSchema()},
+	}))
+
+	props := orderedmap.New[string, *base.SchemaProxy]()
+	props.Set("status", statusSchema())
+	props.Set("data", base.CreateSchemaProxy(&base.Schema{
+		Type:                 []string{"object"},
+		Description:          "Info labels result containing labels map and ordered label names.",
+		Required:             []string{"labels", "labelOrder"},
+		AdditionalProperties: &base.DynamicValue[*base.SchemaProxy, bool]{N: 1, B: false},
+		Properties:           dataProps,
+	}))
+	props.Set("warnings", warningsSchema())
+	props.Set("infos", infosSchema())
+
+	return base.CreateSchemaProxy(&base.Schema{
+		Type:                 []string{"object"},
+		Description:          "Response body for info labels endpoint.",
+		AdditionalProperties: &base.DynamicValue[*base.SchemaProxy, bool]{N: 1, B: false},
+		Required:             []string{"status", "data"},
+		Properties:           props,
+	})
+}
+
+func (*OpenAPIBuilder) infoLabelsPostInputBodySchema() *base.SchemaProxy {
+	props := orderedmap.New[string, *base.SchemaProxy]()
+	props.Set("start", stringSchemaWithDescriptionAndExample("Form field: The start time of the query.", "2023-07-21T20:00:00.000Z"))
+	props.Set("end", stringSchemaWithDescriptionAndExample("Form field: The end time of the query.", "2023-07-21T21:00:00.000Z"))
+	props.Set("expr", stringSchemaWithDescriptionAndExample("Form field: PromQL expression to extract identifying labels from.", "up{job=\"prometheus\"}"))
+	props.Set("metric_match", stringSchemaWithDescriptionAndExample("Form field: Matcher for the info metric name (default: target_info).", "target_info"))
+	props.Set("search", stringSchemaWithDescriptionAndExample("Form field: Filter label names by substring match (case-insensitive). When provided, labelOrder is sorted by relevance.", "env"))
+	props.Set("limit", integerSchemaWithDescriptionAndExample("Form field: Maximum number of values per label to return.", 100))
+
+	return base.CreateSchemaProxy(&base.Schema{
+		Type:                 []string{"object"},
+		Description:          "POST request body for info labels query.",
 		AdditionalProperties: &base.DynamicValue[*base.SchemaProxy, bool]{N: 1, B: false},
 		Properties:           props,
 	})

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1311,7 +1311,7 @@ github.com/prometheus/otlptranslator
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v1.8.2-0.20260225105904-7c22e95a1b6f
+# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v1.8.2-0.20260310150936-1bf6b94cbd54
 ## explicit; go 1.25.5
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -1331,6 +1331,7 @@ github.com/prometheus/prometheus/prompb
 github.com/prometheus/prometheus/prompb/io/prometheus/client
 github.com/prometheus/prometheus/prompb/io/prometheus/write/v2
 github.com/prometheus/prometheus/promql
+github.com/prometheus/prometheus/promql/infohelper
 github.com/prometheus/prometheus/promql/parser
 github.com/prometheus/prometheus/promql/parser/posrange
 github.com/prometheus/prometheus/promql/promqltest
@@ -2306,7 +2307,7 @@ sigs.k8s.io/kustomize/kyaml/yaml/walk
 # sigs.k8s.io/yaml v1.6.0
 ## explicit; go 1.22
 sigs.k8s.io/yaml
-# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20260225105904-7c22e95a1b6f
+# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20260310150936-1bf6b94cbd54
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20251126142931-6f9f62ab6f86
 # go.yaml.in/yaml/v3 => github.com/grafana/go-yaml/v3 v3.0.0-20260130164322-e3c24e8f4c87
 # github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20250905101755-5eb4f3acbf71


### PR DESCRIPTION
#### What this PR does

Adds a new `/api/v1/info_labels` API endpoint that returns data labels from info metrics (like `target_info`) for use in autocomplete suggestions for the PromQL `info()` function. Mimir port of https://github.com/prometheus/prometheus/pull/17930, which is also work in progress.

**Key changes:**
- New `/api/v1/info_labels` endpoint in the querier that queries store-gateways and ingesters
- Query frontend caching support with separate cache prefix (`il:`)
- Integration tests for the new endpoint
- Vendored Prometheus changes to expose the info labels API

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.