### PR TITLE
Grafana Alertmanager: Remove Grafana state methods from the Multi-tenant Alertmanager

### DIFF
--- a/pkg/alertmanager/api_grafana.go
+++ b/pkg/alertmanager/api_grafana.go
@@ -37,15 +37,9 @@ const (
 	statusError   = "error"
 )
 
-var (
-	maxGrafanaConfigSizeMsgFormat = globalerror.AlertmanagerMaxGrafanaConfigSize.MessageWithPerTenantLimitConfig(
-		"Alertmanager configuration is too big, limit: %d bytes",
-		validation.AlertmanagerMaxGrafanaConfigSizeFlag,
-	)
-	maxGrafanaStateSizeMsgFormat = globalerror.AlertmanagerMaxGrafanaStateSize.MessageWithPerTenantLimitConfig(
-		"Alertmanager state is too big, limit: %d bytes",
-		validation.AlertmanagerMaxGrafanaStateSizeFlag,
-	)
+var maxGrafanaConfigSizeMsgFormat = globalerror.AlertmanagerMaxGrafanaConfigSize.MessageWithPerTenantLimitConfig(
+	"Alertmanager configuration is too big, limit: %d bytes",
+	validation.AlertmanagerMaxGrafanaConfigSizeFlag,
 )
 
 type GrafanaAlertmanagerConfig struct {


### PR DESCRIPTION
This PR removes methods related to Grafana state from the multi-tenant Alertmanager. It also removes the `UserGrafanaState` and `PostableUserGrafanaState` structs.

Part of https://github.com/grafana/mimir/pull/14725.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes the `/api/v1/grafana/state` API handlers and related types/constants, which is a backwards-incompatible surface change for any clients relying on Grafana state storage. Runtime risk is otherwise low since remaining Grafana config endpoints are untouched.
> 
> **Overview**
> Removes the multi-tenant Grafana Alertmanager *state* API surface by deleting `GetUserGrafanaState`, `SetUserGrafanaState`, and `DeleteUserGrafanaState`, along with the `UserGrafanaState` / `PostableUserGrafanaState` payload types and state-specific error/size-limit plumbing.
> 
> Cleans up `api_grafana.go` imports/constants accordingly and keeps only the Grafana *config* endpoints and validation logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d775696ef51ca7850963727f2f1336a0d1516231. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->