### PR TITLE
Remove unnecessary series labels deduplication in `Distributor.MetricsForLabelMatchers`

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -3296,6 +3296,7 @@ func (d *Distributor) MetricsForLabelMatchers(ctx context.Context, from, through
 		}
 	}()
 
+	queryLimiter := mimir_limiter.QueryLimiterFromContextWithFallback(ctx)
 	metrics := map[uint64]labels.Labels{}
 respsLoop:
 	for _, resp := range resps {
@@ -3304,31 +3305,18 @@ respsLoop:
 			if len(metrics) >= resultLimit {
 				break respsLoop
 			}
+
+			if err := queryLimiter.AddSeries(m); err != nil {
+				return nil, err
+			}
+
 			metrics[labels.StableHash(m)] = m
 		}
 	}
 
-	queryLimiter := mimir_limiter.QueryLimiterFromContextWithFallback(ctx)
-	deduplicator, err := mimir_limiter.SeriesLabelsDeduplicatorFromContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-	tracker, err := mimir_limiter.MemoryConsumptionTrackerFromContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	result := make([]labels.Labels, 0, len(metrics))
 	for _, m := range metrics {
-		uniqueSeries, err := deduplicator.Deduplicate(m, tracker)
-		if err != nil {
-			return nil, err
-		}
-		if err := queryLimiter.AddSeries(uniqueSeries); err != nil {
-			return nil, err
-		}
-
-		result = append(result, uniqueSeries)
+		result = append(result, m)
 	}
 	return result, nil
 }

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -2682,8 +2682,6 @@ func TestDistributor_MetricsForLabelMatchers(t *testing.T) {
 					// Ensure strong read consistency, required to have no flaky tests when ingest storage is enabled.
 					ctx := user.InjectOrgID(context.Background(), "test")
 					ctx = api.ContextWithReadConsistencyLevel(ctx, api.ReadConsistencyStrong)
-					dedupMetrics := limiter.NewSeriesDeduplicatorMetrics(prometheus.NewPedanticRegistry())
-					ctx = limiter.ContextWithNewSeriesLabelsDeduplicator(ctx, dedupMetrics)
 
 					// Push fixtures
 					for _, series := range fixtures {
@@ -2694,7 +2692,6 @@ func TestDistributor_MetricsForLabelMatchers(t *testing.T) {
 
 					// Set up limiter
 					ctx = limiter.AddQueryLimiterToContext(ctx, limiter.NewQueryLimiter(testData.maxSeriesPerQuery, 0, 0, 0, stats.NewQueryMetrics(prometheus.NewPedanticRegistry())))
-					ctx = limiter.AddMemoryTrackerToContext(ctx, limiter.NewUnlimitedMemoryConsumptionTracker(ctx))
 
 					metrics, err := ds[0].MetricsForLabelMatchers(ctx, now, now, testData.hints, testData.matchers...)
 					if testData.expectedError != nil {
@@ -2804,9 +2801,6 @@ func TestDistributor_MetricsForLabelMatchers_adjustPushDownLimit(t *testing.T) {
 			// Ensure strong read consistency, required to have no flaky tests when ingest storage is enabled.
 			ctx := user.InjectOrgID(context.Background(), "test")
 			ctx = api.ContextWithReadConsistencyLevel(ctx, api.ReadConsistencyStrong)
-			ctx = limiter.AddMemoryTrackerToContext(ctx, limiter.NewUnlimitedMemoryConsumptionTracker(ctx))
-			metrics := limiter.NewSeriesDeduplicatorMetrics(prometheus.NewPedanticRegistry())
-			ctx = limiter.ContextWithNewSeriesLabelsDeduplicator(ctx, metrics)
 
 			for _, series := range fixtures {
 				req := mockWriteRequest(series.lbls, series.value, series.timestamp)


### PR DESCRIPTION
#### What this PR does

I noticed that `Distributor.MetricsForLabelMatchers` was using a `SeriesLabelsDeduplicator` to deduplicate series labels. This is not necessary: `MetricsForLabelMatchers` already does this using the `metrics` map earlier in the method.

I've also taken this opportunity to move the query limiter call earlier, to enforce the series limit earlier.

I've chosen not to add a changelog entry given this is a user-invisible refactor.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `MetricsForLabelMatchers` enforces per-query series limits (now before final dedup) and removes label/memory deduplication tracking, which could slightly alter when limits trigger and how label slices are retained.
> 
> **Overview**
> Removes the `SeriesLabelsDeduplicator`/memory-tracker pass in `Distributor.MetricsForLabelMatchers`, relying solely on the existing stable-hash map for deduplication and returning the collected labels directly.
> 
> Moves `QueryLimiter.AddSeries()` into the ingester-response iteration so series limits are enforced earlier while aggregating results, and updates distributor tests to no longer wire deduplicator/memory-tracker context for this path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98456ddfd170ccc4e4aee714a7ca87147720caf4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->