### PR TITLE
feat(helm): add gateway api option for hosting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main / unreleased
 
+* [FEATURE] HTTPRoute: Add support k8s Gateway API HTTPRoute #14439
+
 ### Grafana Mimir
 
 * [CHANGE] Ingester: Changed default value of `-include-tenant-id-in-profile-labels` from false to true. #13375

--- a/operations/helm/charts/mimir-distributed/templates/gateway/gateway-httproute.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gateway/gateway-httproute.yaml
@@ -1,0 +1,59 @@
+{{- if .Values.gateway.httproute.enabled }}
+apiVersion: {{ .Values.gateway.httproute.apiVersion }}
+kind: {{ .Values.gateway.httproute.kind }}
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" . "component" "gateway") }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" . "component" "gateway") | nindent 4 }}
+    {{- with .Values.gateway.httproute.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.gateway.httproute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  {{- with .Values.gateway.httproute.parentRefs }}
+  parentRefs:
+    {{- range . }}
+    - name: {{ tpl .name $ }}
+      {{- if .namespace }}
+      namespace: {{ tpl .namespace $ }}
+      {{- end }}
+      {{- if .sectionName }}
+      sectionName: {{ tpl .sectionName $ }}
+      {{- end }}
+      {{- if .kind }}
+      kind: {{ .kind }}
+      {{- end }}
+      {{- if .group }}
+      group: {{ .group }}
+      {{- end }}
+      {{- if .port }}
+      port: {{ .port }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- with .Values.gateway.httproute.hostnames }}
+  hostnames:
+    {{- range . }}
+    - {{ tpl . $ | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - {{- if .Values.gateway.httproute.matches }}
+      matches:
+      {{- toYaml .Values.gateway.httproute.matches | nindent 8 }}
+      {{- end }}
+      {{- if .Values.gateway.httproute.filters }}
+      filters:
+      {{- toYaml .Values.gateway.httproute.filters | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ include "mimir.gateway.service.name" . }}
+          port: {{ .Values.gateway.service.port }}
+    {{- with .Values.gateway.httproute.additionalRules }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -3307,6 +3307,49 @@ gateway:
       # For OpenShift 4: https://docs.openshift.com/container-platform/4.11/networking/routes/secured-routes.html
       termination: edge
 
+  # -- Route configuration (Gateway API)
+  httproute:
+    # -- Enables or disables the route
+    enabled: false
+    # -- Set the route apiVersion, e.g. gateway.networking.k8s.io/v1
+    apiVersion: gateway.networking.k8s.io/v1
+    # -- Set the route kind
+    # Valid options are GRPCRoute, HTTPRoute, TCPRoute, TLSRoute, UDPRoute
+    kind: HTTPRoute
+    # -- Annotations for the gateway route
+    annotations: {}
+    # -- Labels for the gateway route
+    labels: {}
+    # -- The list of parent Gateways this route should be attached to, passed through the `tpl` function to allow templating
+    parentRefs: []
+      # - name: example-gateway
+      #   namespace: example-gateway-ns
+      #   sectionName: https
+    # -- Hostnames configuration for the gateway route, passed through the `tpl` function to allow templating
+    hostnames: []
+      # - gateway.mimir.example.com
+    # -- Matches define the predicates used for matching requests to a given action
+    matches:
+      - path:
+          type: PathPrefix
+          value: /
+    # -- Filters define the filters that are applied to requests that match this rule
+    filters: []
+      # - type: RequestHeaderModifier
+      #   requestHeaderModifier:
+      #     add:
+      #       - name: X-Custom-Header
+      #         value: custom-value
+    # -- Additional custom rules that can be added to the route
+    additionalRules: []
+      # - matches:
+      #     - path:
+      #         type: PathPrefix
+      #         value: /custom
+      #   backendRefs:
+      #     - name: custom-backend
+      #       port: 8080
+
   readinessProbe:
     httpGet:
       path: /ready


### PR DESCRIPTION
#### What this PR does

This PR adds full HTTPRoute support (Gateway API v1) to the Mimir Helm chart, providing a modern alternative to traditional Ingress resources for routing traffic to Mimir. 

HTTPRoute is the official successor to Ingress - it's part of the [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/) project, which graduated to GA (v1.0) in October 2023 and is now the [recommended standard](https://kubernetes.io/blog/2023/10/31/gateway-api-ga/) for ingress traffic management in Kubernetes.

The implementation follows similar patterns which have been followed in the `grafana` and `loki` charts. The only difference is that the configuration is under `httproute` as the `route` key in this chart was already used for OpenShift routes.

**Prior art:**
This PR is based on the work done by @lexfrei in this prior PR: https://github.com/grafana/loki/pull/19729

There was also a previous attempt in https://github.com/grafana/loki/pull/16799

#### Which issue(s) this PR fixes or relates to

(None - new feature)

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Helm-only, opt-in template/value additions with no changes to runtime components; risk is limited to users enabling the new `HTTPRoute` and misconfiguring routing.
> 
> **Overview**
> Adds an opt-in Kubernetes Gateway API `HTTPRoute` resource for the `mimir-distributed` Helm chart gateway, as an alternative to existing ingress/route options.
> 
> Introduces a new `gateway.httproute` values block (apiVersion/kind, parentRefs, hostnames, matches/filters, additional rules, labels/annotations) and a corresponding template that routes traffic to the gateway Service. Updates `CHANGELOG.md` with the new feature entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ebe4fef236bb277dd29ed5a6fdb898dfd6973107. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->