### PR TITLE
deps: update grafana/dskit to 3dd00ce01fc0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/golang/snappy v1.0.0
 	github.com/google/gopacket v1.1.19
 	github.com/gorilla/mux v1.8.1
-	github.com/grafana/dskit v0.0.0-20260319050051-803e3aef21e3
+	github.com/grafana/dskit v0.0.0-20260326142830-3dd00ce01fc0
 	github.com/grafana/e2e v0.1.2-0.20260309174126-b5393d4e610f
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/influxdata/influxdb/v2 v2.8.0

--- a/go.sum
+++ b/go.sum
@@ -595,8 +595,8 @@ github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc h1:PXZQA2WCxe85T
 github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc/go.mod h1:AHHlOEv1+GGQ3ktHMlhuTUwo3zljV3QJbC0+8o2kn+4=
 github.com/grafana/alerting v0.0.0-20260227181651-5106b6285f2d h1:QBq2fe3LX/7IyHL8s7NQuCUL5+xhS3IeRACi7AIHtjE=
 github.com/grafana/alerting v0.0.0-20260227181651-5106b6285f2d/go.mod h1:06F4s5KJ6LpL7od+rcusjKnsst+vRhdFqev9GdVNz4c=
-github.com/grafana/dskit v0.0.0-20260319050051-803e3aef21e3 h1:lsKNWLfvr9QXUTafFmUYB/sv268WNlr8ULqDgKdYyTM=
-github.com/grafana/dskit v0.0.0-20260319050051-803e3aef21e3/go.mod h1:Lown5uc/WTIpY4y+O5B3RxVQd7qJ3PLEoEvaAZ/U7cQ=
+github.com/grafana/dskit v0.0.0-20260326142830-3dd00ce01fc0 h1:K6u99Ufcm+eBb9WK3xRO5FRXraSQJMY/aO5PUuu6grg=
+github.com/grafana/dskit v0.0.0-20260326142830-3dd00ce01fc0/go.mod h1:Lown5uc/WTIpY4y+O5B3RxVQd7qJ3PLEoEvaAZ/U7cQ=
 github.com/grafana/e2e v0.1.2-0.20260309174126-b5393d4e610f h1:gxaqz5StufMU078tWFuf8CUi4PZtITBxjM2TZV7NOFw=
 github.com/grafana/e2e v0.1.2-0.20260309174126-b5393d4e610f/go.mod h1:KFvJP5m5GQ837CN7rUbWIiPdw1JZgeRJTEyp2O5U0is=
 github.com/grafana/go-yaml/v3 v3.0.0-20260130164322-e3c24e8f4c87 h1:Op5/Kd8Ae90IC7Ow+CNwGo/oq87cJX2iE+U8Dw4a8Bc=

