### PR TITLE
docs: clarify microservices mode dependencies (#14117)

### DIFF
--- a/docs/sources/mimir/references/architecture/deployment-modes/index.md
+++ b/docs/sources/mimir/references/architecture/deployment-modes/index.md
@@ -52,9 +52,9 @@ Microservices mode deploys each component in separate processes, enabling indepe
 
 {{< admonition type="note" >}}
 Even though the read path (query-frontend, querier, and store-gateway) runs separately from the write path (distributor and ingester), a healthy ring is typically required for successful queries. If the write components (distributor or ingester) are unavailable or unhealthy, the ring health check may fail, causing read queries to fail. Complete isolation of read versus write availability requires careful configuration of ring settings and failure tolerance.
-{{< /admonition >}}
 
 Specifically, the querier consults the [hash ring](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/hash-ring/) to discover ingesters before reading recent data from them. If ingesters are unhealthy or unavailable, the ring reflects that state and the querier may be unable to satisfy queries for recent data. Achieving true read/write isolation requires zone-aware replication and careful ring configuration so that the loss of write-path components does not reduce the ring below the quorum needed for reads. For more information, refer to [Configuring zone-aware replication](https://grafana.com/docs/mimir/<MIMIR_VERSION>/configure/configure-zone-aware-replication/).
+{{< /admonition >}}
 
 The following diagrams show how Mimir works in microservices mode using ingest storage and classic architectures. For more information about the two supported architectures in Grafana Mimir, refer to [Grafana Mimir architecture](https://grafana.com/docs/mimir/<MIMIR_VERSION>/get-started/about-grafana-mimir-architecture/).
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR clarifies the microservices mode documentation regarding the dependency of the read path on the write path.

Key changes:
- Updated [docs/sources/mimir/references/architecture/deployment-modes/index.md](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/references/architecture/deployment-modes/index.md) to explain that a healthy ring (requiring available distributors/ingesters) is typically necessary for successful queries.
- Added a Mermaid diagram to visualize this dependency (`Querier -> Hash Ring <- Ingester`).

#### Which issue(s) this PR fixes or relates to

Fixes #14117

#### Checklist

- [x] Tests updated. (N/A - Documentation only)
- [x] Documentation added.
- [ ] [CHANGELOG.md](https://github.com/grafana/mimir/blob/main/CHANGELOG.md) updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [about-versioning.md](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime or configuration defaults are modified.
> 
> **Overview**
> Clarifies in the microservices deployment mode docs that **read-path availability can still depend on write-path health** because the querier relies on a healthy hash ring to discover ingesters for recent data.
> 
> Adds guidance that true read/write isolation requires careful ring failure-tolerance settings and points readers to zone-aware replication documentation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4ae9c96f2572480c72a3edfdc64cc07052760c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->