### PR TITLE
Remove -ingest-storage.kafka.ingestion-concurrency-sequential-pusher-enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@
 * [ENHANCEMENT] Ingester: Check labels order and uniqueness on ingestion to protect against corruption. #14089
 * [ENHANCEMENT] Ingester: Add experimental file based Kafka consumer group offset tracking via flag `-ingest-storage.kafka.consumer-group-offset-commit-file-enforced`. #14110
 * [ENHANCEMENT] Store-gateway: Add "OOO" column to the tenant blocks page to indicate whether each block was created from out-of-order samples. #14283
+* [ENHANCEMENT] Ingester: Optimize ingestion from Kafka in clusters with mixed size tenants. #13924 #13961 #14302
 * [BUGFIX] API: Fixed web UI links not respecting `-server.path-prefix` configuration. #14090
 * [BUGFIX] Distributor: Fix issue where distributors didn't send custom values of native histograms. #13849
 * [BUGFIX] Compactor: Fix potential concurrent map writes. #13053

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -8687,17 +8687,6 @@
               "fieldDefaultValue": 500,
               "fieldFlag": "ingest-storage.kafka.ingestion-concurrency-estimated-bytes-per-sample",
               "fieldType": "int"
-            },
-            {
-              "kind": "field",
-              "name": "ingestion_concurrency_sequential_pusher_enabled",
-              "required": false,
-              "desc": "When enabled, tenants with few timeseries use a simpler sequential pusher instead of parallel shards.",
-              "fieldValue": null,
-              "fieldDefaultValue": true,
-              "fieldFlag": "ingest-storage.kafka.ingestion-concurrency-sequential-pusher-enabled",
-              "fieldType": "boolean",
-              "fieldCategory": "experimental"
             }
           ],
           "fieldValue": null,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1483,8 +1483,6 @@ Usage of ./cmd/mimir/mimir:
     	The maximum number of concurrent ingestion streams to the TSDB head. Every tenant has their own set of streams. 0 to disable.
   -ingest-storage.kafka.ingestion-concurrency-queue-capacity int
     	The number of batches to prepare and queue to ingest to the TSDB head. Only use this setting when -ingest-storage.kafka.ingestion-concurrency-max is greater than 0. (default 5)
-  -ingest-storage.kafka.ingestion-concurrency-sequential-pusher-enabled
-    	[experimental] When enabled, tenants with few timeseries use a simpler sequential pusher instead of parallel shards. (default true)
   -ingest-storage.kafka.ingestion-concurrency-target-flushes-per-shard int
     	The expected number of times to ingest timeseries to the TSDB head after batching. With fewer flushes, the overhead of splitting up the work is higher than the benefit of parallelization. Only use this setting when -ingest-storage.kafka.ingestion-concurrency-max is greater than 0. (default 80)
   -ingest-storage.kafka.last-produced-offset-poll-interval duration

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -5213,11 +5213,6 @@ kafka:
   # CLI flag: -ingest-storage.kafka.ingestion-concurrency-estimated-bytes-per-sample
   [ingestion_concurrency_estimated_bytes_per_sample: <int> | default = 500]
 
-  # (experimental) When enabled, tenants with few timeseries use a simpler
-  # sequential pusher instead of parallel shards.
-  # CLI flag: -ingest-storage.kafka.ingestion-concurrency-sequential-pusher-enabled
-  [ingestion_concurrency_sequential_pusher_enabled: <boolean> | default = true]
-
 migration:
   # When both this option and ingest storage are enabled, distributors write to
   # both Kafka and ingesters. A write request is considered successful only when

--- a/operations/mimir/mimir-flags-defaults.json
+++ b/operations/mimir/mimir-flags-defaults.json
@@ -600,7 +600,6 @@
   "ingest-storage.kafka.ingestion-concurrency-queue-capacity": 5,
   "ingest-storage.kafka.ingestion-concurrency-target-flushes-per-shard": 80,
   "ingest-storage.kafka.ingestion-concurrency-estimated-bytes-per-sample": 500,
-  "ingest-storage.kafka.ingestion-concurrency-sequential-pusher-enabled": true,
   "ingest-storage.migration.ingest-storage-max-wait-time": 0,
   "ingest-storage.write-logs-fsync-before-kafka-commit-concurrency": 4,
   "blocks-storage.backend": "filesystem",

