### PR TITLE
MQE: fix multiple info() bugs diverging from upstream Prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -284,6 +284,10 @@
 * [BUGFIX] Query-frontend: Fix bugs with matcher propagation for binary operations where it was not being properly applied within nested expressions and also wrongly propagating internal label matchers. #15110
 * [BUGFIX] Distributor: Cancel DoUntilQuorum in cardinality analysis API when active_series_results_max_size_bytes is breached. #15177
 * [BUGFIX] MQE: Fix issue where queries with step-invariant range vector expressions (eg. `quantile_over_time(scalar(arg), metric[5m] @ 1000)`) could return incorrect results. #15192
+* [BUGFIX] MQE: Fix `info()` function not enriching series when inner series are missing one identifying label (instance/job) but matching info series exist. #14832
+* [BUGFIX] MQE: Fix `info()` function only retaining one matcher when multiple data label matchers target the same label name. #14832
+* [BUGFIX] MQE: Fix `info()` function silently overwriting conflicting labels from different info metrics instead of returning an error. #14832
+* [BUGFIX] MQE: Fix `info()` function incorrectly grouping labels from replaced info series at the same evaluation timestamp due to lookback. #14832
 
 ### Mixin
 

--- a/pkg/streamingpromql/operators/functions/info.go
+++ b/pkg/streamingpromql/operators/functions/info.go
@@ -237,9 +237,9 @@ func (f *InfoFunction) processSamplesFromInfoSeries(ctx context.Context, infoMet
 		types.PutInstantVectorSeriesData(d, f.MemoryConsumptionTracker)
 	}
 
