### PR TITLE
Compactor: add missing break after handling permanent compaction error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,7 +111,7 @@
 * [ENHANCEMENT] API: The `/api/v1/cardinality/active_series` endpoint is now stable and no longer experimental. #13111
 * [ENHANCEMENT] Querier: Default to streaming active series responses to query-frontends via `querier.response-streaming-enabled`. #13883
 * [ENHANCEMENT] Store-gateway: Add `cortex_bucket_store_blocks_loaded_size_bytes` metric to track per-tenant disk utilization. #13891
-* [ENHANCEMENT] Compactor: If compaction fails because the result block would exceed the size limit for its postings offsets table, symbol table, or index, mark input blocks for no-compaction to avoid blocking future compactor runs. #13876 #14466
+* [ENHANCEMENT] Compactor: If compaction fails because the result block would exceed the size limit for its postings offsets table, symbol table, or index, mark input blocks for no-compaction to avoid blocking future compactor runs. #13876 #14466 #14482
 * [ENHANCEMENT] Query-frontend: add support for `range()` duration expression. #13931
 * [ENHANCEMENT] Add experimental flag `common.instrument-reference-leaks-percentage` to leaked references to gRPC buffers. #13609 #14083
 * [ENHANCEMENT] Querier: Add experimental flag `-querier.mimir-query-engine.enable-projection-pushdown` to enable an MQE optimization pass for reducing data transferred between queriers and the storage layer. #14006 #14132 #14239 #14241 #14326

--- a/pkg/compactor/bucket_compactor.go
+++ b/pkg/compactor/bucket_compactor.go
@@ -1209,6 +1209,7 @@ func (c *BucketCompactor) handleKnownCompactionErrors(ctx context.Context, job *
 		if allMarked {
 			return nil
 		}
+		break
 	}
 
 	// Unhandled, returning original err


### PR DESCRIPTION
## Summary

- Add missing `break` in the `permanentCompactionErrors` loop in `handleKnownCompactionErrors`. Without it, if marking some blocks fails, the loop unnecessarily continues to check remaining sentinel errors instead of falling through to return the original error.

Follow-up to #14466.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small control-flow fix in compactor error handling; behavior only changes in rare permanent-compaction-error paths and doesn’t affect normal compaction logic.
> 
> **Overview**
> Fixes compactor handling of permanent compaction errors by adding a missing `break` so that if marking some input blocks as no-compact fails, the code stops checking other sentinel errors and falls through to return the original compaction error.
> 
> Updates the changelog entry to include the additional follow-up issue reference (`#14482`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1bb38e2d23f6d2e58ce24b7a8012afa765145b03. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->