### PR TITLE
Run binary builds in parallel in CI

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -34,7 +34,7 @@ runs:
         
         DIRNAME="$(dirname "$TARGET")"
         NAME="$(basename "$DIRNAME")"
-        make \
+        make -j2 \
           BUILD_IN_CONTAINER=false \
           PUSH_MULTIARCH_TARGET="type=oci,dest=$OUTPUT_DIR/$NAME.oci" \
           push-multiarch-$TARGET


### PR DESCRIPTION
#### What this PR does

This PR speeds up CI runs by running the binary builds for Docker images in parallel.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that just increases `make` parallelism; potential impact is limited to build determinism or increased resource usage in GitHub runners.
> 
> **Overview**
> Speeds up the `build-image` composite GitHub Action by running the `make push-multiarch-$TARGET` build with limited parallelism (`make -j2`) instead of single-threaded execution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35823c25fb05f2f8729fc511fa04815ab852f2ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->