### PR TITLE
Rename cacheHashKey to hashCacheKey

### DIFF
--- a/pkg/frontend/querymiddleware/cardinality.go
+++ b/pkg/frontend/querymiddleware/cardinality.go
@@ -181,8 +181,8 @@ func generateCardinalityEstimationCacheKey(userID string, r MetricsQueryRequest,
 
 	// Apply a hash function to user controlled input to make sure we don't exceed
 	// the max number of bytes for the cache key (250 bytes in Memcached).
-	queryHash := cacheHashKey(r.GetQuery())
-	userIDHash := cacheHashKey(userID)
+	queryHash := hashCacheKey(r.GetQuery())
+	userIDHash := hashCacheKey(userID)
 
 	// Prefix key with `QS` (short for "query statistics").
 	return fmt.Sprintf("QS:%s:%s:%d:%d", userIDHash, queryHash, startBucket, rangeBucket)

--- a/pkg/frontend/querymiddleware/cardinality_query_cache_test.go
+++ b/pkg/frontend/querymiddleware/cardinality_query_cache_test.go
@@ -58,7 +58,7 @@ func TestCardinalityQueryCache_RoundTrip_WithTenantFederation(t *testing.T) {
 			// Create the request.
 			reqURL := mustParseURL(t, `/prometheus/api/v1/cardinality/label_names?selector={job="test"}&limit=100`)
 			reqCacheKey := tenant.JoinTenantIDs(testData.tenantIDs) + ":job=\"test\"\x00inmemory\x00100"
-			reqHashedCacheKey := cardinalityLabelNamesQueryCachePrefix + cacheHashKey(reqCacheKey)
+			reqHashedCacheKey := cardinalityLabelNamesQueryCachePrefix + hashCacheKey(reqCacheKey)
 
 			req := &http.Request{URL: reqURL}
 			req = req.WithContext(user.InjectOrgID(context.Background(), tenant.JoinTenantIDs(testData.tenantIDs)))
@@ -105,13 +105,13 @@ func TestCardinalityQueryCache_RoundTrip(t *testing.T) {
 			reqPath:        "/prometheus/api/v1/cardinality/label_names",
 			reqData:        url.Values{"selector": []string{`{job="test"}`}, "limit": []string{"100"}, "count_method": []string{"active"}},
 			cacheKey:       "user-1:job=\"test\"\x00active\x00100",
-			hashedCacheKey: cardinalityLabelNamesQueryCachePrefix + cacheHashKey("user-1:job=\"test\"\x00active\x00100"),
+			hashedCacheKey: cardinalityLabelNamesQueryCachePrefix + hashCacheKey("user-1:job=\"test\"\x00active\x00100"),
 		},
 		"label values request": {
 			reqPath:        "/prometheus/api/v1/cardinality/label_values",
 			reqData:        url.Values{"selector": []string{`{job="test"}`}, "label_names[]": []string{"metric_1", "metric_2"}, "limit": []string{"100"}},
 			cacheKey:       "user-1:metric_1\x01metric_2\x00job=\"test\"\x00inmemory\x00100",
-			hashedCacheKey: cardinalityLabelValuesQueryCachePrefix + cacheHashKey("user-1:metric_1\x01metric_2\x00job=\"test\"\x00inmemory\x00100"),
+			hashedCacheKey: cardinalityLabelValuesQueryCachePrefix + hashCacheKey("user-1:metric_1\x01metric_2\x00job=\"test\"\x00inmemory\x00100"),
 		},
 	})
 }

--- a/pkg/frontend/querymiddleware/cardinality_test.go
+++ b/pkg/frontend/querymiddleware/cardinality_test.go
@@ -49,7 +49,7 @@ func Test_cardinalityEstimateBucket_QueryRequest_keyFormat(t *testing.T) {
 				time:      requestTime.UnixMilli(),
 				queryExpr: parseQuery(t, "up"),
 			},
