### PR TITLE
Add a Helm specific notice to HA tracker storage migration guide

### DIFF
--- a/docs/sources/mimir/configure/migrate-ha-tracker-to-memberlist.md
+++ b/docs/sources/mimir/configure/migrate-ha-tracker-to-memberlist.md
@@ -195,7 +195,8 @@ If you are no longer using Consul or etcd for any other purpose in your Mimir de
 
 ## Helm-specific guidance
 
-If you're using the `mimir-distributed` Helm chart, the migration steps are the same but use Helm values instead of direct YAML configuration. For example:
+If you're using the `mimir-distributed` Helm chart, the migration steps are the same but use Helm values instead of direct YAML configuration.
+Note that you **shouldn't** supply the configuration for the `memberlist` store yourself. Doing so will produce an invalid distributor configuration. For example:
 
 ```yaml
 mimir:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Adds a Helm specific notice to the Helm specific guide of the HA tracker store migration. It isn't clear that the `memberlist` shouldn't be configured manually as in the previous code examples. 

By providing the `memberlist` key the deployment fails with the following error:
```
error loading config from /etc/mimir/mimir.yaml: Error parsing config file: yaml: unmarshal errors:

  line 70: field memberlist not found in type kv.Config
```

I am not sure about the correct wording of this notice, as English is not my native language.

#### Which issue(s) this PR fixes or relates to

None

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
