### PR TITLE
chore: remove downsample argument when creating block meta

### DIFF
--- a/pkg/compactor/bucket_compactor.go
+++ b/pkg/compactor/bucket_compactor.go
@@ -430,7 +430,7 @@ func (c *BucketCompactor) runCompactionJob(ctx context.Context, job *Job) (shoul
 			Downsample:   block.ThanosDownsample{Resolution: job.Resolution()},
 			Source:       block.CompactorSource,
 			SegmentFiles: block.GetSegmentFiles(bdir),
-		}, nil)
+		})
 
 		if err != nil {
 			return fmt.Errorf("failed to finalize the block %s: %w", bdir, err)

--- a/pkg/compactor/bucket_compactor_e2e_test.go
+++ b/pkg/compactor/bucket_compactor_e2e_test.go
@@ -696,7 +696,7 @@ func createEmptyBlock(dir string, mint, maxt int64, extLset labels.Labels, resol
 		Labels:     extLset.Map(),
 		Downsample: block.ThanosDownsample{Resolution: resolution},
 		Source:     block.TestSource,
-	}, nil); err != nil {
+	}); err != nil {
 		return ulid.ULID{}, fmt.Errorf("finalize block: %w", err)
 	}
 
@@ -809,7 +809,7 @@ func createBlockWithOptions(
 		Downsample: block.ThanosDownsample{Resolution: resolution},
 		Source:     block.TestSource,
 		Files:      []block.File{},
-	}, nil); err != nil {
+	}); err != nil {
 		return id, fmt.Errorf("finalize block: %w", err)
 	}
 

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -1635,7 +1635,7 @@ func createCustomTSDBBlock(t *testing.T, bkt objstore.Bucket, userID string, ext
 		Labels: externalLabels,
 		Source: "test",
 	}
-	_, err = block.InjectThanosMeta(log.NewNopLogger(), filepath.Join(snapshotDir, blockID.String()), meta, nil)
+	_, err = block.InjectThanosMeta(log.NewNopLogger(), filepath.Join(snapshotDir, blockID.String()), meta)
 	require.NoError(t, err)
 
 	// Copy the block files to the bucket.

--- a/pkg/storage/fixtures/fixtures.go
+++ b/pkg/storage/fixtures/fixtures.go
@@ -168,7 +168,7 @@ func SetupTestBlock(tb testing.TB, appendFuncs ...AppendFunc) *BucketTestBlock {
 	meta, err := block.InjectThanosMeta(log.NewNopLogger(), compactedBlockDir, block.ThanosMeta{
 		Labels: labels.FromStrings("ext1", "1").Map(),
 		Source: block.TestSource,
-	}, nil)
+	})
 	assert.NoError(tb, err)
 	_, err = block.Upload(context.Background(), log.NewNopLogger(), instrBkt, compactedBlockDir, nil)
 	assert.NoError(tb, err)

--- a/pkg/storage/indexheader/header_test.go
+++ b/pkg/storage/indexheader/header_test.go
@@ -406,7 +406,7 @@ func prepareIndexV2Block(t testing.TB, tmpDir string, bkt objstore.Bucket) *bloc
 	_, err = block.InjectThanosMeta(log.NewNopLogger(), filepath.Join(tmpDir, m.ULID.String()), block.ThanosMeta{
 		Labels: labels.FromStrings("ext1", "1").Map(),
 		Source: block.TestSource,
-	}, &m.BlockMeta)
+	})
 	require.NoError(t, err)
 	_, err = block.Upload(context.Background(), log.NewNopLogger(), bkt, filepath.Join(tmpDir, m.ULID.String()), nil)
 	require.NoError(t, err)

--- a/pkg/storage/tsdb/block/block_generator.go
+++ b/pkg/storage/tsdb/block/block_generator.go
@@ -295,7 +295,7 @@ func CreateBlock(
 		Labels: extLset.Map(),
 		Source: TestSource,
 		Files:  []File{},
-	}, nil); err != nil {
+	}); err != nil {
 		return id, errors.Wrap(err, "finalize block")
 	}
 

