### PR TITLE
test: Add benchmark to measure bucket ops for lazy indexheader reader loads with disk and bucket

### DIFF
--- a/pkg/storage/indexheader/lazy_binary_reader_test.go
+++ b/pkg/storage/indexheader/lazy_binary_reader_test.go
@@ -665,10 +665,10 @@ func BenchmarkNewLazyBinaryReader(b *testing.B) {
 	}
 }
 
-// BenchmarkNewLazyBinaryReader_LoadReader benchmarks the cost of the index header Reader when it is finally loaded.
+// BenchmarkLazyBinaryReader_LoadReader benchmarks the cost of the index header Reader when it is finally loaded.
 // With lazy-loading enabled, the Readers are not fully initialized until they are first queried,
 // which incurs different costs depending on the Reader implementation.
-func BenchmarkNewLazyBinaryReader_LoadReader(b *testing.B) {
+func BenchmarkLazyBinaryReader_LoadReader(b *testing.B) {
 	ctx := context.Background()
 
 	bucketDir := b.TempDir()


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

We are in the midst of fixing the bucket reader calling to object storage to initialize the sparse symbols table instead of reading from disk.
This benchmark that captures the issue and can be merged on its own.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test/benchmark-only changes with no production code-path modifications; risk is limited to longer/flake-prone benchmark runtime if misused in CI.
> 
> **Overview**
> Adds `BenchmarkLazyBinaryReader_LoadReader` to quantify the *first-use* lazy-load overhead for indexheader readers, comparing `StreamBinaryReader` (disk) vs `BucketBinaryReader` across varying label cardinalities.
> 
> The benchmark creates and uploads fresh TSDB blocks per scenario, forces a new `LazyBinaryReader` per iteration, and reports allocations plus `CachingBucket` `get`/`get_range` metric diffs to surface unexpected object-store calls during reader initialization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6604a24b85a39172f2e31ca7529f60fcbf3bb903. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->