### PR TITLE
blockbuilder: fix panic in metrics registration

### DIFF
--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -79,12 +79,7 @@ func newWithSchedulerClient(
 
 	var readerMetrics *ingest.ReaderMetrics
 	if cfg.Kafka.FetchConcurrencyMax > 0 {
-		m := ingest.NewReaderMetrics(
-			prometheus.WrapRegistererWith(prometheus.Labels{"component": "block-builder"}, reg),
-			readerMetricsSource,
-			cfg.Kafka.Topic,
-			kpm,
-		)
+		m := ingest.NewReaderMetrics(reg, readerMetricsSource, cfg.Kafka.Topic, kpm)
 		readerMetrics = &m
 	}
 


### PR DESCRIPTION
#### What this PR does

Fixup for https://github.com/grafana/mimir/pull/14383 where I missed that `NewStrongReadConsistencyInstrumentation` (that lives inside `ReaderMetrics`) already adds a static `component` label to its metrics. Now, with the mentioned changes and the concurrent fetcher enabled, the block-builder panics at the startup:

```
ts=2026-02-16T18:13:01.422128041Z caller=server.go:401 level=info msg="server listening on addresses" http=[::]:80 grpc=[::]:9095
panic: descriptor Desc{fqName: "cortex_ingest_storage_strong_consistency_requests_total", help: "Total number of requests for which strong consistency has been requested. The metric distinguishes between requests with an offset specified and requests requesting to enforce strong consistency up until the last produced offset.", constLabels: {component="partition-reader"}, variableLabels: {with_offset,topic}} is invalid: attempted wrapping with already existing label name "component"

goroutine 1 [running]:
github.com/prometheus/client_golang/prometheus.(*wrappingRegisterer).MustRegister(0x40020242a0, {0x4001eac480?, 0x0?, 0x0?})
	/__w/backend-enterprise/backend-enterprise/vendor/github.com/prometheus/client_golang/prometheus/wrap.go:138 +0x138
github.com/prometheus/client_golang/prometheus/promauto.Factory.NewCounterVec({{0x475f320?, 0x40020242a0?}}, {{0x0, 0x0}, {0x0, 0x0}, {0x3e39e95, 0x37}, {0x3ec791e, 0xe5}, ...}, ...)
	/__w/backend-enterprise/backend-enterprise/vendor/github.com/prometheus/client_golang/prometheus/promauto/auto.go:276 +0x160
github.com/grafana/mimir/pkg/storage/ingest.NewStrongReadConsistencyInstrumentation[...]({0x3d24857?, 0x10}, {0x475f320, 0x40020242a0}, {0x4000fc4e70, 0x1, 0x6b})
	/__w/backend-enterprise/backend-enterprise/vendor/github.com/grafana/mimir/pkg/storage/ingest/reader.go:1255 +0x124
```

Here, I'm simply removing the `component=block-builder`, as it was before my original changes. This is fine, the main point of https://github.com/grafana/mimir/pull/14383 was about starting the service that `ReaderMetrics` exposes.