### PR TITLE
[release-3.0] docs: Add extra slash to DNS resolver scheme

### DIFF
--- a/docs/sources/mimir/references/architecture/components/ruler/index.md
+++ b/docs/sources/mimir/references/architecture/components/ruler/index.md
@@ -38,7 +38,7 @@ When you use the internal mode, the ruler uses no query acceleration techniques 
 
 In this mode the ruler delegates rules evaluation to the query-frontend. When enabled, the ruler leverages all the query acceleration techniques employed by the query-frontend, such as [query sharding](../../query-sharding/).
 To enable the remote operational mode, set the `-ruler.query-frontend.address` CLI flag or its respective YAML configuration parameter for the ruler.
-Communication between ruler and query-frontend is established over gRPC, so you can make use of client-side load balancing by prefixing the query-frontend address URL with `dns://`.
+Communication between ruler and query-frontend is established over gRPC, so you can make use of client-side load balancing by prefixing the query-frontend address URL with `dns:///`.
 
 ![Architecture of Grafana Mimir's ruler component in remote mode](ruler-remote.svg)
 


### PR DESCRIPTION
Backport of #12997 to Mimir 3.0 docs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes the ruler remote mode documentation by changing the gRPC DNS load-balancing prefix from `dns://` to `dns:///` in `ruler/index.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3b7e8215e738353d201db77e4c7d8c4729ee1b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->