### PR TITLE
Grafana Alertmanager: Remove Grafana Alertmanager state methods from the store

### DIFF
--- a/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
+++ b/pkg/alertmanager/alertstore/bucketclient/bucket_client.go
@@ -46,7 +46,6 @@ const (
 	fetchConcurrency = 16
 
 	grafanaConfigName = "grafana_config"
-	grafanaStateName  = "grafana_fullstate"
 )
 
 // BucketAlertStore is used to support the AlertStore interface against an object storage backend. It is implemented
@@ -244,40 +243,6 @@ func (s *BucketAlertStore) DeleteFullState(ctx context.Context, userID string) e
 	if userBkt.IsObjNotFoundErr(err) {
 		return nil
 	}
-	return err
-}
-
-func (s *BucketAlertStore) GetFullGrafanaState(ctx context.Context, userID string) (alertspb.FullStateDesc, error) {
-	bkt := s.getGrafanaAlertmanagerUserBucket(userID)
-	fs := alertspb.FullStateDesc{}
-
-	err := s.get(ctx, bkt, grafanaStateName, &fs)
-	if s.grafanaAMBucket.IsObjNotFoundErr(err) {
-		return fs, alertspb.ErrNotFound
-	}
-
-	return fs, err
-}
-
-func (s *BucketAlertStore) SetFullGrafanaState(ctx context.Context, userID string, fs alertspb.FullStateDesc) error {
-	bkt := s.getGrafanaAlertmanagerUserBucket(userID)
-
-	fsBytes, err := fs.Marshal()
-	if err != nil {
-		return err
-	}
-
-	return bkt.Upload(ctx, grafanaStateName, bytes.NewReader(fsBytes))
-}
-
-func (s *BucketAlertStore) DeleteFullGrafanaState(ctx context.Context, userID string) error {
-	bkt := s.getGrafanaAlertmanagerUserBucket(userID)
-
-	err := bkt.Delete(ctx, grafanaStateName)
-	if bkt.IsObjNotFoundErr(err) {
-		return nil
-	}
-
 	return err
 }
 

--- a/pkg/alertmanager/alertstore/local/store.go
+++ b/pkg/alertmanager/alertstore/local/store.go
@@ -44,18 +44,6 @@ type Store struct {
 	cfg StoreConfig
 }
 
