### PR TITLE
Fix jsonnet tests build by upgrading to k8s 1.35

### DIFF
--- a/operations/mimir-tests/build.sh
+++ b/operations/mimir-tests/build.sh
@@ -8,7 +8,7 @@ rm -rf jsonnet-tests && mkdir jsonnet-tests
 cd jsonnet-tests
 
 # Initialise the Tanka.
-tk init --k8s=1.30
+tk init --k8s=1.35
 
 # Install Mimir jsonnet from this branch.
 jb install ../operations/mimir


### PR DESCRIPTION
#### What this PR does

#### Which issue(s) this PR fixes or relates to

This PR fixes the build that started failing because:
1. Jsonnet-bundler (jb) was encountering a panic when trying to install `k8s-libsonnet`
2. The build script was configured to use `k8s` version `1.30`, which is no longer available in the `k8s-libsonnet` repository (only versions `1.32+` are currently available).

This PR sets the `kbs-libsonnet` version to `1.35`.

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Simple test-script version bump; low blast radius limited to jsonnet test setup, with the main risk being minor manifest-diff churn from the newer Kubernetes library version.
> 
> **Overview**
> Updates `operations/mimir-tests/build.sh` to run `tk init` with `--k8s=1.38` (from `1.30`) so jsonnet/Tanka tests can install a supported `k8s-libsonnet` version and avoid recent build failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 515c37ec070a950b961755e4d21353da24e26385. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->