### PR TITLE
Disable race detector for MQE benchmark unit tests in CI

### DIFF
--- a/.github/workflows/scripts/run-unit-tests-group.sh
+++ b/.github/workflows/scripts/run-unit-tests-group.sh
@@ -42,13 +42,44 @@ ALL_TESTS=$(go list "${MIMIR_DIR}/..." | sort)
 # Filter tests by the requested group.
 GROUP_TESTS=$(echo "$ALL_TESTS" | awk -v TOTAL=$TOTAL -v INDEX=$INDEX 'NR % TOTAL == INDEX')
 
+# The tests in the MQE benchmarks package load an enormous amount of data, which causes the
+# race detector to consume a large amount of memory and run incredibly slowly on CI.
+# The same code is tested by other unit tests which run with the race detector enabled, so
+# don't bother running the benchmark tests with the race detector enabled.
+SKIP_RACE_DETECTOR_PATTERN="^github.com/grafana/mimir/pkg/streamingpromql/benchmarks$"
+
+TESTS_TO_RUN_WITH_RACE_DETECTOR=$(echo "$GROUP_TESTS" | grep -v -e "$SKIP_RACE_DETECTOR_PATTERN")
+TESTS_TO_RUN_WITHOUT_RACE_DETECTOR=$(echo "$GROUP_TESTS" | grep -e "$SKIP_RACE_DETECTOR_PATTERN")
+
 echo "This group will run the following tests:"
 echo "$GROUP_TESTS"
-echo ""
+echo
 
-# shellcheck disable=SC2086 # we *want* word splitting of GROUP_TESTS.
-go test -tags=netgo,stringlabels -timeout 30m -race ${GROUP_TESTS} 2>&1 | tee /tmp/test-output.log
-EXIT_CODE=${PIPESTATUS[0]}
+if [[ -n "$TESTS_TO_RUN_WITH_RACE_DETECTOR" ]]; then
+    echo "These tests will run with the race detector enabled:"
+    echo "$TESTS_TO_RUN_WITH_RACE_DETECTOR"
+    echo
+
+    # shellcheck disable=SC2086 # we *want* word splitting of TESTS_TO_RUN_WITH_RACE_DETECTOR.
+    go test -tags=netgo,stringlabels -timeout 30m -race ${TESTS_TO_RUN_WITH_RACE_DETECTOR} 2>&1 | tee /tmp/test-output.log
+    RACE_ENABLED_EXIT_CODE=${PIPESTATUS[0]}
+    echo
+else
+    RACE_ENABLED_EXIT_CODE=0
+fi
+
+if [[ -n "$TESTS_TO_RUN_WITHOUT_RACE_DETECTOR" ]]; then
+    echo "These tests will run with the race detector disabled (if any):"
+    echo "$TESTS_TO_RUN_WITHOUT_RACE_DETECTOR"
+    echo
+
+    # shellcheck disable=SC2086 # we *want* word splitting of TESTS_TO_RUN_WITHOUT_RACE_DETECTOR.
+    go test -tags=netgo,stringlabels -timeout 30m ${TESTS_TO_RUN_WITHOUT_RACE_DETECTOR} 2>&1 | tee -a /tmp/test-output.log
+    RACE_DISABLED_EXIT_CODE=${PIPESTATUS[0]}
+    echo
+else
+    RACE_DISABLED_EXIT_CODE=0
+fi
 
 # Extract all failed packages
 FAILED_PACKAGES=$(grep "FAIL\s*github.com/grafana/mimir/.*" /tmp/test-output.log | awk '{print $2}' | sort -u | tr '\n' ' ')
@@ -58,4 +89,8 @@ if [[ -n "$FAILED_PACKAGES" ]]; then
     echo "FAILED_PACKAGES=${FAILED_PACKAGES}" >> "$GITHUB_ENV"
 fi
 
-exit $EXIT_CODE
+if [[ $RACE_ENABLED_EXIT_CODE -ne 0 ]]; then
+    exit $RACE_ENABLED_EXIT_CODE
+fi
+
+exit $RACE_DISABLED_EXIT_CODE


### PR DESCRIPTION
#### What this PR does

This PR changes the behaviour of our CI workflow to not run the MQE benchmark unit tests with the race detector enabled.

See the comment in `.github/workflows/scripts/run-unit-tests-group.sh` for more explanation.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only bash script change that reduces race coverage for a single benchmark-heavy package; main risk is missed race issues in that package or unintended package-selection/exit-code behavior.
> 
> **Overview**
> Updates the CI unit-test grouping script to **exclude** `github.com/grafana/mimir/pkg/streamingpromql/benchmarks` from `go test -race`, running that package’s tests separately **without** the race detector to avoid excessive CI memory/slowdowns.
> 
> The script now produces clearer output about which packages run with/without `-race`, appends non-race output to the same log for failure extraction, and returns the appropriate exit code depending on which phase fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d0972e8d409538f7493de1860b4995a727eb7b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->