### PR TITLE
renovate: group mimir-build-image dependency updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -83,6 +83,13 @@
       enabled: false,
     },
     {
+      description: 'Group all dependency updates touching mimir-build-image/Dockerfile into a single PR',
+      matchFileNames: [
+        'mimir-build-image/Dockerfile',
+      ],
+      groupName: 'mimir-build-image',
+    },
+    {
       // Update Go version everywhere at once: build image, go.mod and GitHub Actions workflows.
       matchDatasources: [
         'docker',


### PR DESCRIPTION
#### What this PR does

Following https://github.com/grafana/mimir/pull/14321

Whenever there is an update in `mimir-build-image`, the CI needs to rebuild the image and update the references in the Makefile. This creates a challenge, when Renovate opens several PRs against the mimir-build-image. That is each PR tries the update the build image (which takes 30m), then upon merging one PR, the next one needs to be rebased, and to rebuild the build-image again.

This PR updates Renovate configuration to group the dependency updates, that touch `mimir-build-image/Dockerfile` into one PR.

cc @charleskorn @aknuds1 