### PR TITLE
compactor: log job's number of samples, series and chunks

### DIFF
--- a/pkg/compactor/bucket_compactor.go
+++ b/pkg/compactor/bucket_compactor.go
@@ -353,13 +353,27 @@ func (c *BucketCompactor) runCompactionJob(ctx context.Context, job *Job) (shoul
 
 	blocksToCompactDirs := make([]string, len(toCompact))
 	var totalBlockSize int64
+	var totalSamples, totalSeries, totalChunks uint64
 	for ix, meta := range toCompact {
 		blocksToCompactDirs[ix] = filepath.Join(subDir, meta.ULID.String())
 		totalBlockSize += meta.BlockBytes()
+		totalSamples += meta.Stats.NumSamples
+		totalSeries += meta.Stats.NumSeries
+		totalChunks += meta.Stats.NumChunks
 	}
 
 	elapsed := time.Since(downloadBegin)
-	level.Info(jobLogger).Log("msg", "downloaded and verified blocks; compacting blocks", "block_count", blockCount, "blocks", toCompactStr, "total_size_bytes", totalBlockSize, "duration", elapsed, "duration_ms", elapsed.Milliseconds())
+	level.Info(jobLogger).Log(
+		"msg", "downloaded and verified blocks; compacting blocks",
+		"block_count", blockCount,
+		"blocks", toCompactStr,
+		"total_size_bytes", totalBlockSize,
+		"total_samples", totalSamples,
+		"total_series", totalSeries,
+		"total_chunks", totalChunks,
+		"duration", elapsed,
+		"duration_ms", elapsed.Milliseconds(),
+	)
 
 	compactionBegin := time.Now()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Adds the total number of samples, series and chunks to the already existing logline, to help investigate why a job took the time it took. The total size (already part of the log) does not correlate as well as I'd want.

My motive is I'm trying to come up with a good-ish predictor of how long a job _will_ take; these numbers help with that analysis. Though the stats could be useful in other contexts. 

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change that reads already-available block metadata stats and adds them to an existing log line.
> 
> **Overview**
> Adds aggregation of `meta.Stats` across all planned input blocks and logs `total_samples`, `total_series`, and `total_chunks` in the existing "downloaded and verified blocks; compacting blocks" info log within `BucketCompactor.runCompactionJob`.
> 
> No compaction behavior changes; this is additional observability to help correlate job duration with input data characteristics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1159c9fc807564b59d506802b0d08f815518c385. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->