### PR TITLE
Enable test that was previously disabled due to upstream bug

### DIFF
--- a/pkg/streamingpromql/operators/selectors/instant_vector_selector_test.go
+++ b/pkg/streamingpromql/operators/selectors/instant_vector_selector_test.go
@@ -162,22 +162,20 @@ func TestInstantVectorSelector_NativeHistogramPointerHandling(t *testing.T) {
 				require.Len(t, points, 4)
 			},
 		},
-		// FIXME: this test currently fails due to https://github.com/prometheus/prometheus/issues/14172
-		//
-		//"point has same value as a previous point, but there is a float value in between": {
-		//	data: `
-		//        load 1m
-		//            my_metric {{schema:0 sum:3 count:2 buckets:[1 0 1]}} 2 {{schema:0 sum:3 count:2 buckets:[1 0 1]}}
-		//    `,
-		//	stepCount: 3,
-		//	check: func(t *testing.T, hPoints []promql.HPoint, fPoints []promql.FPoint) {
-		//		require.Len(t, hPoints, 2)
-		//		require.Equal(t, 3.0, hPoints[0].H.Sum)
-		//		require.Equal(t, 3.0, hPoints[1].H.Sum)
-		//
-		//		require.Equal(t, []promql.FPoint{{T: 60000, F: 2}}, fPoints)
-		//	},
-		//},
+		"point has same value as a previous point, but there is a float value in between": {
+			data: `
+		       load 1m
+		           my_metric {{schema:0 sum:3 count:2 buckets:[1 0 1]}} 2 {{schema:0 sum:3 count:2 buckets:[1 0 1]}}
+		   `,
+			stepCount: 3,
+			check: func(t *testing.T, hPoints []promql.HPoint, fPoints []promql.FPoint) {
+				require.Len(t, hPoints, 2)
+				require.Equal(t, 3.0, hPoints[0].H.Sum)
+				require.Equal(t, 3.0, hPoints[1].H.Sum)
+
+				require.Equal(t, []promql.FPoint{{T: 60000, F: 2}}, fPoints)
+			},
+		},
 	}
 
 	for name, testCase := range testCases {


### PR DESCRIPTION
#### What this PR does

This unit test was previously disabled due to https://github.com/prometheus/prometheus/issues/14172 / https://github.com/prometheus/prometheus/issues/15177, but the issue has been fixed.

So in this PR, I'm re-enabling the test.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that re-enables a previously commented-out unit test and does not modify production code paths.
> 
> **Overview**
> Re-enables the previously disabled `InstantVectorSelector` unit test case covering an edge case where a native histogram repeats with an intervening float sample, asserting both histogram sums and the emitted float point.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c04b19be5d399aa8e561e7151ebc92a6b259b40d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->