### PR TITLE
Improve write tee, addressing previous Cursor comments

### DIFF
--- a/tools/writetee/amplification.go
+++ b/tools/writetee/amplification.go
@@ -313,14 +313,16 @@ func AmplifyRequestBody(body []byte, startReplica, endReplica int) ([][]byte, er
 	for replicaNum := startReplica; replicaNum <= endReplica; replicaNum++ {
 		var suffixedReq mimirpb.WriteRequest
 		if replicaNum == 1 {
-			// Replica 1 is the original - no suffix needed
-			suffixedReq = mimirpb.WriteRequest{
-				Timeseries: req.Timeseries,
-			}
+			// Replica 1 is the original - preserve all fields
+			suffixedReq = req
 		} else {
-			// Create a new request with suffixed series
+			// Create a new request with suffixed series, preserving all other fields
 			suffixedReq = mimirpb.WriteRequest{
-				Timeseries: make([]mimirpb.PreallocTimeseries, len(req.Timeseries)),
+				Source:                   req.Source,
+				Metadata:                 req.Metadata,
+				SkipLabelValidation:      req.SkipLabelValidation,
+				SkipLabelCountValidation: req.SkipLabelCountValidation,
+				Timeseries:               make([]mimirpb.PreallocTimeseries, len(req.Timeseries)),
 			}
 			for i := range req.Timeseries {
 				suffixedReq.Timeseries[i] = applySuffixToTimeSeries(&req.Timeseries[i], replicaNum)

--- a/tools/writetee/proxy_endpoint.go
+++ b/tools/writetee/proxy_endpoint.go
@@ -48,6 +48,12 @@ func NewProxyEndpoint(backends []ProxyBackend, route Route, metrics *ProxyMetric
 		return nil, fmt.Errorf("no preferred backend configured")
 	}
 
+	// Warn if preferred backend is configured as amplified - it will not be amplified
+	// since we always send the original body to the preferred backend for fast client responses
+	if preferredBackend.BackendType() == BackendTypeAmplified && amplificationFactor != 1.0 {
+		level.Warn(logger).Log("msg", "Preferred backend is configured with BackendTypeAmplified but will not be amplified. Only non-preferred backends are amplified.", "backend", preferredBackend.Name(), "amplification_factor", amplificationFactor)
+	}
+
 	return &ProxyEndpoint{
 		backends:             backends,
 		route:                route,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Addresses comments from #14343.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized changes to write-tee request replication and logging; main risk is subtle behavioral change if downstream relied on omitted RW1 fields during amplification.
> 
> **Overview**
> Fixes RW 1.0 request amplification to **preserve the full `mimirpb.WriteRequest`** in replica 1 and to **carry over non-timeseries fields** (eg `Source`, `Metadata`, label-validation flags) when constructing suffixed replicas, instead of dropping them.
> 
> Adds a startup warning in `NewProxyEndpoint` when the preferred backend is configured as `BackendTypeAmplified` while `amplificationFactor != 1`, clarifying that the preferred backend always receives the original (non-amplified) request body.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec3be6d93f6f9b8f2c832156356033b6f2ef21d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->