### PR TITLE
release-3.0: Change test matrix to attempt to fix CI

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -149,10 +149,10 @@ jobs:
     strategy:
       # Do not abort other groups when one fails.
       fail-fast: false
-      # Split tests into 4 groups.
+      # Split tests into 10 groups.
       matrix:
-        test_group_id:    [0, 1, 2, 3]
-        test_group_total: [4]
+        test_group_id:    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        test_group_total: [10]
     needs:
       - prepare
     permissions:
@@ -351,10 +351,10 @@ jobs:
     strategy:
       # Do not abort other groups when one fails.
       fail-fast: false
-      # Split tests into 6 groups.
+      # Split tests into 20 groups.
       matrix:
-        test_group_id:    [0, 1, 2, 3, 4, 5]
-        test_group_total: [6]
+        test_group_id:    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
+        test_group_total: [20]
     steps:
       - name: Upgrade golang
         uses: actions/setup-go@v5


### PR DESCRIPTION
#### What this PR does

Changes the test matrix values to match was changed in https://github.com/grafana/mimir/pull/14669 without fully backporting it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that adjusts GitHub Actions test sharding; low product risk but may impact CI runtime/concurrency and shard balancing.
> 
> **Overview**
> Updates the CI workflow to **increase test sharding parallelism** in `test-build-deploy.yml`, changing unit tests from **4→10** matrix groups and integration tests from **6→20** groups.
> 
> This aims to reduce per-job duration and improve CI stability by spreading test load across more shards.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48b00d437fdda45263cf7781b540a54917342640. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->