### PR TITLE
Update rollout-operator to v0.34.0 in helm/jsonnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,7 +232,7 @@
   * `autoscaling_ruler_query_frontend_min_replicas` → `autoscaling_ruler_query_frontend_min_replicas_per_zone`
   * `autoscaling_ruler_query_frontend_max_replicas` → `autoscaling_ruler_query_frontend_max_replicas_per_zone`
 * [CHANGE] Store-gateway: The store-gateway disk class now honors the one configured via `$._config.store_gateway_data_disk_class` and doesn't replace `fast` with `fast-dont-retain`. #13152
-* [CHANGE] Rollout-operator: Vendor jsonnet from rollout-operator repository. #13245 #13317 #13793 #13799 #13840
+* [CHANGE] Rollout-operator: Vendor jsonnet from rollout-operator repository. #13245 #13317 #13793 #13799 #13840 #14240
 * [CHANGE] Ruler: Set default memory ballast to 1GiB to reduce GC pressure during startup. #13376
 * [CHANGE] Zone pod disruption budget: Remove `multi_zone_zpdb_enabled` and replace it with `multi_zone_ingester_zpdb_enabled` and `multi_zone_store_gateway_zpdb_enabled` to allow to selectively enable the zone pod disruption budget on a per-component basis. #13813
 * [FEATURE] Add multi-zone support for read path components (memcached, querier, query-frontend, query-scheduler, ruler, and ruler remote evaluation stack). Add multi-AZ support for ingester and store-gateway multi-zone deployments. Add memberlist-bridge support for zone-aware memberlist routing. #13559 #13628 #13636 #13915

--- a/operations/helm/charts/mimir-distributed/Chart.lock
+++ b/operations/helm/charts/mimir-distributed/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 0.5.2
 - name: rollout-operator
   repository: https://grafana.github.io/helm-charts
-  version: 0.40.0
-digest: sha256:ae9fe2b681a38c878248523b4f62e5ebbda83cce9ed57d2e432577e3a5a57093
-generated: "2025-12-26T19:31:43.954858277Z"
+  version: 0.41.0
+digest: sha256:2e2583cfc961a8d6572f612e63d1e66a4fbc47d16f2ebf46ce551a96b04ff396
+generated: "2026-02-04T18:38:13.587354298Z"

--- a/operations/helm/charts/mimir-distributed/Chart.yaml
+++ b/operations/helm/charts/mimir-distributed/Chart.yaml
@@ -20,5 +20,5 @@ dependencies:
   - name: rollout-operator
     alias: rollout_operator
     repository: https://grafana.github.io/helm-charts
-    version: 0.40.0
+    version: 0.41.0
     condition: rollout_operator.enabled

--- a/operations/helm/charts/mimir-distributed/README.md
+++ b/operations/helm/charts/mimir-distributed/README.md
@@ -26,7 +26,7 @@ Kubernetes: `^1.29.0-0`
 |------------|------|---------|
 | https://charts.min.io/ | minio(minio) | 5.4.0 |
 | https://grafana.github.io/helm-charts | grafana-agent-operator(grafana-agent-operator) | 0.5.2 |
