### PR TITLE
MQE: Don't apply projections to unsupported aggregations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,7 +112,7 @@
 * [ENHANCEMENT] Compactor: If compaction fails because the result block would have a postings offsets table larger than the 4GB limit, mark input blocks for no-compaction to avoid blocking future compactor runs. #13876
 * [ENHANCEMENT] Query-frontend: add support for `range()` duration expression. #13931
 * [ENHANCEMENT] Add experimental flag `common.instrument-reference-leaks-percentage` to leaked references to gRPC buffers. #13609 #14083
-* [ENHANCEMENT] Querier: Add experimental flag `-querier.mimir-query-engine.enable-projection-pushdown` to enable an MQE optimization pass for reducing data transferred between queriers and the storage layer. #14006 #14132 #14239 #14241
+* [ENHANCEMENT] Querier: Add experimental flag `-querier.mimir-query-engine.enable-projection-pushdown` to enable an MQE optimization pass for reducing data transferred between queriers and the storage layer. #14006 #14132 #14239 #14241 #14326
 * [ENHANCEMENT] MQE: Default to enabling the "eliminate deduplicate and merge" optimization pass via `-querier.mimir-query-engine.enable-eliminate-deduplicate-and-merge`. #14172
 * [ENHANCEMENT] Ingester: Reduce likelihood of ingestion being paused while idle TSDB compaction is in progress. #13978
 * [ENHANCEMENT] Ingester: Extend `cortex_ingester_tsdb_forced_compactions_in_progress` metric to report a value of 1 when there's an idle or forced TSDB head compaction in progress. #13979

--- a/pkg/streamingpromql/optimize/plan/projection_pushdown.go
+++ b/pkg/streamingpromql/optimize/plan/projection_pushdown.go
@@ -211,6 +211,15 @@ func examineAggregate(a *core.AggregateExpression) (map[string]struct{}, SkipRea
 		return nil, SkipReasonNotSupported
 	}
 
+	// These aggregations limit the number of results, they don't actually aggregate the
+	// series by any or all labels.
+	if a.Op == core.AGGREGATION_TOPK ||
+		a.Op == core.AGGREGATION_BOTTOMK ||
+		a.Op == core.AGGREGATION_LIMITK ||
+		a.Op == core.AGGREGATION_LIMIT_RATIO {
+		return nil, SkipReasonNotSupported
+	}
+
 	requiredLabels := make(map[string]struct{})
 	for _, l := range a.Grouping {
 		requiredLabels[l] = struct{}{}

--- a/pkg/streamingpromql/optimize/plan/projection_pushdown_test.go
+++ b/pkg/streamingpromql/optimize/plan/projection_pushdown_test.go
@@ -190,7 +190,6 @@ func TestProjectionPushdownOptimizationPass(t *testing.T) {
 			`,
 			expectedModified: 1,
 		},
-
 		"sort_by_label with aggregation": {
 			expr: `sort_by_label(avg by (job) (bar), "zone", "environment")`,
 			expectedPlan: `
@@ -257,6 +256,46 @@ func TestProjectionPushdownOptimizationPass(t *testing.T) {
 			`,
 			expectedModified: 0,
 			expectedSkip:     map[plan.SkipReason]int{plan.SkipReasonDeduplicate: 1},
+		},
+		"unsupported topk aggregation": {
+			expr: `topk(5, foo)`,
+			expectedPlan: `
+				- AggregateExpression: topk
+					- expression: VectorSelector: {__name__="foo"}
+					- parameter: NumberLiteral: 5
+			`,
+			expectedModified: 0,
+			expectedSkip:     map[plan.SkipReason]int{plan.SkipReasonNotSupported: 1},
+		},
+		"unsupported bottomk aggregation": {
+			expr: `bottomk(5, foo)`,
+			expectedPlan: `
+				- AggregateExpression: bottomk
+					- expression: VectorSelector: {__name__="foo"}
+					- parameter: NumberLiteral: 5
+			`,
+			expectedModified: 0,
+			expectedSkip:     map[plan.SkipReason]int{plan.SkipReasonNotSupported: 1},
+		},
+		"unsupported limitk aggregation": {
+			expr: `limitk(5, foo)`,
+			expectedPlan: `
+				- AggregateExpression: limitk
+					- expression: VectorSelector: {__name__="foo"}
+					- parameter: NumberLiteral: 5
+			`,
+			expectedModified: 0,
+			expectedSkip:     map[plan.SkipReason]int{plan.SkipReasonNotSupported: 1},
+		},
+		"unsupported limit_ratio aggregation": {
+			expr: `limit_ratio(0.8, foo)`,
+			expectedPlan: `
+				- AggregateExpression: limit_ratio
+					- expression: VectorSelector: {__name__="foo"}
+					- parameter: NumberLiteral: 0.8
+			`,
+			expectedModified: 0,
+			expectedSkip:     map[plan.SkipReason]int{plan.SkipReasonNotSupported: 1},
 		},
 		"unary expression": {
 			expr: `-foo`,


### PR DESCRIPTION
#### What this PR does

Some PromQL aggregations don't aggregate by a set of labels, they return a subset of series (topk, bottomk, etc). Skip trying to apply projections for these unsupported aggregations.

#### Which issue(s) this PR fixes or relates to

Part of #13863

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-tested change limited to an experimental query optimization pass, and it only disables an optimization for certain aggregations (reducing correctness risk at the cost of potential performance).
> 
> **Overview**
> Projection pushdown now **skips result-limiting aggregations** (`topk`, `bottomk`, `limitk`, `limit_ratio`) so MQE doesn’t attempt to apply label projections where the operator selects a subset of series instead of aggregating by label sets.
> 
> Updates the changelog reference for the `enable-projection-pushdown` enhancement and adds/extends tests to assert these aggregations are treated as `not-supported` (no selector modifications, skip reason recorded).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77324f921de10e304fe5960d35f86e4ba5fa699d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->