### PR TITLE
compactor: conditionally register standalone-only metrics

### DIFF
--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -371,7 +371,7 @@ func newMultitenantCompactor(
 ) (*MultitenantCompactor, error) {
 	var (
 		mode string
-		// dedicated registerers for mode-specific metrics
+		// used to register metrics conditionally for each mode
 		standaloneReg prometheus.Registerer
 		schedulerReg  prometheus.Registerer
 	)


### PR DESCRIPTION
Part of https://github.com/grafana/mimir/issues/13943

Metrics that refer to "runs" don't apply to compactors running on "scheduler" mode. They don't have periodic runs, they poll the scheduler for work.

This is no-op for the default mode.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk functional change; it only affects which Prometheus metrics are registered, but could impact existing dashboards/alerts that expect run-related metrics in scheduler mode.
> 
> **Overview**
> Updates the compactor’s metric registration so **run-cycle metrics** (eg. `cortex_compactor_runs_*`, per-run tenant gauges, and `cortex_compactor_compaction_interval_seconds`) are only registered in *standalone* mode, avoiding misleading/unused metrics when running in *scheduler* mode.
> 
> Mode detection is moved earlier in `newMultitenantCompactor`, and scheduler-only metrics continue to be conditionally registered via a dedicated registerer while `cortex_compactor_info{mode=...}` still exposes the selected mode.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da84c986d519d4a730b8125468eb37c264f78df6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->