### PR TITLE
Fix negative series returned metric on series cache hit with pending matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,7 @@
 * [ENHANCEMENT] API: activity tracker (if enabled) covers the full request lifecycle and used on all routes. #14777
 * [ENHANCEMENT] MQE: Add metrics for tracking in-flight memory consumption tracking. `cortex_querier_inflight_query_max_estimated_memory_consumption_limit_bytes`, `cortex_querier_inflight_query_current_estimated_memory_consumption_bytes`, `cortex_querier_inflight_query_peak_estimated_memory_consumption_bytes` and `cortex_querier_inflight_query_sampled_count`. #14807
 * [BUGFIX] Distributor: Fix race condition where usage-tracker partition ring may not be initialized before the distributor service starts, causing `usage-tracker partition ring is required` error on startup. #14675
+* [BUGFIX] Store-gateway: Fix `cortex_bucket_store_series_data_touched{data_type="series", stage="returned"}` metric observing negative values when series-for-postings cache is hit and pending matchers filter out some series. #14655
 * [BUGFIX] Mimir: Fix false positive in filesystem path overlap detection when one path is a string prefix of another but not an ancestor directory. #14426
 * [BUGFIX] Build: Fixed config descriptor generation to correctly handle custom field types without CLI flags. #14632
 * [BUGFIX] Query-frontend: Fixed blocked queries tests to use production code path instead of bypassing YAML parsing and canonicalization. #14585

--- a/pkg/storegateway/bucket_e2e_test.go
+++ b/pkg/storegateway/bucket_e2e_test.go
@@ -472,6 +472,8 @@ func assertQueryStatsMetricsRecorded(t *testing.T, numSeries int, numChunksPerSe
 		assert.NotZero(t, numObservationsForSummaries(t, "cortex_bucket_store_series_data_fetched", metrics, "data_type", "postings"))
 		assert.NotZero(t, numObservationsForSummaries(t, "cortex_bucket_store_series_data_fetched", metrics, "data_type", "series"))
 
+		assertSeriesTouchedProcessedGreaterOrEqualReturned(t, metrics)
+
 		assert.NotZero(t, numObservationsForHistogram(t, "cortex_bucket_store_series_request_stage_duration_seconds", metrics))
 		assert.NotZero(t, numObservationsForSummaries(t, "cortex_bucket_store_series_blocks_queried", metrics, "source", "test", "level", "1"))
 	}
@@ -834,6 +836,8 @@ func assertQueryStatsLabelNamesMetricsRecorded(t *testing.T, numLabelNames int, 
 		assert.NotZero(t, numObservationsForSummaries(t, "cortex_bucket_store_series_data_fetched", metrics, "data_type", "postings"))
 		assert.NotZero(t, numObservationsForSummaries(t, "cortex_bucket_store_series_data_fetched", metrics, "data_type", "series"))
 
+		assertSeriesTouchedProcessedGreaterOrEqualReturned(t, metrics)
+
 		assert.NotZero(t, numObservationsForHistogram(t, "cortex_bucket_store_series_request_stage_duration_seconds", metrics))
 	}
 }
