### PR TITLE
compactor scheduler: add corruption recovery to runbook

### DIFF
--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -951,10 +951,12 @@ How to **investigate**:
 
 **Recovery from database corruption:**
 
-The compactor scheduler uses bbolt databases on a persistent volume. If there are fatal errors that indicate database corruption, follow these steps to recover:
+The compactor scheduler uses bbolt databases on a persistent volume. If there are fatal errors that indicate database corruption, then the data can be wiped in order to recover.
+
+Follow these steps to wipe all of the persistent state on the compactor scheduler:
 
 - Scale down the compactor scheduler StatefulSet to 0 replicas. Due to its `persistentVolumeClaimRetentionPolicy` this will remove the persistent volume claim, which in turn will remove the persistent volume.
-- Scale the compactor scheduler StatefulSet back to 1 replica. It should now start cleanly. Any previously in-progress jobs will be lost. Workers will stop processing them when they attempt to update the scheduler, then request new work.
+- Scale the compactor scheduler StatefulSet back to 1 replica. The new replica should now start cleanly. Any previously in-progress jobs will be lost. Workers will stop processing them when they attempt to update the scheduler, then request new work.
 - When the scheduler starts from empty state, it delays planning new jobs for a configurable duration (`-compactor-scheduler.maintenance-intervals-before-cold-start-planning`) to prevent job duplication.
 
 ### MimirCompactorSchedulerRepeatedJobFailure


### PR DESCRIPTION
Adds the fatal database corruption recovery procedure to the `MimirCompactorSchedulerUnreachable` runbook.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds an operational recovery procedure; no runtime behavior or interfaces are modified.
> 
> **Overview**
> Adds a new **database corruption recovery** section to the `MimirCompactorSchedulerUnreachable` runbook, documenting how to wipe the compactor scheduler’s bbolt persistent state by scaling its StatefulSet down/up and noting the expected job loss and cold-start planning delay (`-compactor-scheduler.maintenance-intervals-before-cold-start-planning`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2be0a77a17596ec43b960d4caedea2d235d64d34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->