### PR TITLE
[release-3.0] fix jsonnet tests building

### DIFF
--- a/operations/mimir-tests/build.sh
+++ b/operations/mimir-tests/build.sh
@@ -8,7 +8,18 @@ rm -rf jsonnet-tests && mkdir jsonnet-tests
 cd jsonnet-tests
 
 # Initialise the Tanka.
-tk init --k8s=1.29
+# Instead of relying on "tk init --k8s=1.29", this installs versions of k8s-libsonnet from an exact commit, that provided k8s v1.29.
+# See https://github.com/grafana/tanka/issues/1863
+K8S_VERSION=1.29
+tk init --k8s=false
+jb install \
+    github.com/jsonnet-libs/k8s-libsonnet/$K8S_VERSION@291653b2c17d03e855e7e00ce0e4ec25502b2ce2 \
+    github.com/grafana/jsonnet-libs/ksonnet-util \
+    github.com/jsonnet-libs/docsonnet/doc-util
+
+cat <<EOF > lib/k.libsonnet
+import 'github.com/jsonnet-libs/k8s-libsonnet/$K8S_VERSION/main.libsonnet'
+EOF
 
 # Install Mimir jsonnet from this branch.
 jb install ../operations/mimir


### PR DESCRIPTION
#### What this PR does

This PR addresses the problem in release-3.0 (and in release-2.17), where Jsonnet tests fail, trying to init Kubernetes env with k8s 1.29 (see discussion https://github.com/jsonnet-libs/k8s/pull/606#issuecomment-3859578101).

We've fixed that in the `main` branch by updating the k8s environment version to latest. I'm of two minds about doing that in the 3.0 and older releases. These releases promised the support for Kubernetes 1.29 (explicitly in the Helm chart's changelog) and we test the compatibility of Helm chart with Jsonnet here also.

#### Which issue(s) this PR fixes or relates to

Relates to https://github.com/grafana/mimir/pull/14254
