### PR TITLE
docs: fix links pointing to 404 page on the "Ingester" page

### DIFF
--- a/docs/sources/mimir/references/architecture/components/ingester/index.md
+++ b/docs/sources/mimir/references/architecture/components/ingester/index.md
@@ -10,7 +10,7 @@ weight: 30
 # Grafana Mimir ingester
 
 The ingester is a stateful component that processes the most recently ingested samples and makes them available for querying.
-[Queriers](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/querier/) read recent data from ingesters and older data from long-term object storage via [store-gateways](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/store-gateway/).
+[Queriers](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/components/querier/) read recent data from ingesters and older data from long-term object storage via [store-gateways](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/components/store-gateway/).
 
 The ingester stores data both in memory and on disk for a configurable retention period.
 In-memory series are periodically compacted into an on-disk format called a TSDB block and then uploaded to object storage. This process happens every two hours by default.


### PR DESCRIPTION
#### What this PR does

Two links on the [Ingester](https://grafana.com/docs/mimir/latest/references/architecture/components/ingester/)  page lead to a 404 page:

- https://grafana.com/docs/mimir/latest/references/architecture/querier/
- https://grafana.com/docs/mimir/latest/references/architecture/store-gateway/

#### Which issue(s) this PR fixes or relates to

Fixes #

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link updates with no impact on runtime behavior or configuration.
> 
> **Overview**
> Updates the Ingester architecture docs to fix two broken cross-links by changing the `querier` and `store-gateway` URLs to the correct `references/architecture/components/...` paths (preventing 404s).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1ebb7a5c44032b693e76e0e5150a84ad0dcd0a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->