### PR TITLE
refactor: ingester: Use SelectHints to avoid many parameters

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -2420,11 +2420,17 @@ func (i *Ingester) QueryStream(req *client.QueryRequest, stream client.Ingester_
 		return nil
 	}
 
+	selectHints := initSelectHints(int64(from), int64(through))
+	selectHints = configSelectHintsWithShard(selectHints, shard)
+	// Disable chunks trimming, so that we don't have to rewrite chunks which have samples outside
+	// the requested from/through range. PromQL engine can handle it.
+	selectHints = configSelectHintsWithDisabledTrimming(selectHints)
+
 	numSamples := 0
 	numSeries := 0
 
 	spanlog.DebugLog("msg", "using executeStreamingQuery")
-	numSeries, numSamples, err = i.executeStreamingQuery(ctx, db, int64(from), int64(through), matchers, shard, stream, req.StreamingChunksBatchSize, spanlog)
+	numSeries, numSamples, err = i.executeStreamingQuery(ctx, db, selectHints, matchers, stream, req.StreamingChunksBatchSize, spanlog)
 	if err != nil {
 		return err
 	}
@@ -2435,13 +2441,13 @@ func (i *Ingester) QueryStream(req *client.QueryRequest, stream client.Ingester_
 	return nil
 }
 
-func (i *Ingester) executeStreamingQuery(ctx context.Context, db *userTSDB, from, through int64, matchers []*labels.Matcher, shard *sharding.ShardSelector, stream client.Ingester_QueryStreamServer, batchSize uint64, spanlog *spanlogger.SpanLogger) (numSeries, numSamples int, _ error) {
+func (i *Ingester) executeStreamingQuery(ctx context.Context, db *userTSDB, hints *storage.SelectHints, matchers []*labels.Matcher, stream client.Ingester_QueryStreamServer, batchSize uint64, spanlog *spanlogger.SpanLogger) (numSeries, numSamples int, _ error) {
 	var q storage.ChunkQuerier
 	var err error
 	if i.limits.OutOfOrderTimeWindow(db.userID) > 0 {
-		q, err = db.UnorderedChunkQuerier(from, through)
+		q, err = db.UnorderedChunkQuerier(hints.Start, hints.End)
 	} else {
-		q, err = db.ChunkQuerier(from, through)
+		q, err = db.ChunkQuerier(hints.Start, hints.End)
 	}
 	if err != nil {
 		return 0, 0, err
@@ -2450,7 +2456,7 @@ func (i *Ingester) executeStreamingQuery(ctx context.Context, db *userTSDB, from
 	// The querier must remain open until we've finished streaming chunks.
 	defer q.Close()
 
-	allSeries, numSeries, err := i.sendStreamingQuerySeries(ctx, q, from, through, matchers, shard, stream)
+	allSeries, numSeries, err := i.sendStreamingQuerySeries(ctx, q, hints, matchers, stream)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -2500,13 +2506,7 @@ func putChunkSeriesNode(sn *chunkSeriesNode) {
 	chunkSeriesNodePool.Put(sn)
 }
 
-func (i *Ingester) sendStreamingQuerySeries(ctx context.Context, q storage.ChunkQuerier, from, through int64, matchers []*labels.Matcher, shard *sharding.ShardSelector, stream client.Ingester_QueryStreamServer) (*chunkSeriesNode, int, error) {
-	// Disable chunks trimming, so that we don't have to rewrite chunks which have samples outside
-	// the requested from/through range. PromQL engine can handle it.
-	hints := initSelectHints(from, through)
-	hints = configSelectHintsWithShard(hints, shard)
-	hints = configSelectHintsWithDisabledTrimming(hints)
-
+func (i *Ingester) sendStreamingQuerySeries(ctx context.Context, q storage.ChunkQuerier, hints *storage.SelectHints, matchers []*labels.Matcher, stream client.Ingester_QueryStreamServer) (*chunkSeriesNode, int, error) {
 	// Series must be sorted so that they can be read by the querier in the order the PromQL engine expects.
 	ss := q.Select(ctx, true, hints, matchers...)
 	if ss.Err() != nil {

--- a/pkg/ingester/ingester_streaming_memory_test.go
+++ b/pkg/ingester/ingester_streaming_memory_test.go
@@ -108,7 +108,10 @@ func TestIngester_SendStreamingQuerySeries_ConcurrentMemoryUsage(t *testing.T) {
 				coordinator: coordinator,
 			}
 
-			_, _, err = i.sendStreamingQuerySeries(ctx, q, now-1000, now+1000, matchers, nil, stream)
+			hints := initSelectHints(now-1000, now+1000)
+			hints = configSelectHintsWithDisabledTrimming(hints)
+
+			_, _, err = i.sendStreamingQuerySeries(ctx, q, hints, matchers, stream)
 			if err != nil {
 				errCh <- err
 			}


### PR DESCRIPTION
#### What this PR does

Reduce the number of parameters that need to be passed around for query methods in ingesters. When projections are introduced this will help with the proliferation of parameters.

#### Which issue(s) this PR fixes or relates to

Related #13863

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of query plumbing and test updates; behavior should be unchanged aside from how hints are propagated.
> 
> **Overview**
> Refactors `QueryStream`’s streaming execution to construct `storage.SelectHints` once (including shard info and disabled trimming) and pass it through `executeStreamingQuery`/`sendStreamingQuerySeries`, reducing parameter churn and centralizing query selection options.
> 
> Updates the streaming memory test to create and pass `SelectHints` explicitly to match the new function signatures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02ab7eb43a7ea5b21a326f2cedc45002cb16bb71. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->