### PR TITLE
compactor: move known compaction error handling to a function

### DIFF
--- a/pkg/compactor/bucket_compactor.go
+++ b/pkg/compactor/bucket_compactor.go
@@ -998,95 +998,11 @@ func (c *BucketCompactor) Compact(ctx context.Context, maxCompactionTime time.Du
 					// At this point the compaction has failed.
 					c.metrics.groupCompactionRunsFailed.Inc()
 
-					if ok, issue347Err := isIssue347Error(err); ok {
-						if err := repairIssue347(workCtx, c.logger, c.bkt, c.sy.metrics.blocksMarkedForDeletion, issue347Err); err == nil {
-							mtx.Lock()
-							finishedAllJobs = false
-							mtx.Unlock()
-							continue
-						}
-					}
-					// If the block has an out of order chunk and we have been configured to skip it,
-					// then we can mark the block for no compaction so that the next compaction run
-					// will skip it.
-					if ok, outOfOrderChunksErr := IsOutOfOrderChunkError(err); ok && c.skipUnhealthyBlocks {
-						err := block.MarkForNoCompact(
-							ctx,
-							c.logger,
-							c.bkt,
-							outOfOrderChunksErr.id,
-							block.OutOfOrderChunksNoCompactReason,
-							"OutofOrderChunk: marking block with out-of-order series/chunks as no compact to unblock compaction",
-							c.metrics.blocksMarkedForNoCompact.WithLabelValues(block.OutOfOrderChunksNoCompactReason),
-						)
-						if err == nil {
-							mtx.Lock()
-							finishedAllJobs = false
-							mtx.Unlock()
-							continue
-						}
-					}
-
-					// In case an unhealthy block is found, we mark it for no compaction
-					// to unblock future compaction run.
-					if ok, criticalErr := IsCriticalError(err); ok && c.skipUnhealthyBlocks {
-						err := block.MarkForNoCompact(
-							ctx,
-							c.logger,
-							c.bkt,
-							criticalErr.id,
-							block.CriticalNoCompactReason,
-							"UnhealthyBlock: marking unhealthy block as no compact to unblock compaction",
-							c.metrics.blocksMarkedForNoCompact.WithLabelValues(block.CriticalNoCompactReason),
-						)
-						if err == nil {
-							mtx.Lock()
-							finishedAllJobs = false
-							mtx.Unlock()
-							continue
-						}
-					}
-
-					// Handle postings offset table size errors by marking all input blocks as no-compact.
-					// This error indicates the blocks have extremely high label cardinality and cannot be
-					// compacted together without exceeding the 4GB offset table size limit.
-					if errors.Is(err, index.ErrPostingsOffsetTableTooLarge) && c.skipUnhealthyBlocks {
-						blockIDs := g.IDs()
-						level.Warn(c.logger).Log(
-							"msg", "compaction failed due to postings offset table size limit; marking input blocks as no-compact",
-							"groupKey", g.Key(),
-							"block_count", len(blockIDs),
-							"blocks", fmt.Sprintf("%v", blockIDs),
-							"err", err,
-						)
-
-						allMarked := true
-						for _, blockID := range blockIDs {
-							markErr := block.MarkForNoCompact(
-								ctx,
-								c.logger,
-								c.bkt,
-								blockID,
-								block.PostingsOffsetTableTooLargeNoCompactReason,
-								"PostingsOffsetTableTooLarge: marking input block as no compact to unblock compaction",
-								c.metrics.blocksMarkedForNoCompact.WithLabelValues(block.PostingsOffsetTableTooLargeNoCompactReason),
-							)
-							if markErr != nil {
-								level.Error(c.logger).Log(
-									"msg", "failed to mark block as no-compact after postings offset table size error",
-									"block", blockID,
-									"err", markErr,
-								)
-								allMarked = false
-							}
-						}
-
-						if allMarked {
-							mtx.Lock()
-							finishedAllJobs = false
-							mtx.Unlock()
-							continue
-						}
+					if handleErr := c.handleKnownCompactionErrors(workCtx, g, err); handleErr == nil {
+						mtx.Lock()
+						finishedAllJobs = false
+						mtx.Unlock()
+						continue
 					}
 
 					errChan <- fmt.Errorf("group %s: %w", g.Key(), err)
@@ -1191,6 +1107,84 @@ func (c *BucketCompactor) Compact(ctx context.Context, maxCompactionTime time.Du
 	}
 	level.Info(c.logger).Log("msg", "compaction iterations done")
 	return nil
+}
+
+// handleKnownCompactionErrors handles errors that have known mitigations such as marking blocks as no-compact.
+// Returns nil if the error was recognized and handled successfully, otherwise returns a non-nil error.
+func (c *BucketCompactor) handleKnownCompactionErrors(ctx context.Context, job *Job, err error) error {
+	if ok, issue347Err := isIssue347Error(err); ok {
+		return repairIssue347(ctx, c.logger, c.bkt, c.sy.metrics.blocksMarkedForDeletion, issue347Err)
+	}
+
+	// If the block has an out of order chunk and we have been configured to skip it,
+	// then we can mark the block for no compaction so that the next compaction run
+	// will skip it.
+	if ok, outOfOrderChunksErr := IsOutOfOrderChunkError(err); ok && c.skipUnhealthyBlocks {
+		return block.MarkForNoCompact(
+			ctx,
+			c.logger,
+			c.bkt,
+			outOfOrderChunksErr.id,
+			block.OutOfOrderChunksNoCompactReason,
+			"OutofOrderChunk: marking block with out-of-order series/chunks as no compact to unblock compaction",
+			c.metrics.blocksMarkedForNoCompact.WithLabelValues(block.OutOfOrderChunksNoCompactReason),
+		)
+	}
+
+	// In case an unhealthy block is found, we mark it for no compaction
+	// to unblock future compaction run.
+	if ok, criticalErr := IsCriticalError(err); ok && c.skipUnhealthyBlocks {
+		return block.MarkForNoCompact(
+			ctx,
+			c.logger,
+			c.bkt,
+			criticalErr.id,
+			block.CriticalNoCompactReason,
+			"UnhealthyBlock: marking unhealthy block as no compact to unblock compaction",
+			c.metrics.blocksMarkedForNoCompact.WithLabelValues(block.CriticalNoCompactReason),
+		)
+	}
+
+	// Handle postings offset table size errors by marking all input blocks as no-compact.
+	// This error indicates the blocks have extremely high label cardinality and cannot be
+	// compacted together without exceeding the 4GB offset table size limit.
+	if errors.Is(err, index.ErrPostingsOffsetTableTooLarge) && c.skipUnhealthyBlocks {
+		blockIDs := job.IDs()
+		level.Warn(c.logger).Log(
+			"msg", "compaction failed due to postings offset table size limit; marking input blocks as no-compact",
+			"groupKey", job.Key(),
+			"block_count", len(blockIDs),
+			"blocks", fmt.Sprintf("%v", blockIDs),
+			"err", err,
+		)
+
+		allMarked := true
+		for _, blockID := range blockIDs {
+			markErr := block.MarkForNoCompact(
+				ctx,
+				c.logger,
+				c.bkt,
+				blockID,
+				block.PostingsOffsetTableTooLargeNoCompactReason,
+				"PostingsOffsetTableTooLarge: marking input block as no compact to unblock compaction",
+				c.metrics.blocksMarkedForNoCompact.WithLabelValues(block.PostingsOffsetTableTooLargeNoCompactReason),
+			)
+			if markErr != nil {
+				level.Error(c.logger).Log(
+					"msg", "failed to mark block as no-compact after postings offset table size error",
+					"block", blockID,
+					"err", markErr,
+				)
+				allMarked = false
+			}
+		}
+		if allMarked {
+			return nil
+		}
+	}
+
+	// Unhandled, returning original err
+	return err
 }
 
 // blockMaxTimeDeltas returns a slice of the difference between now and the MaxTime of each


### PR DESCRIPTION
#### What this PR does

This moves some compaction error handling to a function. Note that there is a control flow difference: if an error is identified, the function returns immediately without checking other error variants. The behavior is still the same.

This change was originally made in the compactor scheduler feature branch. I'm porting the feature over in logical pieces. In the feature code we also call this function to handle known errors, but from a different flow.

#### Which issue(s) this PR fixes or relates to

Fixes: N/A

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of existing error-handling paths with minimal behavioral change; main risk is subtle control-flow differences in which mitigation is attempted first.
> 
> **Overview**
> Refactors compaction failure handling in `BucketCompactor.Compact` by extracting all “known error” mitigations into a new helper `handleKnownCompactionErrors`.
> 
> On compaction failure, the worker now calls this helper to attempt repairs/mitigations (issue 347 repair; marking blocks no-compact for out-of-order chunks, critical health issues, or `ErrPostingsOffsetTableTooLarge` across all job input blocks) and, if handled, forces another iteration instead of surfacing the error.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e92515feadb8a5d353aa3f9c4e5e36db7106088. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->