### PR TITLE
Reduce scale and increase error rate in test TestPartitionReader_ShouldNotMissRecordsIfKafkaReturnsAFetchBothWithAnErrorAndSomeRecords

### DIFF
--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -2382,7 +2382,7 @@ func TestPartitionReader_ShouldNotMissRecordsIfKafkaReturnsAFetchBothWithAnError
 	const (
 		topicName            = "test"
 		partitionID          = 1
-		totalProducedRecords = 10000
+		totalProducedRecords = 1000
 		recordSizeBytes      = initialBytesPerRecord
 		maxBufferedBytes     = (totalProducedRecords * initialBytesPerRecord) / 100
 	)
@@ -2457,8 +2457,8 @@ func TestPartitionReader_ShouldNotMissRecordsIfKafkaReturnsAFetchBothWithAnError
 							return nil, fmt.Errorf("expected 1 partition in the response, got %d", len(res.Topics[0].Partitions)), true
 						}
 
-						// Simulate a 10% error rate in the Kafka responses, mixed with records.
-						if rand.Int()%10 == 0 {
+						// Simulate a 25% error rate in the Kafka responses, mixed with records.
+						if rand.Int()%4 == 0 {
 							// Make a copy so we don't overwrite the cached version, which will be later requested again.
 							resCopy := &kmsg.FetchResponse{Version: req.Version}
 							if err := resCopy.ReadFrom(res.AppendTo(nil)); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR aims to reduce flakiness in the test `TestPartitionReader_ShouldNotMissRecordsIfKafkaReturnsAFetchBothWithAnErrorAndSomeRecords`

Recent failed runs show (See the issue for other runs):
- `reader_test.go:2510: expected 10000, got 9110` `Error: Received unexpected error: context deadline exceeded` ([Source](https://github.com/grafana/mimir/actions/runs/22657668941/job/65670857643))
- `reader_test.go:2510: expected 10000, got 6630` `Error: Received unexpected error: context deadline exceeded` ([Source](https://github.com/grafana/mimir/actions/runs/22644169976/job/65627782237))

Reducing `totalProducedRecords` should make the test quicker while still proving it's original intent.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/12204

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only parameter tuning; no production code paths or behavior change.
> 
> **Overview**
> Reduces runtime and flakiness of `TestPartitionReader_ShouldNotMissRecordsIfKafkaReturnsAFetchBothWithAnErrorAndSomeRecords` by cutting produced records from 10,000 to 1,000.
> 
> To keep the failure-path coverage while running fewer iterations, the mocked Kafka fetch responses now inject mixed-in error codes more often (from ~10% to ~25%).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b08d6d465b53b0ae0a2f0c21005593431d0d6858. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->