### PR TITLE
tsdb: add TSDBMetrics.ForceRemoveRegistryForTenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,7 +144,7 @@
 * [ENHANCEMENT] Ingester: Add `cortex_ingester_queried_blocks_total` metric to track TSDB block generations queried. #14572
 * [ENHANCEMENT] Distributor, ingest storage: Add `cortex_distributor_received_bytes_total` and `cortex_ingest_storage_writer_input_bytes_total` metrics to measure Remote Write v2 symbols table compression effectiveness. #14453
 * [ENHANCEMENT] Store-gateway: Added `cortex_bucket_store_chunk_size_estimate_type_total` metric to track how often do we infer the size of a chunk or use the default size. #14477
-* [ENHANCEMENT] Block-builder: Expose per-tenant TSDB metrics. #14364
+* [ENHANCEMENT] Block-builder: Expose per-tenant TSDB metrics. #14364 #14699
 * [ENHANCEMENT] Block-builder: Add experimental `-block-builder.generate-sparse-index-headers` option. Construct and upload sparse index headers to object storage as part of block creation to make the sparse headers available to store-gateways when loading uncompacted blocks. #14494
 * [ENHANCEMENT] Add experimental `-http.response-compression-level` CLI flag to set the gzip compression level used for compressed HTTP responses. #14586
 * [ENHANCEMENT] Query-frontend: Add support for `lookback_delta` query parameter for instant and range queries. #14582 #14588

--- a/pkg/blockbuilder/tsdb.go
+++ b/pkg/blockbuilder/tsdb.go
@@ -391,7 +391,7 @@ func (b *TSDBBuilder) CompactAndUpload(ctx context.Context, uploadBlocks blockUp
 			merr.Add(os.RemoveAll(db.Dir()))
 
 			// Remove all registered per-tenant TSDB metrics. Their local DBs are wiped out from the block-builder no-matter what.
-			b.tsdbMetrics.RemoveRegistryForTenant(tenant.tenantID)
+			b.tsdbMetrics.ForceRemoveRegistryForTenant(tenant.tenantID)
 		}
 
 		// Clear the map so that it can be released from the memory. Not setting to nil in case we want to reuse the TSDBBuilder.
@@ -480,7 +480,7 @@ func (b *TSDBBuilder) Close() error {
 		merr.Add(db.Close())
 		merr.Add(os.RemoveAll(dbDir))
 
-		b.tsdbMetrics.RemoveRegistryForTenant(tenant.tenantID)
+		b.tsdbMetrics.ForceRemoveRegistryForTenant(tenant.tenantID)
 	}
 
 	// Clear the map so that it can be released from the memory. Not setting to nil in case

--- a/pkg/storage/tsdb/tsdb_metrics.go
+++ b/pkg/storage/tsdb/tsdb_metrics.go
@@ -389,3 +389,7 @@ func (sm *TSDBMetrics) SetRegistryForTenant(userID string, registry *prometheus.
 func (sm *TSDBMetrics) RemoveRegistryForTenant(userID string) {
 	sm.regs.RemoveTenantRegistry(userID, false)
 }
+
+func (sm *TSDBMetrics) ForceRemoveRegistryForTenant(userID string) {
+	sm.regs.RemoveTenantRegistry(userID, true)
+}


### PR DESCRIPTION
#### What this PR does

Following #14364

This PR fixes a leak that we started to see in the block-builder after the mentioned PR was deployed. 

The block-builder churns its per-user metrics after every job. Since every job teardown does soft-remove, the number of `lastGather` kept in the `TenantRegistries` becomes visible over time in low volume cells, causing occasional OOM.

<img width="1451" height="806" alt="Screenshot 2026-03-16 at 12 54 30" src="https://github.com/user-attachments/assets/baa6aaaa-7855-4bf1-a05d-2c6d95542a44" />

The PR fixes that by force-deleting tenants' registry. This will come with a reset in the registry's counters. I don't think this will be a problem for block-builder — will double-check (Update: it's been doing fine in dev).