### PR TITLE
docs: fix missing image link (Fixes #14220)

### DIFF
--- a/docs/sources/mimir/get-started/about-grafana-mimir-architecture/about-ingest-storage-architecture/index.md
+++ b/docs/sources/mimir/get-started/about-grafana-mimir-architecture/about-ingest-storage-architecture/index.md
@@ -23,7 +23,26 @@ The following diagram shows how ingest storage architecture works:
 
 <div align="center">
 
-![Ingest storage architecture diagram](/media/docs/mimir/ingest-storage-overview.png)
+```mermaid
+flowchart LR
+    subgraph Write_Path ["Write Path"]
+        Dist[Distributor]
+    end
+
+    subgraph Event_Bus ["Event Bus"]
+        Kafka{Apache Kafka}
+    end
+
+    subgraph Read_Path ["Read Path"]
+        Ing[Ingester]
+        Store[(Long-term Storage)]
+    end
+
+    Dist -- "Writes Samples (Push)" --> Kafka
+    Kafka -- "Consumes Samples (Pull)" --> Ing
+    Ing -- "Uploads Blocks" --> Store
+```
+*Ingest storage architecture diagram*
 
 </div>
 

--- a/docs/sources/mimir/references/architecture/deployment-modes/index.md
+++ b/docs/sources/mimir/references/architecture/deployment-modes/index.md
@@ -56,7 +56,26 @@ Ingest storage architecture:
 
 <div align="center">
 
-![Ingest storage architecture diagram](/media/docs/mimir/ingest-storage-overview.png)
+```mermaid
+flowchart LR
+    subgraph Write_Path ["Write Path"]
+        Dist[Distributor]
+    end
+
+    subgraph Event_Bus ["Event Bus"]
+        Kafka{Apache Kafka}
+    end
+
+    subgraph Read_Path ["Read Path"]
+        Ing[Ingester]
+        Store[(Long-term Storage)]
+    end
+
+    Dist -- "Writes Samples (Push)" --> Kafka
+    Kafka -- "Consumes Samples (Pull)" --> Ing
+    Ing -- "Uploads Blocks" --> Store
+```
+*Ingest storage architecture diagram*
 
 </div>
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR fixes a broken image link (`ingest-storage-overview.png`) in the documentation. The image file was missing from the repository, so I have replaced it with a Mermaid diagram that accurately illustrates the Ingest Storage architecture described in the text.

**Changes:**
- Replaced missing image with Mermaid diagram in:
  - [`docs/sources/mimir/references/architecture/deployment-modes/index.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/references/architecture/deployment-modes/index.md)
  - [`docs/sources/mimir/get-started/about-grafana-mimir-architecture/about-ingest-storage-architecture/index.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/get-started/about-grafana-mimir-architecture/about-ingest-storage-architecture/index.md)

#### Which issue(s) this PR fixes or relates to

Fixes #14220

#### Checklist

- [x] Documentation added.
- [ ] [`CHANGELOG.md`](https://github.com/grafana/mimir/blob/main/CHANGELOG.md) updated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that replaces a broken image reference with inline Mermaid diagrams; minimal risk beyond potential rendering differences in doc build output.
> 
> **Overview**
> Replaces the broken `ingest-storage-overview.png` reference with an inline Mermaid flowchart diagram (plus caption) to document ingest storage architecture.
> 
> This update is applied in both the ingest storage architecture page and the microservices deployment-mode docs so the ingest-storage overview renders correctly without relying on a missing image asset.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95f73402d701b195d0c1c35ca6b3a1de97ac9dce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->