### PR TITLE
MQE: Introduce projection logic and measure effectiveness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,7 +117,7 @@
 * [ENHANCEMENT] Compactor: If compaction fails because the result block would exceed the size limit for its postings offsets table, symbol table, or index, mark input blocks for no-compaction to avoid blocking future compactor runs. #13876 #14466 #14482
 * [ENHANCEMENT] Query-frontend: add support for `range()` duration expression. #13931
 * [ENHANCEMENT] Add experimental flag `common.instrument-reference-leaks-percentage` to leaked references to gRPC buffers. #13609 #14083
-* [ENHANCEMENT] Querier: Add experimental flag `-querier.mimir-query-engine.enable-projection-pushdown` to enable an MQE optimization pass for reducing data transferred between queriers and the storage layer. #14006 #14132 #14239 #14241 #14326 #14720
+* [ENHANCEMENT] Querier: Add experimental flag `-querier.mimir-query-engine.enable-projection-pushdown` to enable an MQE optimization pass for reducing data transferred between queriers and the storage layer. #14006 #14132 #14239 #14241 #14326 #14720 #14751
 * [ENHANCEMENT] MQE: Default to enabling the "eliminate deduplicate and merge" optimization pass via `-querier.mimir-query-engine.enable-eliminate-deduplicate-and-merge`. #14172
 * [ENHANCEMENT] Ingester: Reduce likelihood of ingestion being paused while idle TSDB compaction is in progress. #13978
 * [ENHANCEMENT] Ingester: Extend `cortex_ingester_tsdb_forced_compactions_in_progress` metric to report a value of 1 when there's an idle or forced TSDB head compaction in progress. #13979

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -45,6 +45,7 @@ import (
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/storage/indexheader"
 	streamindex "github.com/grafana/mimir/pkg/storage/indexheader/index"
+	"github.com/grafana/mimir/pkg/storage/series"
 	"github.com/grafana/mimir/pkg/storage/sharding"
 	"github.com/grafana/mimir/pkg/storage/tsdb"
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
@@ -596,12 +597,18 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, srv storegatewaypb.Stor
 	defer s.recordSeriesCallResult(stats)
 	defer s.recordRequestAmbientTime(stats, time.Now())
 
-	var reqBlockMatchers []*labels.Matcher
+	var (
+		reqBlockMatchers  []*labels.Matcher
+		projectionInclude bool
+		projectionLabels  []string
+	)
 	if req.RequestHints != nil {
 		reqBlockMatchers, err = storepb.MatchersToPromMatchers(req.RequestHints.BlockMatchers...)
 		if err != nil {
 			return status.Error(codes.InvalidArgument, errors.Wrap(err, "translate request hints labels matchers").Error())
 		}
+		projectionInclude = req.RequestHints.ProjectionInclude
+		projectionLabels = req.RequestHints.ProjectionLabels
 	} else if req.Hints != nil { //nolint:staticcheck // Ignore SA1019. This use will be removed in Mimir 3.2
 		// Note that we use a different but equivalent hints type for the opaque field.
 		reqHints := &hintspb.SeriesRequestHints{}
@@ -614,6 +621,8 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, srv storegatewaypb.Stor
 		if err != nil {
 			return status.Error(codes.InvalidArgument, errors.Wrap(err, "translate request hints labels matchers").Error())
 		}
+		projectionInclude = reqHints.ProjectionInclude
+		projectionLabels = reqHints.ProjectionLabels
 	}
 
 	logSeriesRequestToSpan(spanLogger, req.MinTime, req.MaxTime, matchers, reqBlockMatchers, shardSelector, req.StreamingChunksBatchSize)
@@ -663,7 +672,7 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, srv storegatewaypb.Stor
 		return err
 	}
 
-	streamingSeriesCount, err = s.sendStreamingSeriesLabelsAndStats(req, srv, stats, seriesSet)
+	streamingSeriesCount, err = s.sendStreamingSeriesLabelsAndStats(ctx, req, srv, projectionInclude, projectionLabels, stats, seriesSet)
 	if err != nil {
 		return err
 	}
