### PR TITLE
ingester: delete blocks after block-builder persisted all their series

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -12177,6 +12177,28 @@
                   "fieldFlag": "blocks-storage.tsdb.offset-catalogue.sync-concurrency",
                   "fieldType": "int",
                   "fieldCategory": "experimental"
+                },
+                {
+                  "kind": "field",
+                  "name": "consumer_group",
+                  "required": false,
+                  "desc": "The Kafka consumer group whose committed offset is compared against block watermarks to determine when ingester blocks can be deleted.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": "",
+                  "fieldFlag": "blocks-storage.tsdb.offset-catalogue.consumer-group",
+                  "fieldType": "string",
+                  "fieldCategory": "experimental"
+                },
+                {
+                  "kind": "field",
+                  "name": "consumer_group_poll_interval",
+                  "required": false,
+                  "desc": "How frequently the ingester polls Kafka for the committed offset of the configured consumer group.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 60000000000,
+                  "fieldFlag": "blocks-storage.tsdb.offset-catalogue.consumer-group-poll-interval",
+                  "fieldType": "duration",
+                  "fieldCategory": "experimental"
                 }
               ],
               "fieldValue": null,

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -12195,7 +12195,7 @@
                   "required": false,
                   "desc": "How frequently the ingester polls Kafka for the committed offset of the configured consumer group.",
                   "fieldValue": null,
-                  "fieldDefaultValue": 60000000000,
+                  "fieldDefaultValue": 300000000000,
                   "fieldFlag": "blocks-storage.tsdb.offset-catalogue.consumer-group-poll-interval",
                   "fieldType": "duration",
                   "fieldCategory": "experimental"

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -833,6 +833,10 @@ Usage of ./cmd/mimir/mimir:
     	[experimental] How frequently to collect block statistics, which are used in query execution optimization. 0 to disable. (default 1h0m0s)
   -blocks-storage.tsdb.memory-snapshot-on-shutdown
     	[experimental] True to enable snapshotting of in-memory TSDB data on disk when shutting down.
+  -blocks-storage.tsdb.offset-catalogue.consumer-group string
+    	[experimental] The Kafka consumer group whose committed offset is compared against block watermarks to determine when ingester blocks can be deleted.
+  -blocks-storage.tsdb.offset-catalogue.consumer-group-poll-interval duration
+    	[experimental] How frequently the ingester polls Kafka for the committed offset of the configured consumer group. (default 1m0s)
   -blocks-storage.tsdb.offset-catalogue.enabled
     	[experimental] Controls the maintaining of kafka offset catalogue per block.
   -blocks-storage.tsdb.offset-catalogue.sync-concurrency int

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -836,7 +836,7 @@ Usage of ./cmd/mimir/mimir:
   -blocks-storage.tsdb.offset-catalogue.consumer-group string
     	[experimental] The Kafka consumer group whose committed offset is compared against block watermarks to determine when ingester blocks can be deleted.
   -blocks-storage.tsdb.offset-catalogue.consumer-group-poll-interval duration
-    	[experimental] How frequently the ingester polls Kafka for the committed offset of the configured consumer group. (default 1m0s)
+    	[experimental] How frequently the ingester polls Kafka for the committed offset of the configured consumer group. (default 5m0s)
   -blocks-storage.tsdb.offset-catalogue.enabled
     	[experimental] Controls the maintaining of kafka offset catalogue per block.
   -blocks-storage.tsdb.offset-catalogue.sync-concurrency int

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -6112,7 +6112,7 @@ tsdb:
     # (experimental) How frequently the ingester polls Kafka for the committed
     # offset of the configured consumer group.
     # CLI flag: -blocks-storage.tsdb.offset-catalogue.consumer-group-poll-interval
-    [consumer_group_poll_interval: <duration> | default = 1m]
+    [consumer_group_poll_interval: <duration> | default = 5m]
 ```
 
 ### compactor

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -6103,6 +6103,16 @@ tsdb:
     # catalogue to disk.
     # CLI flag: -blocks-storage.tsdb.offset-catalogue.sync-concurrency
     [sync_concurrency: <int> | default = 10]
+
+    # (experimental) The Kafka consumer group whose committed offset is compared
+    # against block watermarks to determine when ingester blocks can be deleted.
+    # CLI flag: -blocks-storage.tsdb.offset-catalogue.consumer-group
+    [consumer_group: <string> | default = ""]
+
+    # (experimental) How frequently the ingester polls Kafka for the committed
+    # offset of the configured consumer group.
+    # CLI flag: -blocks-storage.tsdb.offset-catalogue.consumer-group-poll-interval
+    [consumer_group_poll_interval: <duration> | default = 1m]
 ```
 
 ### compactor

--- a/operations/mimir/mimir-flags-defaults.json
+++ b/operations/mimir/mimir-flags-defaults.json
@@ -862,7 +862,7 @@
   "blocks-storage.tsdb.index-lookup-planning.statistics-collection-frequency": 3600000000000,
   "blocks-storage.tsdb.offset-catalogue.sync-concurrency": 10,
   "blocks-storage.tsdb.offset-catalogue.consumer-group": "",
-  "blocks-storage.tsdb.offset-catalogue.consumer-group-poll-interval": 60000000000,
+  "blocks-storage.tsdb.offset-catalogue.consumer-group-poll-interval": 300000000000,
   "compactor.block-ranges": [],
   "compactor.block-sync-concurrency": 8,
   "compactor.meta-sync-concurrency": 20,

