### PR TITLE
ruler: validate query-frontend address when using GRPC

### DIFF
--- a/pkg/ruler/http_roundtripper.go
+++ b/pkg/ruler/http_roundtripper.go
@@ -36,14 +36,14 @@ func newHTTPRoundTripper(cfg *HTTPConfig) http.RoundTripper {
 
 // dialQueryFrontendHTTP creates and initializes a new httpgrpc.HTTPClient taking a QueryFrontendConfig configuration.
 func dialQueryFrontendHTTP(cfg QueryFrontendConfig, _ prometheus.Registerer, _ log.Logger) (http.RoundTripper, *url.URL, error) {
-	url, err := url.Parse(cfg.Address)
+	u, err := url.Parse(cfg.Address)
 	if err != nil {
 		return nil, nil, err
 	}
 	// this makes .JoinPath("/absolute/path") work as we need
-	if url.Path == "" {
-		url.Path = "/"
+	if u.Path == "" {
+		u.Path = "/"
 	}
 
-	return newHTTPRoundTripper(&cfg.HTTPClientConfig), url, nil
+	return newHTTPRoundTripper(&cfg.HTTPClientConfig), u, nil
 }

--- a/pkg/ruler/remotequerier_test.go
+++ b/pkg/ruler/remotequerier_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/status"
 	"github.com/golang/snappy"
+	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/grpcutil"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/prometheus/prometheus/model/histogram"
@@ -30,6 +31,40 @@ import (
 	"github.com/grafana/mimir/pkg/querier/api"
 	"github.com/grafana/mimir/pkg/util/httpgrpcutil"
 )
+
+func TestQueryFrontendConfig_Validate(t *testing.T) {
+	t.Run("invalid response format", func(t *testing.T) {
+		var cfg QueryFrontendConfig
+		flagext.DefaultValues(&cfg)
+		cfg.QueryResultResponseFormat = "invalid!"
+
+		require.Error(t, cfg.Validate())
+	})
+
+	t.Run("valid response format", func(t *testing.T) {
+		var cfg QueryFrontendConfig
+		flagext.DefaultValues(&cfg)
+		cfg.QueryResultResponseFormat = "json"
+
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("invalid query-frontend address", func(t *testing.T) {
+		var cfg QueryFrontendConfig
+		flagext.DefaultValues(&cfg)
+		cfg.Address = "dns://localhost:9095/"
+
+		require.Error(t, cfg.Validate())
+	})
+
+	t.Run("valid query-frontend address", func(t *testing.T) {
+		var cfg QueryFrontendConfig
+		flagext.DefaultValues(&cfg)
+		cfg.Address = "dns:///localhost:9095/"
+
+		require.NoError(t, cfg.Validate())
+	})
+}
 
 type mockHTTPGRPCClient func(ctx context.Context, req *httpgrpc.HTTPRequest, _ ...grpc.CallOption) (*httpgrpc.HTTPResponse, error)
 


### PR DESCRIPTION
#### What this PR does

Validate that the service discovery form of a GRPC address for the query-frontend is correct to avoid inscrutable errors from GRPC.

#### Which issue(s) this PR fixes or relates to

Fixes #13405

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds early validation for `QueryFrontendConfig.Address` to require `dns:///` when using GRPC service discovery, preventing ambiguous GRPC errors.
> 
> - Enforces response format validity and `dns:///` prefix in `QueryFrontendConfig.Validate()`
> - Introduces unit tests for address/format validation
> - Minor refactor in HTTP round-tripper URL parsing (variable rename, ensure root path)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17b2b4a7a60e123949cd2fea4fa70879e3e4a02f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->