### PR TITLE
Skip kotel tracing hooks for unsampled traces in franz-go Kafka client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,7 @@
 * [ENHANCEMENT] Ingester: Eliminate 20-minute active series metrics loading period when custom tracker or cost attribution configuration changes. Active series counts are now immediately correct after a config reload. #14537
 * [ENHANCEMENT] Ingester: Use Kafka record timestamps instead of wall-clock time for active series tracking, grace period validation, and purging when ingest storage is enabled. This prevents premature purging or stale series caused by lag between record production and consumption. #14611 #14744
 * [ENHANCEMENT] Ingester: Export `cortex_ingester_active_series_loading` gauge metric that is `1` while active series counts are still warming up after ingester startup, and `0` once they are accurate (after IdleTimeout has elapsed). #14783
+* [ENHANCEMENT] Ingest storage: Skip kotel tracing hooks for unsampled traces in the franz-go Kafka client, significantly reducing CPU and memory overhead. #14852
 * [ENHANCEMENT] Ingest storage: Allow configuring multiple Kafka seed brokers via `-ingest-storage.kafka.address` (comma-separated). #14328
 * [ENHANCEMENT] MQE: Add experimental support for eliminating selectors that are a subset of another selector. Enable with `-querier.mimir-query-engine.enable-subset-selector-elimination=true`. #14456 #14457 #14546 #14559 #14561 #14621
 * [ENHANCEMENT] Ingest storage: Add `-ingest-storage.kafka.client-rack` flag to enable rack awareness. #14434