--- a/operations/mimir/mimir-flags-defaults.json
+++ b/operations/mimir/mimir-flags-defaults.json
@@ -861,6 +861,8 @@
   "blocks-storage.tsdb.index-lookup-planning.comparison-portion": 0,
   "blocks-storage.tsdb.index-lookup-planning.statistics-collection-frequency": 3600000000000,
   "blocks-storage.tsdb.offset-catalogue.sync-concurrency": 10,
+  "blocks-storage.tsdb.offset-catalogue.consumer-group": "",
+  "blocks-storage.tsdb.offset-catalogue.consumer-group-poll-interval": 60000000000,
   "compactor.block-ranges": [],
   "compactor.block-sync-concurrency": 8,
   "compactor.meta-sync-concurrency": 20,

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -624,7 +624,7 @@ func New(cfg Config, limits *validation.Overrides, ingestersRing ring.ReadRing, 
 			if err != nil {
 				return nil, fmt.Errorf("creating kafka client for committed offset reader: %w", err)
 			}
-			i.committedOffsetClient = ingest.NewCommittedOffsetClient(cl, kafkaCfg.Topic)
+			i.committedOffsetClient = ingest.NewCommittedOffsetClient(cl, consumerGroup, kafkaCfg.Topic, i.ingestPartitionID)
 		}
 	}
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -348,6 +348,7 @@ type Ingester struct {
 	ingestReader              *ingest.PartitionReader
 	ingestPartitionID         int32
 	ingestPartitionLifecycler *ring.PartitionInstanceLifecycler
+	committedOffsetClient     *ingest.CommittedOffsetClient
 
 	// latestKafkaRecordTimestamp tracks the most recent Kafka record timestamp
 	// seen by the ingester (unix milliseconds). Used to provide a Kafka-time-aware
@@ -616,6 +617,15 @@ func New(cfg Config, limits *validation.Overrides, ingestersRing ring.ReadRing, 
 		if !cfg.IngestStorageConfig.Enabled {
 			return nil, fmt.Errorf("kafka offset catalogue can only be enabled when ingest storage is enabled")
 		}
+
+		if consumerGroup := cfg.BlocksStorageConfig.TSDB.OffsetCatalogue.ConsumerGroup; consumerGroup != "" {
+			kafkaCfg := cfg.IngestStorageConfig.KafkaConfig
+			cl, err := ingest.NewKafkaReaderClient(kafkaCfg, nil, log.With(logger, "component", "committed-offset-client"))
+			if err != nil {
+				return nil, fmt.Errorf("creating kafka client for committed offset reader: %w", err)
+			}
+			i.committedOffsetClient = ingest.NewCommittedOffsetClient(cl, kafkaCfg.Topic)
+		}
 	}
 
 	i.BasicService = services.NewBasicService(i.starting, i.ingesterRunning, i.stopping).WithName("ingester")
@@ -753,6 +763,12 @@ func (i *Ingester) starting(ctx context.Context) (err error) {
 
 	if i.ingestPartitionLifecycler != nil {
 		servs = append(servs, i.ingestPartitionLifecycler)
+	}
+
+	if i.committedOffsetClient != nil {
+		interval := i.cfg.BlocksStorageConfig.TSDB.OffsetCatalogue.ConsumerGroupPollInterval
+		committedOffsetService := services.NewTimerService(interval, nil, i.updateCommittedOffset, nil)
+		servs = append(servs, committedOffsetService)
 	}
 
 	// Since subservices are conditional, We add an idle service if there are no subservices to

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -767,7 +767,8 @@ func (i *Ingester) starting(ctx context.Context) (err error) {
 
 	if i.committedOffsetClient != nil {
 		interval := i.cfg.BlocksStorageConfig.TSDB.OffsetCatalogue.ConsumerGroupPollInterval
-		committedOffsetService := services.NewTimerService(interval, nil, i.updateCommittedOffset, nil)
+		// Calling updateCommittedOffset on service's start: this expects all existing TSDBs were opened above.
+		committedOffsetService := services.NewTimerService(interval, i.updateCommittedOffset, i.updateCommittedOffset, nil)
 		servs = append(servs, committedOffsetService)
 	}
 

--- a/pkg/ingester/ingester_compaction.go
+++ b/pkg/ingester/ingester_compaction.go
@@ -210,6 +210,28 @@ func (i *Ingester) offsetCataloguesSync(ctx context.Context) {
 	})
 }
 
+func (i *Ingester) updateCommittedOffset(ctx context.Context) error {
+	consumerGroup := i.cfg.BlocksStorageConfig.TSDB.OffsetCatalogue.ConsumerGroup
+	offset, exists, err := i.committedOffsetClient.FetchLastCommittedOffset(ctx, consumerGroup, i.ingestPartitionID)
+	if err != nil {
+		level.Warn(i.logger).Log("msg", "failed to fetch committed offset", "consumer_group", consumerGroup, "partition", i.ingestPartitionID, "err", err)
+		return nil
+	}
+	if !exists {
+		return nil
+	}
+
+	level.Info(i.logger).Log("msg", "updating commited offset", "consumer_group", consumerGroup, "partition", i.ingestPartitionID, "offset", offset)
+
+	i.tsdbsMtx.RLock()
+	defer i.tsdbsMtx.RUnlock()
+
+	for _, db := range i.tsdbs {
+		db.committedOffset.Store(offset)
+	}
+	return nil
+}
+
 // compactionServiceInterval returns how frequently the TSDB Head should be checked for compaction.
 // The returned standardInterval is guaranteed to have no jittering or staggering per zone applied.
 // The returned intervals may change over time, depending on the ingester service state.

--- a/pkg/ingester/ingester_compaction.go
+++ b/pkg/ingester/ingester_compaction.go
@@ -211,17 +211,20 @@ func (i *Ingester) offsetCataloguesSync(ctx context.Context) {
 }
 
 func (i *Ingester) updateCommittedOffset(ctx context.Context) error {
-	consumerGroup := i.cfg.BlocksStorageConfig.TSDB.OffsetCatalogue.ConsumerGroup
-	offset, exists, err := i.committedOffsetClient.FetchLastCommittedOffset(ctx, consumerGroup, i.ingestPartitionID)
+	if !i.cfg.BlocksStorageConfig.TSDB.OffsetCatalogue.Enabled {
+		return nil
+	}
+
+	offset, exists, err := i.committedOffsetClient.FetchLastCommittedOffset(ctx)
 	if err != nil {
-		level.Warn(i.logger).Log("msg", "failed to fetch committed offset", "consumer_group", consumerGroup, "partition", i.ingestPartitionID, "err", err)
+		level.Warn(i.logger).Log("msg", "failed to fetch committed offset", "err", err)
 		return nil
 	}
 	if !exists {
 		return nil
 	}
 
-	level.Info(i.logger).Log("msg", "updating committed offset", "consumer_group", consumerGroup, "partition", i.ingestPartitionID, "offset", offset)
+	level.Info(i.logger).Log("msg", "updating committed offset", "partition", i.ingestPartitionID, "offset", offset)
 
 	i.tsdbsMtx.RLock()
 	defer i.tsdbsMtx.RUnlock()

--- a/pkg/ingester/ingester_compaction.go
+++ b/pkg/ingester/ingester_compaction.go
@@ -221,7 +221,7 @@ func (i *Ingester) updateCommittedOffset(ctx context.Context) error {
 		return nil
 	}
 
-	level.Info(i.logger).Log("msg", "updating commited offset", "consumer_group", consumerGroup, "partition", i.ingestPartitionID, "offset", offset)
+	level.Info(i.logger).Log("msg", "updating committed offset", "consumer_group", consumerGroup, "partition", i.ingestPartitionID, "offset", offset)
 
 	i.tsdbsMtx.RLock()
 	defer i.tsdbsMtx.RUnlock()

--- a/pkg/ingester/ingester_ingest_storage_test.go
+++ b/pkg/ingester/ingester_ingest_storage_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1549,4 +1550,115 @@ func BenchmarkIngester_ReplayFromKafka_Dump(b *testing.B) {
 			b.ReportMetric(float64(totalTimeseries)/b.Elapsed().Seconds(), "timeseries/sec")
 		})
 	}
