### PR TITLE
Speed up prepare job in CI

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -28,10 +28,15 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     steps:
+      # Only the Makefile is needed to run `make print-build-image`, so we use
+      # sparse checkout to avoid fetching the entire repository.
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
+          sparse-checkout: |
+            Makefile
+          sparse-checkout-cone-mode: false
       - name: Get build image from Makefile
         id: build_image_step
         run: echo "build_image=$(make print-build-image)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
#### What this PR does

Most of CI jobs depend on `prepare`, so it's a blocker to start most of the CI jobs. `prepare` currently checkouts the whole repo, that takes between 5s and 30s. However, `prepare` just need `Makefile`, so we could do a sparse checkout to speed it up.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
