### PR TITLE
Improve runbook for query debugging

### DIFF
--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -3526,7 +3526,7 @@ Possible reasons for this are:
 
 ### How it Works
 
-- For range and instant queries, the query-frontend normalizes and optimizes the query structure, and (when configured) splits by time interval, shards by series (**query_shard**), and extracts subqueries.
+- For range and instant queries, the query-frontend normalizes and optimizes the query structure, and (when configured) splits by time interval, shards by series (`__query_shard__`), and extracts subqueries.
 - The query-frontend enqueues the resulting sub-requests with the query-scheduler.
 - The query-scheduler dispatches enqueued queries to idle querier workers.
 - The querier fetches data from ingesters, store-gateways, or both. In the classic path it also evaluates the PromQL expression; with remote execution enabled, data is streamed back to the query-frontend where evaluation occurs.


### PR DESCRIPTION
#### What this PR does

This PR adds additional information to the runbook for debugging and analyzing queries. 

The extended information set is both useful for human operators, but it also gives hints to an AI agent who has consumed the runbook on what to look for in logs and queries.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [x ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates with no runtime or behavioral changes; risk is limited to potential operator confusion if guidance is inaccurate.
> 
> **Overview**
> Adds a new **"Investigating query evaluation issues"** runbook section with an overview of the read-path execution flow, key dashboards/PromQL snippets, and detailed guidance on using query-frontend `query stats`/`evaluation stats` logs to diagnose latency, sharding/splitting, cache behavior, and failures.
> 
> Wires this new section into multiple existing alerts (`MimirRequestLatency` read path, `MimirRequestErrors`, `MimirRulerTooManyFailedQueries`, `MimirSchedulerQueriesStuck`) via *See also* links, and refines crash/OOM troubleshooting to point to `activity-tracker` logs; also trims redundant query-scheduler investigation text to rely on the centralized guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 456c4f68c18cdc8f267e100e64a4d4bad8af3930. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->