-| https://grafana.github.io/helm-charts | rollout_operator(rollout-operator) | 0.40.0 |
+| https://grafana.github.io/helm-charts | rollout_operator(rollout-operator) | 0.41.0 |
 
 # Contributing and releasing
 

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: classic-architecture-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: classic-architecture-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.33.0
+          image: docker.io/grafana/rollout-operator:v0.34.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: classic-architecture-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: classic-architecture-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: classic-architecture-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: classic-architecture-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: classic-architecture-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: classic-architecture-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: classic-architecture-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: classic-architecture-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: classic-architecture-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: classic-architecture-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: classic-architecture-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: classic-architecture-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: gateway-nginx-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.33.0
+          image: docker.io/grafana/rollout-operator:v0.34.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: gateway-nginx-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: gateway-nginx-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: gateway-nginx-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: gateway-nginx-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-global-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-global-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.33.0
+          image: docker.io/grafana/rollout-operator:v0.34.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-global-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-global-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-global-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-global-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-global-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-global-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-global-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-global-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-global-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: keda-autoscaling-global-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-global-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-global-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-metamonitoring-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.33.0
+          image: docker.io/grafana/rollout-operator:v0.34.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-metamonitoring-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-metamonitoring-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-metamonitoring-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: keda-autoscaling-metamonitoring-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.33.0
+          image: docker.io/grafana/rollout-operator:v0.34.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: keda-autoscaling-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: large-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.33.0
+          image: docker.io/grafana/rollout-operator:v0.34.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: large-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: large-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: large-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: large-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: openshift-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: openshift-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -43,7 +43,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.33.0
+          image: docker.io/grafana/rollout-operator:v0.34.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: openshift-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: openshift-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: openshift-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: openshift-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: openshift-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: openshift-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: openshift-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: openshift-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: openshift-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: openshift-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: openshift-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: openshift-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: scheduler-name-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.33.0
+          image: docker.io/grafana/rollout-operator:v0.34.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: scheduler-name-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: scheduler-name-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: scheduler-name-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: scheduler-name-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: small-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.33.0
+          image: docker.io/grafana/rollout-operator:v0.34.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: small-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: small-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: small-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: small-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-extra-args-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-args-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.33.0
+          image: docker.io/grafana/rollout-operator:v0.34.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-args-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-args-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-args-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-extra-args-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-args-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-extra-args-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-args-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-extra-args-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-args-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: test-extra-args-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-args-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-args-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-extra-objects-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-objects-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.33.0
+          image: docker.io/grafana/rollout-operator:v0.34.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-objects-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-objects-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-objects-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-extra-objects-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-objects-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-extra-objects-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-objects-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-extra-objects-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-objects-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: test-extra-objects-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-objects-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-objects-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-gomaxprocs-override-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-gomaxprocs-override-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.33.0
+          image: docker.io/grafana/rollout-operator:v0.34.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-gomaxprocs-override-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-gomaxprocs-override-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-gomaxprocs-override-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-gomaxprocs-override-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-gomaxprocs-override-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-gomaxprocs-override-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-gomaxprocs-override-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-gomaxprocs-override-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-gomaxprocs-override-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: test-gomaxprocs-override-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-gomaxprocs-override-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-gomaxprocs-override-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ingest-storage-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingest-storage-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.33.0
+          image: docker.io/grafana/rollout-operator:v0.34.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingest-storage-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingest-storage-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingest-storage-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ingest-storage-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingest-storage-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ingest-storage-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingest-storage-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ingest-storage-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingest-storage-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: test-ingest-storage-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingest-storage-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingest-storage-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ingress-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingress-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.33.0
+          image: docker.io/grafana/rollout-operator:v0.34.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingress-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingress-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingress-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ingress-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingress-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ingress-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingress-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ingress-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingress-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: test-ingress-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingress-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingress-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-component-image-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-component-image-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.33.0
+          image: docker.io/grafana/rollout-operator:v0.34.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-component-image-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-component-image-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-component-image-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-component-image-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-component-image-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-component-image-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-component-image-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-component-image-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-component-image-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: test-oss-component-image-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-component-image-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-component-image-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-emptydir-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-emptydir-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.33.0
+          image: docker.io/grafana/rollout-operator:v0.34.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-emptydir-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-emptydir-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-emptydir-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-emptydir-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-emptydir-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-emptydir-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-emptydir-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-emptydir-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-emptydir-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: test-oss-emptydir-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-emptydir-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-emptydir-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-logical-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.33.0
+          image: docker.io/grafana/rollout-operator:v0.34.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-logical-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-logical-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-logical-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: test-oss-logical-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.33.0
+          image: docker.io/grafana/rollout-operator:v0.34.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: test-oss-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-topology-spread-constraints-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.33.0
+          image: docker.io/grafana/rollout-operator:v0.34.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-topology-spread-constraints-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-topology-spread-constraints-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-topology-spread-constraints-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: test-oss-topology-spread-constraints-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-requests-and-limits-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-requests-and-limits-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.33.0
+          image: docker.io/grafana/rollout-operator:v0.34.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-requests-and-limits-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-requests-and-limits-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-requests-and-limits-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-requests-and-limits-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-requests-and-limits-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-requests-and-limits-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-requests-and-limits-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-requests-and-limits-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-requests-and-limits-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: test-requests-and-limits-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-requests-and-limits-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-requests-and-limits-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-revisionhistorylimit-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-revisionhistorylimit-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.33.0
+          image: docker.io/grafana/rollout-operator:v0.34.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-revisionhistorylimit-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-revisionhistorylimit-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-revisionhistorylimit-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-revisionhistorylimit-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-revisionhistorylimit-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-revisionhistorylimit-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-revisionhistorylimit-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-revisionhistorylimit-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-revisionhistorylimit-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: test-revisionhistorylimit-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-revisionhistorylimit-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-revisionhistorylimit-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ruler-dedicated-query-path-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.33.0
+          image: docker.io/grafana/rollout-operator:v0.34.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ruler-dedicated-query-path-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ruler-dedicated-query-path-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ruler-dedicated-query-path-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: test-ruler-dedicated-query-path-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-vault-agent-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-vault-agent-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,7 +46,7 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.33.0
+          image: docker.io/grafana/rollout-operator:v0.34.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-vault-agent-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-vault-agent-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-vault-agent-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-vault-agent-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-vault-agent-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-vault-agent-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-vault-agent-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-vault-agent-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-vault-agent-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: test-vault-agent-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-vault-agent-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.40.0
+    helm.sh/chart: rollout-operator-0.41.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-vault-agent-values
-    app.kubernetes.io/version: "v0.33.0"
+    app.kubernetes.io/version: "v0.34.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/mimir-tests/test-automated-downscale-generated.yaml
+++ b/operations/mimir-tests/test-automated-downscale-generated.yaml
@@ -1081,7 +1081,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-automated-downscale-v2-generated.yaml
+++ b/operations/mimir-tests/test-automated-downscale-v2-generated.yaml
@@ -1140,7 +1140,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-compactor-concurrent-rollout-generated.yaml
+++ b/operations/mimir-tests/test-compactor-concurrent-rollout-generated.yaml
@@ -848,7 +848,7 @@ spec:
         - -kubernetes.namespace=default
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-compactor-concurrent-rollout-max-unavailable-percent-generated.yaml
+++ b/operations/mimir-tests/test-compactor-concurrent-rollout-max-unavailable-percent-generated.yaml
@@ -848,7 +848,7 @@ spec:
         - -kubernetes.namespace=default
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -1452,7 +1452,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-custom-stabilization-window-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-custom-stabilization-window-generated.yaml
@@ -1355,7 +1355,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-multiple-triggers-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-multiple-triggers-generated.yaml
@@ -1286,7 +1286,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-one-trigger-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-one-trigger-generated.yaml
@@ -1286,7 +1286,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-0-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-0-generated.yaml
@@ -1272,7 +1272,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-1-generated.yaml
@@ -1343,7 +1343,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
@@ -1332,7 +1332,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
@@ -1332,7 +1332,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-12-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-12-generated.yaml
@@ -1332,7 +1332,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
@@ -1351,7 +1351,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
@@ -1362,7 +1362,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
@@ -1361,7 +1361,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-5a-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-5a-generated.yaml
@@ -1361,7 +1361,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-5b-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-5b-generated.yaml
@@ -1361,7 +1361,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
@@ -1292,7 +1292,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
@@ -1296,7 +1296,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
@@ -1296,7 +1296,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
@@ -1273,7 +1273,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
@@ -1355,7 +1355,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-generated.yaml
@@ -2196,7 +2196,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-0-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-0-generated.yaml
@@ -1675,7 +1675,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-1-generated.yaml
@@ -2982,7 +2982,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2-generated.yaml
@@ -2982,7 +2982,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-3-generated.yaml
@@ -2982,7 +2982,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-4-generated.yaml
@@ -2982,7 +2982,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-5-generated.yaml
@@ -3044,7 +3044,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-6-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-6-generated.yaml
@@ -3044,7 +3044,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-7-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-7-generated.yaml
@@ -3013,7 +3013,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-8-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-8-generated.yaml
@@ -2367,7 +2367,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-final-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-final-generated.yaml
@@ -2367,7 +2367,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-write-path-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-write-path-generated.yaml
@@ -1306,7 +1306,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-write-path-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-write-path-migration-generated.yaml
@@ -1435,7 +1435,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -1150,7 +1150,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -1218,7 +1218,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
@@ -1150,7 +1150,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-pvc-auto-deletion-generated.yaml
+++ b/operations/mimir-tests/test-pvc-auto-deletion-generated.yaml
@@ -1084,7 +1084,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-replica-template-generated.yaml
+++ b/operations/mimir-tests/test-replica-template-generated.yaml
@@ -308,7 +308,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.33.0
+        image: grafana/rollout-operator:v0.34.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir/jsonnetfile.json
+++ b/operations/mimir/jsonnetfile.json
@@ -35,7 +35,7 @@
           "subdir": "operations/rollout-operator"
         }
       },
