### PR TITLE
docs: Remove block cutting latency tip re: block ranges

### DIFF
--- a/docs/sources/mimir/manage/run-production-environment/production-tips/index.md
+++ b/docs/sources/mimir/manage/run-production-environment/production-tips/index.md
@@ -217,4 +217,3 @@ Depending on the workload, you might witness latency spikes when Mimir cuts bloc
 To reduce the impact of this behavior, consider the following:
 
 - Upgrade to `2.15+`. Refer to <https://github.com/grafana/mimir/commit/03f2f06e1247e997a0246d72f5c2c1fd9bd386df>.
-- Reduce `-blocks-storage.tsdb.block-ranges-period`, default `2h`. For example. try `1h`.


### PR DESCRIPTION
#### What this PR does

Removes suggestion at https://grafana.com/docs/mimir/latest/manage/run-production-environment/production-tips/#periodic-latency-spikes-when-cutting-blocks per #3518.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that removes a configuration recommendation; no runtime or behavioral code changes.
> 
> **Overview**
> Removes the production tip that suggested reducing `-blocks-storage.tsdb.block-ranges-period` to mitigate periodic latency spikes during TSDB block cutting.
> 
> The “Periodic latency spikes when cutting blocks” section now only recommends upgrading to `2.15+` (with a reference commit) as the mitigation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a00b4d78a9c6710e018476def5dc6e68b39d604e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->