### PR TITLE
MQE: check for errors returned in `TestRangeVectorSelectors`

### DIFF
--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -734,6 +734,7 @@ func TestRangeVectorSelectors(t *testing.T) {
 				defer q.Close()
 
 				res := q.Exec(context.Background())
+				require.NoError(t, res.Err)
 
 				// Because Histograms are pointers, it is hard to use Equal for the whole result
 				// Instead, compare each point individually.


### PR DESCRIPTION
#### What this PR does

This PR adds an additional assertion to `TestRangeVectorSelectors`. It ensures that the query has not failed before attempting to access the result, which panics if the query has failed.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that adds an explicit assertion on `res.Err`, potentially surfacing previously ignored query execution failures.
> 
> **Overview**
> Tightens `TestRangeVectorSelectors` by asserting `q.Exec(...)` returns no error via `require.NoError(t, res.Err)` before comparing returned matrices.
> 
> This ensures the test fails immediately on query execution errors instead of panicking or producing misleading result comparisons.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15257f3d1eca1f0ae5a2e09fc4a33ec6bc76e0e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->