--- a/pkg/ingester/ingester_ingest_storage_test.go
+++ b/pkg/ingester/ingester_ingest_storage_test.go
@@ -1213,7 +1213,6 @@ func BenchmarkIngester_ReplayFromKafka(b *testing.B) {
 			cfg.IngestStorageConfig.KafkaConfig.IngestionConcurrencyEstimatedBytesPerSample = 200
 			cfg.IngestStorageConfig.KafkaConfig.IngestionConcurrencyQueueCapacity = 3
 			cfg.IngestStorageConfig.KafkaConfig.IngestionConcurrencyTargetFlushesPerShard = 40
-			cfg.IngestStorageConfig.KafkaConfig.IngestionConcurrencySequentialPusherEnabled = false
 
 			// Disable TSDB WAL to reduce variance in test executions.
 			cfg.BlocksStorageConfig.TSDB.WALSegmentSizeBytes = -1
@@ -1292,7 +1291,6 @@ func BenchmarkIngester_ReplayFromKafka_Dump(b *testing.B) {
 			cfg.IngestStorageConfig.KafkaConfig.IngestionConcurrencyEstimatedBytesPerSample = 200
 			cfg.IngestStorageConfig.KafkaConfig.IngestionConcurrencyQueueCapacity = 3
 			cfg.IngestStorageConfig.KafkaConfig.IngestionConcurrencyTargetFlushesPerShard = 40
-			cfg.IngestStorageConfig.KafkaConfig.IngestionConcurrencySequentialPusherEnabled = false
 
 			// Disable TSDB WAL to reduce variance in benchmark executions.
 			cfg.BlocksStorageConfig.TSDB.WALSegmentSizeBytes = -1

--- a/pkg/storage/ingest/config.go
+++ b/pkg/storage/ingest/config.go
@@ -147,10 +147,6 @@ type KafkaConfig struct {
 	// Our data indicates that the average sample size is somewhere between ~250 and ~500 bytes. We'll use 500 bytes as a conservative estimate.
 	IngestionConcurrencyEstimatedBytesPerSample int `yaml:"ingestion_concurrency_estimated_bytes_per_sample"`
 
-	// IngestionConcurrencySequentialPusherEnabled controls whether to use the sequential storage pusher
-	// for tenants with few timeseries. When false, parallelStorageShards is always used even for small tenants.
-	IngestionConcurrencySequentialPusherEnabled bool `yaml:"ingestion_concurrency_sequential_pusher_enabled" category:"experimental"`
-
 	// The fetch backoff config to use in the concurrent fetchers (when enabled). This setting
 	// is just used to change the default backoff in tests.
 	concurrentFetchersFetchBackoffConfig backoff.Config `yaml:"-"`
@@ -212,7 +208,6 @@ func (cfg *KafkaConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) 
 	f.IntVar(&cfg.IngestionConcurrencyQueueCapacity, prefix+"ingestion-concurrency-queue-capacity", 5, "The number of batches to prepare and queue to ingest to the TSDB head. Only use this setting when -ingest-storage.kafka.ingestion-concurrency-max is greater than 0.")
 	f.IntVar(&cfg.IngestionConcurrencyTargetFlushesPerShard, prefix+"ingestion-concurrency-target-flushes-per-shard", 80, "The expected number of times to ingest timeseries to the TSDB head after batching. With fewer flushes, the overhead of splitting up the work is higher than the benefit of parallelization. Only use this setting when -ingest-storage.kafka.ingestion-concurrency-max is greater than 0.")
 	f.IntVar(&cfg.IngestionConcurrencyEstimatedBytesPerSample, prefix+"ingestion-concurrency-estimated-bytes-per-sample", 500, "The estimated number of bytes a sample has at time of ingestion. This value is used to estimate the timeseries without decompressing them. Only use this setting when -ingest-storage.kafka.ingestion-concurrency-max is greater than 0.")
-	f.BoolVar(&cfg.IngestionConcurrencySequentialPusherEnabled, prefix+"ingestion-concurrency-sequential-pusher-enabled", true, "When enabled, tenants with few timeseries use a simpler sequential pusher instead of parallel shards.")
 }
 
 func (cfg *KafkaConfig) Validate() error {


### PR DESCRIPTION
#### What this PR does

In https://github.com/grafana/mimir/pull/13924 I've introduced a temporary CLI flag (`-ingest-storage.kafka.ingestion-concurrency-sequential-pusher-enabled`) to have a quick way to revert back the change in case anything was wrong during the production rollout.

The rollout completed at Grafana Labs and consumption speed has been significantly increased in clusters with a large number of mixed size tenants, with no downsides on single-tenant clusters. In this PR I remove the temporarily CLI flag and enable the new behaviour (don't use sequential pusher anymore) by default.

I'm also adding a CHANGELOG entry because it wasn't (intentionally) added in the previous PRs.

Note to reviewers: review with "hide whitespace changes" enabled.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
