### PR TITLE
MQE: Add `OperatorEvaluationStats.ExtendStepInvariantToFullRange`

### DIFF
--- a/pkg/streamingpromql/types/stats.go
+++ b/pkg/streamingpromql/types/stats.go
@@ -7,6 +7,7 @@ package types
 
 import (
 	"errors"
+	"fmt"
 	"unsafe"
 
 	"github.com/prometheus/prometheus/model/histogram"
@@ -134,6 +135,29 @@ func (s *OperatorEvaluationStats) Clone() (*OperatorEvaluationStats, error) {
 	copy(clone.newSamplesReadPerStep, s.newSamplesReadPerStep)
 
 	return clone, nil
+}
+
+// ExtendStepInvariantToFullRange calculates the equivalent statistics for a step invariant
+// operation that is used for multiple steps in a range query.
+//
+// It is the caller's responsibility to call Close on the original OperatorEvaluationStats instance.
+func (s *OperatorEvaluationStats) ExtendStepInvariantToFullRange(timeRange QueryTimeRange) (*OperatorEvaluationStats, error) {
+	if !s.timeRange.IsInstant {
+		return nil, fmt.Errorf("cannot extend step invariant to full range for non-instant time range %v", s.timeRange)
+	}
+
+	expanded, err := NewOperatorEvaluationStats(timeRange, s.memoryConsumptionTracker)
+	if err != nil {
+		return nil, err
+	}
+
+	expanded.newSamplesReadPerStep[0] = s.newSamplesReadPerStep[0]
+
+	for idx := range timeRange.StepCount {
+		expanded.samplesProcessedPerStep[idx] = s.samplesProcessedPerStep[0]
+	}
+
+	return expanded, nil
 }
 
 func (s *OperatorEvaluationStats) Close() {

--- a/pkg/streamingpromql/types/stats_test.go
+++ b/pkg/streamingpromql/types/stats_test.go
@@ -330,3 +330,31 @@ func TestOperatorEvaluationStats_Clone(t *testing.T) {
 	clone.Close()
 	require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
 }
+
+func TestOperatorEvaluationStats_ExtendStepInvariant(t *testing.T) {
+	ctx := context.Background()
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
+
+	// Create a set of stats corresponding to the single evaluated step.
+	stepInvariant, err := NewOperatorEvaluationStats(NewInstantQueryTimeRange(timestamp.Time(10000)), memoryConsumptionTracker)
+	require.NoError(t, err)
+
+	stepInvariant.samplesProcessedPerStep[0] = 100
+	stepInvariant.newSamplesReadPerStep[0] = 40
+
+	// Extend it to the full time range.
+	start := timestamp.Time(20000)
+	step := time.Minute
+	end := start.Add(2 * step)
+	timeRange := NewRangeQueryTimeRange(start, end, step)
+	extended, err := stepInvariant.ExtendStepInvariantToFullRange(timeRange)
+	require.NoError(t, err)
+
+	require.Equal(t, []int64{100, 100, 100}, extended.samplesProcessedPerStep)
+	require.Equal(t, []int64{40, 0, 0}, extended.newSamplesReadPerStep)
+
+	// Make sure everything was returned to the pool.
+	extended.Close()
+	stepInvariant.Close()
+	require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
+}


### PR DESCRIPTION
#### What this PR does

This PR extends the `OperatorEvaluationStats` type introduced in https://github.com/grafana/mimir/pull/14497 with a method to calculate the equivalent query stats for a step-invariant operator.

Given this is not a user-visible change, I've chosen not to add a changelog entry.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: isolated, additive query-stats helper with a guard for invalid inputs and test coverage; main impact is potential mis-accounting of per-step stats if assumptions about step invariance change.
> 
> **Overview**
> Adds `OperatorEvaluationStats.ExtendStepInvariantToFullRange`, which takes stats collected for a single instant (step-invariant) evaluation and returns a new stats object sized for a provided range `QueryTimeRange`, repeating `samplesProcessedPerStep[0]` across all steps while only attributing `newSamplesReadPerStep` to the first step.
> 
> Includes a new unit test validating the expansion behavior and ensuring pooled slice memory is returned via `Close`, and adds `fmt` for the new error message when called on non-instant stats.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e2388e18c42b345245786cdb016842be649c9eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->