-			expected: fmt.Sprintf("QS:%s:%s:%d:%d", cacheHashKey("tenant-a"), cacheHashKey("up"), daysSinceEpoch, 0),
+			expected: fmt.Sprintf("QS:%s:%s:%d:%d", hashCacheKey("tenant-a"), hashCacheKey("up"), daysSinceEpoch, 0),
 		},
 		{
 			name:   "range query",
@@ -59,7 +59,7 @@ func Test_cardinalityEstimateBucket_QueryRequest_keyFormat(t *testing.T) {
 				end:       requestTime.Add(2 * time.Hour).UnixMilli(),
 				queryExpr: parseQuery(t, "up"),
 			},
-			expected: fmt.Sprintf("QS:%s:%s:%d:%d", cacheHashKey("tenant-b"), cacheHashKey("up"), daysSinceEpoch, 0),
+			expected: fmt.Sprintf("QS:%s:%s:%d:%d", hashCacheKey("tenant-b"), hashCacheKey("up"), daysSinceEpoch, 0),
 		},
 		{
 			name:   "range query with large range",
@@ -70,7 +70,7 @@ func Test_cardinalityEstimateBucket_QueryRequest_keyFormat(t *testing.T) {
 				end:       requestTime.Add(25 * time.Hour).UnixMilli(),
 				queryExpr: parseQuery(t, "up"),
 			},
-			expected: fmt.Sprintf("QS:%s:%s:%d:%d", cacheHashKey("tenant-b"), cacheHashKey("up"), daysSinceEpoch, 1),
+			expected: fmt.Sprintf("QS:%s:%s:%d:%d", hashCacheKey("tenant-b"), hashCacheKey("up"), daysSinceEpoch, 1),
 		},
 		{
 			name:   "long userID creates a valid key",
@@ -81,7 +81,7 @@ func Test_cardinalityEstimateBucket_QueryRequest_keyFormat(t *testing.T) {
 				end:       requestTime.Add(25 * time.Hour).UnixMilli(),
 				queryExpr: parseQuery(t, "up"),
 			},
-			expected: fmt.Sprintf("QS:%s:%s:%d:%d", cacheHashKey(longUserID), cacheHashKey("up"), daysSinceEpoch, 1),
+			expected: fmt.Sprintf("QS:%s:%s:%d:%d", hashCacheKey(longUserID), hashCacheKey("up"), daysSinceEpoch, 1),
 		},
 	}
 
