### PR TITLE
MQE: Add flags to set __series_hash__ external label on blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,7 +119,7 @@
 * [ENHANCEMENT] Compactor: If compaction fails because the result block would exceed the size limit for its postings offsets table, symbol table, or index, mark input blocks for no-compaction to avoid blocking future compactor runs. #13876 #14466 #14482
 * [ENHANCEMENT] Query-frontend: add support for `range()` duration expression. #13931
 * [ENHANCEMENT] Add experimental flag `common.instrument-reference-leaks-percentage` to leaked references to gRPC buffers. #13609 #14083
-* [ENHANCEMENT] Querier: Add experimental flag `-querier.mimir-query-engine.enable-projection-pushdown` to enable an MQE optimization pass for reducing data transferred between queriers and the storage layer. #14006 #14132 #14239 #14241 #14326 #14720 #14751 #14800
+* [ENHANCEMENT] Querier: Add experimental flag `-querier.mimir-query-engine.enable-projection-pushdown` to enable an MQE optimization pass for reducing data transferred between queriers and the storage layer. #14006 #14132 #14239 #14241 #14326 #14720 #14751 #14800 #14835
 * [ENHANCEMENT] MQE: Default to enabling the "eliminate deduplicate and merge" optimization pass via `-querier.mimir-query-engine.enable-eliminate-deduplicate-and-merge`. #14172
 * [ENHANCEMENT] Ingester: Reduce likelihood of ingestion being paused while idle TSDB compaction is in progress. #13978
 * [ENHANCEMENT] Ingester: Extend `cortex_ingester_tsdb_forced_compactions_in_progress` metric to report a value of 1 when there's an idle or forced TSDB head compaction in progress. #13979

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -5289,6 +5289,17 @@
           ],
           "fieldValue": null,
           "fieldDefaultValue": null
+        },
+        {
+          "kind": "field",
+          "name": "series_hash_enabled",
+          "required": false,
+          "desc": "Set an external label on blocks that indicates the series include a generated unique ID. Required for the MQE projection optimization.",
+          "fieldValue": null,
+          "fieldDefaultValue": false,
+          "fieldFlag": "ingester.series-hash-enabled",
+          "fieldType": "boolean",
+          "fieldCategory": "experimental"
         }
       ],
       "fieldValue": null,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1903,6 +1903,8 @@ Usage of ./cmd/mimir/mimir:
     	Unregister from the ring upon clean shutdown. It can be useful to disable for rolling restarts with consistent naming. (default true)
   -ingester.ring.zone-awareness-enabled
     	True to enable the zone-awareness and replicate ingested samples across different availability zones. This option needs be set on ingesters, distributors, queriers, and rulers when running in microservices mode.
+  -ingester.series-hash-enabled
+    	[experimental] Set an external label on blocks that indicates the series include a generated unique ID. Required for the MQE projection optimization.
   -ingester.track-ingester-owned-series
     	[experimental] This option enables tracking of ingester-owned series based on ring state, even if -ingester.use-ingester-owned-series-for-limits is disabled.
   -ingester.tsdb-config-update-period duration

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -1677,6 +1677,11 @@ read_reactive_limiter:
   # current inflight requests, after which all requests are rejected
   # CLI flag: -ingester.read-reactive-limiter.max-rejection-factor
   [max_rejection_factor: <float> | default = 3]
