### PR TITLE
Add myself to Maintainers and Team

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -74,6 +74,7 @@ The current team members are:
 - Miguel Ángel Ortuño [@ortuman](https://github.com/ortuman) ([Grafana Labs](https://grafana.com/))
 - Nick Pillitteri — [@56quarters](https://github.com/56quarters) ([Grafana Labs](https://grafana.com/))
 - Oleg Zaytsev — [@colega](https://github.com/colega) ([Grafana Labs](https://grafana.com/))
+- Oliver Herrmann - [@monoxane](https://github.com/monoxane) ([Grafana Labs](https://grafana.com/))
 - Patrick Oyarzun - [@Logiraptor](https://github.com/Logiraptor) ([Grafana Labs](https://grafana.com/))
 - Patryk Prus [@pr00se](https://github.com/pr00se) ([Grafana Labs](https://grafana.com/))
 - Peter Štibraný — [@pstibrany](https://github.com/pstibrany) ([Grafana Labs](https://grafana.com/))

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -28,6 +28,7 @@ The following are the main/default maintainers:
 - Miguel Ángel Ortuño [@ortuman](https://github.com/ortuman) ([Grafana Labs](https://grafana.com/))
 - Nick Pillitteri — [@56quarters](https://github.com/56quarters) ([Grafana Labs](https://grafana.com/))
 - Oleg Zaytsev — [@colega](https://github.com/colega) ([Grafana Labs](https://grafana.com/))
+- Oliver Herrmann - [@monoxane](https://github.com/monoxane) ([Grafana Labs](https://grafana.com/))
 - Patrick Oyarzun - [@Logiraptor](https://github.com/Logiraptor) ([Grafana Labs](https://grafana.com/))
 - Patryk Prus [@pr00se](https://github.com/pr00se) ([Grafana Labs](https://grafana.com/))
 - Peter Štibraný — [@pstibrany](https://github.com/pstibrany) ([Grafana Labs](https://grafana.com/))


### PR DESCRIPTION
#### What this PR does
This PR adds myself to Maintainers and Team as I have now joined the Grafana Cloud Hosted Metrics On-Call rotation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update to maintainer/team rosters with no runtime or behavioral impact.
> 
> **Overview**
> Adds Oliver Herrmann ([@monoxane](https://github.com/monoxane)) to the *current team members* list in `GOVERNANCE.md` and to the *main/default maintainers* list in `MAINTAINERS.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd68cc668130be37eda906315dcfee5cd23b4b02. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->