### PR TITLE
write-tee: amplify all label values

### DIFF
--- a/tools/writetee/proxy.go
+++ b/tools/writetee/proxy.go
@@ -86,7 +86,7 @@ func (cfg *ProxyConfig) RegisterFlags(f *flag.FlagSet) {
 		"The factor by which to amplify or sample writes to amplified backends. "+
 			"Values > 1.0 amplify (duplicate) metrics: 3.5 means each metric is duplicated 3.5 times on average. "+
 			"Values < 1.0 sample (reduce) metrics: 0.1 means only 10% of metrics are sent. "+
-			"Amplified metrics have an additional __amplified__=\"<replica>\" label. "+
+			"Amplified metrics have all label values (except __name__) suffixed with _amp{N} where N is the replica number. "+
 			"Only applies to backends specified in backend.amplified-endpoints.",
 	)
 	f.BoolVar(&cfg.BackendSkipTLSVerify, "backend.skip-tls-verify", false, "Skip TLS verification on backend targets.")


### PR DESCRIPTION
#### What this PR does

I propose to amplify all label values, instead of adding 1 extra label named `__amplified__`.

Why?
- If you have 10x more series, probably you have 10x more pods, namespaces, clusters, etc... so amplifying all label values may be a better simulation of a 10x load
- A more realistic amplified data pattern would result in a different – possibly more realistic – compression ratio (especially with RW2)

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
