### PR TITLE
Grafana Alertmanager: Remove Grafana Alertmanager template testing

### DIFF
--- a/development/common/config/nginx.conf.template
+++ b/development/common/config/nginx.conf.template
@@ -76,9 +76,6 @@ http {
     location = /api/v1/grafana/receivers/test {
       proxy_pass      http://${ALERT_MANAGER_HOST}$request_uri;
     }
-    location = /api/v1/grafana/templates/test {
-      proxy_pass      http://${ALERT_MANAGER_HOST}$request_uri;
-    }
 
     # Ruler endpoints
     location /prometheus/config/v1/rules {

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -331,7 +331,6 @@ func New(cfg *Config, reg *prometheus.Registry) (*Alertmanager, error) {
 	// it under an additional prefix to avoid any confusion with upstream Alertmanager.
 	if cfg.GrafanaAlertmanagerCompatibility {
 		am.mux.Handle("/api/v1/grafana/receivers", http.HandlerFunc(am.GetReceiversHandler))
-		am.mux.Handle("/api/v1/grafana/templates/test", http.HandlerFunc(am.TestTemplatesHandler))
 		am.mux.Handle("/api/v1/grafana/receivers/test", http.HandlerFunc(am.TestReceiversHandler))
 	}
 
@@ -358,47 +357,6 @@ func (am *Alertmanager) GetReceiversHandler(w http.ResponseWriter, _ *http.Reque
 
 	w.Header().Set("Content-Type", "application/json")
 	if _, err := w.Write(d); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-}
-
-func (am *Alertmanager) TestTemplatesHandler(w http.ResponseWriter, r *http.Request) {
-	c := alertingNotify.TestTemplatesConfigBodyParams{}
-	if err := json.NewDecoder(r.Body).Decode(&c); err != nil {
-		http.Error(w,
-			fmt.Sprintf("error unmarshalling test templates config JSON: %s", err.Error()),
-			http.StatusBadRequest)
-		return
-	}
-
-	am.templatesMtx.RLock()
-	tmplCfg, err := alertingTemplates.NewConfig(am.cfg.UserID, am.cfg.ExternalURL.String(), version.Version, alertingTemplates.Limits{})
-	if err != nil {
-		am.templatesMtx.RUnlock()
-		http.Error(w,
-			fmt.Sprintf("error creating template config: %s", err.Error()),
-			http.StatusInternalServerError)
-		return
-	}
-	factory, err := alertingTemplates.NewFactory(am.templates, tmplCfg, am.logger)
-	am.templatesMtx.RUnlock()
-	if err != nil {
-		http.Error(w,
-			fmt.Sprintf("error initializing configured templates: %s", err.Error()),
-			http.StatusInternalServerError)
-		return
-	}
-	response, err := alertingNotify.TestTemplate(r.Context(), c, factory, am.logger)
-	if err != nil {
-		http.Error(w,
-			fmt.Sprintf("error testing templates: %s", err.Error()),
-			http.StatusInternalServerError)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(response); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/pkg/alertmanager/distributor.go
+++ b/pkg/alertmanager/distributor.go
@@ -77,9 +77,6 @@ func (d *Distributor) isUnaryWritePath(p string) bool {
 	if strings.HasSuffix(p, "/silences") {
 		return true
 	}
-	if strings.HasSuffix(p, "/api/v1/grafana/templates/test") {
-		return true
-	}
 	if strings.HasSuffix(p, "/api/v1/grafana/receivers/test") {
 		return true
 	}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -237,7 +237,6 @@ func (a *API) RegisterAlertmanager(am *alertmanager.MultitenantAlertmanager, api
 			// These APIs are handled by the per-tenant Alertmanager, so they are handled by the distributor.
 			a.RegisterRoute("/api/v1/grafana/receivers", am, true, true, http.MethodGet)
 			a.RegisterRoute("/api/v1/grafana/receivers/test", am, true, true, http.MethodPost)
-			a.RegisterRoute("/api/v1/grafana/templates/test", am, true, true, http.MethodPost)
 		}
 	}
 }


### PR DESCRIPTION
This PR removes logic for testing Grafana templates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this removes an experimental Grafana-compatibility endpoint and related routing, with no changes to core alert processing or state handling.
> 
> **Overview**
> Removes the experimental Grafana Alertmanager template-testing API (`POST /api/v1/grafana/templates/test`) end-to-end.
> 
> This deletes the `TestTemplatesHandler` implementation, unregisters the route from the API and per-tenant Alertmanager mux, removes distributor special-casing for unary writes, and drops the corresponding NGINX proxy location.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a2d2c05f1eefc879732a0990fc83826247ee96e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->