### PR TITLE
blockbuilder: explicitly pause internal consumption loop

### DIFF
--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -408,19 +408,22 @@ func (b *BlockBuilder) consumePartitionSection(
 			"last_consumed_offset", lastConsumedOffset, "num_blocks", len(blockMetas))
 	}(time.Now())
 
+	// With concurrent fetching enabled, the fetcher doesn't run the consumption through kafkaClient. Instead, it manually fetches from the partition.
+	// To stop kafkaClient from buffering any data, that no one will read, we pause fetching explicitly.
+	// We still want kafkaClient to get the partition's metadata, which is used inside our concurrent fetcher. Thus, we still do "AddConsumePartitions".
+	b.kafkaClient.PauseFetchPartitions(map[string][]int32{
+		b.cfg.Kafka.Topic: {partition},
+	})
 	b.kafkaClient.AddConsumePartitions(map[string]map[int32]kgo.Offset{
-		b.cfg.Kafka.Topic: {
-			partition: kgo.NewOffset().At(startOffset),
-		},
+		b.cfg.Kafka.Topic: {partition: kgo.NewOffset().At(startOffset)},
 	})
 	defer b.kafkaClient.RemoveConsumePartitions(map[string][]int32{b.cfg.Kafka.Topic: {partition}})
 
 	var fetchPoller fetchPoller = b.kafkaClient
-
 	if b.cfg.Kafka.FetchConcurrencyMax > 0 {
-		f, ferr := b.newFetchers(ctx, logger, partition, startOffset)
-		if ferr != nil {
-			return fmt.Errorf("creating concurrent fetcher: %w", ferr)
+		f, err := b.newFetchers(ctx, logger, partition, startOffset)
+		if err != nil {
+			return fmt.Errorf("creating concurrent fetcher: %w", err)
 		}
 
 		b.readerMetricsSource.set(f)
@@ -429,6 +432,9 @@ func (b *BlockBuilder) consumePartitionSection(
 		defer f.Stop()
 
 		fetchPoller = &fetchWrapper{f}
+	} else {
+		// Explicitly resume the consumption if the concurrent fetches isn't used.
+		b.kafkaClient.ResumeFetchPartitions(map[string][]int32{b.cfg.Kafka.Topic: {partition}})
 	}
 
 	level.Info(logger).Log("msg", "start consuming", "partition", partition, "start_offset", startOffset, "end_offset", endOffset)


### PR DESCRIPTION
#### What this PR does

This PR holds a small clean up of block-builder's internals. The changes explicitly pause consumption through the `kafkaClient`, when parallel fetcher is used. This is to align with how ingest-storage uses the fetcher (ref. https://github.com/grafana/mimir/blob/ae29de23395b55f08fdf25327476f705530f3225/pkg/storage/ingest/reader.go#L244-L265).