### PR TITLE
MQE: add info about fuzz test data to `testdata/README.md`

### DIFF
--- a/pkg/streamingpromql/testdata/README.md
+++ b/pkg/streamingpromql/testdata/README.md
@@ -2,7 +2,7 @@ This directory contains sets of test cases used to test Mimir's query engine (MQ
 
 There are four subdirectories, each with a different purpose:
 
-- `fuzz`: contains test data and seed queries used specifically for fuzz testing MQE. 
+- `fuzz`: contains test data and seed queries used specifically for fuzz testing MQE.
   These are used by `FuzzQuery` to generate and validate a wide variety of PromQL queries, helping catch edge cases and inconsistencies between MQE and Prometheus query engines.
 - `ours`: test cases we have created. These are run against MQE by `TestOurTestCases`, and also run against Prometheus' engine to confirm they are valid test cases.
 - `ours-only`: same as above, but the comparison against Prometheus' engine is skipped.


### PR DESCRIPTION
#### What this PR does

Make `testdata/README.md` more consistent by adding information about the fuzz folder.

#### Which issue(s) this PR fixes or relates to

Fixes #

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no impact on runtime behavior or test execution.
> 
> **Overview**
> Updates `pkg/streamingpromql/testdata/README.md` to document the `fuzz` subdirectory, including how its seed queries/test data are used by `FuzzQuery` for PromQL fuzz testing and engine comparison.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2c0e5ee78e9658178b2e40d0199789c645b1580. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->