### PR TITLE
Fix flaky TestIngester_Startup_PartitionRingActiveBlocksOnInstanceRingActive

### DIFF
--- a/pkg/ingester/ingester_ingest_storage_test.go
+++ b/pkg/ingester/ingester_ingest_storage_test.go
@@ -101,7 +101,7 @@ func TestIngester_Startup_PartitionRingActiveBlocksOnInstanceRingActive(t *testi
 		require.NoError(t, i0.StartAsync(i0Ctx))
 		err := services.StopAndAwaitTerminated(ctx, i0)
 		// Service failure case error is propagated from error returned by ingester.starting().
-		require.ErrorIs(t, err, context.Canceled)
+		require.Error(t, err)
 	})
 	i0Ro, i0RoTs := i0.lifecycler.GetReadOnlyState()
 	ringDesc.AddIngester(


### PR DESCRIPTION
#### What this PR does

Fixes flaky test by relaxing an overly strict error assertion in test cleanup.

The test cleanup starts ingester `i0` with an already-cancelled context to trigger goroutine cleanup via `ingester.starting()` failure. The assertion expected exactly `context.Canceled`, but `starting()` can fail at different points in its startup sequence depending on goroutine scheduling — sometimes the subservices manager observes the cancellation first, producing `"failed to start ingester subservices before partition reader"` instead. Since the cleanup only needs to ensure the ingester fails to start, the specific error doesn't matter.

Verified by running the test 50 times with `-race` after the fix with no failures.

#### Which issue(s) this PR fixes or relates to

Fixes #14795

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to a test cleanup assertion and doesn’t affect production code paths. It only broadens the accepted error type when startup is intentionally forced to fail.
> 
> **Overview**
> Reduces flakiness in `TestIngester_Startup_PartitionRingActiveBlocksOnInstanceRingActive` by changing the cleanup assertion from `require.ErrorIs(..., context.Canceled)` to `require.Error(...)`, since the forced-failure startup path can return different errors depending on scheduling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0c351e7a91e2707bc856ce1c1b4c968eaba394d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->