### PR TITLE
MQE: don't disable "eliminate deduplicate and merge" optimisation pass when running upstream tests

### DIFF
--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -196,8 +196,6 @@ func TestNewInstantQuery_Strings(t *testing.T) {
 // Once the streaming engine supports all PromQL features exercised by Prometheus' test cases, we can remove these files and instead call promql.RunBuiltinTests here instead.
 func TestUpstreamTestCases(t *testing.T) {
 	opts := NewTestEngineOpts()
-	// Disable the optimization pass, since it requires delayed name removal to be enabled.
-	opts.EnableEliminateDeduplicateAndMerge = false
 	limits := NewStaticQueryLimitsProvider()
 	limits.EnableDelayedNameRemoval = true
 	opts.Limits = limits


### PR DESCRIPTION
#### What this PR does

Disabling this optimisation pass is not necessary, the tests pass with the optimisation pass enabled.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that alters the optimization configuration used during upstream fixture runs; main risk is exposing latent test flakiness or planner edge cases, not production behavior.
> 
> **Overview**
> Stops forcing `EnableEliminateDeduplicateAndMerge` off in `TestUpstreamTestCases`, so upstream PromQL `.test` fixtures now run with this query-plan optimization enabled (while still enabling delayed name removal via limits).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ec14375271f5479867bb415a4806b54249ab750. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->