### PR TITLE
Use `limiter.NewUnlimitedMemoryConsumptionTracker` where possible

### DIFF
--- a/pkg/frontend/v2/remoteexec_test.go
+++ b/pkg/frontend/v2/remoteexec_test.go
@@ -49,7 +49,7 @@ import (
 
 func TestScalarExecutionResponse(t *testing.T) {
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
 	stream := &mockResponseStream{
 		responses: []mockResponse{
@@ -92,7 +92,7 @@ func TestScalarExecutionResponse(t *testing.T) {
 
 func TestInstantVectorExecutionResponse(t *testing.T) {
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
 	stream := &mockResponseStream{
 		responses: []mockResponse{
@@ -161,7 +161,7 @@ func TestInstantVectorExecutionResponse(t *testing.T) {
 
 func TestInstantVectorExecutionResponse_Batching(t *testing.T) {
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
 	stream := &mockResponseStream{
 		responses: []mockResponse{
@@ -255,7 +255,7 @@ func TestInstantVectorExecutionResponse_Batching(t *testing.T) {
 
 func TestInstantVectorExecutionResponse_DelayedNameRemoval(t *testing.T) {
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
 	stream := &mockResponseStream{
 		responses: []mockResponse{
@@ -291,7 +291,7 @@ func TestInstantVectorExecutionResponse_DelayedNameRemoval(t *testing.T) {
 
 func TestInstantVectorExecutionResponse_PointSliceLengthNotAPowerOfTwo(t *testing.T) {
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
 	stream := &mockResponseStream{
 		responses: []mockResponse{
@@ -341,7 +341,7 @@ func TestInstantVectorExecutionResponse_PointSliceLengthNotAPowerOfTwo(t *testin
 
 func TestRangeVectorExecutionResponse(t *testing.T) {
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
 	stream := &mockResponseStream{
 		responses: []mockResponse{
@@ -459,7 +459,7 @@ func TestRangeVectorExecutionResponse(t *testing.T) {
 
 func TestRangeVectorExecutionResponse_DelayedNameRemoval(t *testing.T) {
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
 	stream := &mockResponseStream{
 		responses: []mockResponse{
@@ -495,7 +495,7 @@ func TestRangeVectorExecutionResponse_DelayedNameRemoval(t *testing.T) {
 
 func TestRangeVectorExecutionResponse_ExpectedSeriesMismatch(t *testing.T) {
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
 	stream := &mockResponseStream{
 		responses: []mockResponse{
@@ -571,7 +571,7 @@ func TestRangeVectorExecutionResponse_ExpectedSeriesMismatch(t *testing.T) {
 
 func TestRangeVectorExecutionResponse_PointSliceLengthNotAPowerOfTwo(t *testing.T) {
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
 	stream := &mockResponseStream{
 		responses: []mockResponse{

--- a/pkg/ingester/client/streaming_test.go
+++ b/pkg/ingester/client/streaming_test.go
@@ -80,7 +80,7 @@ func TestSeriesChunksStreamReader_HappyPaths(t *testing.T) {
 			cleanedUp := atomic.NewBool(false)
 			cleanup := func() { cleanedUp.Store(true) }
 			queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
-			memoryTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+			memoryTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 			reader := NewSeriesChunksStreamReader(ctx, mockClient, "ingester", 5, queryLimiter, memoryTracker, cleanup, log.NewNopLogger())
 			reader.StartBuffering()
 
@@ -123,7 +123,7 @@ func TestSeriesChunksStreamReader_AbortsWhenParentContextCancelled(t *testing.T)
 
 	parentCtx, cancel := context.WithCancel(context.Background())
 	queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
-	memoryTracker := limiter.NewMemoryConsumptionTracker(parentCtx, 0, nil, "")
+	memoryTracker := limiter.NewUnlimitedMemoryConsumptionTracker(parentCtx)
 	reader := NewSeriesChunksStreamReader(parentCtx, mockClient, "ingester", 3, queryLimiter, memoryTracker, cleanup, log.NewNopLogger())
 	cancel()
 	reader.StartBuffering()
@@ -170,7 +170,7 @@ func TestSeriesChunksStreamReader_DoesNotAbortWhenStreamContextCancelled(t *test
 
 	parentCtx := context.Background()
 	queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
-	memoryTracker := limiter.NewMemoryConsumptionTracker(parentCtx, 0, nil, "")
+	memoryTracker := limiter.NewUnlimitedMemoryConsumptionTracker(parentCtx)
 	reader := NewSeriesChunksStreamReader(parentCtx, mockClient, "ingester", 3, queryLimiter, memoryTracker, cleanup, log.NewNopLogger())
 	cancel()
 	reader.StartBuffering()
@@ -195,7 +195,7 @@ func TestSeriesChunksStreamReader_ReadingSeriesOutOfOrder(t *testing.T) {
 	mockClient := &mockQueryStreamClient{ctx: ctx, batches: batches}
 	cleanup := func() {}
 	queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
-	memoryTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	reader := NewSeriesChunksStreamReader(ctx, mockClient, "ingester", 1, queryLimiter, memoryTracker, cleanup, log.NewNopLogger())
 	reader.StartBuffering()
 
@@ -223,7 +223,7 @@ func TestSeriesChunksStreamReader_ReadingMoreSeriesThanAvailable(t *testing.T) {
 	mockClient := &mockQueryStreamClient{ctx: ctx, batches: batches}
 	cleanup := func() {}
 	queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
-	memoryTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	reader := NewSeriesChunksStreamReader(ctx, mockClient, "ingester", 1, queryLimiter, memoryTracker, cleanup, log.NewNopLogger())
 	reader.StartBuffering()
 
@@ -256,7 +256,7 @@ func TestSeriesChunksStreamReader_ReceivedFewerSeriesThanExpected(t *testing.T) 
 	cleanedUp := atomic.NewBool(false)
 	cleanup := func() { cleanedUp.Store(true) }
 	queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
-	memoryTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	reader := NewSeriesChunksStreamReader(ctx, mockClient, "ingester", 3, queryLimiter, memoryTracker, cleanup, log.NewNopLogger())
 	reader.StartBuffering()
 
@@ -306,7 +306,7 @@ func TestSeriesChunksStreamReader_ReceivedMoreSeriesThanExpected(t *testing.T) {
 			cleanedUp := atomic.NewBool(false)
 			cleanup := func() { cleanedUp.Store(true) }
 			queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
-			memoryTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+			memoryTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 			reader := NewSeriesChunksStreamReader(ctx, mockClient, "ingester", 1, queryLimiter, memoryTracker, cleanup, log.NewNopLogger())
 			reader.StartBuffering()
 

--- a/pkg/querier/block_streaming_test.go
+++ b/pkg/querier/block_streaming_test.go
@@ -317,7 +317,7 @@ func TestStoreGatewayStreamReader_HappyPaths(t *testing.T) {
 			ctx := context.Background()
 			mockClient := &mockStoreGatewayQueryStreamClient{ctx: ctx, messages: testCase.messages}
 			queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
-			memoryTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+			memoryTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 			metrics := newBlocksStoreQueryableMetrics(prometheus.NewPedanticRegistry())
 			reader := newStoreGatewayStreamReader(ctx, mockClient, 5, queryLimiter, memoryTracker, &stats.SafeStats{}, metrics, log.NewNopLogger())
 			reader.StartBuffering()
@@ -389,7 +389,7 @@ func TestStoreGatewayStreamReader_AbortsWhenParentContextCancelled(t *testing.T)
 
 			parentCtx, cancel := context.WithCancel(context.Background())
 			queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
-			memoryTracker := limiter.NewMemoryConsumptionTracker(parentCtx, 0, nil, "")
+			memoryTracker := limiter.NewUnlimitedMemoryConsumptionTracker(parentCtx)
 			metrics := newBlocksStoreQueryableMetrics(prometheus.NewPedanticRegistry())
 			reader := newStoreGatewayStreamReader(parentCtx, mockClient, 3, queryLimiter, memoryTracker, &stats.SafeStats{}, metrics, log.NewNopLogger())
 			cancel()
@@ -421,7 +421,7 @@ func TestStoreGatewayStreamReader_DoesNotAbortWhenStreamContextCancelled(t *test
 	metrics := newBlocksStoreQueryableMetrics(prometheus.NewPedanticRegistry())
 
 	parentCtx := context.Background()
-	memoryTracker := limiter.NewMemoryConsumptionTracker(parentCtx, 0, nil, "")
+	memoryTracker := limiter.NewUnlimitedMemoryConsumptionTracker(parentCtx)
 	reader := newStoreGatewayStreamReader(parentCtx, mockClient, 3, queryLimiter, memoryTracker, &stats.SafeStats{}, metrics, log.NewNopLogger())
 	reader.StartBuffering()
 
@@ -444,7 +444,7 @@ func TestStoreGatewayStreamReader_ReadingSeriesOutOfOrder(t *testing.T) {
 	ctx := context.Background()
 	mockClient := &mockStoreGatewayQueryStreamClient{ctx: ctx, messages: batchesToMessages(3, batches...)}
 	queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
-	memoryTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	metrics := newBlocksStoreQueryableMetrics(prometheus.NewPedanticRegistry())
 	reader := newStoreGatewayStreamReader(ctx, mockClient, 1, queryLimiter, memoryTracker, &stats.SafeStats{}, metrics, log.NewNopLogger())
 	reader.StartBuffering()
@@ -463,7 +463,7 @@ func TestStoreGatewayStreamReader_ReadingMoreSeriesThanAvailable(t *testing.T) {
 	ctx := context.Background()
 	mockClient := &mockStoreGatewayQueryStreamClient{ctx: ctx, messages: batchesToMessages(3, batches...)}
 	queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
-	memoryTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	metrics := newBlocksStoreQueryableMetrics(prometheus.NewPedanticRegistry())
 	reader := newStoreGatewayStreamReader(ctx, mockClient, 1, queryLimiter, memoryTracker, &stats.SafeStats{}, metrics, log.NewNopLogger())
 	reader.StartBuffering()
@@ -493,7 +493,7 @@ func TestStoreGatewayStreamReader_ReceivedFewerSeriesThanExpected(t *testing.T) 
 	ctx := context.Background()
 	mockClient := &mockStoreGatewayQueryStreamClient{ctx: ctx, messages: batchesToMessages(3, batches...)}
 	queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
-	memoryTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	metrics := newBlocksStoreQueryableMetrics(prometheus.NewPedanticRegistry())
 	reader := newStoreGatewayStreamReader(ctx, mockClient, 3, queryLimiter, memoryTracker, &stats.SafeStats{}, metrics, log.NewNopLogger())
 	reader.StartBuffering()
@@ -548,7 +548,7 @@ func TestStoreGatewayStreamReader_ReceivedMoreSeriesThanExpected(t *testing.T) {
 			ctx := context.Background()
 			mockClient := &mockStoreGatewayQueryStreamClient{ctx: ctx, messages: batchesToMessages(3, batches...)}
 			queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
-			memoryTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+			memoryTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 			metrics := newBlocksStoreQueryableMetrics(prometheus.NewPedanticRegistry())
 			reader := newStoreGatewayStreamReader(ctx, mockClient, 1, queryLimiter, memoryTracker, &stats.SafeStats{}, metrics, log.NewNopLogger())
 			reader.StartBuffering()

--- a/pkg/querier/distributor_queryable_streaming_test.go
+++ b/pkg/querier/distributor_queryable_streaming_test.go
@@ -159,7 +159,7 @@ func createTestStreamReader(batches ...[]client.QueryStreamSeriesChunks) *client
 
 	cleanup := func() {}
 	queryLimiter := limiter.NewQueryLimiter(0, 0, 0, 0, nil)
-	memoryTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
 	reader := client.NewSeriesChunksStreamReader(ctx, mockClient, "ingester", seriesCount, queryLimiter, memoryTracker, cleanup, log.NewNopLogger())
 	reader.StartBuffering()

--- a/pkg/streamingpromql/operators/aggregations/aggregation_test.go
+++ b/pkg/streamingpromql/operators/aggregations/aggregation_test.go
@@ -86,7 +86,7 @@ func TestAggregator_ReturnsGroupsFinishedFirstEarliest(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, "")
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(context.Background())
 			aggregator, err := NewAggregator(parser.SUM, testCase.grouping, false, memoryConsumptionTracker, annotations.New(), types.NewInstantQueryTimeRange(time.Now()), posrange.PositionRange{})
 			require.NoError(t, err)
 

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
@@ -298,7 +298,7 @@ func TestGroupedVectorVectorBinaryOperation_OutputSeriesSorting(t *testing.T) {
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
 			ctx := context.Background()
-			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 			left := &operators.TestOperator{Series: testCase.leftSeries, MemoryConsumptionTracker: memoryConsumptionTracker}
 			right := &operators.TestOperator{Series: testCase.rightSeries, MemoryConsumptionTracker: memoryConsumptionTracker}
 

--- a/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation_test.go
@@ -197,7 +197,7 @@ func TestOneToOneVectorVectorBinaryOperation_SeriesMerging(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, "")
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(context.Background())
 			o := &OneToOneVectorVectorBinaryOperation{
 				// Simulate an expression with "on (env)".
 				// This is used to generate error messages.
@@ -623,7 +623,7 @@ func TestOneToOneVectorVectorBinaryOperation_ClosesInnerOperatorsAsSoonAsPossibl
 
 			ctx := context.Background()
 			timeRange := types.NewInstantQueryTimeRange(time.Now())
-			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 			left := &operators.TestOperator{Series: testCase.leftSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.leftSeries)), MemoryConsumptionTracker: memoryConsumptionTracker}
 			right := &operators.TestOperator{Series: testCase.rightSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.rightSeries)), MemoryConsumptionTracker: memoryConsumptionTracker}
 			vectorMatching := parser.VectorMatching{On: true, MatchingLabels: []string{"group"}}
@@ -705,7 +705,7 @@ func TestOneToOneVectorVectorBinaryOperation_ReleasesIntermediateStateIfClosedEa
 			timeRange := types.NewRangeQueryTimeRange(step1, step2, time.Minute)
 
 			ctx := context.Background()
-			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
 			var err error
 			left1Data := types.InstantVectorSeriesData{}

--- a/pkg/streamingpromql/operators/binops/or_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/or_binary_operation_test.go
@@ -292,7 +292,7 @@ func TestOrBinaryOperationSorting(t *testing.T) {
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
 			ctx := context.Background()
-			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 			left := &operators.TestOperator{Series: testCase.leftSeries, MemoryConsumptionTracker: memoryConsumptionTracker}
 			right := &operators.TestOperator{Series: testCase.rightSeries, MemoryConsumptionTracker: memoryConsumptionTracker}
 
@@ -534,7 +534,7 @@ func TestOrBinaryOperation_ClosesInnerOperatorsAsSoonAsPossible(t *testing.T) {
 
 			ctx := context.Background()
 			timeRange := types.NewInstantQueryTimeRange(time.Now())
-			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 			left := &operators.TestOperator{Series: testCase.leftSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.leftSeries)), MemoryConsumptionTracker: memoryConsumptionTracker}
 			right := &operators.TestOperator{Series: testCase.rightSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.rightSeries)), MemoryConsumptionTracker: memoryConsumptionTracker}
 			vectorMatching := parser.VectorMatching{On: true, MatchingLabels: []string{"group"}}
@@ -688,7 +688,7 @@ func TestOrBinaryOperation_ReleasesIntermediateStateIfClosedEarly(t *testing.T) 
 		t.Run(name, func(t *testing.T) {
 			ctx := context.Background()
 			timeRange := types.NewInstantQueryTimeRange(time.Now())
-			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 			left := &operators.TestOperator{Series: testCase.leftSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.leftSeries)), MemoryConsumptionTracker: memoryConsumptionTracker}
 			right := &operators.TestOperator{Series: testCase.rightSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.rightSeries)), MemoryConsumptionTracker: memoryConsumptionTracker}
 			vectorMatching := parser.VectorMatching{On: true, MatchingLabels: []string{"group"}}

--- a/pkg/streamingpromql/operators/deduplicate_and_merge_test.go
+++ b/pkg/streamingpromql/operators/deduplicate_and_merge_test.go
@@ -158,7 +158,7 @@ func TestDeduplicateAndMerge(t *testing.T) {
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
 			ctx := context.Background()
-			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 			inner := &TestOperator{Series: testCase.inputSeries, Data: testCase.inputData, MemoryConsumptionTracker: memoryConsumptionTracker}
 			o := NewDeduplicateAndMerge(inner, memoryConsumptionTracker)
 

--- a/pkg/streamingpromql/operators/drop_name_test.go
+++ b/pkg/streamingpromql/operators/drop_name_test.go
@@ -63,7 +63,7 @@ func TestDropName(t *testing.T) {
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
 			ctx := context.Background()
-			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 			inner := &TestOperator{
 				Series:                   testCase.inputSeries,
 				Data:                     testCase.inputData,

--- a/pkg/streamingpromql/operators/functions/absent_test.go
+++ b/pkg/streamingpromql/operators/functions/absent_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestAbsent_NextSeries_ExhaustedCondition(t *testing.T) {
 	ctx := context.Background()
-	memTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
 	a := &Absent{
 		TimeRange: types.QueryTimeRange{

--- a/pkg/streamingpromql/operators/functions/common_test.go
+++ b/pkg/streamingpromql/operators/functions/common_test.go
@@ -26,7 +26,7 @@ func TestDropSeriesName(t *testing.T) {
 		{Labels: labels.FromStrings("label2", "value2")},
 	}
 
-	tracker := limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, "")
+	tracker := limiter.NewUnlimitedMemoryConsumptionTracker(context.Background())
 	for _, metadata := range seriesMetadata {
 		err := tracker.IncreaseMemoryConsumptionForLabels(metadata.Labels)
 		require.NoError(t, err)

--- a/pkg/streamingpromql/operators/functions/function_over_instant_vector_test.go
+++ b/pkg/streamingpromql/operators/functions/function_over_instant_vector_test.go
@@ -30,7 +30,7 @@ func TestFunctionOverInstantVector(t *testing.T) {
 			{Floats: []promql.FPoint{{T: 0, F: 1}}},
 			{Floats: []promql.FPoint{{T: 0, F: 2}}},
 		},
-		MemoryConsumptionTracker: limiter.NewMemoryConsumptionTracker(ctx, 0, nil, ""),
+		MemoryConsumptionTracker: limiter.NewUnlimitedMemoryConsumptionTracker(ctx),
 	}
 
 	metadataFuncCalled := false
@@ -49,7 +49,7 @@ func TestFunctionOverInstantVector(t *testing.T) {
 
 	operator := &FunctionOverInstantVector{
 		Inner:                    inner,
-		MemoryConsumptionTracker: limiter.NewMemoryConsumptionTracker(ctx, 0, nil, ""),
+		MemoryConsumptionTracker: limiter.NewUnlimitedMemoryConsumptionTracker(ctx),
 		Func: FunctionOverInstantVectorDefinition{
 			SeriesDataFunc: mustBeCalledSeriesData,
 			SeriesMetadataFunction: SeriesMetadataFunctionDefinition{
@@ -71,7 +71,7 @@ func TestFunctionOverInstantVector(t *testing.T) {
 
 func TestFunctionOverInstantVectorWithScalarArgs(t *testing.T) {
 	ctx := context.Background()
-	tracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	tracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	inner := &operators.TestOperator{
 		Series: []labels.Labels{
 			labels.FromStrings("series", "0"),

--- a/pkg/streamingpromql/operators/functions/histogram_function_test.go
+++ b/pkg/streamingpromql/operators/functions/histogram_function_test.go
@@ -114,7 +114,7 @@ func TestHistogramFunction_ReturnsGroupsFinishedFirstEarliest(t *testing.T) {
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
 			ctx := context.Background()
-			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 			hOp := &HistogramFunction{
 				f: &histogramQuantile{
 					phArg: &testScalarOperator{},

--- a/pkg/streamingpromql/operators/operator_buffer_test.go
+++ b/pkg/streamingpromql/operators/operator_buffer_test.go
@@ -45,7 +45,7 @@ func TestInstantVectorOperatorBuffer_BufferingSubsetOfInputSeries(t *testing.T) 
 
 	seriesUsed := []bool{true, false, true, true, true}
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	require.NoError(t, memoryConsumptionTracker.IncreaseMemoryConsumption(types.FPointSize*6, limiter.FPointSlices)) // We have 6 FPoints from the inner series.
 	buffer := NewInstantVectorOperatorBuffer(inner, seriesUsed, 4, memoryConsumptionTracker)
 
@@ -120,7 +120,7 @@ func TestInstantVectorOperatorBuffer_BufferingAllInputSeries(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	require.NoError(t, memoryConsumptionTracker.IncreaseMemoryConsumption(types.FPointSize*6, limiter.FPointSlices)) // We have 6 FPoints from the inner series.
 	buffer := NewInstantVectorOperatorBuffer(inner, nil, 6, memoryConsumptionTracker)
 
@@ -174,7 +174,7 @@ func TestInstantVectorOperatorBuffer_BufferingAllInputSeries(t *testing.T) {
 
 func TestInstantVectorOperatorBuffer_ReleasesBufferWhenClosedEarly(t *testing.T) {
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
 	createTestData := func(val float64) types.InstantVectorSeriesData {
 		floats, err := types.FPointSlicePool.Get(1, memoryConsumptionTracker)

--- a/pkg/streamingpromql/operators/selectors/instant_vector_selector_test.go
+++ b/pkg/streamingpromql/operators/selectors/instant_vector_selector_test.go
@@ -188,7 +188,7 @@ func TestInstantVectorSelector_NativeHistogramPointerHandling(t *testing.T) {
 			endTime := startTime.Add(time.Duration(testCase.stepCount-1) * time.Minute)
 
 			ctx := context.Background()
-			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 			selector := &InstantVectorSelector{
 				Selector: &Selector{
 					Queryable: storage,
@@ -236,7 +236,7 @@ func TestInstantVectorSelector_SliceSizing(t *testing.T) {
 			endTime := timeZero.Add(7 * time.Minute)
 
 			ctx := context.Background()
-			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 			selector := &InstantVectorSelector{
 				Selector: &Selector{
 					Queryable: storage,

--- a/pkg/streamingpromql/operators/selectors/selector_test.go
+++ b/pkg/streamingpromql/operators/selectors/selector_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestSeriesList_BasicListOperations(t *testing.T) {
-	list := newSeriesList(limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, ""))
+	list := newSeriesList(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))
 	require.Equal(t, 0, list.Len())
 
 	series1 := mockSeries{labels.FromStrings("series", "1")}
@@ -59,7 +59,7 @@ func TestSeriesList_OperationsNearBatchBoundaries(t *testing.T) {
 
 	for _, seriesCount := range cases {
 		t.Run(fmt.Sprintf("N=%v", seriesCount), func(t *testing.T) {
-			list := newSeriesList(limiter.NewMemoryConsumptionTracker(ctx, 0, nil, ""))
+			list := newSeriesList(limiter.NewUnlimitedMemoryConsumptionTracker(ctx))
 
 			seriesAdded := make([]storage.Series, 0, seriesCount)
 
@@ -123,7 +123,7 @@ func TestSelector_QueryRanges(t *testing.T) {
 			TimeRange:                timeRange,
 			LookbackDelta:            lookbackDelta,
 			Matchers:                 matchers,
-			MemoryConsumptionTracker: limiter.NewMemoryConsumptionTracker(ctx, 0, nil, ""),
+			MemoryConsumptionTracker: limiter.NewUnlimitedMemoryConsumptionTracker(ctx),
 		}
 
 		_, err := s.SeriesMetadata(ctx, nil)
@@ -147,7 +147,7 @@ func TestSelector_QueryRanges(t *testing.T) {
 			TimeRange:                timeRange,
 			LookbackDelta:            lookbackDelta,
 			Matchers:                 matchers,
-			MemoryConsumptionTracker: limiter.NewMemoryConsumptionTracker(ctx, 0, nil, ""),
+			MemoryConsumptionTracker: limiter.NewUnlimitedMemoryConsumptionTracker(ctx),
 		}
 
 		runtimeMatchers := types.Matchers{
@@ -176,7 +176,7 @@ func TestSelector_QueryRanges(t *testing.T) {
 			TimeRange:                timeRange,
 			Range:                    selectorRange,
 			Matchers:                 matchers,
-			MemoryConsumptionTracker: limiter.NewMemoryConsumptionTracker(ctx, 0, nil, ""),
+			MemoryConsumptionTracker: limiter.NewUnlimitedMemoryConsumptionTracker(ctx),
 		}
 
 		_, err := s.SeriesMetadata(ctx, nil)
@@ -200,7 +200,7 @@ func TestSelector_QueryRanges(t *testing.T) {
 			TimeRange:                timeRange,
 			Range:                    selectorRange,
 			Matchers:                 matchers,
-			MemoryConsumptionTracker: limiter.NewMemoryConsumptionTracker(ctx, 0, nil, ""),
+			MemoryConsumptionTracker: limiter.NewUnlimitedMemoryConsumptionTracker(ctx),
 		}
 
 		runtimeMatchers := types.Matchers{

--- a/pkg/streamingpromql/operators/series_merging_test.go
+++ b/pkg/streamingpromql/operators/series_merging_test.go
@@ -759,7 +759,7 @@ func TestMergeSeries(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			result, conflict, err := MergeSeries(testCase.input, testCase.sourceSeriesIndices, limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, ""))
+			result, conflict, err := MergeSeries(testCase.input, testCase.sourceSeriesIndices, limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))
 
 			require.NoError(t, err)
 

--- a/pkg/streamingpromql/operators/subquery_test.go
+++ b/pkg/streamingpromql/operators/subquery_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestSubquery_CloseWithoutPrepare(t *testing.T) {
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
 	inner := &TestOperator{
 		Series:                   []labels.Labels{},

--- a/pkg/streamingpromql/optimize/ast/sharding/concat_test.go
+++ b/pkg/streamingpromql/optimize/ast/sharding/concat_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestConcat(t *testing.T) {
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
 	inner1 := &operators.TestOperator{
 		Series: []labels.Labels{
@@ -101,7 +101,7 @@ func TestConcat(t *testing.T) {
 
 func TestConcat_InnerOperatorsWithNoSeries(t *testing.T) {
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
 	inner1 := &operators.TestOperator{MemoryConsumptionTracker: memoryConsumptionTracker}
 	inner2 := &operators.TestOperator{MemoryConsumptionTracker: memoryConsumptionTracker}

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/instant_vector_operator_test.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/instant_vector_operator_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestInstantVectorOperator_Buffering_NoFiltering(t *testing.T) {
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	inner, expectedData := createTestInstantVectorOperator(t, 6, memoryConsumptionTracker)
 
 	buffer := NewInstantVectorDuplicationBuffer(inner, memoryConsumptionTracker)
@@ -127,7 +127,7 @@ func TestInstantVectorOperator_Buffering_NoFiltering(t *testing.T) {
 
 func TestInstantVectorOperator_Buffering_Filtering_AllConsumersOpen(t *testing.T) {
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	inner, expectedData := createTestInstantVectorOperator(t, 6, memoryConsumptionTracker)
 
 	buffer := NewInstantVectorDuplicationBuffer(inner, memoryConsumptionTracker)
@@ -213,7 +213,7 @@ func TestInstantVectorOperator_Buffering_Filtering_AllConsumersOpen(t *testing.T
 
 func TestInstantVectorOperator_Buffering_Filtering_IteratingBeforeCallingSeriesMetadataOnAllConsumers(t *testing.T) {
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	inner, expectedData := createTestInstantVectorOperator(t, 6, memoryConsumptionTracker)
 
 	buffer := NewInstantVectorDuplicationBuffer(inner, memoryConsumptionTracker)
@@ -293,7 +293,7 @@ func TestInstantVectorOperator_Buffering_Filtering_IteratingBeforeCallingSeriesM
 
 func TestInstantVectorOperator_Buffering_Filtering_DoesNotBufferForClosedConsumer(t *testing.T) {
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	inner, expectedData := createTestInstantVectorOperator(t, 6, memoryConsumptionTracker)
 
 	buffer := NewInstantVectorDuplicationBuffer(inner, memoryConsumptionTracker)
@@ -358,7 +358,7 @@ func TestInstantVectorOperator_Buffering_Filtering_DoesNotBufferForClosedConsume
 
 func TestInstantVectorOperator_Buffering_Filtering_DoesNotBufferUnnecessarilyForLaggingConsumer(t *testing.T) {
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	inner, expectedData := createTestInstantVectorOperator(t, 3, memoryConsumptionTracker)
 
 	buffer := NewInstantVectorDuplicationBuffer(inner, memoryConsumptionTracker)
@@ -409,7 +409,7 @@ func TestInstantVectorOperator_Buffering_Filtering_DoesNotBufferUnnecessarilyFor
 
 func TestInstantVectorOperator_Buffering_NonContiguousSeries(t *testing.T) {
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	inner, expectedData := createTestInstantVectorOperator(t, 4, memoryConsumptionTracker)
 
 	buffer := NewInstantVectorDuplicationBuffer(inner, memoryConsumptionTracker)
@@ -500,7 +500,7 @@ func TestInstantVectorOperator_Buffering_NonContiguousSeries(t *testing.T) {
 
 func TestInstantVectorOperator_Filtering_SingleConsumer(t *testing.T) {
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	inner, expectedData := createTestInstantVectorOperator(t, 6, memoryConsumptionTracker)
 
 	buffer := NewInstantVectorDuplicationBuffer(inner, memoryConsumptionTracker)
@@ -527,7 +527,7 @@ func TestInstantVectorOperator_Filtering_SingleConsumer(t *testing.T) {
 
 func TestInstantVectorOperator_ClosedWithBufferedData_NoFiltering(t *testing.T) {
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	inner, expectedData := createTestInstantVectorOperator(t, 3, memoryConsumptionTracker)
 
 	buffer := NewInstantVectorDuplicationBuffer(inner, memoryConsumptionTracker)
@@ -586,7 +586,7 @@ func TestInstantVectorOperator_ClosedWithBufferedData_NoFiltering(t *testing.T) 
 
 func TestInstantVectorOperator_ClosedWithBufferedData_Filtering(t *testing.T) {
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	inner, expectedData := createTestInstantVectorOperator(t, 3, memoryConsumptionTracker)
 
 	buffer := NewInstantVectorDuplicationBuffer(inner, memoryConsumptionTracker)

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator_test.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestRangeVectorOperator_Buffering_NoFiltering(t *testing.T) {
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	inner, expectedData := createTestRangeVectorOperator(t, 6, memoryConsumptionTracker)
 
 	buffer := NewRangeVectorDuplicationBuffer(inner, memoryConsumptionTracker)
@@ -148,7 +148,7 @@ func TestRangeVectorOperator_Buffering_NoFiltering(t *testing.T) {
 
 func TestRangeVectorOperator_Buffering_Filtering_AllConsumersOpen(t *testing.T) {
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	inner, expectedData := createTestRangeVectorOperator(t, 6, memoryConsumptionTracker)
 
 	buffer := NewRangeVectorDuplicationBuffer(inner, memoryConsumptionTracker)
@@ -241,7 +241,7 @@ func TestRangeVectorOperator_Buffering_Filtering_AllConsumersOpen(t *testing.T) 
 
 func TestRangeVectorOperator_Buffering_Filtering_IteratingBeforeCallingSeriesMetadataOnAllConsumers(t *testing.T) {
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	inner, expectedData := createTestRangeVectorOperator(t, 6, memoryConsumptionTracker)
 
 	buffer := NewRangeVectorDuplicationBuffer(inner, memoryConsumptionTracker)
@@ -335,7 +335,7 @@ func TestRangeVectorOperator_Buffering_Filtering_IteratingBeforeCallingSeriesMet
 
 func TestRangeVectorOperator_Buffering_Filtering_DoesNotBufferForClosedConsumer(t *testing.T) {
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	inner, expectedData := createTestRangeVectorOperator(t, 6, memoryConsumptionTracker)
 
 	buffer := NewRangeVectorDuplicationBuffer(inner, memoryConsumptionTracker)
@@ -404,7 +404,7 @@ func TestRangeVectorOperator_Buffering_Filtering_DoesNotBufferForClosedConsumer(
 
 func TestRangeVectorOperator_Buffering_Filtering_DoesNotBufferUnnecessarilyForLaggingConsumer(t *testing.T) {
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	inner, expectedData := createTestRangeVectorOperator(t, 3, memoryConsumptionTracker)
 
 	buffer := NewRangeVectorDuplicationBuffer(inner, memoryConsumptionTracker)
@@ -457,7 +457,7 @@ func TestRangeVectorOperator_Buffering_Filtering_DoesNotBufferUnnecessarilyForLa
 
 func TestRangeVectorOperator_Buffering_NonContiguousSeries(t *testing.T) {
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	inner, expectedData := createTestRangeVectorOperator(t, 4, memoryConsumptionTracker)
 
 	buffer := NewRangeVectorDuplicationBuffer(inner, memoryConsumptionTracker)
@@ -556,7 +556,7 @@ func TestRangeVectorOperator_Buffering_NonContiguousSeries(t *testing.T) {
 
 func TestRangeVectorOperator_Filtering_SingleConsumer(t *testing.T) {
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	inner, expectedData := createTestRangeVectorOperator(t, 6, memoryConsumptionTracker)
 
 	buffer := NewRangeVectorDuplicationBuffer(inner, memoryConsumptionTracker)
@@ -584,7 +584,7 @@ func TestRangeVectorOperator_Filtering_SingleConsumer(t *testing.T) {
 
 func TestRangeVectorOperator_ClosedWithBufferedData_NoFiltering(t *testing.T) {
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	inner, expectedData := createTestRangeVectorOperator(t, 3, memoryConsumptionTracker)
 
 	buffer := NewRangeVectorDuplicationBuffer(inner, memoryConsumptionTracker)
@@ -647,7 +647,7 @@ func TestRangeVectorOperator_ClosedWithBufferedData_NoFiltering(t *testing.T) {
 
 func TestRangeVectorOperator_ClosedWithBufferedData_Filtering(t *testing.T) {
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	inner, expectedData := createTestRangeVectorOperator(t, 3, memoryConsumptionTracker)
 
 	buffer := NewRangeVectorDuplicationBuffer(inner, memoryConsumptionTracker)
@@ -704,7 +704,7 @@ func TestRangeVectorOperator_ClosedWithBufferedData_Filtering(t *testing.T) {
 // Should this test fail, add the necessary field handling to this test and update range_vector_operator.go cloneStepData().
 func TestRangeVectorOperator_StepDataStructure(t *testing.T) {
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
 	data := &types.RangeVectorStepData{}
 
@@ -771,7 +771,7 @@ func TestRangeVectorOperator_Cloning_SmoothedAnchored(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			ctx := context.Background()
-			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 			tc.stepData.Floats = types.NewFPointRingBuffer(memoryConsumptionTracker).ViewAll(nil)
 			tc.stepData.Histograms = types.NewHPointRingBuffer(memoryConsumptionTracker).ViewUntilSearchingBackwards(0, nil)
 			clonedStepData, err := cloneStepData(&tc.stepData)
@@ -797,7 +797,7 @@ func TestRangeVectorOperator_Cloning(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	inner := newTestRangeVectorOperator(
 		[]labels.Labels{labels.FromStrings(model.MetricNameLabel, "test_series")},
 		[]types.InstantVectorSeriesData{series},
@@ -875,7 +875,7 @@ func createTestRangeVectorOperator(t *testing.T, seriesCount int, memoryConsumpt
 
 func TestRangeVectorOperator_ClosingAfterFirstReadFails(t *testing.T) {
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	series, err := types.SeriesMetadataSlicePool.Get(1, memoryConsumptionTracker)
 	require.NoError(t, err)
 
@@ -905,7 +905,7 @@ func TestRangeVectorOperator_ClosingAfterFirstReadFails(t *testing.T) {
 
 func TestRangeVectorOperator_ClosingAfterSubsequentReadFails(t *testing.T) {
 	ctx := context.Background()
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	series, err := types.SeriesMetadataSlicePool.Get(2, memoryConsumptionTracker)
 	require.NoError(t, err)
 

--- a/pkg/streamingpromql/types/data_test.go
+++ b/pkg/streamingpromql/types/data_test.go
@@ -29,7 +29,7 @@ func TestInstantVectorSeriesData_Clone(t *testing.T) {
 		},
 	}
 
-	memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, "")
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(context.Background())
 	cloned, err := original.Clone(memoryConsumptionTracker)
 
 	require.NoError(t, err)
@@ -335,7 +335,7 @@ func TestQueryTimeRange(t *testing.T) {
 }
 
 func TestRangeVectorStepData_SubStep(t *testing.T) {
-	memoryTracker := limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, "")
+	memoryTracker := limiter.NewUnlimitedMemoryConsumptionTracker(context.Background())
 	floats := NewFPointRingBuffer(memoryTracker)
 	histograms := NewHPointRingBuffer(memoryTracker)
 
@@ -462,7 +462,7 @@ func TestRangeVectorStepData_SubStep_ErrorCases(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			memoryTracker := limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, "")
+			memoryTracker := limiter.NewUnlimitedMemoryConsumptionTracker(context.Background())
 			floats := NewFPointRingBuffer(memoryTracker)
 			histograms := NewHPointRingBuffer(memoryTracker)
 

--- a/pkg/streamingpromql/types/limiting_pool_test.go
+++ b/pkg/streamingpromql/types/limiting_pool_test.go
@@ -148,7 +148,7 @@ func TestLimitingPool_Limited(t *testing.T) {
 }
 
 func TestLimitingPool_ClearsReturnedSlices(t *testing.T) {
-	tracker := limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, "")
+	tracker := limiter.NewUnlimitedMemoryConsumptionTracker(context.Background())
 
 	// Get a slice, put it back in the pool and get it back again.
 	// Make sure all elements are zero or false when we get it back.
@@ -242,7 +242,7 @@ func TestLimitingPool_Mangling(t *testing.T) {
 }
 
 func TestLimitingBucketedPool_AppendToSlice(t *testing.T) {
-	tracker := limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, "")
+	tracker := limiter.NewUnlimitedMemoryConsumptionTracker(context.Background())
 	onPutHookSlices := [][]promql.FPoint{}
 	p := NewLimitingBucketedPool(
 		pool.NewBucketedPool(1024, func(size int) []promql.FPoint { return make([]promql.FPoint, 0, size) }),

--- a/pkg/streamingpromql/types/ring_buffer_test.go
+++ b/pkg/streamingpromql/types/ring_buffer_test.go
@@ -55,7 +55,7 @@ func TestRingBuffer(t *testing.T) {
 			{T: 8, F: 800},
 			{T: 9, F: 900},
 		}
-		buf := &fPointRingBufferWrapper{NewFPointRingBuffer(limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, ""))}
+		buf := &fPointRingBufferWrapper{NewFPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))}
 		testRingBuffer(t, buf, points)
 	})
 
@@ -71,7 +71,7 @@ func TestRingBuffer(t *testing.T) {
 			{T: 8, H: &histogram.FloatHistogram{Count: 800}},
 			{T: 9, H: &histogram.FloatHistogram{Count: 900}},
 		}
-		buf := &hPointRingBufferWrapper{NewHPointRingBuffer(limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, ""))}
+		buf := &hPointRingBufferWrapper{NewHPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))}
 		testRingBuffer(t, buf, points)
 	})
 }
@@ -156,7 +156,7 @@ func TestRingBuffer_DiscardPointsBefore_ThroughWrapAround(t *testing.T) {
 			{T: 5, F: 500},
 			{T: 6, F: 600},
 		}
-		buf := &fPointRingBufferWrapper{NewFPointRingBuffer(limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, ""))}
+		buf := &fPointRingBufferWrapper{NewFPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))}
 		testDiscardPointsBeforeThroughWrapAround(t, buf, points)
 	})
 
@@ -169,7 +169,7 @@ func TestRingBuffer_DiscardPointsBefore_ThroughWrapAround(t *testing.T) {
 			{T: 5, H: &histogram.FloatHistogram{Count: 500}},
 			{T: 6, H: &histogram.FloatHistogram{Count: 600}},
 		}
-		buf := &hPointRingBufferWrapper{NewHPointRingBuffer(limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, ""))}
+		buf := &hPointRingBufferWrapper{NewHPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))}
 		testDiscardPointsBeforeThroughWrapAround(t, buf, points)
 	})
 }
@@ -216,7 +216,7 @@ func TestRingBuffer_RemoveLastPoint(t *testing.T) {
 		{T: 6, H: &histogram.FloatHistogram{Count: 600}},
 	}
 
-	buf := &hPointRingBufferWrapper{NewHPointRingBuffer(limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, ""))}
+	buf := &hPointRingBufferWrapper{NewHPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))}
 
 	t.Run("test removing points until none exist", func(t *testing.T) {
 		buf.Reset()
@@ -297,7 +297,7 @@ func TestRingBuffer_RemoveLastPoint(t *testing.T) {
 
 func TestRingBuffer_ViewUntilWithExistingView(t *testing.T) {
 	t.Run("FPoint ring buffer", func(t *testing.T) {
-		buf := NewFPointRingBuffer(limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, ""))
+		buf := NewFPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))
 		require.NoError(t, buf.Append(promql.FPoint{T: 1, F: 100}))
 		require.NoError(t, buf.Append(promql.FPoint{T: 2, F: 200}))
 		require.NoError(t, buf.Append(promql.FPoint{T: 3, F: 300}))
@@ -323,7 +323,7 @@ func TestRingBuffer_ViewUntilWithExistingView(t *testing.T) {
 		h3 := &histogram.FloatHistogram{Count: 300}
 		h4 := &histogram.FloatHistogram{Count: 400}
 
-		buf := NewHPointRingBuffer(limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, ""))
+		buf := NewHPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))
 		require.NoError(t, buf.Append(promql.HPoint{T: 1, H: h1}))
 		require.NoError(t, buf.Append(promql.HPoint{T: 2, H: h2}))
 		require.NoError(t, buf.Append(promql.HPoint{T: 3, H: h3}))
@@ -484,7 +484,7 @@ func (w *hPointRingBufferWrapper) GetTimestamp(point promql.HPoint) int64 {
 }
 
 func TestRingBuffer_FPointView_Cloning(t *testing.T) {
-	originalBuffer := NewFPointRingBuffer(limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, ""))
+	originalBuffer := NewFPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))
 	require.NoError(t, originalBuffer.Append(promql.FPoint{T: 0, F: 10}))
 	require.NoError(t, originalBuffer.Append(promql.FPoint{T: 1, F: 11}))
 
@@ -505,7 +505,7 @@ func TestRingBuffer_FPointView_Cloning(t *testing.T) {
 }
 
 func TestRingBuffer_HPointView_Cloning(t *testing.T) {
-	originalBuffer := NewHPointRingBuffer(limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, ""))
+	originalBuffer := NewHPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))
 	h1 := &histogram.FloatHistogram{Count: 100}
 	h2 := &histogram.FloatHistogram{Count: 200}
 	require.NoError(t, originalBuffer.Append(promql.HPoint{T: 0, H: h1}))
@@ -545,7 +545,7 @@ func TestRingBufferView_SubView(t *testing.T) {
 				name:       "without wraparound",
 				wraparound: false,
 				setupBuffer: func(t *testing.T) *FPointRingBufferView {
-					memoryTracker := limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, "")
+					memoryTracker := limiter.NewUnlimitedMemoryConsumptionTracker(context.Background())
 					buf := NewFPointRingBuffer(memoryTracker)
 					points := []promql.FPoint{
 						{T: 10, F: 100},
@@ -563,7 +563,7 @@ func TestRingBufferView_SubView(t *testing.T) {
 				name:       "with wraparound",
 				wraparound: true,
 				setupBuffer: func(t *testing.T) *FPointRingBufferView {
-					memoryTracker := limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, "")
+					memoryTracker := limiter.NewUnlimitedMemoryConsumptionTracker(context.Background())
 					buf := NewFPointRingBuffer(memoryTracker)
 					// Strategy: Create a buffer with wraparound where newer samples wrap to the beginning.
 					// Final buffer: [T=40, T=10, T=20, T=30] with firstIndex=1, size=4
@@ -690,7 +690,7 @@ func TestRingBufferView_SubView(t *testing.T) {
 				name:       "without wraparound",
 				wraparound: false,
 				setupBuffer: func(t *testing.T) *HPointRingBufferView {
-					memoryTracker := limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, "")
+					memoryTracker := limiter.NewUnlimitedMemoryConsumptionTracker(context.Background())
 					buf := NewHPointRingBuffer(memoryTracker)
 					points := []promql.HPoint{
 						{T: 10, H: &histogram.FloatHistogram{Count: 100}},

--- a/pkg/util/limiter/memory_consumption_test.go
+++ b/pkg/util/limiter/memory_consumption_test.go
@@ -29,7 +29,7 @@ func TestMemoryConsumptionTrackerFromContext(t *testing.T) {
 
 	t.Run("exists", func(t *testing.T) {
 		ctx := context.Background()
-		existing := NewMemoryConsumptionTracker(ctx, 0, nil, "")
+		existing := NewUnlimitedMemoryConsumptionTracker(ctx)
 		require.NoError(t, existing.IncreaseMemoryConsumption(uint64(512), IngesterChunks))
 
 		ctx = context.WithValue(ctx, memoryConsumptionTracker, existing)
@@ -43,7 +43,7 @@ func TestMemoryConsumptionTrackerFromContext(t *testing.T) {
 
 func TestAddToContext(t *testing.T) {
 	ctx := context.Background()
-	existing := NewMemoryConsumptionTracker(ctx, 0, nil, "")
+	existing := NewUnlimitedMemoryConsumptionTracker(ctx)
 	require.NoError(t, existing.IncreaseMemoryConsumption(uint64(512), IngesterChunks))
 
 	ctx = AddMemoryTrackerToContext(ctx, existing)
@@ -171,7 +171,7 @@ func BenchmarkMemoryConsumptionTracker(b *testing.B) {
 	const source = IngesterChunks
 
 	b.Run("no limits single threaded", func(b *testing.B) {
-		l := NewMemoryConsumptionTracker(context.Background(), 0, nil, "")
+		l := NewUnlimitedMemoryConsumptionTracker(context.Background())
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			_ = l.IncreaseMemoryConsumption(uint64(b.N), source)
@@ -198,7 +198,7 @@ func BenchmarkMemoryConsumptionTracker(b *testing.B) {
 	})
 
 	b.Run("no limits multiple threads", func(b *testing.B) {
-		l := NewMemoryConsumptionTracker(context.Background(), 0, nil, "")
+		l := NewUnlimitedMemoryConsumptionTracker(context.Background())
 		wg := sync.WaitGroup{}
 		run := atomic.NewBool(true)
 


### PR DESCRIPTION
#### What this PR does

This PR addresses https://github.com/grafana/mimir/pull/14377#discussion_r2838662661, simplifying code in tests.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor that swaps tracker construction helpers without changing production logic; low risk aside from potential test behavior differences if the unlimited helper is misused.
> 
> **Overview**
> Updates a broad set of query/streaming PromQL and streaming-reader tests to construct memory trackers via `limiter.NewUnlimitedMemoryConsumptionTracker(...)` instead of `NewMemoryConsumptionTracker(..., 0, nil, "")`, making the *no-limit but still tracked* intent explicit.
> 
> Also adjusts limiter tracker context/benchmark tests to use the new helper where appropriate, keeping the remaining limited-memory tests on the explicit constructor.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3c36636fa654604f865da3738b21349ac09bed0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->