### PR TITLE
Usage-tracker: add verbose per-user series created/removed metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@
 * [ENHANCEMENT] Ingester: New `-blocks-storage.tsdb.close-idle-tsdb-when-shipping-disabled` flag to enforce closing of idle TSDBs when block shipping is disabled. #13862
 * [ENHANCEMENT] Partitions ring: Add support to forcefully lock a partition state through the web UI. #13811
 * [ENHANCEMENT] Usage-tracker: Serialize metrics gathering to reduce tail latency when running many partitions on a single instance. #13886
+* [ENHANCEMENT] Usage-tracker: Add experimental per-user series created and removed counter metrics, gated behind `-usage-tracker.enable-verbose-series-creation-deletion-prometheus-metrics`. #14486
 * [ENHANCEMENT] API: The `/api/v1/user_limits` endpoint is now stable and no longer experimental. #13218
 * [ENHANCEMENT] Ingester: limiting CPU and memory utilized by the read path (`-ingester.read-path-cpu-utilization-limit` and `-ingester.read-path-memory-utilization-limit`) is now considered stable. #13167
 * [ENHANCEMENT] Querier: `-querier.max-estimated-fetched-chunks-per-query-multiplier` is now stable and no longer experimental. #13120

--- a/pkg/usagetracker/partition_handler.go
+++ b/pkg/usagetracker/partition_handler.go
@@ -201,7 +201,7 @@ func newPartitionHandler(
 	}
 
 	eventsPublisher := chanEventsPublisher{events: p.pendingCreatedSeriesMarshaledEvents, logger: logger}
-	p.store = newTrackerStore(cfg.IdleTimeout, cfg.UserCloseToLimitPercentageThreshold, logger, lim, eventsPublisher)
+	p.store = newTrackerStore(cfg.IdleTimeout, cfg.UserCloseToLimitPercentageThreshold, logger, lim, eventsPublisher, cfg.EnableVerboseSeriesCreationDeletionPrometheusMetrics)
 	p.Service = services.NewBasicService(p.start, p.run, p.stop)
 	return p, nil
 }

