### PR TITLE
mimir-mixin: Fix legend for Kafka e2e latency outliers panel on baremetal

### DIFF
--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-writes.json
@@ -2029,7 +2029,7 @@
                         "exemplar": true,
                         "expr": "histogram_quantile(1.0, sum by(instance) (rate(cortex_ingest_storage_reader_receive_delay_seconds{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir))\", phase=\"running\"}[$__rate_interval])))\n\n# Add a filter to show only the outliers. We consider an ingester an outlier if its\n# 100th percentile latency is greater than the 200% of the average 100th of the 10%\n# worst ingesters (minimum 10 ingesters; if there are less than 10 ingesters, then all\n# ingesters will be took in account).\n> scalar(\n  avg(\n    topk(\n        scalar(\n            clamp_min(\n                ceil(\n                    count(count by(namespace, instance) (cortex_ingest_storage_reader_receive_delay_seconds{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir))\", phase=\"running\"}))\n                    * 0.1\n                ), 10\n            )\n        ),\n        histogram_quantile(1.0, sum by(instance) (rate(cortex_ingest_storage_reader_receive_delay_seconds{cluster=~\"$cluster\", job=~\"($namespace)/((ingester.*|cortex|mimir))\", phase=\"running\"}[$__rate_interval])))\n        > 0\n    )\n  )\n  * 2\n)\n",
                         "format": "time_series",
-                        "legendFormat": "{{pod}}",
+                        "legendFormat": "{{instance}}",
                         "legendLink": null
                      }
                   ],

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -2018,7 +2018,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
         per_instance_label: $._config.per_instance_label,
         per_namespace_label: $._config.per_namespace_label,
       },
-      '{{pod}}',
+      '{{%(per_instance_label)s}}' % {
+        per_instance_label: $._config.per_instance_label,
+      },
     ) + {
       fieldConfig+: {
         defaults+: { unit: 's' },


### PR DESCRIPTION
#### What this PR does

The query aggregates by `instance` instead of `pod` when the mixin is compiled for bare metal.
The aggregation labels in the query are templated accordingly, but the legend still says `{{pod}}` which doesn't exist in that context.

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only legend/template change; no impact to queries or runtime behavior beyond how series are displayed.
> 
> **Overview**
> Fixes the bare-metal compiled `Mimir / Writes` dashboard so the *Kafka end-to-end latency outliers* panel legend matches the query grouping, switching the series label from `{{pod}}` to `{{instance}}` (via templating `per_instance_label`) so outlier series render with correct names.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b34f6be12c4a1b4bffe76b630b36842f0d24c15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->