### PR TITLE
store-gateway: Extend block load logs to include basic block info

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -455,7 +455,7 @@ func (s *BucketStore) addBlock(ctx context.Context, meta *block.Meta) (err error
 			}
 			level.Error(s.logger).Log("msg", "loading block failed", "elapsed", time.Since(start), "id", meta.ULID, "err", err)
 		} else {
-			level.Info(s.logger).Log("msg", "loaded new block", "elapsed", time.Since(start), "id", meta.ULID, "level", meta.Compaction.Level, "numSeries", meta.Stats.NumSeries, "ooo", meta.IsOutOfOrder(), "from", meta.MinTime, "to", meta.MaxTime)
+			level.Info(s.logger).Log("msg", "loaded new block", "elapsed", time.Since(start), "id", meta.ULID, "compaction_level", meta.Compaction.Level, "num_series", meta.Stats.NumSeries, "ooo", meta.IsOutOfOrder(), "from", meta.MinTime, "to", meta.MaxTime)
 		}
 	}()
 	s.metrics.blockLoads.Inc()


### PR DESCRIPTION
#### What this PR does

This is a tiny change that just adds extra info to the log when a block is loaded during the sync process.
It can answer questions like "how often are we loading L2 blocks," at the point where the blocked is synced instead of needing to wait for a query to touch the block.

It also includes extra general info about the block, so we can get an idea of size and not need to cross reference the ULID against other logs or the bucket.

#### Which issue(s) this PR fixes or relates to

Supporting https://github.com/grafana/mimir-squad/issues/3373

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Log-only change that adds extra fields on successful block load; no functional, security, or data-path behavior changes.
> 
> **Overview**
> Extends the store-gateway `addBlock()` success log line to include basic block metadata when a block is loaded during sync.
> 
> The `loaded new block` log now emits `compaction_level`, `num_series`, out-of-order flag (`ooo`), and the block time range (`from`/`to`), improving observability without changing load behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5ab7dc6d6ab05f3eada19d69e95be33c15100ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->