+}
+
+func TestIngester_TSDBRetention_offsetCatalogue(t *testing.T) {
+	// oldSampleTs is old enough to be compacted from the head on the first forced
+	// compaction, and old enough to exceed the short retention we set below.
+	oldSampleTs := time.Now().Add(-3 * time.Hour).UnixMilli()
+
+	ctx := t.Context()
+	logger := util_test.NewTestingLogger(t)
+
+	cfg := defaultIngesterTestConfig(t)
+	cfg.BlocksStorageConfig.TSDB.HeadCompactionInterval = math.MaxInt64 // manual control
+	cfg.BlocksStorageConfig.TSDB.HeadCompactionIntervalJitterEnabled = false
+	// Short retention so that the compacted block becomes eligible for deletion by DefaultBlocksToDelete;
+	// the offset-catalogue check then gates whether it actually gets deleted.
+	cfg.BlocksStorageConfig.TSDB.Retention = time.Second
+	cfg.BlocksStorageConfig.TSDB.OffsetCatalogue.Enabled = true
+
+	overrides := validation.NewOverrides(defaultLimitsTestConfig(), nil)
+	ingester, _, _ := createTestIngesterWithIngestStorage(t, &cfg, overrides, nil, nil, logger)
+
+	require.NoError(t, services.StartAndAwaitRunning(ctx, ingester))
+	t.Cleanup(func() { require.NoError(t, services.StopAndAwaitTerminated(context.Background(), ingester)) })
+
+	partitionID := ingester.ingestPartitionID
+	writer := ingest.NewWriter(cfg.IngestStorageConfig.KafkaConfig, log.NewNopLogger(), nil)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, writer))
+	t.Cleanup(func() { require.NoError(t, services.StopAndAwaitTerminated(context.Background(), writer)) })
+
+	writeSeries := func(metricName string, ts int64) {
+		s := mimirpb.PreallocTimeseries{TimeSeries: &mimirpb.TimeSeries{
+			Labels:  mimirpb.FromLabelsToLabelAdapters(labels.FromStrings(model.MetricNameLabel, metricName)),
+			Samples: []mimirpb.Sample{{TimestampMs: ts, Value: 1}},
+		}}
+		require.NoError(t, writer.WriteSync(ctx, partitionID, userID, &mimirpb.WriteRequest{
+			Timeseries: []mimirpb.PreallocTimeseries{s},
+			Source:     mimirpb.API,
+		}))
+	}
+
+	// Write and compact two blocks by force-compacting after each sample was written.
+	// DefaultBlocksToDelete will mark the older one deletable once retention expires.
+	writeSeries("metric_old", oldSampleTs)
+	test.Poll(t, 5*time.Second, 1, func() interface{} {
+		db := ingester.getTSDB(userID)
+		if db == nil {
+			return 0
+		}
+		return int(db.Head().NumSeries())
+	})
+	ingester.compactBlocks(ctx, true, math.MaxInt64, nil)
+
+	writeSeries("metric_new", time.Now().UnixMilli())
+	test.Poll(t, 5*time.Second, 1, func() interface{} {
+		return int(ingester.getTSDB(userID).Head().NumSeries())
+	})
+	ingester.compactBlocks(ctx, true, math.MaxInt64, nil)
+
+	userBlocksDir := filepath.Join(cfg.BlocksStorageConfig.TSDB.Dir, userID)
+	require.Len(t, listBlocksInDir(t, userBlocksDir), 2, "force-compaction expected to produce two blocks")
+
+	// Stamp both blocks in the offset-catalogue.
+	ingester.offsetCataloguesSync(ctx)
+
+	db := ingester.getTSDB(userID)
+	require.NotNil(t, db)
+
+	catalogue := db.offsetCatalogue.Data()
+	require.Len(t, catalogue.Data, 2)
+
+	// Find the older block (lowest ULID time = first compacted).
+	blocks := listBlocksInDir(t, userBlocksDir)
+	oldBlockID := blocks[0].String()
+	var watermark int64
+	for id, wm := range catalogue.Data {
+		if id == oldBlockID {
+			watermark = wm.Offset
+			break
+		}
+	}
+
+	// compactWithNewSeries pushes a fresh series and force-compacts so that
+	// reloadBlocks fires — the only path that calls our blocksToDelete callback.
+	compactWithNewSeries := func(metricName string) {
+		writeSeries(metricName, time.Now().UnixMilli())
+		test.Poll(t, 5*time.Second, 1, func() interface{} {
+			return int(db.Head().NumSeries())
+		})
+		ingester.compactBlocks(ctx, true, math.MaxInt64, nil)
+	}
+
+	t.Run("block retained when committedOffset is unknown", func(t *testing.T) {
+		// committedOffset=-1; offset-catalogue path is skipped entirely.
+		compactWithNewSeries("metric_guard_1")
+		require.Contains(t, listBlocksInDir(t, userBlocksDir), blocks[0])
+	})
+
+	t.Run("block retained when committedOffset is below watermark", func(t *testing.T) {
+		db.committedOffset.Store(watermark - 1)
+		compactWithNewSeries("metric_guard_2")
+		require.Contains(t, listBlocksInDir(t, userBlocksDir), blocks[0])
+	})
+
+	t.Run("block deleted when committedOffset reaches watermark", func(t *testing.T) {
+		db.committedOffset.Store(watermark)
+		compactWithNewSeries("metric_trigger")
+		remaining := listBlocksInDir(t, userBlocksDir)
+		for _, id := range remaining {
+			require.NotEqual(t, oldBlockID, id.String())
+		}
+	})
 }