--- a/vendor/github.com/grafana/dskit/flagext/env.go
+++ b/vendor/github.com/grafana/dskit/flagext/env.go
@@ -1,0 +1,74 @@
+package flagext
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+)
+
+var flagNameReplacer = strings.NewReplacer(".", "_", "-", "_")
+
+// FlagToEnvVar converts a flag name to its corresponding environment variable name.
+// The flag name is uppercased and all dots, dashes, and underscores in the flag name
+// are replaced with (or kept as) underscores. The prefix is similarly upper-cased with
+// symbol substitution. If prefix is non-empty, an _ is placed between the flag name and prefix
+//
+// Note that distinct flag names can map to the same environment variable. For example,
+// "a.b" and "a-b" both map to "A_B". Callers should avoid registering flags whose
+// names differ only in dots, dashes, and underscores.
+//
+// For example, FlagToEnvVar("myapp-name", "server.http-listen-port") returns
+// "MYAPP_NAME_SERVER_HTTP_LISTEN_PORT".
+func FlagToEnvVar(prefix, flagName string) string {
+	envVar := strings.ToUpper(flagName)
+	envVar = flagNameReplacer.Replace(envVar)
+	if prefix != "" {
+		prefix = strings.ToUpper(prefix)
+		prefix = flagNameReplacer.Replace(prefix)
+		return prefix + "_" + envVar
+	}
+	return envVar
+}
+
+// SetFlagsFromEnv sets flag values from environment variables for any flags
+// that were not explicitly set on the command line. It must be called after
+// f.Parse() so that explicitly-set CLI flags can be detected.
+//
+// The environment variable name for each flag is derived by [FlagToEnvVar].
+// CLI flags always take precedence over environment variables, and environment
+// variables take precedence over default values.
+func SetFlagsFromEnv(f *flag.FlagSet, prefix string) error {
+	return SetFlagsFromEnvWithLookup(f, prefix, os.LookupEnv)
+}
+
+// SetFlagsFromEnvWithLookup is like [SetFlagsFromEnv] but uses the provided
+// lookup function instead of [os.LookupEnv]. This is useful for testing or for
+// providing an alternative source of configuration values.
+func SetFlagsFromEnvWithLookup(f *flag.FlagSet, prefix string, lookup func(string) (string, bool)) error {
+	// Collect the set of flags that were explicitly provided on the command line.
+	explicitlySet := make(map[string]struct{})
+	f.Visit(func(fl *flag.Flag) {
+		explicitlySet[fl.Name] = struct{}{}
+	})
+
+	var errs []error
+	f.VisitAll(func(fl *flag.Flag) {
+		if _, ok := explicitlySet[fl.Name]; ok {
+			return // CLI flag takes precedence.
+		}
+
+		envVar := FlagToEnvVar(prefix, fl.Name)
+		val, ok := lookup(envVar)
+		if !ok {
+			return // Environment variable not set.
+		}
+
+		if err := f.Set(fl.Name, val); err != nil {
+			errs = append(errs, fmt.Errorf("setting flag %q from environment variable %s: %w", fl.Name, envVar, err))
+		}
+	})
+
+	return errors.Join(errs...)
+}

--- a/vendor/github.com/grafana/dskit/flagext/parse.go
+++ b/vendor/github.com/grafana/dskit/flagext/parse.go
@@ -26,3 +26,39 @@ func ParseFlagsWithoutArguments(f *flag.FlagSet) error {
 
 	return nil
 }
+
+// ParseFlagsAndArgumentsWithEnv is like [ParseFlagsAndArguments] but also sets
+// flag values from environment variables using [SetFlagsFromEnv].
+// CLI flags take precedence over environment variables, which take precedence
+// over default values.
+func ParseFlagsAndArgumentsWithEnv(f *flag.FlagSet, prefix string) ([]string, error) {
+	if err := f.Parse(os.Args[1:]); err != nil {
+		return f.Args(), err
+	}
+
+	if err := SetFlagsFromEnv(f, prefix); err != nil {
+		return f.Args(), err
+	}
+
+	return f.Args(), nil
+}
+
+// ParseFlagsWithoutArgumentsWithEnv is like [ParseFlagsWithoutArguments] but also sets
+// flag values from environment variables using [SetFlagsFromEnv].
+// CLI flags take precedence over environment variables, which take precedence
+// over default values.
+func ParseFlagsWithoutArgumentsWithEnv(f *flag.FlagSet, prefix string) error {
+	if err := f.Parse(os.Args[1:]); err != nil {
+		return err
+	}
+
+	if err := SetFlagsFromEnv(f, prefix); err != nil {
+		return err
+	}
+
+	if f.NArg() > 0 {
+		return fmt.Errorf("the command does not support any argument, but some were provided: %s", strings.Join(f.Args(), " "))
+	}
+
+	return nil
+}

--- a/vendor/github.com/grafana/dskit/limiter/rate_limiter.go
+++ b/vendor/github.com/grafana/dskit/limiter/rate_limiter.go
@@ -66,6 +66,21 @@ func (l *RateLimiter) Burst(now time.Time, tenantID string) int {
 	return l.getTenantLimiter(now, tenantID).Burst()
 }
 
