### PR TITLE
Upgrade dskit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/golang/snappy v1.0.0
 	github.com/google/gopacket v1.1.19
 	github.com/gorilla/mux v1.8.1
-	github.com/grafana/dskit v0.0.0-20260312141034-c3cfcb4a37bc
+	github.com/grafana/dskit v0.0.0-20260318051422-6eb5ee5d450a
 	github.com/grafana/e2e v0.1.2-0.20260309174126-b5393d4e610f
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/influxdata/influxdb/v2 v2.8.0

--- a/go.sum
+++ b/go.sum
@@ -595,8 +595,8 @@ github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc h1:PXZQA2WCxe85T
 github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc/go.mod h1:AHHlOEv1+GGQ3ktHMlhuTUwo3zljV3QJbC0+8o2kn+4=
 github.com/grafana/alerting v0.0.0-20260227181651-5106b6285f2d h1:QBq2fe3LX/7IyHL8s7NQuCUL5+xhS3IeRACi7AIHtjE=
 github.com/grafana/alerting v0.0.0-20260227181651-5106b6285f2d/go.mod h1:06F4s5KJ6LpL7od+rcusjKnsst+vRhdFqev9GdVNz4c=
-github.com/grafana/dskit v0.0.0-20260312141034-c3cfcb4a37bc h1:SPtjZC52HeIW4XhSJY0THRR38vKZ5ayTC68jXQl3Afs=
-github.com/grafana/dskit v0.0.0-20260312141034-c3cfcb4a37bc/go.mod h1:Lown5uc/WTIpY4y+O5B3RxVQd7qJ3PLEoEvaAZ/U7cQ=
+github.com/grafana/dskit v0.0.0-20260318051422-6eb5ee5d450a h1:Z82mwY9B33MolHKO2M47y24wOBvRXz6XRV3fhhISuXs=
+github.com/grafana/dskit v0.0.0-20260318051422-6eb5ee5d450a/go.mod h1:Lown5uc/WTIpY4y+O5B3RxVQd7qJ3PLEoEvaAZ/U7cQ=
 github.com/grafana/e2e v0.1.2-0.20260309174126-b5393d4e610f h1:gxaqz5StufMU078tWFuf8CUi4PZtITBxjM2TZV7NOFw=
 github.com/grafana/e2e v0.1.2-0.20260309174126-b5393d4e610f/go.mod h1:KFvJP5m5GQ837CN7rUbWIiPdw1JZgeRJTEyp2O5U0is=
 github.com/grafana/go-yaml/v3 v3.0.0-20260130164322-e3c24e8f4c87 h1:Op5/Kd8Ae90IC7Ow+CNwGo/oq87cJX2iE+U8Dw4a8Bc=

