### PR TITLE
chore: use validationConfig for exemplars validations in Distributor.prePushValidationMiddleware

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1640,13 +1640,13 @@ func (d *Distributor) prePushValidationMiddleware(next PushFunc) PushFunc {
 		if earliestSampleTimestampMs != math.MaxInt64 {
 			minExemplarTS = earliestSampleTimestampMs - 5*time.Minute.Milliseconds()
 
-			if d.limits.PastGracePeriod(userID) > 0 {
-				minExemplarTS = max(minExemplarTS, now.Add(-d.limits.PastGracePeriod(userID)).Add(-d.limits.OutOfOrderTimeWindow(userID)).UnixMilli())
+			if cfg.samples.pastGracePeriod > 0 {
+				minExemplarTS = max(minExemplarTS, now.Add(-cfg.samples.pastGracePeriod).Add(-cfg.samples.outOfOrderTimeWindow).UnixMilli())
 			}
 		}
 
 		// Enforce the creation grace period on exemplars too.
-		maxExemplarTS := now.Add(d.limits.CreationGracePeriod(userID)).UnixMilli()
+		maxExemplarTS := now.Add(cfg.samples.creationGracePeriod).UnixMilli()
 
 		// Are we going to drop native histograms? If yes, let's count and report them.
 		countDroppedNativeHistograms := !d.limits.NativeHistogramsIngestionEnabled(userID)


### PR DESCRIPTION
#### What this PR does

Avoids extra access to overrides config by reusing the already resolved validation config.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to exemplar timestamp cutoff calculations; behavior should remain identical aside from avoiding repeated overrides lookups.
> 
> **Overview**
> `Distributor.prePushValidationMiddleware` now derives exemplar timestamp validation bounds (`minExemplarTS` / `maxExemplarTS`) from the precomputed per-tenant `validationConfig` (`cfg.samples.*`) instead of re-reading values from `d.limits`.
> 
> This reduces repeated overrides access while keeping the exemplar age and creation grace period enforcement logic in the same place.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63ddd50f281c20647a7f57854e838f471a634dc7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->