+
+# (experimental) Set an external label on blocks that indicates the series
+# include a generated unique ID. Required for the MQE projection optimization.
+# CLI flag: -ingester.series-hash-enabled
+[series_hash_enabled: <boolean> | default = false]
 ```
 
 ### querier

--- a/pkg/blockbuilder/blockbuilder.go
+++ b/pkg/blockbuilder/blockbuilder.go
@@ -529,6 +529,13 @@ func (b *BlockBuilder) uploadBlocks(ctx context.Context, tenantID, dbDir string,
 			meta.Thanos.Labels[block.OutOfOrderExternalLabel] = block.OutOfOrderExternalLabelValue
 		}
 
+		if b.cfg.SeriesHashEnabled {
+			if meta.Thanos.Labels == nil {
+				meta.Thanos.Labels = map[string]string{}
+			}
+			meta.Thanos.Labels[block.SeriesHashExternalLabel] = block.SeriesHashExternalLabelValue
+		}
+
 		boff := backoff.New(ctx, backoff.Config{
 			MinBackoff: 100 * time.Millisecond,
 			MaxBackoff: time.Minute, // If there is a network hiccup, we prefer to wait longer retrying, than fail the whole section.

--- a/pkg/blockbuilder/config.go
+++ b/pkg/blockbuilder/config.go
@@ -26,6 +26,8 @@ type Config struct {
 
 	GenerateSparseIndexHeaders bool `yaml:"generate_sparse_index_headers" category:"experimental"`
 
+	SeriesHashEnabled bool `yaml:"series_hash_enabled" category:"experimental"`
+
 	// Config parameters defined outside the block-builder config and are injected dynamically.
 	Kafka         ingest.KafkaConfig       `yaml:"-"`
 	BlocksStorage tsdb.BlocksStorageConfig `yaml:"-"`
@@ -49,6 +51,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.StringVar(&cfg.DataDir, "block-builder.data-dir", "./data-block-builder/", "Directory to temporarily store blocks during building. This directory is wiped out between the restarts.")
 	f.IntVar(&cfg.ApplyMaxGlobalSeriesPerUserBelow, "block-builder.apply-max-global-series-per-user-below", 0, "Apply the global series limit per partition if the global series limit for the user is <= this given value. 0 means limits are disabled. If a user's limit is more than the given value, then the limits are not applied as well.")
 	f.BoolVar(&cfg.GenerateSparseIndexHeaders, "block-builder.generate-sparse-index-headers", false, "Construct and upload sparse index headers to object storage as part of block creation. This makes the sparse headers available to store-gateways when loading uncompacted blocks.")
+	f.BoolVar(&cfg.SeriesHashEnabled, "block-builder.series-hash-enabled", false, "Set an external label on blocks that indicates the series include a generated unique ID. Required for the MQE projection optimization.")
 
 	cfg.SchedulerConfig.RegisterFlags(f)
 }

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -220,6 +220,8 @@ type Config struct {
 
 	PushGrpcMethodEnabled bool `yaml:"push_grpc_method_enabled" category:"experimental" doc:"hidden"`
 
+	SeriesHashEnabled bool `yaml:"series_hash_enabled" category:"experimental"`
+
 	// This config is dynamically injected because defined outside the ingester config.
 	IngestStorageConfig ingest.Config `yaml:"-"`
 
@@ -250,6 +252,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.BoolVar(&cfg.UpdateIngesterOwnedSeries, "ingester.track-ingester-owned-series", false, "This option enables tracking of ingester-owned series based on ring state, even if -ingester.use-ingester-owned-series-for-limits is disabled.")
 	f.DurationVar(&cfg.OwnedSeriesUpdateInterval, "ingester.owned-series-update-interval", 15*time.Second, "How often to check for ring changes and possibly recompute owned series as a result of detected change.")
 	f.BoolVar(&cfg.PushGrpcMethodEnabled, "ingester.push-grpc-method-enabled", true, "Enables Push gRPC method on ingester. Can be only disabled when using ingest-storage to make sure ingesters only receive data from Kafka.")
+	f.BoolVar(&cfg.SeriesHashEnabled, "ingester.series-hash-enabled", false, "Set an external label on blocks that indicates the series include a generated unique ID. Required for the MQE projection optimization.")
 
 	// Hardcoded config (can only be overridden in tests).
 	cfg.limitMetricsUpdatePeriod = time.Second * 15
@@ -2962,6 +2965,7 @@ func (i *Ingester) createTSDB(userID string, walReplayConcurrency int) (*userTSD
 			udir,
 			bucket.NewUserBucketClient(userID, i.bucket, i.limits),
 			block.ReceiveSource,
+			i.cfg.SeriesHashEnabled,
 		)
 
 		// Initialise the shipper blocks cache.

--- a/pkg/ingester/shipper.go
+++ b/pkg/ingester/shipper.go
@@ -63,13 +63,14 @@ type ShipperConfigProvider interface {
 // them to a remote data store.
 // shipper implements BlocksUploader interface.
 type shipper struct {
-	logger      log.Logger
-	cfgProvider ShipperConfigProvider
-	userID      string
-	dir         string
-	metrics     *shipperMetrics
-	bucket      objstore.Bucket
-	source      block.SourceType
+	logger            log.Logger
+	cfgProvider       ShipperConfigProvider
+	userID            string
+	dir               string
+	metrics           *shipperMetrics
+	bucket            objstore.Bucket
+	source            block.SourceType
+	seriesHashEnabled bool
 }
 
 // newShipper creates a new uploader that detects new TSDB blocks in dir and uploads them to
@@ -83,19 +84,21 @@ func newShipper(
 	dir string,
 	bucket objstore.Bucket,
 	source block.SourceType,
+	seriesHashEnabled bool,
 ) *shipper {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
 
 	return &shipper{
-		logger:      logger,
-		cfgProvider: cfgProvider,
-		userID:      userID,
-		dir:         dir,
-		bucket:      bucket,
-		metrics:     metrics,
-		source:      source,
+		logger:            logger,
+		cfgProvider:       cfgProvider,
+		userID:            userID,
+		dir:               dir,
+		bucket:            bucket,
+		metrics:           metrics,
+		source:            source,
+		seriesHashEnabled: seriesHashEnabled,
 	}
 }
 
@@ -198,6 +201,10 @@ func (s *shipper) upload(ctx context.Context, logger log.Logger, meta *block.Met
 	if meta.Compaction.FromOutOfOrder() && s.cfgProvider.OutOfOrderBlocksExternalLabelEnabled(s.userID) {
 		// At this point the OOO data was already ingested and compacted, so there's no point in checking for the OOO feature flag
 		meta.Thanos.Labels[block.OutOfOrderExternalLabel] = block.OutOfOrderExternalLabelValue
+	}
+
+	if s.seriesHashEnabled {
+		meta.Thanos.Labels[block.SeriesHashExternalLabel] = block.SeriesHashExternalLabelValue
 	}
 
 	// Upload block with custom metadata.

--- a/pkg/ingester/shipper_test.go
+++ b/pkg/ingester/shipper_test.go
@@ -50,7 +50,7 @@ func TestShipper(t *testing.T) {
 	logs := &concurrency.SyncBuffer{}
 	logger := log.NewLogfmtLogger(logs)
 	overrides := validation.NewOverrides(defaultLimitsTestConfig(), nil)
-	s := newShipper(logger, overrides, "", newShipperMetrics(nil), blocksDir, bkt, block.TestSource)
+	s := newShipper(logger, overrides, "", newShipperMetrics(nil), blocksDir, bkt, block.TestSource, false)
 
 	t.Run("no shipper file yet", func(t *testing.T) {
 		// No shipper file = nothing is reported as shipped.
@@ -191,7 +191,7 @@ func TestShipper_DeceivingUploadErrors(t *testing.T) {
 
 	logger := log.NewLogfmtLogger(os.Stderr)
 	overrides := validation.NewOverrides(defaultLimitsTestConfig(), nil)
-	s := newShipper(logger, overrides, "", newShipperMetrics(nil), blocksDir, bkt, block.TestSource)
+	s := newShipper(logger, overrides, "", newShipperMetrics(nil), blocksDir, bkt, block.TestSource, false)
 
 	// Create and upload a block
 	id1 := ulid.MustNew(1, nil)
@@ -256,7 +256,7 @@ func TestIterBlockMetas(t *testing.T) {
 		},
 	}.WriteToDir(log.NewNopLogger(), path.Join(dir, id3.String())))
 	overrides := validation.NewOverrides(defaultLimitsTestConfig(), nil)
-	shipper := newShipper(nil, overrides, "", newShipperMetrics(nil), dir, nil, block.TestSource)
+	shipper := newShipper(nil, overrides, "", newShipperMetrics(nil), dir, nil, block.TestSource, false)
 	metas, err := shipper.blockMetasFromOldest()
 	require.NoError(t, err)
 	require.True(t, slices.IsSortedFunc(metas, func(a, b *block.Meta) int {
@@ -269,7 +269,7 @@ func TestShipperAddsSegmentFiles(t *testing.T) {
 
 	inmemory := objstore.NewInMemBucket()
 	overrides := validation.NewOverrides(defaultLimitsTestConfig(), nil)
-	s := newShipper(nil, overrides, "", newShipperMetrics(nil), dir, inmemory, block.TestSource)
+	s := newShipper(nil, overrides, "", newShipperMetrics(nil), dir, inmemory, block.TestSource, false)
 
 	id := ulid.MustNew(1, nil)
 	blockDir := path.Join(dir, id.String())
@@ -412,7 +412,7 @@ func TestShipper_AddOOOLabel(t *testing.T) {
 				},
 			}
 			overrides := validation.NewOverrides(defaultLimitsTestConfig(), validation.NewMockTenantLimits(tenantLimits))
-			s := newShipper(logger, overrides, "", newShipperMetrics(nil), blocksDir, bkt, block.TestSource)
+			s := newShipper(logger, overrides, "", newShipperMetrics(nil), blocksDir, bkt, block.TestSource, false)
 
 			createBlock(t, blocksDir, tc.meta.ULID, tc.meta)
 
@@ -425,6 +425,59 @@ func TestShipper_AddOOOLabel(t *testing.T) {
 			readMeta, err := block.DownloadMeta(context.Background(), log.NewNopLogger(), bkt, tc.meta.ULID)
 			require.NoError(t, err)
 			require.Equal(t, tc.oooCompactionHintExpected, readMeta.Compaction.FromOutOfOrder())
+			require.Equal(t, tc.expectedLabels, readMeta.Thanos.Labels)
+		})
+	}
+}
+
+func TestShipper_AddSeriesHashLabel(t *testing.T) {
+	for _, tc := range []struct {
+		id               ulid.ULID
+		serisHashEnabled bool
+		expectedLabels   map[string]string
+	}{
+		{
+			id:               ulid.MustNew(1, nil),
+			serisHashEnabled: false,
+			expectedLabels:   map[string]string{},
+		},
+		{
+			id:               ulid.MustNew(2, nil),
+			serisHashEnabled: true,
+			expectedLabels: map[string]string{
+				block.SeriesHashExternalLabel: block.SeriesHashExternalLabelValue,
+			},
+		},
+	} {
+		t.Run(fmt.Sprintf("series hash enabled=%v", tc.serisHashEnabled), func(t *testing.T) {
+			blocksDir := t.TempDir()
+			bucketDir := t.TempDir()
+
+			bkt, err := filesystem.NewBucketClient(filesystem.Config{Directory: bucketDir})
+			require.NoError(t, err)
+
+			logger := log.NewNopLogger()
+			overrides := validation.NewOverrides(defaultLimitsTestConfig(), nil)
+
+			createBlock(t, blocksDir, tc.id, block.Meta{
+				BlockMeta: tsdb.BlockMeta{
+					ULID:    tc.id,
+					MaxTime: 4000,
+					MinTime: 2000,
+					Version: 1,
+					Stats: tsdb.BlockStats{
+						NumSamples: 100,
+					},
+				},
+			})
+
+			s := newShipper(logger, overrides, "", newShipperMetrics(nil), blocksDir, bkt, block.TestSource, tc.serisHashEnabled)
+			uploaded, err := s.Sync(context.Background())
+			require.NoError(t, err)
+			require.Equal(t, 1, uploaded)
+
+			readMeta, err := block.DownloadMeta(context.Background(), logger, bkt, tc.id)
+			require.NoError(t, err)
 			require.Equal(t, tc.expectedLabels, readMeta.Thanos.Labels)
 		})
 	}

--- a/pkg/storage/tsdb/block/meta.go
+++ b/pkg/storage/tsdb/block/meta.go
@@ -65,9 +65,12 @@ const (
 	DeprecatedShardIDExternalLabel = "__shard_id__"
 
 	// OutOfOrderExternalLabel is the external label used to mark blocks containing out-of-order data.
-	OutOfOrderExternalLabel = "__out_of_order__"
-	// OutOfOrderExternalLabelValue is the value to be used for the OutOfOrderExternalLabel label
+	OutOfOrderExternalLabel      = "__out_of_order__"
 	OutOfOrderExternalLabelValue = "true"
+
+	// SeriesHashExternalLabel is the external label used to mark blocks containing series with generated unique IDs.
+	SeriesHashExternalLabel      = "__series_hash__"
+	SeriesHashExternalLabelValue = "true"
 )
 
 // Meta describes the a block's meta. It wraps the known TSDB meta structure and


### PR DESCRIPTION
#### What this PR does

Add flags to block-builder and ingesters to have them set an external label when TSDB blocks are uploaded indicating the series contain a `__series_hash__` label. This is required to be able to use or not use the MQE projections optimization at query time.

#### Which issue(s) this PR fixes or relates to

Part of #13863

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
