### PR TITLE
compactor scheduler: clean up executor tests

### DIFF
--- a/pkg/compactor/executor_test.go
+++ b/pkg/compactor/executor_test.go
@@ -366,9 +366,10 @@ func TestSchedulerExecutor_BackoffBehavior(t *testing.T) {
 				}()
 
 				// Iteration 1 should fire immediately
-				sleepUntil(t, func() bool { return mockSchedulerClient.GetLeaseJobCallCount() == 1 }, cfg.SchedulerMaxLeasingBackoff)
-				delay1 := sleepUntil(t, func() bool { return mockSchedulerClient.GetLeaseJobCallCount() == 2 }, cfg.SchedulerMaxLeasingBackoff)
-				delay2 := sleepUntil(t, func() bool { return mockSchedulerClient.GetLeaseJobCallCount() == 3 }, cfg.SchedulerMaxLeasingBackoff)
+				waitTimeout := 2 * cfg.SchedulerMaxLeasingBackoff
+				sleepUntil(t, func() bool { return mockSchedulerClient.GetLeaseJobCallCount() == 1 }, waitTimeout)
+				delay1 := sleepUntil(t, func() bool { return mockSchedulerClient.GetLeaseJobCallCount() == 2 }, waitTimeout)
+				delay2 := sleepUntil(t, func() bool { return mockSchedulerClient.GetLeaseJobCallCount() == 3 }, waitTimeout)
 				runCancel()
 				synctest.Wait()
 				require.NoError(t, <-errCh, "executor should exit without error")


### PR DESCRIPTION
Cleans up `executor_test.go`:

- Use `synctest` where possible for deterministic fake-time control
- Rewrite `TestSchedulerExecutor_BackoffBehavior` to actually assert that the backoff delay grows or stays flat depending on whether work was obtained
- Add helpers to reduce setup boilerplate (`newTestSchedulerExecutor`, `prepareCompactorForExecutorTest`, `makeSchedulerTestConfig`)
- Add new test cases for missing coverage
- Fix `TestBuildCompactionJobFromMetas` to use `job.MaxTime()` instead of the last block's MaxTime — incorrect for overlapping time ranges

The `synctest` migration brings the test suite from ~9.5s to ~1.9s.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor that changes timing and assertions around scheduler backoff/status update behavior; low production risk but may affect test determinism/coverage expectations.
> 
> **Overview**
> Refactors `pkg/compactor/executor_test.go` to reduce boilerplate and make scheduler-executor tests deterministic by adopting `testing/synctest`, adding shared setup helpers, and using fixed ULIDs.
> 
> Reworks `TestSchedulerExecutor_BackoffBehavior` to assert whether lease backoff *grows* (errors/no work) or stays flat (a job was leased), adds coverage for planning-job transient bucket failures sending `REASSIGN`, and updates retry/cancellation tests to avoid real sleeps.
> 
> Fixes `TestBuildCompactionJobFromMetas` to assert `job.MinTime()`/`job.MaxTime()` (including overlapping time-range cases) instead of assuming the last block’s `MaxTime` is the job max.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26b52b740201f4daa46c0b54fcb3690ee22eda70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->