### PR TITLE
feat(labels): include global.extraLabels in kubernetes resources

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -45,6 +45,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Add support for custom labels on PersistentVolumeClaim resources for alertmanager, compactor, ingester, and store-gateway. #14373
 * [ENHANCEMENT] Ingester: Add `ingester.zoneAwareReplication.autoIngestStorageClientRack` to pass `-ingest-storage.kafka.client-rack` when zone-aware replication is enabled. #14654
 * [ENHANCEMENT] Allow zone-aware replication for ingesters with 2 zones when ingest storage is enabled. #14449
+* [ENHANCEMENT] Add support for a custom global labels
 * [BUGFIX] Fix missing newline for custom pod labels. #13325
 * [BUGFIX] Upgrade rollout-operator chart to 0.37.1, which fixes server-tls.self-signed-cert.dns-name to use the full release name instead of always being set to `rollout-operator.NAMESPACE.svc`. If upgrading from 6.0.0 or 6.0.1, delete the `certificate` secret created by the rollout-operator pod and recreate the rollout-operator pod. #13357
 * [BUGFIX] Delete gateway's serviceMonitor #13481

--- a/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
@@ -250,6 +250,9 @@ name: "{{ .component }}-{{ .rolloutZoneName }}" {{- /* Currently required for ro
 rollout-group: {{ .component }}
 zone: {{ .rolloutZoneName }}
 {{- end }}
+{{- if .ctx.Values.global.extraLabels }}
+{{ toYaml .ctx.Values.global.extraLabels | indent 0 }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -60,6 +60,10 @@ global:
   #       name: mysecret
   extraEnvFrom: []
 
+  # -- Common labels to add to all resources excluding pods directly managed by this chart.
+  # scope: alertmanager, compactor, continuous-test, distributor, gateway, ingester, memcached, nginx, overrides-exporter, querier, query-frontend, query-scheduler, ruler, store-gateway, smoke-test
+  extraLabels: {}
+  
   # -- Common volumes to add to all pods directly managed by this chart.
   # scope: alertmanager, compactor, continuous-test, distributor, gateway, ingester, memcached, nginx, overrides-exporter, querier, query-frontend, query-scheduler, ruler, store-gateway, smoke-test
   extraVolumes: []


### PR DESCRIPTION
#### What this PR does
This allows users to include a custom label for the Kubernetes manifests


#### Checklist

- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Helm templating change that only adds optional user-provided labels to rendered Kubernetes manifests; main risk is unintended label collisions or selector-related expectations in downstream tooling.
> 
> **Overview**
> Adds a new Helm value `global.extraLabels` and injects it into the chart’s common `mimir.labels` helper so **all non-pod resources generated by the chart** can receive user-defined labels.
> 
> Updates `values.yaml` documentation for the new setting and adds a corresponding `[ENHANCEMENT]` entry to the `mimir-distributed` changelog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc9bfd363ec38001c0439c1bdb42e145dbefed24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->