### PR TITLE
Upgrade dskit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/golang/snappy v1.0.0
 	github.com/google/gopacket v1.1.19
 	github.com/gorilla/mux v1.8.1
-	github.com/grafana/dskit v0.0.0-20260318051422-6eb5ee5d450a
+	github.com/grafana/dskit v0.0.0-20260319050051-803e3aef21e3
 	github.com/grafana/e2e v0.1.2-0.20260309174126-b5393d4e610f
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/influxdata/influxdb/v2 v2.8.0

--- a/go.sum
+++ b/go.sum
@@ -595,8 +595,8 @@ github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc h1:PXZQA2WCxe85T
 github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc/go.mod h1:AHHlOEv1+GGQ3ktHMlhuTUwo3zljV3QJbC0+8o2kn+4=
 github.com/grafana/alerting v0.0.0-20260227181651-5106b6285f2d h1:QBq2fe3LX/7IyHL8s7NQuCUL5+xhS3IeRACi7AIHtjE=
 github.com/grafana/alerting v0.0.0-20260227181651-5106b6285f2d/go.mod h1:06F4s5KJ6LpL7od+rcusjKnsst+vRhdFqev9GdVNz4c=
-github.com/grafana/dskit v0.0.0-20260318051422-6eb5ee5d450a h1:Z82mwY9B33MolHKO2M47y24wOBvRXz6XRV3fhhISuXs=
-github.com/grafana/dskit v0.0.0-20260318051422-6eb5ee5d450a/go.mod h1:Lown5uc/WTIpY4y+O5B3RxVQd7qJ3PLEoEvaAZ/U7cQ=
+github.com/grafana/dskit v0.0.0-20260319050051-803e3aef21e3 h1:lsKNWLfvr9QXUTafFmUYB/sv268WNlr8ULqDgKdYyTM=
+github.com/grafana/dskit v0.0.0-20260319050051-803e3aef21e3/go.mod h1:Lown5uc/WTIpY4y+O5B3RxVQd7qJ3PLEoEvaAZ/U7cQ=
 github.com/grafana/e2e v0.1.2-0.20260309174126-b5393d4e610f h1:gxaqz5StufMU078tWFuf8CUi4PZtITBxjM2TZV7NOFw=
 github.com/grafana/e2e v0.1.2-0.20260309174126-b5393d4e610f/go.mod h1:KFvJP5m5GQ837CN7rUbWIiPdw1JZgeRJTEyp2O5U0is=
 github.com/grafana/go-yaml/v3 v3.0.0-20260130164322-e3c24e8f4c87 h1:Op5/Kd8Ae90IC7Ow+CNwGo/oq87cJX2iE+U8Dw4a8Bc=

