### PR TITLE
[r378] Block-builder-scheduler: fix data loss bug in partitions that are fully consumed at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,7 @@
 * [BUGFIX] Ingester: Defensive correctness fix for buffer reference counting in pkg/mimirpb. #14108
 * [BUGFIX] Ingester: Fix race condition during shutdown where TSDBs could be closed while appends are still in progress. #14094 #14127
 * [BUGFIX] Ingester: Add timeouts to wait for instance state on startup and deferred shutdown of tasks on failure. #14134
+* [BUGFIX] Block-builder-scheduler: Fix bug where data could be skipped when partition is fully consumed at startup but later grows. #14136
 
 ### Mixin
 

--- a/pkg/blockbuilder/scheduler/scheduler.go
+++ b/pkg/blockbuilder/scheduler/scheduler.go
@@ -175,7 +175,7 @@ func (s *BlockBuilderScheduler) completeObservationMode(ctx context.Context) {
 		return
 	}
 
-	s.populateInitialJobs(ctx, consumeOffs, newOffsetFinder(s.adminClient, s.logger))
+	s.populateInitialJobs(ctx, consumeOffs, newOffsetFinder(s.adminClient, s.logger), time.Now())
 	s.observations = nil
 	s.observationComplete = true
 }
@@ -239,6 +239,7 @@ type partitionState struct {
 	// plannedJobsMap is a map of jobID to jobState for quick lookup.
 	plannedJobsMap map[string]*jobState
 }
+
 type jobState struct {
 	jobID    string
 	spec     schedulerpb.JobSpec
@@ -409,7 +410,7 @@ func (s *BlockBuilderScheduler) enqueuePendingJobs() {
 	}
 }
 
-func (s *BlockBuilderScheduler) populateInitialJobs(ctx context.Context, consumeOffs []partitionOffsets, offStore offsetStore) {
+func (s *BlockBuilderScheduler) populateInitialJobs(ctx context.Context, consumeOffs []partitionOffsets, offStore offsetStore, endTime time.Time) {
 	// (Note that the lock is already held because we're in startup mode.)
 
 	// While during normal operation we are periodically asking about every
@@ -420,7 +421,6 @@ func (s *BlockBuilderScheduler) populateInitialJobs(ctx context.Context, consume
 	// those two offsets and seeding the schedule by calling updateEndOffset for
 	// each of them- just like we do during normal operation.
 
-	endTime := time.Now()
 	minScanTime := endTime.Add(-s.cfg.MaxScanAge)
 
 	for _, off := range consumeOffs {
@@ -487,8 +487,8 @@ func probeInitialOffsets(ctx context.Context, offs offsetStore, topic string, pa
 	endTime time.Time, jobSize time.Duration, minScanTime time.Time, logger log.Logger) ([]*offsetTime, error) {
 
 	if commit >= end || start >= end {
-		// No new data to consume.
-		return []*offsetTime{}, nil
+		// No new data to consume. Return the single end offset so it is initially registered.
+		return []*offsetTime{{offset: end, time: endTime}}, nil
 	}
 
 	// Pick a more high-resolution interval to scan for the sentinel offsets.


### PR DESCRIPTION
Backport 91972b95ebd9d565ada4837029dbda5b2673ff34 from https://github.com/grafana/mimir/pull/14136 into 378