### PR TITLE
MQE: fix issue where operators for scalar arguments to functions aren't closed

### DIFF
--- a/pkg/streamingpromql/operators/functions/function_over_instant_vector.go
+++ b/pkg/streamingpromql/operators/functions/function_over_instant_vector.go
@@ -149,6 +149,10 @@ func (m *FunctionOverInstantVector) Finalize(ctx context.Context) error {
 func (m *FunctionOverInstantVector) Close() {
 	m.Inner.Close()
 
+	for _, sa := range m.ScalarArgs {
+		sa.Close()
+	}
+
 	for _, sd := range m.scalarArgsData {
 		types.FPointSlicePool.Put(&sd.Samples, m.MemoryConsumptionTracker)
 	}

--- a/pkg/streamingpromql/operators/functions/function_over_range_vector.go
+++ b/pkg/streamingpromql/operators/functions/function_over_range_vector.go
@@ -237,6 +237,10 @@ func (m *FunctionOverRangeVector) Finalize(ctx context.Context) error {
 func (m *FunctionOverRangeVector) Close() {
 	m.Inner.Close()
 
+	for _, sa := range m.ScalarArgs {
+		sa.Close()
+	}
+
 	for _, d := range m.scalarArgsData {
 		types.FPointSlicePool.Put(&d.Samples, m.MemoryConsumptionTracker)
 	}


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue where the operators for scalar arguments to functions aren't closed when the function operator is closed.

This generally has no user-facing impact (only issue is that pooled slices aren't returned), so I've opted not to add a changelog entry.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Limited lifecycle fix: ensures scalar-argument operators are closed, reducing pooled-slice/memory leaks with minimal behavior change risk.
> 
> **Overview**
> Fixes a resource/lifecycle leak where function operators over instant and range vectors did not close their `ScalarArgs` operators when the parent operator was closed.
> 
> Updates tests to assert scalar-arg operators are closed and adjusts the scalar-args test setup to account for memory tracking when allocating/returning pooled sample slices.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cba4c90525cfe31203fd6909aca2962ea43b3bc9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->