### PR TITLE
Pass in a prometheus registry when creating engine

### DIFF
--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/user"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
 	"github.com/prometheus/prometheus/model/histogram"
@@ -246,7 +247,7 @@ func TestQuerier(t *testing.T) {
 
 			planner, err := streamingpromql.NewQueryPlanner(cfg.EngineConfig.MimirQueryEngine, streamingpromql.NewMaximumSupportedVersionQueryPlanVersionProvider())
 			require.NoError(t, err)
-			queryable, _, _, _, err := New(cfg, overrides, distributor, []TimeRangeQueryable{dbQueryable}, nil, log.NewNopLogger(), nil, planner, unlimitedQueryLimitsProvider())
+			queryable, _, _, _, err := New(cfg, overrides, distributor, []TimeRangeQueryable{dbQueryable}, prometheus.NewRegistry(), log.NewNopLogger(), nil, planner, unlimitedQueryLimitsProvider())
 			require.NoError(t, err)
 
 			testRangeQuery(t, queryable, through, q)
@@ -357,7 +358,7 @@ func TestQuerier_QueryableReturnsChunksOutsideQueriedRange(t *testing.T) {
 
 	planner, err := streamingpromql.NewQueryPlanner(cfg.EngineConfig.MimirQueryEngine, streamingpromql.NewMaximumSupportedVersionQueryPlanVersionProvider())
 	require.NoError(t, err)
-	queryable, _, _, _, err := New(cfg, overrides, distributor, nil, nil, logger, nil, planner, unlimitedQueryLimitsProvider())
+	queryable, _, _, _, err := New(cfg, overrides, distributor, nil, prometheus.NewRegistry(), logger, nil, planner, unlimitedQueryLimitsProvider())
 	require.NoError(t, err)
 
 	query, err := engine.NewRangeQuery(ctx, queryable, nil, `sum({__name__=~".+"})`, queryStart, queryEnd, queryStep)
@@ -465,7 +466,7 @@ func TestBatchMergeChunks(t *testing.T) {
 
 	planner, err := streamingpromql.NewQueryPlanner(cfg.EngineConfig.MimirQueryEngine, streamingpromql.NewMaximumSupportedVersionQueryPlanVersionProvider())
 	require.NoError(t, err)
-	queryable, _, _, _, err := New(cfg, overrides, distributor, nil, nil, logger, nil, planner, unlimitedQueryLimitsProvider())
+	queryable, _, _, _, err := New(cfg, overrides, distributor, nil, prometheus.NewRegistry(), logger, nil, planner, unlimitedQueryLimitsProvider())
 	require.NoError(t, err)
 
 	query, err := engine.NewRangeQuery(ctx, queryable, nil, `rate({__name__=~".+"}[10s])`, queryStart, queryEnd, queryStep)
@@ -596,7 +597,7 @@ func TestQuerier_QueryIngestersWithinConfig(t *testing.T) {
 			limits.QueryIngestersWithin = model.Duration(c.queryIngestersWithin)
 			overrides := validation.NewOverrides(limits, nil)
 
-			queryable, _, _, _, err := New(cfg, overrides, distributor, nil, nil, log.NewNopLogger(), nil, nil, unlimitedQueryLimitsProvider())
+			queryable, _, _, _, err := New(cfg, overrides, distributor, nil, prometheus.NewRegistry(), log.NewNopLogger(), nil, nil, unlimitedQueryLimitsProvider())
 			require.NoError(t, err)
 			ctx := user.InjectOrgID(context.Background(), "0")
 			ctx = limiter.AddMemoryTrackerToContext(ctx, limiter.NewUnlimitedMemoryConsumptionTracker(ctx))
@@ -676,7 +677,7 @@ func TestQuerier_ValidateQueryTimeRange(t *testing.T) {
 
 			planner, err := streamingpromql.NewQueryPlanner(cfg.EngineConfig.MimirQueryEngine, streamingpromql.NewMaximumSupportedVersionQueryPlanVersionProvider())
 			require.NoError(t, err)
-			queryable, _, _, _, err := New(cfg, overrides, distributor, nil, nil, log.NewNopLogger(), nil, planner, unlimitedQueryLimitsProvider())
+			queryable, _, _, _, err := New(cfg, overrides, distributor, nil, prometheus.NewRegistry(), log.NewNopLogger(), nil, planner, unlimitedQueryLimitsProvider())
 			require.NoError(t, err)
 
 			query, err := engine.NewRangeQuery(ctx, queryable, nil, "dummy", c.queryStartTime, c.queryEndTime, time.Minute)
@@ -754,7 +755,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLength(t *testing.T) {
 
 			planner, err := streamingpromql.NewQueryPlanner(cfg.EngineConfig.MimirQueryEngine, streamingpromql.NewMaximumSupportedVersionQueryPlanVersionProvider())
 			require.NoError(t, err)
-			queryable, _, _, _, err := New(cfg, overrides, distributor, nil, nil, log.NewNopLogger(), nil, planner, unlimitedQueryLimitsProvider())
+			queryable, _, _, _, err := New(cfg, overrides, distributor, nil, prometheus.NewRegistry(), log.NewNopLogger(), nil, planner, unlimitedQueryLimitsProvider())
 			require.NoError(t, err)
 
 			// Create the PromQL engine to execute the query.
@@ -882,7 +883,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLookback(t *testing.T) {
 
 				planner, err := streamingpromql.NewQueryPlanner(cfg.EngineConfig.MimirQueryEngine, streamingpromql.NewMaximumSupportedVersionQueryPlanVersionProvider())
 				require.NoError(t, err)
-				queryable, _, _, _, err := New(cfg, overrides, distributor, nil, nil, logger, nil, planner, unlimitedQueryLimitsProvider())
+				queryable, _, _, _, err := New(cfg, overrides, distributor, nil, prometheus.NewRegistry(), logger, nil, planner, unlimitedQueryLimitsProvider())
 				require.NoError(t, err)
 
 				query, err := engine.NewRangeQuery(ctx, queryable, nil, testData.query, testData.queryStartTime, testData.queryEndTime, time.Minute)
@@ -912,7 +913,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLookback(t *testing.T) {
 
 				planner, err := streamingpromql.NewQueryPlanner(cfg.EngineConfig.MimirQueryEngine, streamingpromql.NewMaximumSupportedVersionQueryPlanVersionProvider())
 				require.NoError(t, err)
-				queryable, _, _, _, err := New(cfg, overrides, distributor, nil, nil, logger, nil, planner, unlimitedQueryLimitsProvider())
+				queryable, _, _, _, err := New(cfg, overrides, distributor, nil, prometheus.NewRegistry(), logger, nil, planner, unlimitedQueryLimitsProvider())
 				require.NoError(t, err)
 
 				q, err := queryable.Querier(util.TimeToMillis(testData.queryStartTime), util.TimeToMillis(testData.queryEndTime))
@@ -952,7 +953,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLookback(t *testing.T) {
 
 				planner, err := streamingpromql.NewQueryPlanner(cfg.EngineConfig.MimirQueryEngine, streamingpromql.NewMaximumSupportedVersionQueryPlanVersionProvider())
 				require.NoError(t, err)
-				queryable, _, _, _, err := New(cfg, overrides, distributor, nil, nil, logger, nil, planner, unlimitedQueryLimitsProvider())
+				queryable, _, _, _, err := New(cfg, overrides, distributor, nil, prometheus.NewRegistry(), logger, nil, planner, unlimitedQueryLimitsProvider())
 				require.NoError(t, err)
 
 				q, err := queryable.Querier(util.TimeToMillis(testData.queryStartTime), util.TimeToMillis(testData.queryEndTime))
@@ -984,7 +985,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxQueryLookback(t *testing.T) {
 
 				planner, err := streamingpromql.NewQueryPlanner(cfg.EngineConfig.MimirQueryEngine, streamingpromql.NewMaximumSupportedVersionQueryPlanVersionProvider())
 				require.NoError(t, err)
-				queryable, _, _, _, err := New(cfg, overrides, distributor, nil, nil, logger, nil, planner, unlimitedQueryLimitsProvider())
+				queryable, _, _, _, err := New(cfg, overrides, distributor, nil, prometheus.NewRegistry(), logger, nil, planner, unlimitedQueryLimitsProvider())
 				require.NoError(t, err)
 
 				q, err := queryable.Querier(util.TimeToMillis(testData.queryStartTime), util.TimeToMillis(testData.queryEndTime))
@@ -1085,7 +1086,7 @@ func TestQuerier_ValidateQueryTimeRange_MaxLabelsQueryRange(t *testing.T) {
 
 			planner, err := streamingpromql.NewQueryPlanner(cfg.EngineConfig.MimirQueryEngine, streamingpromql.NewMaximumSupportedVersionQueryPlanVersionProvider())
 			require.NoError(t, err)
-			queryable, _, _, _, err := New(cfg, overrides, distributor, nil, nil, log.NewNopLogger(), nil, planner, unlimitedQueryLimitsProvider())
+			queryable, _, _, _, err := New(cfg, overrides, distributor, nil, prometheus.NewRegistry(), log.NewNopLogger(), nil, planner, unlimitedQueryLimitsProvider())
 			require.NoError(t, err)
 
 			q, err := queryable.Querier(util.TimeToMillis(testData.queryStartTime), util.TimeToMillis(testData.queryEndTime))
@@ -1203,7 +1204,7 @@ func TestQuerier_ValidateQuery_MaxSeriesQueryLimit(t *testing.T) {
 
 			planner, err := streamingpromql.NewQueryPlanner(cfg.EngineConfig.MimirQueryEngine, streamingpromql.NewMaximumSupportedVersionQueryPlanVersionProvider())
 			require.NoError(t, err)
-			queryable, _, _, _, err := New(cfg, overrides, distributor, nil, nil, log.NewNopLogger(), nil, planner, unlimitedQueryLimitsProvider())
+			queryable, _, _, _, err := New(cfg, overrides, distributor, nil, prometheus.NewRegistry(), log.NewNopLogger(), nil, planner, unlimitedQueryLimitsProvider())
 			require.NoError(t, err)
 
 			q, err := queryable.Querier(util.TimeToMillis(testData.queryStartTime), util.TimeToMillis(testData.queryEndTime))
@@ -1303,7 +1304,7 @@ func TestQuerier_ValidateQuery_MaxLabelNamesLimit(t *testing.T) {
 			planner, err := streamingpromql.NewQueryPlanner(cfg.EngineConfig.MimirQueryEngine, streamingpromql.NewMaximumSupportedVersionQueryPlanVersionProvider())
 			require.NoError(t, err)
 
-			queryable, _, _, _, err := New(cfg, overrides, distributor, nil, nil, log.NewNopLogger(), nil, planner, unlimitedQueryLimitsProvider())
+			queryable, _, _, _, err := New(cfg, overrides, distributor, nil, prometheus.NewRegistry(), log.NewNopLogger(), nil, planner, unlimitedQueryLimitsProvider())
 			require.NoError(t, err)
 
 			q, err := queryable.Querier(util.TimeToMillis(start), util.TimeToMillis(end))
@@ -1396,7 +1397,7 @@ func TestQuerier_ValidateQuery_MaxLabelValuesLimit(t *testing.T) {
 			planner, err := streamingpromql.NewQueryPlanner(cfg.EngineConfig.MimirQueryEngine, streamingpromql.NewMaximumSupportedVersionQueryPlanVersionProvider())
 			require.NoError(t, err)
 
-			queryable, _, _, _, err := New(cfg, overrides, distributor, nil, nil, log.NewNopLogger(), nil, planner, unlimitedQueryLimitsProvider())
+			queryable, _, _, _, err := New(cfg, overrides, distributor, nil, prometheus.NewRegistry(), log.NewNopLogger(), nil, planner, unlimitedQueryLimitsProvider())
 			require.NoError(t, err)
 
 			q, err := queryable.Querier(util.TimeToMillis(start), util.TimeToMillis(end))
@@ -1572,7 +1573,7 @@ func TestQuerier_QueryStoreAfterConfig(t *testing.T) {
 
 			planner, err := streamingpromql.NewQueryPlanner(cfg.EngineConfig.MimirQueryEngine, streamingpromql.NewMaximumSupportedVersionQueryPlanVersionProvider())
 			require.NoError(t, err)
-			queryable, _, _, _, err := New(cfg, overrides, distributor, querierQueryables, nil, log.NewNopLogger(), nil, planner, unlimitedQueryLimitsProvider())
+			queryable, _, _, _, err := New(cfg, overrides, distributor, querierQueryables, prometheus.NewRegistry(), log.NewNopLogger(), nil, planner, unlimitedQueryLimitsProvider())
 			require.NoError(t, err)
 			ctx := user.InjectOrgID(context.Background(), "0")
 			ctx = limiter.AddMemoryTrackerToContext(ctx, limiter.NewUnlimitedMemoryConsumptionTracker(ctx))


### PR DESCRIPTION
#### What this PR does

This PR updates querier unit tests to pass in a prometheus registry for use in the engine.

This is a precondition to a subsequent PR which will require the registry to be set in the engine.

Since this is only a change to tests no changelog has been recorded.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to unit tests wiring a non-nil Prometheus registry into `querier.New`, with no production logic changes.
> 
> **Overview**
> Updates `pkg/querier/querier_test.go` to consistently pass a real Prometheus `Registry` (`prometheus.NewRegistry()`) into `querier.New()` instead of `nil`, aligning test setup with the querier/engine’s metrics registration requirements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82c9c27b0f08fb8f7819532e2341ba2e5087099f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->