### PR TITLE
fix: MQE: Don't remove DeduplicateAndMerge from binary `or`

### DIFF
--- a/pkg/streamingpromql/optimize/plan/eliminate_deduplicate_and_merge.go
+++ b/pkg/streamingpromql/optimize/plan/eliminate_deduplicate_and_merge.go
@@ -119,6 +119,10 @@ func (e *EliminateDeduplicateAndMergeOptimizationPass) apply(node planning.Node,
 
 func canEliminateDeduplicateAndMergeDelayedNameRemoval(node planning.Node) bool {
 	switch node := node.(type) {
+	case *core.BinaryExpression:
+		return node.Op != core.BINARY_LOR
+	case *core.DropName:
+		return areSeriesUniqueDropName(node)
 	case *core.FunctionCall:
 		if isLabelReplaceOrJoinFunction(node) {
 			return false
@@ -131,8 +135,6 @@ func canEliminateDeduplicateAndMergeDelayedNameRemoval(node planning.Node) bool 
 		}
 
 		return true
-	case *core.DropName:
-		return areSeriesUniqueDropName(node)
 	default:
 		return true
 	}
@@ -185,7 +187,6 @@ func canEliminateDeduplicateAndMerge(node planning.Node) (bool, error) {
 		}
 
 		return true, nil
-
 	default:
 		return false, nil
 	}

--- a/pkg/streamingpromql/optimize/plan/eliminate_deduplicate_and_merge_test.go
+++ b/pkg/streamingpromql/optimize/plan/eliminate_deduplicate_and_merge_test.go
@@ -858,13 +858,14 @@ func TestEliminateDeduplicateAndMergeOptimizationPassPlan(t *testing.T) {
 				- DeduplicateAndMerge
 					- DropName
 						- BinaryExpression: LHS or RHS
-							- LHS: BinaryExpression: LHS or RHS
-								- LHS: VectorSelector: {__name__="foo"}
-								- RHS: VectorSelector: {__name__="bar"}
+							- LHS: DeduplicateAndMerge
+								- BinaryExpression: LHS or RHS
+									- LHS: VectorSelector: {__name__="foo"}
+									- RHS: VectorSelector: {__name__="bar"}
 							- RHS: VectorSelector: {__name__="baz"}
 				`,
 			nodesEliminatedWithoutDelayedNameRemoval: 0,
-			nodesEliminatedWithDelayedNameRemoval:    1,
+			nodesEliminatedWithDelayedNameRemoval:    0,
 		},
 		"nested binary operations with rate functions": {
 			expr: `rate(foo[5m]) or rate(bar[5m]) or rate(baz[5m])`,
@@ -884,16 +885,17 @@ func TestEliminateDeduplicateAndMergeOptimizationPassPlan(t *testing.T) {
 				- DeduplicateAndMerge
 					- DropName
 						- BinaryExpression: LHS or RHS
-							- LHS: BinaryExpression: LHS or RHS
-								- LHS: FunctionCall: rate(...)
-									- MatrixSelector: {__name__="foo"}[5m0s]
-								- RHS: FunctionCall: rate(...)
-									- MatrixSelector: {__name__="bar"}[5m0s]
+							- LHS: DeduplicateAndMerge
+								- BinaryExpression: LHS or RHS
+									- LHS: FunctionCall: rate(...)
+										- MatrixSelector: {__name__="foo"}[5m0s]
+									- RHS: FunctionCall: rate(...)
+										- MatrixSelector: {__name__="bar"}[5m0s]
 							- RHS: FunctionCall: rate(...)
 								- MatrixSelector: {__name__="baz"}[5m0s]
 				`,
 			nodesEliminatedWithoutDelayedNameRemoval: 3,
-			nodesEliminatedWithDelayedNameRemoval:    4,
+			nodesEliminatedWithDelayedNameRemoval:    3,
 		},
 		"nested binary operations not wrapped in DeduplicateAndMerge, with one eligible for elimination": {
 			expr: `rate(bar[5m]) / (baz * foo)`,
@@ -936,12 +938,13 @@ func TestEliminateDeduplicateAndMergeOptimizationPassPlan(t *testing.T) {
 						- BinaryExpression: LHS or RHS
 							- LHS: FunctionCall: rate(...)
 								- MatrixSelector: {__name__="bar"}[5m0s]
-							- RHS: BinaryExpression: LHS or RHS
-								- LHS: VectorSelector: {__name__="baz"}
-								- RHS: VectorSelector: {__name__="foo"}
+							- RHS: DeduplicateAndMerge
+								- BinaryExpression: LHS or RHS
+									- LHS: VectorSelector: {__name__="baz"}
+									- RHS: VectorSelector: {__name__="foo"}
 				`,
 			nodesEliminatedWithoutDelayedNameRemoval: 1,
-			nodesEliminatedWithDelayedNameRemoval:    2,
+			nodesEliminatedWithDelayedNameRemoval:    1,
 		},
 	}
 

--- a/pkg/streamingpromql/testdata/ours/eliminate_deduplicate_and_merge_delayed_name_removal_enabled.test
+++ b/pkg/streamingpromql/testdata/ours/eliminate_deduplicate_and_merge_delayed_name_removal_enabled.test
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# This tests for a bug introduced https://github.com/grafana/mimir/pull/14228
+# Note that there is no increase for {op="get"} for one step. This causes the
+# `or` operation from the query to use the leg that doesn't have the `> 0`
+# conditional. Without a `DeduplicateAndMerge` node wrapping the binary `or`,
+# we end up with duplicate series with values in the final `DeduplicateAndMerge`
+# node at the root of query.
+
+load 1m
+  metric_total{op="get", pod="sg-1"} 1 2 3 4  4  6  7  8  9  10
+  metric_total{op="get", pod="sg-2"} 1 2 3 4  4  6  7  8  9  10
+  metric_total{op="set", pod="sg-1"} 2 4 6 8  10 12 14 16 18 20
+  metric_total{op="set", pod="sg-2"} 2 4 6 8  10 12 14 16 18 20
+  metric_total{op="del", pod="sg-1"} 3 6 9 12 15 18 18 24 27 30
+  metric_total{op="del", pod="sg-2"} 3 6 9 12 15 18 18 24 27 30
+
+eval instant at 3m avg_over_time(((sum by(op) (rate(metric_total{pod=~"sg.+"}[2m])) > 0) or (sum by(op) (rate(metric_total{pod=~"sg.+"}[2m]))))[5m:1m])
+  {op="del"} 0.1
+  {op="get"} 0.03333333333333333
+  {op="set"} 0.06666666666666667


### PR DESCRIPTION
#### What this PR does

Fix and issue where DeduplicateAndMerge planning nodes where removed from binary `or` expressions even though they are needed. This resulted in errant "vector cannot contain metrics with the same labelset" error messages when the EliminateDeduplicateAndMerge pass was enabled.

#### Which issue(s) this PR fixes or relates to


Introduced in #14228

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes query-plan optimization logic in a correctness-sensitive area; incorrect elimination could reintroduce duplicate-series errors or alter results for `or` expressions when delayed name removal is enabled.
> 
> **Overview**
> Prevents the `EliminateDeduplicateAndMerge` optimization from removing `DeduplicateAndMerge` nodes around binary `or` (`BINARY_LOR`) when *delayed name removal* is enabled, avoiding duplicate labelset errors at execution time.
> 
> Updates planner-structure expectations/counts in the optimization tests for nested `or` expressions, and adds a new promql test script reproducing the regression to ensure the `or` branch remains properly deduplicated.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02ae80af6d0b0ad5bf8c50fc7c01fc387fb3bc6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->