### PR TITLE
Fix nil pointer dereference when target is empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,7 @@
 * [ENHANCEMENT] Ingester: Add experimental file based Kafka consumer group offset tracking via flag `-ingest-storage.kafka.consumer-group-offset-commit-file-enforced`. #14110
 * [ENHANCEMENT] Store-gateway: Add "OOO" column to the tenant blocks page to indicate whether each block was created from out-of-order samples. #14283
 * [ENHANCEMENT] Ingester: Optimize ingestion from Kafka in clusters with mixed size tenants. #13924 #13961 #14302
+* [BUGFIX] Mimir: Fix nil pointer dereference when `-target` is set to an empty string. #14381
 * [BUGFIX] API: Fixed web UI links not respecting `-server.path-prefix` configuration. #14090
 * [BUGFIX] Distributor: Fix issue where distributors didn't send custom values of native histograms. #13849
 * [BUGFIX] Compactor: Fix potential concurrent map writes. #13053

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -909,6 +909,10 @@ type Mimir struct {
 
 // New makes a new Mimir.
 func New(cfg Config, reg prometheus.Registerer) (*Mimir, error) {
+	if len(cfg.Target) == 0 {
+		return nil, fmt.Errorf("no target module specified, the -target flag must be set to a valid module (e.g. \"all\")")
+	}
+
 	if cfg.PrintConfig {
 		if err := yaml.NewEncoder(os.Stdout).Encode(&cfg); err != nil {
 			fmt.Println("Error encoding config:", err)

--- a/pkg/mimir/mimir_test.go
+++ b/pkg/mimir/mimir_test.go
@@ -1055,6 +1055,20 @@ func getHostnameAndRandomPort(t *testing.T) (string, int) {
 	return host, portNum
 }
 
+func TestNewReturnsErrorOnEmptyTarget(t *testing.T) {
+	args := []string{
+		"-target=",
+	}
+	var cfg Config
+	fs := flag.NewFlagSet("test", flag.PanicOnError)
+	cfg.RegisterFlags(fs, log.NewNopLogger())
+	require.NoError(t, fs.Parse(args))
+
+	_, err := New(cfg, prometheus.NewPedanticRegistry())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no target module specified")
+}
+
 type mockGrpcServiceHandler struct {
 	querierShutdownCalled atomic.Bool
 	rulerSyncRulesCalled  atomic.Bool


### PR DESCRIPTION
#### What this PR does

When a user sets `target: ""` in the config (or `-target=""`), `StringSliceCSV.Set("")` sets `Target` to `nil`. This means no modules are initialized — including the API module — causing a nil pointer dereference at `t.API.RegisterServiceMapHandler(...)` in `Run()`.

This PR adds a validation check at the top of `New()` that returns a clear error message when `Target` is empty, failing fast before any setup work is done.

#### Which issue(s) this PR fixes or relates to

Fixes #14380

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.