### PR TITLE
MQE: Update new annotation details for classic histogram quantile monotonicity

### DIFF
--- a/pkg/streamingpromql/operators/functions/histogram_function.go
+++ b/pkg/streamingpromql/operators/functions/histogram_function.go
@@ -597,16 +597,18 @@ func (q *histogramQuantile) getMetricNameForSeries(seriesIndex int) string {
 
 func (q *histogramQuantile) ComputeClassicHistogramResult(pointIndex int, seriesIndex int, buckets promql.Buckets) float64 {
 	ph := q.phValues.Samples[pointIndex].F
-	res, forcedMonotonicity, _ := promql.BucketQuantile(ph, buckets)
+	ts := q.phValues.Samples[pointIndex].T
+	quantile, forcedMonotonicity, _, minBucket, maxBucket, maxDiff := promql.BucketQuantile(ph, buckets)
 
 	if forcedMonotonicity {
 		q.annotations.Add(annotations.NewHistogramQuantileForcedMonotonicityInfo(
 			q.getMetricNameForSeries(seriesIndex),
 			q.innerExpressionPosition,
+			ts, minBucket, maxBucket, maxDiff,
 		))
 	}
 
-	return res
+	return quantile
 }
 
 func (q *histogramQuantile) ComputeNativeHistogramResult(pointIndex int, seriesIndex int, h *histogram.FloatHistogram) (float64, annotations.Annotations) {


### PR DESCRIPTION
#### What this PR does

Update MQE to match Prometheus when the change from https://github.com/prometheus/prometheus/pull/15578 to add more details to the classic histogram quantile monotonicity annotation is vendored in.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
