### PR TITLE
Release: Add prerequisite check that the version string is well-formed

### DIFF
--- a/tools/release/tag-release.sh
+++ b/tools/release/tag-release.sh
@@ -21,6 +21,10 @@ BRANCH_VERSION=${BASH_REMATCH[1]}
 
 # Load the version and ensure it matches.
 ACTUAL_VERSION=$(cat VERSION)
+if [[ ! $ACTUAL_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
+  echo "The VERSION file contains an invalid version '${ACTUAL_VERSION}'. Expected format: MAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH-rc.N" > /dev/stderr
+  exit 1
+fi
 if [[ ! $ACTUAL_VERSION =~ ^$BRANCH_VERSION ]]; then
   echo "The current branch '${BRANCH}' doesn't match the content of the VERSION file '${ACTUAL_VERSION}'" > /dev/stderr
   exit 1


### PR DESCRIPTION
#### What this PR does

This is inspired by a typo I nearly included in a tag, where I named a release `3.0.3-rc0` instead of `3.0.3-rc.0`.
The release guide has pretty strict text instructions on release spelling, but nothing in the process validates it.

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
