### PR TITLE
Do not pass ignore_null_values if true when creating querier ScaledObjects

### DIFF
--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -2090,7 +2090,6 @@ spec:
     name: querier
   triggers:
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_hpa_default
       query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -2098,7 +2097,6 @@ spec:
     name: cortex_querier_hpa_default
     type: prometheus
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_hpa_default_requests_duration
       query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -2106,7 +2104,6 @@ spec:
     name: cortex_querier_hpa_default_requests_duration
     type: prometheus
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_hpa_default_7d_offset
       query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5"}[30m]
         offset 6d23h30m))

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -2090,7 +2090,6 @@ spec:
     name: querier
   triggers:
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_hpa_default
       query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -2098,7 +2097,6 @@ spec:
     name: cortex_querier_hpa_default
     type: prometheus
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_hpa_default_requests_duration
       query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -2106,7 +2104,6 @@ spec:
     name: cortex_querier_hpa_default_requests_duration
     type: prometheus
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_hpa_default_7d_offset
       query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5"}[30m]
         offset 6d23h30m))

--- a/operations/mimir-tests/test-multi-az-read-path-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-generated.yaml
@@ -4793,7 +4793,6 @@ spec:
     name: querier-zone-a
   triggers:
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_a_hpa_default
       query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -4801,7 +4800,6 @@ spec:
     name: cortex_querier_zone_a_hpa_default
     type: prometheus
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
       query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -4840,7 +4838,6 @@ spec:
     name: querier-zone-b
   triggers:
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_b_hpa_default
       query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -4848,7 +4845,6 @@ spec:
     name: cortex_querier_zone_b_hpa_default
     type: prometheus
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
       query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-0-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-0-generated.yaml
@@ -3401,7 +3401,6 @@ spec:
     name: querier
   triggers:
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_hpa_default
       query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -3409,7 +3408,6 @@ spec:
     name: cortex_querier_hpa_default
     type: prometheus
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_hpa_default_requests_duration
       query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-1-generated.yaml
@@ -5922,7 +5922,6 @@ spec:
     name: querier
   triggers:
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_hpa_default
       query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -5930,7 +5929,6 @@ spec:
     name: cortex_querier_hpa_default
     type: prometheus
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_hpa_default_requests_duration
       query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -5969,7 +5967,6 @@ spec:
     name: querier-zone-a
   triggers:
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_a_hpa_default
       query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -5977,7 +5974,6 @@ spec:
     name: cortex_querier_zone_a_hpa_default
     type: prometheus
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
       query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -6016,7 +6012,6 @@ spec:
     name: querier-zone-b
   triggers:
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_b_hpa_default
       query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -6024,7 +6019,6 @@ spec:
     name: cortex_querier_zone_b_hpa_default
     type: prometheus
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
       query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2-generated.yaml
@@ -5948,7 +5948,6 @@ spec:
     name: querier
   triggers:
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_hpa_default
       query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -5956,7 +5955,6 @@ spec:
     name: cortex_querier_hpa_default
     type: prometheus
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_hpa_default_requests_duration
       query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -5995,7 +5993,6 @@ spec:
     name: querier-zone-a
   triggers:
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_a_hpa_default
       query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -6003,7 +6000,6 @@ spec:
     name: cortex_querier_zone_a_hpa_default
     type: prometheus
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
       query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -6042,7 +6038,6 @@ spec:
     name: querier-zone-b
   triggers:
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_b_hpa_default
       query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -6050,7 +6045,6 @@ spec:
     name: cortex_querier_zone_b_hpa_default
     type: prometheus
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
       query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-3-generated.yaml
@@ -5974,7 +5974,6 @@ spec:
     name: querier
   triggers:
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_hpa_default
       query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -5982,7 +5981,6 @@ spec:
     name: cortex_querier_hpa_default
     type: prometheus
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_hpa_default_requests_duration
       query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -6021,7 +6019,6 @@ spec:
     name: querier-zone-a
   triggers:
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_a_hpa_default
       query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -6029,7 +6026,6 @@ spec:
     name: cortex_querier_zone_a_hpa_default
     type: prometheus
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
       query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -6068,7 +6064,6 @@ spec:
     name: querier-zone-b
   triggers:
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_b_hpa_default
       query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -6076,7 +6071,6 @@ spec:
     name: cortex_querier_zone_b_hpa_default
     type: prometheus
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
       query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-4-generated.yaml
@@ -5974,7 +5974,6 @@ spec:
     name: querier
   triggers:
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_hpa_default
       query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -5982,7 +5981,6 @@ spec:
     name: cortex_querier_hpa_default
     type: prometheus
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_hpa_default_requests_duration
       query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -6021,7 +6019,6 @@ spec:
     name: querier-zone-a
   triggers:
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_a_hpa_default
       query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -6029,7 +6026,6 @@ spec:
     name: cortex_querier_zone_a_hpa_default
     type: prometheus
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
       query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -6068,7 +6064,6 @@ spec:
     name: querier-zone-b
   triggers:
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_b_hpa_default
       query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -6076,7 +6071,6 @@ spec:
     name: cortex_querier_zone_b_hpa_default
     type: prometheus
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
       query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-5-generated.yaml
@@ -6282,7 +6282,6 @@ spec:
     name: querier
   triggers:
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_hpa_default
       query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -6290,7 +6289,6 @@ spec:
     name: cortex_querier_hpa_default
     type: prometheus
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_hpa_default_requests_duration
       query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -6329,7 +6327,6 @@ spec:
     name: querier-zone-a
   triggers:
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_a_hpa_default
       query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -6337,7 +6334,6 @@ spec:
     name: cortex_querier_zone_a_hpa_default
     type: prometheus
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
       query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -6376,7 +6372,6 @@ spec:
     name: querier-zone-b
   triggers:
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_b_hpa_default
       query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -6384,7 +6379,6 @@ spec:
     name: cortex_querier_zone_b_hpa_default
     type: prometheus
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
       query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-6-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-6-generated.yaml
