### PR TITLE
Speed up lint CI job by merging faillint calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -315,7 +315,7 @@ lint: check-makefiles check-merge-conflicts
 	# For this reason, we recommend to not use errors.Cause() anywhere, so that we don't have to
 	# question whether the usage is safe or not.
 	#
-  	# github.com/gogo/status.FromError:
+	# github.com/gogo/status.FromError:
 	# gogo/status allows to easily customize error details while grpc/status doesn't:
 	# for this reason we use gogo/status in several places. However, gogo/status.FromError()
 	# doesn't support wrapped errors, while grpc/status.FromError() does.


### PR DESCRIPTION
#### What this PR does

Follow up of https://github.com/grafana/mimir/pull/14721. We can further speed up the `lint` CI job by merging `faillint` calls that run on the same set of files. Shaves a few seconds, but it's better than nothing.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
