### PR TITLE
chore: update docker version installed for Github CI

### DIFF
--- a/.github/workflows/scripts/install-docker.sh
+++ b/.github/workflows/scripts/install-docker.sh
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 set -x
-VER="20.10.14"
+VER="29.2.1"
 curl -L -o /tmp/docker-$VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VER.tgz
 tar -xz -C /tmp -f /tmp/docker-$VER.tgz
 mv /tmp/docker/* /usr/bin


### PR DESCRIPTION
#### What this PR does

Update from Docker 20.10.14 to 29.2.1 due to server/client version mismatch.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Simple CI tooling version bump; primary risk is potential incompatibility or behavior changes in Docker CLI during builds.
> 
> **Overview**
> Updates the GitHub Actions `install-docker.sh` script to install Docker `29.2.1` instead of `20.10.14`, affecting workflows that run `./.github/workflows/scripts/install-docker.sh` to provision the Docker CLI in CI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9683466c32df282a819ad4bd74734775a44f41e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->