### PR TITLE
Mixin: Add usage-tracker snapshot upload/download alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -266,6 +266,7 @@
 * [ENHANCEMENT] Dashboards: Add panels showing the distribution of estimated query memory consumption and rate of fallback to Prometheus' query engine in query-frontends to the Queries dashboard. #14029
 * [ENHANCEMENT] Dashboards: Add "Forced TSDB head compactions in progress" panel to "Mimir / Writes" dashboard. #14248
 * [ENHANCEMENT] Dashboards: Improve "Last successful run per-compactor replica" table in the compactor dashboard to show time since process start for compactors that haven't completed their first run yet. #14285
+* [ENHANCEMENT] Alerts: Add `MimirUsageTrackerSnapshotUploadFailing` and `MimirUsageTrackerSnapshotDownloadFailing` alerts to detect usage-tracker snapshot upload/download failures. #14778
 * [ENHANCEMENT] Alerts: Add dashboard_url annotations to Prometheus alerts. #14458
 * [ENHANCEMENT] Dashboards: Change the "Rules" panel in the "Mimir / Reads resources" dashboard to use a stacked visualization. #14707
 * [ENHANCEMENT] Dashboards: Split the "All series" panel in the Tenants dashboard into "Active series" and "Owned & in-memory series" panels, and added the active series limit. #14648

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -2288,6 +2288,41 @@ This shouldn't happen in normal circumstances and is most likely indicative of a
 - Immediately scale out ingesters to the number of active partitions to consume the data.
 - Check that the ingester shutdowns are working as expected. When ingesters are downscaled, they should set their partition as INACTIVE before shutting down. Ingesters are most likely the cause of this issue.
 
+### MimirUsageTrackerSnapshotUploadFailing
+
+This alert fires when the usage-tracker is failing to upload snapshots to object storage for more than 15 minutes.
+
+How it **works**:
+
+- The usage-tracker periodically uploads snapshots of tracked usage data to object storage.
+- When snapshot uploads fail, the metric `cortex_usage_tracker_snapshot_events_publish_failures_total` is incremented.
+- If the failure rate is greater than 0 for 15 minutes, this alert fires.
+
+How to **investigate**:
+
+- Check the usage-tracker logs for `"failed to publish snapshot"` error messages.
+- Verify that the configured object storage bucket exists and is accessible.
+- Verify that the credentials used by the usage-tracker have write permissions to the bucket.
+- Check for network issues between the usage-tracker and the object storage backend.
+
+### MimirUsageTrackerSnapshotDownloadFailing
+
+This alert fires when the usage-tracker is failing to download snapshots from object storage for more than 15 minutes.
+
+How it **works**:
+
+- The usage-tracker downloads snapshots from object storage to restore previously tracked usage data.
+- When snapshot downloads fail, the metric `cortex_usage_tracker_snapshot_events_errors_total{error="download"}` is incremented.
+- If the failure rate is greater than 0 for 15 minutes, this alert fires.
+
+How to **investigate**:
+
+- Check the usage-tracker logs for `"failed to load snapshot file"` error messages.
+- Verify that the configured object storage bucket exists and is accessible.
+- Verify that the credentials used by the usage-tracker have read permissions to the bucket.
+- Check whether the expected snapshot files exist in the bucket — they may have been deleted or never uploaded.
+- Check for network issues between the usage-tracker and the object storage backend.
+
 ## Errors catalog
 
 Mimir has some codified error IDs that you might see in HTTP responses or logs.

--- a/operations/mimir-mixin/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts.libsonnet
@@ -11,5 +11,6 @@
     (if $._config.rollout_operator_alerts_enable then import 'rollout-operator-mixin/alerts/alerts.libsonnet' else {}) +
 
     (import 'alerts/continuous-test.libsonnet') +
-    (if $._config.gem_enabled then import 'alerts/gem.libsonnet' else {}),
+    (if $._config.gem_enabled then import 'alerts/gem.libsonnet' else {}) +
+    (if $._config.usage_tracker_enabled then import 'alerts/usage-tracker.libsonnet' else {}),
 }

--- a/operations/mimir-mixin/alerts/usage-tracker.libsonnet
+++ b/operations/mimir-mixin/alerts/usage-tracker.libsonnet
@@ -1,0 +1,41 @@
+(import 'alerts-utils.libsonnet') {
+  local alertGroups = [
+    {
+      name: 'mimir_usage_tracker_alerts',
+      rules: [
+        {
+          alert: $.alertName('UsageTrackerSnapshotUploadFailing'),
+          'for': '15m',
+          expr: |||
+            sum by(%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_usage_tracker_snapshot_events_publish_failures_total[5m])) > 0
+          ||| % $._config,
+          labels: {
+            severity: 'critical',
+          },
+          annotations: {
+            message: '%(product)s usage-tracker %(alert_instance_variable)s in %(alert_aggregation_variables)s is failing to upload snapshots.' % $._config,
+          },
+        },
+        {
+          alert: $.alertName('UsageTrackerSnapshotDownloadFailing'),
+          'for': '15m',
+          expr: |||
+            sum by(%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_usage_tracker_snapshot_events_errors_total{error="download"}[5m])) > 0
+          ||| % $._config,
+          labels: {
+            severity: 'critical',
+          },
+          annotations: {
+            message: '%(product)s usage-tracker %(alert_instance_variable)s in %(alert_aggregation_variables)s is failing to download snapshots from object storage.' % $._config,
+          },
+        },
+      ],
+    },
+  ],
+
+  groups+:
+    $.withRunbookURL(
+      'https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#%s',
+      $.withExtraLabelsAnnotations(alertGroups)
+    ),
+}


### PR DESCRIPTION
#### What this PR does

Adds two new mixin alerts to detect usage-tracker snapshot failures:

- **MimirUsageTrackerSnapshotUploadFailing** — fires when snapshot uploads to object storage fail for more than 15 minutes.
- **MimirUsageTrackerSnapshotDownloadFailing** — fires when snapshot downloads from object storage fail for more than 15 minutes.

Both alerts are gated behind `usage_tracker_enabled` config, consistent with existing usage-tracker dashboard support.

Without these alerts, snapshot failures are silent — the usage-tracker increments error metrics but operators have no way to be notified. This is particularly dangerous when the object storage bucket doesn't exist or is misconfigured.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new Prometheus alert rules and documentation only, gated behind `usage_tracker_enabled`, with no changes to runtime behavior beyond additional alerting output.
> 
> **Overview**
> Adds two new mixin alerts, `MimirUsageTrackerSnapshotUploadFailing` and `MimirUsageTrackerSnapshotDownloadFailing`, that fire when usage-tracker snapshot uploads or downloads from object storage fail for 15 minutes.
> 
> The alerts are included only when `usage_tracker_enabled` is set, are wired into the main `alerts.libsonnet` composition, and include runbook links plus new runbook sections describing investigation steps. A changelog entry documents the new alerts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5dad64d22b7ae2514e1a975dc3334c5d3f263719. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->