### PR TITLE
alerts: Add "Ring Failures" to MimirCompactorNotRunningCompaction runbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -281,6 +281,7 @@
 
 ### Documentation
 
+* [ENHANCEMENT] Runbook: Add section on "Ring Failures" to `MimirCompactorNotRunningCompaction` runbook. #14391
 * [ENHANCEMENT] Add Azure object store workload identity example configuration. #13135
 * [ENHANCEMENT] Ruler: clarify that internal distributor applies to both operational modes. #13300
 * [ENHANCEMENT] Native histograms: Set expectations on querying classic histograms versus NHCBs. #13689

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -701,6 +701,7 @@ How to **investigate**:
           ```
           For examples using AWS S3 or Azure, see [How to use the mark-blocks tool](#how-to-use-the-mark-blocks-tool).
   - Result block exceeds symbol table maximum size:
+
     - **How to detect**: Search compactor logs for `symbol table size exceeds`.
     - **What it means**: The compactor successfully validated the source blocks. But the resulting block is impossible to write due to the error above.
     - This is caused by too many series being stored in the blocks, which indicates that `-compactor.split-and-merge-shards` is too low for the tenant. Could be also an indication of very high churn in labels causing label cardinality explosion.
@@ -717,6 +718,15 @@ How to **investigate**:
         ```
         For examples using AWS S3 or Azure, see [How to use the mark-blocks tool](#how-to-use-the-mark-blocks-tool).
     - Further reading: [Compaction algorithm](../../references/architecture/components/compactor/#compaction-algorithm).
+
+  - Ring failures:
+
+    - **How to detect**:
+      - Search compactor logs for `unhealthy instances`.
+      - Check the [compactor ring web page](../../references/http-api/#compactor-ring-status) for unhealthy instances.
+    - **What it means**: The compactor ring contains unhealthy instances and compactor(s) cannot check the tenant-shard relationship.
+    - **How to mitigate**: Ring failures are typically transient and the alert self-resolves. Otherwise: consider manually forgetting unexpected instances in an `Unhealthy` state on the compactor ring web page.
+
   - Compactor network disk unresponsive:
     - **How to detect**: A telltale sign is having many cores of sustained kernel-mode CPU usage by the compactor process. Check the metric `rate(container_cpu_system_seconds_total{pod="<pod>"}[$__rate_interval])` for the affected pod.
     - **What it means**: The compactor process has frozen because it's blocked on kernel-mode flushes to an unresponsive network block storage device.


### PR DESCRIPTION
#### What this PR does

This PR adjusts the `CompactorNotRunningCompaction` runbook to contain a section on "Ring Failures".


#### Checklist

- [n/a] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update (runbook text plus changelog entry) with no code or runtime behavior changes.
> 
> **Overview**
> Adds a new *Ring failures* troubleshooting section to the `MimirCompactorNotRunningCompaction` runbook, including detection steps (log search for `unhealthy instances` and checking the compactor ring status page) and mitigation guidance (typically transient; optionally forget unexpected `Unhealthy` instances).
> 
> Updates `CHANGELOG.md` to record this documentation enhancement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10bb9801cbb9ef476c515a8afe789bc945d0d26e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->