### PR TITLE
[r385] MQE: Fix issue where inner operator of range vector splitting isn't always finalized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@
 * [FEATURE] Ingester: Added experimental support to run ingesters with no tokens in the ring when ingest storage is enabled. You can set `-ingester.ring.num-tokens=0` to enable this feature. #14024
 * [FEATURE] Store-gateway: Add `-store-gateway.sharding-ring.excluded-zones` flag to exclude specific zones from the store-gateway ring. #14120
 * [FEATURE] Ingest storage: Add `-ingest-storage.kafka.sasl-mechanism` flag supporting more ways to authenticate with Kafka. #14307 #14344 #14540
-* [FEATURE] MQE: Add experimental support for splitting and caching intermediate results for functions over range vectors in instant queries. #13472 #14479 #14506 #14499 #14517 #14536
+* [FEATURE] MQE: Add experimental support for splitting and caching intermediate results for functions over range vectors in instant queries. #13472 #14479 #14506 #14499 #14517 #14536 #14645
 * [ENHANCEMENT] Memberlist: Add experimental propagation delay tracker to measure gossip propagation delay across the memberlist cluster. Enable with `-memberlist.propagation-delay-tracker.enabled=true`. #14312 #14406
 * [ENHANCEMENT] Compactor: Add 0-100% jitter to the first compaction interval to spread compactions when multiple compactors start simultaneously. #14280
 * [ENHANCEMENT] Compactor, Store-gateway: Remove experimental setting `-compactor.upload-sparse-index-headers` and always upload sparse index-headers. This improves lazy loading performance in the store-gateway. #13089 #13882

--- a/pkg/streamingpromql/optimize/plan/rangevectorsplitting/operator.go
+++ b/pkg/streamingpromql/optimize/plan/rangevectorsplitting/operator.go
@@ -438,13 +438,14 @@ func (m *FunctionOverRangeVectorSplit[T]) Finalize(ctx context.Context) error {
 	// if a binary operation short-circuits evaluation early. A cached partial intermediate result might result in an
 	// incorrect calculation for a query spanning a different time range.
 	// TODO: It might be worth processing any remaining series so we can cache the result.
+	shouldCache := true
 	if !m.metadataConsumed {
 		level.Debug(logger).Log("msg", "skipping caching as SeriesMetadata() was not called")
-		return nil
+		shouldCache = false
 	}
 	if m.currentSeriesIdx < len(m.seriesToSplits) {
 		level.Debug(logger).Log("msg", "skipping caching as not all series processed by NextSeries()")
-		return nil
+		shouldCache = false
 	}
 
 	m.finalizeStart = time.Now()
@@ -461,7 +462,7 @@ func (m *FunctionOverRangeVectorSplit[T]) Finalize(ctx context.Context) error {
 	}
 
 	for _, split := range m.splits {
-		if err := split.Finalize(ctx); err != nil {
+		if err := split.Finalize(ctx, shouldCache); err != nil {
 			return err
 		}
 	}
@@ -483,6 +484,7 @@ func (m *FunctionOverRangeVectorSplit[T]) Finalize(ctx context.Context) error {
 		"ranges_total", uncachedRangeCount+cachedRangeCount,
 		"ranges_cached", cachedRangeCount,
 		"ranges_uncached", uncachedRangeCount,
+		"eligible_to_store_results_in_cache", shouldCache,
 		"cache_entries_read", m.cacheStats.ReadEntries,
 		"cache_entries_written", m.cacheStats.WrittenEntries,
 		"max_series_per_entry", m.cacheStats.MaxSeries,
@@ -519,7 +521,7 @@ type Split[T any] interface {
 	// This is used to make sure annotations emitted when generating the result for an uncached split reference the
 	// correct metric name.
 	AppendMergedSeriesIndex(splitLocalIdx int, mergedIdx int)
-	Finalize(ctx context.Context) error
+	Finalize(ctx context.Context, storeResultsInCache bool) error
 	Close()
 	IsCached() bool
 	RangeCount() int
@@ -592,7 +594,7 @@ func (c *CachedSplit[T]) GetResultsAt(_ context.Context, idx int) ([]T, error) {
 	return []T{c.results[idx]}, nil
 }
 
-func (c *CachedSplit[T]) Finalize(ctx context.Context) error {
+func (c *CachedSplit[T]) Finalize(ctx context.Context, storeResultsInCache bool) error {
 	for _, w := range c.annotations.Warnings {
 		c.parent.Annotations.Add(querierpb.NewWarningAnnotation(w))
 	}
@@ -744,13 +746,19 @@ func (p *UncachedSplit[T]) emitAndCaptureAnnotation(rangeIdx int, localSeriesIdx
 	p.rangeAnnotations[rangeIdx].Add(annotationErr)
 }
 
-func (p *UncachedSplit[T]) Finalize(ctx context.Context) error {
+func (p *UncachedSplit[T]) Finalize(ctx context.Context, storeResultsInCache bool) error {
 	if p.finalized {
 		return nil
 	}
 
 	if err := p.operator.Finalize(ctx); err != nil {
 		return err
+	}
+
+	p.finalized = true
+
+	if !storeResultsInCache {
+		return nil
 	}
 
 	for rangeIdx, splitRange := range p.ranges {
@@ -777,7 +785,6 @@ func (p *UncachedSplit[T]) Finalize(ctx context.Context) error {
 		}
 	}
 
-	p.finalized = true
 	return nil
 }
 


### PR DESCRIPTION
Backport of https://github.com/grafana/mimir/pull/14645

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the range-vector splitting finalize path to conditionally skip cache writes when not all series were processed, which can affect correctness and cache behavior for MQE instant queries.
> 
> **Overview**
> Prevents MQE range-vector splitting from writing intermediate results to cache when evaluation ends early (eg. `SeriesMetadata()` not called or not all `NextSeries()` consumed), avoiding potentially incorrect partial cache entries.
> 
> This threads a `storeResultsInCache` flag through `Split.Finalize`, updates uncached splits to always finalize the inner operator but only persist cache entries when eligible, and logs the eligibility decision in the experimental stats output. Also updates the changelog entry to include backport reference `#14645`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efd44260dc78e76b6805b80b526d72d763522a60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->