### PR TITLE
Mixin: Add MimirCompactorOOMKilled alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -433,6 +433,7 @@
 
 ### Mixin
 
+* [FEATURE] Alerts: Add `MimirCompactorOOMKilled` alert. #14286
 * [CHANGE] Enable ingest storage panels by default in all compiled mixins. #13023
 * [CHANGE] Alerts: Removed `MimirFrontendQueriesStuck` alert given this is not relevant when the query-scheduler is running and the query-scheduler is now a required component. #12810
 * [CHANGE] Alerts: Make `MimirIngesterHasNotShippedBlocksSinceStart` weaker to account for block-builder restarts. The change only affects the block-builder version of the alert. #12319

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -1192,6 +1192,42 @@ spec:
             for: 30m
             labels:
               severity: warning
+          - alert: MimirCompactorOOMKilled
+            annotations:
+              message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has been OOMKilled {{ printf "%.2f" $value }} times in the last 4h.
+              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactoroomkilled
+            expr: |
+              (
+                sum by(cluster, namespace, pod) (
+                  increase(kube_pod_container_status_restarts_total{container=~"compactor"}[4h])
+                )
+                > 2
+              )
+              and on (cluster, namespace, pod)
+              (
+                kube_pod_container_status_last_terminated_reason{container=~"compactor", reason="OOMKilled"} > 0
+              )
+            for: 15m
+            labels:
+              severity: warning
+          - alert: MimirCompactorOOMKilled
+            annotations:
+              message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has been OOMKilled {{ printf "%.2f" $value }} times in the last 2h.
+              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactoroomkilled
+            expr: |
+              (
+                sum by(cluster, namespace, pod) (
+                  increase(kube_pod_container_status_restarts_total{container=~"compactor"}[2h])
+                )
+                > 5
+              )
+              and on (cluster, namespace, pod)
+              (
+                kube_pod_container_status_last_terminated_reason{container=~"compactor", reason="OOMKilled"} > 0
+              )
+            for: 15m
+            labels:
+              severity: critical
       - name: mimir_distributor_alerts
         rules:
           - alert: MimirDistributorGcUsesTooMuchCpu

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -1166,6 +1166,42 @@ groups:
           for: 30m
           labels:
             severity: warning
+        - alert: MimirCompactorOOMKilled
+          annotations:
+            message: Mimir Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has been OOMKilled {{ printf "%.2f" $value }} times in the last 4h.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactoroomkilled
+          expr: |
+            (
+              sum by(cluster, namespace, instance) (
+                increase(kube_pod_container_status_restarts_total{container=~"compactor"}[4h])
+              )
+              > 2
+            )
+            and on (cluster, namespace, instance)
+            (
+              kube_pod_container_status_last_terminated_reason{container=~"compactor", reason="OOMKilled"} > 0
+            )
+          for: 15m
+          labels:
+            severity: warning
+        - alert: MimirCompactorOOMKilled
+          annotations:
+            message: Mimir Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has been OOMKilled {{ printf "%.2f" $value }} times in the last 2h.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactoroomkilled
+          expr: |
+            (
+              sum by(cluster, namespace, instance) (
+                increase(kube_pod_container_status_restarts_total{container=~"compactor"}[2h])
+              )
+              > 5
+            )
+            and on (cluster, namespace, instance)
+            (
+              kube_pod_container_status_last_terminated_reason{container=~"compactor", reason="OOMKilled"} > 0
+            )
+          for: 15m
+          labels:
+            severity: critical
     - name: mimir_distributor_alerts
       rules:
         - alert: MimirDistributorGcUsesTooMuchCpu

--- a/operations/mimir-mixin-compiled-gem/alerts.yaml
+++ b/operations/mimir-mixin-compiled-gem/alerts.yaml
@@ -1180,6 +1180,42 @@ groups:
           for: 30m
           labels:
             severity: warning
+        - alert: MimirCompactorOOMKilled
+          annotations:
+            message: GEM Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has been OOMKilled {{ printf "%.2f" $value }} times in the last 4h.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactoroomkilled
+          expr: |
+            (
+              sum by(cluster, namespace, pod) (
+                increase(kube_pod_container_status_restarts_total{container=~"compactor"}[4h])
+              )
+              > 2
+            )
+            and on (cluster, namespace, pod)
+            (
+              kube_pod_container_status_last_terminated_reason{container=~"compactor", reason="OOMKilled"} > 0
+            )
+          for: 15m
+          labels:
+            severity: warning
+        - alert: MimirCompactorOOMKilled
+          annotations:
+            message: GEM Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has been OOMKilled {{ printf "%.2f" $value }} times in the last 2h.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactoroomkilled
+          expr: |
+            (
+              sum by(cluster, namespace, pod) (
+                increase(kube_pod_container_status_restarts_total{container=~"compactor"}[2h])
+              )
+              > 5
+            )
+            and on (cluster, namespace, pod)
+            (
+              kube_pod_container_status_last_terminated_reason{container=~"compactor", reason="OOMKilled"} > 0
+            )
+          for: 15m
+          labels:
+            severity: critical
     - name: mimir_distributor_alerts
       rules:
         - alert: MimirDistributorGcUsesTooMuchCpu

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -1180,6 +1180,42 @@ groups:
           for: 30m
           labels:
             severity: warning
+        - alert: MimirCompactorOOMKilled
+          annotations:
+            message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has been OOMKilled {{ printf "%.2f" $value }} times in the last 4h.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactoroomkilled
+          expr: |
+            (
+              sum by(cluster, namespace, pod) (
+                increase(kube_pod_container_status_restarts_total{container=~"compactor"}[4h])
+              )
+              > 2
+            )
+            and on (cluster, namespace, pod)
+            (
+              kube_pod_container_status_last_terminated_reason{container=~"compactor", reason="OOMKilled"} > 0
+            )
+          for: 15m
+          labels:
+            severity: warning
+        - alert: MimirCompactorOOMKilled
+          annotations:
+            message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has been OOMKilled {{ printf "%.2f" $value }} times in the last 2h.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactoroomkilled
+          expr: |
+            (
+              sum by(cluster, namespace, pod) (
+                increase(kube_pod_container_status_restarts_total{container=~"compactor"}[2h])
+              )
+              > 5
+            )
+            and on (cluster, namespace, pod)
+            (
+              kube_pod_container_status_last_terminated_reason{container=~"compactor", reason="OOMKilled"} > 0
+            )
+          for: 15m
+          labels:
+            severity: critical
     - name: mimir_distributor_alerts
       rules:
         - alert: MimirDistributorGcUsesTooMuchCpu


### PR DESCRIPTION
#### What this PR does

In this PR I'm adding the `MimirCompactorOOMKilled` alert. Contrary to other Mimir components, when a compactor OOM it's very likely that will continue to OOM until we give it more memory. Why? Because if a compactor OOMs when processing a compaction job, that same compaction job will retried over and over.

Today we don't have any alert firing when a compactor OOMs continuously. In this PR I'm proposing a new alert, both  warning and critical severity.

I've backtested the alert at Grafana Labs (last 30d) and it would have always fired when there was a real issue, and compactor memory should have been increased (left side = warning query, right side = critical query):

<img width="2544" height="733" alt="Screenshot 2026-02-09 at 12 00 26" src="https://github.com/user-attachments/assets/551a0f19-0f99-4210-b638-3d9125e31069" />

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