--- a/pkg/ingester/ingester_tsdb.go
+++ b/pkg/ingester/ingester_tsdb.go
@@ -167,6 +167,7 @@ func (i *Ingester) createTSDB(userID string, walReplayConcurrency int) (*userTSD
 		},
 	}
 	userDB.triggerRecomputeOwnedSeries(recomputeOwnedSeriesReasonNewUser)
+	userDB.committedOffset.Store(-1)
 
 	if i.cfg.BlocksStorageConfig.TSDB.IndexLookupPlanning.Enabled {
 		plannerFactory := lookupplan.NewPlannerFactory(i.lookupPlanMetrics.ForUser(userID), userLogger, lookupplan.NewStatisticsGenerator(userLogger), i.cfg.BlocksStorageConfig.TSDB.IndexLookupPlanning.CostConfig)

--- a/pkg/ingester/ingester_tsdb.go
+++ b/pkg/ingester/ingester_tsdb.go
@@ -179,7 +179,7 @@ func (i *Ingester) createTSDB(userID string, walReplayConcurrency int) (*userTSD
 		if !userDBHasDB.Load() {
 			return nil
 		}
-		return userDB.blocksToDelete(userLogger, blocks)
+		return userDB.blocksToDelete(blocks)
 	}
 	blockGeneration := blockGenerationCalculator(userDB, blockRanges[0])
 

--- a/pkg/ingester/ingester_tsdb.go
+++ b/pkg/ingester/ingester_tsdb.go
@@ -179,7 +179,7 @@ func (i *Ingester) createTSDB(userID string, walReplayConcurrency int) (*userTSD
 		if !userDBHasDB.Load() {
 			return nil
 		}
-		return userDB.blocksToDelete(blocks)
+		return userDB.blocksToDelete(userLogger, blocks)
 	}
 	blockGeneration := blockGenerationCalculator(userDB, blockRanges[0])
 

--- a/pkg/ingester/offset_catalogue.go
+++ b/pkg/ingester/offset_catalogue.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/dskit/runutil"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"go.uber.org/atomic"
 
 	"github.com/grafana/mimir/pkg/util/atomicfs"
 	"github.com/grafana/mimir/pkg/util/spanlogger"
@@ -74,6 +75,9 @@ type offsetCatalogue struct {
 	dir       string
 	userID    string
 	partition int32
+
+	// cachedData is a pointer to the latest version of catalogue data.
+	cachedData atomic.Pointer[offsetCatalogueData]
 }
 
 func newOffsetCatalogue(logger log.Logger, metrics *offsetCatalogueMetrics, dir, userID string, partition int32) *offsetCatalogue {
@@ -144,11 +148,25 @@ func (c *offsetCatalogue) Sync(ctx context.Context, offsetHW int64) (err error) 
 		return err
 	}
 
+	c.cachedData.Store(&data)
+
 	c.metrics.syncs.Inc()
 	c.metrics.lastSyncTime.SetToCurrentTime()
 	c.metrics.lastSyncedOffset.Set(float64(offsetHW))
 
 	return nil
+}
+
+func (c *offsetCatalogue) Data() offsetCatalogueData {
+	// cachedData is replaced on successful sync; it's safe to return the current copy.
+	if data := c.cachedData.Load(); data != nil {
+		return *data
+	}
+	// Return a dummy version of data, to simplify how the method is used.
+	return offsetCatalogueData{
+		Version: offsetCatalogueVersion,
+		Data:    make(map[string]offsetWatermark),
+	}
 }
 
 func readOffsetCatalogueFromFile(dir string) (offsetCatalogueData, error) {

--- a/pkg/ingester/offset_catalogue.go
+++ b/pkg/ingester/offset_catalogue.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/runutil"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -98,11 +99,13 @@ func (c *offsetCatalogue) Sync(ctx context.Context, offsetHW int64) (err error) 
 	}()
 
 	oldData, err := readOffsetCatalogueFromFile(c.dir)
