### PR TITLE
ingester: Fix goroutine leaks in tests detected by goleak

### DIFF
--- a/pkg/ingester/ingester_ingest_storage_test.go
+++ b/pkg/ingester/ingester_ingest_storage_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
 	"go.uber.org/atomic"
-	"go.uber.org/goleak"
 
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/querier/api"
@@ -48,15 +47,7 @@ import (
 	"github.com/grafana/mimir/pkg/util/validation"
 )
 
-var goleakOpts = []goleak.Option{
-	// TestIngester_Startup_PartitionRingActiveBlocksOnInstanceRingActive
-	// tests ingester failure on startup, which does not clean up all goroutines.
-	// This goroutine will be detected by other tests running in parallel with VerifyNoLeak.
-	goleak.IgnoreAnyFunction("github.com/grafana/dskit/services.funcBasedListener.Failed"),
-}
-
 func TestIngester_Startup_PartitionRingActiveBlocksOnInstanceRingActive(t *testing.T) {
-	util_test.VerifyNoLeak(t, goleakOpts...)
 	var err error
 
 	cfg := defaultIngesterTestConfig(t)
@@ -167,7 +158,6 @@ func TestIngester_Startup_PartitionRingActiveBlocksOnInstanceRingActive(t *testi
 }
 
 func TestIngester_Start(t *testing.T) {
-	util_test.VerifyNoLeak(t, goleakOpts...)
 
 	t.Run("should replay the partition at startup (after a restart) and then join the ingesters and partitions ring", func(t *testing.T) {
 		var (
@@ -890,6 +880,9 @@ func TestIngester_compactionServiceInterval(t *testing.T) {
 					_ = services.StopAndAwaitTerminated(context.Background(), ingester)
 				})
 			case services.Running:
+				t.Cleanup(func() {
+					ingester.subservicesWatcher.Close()
+				})
 			default:
 				t.Fatalf("unsupported state %s", tt.state)
 			}
@@ -999,6 +992,9 @@ func TestIngester_timeToNextZoneAwareCompaction(t *testing.T) {
 			cfg.BlocksStorageConfig.TSDB.HeadCompactionInterval = defaultBaseHeadCompactionInterval
 
 			ingester, _, _ := createTestIngesterWithIngestStorage(t, &cfg, overrides, nil, nil, util_test.NewTestingLogger(t))
+			t.Cleanup(func() {
+				ingester.subservicesWatcher.Close()
+			})
 
 			headCompactionInterval := ingester.timeToNextZoneAwareCompaction(fakeNow, tt.zones)
 			require.Equal(t, tt.expected, headCompactionInterval)

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -56,6 +56,7 @@ import (
 	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/objstore/providers/filesystem"
 	"go.uber.org/atomic"
+	"go.uber.org/goleak"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 
@@ -76,6 +77,21 @@ import (
 	util_test "github.com/grafana/mimir/pkg/util/test"
 	"github.com/grafana/mimir/pkg/util/validation"
 )
+
+func TestMain(m *testing.M) {
+	util_test.VerifyNoLeakTestMain(m,
+		// TestIngester_Startup_PartitionRingActiveBlocksOnInstanceRingActive
+		// tests ingester failure on startup, which does not clean up all goroutines.
+		// This goroutine will be detected by other tests running in parallel with VerifyNoLeak.
+		goleak.IgnoreAnyFunction("github.com/grafana/dskit/services.funcBasedListener.Failed"),
+
+		// TestIngester_OpenExistingTSDBOnStartup rollback subtests create corrupt chunks_head
+		// files to trigger a tsdb.Open() failure. Prometheus TSDB internally starts WAL and
+		// chunkWriteQueue goroutines before encountering the error and doesn't clean them up.
+		goleak.IgnoreAnyFunction("github.com/prometheus/prometheus/tsdb/wlog.(*WL).run"),
+		goleak.IgnoreAnyFunction("github.com/prometheus/prometheus/tsdb/chunks.(*chunkWriteQueue).start.func1"),
+	)
+}
 
 func mustNewActiveSeriesCustomTrackersConfigFromMap(t *testing.T, source map[string]string) asmodel.CustomTrackersConfig {
 	m, err := asmodel.NewCustomTrackersConfig(source)
@@ -7160,7 +7176,11 @@ func TestIngester_OpenExistingTSDBOnStartup(t *testing.T) {
 				assert.Contains(t, startErr.Error(), testData.expectedErr)
 			}
 
-			defer services.StopAndAwaitTerminated(context.Background(), ingester) //nolint:errcheck
+			t.Cleanup(func() {
+				_ = services.StopAndAwaitTerminated(context.Background(), ingester)
+				ingester.closeAllTSDB()
+				ingester.subservicesWatcher.Close()
+			})
 			testData.check(t, ingester)
 		})
 	}
@@ -7309,7 +7329,11 @@ func TestIngester_closeAndDeleteUserTSDBIfIdle_shouldNotCloseTSDBIfShippingIsInP
 	}))
 
 	// Run blocks shipping in a separate go routine.
