### PR TITLE
chore(deps): update jsonnet-libs

### DIFF
--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -260,8 +260,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
       },
     },
 
-  qpsPanelNativeHistogram(metricName, selector, statusLabelName='status_code')::
-    super.qpsPanelNativeHistogram(metricName, selector, statusLabelName) +
+  qpsPanelNativeHistogram(metricName, selector, statusLabelName='status_code', nativeOnly=false)::
+    super.qpsPanelNativeHistogram(metricName, selector, statusLabelName, nativeOnly) +
     $.aliasColors(qpsPanelColors) + {
       fieldConfig+: {
         defaults+: {

--- a/operations/mimir-mixin/jsonnetfile.lock.json
+++ b/operations/mimir-mixin/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "grafana-builder"
         }
       },
-      "version": "cef6487abc4f60b6363dc7188af02851a4eb36da",
-      "sum": "+slXP8gi75OS343Khtz3i7va9csGTLhPoLUVu8vRuRc="
+      "version": "c29f54867eb28dc5697a5446180d6e1889d9685e",
+      "sum": "UPu3bKcy+GTMgx2yNyrzfKOWGnoc9EFhAUgs2lTcU1k="
     },
     {
       "source": {
@@ -18,8 +18,8 @@
           "subdir": "mixin-utils"
         }
       },
-      "version": "86f29cfec63cccf41928146e1f9ce5e9526eb210",
-      "sum": "juQsRDtnqZWgCRDgl8abH7ZmIuJnrSu9vM+vUjGT/0g="
+      "version": "c29f54867eb28dc5697a5446180d6e1889d9685e",
+      "sum": "Yqni3FxJzw4DMlXBFf2mmKU5UEPOzWw0FmIlZbv+89Q="
     },
     {
       "source": {


### PR DESCRIPTION
Add nativeOnly pass through to qpsPanelNativeHistogram The new parameter is used internally at Grafana, no effect on Mimir itself.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to Grafana dashboard Jsonnet helpers and a lockfile bump, with a backwards-compatible optional parameter added to a panel helper.
> 
> **Overview**
> Updates the Jsonnet dependencies (`grafana-builder` and `mixin-utils`) to newer `jsonnet-libs` revisions.
> 
> Extends `qpsPanelNativeHistogram` in `dashboard-utils.libsonnet` with a new optional `nativeOnly` argument and forwards it to `super.qpsPanelNativeHistogram`, without changing default behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4453a27d5e10f98f7b65d215183dadb8915dfe86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->