### PR TITLE
renovate: add Makefile to auto-rebase matchers

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -131,6 +131,7 @@
       description: 'Automatically rebase all dependency update PRs touching mimir-build-image/Dockerfile, and ignore pushes from GitHub Actions with new image reference when considering if the PR is modified and can be rebased',
       matchFileNames: [
         'mimir-build-image/Dockerfile',
+        'Makefile',
       ],
       rebaseWhen: 'behind-base-branch',
       gitIgnoredAuthors: ['199097951+mimir-github-bot[bot]@users.noreply.github.com'],


### PR DESCRIPTION
#### What this PR does

Following https://github.com/grafana/mimir/pull/14524 https://github.com/grafana/mimir/pull/14671

Renovate still ignores changes, pushed to the dependency update PRs, made by `mimir-github-bot` (example https://github.com/grafana/mimir/pull/14706). We suspect, this is because the bot's changes aren't matched by the matcher, that has `gitIgnoredAuthors`. This PR tries to address that, by adding Makefile to the matcher's list.