### PR TITLE
Move check to speed up TestPartitionReader_getStartOffset_RetentionPeriodFallback

### DIFF
--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -726,6 +726,12 @@ func (r *PartitionReader) getStartOffset(ctx context.Context) (startOffset, last
 		return startOffset, -1, nil
 	}
 
+	// Validate configuration before doing any work. This is a static check that won't change between retries.
+	// MaxReplayPeriod is only used when consuming from last offset with file-based offset enforcement.
+	if r.kafkaCfg.ConsumeFromPositionAtStartup != consumeFromTimestamp && r.kafkaCfg.ConsumerGroupOffsetCommitFileEnforced && r.kafkaCfg.MaxReplayPeriod <= 0 {
+		return 0, -1, fmt.Errorf("max replay period must be positive when file offset enforcement is enabled")
+	}
+
 	// We use an ephemeral client to fetch the offset and then create a new client with this offset.
 	// The reason for this is that changing the offset of an existing client requires to have used this client for fetching at least once.
 	// We don't want to do noop fetches just to warm up the client, so we create a new client instead.
@@ -748,9 +754,6 @@ func (r *PartitionReader) getStartOffset(ctx context.Context) (startOffset, last
 				return offset, lastConsumedOffset, nil
 			}
 		} else if r.kafkaCfg.ConsumerGroupOffsetCommitFileEnforced {
-			if r.kafkaCfg.MaxReplayPeriod <= 0 {
-				return 0, -1, fmt.Errorf("max replay period must be positive when file offset enforcement is enabled")
-			}
 			// File-based offset enforcement: use file offset only if it exists.
 			if fileOffset, exists := r.offsetFile.Read(); exists {
 				partitionStart, startExists, err := r.fetchPartitionStartOffset(ctx, cl)


### PR DESCRIPTION
#### What this PR does

Move static config validation (`MaxReplayPeriod <= 0`) in `PartitionReader.getStartOffset()` out of the retry loop, so it fails immediately instead of retrying 10 times with exponential backoff. This saves about 11s in `TestPartitionReader_getStartOffset_RetentionPeriodFallback`.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
