### PR TITLE
update ingest storage diagram for typo

### DIFF
--- a/docs/sources/mimir/get-started/about-grafana-mimir-architecture/about-ingest-storage-architecture/index.md
+++ b/docs/sources/mimir/get-started/about-grafana-mimir-architecture/about-ingest-storage-architecture/index.md
@@ -23,7 +23,7 @@ The following diagram shows how ingest storage architecture works:
 
 <div align="center">
 
-![Ingest storage architecture diagram](/media/docs/mimir/ingest-storage-overview.png)
+![Ingest storage architecture diagram](/media/docs/mimir/ingest-storage-overview2.png)
 
 </div>
 


### PR DESCRIPTION
This pull request updates the documentation for the ingest storage architecture diagram in the Mimir docs. The only change is replacing the existing diagram image with a new version to fix a typo.

* Updated the ingest storage architecture diagram to use a new image (`ingest-storage-overview2.png`) in `about-ingest-storage-architecture/index.md`.

Fixes https://github.com/grafana/mimir-squad/issues/3534

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change that swaps an image reference; no code or behavioral impact beyond ensuring the new asset exists and renders.
> 
> **Overview**
> Updates the ingest storage architecture documentation to reference a corrected diagram image by switching the embedded diagram from `ingest-storage-overview.png` to `ingest-storage-overview2.png`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a580bfbf3924f753330f34d19168beacafa311a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->