### PR TITLE
Fix flaky TestActiveSeriesLoadingMetric

### DIFF
--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -12508,8 +12508,12 @@ func TestActiveSeriesLoadingMetric(t *testing.T) {
 		req := mockWriteRequest(t, labels.FromStrings(model.MetricNameLabel, "test"), 1, time.Now().UnixMilli())
 		require.NoError(t, ing.PushWithCleanup(ctx, req, func() {}))
 
+		// Use a deterministic time relative to activeSeriesStartMs to avoid flakiness
+		// when wall-clock time between ingester startup and this point exceeds IdleTimeout.
+		startTime := time.UnixMilli(ing.activeSeriesStartMs.Load())
+
 		// Before idle timeout elapses, metric should be 1.
-		ing.updateActiveSeries(time.Now())
+		ing.updateActiveSeries(startTime.Add(cfg.ActiveSeriesMetrics.IdleTimeout - time.Millisecond))
 		require.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(`
 			# HELP cortex_ingester_active_series_loading 1 if active series counts are still warming up and may be underreported, 0 once they are accurate.
 			# TYPE cortex_ingester_active_series_loading gauge
@@ -12517,7 +12521,7 @@ func TestActiveSeriesLoadingMetric(t *testing.T) {
 		`), "cortex_ingester_active_series_loading"))
 
 		// After idle timeout, metric should be 0.
-		ing.updateActiveSeries(time.Now().Add(cfg.ActiveSeriesMetrics.IdleTimeout))
+		ing.updateActiveSeries(startTime.Add(cfg.ActiveSeriesMetrics.IdleTimeout))
 		require.NoError(t, testutil.GatherAndCompare(registry, strings.NewReader(`
 			# HELP cortex_ingester_active_series_loading 1 if active series counts are still warming up and may be underreported, 0 once they are accurate.
 			# TYPE cortex_ingester_active_series_loading gauge


### PR DESCRIPTION
#### What this PR does

The test used `time.Now()` to drive `updateActiveSeries()`, but the idle timeout comparison inside that function is against `activeSeriesStartMs`, which is set during ingester startup. On slow CI the elapsed wall-clock time between startup and the test assertion can exceed the 200ms `IdleTimeout`, causing the "metric should still be 1" check to fail.

This fixes the flakiness by computing deterministic times relative to `activeSeriesStartMs` instead of relying on wall-clock time.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts test timing to be deterministic; no production logic changes.
> 
> **Overview**
> Fixes flakiness in `TestActiveSeriesLoadingMetric` by driving `updateActiveSeries()` with a deterministic timestamp derived from `ing.activeSeriesStartMs` instead of `time.Now()`, ensuring the pre/post `IdleTimeout` assertions are stable on slow CI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d33fe26a71fd76577f6b86eaa07400183cbfa1d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->