--- a/pkg/storage/tsdb/block/meta.go
+++ b/pkg/storage/tsdb/block/meta.go
@@ -151,17 +151,12 @@ type ThanosDownsample struct {
 
 // InjectThanosMeta sets Thanos meta to the block meta JSON and saves it to the disk.
 // NOTE: It should be used after writing any block by any Thanos component, otherwise we will miss crucial metadata.
-func InjectThanosMeta(logger log.Logger, bdir string, meta ThanosMeta, downsampledMeta *tsdb.BlockMeta) (*Meta, error) {
+func InjectThanosMeta(logger log.Logger, bdir string, meta ThanosMeta) (*Meta, error) {
 	newMeta, err := ReadMetaFromDir(bdir)
 	if err != nil {
 		return nil, errors.Wrap(err, "read new meta")
 	}
 	newMeta.Thanos = meta
-
-	// While downsampling we need to copy original compaction.
-	if downsampledMeta != nil {
-		newMeta.Compaction = downsampledMeta.Compaction
-	}
 
 	if err := newMeta.WriteToDir(logger, bdir); err != nil {
 		return nil, errors.Wrap(err, "write new meta")

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -1124,7 +1124,7 @@ func uploadTestBlock(t testing.TB, tmpDir string, bkt objstore.Bucket, dataSetup
 	_, err = block.InjectThanosMeta(log.NewNopLogger(), filepath.Join(tmpDir, "tmp", id.String()), block.ThanosMeta{
 		Labels: labels.FromStrings("ext1", "1").Map(),
 		Source: block.TestSource,
-	}, nil)
+	})
 	assert.NoError(t, err)
 	_, err = block.Upload(context.Background(), logger, bkt, filepath.Join(tmpDir, "tmp", id.String()), nil)
 	assert.NoError(t, err)
@@ -1349,7 +1349,7 @@ func benchBucketSeries(t test.TB, skipChunk bool, samplesPerSeries, totalSeries 
 		series = append(series, bSeries...)
 		expectedQueriesBlocks = append(expectedQueriesBlocks, hintspb.Block{Id: id.String()})
 
-		meta, err := block.InjectThanosMeta(logger, filepath.Join(blockDir, id.String()), thanosMeta, nil)
+		meta, err := block.InjectThanosMeta(logger, filepath.Join(blockDir, id.String()), thanosMeta)
 		assert.NoError(t, err)
 
 		assert.NoError(t, meta.WriteToDir(logger, filepath.Join(blockDir, id.String())))
@@ -1716,7 +1716,7 @@ func TestBucketStore_Series_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 		blockDir := filepath.Join(tmpDir, "tmp")
 		id := createBlockFromHead(t, blockDir, h)
 
-		meta, err := block.InjectThanosMeta(log.NewNopLogger(), filepath.Join(blockDir, id.String()), thanosMeta, nil)
+		meta, err := block.InjectThanosMeta(log.NewNopLogger(), filepath.Join(blockDir, id.String()), thanosMeta)
 		assert.NoError(t, err)
 		_, err = block.Upload(context.Background(), logger, bkt, filepath.Join(blockDir, id.String()), nil)
 		assert.NoError(t, err)
@@ -1755,7 +1755,7 @@ func TestBucketStore_Series_OneBlock_InMemIndexCacheSegfault(t *testing.T) {
 		blockDir := filepath.Join(tmpDir, "tmp2")
 		id := createBlockFromHead(t, blockDir, h)
 
-		meta, err := block.InjectThanosMeta(log.NewNopLogger(), filepath.Join(blockDir, id.String()), thanosMeta, nil)
+		meta, err := block.InjectThanosMeta(log.NewNopLogger(), filepath.Join(blockDir, id.String()), thanosMeta)
 		assert.NoError(t, err)
 		_, err = block.Upload(context.Background(), logger, bkt, filepath.Join(blockDir, id.String()), nil)
 		assert.NoError(t, err)
@@ -2251,7 +2251,7 @@ func testBucketStoreSeriesBlockWithMultipleChunks(
 		Source: block.TestSource,
 	}
 
-	_, err = block.InjectThanosMeta(log.NewNopLogger(), filepath.Join(headOpts.ChunkDirRoot, blk.String()), thanosMeta, nil)
+	_, err = block.InjectThanosMeta(log.NewNopLogger(), filepath.Join(headOpts.ChunkDirRoot, blk.String()), thanosMeta)
 	assert.NoError(t, err)
 
 	// Create a bucket and upload the block there.
@@ -2542,7 +2542,7 @@ func setupStoreForHintsTest(t *testing.T, maxSeriesPerBatch int, opts ...BucketS
 	assert.NoError(t, head2.Close())
 
 	for _, blockID := range []ulid.ULID{block1, block2} {
-		_, err := block.InjectThanosMeta(logger, filepath.Join(bktDir, blockID.String()), thanosMeta, nil)
+		_, err := block.InjectThanosMeta(logger, filepath.Join(bktDir, blockID.String()), thanosMeta)
 		assert.NoError(t, err)
 	}
 

--- a/pkg/storegateway/gateway_test.go
+++ b/pkg/storegateway/gateway_test.go
@@ -1041,7 +1041,7 @@ func TestStoreGateway_SeriesQueryingShouldRemoveExternalLabels(t *testing.T) {
 			Source: block.TestSource,
 		}
 
-		_, err := block.InjectThanosMeta(logger, filepath.Join(storageDir, userID, blockID), meta, nil)
+		_, err := block.InjectThanosMeta(logger, filepath.Join(storageDir, userID, blockID), meta)
 		require.NoError(t, err)
 	}
 


### PR DESCRIPTION
#### What this PR does

Removes a parameter used when injecting Thanos metadata into regular block metadata since we don't use downsampling.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk API cleanup: removes an unused parameter and updates call sites, with minimal behavior change aside from no longer copying compaction metadata from an optional input meta.
> 
> **Overview**
> Simplifies block meta writing by removing the `downsampledMeta *tsdb.BlockMeta` parameter from `block.InjectThanosMeta` and dropping the conditional logic that copied `Compaction` from that meta.
> 
> Updates the compactor and multiple test/fixture helpers to call the new 3-argument `InjectThanosMeta` signature when finalizing blocks (including compaction upload paths and block generators).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d7d75cd6632d7d7fff1383b3b2eda7b21b7ed28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->