### PR TITLE
Always include suffix when amplifying

### DIFF
--- a/tools/writetee/amplification_test.go
+++ b/tools/writetee/amplification_test.go
@@ -64,23 +64,20 @@ func TestSampleWriteRequest_RW2(t *testing.T) {
 
 // TestAmplifyRequestBody_RW2 tests amplifying RW2 request bodies.
 func TestAmplifyRequestBody_RW2(t *testing.T) {
-	t.Run("replica 1 returns original (no suffix)", func(t *testing.T) {
+	t.Run("rejects startSuffix < 1", func(t *testing.T) {
 		req := makeRW2RequestWithLabels(1)
 		compressed := compressRequest(t, &req)
 
-		suffixed, err := AmplifyRequestBody(compressed, 1, 1)
-		require.NoError(t, err)
-		require.Len(t, suffixed, 1)
-
-		// Should be identical to input
-		assert.Equal(t, compressed, suffixed[0])
+		_, err := AmplifyRequestBody(compressed, 1, 0)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "startSuffix must be >= 1")
 	})
 
 	t.Run("replica 2 suffixes all label values", func(t *testing.T) {
 		req := makeRW2RequestWithLabels(1)
 		compressed := compressRequest(t, &req)
 
-		suffixed, err := AmplifyRequestBody(compressed, 2, 2)
+		suffixed, err := AmplifyRequestBody(compressed, 1, 2)
 		require.NoError(t, err)
 		require.Len(t, suffixed, 1)
 
@@ -101,7 +98,7 @@ func TestAmplifyRequestBody_RW2(t *testing.T) {
 		req := makeRW2RequestWithLabels(1)
 		compressed := compressRequest(t, &req)
 
-		suffixed, err := AmplifyRequestBody(compressed, 3, 3)
+		suffixed, err := AmplifyRequestBody(compressed, 1, 3)
 		require.NoError(t, err)
 		require.Len(t, suffixed, 1)
 
@@ -118,7 +115,7 @@ func TestAmplifyRequestBody_RW2(t *testing.T) {
 		req := makeRW2RequestWithoutName(1)
 		compressed := compressRequest(t, &req)
 
-		suffixed, err := AmplifyRequestBody(compressed, 2, 2)
+		suffixed, err := AmplifyRequestBody(compressed, 1, 2)
 		require.NoError(t, err)
 		require.Len(t, suffixed, 1)
 
@@ -168,23 +165,20 @@ func TestSampleWriteRequest_RW1(t *testing.T) {
 
 // TestAmplifyRequestBody_RW1 tests amplifying RW1 request bodies.
 func TestAmplifyRequestBody_RW1(t *testing.T) {
-	t.Run("replica 1 returns original (no suffix)", func(t *testing.T) {
+	t.Run("rejects startSuffix < 1", func(t *testing.T) {
 		req := makeRW1RequestWithLabels(1)
 		compressed := compressRequest(t, &req)
 
-		suffixed, err := AmplifyRequestBody(compressed, 1, 1)
-		require.NoError(t, err)
-		require.Len(t, suffixed, 1)
-
-		// Should be identical to input
-		assert.Equal(t, compressed, suffixed[0])
+		_, err := AmplifyRequestBody(compressed, 1, 0)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "startSuffix must be >= 1")
 	})
 
 	t.Run("replica 2 suffixes all label values", func(t *testing.T) {
 		req := makeRW1RequestWithLabels(1)
 		compressed := compressRequest(t, &req)
 
-		suffixed, err := AmplifyRequestBody(compressed, 2, 2)
+		suffixed, err := AmplifyRequestBody(compressed, 1, 2)
 		require.NoError(t, err)
 		require.Len(t, suffixed, 1)
 
@@ -201,7 +195,7 @@ func TestAmplifyRequestBody_RW1(t *testing.T) {
 		req := makeRW1RequestWithLabels(1)
 		compressed := compressRequest(t, &req)
 
-		suffixed, err := AmplifyRequestBody(compressed, 3, 3)
+		suffixed, err := AmplifyRequestBody(compressed, 1, 3)
 		require.NoError(t, err)
 		require.Len(t, suffixed, 1)
 
@@ -218,7 +212,7 @@ func TestAmplifyRequestBody_RW1(t *testing.T) {
 		req := makeRW1RequestWithoutName(1)
 		compressed := compressRequest(t, &req)
 
-		suffixed, err := AmplifyRequestBody(compressed, 2, 2)
+		suffixed, err := AmplifyRequestBody(compressed, 1, 2)
 		require.NoError(t, err)
 		require.Len(t, suffixed, 1)
 

--- a/tools/writetee/proxy_endpoint.go
+++ b/tools/writetee/proxy_endpoint.go
@@ -283,8 +283,9 @@ func (p *ProxyEndpoint) prepareAmplifiedBodies(body []byte, backend ProxyBackend
 	fullCopies := int(p.amplificationFactor)
 	fractionalPart := p.amplificationFactor - float64(fullCopies)
 
-	// Create replicas 1 through fullCopies
-	replicaBodies, err := AmplifyRequestBody(body, 1, fullCopies)
+	// Create replicas 2 through fullCopies+1 (starting at 2 so all copies have a suffix,
+	// avoiding a series clash with the unsuffixed mirrored/preferred endpoint)
+	replicaBodies, err := AmplifyRequestBody(body, fullCopies, 1)
 	if err != nil {
 		level.Error(logger).Log("msg", "Failed to create amplified replicas", "backend", backend.Name(), "err", err)
 		return [][]byte{body} // Fall back to original
@@ -299,8 +300,7 @@ func (p *ProxyEndpoint) prepareAmplifiedBodies(body []byte, backend ProxyBackend
 		if err != nil {
 			level.Error(logger).Log("msg", "Failed to create fractional request", "backend", backend.Name(), "err", err)
 		} else {
-			// Create replica fullCopies+1 from the sampled data
-			fractionalBodies, err := AmplifyRequestBody(result.Body, fullCopies+1, fullCopies+1)
+			fractionalBodies, err := AmplifyRequestBody(result.Body, 1, fullCopies+1)
 			if err != nil {
 				level.Error(logger).Log("msg", "Failed to suffix fractional request", "backend", backend.Name(), "err", err)
 			} else {

--- a/tools/writetee/proxy_test.go
+++ b/tools/writetee/proxy_test.go
@@ -556,10 +556,10 @@ func TestPrepareAmplifiedBodies(t *testing.T) {
 
 			assert.Equal(t, tt.expectedBodies, len(bodies), "expected %d bodies, got %d", tt.expectedBodies, len(bodies))
 
-			// For amplification > 1, verify bodies are different (except first which is original)
+			// For amplification > 1, verify all bodies have suffixes (none should equal the original)
 			if tt.amplifyFactor > 1.0 && tt.backendType == BackendTypeAmplified && len(bodies) > 1 {
-				for i := 1; i < len(bodies); i++ {
-					assert.NotEqual(t, bodies[0], bodies[i], "body %d should differ from original due to label suffixes", i)
+				for i := 0; i < len(bodies); i++ {
+					assert.NotEqual(t, body, bodies[i], "body %d should differ from original - all amplified copies must have a label suffix to avoid clashing with the mirrored endpoint", i)
 				}
 			}
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

- Updates the write-tee to always include a suffix when amplifying requests. This will allow them to not collide with mirror'ed requests in the same cluster.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request-body generation for amplified backends, which can affect cardinality and duplication semantics; failures could cause data collisions or unexpected series fan-out despite being covered by updated unit tests.
> 
> **Overview**
> Write-tee amplification now **always applies `_ampN` suffixes** to every amplified request copy (RW1 and RW2), instead of emitting an unsuffixed “replica 1” body.
> 
> `AmplifyRequestBody` is refactored to generate a configurable number of suffixed copies (`count` + `startSuffix`) and `prepareAmplifiedBodies` is updated to start amplified replicas at suffix `2` (and to suffix the fractional sampled body with the next suffix). Tests are updated to validate the new API and to assert that *no amplified body equals the original*.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa672842e2b201d16e5e33f760657e246f9287f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->