### PR TITLE
Jsonnet: change default value of memberlist_bridge_replicas_per_zone from 2 to 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,6 +292,7 @@
   * `$._config.shuffle_sharding.store_gateway_shard_size_per_zone_overrides_enabled` (takes precedence over `store_gateway_shard_size_per_zone_enabled`)
 * [FEATURE] Ruler: Add `$._config.multi_zone_ruler_balanced_autoscaling_enabled` option to ensure equally balanced replica counts across ruler zones in multi-AZ deployments by using aggregate metrics for autoscaling. #14198
 * [FEATURE] Add `query_engine_range_vector_splitting_enabled` configuration option to enable experimental range vector splitting with memcached cache. #14435
+* [CHANGE] Memberlist bridge: Changed default value of `memberlist_bridge_replicas_per_zone` from 2 to 3. #14667
 * [ENHANCEMENT] Ruler querier and query-frontend: Add support for newly-introduced querier ring, which is used when performing query planning in query-frontends and distributing portions of the plan to queriers for execution. #13017
 * [ENHANCEMENT] Ingester: Increase `$._config.ingester_tsdb_head_early_compaction_min_in_memory_series` default when Mimir is running with the ingest storage architecture. #13450
 * [ENHANCEMENT] Memberlist bridge: Add `memberlist_bridge_replicas_per_zone` configuration option (default: 2). #13727

--- a/operations/mimir-tests/test-multi-az-read-path-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-generated.yaml
@@ -1392,7 +1392,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:
@@ -1477,7 +1477,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-0-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-0-generated.yaml
@@ -1218,7 +1218,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:
@@ -1303,7 +1303,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-1-generated.yaml
@@ -1903,7 +1903,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:
@@ -1988,7 +1988,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2-generated.yaml
@@ -1949,7 +1949,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:
@@ -2034,7 +2034,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2a-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2a-generated.yaml
@@ -1949,7 +1949,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:
@@ -2034,7 +2034,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2b-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2b-generated.yaml
@@ -1949,7 +1949,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:
@@ -2034,7 +2034,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2c-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2c-generated.yaml
@@ -1949,7 +1949,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:
@@ -2034,7 +2034,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2d-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2d-generated.yaml
@@ -1949,7 +1949,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:
@@ -2034,7 +2034,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2e-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2e-generated.yaml
@@ -1926,7 +1926,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:
@@ -2011,7 +2011,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2f-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2f-generated.yaml
@@ -1926,7 +1926,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:
@@ -2011,7 +2011,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-3-generated.yaml
@@ -1926,7 +1926,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:
@@ -2011,7 +2011,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-4-generated.yaml
@@ -1926,7 +1926,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:
@@ -2011,7 +2011,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-5-generated.yaml
@@ -1988,7 +1988,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:
@@ -2073,7 +2073,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-6-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-6-generated.yaml
@@ -1988,7 +1988,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:
@@ -2073,7 +2073,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-7-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-7-generated.yaml
@@ -1957,7 +1957,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:
@@ -2042,7 +2042,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-8-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-8-generated.yaml
@@ -1578,7 +1578,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:
@@ -1663,7 +1663,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-final-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-final-generated.yaml
@@ -1578,7 +1578,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:
@@ -1663,7 +1663,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:

--- a/operations/mimir-tests/test-range-vector-splitting-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-range-vector-splitting-multi-zone-generated.yaml
@@ -1456,7 +1456,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:
@@ -1541,7 +1541,7 @@ metadata:
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 2
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:

--- a/operations/mimir/multi-zone-memberlist-bridge.libsonnet
+++ b/operations/mimir/multi-zone-memberlist-bridge.libsonnet
@@ -11,9 +11,9 @@
 
     // Number of memberlist-bridge replicas per zone. Memberlist zone-aware routing has an
     // auto-failover mechanism to temporarily disable zone-aware routing if it detects that
-    // a zone has no healthy bridges; for this reason, 2 replicas are enough for high-availability
-    // without a significant risk of network partitioning if both bridges in a zone are unhealthy.
-    memberlist_bridge_replicas_per_zone: 2,
+    // a zone has no healthy bridges; 3 replicas provide high-availability without a significant
+    // risk of network partitioning if some bridges in a zone are unhealthy.
+    memberlist_bridge_replicas_per_zone: 3,
   },
 
   _images+:: if $._config.multi_zone_memberlist_bridge_enabled then {


### PR DESCRIPTION
#### What this PR does

At Grafana Labs we changed the memberlist-bridge per-zone replicas from 2 to 3, because it's safer with the new zone-aware routing. In this PR I'm upstreaming the same change.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
