### PR TITLE
dev: pin tempo image

### DIFF
--- a/development/mimir-ingest-storage/docker-compose.jsonnet
+++ b/development/mimir-ingest-storage/docker-compose.jsonnet
@@ -345,7 +345,7 @@ std.manifestYamlDoc({
 
   tempo:: {
     tempo: {
-      image: 'grafana/tempo:latest',
+      image: 'grafana/tempo:2.10.3',
       command: ['-config.file=/etc/config/tempo.yaml'],
       volumes: ['./config:/etc/config'],
       ports: [

--- a/development/mimir-ingest-storage/docker-compose.yml
+++ b/development/mimir-ingest-storage/docker-compose.yml
@@ -469,7 +469,7 @@
   "tempo":
     "command":
       - "-config.file=/etc/config/tempo.yaml"
-    "image": "grafana/tempo:latest"
+    "image": "grafana/tempo:2.10.3"
     "ports":
       - "3200"
       - "9095"


### PR DESCRIPTION
Tempo 3 changed the config layout, so our current dev setup doesn't fully work any more.

I don't have capacity to delve into deeps of how to make it work with Tempo 3. So, for now, I'd rather pin `tempo` image to 2.x. This version works perfectly fine for quick dev testing.

(Note: The latest `tempo:2.10.x` was releases, roughly one week ago)