@@ -6282,7 +6282,6 @@ spec:
     name: querier
   triggers:
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_hpa_default
       query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -6290,7 +6289,6 @@ spec:
     name: cortex_querier_hpa_default
     type: prometheus
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_hpa_default_requests_duration
       query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -6329,7 +6327,6 @@ spec:
     name: querier-zone-a
   triggers:
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_a_hpa_default
       query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -6337,7 +6334,6 @@ spec:
     name: cortex_querier_zone_a_hpa_default
     type: prometheus
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
       query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -6376,7 +6372,6 @@ spec:
     name: querier-zone-b
   triggers:
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_b_hpa_default
       query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -6384,7 +6379,6 @@ spec:
     name: cortex_querier_zone_b_hpa_default
     type: prometheus
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
       query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-7-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-7-generated.yaml
@@ -6142,7 +6142,6 @@ spec:
     name: querier
   triggers:
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_hpa_default
       query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -6150,7 +6149,6 @@ spec:
     name: cortex_querier_hpa_default
     type: prometheus
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_hpa_default_requests_duration
       query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -6189,7 +6187,6 @@ spec:
     name: querier-zone-a
   triggers:
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_a_hpa_default
       query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -6197,7 +6194,6 @@ spec:
     name: cortex_querier_zone_a_hpa_default
     type: prometheus
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
       query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -6236,7 +6232,6 @@ spec:
     name: querier-zone-b
   triggers:
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_b_hpa_default
       query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -6244,7 +6239,6 @@ spec:
     name: cortex_querier_zone_b_hpa_default
     type: prometheus
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
       query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-8-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-8-generated.yaml
@@ -4984,7 +4984,6 @@ spec:
     name: querier-zone-a
   triggers:
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_a_hpa_default
       query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -4992,7 +4991,6 @@ spec:
     name: cortex_querier_zone_a_hpa_default
     type: prometheus
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
       query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -5031,7 +5029,6 @@ spec:
     name: querier-zone-b
   triggers:
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_b_hpa_default
       query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -5039,7 +5036,6 @@ spec:
     name: cortex_querier_zone_b_hpa_default
     type: prometheus
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
       query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-final-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-final-generated.yaml
@@ -4984,7 +4984,6 @@ spec:
     name: querier-zone-a
   triggers:
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_a_hpa_default
       query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -4992,7 +4991,6 @@ spec:
     name: cortex_querier_zone_a_hpa_default
     type: prometheus
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
       query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -5031,7 +5029,6 @@ spec:
     name: querier-zone-b
   triggers:
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_b_hpa_default
       query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus
@@ -5039,7 +5036,6 @@ spec:
     name: cortex_querier_zone_b_hpa_default
     type: prometheus
   - metadata:
-      ignoreNullValues: "true"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
       query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
       serverAddress: http://prometheus.default:9090/prometheus

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -206,7 +206,8 @@
             query: queryWithWeight('sum(max_over_time(cortex_query_scheduler_inflight_requests{container="%(query_scheduler_container_name)s",namespace="%(namespace)s",quantile="0.5"%(extra_matchers)s}[1m]))' % queryParams, weight),
 
             threshold: '%d' % std.floor(querier_max_concurrent * target_utilization),
-            ignore_null_values: ignore_null_values,
+            // We only need to pass ignore_null_values if it's false
+            [if !ignore_null_values then 'ignore_null_values']: ignore_null_values,
           },
           {
             metric_name: 'cortex_%s_hpa_%s_requests_duration' % [std.strReplace(name, '-', '_'), $._config.namespace],
@@ -218,7 +219,8 @@
             query: queryWithWeight('sum(rate(cortex_querier_request_duration_seconds_sum{container="%(querier_container_name)s",namespace="%(namespace)s"%(extra_matchers)s}[1m]))' % queryParams, weight),
 
             threshold: '%d' % std.floor(querier_max_concurrent * target_utilization),
-            ignore_null_values: ignore_null_values,
+            // We only need to pass ignore_null_values if it's false
+            [if !ignore_null_values then 'ignore_null_values']: ignore_null_values,
           },
         ]
         + if !$._config.autoscaling_querier_predictive_scaling_enabled then [] else [
@@ -234,7 +236,8 @@
               }
             ), weight),
             threshold: '%d' % std.floor(querier_max_concurrent * target_utilization),
-            ignore_null_values: ignore_null_values,
+            // We only need to pass ignore_null_values if it's false
+            [if !ignore_null_values then 'ignore_null_values']: ignore_null_values,
           },
         ],
     }) + {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
In #14101, we made passing `ignore_null_values` to `newQuerierScaledObject` an option; however, if `ignore_null_values` is `true`, we don't actually need to set it since that's the KEDA default, so let's avoid explicitly setting it where unnecessary.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to autoscaling manifest generation that should be behavior-preserving when `ignore_null_values` is `true`; risk is limited to KEDA trigger rendering differences affecting querier scaling if the condition is wrong.
> 
> **Overview**
> Querier `ScaledObject` generation now **conditionally includes** the `ignore_null_values` trigger field only when it is `false`, avoiding redundant config when the value is `true` (KEDA default).
> 
> Regenerates the autoscaling test manifests so querier-related triggers no longer contain `ignoreNullValues: "true"` in metadata (with associated golden output updates).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 64b5d9aa448a58a3b98eb6080acca21b9067c9f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->