### PR TITLE
chore: remove use of github.com/pkg/errors from scheduler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -338,6 +338,7 @@ lint: check-makefiles check-merge-conflicts
 		./pkg/cardinality... \
 		./pkg/compactor... \
 		./pkg/continuoustest... \
+		./pkg/scheduler... \
 		./pkg/util/... \
 		./cmd/... \
 		./integration/...

--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -8,6 +8,7 @@ package queue
 import (
 	"container/list"
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -15,7 +16,6 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/services"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/atomic"

--- a/pkg/scheduler/queue/queue_test.go
+++ b/pkg/scheduler/queue/queue_test.go
@@ -6,6 +6,7 @@ package queue
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"strconv"
@@ -16,7 +17,6 @@ import (
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/grafana/dskit/services"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/stretchr/testify/assert"

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -7,6 +7,7 @@ package scheduler
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -26,7 +27,6 @@ import (
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/dskit/tenant"
 	"github.com/grafana/dskit/user"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.opentelemetry.io/otel"
@@ -698,7 +698,7 @@ func (s *Scheduler) starting(ctx context.Context) error {
 	s.subservicesWatcher.WatchManager(s.subservices)
 
 	if err := services.StartManagerAndAwaitHealthy(ctx, s.subservices); err != nil {
-		return errors.Wrap(err, "unable to start scheduler subservices")
+		return fmt.Errorf("unable to start scheduler subservices: %w", err)
 	}
 
 	return nil
@@ -719,7 +719,7 @@ func (s *Scheduler) running(ctx context.Context) error {
 		case <-ctx.Done():
 			return nil
 		case err := <-s.subservicesWatcher.Chan():
-			return errors.Wrap(err, "scheduler subservice failed")
+			return fmt.Errorf("scheduler subservice failed: %w", err)
 		}
 	}
 }

--- a/pkg/scheduler/schedulerdiscovery/ring.go
+++ b/pkg/scheduler/schedulerdiscovery/ring.go
@@ -4,6 +4,7 @@ package schedulerdiscovery
 
 import (
 	"flag"
+	"fmt"
 	"net"
 	"os"
 	"strconv"
@@ -15,7 +16,6 @@ import (
 	"github.com/grafana/dskit/kv"
 	"github.com/grafana/dskit/netutil"
 	"github.com/grafana/dskit/ring"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -116,12 +116,12 @@ func NewRingLifecycler(cfg RingConfig, logger log.Logger, reg prometheus.Registe
 	reg = prometheus.WrapRegistererWithPrefix("cortex_", reg)
 	kvStore, err := kv.NewClient(cfg.KVStore, ring.GetCodec(), kv.RegistererWithKVName(reg, "query-scheduler-lifecycler"), logger)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to initialize query-schedulers' KV store")
+		return nil, fmt.Errorf("failed to initialize query-schedulers' KV store: %w", err)
 	}
 
 	lifecyclerCfg, err := cfg.ToBasicLifecyclerConfig(logger)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to build query-schedulers' lifecycler config")
+		return nil, fmt.Errorf("failed to build query-schedulers' lifecycler config: %w", err)
 	}
 
 	var delegate ring.BasicLifecyclerDelegate
@@ -133,7 +133,7 @@ func NewRingLifecycler(cfg RingConfig, logger log.Logger, reg prometheus.Registe
 
 	lifecycler, err := ring.NewBasicLifecycler(lifecyclerCfg, "query-scheduler", ringKey, kvStore, delegate, logger, reg)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to initialize query-schedulers' lifecycler")
+		return nil, fmt.Errorf("failed to initialize query-schedulers' lifecycler: %w", err)
 	}
 
 	return lifecycler, nil
@@ -143,7 +143,7 @@ func NewRingLifecycler(cfg RingConfig, logger log.Logger, reg prometheus.Registe
 func NewRingClient(cfg RingConfig, component string, logger log.Logger, reg prometheus.Registerer) (*ring.Ring, error) {
 	client, err := ring.New(cfg.ToRingConfig(), component, ringKey, logger, prometheus.WrapRegistererWithPrefix("cortex_", reg))
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to initialize query-schedulers' ring client")
+		return nil, fmt.Errorf("failed to initialize query-schedulers' ring client: %w", err)
 	}
 
 	return client, err

--- a/pkg/scheduler/schedulerpb/custom.go
+++ b/pkg/scheduler/schedulerpb/custom.go
@@ -2,9 +2,7 @@
 
 package schedulerpb
 
-import (
-	"github.com/pkg/errors"
-)
+import "errors"
 
 var (
 	ErrSchedulerIsNotRunning = errors.New("scheduler is not running")


### PR DESCRIPTION
#### What this PR does

Removes use of the github.com/pkg/errors package from the scheduler.

#### Which issue(s) this PR fixes or relates to

Related #13535

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 75182a29371700c1fe1792db5e85b79a2aab3d2b. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->