### PR TITLE
fix(docs): native histograms and OTLP are both GA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -293,6 +293,7 @@
 * [ENHANCEMENT] Document how ingesters calculate partition ID from ring's instance ID in ingest storage. #13903
 * [ENHANCEMENT] Add AWS profile authentication example to `mark-blocks` tool documentation and add centralized section in runbooks with examples for all cloud providers. #14281
 * [BUGFIX] Distributor: Fix type error in multi-zone distributor container constructor's env map. #14403
+* [BUGFIX] OTLP: Exponential histograms over OTLP are not experimental. #14437
 
 ### Tools
 

--- a/docs/sources/mimir/send/otel-exponential-histograms/_index.md
+++ b/docs/sources/mimir/send/otel-exponential-histograms/_index.md
@@ -12,10 +12,6 @@ weight: 200
 
 # Send OpenTelemetry exponential histograms to Mimir
 
-{{% admonition type="note" %}}
-Sending OpenTelemetry exponential histograms is an experimental feature of Grafana Mimir.
-{{% /admonition %}}
-
 You can collect and send exponential histograms to Mimir with the OpenTelemetry Collector. OpenTelemetry [exponential histograms](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#exponentialhistogram) are compatible with Prometheus native histograms. The key difference is that exponential histograms store the `min` and `max` observation values explicitly, whereas native histograms don't. This means that for exponential histograms, you don't need to estimate these values using the 0.0 and 1.0 quantiles.
 
 The OpenTelemetry Collector supports collecting exponential histograms and other compatible data formats, including native histograms and Datadog sketches, through its receivers and sending them through its exporters.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Remove leftover experimental warning from old docs.

#### Which issue(s) this PR fixes or relates to

Fixes: N/A
Related: #7348 #11366 

#### Checklist

- [N/A] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [N/A] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change plus a changelog entry; no runtime or data-path behavior is modified.
> 
> **Overview**
> Removes the *experimental* warning from the `otel-exponential-histograms` documentation, reflecting that OTLP exponential histograms are GA.
> 
> Adds a corresponding `CHANGELOG.md` documentation bugfix entry noting that OTLP exponential histograms are not experimental.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b91df78547ae12d7137b338cf0cc9217fe30718. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->