### PR TITLE
perf: O(1) buffer view boundary check in NextStepSamples hot path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@
 * [FEATURE] Store-gateway: Add `-store-gateway.sharding-ring.excluded-zones` flag to exclude specific zones from the store-gateway ring. #14120
 * [FEATURE] Ingest storage: Add `-ingest-storage.kafka.sasl-mechanism` flag supporting more ways to authenticate with Kafka. #14307 #14344
 * [FEATURE] MQE: Add experimental support for splitting and caching intermediate results for functions over range vectors in instant queries. #13472 #14479 #14506 #14499 #14517 #14536
-* [ENHANCEMENT] MQE: Add `ViewUntilWithSinglePointOvershoot` O(1) view method to `FPointRingBuffer` and `HPointRingBuffer` for callers that guarantee at most one trailing point past the boundary. #14564
+* [ENHANCEMENT] MQE: Optimize `ViewUntilSearchingBackwards` on `FPointRingBuffer` and `HPointRingBuffer` with a peeled first iteration, avoiding loop overhead in the common case where `fillBuffer` leaves at most one trailing point past the range boundary. #14564
 * [ENHANCEMENT] Memberlist: Add experimental propagation delay tracker to measure gossip propagation delay across the memberlist cluster. Enable with `-memberlist.propagation-delay-tracker.enabled=true`. #14312 #14406
 * [ENHANCEMENT] Compactor: Add 0-100% jitter to the first compaction interval to spread compactions when multiple compactors start simultaneously. #14280
 * [ENHANCEMENT] Compactor, Store-gateway: Remove experimental setting `-compactor.upload-sparse-index-headers` and always upload sparse index-headers. This improves lazy loading performance in the store-gateway. #13089 #13882

--- a/pkg/streamingpromql/operators/selectors/range_vector_selector_bench_test.go
+++ b/pkg/streamingpromql/operators/selectors/range_vector_selector_bench_test.go
@@ -96,9 +96,9 @@ func BenchmarkNextStepSamples(b *testing.B) {
 	}
 }
 
-// BenchmarkViewUntilSearchingBackwards benchmarks the old O(k) backward-scan
-// view method. Pair with BenchmarkViewUntilWithSinglePointOvershoot to see the
-// isolated gain from the optimisation.
+// BenchmarkViewUntilSearchingBackwards benchmarks the ViewUntilSearchingBackwards
+// method called by NextStepSamples on the hot path. The buffer is set up with one
+// trailing point past maxT, which is the common case guaranteed by fillBuffer.
 func BenchmarkViewUntilSearchingBackwards(b *testing.B) {
 	for _, n := range []int{8, 32, 128} {
 		n := n
@@ -116,31 +116,6 @@ func BenchmarkViewUntilSearchingBackwards(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				view = buf.ViewUntilSearchingBackwards(maxT, view)
-			}
-			_ = view
-		})
-	}
-}
-
-// BenchmarkViewUntilWithSinglePointOvershoot benchmarks the new O(1) view method
-// that exploits the guarantee that fillBuffer appends at most one point past maxT.
-func BenchmarkViewUntilWithSinglePointOvershoot(b *testing.B) {
-	for _, n := range []int{8, 32, 128} {
-		n := n
-		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
-			mc := limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, "")
-			buf := types.NewFPointRingBuffer(mc)
-			for i := 0; i < n; i++ {
-				if err := buf.Append(promql.FPoint{T: int64(i * 1000), F: float64(i)}); err != nil {
-					b.Fatal(err)
-				}
-			}
-			maxT := int64((n - 2) * 1000) // last point is past maxT
-			var view *types.FPointRingBufferView
-			b.ReportAllocs()
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				view = buf.ViewUntilWithSinglePointOvershoot(maxT, view)
 			}
 			_ = view
 		})

--- a/pkg/streamingpromql/types/fpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/fpoint_ring_buffer.go
@@ -234,35 +234,15 @@ func (b *FPointRingBuffer) ViewUntilSearchingBackwards(maxT int64, existing *FPo
 		existing = &FPointRingBufferView{buffer: b}
 	}
 
