### PR TITLE
docs: clarify that head-chunks-write-buffer-size-bytes value is integer

### DIFF
--- a/docs/sources/mimir/manage/run-production-environment/production-tips/index.md
+++ b/docs/sources/mimir/manage/run-production-environment/production-tips/index.md
@@ -207,7 +207,7 @@ To configure gRPC compression, use the following CLI flags or their YAML equival
 For each tenant, Mimir opens and maintains a TSDB in memory. If you have a significant number of tenants, the memory overhead might become prohibitive.
 To reduce the associated overhead, consider the following:
 
-- Reduce `-blocks-storage.tsdb.head-chunks-write-buffer-size-bytes`, default `4MB`. For example, try `1MB` or `128KB`.
+- Reduce `-blocks-storage.tsdb.head-chunks-write-buffer-size-bytes`, default `4194304` (4 MB). For example, try `1048576` (1 MB) or `131072` (128 KB).
 - Reduce `-blocks-storage.tsdb.stripe-size`, default `16384`. For example, try `256`, or even `64`.
 - Configure [shuffle sharding](https://grafana.com/docs/mimir/latest/configure/configure-shuffle-sharding/)
 


### PR DESCRIPTION
#### What this PR does

Updated guidance to be more clear that the value of `head-chunks-write-buffer-size-bytes` should be specified as integer bytes without any units.

See: https://github.com/grafana/mimir/blob/mimir-3.0.0/docs/sources/mimir/configure/configuration-parameters/index.md?plain=1#L4969

Otherwise, using examples as-is causes ingester to crash with:

```
error loading config from /etc/mimir/mimir.yaml: Error parsing config file: yaml: unmarshal errors:
  line 16: cannot unmarshal !!str `128KB` into int
```

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to production tips; no runtime or configuration code is modified.
> 
> **Overview**
> Updates the **Heavy multi-tenancy** production tip so examples for `-blocks-storage.tsdb.head-chunks-write-buffer-size-bytes` use **integer byte values** (matching the `<int>` config type) instead of suffixed strings like `4MB` / `128KB`.
> 
> The default and suggested values are now written as `4194304` (4 MB), `1048576` (1 MB), and `131072` (128 KB), with human-readable sizes kept in parentheses for readability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9145b56dc93e1e9906c450ccb4859d2501fd1530. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->