### PR TITLE
Remove @tacole02 from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,6 +8,7 @@
 /.github/workflows/publish-technical-documentation-release-mimir.yml        @grafana/docs-tooling @grafana/mimir-maintainers
 /.github/workflows/update-make-docs.yml                                     @grafana/docs-tooling @grafana/mimir-maintainers
 
+/docs/                                                                      @grafana/docs-metrics @grafana/mimir-maintainers
 /docs/docs.mk                                                               @grafana/docs-tooling @grafana/mimir-maintainers
 /docs/internal/                                                             @grafana/mimir-maintainers
 /docs/make-docs                                                             @grafana/docs-tooling @grafana/mimir-maintainers


### PR DESCRIPTION
Removes @tacole02 from CODEOWNERS as her focus is elsewhere, and modifying to use the @grafana/docs-metrics team instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only adjusts repository ownership metadata and does not affect runtime code or build behavior.
> 
> **Overview**
> Updates `CODEOWNERS` so that `/docs/` changes are owned by `@grafana/docs-metrics` instead of `@tacole02` (while keeping `@grafana/mimir-maintainers` as co-owner).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1fe03dfdfb346dfbde339868786653471cc3b060. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->