### PR TITLE
fix(frontend/grpc): set content length correctly

### DIFF
--- a/pkg/util/httpgrpcutil/grpc_roundtripper.go
+++ b/pkg/util/httpgrpcutil/grpc_roundtripper.go
@@ -114,7 +114,7 @@ func setContentLength(resp *httpgrpc.HTTPResponse, httpResp *http.Response) {
 		contentLength = len(resp.Body)
 	} else if l := httpResp.Header.Get("Content-Length"); l != "" {
 		cl, err := strconv.Atoi(l)
-		if err == nil {
+		if err == nil && cl >= 0 {
 			contentLength = cl
 		}
 	}

--- a/pkg/util/httpgrpcutil/grpc_roundtripper_test.go
+++ b/pkg/util/httpgrpcutil/grpc_roundtripper_test.go
@@ -37,6 +37,11 @@ func TestSetContentLength(t *testing.T) {
 			responseHeaders:    []*httpgrpc.Header{{Key: "Content-Length", Values: []string{"not-a-number"}}},
 			expectedContentLen: -1,
 		},
+		"empty gRPC body with negative Content-Length header falls back to -1": {
+			grpcBody:           nil,
+			responseHeaders:    []*httpgrpc.Header{{Key: "Content-Length", Values: []string{"-1000"}}},
+			expectedContentLen: -1,
+		},
 		"empty gRPC body with no Content-Length header falls back to -1": {
 			grpcBody:           nil,
 			expectedContentLen: -1,


### PR DESCRIPTION
In the frontend's query middleware, we pre-allocate a buffer to avoid
extra allocations. This is based on the ContentLength header:

```go
// pkg/frontend/querymiddleware/codec.go
func readResponseBody(res *http.Response) ([]byte, error) {
  // ... snip ...

  // Preallocate the buffer with the exact size so we don't waste allocations
  // while progressively growing an initial small buffer. The buffer capacity
  // is increased by MinRead to avoid extra allocations due to how ReadFrom()
  // internally works.
  buf := bytes.NewBuffer(make([]byte, 0, res.ContentLength+bytes.MinRead))
  if _, err := buf.ReadFrom(res.Body); err != nil {
    return nil, apierror.Newf(apierror.TypeInternal, "error decoding response with status %d: %v", res.StatusCode, err)
  }
  return buf.Bytes(), nil
}
```

This field is set by the frontend roundtripper, which in turn calls
`setContentLength`. When the content length is valid, it is wiped (i.e.
set to `-1`) instead of being set correctly; when it is invalid, it is
set to whatever `Atoi` returns, which is `0` for most cases (int max for
overflowing numbers).

As such, we don't gain anything from the buffer pre-allocation as it
stands right now. This commit fixes the issue by setting the content
length properly when it is a valid number.

```
       (*pkg/frontend/transport.Handler).ServeHTTP                                                                                                                                                    
                                                                                                                                                                                                      
          ...                                                                                                                                                                                         
          startTime := time.Now()                                                                                                                                                                     
┌─────────resp, err := f.roundTripper.RoundTrip(r)                                                                                                                                                    
│         queryResponseTime := time.Since(startTime)                                                                                                                                                  
│                                                                                                                                                                                                     
│                                                                                                                                                                                                     
│                                                                                                                                                                                                     
└─────►(pkg/frontend/querymiddleware.limitedParallelismRoundTripper).RoundTrip                                                                                                                        
                                                                                                                                                                                                      
          ...                                                                                                                                                                                         
          response, err := rt.middleware.Wrap(                                                                                                                                                        
            HandlerFunc(func(ctx context.Context, r MetricsQueryRequest) (Response, error) {                                                                                                          
              ...                                                                                                                                                                                     
┌───────────})).Do(ctx, request)                                                                                                                                                                      
│                                                                                                                                                                                                     
│                                                                                                                                                                                                     
└─────►(pkg/frontend/querymiddleware.httpQueryRequestRoundTripperHandler).Do              ┌────►(pkg/frontend/querymiddleware.Codec).DecodeMetricsQueryResponse                                       
                                                                                          │                                                                                                           
          ...                                                                             │        ...                                                                                                
           request, err := rth.codec.EncodeMetricsQueryRequest(ctx, r)                    │   ┌────buf, err := readResponseBody(r)                                                                    
           if err != nil {                                                                │   │                                                                                                       
            return nil, err                                                               │   └►pkg/frontend/querymiddleware.readResponseBody                                                         
           }                                                                              │      ▲                                                                                                    
                                                                                          │      │ ...                                                                                                
 ┌──────── response, err := rth.next.RoundTrip(request)                                   │      │ buf := bytes.NewBuffer(make([]byte, 0, res.ContentLength+bytes.MinRead))                           
 │         if err != nil {                                                                │      │                                        ────────────────────────────────                            
 │          return nil, err                                                               │      │                                                  ▲                                                 
 │         }                                                                              │      │                                                  │                                                 
 │         defer func() { _ = response.Body.Close() }()                                   │      │                                        BUG: -1+512 == 511. Doesn't pre-allocate as intended        
 │                                                                                        │      │                                                                                                    
 │         return rth.codec.DecodeMetricsQueryResponse(ctx, response, r, rth.logger)──────┘      └─────────────────────────────────────────────────┐                                                  
 │                                                                                                                                                 │                                                  
 │                                                                                                                                                 │                                                  
 └────►(*pkg/util/httpgrpcutil.grpcRoundTripperAdapter).RoundTrip                    ┌─────────►(*pkg/frontend/v2.Frontend).RoundTripGRPC          │                                                  
                                                                                     │                                                             │                                                  
           ...                                                                       │              ...                                            │                                                  
           resp, body, err := a.roundTripper.RoundTripGRPC(r.Context(), req)─────────┘              case resp := <-freq.httpResponse:              │                                                  
           ...                                                                                      ...                                            │                                                  
                                                                                                    body := &cleanupReadCloser{cleanup: cleanup}◄──NOTE: (*cleanupReadCloser).Bytes() doesn't exist   
           httpResp := &http.Response{                                                              if resp.bodyStream != nil {                    This makes fast-path be ignored in readResponseBody
            StatusCode: int(resp.Code),                                                              body.rc = resp.bodyStream                                                                        
            Body:       respBody,                                                                   } else {                                                                                          
            Header:     http.Header{},                                                               body.rc = io.NopCloser(bytes.NewReader(resp.queryResult.HttpResponse.Body))                      
           }                                                                                        }                                                                                                 
           httpgrpc.ToHeader(resp.Headers, httpResp.Header)                                         return resp.queryResult.HttpResponse, body, nil                                                   
  ┌────────setContentLength(resp, httpResp)                                                                                                                                                           
  │                                                                                                                                                                                                   
  └───►pkg/util/httpgrpcutil.setContentLength                                                                                                                                                         
                                                                                                                                                                                                      
           ...                                                                                                                                                                                        
           func setContentLength(resp *httpgrpc.HTTPResponse, httpResp *http.Response) {                                                                                                              
            contentLength := -1                                                                                                                                                                       
            if len(resp.Body) > 0 {                                                                                                                                                                   
             contentLength = len(resp.Body)                                                                                                                                                           
            } else if l := httpResp.Header.Get("Content-Length"); l != "" {                                                                                                                           
             cl, err := strconv.Atoi(l)                                                                                                                                                               
             if err != nil {                                                                                                                                                                          
              contentLength = cl ◄───────── BUG: Sets to -1 for valid, and 0 OR MAX for invalid.                                                                                                      
             }                                                                                                                                                                                        
            }                                                                                                                                                                                         
            httpResp.ContentLength = int64(contentLength)                                                                                                                                             
           }                                                                                                                                                                                          
```

This bug was identified by LLM-driven vulnerability detection. There is no
attack vector here, as it only amounts to the service not performing as well as
it was intended to in this specific (gRPC streaming only?) instance. As such,
this is not a vulnerability.

(No, the ASCII graph was not generated... unfortunately... that took quite
some time.)

#### Checklist

- [x] Tests updated.
- [N/A] Documentation added.
- [N/A] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [N/A] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized bugfix in response metadata handling with straightforward test coverage; low risk aside from potential behavior change for callers relying on the previous incorrect `ContentLength`.
> 
> **Overview**
> Fixes `setContentLength` in `grpc_roundtripper.go` to only apply the `Content-Length` header when it parses successfully and is non-negative, otherwise leaving `http.Response.ContentLength` at `-1`.
> 
> Adds unit tests covering body-length precedence and header parsing edge cases (valid, zero, invalid, negative, missing).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5dc8ef906af48b765b4ae5f77507b60db2060e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->