@@ -848,6 +852,8 @@ func assertQueryStatsLabelValuesMetricsRecorded(t *testing.T, registry *promethe
 	assert.NotZero(t, numObservationsForSummaries(t, "cortex_bucket_store_series_data_touched", metrics, "data_type", "series"))
 	assert.NotZero(t, numObservationsForSummaries(t, "cortex_bucket_store_series_data_fetched", metrics, "data_type", "postings"))
 	assert.NotZero(t, numObservationsForSummaries(t, "cortex_bucket_store_series_data_fetched", metrics, "data_type", "series"))
+
+	assertSeriesTouchedProcessedGreaterOrEqualReturned(t, metrics)
 }
 
 func TestBucketStore_LabelNames_e2e(t *testing.T) {
@@ -1141,6 +1147,27 @@ func numObservationsForSummaries(t *testing.T, summaryName string, metrics dskit
 	m := &dto.Metric{}
 	require.NoError(t, summaryData.Metric(prometheus.NewDesc("test", "", nil, nil)).Write(m))
 	return m.GetSummary().GetSampleCount()
+}
+
+func sumOfSummaryValues(t *testing.T, summaryName string, metrics dskit_metrics.MetricFamilyMap, labelValuePairs ...string) float64 {
+	t.Helper()
+
+	var sum float64
+	for _, m := range dskit_metrics.FindMetricsInFamilyMatchingLabels(metrics[summaryName], labelValuePairs...) {
+		sum += m.GetSummary().GetSampleSum()
+	}
+	return sum
+}
+
+func assertSeriesTouchedProcessedGreaterOrEqualReturned(t *testing.T, metrics dskit_metrics.MetricFamilyMap) {
+	t.Helper()
+
+	processedSum := sumOfSummaryValues(t, "cortex_bucket_store_series_data_touched", metrics, "data_type", "series", "stage", "processed")
+	returnedSum := sumOfSummaryValues(t, "cortex_bucket_store_series_data_touched", metrics, "data_type", "series", "stage", "returned")
+	assert.GreaterOrEqual(t, returnedSum, float64(0),
+		"cortex_bucket_store_series_data_touched{data_type=series, stage=returned} sum must be non-negative")
+	assert.GreaterOrEqual(t, processedSum, returnedSum,
+		"cortex_bucket_store_series_data_touched{data_type=series, stage=processed} sum must be >= returned sum")
 }
 
 func numObservationsForHistogram(t *testing.T, histogramName string, metrics dskit_metrics.MetricFamilyMap, labelValuePairs ...string) uint64 {

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -414,6 +414,46 @@ func TestBlockLabelNames(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, jNotFooLabelNames, names)
 	})
