### PR TITLE
Fix flaky TestActiveSeriesLoadingMetric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,7 @@
 * [ENHANCEMENT] MQE: Improve per-query memory consumption limit enforcement in histogram function evaluations. #14691
 * [ENHANCEMENT] MQE: Improve per-query memory consumption limit enforcement within aggregation operations. #14735
 * [ENHANCEMENT] Usage-tracker: Improve performance by using a special shard grouping algorithm. #14715
+* [BUGFIX] Ingester: Fix flaky `TestActiveSeriesLoadingMetric` by increasing simulated idle timeout and assertion slack for CI scheduling. #14830
 * [BUGFIX] Distributor: Fix race condition where usage-tracker partition ring may not be initialized before the distributor service starts, causing `usage-tracker partition ring is required` error on startup. #14675
 * [BUGFIX] Mimir: Fix false positive in filesystem path overlap detection when one path is a string prefix of another but not an ancestor directory. #14426
 * [BUGFIX] Build: Fixed config descriptor generation to correctly handle custom field types without CLI flags. #14632

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -12496,7 +12496,7 @@ func TestActiveSeriesLoadingMetric(t *testing.T) {
 		registry := prometheus.NewRegistry()
 		cfg := defaultIngesterTestConfig(t)
 		cfg.ActiveSeriesMetrics.Enabled = true
-		cfg.ActiveSeriesMetrics.IdleTimeout = 200 * time.Millisecond
+		cfg.ActiveSeriesMetrics.IdleTimeout = 20 * time.Second
 
 		ing, r, err := prepareIngesterWithBlocksStorage(t, cfg, nil, registry)
 		require.NoError(t, err)
@@ -12517,7 +12517,8 @@ func TestActiveSeriesLoadingMetric(t *testing.T) {
 		`), "cortex_ingester_active_series_loading"))
 
 		// After idle timeout, metric should be 0.
-		ing.updateActiveSeries(time.Now().Add(cfg.ActiveSeriesMetrics.IdleTimeout))
+		// Add an extra second to avoid flakes if activeSeriesStartMs was recorded slightly after time.Now()
+		ing.updateActiveSeries(time.Now().Add(cfg.ActiveSeriesMetrics.IdleTimeout).Add(time.Second))
 		require.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(`
 			# HELP cortex_ingester_active_series_loading 1 if active series counts are still warming up and may be underreported, 0 once they are accurate.
 			# TYPE cortex_ingester_active_series_loading gauge


### PR DESCRIPTION
Fixes #14818. Increases simulated IdleTimeout to 20s and allows 1s clock drift to prevent test flakiness due to goroutine scheduling delays in CI environments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only test timing parameters and changelog are updated, with no production behavior changes.
> 
> **Overview**
> Fixes a flaky ingester metric test by increasing the simulated `ActiveSeriesMetrics.IdleTimeout` to `20s` and adding a `+1s` buffer before asserting the `cortex_ingester_active_series_loading` transition to `0`.
> 
> Adds a changelog entry noting the `TestActiveSeriesLoadingMetric` flake fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e90a520414d4f67f1d60fc0e2666b8fdaa397a50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->