### PR TITLE
fix(helm): route alertmanager ingress to headless service when zone-aware replication enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,6 +227,7 @@
 * [BUGFIX] Query-frontend: Fixed partial cache hit returning incomplete data for native histogram series due to incorrect response ordering before merge. #14612
 * [BUGFIX] Distributor: Fix nil pointer panic in `WriteRequest.Unmarshal` when receiving a Remote Write 2.0 request with zero timeseries. #14698
 * [BUGFIX] MQE: Fix `info()` incorrectly dropping inner series with no matching info series when a data label matcher matches the empty string. #14819
+* [BUGFIX] Helm: Fix ingress backend service name for alertmanager when `alertmanager.zoneAwareReplication.enabled: true`. The ingress now routes to the headless service (`mimir-alertmanager-headless`) instead of the non-existent plain service. #14334
 
 ### Mixin
 

--- a/operations/helm/charts/mimir-distributed/ci/offline/test-ingress-zone-aware-values.yaml
+++ b/operations/helm/charts/mimir-distributed/ci/offline/test-ingress-zone-aware-values.yaml
@@ -1,0 +1,15 @@
+# Pin kube version so results are the same for running in CI and locally where the installed kube version may be different.
+kubeVersionOverride: "1.32"
+
+# Test: ingress enabled + alertmanager zoneAwareReplication enabled (regression for #14334)
+alertmanager:
+  enabled: true
+  zoneAwareReplication:
+    enabled: true
+    migration:
+      enabled: false
+
+ingress:
+  enabled: true
+  hosts:
+    - mimir.example.com

--- a/operations/helm/charts/mimir-distributed/templates/ingress.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingress.yaml
@@ -32,12 +32,16 @@ spec:
       http:
         paths:
           {{- range $svcName, $paths := $.Values.ingress.paths }}
+            {{- $resolvedSvcName := printf "%s-%s" (include "mimir.fullname" $) $svcName -}}
+            {{- if and (eq $svcName "alertmanager") $.Values.alertmanager.zoneAwareReplication.enabled (not $.Values.alertmanager.zoneAwareReplication.migration.enabled) }}
+            {{- $resolvedSvcName = printf "%s-%s-headless" (include "mimir.fullname" $) $svcName -}}
+            {{- end }}
             {{- range $paths }}
           - path: {{ .path }}
             pathType: {{ .pathType | default "Prefix" }}
             backend:
               service:
-                name: {{ include "mimir.fullname" $ }}-{{ $svcName }}
+                name: {{ $resolvedSvcName }}
                 port:
                   number: {{ include "mimir.serverHttpListenPort" $ }}
             {{- end }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

When `alertmanager.zoneAwareReplication.enabled: true` (and migration mode is off), the mimir-distributed Helm chart only creates zone-specific services (`mimir-alertmanager-zone-a/b/c`) and a headless service. The plain `mimir-alertmanager` service does not exist in this configuration.

The ingress template was unconditionally constructing the backend service name as `mimir-alertmanager`, causing all alertmanager ingress paths to return `services "mimir-alertmanager" not found` and fail.

This PR fixes the ingress template to detect zone-aware replication and resolve the backend service name to `mimir-alertmanager-headless` when zone-aware replication is enabled and migration mode is off — matching the behavior already used by the gateway nginx configuration. A CI test values file covering the `ingress + zoneAwareReplication` combination (which had zero test coverage) is also added.

#### Which issue(s) this PR fixes or relates to

Fixes #14334

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Helm templating change limited to the Alertmanager ingress backend name when zone-aware replication is enabled; main risk is misrouting ingress if the conditional logic is wrong for edge configurations (eg. migration mode).
> 
> **Overview**
> Fixes `mimir-distributed` Helm ingress generation so Alertmanager paths route to `mimir-alertmanager-headless` when `alertmanager.zoneAwareReplication.enabled: true` and migration is off, avoiding ingress backends pointing at a non-existent `mimir-alertmanager` service.
> 
> Adds an offline CI values fixture to cover the previously untested `ingress + zoneAwareReplication` combination, and records the fix in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f4965052187fc8961da176eb6ac1c5476789305. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->