### PR TITLE
compactor: fix flaky TestMultitenantCompactor_ShouldIncrementCompactionShutdownIfTheContextIsCancelled

### DIFF
--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -530,7 +530,7 @@ func TestMultitenantCompactor_ShouldIncrementCompactionShutdownIfTheContextIsCan
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 
 	// Wait until at least one compaction run has been counted as shutdown. The variable
-	// first-tick interval introduced in the running() loop may cause a second run to
+	// first-tick interval in the running() loop may cause a second run to
 	// start before we can stop the compactor, so we check for >= 1 rather than == 1.
 	require.Eventually(t, func() bool {
 		return prom_testutil.ToFloat64(c.compactionRunsShutdown) >= 1


### PR DESCRIPTION
#### What this PR does

Fixes a flaky test in the compactor package.

Commit af0592bd8b (`Compactor: Add 0-100% jitter to the first compaction interval`) introduced a variable first-tick interval using `DurationWithNegativeJitter(CompactionInterval, 1.0)`. With `variancePerc=1.0` the result is uniformly distributed in `[2 ns, CompactionInterval+1 ns]`, so on rare occasions the ticker fires almost immediately after the initial `compactUsers()` call returns. When that happens a second compaction run can start (and possibly complete) between the test's poll returning and `StopAndAwaitTerminated` cancelling the running context — breaking the test's assumption that exactly one run occurred.

The fix makes the test resilient to this intentional production behaviour:

- Replace `test.Poll(..., 1.0)` (exact equality) with `require.Eventually(..., >= 1)` so the poll still succeeds if a second run completes before the check.
- Replace exact-value `GatherAndCompare` assertions with invariant-based checks: `runs_started >= 1`, `runs_completed == 0`, `runs_erred == 0`, and `runs_started == runs_shutdown` (every run ended as a context-cancellation shutdown, not a success or unrelated error).

The test continues to verify the core property: when the planner returns `context.Canceled`, all compaction runs are counted as shutdowns and never as completions or errors.

#### Which issue(s) this PR fixes or relates to

Fixes #14689

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to a single unit test and only relax assertions to avoid flakiness from timing/jitter, without altering production code paths.
> 
> **Overview**
> Fixes flakiness in `TestMultitenantCompactor_ShouldIncrementCompactionShutdownIfTheContextIsCancelled` by no longer assuming exactly one compaction run occurs before shutdown.
> 
> The test now waits for `compactionRunsShutdown >= 1` and asserts metric *invariants* after stop (started >= 1, completed/erred == 0, and `started == shutdown`) instead of exact `GatherAndCompare` counters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b950ede11fef0cdd61a6ffd6f844b2f1384e29ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->