### PR TITLE
[mimirtool] Update Prometheus query to include __ignore_usage__ label selector for Adaptive Metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -308,6 +308,7 @@
 * [FEATURE] mimir-tool: Add `partition-ring add-owner` and `partition-ring remove-owner` commands. #14462
 * [FEATURE] tsdb-index-header: Add tool to inspect the content of a block's index or index-header. #13738 #14279
 * [FEATURE] tsdb-chunks, tsdb-print-chunk: When printing samples, include the start time (ST) in the output. #14337
+* [ENHANCEMENT] mimir-tool: Add `__ignore_usage__=""` label selector to queries used in `analyze prometheus` command, so that Adaptive Metrics' recommendations service ignores them. #14474
 * [BUGFIX] mimir-tool-action: Fix base image of the Github action. #13303
 * [BUGFIX] mimir-tool: do not fail on `$latency_metrics` dashboard variable, documented for native histograms migrations. #13526
 * [BUGFIX] kafkatool: Fix `kafkatool dump print` to support RW2 records. #13848

--- a/pkg/mimirtool/commands/analyse_prometheus.go
+++ b/pkg/mimirtool/commands/analyse_prometheus.go
@@ -162,7 +162,10 @@ func AnalyzePrometheus(api v1.API, metrics model.LabelValues, skip func(model.La
 		defer cancel()
 
 		var result model.Value
-		query := string("count by (job) (" + metric + ")")
+		// The __ignore_usage__ label selector tells Adaptive Metrics' recommendations
+		// service to not factor this query into its analysis.
+		// See https://grafana.com/docs/grafana-cloud/adaptive-telemetry/adaptive-metrics/manage-recommendations/understand-recommended-rules/#make-the-recommendations-service-ignore-a-query
+		query := fmt.Sprintf(`count by (job) (%s{__ignore_usage__=""})`, metric)
 		err := withBackoff(ctx, func() error {
 			var err error
 			result, _, err = api.Query(ctx, query, time.Now())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Update Prometheus query to include __ignore_usage__ label selector for Adaptive Metrics Recommendation service.  It will prevent taking into account the queries run from `mimirtool analyze prometheus ... ` CLI command while providing Aggregation Rules recommendations.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change limited to `mimirtool analyze prometheus` query construction; low blast radius, with minor risk that metrics without the label selector behave differently in some PromQL environments.
> 
> **Overview**
> Updates `mimirtool analyze prometheus` to add the `__ignore_usage__=""` label selector to its PromQL `count by (job)` queries so Grafana Cloud Adaptive Metrics recommendations ignore these tool-generated queries.
> 
> Adds a matching `CHANGELOG.md` entry documenting the enhancement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc864a435da88165dee3b3a64379d5559cd4937e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->