### PR TITLE
Fix make-docs to work when checkout isn't named "mimir"

### DIFF
--- a/docs/variables.mk
+++ b/docs/variables.mk
@@ -8,7 +8,7 @@ MIMIR_DOCS_BRANCH := $(patsubst v%.x,release-%,$(MIMIR_DOCS_VERSION))
 endif
 
 # Repo name is the basename of the git root, which may be a worktree with an arbitrary name.
-MIMIR_REPO_NAME := $(shell basename $(GIT_ROOT))
+MIMIR_REPO_NAME := $(notdir $(basename $(GIT_ROOT)))
 
 # List of projects to provide to the make-docs script.
 PROJECTS := mimir:next:$(MIMIR_REPO_NAME) mimir:$(MIMIR_DOCS_VERSION):mimir-$(MIMIR_DOCS_VERSION) helm-charts/mimir-distributed:latest:$(MIMIR_REPO_NAME)


### PR DESCRIPTION
#### What this PR does

Today, running `make docs` from a worktree, that isn't named "mimir" fails with a note: `you must have a checkout of the project 'mimir'`.

E.g. I have multiple checkouts of mimir in my `mimir-worktrees/` directory. Today, during a code review, I bumped into this failure:

```
···
cd docs && /Library/Developer/CommandLineTools/usr/bin/make docs
docker pull -q grafana/docs-base:latest
docker.io/grafana/docs-base:latest
/Users/v/Documents/Code/grafana/mimir-worktrees/mimir-review/docs/make-docs mimir:next:mimir-review mimir:v3.0.x:mimir-v3.0.x helm-charts/mimir-distributed
ERRR: could not find project 'mimir' in any of the paths in REPOS_PATH '/Users/v/Documents/Code/grafana/mimir-worktrees'.
NOTE: you must have a checkout of the project 'mimir' at '/Users/v/Documents/Code/grafana/mimir-worktrees/mimir'.
NOTE: if you have cloned the repository into a directory with a different name, consider changing it to mimir.
make[1]: *** [docs] Error 1
make: *** [docs] Error 2
```

This PR improves it, by calculating the name of the checkout from the git root.