-	// Build f.sigTimestamps from sigTimestampsByMetric. This ensures that when
-	// duplicate resolution picks a winner (newer original timestamp), only the
-	// winner's labels appear in f.sigTimestamps — not both old and new.
+	// Summarise the info series by recording per timestamp and labels-only signature
+	// the series labels we've seen. We do this in a second pass so the inner loop's
+	// per-(metric, sig) duplicate resolution finalises before we write the result.
 	for _, metricSigTimestamps := range sigTimestampsByMetric {
 		for t, sigsAtTimestamp := range metricSigTimestamps {
 			sigAtTimestamp, exists := f.sigTimestamps[t]

--- a/pkg/streamingpromql/operators/functions/info.go
+++ b/pkg/streamingpromql/operators/functions/info.go
@@ -129,7 +129,10 @@ func (f *InfoFunction) generateInfoMatchers(innerMetadata []types.SeriesMetadata
 		values := identifyingLabelValues[labelName]
 		switch len(values) {
 		case 0:
-			return nil, true
+			// No inner series have this identifying label; skip generating a matcher
+			// for it but continue processing other labels. Only skip querying info
+			// entirely if no identifying labels have any values at all.
+			continue
 		case 1:
 			for value := range values {
 				matchers = append(matchers, types.Matcher{
@@ -151,6 +154,10 @@ func (f *InfoFunction) generateInfoMatchers(innerMetadata []types.SeriesMetadata
 				Value: regexPattern,
 			})
 		}
+	}
+
+	if len(matchers) == 0 {
+		return nil, true
 	}
 
 	return matchers, false
@@ -201,12 +208,12 @@ func (f *InfoFunction) processSamplesFromInfoSeries(ctx context.Context, infoMet
 			// Check for duplicate series for the same timestamp and signature.
 			// If a duplicate is found, only error out if the original timestamp is the same.
 			// Otherwise, keep the one with the latest original timestamp.
-			sigTimestamps, exists := sigTimestampsByMetric[metricName]
+			metricSigTimestamps, exists := sigTimestampsByMetric[metricName]
 			if !exists {
-				sigTimestamps = make(map[int64]map[string]labelsTime)
-				sigTimestampsByMetric[metricName] = sigTimestamps
+				metricSigTimestamps = make(map[int64]map[string]labelsTime)
+				sigTimestampsByMetric[metricName] = metricSigTimestamps
 			}
-			sigsAtTimestamp, exists := sigTimestamps[sample.T]
+			sigsAtTimestamp, exists := metricSigTimestamps[sample.T]
 			if !exists {
 				sigsAtTimestamp = make(map[string]labelsTime)
 			}
@@ -222,21 +229,28 @@ func (f *InfoFunction) processSamplesFromInfoSeries(ctx context.Context, infoMet
 				labels: metadata.Labels,
 				time:   origTs,
 			}
-			sigTimestamps[sample.T] = sigsAtTimestamp
-
-			// We summarise the info series by recording per timestamp and labels-only signature
-			// the series labels we've seen.
-			sigAtTimestamp, exists := f.sigTimestamps[sample.T]
-			if !exists {
-				sigAtTimestamp = make(map[string][]labels.Labels)
-			}
-			sigAtTimestamp[string(sig)] = append(sigAtTimestamp[string(sig)], metadata.Labels)
-			f.sigTimestamps[sample.T] = sigAtTimestamp
+			metricSigTimestamps[sample.T] = sigsAtTimestamp
 		}
 
 		// Return the info series data to the pool as we no longer need the raw samples
 		// now that we've saved the processed summary.
 		types.PutInstantVectorSeriesData(d, f.MemoryConsumptionTracker)
+	}
+
+	// Build f.sigTimestamps from sigTimestampsByMetric. This ensures that when
+	// duplicate resolution picks a winner (newer original timestamp), only the
+	// winner's labels appear in f.sigTimestamps — not both old and new.
+	for _, metricSigTimestamps := range sigTimestampsByMetric {
+		for t, sigsAtTimestamp := range metricSigTimestamps {
+			sigAtTimestamp, exists := f.sigTimestamps[t]
+			if !exists {
+				sigAtTimestamp = make(map[string][]labels.Labels)
+			}
+			for sig, lt := range sigsAtTimestamp {
+				sigAtTimestamp[sig] = append(sigAtTimestamp[sig], lt.labels)
+			}
+			f.sigTimestamps[t] = sigAtTimestamp
+		}
 	}
 
 	// Now that we've seen all info series, summarise them overall across all timestamps.
@@ -321,7 +335,9 @@ func matchersMatch(matchers []*labels.Matcher, value string) bool {
 // combineSeriesMetadata combines inner series metadata with info series labels.
 func (f *InfoFunction) combineSeriesMetadata(innerMetadata []types.SeriesMetadata, ignoreSeries map[int]struct{}, dataLabelMatchers types.Matchers) ([]types.SeriesMetadata, error) {
 	// Store user-specified label matchers in a map for easy retrieval.
-	dataLabelMatchersMap := make(map[string]*labels.Matcher)
+	// Multiple matchers may target the same label name (e.g. {data=~".+", data=~".*"}),
+	// so we store all of them per name to match upstream Prometheus behaviour.
+	dataLabelMatchersMap := make(map[string][]*labels.Matcher)
 	for _, m := range dataLabelMatchers {
 		if m.Name == model.MetricNameLabel {
 			continue
@@ -330,15 +346,20 @@ func (f *InfoFunction) combineSeriesMetadata(innerMetadata []types.SeriesMetadat
 		if err != nil {
 			return nil, err
 		}
-		dataLabelMatchersMap[m.Name] = matcher
+		dataLabelMatchersMap[m.Name] = append(dataLabelMatchersMap[m.Name], matcher)
 	}
 
 	// Check if any data label matcher doesn't match the empty string (e.g. {cluster=~".+"}).
 	// If so, inner series without a matching info series should be suppressed.
 	hasNonEmptyDataLabelMatcher := false
-	for _, m := range dataLabelMatchersMap {
-		if !m.Matches("") {
-			hasNonEmptyDataLabelMatcher = true
+	for _, ms := range dataLabelMatchersMap {
+		for _, m := range ms {
+			if !m.Matches("") {
+				hasNonEmptyDataLabelMatcher = true
+				break
+			}
+		}
+		if hasNonEmptyDataLabelMatcher {
 			break
 		}
 	}
@@ -377,7 +398,10 @@ func (f *InfoFunction) combineSeriesMetadata(innerMetadata []types.SeriesMetadat
 
 		// Get all possible combinations of info series labels with this inner series,
 		// and track them properly so we know exactly how many to pull from the pool later.
-		newLabelSets, labelSetsOrder := combineLabels(lb, innerSeries, labelSetsMap, dataLabelMatchersMap)
+		newLabelSets, labelSetsOrder, err := combineLabels(lb, innerSeries, labelSetsMap, dataLabelMatchersMap)
+		if err != nil {
+			return nil, err
+		}
 
 		// If user specified label matchers but no labels from info series matched, skip this series.
 		if len(dataLabelMatchersMap) > 0 && len(newLabelSets) == 0 {
@@ -444,7 +468,7 @@ func (f *InfoFunction) combineSeriesMetadata(innerMetadata []types.SeriesMetadat
 }
 
 // combineLabels combines inner series labels with info series label sets.
-func combineLabels(lb *labels.Builder, innerSeries types.SeriesMetadata, labelSetsMap map[string][]labels.Labels, dataLabelMatchersMap map[string]*labels.Matcher) ([]labels.Labels, []string) {
+func combineLabels(lb *labels.Builder, innerSeries types.SeriesMetadata, labelSetsMap map[string][]labels.Labels, dataLabelMatchersMap map[string][]*labels.Matcher) ([]labels.Labels, []string, error) {
 	newLabelSets := make([]labels.Labels, 0, len(labelSetsMap))
 	labelSetsOrder := make([]string, 0, len(labelSetsMap))
 	savedLabels := make(map[string]struct{})
@@ -453,9 +477,14 @@ func combineLabels(lb *labels.Builder, innerSeries types.SeriesMetadata, labelSe
 		lb.Reset(innerSeries.Labels)
 		clear(savedLabels)
 
+		var conflictErr error
 		for _, infoLabels := range labelSets {
 			// Add requested labels to inner series.
 			infoLabels.Range(func(l labels.Label) {
+				if conflictErr != nil {
+					return
+				}
+
 				// Ignore metric name.
 				if l.Name == model.MetricNameLabel {
 					return
@@ -467,23 +496,40 @@ func combineLabels(lb *labels.Builder, innerSeries types.SeriesMetadata, labelSe
 					return
 				}
 
-				// If user specified certain label matchers, ignore labels that don't match.
+				// If user specified certain label matchers, only include labels
+				// whose name is among the specified data label matchers.
+				// Value filtering is not needed here as info series were already
+				// pre-filtered by the selector during fetching.
 				if len(dataLabelMatchersMap) > 0 {
-					if matcher, ok := dataLabelMatchersMap[l.Name]; !ok || !matcher.Matches(l.Value) {
+					if _, ok := dataLabelMatchersMap[l.Name]; !ok {
 						return
 					}
+				}
+
+				// Detect conflicting labels from different info metrics.
+				if v := lb.Get(l.Name); v != "" && v != l.Value {
+					conflictErr = fmt.Errorf("conflicting label: %s", l.Name)
+					return
 				}
 
 				lb.Set(l.Name, l.Value)
 				savedLabels[l.Name] = struct{}{}
 			})
+			if conflictErr != nil {
+				return nil, nil, conflictErr
+			}
 		}
 
 		shouldSkip := false
 		// If user specified certain label matchers but no labels matched, skip this series.
-		for _, m := range dataLabelMatchersMap {
-			if _, saved := savedLabels[m.Name]; !saved && !m.Matches("") {
-				shouldSkip = true
+		for _, ms := range dataLabelMatchersMap {
+			for _, m := range ms {
+				if _, saved := savedLabels[m.Name]; !saved && !m.Matches("") {
+					shouldSkip = true
+					break
+				}
+			}
+			if shouldSkip {
 				break
 			}
 		}
@@ -495,7 +541,7 @@ func combineLabels(lb *labels.Builder, innerSeries types.SeriesMetadata, labelSe
 		labelSetsOrder = append(labelSetsOrder, makeLabelSetsHash(labelSets))
 	}
 
-	return newLabelSets, labelSetsOrder
+	return newLabelSets, labelSetsOrder, nil
 }
 
 func (f *InfoFunction) NextSeries(ctx context.Context) (types.InstantVectorSeriesData, error) {

--- a/pkg/streamingpromql/testdata/ours/info.test
+++ b/pkg/streamingpromql/testdata/ours/info.test
@@ -199,25 +199,3 @@ eval range from 0m to 2m step 1m info(test_metric, {priority=~"high|medium", pri
 eval range from 0m to 2m step 1m info(test_metric, {__name__=~".*info", __name__=~"target.*", category=~"web|api"})
   test_metric{instance="a", job="1", env="prod", category="web"} 1 2 3
   test_metric{instance="b", job="2", env="dev", category="api"} 4 5 6
-
-clear
-
-# When inner series are missing one identifying label (e.g. job) but info series
-# match on the present identifying label, enrichment should still happen.
-load 1m
-  metric{instance="a"} 1 2 3
-  custom_info{instance="a", enriched="yes"} 1 1 1
-
-eval range from 0m to 2m step 1m info(metric, {__name__="custom_info"})
-  metric{instance="a", enriched="yes"} 1 2 3
-
-clear
-
-# Conflicting labels across different info metrics should error.
-load 1m
-  metric{instance="a", job="1"} 1 2 3
-  target_info{instance="a", job="1", x="from_target"} 1 1 1
-  build_info{instance="a", job="1", x="from_build"} 1 1 1
-
-eval_fail range from 0m to 2m step 1m info(metric, {__name__=~".+_info"})
-  expected_fail_regexp conflicting label

--- a/pkg/streamingpromql/testdata/ours/info.test
+++ b/pkg/streamingpromql/testdata/ours/info.test
@@ -199,3 +199,25 @@ eval range from 0m to 2m step 1m info(test_metric, {priority=~"high|medium", pri
 eval range from 0m to 2m step 1m info(test_metric, {__name__=~".*info", __name__=~"target.*", category=~"web|api"})
   test_metric{instance="a", job="1", env="prod", category="web"} 1 2 3
   test_metric{instance="b", job="2", env="dev", category="api"} 4 5 6
+
+clear
+
+# When inner series are missing one identifying label (e.g. job) but info series
+# match on the present identifying label, enrichment should still happen.
+load 1m
+  metric{instance="a"} 1 2 3
+  custom_info{instance="a", enriched="yes"} 1 1 1
+
+eval range from 0m to 2m step 1m info(metric, {__name__="custom_info"})
+  metric{instance="a", enriched="yes"} 1 2 3
+
+clear
+
+# Conflicting labels across different info metrics should error.
+load 1m
+  metric{instance="a", job="1"} 1 2 3
+  target_info{instance="a", job="1", x="from_target"} 1 1 1
+  build_info{instance="a", job="1", x="from_build"} 1 1 1
+
+eval_fail range from 0m to 2m step 1m info(metric, {__name__=~".+_info"})
+  expected_fail_regexp conflicting label

--- a/pkg/streamingpromql/testdata/upstream/info.test
+++ b/pkg/streamingpromql/testdata/upstream/info.test
@@ -297,9 +297,8 @@ load 1m
 	metric{instance="a"} 1 2 3
 	custom_info{instance="a", enriched="yes"} 1 1 1
 
-# Unsupported by streaming engine.
-# eval range from 0m to 2m step 1m info(metric, {__name__="custom_info"})
-#	metric{instance="a", enriched="yes"} 1 2 3
+eval range from 0m to 2m step 1m info(metric, {__name__="custom_info"})
+	metric{instance="a", enriched="yes"} 1 2 3
 
 clear
 
@@ -309,6 +308,5 @@ load 1m
 	target_info{instance="a", job="1", x="from_target"} 1 1 1
 	build_info{instance="a", job="1", x="from_build"} 1 1 1
 
-# Unsupported by streaming engine.
-# eval range from 0m to 2m step 1m info(metric, {__name__=~".+_info"})
-#	expect fail regex: conflicting label
+eval range from 0m to 2m step 1m info(metric, {__name__=~".+_info"})
+	expect fail regex: conflicting label


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->
#### What this PR does

Fix four bugs where the MQE `info()` implementation diverged from the upstream Prometheus engine:

- `generateInfoMatchers` skipped querying info series entirely when any identifying label (instance/job) had zero values across all inner series, instead of only when no identifying labels had values at all.

- `dataLabelMatchersMap` stored only one matcher per label name, losing subsequent matchers when multiple targeted the same name (e.g. `{data=~".+", data=~".*"}`).

- `combineLabels` silently overwrote conflicting labels from different info metrics instead of returning an error.

- `processSamplesFromInfoSeries` accumulated both old and new info series labels in `sigTimestamps` when duplicate resolution replaced an older entry at the same evaluation timestamp via lookback.

I'm adding the test cases upstream in https://github.com/prometheus/prometheus/pull/18367.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core MQE `info()` label-enrichment behavior (matcher generation, duplicate handling, and conflict errors), which can alter query results and introduce new user-visible failures for previously accepted ambiguous data.
> 
> **Overview**
> Fixes several correctness gaps in MQE’s streaming `info()` implementation to match upstream Prometheus behavior.
> 
> `generateInfoMatchers` now still queries info series when some inner series lack one identifying label (only skipping when *all* identifying labels have no values), `dataLabelMatchers` now preserves multiple matchers per label name, and enrichment now **errors on conflicting labels** from different info metrics instead of silently overwriting.
> 
> Also refactors info-series sample processing so duplicate resolution finalizes before summarizing labels per timestamp (avoiding incorrect grouping due to lookback), and enables/updates upstream-style tests plus changelog entries covering these fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6564b6048fb5180eacca72e307fc83227c86e40e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->