### PR TITLE
usage-tracker: remove debug log from trackSeries.

### DIFF
--- a/pkg/usagetracker/tracker_store.go
+++ b/pkg/usagetracker/tracker_store.go
@@ -111,7 +111,6 @@ func (t *trackerStore) trackSeries(ctx context.Context, tenantID string, series 
 		tenant.seriesCreated.Add(uint64(len(createdRefs)))
 	}
 
-	level.Debug(t.logger).Log("msg", "tracked series", "tenant", tenantID, "received_len", len(series), "created_len", len(createdRefs), "rejected_len", len(rejectedRefs), "now", timeNow.Unix(), "now_minutes", now)
 	if len(createdRefs) == 0 {
 		return rejectedRefs, nil
 	}


### PR DESCRIPTION
#### What this PR does

Removes a debug log (that isn't used) from `trackSeries` which is in the hot path of TrackSeriesBatch and does some allocations.

```
                                                        │  before.txt  │               after.txt               │
                                                        │    sec/op    │    sec/op     vs base                 │
TrackSeriesBatch/users=1/hashes=1500/entries=500-11       26.29µ ± ∞ ¹   26.51µ ± ∞ ¹        ~ (p=1.000 n=1) ²
TrackSeriesBatch/users=1/hashes=100000/entries=5-11       1.459m ± ∞ ¹   1.480m ± ∞ ¹        ~ (p=1.000 n=1) ²
TrackSeriesBatch/users=50/hashes=100000/entries=500-11    5.502m ± ∞ ¹   5.952m ± ∞ ¹        ~ (p=1.000 n=1) ²
TrackSeriesBatch/users=950/hashes=100000/entries=500-11   33.62m ± ∞ ¹   18.63m ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                                                   1.632m         1.444m        -11.51%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                                        │  before.txt   │               after.txt                │
                                                        │     B/op      │     B/op       vs base                 │
TrackSeriesBatch/users=1/hashes=1500/entries=500-11       3.577Ki ± ∞ ¹   2.911Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
TrackSeriesBatch/users=1/hashes=100000/entries=5-11       168.6Ki ± ∞ ¹   170.8Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
TrackSeriesBatch/users=50/hashes=100000/entries=500-11    675.1Ki ± ∞ ¹   707.6Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
TrackSeriesBatch/users=950/hashes=100000/entries=500-11   4.221Mi ± ∞ ¹   2.006Mi ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                                                   204.8Ki         164.0Ki        -19.95%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                                        │  before.txt  │               after.txt               │
                                                        │  allocs/op   │  allocs/op    vs base                 │
TrackSeriesBatch/users=1/hashes=1500/entries=500-11        9.000 ± ∞ ¹    2.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
TrackSeriesBatch/users=1/hashes=100000/entries=5-11        112.0 ± ∞ ¹    107.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
TrackSeriesBatch/users=50/hashes=100000/entries=500-11     751.0 ± ∞ ¹    440.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
TrackSeriesBatch/users=950/hashes=100000/entries=500-11   8.225k ± ∞ ¹   1.391k ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                                                    280.9          107.0        -61.92%
```

#### Checklist

- n/a Tests updated.
- n/a Documentation added.
- n/a `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- n/a [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change that only removes a `level.Debug` log line from `trackSeries`, reducing allocations and work in a hot path without altering behavior.
> 
> **Overview**
> Removes a debug-level "tracked series" log statement from `trackerStore.trackSeries`, avoiding extra allocations and logging overhead on the `TrackSeriesBatch` hot path.
> 
> No functional changes to series tracking or event publication logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ce27fec74fd6e220d3b09720001c6d64bd412cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->