### PR TITLE
Query-frontend: Refactor blocked_queries tests

### DIFF
--- a/pkg/frontend/querymiddleware/query_blocker_test.go
+++ b/pkg/frontend/querymiddleware/query_blocker_test.go
@@ -71,8 +71,8 @@ func runBlockerTest(t *testing.T, limitsYAML string, makeReq func(*testing.T) Me
 	}
 }
 
-// TestQueryBlockerMiddleware_UnalignedRangeQueries exercises the pre-switch alignment filter:
-// when unaligned_range_queries=true, a rule is skipped for aligned queries.
+// TestQueryBlockerMiddleware_UnalignedRangeQueries verifies the pre-filter: when unaligned_range_queries
+// is true, a rule is skipped for aligned queries before the conjunction is evaluated.
 func TestQueryBlockerMiddleware_UnalignedRangeQueries(t *testing.T) {
 	step := time.Minute
 	alignedStart := timestamp.Time(0).Add(100 * step)
@@ -215,336 +215,9 @@ blocked_queries:
 	}
 }
 
-// TestQueryBlockerMiddleware_AllConditions exercises: case pattern != "" && TimeRangeLongerThan > 0 && MinimumStepSize > 0:
-// Minimal truth table: 8 combinations of pattern∈{match,no-match} × time_range∈{over,under} × step∈{below,ok}.
-func TestQueryBlockerMiddleware_AllConditions(t *testing.T) {
-	now := time.Now()
-
-	step30s := (30 * time.Second).Milliseconds()
-	step5m := (5 * time.Minute).Milliseconds()
-
-	rangeReq := func(query string, start time.Time, stepMs int64) func(t *testing.T) MetricsQueryRequest {
-		return func(t *testing.T) MetricsQueryRequest {
-			return &PrometheusRangeQueryRequest{
-				queryExpr: parseQuery(t, query),
-				start:     start.UnixMilli(),
-				end:       now.UnixMilli(),
-				step:      stepMs,
-			}
-		}
-	}
-
-	tests := []struct {
-		name            string
-		limitsYAML      string
-		makeReq         func(t *testing.T) MetricsQueryRequest
-		expectedBlocked bool
-	}{
-		{
-			// pattern=match, time_range=over, step=below → blocked
-			name: "pattern + time_range + step all violated is blocked",
-			limitsYAML: `
-blocked_queries:
-  - pattern: ".*expensive.*"
-    regex: true
-    time_range_longer_than: "24h"
-    minimum_step_size: "1m"
-    reason: "all three conditions met"
-`,
-			makeReq:         rangeReq("rate(expensive_metric[5m])", now.Add(-48*time.Hour), step30s),
-			expectedBlocked: true,
-		},
-		{
-			// pattern=no-match, time_range=over, step=below → not blocked
-			name: "pattern not matched - not blocked",
-			limitsYAML: `
-blocked_queries:
-  - pattern: ".*expensive.*"
-    regex: true
-    time_range_longer_than: "24h"
-    minimum_step_size: "1m"
-`,
-			makeReq:         rangeReq("rate(cheap_metric[5m])", now.Add(-48*time.Hour), step30s),
-			expectedBlocked: false,
-		},
-		{
-			// pattern=match, time_range=under, step=below → not blocked
-			name: "time_range not violated - not blocked",
-			limitsYAML: `
-blocked_queries:
-  - pattern: ".*expensive.*"
-    regex: true
-    time_range_longer_than: "24h"
-    minimum_step_size: "1m"
-`,
-			makeReq:         rangeReq("rate(expensive_metric[5m])", now.Add(-12*time.Hour), step30s),
-			expectedBlocked: false,
-		},
-		{
-			// pattern=match, time_range=over, step=ok → not blocked
-			name: "step not violated - not blocked",
-			limitsYAML: `
-blocked_queries:
-  - pattern: ".*expensive.*"
-    regex: true
-    time_range_longer_than: "24h"
-    minimum_step_size: "1m"
-`,
-			makeReq:         rangeReq("rate(expensive_metric[5m])", now.Add(-48*time.Hour), step5m),
-			expectedBlocked: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			runBlockerTest(t, tt.limitsYAML, tt.makeReq, tt.expectedBlocked)
-		})
-	}
-}
-
-// TestQueryBlockerMiddleware_PatternAndTimeRange exercises: case pattern != "" && TimeRangeLongerThan > 0:
-// Truth table: pattern∈{match,no-match} × time_range∈{over,under}.
-func TestQueryBlockerMiddleware_PatternAndTimeRange(t *testing.T) {
-	now := time.Now()
-
-	rangeReq := func(query string, start, end time.Time) func(t *testing.T) MetricsQueryRequest {
-		return func(t *testing.T) MetricsQueryRequest {
-			return &PrometheusRangeQueryRequest{
-				queryExpr: parseQuery(t, query),
-				start:     start.UnixMilli(),
-				end:       end.UnixMilli(),
-			}
-		}
-	}
-	instantReq := func(query string) func(t *testing.T) MetricsQueryRequest {
-		return func(t *testing.T) MetricsQueryRequest {
-			return &PrometheusInstantQueryRequest{
-				queryExpr: parseQuery(t, query),
-				time:      now.UnixMilli(),
-			}
-		}
-	}
-
-	tests := []struct {
-		name            string
-		limitsYAML      string
-		makeReq         func(t *testing.T) MetricsQueryRequest
-		expectedBlocked bool
-	}{
-		{
-			// pattern=match, time_range=over → blocked
-			name: "pattern matches AND time range longer than threshold (range - blocked)",
-			limitsYAML: `
-blocked_queries:
-  - pattern: ".*expensive.*"
-    regex: true
-    time_range_longer_than: "24h"
-    reason: "expensive queries over 1 day are blocked"
-`,
-			makeReq:         rangeReq("rate(expensive_metric[5m])", now.Add(-2*24*time.Hour), now),
-			expectedBlocked: true,
-		},
-		{
-			// pattern=match, time_range=over (instant) → not blocked (no time range)
-			name: "pattern matches AND time range longer than threshold (instant - not blocked)",
-			limitsYAML: `
-blocked_queries:
-  - pattern: ".*expensive.*"
-    regex: true
-    time_range_longer_than: "24h"
-    reason: "expensive queries over 1 day are blocked"
-`,
-			makeReq:         instantReq("rate(expensive_metric[5m])"),
-			expectedBlocked: false,
-		},
-		{
-			// pattern=match, time_range=under → not blocked
-			name: "pattern matches but time range under threshold",
-			limitsYAML: `
-blocked_queries:
-  - pattern: ".*expensive.*"
-    regex: true
-    time_range_longer_than: "168h"
-`,
-			makeReq:         rangeReq("rate(expensive_metric[5m])", now.Add(-2*24*time.Hour), now),
-			expectedBlocked: false,
-		},
-		{
-			// pattern=no-match, time_range=over → not blocked
-			name: "different pattern but time range longer than threshold",
-			limitsYAML: `
-blocked_queries:
-  - pattern: ".*expensive.*"
-    regex: true
-    time_range_longer_than: "168h"
-`,
-			makeReq:         rangeReq("rate(cheap_metric[5m])", now.Add(-10*24*time.Hour), now),
-			expectedBlocked: false,
-		},
-		{
-			// invalid regex: must bail out even when time range is over threshold
-			name: "invalid regex pattern with time_range_longer_than",
-			limitsYAML: `
-blocked_queries:
-  - pattern: "[a-9}"
-    regex: true
-    time_range_longer_than: "1h"
-    reason: "invalid regex - must bail out to avoid matching all queries"
-`,
-			makeReq:         rangeReq("rate(metric_counter[5m])", now.Add(-25*time.Hour), now),
-			expectedBlocked: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			runBlockerTest(t, tt.limitsYAML, tt.makeReq, tt.expectedBlocked)
-		})
-	}
-}
-
-// TestQueryBlockerMiddleware_PatternAndStepSize exercises: case pattern != "" && MinimumStepSize > 0:
-// Truth table: pattern∈{match,no-match} × step∈{below,at/above threshold}.
-func TestQueryBlockerMiddleware_PatternAndStepSize(t *testing.T) {
-	now := time.Now()
-
-	step30s := (30 * time.Second).Milliseconds()
-	step1m := time.Minute.Milliseconds()
-
-	rangeReq := func(query string, stepMs int64) func(t *testing.T) MetricsQueryRequest {
-		return func(t *testing.T) MetricsQueryRequest {
-			return &PrometheusRangeQueryRequest{
-				queryExpr: parseQuery(t, query),
-				start:     now.Add(-time.Hour).UnixMilli(),
-				end:       now.UnixMilli(),
-				step:      stepMs,
-			}
-		}
-	}
-
-	tests := []struct {
-		name            string
-		limitsYAML      string
-		makeReq         func(t *testing.T) MetricsQueryRequest
-		expectedBlocked bool
-	}{
-		{
-			// pattern=match, step=below → blocked
-			name: "pattern matches and step below threshold is blocked",
-			limitsYAML: `
-blocked_queries:
-  - pattern: ".*expensive.*"
-    regex: true
-    minimum_step_size: "1m"
-    reason: "expensive query with small step"
-`,
-			makeReq:         rangeReq("rate(expensive_metric[5m])", step30s),
-			expectedBlocked: true,
-		},
-		{
-			// pattern=no-match, step=below → not blocked
-			name: "pattern does not match - not blocked despite step below threshold",
-			limitsYAML: `
-blocked_queries:
-  - pattern: ".*expensive.*"
-    regex: true
-    minimum_step_size: "1m"
-`,
-			makeReq:         rangeReq("rate(cheap_metric[5m])", step30s),
-			expectedBlocked: false,
-		},
-		{
-			// pattern=match, step=at threshold → not blocked
-			name: "pattern matches but step at threshold - not blocked",
-			limitsYAML: `
-blocked_queries:
-  - pattern: ".*expensive.*"
-    regex: true
-    minimum_step_size: "1m"
-`,
-			makeReq:         rangeReq("rate(expensive_metric[5m])", step1m),
-			expectedBlocked: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			runBlockerTest(t, tt.limitsYAML, tt.makeReq, tt.expectedBlocked)
-		})
-	}
-}
-
-// TestQueryBlockerMiddleware_TimeRangeAndStepSize exercises: case TimeRangeLongerThan > 0 && MinimumStepSize > 0:
-// Truth table: time_range∈{over,under} × step∈{below,at/above threshold}.
-func TestQueryBlockerMiddleware_TimeRangeAndStepSize(t *testing.T) {
-	now := time.Now()
-
-	step30s := (30 * time.Second).Milliseconds()
-	step5m := (5 * time.Minute).Milliseconds()
-
-	rangeReq := func(query string, start time.Time, stepMs int64) func(t *testing.T) MetricsQueryRequest {
-		return func(t *testing.T) MetricsQueryRequest {
-			return &PrometheusRangeQueryRequest{
-				queryExpr: parseQuery(t, query),
-				start:     start.UnixMilli(),
-				end:       now.UnixMilli(),
-				step:      stepMs,
-			}
-		}
-	}
-
-	tests := []struct {
-		name            string
-		limitsYAML      string
-		makeReq         func(t *testing.T) MetricsQueryRequest
-		expectedBlocked bool
-	}{
-		{
-			// time_range=over, step=below → blocked
-			name: "time_range and step both violated is blocked",
-			limitsYAML: `
-blocked_queries:
-  - time_range_longer_than: "24h"
-    minimum_step_size: "1m"
-    reason: "long range with small step"
-`,
-			makeReq:         rangeReq("rate(expensive_metric[5m])", now.Add(-48*time.Hour), step30s),
-			expectedBlocked: true,
-		},
-		{
-			// time_range=over, step=above → not blocked
-			name: "time_range violated but step ok - not blocked",
-			limitsYAML: `
-blocked_queries:
-  - time_range_longer_than: "24h"
-    minimum_step_size: "1m"
-`,
-			makeReq:         rangeReq("rate(expensive_metric[5m])", now.Add(-48*time.Hour), step5m),
-			expectedBlocked: false,
-		},
-		{
-			// time_range=under, step=below → not blocked
-			name: "time_range ok but step violated - not blocked",
-			limitsYAML: `
-blocked_queries:
-  - time_range_longer_than: "24h"
-    minimum_step_size: "1m"
-`,
-			makeReq:         rangeReq("rate(expensive_metric[5m])", now.Add(-12*time.Hour), step30s),
-			expectedBlocked: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			runBlockerTest(t, tt.limitsYAML, tt.makeReq, tt.expectedBlocked)
-		})
-	}
-}
-
-// TestQueryBlockerMiddleware_Pattern exercises: case pattern != "":
-// Tests the patternMatches predicate in isolation, including canonicalisation
-// and regex edge cases.
+// TestQueryBlockerMiddleware_Pattern verifies conjunction: when only pattern is configured,
+// the pattern must match to block. Tests the patternMatches predicate in isolation, including
+// canonicalisation and regex edge cases.
 func TestQueryBlockerMiddleware_Pattern(t *testing.T) {
 	now := time.Now()
 
@@ -798,7 +471,8 @@ blocked_queries:
 	}
 }
 
