### PR TITLE
chore(helm): add CPU requests default value description to Memcached caches

### DIFF
--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -2669,7 +2669,9 @@ chunks-cache:
   volumeClaimTemplates: []
 
   # -- Resource requests and limits for the chunks-cache
-  # By default a safe memory limit will be requested based on allocatedMemory value (floor (* 1.2 allocatedMemory)).
+  # If undefined or set to null (the default):
+  # - Safe memory requests and limits will be requested based on allocatedMemory value (floor (* 1.2 allocatedMemory))
+  # - CPU requests: 500m.
   resources: null
 
   # -- Service annotations and labels
@@ -2774,7 +2776,9 @@ index-cache:
   volumeClaimTemplates: []
 
   # -- Resource requests and limits for the index-cache
-  # By default a safe memory limit will be requested based on allocatedMemory value (floor (* 1.2 allocatedMemory)).
+  # If undefined or set to null (the default):
+  # - Safe memory requests and limits will be requested based on allocatedMemory value (floor (* 1.2 allocatedMemory))
+  # - CPU requests: 500m.
   resources: null
 
   # -- Service annotations and labels
@@ -2879,7 +2883,9 @@ metadata-cache:
   volumeClaimTemplates: []
 
   # -- Resource requests and limits for the metadata-cache
-  # By default a safe memory limit will be requested based on allocatedMemory value (floor (* 1.2 allocatedMemory)).
+  # If undefined or set to null (the default):
+  # - Safe memory requests and limits will be requested based on allocatedMemory value (floor (* 1.2 allocatedMemory))
+  # - CPU requests: 500m.
   resources: null
 
   # -- Service annotations and labels
@@ -2984,7 +2990,9 @@ results-cache:
   volumeClaimTemplates: []
 
   # -- Resource requests and limits for the results-cache
-  # By default a safe memory limit will be requested based on allocatedMemory value (floor (* 1.2 allocatedMemory)).
+  # If undefined or set to null (the default):
+  # - Safe memory requests and limits will be requested based on allocatedMemory value (floor (* 1.2 allocatedMemory))
+  # - CPU requests: 500m.
   resources: null
 
   # -- Service annotations and labels


### PR DESCRIPTION
#### What this PR does

Improves the resource documentation for `index-cache`, `results-cache` etc. in `values.yaml` to make it clear that when resources is not set, CPU requests default to `500m` (hardcoded in the template) and memory requests and limits are calculated as `floor(allocatedMemory * 1.2)`.

#### Which issue(s) this PR fixes or relates to

Fixes #9737

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only updates in `values.yaml`; no template or behavior changes, so deployment risk is minimal.
> 
> **Overview**
> Clarifies the Helm chart documentation for memcached-backed caches (`chunks-cache`, `index-cache`, `metadata-cache`, `results-cache`) by explicitly stating what happens when `resources` is `null`/unset.
> 
> The comments now document that the templates default CPU requests to `500m` and compute safe memory requests/limits from `allocatedMemory` (`floor(allocatedMemory * 1.2)`), without changing any rendered manifests or runtime behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f14b861010f700d297c3b07df3217638d0942038. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->