### PR TITLE
renovate: disable updates for upstream Prometheus

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -73,6 +73,8 @@
       // Don't update replace directives.
       matchPackageNames: [
         'github.com/grafana/mimir-prometheus',
+        // Don't attempt to upgrade the upstream Prometheus dependency, as it's replaced by our fork.
+        'github.com/prometheus/prometheus',
         'github.com/grafana/memberlist',
         'github.com/grafana/regexp',
         'github.com/colega/go-yaml-yaml',


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Disable updates for upstream Prometheus, as we replace it (in go.mod) with our mimir-prometheus fork, and Renovate tends to pick a bogus version. See https://github.com/grafana/mimir/pull/14484 for an example.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change that affects dependency update automation, not runtime code; risk is limited to potentially missing Renovate prompts for upstream Prometheus versions.
> 
> **Overview**
> Updates Renovate configuration to **disable updates for `github.com/prometheus/prometheus`**, alongside other `replace`-managed Go modules, to prevent Renovate from proposing incorrect upstream Prometheus version bumps when the project uses a fork.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06a9157bd99a9b697d99f82a83e868ec9b6690e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->