### PR TITLE
MQE: perform cleanup in `Finalize` for CSE/SSE operators

### DIFF
--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/instant_vector_operator.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/instant_vector_operator.go
@@ -163,15 +163,30 @@ func (b *InstantVectorDuplicationBuffer) CloseConsumer(consumer *InstantVectorDu
 		return
 	}
 
+	b.releaseBufferedData(consumer)
 	consumer.closed = true
+
+	if b.allConsumersClosed() {
+		b.Inner.Close()
+	}
+}
+
+func (b *InstantVectorDuplicationBuffer) releaseBufferedData(consumer *InstantVectorDuplicationConsumer) {
+	if consumer.finalized {
+		return
+	}
+
+	consumer.finalized = true
+
+	defer types.BoolSlicePool.Put(&consumer.unfilteredSeriesBitmap, b.MemoryConsumptionTracker)
 
 	// Remove any buffered series that are no longer needed because they were only being retained for the consumer
 	// that was just closed.
 	earliestSeriesIndexStillToReturn := b.earliestSeriesIndexStillToReturn()
 
 	if earliestSeriesIndexStillToReturn == math.MaxInt {
-		// All other consumers are already closed. Close everything.
-		b.close()
+		// All other consumers are already finalized. Clean up everything.
+		b.releaseAllBufferedData()
 		return
 	}
 
@@ -218,10 +233,18 @@ func (b *InstantVectorDuplicationBuffer) CloseConsumer(consumer *InstantVectorDu
 	}
 }
 