-// TestQueryBlockerMiddleware_TimeRange exercises: case TimeRangeLongerThan > 0:
+// TestQueryBlockerMiddleware_TimeRange verifies conjunction: when only time_range_longer_than is
+// configured, the time range must exceed the threshold to block.
 func TestQueryBlockerMiddleware_TimeRange(t *testing.T) {
 	now := time.Now()
 
@@ -864,7 +538,8 @@ blocked_queries:
 	}
 }
 
-// TestQueryBlockerMiddleware_StepSize exercises: case MinimumStepSize > 0:
+// TestQueryBlockerMiddleware_StepSize verifies conjunction: when only minimum_step_size is
+// configured, the step must be below the threshold to block.
 func TestQueryBlockerMiddleware_StepSize(t *testing.T) {
 	now := time.Now()
 
@@ -943,7 +618,334 @@ blocked_queries:
 	}
 }
 
-// TestQueryBlockerMiddleware_RemoteRead exercises pattern matching for remote-read requests.
+// TestQueryBlockerMiddleware_PatternAndTimeRange verifies conjunction: when pattern and
+// time_range_longer_than are both configured, both conditions must be violated to block.
+func TestQueryBlockerMiddleware_PatternAndTimeRange(t *testing.T) {
+	now := time.Now()
+
+	rangeReq := func(query string, start, end time.Time) func(t *testing.T) MetricsQueryRequest {
+		return func(t *testing.T) MetricsQueryRequest {
+			return &PrometheusRangeQueryRequest{
+				queryExpr: parseQuery(t, query),
+				start:     start.UnixMilli(),
+				end:       end.UnixMilli(),
+			}
+		}
+	}
+	instantReq := func(query string) func(t *testing.T) MetricsQueryRequest {
+		return func(t *testing.T) MetricsQueryRequest {
+			return &PrometheusInstantQueryRequest{
+				queryExpr: parseQuery(t, query),
+				time:      now.UnixMilli(),
+			}
+		}
+	}
+
+	tests := []struct {
+		name            string
+		limitsYAML      string
+		makeReq         func(t *testing.T) MetricsQueryRequest
+		expectedBlocked bool
+	}{
+		{
+			// pattern=match, time_range=over → blocked
+			name: "pattern matches AND time range longer than threshold (range - blocked)",
+			limitsYAML: `
+blocked_queries:
+  - pattern: ".*expensive.*"
+    regex: true
+    time_range_longer_than: "24h"
+    reason: "expensive queries over 1 day are blocked"
+`,
+			makeReq:         rangeReq("rate(expensive_metric[5m])", now.Add(-2*24*time.Hour), now),
+			expectedBlocked: true,
+		},
+		{
+			// pattern=match, time_range=over (instant) → not blocked (no time range)
+			name: "pattern matches AND time range longer than threshold (instant - not blocked)",
+			limitsYAML: `
+blocked_queries:
+  - pattern: ".*expensive.*"
+    regex: true
+    time_range_longer_than: "24h"
+    reason: "expensive queries over 1 day are blocked"
+`,
+			makeReq:         instantReq("rate(expensive_metric[5m])"),
+			expectedBlocked: false,
+		},
+		{
+			// pattern=match, time_range=under → not blocked
+			name: "pattern matches but time range under threshold",
+			limitsYAML: `
+blocked_queries:
+  - pattern: ".*expensive.*"
+    regex: true
+    time_range_longer_than: "168h"
+`,
+			makeReq:         rangeReq("rate(expensive_metric[5m])", now.Add(-2*24*time.Hour), now),
+			expectedBlocked: false,
+		},
+		{
+			// pattern=no-match, time_range=over → not blocked
+			name: "different pattern but time range longer than threshold",
+			limitsYAML: `
+blocked_queries:
+  - pattern: ".*expensive.*"
+    regex: true
+    time_range_longer_than: "168h"
+`,
+			makeReq:         rangeReq("rate(cheap_metric[5m])", now.Add(-10*24*time.Hour), now),
+			expectedBlocked: false,
+		},
+		{
+			// invalid regex: must bail out even when time range is over threshold
+			name: "invalid regex pattern with time_range_longer_than",
+			limitsYAML: `
+blocked_queries:
+  - pattern: "[a-9}"
+    regex: true
+    time_range_longer_than: "1h"
+    reason: "invalid regex - must bail out to avoid matching all queries"
+`,
+			makeReq:         rangeReq("rate(metric_counter[5m])", now.Add(-25*time.Hour), now),
+			expectedBlocked: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runBlockerTest(t, tt.limitsYAML, tt.makeReq, tt.expectedBlocked)
+		})
+	}
+}
+
+// TestQueryBlockerMiddleware_PatternAndStepSize verifies conjunction: when pattern and
+// minimum_step_size are both configured, both conditions must be violated to block.
+func TestQueryBlockerMiddleware_PatternAndStepSize(t *testing.T) {
+	now := time.Now()
+
+	step30s := (30 * time.Second).Milliseconds()
+	step1m := time.Minute.Milliseconds()
+
+	rangeReq := func(query string, stepMs int64) func(t *testing.T) MetricsQueryRequest {
+		return func(t *testing.T) MetricsQueryRequest {
+			return &PrometheusRangeQueryRequest{
+				queryExpr: parseQuery(t, query),
+				start:     now.Add(-time.Hour).UnixMilli(),
+				end:       now.UnixMilli(),
+				step:      stepMs,
+			}
+		}
+	}
+
+	tests := []struct {
+		name            string
+		limitsYAML      string
+		makeReq         func(t *testing.T) MetricsQueryRequest
+		expectedBlocked bool
+	}{
+		{
+			// pattern=match, step=below → blocked
+			name: "pattern matches and step below threshold is blocked",
+			limitsYAML: `
+blocked_queries:
+  - pattern: ".*expensive.*"
+    regex: true
+    minimum_step_size: "1m"
+    reason: "expensive query with small step"
+`,
+			makeReq:         rangeReq("rate(expensive_metric[5m])", step30s),
+			expectedBlocked: true,
+		},
+		{
+			// pattern=no-match, step=below → not blocked
+			name: "pattern does not match - not blocked despite step below threshold",
+			limitsYAML: `
+blocked_queries:
+  - pattern: ".*expensive.*"
+    regex: true
+    minimum_step_size: "1m"
+`,
+			makeReq:         rangeReq("rate(cheap_metric[5m])", step30s),
+			expectedBlocked: false,
+		},
+		{
+			// pattern=match, step=at threshold → not blocked
+			name: "pattern matches but step at threshold - not blocked",
+			limitsYAML: `
+blocked_queries:
+  - pattern: ".*expensive.*"
+    regex: true
+    minimum_step_size: "1m"
+`,
+			makeReq:         rangeReq("rate(expensive_metric[5m])", step1m),
+			expectedBlocked: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runBlockerTest(t, tt.limitsYAML, tt.makeReq, tt.expectedBlocked)
+		})
+	}
+}
+
+// TestQueryBlockerMiddleware_TimeRangeAndStepSize verifies conjunction: when time_range_longer_than
+// and minimum_step_size are both configured, both conditions must be violated to block.
+func TestQueryBlockerMiddleware_TimeRangeAndStepSize(t *testing.T) {
+	now := time.Now()
+
+	step30s := (30 * time.Second).Milliseconds()
+	step5m := (5 * time.Minute).Milliseconds()
+
+	rangeReq := func(query string, start time.Time, stepMs int64) func(t *testing.T) MetricsQueryRequest {
+		return func(t *testing.T) MetricsQueryRequest {
+			return &PrometheusRangeQueryRequest{
+				queryExpr: parseQuery(t, query),
+				start:     start.UnixMilli(),
+				end:       now.UnixMilli(),
+				step:      stepMs,
+			}
+		}
+	}
+
+	tests := []struct {
+		name            string
+		limitsYAML      string
+		makeReq         func(t *testing.T) MetricsQueryRequest
+		expectedBlocked bool
+	}{
+		{
+			// time_range=over, step=below → blocked
+			name: "time_range and step both violated is blocked",
+			limitsYAML: `
+blocked_queries:
+  - time_range_longer_than: "24h"
+    minimum_step_size: "1m"
+    reason: "long range with small step"
+`,
+			makeReq:         rangeReq("rate(expensive_metric[5m])", now.Add(-48*time.Hour), step30s),
+			expectedBlocked: true,
+		},
+		{
+			// time_range=over, step=above → not blocked
+			name: "time_range violated but step ok - not blocked",
+			limitsYAML: `
+blocked_queries:
+  - time_range_longer_than: "24h"
+    minimum_step_size: "1m"
+`,
+			makeReq:         rangeReq("rate(expensive_metric[5m])", now.Add(-48*time.Hour), step5m),
+			expectedBlocked: false,
+		},
+		{
+			// time_range=under, step=below → not blocked
+			name: "time_range ok but step violated - not blocked",
+			limitsYAML: `
+blocked_queries:
+  - time_range_longer_than: "24h"
+    minimum_step_size: "1m"
+`,
+			makeReq:         rangeReq("rate(expensive_metric[5m])", now.Add(-12*time.Hour), step30s),
+			expectedBlocked: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runBlockerTest(t, tt.limitsYAML, tt.makeReq, tt.expectedBlocked)
+		})
+	}
+}
+
+// TestQueryBlockerMiddleware_AllConditions verifies conjunction: when all three conditions are
+// configured, all must be violated to block.
+func TestQueryBlockerMiddleware_AllConditions(t *testing.T) {
+	now := time.Now()
+
+	step30s := (30 * time.Second).Milliseconds()
+	step5m := (5 * time.Minute).Milliseconds()
+
+	rangeReq := func(query string, start time.Time, stepMs int64) func(t *testing.T) MetricsQueryRequest {
+		return func(t *testing.T) MetricsQueryRequest {
+			return &PrometheusRangeQueryRequest{
+				queryExpr: parseQuery(t, query),
+				start:     start.UnixMilli(),
+				end:       now.UnixMilli(),
+				step:      stepMs,
+			}
+		}
+	}
+
+	tests := []struct {
+		name            string
+		limitsYAML      string
+		makeReq         func(t *testing.T) MetricsQueryRequest
+		expectedBlocked bool
+	}{
+		{
+			// pattern=match, time_range=over, step=below → blocked
+			name: "pattern + time_range + step all violated is blocked",
+			limitsYAML: `
+blocked_queries:
+  - pattern: ".*expensive.*"
+    regex: true
+    time_range_longer_than: "24h"
+    minimum_step_size: "1m"
+    reason: "all three conditions met"
+`,
+			makeReq:         rangeReq("rate(expensive_metric[5m])", now.Add(-48*time.Hour), step30s),
+			expectedBlocked: true,
+		},
+		{
+			// pattern=no-match, time_range=over, step=below → not blocked
+			name: "pattern not matched - not blocked",
+			limitsYAML: `
+blocked_queries:
+  - pattern: ".*expensive.*"
+    regex: true
+    time_range_longer_than: "24h"
+    minimum_step_size: "1m"
+`,
+			makeReq:         rangeReq("rate(cheap_metric[5m])", now.Add(-48*time.Hour), step30s),
+			expectedBlocked: false,
+		},
+		{
+			// pattern=match, time_range=under, step=below → not blocked
+			name: "time_range not violated - not blocked",
+			limitsYAML: `
+blocked_queries:
+  - pattern: ".*expensive.*"
+    regex: true
+    time_range_longer_than: "24h"
+    minimum_step_size: "1m"
+`,
+			makeReq:         rangeReq("rate(expensive_metric[5m])", now.Add(-12*time.Hour), step30s),
+			expectedBlocked: false,
+		},
+		{
+			// pattern=match, time_range=over, step=ok → not blocked
+			name: "step not violated - not blocked",
+			limitsYAML: `
+blocked_queries:
+  - pattern: ".*expensive.*"
+    regex: true
+    time_range_longer_than: "24h"
+    minimum_step_size: "1m"
+`,
+			makeReq:         rangeReq("rate(expensive_metric[5m])", now.Add(-48*time.Hour), step5m),
+			expectedBlocked: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runBlockerTest(t, tt.limitsYAML, tt.makeReq, tt.expectedBlocked)
+		})
+	}
+}
+
+// TestQueryBlockerMiddleware_RemoteRead verifies pattern matching for remote-read requests.
 //
 // Remote read query strings are always in selector form ({label=value,...}) produced by
 // LabelMatchersToString — never PromQL syntax. Non-regex matching is a raw string compare


