### PR TITLE
limits: make otel_metric_suffixes_enabled pointer to distinguish empty from disabled

### DIFF
--- a/pkg/distributor/otel_test.go
+++ b/pkg/distributor/otel_test.go
@@ -1741,7 +1741,7 @@ func TestHandlerOTLPPush(t *testing.T) {
 			testLimits := &validation.Limits{
 				PromoteOTelResourceAttributes: tt.promoteResourceAttributes,
 				NameValidationScheme:          model.LegacyValidation,
-				OTelMetricSuffixesEnabled:     false,
+				OTelMetricSuffixesEnabled:     boolPtr(false),
 			}
 			limits := validation.NewOverrides(
 				validation.Limits{},
@@ -2272,7 +2272,7 @@ func TestOTLPResponseContentType(t *testing.T) {
 			limits := validation.NewOverrides(
 				validation.Limits{},
 				validation.NewMockTenantLimits(map[string]*validation.Limits{
-					"test": {NameValidationScheme: model.LegacyValidation, OTelMetricSuffixesEnabled: false},
+					"test": {NameValidationScheme: model.LegacyValidation, OTelMetricSuffixesEnabled: boolPtr(false)},
 				}),
 			)
 			handler := OTLPHandler(100000, nil, nil, limits, nil, nil, RetryConfig{}, nil, func(_ context.Context, req *Request) error {
@@ -2302,4 +2302,8 @@ type fakeResourceAttributePromotionConfig struct {
 
 func (c fakeResourceAttributePromotionConfig) PromoteOTelResourceAttributes(string) []string {
 	return c.promote
+}
+
+func boolPtr(b bool) *bool {
+	return &b
 }

--- a/pkg/mimir/runtime_config_test.go
+++ b/pkg/mimir/runtime_config_test.go
@@ -59,6 +59,7 @@ overrides:
 	expected.MaxGlobalSeriesPerMetric = 7000
 	expected.RulerMaxRulesPerRuleGroup = 20
 	expected.RulerMaxRuleGroupsPerTenant = 20
+	expected.OTelMetricSuffixesEnabled = nil
 
 	loadedLimits := runtimeCfg.(*runtimeConfigValues).TenantLimits
 	require.Equal(t, 3, len(loadedLimits))

--- a/pkg/util/usage/usage.go
+++ b/pkg/util/usage/usage.go
@@ -151,6 +151,12 @@ func parseStructure(structure interface{}, fields map[uintptr]reflect.StructFiel
 		// Take address of field value and map it to field
 		fields[fieldValue.Addr().Pointer()] = field
 
+		// For pointer fields (e.g. *bool), the flag is registered with the
+		// pointed-to address, not the address of the pointer field itself.
+		if fieldValue.Kind() == reflect.Ptr && !fieldValue.IsNil() {
+			fields[fieldValue.Pointer()] = field
+		}
+
 		// Recurse if a struct
 		if field.Type.Kind() != reflect.Struct || isFieldHidden(field, "") || ignoreStructType(field.Type) || !field.IsExported() {
 			continue

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -309,7 +309,7 @@ type Limits struct {
 	AlertmanagerNotifyHookTimeout              model.Duration         `yaml:"alertmanager_notify_hook_timeout" json:"alertmanager_notify_hook_timeout"`
 
 	// OpenTelemetry
-	OTelMetricSuffixesEnabled                bool                         `yaml:"otel_metric_suffixes_enabled" json:"otel_metric_suffixes_enabled" category:"advanced"`
+	OTelMetricSuffixesEnabled                *bool                        `yaml:"otel_metric_suffixes_enabled" json:"otel_metric_suffixes_enabled" category:"advanced"`
 	OTelCreatedTimestampZeroIngestionEnabled bool                         `yaml:"otel_created_timestamp_zero_ingestion_enabled" json:"otel_created_timestamp_zero_ingestion_enabled" category:"experimental"`
 	PromoteOTelResourceAttributes            flagext.StringSliceCSV       `yaml:"promote_otel_resource_attributes" json:"promote_otel_resource_attributes" category:"experimental"`
 	OTelKeepIdentifyingResourceAttributes    bool                         `yaml:"otel_keep_identifying_resource_attributes" json:"otel_keep_identifying_resource_attributes" category:"experimental"`
@@ -366,7 +366,8 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.Var(&l.CreationGracePeriod, CreationGracePeriodFlag, "Controls how far into the future incoming samples and exemplars are accepted compared to the wall clock. Any sample or exemplar will be rejected if its timestamp is greater than '(now + creation_grace_period)'. This configuration is enforced in the distributor and ingester.")
 	f.Var(&l.PastGracePeriod, PastGracePeriodFlag, "Controls how far into the past incoming samples and exemplars are accepted compared to the wall clock. Any sample or exemplar will be rejected if its timestamp is lower than '(now - OOO window - past_grace_period)'. This configuration is enforced in the distributor and ingester. 0 to disable.")
 	f.BoolVar(&l.EnforceMetadataMetricName, "validation.enforce-metadata-metric-name", true, "Enforce every metadata has a metric name.")
-	f.BoolVar(&l.OTelMetricSuffixesEnabled, "distributor.otel-metric-suffixes-enabled", false, "Whether to enable automatic suffixes to names of metrics ingested through OTLP.")
+	l.OTelMetricSuffixesEnabled = new(bool)
+	f.BoolVar(l.OTelMetricSuffixesEnabled, "distributor.otel-metric-suffixes-enabled", false, "Whether to enable automatic suffixes to names of metrics ingested through OTLP.")
 	f.BoolVar(&l.OTelCreatedTimestampZeroIngestionEnabled, "distributor.otel-created-timestamp-zero-ingestion-enabled", false, "Whether to enable translation of OTel start timestamps to Prometheus zero samples in the OTLP endpoint.")
 	f.Var(&l.PromoteOTelResourceAttributes, "distributor.otel-promote-resource-attributes", "Optionally specify OTel resource attributes to promote to labels.")
 	f.BoolVar(&l.OTelKeepIdentifyingResourceAttributes, "distributor.otel-keep-identifying-resource-attributes", false, "Whether to keep identifying OTel resource attributes in the target_info metric on top of converting to job and instance labels.")
@@ -558,10 +559,14 @@ func (l *Limits) unmarshal(decode func(any) error) error {
 	if defaultLimits != nil {
 		*l = *defaultLimits
 
-		// Make copy of default limits, otherwise unmarshalling would modify map in default limits.
+		// Make copy of default limits, otherwise unmarshalling would modify values in default limits.
 		l.NotificationRateLimitPerIntegration = defaultLimits.NotificationRateLimitPerIntegration.Clone()
 		l.RulerMaxRulesPerRuleGroupByNamespace = defaultLimits.RulerMaxRulesPerRuleGroupByNamespace.Clone()
 		l.RulerMaxRuleGroupsPerTenantByNamespace = defaultLimits.RulerMaxRuleGroupsPerTenantByNamespace.Clone()
+
+		// Reset to nil so we can distinguish "not set" from "explicitly set"
+		// after decoding. The Overrides getter falls back to the global default when nil.
+		l.OTelMetricSuffixesEnabled = nil
 
 		// Reset the merged custom active series trackers config, to not interfere with the default limits.
 		l.activeSeriesMergedCustomTrackersConfig = atomic.NewPointer[asmodel.CustomTrackersConfig](nil)
@@ -619,7 +624,7 @@ func (l *Limits) Validate() error {
 				l.OTelTranslationStrategy, model.LegacyValidation,
 			)
 		}
-		if l.OTelMetricSuffixesEnabled {
+		if l.OTelMetricSuffixesEnabled != nil && *l.OTelMetricSuffixesEnabled {
 			return fmt.Errorf("OTLP translation strategy %s is not allowed unless metric suffixes are disabled", l.OTelTranslationStrategy)
 		}
 	case otlptranslator.UnderscoreEscapingWithSuffixes:
@@ -629,7 +634,7 @@ func (l *Limits) Validate() error {
 				l.OTelTranslationStrategy, model.LegacyValidation,
 			)
 		}
-		if !l.OTelMetricSuffixesEnabled {
+		if l.OTelMetricSuffixesEnabled != nil && !*l.OTelMetricSuffixesEnabled {
 			return fmt.Errorf("OTLP translation strategy %s is not allowed unless metric suffixes are enabled", l.OTelTranslationStrategy)
 		}
 	case otlptranslator.NoUTF8EscapingWithSuffixes:
@@ -639,7 +644,7 @@ func (l *Limits) Validate() error {
 				l.OTelTranslationStrategy, model.UTF8Validation,
 			)
 		}
-		if !l.OTelMetricSuffixesEnabled {
+		if l.OTelMetricSuffixesEnabled != nil && !*l.OTelMetricSuffixesEnabled {
 			return fmt.Errorf("OTLP translation strategy %s is not allowed unless metric suffixes are enabled", l.OTelTranslationStrategy)
 		}
 	case otlptranslator.NoTranslation:
@@ -649,7 +654,7 @@ func (l *Limits) Validate() error {
 				l.OTelTranslationStrategy, model.UTF8Validation,
 			)
 		}
-		if l.OTelMetricSuffixesEnabled {
+		if l.OTelMetricSuffixesEnabled != nil && *l.OTelMetricSuffixesEnabled {
 			return fmt.Errorf("OTLP translation strategy %s is not allowed unless metric suffixes are disabled", l.OTelTranslationStrategy)
 		}
 	case "":
@@ -1536,7 +1541,11 @@ func (o *Overrides) Prom2RangeCompat(userID string) bool {
 }
 
 func (o *Overrides) OTelMetricSuffixesEnabled(tenantID string) bool {
-	return o.getOverridesForUser(tenantID).OTelMetricSuffixesEnabled
+	v := o.getOverridesForUser(tenantID).OTelMetricSuffixesEnabled
+	if v != nil {
+		return *v
+	}
+	return o.defaultLimits.OTelMetricSuffixesEnabled != nil && *o.defaultLimits.OTelMetricSuffixesEnabled
 }
 
 func (o *Overrides) OTelCreatedTimestampZeroIngestionEnabled(tenantID string) bool {

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -1628,7 +1628,7 @@ func TestLimits_Validate(t *testing.T) {
 				cfg := Limits{}
 				flagext.DefaultValues(&cfg)
 				cfg.NameValidationScheme = model.LegacyValidation
-				cfg.OTelMetricSuffixesEnabled = false
+				cfg.OTelMetricSuffixesEnabled = boolPtr(false)
 				cfg.OTelTranslationStrategy = OTelTranslationStrategyValue(otlptranslator.UnderscoreEscapingWithoutSuffixes)
 				return cfg
 			}(),
@@ -1639,7 +1639,7 @@ func TestLimits_Validate(t *testing.T) {
 				cfg := Limits{}
 				flagext.DefaultValues(&cfg)
 				cfg.NameValidationScheme = model.LegacyValidation
-				cfg.OTelMetricSuffixesEnabled = true
+				cfg.OTelMetricSuffixesEnabled = boolPtr(true)
 				cfg.OTelTranslationStrategy = OTelTranslationStrategyValue(otlptranslator.UnderscoreEscapingWithSuffixes)
 				return cfg
 			}(),
@@ -1650,7 +1650,7 @@ func TestLimits_Validate(t *testing.T) {
 				cfg := Limits{}
 				flagext.DefaultValues(&cfg)
 				cfg.NameValidationScheme = model.UTF8Validation
-				cfg.OTelMetricSuffixesEnabled = true
+				cfg.OTelMetricSuffixesEnabled = boolPtr(true)
 				cfg.OTelTranslationStrategy = OTelTranslationStrategyValue(otlptranslator.NoUTF8EscapingWithSuffixes)
 				return cfg
 			}(),
@@ -1661,7 +1661,7 @@ func TestLimits_Validate(t *testing.T) {
 				cfg := Limits{}
 				flagext.DefaultValues(&cfg)
 				cfg.NameValidationScheme = model.UTF8Validation
-				cfg.OTelMetricSuffixesEnabled = false
+				cfg.OTelMetricSuffixesEnabled = boolPtr(false)
 				cfg.OTelTranslationStrategy = OTelTranslationStrategyValue(otlptranslator.NoTranslation)
 				return cfg
 			}(),
@@ -1672,7 +1672,7 @@ func TestLimits_Validate(t *testing.T) {
 				cfg := Limits{}
 				flagext.DefaultValues(&cfg)
 				cfg.NameValidationScheme = model.LegacyValidation
-				cfg.OTelMetricSuffixesEnabled = false
+				cfg.OTelMetricSuffixesEnabled = boolPtr(false)
 				cfg.OTelTranslationStrategy = OTelTranslationStrategyValue("")
 				return cfg
 			}(),
@@ -1687,7 +1687,7 @@ func TestLimits_Validate(t *testing.T) {
 				cfg := Limits{}
 				flagext.DefaultValues(&cfg)
 				cfg.NameValidationScheme = model.LegacyValidation
-				cfg.OTelMetricSuffixesEnabled = true
+				cfg.OTelMetricSuffixesEnabled = boolPtr(true)
 				cfg.OTelTranslationStrategy = OTelTranslationStrategyValue("")
 				return cfg
 			}(),
@@ -1702,7 +1702,7 @@ func TestLimits_Validate(t *testing.T) {
 				cfg := Limits{}
 				flagext.DefaultValues(&cfg)
 				cfg.NameValidationScheme = model.UTF8Validation
-				cfg.OTelMetricSuffixesEnabled = true
+				cfg.OTelMetricSuffixesEnabled = boolPtr(true)
 				cfg.OTelTranslationStrategy = OTelTranslationStrategyValue("")
 				return cfg
 			}(),
@@ -1717,7 +1717,7 @@ func TestLimits_Validate(t *testing.T) {
 				cfg := Limits{}
 				flagext.DefaultValues(&cfg)
 				cfg.NameValidationScheme = model.UTF8Validation
-				cfg.OTelMetricSuffixesEnabled = false
+				cfg.OTelMetricSuffixesEnabled = boolPtr(false)
 				cfg.OTelTranslationStrategy = OTelTranslationStrategyValue("")
 				return cfg
 			}(),
@@ -1732,7 +1732,7 @@ func TestLimits_Validate(t *testing.T) {
 				cfg := Limits{}
 				flagext.DefaultValues(&cfg)
 				cfg.NameValidationScheme = model.UTF8Validation
-				cfg.OTelMetricSuffixesEnabled = false
+				cfg.OTelMetricSuffixesEnabled = boolPtr(false)
 				cfg.OTelTranslationStrategy = OTelTranslationStrategyValue(otlptranslator.UnderscoreEscapingWithoutSuffixes)
 				return cfg
 			}(),
@@ -1743,7 +1743,7 @@ func TestLimits_Validate(t *testing.T) {
 				cfg := Limits{}
 				flagext.DefaultValues(&cfg)
 				cfg.NameValidationScheme = model.LegacyValidation
-				cfg.OTelMetricSuffixesEnabled = true
+				cfg.OTelMetricSuffixesEnabled = boolPtr(true)
 				cfg.OTelTranslationStrategy = OTelTranslationStrategyValue(otlptranslator.UnderscoreEscapingWithoutSuffixes)
 				return cfg
 			}(),
@@ -1754,7 +1754,7 @@ func TestLimits_Validate(t *testing.T) {
 				cfg := Limits{}
 				flagext.DefaultValues(&cfg)
 				cfg.NameValidationScheme = model.UTF8Validation
-				cfg.OTelMetricSuffixesEnabled = true
+				cfg.OTelMetricSuffixesEnabled = boolPtr(true)
 				cfg.OTelTranslationStrategy = OTelTranslationStrategyValue(otlptranslator.UnderscoreEscapingWithSuffixes)
 				return cfg
 			}(),
@@ -1765,7 +1765,7 @@ func TestLimits_Validate(t *testing.T) {
 				cfg := Limits{}
 				flagext.DefaultValues(&cfg)
 				cfg.NameValidationScheme = model.LegacyValidation
-				cfg.OTelMetricSuffixesEnabled = false
+				cfg.OTelMetricSuffixesEnabled = boolPtr(false)
 				cfg.OTelTranslationStrategy = OTelTranslationStrategyValue(otlptranslator.UnderscoreEscapingWithSuffixes)
 				return cfg
 			}(),
@@ -1776,7 +1776,7 @@ func TestLimits_Validate(t *testing.T) {
 				cfg := Limits{}
 				flagext.DefaultValues(&cfg)
 				cfg.NameValidationScheme = model.LegacyValidation
-				cfg.OTelMetricSuffixesEnabled = true
+				cfg.OTelMetricSuffixesEnabled = boolPtr(true)
 				cfg.OTelTranslationStrategy = OTelTranslationStrategyValue(otlptranslator.NoUTF8EscapingWithSuffixes)
 				return cfg
 			}(),
@@ -1787,7 +1787,7 @@ func TestLimits_Validate(t *testing.T) {
 				cfg := Limits{}
 				flagext.DefaultValues(&cfg)
 				cfg.NameValidationScheme = model.UTF8Validation
-				cfg.OTelMetricSuffixesEnabled = false
+				cfg.OTelMetricSuffixesEnabled = boolPtr(false)
 				cfg.OTelTranslationStrategy = OTelTranslationStrategyValue(otlptranslator.NoUTF8EscapingWithSuffixes)
 				return cfg
 			}(),
@@ -1798,7 +1798,7 @@ func TestLimits_Validate(t *testing.T) {
 				cfg := Limits{}
 				flagext.DefaultValues(&cfg)
 				cfg.NameValidationScheme = model.LegacyValidation
-				cfg.OTelMetricSuffixesEnabled = false
+				cfg.OTelMetricSuffixesEnabled = boolPtr(false)
 				cfg.OTelTranslationStrategy = OTelTranslationStrategyValue(otlptranslator.NoTranslation)
 				return cfg
 			}(),
@@ -1809,7 +1809,7 @@ func TestLimits_Validate(t *testing.T) {
 				cfg := Limits{}
 				flagext.DefaultValues(&cfg)
 				cfg.NameValidationScheme = model.UTF8Validation
-				cfg.OTelMetricSuffixesEnabled = true
+				cfg.OTelMetricSuffixesEnabled = boolPtr(true)
 				cfg.OTelTranslationStrategy = OTelTranslationStrategyValue(otlptranslator.NoTranslation)
 				return cfg
 			}(),
@@ -2424,7 +2424,7 @@ func TestOverrides_OTelTranslationStrategy(t *testing.T) {
 				"tenant1": {
 					OTelTranslationStrategy:   OTelTranslationStrategyValue(otlptranslator.UnderscoreEscapingWithSuffixes),
 					NameValidationScheme:      model.UTF8Validation,
-					OTelMetricSuffixesEnabled: false,
+					OTelMetricSuffixesEnabled: boolPtr(false),
 				},
 			},
 			tenantID:                    "tenant1",
@@ -2436,7 +2436,7 @@ func TestOverrides_OTelTranslationStrategy(t *testing.T) {
 				"tenant1": {
 					OTelTranslationStrategy:   OTelTranslationStrategyValue(""),
 					NameValidationScheme:      model.LegacyValidation,
-					OTelMetricSuffixesEnabled: true,
+					OTelMetricSuffixesEnabled: boolPtr(true),
 				},
 			},
 			tenantID:                    "tenant1",
@@ -2448,7 +2448,7 @@ func TestOverrides_OTelTranslationStrategy(t *testing.T) {
 				"tenant1": {
 					OTelTranslationStrategy:   OTelTranslationStrategyValue(""),
 					NameValidationScheme:      model.LegacyValidation,
-					OTelMetricSuffixesEnabled: false,
+					OTelMetricSuffixesEnabled: boolPtr(false),
 				},
 			},
 			tenantID:                    "tenant1",
@@ -2460,7 +2460,7 @@ func TestOverrides_OTelTranslationStrategy(t *testing.T) {
 				"tenant1": {
 					OTelTranslationStrategy:   OTelTranslationStrategyValue(""),
 					NameValidationScheme:      model.UTF8Validation,
-					OTelMetricSuffixesEnabled: true,
+					OTelMetricSuffixesEnabled: boolPtr(true),
 				},
 			},
 			tenantID:                    "tenant1",
@@ -2472,7 +2472,7 @@ func TestOverrides_OTelTranslationStrategy(t *testing.T) {
 				"tenant1": {
 					OTelTranslationStrategy:   OTelTranslationStrategyValue(""),
 					NameValidationScheme:      model.UTF8Validation,
-					OTelMetricSuffixesEnabled: false,
+					OTelMetricSuffixesEnabled: boolPtr(false),
 				},
 			},
 			tenantID:                    "tenant1",
@@ -2501,7 +2501,7 @@ func TestOverrides_OTelTranslationStrategy(t *testing.T) {
 			"tenant1": {
 				OTelTranslationStrategy:   OTelTranslationStrategyValue(""),
 				NameValidationScheme:      model.ValidationScheme(999), // Invalid scheme
-				OTelMetricSuffixesEnabled: true,
+				OTelMetricSuffixesEnabled: boolPtr(true),
 			},
 		}
 
@@ -2518,4 +2518,8 @@ func getDefaultLimits() Limits {
 	limits := Limits{}
 	flagext.DefaultValues(&limits)
 	return limits
+}
+
+func boolPtr(b bool) *bool {
+	return &b
 }

--- a/tools/doc-generator/parse/parser.go
+++ b/tools/doc-generator/parse/parser.go
@@ -187,8 +187,9 @@ func config(block *ConfigBlock, cfg any, flags map[uintptr]*flag.Flag, rootBlock
 			continue
 		}
 
-		// Recursively re-iterate if it's a struct and it's not a custom type.
-		if _, custom := getFieldCustomType(field.Type); (field.Type.Kind() == reflect.Struct || field.Type.Kind() == reflect.Ptr) && !custom {
+		// Recursively re-iterate if it's a struct (or pointer to struct) and it's not a custom type.
+		if _, custom := getFieldCustomType(field.Type); !custom &&
+			(field.Type.Kind() == reflect.Struct || (field.Type.Kind() == reflect.Ptr && field.Type.Elem().Kind() == reflect.Struct)) {
 			// Check whether the sub-block is a root config block
 			rootName, rootDesc, isRoot := isRootBlock(field.Type, rootBlocks)
 
@@ -493,7 +494,12 @@ func getFieldFlag(field reflect.StructField, fieldValue reflect.Value, flags map
 	if isAbsentInCLI(field) {
 		return nil, nil
 	}
-	fieldPtr := fieldValue.Addr().Pointer()
+	var fieldPtr uintptr
+	if fieldValue.Kind() == reflect.Ptr && !fieldValue.IsNil() {
+		fieldPtr = fieldValue.Pointer()
+	} else {
+		fieldPtr = fieldValue.Addr().Pointer()
+	}
 	fieldFlag, ok := flags[fieldPtr]
 	if !ok {
 		return nil, nil


### PR DESCRIPTION
#### What this PR does

This PR changes `OTelMetricSuffixesEnabled` limit to be a `*bool` rather than `bool`. This allows us to differentitate empty and disabled states.
This is a requirement for https://github.com/grafana/mimir/pull/14289.

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the type and defaulting behavior of the `OTelMetricSuffixesEnabled` limit to distinguish unset vs explicit values, affecting config unmarshalling and per-tenant override resolution. Moderate risk due to potential behavioral differences in how defaults/CLI flags and runtime overrides are interpreted.
> 
> **Overview**
> Updates the `OTelMetricSuffixesEnabled` limit from `bool` to `*bool` so the system can distinguish *unset* from *explicitly enabled/disabled*, and adjusts defaults/override resolution accordingly (including nil-aware validation of `OTelTranslationStrategy`).
> 
> Updates flag/doc/usage reflection helpers to correctly associate CLI flags with pointer-backed fields, and refreshes runtime config + validation + distributor tests to pass `*bool` values (adding local `boolPtr` helpers) and to expect `nil` when the setting is omitted.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 048489fff42e4c943960607a8202cdfee85bf0b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->