### PR TITLE
ci: fix build-image git author

### DIFF
--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -218,7 +218,7 @@ jobs:
           else
             echo "Build Image Version is not up to date"
             sed -i "s/$MAIN_TAG/${{ steps.compute_hash.outputs.tag }}/g" Makefile
-            git config --global user.email "${GITHUB_LOGIN}@users.noreply.github.com"
+            git config --global user.email "${GITHUB_EMAIL}"
             git config --global user.name "${GITHUB_LOGIN}"
             git config --global url.https://x-access-token:${GITHUB_TOKEN}@github.com/.insteadOf https://github.com/
             git add Makefile
@@ -228,5 +228,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token-for-commit.outputs.token }}
           GITHUB_LOGIN: mimir-github-bot[bot]
+          GITHUB_EMAIL: 199097951+mimir-github-bot[bot]@users.noreply.github.com
           TAG: ${{ steps.compute_hash.outputs.tag }}
           MAIN_TAG: ${{ steps.prepare.outputs.main_image_tag }}

--- a/renovate.json5
+++ b/renovate.json5
@@ -133,7 +133,7 @@
         'mimir-build-image/Dockerfile',
       ],
       rebaseWhen: 'behind-base-branch',
-      gitIgnoredAuthors: ['mimir-github-bot[bot]@users.noreply.github.com'],
+      gitIgnoredAuthors: ['199097951+mimir-github-bot[bot]@users.noreply.github.com'],
     }
   ],
   branchPrefix: 'deps-update/',


### PR DESCRIPTION
Fix up https://github.com/grafana/mimir/pull/14524

In the mentioned PR we updated the git author of commits made from `push-build-image` to `mimir-github-bot`. This broke CLA check, which requires the commit author to have a GitHub account (see [failure][1])

<img width="943" height="324" alt="Screenshot 2026-03-13 at 11 52 21" src="https://github.com/user-attachments/assets/6baa1932-6aa6-4ace-a3f7-f61adfd5c3bc" />

This PR should fix it be making bot account the commit author.

**Note:** We already have an exception for `mimir-github-bot[bot]` account — the correct github account of the bot — in the CLA.

jfi @charleskorn 

[1]: https://github.com/grafana/mimir/pull/14660#issuecomment-4052162554