### PR TITLE
MQE: subset selector elimination: introduce CLI flag and tests, introduce helpers for dealing with matcher types

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -2561,6 +2561,17 @@
             },
             {
               "kind": "field",
+              "name": "enable_subset_selector_elimination",
+              "required": false,
+              "desc": "Enable subset selector elimination when evaluating queries.",
+              "fieldValue": null,
+              "fieldDefaultValue": false,
+              "fieldFlag": "querier.mimir-query-engine.enable-subset-selector-elimination",
+              "fieldType": "boolean",
+              "fieldCategory": "experimental"
+            },
+            {
+              "kind": "field",
               "name": "enable_narrow_binary_selectors",
               "required": false,
               "desc": "Enable generating selectors for one side of a binary expression based on results from the other side.",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2197,6 +2197,8 @@ Usage of ./cmd/mimir/mimir:
     	[experimental] Enable pruning query expressions that are toggled off with constants. (default true)
   -querier.mimir-query-engine.enable-reduce-matchers
     	[experimental] Enable eliminating duplicate or redundant matchers that are part of selector expressions. (default true)
+  -querier.mimir-query-engine.enable-subset-selector-elimination
+    	[experimental] Enable subset selector elimination when evaluating queries.
   -querier.mimir-query-engine.range-vector-splitting.backend string
     	Backend for intermediate results cache, if not empty. Supported values: memcached.
   -querier.mimir-query-engine.range-vector-splitting.compression string

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -1939,6 +1939,10 @@ mimir_query_engine:
   # CLI flag: -querier.mimir-query-engine.enable-common-subexpression-elimination
   [enable_common_subexpression_elimination: <boolean> | default = true]
 
+  # (experimental) Enable subset selector elimination when evaluating queries.
+  # CLI flag: -querier.mimir-query-engine.enable-subset-selector-elimination
+  [enable_subset_selector_elimination: <boolean> | default = false]
+
   # (experimental) Enable generating selectors for one side of a binary
   # expression based on results from the other side.
   # CLI flag: -querier.mimir-query-engine.enable-narrow-binary-selectors

--- a/pkg/streamingpromql/benchmarks/comparison_test.go
+++ b/pkg/streamingpromql/benchmarks/comparison_test.go
@@ -115,7 +115,7 @@ func TestBothEnginesReturnSameResultsForBenchmarkQueries(t *testing.T) {
 			prometheusResult, prometheusClose := c.Run(ctx, t, start, end, interval, prometheusEngine, q)
 			mimirResult, mimirClose := c.Run(ctx, t, start, end, interval, mimirEngine, q)
 
-			testutils.RequireEqualResults(t, c.Expr, prometheusResult, mimirResult, false)
+			testutils.RequireEqualResults(t, c.Expr, prometheusResult, mimirResult, c.IgnoreAnnotationDifferences)
 
 			prometheusClose()
 			mimirClose()

--- a/pkg/streamingpromql/config.go
+++ b/pkg/streamingpromql/config.go
@@ -38,6 +38,7 @@ type EngineOpts struct {
 
 	EnablePruneToggles                   bool `yaml:"enable_prune_toggles" category:"experimental"`
 	EnableCommonSubexpressionElimination bool `yaml:"enable_common_subexpression_elimination" category:"experimental"`
+	EnableSubsetSelectorElimination      bool `yaml:"enable_subset_selector_elimination" category:"experimental"`
 	EnableNarrowBinarySelectors          bool `yaml:"enable_narrow_binary_selectors" category:"experimental"`
 	EnableEliminateDeduplicateAndMerge   bool `yaml:"enable_eliminate_deduplicate_and_merge" category:"experimental"`
 	EnableReduceMatchers                 bool `yaml:"enable_reduce_matchers" category:"experimental"`
@@ -65,6 +66,7 @@ type RangeVectorSplittingConfig struct {
 func (o *EngineOpts) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&o.EnablePruneToggles, "querier.mimir-query-engine.enable-prune-toggles", true, "Enable pruning query expressions that are toggled off with constants.")
 	f.BoolVar(&o.EnableCommonSubexpressionElimination, "querier.mimir-query-engine.enable-common-subexpression-elimination", true, "Enable common subexpression elimination when evaluating queries.")
+	f.BoolVar(&o.EnableSubsetSelectorElimination, "querier.mimir-query-engine.enable-subset-selector-elimination", false, "Enable subset selector elimination when evaluating queries.")
 	f.BoolVar(&o.EnableNarrowBinarySelectors, "querier.mimir-query-engine.enable-narrow-binary-selectors", false, "Enable generating selectors for one side of a binary expression based on results from the other side.")
 	f.BoolVar(&o.EnableEliminateDeduplicateAndMerge, "querier.mimir-query-engine.enable-eliminate-deduplicate-and-merge", true, "Enable eliminating redundant DeduplicateAndMerge nodes from the query plan when it can be proven that each input series produces a unique output series.")
 	f.BoolVar(&o.EnableReduceMatchers, "querier.mimir-query-engine.enable-reduce-matchers", true, "Enable eliminating duplicate or redundant matchers that are part of selector expressions.")
@@ -118,6 +120,7 @@ func NewTestEngineOpts() EngineOpts {
 
 		EnablePruneToggles:                   true,
 		EnableCommonSubexpressionElimination: true,
+		EnableSubsetSelectorElimination:      true,
 		EnableNarrowBinarySelectors:          true,
 		EnableEliminateDeduplicateAndMerge:   true,
 		EnableReduceMatchers:                 true,

--- a/pkg/streamingpromql/optimize/ast/sort_labels_and_matchers.go
+++ b/pkg/streamingpromql/optimize/ast/sort_labels_and_matchers.go
@@ -6,10 +6,11 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"strings"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/grafana/mimir/pkg/streamingpromql/planning/core"
 )
 
 // SortLabelsAndMatchers is an optimization pass that ensures that all label names and matchers are sorted.
@@ -54,13 +55,5 @@ func (s *SortLabelsAndMatchers) Apply(_ context.Context, expr parser.Expr) (pars
 }
 
 func compareMatchers(a, b *labels.Matcher) int {
-	if a.Name != b.Name {
-		return strings.Compare(a.Name, b.Name)
-	}
-
-	if a.Type != b.Type {
-		return int(a.Type - b.Type)
-	}
-
-	return strings.Compare(a.Value, b.Value)
+	return core.CompareMatchers(a.Name, b.Name, a.Type, b.Type, a.Value, b.Value)
 }

--- a/pkg/streamingpromql/planning.go
+++ b/pkg/streamingpromql/planning.go
@@ -125,6 +125,10 @@ func NewQueryPlanner(opts EngineOpts, versionProvider QueryPlanVersionProvider) 
 		planner.RegisterQueryPlanOptimizationPass(rangevectorsplitting.NewOptimizationPass(splitInterval, opts.Limits, time.Now, opts.CommonOpts.Reg, opts.Logger))
 	}
 
+	if opts.EnableSubsetSelectorElimination && !opts.EnableCommonSubexpressionElimination {
+		return nil, errors.New("cannot enable subset selector elimination without common subexpression elimination")
+	}
+
 	if opts.EnableCommonSubexpressionElimination {
 		planner.RegisterQueryPlanOptimizationPass(commonsubexpressionelimination.NewOptimizationPass(opts.CommonOpts.Reg, opts.Logger))
 	}

--- a/pkg/streamingpromql/planning/core/conversions.go
+++ b/pkg/streamingpromql/planning/core/conversions.go
@@ -136,10 +136,27 @@ func LabelMatchersToOperatorType(matchers []*LabelMatcher) types.Matchers {
 	return converted
 }
 
+func LabelMatchersToPrometheusType(matchers []*LabelMatcher) ([]*labels.Matcher, error) {
+	if len(matchers) == 0 {
+		return nil, nil
+	}
+
+	converted := make([]*labels.Matcher, 0, len(matchers))
+
+	for _, m := range matchers {
+		matcher, err := labels.NewMatcher(m.Type, m.Name, m.Value)
+		if err != nil {
+			return nil, err
+		}
+
+		converted = append(converted, matcher)
+	}
+
+	return converted, nil
+}
+
 func matchersEqual(a, b *LabelMatcher) bool {
-	return a.Type == b.Type &&
-		a.Name == b.Name &&
-		a.Value == b.Value
+	return a.Equal(b)
 }
 
 // LabelMatchersStringer generates a human-readable version of multiple LabelMatchers

--- a/pkg/streamingpromql/planning/core/matchers.go
+++ b/pkg/streamingpromql/planning/core/matchers.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package core
+
+import (
+	"strings"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+func (m *LabelMatcher) Equal(other *LabelMatcher) bool {
+	return m.Type == other.Type && m.Name == other.Name && m.Value == other.Value
+}
+
+func CompareMatchers(firstName, secondName string, firstType, secondType labels.MatchType, firstValue, secondValue string) int {
+	if firstName != secondName {
+		return strings.Compare(firstName, secondName)
+	}
+
+	if firstType != secondType {
+		return int(firstType - secondType)
+	}
+
+	return strings.Compare(firstValue, secondValue)
+}
+
+func FormatMatchers(builder *strings.Builder, matchers []*LabelMatcher) {
+	builder.WriteRune('{')
+
+	for i, m := range matchers {
+		if i > 0 {
+			builder.WriteString(", ")
+		}
+
+		// Convert to the Prometheus type so we can use its String().
+		promMatcher := labels.Matcher{Type: m.Type, Name: m.Name, Value: m.Value}
+		builder.WriteString(promMatcher.String())
+	}
+
+	builder.WriteRune('}')
+}

--- a/pkg/streamingpromql/planning/core/selectors.go
+++ b/pkg/streamingpromql/planning/core/selectors.go
@@ -8,23 +8,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/timestamp"
 )
 
 func describeSelector(matchers []*LabelMatcher, ts *time.Time, offset time.Duration, rng *time.Duration, skipHistogramBuckets, anchored, smooothed, counterAware bool, projectionLabels []string, projectionInclude bool) string {
 	builder := &strings.Builder{}
-	builder.WriteRune('{')
-	for i, m := range matchers {
-		if i > 0 {
-			builder.WriteString(", ")
-		}
-
-		// Convert to the Prometheus type so we can use its String().
-		promMatcher := labels.Matcher{Type: m.Type, Name: m.Name, Value: m.Value}
-		builder.WriteString(promMatcher.String())
-	}
-	builder.WriteRune('}')
+	FormatMatchers(builder, matchers)
 
 	if rng != nil {
 		builder.WriteRune('[')

--- a/pkg/streamingpromql/testdata/ours/name_label_dropping.test
+++ b/pkg/streamingpromql/testdata/ours/name_label_dropping.test
@@ -100,3 +100,9 @@ eval instant at 10m sum by (__name__) (up{foo="bar"} or rate(up{foo="bar2"}[5m])
 
 eval instant at 10m sum by (__name__) (rate(up{foo="bar2"}[5m]) or up{foo="bar"})
   {} 10.05
+
+# Aggregations with 'without' should always drop __name__.
+eval instant at 10m label_replace(sum without () (up), "old_name", "$1", "__name__", "(.*)")
+  {foo="bar"} 10
+  {foo="bar2"} 30
+  {foo="bar3"} 50

--- a/pkg/streamingpromql/testdata/ours/subset_selector_elimination.test
+++ b/pkg/streamingpromql/testdata/ours/subset_selector_elimination.test
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# The goal of these tests is not to ensure that subset selectors are correctly identified
+# (this is tested in the tests for the optimization pass), but to ensure that expressions containing
+# subset selectors are correctly evaluated.
+
+load 1m
+  metric{idx="1"} 1+1x5
+  metric{idx="2"} 2+2x5
+  metric{idx="3"} 3+3x5
+  metric{idx="4"} 4+4x5
+  metric{idx="5"} 5+5x5
+
+# Instant vector selectors
+eval range from 0 to 5m step 1m metric{idx=~"2|3"} * metric
+  {idx="2"} 4 16 36 64 100 144
+  {idx="3"} 9 36 81 144 225 324
+
+eval range from 0 to 5m step 1m metric{idx="2"} * metric
+  {idx="2"} 4 16 36 64 100 144
+
+eval range from 0 to 5m step 1m metric{idx!~"2|3"} * metric
+  {idx="1"} 1 4 9 16 25 36
+  {idx="4"} 16 64 144 256 400 576
+  {idx="5"} 25 100 225 400 625 900
+
+eval range from 0 to 5m step 1m metric{idx!="2"} * metric
+  {idx="1"} 1 4 9 16 25 36
+  {idx="3"} 9 36 81 144 225 324
+  {idx="4"} 16 64 144 256 400 576
+  {idx="5"} 25 100 225 400 625 900
+
+eval range from 0 to 5m step 1m metric{idx=~"2|3"} * metric * metric{idx="3"}
+  {idx="3"} 27 216 729 1728 3375 5832
+
+eval range from 0 to 5m step 1m topk(3, metric) + topk(3, metric{idx=~"1|2|3|4"})
+  {idx="3"} 6 12 18 24 30 36
+  {idx="4"} 8 16 24 32 40 48
+
+eval range from 0 to 5m step 1m topk(3, metric) + topk(3, metric{idx=~"1|2|3|4"}) + topk(3, metric) + topk(3, metric{idx=~"1|2|3|4"})
+  {idx="3"} 12 24 36 48 60 72
+  {idx="4"} 16 32 48 64 80 96
+
+eval range from 0 to 5m step 1m topk(3, metric) + topk(3, metric{idx=~"1|2|3|4"}) + topk(2, metric) + topk(2, metric{idx=~"1|2|3|4"})
+  {idx="4"} 16 32 48 64 80 96
+
+# Range vector selectors - use instant query to ensure that CSE still applies
+eval instant at 2m rate(metric[2m]) * increase(metric{idx=~"2|3"}[2m])
+  {idx="2"} 0.13333333333333333
+  {idx="3"} 0.30000000000000004
+
+# Multi-aggregation
+eval range from 0 to 5m step 1m sum(metric{idx=~"2|3"}) * count(metric)
+  {} 25 50 75 100 125 150
+
+eval range from 0 to 5m step 1m (sum(metric{idx="2"}) + sum(metric{idx="3"})) * count(metric)
+  {} 25 50 75 100 125 150
+
+eval range from 0 to 5m step 1m sum by (idx) (metric{idx=~"2|3"}) * count by (idx) (metric)
+  {idx="2"} 2 4 6 8 10 12
+  {idx="3"} 3 6 9 12 15 18
+
+# Test cases where filtering can / can't be lifted higher than the selector
+eval range from 0 to 5m step 1m sum(rate(metric{idx=~"2|3"}[2m])) / sum(rate(metric[2m]))
+  {} _ 0.33333333333333337 0.33333333333333337 0.33333333333333337 0.33333333333333337 0.33333333333333337
+
+eval range from 0 to 5m step 1m cos(metric{idx=~"2|3"}) * cos(metric)
+  {idx="2"} 0.17317818956819406 0.4272499830956933 0.9219269793662461 0.021170259838307684 0.704041030906696 0.7120895036684985
+  {idx="3"} 0.9800851433251829 0.9219269793662461 0.83015835412204 0.7120895036684985 0.5771257249437919 0.4360181551862977
+
+eval range from 0 to 5m step 1m absent(metric{idx=~"2|3"}) + absent(metric)
+  # Should return no results.
+
+eval instant at 2m absent_over_time(metric{idx=~"2|3"}[2m]) + absent_over_time(metric[2m])
+  # Should return no results.
+
+eval range from 0 to 5m step 1m absent(does_not_exist{idx=~"2|3"}) + absent(does_not_exist)
+  {} 2 2 2 2 2 2
+
+eval instant at 2m absent_over_time(does_not_exist{idx=~"2|3"}[2m]) + absent_over_time(does_not_exist[2m])
+  {} 2
+
+# Multiple levels of duplication
+eval range from 0 to 5m step 1m sum(metric) / (sum(metric) + sum(metric{idx=~"2|3"}))
+  {} 0.75x5
+
+eval range from 0 to 5m step 1m sum(metric{idx=~"2|3"}) / (sum(metric) + sum(metric{idx=~"2|3"}))
+  {} 0.25x5
+
+# Subset returns no results
+eval range from 0 to 5m step 1m metric{something="does-not-exist"} / metric
+  # Should return no results.
+
+eval range from 0 to 5m step 1m sum(metric{something="does-not-exist"}) / sum(metric)
+  # Should return no results.
+
+eval range from 0 to 5m step 1m sum(rate(metric{something="does-not-exist"}[1m])) / sum(rate(metric[1m]))
+  # Should return no results.

--- a/pkg/streamingpromql/types/operator.go
+++ b/pkg/streamingpromql/types/operator.go
@@ -119,6 +119,14 @@ type Matcher struct {
 	Value string
 }
 
+func NewMatcherFromPrometheusType(m *labels.Matcher) Matcher {
+	return Matcher{
+		Type:  m.Type,
+		Name:  m.Name,
+		Value: m.Value,
+	}
+}
+
 func (m Matcher) ToPrometheusType() (*labels.Matcher, error) {
 	return labels.NewMatcher(m.Type, m.Name, m.Value)
 }


### PR DESCRIPTION
#### What this PR does

This PR is derived from https://github.com/grafana/mimir/pull/14377, and contains just some preparatory refactoring, tests and a CLI flag.

See #14377 for more context.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches query-planner configuration/validation and adds a new engine flag that can change startup behavior (new config error path) and later query optimization behavior. Changes are mostly additive and guarded behind an experimental flag, but affect core query-engine plumbing and tests.
> 
> **Overview**
> Adds a new *experimental* query-engine toggle `-querier.mimir-query-engine.enable-subset-selector-elimination` (default `false`), wires it into `EngineOpts`, and documents it in generated config/help outputs.
> 
> Updates planning validation to reject enabling subset selector elimination unless common subexpression elimination is also enabled.
> 
> Extends benchmark and correctness comparison coverage with subset-selector-focused cases, adds an option to ignore annotation-only differences, and refactors matcher comparison/formatting into shared helpers (`planning/core`) plus small matcher conversion helpers and new promql testdata for subset selector elimination and `__name__` dropping behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 385cac1052c0d9c3cb03bb53c1261d052929ddab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->