### PR TITLE
Add /split-file Claude Code skill

### DIFF
--- a/.claude/skills/split-file/SKILL.md
+++ b/.claude/skills/split-file/SKILL.md
@@ -93,7 +93,7 @@ Each new file should show the full commit history from before the split.
 
 ### Per-declaration content hash verification
 
-Use `tools/split-file-verify` to prove that every declaration was moved intact. The tool parses Go files using the AST, extracts every top-level declaration (functions, methods, types, var/const blocks), and outputs a sorted TSV of `name \t sha256_hash \t file`.
+Use `tools/split-file-verify` to prove that every declaration was moved intact. The tool parses Go files using the AST, extracts every top-level declaration (functions, methods, types, var/const blocks), and outputs a sorted TSV of `name \t sha256_hash`.
 
 ```bash
 # Build the tool

--- a/tools/split-file-verify/main.go
+++ b/tools/split-file-verify/main.go
@@ -21,14 +21,13 @@ import (
 //
 //	split-verify <file1.go> [file2.go ...]
 //
-// Output is TSV: name, sha256 hash (first 16 hex chars), file path.
+// Output is TSV: name, sha256 hash (first 16 hex chars).
 // Compare the output of the original file against the split files to
 // verify nothing was lost or modified.
 
 type decl struct {
 	Name string
 	Hash string
-	File string
 }
 
 func main() {
@@ -47,12 +46,15 @@ func main() {
 		decls = append(decls, fileDecls...)
 	}
 
-	sort.Slice(decls, func(i, j int) bool {
-		return decls[i].Name < decls[j].Name
+	sort.SliceStable(decls, func(i, j int) bool {
+		if decls[i].Name != decls[j].Name {
+			return decls[i].Name < decls[j].Name
+		}
+		return decls[i].Hash < decls[j].Hash
 	})
 
 	for _, d := range decls {
-		fmt.Printf("%s\t%s\t%s\n", d.Name, d.Hash, d.File)
+		fmt.Printf("%s\t%s\n", d.Name, d.Hash)
 	}
 }
 
@@ -78,7 +80,6 @@ func extractDecls(path string) ([]decl, error) {
 			result = append(result, decl{
 				Name: name,
 				Hash: hash(body),
-				File: path,
 			})
 
 		case *ast.GenDecl:
@@ -86,21 +87,11 @@ func extractDecls(path string) ([]decl, error) {
 			case token.TYPE:
 				for _, spec := range dt.Specs {
 					ts := spec.(*ast.TypeSpec)
-					if len(dt.Specs) == 1 {
-						body := extractSource(src, fset, d)
-						result = append(result, decl{
-							Name: "type " + ts.Name.Name,
-							Hash: hash(body),
-							File: path,
-						})
-					} else {
-						body := extractSource(src, fset, spec)
-						result = append(result, decl{
-							Name: "type " + ts.Name.Name,
-							Hash: hash(body),
-							File: path,
-						})
-					}
+					body := extractSource(src, fset, spec)
+					result = append(result, decl{
+						Name: "type " + ts.Name.Name,
+						Hash: hash(body),
+					})
 				}
 
 			case token.VAR, token.CONST:
@@ -109,7 +100,6 @@ func extractDecls(path string) ([]decl, error) {
 				result = append(result, decl{
 					Name: dt.Tok.String() + " " + names,
 					Hash: hash(body),
-					File: path,
 				})
 			}
 		}


### PR DESCRIPTION
## Summary

Adds a reusable `/split-file` skill for Claude Code that splits large Go files into smaller focused modules while preserving `git log --follow` history.

The skill uses a [rename/rename merge conflict technique to maintain full commit history for each new file](https://beyermatthias.de/splitting-files-while-preserving-history-in-git), and documents the gotchas we discovered (goimports alias resolution, the need for rename on both sides, etc.).

This has been used for https://github.com/grafana/mimir/pull/14846


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds documentation and a small standalone Go CLI used for verifying declaration hashes; it doesn’t affect runtime code paths but could cause minor friction if the tool/output format is relied on by scripts.
> 
> **Overview**
> Introduces a new Claude Code skill, `split-file`, documenting a repeatable workflow to split large Go files while preserving `git log --follow` history via a rename/rename merge-conflict technique.
> 
> Adds a small CLI tool, `tools/split-file-verify`, that parses Go files and outputs per-top-level-declaration SHA-256 hashes (TSV) to mechanically verify that a split moved declarations without modifying content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d83dc50dca8730a3edc1127e52974829750ab8f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->