+// RemoveStaleEntries removes entries that have not been accessed since
+// the given cutoff time and returns the number of removed entries.
+func (l *RateLimiter) RemoveStaleEntries(cutoff time.Time) int {
+	l.tenantsLock.Lock()
+	defer l.tenantsLock.Unlock()
+	removed := 0
+	for tenantID, entry := range l.tenants {
+		if entry.recheckAt.Before(cutoff) {
+			delete(l.tenants, tenantID)
+			removed++
+		}
+	}
+	return removed
+}
+
 func (l *RateLimiter) getTenantLimiter(now time.Time, tenantID string) *rate.Limiter {
 	recheck := false
 
@@ -108,7 +123,12 @@ func (l *RateLimiter) recheckTenantLimiter(now time.Time, tenantID string) *rate
 	l.tenantsLock.Lock()
 	defer l.tenantsLock.Unlock()
 
-	entry := l.tenants[tenantID]
+	entry, ok := l.tenants[tenantID]
+	if !ok {
+		entry = &tenantLimiter{rate.NewLimiter(limit, burst), now.Add(l.recheckPeriod)}
+		l.tenants[tenantID] = entry
+		return entry.limiter
+	}
 
 	// We check again if the recheck period elapsed, cause it may
 	// have already been rechecked in the meanwhile.

--- a/vendor/github.com/grafana/dskit/tenant/resolver.go
+++ b/vendor/github.com/grafana/dskit/tenant/resolver.go
@@ -28,13 +28,13 @@ func TenantID(ctx context.Context) (string, error) {
 		return "", err
 	}
 	orgID, remaining, hasMoreIDs := stringsCut(orgIDs, tenantIDsSeparator)
-	tenantID := trimMetadata(orgID)
+	tenantID := TrimMetadata(orgID)
 	if err := ValidTenantID(tenantID); err != nil {
 		return "", err
 	}
 	for hasMoreIDs {
 		orgID, remaining, hasMoreIDs = stringsCut(remaining, tenantIDsSeparator)
-		if tenantID != trimMetadata(orgID) {
+		if tenantID != TrimMetadata(orgID) {
 			return "", user.ErrTooManyOrgIDs
 		}
 	}
@@ -67,7 +67,7 @@ func TenantIDs(ctx context.Context) ([]string, error) {
 func parseTenantIDs(orgID string) ([]string, error) {
 	orgIDs := strings.Split(orgID, string(tenantIDsSeparator))
 	for i, part := range orgIDs {
-		tenantId := trimMetadata(part)
+		tenantId := TrimMetadata(part)
 		if err := ValidTenantID(tenantId); err != nil {
 			return nil, err
 		}

--- a/vendor/github.com/grafana/dskit/tenant/tenant.go
+++ b/vendor/github.com/grafana/dskit/tenant/tenant.go
@@ -124,7 +124,8 @@ func TenantIDsFromOrgID(orgID string) ([]string, error) {
 	return TenantIDs(user.InjectOrgID(context.TODO(), orgID))
 }
 
-func trimMetadata(orgID string) string {
+// TrimMetadata removes metadata from a orgID without validating the input.
+func TrimMetadata(orgID string) string {
 	idx := strings.IndexByte(orgID, metadataSeparator)
 	if idx == -1 {
 		return orgID

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -803,7 +803,7 @@ github.com/grafana/alerting/templates/email
 github.com/grafana/alerting/templates/gomplate
 github.com/grafana/alerting/templates/mimir
 github.com/grafana/alerting/utils
-# github.com/grafana/dskit v0.0.0-20260319050051-803e3aef21e3
+# github.com/grafana/dskit v0.0.0-20260326142830-3dd00ce01fc0
 ## explicit; go 1.25.7
 github.com/grafana/dskit/backoff
 github.com/grafana/dskit/ballast


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Dependency update that changes vendored flag parsing/config precedence and tenant rate-limiter behavior, which could affect runtime configuration and throttling in subtle ways.
> 
> **Overview**
> Updates `github.com/grafana/dskit` to `3dd00ce01fc0` (and refreshes `go.sum`/`vendor`).
> 
> This vendor update adds environment-variable support for `flag.FlagSet` parsing in `flagext` (new `FlagToEnvVar`/`SetFlagsFromEnv` plus `Parse*WithEnv` helpers), introduces `RateLimiter.RemoveStaleEntries` and hardens `recheckTenantLimiter` to handle missing tenant entries, and exports tenant metadata stripping as `tenant.TrimMetadata` (replacing internal `trimMetadata`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd2949def8ecf12103cdd68a8ddc54fb02de8fa4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->