### PR TITLE
Docs: Fix Mimir v3 deployment issues

### DIFF
--- a/docs/sources/helm-charts/mimir-distributed/get-started-helm-charts/_index.md
+++ b/docs/sources/helm-charts/mimir-distributed/get-started-helm-charts/_index.md
@@ -236,7 +236,7 @@ We will install [Grafana Alloy](https://grafana.com/docs/alloy/latest/), preconf
 
    # Disable ServiceMonitor for monitoring Alloy itself
    serviceMonitor:
-   enabled: false
+     enabled: false
    ```
 
    {{< admonition type="note" >}}

--- a/docs/sources/mimir/references/architecture/deployment-modes/index.md
+++ b/docs/sources/mimir/references/architecture/deployment-modes/index.md
@@ -68,4 +68,4 @@ Classic architecture:
 
 In microservices mode, each Grafana Mimir process is invoked with its `-target` parameter set to a specific Grafana Mimir component (for example, `-target=ingester` or `-target=distributor`). To get a working Grafana Mimir instance, you must deploy every required component. For more information about each of the Grafana Mimir components, refer to [Grafana Mimir advanced architecture](https://grafana.com/docs/mimir/<GRAFANA_VERSION>/references/architecture/).
 
-To deploy Grafana Mimir in microservices mode, use [Kubernetes](https://kubernetes.io/) and the [mimir-distributed Helm chart](https://github.com/grafana/mimir/tree/main/operations/helm/charts/mimir-distributed).
+To deploy Grafana Mimir in microservices mode, use [Kubernetes](https://kubernetes.io/) and the [mimir-distributed Helm chart](https://grafana.com/docs/helm-charts/mimir-distributed/latest/).


### PR DESCRIPTION
## Summary

Fixes documentation issues discovered when deploying Mimir v3, reported by @eamonryan and @hedss.

- Fix navigation loop by linking directly to Helm chart docs
- Correct YAML indentation in Alloy configuration example

## Changes

1. **deployment-modes/index.md**: Updated mimir-distributed Helm chart link to point to the official documentation instead of GitHub, eliminating a confusing redirect loop
   
2. **get-started-helm-charts/_index.md**: Fixed YAML indentation for `serviceMonitor.enabled` in the Alloy configuration example (the missing indentation caused deployment failures)

## Test plan

- [x] Verified YAML syntax is now correct
- [x] Confirmed navigation flow no longer loops through GitHub
- [x] Checked that data source URL is already correct in documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes; primary risk is minor link or formatting regressions, with no runtime code impact.
> 
> **Overview**
> Fixes the Alloy Helm overrides example in `get-started-helm-charts/_index.md` by correcting the indentation of `serviceMonitor.enabled`, preventing readers from copying invalid YAML.
> 
> Updates the microservices deployment docs in `deployment-modes/index.md` to point the `mimir-distributed` Helm chart link at the official Helm chart documentation site instead of the GitHub source path (avoiding confusing navigation/redirect behavior).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9cd1f689b4742782aa440b19a7f6bddc5ac1dcc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->