+func (b *InstantVectorDuplicationBuffer) releaseAllBufferedData() {
+	types.SeriesMetadataSlicePool.Put(&b.seriesMetadata, b.MemoryConsumptionTracker)
+
+	for b.buffer.Size() > 0 {
+		types.PutInstantVectorSeriesData(b.buffer.RemoveFirst(), b.MemoryConsumptionTracker)
+	}
+}
+
 func (b *InstantVectorDuplicationBuffer) earliestSeriesIndexStillToReturn() int {
 	idx := math.MaxInt
 	for _, consumer := range b.consumers {
-		if consumer.closed {
+		if consumer.finalized {
 			continue
 		}
 
@@ -233,7 +256,7 @@ func (b *InstantVectorDuplicationBuffer) earliestSeriesIndexStillToReturn() int 
 
 func (b *InstantVectorDuplicationBuffer) allOpenConsumersHaveNoFilters() bool {
 	for _, consumer := range b.consumers {
-		if consumer.closed {
+		if consumer.finalized {
 			continue
 		}
 
@@ -268,7 +291,7 @@ func (b *InstantVectorDuplicationBuffer) Finalize(ctx context.Context, consumer 
 		return nil
 	}
 
-	consumer.finalized = true
+	b.releaseBufferedData(consumer)
 
 	if !b.allConsumersFinalized() {
 		return nil
@@ -287,16 +310,14 @@ func (b *InstantVectorDuplicationBuffer) allConsumersFinalized() bool {
 	return true
 }
 
-func (b *InstantVectorDuplicationBuffer) close() {
-	types.SeriesMetadataSlicePool.Put(&b.seriesMetadata, b.MemoryConsumptionTracker)
-
-	for b.buffer.Size() > 0 {
-		types.PutInstantVectorSeriesData(b.buffer.RemoveFirst(), b.MemoryConsumptionTracker)
+func (b *InstantVectorDuplicationBuffer) allConsumersClosed() bool {
+	for _, consumer := range b.consumers {
+		if !consumer.closed {
+			return false
+		}
 	}
 
-	b.buffer = nil
-
-	b.Inner.Close()
+	return true
 }
 
 type InstantVectorDuplicationConsumer struct {
@@ -342,7 +363,7 @@ func (d *InstantVectorDuplicationConsumer) SeriesMetadata(ctx context.Context, m
 }
 
 func (d *InstantVectorDuplicationConsumer) shouldReturnUnfilteredSeries(unfilteredSeriesIndex int) bool {
-	if d.closed {
+	if d.finalized {
 		return false
 	}
 
@@ -383,7 +404,6 @@ func (d *InstantVectorDuplicationConsumer) Finalize(ctx context.Context) error {
 
 func (d *InstantVectorDuplicationConsumer) Close() {
 	d.Buffer.CloseConsumer(d)
-	types.BoolSlicePool.Put(&d.unfilteredSeriesBitmap, d.Buffer.MemoryConsumptionTracker)
 }
 
 func matchesSeries(filters []*labels.Matcher, series labels.Labels) bool {

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/instant_vector_operator_test.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/instant_vector_operator_test.go
@@ -291,7 +291,7 @@ func TestInstantVectorOperator_Buffering_Filtering_IteratingBeforeCallingSeriesM
 	requireNoMemoryConsumption(t, memoryConsumptionTracker)
 }
 
-func TestInstantVectorOperator_Buffering_Filtering_DoesNotBufferForClosedConsumer(t *testing.T) {
+func TestInstantVectorOperator_Buffering_Filtering_DoesNotBufferForFinalizedConsumer(t *testing.T) {
 	ctx := context.Background()
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	inner, expectedData := createTestInstantVectorOperator(t, 6, memoryConsumptionTracker)
@@ -317,10 +317,10 @@ func TestInstantVectorOperator_Buffering_Filtering_DoesNotBufferForClosedConsume
 	require.Equal(t, 2, buffer.buffer.Size(), "the first and second series should be buffered for the first consumer")
 	types.PutInstantVectorSeriesData(d, memoryConsumptionTracker)
 
-	// Finalize and close the first consumer, check that the data that was being buffered for it is released.
+	// The data being buffered for the first consumer should be released when it's finalized.
 	require.NoError(t, consumer1.Finalize(ctx))
-	consumer1.Close()
 	require.Equal(t, 0, buffer.buffer.Size())
+	consumer1.Close()
 
 	// Check that the inner operator hasn't been closed or finalized yet.
 	require.False(t, inner.Finalized)
@@ -390,10 +390,10 @@ func TestInstantVectorOperator_Buffering_Filtering_DoesNotBufferUnnecessarilyFor
 	require.Equal(t, 1, buffer.buffer.Size(), "only the first series should be buffered for the first consumer")
 	types.PutInstantVectorSeriesData(d, memoryConsumptionTracker)
 
-	// Finalize and close the first consumer, check that the data that was being buffered for it is released.
+	// The data being buffered for the first consumer should be released when it's finalized.
 	require.NoError(t, consumer1.Finalize(ctx))
-	consumer1.Close()
 	require.Equal(t, 0, buffer.buffer.Size())
+	consumer1.Close()
 
 	// Check that the inner operator hasn't been closed or finalized yet.
 	require.False(t, inner.Finalized)
@@ -401,8 +401,8 @@ func TestInstantVectorOperator_Buffering_Filtering_DoesNotBufferUnnecessarilyFor
 
 	// And the same for the second consumer.
 	require.NoError(t, consumer2.Finalize(ctx))
-	consumer2.Close()
 	require.True(t, inner.Finalized)
+	consumer2.Close()
 	require.True(t, inner.Closed)
 	requireNoMemoryConsumption(t, memoryConsumptionTracker)
 }
@@ -525,7 +525,7 @@ func TestInstantVectorOperator_Filtering_SingleConsumer(t *testing.T) {
 	}
 }
 
-func TestInstantVectorOperator_ClosedWithBufferedData_NoFiltering(t *testing.T) {
+func TestInstantVectorOperator_FinalizedWithBufferedData_NoFiltering(t *testing.T) {
 	ctx := context.Background()
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	inner, expectedData := createTestInstantVectorOperator(t, 3, memoryConsumptionTracker)
@@ -562,8 +562,8 @@ func TestInstantVectorOperator_ClosedWithBufferedData_NoFiltering(t *testing.T) 
 	require.Equal(t, 3, buffer.buffer.Size())
 	types.PutInstantVectorSeriesData(d, memoryConsumptionTracker)
 
-	// Close the first consumer, and check the data remains buffered for the second consumer.
-	consumer1.Close()
+	// Finalize the first consumer, and check the data remains buffered for the second consumer.
+	require.NoError(t, consumer1.Finalize(ctx))
 	require.Equal(t, 3, buffer.buffer.Size())
 
 	// Read some of the buffered data.
@@ -573,18 +573,18 @@ func TestInstantVectorOperator_ClosedWithBufferedData_NoFiltering(t *testing.T) 
 	require.Equal(t, 2, buffer.buffer.Size())
 	types.PutInstantVectorSeriesData(d, memoryConsumptionTracker)
 
-	// Close the second consumer, and check that the inner operator was closed and all buffered data was released.
-	consumer2.Close()
-	require.True(t, inner.Closed)
+	// Finalize the second consumer, and check that the inner operator was finalized and all buffered data was released.
+	require.NoError(t, consumer2.Finalize(ctx))
+	require.True(t, inner.Finalized)
 	requireNoMemoryConsumption(t, memoryConsumptionTracker)
 
-	// Make sure it's safe to close either consumer a second time.
-	consumer1.Close()
-	consumer2.Close()
+	// Make sure it's safe to finalize either consumer a second time.
+	require.NoError(t, consumer1.Finalize(ctx))
+	require.NoError(t, consumer2.Finalize(ctx))
 	requireNoMemoryConsumption(t, memoryConsumptionTracker)
 }
 
-func TestInstantVectorOperator_ClosedWithBufferedData_Filtering(t *testing.T) {
+func TestInstantVectorOperator_FinalizedWithBufferedData_Filtering(t *testing.T) {
 	ctx := context.Background()
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	inner, expectedData := createTestInstantVectorOperator(t, 3, memoryConsumptionTracker)
@@ -619,7 +619,7 @@ func TestInstantVectorOperator_ClosedWithBufferedData_Filtering(t *testing.T) {
 	}
 
 	require.Equal(t, 3, buffer.buffer.Size(), "buffer should contain all three series for the remaining two consumers")
-	consumer2.Close()
+	require.NoError(t, consumer2.Finalize(ctx))
 	require.Equal(t, 1, buffer.buffer.Size(), "buffer should only contain remaining series required by remaining consumer")
 
 	d, err := consumer3.NextSeries(ctx)
@@ -628,8 +628,8 @@ func TestInstantVectorOperator_ClosedWithBufferedData_Filtering(t *testing.T) {
 	require.Equal(t, 0, buffer.buffer.Size())
 	types.PutInstantVectorSeriesData(d, memoryConsumptionTracker)
 
-	consumer1.Close()
-	consumer3.Close()
+	require.NoError(t, consumer1.Finalize(ctx))
+	require.NoError(t, consumer3.Finalize(ctx))
 	requireNoMemoryConsumption(t, memoryConsumptionTracker)
 }
 

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator.go
@@ -108,8 +108,8 @@ func (b *RangeVectorDuplicationBuffer) SeriesMetadata(ctx context.Context, match
 }
 
 func (b *RangeVectorDuplicationBuffer) NextSeries(consumer *RangeVectorDuplicationConsumer) error {
-	if consumer.closed {
-		return fmt.Errorf("consumer %p is already closed, can't advance to next series", consumer)
+	if consumer.finalized {
+		return fmt.Errorf("consumer %p is already finalized, can't advance to next series", consumer)
 	}
 
 	thisSeriesIndex := consumer.nextUnfilteredSeriesIndex
@@ -249,10 +249,25 @@ func (b *RangeVectorDuplicationBuffer) CloseConsumer(consumer *RangeVectorDuplic
 		return
 	}
 
+	b.releaseBufferedData(consumer)
 	consumer.closed = true
 
 	if b.allConsumersClosed() {
-		b.close()
+		b.Inner.Close()
+	}
+}
+
+func (b *RangeVectorDuplicationBuffer) releaseBufferedData(consumer *RangeVectorDuplicationConsumer) {
+	if consumer.finalized {
+		return
+	}
+
+	consumer.finalized = true
+
+	defer types.BoolSlicePool.Put(&consumer.unfilteredSeriesBitmap, b.MemoryConsumptionTracker)
+
+	if b.allConsumersFinalized() {
+		b.releaseAllBufferedData()
 		return
 	}
 
@@ -307,11 +322,20 @@ func (b *RangeVectorDuplicationBuffer) CloseConsumer(consumer *RangeVectorDuplic
 	}
 }
 
+func (b *RangeVectorDuplicationBuffer) releaseAllBufferedData() {
+	types.SeriesMetadataSlicePool.Put(&b.seriesMetadata, b.MemoryConsumptionTracker)
+
+	for b.buffer.Size() > 0 {
+		d := b.buffer.RemoveFirst()
+		d.Close()
+	}
+}
+
 func (b *RangeVectorDuplicationBuffer) earliestSeriesIndexStillToReturn() int {
 	idx := math.MaxInt
 
 	for _, consumer := range b.consumers {
-		if consumer.closed {
+		if consumer.finalized {
 			continue
 		}
 
@@ -329,7 +353,7 @@ func (b *RangeVectorDuplicationBuffer) earliestSeriesIndexStillToReturn() int {
 
 func (b *RangeVectorDuplicationBuffer) allOpenConsumersHaveNoFilters() bool {
 	for _, consumer := range b.consumers {
-		if consumer.closed {
+		if consumer.finalized {
 			continue
 		}
 
@@ -339,19 +363,6 @@ func (b *RangeVectorDuplicationBuffer) allOpenConsumersHaveNoFilters() bool {
 	}
 
 	return true
-}
-
-func (b *RangeVectorDuplicationBuffer) close() {
-	types.SeriesMetadataSlicePool.Put(&b.seriesMetadata, b.MemoryConsumptionTracker)
-
-	for b.buffer.Size() > 0 {
-		d := b.buffer.RemoveFirst()
-		d.Close()
-	}
-
-	b.buffer = nil
-
-	b.Inner.Close()
 }
 
 func (b *RangeVectorDuplicationBuffer) allConsumersClosed() bool {
@@ -387,7 +398,7 @@ func (b *RangeVectorDuplicationBuffer) Finalize(ctx context.Context, consumer *R
 		return nil
 	}
 
-	consumer.finalized = true
+	b.releaseBufferedData(consumer)
 
 	if !b.allConsumersFinalized() {
 		return nil
@@ -476,7 +487,7 @@ func (d *RangeVectorDuplicationConsumer) SeriesMetadata(ctx context.Context, mat
 }
 
 func (d *RangeVectorDuplicationConsumer) shouldReturnUnfilteredSeries(unfilteredSeriesIndex int) bool {
-	if d.closed {
+	if d.finalized {
 		return false
 	}
 
@@ -521,5 +532,4 @@ func (d *RangeVectorDuplicationConsumer) Finalize(ctx context.Context) error {
 
 func (d *RangeVectorDuplicationConsumer) Close() {
 	d.Buffer.CloseConsumer(d)
-	types.BoolSlicePool.Put(&d.unfilteredSeriesBitmap, d.Buffer.MemoryConsumptionTracker)
 }

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator_test.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator_test.go
@@ -63,7 +63,7 @@ func TestRangeVectorOperator_Buffering_NoFiltering(t *testing.T) {
 	d, err = consumer2.NextStepSamples(ctx)
 	require.NoError(t, err)
 	requireEqualDataAndReturnToPool(t, expectedData[0], d, memoryConsumptionTracker)
-	require.Equal(t, 2, buffer.buffer.Size(), "buffered data should remain buffered until the next NextSeries or Close call")
+	require.Equal(t, 2, buffer.buffer.Size(), "buffered data should remain buffered until the next NextSeries or Finalize call")
 
 	err = consumer2.NextSeries(ctx)
 	require.NoError(t, err)
@@ -93,7 +93,7 @@ func TestRangeVectorOperator_Buffering_NoFiltering(t *testing.T) {
 	d, err = consumer1.NextStepSamples(ctx)
 	require.NoError(t, err)
 	requireEqualDataAndReturnToPool(t, expectedData[2], d, memoryConsumptionTracker)
-	require.Equal(t, 2, buffer.buffer.Size(), "buffered data should remain buffered until the next NextSeries or Close call")
+	require.Equal(t, 2, buffer.buffer.Size(), "buffered data should remain buffered until the next NextSeries or Finalize call")
 
 	err = consumer2.NextSeries(ctx)
 	require.NoError(t, err)
@@ -109,10 +109,10 @@ func TestRangeVectorOperator_Buffering_NoFiltering(t *testing.T) {
 	d, err = consumer1.NextStepSamples(ctx)
 	require.NoError(t, err)
 	requireEqualDataAndReturnToPool(t, expectedData[3], d, memoryConsumptionTracker)
-	require.Equal(t, 2, buffer.buffer.Size(), "buffered data should remain buffered until the next NextSeries or Close call")
+	require.Equal(t, 2, buffer.buffer.Size(), "buffered data should remain buffered until the next NextSeries or Finalize call")
 
-	// Close the first consumer, check that the data that was being buffered for it is released.
-	consumer1.Close()
+	// Finalize the first consumer, check that the data that was being buffered for it is released.
+	require.NoError(t, consumer1.Finalize(ctx))
 	require.Equal(t, 0, buffer.buffer.Size())
 
 	// Check that the second consumer can still read data and that we don't bother buffering it.
@@ -127,15 +127,14 @@ func TestRangeVectorOperator_Buffering_NoFiltering(t *testing.T) {
 	require.False(t, inner.finalized)
 	require.False(t, inner.closed)
 
-	// Finalize each consumer, and check that the inner operator was only finalized after the last consumer is finalized.
-	require.NoError(t, consumer1.Finalize(ctx))
-	require.False(t, inner.finalized)
+	// Finalize the second consumer, and check that the inner operator was finalized after the last consumer is finalized.
 	require.NoError(t, consumer2.Finalize(ctx))
 	require.True(t, inner.finalized)
 	require.NoError(t, consumer1.Finalize(ctx), "it should be safe to finalize either consumer a second time")
 	require.NoError(t, consumer2.Finalize(ctx), "it should be safe to finalize either consumer a second time")
 
-	// Close the second consumer, and check that the inner operator was closed.
+	// Close both consumers, and check that the inner operator was closed.
+	consumer1.Close()
 	consumer2.Close()
 	require.True(t, inner.closed)
 	requireNoMemoryConsumption(t, memoryConsumptionTracker)
@@ -187,7 +186,7 @@ func TestRangeVectorOperator_Buffering_Filtering_AllConsumersOpen(t *testing.T) 
 	d, err = consumer2.NextStepSamples(ctx)
 	require.NoError(t, err)
 	requireEqualDataAndReturnToPool(t, expectedData[1], d, memoryConsumptionTracker)
-	require.Equal(t, 1, buffer.buffer.Size(), "buffered data should remain buffered until the next NextSeries or Close call")
+	require.Equal(t, 1, buffer.buffer.Size(), "buffered data should remain buffered until the next NextSeries or Finalize call")
 
 	err = consumer2.NextSeries(ctx)
 	require.NoError(t, err)
@@ -210,25 +209,24 @@ func TestRangeVectorOperator_Buffering_Filtering_AllConsumersOpen(t *testing.T) 
 	d, err = consumer1.NextStepSamples(ctx)
 	require.NoError(t, err)
 	requireEqualDataAndReturnToPool(t, expectedData[2], d, memoryConsumptionTracker)
-	require.Equal(t, 4, buffer.buffer.Size(), "buffered data should remain buffered until the next NextSeries or Close call")
+	require.Equal(t, 4, buffer.buffer.Size(), "buffered data should remain buffered until the next NextSeries or Finalize call")
 
-	// Close the first consumer, check that the data that was being buffered for it is released.
-	consumer1.Close()
+	// Finalize the first consumer, check that the data that was being buffered for it is released.
+	require.NoError(t, consumer1.Finalize(ctx))
 	require.Equal(t, 0, buffer.buffer.Size())
 
 	// Check that the inner operator hasn't been closed or finalized yet.
 	require.False(t, inner.finalized)
 	require.False(t, inner.closed)
 
-	// Finalize each consumer, and check that the inner operator was only finalized after the last consumer is finalized.
-	require.NoError(t, consumer1.Finalize(ctx))
-	require.False(t, inner.finalized)
+	// Finalize the second consumer, and check that the inner operator was finalized after the last consumer is finalized.
 	require.NoError(t, consumer2.Finalize(ctx))
 	require.True(t, inner.finalized)
 	require.NoError(t, consumer1.Finalize(ctx), "it should be safe to finalize either consumer a second time")
 	require.NoError(t, consumer2.Finalize(ctx), "it should be safe to finalize either consumer a second time")
 
-	// Close the second consumer, and check that the inner operator was closed.
+	// Close both consumers, and check that the inner operator was closed.
+	consumer1.Close()
 	consumer2.Close()
 	require.True(t, inner.closed)
 	requireNoMemoryConsumption(t, memoryConsumptionTracker)
@@ -281,7 +279,7 @@ func TestRangeVectorOperator_Buffering_Filtering_IteratingBeforeCallingSeriesMet
 	d, err = consumer2.NextStepSamples(ctx)
 	require.NoError(t, err)
 	requireEqualDataAndReturnToPool(t, expectedData[1], d, memoryConsumptionTracker)
-	require.Equal(t, 1, buffer.buffer.Size(), "buffered data should remain buffered until the next NextSeries or Close call")
+	require.Equal(t, 1, buffer.buffer.Size(), "buffered data should remain buffered until the next NextSeries or Finalize call")
 
 	err = consumer2.NextSeries(ctx)
 	require.NoError(t, err)
@@ -304,25 +302,24 @@ func TestRangeVectorOperator_Buffering_Filtering_IteratingBeforeCallingSeriesMet
 	d, err = consumer1.NextStepSamples(ctx)
 	require.NoError(t, err)
 	requireEqualDataAndReturnToPool(t, expectedData[2], d, memoryConsumptionTracker)
-	require.Equal(t, 4, buffer.buffer.Size(), "buffered data should remain buffered until the next NextSeries or Close call")
+	require.Equal(t, 4, buffer.buffer.Size(), "buffered data should remain buffered until the next NextSeries or Finalize call")
 
-	// Close the first consumer, check that the data that was being buffered for it is released.
-	consumer1.Close()
+	// Finalize the first consumer, check that the data that was being buffered for it is released.
+	require.NoError(t, consumer1.Finalize(ctx))
 	require.Equal(t, 0, buffer.buffer.Size())
 
 	// Check that the inner operator hasn't been closed or finalized yet.
 	require.False(t, inner.finalized)
 	require.False(t, inner.closed)
 
-	// Finalize each consumer, and check that the inner operator was only finalized after the last consumer is finalized.
-	require.NoError(t, consumer1.Finalize(ctx))
-	require.False(t, inner.finalized)
+	// Finalize the remaining consumer, and check that the inner operator was finalized after the last consumer is finalized.
 	require.NoError(t, consumer2.Finalize(ctx))
 	require.True(t, inner.finalized)
 	require.NoError(t, consumer1.Finalize(ctx), "it should be safe to finalize either consumer a second time")
 	require.NoError(t, consumer2.Finalize(ctx), "it should be safe to finalize either consumer a second time")
 
-	// Close the second consumer, and check that the inner operator was closed.
+	// Close both consumers, and check that the inner operator was closed.
+	consumer1.Close()
 	consumer2.Close()
 	require.True(t, inner.closed)
 	requireNoMemoryConsumption(t, memoryConsumptionTracker)
@@ -333,7 +330,7 @@ func TestRangeVectorOperator_Buffering_Filtering_IteratingBeforeCallingSeriesMet
 	requireNoMemoryConsumption(t, memoryConsumptionTracker)
 }
 
-func TestRangeVectorOperator_Buffering_Filtering_DoesNotBufferForClosedConsumer(t *testing.T) {
+func TestRangeVectorOperator_Buffering_Filtering_DoesNotBufferForFinalizedConsumer(t *testing.T) {
 	ctx := context.Background()
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	inner, expectedData := createTestRangeVectorOperator(t, 6, memoryConsumptionTracker)
@@ -361,10 +358,10 @@ func TestRangeVectorOperator_Buffering_Filtering_DoesNotBufferForClosedConsumer(
 	requireEqualDataAndReturnToPool(t, expectedData[1], d, memoryConsumptionTracker)
 	require.Equal(t, 2, buffer.buffer.Size(), "the first and second series should be buffered for the first consumer")
 
-	// Finalize and close the first consumer, check that the data that was being buffered for it is released.
+	// The data being buffered for the first consumer should be released when it's finalized.
 	require.NoError(t, consumer1.Finalize(ctx))
-	consumer1.Close()
 	require.Equal(t, 0, buffer.buffer.Size())
+	consumer1.Close()
 
 	// Check that the inner operator hasn't been closed or finalized yet.
 	require.False(t, inner.finalized)
@@ -438,10 +435,10 @@ func TestRangeVectorOperator_Buffering_Filtering_DoesNotBufferUnnecessarilyForLa
 	requireEqualDataAndReturnToPool(t, expectedData[2], d, memoryConsumptionTracker)
 	require.Equal(t, 1, buffer.buffer.Size(), "only the first series should be buffered for the first consumer")
 
-	// Finalize and close the first consumer, check that the data that was being buffered for it is released.
+	// The data being buffered for the first consumer should be released when it's finalized.
 	require.NoError(t, consumer1.Finalize(ctx))
-	consumer1.Close()
 	require.Equal(t, 0, buffer.buffer.Size())
+	consumer1.Close()
 
 	// Check that the inner operator hasn't been closed or finalized yet.
 	require.False(t, inner.finalized)
@@ -449,8 +446,8 @@ func TestRangeVectorOperator_Buffering_Filtering_DoesNotBufferUnnecessarilyForLa
 
 	// And the same for the second consumer.
 	require.NoError(t, consumer2.Finalize(ctx))
-	consumer2.Close()
 	require.True(t, inner.finalized)
+	consumer2.Close()
 	require.True(t, inner.closed)
 	requireNoMemoryConsumption(t, memoryConsumptionTracker)
 }
@@ -542,7 +539,7 @@ func TestRangeVectorOperator_Buffering_NonContiguousSeries(t *testing.T) {
 	d, err = consumer2.NextStepSamples(ctx)
 	require.NoError(t, err)
 	requireEqualDataAndReturnToPool(t, expectedData[0], d, memoryConsumptionTracker)
-	require.Equal(t, 1, buffer.buffer.Size(), "buffered data should remain buffered until the next NextSeries or Close call")
+	require.Equal(t, 1, buffer.buffer.Size(), "buffered data should remain buffered until the next NextSeries or Finalize call")
 
 	// Make sure everything is cleaned up properly.
 	require.False(t, inner.finalized)
@@ -582,7 +579,7 @@ func TestRangeVectorOperator_Filtering_SingleConsumer(t *testing.T) {
 	}
 }
 
-func TestRangeVectorOperator_ClosedWithBufferedData_NoFiltering(t *testing.T) {
+func TestRangeVectorOperator_FinalizedWithBufferedData_NoFiltering(t *testing.T) {
 	ctx := context.Background()
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	inner, expectedData := createTestRangeVectorOperator(t, 3, memoryConsumptionTracker)
@@ -622,8 +619,8 @@ func TestRangeVectorOperator_ClosedWithBufferedData_NoFiltering(t *testing.T) {
 	requireEqualDataAndReturnToPool(t, expectedData[2], d, memoryConsumptionTracker)
 	require.Equal(t, 3, buffer.buffer.Size())
 
-	// Close the first consumer, and check the data remains buffered for the second consumer.
-	consumer1.Close()
+	// Finalize the first consumer, and check the data remains buffered for the second consumer.
+	require.NoError(t, consumer1.Finalize(ctx))
 	require.Equal(t, 3, buffer.buffer.Size())
 
 	// Read some of the buffered data.
@@ -632,11 +629,14 @@ func TestRangeVectorOperator_ClosedWithBufferedData_NoFiltering(t *testing.T) {
 	d, err = consumer2.NextStepSamples(ctx)
 	require.NoError(t, err)
 	requireEqualDataAndReturnToPool(t, expectedData[0], d, memoryConsumptionTracker)
-	require.Equal(t, 3, buffer.buffer.Size(), "buffered data should remain in the buffer until the next NextSeries or Close call")
+	require.Equal(t, 3, buffer.buffer.Size(), "buffered data should remain in the buffer until the next NextSeries or Finalize call")
 
-	// Close the second consumer, and check that the inner operator was closed and all buffered data was released.
+	// Finalize the second consumer, and check that the inner operator was finalized and all buffered data was released.
+	require.NoError(t, consumer2.Finalize(ctx))
+	require.True(t, inner.finalized)
+
+	consumer1.Close()
 	consumer2.Close()
-	require.True(t, inner.closed)
 	requireNoMemoryConsumption(t, memoryConsumptionTracker)
 
 	// Make sure it's safe to close either consumer a second time.
@@ -645,7 +645,7 @@ func TestRangeVectorOperator_ClosedWithBufferedData_NoFiltering(t *testing.T) {
 	requireNoMemoryConsumption(t, memoryConsumptionTracker)
 }
 
-func TestRangeVectorOperator_ClosedWithBufferedData_Filtering(t *testing.T) {
+func TestRangeVectorOperator_FinalizedWithBufferedData_Filtering(t *testing.T) {
 	ctx := context.Background()
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	inner, expectedData := createTestRangeVectorOperator(t, 3, memoryConsumptionTracker)
@@ -681,7 +681,7 @@ func TestRangeVectorOperator_ClosedWithBufferedData_Filtering(t *testing.T) {
 	}
 
 	require.Equal(t, 3, buffer.buffer.Size(), "buffer should contain all three series for the remaining two consumers")
-	consumer2.Close()
+	require.NoError(t, consumer2.Finalize(ctx))
 	require.Equal(t, 1, buffer.buffer.Size(), "buffer should only contain remaining series required by remaining consumer")
 
 	err = consumer3.NextSeries(ctx)
@@ -689,11 +689,11 @@ func TestRangeVectorOperator_ClosedWithBufferedData_Filtering(t *testing.T) {
 	d, err := consumer3.NextStepSamples(ctx)
 	require.NoError(t, err)
 	requireEqualDataAndReturnToPool(t, expectedData[1], d, memoryConsumptionTracker)
-	require.Equal(t, 1, buffer.buffer.Size(), "buffered data should remain in the buffer until the next NextSeries or Close call")
+	require.Equal(t, 1, buffer.buffer.Size(), "buffered data should remain in the buffer until the next NextSeries or Finalize call")
 
-	consumer3.Close()
+	require.NoError(t, consumer3.Finalize(ctx))
 	require.Equal(t, 0, buffer.buffer.Size())
-	consumer1.Close()
+	require.NoError(t, consumer1.Finalize(ctx))
 	requireNoMemoryConsumption(t, memoryConsumptionTracker)
 }
 
@@ -1073,11 +1073,6 @@ func (t *testRangeVectorOperator) AfterPrepare(_ context.Context) error {
 
 func (t *testRangeVectorOperator) Finalize(_ context.Context) error {
 	t.finalized = true
-	return nil
-}
-
-func (t *testRangeVectorOperator) Close() {
-	t.closed = true
 
 	if t.floats != nil {
 		t.floats.Close()
@@ -1091,6 +1086,12 @@ func (t *testRangeVectorOperator) Close() {
 	t.floatsView = nil
 	t.histograms = nil
 	t.histogramsView = nil
+
+	return nil
+}
+
+func (t *testRangeVectorOperator) Close() {
+	t.closed = true
 }
 
 type failingRangeVectorOperator struct {


### PR DESCRIPTION
#### What this PR does

This PR builds upon #14647, and applies similar changes to the common subexpression elimination / subset selector elimination operators.

Similar to #14647, I've chosen not to add a changelog entry given this is a user-invisible refactor.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes resource-lifecycle semantics (when buffers and pooled bitmaps are released, and when inner operators are finalized/closed) in streaming PromQL execution. Bugs here could manifest as leaks, double-frees, or premature cleanup under multi-consumer scenarios.
> 
> **Overview**
> Updates the CSE/SSE instant and range vector duplication buffers so **memory/buffer cleanup happens during `Finalize`** (via new `releaseBufferedData`/`releaseAllBufferedData`) rather than being tied to `Close`, and ensures filter bitmaps are returned to pools only once.
> 
> `Close` now primarily marks consumers closed and only calls `Inner.Close()` once *all* consumers are closed, while `Inner.Finalize()` is triggered once *all* consumers are finalized; tests are updated/renamed to assert buffered data is released on finalize and to reflect the new finalize-vs-close responsibilities.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f21472df70d0d49a76f1890678a138cdf328d444. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->