### PR TITLE
feat(labels): include `global.podLabels` in sts/deployment resource metadata

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -29,6 +29,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
+* [ENHANCEMENT] Include global.podLabels in resource metadata labels for all workloads, enabling better integration with observability and security tools. #14845
 * [CHANGE] Update minimum supported Kubernetes version to 1.32. This reflects the fact that Grafana does not test with older versions of Kubernetes. #14335
 * [CHANGE] Set default memory ballast for ruler to 1GiB to reduce GC pressure during startup. #13376
 * [CHANGE] Set docker.io as the default registry for mimir image. #13267

--- a/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
@@ -242,6 +242,9 @@ app.kubernetes.io/part-of: memberlist
 app.kubernetes.io/version: {{ .ctx.Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .ctx.Release.Service }}
+{{- with .ctx.Values.global.podLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- if .rolloutZoneName }}
 {{-   if not .component }}
 {{-     printf "Component name cannot be empty if rolloutZoneName (%s) is set" .rolloutZoneName | fail }}


### PR DESCRIPTION
Include `global.podLabels` in the `mimir.labels` template so custom labels defined globally appear in both the StatefulSet/Deployment metadata and pod templates.

Feature reported: #14845

> **Much cleaner**, we should extend options to include `commonLabels` as defined in [loki](https://github.com/grafana-community/helm-charts/blob/main/charts/loki/templates/_helpers.tpl#L141), [values.yaml](https://github.com/grafana-community/helm-charts/blob/main/charts/loki/values.yaml#L61) 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Helm templating change that only adds additional metadata labels; primary impact is potential label/annotation-based tooling behavior or extra diffs on upgrade.
> 
> **Overview**
> Adds `global.podLabels` to the shared `mimir.labels` helper so globally-defined pod labels are also applied to **workload resource metadata labels** (eg, StatefulSets/Deployments), not just pod templates.
> 
> Updates the chart changelog to document the new labeling behavior (#14845).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a8f8205f4d37e86ce76a1e4897155993d2e9660. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->