### PR DESCRIPTION
#### What this PR does

The tests are getting unwieldy with multiple separate files and duplicated test cases.

 - Extracted `runBlockerTest` helper — eliminates repeated registry/middleware setup and assertion boilerplate from every test case.               
  - Extracted `rangeReq/instantReq/remoteReadReq` closures per function — test cases reduce to a single-line `makeReq:` field.                        
  - Split the original monolithic table into one function per condition (or combination), each with its own minimal truth table.                  
  - Rewrote `TestQueryBlockerMiddleware_RemoteRead` with realistic `{label=value}` selector patterns matching actual remote-read wire format, and     
  documented why matcher order matters (no canonicalization unlike PromQL path).                                                                  
  - Reordered functions to mirror production logic: pre-filter → single conditions → pairwise combinations → all-three → remote-read variant;     
  updated comments from stale switch-arm references to conjunction semantics.    

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are test-only refactoring, though it reshapes coverage and expectations around remote-read string matching and conjunction semantics.
> 
> **Overview**
> **Refactors `blocked_queries` test coverage for the query-frontend query blocker.** The previously monolithic tables and repeated setup are replaced with a shared `runBlockerTest` helper and per-test `makeReq` closures to reduce boilerplate and make failures easier to localize.
> 
> Tests are reorganized into focused suites for each predicate and their conjunctions (`pattern`, `time_range_longer_than`, `minimum_step_size`, plus `unaligned_range_queries` as a pre-filter), including explicit truth tables for pairwise/all-condition combinations and an added bail-out case for invalid regex with time range.
> 
> Remote-read tests are rewritten to use realistic selector-form query strings (as produced on the remote-read path), explicitly asserting matcher-order sensitivity for non-regex patterns and verifying regex patterns that target selector-form queries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9a6da22b3b7fc8c407b301baddd5c1d6e882c91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->