### PR TITLE
release-2.17: Change test matrix to attempt to fix CI

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -151,10 +151,10 @@ jobs:
     strategy:
       # Do not abort other groups when one fails.
       fail-fast: false
-      # Split tests into 4 groups.
+      # Split tests into 10 groups.
       matrix:
-        test_group_id:    [0, 1, 2, 3]
-        test_group_total: [4]
+        test_group_id:    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        test_group_total: [10]
     needs:
       - prepare
     container:
@@ -241,10 +241,10 @@ jobs:
     strategy:
       # Do not abort other groups when one fails.
       fail-fast: false
-      # Split tests into 6 groups.
+      # Split tests into 20 groups.
       matrix:
-        test_group_id:    [0, 1, 2, 3, 4, 5]
-        test_group_total: [6]
+        test_group_id:    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
+        test_group_total: [20]
     steps:
       - name: Upgrade golang
         uses: actions/setup-go@v5


### PR DESCRIPTION
#### What this PR does

Changes the test matrix values to match was changed in https://github.com/grafana/mimir/pull/14669 without fully backporting it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts GitHub Actions matrix parameters; main impact is CI runtime/parallelism and potential changes in job scheduling/flakiness visibility.
> 
> **Overview**
> **CI test sharding is increased** in `.github/workflows/test-build-deploy.yml` to improve pipeline stability/throughput.
> 
> The `test` job matrix is expanded from **4 to 10** groups, and the `integration` job matrix from **6 to 20** groups, updating `test_group_id`/`test_group_total` accordingly while leaving the underlying test commands unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02e9f713c86269e884e7d4c291d7d9509525df5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->