### PR TITLE
jsonnet: render the distributor.max-active-series-per-user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -310,6 +310,7 @@
   * `multi_zone_store_gateway_zone_c_multi_az_enabled`
 * [ENHANCEMENT] Querier: Add `autoscaling_querier_ignore_null_values` option to set KEDA `ignoreNullValues` for querier autoscaling metrics. #14101
 * [ENHANCEMENT] Multi-zone: Add config validation for `-querier.prefer-availability-zones` flag on querier and ruler-querier deployments. #14539
+* [ENHANCEMENT] Distributor: render the experimental `-distributor.max-active-series-per-user` flag on distributor if `$._config.limits.max_active_series_per_user` is set. #14636
 * [BUGFIX] Ingester: Fix `$._config.ingest_storage_ingester_autoscaling_max_owned_series_threshold` default value, to compute it based on the configured `$._config.ingester_instance_limits.max_series`. #13448
 
 ### Documentation

--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -334,6 +334,7 @@
 
     // These are all the flags for the default limits.
     distributorLimitsConfig: {
+      [if std.get($._config.limits, 'max_active_series_per_user') != null then 'distributor.max-active-series-per-user']: $._config.limits.max_active_series_per_user,
       'distributor.ingestion-rate-limit': $._config.limits.ingestion_rate,
       'distributor.ingestion-burst-size': $._config.limits.ingestion_burst_size,
     },


### PR DESCRIPTION
#### What this PR does

Even though this limit is enforced by usage-tracker, which isn't present yet in the OSS jsonnet, it should be set on the distributors as well as they use it to render the error message.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single conditional CLI flag is added to distributor configuration and a matching changelog entry; it only affects deployments that set `limits.max_active_series_per_user`.
> 
> **Overview**
> Adds conditional rendering of the experimental distributor flag `-distributor.max-active-series-per-user` when `$._config.limits.max_active_series_per_user` is set, so distributors receive the configured per-tenant active-series limit.
> 
> Updates `CHANGELOG.md` to document the new jsonnet-rendered flag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 940f32495f4351b47ffef000534a0ce118ceb090. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->