### PR TITLE
Renovate: only rebase build image PRs

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -126,7 +126,7 @@
       ],
     },
     {
-      description: 'Group all dependency updates touching mimir-build-image/Dockerfile into a single PR',
+      description: 'Automatically rebase all dependency update PRs touching mimir-build-image/Dockerfile',
       matchFileNames: [
         'mimir-build-image/Dockerfile',
       ],


### PR DESCRIPTION
#### What this PR does

This is a follow-up to #14476 addressing https://github.com/grafana/mimir/pull/14476#discussion_r2851549400.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that affects Renovate PR maintenance behavior; main impact is reduced automatic rebasing for non-build-image dependency updates.
> 
> **Overview**
> Removes the global Renovate setting to auto-rebase PRs when they fall behind the base branch.
> 
> Adds a targeted `packageRules` override so only dependency update PRs touching `mimir-build-image/Dockerfile` are automatically rebased when behind, reducing rebase churn for other updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c86e8676b030d916af389ae2a94ab96ee914392c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->