### PR TITLE
cache: reuse promises for identical queries in frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## main / unreleased
 
 ### Grafana Mimir
-
+* [ENHANCEMENT] Query-frontend: Reuse responses for identical requests while processing queries. #14205
 * [CHANGE] Ingester: Changed default value of `-include-tenant-id-in-profile-labels` from false to true. #13375
 * [CHANGE] Hash ring: removed experimental support for disabling heartbeats (setting `-*.ring.heartbeat-period=0`) and heartbeat timeouts (setting `-*.ring.heartbeat-timeout=0`). These configurations are now invalid. #13104
 * [CHANGE] Distributor: removed experimental flag `-distributor.metric-relabeling-enabled`. #13143

--- a/pkg/frontend/querymiddleware/model_extra.go
+++ b/pkg/frontend/querymiddleware/model_extra.go
@@ -14,6 +14,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/gogo/protobuf/proto"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/timestamp"
@@ -1046,6 +1047,24 @@ func (resp *PrometheusResponseWithFinalizer) Close() {
 
 func (resp *PrometheusResponseWithFinalizer) GetPrometheusResponse() (*PrometheusResponse, bool) {
 	return resp.PrometheusResponse, true
+}
+
+func (resp *PrometheusResponse) Clone() *PrometheusResponse {
+	respClone := &PrometheusResponse{
+		Status:    resp.Status,
+		Data:      resp.Data,
+		ErrorType: resp.ErrorType,
+		Error:     resp.Error,
+		Headers:   make([]*PrometheusHeader, len(resp.Headers)),
+		Warnings:  make([]string, len(resp.Warnings)),
+		Infos:     make([]string, len(resp.Infos)),
+	}
+	copy(respClone.Warnings, resp.Warnings)
+	copy(respClone.Infos, resp.Infos)
+	for i, header := range resp.Headers {
+		respClone.Headers[i] = proto.Clone(header).(*PrometheusHeader)
+	}
+	return respClone
 }
 
 // EncodeCachedHTTPResponse encodes the input http.Response into CachedHTTPResponse.

--- a/pkg/frontend/querymiddleware/model_extra.go
+++ b/pkg/frontend/querymiddleware/model_extra.go
@@ -1049,6 +1049,8 @@ func (resp *PrometheusResponseWithFinalizer) GetPrometheusResponse() (*Prometheu
 	return resp.PrometheusResponse, true
 }
 
+// create a semi clone
+// Data field points to the original response field
 func (resp *PrometheusResponse) Clone() *PrometheusResponse {
 	respClone := &PrometheusResponse{
 		Status:    resp.Status,

--- a/pkg/frontend/querymiddleware/model_extra.go
+++ b/pkg/frontend/querymiddleware/model_extra.go
@@ -1049,12 +1049,11 @@ func (resp *PrometheusResponseWithFinalizer) GetPrometheusResponse() (*Prometheu
 	return resp.PrometheusResponse, true
 }
 
-// create a semi clone
-// Data field points to the original response field
+// Creates a deep clone
 func (resp *PrometheusResponse) Clone() *PrometheusResponse {
 	respClone := &PrometheusResponse{
 		Status:    resp.Status,
-		Data:      resp.Data,
+		Data:      proto.Clone(resp.Data).(*PrometheusData),
 		ErrorType: resp.ErrorType,
 		Error:     resp.Error,
 		Headers:   make([]*PrometheusHeader, len(resp.Headers)),

--- a/pkg/frontend/querymiddleware/querysharding_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test.go
@@ -1188,7 +1188,7 @@ func TestQuerySharding_Annotations(t *testing.T) {
 					mockLimits{},
 					newTestCodec(),
 					nil,
-					nil,
+					DefaultCacheKeyGenerator{interval: day},
 					nil,
 					nil,
 					log.NewNopLogger(),

--- a/pkg/frontend/querymiddleware/split_and_cache.go
+++ b/pkg/frontend/querymiddleware/split_and_cache.go
@@ -8,6 +8,7 @@ package querymiddleware
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -97,6 +98,9 @@ type splitAndCacheMiddleware struct {
 	splitter       CacheKeyGenerator
 	extractor      Extractor
 	shouldCacheReq shouldCacheFn
+
+	//promises map
+	reqPromises sync.Map
 
 	// Can be set from tests
 	currentTime func() time.Time
@@ -229,7 +233,7 @@ func (s *splitAndCacheMiddleware) Do(ctx context.Context, req MetricsQueryReques
 	queryTime := s.currentTime()
 
 	if len(execReqs) > 0 {
-		execResps, err := doRequests(ctx, s.next, execReqs)
+		execResps, err := s.doRequests(ctx, tenantIDs, s.next, execReqs)
 		if err != nil {
 			return nil, err
 		}
@@ -605,8 +609,56 @@ type requestResponse struct {
 	Stats    *stats.SafeStats
 }
 
+type doReqestPromise = func(context.Context) (Response, error)
+
+/*
+Executes a query request and returns a promise for the results
+first request of a query is executed to produce results ,
+subsequent requests for same query will reuse the same results for promise
+deduplication of execution of a query is guranteed while the first request is being evaulated
+*/
+func (s *splitAndCacheMiddleware) doRequest(ctx context.Context, tenantIDs []string, downstream MetricsQueryHandler, req MetricsQueryRequest) (doReqestPromise, bool) {
+	var (
+		res  Response
+		err  error
+		done = make(chan struct{})
+	)
+
+	promise := func(ctx context.Context) (Response, error) {
+		select {
+		case <-ctx.Done():
+			{
+				return nil, ctx.Err()
+			}
+		case <-done:
+		}
+		if err != nil {
+			return nil, err
+		}
+		promRes, ok := res.GetPrometheusResponse()
+		if !ok {
+			return nil, fmt.Errorf("Expected Prometheus Response")
+		}
+		responseCopy := promRes.Clone()
+		return responseCopy, nil
+	}
+
+	key := s.splitter.QueryRequest(ctx, tenant.JoinTenantIDs(tenantIDs), req)
+	reqPromise, fetched := s.reqPromises.LoadOrStore(key, promise)
+	if fetched {
+		return reqPromise.(doReqestPromise), true
+	}
+
+	defer close(done)
+	defer s.reqPromises.Delete(key)
+
+	res, err = downstream.Do(ctx, req)
+
+	return reqPromise.(doReqestPromise), false
+}
+
 // doRequests executes a list of requests in parallel.
-func doRequests(ctx context.Context, downstream MetricsQueryHandler, reqs []MetricsQueryRequest) ([]requestResponse, error) {
+func (s *splitAndCacheMiddleware) doRequests(ctx context.Context, tenantIds []string, downstream MetricsQueryHandler, reqs []MetricsQueryRequest) ([]requestResponse, error) {
 	g, ctx := errgroup.WithContext(ctx)
 	mtx := sync.Mutex{}
 	resps := make([]requestResponse, 0, len(reqs))
@@ -622,7 +674,9 @@ func doRequests(ctx context.Context, downstream MetricsQueryHandler, reqs []Metr
 			req.AddSpanTags(span)
 			defer span.End()
 
-			resp, err := downstream.Do(childCtx, req)
+			reqPromise, _ := s.doRequest(childCtx, tenantIds, downstream, req)
+			resp, err := reqPromise(childCtx)
+
 			queryStatistics.Merge(partialStats)
 			if err != nil {
 				return err

--- a/pkg/frontend/querymiddleware/split_and_cache.go
+++ b/pkg/frontend/querymiddleware/split_and_cache.go
@@ -639,6 +639,7 @@ func (s *splitAndCacheMiddleware) doRequest(ctx context.Context, tenantIDs []str
 		if !ok {
 			return nil, fmt.Errorf("Expected Prometheus Response")
 		}
+		//create a response copy from original for each request 
 		responseCopy := promRes.Clone()
 		return responseCopy, nil
 	}

--- a/pkg/frontend/querymiddleware/split_and_cache_test.go
+++ b/pkg/frontend/querymiddleware/split_and_cache_test.go
@@ -174,7 +174,7 @@ func TestSplitAndCacheMiddleware_SplitByInterval(t *testing.T) {
 		mockLimits{},
 		codec,
 		nil,
-		nil,
+		DefaultCacheKeyGenerator{interval: day},
 		nil,
 		nil,
 		log.NewNopLogger(),
@@ -1347,6 +1347,7 @@ func TestSplitAndCacheMiddleware_ResultsCache_ExtentsEdgeCases(t *testing.T) {
 
 			// Run the request.
 			actualRes, err := mw.Do(ctx, testData.req)
+			fmt.Println(err)
 			require.NoError(t, err)
 
 			expectedResponse := mkAPIResponse(testData.req.GetStart(), testData.req.GetEnd(), testData.req.GetStep())

--- a/pkg/frontend/querymiddleware/split_and_cache_test.go
+++ b/pkg/frontend/querymiddleware/split_and_cache_test.go
@@ -1347,7 +1347,6 @@ func TestSplitAndCacheMiddleware_ResultsCache_ExtentsEdgeCases(t *testing.T) {
 
 			// Run the request.
 			actualRes, err := mw.Do(ctx, testData.req)
-			fmt.Println(err)
 			require.NoError(t, err)
 
 			expectedResponse := mkAPIResponse(testData.req.GetStart(), testData.req.GetEnd(), testData.req.GetStep())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Implements a cache for requests to reuse response for identical requests while a query is being processed

Technical Details 
splitAndCacheMiddleware now utilizes a map to store promises of requests , these promises are reused to serve identical requests for a given query
#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>
#3791 
#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches query-frontend concurrency and response handling; bugs could cause request hangs, incorrect sharing across tenants/keys, or higher memory/CPU due to cloning.
> 
> **Overview**
> Adds *in-flight request deduplication* to `splitAndCacheMiddleware` so identical downstream `MetricsQueryRequest`s share the same execution while the first is still running, reducing duplicate work during query processing.
> 
> This introduces a `sync.Map` of per-request promises keyed by the cache key generator, updates `doRequests` to resolve via the shared promise, and adds `PrometheusResponse.Clone()` (deep copy via `proto.Clone`) to safely return independent response instances to each waiter. Tests are adjusted to always pass a `DefaultCacheKeyGenerator`, and `CHANGELOG.md` records the enhancement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5abb1ff9eb80f959309c60c227f836e62109094c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->