### PR TITLE
Experiment with reducing GetRange ops for BucketDecbufFactory

### DIFF
--- a/pkg/storage/indexheader/index/postings.go
+++ b/pkg/storage/indexheader/index/postings.go
@@ -399,7 +399,8 @@ func (t *PostingOffsetTableV2) LabelValuesOffsets(ctx context.Context, name, pre
 	d := t.factory.NewDecbufAtUnchecked(t.tableOffset)
 	defer runutil.CloseWithErrCapture(&err, &d, "get label values")
 
-	d.ResetAt(e.offsets[offsetsStart].tableOff)
+	// Skip ahead to the offsets start. Do this instead of a ResetAt to save a GetRange op for the BucketDecbufFactory.
+	d.Skip(e.offsets[offsetsStart].tableOff - d.Offset())
 
 	// The last value of a label gets its own offset in e.offsets.
 	// If that value matches, then later we should use e.lastValOffset

--- a/pkg/storage/indexheader/index/postings.go
+++ b/pkg/storage/indexheader/index/postings.go
@@ -399,8 +399,13 @@ func (t *PostingOffsetTableV2) LabelValuesOffsets(ctx context.Context, name, pre
 	d := t.factory.NewDecbufAtUnchecked(t.tableOffset)
 	defer runutil.CloseWithErrCapture(&err, &d, "get label values")
 
-	// Skip ahead to the offsets start. Do this instead of a ResetAt to save a GetRange op for the BucketDecbufFactory.
-	d.Skip(e.offsets[offsetsStart].tableOff - d.Offset())
+	if _, ok := t.factory.(*streamencoding.BucketDecbufFactory); ok {
+		// Skip ahead to the offset start, discarding all bytes in between.
+		// For the BucketDecbufFactory, this saves a GetRange operation.
+		d.Skip(e.offsets[offsetsStart].tableOff - d.Offset())
+	} else {
+		d.ResetAt(e.offsets[offsetsStart].tableOff)
+	}
 
 	// The last value of a label gets its own offset in e.offsets.
 	// If that value matches, then later we should use e.lastValOffset


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Uses `Skip` to advance the pointer when reading from buckets instead of `ResetAt`. At this point, `ResetAt` always performs an extra `GetRange` op because nothing is buffered into `streamReader.buf` yet.

We can't use `Skip` universally because it pretty dramatically negatively impacts CPU when we use the existing `StreamBinaryReader`.

<details><summary>LabelValuesOffsets CPU benchmark for StreamBinaryReader</summary>

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/mimir/pkg/storage/indexheader
cpu: Apple M2 Pro
                                                               │ label_values_offsets_index_v2_disk_reader_original.txt │ label_values_offsets_index_v2_disk_reader_with_skip.txt │
                                                               │                         sec/op                         │             sec/op               vs base                │
LabelValuesOffsetsIndexV2/Names=50/Values=100/Reader=disk-10                                               21.90µ ±  1%                      30.73µ ± 10%   +40.30% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=50/Values=500/Reader=disk-10                                               44.45µ ±  0%                      82.63µ ±  6%   +85.88% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=50/Values=1000/Reader=disk-10                                              74.94µ ±  5%                     151.61µ ±  3%  +102.29% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=50/Values=5000/Reader=disk-10                                              288.7µ ±  1%                      698.7µ ±  3%  +141.99% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=100/Values=100/Reader=disk-10                                              21.86µ ±  0%                      37.23µ ±  3%   +70.29% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=100/Values=500/Reader=disk-10                                              45.30µ ± 12%                     123.67µ ±  3%  +173.03% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=100/Values=1000/Reader=disk-10                                             74.20µ ±  1%                     234.92µ ±  3%  +216.58% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=100/Values=5000/Reader=disk-10                                             287.3µ ±  3%                     1158.4µ ±  2%  +303.15% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=200/Values=100/Reader=disk-10                                              22.08µ ± 16%                      54.94µ ± 15%  +148.88% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=200/Values=500/Reader=disk-10                                              46.07µ ± 15%                     222.27µ ±  3%  +382.48% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=200/Values=1000/Reader=disk-10                                             74.49µ ± 10%                     437.34µ ±  4%  +487.10% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=200/Values=5000/Reader=disk-10                                             290.0µ ±  9%                     2437.9µ ±  6%  +740.55% (p=0.002 n=6)
geomean                                                                                                    68.00µ                            201.1µ        +195.81%
```
</details>


When using `Skip` for `BucketDecbufFactory`, we save nearly half of all GetRange ops, but at the cost of CPU that gets ~exponentially worse with cardinality increases:
<img width="1000" height="600" alt="cardinalityxcpu" src="https://github.com/user-attachments/assets/68d9ac46-325d-4ce7-994b-e12db52582c4" />

**TODO:** Try running it and see how bad this is in practice, and also investigate mitigations.

<details><summary>LabelValuesOffsetsV2 benchmark results for BucketDecbufFactory</summary>

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/mimir/pkg/storage/indexheader
cpu: Apple M2 Pro
                                                                 │ label_values_offsets_index_v2_original.txt │ label_values_offsets_index_v2_with_skip.txt │
                                                                 │                   sec/op                   │       sec/op         vs base                │
LabelValuesOffsetsIndexV2/Names=50/Values=100/Reader=bucket-10                                    42.83µ ± 3%          28.33µ ±  1%   -33.86% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=50/Values=500/Reader=bucket-10                                    70.89µ ± 3%          61.44µ ±  0%   -13.34% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=50/Values=1000/Reader=bucket-10                                   106.3µ ± 6%          105.9µ ±  3%         ~ (p=0.180 n=6)
LabelValuesOffsetsIndexV2/Names=50/Values=5000/Reader=bucket-10                                   314.8µ ± 1%          392.4µ ± 14%   +24.66% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=100/Values=100/Reader=bucket-10                                   45.26µ ± 2%          31.98µ ±  2%   -29.34% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=100/Values=500/Reader=bucket-10                                   79.23µ ± 3%          77.27µ ±  1%    -2.47% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=100/Values=1000/Reader=bucket-10                                  116.8µ ± 1%          121.1µ ±  3%    +3.65% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=100/Values=5000/Reader=bucket-10                                  326.2µ ± 2%          508.9µ ±  8%   +56.02% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=200/Values=100/Reader=bucket-10                                   48.89µ ± 4%          38.45µ ±  2%   -21.36% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=200/Values=500/Reader=bucket-10                                   92.08µ ± 3%          97.32µ ±  8%    +5.69% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=200/Values=1000/Reader=bucket-10                                  120.2µ ± 4%          173.9µ ±  9%   +44.69% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=200/Values=5000/Reader=bucket-10                                  344.1µ ± 3%          915.1µ ±  4%  +165.97% (p=0.002 n=6)
geomean                                                                                           108.2µ               117.0µ          +8.06%

                                                                 │ label_values_offsets_index_v2_original.txt │ label_values_offsets_index_v2_with_skip.txt │
                                                                 │             get_range-bytes/op             │ get_range-bytes/op   vs base                │
LabelValuesOffsetsIndexV2/Names=50/Values=100/Reader=bucket-10                                  1.377Gi ±  3%         4.083Gi ±  1%  +196.51% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=50/Values=500/Reader=bucket-10                                  4.368Gi ±  7%         9.834Gi ±  0%  +125.13% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=50/Values=1000/Reader=bucket-10                                 5.309Gi ±  0%         9.802Gi ±  0%   +84.64% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=50/Values=5000/Reader=bucket-10                                 3.417Gi ±  4%        10.135Gi ±  5%  +196.64% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=100/Values=100/Reader=bucket-10                                 2.602Gi ±  1%         7.183Gi ±  3%  +176.06% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=100/Values=500/Reader=bucket-10                                 7.984Gi ±  0%        15.233Gi ±  1%   +90.78% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=100/Values=1000/Reader=bucket-10                                7.427Gi ±  3%        14.728Gi ±  3%   +98.31% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=100/Values=5000/Reader=bucket-10                                3.487Gi ± 11%        14.326Gi ± 17%  +310.80% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=200/Values=100/Reader=bucket-10                                 4.920Gi ±  7%        12.451Gi ±  2%  +153.04% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=200/Values=500/Reader=bucket-10                                 9.763Gi ±  7%        19.073Gi ± 14%   +95.37% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=200/Values=1000/Reader=bucket-10                                8.337Gi ±  9%        19.594Gi ± 11%  +135.02% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=200/Values=5000/Reader=bucket-10                                3.288Gi ± 10%        16.369Gi ±  5%  +397.78% (p=0.002 n=6)
geomean                                                                                         4.543Gi               11.76Gi        +158.91%

                                                                 │ label_values_offsets_index_v2_original.txt │ label_values_offsets_index_v2_with_skip.txt │
                                                                 │              get_range-ops/op              │   get_range-ops/op    vs base               │
LabelValuesOffsetsIndexV2/Names=50/Values=100/Reader=bucket-10                                   56.09k ±  3%           42.33k ±  1%  -24.53% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=50/Values=500/Reader=bucket-10                                   34.16k ±  7%           19.57k ±  0%  -42.71% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=50/Values=1000/Reader=bucket-10                                  20.00k ±  0%           10.00k ±  0%  -50.00% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=50/Values=5000/Reader=bucket-10                                  7.618k ±  4%           3.093k ±  5%  -59.40% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=100/Values=100/Reader=bucket-10                                  53.12k ±  1%           37.07k ±  3%  -30.21% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=100/Values=500/Reader=bucket-10                                  30.28k ±  0%           15.54k ±  1%  -48.67% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=100/Values=1000/Reader=bucket-10                                19.618k ±  3%           9.705k ±  3%  -50.53% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=100/Values=5000/Reader=bucket-10                                 7.435k ± 11%           2.369k ± 17%  -68.14% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=200/Values=100/Reader=bucket-10                                  49.76k ±  7%           31.30k ±  2%  -37.08% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=200/Values=500/Reader=bucket-10                                  25.91k ±  7%           12.35k ± 14%  -52.35% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=200/Values=1000/Reader=bucket-10                                19.234k ±  9%           7.367k ± 11%  -61.70% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=200/Values=5000/Reader=bucket-10                                 6.869k ± 10%           1.372k ±  5%  -80.03% (p=0.002 n=6)
geomean                                                                                          21.82k                 10.24k        -53.09%

                                                                 │ label_values_offsets_index_v2_original.txt │ label_values_offsets_index_v2_with_skip.txt │
                                                                 │                    B/op                    │         B/op           vs base              │
LabelValuesOffsetsIndexV2/Names=50/Values=100/Reader=bucket-10                                   9.636Ki ± 3%            8.942Ki ± 3%  -7.20% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=50/Values=500/Reader=bucket-10                                   31.22Ki ± 2%            30.49Ki ± 1%  -2.32% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=50/Values=1000/Reader=bucket-10                                  63.52Ki ± 2%            62.21Ki ± 1%  -2.07% (p=0.015 n=6)
LabelValuesOffsetsIndexV2/Names=50/Values=5000/Reader=bucket-10                                  250.8Ki ± 1%            247.2Ki ± 1%  -1.44% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=100/Values=100/Reader=bucket-10                                  9.385Ki ± 2%            8.449Ki ± 2%  -9.97% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=100/Values=500/Reader=bucket-10                                  30.39Ki ± 3%            29.25Ki ± 2%  -3.75% (p=0.009 n=6)
LabelValuesOffsetsIndexV2/Names=100/Values=1000/Reader=bucket-10                                 61.59Ki ± 2%            60.99Ki ± 1%       ~ (p=0.240 n=6)
LabelValuesOffsetsIndexV2/Names=100/Values=5000/Reader=bucket-10                                 245.8Ki ± 1%            246.5Ki ± 1%       ~ (p=0.310 n=6)
LabelValuesOffsetsIndexV2/Names=200/Values=100/Reader=bucket-10                                  8.827Ki ± 2%            8.112Ki ± 4%  -8.10% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=200/Values=500/Reader=bucket-10                                  28.88Ki ± 2%            28.33Ki ± 3%  -1.89% (p=0.009 n=6)
LabelValuesOffsetsIndexV2/Names=200/Values=1000/Reader=bucket-10                                 60.55Ki ± 2%            59.12Ki ± 1%  -2.37% (p=0.009 n=6)
LabelValuesOffsetsIndexV2/Names=200/Values=5000/Reader=bucket-10                                 245.1Ki ± 1%            241.8Ki ± 1%  -1.34% (p=0.002 n=6)
geomean                                                                                          45.48Ki                 43.90Ki       -3.48%

                                                                 │ label_values_offsets_index_v2_original.txt │ label_values_offsets_index_v2_with_skip.txt │
                                                                 │                 allocs/op                  │       allocs/op        vs base              │
LabelValuesOffsetsIndexV2/Names=50/Values=100/Reader=bucket-10                                     124.0 ± 0%              115.0 ± 0%  -7.26% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=50/Values=500/Reader=bucket-10                                     524.0 ± 0%              515.0 ± 0%  -1.72% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=50/Values=1000/Reader=bucket-10                                   1.024k ± 0%             1.015k ± 0%  -0.88% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=50/Values=5000/Reader=bucket-10                                   5.024k ± 0%             5.015k ± 0%  -0.18% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=100/Values=100/Reader=bucket-10                                    124.0 ± 0%              115.0 ± 0%  -7.26% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=100/Values=500/Reader=bucket-10                                    524.0 ± 0%              515.0 ± 0%  -1.72% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=100/Values=1000/Reader=bucket-10                                  1.024k ± 0%             1.015k ± 0%  -0.88% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=100/Values=5000/Reader=bucket-10                                  5.024k ± 0%             5.016k ± 0%  -0.16% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=200/Values=100/Reader=bucket-10                                    124.0 ± 0%              115.0 ± 0%  -7.26% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=200/Values=500/Reader=bucket-10                                    524.0 ± 0%              515.0 ± 0%  -1.72% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=200/Values=1000/Reader=bucket-10                                  1.024k ± 0%             1.015k ± 0%  -0.88% (p=0.002 n=6)
LabelValuesOffsetsIndexV2/Names=200/Values=5000/Reader=bucket-10                                  5.024k ± 0%             5.016k ± 0%  -0.16% (p=0.002 n=6)
geomean                                                                                            760.4                   741.0       -2.55%
```

</details>

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
