### PR TITLE
Compactor scheduler: clean up leftover meta sync directories

### DIFF
--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -760,29 +760,7 @@ func (c *MultitenantCompactor) compactUsers(ctx context.Context) {
 	// Delete local files for unowned tenants, if there are any. This cleans up
 	// leftover local files for tenants that belong to different compactors now,
 	// or have been deleted completely.
-	for userID := range c.listTenantsWithMetaSyncDirectories() {
-		if _, owned := ownedUsers[userID]; owned {
-			continue
-		}
-
-		dir := c.metaSyncDirForUser(userID)
-		s, err := os.Stat(dir)
-		if err != nil {
-			if !os.IsNotExist(err) {
-				level.Warn(c.logger).Log("msg", "failed to stat local directory with user data", "dir", dir, "err", err)
-			}
-			continue
-		}
-
-		if s.IsDir() {
-			err := os.RemoveAll(dir)
-			if err == nil {
-				level.Info(c.logger).Log("msg", "deleted directory for user not owned by this shard", "dir", dir)
-			} else {
-				level.Warn(c.logger).Log("msg", "failed to delete directory for user not owned by this shard", "dir", dir, "err", err)
-			}
-		}
-	}
+	c.deleteUnownedMetaSyncDirs(ownedUsers)
 
 	succeeded = true
 }
@@ -1056,4 +1034,31 @@ func (c *MultitenantCompactor) listTenantsWithMetaSyncDirectories() map[string]s
 	}
 
 	return result
+}
+
+// deleteUnownedMetaSyncDirs deletes meta sync directories for tenants not present in ownedUsers.
+func (c *MultitenantCompactor) deleteUnownedMetaSyncDirs(ownedUsers map[string]struct{}) {
+	for userID := range c.listTenantsWithMetaSyncDirectories() {
+		if _, owned := ownedUsers[userID]; owned {
+			continue
+		}
+
+		dir := c.metaSyncDirForUser(userID)
+		s, err := os.Stat(dir)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				level.Warn(c.logger).Log("msg", "failed to stat meta sync directory", "dir", dir, "err", err)
+			}
+			continue
+		}
+
+		if s.IsDir() {
+			err := os.RemoveAll(dir)
+			if err == nil {
+				level.Info(c.logger).Log("msg", "deleted meta sync directory", "dir", dir)
+			} else {
+				level.Warn(c.logger).Log("msg", "failed to delete meta sync directory", "dir", dir, "err", err)
+			}
+		}
+	}
 }

--- a/pkg/compactor/executor.go
+++ b/pkg/compactor/executor.go
@@ -187,6 +187,11 @@ func (e *schedulerExecutor) run(ctx context.Context, c *MultitenantCompactor) er
 	workerID := fmt.Sprintf("compactor-%s", c.ringLifecycler.GetInstanceID())
 	level.Info(e.logger).Log("msg", "compactor running in scheduler mode", "scheduler_endpoint", e.cfg.SchedulerEndpoint, "worker_id", workerID)
 
+	// Scheduler mode compactors work on jobs for arbitrary tenants, so unlike standalone mode they
+	// do not cache metadata on disk. Pass nil for ownedUsers to delete any meta sync directories
+	// that may have been left over from standalone mode.
+	c.deleteUnownedMetaSyncDirs(nil)
+
 	compactDir := filepath.Join(c.compactorCfg.DataDir, "compact")
 
 	b := backoff.New(ctx, backoff.Config{


### PR DESCRIPTION
#### What this PR does

We don't cache metadata on disk in scheduler mode since compactors working with a scheduler can work on jobs from any tenant. Directories containing cached metadata weren't being cleaned up though, so it silently leaked the space. 

This adds cleaning up those directories on startup by extracting a function for it then calling it from scheduler mode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to deleting local `compactor-meta-*` cache directories, with no impact to compaction planning/execution besides disk cleanup; main risk is accidental deletion if `DataDir` is misconfigured.
> 
> **Overview**
> Ensures scheduler-mode compactors proactively clean up any leftover on-disk meta sync cache directories (e.g., from prior standalone runs) to prevent silent disk space leaks.
> 
> This extracts the standalone cleanup loop into `deleteUnownedMetaSyncDirs()` and reuses it after standalone compaction runs and once on scheduler executor startup (passing `nil` to delete all meta sync dirs), with updated, more specific log messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a279288b0bf957ff632c9c26110981575fb8f2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->