### PR TITLE
Remove usage of alternative errors package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -267,7 +267,7 @@ require (
 	github.com/dgraph-io/ristretto v0.2.0 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
-	github.com/efficientgo/core v1.0.0-rc.3
+	github.com/efficientgo/core v1.0.0-rc.3 // indirect
 	github.com/efficientgo/e2e v0.13.1-0.20220923082810-8fa9daa8af8a // indirect
 	github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb
 	github.com/fatih/color v1.18.0 // indirect

--- a/pkg/util/time.go
+++ b/pkg/util/time.go
@@ -6,12 +6,12 @@
 package util
 
 import (
+	"fmt"
 	"math"
 	"math/rand"
 	"strconv"
 	"time"
 
-	"github.com/efficientgo/core/errors"
 	"github.com/prometheus/common/model"
 )
 
@@ -45,7 +45,7 @@ func ParseTime(s string) (int64, error) {
 	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
 		return TimeToMillis(t), nil
 	}
-	return 0, errors.Newf("cannot parse %q to a valid timestamp", s)
+	return 0, fmt.Errorf("cannot parse %q to a valid timestamp", s)
 }
 
 // ParseDurationMS parses the string into an int64 duration, the elapsed milliseconds between two instants
@@ -53,14 +53,14 @@ func ParseDurationMS(s string) (int64, error) {
 	if d, err := strconv.ParseFloat(s, 64); err == nil {
 		ts := d * float64(time.Second/time.Millisecond)
 		if ts > float64(math.MaxInt64) || ts < float64(math.MinInt64) {
-			return 0, errors.Newf("cannot parse %q to a valid duration. It overflows int64", s)
+			return 0, fmt.Errorf("cannot parse %q to a valid duration. It overflows int64", s)
 		}
 		return int64(ts), nil
 	}
 	if d, err := model.ParseDuration(s); err == nil {
 		return int64(d) / int64(time.Millisecond/time.Nanosecond), nil
 	}
-	return 0, errors.Newf("cannot parse %q to a valid duration", s)
+	return 0, fmt.Errorf("cannot parse %q to a valid duration", s)
 }
 
 // DurationWithJitter returns random duration from "input - input*variance" to "input + input*variance" interval.

--- a/tools/promql-generator/promql-generator.go
+++ b/tools/promql-generator/promql-generator.go
@@ -22,6 +22,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"math/rand"
@@ -30,7 +31,6 @@ import (
 	"time"
 
 	"github.com/cortexproject/promqlsmith"
-	"github.com/efficientgo/core/errors"
 	"github.com/grafana/dskit/flagext"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"


### PR DESCRIPTION
#### What this PR does

`github.com/efficientgo/core/errors` was being imported by some code, but there was no benefit to using it over `fmt.Errorf` or the standard `errors`.

#### Which issue(s) this PR fixes or relates to

Fixes N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes error construction/imports and adjusts `go.mod` dependency classification; runtime behavior should be unchanged aside from error types/messages being produced by stdlib.
> 
> **Overview**
> Removes remaining usage of `github.com/efficientgo/core/errors` by switching to standard library error helpers: `pkg/util/time.go` now uses `fmt.Errorf`, and `tools/promql-generator` uses Go's `errors.New`.
> 
> Updates `go.mod` to mark `github.com/efficientgo/core` as an *indirect* dependency after the import cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4a0388eee761b9260c12e21443dd7a9b1581fb2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->