### PR TITLE
Fix jsonnet linting error

### DIFF
--- a/operations/mimir-tests/test-range-vector-splitting-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-range-vector-splitting-multi-zone-generated.yaml
@@ -2280,7 +2280,7 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.34.0
+        image: grafana/rollout-operator:v0.35.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:


### PR DESCRIPTION
There's a build error in main at the moment, the jsonnet tests check is failing
https://github.com/grafana/mimir/actions/runs/22347420163/job/64665571160

This is due to https://github.com/grafana/mimir/pull/14435

The problem was that that PR added new generated jsonnet test files. However, after the CI checks ran for that PR, https://github.com/grafana/mimir/pull/14463 was merged which bumped up the rollout-operator version. This mean the jsonnet for https://github.com/grafana/mimir/pull/14435 was stale when merged.

Fixed by running `make build-jsonnet-tests`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit b22cd61f74c553daf275d408685e499a22cef521. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->