### PR TITLE
Attempt to speed up CI

### DIFF
--- a/.github/workflows/scripts/run-integration-tests-group.sh
+++ b/.github/workflows/scripts/run-integration-tests-group.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # SPDX-License-Identifier: AGPL-3.0-only
+set -o pipefail
 
 SCRIPT_DIR=$(cd `dirname $0` && pwd)
 INTEGRATION_DIR=$(realpath "${SCRIPT_DIR}/../../../integration/")
@@ -37,10 +38,15 @@ if [[ -z "$TOTAL" ]]; then
 fi
 
 # List all tests.
-ALL_TESTS=$(go test -tags=requires_docker,stringlabels -list 'Test.*' "${INTEGRATION_DIR}/..." | grep -E '^Test.*' | sort)
+ALL_TESTS=$(go test -tags=requires_docker,stringlabels -list 'Test.*' "${INTEGRATION_DIR}" | grep -E '^Test.*' | sort)
 
 # Filter tests by the requested group.
 GROUP_TESTS=$(echo "$ALL_TESTS" | awk -v TOTAL="$TOTAL" -v INDEX="$INDEX" 'NR % TOTAL == INDEX')
+
+if [[ -z "$GROUP_TESTS" ]]; then
+    echo "ERROR: No tests found for group $INDEX of $TOTAL. This likely indicates a compilation error or misconfiguration."
+    exit 1
+fi
 
 echo "This group will run the following tests:"
 echo "$GROUP_TESTS"
@@ -50,6 +56,16 @@ echo ""
 # This setting tells Go runtime to exit the binary when data race is detected. This increases the chance
 # that integration tests will fail on data races.
 export MIMIR_ENV_VARS_JSON='{"GORACE": "halt_on_error=1"}'
+
+# Compile the integration test binary once upfront. Running "go test" per test would repeat
+# compilation/linking work on every invocation, adding significant overhead across many tests.
+# If you change the build tags here, also update warmup-build-cache-integration-tests in the Makefile.
+TEST_BINARY="${INTEGRATION_DIR}/integration.test"
+go test -tags=requires_docker,stringlabels -c -o "$TEST_BINARY" "${INTEGRATION_DIR}"
+if [[ $? -ne 0 ]]; then
+    echo "ERROR: Failed to compile integration test binary."
+    exit 1
+fi
 
 EXIT_CODE=0
 
@@ -66,8 +82,7 @@ for TEST in $GROUP_TESTS; do
             echo "Running test: $TEST"
         fi
 
-        # If you change the build tags or CLI flags, update warmup-build-cache-integration-tests in the Makefile too.
-        go test -tags=requires_docker,stringlabels -timeout 2400s -v -count=1 -run "^${TEST}$" "${INTEGRATION_DIR}/..."
+        "$TEST_BINARY" -test.timeout 2400s -test.v -test.count=1 -test.run "^${TEST}$"
         TEST_EXIT_CODE=$?
 
         if [[ $TEST_EXIT_CODE -eq 0 ]]; then

--- a/.github/workflows/scripts/run-unit-tests-group.sh
+++ b/.github/workflows/scripts/run-unit-tests-group.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # SPDX-License-Identifier: AGPL-3.0-only
+set -o pipefail
 
 SCRIPT_DIR=$(cd `dirname $0` && pwd)
 MIMIR_DIR=$(realpath "${SCRIPT_DIR}/../../../")
@@ -46,7 +47,12 @@ fi
 ALL_TESTS=$(go list "${MIMIR_DIR}/..." | sort)
 
 # Filter tests by the requested group.
-GROUP_TESTS=$(echo "$ALL_TESTS" | awk -v TOTAL=$TOTAL -v INDEX=$INDEX 'NR % TOTAL == INDEX')
+GROUP_TESTS=$(echo "$ALL_TESTS" | awk -v TOTAL="$TOTAL" -v INDEX="$INDEX" 'NR % TOTAL == INDEX')
+
+if [[ -z "$GROUP_TESTS" ]]; then
+    echo "ERROR: No packages found for group $INDEX of $TOTAL. This likely indicates a compilation error or misconfiguration."
+    exit 1
+fi
 
 # The tests in the MQE benchmarks package load an enormous amount of data, which causes the
 # race detector to consume a large amount of memory and run incredibly slowly on CI.

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -12,7 +12,7 @@ on:
 env:
   # Set to 'true' to force Go build cache warmup on all branches (useful when iterating on cache changes).
   # When 'false', the cache is only built on main (see warmup-go-build-cache-integration-tests job for details).
-  FORCE_BUILD_CACHE_WARMUP: 'true'
+  FORCE_BUILD_CACHE_WARMUP: 'false'
 
 permissions:
   contents: read

--- a/Makefile
+++ b/Makefile
@@ -795,7 +795,7 @@ integration-tests-race: cmd/mimir/$(UPTODATE_RACE)
 # jobs can skip most compilation. The flags here MUST match the ones used by the real targets.
 
 warmup-build-cache-integration-tests: ## Warm the Go build cache for integration tests.
-	go test -run=^$ -count=1 -tags=requires_docker,stringlabels ./integration/... 2>&1 || true
+	go test -run=^$ -count=1 -tags=requires_docker,stringlabels ./integration/ 2>&1 || true
 	go build ./tools/pre-pull-images/... 2>&1 || true
 
 warmup-build-cache-unit-tests: ## Warm the Go build cache for unit tests.


### PR DESCRIPTION
#### What this PR does

In this PR I'm attempting some changes to try to speed up CI:

- Share Go build cache for CI unit tests, integration tests and images (different caches to keep each cache entry smaller)
- Increase CI parallelism: unit tests from 4 to 10 groups, integration tests from 6 to 20 groups                                                         
- Retry failed tests at per-test (integration tests) or per-package (unit tests) level instead of retrying the entire group

**Go build cache warmup**:
Previously, each unit and integration test job, and image building job, compiled Go packages from scratch, even though they share most dependencies. The `warmup-go-build-cache-*` jobs compile all test/app binaries once — with -race (for unit tests) and without (for integration tests) — and saves the resulting Go build cache via `actions/cache`.

All test jobs then restore this cache, skipping compilation of unchanged dependencies. The cache is keyed by `go.sum` hash and rebuilt only  when dependencies change; source file changes are still compiled in each test job but dependencies (the bulk of compilation) are cached.

By default, the cache is only built on pushes to main because GitHub Actions caches created on main are accessible from all branches, while caches created on PR branches are scoped to that branch only. This keeps cache storage small while benefiting all branches. The `FORCE_BUILD_CACHE_WARMUP` env var at the top of the workflow can be set to 'true' to override this during development.
                              
**Increased CI parallelism**

Unit tests are split from 4 to 10 groups and integration tests from 6 to 20 groups. With the build cache in place, each group spends less time compiling, so the added parallelism translates directly into shorter wall-clock CI time.

**Per-test retry**

Previously, CI used the `nick-fields/retry` GitHub Action to re-run the whole step after a failure. Now, both unit and integration test scripts run one package/test at a time and retry only the failed item. This avoids re-running passing tests

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
