### PR TITLE
fix(ingester): revert to only shut down ring lifecycler on startup fa…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,7 +146,7 @@
 * [BUGFIX] Store-gateway: Fix blocks being incorrectly dropped during shutdown when the store-gateway is terminated while fetching an updated bucket index. #14113
 * [BUGFIX] Ingester: Defensive correctness fix for buffer reference counting in pkg/mimirpb. #14108
 * [BUGFIX] Ingester: Fix race condition during shutdown where TSDBs could be closed while appends are still in progress. #14094 #14127
-* [BUGFIX] Ingester: Add timeouts to wait for instance state on startup and deferred shutdown of tasks on failure. #14134
+* [BUGFIX] Ingester: Add timeouts to wait for instance state on startup and deferred shutdown of tasks on failure. #14134, #14180
 * [BUGFIX] Block-builder-scheduler: Fix bug where data could be skipped when partition is fully consumed at startup but later grows. #14136
 
 ### Mixin

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -660,35 +660,15 @@ func (i *Ingester) startingForFlusher(ctx context.Context) error {
 }
 
 func (i *Ingester) starting(ctx context.Context) (err error) {
+
 	defer func() {
 		if err != nil {
-			// If starting() fails for any reason (e.g., context canceled), services must be stopped.
-
-			// Subservices watcher was started in New();
-			// Failure to close it can block subservices from shutting down
-			// and leave hanging goroutines after exit.
-			i.subservicesWatcher.Close()
-
-			shutdownTimeout := 3 * time.Minute
+			// If starting() fails for any reason (e.g., context canceled), lifecycler must be stopped.
+			shutdownTimeout := 1 * time.Minute
 			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), shutdownTimeout)
 			defer shutdownCancel()
 
-			// Stop any services that may have been started in this method, in reverse order.
-			if i.subservicesAfterIngesterRingLifecycler != nil {
-				_ = services.StopManagerAndAwaitStopped(shutdownCtx, i.subservicesAfterIngesterRingLifecycler)
-			}
-			if i.lifecycler != nil {
-				_ = services.StopAndAwaitTerminated(shutdownCtx, i.lifecycler)
-			}
-			if i.ingestReader != nil {
-				_ = services.StopAndAwaitTerminated(shutdownCtx, i.ingestReader)
-			}
-			if i.subservicesForPartitionReplay != nil {
-				_ = services.StopManagerAndAwaitStopped(shutdownCtx, i.subservicesForPartitionReplay)
-			}
-			if i.ownedSeriesService != nil {
-				_ = services.StopAndAwaitTerminated(shutdownCtx, i.ownedSeriesService)
-			}
+			_ = services.StopAndAwaitTerminated(shutdownCtx, i.lifecycler)
 		}
 	}()
 


### PR DESCRIPTION
…ilure (#14180)

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main -->

Follow-up to https://github.com/grafana/mimir/pull/14025 and https://github.com/grafana/mimir/pull/14134.

We originally tried to have a nice clean shutdown in order to pass the tests with `VerifyNoLeak`, but there are issues with circular dependencies blocking the process as we shutdown various services.

We are going back to only shutting down the ring lifecycler and ignoring the hanging goroutines in tests.
We are keeping the context deadline for the shutdown we introduced in an attempt to prevent stuck shutdowns.

Fixes #<issue number>

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - Reverts startup-failure shutdown logic in `ingester.go` to stop only the `lifecycler` (with a 1m timeout), removing shutdown of other subservices and the subservices watcher
> - Updates tests to pass `goleak` ignore options and use `VerifyNoLeak(t, goleakOpts...)` to avoid false positives
> - Adds reference `#14180` to the related `[BUGFIX] Ingester` entry in `CHANGELOG.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a73b8a8daa81f04a144ccd449dd6af7f89d08ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



(cherry picked from commit ac8a2e3166c6203f4bb6ef84fc9b6d7fddf4ddcf)

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