-	go i.shipBlocks(ctx, nil)
+	shipDone := make(chan struct{})
+	go func() {
+		defer close(shipDone)
+		i.shipBlocks(ctx, nil)
+	}()
 
 	// Wait until shipping starts.
 	test.Poll(t, 1*time.Second, activeShipping, func() interface{} {
@@ -7319,6 +7343,9 @@ func TestIngester_closeAndDeleteUserTSDBIfIdle_shouldNotCloseTSDBIfShippingIsInP
 	})
 
 	assert.Equal(t, tsdbNotActive, i.closeAndDeleteUserTSDBIfIdle(userID))
+
+	// Wait for shipBlocks goroutine to finish to avoid goroutine leak.
+	<-shipDone
 }
 
 func TestIngester_closingAndOpeningTsdbConcurrently(t *testing.T) {
@@ -7770,6 +7797,9 @@ func TestIngester_flushing(t *testing.T) {
 			i, r, err := prepareIngesterWithBlocksStorage(t, cfg, nil, reg)
 			require.NoError(t, err)
 			startAndWaitHealthy(t, i, r)
+			t.Cleanup(func() {
+				i.closeAllTSDB()
+			})
 
 			// mock user's shipper
 			tc.action(t, i, reg)
@@ -8791,8 +8821,11 @@ func TestIngester_instanceLimitsMetrics(t *testing.T) {
 		return &l
 	}
 
-	_, _, err := prepareIngesterWithBlocksStorage(t, cfg, nil, reg)
+	ing, _, err := prepareIngesterWithBlocksStorage(t, cfg, nil, reg)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		ing.subservicesWatcher.Close()
+	})
 
 	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
 		# HELP cortex_ingester_instance_limits Instance limits used by this ingester.
@@ -11950,6 +11983,10 @@ func TestIngester_PrepareUnregisterHandler(t *testing.T) {
 
 			test.Poll(t, 1*time.Second, 1, func() interface{} {
 				return healthyInstancesCount(ingester.instanceRing)
+			})
+		} else {
+			t.Cleanup(func() {
+				ingester.subservicesWatcher.Close()
 			})
 		}
 


### PR DESCRIPTION
#### What this PR does

Adds `TestMain` with `goleak` verification to the ingester package and fixes 7 tests that were leaking goroutines. The leaks fall into three categories:

1. **Unwaited goroutines** — `shipBlocks` launched in a goroutine but never waited on.
2. **subservicesWatcher not closed** — ingester created via `New()` but never started/stopped, leaving `AddListener` goroutines from `subservicesWatcher.WatchService()` running forever.
3. **TSDBs left open** — subtests with `KeepUserTSDBOpenOnShutdown=true` left TSDB internal goroutines running after the ingester stopped.

Two `goleak.IgnoreAnyFunction` entries are added for an upstream prometheus/tsdb issue where `tsdb.Open()` leaks WAL and chunkWriteQueue goroutines when it fails on corrupt data.

#### Which issue(s) this PR fixes or relates to

I found these leaks in https://github.com/grafana/mimir/pull/14611 and decided to send a separate PR to fix them.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test code and cleanup logic, mainly affecting how tests start/stop services and wait for background goroutines.
> 
> **Overview**
> Adds package-level `TestMain` for `pkg/ingester` to run `goleak` verification (with ignores for known dskit/Prometheus TSDB failure-path goroutines).
> 
> Fixes multiple ingester tests to avoid goroutine leaks by switching `defer` to `t.Cleanup`, explicitly closing `subservicesWatcher`, ensuring TSDBs are closed after tests, and waiting for background goroutines like `shipBlocks` to finish.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a78b181623782d3bdd775bf30b6026b73d86e1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->