-func (f *Store) GetFullGrafanaState(_ context.Context, _ string) (alertspb.FullStateDesc, error) {
-	return alertspb.FullStateDesc{}, errGrafanaStateAndConfig
-}
-
-func (f *Store) SetFullGrafanaState(_ context.Context, _ string, _ alertspb.FullStateDesc) error {
-	return errGrafanaStateAndConfig
-}
-
-func (f *Store) DeleteFullGrafanaState(_ context.Context, _ string) error {
-	return errGrafanaStateAndConfig
-}
-
 // NewStore returns a new file alert store.
 func NewStore(cfg StoreConfig) (*Store, error) {
 	return &Store{cfg}, nil

--- a/pkg/alertmanager/alertstore/store.go
+++ b/pkg/alertmanager/alertstore/store.go
@@ -48,16 +48,6 @@ type AlertStore interface {
 	// If configuration for the user doesn't exist, no error is reported.
 	DeleteGrafanaAlertConfig(ctx context.Context, user string) error
 
-	// GetFullGrafanaState returns the Grafana Alertmanager state for a user.
-	GetFullGrafanaState(ctx context.Context, user string) (alertspb.FullStateDesc, error)
-
-	// SetFullGrafanaState stores the Grafana Alertmanager state for a user.
-	SetFullGrafanaState(ctx context.Context, user string, fs alertspb.FullStateDesc) error
-
-	// DeleteFullGrafanaState delete the Grafana Alertmanager state for a user.
-	// If state for the user doesn't exist, no error is reported.
-	DeleteFullGrafanaState(ctx context.Context, user string) error
-
 	// ListUsersWithFullState returns the list of users which have had state written.
 	ListUsersWithFullState(ctx context.Context) ([]string, error)
 

--- a/pkg/alertmanager/alertstore/store_test.go
+++ b/pkg/alertmanager/alertstore/store_test.go
@@ -314,64 +314,6 @@ func TestBucketAlertStore_GetSetDeleteFullState(t *testing.T) {
 	}
 }
 
-func TestBucketAlertStore_GetSetDeleteGrafanaState(t *testing.T) {
-	bucket := objstore.NewInMemBucket()
-	store := bucketclient.NewBucketAlertStore(bucketclient.BucketAlertStoreConfig{}, bucket, nil, log.NewNopLogger())
-
-	ctx := context.Background()
-	state1 := makeTestFullState("one")
-	state2 := makeTestFullState("two")
-
-	// The storage is empty.
-	{
-		_, err := store.GetFullGrafanaState(ctx, "user-1")
-		assert.Equal(t, alertspb.ErrNotFound, err)
-
-		_, err = store.GetFullGrafanaState(ctx, "user-2")
-		assert.Equal(t, alertspb.ErrNotFound, err)
-	}
-
-	// The storage contains users.
-	{
-		require.NoError(t, store.SetFullGrafanaState(ctx, "user-1", state1))
-		require.NoError(t, store.SetFullGrafanaState(ctx, "user-2", state2))
-
-		res, err := store.GetFullGrafanaState(ctx, "user-1")
-		require.NoError(t, err)
-		assert.Equal(t, state1, res)
-
-		res, err = store.GetFullGrafanaState(ctx, "user-2")
-		require.NoError(t, err)
-		assert.Equal(t, state2, res)
-
-		// Ensure the state is stored at the expected location. Without this check
-		// we have no guarantee that the objects are stored at the expected location.
-		exists, err := bucket.Exists(ctx, "grafana_alertmanager/user-1/grafana_fullstate")
-		require.NoError(t, err)
-		assert.True(t, exists)
-
-		exists, err = bucket.Exists(ctx, "grafana_alertmanager/user-2/grafana_fullstate")
-		require.NoError(t, err)
-		assert.True(t, exists)
-	}
-
-	// The storage has had user-1 deleted.
-	{
-		require.NoError(t, store.DeleteFullGrafanaState(ctx, "user-1"))
-
-		// Ensure the correct entry has been deleted.
-		_, err := store.GetFullGrafanaState(ctx, "user-1")
-		assert.Equal(t, alertspb.ErrNotFound, err)
-
-		res, err := store.GetFullGrafanaState(ctx, "user-2")
-		require.NoError(t, err)
-		assert.Equal(t, state2, res)
-
-		// Delete again (should be idempotent).
-		require.NoError(t, store.DeleteGrafanaAlertConfig(ctx, "user-1"))
-	}
-}
-
 func TestBucketAlertStore_GetSetDeleteGrafanaAlertConfig(t *testing.T) {
 	bucket := objstore.NewInMemBucket()
 	store := bucketclient.NewBucketAlertStore(bucketclient.BucketAlertStoreConfig{}, bucket, nil, log.NewNopLogger())


### PR DESCRIPTION
This PR removes methods related to the Grafana Alertmanager state from our store implementations.
Part of https://github.com/grafana/mimir/pull/14725.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it removes `Get/Set/DeleteFullGrafanaState` from the `AlertStore` interface and implementations, which can break downstream callers and disable Grafana Alertmanager state persistence if any code still relies on these methods.
> 
> **Overview**
> Removes support for persisting **Grafana Alertmanager full state** (notification log + silences) from the alertstore layer.
> 
> This deletes the `GetFullGrafanaState`/`SetFullGrafanaState`/`DeleteFullGrafanaState` methods from the `AlertStore` interface and drops the corresponding bucket and local-store implementations (including the `grafana_fullstate` object name), along with the associated unit test coverage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d223ea34f9aef401c5eba532f451f10b12580571. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->