### PR TITLE
Add query sharding integration test

### DIFF
--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -304,7 +304,7 @@ func checkQueries(
 
 				for _, query := range instantQueries {
 					t.Run(fmt.Sprintf("%s: instant query: %s", endpoint, query.expr), func(t *testing.T) {
-						result, err := c.Query(query.expr, query.time)
+						result, _, err := c.Query(query.expr, query.time)
 						require.NoError(t, err)
 						require.Equal(t, model.ValVector, result.Type())
 						require.Equal(t, query.expectedVector, result.(model.Vector))

--- a/integration/distributor_test.go
+++ b/integration/distributor_test.go
@@ -1136,7 +1136,7 @@ func TestDistributor_RW2_RC3_CreatedTimestamp(t *testing.T) {
 			{Timestamp: model.Time(queryStart.Add(5 * time.Minute).UnixMilli()), Value: model.SampleValue(100)},
 		},
 	}}
-	got, err := client.QueryRange("foobarC_CT_total", queryStart, queryEnd, queryStep)
+	got, _, err := client.QueryRange("foobarC_CT_total", queryStart, queryEnd, queryStep)
 	require.NoError(t, err)
 	require.Equal(t, want.String(), got.String())
 }
@@ -1285,7 +1285,7 @@ func testDistributorCases(t *testing.T, cachingUnmarshalDataEnabled bool, rwVers
 			}
 
 			for q, res := range tc.queries {
-				result, err := client.QueryRange(q, queryStart, queryEnd, queryStep)
+				result, _, err := client.QueryRange(q, queryStart, queryEnd, queryStep)
 				require.NoError(t, err)
 
 				require.Equal(t, res.String(), result.String())
@@ -1596,7 +1596,7 @@ func testDistributorNameValidation(
 				return
 			}
 			for q, want := range tc.queries {
-				got, err := client.QueryRange(q, queryStart, queryEnd, queryStep)
+				got, _, err := client.QueryRange(q, queryStart, queryEnd, queryStep)
 				require.NoError(t, err)
 				require.Equal(t, want.String(), got.String())
 			}

--- a/integration/e2emimir/client.go
+++ b/integration/e2emimir/client.go
@@ -322,25 +322,25 @@ func (c *Client) PushOTLPPayload(payload []byte, contentType string) (*http.Resp
 }
 
 // Query runs an instant query.
-func (c *Client) Query(query string, ts time.Time, opts ...promv1.Option) (model.Value, error) {
+func (c *Client) Query(query string, ts time.Time, opts ...promv1.Option) (model.Value, promv1.Warnings, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
 	defer cancel()
 
-	value, _, err := c.querierClient.Query(ctx, query, ts, opts...)
-	return value, err
+	value, annos, err := c.querierClient.Query(ctx, query, ts, opts...)
+	return value, annos, err
 }
 
 // QueryRange runs a range query.
-func (c *Client) QueryRange(query string, start, end time.Time, step time.Duration, opts ...promv1.Option) (model.Value, error) {
+func (c *Client) QueryRange(query string, start, end time.Time, step time.Duration, opts ...promv1.Option) (model.Value, promv1.Warnings, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
 	defer cancel()
 
-	value, _, err := c.querierClient.QueryRange(ctx, query, promv1.Range{
+	value, annos, err := c.querierClient.QueryRange(ctx, query, promv1.Range{
 		Start: start,
 		End:   end,
 		Step:  step,
 	}, opts...)
-	return value, err
+	return value, annos, err
 }
 
 // QueryRangeRaw runs a ranged query directly against the querier API.

--- a/integration/getting_started_with_gossiped_ring_test.go
+++ b/integration/getting_started_with_gossiped_ring_test.go
@@ -117,7 +117,7 @@ func runTestGettingStartedWithGossipedRing(t *testing.T, mimir1 *e2emimir.MimirS
 	require.Equal(t, 200, res.StatusCode)
 
 	// Query the series via Mimir 1
-	result, err := c1.Query(seriesName, now)
+	result, _, err := c1.Query(seriesName, now)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, result.Type())
 	assert.Equal(t, expectedVector, result.(model.Vector))

--- a/integration/getting_started_with_grafana_mimir_test.go
+++ b/integration/getting_started_with_grafana_mimir_test.go
@@ -88,7 +88,7 @@ func runTestPushSeriesAndQueryBack(t *testing.T, mimir *e2emimir.MimirService, s
 	require.Equal(t, http.StatusOK, res.StatusCode)
 
 	// Query the series.
-	result, err := c.Query(seriesName, now)
+	result, _, err := c.Query(seriesName, now)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, result.Type())
 	assert.Equal(t, expectedVector, result.(model.Vector))
@@ -101,7 +101,7 @@ func runTestPushSeriesAndQueryBack(t *testing.T, mimir *e2emimir.MimirService, s
 	require.NoError(t, err)
 	require.Equal(t, []string{"__name__", "foo"}, labelNames)
 
-	rangeResult, err := c.QueryRange(seriesName, now.Add(-15*time.Minute), now, 15*time.Second)
+	rangeResult, _, err := c.QueryRange(seriesName, now.Add(-15*time.Minute), now, 15*time.Second)
 	require.NoError(t, err)
 	require.Equal(t, model.ValMatrix, rangeResult.Type())
 	require.Equal(t, expectedMatrix, rangeResult.(model.Matrix))

--- a/integration/influx_ingestion_test.go
+++ b/integration/influx_ingestion_test.go
@@ -77,7 +77,7 @@ func TestInfluxIngestion(t *testing.T) {
 		labels.MustNewMatcher(labels.MatchEqual, "user", "user-1"))))
 
 	// Query the series.
-	result, err := c.Query("series_f1", now)
+	result, _, err := c.Query("series_f1", now)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, result.Type())
 	assert.Equal(t, expectedVector, result.(model.Vector))
@@ -90,7 +90,7 @@ func TestInfluxIngestion(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []string{"__name__", "__proxy_source__", "foo"}, labelNames)
 
-	rangeResult, err := c.QueryRange("series_f1", now.Add(-15*time.Minute), now, 15*time.Second)
+	rangeResult, _, err := c.QueryRange("series_f1", now.Add(-15*time.Minute), now, 15*time.Second)
 	require.NoError(t, err)
 	require.Equal(t, model.ValMatrix, rangeResult.Type())
 	require.Equal(t, expectedMatrix, rangeResult.(model.Matrix))

--- a/integration/ingester_sharding_test.go
+++ b/integration/ingester_sharding_test.go
@@ -150,7 +150,7 @@ func TestIngesterSharding(t *testing.T) {
 
 			// Query back series.
 			for metricName, expectedVector := range expectedVectors {
-				result, err := client.Query(metricName, now)
+				result, _, err := client.Query(metricName, now)
 				require.NoError(t, err)
 				require.Equal(t, model.ValVector, result.Type())
 				assert.Equal(t, expectedVector, result.(model.Vector))

--- a/integration/ingester_test.go
+++ b/integration/ingester_test.go
@@ -536,14 +536,14 @@ func TestIngesterQuerying(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, http.StatusOK, res.StatusCode)
 
-			result, err := client.QueryRange(query, queryStart, queryEnd, queryStep)
+			result, _, err := client.QueryRange(query, queryStart, queryEnd, queryStep)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedQueryResult, result)
 
 			// The PromQL engine does some special handling for the timestamp() function which previously
 			// caused queries to fail when streaming chunks was enabled, so check that this regression
 			// has not been reintroduced.
-			result, err = client.QueryRange(timestampQuery, queryStart, queryEnd, queryStep)
+			result, _, err = client.QueryRange(timestampQuery, queryStart, queryEnd, queryStep)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedTimestampQueryResult, result)
 
@@ -640,7 +640,7 @@ func TestIngesterQueryingWithRequestMinimization(t *testing.T) {
 	require.Equal(t, 200, res.StatusCode)
 
 	// Verify we can query the data we just pushed.
-	queryResult, err := client.Query(seriesName, now)
+	queryResult, _, err := client.Query(seriesName, now)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, queryResult.Type())
 	require.Equal(t, expectedVector, queryResult.(model.Vector))
@@ -749,7 +749,7 @@ func TestIngesterReportGRPCStatusCodes(t *testing.T) {
 	pushRequests := sums[0]
 	require.Equal(t, pushRequests, 1.0)
 
-	result, err := client.QueryRange(query, queryStart, queryEnd, queryStep)
+	result, _, err := client.QueryRange(query, queryStart, queryEnd, queryStep)
 	require.NoError(t, err)
 	require.Equal(t, expectedQueryResult, result)
 

--- a/integration/kafka_auth_test.go
+++ b/integration/kafka_auth_test.go
@@ -207,7 +207,7 @@ printf '%s' "$BODY"
 
 			// Query the series back and verify the result matches what was pushed.
 			require.EventuallyWithT(t, func(c *assert.CollectT) {
-				result, err := client.Query("test_series", now)
+				result, _, err := client.Query("test_series", now)
 				require.NoError(c, err)
 				require.Equal(c, model.ValVector, result.Type())
 				assert.Equal(c, expectedVector, result.(model.Vector))

--- a/integration/ooo_ingestion_test.go
+++ b/integration/ooo_ingestion_test.go
@@ -81,7 +81,7 @@ func TestOOOIngestion(t *testing.T) {
 	expectedMatrix[0].Values = append(expectedMatrix[0].Values, model.SamplePair{Timestamp: expectedVector[0].Timestamp, Value: expectedVector[0].Value})
 
 	// Query float series.
-	rangeResult, err := c.QueryRange(floatSeriesName, nowTS.Add(-time.Minute), nowTS, time.Minute)
+	rangeResult, _, err := c.QueryRange(floatSeriesName, nowTS.Add(-time.Minute), nowTS, time.Minute)
 	require.NoError(t, err)
 	require.Equal(t, model.ValMatrix, rangeResult.Type())
 	require.Equal(t, expectedMatrix, rangeResult.(model.Matrix))
@@ -110,7 +110,7 @@ func TestOOOIngestion(t *testing.T) {
 	expectedMatrix[0].Histograms = append(expectedMatrix[0].Histograms, model.SampleHistogramPair{Timestamp: expectedVector[0].Timestamp, Histogram: expectedVector[0].Histogram})
 
 	// Query int histogram series.
-	rangeResult, err = c.QueryRange(intHistogramSeriesName, nowTS.Add(-time.Minute), nowTS, time.Minute)
+	rangeResult, _, err = c.QueryRange(intHistogramSeriesName, nowTS.Add(-time.Minute), nowTS, time.Minute)
 	require.NoError(t, err)
 	require.Equal(t, model.ValMatrix, rangeResult.Type())
 	require.Equal(t, expectedMatrix, rangeResult.(model.Matrix))
@@ -139,7 +139,7 @@ func TestOOOIngestion(t *testing.T) {
 	expectedMatrix[0].Histograms = append(expectedMatrix[0].Histograms, model.SampleHistogramPair{Timestamp: expectedVector[0].Timestamp, Histogram: expectedVector[0].Histogram})
 
 	// Query float histogram series.
-	rangeResult, err = c.QueryRange(floatHistogramSeriesName, nowTS.Add(-time.Minute), nowTS, time.Minute)
+	rangeResult, _, err = c.QueryRange(floatHistogramSeriesName, nowTS.Add(-time.Minute), nowTS, time.Minute)
 	require.NoError(t, err)
 	require.Equal(t, model.ValMatrix, rangeResult.Type())
 	require.Equal(t, expectedMatrix, rangeResult.(model.Matrix))

--- a/integration/otlp_ingestion_test.go
+++ b/integration/otlp_ingestion_test.go
@@ -127,7 +127,7 @@ func testOTLPIngestion(t *testing.T, opts testOTLPIngestionOpts) {
 	metricQuery := fmt.Sprintf(`{"%s"}`, convertedMetricName)
 
 	// Query the series.
-	result, err := c.Query(metricQuery, now)
+	result, _, err := c.Query(metricQuery, now)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, result.Type())
 	assert.Equal(t, expectedVector, result.(model.Vector))
@@ -140,7 +140,7 @@ func testOTLPIngestion(t *testing.T, opts testOTLPIngestionOpts) {
 	require.NoError(t, err)
 	require.Equal(t, []string{"__name__", "foo"}, labelNames)
 
-	rangeResult, err := c.QueryRange(metricQuery, now.Add(-15*time.Minute), now, 15*time.Second)
+	rangeResult, _, err := c.QueryRange(metricQuery, now.Add(-15*time.Minute), now, 15*time.Second)
 	require.NoError(t, err)
 	require.Equal(t, model.ValMatrix, rangeResult.Type())
 	require.Equal(t, expectedMatrix, rangeResult.(model.Matrix))
@@ -194,7 +194,7 @@ func testOTLPIngestion(t *testing.T, opts testOTLPIngestionOpts) {
 
 	// UTF-8 format names have to be in quotes.
 	histogramQuery := fmt.Sprintf(`{"%s"}`, convertedHistogramName)
-	result, err = c.Query(histogramQuery, now)
+	result, _, err = c.Query(histogramQuery, now)
 	require.NoError(t, err)
 
 	want := expectedVector[0]
@@ -369,7 +369,7 @@ func testOTLPHistogramIngestion(t *testing.T, enableExplicitHistogramToNHCB bool
 	// Query the histogram series
 	if enableExplicitHistogramToNHCB {
 		// Verify that when flag is disabled, OTel explicit bucket histograms are converted to native histograms with custom buckets
-		result, err := c.Query("explicit_bucket_histogram_series", now)
+		result, _, err := c.Query("explicit_bucket_histogram_series", now)
 		require.NoError(t, err)
 		require.Equal(t, result.(model.Vector)[0].Histogram, &model.SampleHistogram{
 			Count: model.FloatString(10),
@@ -407,14 +407,14 @@ func testOTLPHistogramIngestion(t *testing.T, enableExplicitHistogramToNHCB bool
 			{`explicit_bucket_histogram_series_bucket{le="+Inf"}`, 10},
 		}
 		for _, exp := range expected {
-			result, err := c.Query(exp.name, now)
+			result, _, err := c.Query(exp.name, now)
 			require.NoError(t, err)
 			require.Equal(t, exp.value, result.(model.Vector)[0].Value)
 		}
 	}
 
 	// Verify that OTel exponential histograms are converted to native histograms
-	result, err := c.Query("exponential_histogram_series", now)
+	result, _, err := c.Query("exponential_histogram_series", now)
 	require.NoError(t, err)
 	require.Equal(t, result.(model.Vector)[0].Histogram.Count, model.FloatString(15))
 	require.Equal(t, result.(model.Vector)[0].Histogram.Sum, model.FloatString(25))
@@ -599,7 +599,7 @@ func testStartTimeHandling(t *testing.T, enableCTzero bool) {
 
 			for _, metric := range []string{counterMetric, histogramMetric} {
 				t.Run(metric, func(t *testing.T) {
-					result, err := c.Query(metric+"[1h]", now.Add(30*time.Minute))
+					result, _, err := c.Query(metric+"[1h]", now.Add(30*time.Minute))
 					require.NoError(t, err)
 
 					m, ok := result.(model.Matrix)
@@ -652,7 +652,7 @@ func testStartTimeHandling(t *testing.T, enableCTzero bool) {
 					// the injected zero histogram has a scale == 0.
 					// The resolution isn't returned directly, but we can check the
 					// number of buckets to see if some were merged together.
-					result, err = c.Query("rate("+metric+"[1m])", now.Add(1*time.Second))
+					result, _, err = c.Query("rate("+metric+"[1m])", now.Add(1*time.Second))
 					require.NoError(t, err)
 
 					v, ok := result.(model.Vector)

--- a/integration/querier_sharding_test.go
+++ b/integration/querier_sharding_test.go
@@ -153,7 +153,7 @@ func runQuerierShardingTest(t *testing.T, cfg querierShardingTestConfig) {
 		c, err := e2emimir.NewClient("", q.HTTPEndpoint(), "", "", userID)
 		require.NoError(t, err)
 
-		_, err = c.Query("series_1", now)
+		_, _, err = c.Query("series_1", now)
 		require.NoError(t, err)
 	}
 
@@ -171,7 +171,7 @@ func runQuerierShardingTest(t *testing.T, cfg querierShardingTestConfig) {
 			c, err := e2emimir.NewClient("", queryFrontend.HTTPEndpoint(), "", "", userID)
 			require.NoError(t, err)
 
-			result, err := c.Query("series_1", now)
+			result, _, err := c.Query("series_1", now)
 			require.NoError(t, err)
 			require.Equal(t, model.ValVector, result.Type())
 			assert.Equal(t, expectedVector, result.(model.Vector))

--- a/integration/querier_sharding_test.go
+++ b/integration/querier_sharding_test.go
@@ -8,6 +8,8 @@ package integration
 
 import (
 	"fmt"
+	"math"
+	"path/filepath"
 	"strconv"
 	"sync"
 	"testing"
@@ -18,6 +20,7 @@ import (
 	e2edb "github.com/grafana/e2e/db"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -219,4 +222,196 @@ func runQuerierShardingTest(t *testing.T, cfg querierShardingTestConfig) {
 	assertServiceMetricsPrefixes(t, Querier, querier2)
 	assertServiceMetricsPrefixes(t, QueryFrontend, queryFrontend)
 	assertServiceMetricsPrefixes(t, QueryScheduler, queryScheduler)
+}
+
+// TestQuerySharding_ResultConsistency verifies that sharded queries (via query-frontend)
+// produce the same results as unsharded queries (direct to querier) for functions like
+// rate(), sum(), avg(), etc. that operate over range vectors.
+func TestQuerySharding_ResultConsistency(t *testing.T) {
+	s, err := e2e.NewScenario(networkName)
+	require.NoError(t, err)
+	defer s.Close()
+
+	memcached := e2ecache.NewMemcached()
+	consul := e2edb.NewConsul()
+	require.NoError(t, s.StartAndWaitReady(consul, memcached))
+
+	flags := mergeFlags(BlocksStorageFlags(), BlocksStorageS3Flags(), map[string]string{
+		"-query-frontend.cache-results":                       "false",
+		"-query-frontend.parallelize-shardable-queries":       "true",
+		"-query-frontend.query-sharding-total-shards":         "0", // Disable sharding by default.
+		"-query-frontend.results-cache.backend":               "memcached",
+		"-query-frontend.results-cache.memcached.addresses":   "dns+" + memcached.NetworkEndpoint(e2ecache.MemcachedPort),
+		"-query-frontend.enable-remote-execution":             "true",
+		"-query-frontend.use-mimir-query-engine-for-sharding": "true",
+	})
+
+	minio := e2edb.NewMinio(9000, flags["-blocks-storage.s3.bucket-name"])
+	require.NoError(t, s.StartAndWaitReady(minio))
+
+	// Enable query sharding for a specific tenant via runtime config.
+	runtimeConfig := "runtime-config.yaml"
+	require.NoError(t, writeFileToSharedDir(s, runtimeConfig, []byte(`
+overrides:
+  sharded-tenant:
+    query_sharding_total_shards: 8
+`)))
+	flags["-runtime-config.file"] = filepath.Join(e2e.ContainerSharedDir, runtimeConfig)
+
+	// Start query-scheduler.
+	queryScheduler := e2emimir.NewQueryScheduler("query-scheduler", flags)
+	require.NoError(t, s.StartAndWaitReady(queryScheduler))
+	flags["-query-frontend.scheduler-address"] = queryScheduler.NetworkGRPCEndpoint()
+	flags["-querier.scheduler-address"] = queryScheduler.NetworkGRPCEndpoint()
+
+	// Start services.
+	queryFrontend := e2emimir.NewQueryFrontend("query-frontend", consul.NetworkHTTPEndpoint(), flags)
+	require.NoError(t, s.Start(queryFrontend))
+
+	ingester := e2emimir.NewIngester("ingester", consul.NetworkHTTPEndpoint(), flags)
+	distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags)
+	querier1 := e2emimir.NewQuerier("querier-1", consul.NetworkHTTPEndpoint(), flags)
+	querier2 := e2emimir.NewQuerier("querier-2", consul.NetworkHTTPEndpoint(), flags)
+
+	require.NoError(t, s.StartAndWaitReady(querier1, querier2, ingester, distributor))
+	require.NoError(t, s.WaitReady(queryFrontend))
+
+	require.NoError(t, distributor.WaitSumMetrics(e2e.Equals(512+1), "cortex_ring_tokens_total"))
+	require.NoError(t, querier1.WaitSumMetrics(e2e.Equals(512), "cortex_ring_tokens_total"))
+	require.NoError(t, querier2.WaitSumMetrics(e2e.Equals(512), "cortex_ring_tokens_total"))
+
+	now := time.Now()
+	numSamples := 20
+	numSeries := 10
+
+	// Push multiple counter-like series with samples spanning 20 minutes (one per minute).
+	// Build all series upfront and push in a single batch per tenant to avoid timestamp-too-old rejections.
+	for _, tenant := range []string{userID, "sharded-tenant"} {
+		writeClient, err := e2emimir.NewClient(distributor.HTTPEndpoint(), "", "", "", tenant)
+		require.NoError(t, err)
+
+		var allSeries []prompb.TimeSeries
+		for seriesIdx := 0; seriesIdx < numSeries; seriesIdx++ {
+			samples := make([]prompb.Sample, numSamples)
+			for i := 0; i < numSamples; i++ {
+				// Monotonically increasing values (counter-like).
+				samples[i] = prompb.Sample{
+					Value:     float64((seriesIdx+1)*100 + i),
+					Timestamp: now.Add(time.Duration(i-numSamples+1) * time.Minute).UnixMilli(),
+				}
+			}
+
+			allSeries = append(allSeries, prompb.TimeSeries{
+				Labels: []prompb.Label{
+					{Name: model.MetricNameLabel, Value: "test_counter"},
+					{Name: "instance", Value: fmt.Sprintf("instance_%d", seriesIdx)},
+					{Name: "group", Value: fmt.Sprintf("group_%d", seriesIdx%3)},
+				},
+				Samples: samples,
+			})
+		}
+
+		res, err := writeClient.Push(allSeries)
+		require.NoError(t, err)
+		require.Equal(t, 200, res.StatusCode)
+	}
+
+	// Create clients:
+	// - unshardedClient queries the querier directly (no sharding).
+	// - shardedClient queries the query-frontend with sharding enabled (via per-tenant override).
+	unshardedClient, err := e2emimir.NewClient("", querier1.HTTPEndpoint(), "", "", userID)
+	require.NoError(t, err)
+	shardedClient, err := e2emimir.NewClient("", queryFrontend.HTTPEndpoint(), "", "", "sharded-tenant")
+	require.NoError(t, err)
+
+	queries := []struct {
+		name  string
+		query string
+	}{
+		{"sum_rate", `sum(rate(test_counter[5m]))`},
+		{"avg_rate", `avg(rate(test_counter[5m]))`},
+	}
+
+	queryStart := now.Add(-15 * time.Minute)
+	queryEnd := now.Add(-1 * time.Minute)
+	queryStep := time.Minute
+
+	for _, tc := range queries {
+		t.Run(tc.name+"/instant", func(t *testing.T) {
+			unshardedResult, unshardedResultAnnos, err := unshardedClient.Query(tc.query, queryEnd)
+			require.NoError(t, err)
+			require.NotNil(t, unshardedResult)
+
+			shardedResult, shardedResultAnnos, err := shardedClient.Query(tc.query, queryEnd)
+			require.NoError(t, err)
+			require.NotNil(t, shardedResult)
+
+			requireModelValueApproxEqual(t, unshardedResult, shardedResult)
+			require.Equal(t, unshardedResultAnnos, shardedResultAnnos)
+			require.Equal(t, 1, len(unshardedResultAnnos))
+		})
+
+		t.Run(tc.name+"/range", func(t *testing.T) {
+			unshardedResult, unshardedResultAnnos, err := unshardedClient.QueryRange(tc.query, queryStart, queryEnd, queryStep)
+			require.NoError(t, err)
+			require.NotNil(t, unshardedResult)
+
+			shardedResult, shardedResultAnnos, err := shardedClient.QueryRange(tc.query, queryStart, queryEnd, queryStep)
+			require.NoError(t, err)
+			require.NotNil(t, shardedResult)
+
+			requireModelValueApproxEqual(t, unshardedResult, shardedResult)
+			require.Equal(t, unshardedResultAnnos, shardedResultAnnos)
+			require.Equal(t, 1, len(unshardedResultAnnos))
+		})
+	}
+}
+
+// requireModelValueApproxEqual compares two model.Value results allowing for small
+// floating-point precision differences that can arise from sharded vs unsharded evaluation.
+func requireModelValueApproxEqual(t *testing.T, expected, actual model.Value) {
+	t.Helper()
+	require.Equal(t, expected.Type(), actual.Type(), "result types differ")
+
+	const epsilon = 1e-12
+
+	switch exp := expected.(type) {
+	case model.Vector:
+		act := actual.(model.Vector)
+		require.Equal(t, len(exp), len(act), "vector lengths differ")
+		for i := range exp {
+			require.Equal(t, exp[i].Metric, act[i].Metric, "sample %d: metric labels differ", i)
+			require.Equal(t, exp[i].Timestamp, act[i].Timestamp, "sample %d: timestamps differ", i)
+			if math.IsNaN(float64(exp[i].Value)) {
+				require.True(t, math.IsNaN(float64(act[i].Value)), "sample %d: expected NaN", i)
+			} else {
+				require.InEpsilon(t, float64(exp[i].Value), float64(act[i].Value), epsilon,
+					"sample %d: values differ beyond tolerance", i)
+			}
+		}
+	case *model.Scalar:
+		act := actual.(*model.Scalar)
+		require.Equal(t, exp.Timestamp, act.Timestamp)
+		require.InEpsilon(t, float64(exp.Value), float64(act.Value), epsilon)
+	case model.Matrix:
+		act := actual.(model.Matrix)
+		require.Equal(t, len(exp), len(act), "matrix series count differs")
+		for i := range exp {
+			require.Equal(t, exp[i].Metric, act[i].Metric, "series %d: metric labels differ", i)
+			require.Equal(t, len(exp[i].Values), len(act[i].Values), "series %d: sample count differs", i)
+			for j := range exp[i].Values {
+				require.Equal(t, exp[i].Values[j].Timestamp, act[i].Values[j].Timestamp,
+					"series %d sample %d: timestamps differ", i, j)
+				if math.IsNaN(float64(exp[i].Values[j].Value)) {
+					require.True(t, math.IsNaN(float64(act[i].Values[j].Value)),
+						"series %d sample %d: expected NaN", i, j)
+				} else {
+					require.InEpsilon(t, float64(exp[i].Values[j].Value), float64(act[i].Values[j].Value), epsilon,
+						"series %d sample %d: values differ beyond tolerance", i, j)
+				}
+			}
+		}
+	default:
+		require.Equal(t, expected, actual, "unsupported model.Value type")
+	}
 }

--- a/integration/querier_tenant_federation_test.go
+++ b/integration/querier_tenant_federation_test.go
@@ -131,7 +131,7 @@ func runQuerierTenantFederationTest(t *testing.T, cfg querierTenantFederationCon
 	c, err := e2emimir.NewClient(distributor.HTTPEndpoint(), queryFrontend.HTTPEndpoint(), "", "", strings.Join(tenantIDs, "|"))
 	require.NoError(t, err)
 
-	result, err := c.Query("series_1", now)
+	result, _, err := c.Query("series_1", now)
 	require.NoError(t, err)
 
 	assert.ElementsMatch(t, mergeResults(tenantIDs, expectedVectors), result.(model.Vector))

--- a/integration/querier_test.go
+++ b/integration/querier_test.go
@@ -201,7 +201,7 @@ func testQuerierWithBlocksStorageRunningInMicroservicesMode(t *testing.T, series
 			require.NoError(t, err)
 			instantQueriesCount++
 
-			result, err := c.Query(series1Name, series1Timestamp)
+			result, _, err := c.Query(series1Name, series1Timestamp)
 			require.NoError(t, err)
 			require.Equal(t, model.ValVector, result.Type())
 			assert.Equal(t, expectedVector1, result.(model.Vector))
@@ -209,7 +209,7 @@ func testQuerierWithBlocksStorageRunningInMicroservicesMode(t *testing.T, series
 			// thanos_store_index_cache_requests_total: ExpandedPostings: 1, Postings: 1, Series: 1
 			instantQueriesCount++
 
-			result, err = c.Query(series2Name, series2Timestamp)
+			result, _, err = c.Query(series2Name, series2Timestamp)
 			require.NoError(t, err)
 			require.Equal(t, model.ValVector, result.Type())
 			assert.Equal(t, expectedVector2, result.(model.Vector))
@@ -217,7 +217,7 @@ func testQuerierWithBlocksStorageRunningInMicroservicesMode(t *testing.T, series
 			// thanos_store_index_cache_requests_total: ExpandedPostings: 3, Postings: 2, Series: 2
 			instantQueriesCount++
 
-			result, err = c.Query(series3Name, series3Timestamp)
+			result, _, err = c.Query(series3Name, series3Timestamp)
 			require.NoError(t, err)
 			require.Equal(t, model.ValVector, result.Type())
 			assert.Equal(t, expectedVector3, result.(model.Vector))
@@ -243,7 +243,7 @@ func testQuerierWithBlocksStorageRunningInMicroservicesMode(t *testing.T, series
 			}
 
 			// Query back again the 1st series from storage. This time it should use the index cache.
-			result, err = c.Query(series1Name, series1Timestamp)
+			result, _, err = c.Query(series1Name, series1Timestamp)
 			require.NoError(t, err)
 			require.Equal(t, model.ValVector, result.Type())
 			assert.Equal(t, expectedVector1, result.(model.Vector))
@@ -265,7 +265,7 @@ func testQuerierWithBlocksStorageRunningInMicroservicesMode(t *testing.T, series
 			const numRangeQueries = 10
 
 			for i := 0; i < numRangeQueries; i++ {
-				result, err = c.QueryRange(`count({__name__=~"series.*"})`, series3Timestamp, series3Timestamp, time.Minute)
+				result, _, err = c.QueryRange(`count({__name__=~"series.*"})`, series3Timestamp, series3Timestamp, time.Minute)
 				require.NoError(t, err)
 				require.Equal(t, model.ValMatrix, result.Type())
 
@@ -277,7 +277,7 @@ func testQuerierWithBlocksStorageRunningInMicroservicesMode(t *testing.T, series
 			}
 
 			// This instant query can be sharded.
-			result, err = c.Query(`count({__name__=~"series.*"})`, series3Timestamp)
+			result, _, err = c.Query(`count({__name__=~"series.*"})`, series3Timestamp)
 			require.NoError(t, err)
 			require.Equal(t, model.ValVector, result.Type())
 			vector := result.(model.Vector)
@@ -456,21 +456,21 @@ func TestQuerierWithBlocksStorageRunningInSingleBinaryMode(t *testing.T) {
 			//
 			// If the series does not exist in the block, then we return early after checking expanded postings and
 			// subsequently the index on disk.
-			result, err := c.Query(series1Name, series1Timestamp)
+			result, _, err := c.Query(series1Name, series1Timestamp)
 			require.NoError(t, err)
 			require.Equal(t, model.ValVector, result.Type())
 			assert.Equal(t, expectedVector1, result.(model.Vector))
 			expectedCacheRequests += seriesReplicationFactor * 3                                  // expanded postings, postings, series
 			expectedMemcachedOps += (seriesReplicationFactor * 3) + (seriesReplicationFactor * 3) // Same reasoning as for expectedCacheRequests, but this also includes a set for each get that is not a hit
 
-			result, err = c.Query(series2Name, series2Timestamp)
+			result, _, err = c.Query(series2Name, series2Timestamp)
 			require.NoError(t, err)
 			require.Equal(t, model.ValVector, result.Type())
 			assert.Equal(t, expectedVector2, result.(model.Vector))
 			expectedCacheRequests += seriesReplicationFactor*3 + seriesReplicationFactor      // expanded postings, postings, series for 1 time range; only expanded postings for another
 			expectedMemcachedOps += 2 * (seriesReplicationFactor*3 + seriesReplicationFactor) // Same reasoning as for expectedCacheRequests, but this also includes a set for each get that is not a hit
 
-			result, err = c.Query(series3Name, series3Timestamp)
+			result, _, err = c.Query(series3Name, series3Timestamp)
 			require.NoError(t, err)
 			require.Equal(t, model.ValVector, result.Type())
 			assert.Equal(t, expectedVector3, result.(model.Vector))
@@ -492,7 +492,7 @@ func TestQuerierWithBlocksStorageRunningInSingleBinaryMode(t *testing.T) {
 			// It should get a hit on expanded postings; this means that it will not request individual postings for matchers.
 			// It should get a hit on series.
 			// We expect 2 cache requests and 2 cache hits.
-			result, err = c.Query(series1Name, series1Timestamp)
+			result, _, err = c.Query(series1Name, series1Timestamp)
 			require.NoError(t, err)
 			require.Equal(t, model.ValVector, result.Type())
 			assert.Equal(t, expectedVector1, result.(model.Vector))
@@ -565,7 +565,7 @@ func testPromQLEngine(t *testing.T, engineType string) {
 	c, err := e2emimir.NewClient("", querier.HTTPEndpoint(), "", "", "user-1")
 	require.NoError(t, err)
 
-	result, err := c.Query(seriesName, seriesTimestamp)
+	result, _, err := c.Query(seriesName, seriesTimestamp)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, result.Type())
 	assert.Equal(t, expectedVector, result.(model.Vector))
@@ -875,12 +875,12 @@ func TestQuerierWithBlocksStorageOnMissingBlocksFromStorage(t *testing.T) {
 	c, err = e2emimir.NewClient("", querier.HTTPEndpoint(), "", "", "user-1")
 	require.NoError(t, err)
 
-	result, err := c.Query(series1Name, series1Timestamp)
+	result, _, err := c.Query(series1Name, series1Timestamp)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, result.Type())
 	assert.Equal(t, expectedVector1, result.(model.Vector))
 
-	result, err = c.Query(series2Name, series2Timestamp)
+	result, _, err = c.Query(series2Name, series2Timestamp)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, result.Type())
 	assert.Equal(t, expectedVector2, result.(model.Vector))
@@ -892,14 +892,14 @@ func TestQuerierWithBlocksStorageOnMissingBlocksFromStorage(t *testing.T) {
 
 	// Query back again the series. Now we do expect a 500 error because the blocks are
 	// missing from the storage.
-	_, err = c.Query(series1Name, series1Timestamp)
+	_, _, err = c.Query(series1Name, series1Timestamp)
 	require.Error(t, err)
 	var apiErr *v1.Error
 	require.ErrorAs(t, err, &apiErr)
 	assert.Contains(t, apiErr.Detail, "get range reader: The specified key does not exist")
 
 	// We expect this to still be queryable as it was not in the cleared storage
-	_, err = c.Query(series2Name, series2Timestamp)
+	_, _, err = c.Query(series2Name, series2Timestamp)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, result.Type())
 	assert.Equal(t, expectedVector2, result.(model.Vector))
@@ -965,7 +965,7 @@ func TestQueryLimitsWithBlocksStorageRunningInMicroServices(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 200, res.StatusCode)
 
-	result, err := c.QueryRange("{__name__=~\"series_.+\"}", series1Timestamp, series2Timestamp.Add(1*time.Hour), blockRangePeriod)
+	result, _, err := c.QueryRange("{__name__=~\"series_.+\"}", series1Timestamp, series2Timestamp.Add(1*time.Hour), blockRangePeriod)
 	require.NoError(t, err)
 	require.Equal(t, model.ValMatrix, result.Type())
 
@@ -976,7 +976,7 @@ func TestQueryLimitsWithBlocksStorageRunningInMicroServices(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 200, res.StatusCode)
 
-	_, err = c.QueryRange("{__name__=~\"series_.+\"}", series1Timestamp, series4Timestamp.Add(1*time.Hour), blockRangePeriod)
+	_, _, err = c.QueryRange("{__name__=~\"series_.+\"}", series1Timestamp, series4Timestamp.Add(1*time.Hour), blockRangePeriod)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "the query exceeded the maximum number of series")
 }
@@ -1062,7 +1062,7 @@ func TestHashCollisionHandling(t *testing.T) {
 	c, err = e2emimir.NewClient("", querier.HTTPEndpoint(), "", "", "user-0")
 	require.NoError(t, err)
 
-	result, err := c.Query("fingerprint_collision", now)
+	result, _, err := c.Query("fingerprint_collision", now)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, result.Type())
 	require.Equal(t, expectedVector, result.(model.Vector))

--- a/integration/query_frontend_cache_test.go
+++ b/integration/query_frontend_cache_test.go
@@ -111,7 +111,7 @@ func runTestPushSeriesAndUnalignedQuery(t *testing.T, c *e2emimir.Client, queryF
 		c, err := e2emimir.NewClient("", queryFrontendAligned.HTTPEndpoint(), "", "", user)
 		require.NoError(t, err)
 
-		res, err := c.QueryRange(seriesName, start, end, step)
+		res, _, err := c.QueryRange(seriesName, start, end, step)
 		require.NoError(t, err)
 
 		// Verify that returned range has sample appearing after "sampleTime", all ts are step-aligned (truncated to step).
@@ -126,7 +126,7 @@ func runTestPushSeriesAndUnalignedQuery(t *testing.T, c *e2emimir.Client, queryF
 		c, err := e2emimir.NewClient("", queryFrontendUnaligned.HTTPEndpoint(), "", "", user)
 		require.NoError(t, err)
 
-		res, err := c.QueryRange(seriesName, start, end, step)
+		res, _, err := c.QueryRange(seriesName, start, end, step)
 		require.NoError(t, err)
 
 		// Verify that returned result is not step-aligned ("now" is not step-aligned)

--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -392,7 +392,7 @@ func runQueryFrontendTest(t *testing.T, cfg queryFrontendTestConfig) {
 			require.NoError(t, queryFrontend.WaitSumMetrics(e2e.Equals(0), "cortex_frontend_split_queries_total"))
 			end := now
 			start := end.Add(-(30*24*time.Hour + 1*time.Hour)) // 30 days + 1 hour. Makes sure we can go above the max partial query length.
-			_, err = c.QueryRange("{instance=~\"hello.*\"}", start, end, time.Hour)
+			_, _, err = c.QueryRange("{instance=~\"hello.*\"}", start, end, time.Hour)
 			require.NoError(t, err)
 
 			// Depending on what time it is and how that aligns with midnight UTC, the query may be broken into 31 or 32 parts.
@@ -404,7 +404,7 @@ func runQueryFrontendTest(t *testing.T, cfg queryFrontendTestConfig) {
 			start := time.Unix(1595846748, 806*1e6)
 			end := time.Unix(1595846750, 806*1e6)
 
-			result, err := c.QueryRange("time()", start, end, time.Second)
+			result, _, err := c.QueryRange("time()", start, end, time.Second)
 			require.NoError(t, err)
 			require.Equal(t, model.ValMatrix, result.Type())
 
@@ -434,7 +434,7 @@ func runQueryFrontendTest(t *testing.T, cfg queryFrontendTestConfig) {
 
 		// Test that evaluating a query with a scalar result works as expected.
 		if userID == 0 {
-			result, err := c.Query("scalar(series_1)", now)
+			result, _, err := c.Query("scalar(series_1)", now)
 			require.NoError(t, err)
 			require.Equal(t, model.ValScalar, result.Type())
 			scalar := result.(*model.Scalar)
@@ -444,7 +444,7 @@ func runQueryFrontendTest(t *testing.T, cfg queryFrontendTestConfig) {
 
 		// Same thing, but with a range vector result.
 		if userID == 0 {
-			result, err := c.Query("series_1[5m]", now)
+			result, _, err := c.Query("series_1[5m]", now)
 			require.NoError(t, err)
 			require.Equal(t, model.ValMatrix, result.Type())
 			matrix := result.(model.Matrix)
@@ -458,7 +458,7 @@ func runQueryFrontendTest(t *testing.T, cfg queryFrontendTestConfig) {
 		// Test subquery spin-off.
 		if userID == 0 {
 			require.NoError(t, queryFrontend.WaitSumMetrics(e2e.Equals(0), "cortex_frontend_spun_off_subqueries_total"))
-			result, err := c.Query("sum_over_time(((count(series_1) * count(series_1)) or vector(1))[6h:15m])", now)
+			result, _, err := c.Query("sum_over_time(((count(series_1) * count(series_1)) or vector(1))[6h:15m])", now)
 			require.NoError(t, err)
 			require.Len(t, result, 1)
 			require.Equal(t, result.(model.Vector)[0].Metric, model.Metric{})
@@ -470,7 +470,7 @@ func runQueryFrontendTest(t *testing.T, cfg queryFrontendTestConfig) {
 			go func() {
 				defer wg.Done()
 
-				result, err := c.Query("series_1", now)
+				result, _, err := c.Query("series_1", now)
 				require.NoError(t, err)
 				require.Equal(t, model.ValVector, result.Type())
 				assert.Equal(t, expectedVectors[userID], result.(model.Vector))
@@ -1155,7 +1155,7 @@ func TestQueryFrontendWithExplicitLookbackDelta(t *testing.T) {
 }
 
 func queryLookbackDeltaTest(t *testing.T, client *e2emimir.Client, seriesName string, ts time.Time, expectResult bool, expectedValue float64, opts ...promv1.Option) {
-	res, err := client.Query(seriesName, ts, opts...)
+	res, _, err := client.Query(seriesName, ts, opts...)
 	require.NoError(t, err)
 
 	v, ok := res.(model.Vector)
@@ -1172,7 +1172,7 @@ func queryLookbackDeltaTest(t *testing.T, client *e2emimir.Client, seriesName st
 	}
 
 	step := 100 * time.Minute
-	res, err = client.QueryRange(seriesName, ts.Add(-step), ts.Add(step), step, opts...)
+	res, _, err = client.QueryRange(seriesName, ts.Add(-step), ts.Add(step), step, opts...)
 	require.NoError(t, err)
 
 	m, ok := res.(model.Matrix)

--- a/integration/query_scheduler_test.go
+++ b/integration/query_scheduler_test.go
@@ -112,7 +112,7 @@ func runTestQuerySchedulerWithMaxUsedInstances(t *testing.T, seriesName string, 
 	require.Equal(t, 200, res.StatusCode)
 
 	// Query the series.
-	result, err := c.Query(seriesName, now)
+	result, _, err := c.Query(seriesName, now)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, result.Type())
 	assert.Equal(t, expectedVector, result.(model.Vector))
@@ -127,7 +127,7 @@ func runTestQuerySchedulerWithMaxUsedInstances(t *testing.T, seriesName string, 
 	require.NoError(t, notInUseScheduler.WaitSumMetricsWithOptions(e2e.Greater(0), []string{"cortex_query_scheduler_connected_frontend_clients"}))
 
 	// Query the series.
-	result, err = c.Query(seriesName, now)
+	result, _, err = c.Query(seriesName, now)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, result.Type())
 	assert.Equal(t, expectedVector, result.(model.Vector))

--- a/integration/range_vector_splitting_test.go
+++ b/integration/range_vector_splitting_test.go
@@ -79,7 +79,7 @@ func TestQuerySplittingWithRangeVectorFunction(t *testing.T) {
 	queryClient, err := e2emimir.NewClient("", querier.HTTPEndpoint(), "", "", "user-1")
 	require.NoError(t, err)
 
-	result, err := queryClient.Query("sum_over_time(test_metric[15m])", now)
+	result, _, err := queryClient.Query("sum_over_time(test_metric[15m])", now)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, result.Type())
 
@@ -93,7 +93,7 @@ func TestQuerySplittingWithRangeVectorFunction(t *testing.T) {
 	require.NoError(t, querier.WaitSumMetrics(e2e.Equals(1), "cortex_mimir_query_engine_range_vector_splitting_nodes_introduced_total"))
 
 	// Run the same query again to verify cached intermediate results are read back correctly.
-	result2, err := queryClient.Query("sum_over_time(test_metric[15m])", now)
+	result2, _, err := queryClient.Query("sum_over_time(test_metric[15m])", now)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, result2.Type())
 

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -1139,7 +1139,7 @@ func TestRulerFederatedRules(t *testing.T) {
 			// Wait until rule evaluation resulting series had been pushed
 			require.NoError(t, ingester.WaitSumMetrics(e2e.Greater(totalSeriesBeforeEval[0]), "cortex_ingester_memory_series"))
 
-			result, err := c.Query(ruleName, time.Now())
+			result, _, err := c.Query(ruleName, time.Now())
 			require.NoError(t, err)
 			tc.assertEvalResult(result.(model.Vector))
 		})
@@ -1307,7 +1307,7 @@ func TestRulerRemoteEvaluation(t *testing.T) {
 			))
 
 			// Assert rule evaluation result
-			result, err := c.Query(ruleName, time.Now())
+			result, _, err := c.Query(ruleName, time.Now())
 			require.NoError(t, err)
 			tc.assertEvalResult(result.(model.Vector))
 		})

--- a/integration/zone_aware_test.go
+++ b/integration/zone_aware_test.go
@@ -86,7 +86,7 @@ func TestZoneAwareReplication(t *testing.T) {
 
 	// Query back series => all good
 	for metricName, expectedVector := range expectedVectors {
-		result, err := client.Query(metricName, now)
+		result, _, err := client.Query(metricName, now)
 		require.NoError(t, err)
 		require.Equal(t, model.ValVector, result.Type())
 		assert.Equal(t, expectedVector, result.(model.Vector))
@@ -107,7 +107,7 @@ func TestZoneAwareReplication(t *testing.T) {
 
 	// Query back series => all good
 	for metricName, expectedVector := range expectedVectors {
-		result, err := client.Query(metricName, now)
+		result, _, err := client.Query(metricName, now)
 		require.NoError(t, err)
 		require.Equal(t, model.ValVector, result.Type())
 		assert.Equal(t, expectedVector, result.(model.Vector))
@@ -128,7 +128,7 @@ func TestZoneAwareReplication(t *testing.T) {
 
 	// Query back series => all good
 	for metricName, expectedVector := range expectedVectors {
-		result, err := client.Query(metricName, now)
+		result, _, err := client.Query(metricName, now)
 		require.NoError(t, err)
 		require.Equal(t, model.ValVector, result.Type())
 		assert.Equal(t, expectedVector, result.(model.Vector))

--- a/vendor/github.com/prometheus/client_golang/api/prometheus/v1/api.go
+++ b/vendor/github.com/prometheus/client_golang/api/prometheus/v1/api.go
@@ -1479,6 +1479,7 @@ type apiResponse struct {
 	ErrorType ErrorType       `json:"errorType"`
 	Error     string          `json:"error"`
 	Warnings  []string        `json:"warnings,omitempty"`
+	Infos     []string        `json:"infos,omitempty"`
 }
 
 func apiError(code int) bool {
@@ -1542,7 +1543,7 @@ func (h *apiClientImpl) Do(ctx context.Context, req *http.Request) (*http.Respon
 		}
 	}
 
-	return resp, []byte(result.Data), result.Warnings, err
+	return resp, []byte(result.Data), append(result.Warnings, result.Infos...), err
 }
 
 // DoGetFallback will attempt to do the request as-is, and on a 405 or 501 it


### PR DESCRIPTION
#### What this PR does

Adds an integration test to check that results with and without query sharding (within MQE with remote execution) are the same (along with the annotations).

Draft for now as we need https://github.com/prometheus/client_golang/pull/1963 to be merged and vendored first

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

No changelog as it's not user-facing