--- a/vendor/github.com/grafana/dskit/cache/memcached_client.go
+++ b/vendor/github.com/grafana/dskit/cache/memcached_client.go
@@ -304,9 +304,7 @@ func (c *MemcachedClient) SetMultiAsync(data map[string][]byte, ttl time.Duratio
 }
 
 func (c *MemcachedClient) SetAsync(key string, value []byte, ttl time.Duration) {
-	if c.config.MaxItemSize > 0 && len(value) > c.config.MaxItemSize {
-		c.metrics.skipped.WithLabelValues(opSet, reasonMaxItemSize).Inc()
-		level.Debug(c.logger).Log("msg", "failed to store item to cache because it is too large", "key", key, "size", len(value), "max_item_size", c.config.MaxItemSize)
+	if !c.itemSizeIsAcceptable(key, value, opSet) {
 		return
 	}
 
@@ -323,6 +321,17 @@ func (c *MemcachedClient) SetAsync(key string, value []byte, ttl time.Duration) 
 		c.metrics.skipped.WithLabelValues(opSet, reasonAsyncBufferFull).Inc()
 		level.Debug(c.logger).Log("msg", "failed to store item to cache because the async buffer is full", "key", key, "err", err, "buffer_size", c.config.MaxAsyncBufferSize)
 	}
+}
+
+func (c *MemcachedClient) itemSizeIsAcceptable(key string, value []byte, op string) bool {
+	if c.config.MaxItemSize > 0 && len(value) > c.config.MaxItemSize {
+		c.metrics.skipped.WithLabelValues(op, reasonMaxItemSize).Inc()
+		c.metrics.skippedDataSize.WithLabelValues(op).Observe(float64(len(value)))
+		level.Debug(c.logger).Log("msg", "failed to store item to cache because it is too large", "key", key, "size", len(value), "max_item_size", c.config.MaxItemSize, "op", op)
+		return false
+	}
+
+	return true
 }
 
 func (c *MemcachedClient) Set(ctx context.Context, key string, value []byte, ttl time.Duration) error {
@@ -574,8 +583,7 @@ func (c *MemcachedClient) FlushAll(ctx context.Context) error {
 }
 
 func (c *MemcachedClient) storeOperation(ctx context.Context, key string, value []byte, ttl time.Duration, operation string, f func(ctx context.Context, key string, value []byte, ttl time.Duration) error) error {
-	if c.config.MaxItemSize > 0 && len(value) > c.config.MaxItemSize {
-		c.metrics.skipped.WithLabelValues(operation, reasonMaxItemSize).Inc()
+	if !c.itemSizeIsAcceptable(key, value, operation) {
 		return nil
 	}
 

--- a/vendor/github.com/grafana/dskit/cache/memcached_client_metrics.go
+++ b/vendor/github.com/grafana/dskit/cache/memcached_client_metrics.go
@@ -39,13 +39,14 @@ const (
 )
 
 type clientMetrics struct {
-	requests   prometheus.Counter
-	hits       prometheus.Counter
-	operations *prometheus.CounterVec
-	failures   *prometheus.CounterVec
-	skipped    *prometheus.CounterVec
-	duration   *prometheus.HistogramVec
-	dataSize   *prometheus.HistogramVec
+	requests        prometheus.Counter
+	hits            prometheus.Counter
+	operations      *prometheus.CounterVec
+	failures        *prometheus.CounterVec
+	skipped         *prometheus.CounterVec
+	duration        *prometheus.HistogramVec
+	dataSize        *prometheus.HistogramVec
+	skippedDataSize *prometheus.HistogramVec
 }
 
 // newClientMetrics creates a new bundle of metrics about an instance of a cache client. Note
@@ -127,6 +128,7 @@ func newClientMetrics(reg prometheus.Registerer) *clientMetrics {
 		Buckets: []float64{
 			32, 256, 512, 1024, 32 * 1024, 256 * 1024, 512 * 1024, 1024 * 1024, 32 * 1024 * 1024, 256 * 1024 * 1024, 512 * 1024 * 1024,
 		},
+		NativeHistogramBucketFactor: 1.1,
 	},
 		[]string{"operation"},
 	)
@@ -134,6 +136,20 @@ func newClientMetrics(reg prometheus.Registerer) *clientMetrics {
 	cm.dataSize.WithLabelValues(opAdd)
 	cm.dataSize.WithLabelValues(opSet)
 	cm.dataSize.WithLabelValues(opCompareAndSwap)
+
+	cm.skippedDataSize = promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+		Name: "operation_skipped_data_size_bytes",
+		Help: "Tracks the size of data not stored in the cache because it exceeds the maximum size limit.",
+		Buckets: []float64{
+			32, 256, 512, 1024, 32 * 1024, 256 * 1024, 512 * 1024, 1024 * 1024, 32 * 1024 * 1024, 256 * 1024 * 1024, 512 * 1024 * 1024,
+		},
+		NativeHistogramBucketFactor: 1.1,
+	},
+		[]string{"operation"},
+	)
+	cm.skippedDataSize.WithLabelValues(opAdd)
+	cm.skippedDataSize.WithLabelValues(opSet)
+	cm.skippedDataSize.WithLabelValues(opCompareAndSwap)
 
 	return cm
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -803,7 +803,7 @@ github.com/grafana/alerting/templates/email
 github.com/grafana/alerting/templates/gomplate
 github.com/grafana/alerting/templates/mimir
 github.com/grafana/alerting/utils
-# github.com/grafana/dskit v0.0.0-20260318051422-6eb5ee5d450a
+# github.com/grafana/dskit v0.0.0-20260319050051-803e3aef21e3
 ## explicit; go 1.25.7
 github.com/grafana/dskit/backoff
 github.com/grafana/dskit/ballast


### PR DESCRIPTION
#### What this PR does

This PR upgrades dskit to bring in https://github.com/grafana/dskit/pull/937.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency bump; behavior for oversized cache items remains the same but adds extra metrics/log labels, which could slightly affect observability or metric cardinality.
> 
> **Overview**
> Upgrades `github.com/grafana/dskit` to a newer commit and refreshes vendored code.
> 
> The vendored memcached client now centralizes max-item-size checks via `itemSizeIsAcceptable()` and records a new histogram (`operation_skipped_data_size_bytes`) for payloads skipped due to size limits, also tagging debug logs with the operation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 262c6c037d7e90c2055f4cd86e6cbde06194c66d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->