### PR TITLE
Fix nil pointer panic in WriteRequest.Unmarshal for empty RW2 requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,7 @@
 * [BUGFIX] Querier: Fix issue where queries can time out if remote execution is enabled and sending the initial message from queriers to query-frontends fails. #14557
 * [BUGFIX] Querier: Fix issue where different sharded legs of a query could be evaluated with different lookback deltas if different queriers were configured with different default lookback deltas. #14575
 * [BUGFIX] Query-frontend: Fixed partial cache hit returning incomplete data for native histogram series due to incorrect response ordering before merge. #14612
+* [BUGFIX] Distributor: Fix nil pointer panic in `WriteRequest.Unmarshal` when receiving a Remote Write 2.0 request with zero timeseries. #14698
 
 ### Mixin
 

--- a/pkg/mimirpb/compat_rw2_test.go
+++ b/pkg/mimirpb/compat_rw2_test.go
@@ -128,6 +128,24 @@ func TestRW2Unmarshal(t *testing.T) {
 		require.Equal(t, expected, &received)
 	})
 
+	t.Run("zero timeseries does not panic", func(t *testing.T) {
+		syms := rw2util.NewSymbolTableBuilder(nil)
+		syms.GetSymbol("unused_symbol")
+		req := &WriteRequest{
+			SymbolsRW2: syms.GetSymbols(),
+		}
+
+		data, err := req.Marshal()
+		require.NoError(t, err)
+
+		received := PreallocWriteRequest{
+			UnmarshalFromRW2: true,
+		}
+		require.NoError(t, received.Unmarshal(data))
+		require.Empty(t, received.Timeseries)
+		require.Empty(t, received.Metadata)
+	})
+
 	t.Run("metadata for all metric types map to expected values", func(t *testing.T) {
 		tc := []struct {
 			name    string

--- a/pkg/mimirpb/mimir.pb.go
+++ b/pkg/mimirpb/mimir.pb.go
@@ -7658,7 +7658,9 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
 	}
 
 	if m.unmarshalFromRW2 {
-		m.Metadata = metadata.slice()
+		if metadata != nil {
+			m.Metadata = metadata.slice()
+		}
 		m.rw2symbols.releasePages()
 	}
 

--- a/pkg/mimirpb/mimir.pb.go.expdiff
+++ b/pkg/mimirpb/mimir.pb.go.expdiff
@@ -209,13 +209,15 @@ index 986c4e1867..dda8609298 100644
  				return err
  			}
  			iNdEx = postIndex
-@@ -7656,12 +7593,6 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
+@@ -7656,14 +7593,6 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
  	if iNdEx > l {
  		return io.ErrUnexpectedEOF
  	}
 -
 -	if m.unmarshalFromRW2 {
--		m.Metadata = metadata.slice()
+-		if metadata != nil {
+-			m.Metadata = metadata.slice()
+-		}
 -		m.rw2symbols.releasePages()
 -	}
 -


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

When unmarshalling a Remote Write 2.0 request with zero timeseries, the metadata variable (`metadataSet` interface) is never initialized because the case 5 branch that lazily creates it is never entered. The finalization block then unconditionally calls `metadata.slice()`, causing a nil pointer dereference panic.

Add a nil guard before calling `metadata.slice()` so that empty RW2 requests are handled gracefully, matching the behavior of empty RW1 requests.

Test case is included.

#### Which issue(s) this PR fixes or relates to

Fixes #14653.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small nil-guard in RW2 `WriteRequest.Unmarshal` plus a targeted regression test; behavior only changes for empty-timeseries RW2 payloads that previously panicked.
> 
> **Overview**
> Fixes a nil-pointer panic when unmarshalling Prometheus Remote Write 2.0 requests that contain symbols but **zero** timeseries, by guarding the RW2 finalization step to only slice metadata when it was actually initialized.
> 
> Adds a regression test ensuring an empty RW2 request unmarshals successfully with empty `Timeseries`/`Metadata`, and records the fix in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 040be01cdafb5171bd41bfa21b6e3c523a367bb3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->