### PR TITLE
Jsonnet: add memberlist_bridge_container field

### DIFF
--- a/operations/mimir/multi-zone-memberlist-bridge.libsonnet
+++ b/operations/mimir/multi-zone-memberlist-bridge.libsonnet
@@ -34,6 +34,15 @@
   memberlist_bridge_ports:: $.util.defaultPorts,
   memberlist_bridge_node_affinity_matchers:: [],
 
+  memberlist_bridge_container::
+    container.new('memberlist-bridge', $._images.memberlist_bridge)
+    + container.withPorts($.memberlist_bridge_ports)
+    + container.withArgs($.util.mapToFlags($.memberlist_bridge_args))
+    + $.tracing_env_mixin
+    + $.util.readinessProbe
+    + $.util.resourcesRequests('0.25', '1Gi')
+    + $.util.resourcesLimits(null, '2Gi'),
+
   memberlist_bridge_args::
     $._config.commonConfig
     + $._config.usageStatsConfig
@@ -107,13 +116,8 @@
     $.newMimirPdb('memberlist-bridge-zone-c'),
 
   newMemberlistBridgeZoneContainer(zone, args, extraEnvVarMap={})::
-    container.new('memberlist-bridge', $._images.memberlist_bridge)
-    + container.withPorts($.memberlist_bridge_ports)
+    $.memberlist_bridge_container
     + container.withArgs($.util.mapToFlags(args))
-    + $.tracing_env_mixin
-    + $.util.readinessProbe
-    + $.util.resourcesRequests('0.25', '1Gi')
-    + $.util.resourcesLimits(null, '2Gi')
     + (if std.length(extraEnvVarMap) > 0 then container.withEnvMixin(std.prune(extraEnvVarMap)) else {}),
 
   newMemberlistBridgeZoneDeployment(zone, container, nodeAffinityMatchers=[])::


### PR DESCRIPTION
#### What this PR does

Add `memberlist_bridge_container` field, used to define the base container among zones. This makes it easier to override the container for all zones, and it's also a pattern required by Grafana Labs automations.

Functionally, this is expected to be a no-op (no diff in jsonnet tests output).

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
