### PR TITLE
distributors: make global rate limiting strategy zone-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 * [FEATURE] MQE: Add experimental support for splitting and caching intermediate results for functions over range vectors in instant queries. #13472 #14479 #14506 #14499 #14517 #14536 #14614 #14645 #14677
 * [FEATURE] MQE: Add experimental support for reporting the number of samples read per query. #14828
 * [ENHANCEMENT] Query-frontend: Add support for blocking queries exceeding a time range duration with `time_range_longer_than`. #14609
+* [ENHANCEMENT] Distributor: Add zone-aware rate limiting via `-distributor.ring.instance-availability-zone`. When configured the global ingestion rate limit is divided by the number of zones and the number of distributors in the local zone, instead of the total number of distributors. #14515
 * [ENHANCEMENT] Memberlist: Add experimental propagation delay tracker to measure gossip propagation delay across the memberlist cluster. Enable with `-memberlist.propagation-delay-tracker.enabled=true`. #14312 #14406
 * [ENHANCEMENT] Compactor: Add 0-100% jitter to the first compaction interval to spread compactions when multiple compactors start simultaneously. #14280
 * [ENHANCEMENT] Compactor, Store-gateway: Remove experimental setting `-compactor.upload-sparse-index-headers` and always upload sparse index-headers. This improves lazy loading performance in the store-gateway. #13089 #13882

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -1801,6 +1801,17 @@
             },
             {
               "kind": "field",
+              "name": "instance_availability_zone",
+              "required": false,
+              "desc": "The availability zone where this instance is running. Used for zone-aware rate limiting.",
+              "fieldValue": null,
+              "fieldDefaultValue": "",
+              "fieldFlag": "distributor.ring.instance-availability-zone",
+              "fieldType": "string",
+              "fieldCategory": "advanced"
+            },
+            {
+              "kind": "field",
               "name": "auto_forget_unhealthy_periods",
               "required": false,
               "desc": "Number of consecutive timeout periods after which Mimir automatically removes an unhealthy instance in the ring. Set to 0 to disable auto-forget.",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1415,6 +1415,8 @@ Usage of ./cmd/mimir/mimir:
     	Heartbeat timeout after which Mimir marks distributors as unhealthy in the ring. (default 1m0s)
   -distributor.ring.instance-addr string
     	IP address to advertise in the ring. Default is auto-detected.
+  -distributor.ring.instance-availability-zone string
+    	The availability zone where this instance is running. Used for zone-aware rate limiting.
   -distributor.ring.instance-enable-ipv6
     	Enable using an IPv6 instance address.
   -distributor.ring.instance-id string

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -1043,6 +1043,11 @@ ring:
   # CLI flag: -distributor.ring.instance-enable-ipv6
   [instance_enable_ipv6: <boolean> | default = false]
 
+  # (advanced) The availability zone where this instance is running. Used for
+  # zone-aware rate limiting.
+  # CLI flag: -distributor.ring.instance-availability-zone
+  [instance_availability_zone: <string> | default = ""]
+
   # (advanced) Number of consecutive timeout periods after which Mimir
   # automatically removes an unhealthy instance in the ring. Set to 0 to disable
   # auto-forget.

--- a/operations/mimir/mimir-flags-defaults.json
+++ b/operations/mimir/mimir-flags-defaults.json
@@ -117,6 +117,7 @@
   "distributor.ring.instance-interface-names": [],
   "distributor.ring.instance-port": 0,
   "distributor.ring.instance-addr": "",
+  "distributor.ring.instance-availability-zone": "",
   "distributor.ring.auto-forget-unhealthy-periods": 10,
   "distributor.instance-limits.max-ingestion-rate": 0,
   "distributor.instance-limits.max-inflight-push-requests": 2000,

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -122,7 +122,18 @@ type Distributor struct {
 	// the number of healthy instances
 	distributorsLifecycler *ring.BasicLifecycler
 	distributorsRing       *ring.Ring
-	healthyInstancesCount  *atomic.Uint32
+
+	// healthyInstancesCount stores the number of healthy instances in the
+	// distributors ring.
+	healthyInstancesCount *atomic.Uint32
+
+	// healthyInstancesInZoneCount stores the number of healthy instances in the
+	// distributors ring that are also in the same zone as this instance.
+	healthyInstancesInZoneCount *atomic.Uint32
+
+	// ringZonesCount stores the number of non-empty ring zones. If the distributor
+	// is not zone-aware, ringZonesCount is 1.
+	ringZonesCount *atomic.Uint32
 
 	costAttributionMgr *costattribution.Manager
 	// For handling HA replicas.
@@ -498,16 +509,18 @@ func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Ove
 	requestBufferPool := util.NewBufferPool(cfg.MaxRequestPoolBufferSize)
 
 	d := &Distributor{
-		cfg:                   cfg,
-		log:                   log,
-		ingestersRing:         ingestersRing,
-		RequestBufferPool:     requestBufferPool,
-		partitionsRing:        partitionsRing,
-		ingesterPool:          NewPool(cfg.PoolConfig, ingestersRing, cfg.IngesterClientFactory, log),
-		healthyInstancesCount: atomic.NewUint32(0),
-		limits:                limits,
-		costAttributionMgr:    costAttributionMgr,
-		ingestionRate:         util_math.NewEWMARate(0.2, instanceIngestionRateTickInterval),
+		cfg:                         cfg,
+		log:                         log,
+		ingestersRing:               ingestersRing,
+		RequestBufferPool:           requestBufferPool,
+		partitionsRing:              partitionsRing,
+		ingesterPool:                NewPool(cfg.PoolConfig, ingestersRing, cfg.IngesterClientFactory, log),
+		healthyInstancesCount:       atomic.NewUint32(0),
+		healthyInstancesInZoneCount: atomic.NewUint32(0),
+		ringZonesCount:              atomic.NewUint32(1),
+		limits:                      limits,
+		costAttributionMgr:          costAttributionMgr,
+		ingestionRate:               util_math.NewEWMARate(0.2, instanceIngestionRateTickInterval),
 
 		queryDuration: instrument.NewHistogramCollector(promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "cortex_distributor_query_duration_seconds",
@@ -698,14 +711,15 @@ func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Ove
 		requestRateStrategy = newInfiniteRateStrategy()
 		ingestionRateStrategy = newInfiniteRateStrategy()
 	} else {
-		distributorsRing, distributorsLifecycler, err = newRingAndLifecycler(cfg.DistributorRing, d.healthyInstancesCount, log, reg)
+		distributorsRing, distributorsLifecycler, err = newRingAndLifecycler(cfg.DistributorRing, d.healthyInstancesCount, d.healthyInstancesInZoneCount, d.ringZonesCount, log, reg)
 		if err != nil {
 			return nil, err
 		}
 
 		subservices = append(subservices, distributorsLifecycler, distributorsRing)
 		requestRateStrategy = newGlobalRateStrategy(newRequestRateStrategy(limits), d)
-		ingestionRateStrategy = newGlobalRateStrategyWithBurstFactor(limits, d)
+		zoneAware := cfg.DistributorRing.InstanceZone != ""
+		ingestionRateStrategy = newGlobalRateStrategyWithBurstFactor(limits, d, zoneAware)
 	}
 
 	// If this isn't a real distributor that will be accepting writes or if the HA tracker is
@@ -802,7 +816,7 @@ func exportStorageModeMetrics(reg prometheus.Registerer, classicStorageEnabled, 
 }
 
 // newRingAndLifecycler creates a new distributor ring and lifecycler with all required lifecycler delegates
-func newRingAndLifecycler(cfg RingConfig, instanceCount *atomic.Uint32, logger log.Logger, reg prometheus.Registerer) (*ring.Ring, *ring.BasicLifecycler, error) {
+func newRingAndLifecycler(cfg RingConfig, instanceCount, instanceInZoneCount, ringZonesCount *atomic.Uint32, logger log.Logger, reg prometheus.Registerer) (*ring.Ring, *ring.BasicLifecycler, error) {
 	reg = prometheus.WrapRegistererWithPrefix("cortex_", reg)
 	kvStore, err := kv.NewClient(cfg.Common.KVStore, ring.GetCodec(), kv.RegistererWithKVName(reg, "distributor-lifecycler"), logger)
 	if err != nil {
@@ -816,7 +830,7 @@ func newRingAndLifecycler(cfg RingConfig, instanceCount *atomic.Uint32, logger l
 
 	var delegate ring.BasicLifecyclerDelegate
 	delegate = ring.NewInstanceRegisterDelegate(ring.ACTIVE, lifecyclerCfg.NumTokens)
-	delegate = newHealthyInstanceDelegate(instanceCount, cfg.Common.HeartbeatTimeout, delegate)
+	delegate = newHealthyInstanceDelegate(instanceCount, instanceInZoneCount, ringZonesCount, cfg.Common.HeartbeatTimeout, delegate)
 	delegate = ring.NewLeaveOnStoppingDelegate(delegate, logger)
 	if cfg.AutoForgetUnhealthyPeriods > 0 {
 		delegate = ring.NewAutoForgetDelegate(time.Duration(cfg.AutoForgetUnhealthyPeriods)*cfg.Common.HeartbeatTimeout, delegate, logger)
@@ -3862,10 +3876,16 @@ func (d *Distributor) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 }
 
 // HealthyInstancesCount implements the ReadLifecycler interface
-//
-// We use a ring lifecycler delegate to count the number of members of the
-// ring. The count is then used to enforce rate limiting correctly for each
-// distributor. $EFFECTIVE_RATE_LIMIT = $GLOBAL_RATE_LIMIT / $NUM_INSTANCES
 func (d *Distributor) HealthyInstancesCount() int {
 	return int(d.healthyInstancesCount.Load())
+}
+
+// HealthyInstancesInZoneCount implements the ReadLifecycler interface.
+func (d *Distributor) HealthyInstancesInZoneCount() int {
+	return int(d.healthyInstancesInZoneCount.Load())
+}
+
+// ZonesCount implements the ReadLifecycler interface.
+func (d *Distributor) ZonesCount() int {
+	return int(d.ringZonesCount.Load())
 }

--- a/pkg/distributor/distributor_ring.go
+++ b/pkg/distributor/distributor_ring.go
@@ -30,11 +30,14 @@ const (
 type RingConfig struct {
 	Common util.CommonRingConfig `yaml:",inline"`
 
+	InstanceZone string `yaml:"instance_availability_zone" category:"advanced"`
+
 	AutoForgetUnhealthyPeriods int `yaml:"auto_forget_unhealthy_periods" category:"advanced"`
 }
 
 func (cfg *RingConfig) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	cfg.Common.RegisterFlags("distributor.ring.", "collectors/", "distributors", f, logger)
+	f.StringVar(&cfg.InstanceZone, "distributor.ring.instance-availability-zone", "", "The availability zone where this instance is running. Used for zone-aware rate limiting.")
 	f.IntVar(&cfg.AutoForgetUnhealthyPeriods, "distributor.ring.auto-forget-unhealthy-periods", 10, "Number of consecutive timeout periods after which Mimir automatically removes an unhealthy instance in the ring. Set to 0 to disable auto-forget.")
 }
 
@@ -49,6 +52,7 @@ func (cfg *RingConfig) ToBasicLifecyclerConfig(logger log.Logger) (ring.BasicLif
 	return ring.BasicLifecyclerConfig{
 		ID:                              cfg.Common.InstanceID,
 		Addr:                            net.JoinHostPort(instanceAddr, strconv.Itoa(instancePort)),
+		Zone:                            cfg.InstanceZone,
 		HeartbeatPeriod:                 cfg.Common.HeartbeatPeriod,
 		HeartbeatTimeout:                cfg.Common.HeartbeatTimeout,
 		TokensObservePeriod:             0,

--- a/pkg/distributor/instance_count.go
+++ b/pkg/distributor/instance_count.go
@@ -12,14 +12,30 @@ import (
 // healthyInstanceDelegate counts the number of healthy instances that are part of the ring
 // and stores the count to the provided atomic integer. Used here to count the number of
 // distributors in the ring to determine how to enforce rate limiting.
+//
+// If the ring is zone-aware healthyInstanceDelegate counts the number of healthy
+// instances in the current instance's zone and the number of ring zones.
 type healthyInstanceDelegate struct {
-	count            *atomic.Uint32
+	healthyInstancesCount       *atomic.Uint32
+	healthyInstancesInZoneCount *atomic.Uint32
+	ringZonesCount              *atomic.Uint32
+
 	heartbeatTimeout time.Duration
 	next             ring.BasicLifecyclerDelegate
 }
 
-func newHealthyInstanceDelegate(count *atomic.Uint32, heartbeatTimeout time.Duration, next ring.BasicLifecyclerDelegate) *healthyInstanceDelegate {
-	return &healthyInstanceDelegate{count: count, heartbeatTimeout: heartbeatTimeout, next: next}
+func newHealthyInstanceDelegate(
+	instanceCount, instanceInZoneCount, zoneCount *atomic.Uint32,
+	heartbeatTimeout time.Duration,
+	next ring.BasicLifecyclerDelegate,
+) *healthyInstanceDelegate {
+	return &healthyInstanceDelegate{
+		healthyInstancesCount:       instanceCount,
+		healthyInstancesInZoneCount: instanceInZoneCount,
+		ringZonesCount:              zoneCount,
+		heartbeatTimeout:            heartbeatTimeout,
+		next:                        next,
+	}
 }
 
 // OnRingInstanceRegister implements the ring.BasicLifecyclerDelegate interface
@@ -40,14 +56,31 @@ func (d *healthyInstanceDelegate) OnRingInstanceStopping(lifecycler *ring.BasicL
 // OnRingInstanceHeartbeat implements the ring.BasicLifecyclerDelegate interface
 func (d *healthyInstanceDelegate) OnRingInstanceHeartbeat(lifecycler *ring.BasicLifecycler, ringDesc *ring.Desc, instanceDesc *ring.InstanceDesc) {
 	activeMembers := uint32(0)
+	activeMembersInZone := uint32(0)
+	zoneCount := uint32(1)
 	now := time.Now()
+
+	zone := lifecycler.GetInstanceZone()
+	zones := make(map[string]struct{}, 5)
+	zones[zone] = struct{}{}
 
 	for _, instance := range ringDesc.Ingesters {
 		if ring.ACTIVE == instance.State && instance.IsHeartbeatHealthy(d.heartbeatTimeout, now) {
 			activeMembers++
+			if zone != "" && instance.Zone == zone {
+				activeMembersInZone++
+			}
+		}
+		if zone != "" {
+			if _, ok := zones[instance.Zone]; !ok {
+				zones[instance.Zone] = struct{}{}
+				zoneCount++
+			}
 		}
 	}
 
-	d.count.Store(activeMembers)
+	d.ringZonesCount.Store(zoneCount)
+	d.healthyInstancesCount.Store(activeMembers)
+	d.healthyInstancesInZoneCount.Store(activeMembersInZone)
 	d.next.OnRingInstanceHeartbeat(lifecycler, ringDesc, instanceDesc)
 }

--- a/pkg/distributor/instance_count_test.go
+++ b/pkg/distributor/instance_count_test.go
@@ -3,6 +3,7 @@
 package distributor
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -28,59 +29,180 @@ func (n nopDelegate) OnRingInstanceHeartbeat(*ring.BasicLifecycler, *ring.Desc, 
 
 func TestHealthyInstanceDelegate_OnRingInstanceHeartbeat(t *testing.T) {
 	// addInstance registers a new instance with the given ring and sets its last heartbeat timestamp
-	addInstance := func(desc *ring.Desc, id string, state ring.InstanceState, timestamp int64) {
-		instance := desc.AddIngester(id, "127.0.0.1", "", []uint32{1}, state, time.Now(), false, time.Time{}, nil)
+	addInstance := func(desc *ring.Desc, id, zone string, state ring.InstanceState, timestamp int64) {
+		instance := desc.AddIngester(id, "127.0.0.1", zone, []uint32{1}, state, time.Now(), false, time.Time{}, nil)
 		instance.Timestamp = timestamp
 		desc.Ingesters[id] = instance
 	}
 
 	tests := map[string]struct {
-		ringSetup     func(desc *ring.Desc)
-		expectedCount uint32
+		ringSetup         func(desc *ring.Desc)
+		zone              string
+		expectedInstances uint32
+		expectedInZone    uint32
+		expectedRingZones uint32
 	}{
 		"all instances healthy and active": {
 			ringSetup: func(desc *ring.Desc) {
 				now := time.Now()
-				addInstance(desc, "distributor-1", ring.ACTIVE, now.Unix())
-				addInstance(desc, "distributor-2", ring.ACTIVE, now.Unix())
-				addInstance(desc, "distributor-3", ring.ACTIVE, now.Unix())
+				addInstance(desc, "distributor-1", "", ring.ACTIVE, now.Unix())
+				addInstance(desc, "distributor-2", "", ring.ACTIVE, now.Unix())
+				addInstance(desc, "distributor-3", "", ring.ACTIVE, now.Unix())
 			},
-			expectedCount: 3,
+			expectedInstances: 3,
+			expectedRingZones: 1,
 		},
-
 		"all instances healthy not all instances active": {
 			ringSetup: func(desc *ring.Desc) {
 				now := time.Now()
-				addInstance(desc, "distributor-1", ring.ACTIVE, now.Unix())
-				addInstance(desc, "distributor-2", ring.LEAVING, now.Unix())
-				addInstance(desc, "distributor-3", ring.ACTIVE, now.Unix())
+				addInstance(desc, "distributor-1", "", ring.ACTIVE, now.Unix())
+				addInstance(desc, "distributor-2", "", ring.LEAVING, now.Unix())
+				addInstance(desc, "distributor-3", "", ring.ACTIVE, now.Unix())
 			},
-			expectedCount: 2,
+			expectedInstances: 2,
+			expectedRingZones: 1,
 		},
-
 		"some instances healthy all instances active": {
 			ringSetup: func(desc *ring.Desc) {
 				now := time.Now()
-				addInstance(desc, "distributor-1", ring.ACTIVE, now.Unix())
-				addInstance(desc, "distributor-2", ring.ACTIVE, now.Unix())
-				addInstance(desc, "distributor-3", ring.ACTIVE, now.Add(-5*time.Minute).Unix())
+				addInstance(desc, "distributor-1", "", ring.ACTIVE, now.Unix())
+				addInstance(desc, "distributor-2", "", ring.ACTIVE, now.Unix())
+				addInstance(desc, "distributor-3", "", ring.ACTIVE, now.Add(-5*time.Minute).Unix())
 			},
-			expectedCount: 2,
+			expectedInstances: 2,
+			expectedRingZones: 1,
+		},
+		"all instances healthy across multiple zones": {
+			zone: "zone-a",
+			ringSetup: func(desc *ring.Desc) {
+				now := time.Now()
+				addInstance(desc, "distributor-1", "zone-a", ring.ACTIVE, now.Unix())
+				addInstance(desc, "distributor-2", "zone-b", ring.ACTIVE, now.Unix())
+				addInstance(desc, "distributor-3", "zone-c", ring.ACTIVE, now.Unix())
+			},
+			expectedInstances: 3,
+			expectedRingZones: 3,
+			expectedInZone:    1,
+		},
+		"all instances healthy across multiple zones, but ring not configured to use zone": {
+			zone: "",
+			ringSetup: func(desc *ring.Desc) {
+				now := time.Now()
+				addInstance(desc, "distributor-1", "zone-a", ring.ACTIVE, now.Unix())
+				addInstance(desc, "distributor-2", "zone-b", ring.ACTIVE, now.Unix())
+				addInstance(desc, "distributor-3", "zone-c", ring.ACTIVE, now.Unix())
+			},
+			expectedInstances: 3,
+			expectedRingZones: 1,
+		},
+		"uneven distribution across 2 zones, distributor is placed in the zone with higher number of instances": {
+			zone: "zone-a",
+			ringSetup: func(desc *ring.Desc) {
+				now := time.Now()
+				for i := 0; i < 35; i++ {
+					addInstance(desc, fmt.Sprintf("distributor-a-%d", i), "zone-a", ring.ACTIVE, now.Unix())
+				}
+				for i := 0; i < 5; i++ {
+					addInstance(desc, fmt.Sprintf("distributor-b-%d", i), "zone-b", ring.ACTIVE, now.Unix())
+				}
+			},
+			expectedInstances: 35 + 5,
+			expectedInZone:    35,
+			expectedRingZones: 2,
+		},
+		"uneven distribution across 2 zones, distributor is placed in the zone with lower number of instances": {
+			zone: "zone-b",
+			ringSetup: func(desc *ring.Desc) {
+				now := time.Now()
+				for i := 0; i < 35; i++ {
+					addInstance(desc, fmt.Sprintf("distributor-a-%d", i), "zone-a", ring.ACTIVE, now.Unix())
+				}
+				for i := 0; i < 5; i++ {
+					addInstance(desc, fmt.Sprintf("distributor-b-%d", i), "zone-b", ring.ACTIVE, now.Unix())
+				}
+			},
+			expectedInstances: 35 + 5,
+			expectedInZone:    5,
+			expectedRingZones: 2,
+		},
+		"zone-aware with some unhealthy in own zone": {
+			zone: "zone-a",
+			ringSetup: func(desc *ring.Desc) {
+				now := time.Now()
+				addInstance(desc, "distributor-a-1", "zone-a", ring.ACTIVE, now.Unix())
+				addInstance(desc, "distributor-a-2", "zone-a", ring.ACTIVE, now.Add(-5*time.Minute).Unix())
+				addInstance(desc, "distributor-a-3", "zone-a", ring.ACTIVE, now.Unix())
+				addInstance(desc, "distributor-b-1", "zone-b", ring.ACTIVE, now.Unix())
+			},
+			expectedInstances: 3,
+			expectedInZone:    2,
+			expectedRingZones: 2,
+		},
+		"zone-aware with non-active instances in own zone": {
+			zone: "zone-a",
+			ringSetup: func(desc *ring.Desc) {
+				now := time.Now()
+				addInstance(desc, "distributor-a-1", "zone-a", ring.ACTIVE, now.Unix())
+				addInstance(desc, "distributor-a-2", "zone-a", ring.LEAVING, now.Unix())
+				addInstance(desc, "distributor-b-1", "zone-b", ring.ACTIVE, now.Unix())
+				addInstance(desc, "distributor-b-2", "zone-b", ring.ACTIVE, now.Unix())
+			},
+			expectedInstances: 3,
+			expectedInZone:    1,
+			expectedRingZones: 2,
+		},
+		"zone-aware with unhealthy instances in other zone": {
+			zone: "zone-a",
+			ringSetup: func(desc *ring.Desc) {
+				now := time.Now()
+				addInstance(desc, "distributor-a-1", "zone-a", ring.ACTIVE, now.Unix())
+				addInstance(desc, "distributor-a-2", "zone-a", ring.ACTIVE, now.Unix())
+				addInstance(desc, "distributor-b-1", "zone-b", ring.ACTIVE, now.Add(-5*time.Minute).Unix())
+			},
+			expectedInstances: 2,
+			expectedInZone:    2,
+			expectedRingZones: 2,
+		},
+		"zone-aware single zone": {
+			zone: "zone-a",
+			ringSetup: func(desc *ring.Desc) {
+				now := time.Now()
+				addInstance(desc, "distributor-1", "zone-a", ring.ACTIVE, now.Unix())
+				addInstance(desc, "distributor-2", "zone-a", ring.ACTIVE, now.Unix())
+				addInstance(desc, "distributor-3", "zone-a", ring.ACTIVE, now.Unix())
+			},
+			expectedInstances: 3,
+			expectedInZone:    3,
+			expectedRingZones: 1,
+		},
+		"zone-aware empty ring": {
+			zone: "zone-a",
+			ringSetup: func(desc *ring.Desc) {
+			},
+			expectedInstances: 0,
+			expectedRingZones: 1,
 		},
 	}
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			count := atomic.NewUint32(0)
+			instanceCount := atomic.NewUint32(0)
+			instanceInZoneCount := atomic.NewUint32(0)
+			zoneCount := atomic.NewUint32(0)
 			ringDesc := ring.NewDesc()
+			lifecycler, _ := ring.NewBasicLifecycler(ring.BasicLifecyclerConfig{
+				Zone: testData.zone,
+			}, "", "", nil, nil, nil, nil)
 
 			testData.ringSetup(ringDesc)
 			instance := ringDesc.Ingesters["distributor-1"]
 
-			delegate := newHealthyInstanceDelegate(count, time.Minute, &nopDelegate{})
-			delegate.OnRingInstanceHeartbeat(&ring.BasicLifecycler{}, ringDesc, &instance)
+			delegate := newHealthyInstanceDelegate(instanceCount, instanceInZoneCount, zoneCount, time.Minute, &nopDelegate{})
+			delegate.OnRingInstanceHeartbeat(lifecycler, ringDesc, &instance)
 
-			assert.Equal(t, testData.expectedCount, count.Load())
+			assert.Equal(t, int(testData.expectedInstances), int(instanceCount.Load()))
+			assert.Equal(t, int(testData.expectedInZone), int(instanceInZoneCount.Load()))
+			assert.Equal(t, int(testData.expectedRingZones), int(zoneCount.Load()))
 		})
 	}
 }

--- a/pkg/distributor/rate_strategy.go
+++ b/pkg/distributor/rate_strategy.go
@@ -16,31 +16,55 @@ import (
 
 // ReadLifecycler represents the read interface to the lifecycler.
 type ReadLifecycler interface {
+	// HealthyInstancesCount returns the total number of healthy instances in the
+	// ring.
 	HealthyInstancesCount() int
+	// HealthyInstancesInZoneCount returns the number of healthy instances in the
+	// zone this distributor is running in or the total number of healthy instances
+	// if distributors are not zone-aware.
+	HealthyInstancesInZoneCount() int
+	// ZonesCount returns the number of zones in the ring or 1 if not zone-aware.
+	ZonesCount() int
 }
 
 type globalIngestionStrategyWithBurstFactor struct {
-	limits *validation.Overrides
-	ring   ReadLifecycler
+	limits    *validation.Overrides
+	ring      ReadLifecycler
+	zoneAware bool
 }
 
 // We want a rate limiter that can use the burst factor if it's set for ingest rate limiting.
-func newGlobalRateStrategyWithBurstFactor(limits *validation.Overrides, ring ReadLifecycler) limiter.RateLimiterStrategy {
+//
+// The effective per-instance limit is calculated according to:
+// limit = maxRate / healthyInstances
+//
+// If we run in multiple zones (zoneAware), we can assume requests of a tenant
+// are evenly distributed between zones. However, the number of distributors per
+// zone might differ. Therefore, the effective limit is first divided by zones
+// and then by number of healthy instances, i.e.:
+// limit = maxRate / healthyInstancesInZone / ringZones
+func newGlobalRateStrategyWithBurstFactor(limits *validation.Overrides, ring ReadLifecycler, zoneAware bool) limiter.RateLimiterStrategy {
 	return &globalIngestionStrategyWithBurstFactor{
-		limits: limits,
-		ring:   ring,
+		limits:    limits,
+		ring:      ring,
+		zoneAware: zoneAware,
 	}
 }
 
 func (s *globalIngestionStrategyWithBurstFactor) Limit(tenantID string) float64 {
-	numDistributors := s.ring.HealthyInstancesCount()
-
 	limit := s.limits.IngestionRate(tenantID)
-
-	if numDistributors == 0 || limit == float64(rate.Inf) {
+	var numDistributorsInZone, ringZones int
+	if s.zoneAware {
+		numDistributorsInZone = s.ring.HealthyInstancesInZoneCount()
+		ringZones = s.ring.ZonesCount()
+	} else {
+		numDistributorsInZone = s.ring.HealthyInstancesCount()
+		ringZones = 1
+	}
+	if numDistributorsInZone == 0 || ringZones == 0 || limit == float64(rate.Inf) {
 		return limit
 	}
-	return limit / float64(numDistributors)
+	return limit / float64(numDistributorsInZone*ringZones)
 }
 
 func (s *globalIngestionStrategyWithBurstFactor) Burst(tenantID string) int {
@@ -62,6 +86,9 @@ type globalStrategy struct {
 	ring         ReadLifecycler
 }
 
+// newGlobalRateStrategy constructs a new limiter.RateLimiterStrategy, where the
+// effective per-instance limit is calculated according to:
+// limit = maxRate / healthyInstances
 func newGlobalRateStrategy(baseStrategy limiter.RateLimiterStrategy, ring ReadLifecycler) limiter.RateLimiterStrategy {
 	return &globalStrategy{
 		baseStrategy: baseStrategy,

--- a/pkg/distributor/rate_strategy_test.go
+++ b/pkg/distributor/rate_strategy_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"golang.org/x/time/rate"
 
 	"github.com/grafana/mimir/pkg/util/validation"
@@ -18,79 +17,118 @@ import (
 
 func TestIngestionRateStrategy(t *testing.T) {
 	t.Run("rate limiter should share the limit across the number of distributors", func(t *testing.T) {
-		// Init limits overrides
 		overrides := validation.NewOverrides(validation.Limits{
 			IngestionRate:      float64(1000),
 			IngestionBurstSize: 10000,
 		}, nil)
 
-		mockRing := newReadLifecyclerMock()
-		mockRing.On("HealthyInstancesCount").Return(2)
-
-		strategy := newGlobalRateStrategyWithBurstFactor(overrides, mockRing)
-		assert.Equal(t, strategy.Limit("test"), float64(500))
-		assert.Equal(t, strategy.Burst("test"), 10000)
+		mockRing := newReadLifecyclerMock(2, -1, 1)
+		strategy := newGlobalRateStrategyWithBurstFactor(overrides, mockRing, false)
+		assert.Equal(t, float64(500), strategy.Limit("test"))
+		assert.Equal(t, 10000, strategy.Burst("test"))
 	})
 
 	t.Run("infinite rate limiter should return unlimited settings", func(t *testing.T) {
 		strategy := newInfiniteRateStrategy()
 
-		assert.Equal(t, strategy.Limit("test"), float64(rate.Inf))
-		assert.Equal(t, strategy.Burst("test"), 0)
+		assert.Equal(t, float64(rate.Inf), strategy.Limit("test"))
+		assert.Equal(t, 0, strategy.Burst("test"))
 	})
 	t.Run("Burst factor should be 3x the per distributor limit", func(t *testing.T) {
-		// Init limits overrides
 		overrides := validation.NewOverrides(validation.Limits{
 			IngestionRate:        float64(1000),
 			IngestionBurstFactor: 3,
 		}, nil)
 
-		mockRing := newReadLifecyclerMock()
-		mockRing.On("HealthyInstancesCount").Return(2)
-
-		strategy := newGlobalRateStrategyWithBurstFactor(overrides, mockRing)
-		assert.Equal(t, strategy.Limit("test"), float64(500))
-		assert.Equal(t, strategy.Burst("test"), 1500)
+		mockRing := newReadLifecyclerMock(2, -1, 1)
+		strategy := newGlobalRateStrategyWithBurstFactor(overrides, mockRing, false)
+		assert.Equal(t, float64(500), strategy.Limit("test"))
+		assert.Equal(t, 1500, strategy.Burst("test"))
 	})
-	t.Run("Burst factor should be set to to max int if limit is too large", func(t *testing.T) {
-		// Init limits overrides
+	t.Run("Burst factor should be set to max int if limit is too large", func(t *testing.T) {
 		overrides := validation.NewOverrides(validation.Limits{
 			IngestionRate:        float64(math.MaxInt),
 			IngestionBurstFactor: 3,
 		}, nil)
 
-		mockRing := newReadLifecyclerMock()
-		mockRing.On("HealthyInstancesCount").Return(2)
-
-		strategy := newGlobalRateStrategyWithBurstFactor(overrides, mockRing)
-		assert.Equal(t, strategy.Limit("test"), float64(math.MaxInt)/2)
-		assert.Equal(t, strategy.Burst("test"), math.MaxInt)
+		mockRing := newReadLifecyclerMock(2, -1, 1)
+		strategy := newGlobalRateStrategyWithBurstFactor(overrides, mockRing, false)
+		assert.Equal(t, float64(math.MaxInt)/2, strategy.Limit("test"))
+		assert.Equal(t, math.MaxInt, strategy.Burst("test"))
 	})
-	t.Run("Burst factor should be set to to max int if limit is rate.inf", func(t *testing.T) {
-		// Init limits overrides
+	t.Run("Burst factor should be set to max int if limit is rate.inf", func(t *testing.T) {
 		overrides := validation.NewOverrides(validation.Limits{
 			IngestionRate:        math.MaxFloat64,
 			IngestionBurstFactor: 3,
 		}, nil)
 
-		mockRing := newReadLifecyclerMock()
-		mockRing.On("HealthyInstancesCount").Return(2)
+		mockRing := newReadLifecyclerMock(2, -1, 1)
+		strategy := newGlobalRateStrategyWithBurstFactor(overrides, mockRing, false)
+		assert.Equal(t, math.MaxFloat64, strategy.Limit("test"))
+		assert.Equal(t, math.MaxInt, strategy.Burst("test"))
+	})
 
-		strategy := newGlobalRateStrategyWithBurstFactor(overrides, mockRing)
-		assert.Equal(t, strategy.Limit("test"), math.MaxFloat64)
-		assert.Equal(t, strategy.Burst("test"), math.MaxInt)
+	t.Run("zone-aware: limit is divided by zone count and distributors in zone", func(t *testing.T) {
+		overrides := validation.NewOverrides(validation.Limits{
+			IngestionRate:      float64(100000),
+			IngestionBurstSize: 200000,
+		}, nil)
+
+		mockRing := newReadLifecyclerMock(-1, 35, 2)
+		strategy := newGlobalRateStrategyWithBurstFactor(overrides, mockRing, true)
+		assert.InDelta(t, float64(100000)/35/2, strategy.Limit("test"), 0.01)
+
+		// Zones with less healthy members gets a higher limit:
+		mockRing.healthyInZone = 5
+		mockRing.zonesCount = 2
+		assert.Equal(t, float64(100000)/5/2, strategy.Limit("test"))
+	})
+
+	t.Run("zone-aware: 3 zones with burst factor", func(t *testing.T) {
+		overrides := validation.NewOverrides(validation.Limits{
+			IngestionRate:        float64(9000),
+			IngestionBurstFactor: 2,
+		}, nil)
+
+		mockRing := newReadLifecyclerMock(-1, 10, 3)
+		strategy := newGlobalRateStrategyWithBurstFactor(overrides, mockRing, true)
+		assert.Equal(t, float64(300), strategy.Limit("test"))
+		assert.Equal(t, 600, strategy.Burst("test"))
+	})
+	t.Run("zone-aware: no healthy distributors returns global limit", func(t *testing.T) {
+		overrides := validation.NewOverrides(validation.Limits{
+			IngestionRate:      float64(1000),
+			IngestionBurstSize: 10000,
+		}, nil)
+
+		mockRing := newReadLifecyclerMock(-1, 0, 2)
+		strategy := newGlobalRateStrategyWithBurstFactor(overrides, mockRing, true)
+		assert.Equal(t, float64(1000), strategy.Limit("test"))
 	})
 }
 
 type readLifecyclerMock struct {
-	mock.Mock
+	healthyInstances int
+	healthyInZone    int
+	zonesCount       int
 }
 
-func newReadLifecyclerMock() *readLifecyclerMock {
-	return &readLifecyclerMock{}
+func newReadLifecyclerMock(healthyInstances, healthyInZone, zonesCount int) *readLifecyclerMock {
+	return &readLifecyclerMock{
+		healthyInstances: healthyInstances,
+		healthyInZone:    healthyInZone,
+		zonesCount:       zonesCount,
+	}
 }
 
 func (m *readLifecyclerMock) HealthyInstancesCount() int {
-	args := m.Called()
-	return args.Int(0)
+	return m.healthyInstances
+}
+
+func (m *readLifecyclerMock) HealthyInstancesInZoneCount() int {
+	return m.healthyInZone
+}
+
+func (m *readLifecyclerMock) ZonesCount() int {
+	return m.zonesCount
 }


### PR DESCRIPTION
#### What this PR does

Let's assume zone A=35 replicas, zone B=5 replicas and limit=100K req/s. Effective per-instance rate limit then is: 100K/ 40 = 2.5K.
Let's assume we get 90K req/s, split evenly by zone. The per-instance rate in zone A is 45k/35=1.28k in zone B 45k/5=9k.
Zone A will drop samples as the effective limit doesn't respect the instance-per-zone distribution.

This PR changes that calculation to be `<effective limit> = <totalLimit> / <numZones> / <ringInstancesInZone>`.
With the new calculation, effective ingestion rate limit for zone A=1.4K and zone B=10K and no samples are dropped.

To achieve this, this PR 
- introduces a new flag on distributors `--distributor.ring.instance-availability-zone` that sets the zone on the `BasicLifecyclerConfig`. This paradigm was inspired by the usage-tracker ring setup. When set, rate limit will use the new formula,
- modifies the `instanceCount` ring delegate to count instances in zone and ring zones, and
- modifies `globalIngestionStrategyWithBurstFactor` to have a `zoneAware` flag which enables the new behavior.

#### Which issue(s) this PR fixes or relates to

Closes: https://github.com/grafana/mimir-squad/issues/3547

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core ingestion rate-limiting calculations and ring-derived instance counting; misconfiguration of zone settings or edge cases in zone counting could alter tenant throttling behavior.
> 
> **Overview**
> Enables **zone-aware global ingestion rate limiting** in the distributor so per-instance limits account for uneven replica distribution across availability zones.
> 
> Adds `-distributor.ring.instance-availability-zone` (and config/docs/defaults/help updates) to register distributor zone in the ring, extends the ring heartbeat delegate to track *healthy instances total*, *healthy instances in local zone*, and *number of zones*, and updates the global ingestion limiter to compute `limit = maxRate / zones / healthyInstancesInZone` when zone-aware (with expanded unit tests).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81dcdb2dbf54ce228d246a31da3eed91dea15e3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->