### PR TITLE
Reduce pkg/storegateway unit tests execution time

### DIFF
--- a/pkg/storegateway/bucket_e2e_test.go
+++ b/pkg/storegateway/bucket_e2e_test.go
@@ -621,6 +621,12 @@ func TestBucketStore_Series_ChunksLimiter_e2e(t *testing.T) {
 	// The query will fetch 4 series from 3 blocks each, so we do expect to hit a total of 12 chunks.
 	expectedChunks := uint64(4 * 3)
 
+	// Create blocks once into a shared bucket to avoid repeating expensive block creation I/O.
+	bkt := objstore.NewInMemBucket()
+	sharedCfg := defaultPrepareStoreConfig(t)
+	prepareTestBlocks(t, time.Now(), sharedCfg.numBlocks/2, sharedCfg.tempDir, bkt,
+		sharedCfg.series, labels.FromStrings("ext1", "value1"), sharedCfg.nonOverlappingBlocks)
+
 	cases := map[string]struct {
 		maxChunksLimit uint64
 		maxSeriesLimit uint64
@@ -649,16 +655,17 @@ func TestBucketStore_Series_ChunksLimiter_e2e(t *testing.T) {
 
 	for testName, testData := range cases {
 		t.Run(testName, func(t *testing.T) {
+			// Create one store per case (different limiters), reuse across streaming batch sizes.
+			prepConfig := defaultPrepareStoreConfig(t)
+			prepConfig.numBlocks = 0 // blocks already in shared bucket
+			prepConfig.chunksLimiterFactory = newStaticChunksLimiterFactory(testData.maxChunksLimit)
+			prepConfig.seriesLimiterFactory = newStaticSeriesLimiterFactory(testData.maxSeriesLimit)
+
+			s := prepareStoreWithTestBlocks(t, bkt, prepConfig)
+			srv := newStoreGatewayTestServer(t, s.store)
+
 			for _, streamingBatchSize := range []int{0, 1, 5} {
 				t.Run(fmt.Sprintf("streamingBatchSize=%d", streamingBatchSize), func(t *testing.T) {
-					bkt := objstore.NewInMemBucket()
-
-					prepConfig := defaultPrepareStoreConfig(t)
-					prepConfig.chunksLimiterFactory = newStaticChunksLimiterFactory(testData.maxChunksLimit)
-					prepConfig.seriesLimiterFactory = newStaticSeriesLimiterFactory(testData.maxSeriesLimit)
-
-					s := prepareStoreWithTestBlocks(t, bkt, prepConfig)
-
 					req := &storepb.SeriesRequest{
 						Matchers: []storepb.LabelMatcher{
 							{Type: storepb.LabelMatcher_EQ, Name: "a", Value: "1"},
@@ -668,7 +675,6 @@ func TestBucketStore_Series_ChunksLimiter_e2e(t *testing.T) {
 						StreamingChunksBatchSize: uint64(streamingBatchSize),
 					}
 
-					srv := newStoreGatewayTestServer(t, s.store)
 					_, _, _, _, err := srv.Series(context.Background(), req)
 
 					if testData.expectedErr == "" {

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -1190,17 +1190,21 @@ func benchmarkExpandedPostings(
 	ctx, cancel := context.WithCancel(context.Background())
 	tb.Cleanup(cancel)
 
+	// Reuse a single block across test cases to avoid repeatedly creating StreamBinaryReader
+	// instances (expensive, especially under the race detector).
+	sharedBlock := newTestBucketBlock()
+
+	var allSeries []labels.Labels
+	if !tb.IsBenchmark() {
+		indexr := newBucketIndexReader(sharedBlock, selectAllStrategy{})
+		allPostings, _, err := indexr.ExpandedPostings(ctx, []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "my_made_up_label", "")}, newSafeQueryStats())
+		require.NoError(tb, err)
+		allSeries = loadSeries(ctx, tb, allPostings, indexr)
+	}
+
 	for _, testCase := range fixtures.SeriesSelectorTestCases(tb, series) {
 		tb.Run(testCase.Name, func(tb test.TB) {
-			indexr := newBucketIndexReader(newTestBucketBlock(), selectAllStrategy{})
-
-			var allSeries []labels.Labels
-			if !tb.IsBenchmark() {
-				allPostings, _, err := indexr.ExpandedPostings(ctx, []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "my_made_up_label", "")}, newSafeQueryStats())
-				require.NoError(tb, err)
-				allSeries = loadSeries(ctx, tb, allPostings, indexr)
-			}
-
+			indexr := newBucketIndexReader(sharedBlock, selectAllStrategy{})
 			indexrStats := newSafeQueryStats()
 
 			tb.ResetTimer()
@@ -1218,10 +1222,10 @@ func benchmarkExpandedPostings(
 	}
 }
 
-// filterSeries modified series in place and returns a subslice of series.
+// filterSeries returns a new slice containing only the series that match all matchers.
 func filterSeries(series []labels.Labels, ms []*labels.Matcher) []labels.Labels {
-	writeIdx := 0
-	for i, s := range series {
+	result := make([]labels.Labels, 0)
+	for _, s := range series {
 		matches := true
 		for _, m := range ms {
 			if !m.Matches(s.Get(m.Name)) {
@@ -1230,11 +1234,10 @@ func filterSeries(series []labels.Labels, ms []*labels.Matcher) []labels.Labels 
 			}
 		}
 		if matches {
-			series[writeIdx], series[i] = series[i], series[writeIdx]
-			writeIdx++
+			result = append(result, s)
 		}
 	}
-	return series[:writeIdx]
+	return result
 }
 
 func loadSeries(ctx context.Context, tb test.TB, postings []storage.SeriesRef, indexr *bucketIndexReader) []labels.Labels {
@@ -1561,7 +1564,7 @@ func TestBucketStore_Series_Concurrency(t *testing.T) {
 	marshalledHints, err := types.MarshalAny(hints)
 	require.NoError(t, err)
 
-	runRequest := func(t *testing.T, store *BucketStore, streamBatchSize int) {
+	runRequest := func(t *testing.T, srv *storeTestServer, streamBatchSize int) {
 		req := &storepb.SeriesRequest{
 			MinTime: math.MinInt64,
 			MaxTime: math.MaxInt64,
@@ -1571,7 +1574,6 @@ func TestBucketStore_Series_Concurrency(t *testing.T) {
 			Hints:                    marshalledHints,
 			StreamingChunksBatchSize: uint64(streamBatchSize),
 		}
-		srv := newStoreGatewayTestServer(t, store)
 		seriesSet, warnings, _, _, err := srv.Series(context.Background(), req)
 		require.NoError(t, err)
 		require.Equal(t, 0, len(warnings), "%v", warnings)
@@ -1627,6 +1629,9 @@ func TestBucketStore_Series_Concurrency(t *testing.T) {
 						store.RemoveBlocksAndClose()
 					})
 
+					// Create a single gRPC test server shared across all workers.
+					srv := newStoreGatewayTestServer(t, store)
+
 					// Run workers.
 					wg := sync.WaitGroup{}
 					wg.Add(numWorkers)
@@ -1636,7 +1641,7 @@ func TestBucketStore_Series_Concurrency(t *testing.T) {
 							defer wg.Done()
 
 							for r := 0; r < numRequestsPerWorker; r++ {
-								runRequest(t, store, streamBatchSize)
+								runRequest(t, srv, streamBatchSize)
 							}
 						}()
 					}

--- a/pkg/storegateway/series_refs_test.go
+++ b/pkg/storegateway/series_refs_test.go
@@ -1112,10 +1112,10 @@ func TestLoadingSeriesChunkRefsSetIterator(t *testing.T) {
 	testBlock := fixtures.SetupTestBlock(tb, appendFunc)
 	defaultTestBlockFactory := testBlockToBucketBlock(tb, testBlock)
 
-	const largerTestBlockSeriesCount = 100_000
+	const largerTestBlockSeriesCount = 10_000
 	largerAppendFunc := func(t testing.TB, appenderFactory func() storage.Appender) {
+		appender := appenderFactory()
 		for i := 0; i < largerTestBlockSeriesCount; i++ {
-			appender := appenderFactory()
 			lbls := oneLabel("l1", fmt.Sprintf("v%d", i))
 			var ref storage.SeriesRef
 			const numSamples = 240 // Write enough samples to have two chunks per series
@@ -1124,8 +1124,8 @@ func TestLoadingSeriesChunkRefsSetIterator(t *testing.T) {
 				ref, err = appender.Append(ref, lbls, int64(i*10+j), float64(j))
 				assert.NoError(t, err)
 			}
-			assert.NoError(t, appender.Commit())
 		}
+		assert.NoError(t, appender.Commit())
 	}
 	largerTestBlock := fixtures.SetupTestBlock(tb, largerAppendFunc)
 	largerTestBlockFactory := testBlockToBucketBlock(tb, largerTestBlock)
@@ -1278,7 +1278,7 @@ func TestLoadingSeriesChunkRefsSetIterator(t *testing.T) {
 			blockFactory: largerTestBlockFactory,
 			minT:         0,
 			maxT:         math.MaxInt64,
-			batchSize:    5000,
+			batchSize:    500,
 			matchers:     []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, "l1", ".*")},
 			expectedSets: func() []seriesChunkRefsSet {
 				series := make([]seriesChunkRefs, 0, largerTestBlockSeriesCount)
@@ -1290,7 +1290,7 @@ func TestLoadingSeriesChunkRefsSetIterator(t *testing.T) {
 					return labels.Compare(a.lset, b.lset)
 				})
 
-				const numBatches = largerTestBlockSeriesCount / 5000
+				const numBatches = largerTestBlockSeriesCount / 500
 				sets := make([]seriesChunkRefsSet, numBatches)
 				for setIdx := 0; setIdx < numBatches; setIdx++ {
 					sets[setIdx].series = series[setIdx*largerTestBlockSeriesCount/numBatches : (setIdx+1)*largerTestBlockSeriesCount/numBatches]


### PR DESCRIPTION
#### What this PR does

Follow up of https://github.com/grafana/mimir/pull/14669. In this PR I'm reducing the execution time of the 4 slowest tests in `pkg/storegateway`, that is the slowest package we have.

Changes done (timing diff from running them locally):

- TestLoadingSeriesChunkRefsSetIterator (~82s → ~8s):
  - Reduce the "larger test block" from 100K to 10K series, and adjusted the "many batches" batch size from 5000 to 500 to maintain 20 batches
  - Also switched to a single commit instead of per-series commits
- TestBucketStore_Series_Concurrency (60s → 52s)
  - Reuse a single gRPC test server per sub-test instead of creating a new one for every request
- TestBucketIndexReader_ExpandedPostings (~63s → ~15s)
  - Load all series once before the test case loop instead of re-reading 50k series from disk for each of the 43 sub-tests
  - Reuse a single bucketBlock across test cases (in test mode) to avoid creating 85 redundant StreamBinaryReader instances
- TestBucketStore_Series_ChunksLimiter_e2e (~38s → ~2s)
  - Create TSDB blocks once into a shared in-memory bucket instead of recreating identical blocks 12 times (4 cases × 3 streaming batch sizes)
  - Reuse a single BucketStore per test case across streaming batch sizes, since StreamingChunksBatchSize is a per-request parameter and limiter factories are stateless

I measured the impact in CI: it reduces the `pkg/storegateway` unit tests from 450s to 300s (-33%, -150s =~ 2.5m)

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
