### PR TITLE
renovate: add custom manager to watch for distroless docker image in Makefile

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -14,6 +14,16 @@
       ],
       datasourceTemplate: 'docker',
     },
+    {
+      customType: 'regex',
+      description: 'Update distroless image references in Makefile',
+      managerFilePatterns: ['Makefile'],
+      matchStrings: [
+        "(?<depName>gcr\\.io/distroless/[\\w-]+)@(?<currentDigest>sha256:[a-f0-9]+)",
+      ],
+      currentValueTemplate: 'latest',
+      datasourceTemplate: 'docker',
+    },
   ],
   baseBranchPatterns: [
     'main',


### PR DESCRIPTION
#### What this PR does

This PR adds one more custom renovate manager, that will watch for updates in the distroless images, that Mimir's `Makefile` references as `BASEIMG`.

Note, we've tested a similar change internally in Grafana Labs, and it works as expected 🤖 