### PR TITLE
compactor scheduler: align tenant discovery backoff naming

### DIFF
--- a/pkg/compactor/scheduler/scheduler.go
+++ b/pkg/compactor/scheduler/scheduler.go
@@ -46,7 +46,7 @@ type Config struct {
 	MaintenanceIntervalsBeforeLeaseExpiration   int            `yaml:"maintenance_intervals_before_lease_expiration" category:"experimental"`
 	MaintenanceIntervalsBeforeColdStartPlanning int            `yaml:"maintenance_intervals_before_cold_start_planning" category:"experimental"`
 	TenantDiscoveryInterval                     time.Duration  `yaml:"tenant_discovery_interval" category:"experimental"`
-	UserDiscoveryBackoff                        backoff.Config `yaml:"user_discovery_backoff" category:"experimental"`
+	TenantDiscoveryBackoff                      backoff.Config `yaml:"tenant_discovery_backoff" category:"experimental"`
 	PersistenceType                             string         `yaml:"persistence_type" category:"experimental"`
 	RepeatedFailureReportThreshold              int            `yaml:"repeated_failure_report_threshold" category:"experimental"`
 	Bbolt                                       BboltConfig    `yaml:"bbolt" category:"experimental"`
@@ -60,9 +60,9 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.MaintenanceIntervalsBeforeLeaseExpiration, "compactor-scheduler.maintenance-intervals-before-lease-expiration", 3, "The number of maintenance intervals before lease expiration is enforced. Nonpositive values are all treated as zero.")
 	f.IntVar(&cfg.MaintenanceIntervalsBeforeColdStartPlanning, "compactor-scheduler.maintenance-intervals-before-cold-start-planning", 4, "The number of maintenance intervals before planning occurs when starting from no recovered state. Nonpositive values are all treated as zero.")
 	f.DurationVar(&cfg.TenantDiscoveryInterval, "compactor-scheduler.tenant-discovery-interval", 10*time.Minute, "The duration of time between bucket listings to discover new tenants.")
+	cfg.TenantDiscoveryBackoff.RegisterFlagsWithPrefix("compactor-scheduler.tenant-discovery-backoff", f)
 	f.StringVar(&cfg.PersistenceType, "compactor-scheduler.persistence-type", "bbolt", "The type of persistence the compactor scheduler should use. Valid values: none, bbolt")
 	f.IntVar(&cfg.RepeatedFailureReportThreshold, "compactor-scheduler.repeated-failure-report-threshold", 2, "The number of times a job can fail before a repeated failure is recorded. 0 for no limit.")
-	cfg.UserDiscoveryBackoff.RegisterFlagsWithPrefix("compactor-scheduler", f)
 	cfg.Bbolt.RegisterFlagsWithPrefix("compactor-scheduler.bbolt", f)
 }
 

--- a/pkg/compactor/scheduler/tenant_discovery.go
+++ b/pkg/compactor/scheduler/tenant_discovery.go
@@ -27,7 +27,7 @@ type TenantDiscoverer struct {
 	allowedTenants                 *util.AllowList
 	bkt                            objstore.Bucket
 	jpm                            JobPersistenceManager
-	userDiscoveryBackoff           backoff.Config
+	tenantDiscoveryBackoff         backoff.Config
 	rotator                        *Rotator
 	maxLeases                      int
 	repeatedFailureReportThreshold int
@@ -49,7 +49,7 @@ func NewTenantDiscoverer(
 		allowedTenants:                 allowList,
 		bkt:                            bkt,
 		jpm:                            jpm,
-		userDiscoveryBackoff:           cfg.UserDiscoveryBackoff,
+		tenantDiscoveryBackoff:         cfg.TenantDiscoveryBackoff,
 		rotator:                        rotator,
 		maxLeases:                      cfg.MaxLeases,
 		repeatedFailureReportThreshold: cfg.RepeatedFailureReportThreshold,
@@ -68,7 +68,7 @@ func (s *TenantDiscoverer) RecoverFrom(jobTrackers map[string]*JobTracker) {
 }
 
 func (s *TenantDiscoverer) start(ctx context.Context) error {
-	b := backoff.New(ctx, s.userDiscoveryBackoff)
+	b := backoff.New(ctx, s.tenantDiscoveryBackoff)
 	var err error
 	for b.Ongoing() {
 		err = s.discoverTenants(ctx)


### PR DESCRIPTION
Changes `UserDiscoveryBackoff` to `TenantDiscoveryBackoff` to align with naming used elsewhere in the scheduler. Also fixes the flag naming since previously it would register flags like `compactor-scheduler.backoff-min-period`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Renames a scheduler config field and changes the CLI flag prefix for tenant discovery backoff, which may break existing YAML/flag-based configurations on upgrade. Runtime behavior should be unchanged aside from the corrected flag names taking effect.
> 
> **Overview**
> Aligns naming by renaming `UserDiscoveryBackoff` to `TenantDiscoveryBackoff` in the compactor scheduler config and wiring (`TenantDiscoverer`).
> 
> Fixes flag registration so tenant discovery backoff options are exposed under `compactor-scheduler.tenant-discovery-backoff.*` (instead of the overly generic `compactor-scheduler.*` backoff flags).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 111503e8c212c99ff353a00fa8e80cc0d4982cf4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->