-	if errors.Is(err, os.ErrNotExist) {
+	if err != nil {
+		// If catalogue file is corrupted, we always overwrite it with a fresh copy.
 		// The catalogue file may not exist if that's the first sync of this new tenant.
+		if !errors.Is(err, os.ErrNotExist) {
+			level.Warn(spanLogger).Log("msg", "reading offset catalogue failed, will override", "err", err)
+		}
 		oldData.Data = map[string]offsetWatermark{}
-	} else if err != nil {
-		return fmt.Errorf("read offset catalogue: %w", err)
 	}
 
 	blocks := make(map[string]struct{})

--- a/pkg/ingester/offset_catalogue_test.go
+++ b/pkg/ingester/offset_catalogue_test.go
@@ -80,12 +80,20 @@ func TestOffsetCatalogue(t *testing.T) {
 		require.Empty(t, data.Data)
 	})
 
-	t.Run("rejects version mismatch", func(t *testing.T) {
+	t.Run("overwrites version mismatch", func(t *testing.T) {
 		dir := t.TempDir()
 		content := `{"version":99,"updated_at":0,"data":{}}`
 		require.NoError(t, os.WriteFile(filepath.Join(dir, offsetCatalogueFilename), []byte(content), 0o644))
 
 		_, err := readOffsetCatalogueFromFile(dir)
-		require.Error(t, err)
+		require.Error(t, err, "catalogue file version mismatch")
+
+		// Next sync overwrites corrupted version.
+		c := newOffsetCatalogue(log.NewNopLogger(), newOffsetCatalogueMetrics(prometheus.NewRegistry()), dir, userID, 1)
+		require.NoError(t, c.Sync(t.Context(), 42))
+
+		data, err := readOffsetCatalogueFromFile(dir)
+		require.NoError(t, err)
+		require.Empty(t, data.Data)
 	})
 }

--- a/pkg/ingester/user_tsdb.go
+++ b/pkg/ingester/user_tsdb.go
@@ -151,6 +151,11 @@ type userTSDB struct {
 	// Only set when ingest storage is enabled.
 	offsetCatalogue *offsetCatalogue
 
+	// committedOffset is the last committed offset observed from the consumer group
+	// configured in offset catalogue. Updated by a background service on the ingester.
+	// -1 means unknown (no offset fetched yet).
+	committedOffset atomic.Int64
+
 	requiresOwnedSeriesUpdate atomic.String // Non-empty string means that we need to recompute "owned series" for the user. Value will be used in the log message.
 
 	postingsCache *tsdb.PostingsForMatchersCache

--- a/pkg/ingester/user_tsdb.go
+++ b/pkg/ingester/user_tsdb.go
@@ -434,13 +434,39 @@ func (u *userTSDB) PostDeletion(metrics map[chunks.HeadSeriesRef]labels.Labels) 
 }
 
 // blocksToDelete filters the input blocks and returns the blocks which are safe to be deleted from the ingester.
-func (u *userTSDB) blocksToDelete(blocks []*tsdb.Block) map[ulid.ULID]struct{} {
+func (u *userTSDB) blocksToDelete(logger log.Logger, blocks []*tsdb.Block) map[ulid.ULID]struct{} {
 	if u.db == nil {
 		return nil
 	}
 
 	deletable := tsdb.DefaultBlocksToDelete(u.db)(blocks)
 	result := map[ulid.ULID]struct{}{}
+
+	// Offset-catalogue path drops any block whose watermark is at or below the block-builder's committed offset.
+	// Those series are guaranteed to be in object storage already.
+	// It runs over all blocks, not just the ones in deletable.
+	committedOffset := u.committedOffset.Load()
+	if u.offsetCatalogue != nil && committedOffset >= 0 {
+		catalogue := u.offsetCatalogue.Data()
+		if len(catalogue.Data) > 0 {
+			for _, b := range blocks {
+				blockID := b.Meta().ULID
+				if wm, ok := catalogue.Data[blockID.String()]; ok && wm.Offset <= committedOffset {
+					level.Debug(logger).Log(
+						"msg", "delete block due to its offset catalogue watermark",
+						"ulid", blockID.String(),
+						"mint", b.Meta().MinTime,
+						"maxt", b.Meta().MinTime,
+						"out_of_order", b.Meta().OutOfOrder,
+						"watermark", wm.String(),
+						"committed_offset", committedOffset,
+					)
+					//result[blockID] = struct{}{}
+				}
+			}
+		}
+	}
+
 	deadline := time.Now().Add(-u.blockMinRetention)
 
 	// The shipper enabled case goes first because its common in the way we run the ingesters

--- a/pkg/ingester/user_tsdb.go
+++ b/pkg/ingester/user_tsdb.go
@@ -452,11 +452,11 @@ func (u *userTSDB) blocksToDelete(logger log.Logger, blocks []*tsdb.Block) map[u
 			for _, b := range blocks {
 				blockID := b.Meta().ULID
 				if wm, ok := catalogue.Data[blockID.String()]; ok && wm.Offset <= committedOffset {
-					level.Debug(logger).Log(
+					level.Info(logger).Log(
 						"msg", "delete block due to its offset catalogue watermark",
 						"ulid", blockID.String(),
 						"mint", b.Meta().MinTime,
-						"maxt", b.Meta().MinTime,
+						"maxt", b.Meta().MaxTime,
 						"out_of_order", b.Meta().OutOfOrder,
 						"watermark", wm.String(),
 						"committed_offset", committedOffset,

--- a/pkg/ingester/user_tsdb.go
+++ b/pkg/ingester/user_tsdb.go
@@ -434,7 +434,7 @@ func (u *userTSDB) PostDeletion(metrics map[chunks.HeadSeriesRef]labels.Labels) 
 }
 
 // blocksToDelete filters the input blocks and returns the blocks which are safe to be deleted from the ingester.
-func (u *userTSDB) blocksToDelete(logger log.Logger, blocks []*tsdb.Block) map[ulid.ULID]struct{} {
+func (u *userTSDB) blocksToDelete(blocks []*tsdb.Block) map[ulid.ULID]struct{} {
 	if u.db == nil {
 		return nil
 	}
@@ -444,27 +444,17 @@ func (u *userTSDB) blocksToDelete(logger log.Logger, blocks []*tsdb.Block) map[u
 
 	// Offset-catalogue path drops any block whose watermark is at or below the block-builder's committed offset.
 	// Those series are guaranteed to be in object storage already.
-	// It runs over all blocks, not just the ones in deletable.
 	committedOffset := u.committedOffset.Load()
 	if u.offsetCatalogue != nil && committedOffset >= 0 {
 		catalogue := u.offsetCatalogue.Data()
 		if len(catalogue.Data) > 0 {
-			for _, b := range blocks {
-				blockID := b.Meta().ULID
+			for blockID := range deletable {
 				if wm, ok := catalogue.Data[blockID.String()]; ok && wm.Offset <= committedOffset {
-					level.Info(logger).Log(
-						"msg", "delete block due to its offset catalogue watermark",
-						"ulid", blockID.String(),
-						"mint", b.Meta().MinTime,
-						"maxt", b.Meta().MaxTime,
-						"out_of_order", b.Meta().OutOfOrder,
-						"watermark", wm.String(),
-						"committed_offset", committedOffset,
-					)
-					//result[blockID] = struct{}{}
+					result[blockID] = struct{}{}
 				}
 			}
 		}
+		return result
 	}
 
 	deadline := time.Now().Add(-u.blockMinRetention)

--- a/pkg/storage/ingest/committed_offset_client.go
+++ b/pkg/storage/ingest/committed_offset_client.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package ingest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+// CommittedOffsetClient fetches the last committed offset for a consumer group and partition.
+type CommittedOffsetClient struct {
+	admin *kadm.Client
+	topic string
+}
+
+func NewCommittedOffsetClient(client *kgo.Client, topic string) *CommittedOffsetClient {
+	return &CommittedOffsetClient{
+		admin: kadm.NewClient(client),
+		topic: topic,
+	}
+}
+
+// FetchLastCommittedOffset returns the last committed offset for the given consumer group and partition.
+// Returns exists=false if the consumer group or partition has no committed offset.
+func (c *CommittedOffsetClient) FetchLastCommittedOffset(ctx context.Context, consumerGroup string, partitionID int32) (offset int64, exists bool, _ error) {
+	offsets, err := c.admin.FetchOffsets(ctx, consumerGroup)
+	if errors.Is(err, kerr.GroupIDNotFound) || errors.Is(err, kerr.UnknownTopicOrPartition) {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, fmt.Errorf("unable to fetch group offsets: %w", err)
+	}
+
+	offsetRes, exists := offsets.Lookup(c.topic, partitionID)
+	if !exists {
+		return 0, false, nil
+	}
+	if offsetRes.Err != nil {
+		return 0, false, offsetRes.Err
+	}
+
+	return offsetRes.At, true, nil
+}

--- a/pkg/storage/ingest/committed_offset_client.go
+++ b/pkg/storage/ingest/committed_offset_client.go
@@ -15,33 +15,39 @@ import (
 // CommittedOffsetClient fetches the last committed offset for a consumer group and partition.
 type CommittedOffsetClient struct {
 	admin *kadm.Client
-	topic string
+
+	consumerGroup string
+	topic         string
+	partition     int32
 }
 
-func NewCommittedOffsetClient(client *kgo.Client, topic string) *CommittedOffsetClient {
+func NewCommittedOffsetClient(client *kgo.Client, consumerGroup, topic string, partitionID int32) *CommittedOffsetClient {
 	return &CommittedOffsetClient{
 		admin: kadm.NewClient(client),
-		topic: topic,
+
+		consumerGroup: consumerGroup,
+		topic:         topic,
+		partition:     partitionID,
 	}
 }
 
-// FetchLastCommittedOffset returns the last committed offset for the given consumer group and partition.
-// Returns exists=false if the consumer group or partition has no committed offset.
-func (c *CommittedOffsetClient) FetchLastCommittedOffset(ctx context.Context, consumerGroup string, partitionID int32) (offset int64, exists bool, _ error) {
-	offsets, err := c.admin.FetchOffsets(ctx, consumerGroup)
+// FetchLastCommittedOffset returns the last committed offset.
+// Returns exists=false if the client's consumer group or partition has no committed offset.
+func (c *CommittedOffsetClient) FetchLastCommittedOffset(ctx context.Context) (offset int64, exists bool, _ error) {
+	offsets, err := c.admin.FetchOffsets(ctx, c.consumerGroup)
 	if errors.Is(err, kerr.GroupIDNotFound) || errors.Is(err, kerr.UnknownTopicOrPartition) {
 		return 0, false, nil
 	}
 	if err != nil {
-		return 0, false, fmt.Errorf("unable to fetch group offsets: %w", err)
+		return 0, false, fmt.Errorf("fetch group %s offsets: %w", c.consumerGroup, err)
 	}
 
-	offsetRes, exists := offsets.Lookup(c.topic, partitionID)
+	offsetRes, exists := offsets.Lookup(c.topic, c.partition)
 	if !exists {
 		return 0, false, nil
 	}
 	if offsetRes.Err != nil {
-		return 0, false, offsetRes.Err
+		return 0, false, fmt.Errorf("fetch group %s offset: topic %s, partition %d: %w", c.consumerGroup, c.topic, c.partition, offsetRes.Err)
 	}
 
 	return offsetRes.At, true, nil

--- a/pkg/storage/ingest/committed_offset_client_test.go
+++ b/pkg/storage/ingest/committed_offset_client_test.go
@@ -24,8 +24,8 @@ func TestCommittedOffsetClient_FetchLastCommittedOffset(t *testing.T) {
 		kafkaCfg := createTestKafkaConfig(clusterAddr, topicName)
 		client := createTestKafkaClient(t, kafkaCfg)
 
-		c := NewCommittedOffsetClient(client, topicName)
-		_, exists, err := c.FetchLastCommittedOffset(t.Context(), consumerGroup, partitionID)
+		c := NewCommittedOffsetClient(client, consumerGroup, topicName, partitionID)
+		_, exists, err := c.FetchLastCommittedOffset(t.Context())
 		require.NoError(t, err)
 		require.False(t, exists)
 	})
@@ -45,8 +45,8 @@ func TestCommittedOffsetClient_FetchLastCommittedOffset(t *testing.T) {
 		_, err := adm.CommitOffsets(ctx, consumerGroup, offsets)
 		require.NoError(t, err)
 
-		c := NewCommittedOffsetClient(client, topicName)
-		offset, exists, err := c.FetchLastCommittedOffset(ctx, consumerGroup, partitionID)
+		c := NewCommittedOffsetClient(client, consumerGroup, topicName, partitionID)
+		offset, exists, err := c.FetchLastCommittedOffset(ctx)
 		require.NoError(t, err)
 		require.True(t, exists)
 		require.Equal(t, int64(1), offset)
@@ -67,9 +67,9 @@ func TestCommittedOffsetClient_FetchLastCommittedOffset(t *testing.T) {
 		_, err := adm.CommitOffsets(ctx, consumerGroup, offsets)
 		require.NoError(t, err)
 
-		c := NewCommittedOffsetClient(client, topicName)
 		// Partition 99 was never committed.
-		_, exists, err := c.FetchLastCommittedOffset(ctx, consumerGroup, int32(99))
+		c := NewCommittedOffsetClient(client, consumerGroup, topicName, int32(99))
+		_, exists, err := c.FetchLastCommittedOffset(ctx)
 		require.NoError(t, err)
 		require.False(t, exists)
 	})

--- a/pkg/storage/ingest/committed_offset_client_test.go
+++ b/pkg/storage/ingest/committed_offset_client_test.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package ingest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kadm"
+
+	"github.com/grafana/mimir/pkg/util/testkafka"
+)
+
+func TestCommittedOffsetClient_FetchLastCommittedOffset(t *testing.T) {
+	const (
+		numPartitions = 2
+		topicName     = "test"
+		partitionID   = int32(1)
+		consumerGroup = "test-group"
+	)
+
+	t.Run("returns exists=false when no offset is committed", func(t *testing.T) {
+		_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
+		kafkaCfg := createTestKafkaConfig(clusterAddr, topicName)
+		client := createTestKafkaClient(t, kafkaCfg)
+
+		c := NewCommittedOffsetClient(client, topicName)
+		_, exists, err := c.FetchLastCommittedOffset(t.Context(), consumerGroup, partitionID)
+		require.NoError(t, err)
+		require.False(t, exists)
+	})
+
+	t.Run("returns committed offset", func(t *testing.T) {
+		ctx := t.Context()
+
+		_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
+		kafkaCfg := createTestKafkaConfig(clusterAddr, topicName)
+		client := createTestKafkaClient(t, kafkaCfg)
+
+		produceRecord(ctx, t, client, topicName, partitionID, []byte("msg"))
+
+		adm := kadm.NewClient(client)
+		offsets := kadm.Offsets{}
+		offsets.Add(kadm.Offset{Topic: topicName, Partition: partitionID, At: 1})
+		_, err := adm.CommitOffsets(ctx, consumerGroup, offsets)
+		require.NoError(t, err)
+
+		c := NewCommittedOffsetClient(client, topicName)
+		offset, exists, err := c.FetchLastCommittedOffset(ctx, consumerGroup, partitionID)
+		require.NoError(t, err)
+		require.True(t, exists)
+		require.Equal(t, int64(1), offset)
+	})
+
+	t.Run("returns exists=false for unknown partition", func(t *testing.T) {
+		ctx := t.Context()
+
+		_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
+		kafkaCfg := createTestKafkaConfig(clusterAddr, topicName)
+		client := createTestKafkaClient(t, kafkaCfg)
+
+		produceRecord(ctx, t, client, topicName, partitionID, []byte("msg"))
+
+		adm := kadm.NewClient(client)
+		offsets := kadm.Offsets{}
+		offsets.Add(kadm.Offset{Topic: topicName, Partition: partitionID, At: 1})
+		_, err := adm.CommitOffsets(ctx, consumerGroup, offsets)
+		require.NoError(t, err)
+
+		c := NewCommittedOffsetClient(client, topicName)
+		// Partition 99 was never committed.
+		_, exists, err := c.FetchLastCommittedOffset(ctx, consumerGroup, int32(99))
+		require.NoError(t, err)
+		require.False(t, exists)
+	})
+}

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -355,7 +355,7 @@ func (cfg *TSDBConfig) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.OffsetCatalogue.Enabled, "blocks-storage.tsdb.offset-catalogue.enabled", false, "Controls the maintaining of kafka offset catalogue per block.")
 	f.IntVar(&cfg.OffsetCatalogue.SyncConcurrency, "blocks-storage.tsdb.offset-catalogue.sync-concurrency", 10, "Maximum number of tenants concurrently syncing offset catalogue to disk.")
 	f.StringVar(&cfg.OffsetCatalogue.ConsumerGroup, "blocks-storage.tsdb.offset-catalogue.consumer-group", "", "The Kafka consumer group whose committed offset is compared against block watermarks to determine when ingester blocks can be deleted.")
-	f.DurationVar(&cfg.OffsetCatalogue.ConsumerGroupPollInterval, "blocks-storage.tsdb.offset-catalogue.consumer-group-poll-interval", 1*time.Minute, "How frequently the ingester polls Kafka for the committed offset of the configured consumer group.")
+	f.DurationVar(&cfg.OffsetCatalogue.ConsumerGroupPollInterval, "blocks-storage.tsdb.offset-catalogue.consumer-group-poll-interval", 5*time.Minute, "How frequently the ingester polls Kafka for the committed offset of the configured consumer group.")
 
 	cfg.HeadCompactionIntervalJitterEnabled = true
 	cfg.HeadCompactionIntervalWhileStarting = 30 * time.Second

--- a/pkg/storage/tsdb/config.go
+++ b/pkg/storage/tsdb/config.go
@@ -293,6 +293,9 @@ type TSDBConfig struct {
 		Enabled bool `yaml:"enabled" category:"experimental"`
 
 		SyncConcurrency int `yaml:"sync_concurrency" category:"experimental"`
+
+		ConsumerGroup             string        `yaml:"consumer_group" category:"experimental"`
+		ConsumerGroupPollInterval time.Duration `yaml:"consumer_group_poll_interval" category:"experimental"`
 	} `yaml:"offset_catalogue" category:"experimental"`
 }
 
@@ -351,6 +354,8 @@ func (cfg *TSDBConfig) RegisterFlags(f *flag.FlagSet) {
 
 	f.BoolVar(&cfg.OffsetCatalogue.Enabled, "blocks-storage.tsdb.offset-catalogue.enabled", false, "Controls the maintaining of kafka offset catalogue per block.")
 	f.IntVar(&cfg.OffsetCatalogue.SyncConcurrency, "blocks-storage.tsdb.offset-catalogue.sync-concurrency", 10, "Maximum number of tenants concurrently syncing offset catalogue to disk.")
+	f.StringVar(&cfg.OffsetCatalogue.ConsumerGroup, "blocks-storage.tsdb.offset-catalogue.consumer-group", "", "The Kafka consumer group whose committed offset is compared against block watermarks to determine when ingester blocks can be deleted.")
+	f.DurationVar(&cfg.OffsetCatalogue.ConsumerGroupPollInterval, "blocks-storage.tsdb.offset-catalogue.consumer-group-poll-interval", 1*time.Minute, "How frequently the ingester polls Kafka for the committed offset of the configured consumer group.")
 
 	cfg.HeadCompactionIntervalJitterEnabled = true
 	cfg.HeadCompactionIntervalWhileStarting = 30 * time.Second
@@ -404,6 +409,12 @@ func (cfg *TSDBConfig) Validate(activeSeriesCfg activeseries.Config) error {
 		}
 		if cfg.IndexLookupPlanning.StatisticsCollectionFrequency <= 0 {
 			return errors.Errorf("head statistics collection frequency must be a non-negative duration. 0 to disable")
+		}
+	}
+
+	if cfg.OffsetCatalogue.Enabled {
+		if cfg.OffsetCatalogue.ConsumerGroup != "" && cfg.OffsetCatalogue.ConsumerGroupPollInterval <= 0 {
+			return fmt.Errorf("offset catalogue poll interval for consumer group %s must be non-negative", cfg.OffsetCatalogue.ConsumerGroup)
 		}
 	}
 


### PR DESCRIPTION
#### What this PR does

_Following https://github.com/grafana/mimir/pull/14786_

This PR updates the `ingester` to allow it to watch for committed offset in the block-builder's kafka consumer-group.

When the `ingester` decides if it's time to delete the block due to its retention, the ingester checks if the block is present in the offset-catalogue, and if the block's watermark is below the committed offset (see https://github.com/grafana/mimir/pull/14786 for detailed explanation).

These changes will allow the ingesters to run with `-blocks-storage.tsdb.retention-period` equal to `-querier.query-store-after`, regardless to the configured OOO window.

I'm currently testing the changes in a dev cell, and so far it looks promising: I'm observing 10-15% CPU reduction in the ingester of one zone, that has offset-catalogue enabled, and `querier.query-ingesters-within=3h`.

####  Which issue(s) this PR fixes or relates to

Relates to https://github.com/grafana/mimir-squad/issues/3373 (internal)