@@ -99,7 +99,7 @@ func Test_cardinalityEstimation_lookupCardinalityForKey(t *testing.T) {
 	ctx := context.Background()
 	c := cache.NewInstrumentedMockCache()
 
-	actualKey := fmt.Sprintf("QS:tenant-a:%s:1234:4321", cacheHashKey("up"))
+	actualKey := fmt.Sprintf("QS:tenant-a:%s:1234:4321", hashCacheKey("up"))
 	userID := "tenant-a"
 	actualValue := uint64(25)
 

--- a/pkg/frontend/querymiddleware/error_caching.go
+++ b/pkg/frontend/querymiddleware/error_caching.go
@@ -88,7 +88,7 @@ func (e *errorCachingHandler) Do(ctx context.Context, request MetricsQueryReques
 
 	addWithExemplar(ctx, e.cacheLoadAttempted, 1)
 	key := e.keyGen.QueryRequestError(ctx, tenant.JoinTenantIDs(tenantIDs), request)
-	hashedKey := cacheHashKey(key)
+	hashedKey := hashCacheKey(key)
 
 	if cachedErr := e.loadErrorFromCache(ctx, key, hashedKey, spanLog); cachedErr != nil {
 		e.cacheLoadHits.Inc()

--- a/pkg/frontend/querymiddleware/error_caching_test.go
+++ b/pkg/frontend/querymiddleware/error_caching_test.go
@@ -108,7 +108,7 @@ func TestErrorCachingHandler_Do(t *testing.T) {
 				})
 				require.NoError(t, err)
 
-				require.NoError(t, c.Set(ctx, cacheHashKey(key), bytes, time.Minute))
+				require.NoError(t, c.Set(ctx, hashCacheKey(key), bytes, time.Minute))
 
 				res, err := runHandler(ctx, inner, c, req)
 
@@ -136,7 +136,7 @@ func TestErrorCachingHandler_Do(t *testing.T) {
 				})
 				require.NoError(t, err)
 
-				require.NoError(t, c.Set(ctx, cacheHashKey(key), bytes, time.Minute))
+				require.NoError(t, c.Set(ctx, hashCacheKey(key), bytes, time.Minute))
 
 				res, err := runHandler(ctx, inner, c, req)
 
@@ -158,7 +158,7 @@ func TestErrorCachingHandler_Do(t *testing.T) {
 
 				key := keyGen.QueryRequestError(ctx, "1234", req)
 				bytes := []byte{0x0, 0x0, 0x0, 0x0}
-				require.NoError(t, c.Set(ctx, cacheHashKey(key), bytes, time.Minute))
+				require.NoError(t, c.Set(ctx, hashCacheKey(key), bytes, time.Minute))
 
 				res, err := runHandler(ctx, inner, c, req)
 

--- a/pkg/frontend/querymiddleware/generic_query_cache.go
+++ b/pkg/frontend/querymiddleware/generic_query_cache.go
@@ -182,7 +182,7 @@ func (c *genericQueryCache) recordCacheStoreQueryDetails(ctx context.Context, to
 
 func generateGenericQueryRequestCacheKey(tenantIDs []string, req *GenericQueryCacheKey) (cacheKey, hashedCacheKey string) {
 	cacheKey = fmt.Sprintf("%s:%s", tenant.JoinTenantIDs(tenantIDs), req.CacheKey)
-	hashedCacheKey = fmt.Sprintf("%s%s", req.CacheKeyPrefix, cacheHashKey(cacheKey))
+	hashedCacheKey = fmt.Sprintf("%s%s", req.CacheKeyPrefix, hashCacheKey(cacheKey))
 	return
 }
 

--- a/pkg/frontend/querymiddleware/labels_query_cache_test.go
+++ b/pkg/frontend/querymiddleware/labels_query_cache_test.go
@@ -22,13 +22,13 @@ func TestLabelsQueryCache_RoundTrip(t *testing.T) {
 			reqPath:        "/prometheus/api/v1/labels",
 			reqData:        url.Values{"start": []string{"2023-07-05T01:00:00Z"}, "end": []string{"2023-07-05T08:00:00Z"}, "match[]": []string{`{job="test_1"}`, `{job!="test_2"}`}},
 			cacheKey:       "user-1:1688515200000\x001688544000000\x00{job!=\"test_2\"},{job=\"test_1\"}",
-			hashedCacheKey: labelNamesQueryCachePrefix + cacheHashKey("user-1:1688515200000\x001688544000000\x00{job!=\"test_2\"},{job=\"test_1\"}"),
+			hashedCacheKey: labelNamesQueryCachePrefix + hashCacheKey("user-1:1688515200000\x001688544000000\x00{job!=\"test_2\"},{job=\"test_1\"}"),
 		},
 		"label values request": {
 			reqPath:        "/prometheus/api/v1/label/test/values",
 			reqData:        url.Values{"start": []string{"2023-07-05T01:00:00Z"}, "end": []string{"2023-07-05T08:00:00Z"}, "match[]": []string{`{job="test_1"}`, `{job!="test_2"}`}},
 			cacheKey:       "user-1:1688515200000\x001688544000000\x00test\x00{job!=\"test_2\"},{job=\"test_1\"}",
-			hashedCacheKey: labelValuesQueryCachePrefix + cacheHashKey("user-1:1688515200000\x001688544000000\x00test\x00{job!=\"test_2\"},{job=\"test_1\"}"),
+			hashedCacheKey: labelValuesQueryCachePrefix + hashCacheKey("user-1:1688515200000\x001688544000000\x00test\x00{job!=\"test_2\"},{job=\"test_1\"}"),
 		},
 	})
 }

--- a/pkg/frontend/querymiddleware/results_cache.go
+++ b/pkg/frontend/querymiddleware/results_cache.go
@@ -653,8 +653,8 @@ func (e *Extent) toResponse() (Response, error) {
 	return resp, nil
 }
 
