### PR TITLE
MQE: finalize operators in `Evaluator` as soon as they're no longer needed

### DIFF
--- a/pkg/streamingpromql/evaluator.go
+++ b/pkg/streamingpromql/evaluator.go
@@ -169,15 +169,13 @@ func (e *Evaluator) Evaluate(ctx context.Context, observer EvaluationObserver) (
 			}
 
 			if !haveMoreWork {
+				if err := evaluator.finalize(ctx); err != nil {
+					return err
+				}
+
 				remainingOperatorEvaluators = append(remainingOperatorEvaluators[:i], remainingOperatorEvaluators[i+1:]...)
 				i--
 			}
-		}
-	}
-
-	for _, req := range e.nodeRequests {
-		if err := req.operator.Finalize(ctx); err != nil {
-			return err
 		}
 	}
 
@@ -209,6 +207,8 @@ type operatorEvaluator interface {
 	//
 	// performWork returns true if there is more work remaining for this operator, or false otherwise.
 	performWork(ctx context.Context, evaluator *Evaluator, observer EvaluationObserver) (bool, error)
+
+	finalize(ctx context.Context) error
 }
 
 type instantVectorEvaluator struct {
@@ -256,6 +256,10 @@ func (e *instantVectorEvaluator) performWork(ctx context.Context, evaluator *Eva
 	haveMoreSeries := e.nextSeriesIndex < e.seriesCount
 
 	return haveMoreSeries, nil
+}
+
+func (e *instantVectorEvaluator) finalize(ctx context.Context) error {
+	return e.operator.Finalize(ctx)
 }
 
 type rangeVectorEvaluator struct {
@@ -321,6 +325,10 @@ func (e *rangeVectorEvaluator) performWork(ctx context.Context, evaluator *Evalu
 	return haveMoreSeries, nil
 }
 
+func (e *rangeVectorEvaluator) finalize(ctx context.Context) error {
+	return e.operator.Finalize(ctx)
+}
+
 type scalarEvaluator struct {
 	node     planning.Node
 	operator types.ScalarOperator
@@ -335,6 +343,10 @@ func (e *scalarEvaluator) performWork(ctx context.Context, evaluator *Evaluator,
 	return false, observer.ScalarEvaluated(ctx, evaluator, e.node, d)
 }
 
+func (e *scalarEvaluator) finalize(ctx context.Context) error {
+	return e.operator.Finalize(ctx)
+}
+
 type stringEvaluator struct {
 	node     planning.Node
 	operator types.StringOperator
@@ -344,6 +356,10 @@ func (e *stringEvaluator) performWork(ctx context.Context, evaluator *Evaluator,
 	v := e.operator.GetValue()
 
 	return false, observer.StringEvaluated(ctx, evaluator, e.node, v)
+}
+
+func (e *stringEvaluator) finalize(ctx context.Context) error {
+	return e.operator.Finalize(ctx)
 }
 
 func (e *Evaluator) Cancel() {


### PR DESCRIPTION
#### What this PR does

This PR changes the behaviour of `Evaluator` to finalize operators as soon as they're no longer needed, rather than waiting until evaluation of all operators is complete.

Given this is a minor user-invisible change, I've chosen not to add a changelog entry.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes operator lifecycle by calling `Finalize` immediately when an operator has no more work, which could expose ordering/side-effect assumptions in operators and affect resource usage during query evaluation.
> 
> **Overview**
> `Evaluator.Evaluate` now finalizes each operator as soon as its evaluator reports no more work, instead of finalizing all operators at the end of the full evaluation loop.
> 
> This introduces a `finalize(ctx)` method on the internal `operatorEvaluator` interface and implements it for instant/range vector, scalar, and string evaluators; pedantic mode still re-runs `Finalize` to verify idempotency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c878c779be7635f5537a78b71e21df7c58608cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->