### PR TITLE
feat: support custom labels in volumeClaimTemplates

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -42,6 +42,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Kafka: Made log retention period configurable via `kafka.logRetentionHours`. #13866
 * [ENHANCEMENT] Allow overwriting `grafana.com/min-time-between-zones-downscale` annotation value for ingester and store-gateway via `zoneAwareReplication.minTimeBetweenZonesDownscale`. #14411
 * [ENHANCEMENT] Upgrade rollout-operator chart to [0.43.0](https://github.com/grafana/helm-charts/blob/main/charts/rollout-operator). #14463
+* [ENHANCEMENT] Add support for custom labels on PersistentVolumeClaim resources for alertmanager, compactor, ingester, and store-gateway. #14373
 * [BUGFIX] Fix missing newline for custom pod labels. #13325
 * [BUGFIX] Upgrade rollout-operator chart to 0.37.1, which fixes server-tls.self-signed-cert.dns-name to use the full release name instead of always being set to `rollout-operator.NAMESPACE.svc`. If upgrading from 6.0.0 or 6.0.1, delete the `certificate` secret created by the rollout-operator pod and recreate the rollout-operator pod. #13357
 * [BUGFIX] Delete gateway's serviceMonitor #13481

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -50,7 +50,11 @@ spec:
         name: {{ .name }}
         {{- if .annotations }}
         annotations:
-          {{ toYaml .annotations | nindent 10 }}
+          {{- toYaml .annotations | nindent 10 }}
+        {{- end }}
+        {{- if .labels }}
+        labels:
+          {{- toYaml .labels | nindent 10 }}
         {{- end }}
       spec:
         {{- $storageClass := default .storageClass $rolloutZone.storageClass }}

--- a/operations/helm/charts/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -31,7 +31,11 @@ spec:
         name: {{ .name }}
         {{- if .annotations }}
         annotations:
-          {{ toYaml .annotations | nindent 10 }}
+          {{- toYaml .annotations | nindent 10 }}
+        {{- end }}
+        {{- if .labels }}
+        labels:
+          {{- toYaml .labels | nindent 10 }}
         {{- end }}
       spec:
         {{- if .storageClass }}

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -57,6 +57,10 @@ spec:
         annotations:
           {{- toYaml .annotations | nindent 10 }}
         {{- end }}
+        {{- if .labels }}
+        labels:
+          {{- toYaml .labels | nindent 10 }}
+        {{- end }}
       spec:
         {{- $storageClass := default .storageClass $rolloutZone.storageClass }}
         {{- if $storageClass }}

--- a/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -57,6 +57,10 @@ spec:
         annotations:
           {{- toYaml .annotations | nindent 10 }}
         {{- end }}
+        {{- if .labels }}
+        labels:
+          {{- toYaml .labels | nindent 10 }}
+        {{- end }}
       spec:
         {{- $storageClass := default .storageClass $rolloutZone.storageClass }}
         {{- if $storageClass }}

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -579,6 +579,10 @@ alertmanager:
     #
     annotations: {}
 
+    # Alertmanager data Persistent Volume Claim labels
+    #
+    labels: {}
+
     # Alertmanager data Persistent Volume access modes
     # Must match those of existing PV or dynamic provisioner
     # Ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
@@ -991,6 +995,10 @@ ingester:
     # Ingester data Persistent Volume Claim annotations
     #
     annotations: {}
+
+    # Ingester data Persistent Volume Claim labels
+    #
+    labels: {}
 
     # Ingester data Persistent Volume access modes
     # Must match those of existing PV or dynamic provisioner
@@ -2192,6 +2200,10 @@ store_gateway:
     #
     annotations: {}
 
+    # Store-gateway data Persistent Volume Claim labels
+    #
+    labels: {}
+
     # Store-gateway data Persistent Volume access modes
     # Must match those of existing PV or dynamic provisioner
     # Ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
@@ -2437,6 +2449,10 @@ compactor:
     # compactor data Persistent Volume Claim annotations
     #
     annotations: {}
+
+    # compactor data Persistent Volume Claim labels
+    #
+    labels: {}
 
     # compactor data Persistent Volume access modes
     # Must match those of existing PV or dynamic provisioner


### PR DESCRIPTION
#### What this PR does

Enhances the mimir-distributed helm chart to define labels for PVCs used by alertmanager, compactor, store-gateway and ingester statfulsets in mimir-distributed helm chart.

#### Which issue(s) this PR fixes or relates to

Fixes #14266 

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Helm templating change that only adds optional PVC labels; risk is limited to potential YAML rendering/indentation mistakes affecting the StatefulSets that use persistent volumes.
> 
> **Overview**
> Helm chart now supports adding custom `metadata.labels` to the `volumeClaimTemplates` PVCs for `alertmanager`, `compactor`, `ingester`, and `store-gateway` StatefulSets via new `*.persistentVolume.labels` values.
> 
> Updates `values.yaml` to expose the new options (default `{}`) and records the enhancement in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 641fd14698000dca60ec2efdd5f88942a090570f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->