### PR TITLE
Renovate: rebase build image PRs even if modified to include new image tag

### DIFF
--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -227,6 +227,6 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ steps.app-token-for-commit.outputs.token }}
-          GITHUB_LOGIN: ${{ github.event.pull_request.user.login }}
+          GITHUB_LOGIN: mimir-github-bot
           TAG: ${{ steps.compute_hash.outputs.tag }}
           MAIN_TAG: ${{ steps.prepare.outputs.main_image_tag }}

--- a/renovate.json5
+++ b/renovate.json5
@@ -128,11 +128,12 @@
       ],
     },
     {
-      description: 'Automatically rebase all dependency update PRs touching mimir-build-image/Dockerfile',
+      description: 'Automatically rebase all dependency update PRs touching mimir-build-image/Dockerfile, and ignore pushes from GitHub Actions with new image reference when considering if the PR is modified and can be rebased',
       matchFileNames: [
         'mimir-build-image/Dockerfile',
       ],
       rebaseWhen: 'behind-base-branch',
+      gitIgnoredAuthors: ['mimir-github-bot@users.noreply.github.com'],
     }
   ],
   branchPrefix: 'deps-update/',


### PR DESCRIPTION
#### What this PR does

This is a follow up to https://github.com/grafana/mimir/pull/14496. The configuration in that PR didn't quite work as we hoped, as Renovate won't automatically rebase PRs that have been modified by another user, but the build image build workflow pushes a commit to each PR with the updated build image tag.

This PR configures Renovate to ignore pushes from the user used to push these commits.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change affecting Renovate rebasing and a GitHub Actions commit author; main risk is unintended CI/automation behavior if the ignored author/email doesn’t match actual commits.
> 
> **Overview**
> Ensures the `push-mimir-build-image` workflow’s auto-commit uses a consistent author (`mimir-github-bot`) instead of the PR author.
> 
> Updates Renovate’s rule for `mimir-build-image/Dockerfile` so rebase decisions ignore commits from `mimir-github-bot@users.noreply.github.com`, allowing dependency PRs to be auto-rebased even after the workflow adds a new build-image tag commit.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32d57989e2beb71023bc206fec908f7128e8230f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->