--- a/pkg/storage/ingest/fetcher.go
+++ b/pkg/storage/ingest/fetcher.go
@@ -21,7 +21,6 @@ import (
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
-	"github.com/twmb/franz-go/plugin/kotel"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/atomic"
 
@@ -272,7 +271,7 @@ type ConcurrentFetchers struct {
 	topicID     [16]byte
 	topicName   string
 	metrics     *ReaderMetrics
-	tracer      *kotel.Tracer
+	tracer      *sampledOnlyTracer
 
 	minBytesWaitTime time.Duration
 
@@ -365,7 +364,7 @@ func NewConcurrentFetchers(
 		rangeErrorPolicy:        rangeErrorPolicy,
 		trackCompressedBytes:    trackCompressedBytes,
 		maxBufferedBytesLimit:   maxBufferedBytesLimit,
-		tracer:                  recordsTracer(),
+		tracer:                  newSampledOnlyTracer(),
 		orderedFetches:          make(chan fetchResult),
 		done:                    make(chan struct{}),
 		fetchBackoffConfig:      fetchBackoffConfig,

--- a/pkg/storage/ingest/util.go
+++ b/pkg/storage/ingest/util.go
@@ -54,13 +54,62 @@ func IngesterPartitionID(ingesterID string) (int32, error) {
 	return int32(ingesterSeq), nil
 }
 
-type onlySampledTraces struct {
+// Compile-time checks to ensure sampledOnlyTracer implements the same hook interfaces as kotel.Tracer.
+var (
+	_ kgo.HookProduceRecordBuffered   = new(sampledOnlyTracer)
+	_ kgo.HookProduceRecordUnbuffered = new(sampledOnlyTracer)
+	_ kgo.HookFetchRecordBuffered     = new(sampledOnlyTracer)
+	_ kgo.HookFetchRecordUnbuffered   = new(sampledOnlyTracer)
+)
+
+// sampledOnlyTracer wraps a kotel.Tracer and skips span creation and header
+// injection on the produce path for unsampled traces. Fetch hooks always
+// delegate to the parent tracer because the consume side needs to extract
+// trace context from record headers regardless of local sampling. Without
+// this wrapper, kotel creates spans for every produced Kafka record regardless
+// of sampling, which is expensive at high volume.
+type sampledOnlyTracer struct {
+	parent *kotel.Tracer
+}
+
+func newSampledOnlyTracer() *sampledOnlyTracer {
+	return &sampledOnlyTracer{parent: recordsTracer()}
+}
+
+func (t *sampledOnlyTracer) OnProduceRecordBuffered(r *kgo.Record) {
+	if !trace.SpanContextFromContext(r.Context).IsSampled() {
+		return
+	}
+	t.parent.OnProduceRecordBuffered(r)
+}
+
+// OnProduceRecordUnbuffered is safe to skip when OnProduceRecordBuffered was also skipped:
+// the record's context still has the original unsampled span, so the parent's
+// OnProduceRecordUnbuffered would only call End() on a no-op span.
+func (t *sampledOnlyTracer) OnProduceRecordUnbuffered(r *kgo.Record, err error) {
+	if !trace.SpanContextFromContext(r.Context).IsSampled() {
+		return
+	}
+	t.parent.OnProduceRecordUnbuffered(r, err)
+}
+
+func (t *sampledOnlyTracer) OnFetchRecordBuffered(r *kgo.Record) {
+	t.parent.OnFetchRecordBuffered(r)
+}
+
+func (t *sampledOnlyTracer) OnFetchRecordUnbuffered(r *kgo.Record, polled bool) {
+	t.parent.OnFetchRecordUnbuffered(r, polled)
+}
+
+// sampledOnlyPropagator is a propagation wrapper that only injects trace context
+// into Kafka record headers when the trace is sampled. This avoids adding
+// headers to every record when the trace won't be collected.
+type sampledOnlyPropagator struct {
 	propagation.TextMapPropagator
 }
 
-func (o onlySampledTraces) Inject(ctx context.Context, carrier propagation.TextMapCarrier) {
-	sc := trace.SpanContextFromContext(ctx)
-	if !sc.IsSampled() {
+func (o sampledOnlyPropagator) Inject(ctx context.Context, carrier propagation.TextMapCarrier) {
+	if !trace.SpanContextFromContext(ctx).IsSampled() {
 		return
 	}
 	o.TextMapPropagator.Inject(ctx, carrier)
@@ -120,7 +169,7 @@ func commonKafkaClientOptions(cfg KafkaConfig, metrics *kprom.Metrics, logger lo
 		opts = append(opts, kgo.DialTLSConfig(tlsConfig))
 	}
 
-	opts = append(opts, kgo.WithHooks(kotel.NewKotel(kotel.WithTracer(recordsTracer())).Hooks()...))
+	opts = append(opts, kgo.WithHooks(newSampledOnlyTracer()))
 
 	if metrics != nil {
 		opts = append(opts, kgo.WithHooks(metrics))
@@ -221,7 +270,7 @@ func requestOAuthToken(ctx context.Context, socketPath string, timeout time.Dura
 }
 
 func recordsTracer() *kotel.Tracer {
-	return kotel.NewTracer(kotel.TracerPropagator(propagation.NewCompositeTextMapPropagator(onlySampledTraces{propagation.TraceContext{}})))
+	return kotel.NewTracer(kotel.TracerPropagator(propagation.NewCompositeTextMapPropagator(sampledOnlyPropagator{propagation.TraceContext{}})))
 }
 
 // resultPromise is a simple utility to have multiple goroutines waiting for a result from another one.

--- a/pkg/storage/ingest/writer_test.go
+++ b/pkg/storage/ingest/writer_test.go
@@ -23,6 +23,9 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
 	"github.com/twmb/franz-go/plugin/kprom"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/atomic"
 
 	"github.com/grafana/mimir/pkg/mimirpb"
@@ -1376,6 +1379,70 @@ func runAsyncAfter(wg *sync.WaitGroup, waitFor chan struct{}, fn func()) {
 		<-waitFor
 		fn()
 	}()
+}
+
+func BenchmarkWriter_WriteSync(b *testing.B) {
+	const (
+		topicName     = "bench"
+		numPartitions = 32
+		tenantID      = "user-1"
+	)
+
+	// Set up a real TracerProvider with a parent-based sampler.
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSampler(sdktrace.ParentBased(sdktrace.TraceIDRatioBased(1.0))),
+	)
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+	otel.SetTracerProvider(tp)
+
+	tr := tp.Tracer("bench")
+
+	// Build a sampled and an unsampled context.
+	sampledCtx, _ := tr.Start(context.Background(), "sampled-request")
+	unsampledCtx := trace.ContextWithSpanContext(context.Background(), trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    trace.TraceID{1},
+		SpanID:     trace.SpanID{1},
+		TraceFlags: 0, // not sampled
+		Remote:     true,
+	}))
+
+	// Create a fake Kafka cluster and a Writer.
+	_, clusterAddr := testkafka.CreateCluster(b, numPartitions, topicName)
+	cfg := createTestKafkaConfig(clusterAddr, topicName)
+	reg := prometheus.NewPedanticRegistry()
+
+	writer := NewWriter(cfg, test.NewTestingLogger(b), reg)
+	require.NoError(b, services.StartAndAwaitRunning(context.Background(), writer))
+	b.Cleanup(func() {
+		require.NoError(b, services.StopAndAwaitTerminated(context.Background(), writer))
+	})
+
+	req := &mimirpb.WriteRequest{
+		Timeseries: []mimirpb.PreallocTimeseries{mockPreallocTimeseries("series_1")},
+		Source:     mimirpb.API,
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	// Run from many concurrent goroutines to simulate the distributor's
+	// concurrent request handling, where each push runs in its own goroutine.
+	b.RunParallel(func(pb *testing.PB) {
+		n := 0
+		for pb.Next() {
+			// 1% sampled, 99% unsampled.
+			ctx := unsampledCtx
+			if n%100 == 0 {
+				ctx = sampledCtx
+			}
+			n++
+
+			partitionID := int32(n % numPartitions)
+			if err := writer.WriteSync(ctx, partitionID, tenantID, req); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
 }
 
 func createTestKafkaConfig(clusterAddr, topicName string) KafkaConfig {


### PR DESCRIPTION
#### What this PR does

Wraps the kotel.Tracer with `sampledOnlyTracer` that checks `IsSampled()` before delegating to kotel's produce/fetch hooks. For unsampled records, this is just a bitfield check and early return — no span creation, no allocations. Sampled traces still get full end-to-end linking (producer → Kafka → consumer) with span creation and header propagation.

CPU profiling showed kotel hooks consuming ~8% CPU in the distributor at scale, mostly from span creation (`tracer.Start()`) for every Kafka record regardless of sampling.

**Benchmark results (direct hooks, 10k records, 1% sampled):**

| Metric | direct kotel | sampledOnlyTracer wrapper | Improvement |
|--------|-------------|--------------------------|-------------|
| ns/op | ~6,083,000 | ~488,000 | **12.5x faster** |
| B/op | 14,153,628 | 293,601 | **48x less memory** |
| allocs/op | 110,400 | 1,500 | **73.6x fewer allocs** |

**Benchmark results (parallel `WriteSync`, 1% sampled):**

| Metric | direct kotel | sampledOnlyTracer wrapper | Improvement |
|--------|-------------|--------------------------|-------------|
| B/op | ~4,251 | ~2,867 | **-32% memory** |
| allocs/op | 47 | 35 | **-26% allocs** |

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.