### PR TITLE
Fix ingestion rate limit error message burst size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,7 @@
 * [ENHANCEMENT] Ingester: reduce heap usage during streaming chunk queries by releasing series label memory after each batch is sent rather than holding it until chunk streaming completes. #14422
 * [ENHANCEMENT] Ingest storage: Allow configuring multiple Kafka seed brokers via `-ingest-storage.kafka.address` (comma-separated). #14328
 * [ENHANCEMENT] Distributor, ingest storage: Add `cortex_distributor_received_bytes_total` and `cortex_ingest_storage_writer_input_bytes_total` metrics to measure Remote Write v2 symbols table compression effectiveness. #14453
+* [BUGFIX] Distributor: Fix ingestion rate limit error message reporting incorrect burst size when `ingestion_burst_factor` is configured. #14471
 * [BUGFIX] Mimir: Fix nil pointer dereference when `-target` is set to an empty string. #14381
 * [BUGFIX] API: Fixed web UI links not respecting `-server.path-prefix` configuration. #14090
 * [BUGFIX] Distributor: Fix issue where distributors didn't send custom values of native histograms. #13849

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1525,11 +1525,7 @@ func (d *Distributor) prePushValidationMiddleware(next PushFunc) PushFunc {
 				return newIngestionBurstSizeLimitedError(limiterBurst, totalN)
 			}
 
-			burstSize := d.limits.IngestionBurstSize(userID)
-			if d.limits.IngestionBurstFactor(userID) > 0 {
-				burstSize = int(d.limits.IngestionRate(userID) * d.limits.IngestionBurstFactor(userID))
-			}
-			return newIngestionRateLimitedError(d.limits.IngestionRate(userID), burstSize)
+			return newIngestionRateLimitedError(d.limits.IngestionRate(userID), limiterBurst)
 		}
 
 		// totalN included samples, exemplars and metadata. Ingester follows this pattern when computing its ingestion rate.

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -690,10 +690,10 @@ func TestDistributor_PushIngestionRateLimiter(t *testing.T) {
 			pushes: []testPush{
 				{samples: 10, expectedError: nil},
 				{samples: 5, expectedError: nil},
-				{samples: 5, metadata: 1, expectedError: status.New(codes.ResourceExhausted, newIngestionRateLimitedError(10, 40).Error())},
+				{samples: 5, metadata: 1, expectedError: status.New(codes.ResourceExhausted, newIngestionRateLimitedError(10, 20).Error())},
 				{samples: 5, expectedError: nil},
-				{samples: 1, expectedError: status.New(codes.ResourceExhausted, newIngestionRateLimitedError(10, 40).Error())},
-				{metadata: 1, expectedError: status.New(codes.ResourceExhausted, newIngestionRateLimitedError(10, 40).Error())},
+				{samples: 1, expectedError: status.New(codes.ResourceExhausted, newIngestionRateLimitedError(10, 20).Error())},
+				{metadata: 1, expectedError: status.New(codes.ResourceExhausted, newIngestionRateLimitedError(10, 20).Error())},
 			},
 		},
 		"Test burstFactor burst limit in one burst": {
@@ -704,7 +704,7 @@ func TestDistributor_PushIngestionRateLimiter(t *testing.T) {
 				// Burst is 10 for the distributor (10/2)*2 = 10
 				{samples: 10, expectedError: nil},
 				// We've drained the pool so this should fail until the bucket re-fills in a few seconds
-				{samples: 1, metadata: 1, expectedError: status.New(codes.ResourceExhausted, newIngestionRateLimitedError(10, 20).Error())},
+				{samples: 1, metadata: 1, expectedError: status.New(codes.ResourceExhausted, newIngestionRateLimitedError(10, 10).Error())},
 			},
 		},
 	}


### PR DESCRIPTION
#### What this PR does

Fixes the ingestion rate limit error message to report the correct burst size when `ingestion_burst_factor` is configured.

Previously, when `IngestionBurstFactor > 0`, the error message computed the burst size as `IngestionRate * IngestionBurstFactor` (the global value), but the actual rate limiter uses `(IngestionRate / numDistributors) * IngestionBurstFactor` (the per-distributor value).

For example, with 2 distributors, rate=10, and burstFactor=4:
- Actual limiter burst: `(10/2) * 4 = 20` per distributor
- Error message incorrectly showed: `10 * 4 = 40`

You may argue that we want to display the "global" burst, like we display the global rate limit, in the error message, but there's no concept of "global" burst. The burst is a local thing. Even before this change, the burst value reported by the error message was the local (per-distributor one) and not a global value, but it was the wrong one if the `ingestion_burst_factor` is configured.

The fix reuses the already-computed `limiterBurst` value (from `d.ingestionRateLimiter.Burst()`) which reflects the actual enforced burst size.

#### Which issue(s) this PR fixes or relates to

N/A - found during code review

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.