### PR TITLE
Simplify type of StrongConsistencyInstrumentation

### DIFF
--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -897,7 +897,7 @@ func (r *PartitionReader) WaitReadConsistencyUntilOffset(ctx context.Context, of
 }
 
 func (r *PartitionReader) waitReadConsistency(ctx context.Context, withOffset bool, getOffset func(context.Context) (int64, error)) error {
-	_, err := r.metrics.strongConsistencyInstrumentation.Observe(r.kafkaCfg.Topic, withOffset, func() (struct{}, error) {
+	_, err := ObserveStrongReadConsistency(r.metrics.strongConsistencyMetrics, r.kafkaCfg.Topic, withOffset, func() (struct{}, error) {
 		spanLog := spanlogger.FromContext(ctx, r.logger)
 		spanLog.DebugLog("msg", "waiting for read consistency")
 
@@ -1137,7 +1137,7 @@ type ReaderMetrics struct {
 	fetchWaitDuration                  prometheus.Histogram
 	fetchMaxBytes                      prometheus.Histogram
 	fetchedDiscardedRecordBytes        prometheus.Counter
-	strongConsistencyInstrumentation   *StrongReadConsistencyInstrumentation[struct{}]
+	strongConsistencyMetrics           *StrongReadConsistencyMetrics
 	lastConsumedOffset                 *prometheus.GaugeVec
 	consumeLatency                     prometheus.Histogram
 	kprom                              *kprom.Metrics
@@ -1228,9 +1228,9 @@ func NewReaderMetrics(reg prometheus.Registerer, metricsSource ReaderMetricsSour
 			Help:                        "How long a consumer spent processing a batch of records from Kafka. This includes retries on server errors.",
 			NativeHistogramBucketFactor: 1.1,
 		}),
-		strongConsistencyInstrumentation: NewStrongReadConsistencyInstrumentation[struct{}](component, reg, []string{topic}),
-		lastConsumedOffset:               lastConsumedOffset,
-		kprom:                            kpromMetrics,
+		strongConsistencyMetrics: NewStrongReadConsistencyMetrics(reg, component, []string{topic}),
+		lastConsumedOffset:       lastConsumedOffset,
+		kprom:                    kpromMetrics,
 		missedRecords: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "cortex_ingest_storage_reader_missed_records_total",
 			Help: "The number of offsets that were never consumed by the reader because they weren't fetched.",
@@ -1244,14 +1244,14 @@ func NewReaderMetrics(reg prometheus.Registerer, metricsSource ReaderMetricsSour
 	return m
 }
 
-type StrongReadConsistencyInstrumentation[T any] struct {
+type StrongReadConsistencyMetrics struct {
 	requests *prometheus.CounterVec
 	failures *prometheus.CounterVec
 	latency  *prometheus.HistogramVec
 }
 
-func NewStrongReadConsistencyInstrumentation[T any](component string, reg prometheus.Registerer, topics []string) *StrongReadConsistencyInstrumentation[T] {
-	i := &StrongReadConsistencyInstrumentation[T]{
+func NewStrongReadConsistencyMetrics(reg prometheus.Registerer, component string, topics []string) *StrongReadConsistencyMetrics {
+	m := &StrongReadConsistencyMetrics{
 		requests: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name:        "cortex_ingest_storage_strong_consistency_requests_total",
 			Help:        "Total number of requests for which strong consistency has been requested. The metric distinguishes between requests with an offset specified and requests requesting to enforce strong consistency up until the last produced offset.",
@@ -1276,18 +1276,18 @@ func NewStrongReadConsistencyInstrumentation[T any](component string, reg promet
 	// Init metrics.
 	for _, topic := range topics {
 		for _, value := range []bool{true, false} {
-			i.requests.WithLabelValues(strconv.FormatBool(value), topic)
+			m.requests.WithLabelValues(strconv.FormatBool(value), topic)
 		}
-		i.failures.WithLabelValues(topic)
-		i.latency.WithLabelValues(topic)
+		m.failures.WithLabelValues(topic)
+		m.latency.WithLabelValues(topic)
 	}
 
-	return i
+	return m
 }
 
-func (i *StrongReadConsistencyInstrumentation[T]) Observe(topic string, withOffset bool, f func() (T, error)) (_ T, returnErr error) {
+func ObserveStrongReadConsistency[T any](m *StrongReadConsistencyMetrics, topic string, withOffset bool, f func() (T, error)) (_ T, returnErr error) {
 	startTime := time.Now()
-	i.requests.WithLabelValues(strconv.FormatBool(withOffset), topic).Inc()
+	m.requests.WithLabelValues(strconv.FormatBool(withOffset), topic).Inc()
 
 	defer func() {
 		// Do not track failure or latency if the request was canceled (because the tracking would be incorrect).
@@ -1297,10 +1297,10 @@ func (i *StrongReadConsistencyInstrumentation[T]) Observe(topic string, withOffs
 
 		// Track latency for failures too, so that we have a better measurement of latency if
 		// backend latency is high and requests fail because of timeouts.
-		i.latency.WithLabelValues(topic).Observe(time.Since(startTime).Seconds())
+		m.latency.WithLabelValues(topic).Observe(time.Since(startTime).Seconds())
 
 		if returnErr != nil {
-			i.failures.WithLabelValues(topic).Inc()
+			m.failures.WithLabelValues(topic).Inc()
 		}
 	}()
 


### PR DESCRIPTION
#### What this PR does

This piece addresses a small annoyance, that bugged me for a while. I find the type of the `ingest.NewStrongReadConsistencyInstrumentation` struct unnecessarily complicated. Today it's generic over some T, even though there is nothing in the type itself that requires `T`.

The generic in the type was added to overcome the lack of support for generic methods in Go (https://github.com/golang/go/issues/77273). That is the `StrongReadConsistencyInstrumentation[T].Observe()` method accepts a callback, that returns `T`, while the observer tracks the metrics around the callback.

This PR simplifies the code, by splitting the `Observe` into a stand-alone generic function, that accepts a `StrongReadConsistencyMetrics` struct and a callback. This allows to simplify all pieces of code, that instantiate the metrics. Functionally, the code behaves as it used to.