+
+	t.Run("series cache hit with pending matchers counts seriesProcessed", func(t *testing.T) {
+		// This test verifies that when series are loaded from the series-for-postings
+		// cache, seriesProcessed is still incremented. Without this, seriesProcessed can
+		// be less than seriesOmitted, causing the "series returned" metric to go negative.
+		b := newTestBucketBlock()
+		b.indexCache = &cacheNotStoringLabelNames{IndexCache: newInMemoryIndexCache(t)}
+
+		// Use a strategy that omits the j=foo matcher, making it a pending matcher.
+		// The pending matcher will filter out series with j!=foo, incrementing seriesOmitted.
+		strategy := &omitMatcherStrategy{omitMatcherString: `j="foo"`}
+
+		matchers := []*labels.Matcher{
+			labels.MustNewMatcher(labels.MatchRegexp, "i", ".+"),
+			labels.MustNewMatcher(labels.MatchEqual, "j", "foo"),
+		}
+
+		// First call: populates the series-for-postings cache.
+		stats1 := newSafeQueryStats()
+		_, err := blockLabelNames(context.Background(), b.indexReader(strategy), matchers, sl, 5000, log.NewNopLogger(), stats1)
+		require.NoError(t, err)
+
+		exportedStats1 := stats1.export()
+		require.Greater(t, exportedStats1.seriesProcessed, 0, "first call should process series")
+		require.Greater(t, exportedStats1.seriesOmitted, 0, "first call should omit series filtered by pending matcher j=foo")
+		require.GreaterOrEqual(t, exportedStats1.seriesProcessed, exportedStats1.seriesOmitted, "seriesProcessed must be >= seriesOmitted")
+
+		// Second call: hits the series-for-postings cache.
+		// The label names cache is disabled, so this goes through the series iterator.
+		stats2 := newSafeQueryStats()
+		_, err = blockLabelNames(context.Background(), b.indexReader(strategy), matchers, sl, 5000, log.NewNopLogger(), stats2)
+		require.NoError(t, err)
+
+		exportedStats2 := stats2.export()
+		require.Greater(t, exportedStats2.seriesProcessed, 0, "second call (cache hit) should still count series as processed")
+		require.Greater(t, exportedStats2.seriesOmitted, 0, "second call should omit series filtered by pending matcher j=foo")
+		require.GreaterOrEqual(t, exportedStats2.seriesProcessed, exportedStats2.seriesOmitted, "seriesProcessed must be >= seriesOmitted (cache hit path)")
+		require.Equal(t, exportedStats1.seriesProcessed, exportedStats2.seriesProcessed, "seriesProcessed should match between cache miss and cache hit")
+		require.Equal(t, exportedStats1.seriesOmitted, exportedStats2.seriesOmitted, "seriesOmitted should match between cache miss and cache hit")
+	})
 }
 
 type cacheNotExpectingToStoreLabelNames struct {
@@ -423,6 +463,41 @@ type cacheNotExpectingToStoreLabelNames struct {
 
 func (c cacheNotExpectingToStoreLabelNames) StoreLabelNames(string, ulid.ULID, indexcache.LabelMatchersKey, []byte) {
 	c.t.Fatalf("StoreLabelNames should not be called")
+}
+
+// cacheNotStoringLabelNames wraps an IndexCache but discards label name cache entries.
+// This forces blockLabelNames to go through the series iterator path on subsequent calls,
+// allowing the series-for-postings cache to be exercised.
+type cacheNotStoringLabelNames struct {
+	indexcache.IndexCache
+}
+
+func (c *cacheNotStoringLabelNames) StoreLabelNames(string, ulid.ULID, indexcache.LabelMatchersKey, []byte) {
+}
+func (c *cacheNotStoringLabelNames) FetchLabelNames(context.Context, string, ulid.ULID, indexcache.LabelMatchersKey) ([]byte, bool) {
+	return nil, false
+}
+
+// omitMatcherStrategy is a postings selection strategy that selects all posting groups
+// except those whose matcher string matches omitMatcherString. The omitted groups become
+// pending matchers that are applied after series loading.
+type omitMatcherStrategy struct {
+	omitMatcherString string
+}
+
+func (s *omitMatcherStrategy) name() string {
+	return "omit"
+}
+
+func (s *omitMatcherStrategy) selectPostings(groups []postingGroup) (selected, omitted []postingGroup) {
+	for _, g := range groups {
+		if g.matcher != nil && g.matcher.String() == s.omitMatcherString {
+			omitted = append(omitted, g)
+		} else {
+			selected = append(selected, g)
+		}
+	}
+	return selected, omitted
 }
 
 func TestBlockLabelValues(t *testing.T) {

--- a/pkg/storegateway/series_refs.go
+++ b/pkg/storegateway/series_refs.go
@@ -885,6 +885,11 @@ func (s *loadingSeriesChunkRefsSetIterator) Next() bool {
 		} else {
 			if cachedSet, isCached := fetchCachedSeriesForPostings(s.ctx, s.tenantID, s.indexCache, s.blockID, s.shard, cachedSeriesID, s.logger); isCached {
 				s.currentSet = cachedSet
+				// Count cached series as processed so that seriesProcessed >= seriesOmitted
+				// holds when a downstream filteringSeriesChunkRefsSetIterator omits some of them.
+				s.stats.update(func(stats *queryStats) {
+					stats.seriesProcessed += cachedSet.len()
+				})
 				return true
 			}
 		}

--- a/pkg/storegateway/stats.go
+++ b/pkg/storegateway/stats.go
@@ -35,8 +35,14 @@ type queryStats struct {
 	cachedPostingsDecompressionErrors  int
 	cachedPostingsDecompressionTimeSum time.Duration
 
-	seriesProcessed        int
+	// seriesProcessed counts series loaded from the index or from the series-for-postings cache.
+	seriesProcessed int
+
+	// seriesProcessedSizeSum tracks the total size in bytes of series entries loaded from the index.
+	// Series loaded from the series-for-postings cache are not included because the cache stores
+	// a re-encoded representation (protobuf + snappy) whose size is not comparable to raw index bytes.
 	seriesProcessedSizeSum int
+
 	seriesOmitted          int
 	seriesFetched          int
 	seriesFetchedSizeSum   int


### PR DESCRIPTION
#### What this PR does

When the series-for-postings cache is hit in `loadingSeriesChunkRefsSetIterator.Next()`, the batch is returned without calling `unsafeLoadSeries()`, so `seriesProcessed` is not incremented. Those cached series still flow through `filteringSeriesChunkRefsSetIterator`, which increments `seriesOmitted` for series filtered by pending matchers. This causes `seriesProcessed - seriesOmitted` to go negative, which is observed by `cortex_bucket_store_series_data_touched{data_type="series", stage="returned"}`.

This bug happens frequently in our clusters. For example:

<img width="2537" height="669" alt="Screenshot 2026-03-12 at 18 50 57" src="https://github.com/user-attachments/assets/42d0a7fa-d117-414b-ad7d-6698bc0b5705" />

The cache is only consulted when `isNoChunkRefsOnEntireBlock()` is true, which applies to `blockLabelNames` and `labelValuesFromSeries` (both use the `noChunkRefs` strategy).

In this PR I'm fixing it.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