-	nextPositionToCheck := b.size - 1
-
-	for nextPositionToCheck >= 0 && b.PointAt(nextPositionToCheck).T > maxT {
-		nextPositionToCheck--
-	}
-
-	existing.offset = 0
-	existing.size = nextPositionToCheck + 1
-	return existing
-}
-
-// ViewUntilWithSinglePointOvershoot returns a view into this buffer including only points with
-// timestamps ≤ maxT, exploiting the caller's guarantee that at most one trailing point in the
-// buffer can have a timestamp > maxT.
-//
-// This is more efficient than ViewUntilSearchingBackwards for callers (such as fillBuffer) that
-// always stop appending after the first point that exceeds maxT, because the boundary check
-// reduces to a single comparison rather than a loop.
-//
-// existing is an existing view instance for this buffer that is reused if provided. It can be nil.
-// The returned view is no longer valid if this buffer is modified (eg. a point is added, or the buffer is reset or closed).
-func (b *FPointRingBuffer) ViewUntilWithSinglePointOvershoot(maxT int64, existing *FPointRingBufferView) *FPointRingBufferView {
-	if existing == nil {
-		existing = &FPointRingBufferView{buffer: b}
-	}
-
+	// Peel the first iteration: use a direct array access rather than routing through PointAt.
+	// fillBuffer guarantees at most one trailing point past maxT in the common case, so this
+	// single check exits immediately without entering the loop.
 	size := b.size
 	if size > 0 && b.points[(b.firstIndex+size-1)&b.pointsIndexMask].T > maxT {
 		size--
+		for size > 0 && b.points[(b.firstIndex+size-1)&b.pointsIndexMask].T > maxT {
+			size--
+		}
 	}
 
 	existing.offset = 0

--- a/pkg/streamingpromql/types/hpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/hpoint_ring_buffer.go
@@ -89,35 +89,15 @@ func (b *HPointRingBuffer) ViewUntilSearchingBackwards(maxT int64, existing *HPo
 		existing = &HPointRingBufferView{buffer: b}
 	}
 
-	nextPositionToCheck := b.size - 1
-
-	for nextPositionToCheck >= 0 && b.pointAt(nextPositionToCheck).T > maxT {
-		nextPositionToCheck--
-	}
-
-	existing.offset = 0
-	existing.size = nextPositionToCheck + 1
-	return existing
-}
-
-// ViewUntilWithSinglePointOvershoot returns a view into this buffer including only points with
-// timestamps ≤ maxT, exploiting the caller's guarantee that at most one trailing point in the
-// buffer can have a timestamp > maxT.
-//
-// This is more efficient than ViewUntilSearchingBackwards for callers (such as fillBuffer) that
-// always stop appending after the first point that exceeds maxT, because the boundary check
-// reduces to a single comparison rather than a loop.
-//
-// existing is an existing view instance for this buffer that is reused if provided. It can be nil.
-// The returned view is no longer valid if this buffer is modified (eg. a point is added, or the buffer is reset or closed).
-func (b *HPointRingBuffer) ViewUntilWithSinglePointOvershoot(maxT int64, existing *HPointRingBufferView) *HPointRingBufferView {
-	if existing == nil {
-		existing = &HPointRingBufferView{buffer: b}
-	}
-
+	// Peel the first iteration: use a direct array access rather than routing through pointAt.
+	// fillBuffer guarantees at most one trailing point past maxT in the common case, so this
+	// single check exits immediately without entering the loop.
 	size := b.size
 	if size > 0 && b.points[(b.firstIndex+size-1)&b.pointsIndexMask].T > maxT {
 		size--
+		for size > 0 && b.points[(b.firstIndex+size-1)&b.pointsIndexMask].T > maxT {
+			size--
+		}
 	}
 
 	existing.offset = 0


### PR DESCRIPTION
## Summary

`NextStepSamples` is the innermost per-step loop for every series in a range query. For the common (non-smoothed, non-anchored) path it calls `ViewUntilSearchingBackwards` twice per step — once for floats and once for histograms — to trim the ring buffer view to `rangeEnd`.

`ViewUntilSearchingBackwards` ran a backward scan through the buffer:

```go
nextPositionToCheck := b.size - 1
for nextPositionToCheck >= 0 && b.PointAt(nextPositionToCheck).T > maxT {
    nextPositionToCheck--
}
```

Each `PointAt` involves a function call and a masked-index array lookup. `fillBuffer` guarantees it stops immediately after appending the first point past `rangeEnd`, so in the common case the loop does exactly one iteration — but still pays loop-setup and `PointAt` call overhead on every invocation.

## Fix

Peel the first iteration in `ViewUntilSearchingBackwards` on both `FPointRingBuffer` and `HPointRingBuffer`, inlining the boundary check as a direct array access:

```go
size := b.size
if size > 0 && b.points[(b.firstIndex+size-1)&b.pointsIndexMask].T > maxT {
    size--
    // Rare: more than one trailing point past maxT (possible when step < range
    // and samples are sparse). Fall into the loop for correctness.
    for size > 0 && b.points[(b.firstIndex+size-1)&b.pointsIndexMask].T > maxT {
        size--
    }
}
```

In the common case the outer `if` exits immediately after a single masked-index comparison, with no loop or function-call overhead. Multiple overshoots are still handled correctly by the inner loop.

Because `ViewUntilSearchingBackwards` is called twice per `NextStepSamples` step (floats + histograms), the saving compounds across every series in every range-vector query.

## Benchmarks

`BenchmarkViewUntilSearchingBackwards` before and after, with one trailing overshoot (the common case guaranteed by `fillBuffer`).  
goos: darwin / goarch: arm64 / cpu: Apple M3 Pro / count=8

```
                                     │   before    │              after              │
                                     │   sec/op    │   sec/op     vs base            │
ViewUntilSearchingBackwards/n=8-11     1.145n ± 1%   1.117n ± 2%  -2.45% (p=0.016 n=8)
ViewUntilSearchingBackwards/n=32-11    1.149n ± 1%   1.140n ± 3%       ~ (p=0.697 n=8)
ViewUntilSearchingBackwards/n=128-11   1.168n ± 3%   1.131n ± 2%  -3.17% (p=0.003 n=8)
geomean                                1.154n        1.129n       -2.15%

B/op and allocs/op: 0 for both (no allocations).
```

## Correctness

- All tests in `pkg/streamingpromql/` pass, including `TestEliminateDeduplicateAndMergeOptimizationWithDelayedNameRemovalDisabled` which exercises mixed float/histogram series with step < range.
- `ViewUntilSearchingBackwards` is called unchanged from `NextStepSamples` — the optimisation is inside the method itself.
- Multiple overshoots (when step < range and samples have large gaps) are handled correctly by the inner loop.