-      "version": "v0.33.0"
+      "version": "v0.34.0"
     },
     {
       "source": {

--- a/operations/mimir/jsonnetfile.lock.json
+++ b/operations/mimir/jsonnetfile.lock.json
@@ -38,8 +38,8 @@
           "subdir": "operations/rollout-operator"
         }
       },
-      "version": "ee4822b061cb7497b7e8a716161dfa0e3230c0ca",
-      "sum": "rBfx/ffgMo6MBNt8+CqJToKEUCdANJU9xMb2KGXEjW4="
+      "version": "566a3ad22150dae675de2572844b673b3c84fee0",
+      "sum": "dXRBHT/Nq0bekYWvtxdFUFJBgjuczgRh1qugA/H1/rs="
     },
     {
       "source": {


### PR DESCRIPTION
#### What this PR does

Updates rollout-operator in Helm and Jsonnet to correspond with https://github.com/grafana/rollout-operator/releases/tag/v0.34.0

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily a dependency bump that changes the rollout-operator image/version used in deployments and webhook configs; risk comes from behavior changes in the upstream operator rather than local logic changes.
> 
> **Overview**
> Updates the `mimir-distributed` Helm chart’s `rollout-operator` dependency from `0.40.0` to `0.41.0` (rollout-operator `v0.34.0`), refreshing the lockfile, README dependency table, and all generated Helm test manifests to reference the new chart/app versions and container image.
> 
> Also updates the changelog entry for the rollout-operator jsonnet vendoring change to include the additional PR reference `#14240`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0bf054263c3b59364cb2451d160b6291de5b3214. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->