### PR TITLE
Fix prom engine panic because no SeriesLabelsDeduplicator in context.

### DIFF
--- a/integration/querier_test.go
+++ b/integration/querier_test.go
@@ -518,12 +518,20 @@ func TestQuerierWithBlocksStorageRunningInSingleBinaryMode(t *testing.T) {
 }
 
 func TestMimirPromQLEngine(t *testing.T) {
+	testPromQLEngine(t, "mimir")
+}
+
+func TestPrometheusPromQLEngine(t *testing.T) {
+	testPromQLEngine(t, "prometheus")
+}
+
+func testPromQLEngine(t *testing.T, engineType string) {
 	s, err := e2e.NewScenario(networkName)
 	require.NoError(t, err)
 	defer s.Close()
 
 	flags := mergeFlags(BlocksStorageFlags(), BlocksStorageS3Flags(), map[string]string{
-		"-querier.query-engine": "mimir",
+		"-querier.query-engine": engineType,
 	})
 
 	consul := e2edb.NewConsul()
@@ -553,7 +561,7 @@ func TestMimirPromQLEngine(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 200, res.StatusCode)
 
-	// Query back the same series using the streaming PromQL engine.
+	// Query back the same series.
 	c, err := e2emimir.NewClient("", querier.HTTPEndpoint(), "", "", "user-1")
 	require.NoError(t, err)
 

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -235,12 +235,12 @@ func New(
 		} else {
 			eng = streamingEngine
 		}
-		// Wrap queryable with memory tracking
-		queryable = NewMemoryTrackingQueryable(queryable)
 	default:
 		panic(fmt.Sprintf("invalid config not caught by validation: unknown PromQL engine '%s'", cfg.QueryEngine))
 	}
 
+	// Wrap queryable with memory tracking so that there will SeriesLabelsDeduplicator in the context.
+	queryable = NewMemoryTrackingQueryable(queryable)
 	lazyQueryable := storage.QueryableFunc(func(minT int64, maxT int64) (storage.Querier, error) {
 		querier, err := queryable.Querier(minT, maxT)
 		if err != nil {


### PR DESCRIPTION
#14148 added SeriesLabelsDeduplicator to deduplicate series labels from Querier via MemoryTrackingQueryable. This Queryable was purposely only added in MQE engine to avoid impacting Prometheus engine query. But actually prometheus engine will need SeriesLabelsDeduplicator notetheless, otherwise it will panic.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to querier wiring plus an added integration test; behavior impact is limited to consistent context injection across engines.
> 
> **Overview**
> Fixes a panic when running the Prometheus PromQL engine by **always wrapping the queryable with `NewMemoryTrackingQueryable`**, ensuring `SeriesLabelsDeduplicator` is injected into the query context regardless of engine selection.
> 
> Updates the integration test to run the same PromQL round-trip query against **both** `mimir` and `prometheus` engine types via a shared `testPromQLEngine` helper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 123bdf85216ca950d792f74b19c646312138a1f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->