### PR TITLE
Update smoothed range selector to require at least 1 sample within th…

### DIFF
--- a/pkg/streamingpromql/operators/selectors/range_vector_selector.go
+++ b/pkg/streamingpromql/operators/selectors/range_vector_selector.go
@@ -164,16 +164,22 @@ func (m *RangeVectorSelector) NextStepSamples(ctx context.Context) (*types.Range
 			return nil, errors.New("smoothed and anchored modifiers do not work with native histograms")
 		}
 
-		// Mutate the floats buffer to align and extend points to the original time boundaries.
-		// The result is either an empty buffer or one containing only points within the
-		// original time range, with points present at both boundaries.
-		err = m.extendedPointsState.ApplyBoundaryMutations(originalRangeStart, originalRangeEnd, rangeEnd)
-		if err != nil {
-			return nil, err
+		if m.floats.Count() > 0 && m.floats.PointAt(0).T > originalRangeEnd {
+			// This will be an empty set
+			m.stepData.Floats = m.floats.ViewUntilSearchingBackwards(originalRangeEnd, m.stepData.Floats)
+		} else {
+			// Mutate the floats buffer to align and extend points to the original time boundaries.
+			// The result is either an empty buffer or one containing only points within the
+			// original time range, with points present at both boundaries.
+			err = m.extendedPointsState.ApplyBoundaryMutations(originalRangeStart, originalRangeEnd, rangeEnd)
+			if err != nil {
+				return nil, err
+			}
+
+			// A ViewAll can be used since we know that this buffer only contains points within the requested range.
+			m.stepData.Floats = m.floats.ViewAll(m.stepData.Floats)
 		}
 
-		// A ViewAll can be used since we know that this buffer only contains points within the requested range.
-		m.stepData.Floats = m.floats.ViewAll(m.stepData.Floats)
 	} else {
 		m.stepData.Floats = m.floats.ViewUntilSearchingBackwards(rangeEnd, m.stepData.Floats)
 	}


### PR DESCRIPTION
#### What this PR does

This PR aligns the extentended `smoothed` range selector functionality with upstream prometheus.

A smoothed value is only calculated if there is at least 1 sample within the original (non extended) range.

Previously, if there was only values after the original range and before the extended window these would be used in the smoothing calculation. This is inconsistent with the inverse scenario where there are only points before the original range start (and within the lookback delta) which would return no results. 

See https://github.com/prometheus/prometheus/pull/18295

Once the above Prometheus PR is merged and mimir-prometheus vendored, this branch should be re-based and this update should fix what will be a failing upstream unit test. 

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
