### PR TITLE
Speed up check-doc in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -503,6 +503,7 @@ check-protobuf-format:
 	buf format --diff --exit-code $(addprefix --path=,$(PROTO_DEFS)) || (echo "Please format Protobuf files by running 'make format-protobuf'" && false)
 
 %.md : %.template
+	# Speed up check-doc in the lint CI job by aligning doc-generator's Go build flags (CGO_ENABLED=0, -tags netgo,stringlabels) with the rest of the lint pipeline, allowing it to reuse the build cache instead of recompiling the entire dependency tree from scratch.
 	CGO_ENABLED=0 go run -tags $(GO_TAGS) ./tools/doc-generator $< > $@
 
 .PHONY: %.md.embedmd


### PR DESCRIPTION
#### What this PR does

Speed up check-doc in the lint CI job by aligning doc-generator's Go build flags (`CGO_ENABLED=0`, `-tags netgo,stringlabels`) with the rest of the lint pipeline, allowing it to reuse the build cache instead of recompiling the entire dependency tree from scratch (~2m → 10s).

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