@@ -762,11 +771,16 @@ func (s *BucketStore) limitConcurrentQueries(ctx context.Context, stats *safeQue
 // Since hints and stats need to be sent before the "end of stream" streaming series message,
 // this function also sends the hints and the stats.
 func (s *BucketStore) sendStreamingSeriesLabelsAndStats(
+	ctx context.Context,
 	req *storepb.SeriesRequest,
 	srv storegatewaypb.StoreGateway_SeriesServer,
+	projectionInclude bool,
+	projectionLabels []string,
 	stats *safeQueryStats,
 	seriesSet storepb.SeriesSet,
 ) (numSeries int, err error) {
+	spanlog := spanlogger.FromContext(ctx, s.logger)
+
 	var (
 		encodeDuration = time.Duration(0)
 		sendDuration   = time.Duration(0)
@@ -775,6 +789,22 @@ func (s *BucketStore) sendStreamingSeriesLabelsAndStats(
 		stats.streamingSeriesEncodeResponseDuration += encodeDuration
 		stats.streamingSeriesSendResponseDuration += sendDuration
 	})
+
+	var (
+		projections *series.ProjectionLabels
+
+		// We keep track of the number of bytes used for the original labels
+		// and the number of bytes saved if we applied the projection optimization.
+		// This allows us to quantify the value of the optimization.
+		originalLabelBytes  uint64
+		reducedLabelBytes   uint64
+		increasedLabelBytes uint64
+	)
+
+	if projectionInclude {
+		spanlog.DebugLog("msg", "applying projections to return subset of series labels", "labels", projectionLabels)
+		projections = series.NewProjectionLabels(projectionLabels)
+	}
 
 	seriesBuffer := make([]*storepb.StreamingSeries, req.StreamingChunksBatchSize)
 	for i := range seriesBuffer {
@@ -790,6 +820,20 @@ func (s *BucketStore) sendStreamingSeriesLabelsAndStats(
 		// Although subsequent call to seriesSet.Next() may release the memory of this series object,
 		// it is safe to hold onto the labels because they are not released.
 		lset, _ = seriesSet.At()
+		if projectionInclude {
+			lblsSize := lset.ByteSize()
+			originalLabelBytes += lblsSize
+
+			reduced := projections.Reduce(lset)
+			// Estimate the size of the series hash label and value since we aren't generating
+			// series hash on ingest currently.
+			reducedSize := reduced.ByteSize() + uint64(len(series.HashLabelName)) + 42 /* 256-bit hash as base64 */
+			if reducedSize < lblsSize {
+				reducedLabelBytes += lblsSize - reducedSize
+			} else {
+				increasedLabelBytes += reducedSize - lblsSize
+			}
+		}
 
 		// We are re-using the slice for every batch this way.
 		seriesBatch.Series = seriesBatch.Series[:len(seriesBatch.Series)+1]
@@ -803,6 +847,11 @@ func (s *BucketStore) sendStreamingSeriesLabelsAndStats(
 			seriesBatch.Series = seriesBatch.Series[:0]
 		}
 	}
+
+	s.metrics.originalLabelBytes.Add(float64(originalLabelBytes))
+	s.metrics.reducedLabelBytes.Add(float64(reducedLabelBytes))
+	s.metrics.increasedLabelBytes.Add(float64(increasedLabelBytes))
+
 	if seriesSet.Err() != nil {
 		return 0, errors.Wrap(seriesSet.Err(), "expand series set")
 	}

--- a/pkg/storegateway/bucket_store_metrics.go
+++ b/pkg/storegateway/bucket_store_metrics.go
@@ -56,6 +56,11 @@ type BucketStoreMetrics struct {
 	postingsFetchDuration prometheus.Histogram
 
 	indexHeaderReaderMetrics *indexheader.ReaderPoolMetrics
+
+	// Quantify how much the projections optimization helps reduce labels sent to queriers.
+	originalLabelBytes  prometheus.Counter
+	reducedLabelBytes   prometheus.Counter
+	increasedLabelBytes prometheus.Counter
 }
 
 func NewBucketStoreMetrics(reg prometheus.Registerer) *BucketStoreMetrics {
@@ -199,6 +204,18 @@ func NewBucketStoreMetrics(reg prometheus.Registerer) *BucketStoreMetrics {
 		Name:    "cortex_bucket_store_series_batch_preloading_wait_duration_seconds",
 		Help:    "Time spent by store-gateway waiting until the next batch is loaded, once the store-gateway is ready to send it. This metric is tracked only if the request is split into 2+ batches.",
 		Buckets: durationBuckets,
+	})
+	m.originalLabelBytes = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name: "cortex_bucket_store_projection_original_label_bytes_total",
+		Help: "Total number of bytes of labels transferred to queriers.",
+	})
+	m.reducedLabelBytes = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name: "cortex_bucket_store_projection_reduced_label_bytes_total",
+		Help: "Total number of bytes of labels saved using projections.",
+	})
+	m.increasedLabelBytes = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name: "cortex_bucket_store_projection_increased_label_bytes_total",
+		Help: "Total number of bytes of labels increased using projections.",
 	})
 
 	return &m


### PR DESCRIPTION
#### What this PR does

Introduce the logic for dropping labels from series that aren't required for a query in store-gateways and use it to estimate the impact of dropping the labels.

#### Which issue(s) this PR fixes or relates to

Follow up to #14720

Part of #13863

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the hot `StoreGateway.Series` streaming path and adds per-series label size calculations, which could impact query performance, but behavior is gated behind request projection hints and doesn’t change returned data.
> 
> **Overview**
> Adds support in `store-gateway` `Series` streaming to read projection hints (`ProjectionInclude`/`ProjectionLabels`) from request hints, compute an estimated label-size reduction using `series.NewProjectionLabels(...).Reduce(...)`, and emit new counters for original/saved/increased label bytes.
> 
> Introduces three new Prometheus metrics (`cortex_bucket_store_projection_*_label_bytes_total`) to quantify projection effectiveness, and updates the changelog entry to include the new PR reference (#14751).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c82462ea0b43e94a4548794ffefee7ba2505fef9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->