### PR TITLE
Add metric to understand how often are chunk size inferred

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,7 @@
 * [ENHANCEMENT] Ingest storage: Allow configuring multiple Kafka seed brokers via `-ingest-storage.kafka.address` (comma-separated). #14328
 * [ENHANCEMENT] Ingest storage: Add `-ingest-storage.kafka.client-rack` flag to enable rack awareness. #14434
 * [ENHANCEMENT] Distributor, ingest storage: Add `cortex_distributor_received_bytes_total` and `cortex_ingest_storage_writer_input_bytes_total` metrics to measure Remote Write v2 symbols table compression effectiveness. #14453
+* [ENHANCEMENT] Store-gateway: Added `cortex_bucket_store_chunk_size_estimate_type_total` metric to track how often do we infer the size of a chunk or use the default size. #14477
 * [BUGFIX] Distributor: Fix ingestion rate limit error message reporting incorrect burst size when `ingestion_burst_factor` is configured. #14471
 * [BUGFIX] Mimir: Fix nil pointer dereference when `-target` is set to an empty string. #14381
 * [BUGFIX] API: Fixed web UI links not respecting `-server.path-prefix` configuration. #14090

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1147,6 +1147,9 @@ func (s *BucketStore) recordSeriesCallResult(safeStats *safeQueryStats) {
 	s.metrics.seriesDataSizeTouched.WithLabelValues("chunks", "returned").Observe(float64(stats.chunksTouchedSizeSum))
 
 	s.metrics.resultSeriesCount.Observe(float64(stats.mergedSeriesCount))
+
+	s.metrics.chunkSizeEstimateType.WithLabelValues("inferred").Add(float64(stats.chunksInferredSizeCount))
+	s.metrics.chunkSizeEstimateType.WithLabelValues("fallback").Add(float64(stats.chunksFallbackSizeCount))
 }
 
 func (s *BucketStore) recordLabelNamesCallResult(safeStats *safeQueryStats) {

--- a/pkg/storegateway/bucket_store_metrics.go
+++ b/pkg/storegateway/bucket_store_metrics.go
@@ -34,6 +34,7 @@ type BucketStoreMetrics struct {
 	seriesBlocksQueried   *prometheus.SummaryVec
 	resultSeriesCount     prometheus.Summary
 	chunkSizeBytes        prometheus.Histogram
+	chunkSizeEstimateType *prometheus.CounterVec
 	queriesDropped        *prometheus.CounterVec
 	seriesRefetches       prometheus.Counter
 
@@ -177,6 +178,10 @@ func NewBucketStoreMetrics(reg prometheus.Registerer) *BucketStoreMetrics {
 			32, 256, 512, 1024, 32 * 1024, 256 * 1024, 512 * 1024, 1024 * 1024, 32 * 1024 * 1024, 256 * 1024 * 1024, 512 * 1024 * 1024,
 		},
 	})
+	m.chunkSizeEstimateType = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		Name: "cortex_bucket_store_chunk_size_estimate_type_total",
+		Help: "Number of time we estimated the size of a chunk with a given type.",
+	}, []string{"type"})
 
 	m.indexHeaderReaderMetrics = indexheader.NewReaderPoolMetrics(prometheus.WrapRegistererWithPrefix("cortex_bucket_store_", reg))
 

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -2019,9 +2019,10 @@ func TestMetasToChunkRefs(t *testing.T) {
 		},
 	}
 
+	queryStats := newQueryStats()
 	for testName, testCase := range testCases {
 		t.Run(testName, func(t *testing.T) {
-			actualRanges := metasToChunkRefs(testCase.partitions, blockID, testCase.minT, testCase.maxT)
+			actualRanges := metasToChunkRefs(testCase.partitions, blockID, testCase.minT, testCase.maxT, queryStats)
 			assert.Equal(t, testCase.expectedChunks, actualRanges)
 			assert.Equal(t, len(testCase.expectedChunks), cap(actualRanges)) // Assert that we've done the slice preallocation correctly. This won't always catch all incorrect or missing preallocations, but might catch some.
 		})

--- a/pkg/storegateway/stats.go
+++ b/pkg/storegateway/stats.go
@@ -57,6 +57,9 @@ type queryStats struct {
 	chunksReturned         int
 	chunksReturnedSizeSum  int
 
+	chunksInferredSizeCount int
+	chunksFallbackSizeCount int
+
 	mergedSeriesCount int
 	mergedChunksCount int
 
@@ -158,6 +161,9 @@ func (s queryStats) merge(o *queryStats) *queryStats {
 	s.chunksProcessedSizeSum += o.chunksProcessedSizeSum
 	s.chunksReturned += o.chunksReturned
 	s.chunksReturnedSizeSum += o.chunksReturnedSizeSum
+
+	s.chunksInferredSizeCount += o.chunksInferredSizeCount
+	s.chunksFallbackSizeCount += o.chunksFallbackSizeCount
 
 	s.mergedSeriesCount += o.mergedSeriesCount
 	s.mergedChunksCount += o.mergedChunksCount


### PR DESCRIPTION
#### What this PR does

This PR introduce a new metric, `cortex_bucket_store_chunk_size_estimate_type_total` to understand how often are we actually able to infer the size of a chunk in comparison to how often we fallback to the default size.

This is done in order to figure out how much the default size still contribute to #3939.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new counters and lightweight per-chunk stat increments on the series/chunk-ref path; behavior is otherwise unchanged aside from minor metric overhead.
> 
> **Overview**
> Adds a new store-gateway Prometheus counter, `cortex_bucket_store_chunk_size_estimate_type_total{type="inferred"|"fallback"}`, to quantify how often chunk size is derived from adjacent chunk refs versus falling back to `tsdb.EstimatedMaxChunkSize`.
> 
> The chunk-ref building path now increments per-request stats for inferred vs fallback sizing (`metasToChunkRefs(...)`), merges them into query stats, and emits them at the end of `BucketStore.Series()`; `CHANGELOG.md` is updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53305d601ad97a6e154c38abd03b2ef0de0a52c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->