-// cacheHashKey hashes key into something you can store in the results cache.
-func cacheHashKey(key string) string {
+// hashCacheKey hashes key into something you can store in the results cache.
+func hashCacheKey(key string) string {
 	hasher := fnv.New64a()
 	_, _ = hasher.Write([]byte(key)) // This'll never error.
 

--- a/pkg/frontend/querymiddleware/split_and_cache.go
+++ b/pkg/frontend/querymiddleware/split_and_cache.go
@@ -347,7 +347,7 @@ func (s *splitAndCacheMiddleware) fetchCacheExtents(ctx context.Context, now tim
 	hashedKeys := make([]string, 0, len(keys))
 	hashedKeysIdx := make(map[string]int, len(keys))
 	for idx, key := range keys {
-		hashed := cacheHashKey(key)
+		hashed := hashCacheKey(key)
 		hashedKeys = append(hashedKeys, hashed)
 		hashedKeysIdx[hashed] = idx
 
@@ -459,7 +459,7 @@ func (s *splitAndCacheMiddleware) storeCacheExtents(key string, tenantIDs []stri
 		return
 	}
 
-	s.cache.SetMultiAsync(map[string][]byte{cacheHashKey(key): buf}, usedTTL)
+	s.cache.SetMultiAsync(map[string][]byte{hashCacheKey(key): buf}, usedTTL)
 }
 
 func getTTLForExtent(now time.Time, ttl, ttlInOOOWindow, oooWindow time.Duration, e Extent) time.Duration {

--- a/pkg/frontend/querymiddleware/split_and_cache_test.go
+++ b/pkg/frontend/querymiddleware/split_and_cache_test.go
@@ -850,7 +850,7 @@ func TestSplitAndCacheMiddleware_ResultsCache_ShouldNotCacheRequestEarlierThanMa
 			require.Equal(t, testData.downstreamResponse, prometheusResponse)
 
 			// Check if the response was cached.
-			cacheKey := cacheHashKey(keyGenerator.QueryRequest(ctx, userID, req))
+			cacheKey := hashCacheKey(keyGenerator.QueryRequest(ctx, userID, req))
 			found := cacheBackend.GetMulti(ctx, []string{cacheKey})
 
 			if len(testData.expectedCachedResponses) == 0 {
@@ -1408,7 +1408,7 @@ func TestSplitAndCacheMiddleware_StoreAndFetchCacheExtents(t *testing.T) {
 		// Simulate an hash collision on "key-1".
 		buf, err := proto.Marshal(&CachedResponse{Key: "another", Extents: []Extent{mkExtent(10, 20)}})
 		require.NoError(t, err)
-		cacheBackend.SetMultiAsync(map[string][]byte{cacheHashKey("key-1"): buf}, 0)
+		cacheBackend.SetMultiAsync(map[string][]byte{hashCacheKey("key-1"): buf}, 0)
 
 		mw.storeCacheExtents("key-3", []string{"tenant"}, []Extent{mkExtent(20, 30), mkExtent(40, 50)})
 
@@ -2087,7 +2087,7 @@ func TestSplitAndCacheMiddlewareLowerTTL(t *testing.T) {
 		})
 
 		// Check.
-		key = cacheHashKey(key)
+		key = hashCacheKey(key)
 		ci := mcache.GetItems()[key]
 		actualTTL := time.Until(ci.ExpiresAt)
 		// We use a tolerance of 50ms to avoid flaky tests.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
From https://github.com/grafana/mimir/pull/13472#discussion_r2790680980

Renaming the `cacheHashKey()` function to `hashCacheKey()`. This makes the intent of the function clearer - we are hashing the cache key, rather than caching a hash key.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure rename with no behavioral changes; risk is limited to missed call sites or build/test failures if any references remain.
> 
> **Overview**
> Renames the results-cache key hashing helper from `cacheHashKey()` to `hashCacheKey()` to clarify intent.
> 
> Updates all call sites across query middleware (cardinality estimation keys, generic/cardinality/labels query caches, split-and-cache extents, and error caching) plus unit tests to use the new function name; hashing algorithm and cache key formats remain unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 063f26aaab70f1f21045b1505ba41589837b8efa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->