--- a/pkg/usagetracker/tracker.go
+++ b/pkg/usagetracker/tracker.go
@@ -85,6 +85,8 @@ type Config struct {
 	MaxEventsFetchSize int `yaml:"max_events_fetch_size"`
 
 	UserCloseToLimitPercentageThreshold int `yaml:"user_close_to_limit_percentage_threshold"`
+
+	EnableVerboseSeriesCreationDeletionPrometheusMetrics bool `yaml:"enable_verbose_series_creation_deletion_prometheus_metrics" category:"experimental"`
 }
 
 func (c *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
@@ -125,6 +127,8 @@ func (c *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.IntVar(&c.MaxEventsFetchSize, "usage-tracker.max-events-fetch-size", 100, "Maximum number of events to fetch from Kafka in a single request. This is used to limit the memory usage when fetching events.")
 
 	f.IntVar(&c.UserCloseToLimitPercentageThreshold, "usage-tracker.user-close-to-limit-percentage-threshold", 90, "Percentage of the local series limit after which a user is considered close to the limit. A user is close to the limit if their series count is above this percentage of their local limit.")
+
+	f.BoolVar(&c.EnableVerboseSeriesCreationDeletionPrometheusMetrics, "usage-tracker.enable-verbose-series-creation-deletion-prometheus-metrics", false, "Enable verbose series creation and deletion Prometheus metrics. When enabled, two additional counters per user and partition are exposed (series created and series removed), increasing the cardinality of exposed metrics and impacting the time and resources needed for scraping in deployments with multiple partitions per pod.")
 }
 
 func (c *Config) ValidateForClient() error {

--- a/pkg/usagetracker/tracker_store_bench_test.go
+++ b/pkg/usagetracker/tracker_store_bench_test.go
@@ -51,7 +51,7 @@ func BenchmarkTrackerStoreTrackSeries(b *testing.B) {
 func benckmarkTrackerStoreTrackSeries(b *testing.B, seriesRefs []uint64, seriesPerRequest, tenantsCount int, cleanupsEnabled bool) {
 	nowSeconds := atomic.NewInt64(0)
 	now := func() time.Time { return time.Unix(nowSeconds.Load(), 0) }
-	t := newTrackerStore(testIdleTimeout, 85, log.NewNopLogger(), limiterMock{}, noopEvents{})
+	t := newTrackerStore(testIdleTimeout, 85, log.NewNopLogger(), limiterMock{}, noopEvents{}, false)
 
 	seriesPerTenant := len(seriesRefs) / tenantsCount
 	// Warmup each tenant.
@@ -110,7 +110,7 @@ func BenchmarkTrackerStoreLoadSnapshot(b *testing.B) {
 
 	b.Run("mode=sequential", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			t := newTrackerStore(testIdleTimeout, 85, log.NewNopLogger(), lim, noopEvents{})
+			t := newTrackerStore(testIdleTimeout, 85, log.NewNopLogger(), lim, noopEvents{}, false)
 			for _, d := range snapshots {
 				require.NoError(b, t.loadSnapshot(d, now))
 			}
@@ -119,7 +119,7 @@ func BenchmarkTrackerStoreLoadSnapshot(b *testing.B) {
 
 	b.Run("mode=parallel", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			t := newTrackerStore(testIdleTimeout, 85, log.NewNopLogger(), lim, noopEvents{})
+			t := newTrackerStore(testIdleTimeout, 85, log.NewNopLogger(), lim, noopEvents{}, false)
 			require.NoError(b, t.loadSnapshots(snapshots, now))
 		}
 	})
@@ -136,7 +136,7 @@ func generateSnapshot(b *testing.B, tenantsCount int, totalSeries int, now time.
 	}
 	seriesPerTenantPerMinute := seriesPerTenant / int(testIdleTimeout.Minutes())
 
-	t := newTrackerStore(testIdleTimeout, 85, log.NewNopLogger(), lim, noopEvents{})
+	t := newTrackerStore(testIdleTimeout, 85, log.NewNopLogger(), lim, noopEvents{}, false)
 	deterministicRand := rand.New(rand.NewSource(0))
 	for timestamp := now.Add(-testIdleTimeout); timestamp.Before(now); timestamp = timestamp.Add(time.Minute) {
 		for i := 0; i < tenantsCount; i++ {

--- a/pkg/usagetracker/tracker_store_collector.go
+++ b/pkg/usagetracker/tracker_store_collector.go
@@ -16,8 +16,24 @@ var activeSeriesMetricDesc = prometheus.NewDesc(
 	[]string{"user"}, nil,
 )
 
+var seriesCreatedTotalDesc = prometheus.NewDesc(
+	"cortex_usage_tracker_series_created_total",
+	"Total number of series created per user.",
+	[]string{"user"}, nil,
+)
+
+var seriesRemovedTotalDesc = prometheus.NewDesc(
+	"cortex_usage_tracker_series_removed_total",
+	"Total number of series removed per user.",
+	[]string{"user"}, nil,
+)
+
 func (t *trackerStore) Describe(descs chan<- *prometheus.Desc) {
 	descs <- activeSeriesMetricDesc
+	if t.enableVerboseSeriesMetrics {
+		descs <- seriesCreatedTotalDesc
+		descs <- seriesRemovedTotalDesc
+	}
 }
 
 func (t *trackerStore) Collect(metrics chan<- prometheus.Metric) {
@@ -28,6 +44,10 @@ func (t *trackerStore) Collect(metrics chan<- prometheus.Metric) {
 	for _, tenantID := range t.sortedTenants {
 		tenant := t.tenants[tenantID]
 		metrics <- prometheus.MustNewConstMetric(activeSeriesMetricDesc, prometheus.GaugeValue, float64(tenant.series.Load()), tenantID)
+		if t.enableVerboseSeriesMetrics {
+			metrics <- prometheus.MustNewConstMetric(seriesCreatedTotalDesc, prometheus.CounterValue, float64(tenant.seriesCreated.Load()), tenantID)
+			metrics <- prometheus.MustNewConstMetric(seriesRemovedTotalDesc, prometheus.CounterValue, float64(tenant.seriesRemoved.Load()), tenantID)
+		}
 	}
 }
 


### PR DESCRIPTION
#### What this PR does

Adds two new per-user counter metrics to the usage tracker for debugging series creation and deletion rates:

- `cortex_usage_tracker_series_created_total{user}` — counter of series created per user
- `cortex_usage_tracker_series_removed_total{user}` — counter of series removed per user

These are gated behind the experimental flag `-usage-tracker.enable-verbose-series-creation-deletion-prometheus-metrics` (disabled by default) because they increase metric cardinality — one counter per user per partition.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Disabled by default, but when enabled it increases metric cardinality and scrape cost and adds extra per-request/cleanup counter updates that could impact performance in large tenant/partition deployments.
> 
> **Overview**
> Adds an *experimental*, opt-in verbose metrics mode for usage-tracker that exposes two new per-user Prometheus counters: `cortex_usage_tracker_series_created_total` and `cortex_usage_tracker_series_removed_total`.
> 
> Wires the new flag `-usage-tracker.enable-verbose-series-creation-deletion-prometheus-metrics` through config and `partitionHandler` into `trackerStore`, tracks created/removed counts during `trackSeries()` and `cleanup()`, and only registers/collects the extra metric descriptors when enabled. Updates unit tests/benchmarks accordingly and adds a changelog entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ebde8697825258711ae650a7470200ceaf28d4d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->