### PR TITLE
Vendor changes into backend-enterprise on every merge to `main`

### DIFF
--- a/.github/workflows/trigger-backend-enterprise-update.yml
+++ b/.github/workflows/trigger-backend-enterprise-update.yml
@@ -1,9 +1,10 @@
-name: Update vendored versions in grafana/backend-enterprise weekly branches
+name: Update vendored version in grafana/backend-enterprise
 
 on:
   push:
     branches:
       - 'r[0-9]*'
+      - 'main'
 
 permissions:
   contents: read


### PR DESCRIPTION
#### What this PR does

This PR changes the behaviour of the automated vendoring trigger to run whenever a PR is merged to `main`, not just weekly release branches.

My rationale is that triggering it on every commit means that most Mimir changes will be vendored in without issue, and so any Mimir changes that can't be merged automatically into backend-enterprise are likely to be isolated to their own vendoring PR, and the author of the Mimir PR will hear about the problem sooner.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that broadens when an existing `repository_dispatch` runs; main risk is increased automation frequency/noise rather than code or security logic changes.
> 
> **Overview**
> Expands the `trigger-backend-enterprise-update` GitHub Actions workflow to also run on pushes to `main`, not just `r[0-9]*` release branches, so merges to `main` automatically dispatch the vendoring update to `grafana/backend-enterprise`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0282d6c2d30e5f83d1298369bd9ad7aa99febb22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->