### PR TITLE
distributor: expose compressed bytes histogram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * [CHANGE] Ruler: Add path traversal checks when parsing namespaces and groups, which prevents namespace and group name from containing non-local paths. #14052
 * [CHANGE] Ingester: Removed the `-target=flusher` mode. If you need to flush ingester data, use the `/ingester/flush` HTTP endpoint instead. #14032
 * [CHANGE] Querier and query-frontend: The experimental `-querier.mimir-query-engine.enable-common-subexpression-elimination-for-range-vector-expressions-in-instant-queries` and `-querier.mimir-query-engine.enable-skipping-histogram-decoding` flags have been removed. Both were previously enabled by default and now cannot be disabled. #14237
+* [FEATURE] Distributor: add `cortex_distributor_request_body_compression_ratio` histogram that tracks the compression of write requests. #14232
 * [FEATURE] Distributor: add `-distributor.otel-label-name-underscore-sanitization` and `-distributor.otel-label-name-preserve-underscores` that control sanitization of underscores during OTLP translation. #13133
 * [FEATURE] Query-frontends: Automatically adjust features used in query plans generated for remote execution based on what the available queriers support. #13017 #13164 #13544
 * [FEATURE] Memberlist: Add experimental support for zone-aware routing in order to reduce memberlist cross-AZ data transfer. #13129 #13651 #13664

--- a/pkg/distributor/otel.go
+++ b/pkg/distributor/otel.go
@@ -363,7 +363,7 @@ func newOTLPParser(
 		validateTranslationStrategy(translationStrategy, limits, tenantID)
 
 		pushMetrics.IncOTLPRequest(tenantID)
-		pushMetrics.ObserveUncompressedBodySize(tenantID, "otlp", float64(uncompressedBodySize))
+		pushMetrics.ObserveRequestBodySize(tenantID, "otlp", int64(uncompressedBodySize), r.ContentLength)
 		pushMetrics.IncOTLPContentType(contentType)
 		observeOTLPFieldsCount(pushMetrics, otlpReq)
 

--- a/pkg/distributor/push.go
+++ b/pkg/distributor/push.go
@@ -108,7 +108,7 @@ func Handler(
 		if err != nil {
 			return err
 		}
-		pushMetrics.ObserveUncompressedBodySize(tenantID, "push", float64(protoBodySize))
+		pushMetrics.ObserveRequestBodySize(tenantID, "push", int64(protoBodySize), r.ContentLength)
 
 		return nil
 	})


### PR DESCRIPTION
#### What this PR does

This PR exports `cortex_distributor_request_body_compression_ratio` which allows users to inspect effectiveness of compression.

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new metric and a small refactor of metric observation without changing ingestion behavior; main risk is minor metric cardinality/labeling or size calculation edge cases (eg `Content-Length` not set).
> 
> **Overview**
> **Adds compression observability for write ingestion.** The distributor now exports a native histogram `cortex_distributor_request_body_compression_ratio` (labeled by `handler`) computed as *uncompressed_size / compressed_size*.
> 
> To support this, `PushMetrics` replaces `ObserveUncompressedBodySize` with `ObserveRequestBodySize`, and both the remote-write (`push`) and OTLP handlers record uncompressed size plus `r.ContentLength` when available. Unit tests were added to assert the new metric is emitted and is a native histogram, and the change is recorded in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12cb485b915c4779d804e40b397bf31302dc7e24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->