### PR TITLE
block-builder: use BlockRanges config for TSDB block range

### DIFF
--- a/pkg/blockbuilder/tsdb.go
+++ b/pkg/blockbuilder/tsdb.go
@@ -315,8 +315,11 @@ func (b *TSDBBuilder) newTSDB(tenant tsdbTenant) (*userTSDB, error) {
 	userID := tenant.tenantID
 	userLogger := util_log.WithUserID(userID, b.logger)
 
+	blockRanges := b.cfg.BlocksStorage.TSDB.BlockRanges.ToMilliseconds()
+
 	udb := &userTSDB{
-		userID: userID,
+		userID:     userID,
+		blockRange: blockRanges[0],
 	}
 
 	// Until we have a better way to enforce the same limits between ingesters and block builders,
@@ -331,8 +334,8 @@ func (b *TSDBBuilder) newTSDB(tenant tsdbTenant) (*userTSDB, error) {
 
 	db, err := tsdb.Open(udir, util_log.SlogFromGoKit(userLogger), tsdbPromReg, &tsdb.Options{
 		RetentionDuration:                    0,
-		MinBlockDuration:                     2 * time.Hour.Milliseconds(),
-		MaxBlockDuration:                     2 * time.Hour.Milliseconds(),
+		MinBlockDuration:                     blockRanges[0],
+		MaxBlockDuration:                     blockRanges[0],
 		NoLockfile:                           true,
 		StripeSize:                           b.cfg.BlocksStorage.TSDB.StripeSize,
 		HeadChunksWriteBufferSize:            b.cfg.BlocksStorage.TSDB.HeadChunksWriteBufferSize,
@@ -498,6 +501,7 @@ type userTSDB struct {
 	*tsdb.DB
 	userID          string
 	maxGlobalSeries int
+	blockRange      int64
 }
 
 var (
@@ -518,7 +522,7 @@ func (u *userTSDB) PostCreation(labels.Labels) {}
 func (u *userTSDB) PostDeletion(map[chunks.HeadSeriesRef]labels.Labels) {}
 
 func (u *userTSDB) compactBlocks(ctx context.Context) error {
-	blockRange := 2 * time.Hour.Milliseconds()
+	blockRange := u.blockRange
 
 	// Compact the in-order data.
 	mint, maxt := u.Head().MinTime(), u.Head().MaxTime()


### PR DESCRIPTION
## What

Use the existing `BlocksStorage.TSDB.BlockRanges` config to determine `MinBlockDuration`/`MaxBlockDuration` and the compaction range in the block-builder, instead of hardcoding `2 * time.Hour`.

## Why

The block range was hardcoded to 2h in three places. This follows the same pattern the ingester already uses (see `pkg/ingester/ingester_tsdb.go`) and allows downstream consumers to control the block range via the existing `blocks-storage.tsdb.block-ranges-period` flag without adding new config fields.

## How

- Compute `blockRanges` from `b.cfg.BlocksStorage.TSDB.BlockRanges.ToMilliseconds()` in `newTSDB`
- Use `blockRanges[0]` for `MinBlockDuration`, `MaxBlockDuration`, and store it in `userTSDB.blockRange`
- `compactBlocks` uses `u.blockRange` instead of hardcoded value
- No new config fields; the default `BlockRanges` is `{2h}` so behavior is unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is localized to block-builder TSDB initialization/compaction and only swaps a constant for an existing config-derived value, but misconfiguration could affect block layout and compaction cadence.
> 
> **Overview**
> Block-builder no longer hardcodes a 2h TSDB block range. It now reads `BlocksStorage.TSDB.BlockRanges` (using the first entry) to set TSDB `MinBlockDuration`/`MaxBlockDuration`, and threads that value into `userTSDB` so `compactBlocks` aligns compaction windows to the same configured range.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2af04623cc92216a8dcc44f408d23b7c19070f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->