--- a/vendor/github.com/grafana/dskit/cache/memcached_client.go
+++ b/vendor/github.com/grafana/dskit/cache/memcached_client.go
@@ -306,6 +306,7 @@ func (c *MemcachedClient) SetMultiAsync(data map[string][]byte, ttl time.Duratio
 func (c *MemcachedClient) SetAsync(key string, value []byte, ttl time.Duration) {
 	if c.config.MaxItemSize > 0 && len(value) > c.config.MaxItemSize {
 		c.metrics.skipped.WithLabelValues(opSet, reasonMaxItemSize).Inc()
+		level.Debug(c.logger).Log("msg", "failed to store item to cache because it is too large", "key", key, "size", len(value), "max_item_size", c.config.MaxItemSize)
 		return
 	}
 
@@ -320,7 +321,7 @@ func (c *MemcachedClient) SetAsync(key string, value []byte, ttl time.Duration) 
 
 	if err != nil {
 		c.metrics.skipped.WithLabelValues(opSet, reasonAsyncBufferFull).Inc()
-		level.Debug(c.logger).Log("msg", "failed to store item to cache because the async buffer is full", "err", err, "size", c.config.MaxAsyncBufferSize)
+		level.Debug(c.logger).Log("msg", "failed to store item to cache because the async buffer is full", "key", key, "err", err, "buffer_size", c.config.MaxAsyncBufferSize)
 	}
 }
 
@@ -455,12 +456,11 @@ func (c *MemcachedClient) Delete(ctx context.Context, key string) error {
 		err = c.client.Delete(key)
 	}
 	if err != nil {
-		level.Debug(c.logger).Log(
+		c.trackError(
+			opDelete, err,
 			"msg", "failed to delete cache item",
 			"key", key,
-			"err", err,
 		)
-		c.trackError(opDelete, err)
 	} else {
 		c.metrics.duration.WithLabelValues(opDelete).Observe(time.Since(start).Seconds())
 	}
@@ -494,13 +494,12 @@ func (c *MemcachedClient) incrDecr(ctx context.Context, key string, operation st
 		newValue, err = f()
 	}
 	if err != nil {
-		level.Debug(c.logger).Log(
+		c.trackError(
+			operation, err,
 			"msg", "failed to incr/decr cache item",
 			"operation", operation,
 			"key", key,
-			"err", err,
 		)
-		c.trackError(operation, err)
 	} else {
 		c.metrics.duration.WithLabelValues(operation).Observe(time.Since(start).Seconds())
 	}
@@ -520,12 +519,11 @@ func (c *MemcachedClient) Touch(ctx context.Context, key string, ttl time.Durati
 		err = c.client.Touch(key, int32(ttl.Seconds()))
 	}
 	if err != nil {
-		level.Debug(c.logger).Log(
+		c.trackError(
+			opTouch, err,
 			"msg", "failed to touch cache item",
 			"key", key,
-			"err", err,
 		)
-		c.trackError(opTouch, err)
 	} else {
 		c.metrics.duration.WithLabelValues(opTouch).Observe(time.Since(start).Seconds())
 	}
@@ -564,11 +562,10 @@ func (c *MemcachedClient) FlushAll(ctx context.Context) error {
 		err = c.client.FlushAll()
 	}
 	if err != nil {
-		level.Debug(c.logger).Log(
+		c.trackError(
+			opFlush, err,
 			"msg", "failed to flush all cache",
-			"err", err,
 		)
-		c.trackError(opFlush, err)
 	} else {
 		c.metrics.duration.WithLabelValues(opFlush).Observe(time.Since(start).Seconds())
 	}
@@ -587,14 +584,13 @@ func (c *MemcachedClient) storeOperation(ctx context.Context, key string, value 
 
 	err := f(ctx, key, value, ttl)
 	if err != nil {
-		level.Debug(c.logger).Log(
+		c.trackError(
+			operation, err,
 			"msg", "failed to store item to cache",
 			"operation", operation,
 			"key", key,
 			"sizeBytes", len(value),
-			"err", err,
 		)
-		c.trackError(operation, err)
 	}
 
 	c.metrics.dataSize.WithLabelValues(operation).Observe(float64(len(value)))
@@ -619,7 +615,9 @@ func (c *MemcachedClient) wait() error {
 	return nil
 }
 
-func (c *MemcachedClient) trackError(op string, err error) {
+func (c *MemcachedClient) trackError(op string, err error, msg ...interface{}) {
+	severity := level.DebugValue()
+
 	var connErr *memcache.ConnectTimeoutError
 	var netErr net.Error
 	switch {
@@ -639,9 +637,16 @@ func (c *MemcachedClient) trackError(op string, err error) {
 		c.metrics.failures.WithLabelValues(op, reasonMalformedKey).Inc()
 	case errors.Is(err, memcache.ErrServerError):
 		c.metrics.failures.WithLabelValues(op, reasonServerError).Inc()
+	case errors.Is(err, context.Canceled):
+		c.metrics.failures.WithLabelValues(op, reasonCanceled).Inc()
 	default:
 		c.metrics.failures.WithLabelValues(op, reasonOther).Inc()
+		severity = level.WarnValue() // Log unexpected kinds of errors with higher severity so they're easier to diagnose.
 	}
+
+	logger := log.WithPrefix(c.logger, level.Key(), severity)
+	logger = log.WithSuffix(logger, "err", err)
+	logger.Log(msg...)
 }
 
 func (c *MemcachedClient) getMultiBatched(ctx context.Context, keys []string, opts ...memcache.Option) ([]map[string]*memcache.Item, error) {
@@ -730,8 +735,10 @@ func (c *MemcachedClient) getMultiSingle(ctx context.Context, keys []string, opt
 	items, err = c.client.GetMulti(ctx, keys, opts...)
 
 	if err != nil {
-		level.Debug(c.logger).Log("msg", "failed to get multiple items from memcached", "err", err)
-		c.trackError(opGetMulti, err)
+		c.trackError(
+			opGetMulti, err,
+			"msg", "failed to get multiple items from memcached",
+		)
 	} else {
 		var total int
 		for _, it := range items {

--- a/vendor/github.com/grafana/dskit/cache/memcached_client_metrics.go
+++ b/vendor/github.com/grafana/dskit/cache/memcached_client_metrics.go
@@ -27,6 +27,7 @@ const (
 	reasonTimeout         = "request-timeout"
 	reasonServerError     = "server-error"
 	reasonNetworkError    = "network-error"
+	reasonCanceled        = "canceled"
 	reasonOther           = "other"
 
 	labelCacheName           = "name"
@@ -88,6 +89,7 @@ func newClientMetrics(reg prometheus.Registerer) *clientMetrics {
 		cm.failures.WithLabelValues(op, reasonNotStored)
 		cm.failures.WithLabelValues(op, reasonServerError)
 		cm.failures.WithLabelValues(op, reasonNetworkError)
+		cm.failures.WithLabelValues(op, reasonCanceled)
 		cm.failures.WithLabelValues(op, reasonOther)
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -803,7 +803,7 @@ github.com/grafana/alerting/templates/email
 github.com/grafana/alerting/templates/gomplate
 github.com/grafana/alerting/templates/mimir
 github.com/grafana/alerting/utils
-# github.com/grafana/dskit v0.0.0-20260312141034-c3cfcb4a37bc
+# github.com/grafana/dskit v0.0.0-20260318051422-6eb5ee5d450a
 ## explicit; go 1.25.7
 github.com/grafana/dskit/backoff
 github.com/grafana/dskit/ballast


### PR DESCRIPTION
#### What this PR does

This PR upgrades dskit to bring in https://github.com/grafana/dskit/pull/934.

I've chosen not to add a changelog entry given this is only a minor change to logging and metrics.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency bump; changes are limited to memcached client logging/metrics behavior (new failure reason and adjusted log severity/fields) without altering cache operation semantics.
> 
> **Overview**
> Upgrades `github.com/grafana/dskit` (and vendored code) to a newer revision.
> 
> The vendored memcached client now centralizes error logging in `trackError`, adds a new `canceled` failure reason (for `context.Canceled`), logs unexpected errors at *warn* level, and improves debug logs with additional fields like `key`, `buffer_size`, and item size context.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba20146ef591669b1458ea82824b19a34eda091f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->