### PR TITLE
Parallelise TestOwnedSeriesServiceWithPartitionsRing subtests execution

### DIFF
--- a/pkg/ingester/owned_series_test.go
+++ b/pkg/ingester/owned_series_test.go
@@ -1432,6 +1432,7 @@ func TestOwnedSeriesServiceWithPartitionsRing(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			c := ownedSeriesWithPartitionsRingTestContext{
 				ownedSeriesTestContextBase: ownedSeriesTestContextBase{
 					user:          ownedServiceTestUserPartitionsRing,


### PR DESCRIPTION
#### What this PR does

Added t.Parallel() to each of the 13 subtests in `TestOwnedSeriesServiceWithPartitionsRing`. Result: 21.4s → 5.3s

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
