### PR TITLE
usage tracker: reduce memory spikes during rehash and snapshot loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,7 @@
 * [ENHANCEMENT] API: activity tracker (if enabled) covers the full request lifecycle and used on all routes. #14777
 * [ENHANCEMENT] MQE: Add metrics for tracking in-flight memory consumption tracking. `cortex_querier_inflight_query_max_estimated_memory_consumption_limit_bytes`, `cortex_querier_inflight_query_current_estimated_memory_consumption_bytes`, `cortex_querier_inflight_query_peak_estimated_memory_consumption_bytes` and `cortex_querier_inflight_query_sampled_count`. #14807
 * [ENHANCEMENT] Activity tracker: Added `activity_tracker_unfinished_activities_loaded` metric to report the number of unfinished activities detected on startup. #14860
+* [ENHANCEMENT] Usage-tracker: Reduce memory spikes during rehash by splitting into compact (reuses existing arrays) and grow (pools arrays across shards) paths, and pool temporary buffers in snapshot loading. #14904
 * [BUGFIX] Distributor: Fix race condition where usage-tracker partition ring may not be initialized before the distributor service starts, causing `usage-tracker partition ring is required` error on startup. #14675
 * [BUGFIX] Store-gateway: Fix `cortex_bucket_store_series_data_touched{data_type="series", stage="returned"}` metric observing negative values when series-for-postings cache is hit and pending matchers filter out some series. #14655
 * [BUGFIX] Mimir: Fix false positive in filesystem path overlap detection when one path is a string prefix of another but not an ancestor directory. #14426

--- a/pkg/usagetracker/tenantshard/map.go
+++ b/pkg/usagetracker/tenantshard/map.go
@@ -246,21 +246,94 @@ func (m *Map) nextSize(limit uint64) uint32 {
 	return numGroups(uint32(target))
 }
 
+// rehashEntry holds a key-value pair extracted during compaction rehash.
+type rehashEntry struct {
+	key  uint64
+	data xorData
+}
+
+var rehashBufPool = &sync.Pool{New: func() any { return &[]rehashEntry{} }}
+
 func (m *Map) rehash(n uint32) {
-	indices, ks, datas := m.index, m.keys, m.data
-	m.index = make([]index, n)
-	m.keys = make([]keys, n)
-	m.data = make([]data, n)
-	m.limit = n * maxAvgGroupLoad
-	m.resident, m.dead = 0, 0
-	for g := range indices {
-		for s := range indices[g] {
-			c := indices[g][s]
-			if c != empty && c != tombstone {
-				m.load(ks[g][s], datas[g][s])
+	// Use the compaction path (reuses existing backing arrays) when the new size fits
+	// within the current allocation AND has enough capacity for all alive entries.
+	alive := m.resident - m.dead
+	if n <= uint32(len(m.index)) && n >= numGroups(alive) {
+		m.rehashCompact(n)
+	} else {
+		m.rehashGrow(n)
+	}
+}
+
+// rehashCompact handles the case where the new size is <= the old size (compaction after cleanup).
+// It collects alive entries into a temporary buffer, clears and reslices the existing backing arrays,
+// then re-inserts. This avoids allocating new arrays entirely, eliminating the 2x peak memory.
+func (m *Map) rehashCompact(n uint32) {
+	alive := int(m.resident - m.dead)
+
+	// Collect alive entries into a pooled temporary buffer.
+	// At 9 bytes/entry this is much smaller than the group arrays (80 bytes/group at load factor 4 = 20 bytes/entry).
+	bufPtr := rehashBufPool.Get().(*[]rehashEntry)
+	buf := *bufPtr
+	if cap(buf) < alive {
+		buf = make([]rehashEntry, 0, alive)
+	}
+	buf = buf[:0]
+	for g := range m.index {
+		for s := range m.index[g] {
+			if c := m.index[g][s]; c != empty && c != tombstone {
+				buf = append(buf, rehashEntry{key: m.keys[g][s], data: m.data[g][s]})
 			}
 		}
 	}
+
+	// Clear and reslice existing arrays to new size.
+	clear(m.index[:n])
+	clear(m.keys[:n])
+	clear(m.data[:n])
+	m.index = m.index[:n]
+	m.keys = m.keys[:n]
+	m.data = m.data[:n]
+	m.limit = n * maxAvgGroupLoad
+	m.resident, m.dead = 0, 0
+
+	// Re-insert from the temporary buffer.
+	for _, e := range buf {
+		m.load(e.key, e.data)
+	}
+
+	// Return buffer to pool.
+	*bufPtr = buf
+	rehashBufPool.Put(bufPtr)
+}
+
+// rehashGrow handles the case where the new size is larger than the old size.
+// It allocates new arrays (trying the pool first), copies entries, then returns old arrays to the pool.
+func (m *Map) rehashGrow(n uint32) {
+	oldIndex, oldKeys, oldData := m.index, m.keys, m.data
+
+	var indexPtr *[]index
+	var keysPtr *[]keys
+	var dataPtr *[]data
+	indexPtr, m.index = getRehashSlice[index](&rehashIndexPool, n)
+	keysPtr, m.keys = getRehashSlice[keys](&rehashKeysPool, n)
+	dataPtr, m.data = getRehashSlice[data](&rehashDataPool, n)
+	m.limit = n * maxAvgGroupLoad
+	m.resident, m.dead = 0, 0
+	for g := range oldIndex {
+		for s := range oldIndex[g] {
+			c := oldIndex[g][s]
+			if c != empty && c != tombstone {
+				m.load(oldKeys[g][s], oldData[g][s])
+			}
+		}
+	}
+
+	// Swap new slices into the pool handles so the old arrays can be reused by other shards.
+	// The new arrays stay live via m.index/m.keys/m.data.
+	putRehashSlice(&rehashIndexPool, indexPtr, oldIndex)
+	putRehashSlice(&rehashKeysPool, keysPtr, oldKeys)
+	putRehashSlice(&rehashDataPool, dataPtr, oldData)
 }
 
 // numGroups returns the minimum number of groups needed to store |n| elems.
@@ -293,7 +366,36 @@ func fastModN(x, n uint32) uint32 {
 var (
 	keysPool = &sync.Pool{New: func() any { return new([]keys) }}
 	dataPool = &sync.Pool{New: func() any { return new([]data) }}
+
+	// Pools for rehash array reuse across shards.
+	rehashIndexPool sync.Pool
+	rehashKeysPool  sync.Pool
+	rehashDataPool  sync.Pool
 )
+
+// getRehashSlice gets a *[]T handle from the pool (or allocates one) and ensures the slice has capacity for n elements.
+// The caller must pass the returned *[]T back to putRehashSlice.
+func getRehashSlice[T index | keys | data](pool *sync.Pool, n uint32) (*[]T, []T) {
+	var sp *[]T
+	if v := pool.Get(); v != nil {
+		sp = v.(*[]T)
+		if s := *sp; uint32(cap(s)) >= n {
+			s = s[:n]
+			clear(s)
+			return sp, s
+		}
+	} else {
+		sp = new([]T)
+	}
+	s := make([]T, n)
+	return sp, s
+}
+
+// putRehashSlice writes the slice back into the pool handle and returns it to the pool.
+func putRehashSlice[T index | keys | data](pool *sync.Pool, sp *[]T, s []T) {
+	*sp = s
+	pool.Put(sp)
+}
 
 func pooledClone[T any](input []T, pool *sync.Pool) *[]T {
 	pooled := pool.Get().(*[]T)

--- a/pkg/usagetracker/tenantshard/map_test.go
+++ b/pkg/usagetracker/tenantshard/map_test.go
@@ -172,6 +172,112 @@ func TestLimitAwareGrowth(t *testing.T) {
 	require.Equal(t, expected, got)
 }
 
+func TestRehash(t *testing.T) {
+	t.Run("compaction", func(t *testing.T) {
+		// Build a map, add entries, kill some via Cleanup, then verify compaction produces identical contents.
+		m := New(1000)
+		r := rand.New(rand.NewSource(42))
+		total := atomic.NewUint64(0)
+
+		for i := range 1000 {
+			key := r.Uint64()
+			val := clock.Minutes(i%200 + 1) // avoid 0xff
+			if val == 0xff {
+				val = 1
+			}
+			m.Put(key, val, total, nil, false)
+		}
+
+		// Kill entries with timestamp <= 100 (about half).
+		removed := m.Cleanup(100, nil)
+		require.True(t, removed > 0, "expected some entries to be removed")
+		require.True(t, m.dead > 0, "expected dead entries after cleanup")
+
+		// Snapshot contents before explicit compaction rehash.
+		beforeItems := map[uint64]clock.Minutes{}
+		l, items := m.Items()
+		for key, val := range items {
+			beforeItems[key] = val
+		}
+		require.Len(t, beforeItems, l)
+
+		// Force a compaction rehash to a smaller size.
+		alive := m.resident - m.dead
+		m.rehash(numGroups(alive))
+
+		// Verify contents are identical.
+		require.Zero(t, m.dead, "compaction should remove all dead entries")
+		afterItems := map[uint64]clock.Minutes{}
+		l2, items2 := m.Items()
+		for key, val := range items2 {
+			afterItems[key] = val
+		}
+		require.Len(t, afterItems, l2)
+		require.Equal(t, beforeItems, afterItems)
+	})
+
+	t.Run("growth pool reuse", func(t *testing.T) {
+		// Verify that growing rehash still produces correct results when pool is active.
+		m := New(100)
+		total := atomic.NewUint64(0)
+		stored := map[uint64]clock.Minutes{}
+
+		for i := range uint64(500) {
+			val := clock.Minutes(i%200 + 1)
+			if val == 0xff {
+				val = 1
+			}
+			m.Put(i, val, total, nil, false)
+			stored[i] = val
+		}
+
+		// Force multiple grow rehashes to exercise pool paths.
+		for _, newSize := range []uint32{600, 800, 1200} {
+			m.rehash(numGroups(newSize))
+		}
+
+		got := map[uint64]clock.Minutes{}
+		_, items := m.Items()
+		for key, val := range items {
+			got[key] = val
+		}
+		require.Equal(t, stored, got)
+	})
+}
+
+func BenchmarkMapRehashAllocs(b *testing.B) {
+	const size = 1e6
+
+	b.Run("compaction", func(b *testing.B) {
+		// Kill ~half the entries, then benchmark compaction rehash.
+		for range b.N {
+			b.StopTimer()
+			mc := New(uint32(size))
+			r := rand.New(rand.NewSource(1))
+			for i := range int(size) {
+				mc.Put(r.Uint64(), clock.Minutes(i%128), nil, nil, false)
+			}
+			mc.Cleanup(64, nil)
+			alive := mc.resident - mc.dead
+			b.StartTimer()
+			mc.rehash(numGroups(alive))
+		}
+	})
+
+	b.Run("growth", func(b *testing.B) {
+		for range b.N {
+			b.StopTimer()
+			mg := New(uint32(size))
+			r := rand.New(rand.NewSource(1))
+			for i := range int(size) {
+				mg.Put(r.Uint64(), clock.Minutes(i%128), nil, nil, false)
+			}
+			b.StartTimer()
+			mg.rehash(numGroups(uint32(size) * 5 / 4))
+		}
+	})
+}
+
 func BenchmarkMapRehash(b *testing.B) {
 	for _, size := range []uint32{1e6, 10e6} {
 		b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {

--- a/pkg/usagetracker/tracker_store.go
+++ b/pkg/usagetracker/tracker_store.go
@@ -201,7 +201,7 @@ func (t *trackerStore) getOrCreateTenant(tenantID string) *trackedTenant {
 	}
 	capacity := int(limit / shards)
 	if limit == noLimit || limit == 0 {
-		capacity = 512 // let's be modest.
+		capacity = 8192
 	} else if capacity > math.MaxUint32 {
 		capacity = math.MaxUint32
 	}

--- a/pkg/usagetracker/tracker_store_snapshot.go
+++ b/pkg/usagetracker/tracker_store_snapshot.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"maps"
 	"runtime"
+	"sync"
 	"time"
 
 	"github.com/prometheus/prometheus/tsdb/encoding"
@@ -13,6 +14,13 @@ import (
 
 	"github.com/grafana/mimir/pkg/usagetracker/clock"
 )
+
+type refTimestamp struct {
+	Ref       uint64
+	Timestamp clock.Minutes
+}
+
+var refTimestampPool = &sync.Pool{New: func() any { return &[]refTimestamp{} }}
 
 const snapshotEncodingVersion = 1
 
@@ -130,20 +138,28 @@ func (t *trackerStore) loadSnapshot(data []byte, now time.Time) error {
 			return fmt.Errorf("failed to read series len: %w", err)
 		}
 
-		type refTimestamp struct {
-			Ref       uint64
-			Timestamp clock.Minutes
+		refsPtr := refTimestampPool.Get().(*[]refTimestamp)
+		refs := *refsPtr
+		if cap(refs) < seriesLen {
+			refs = make([]refTimestamp, 0, seriesLen)
+		}
+		refs = refs[:0]
+
+		returnRefs := func() {
+			*refsPtr = refs
+			refTimestampPool.Put(refsPtr)
 		}
 
-		refs := make([]refTimestamp, 0, seriesLen)
 		for i := 0; i < seriesLen; i++ {
 			s := snapshot.Be64()
 			if err := snapshot.Err(); err != nil {
+				returnRefs()
 				return fmt.Errorf("failed to read series ref %d: %w", i, err)
 			}
 
 			snapshotTs := clock.Minutes(snapshot.Byte())
 			if err := snapshot.Err(); err != nil {
+				returnRefs()
 				return fmt.Errorf("failed to read series timestamp %d: %w", i, err)
 			}
 			if expirationWatermark.GreaterThan(snapshotTs) {
@@ -157,7 +173,7 @@ func (t *trackerStore) loadSnapshot(data []byte, now time.Time) error {
 		m := tenant.shards[shard]
 		m.Lock()
 		// Ensure the shard has enough capacity for this snapshot to minimize the number of rehashes.
-		m.EnsureCapacity(uint32(len(refs)))
+		m.EnsureCapacity(uint32(m.Count()) + uint32(len(refs)))
 
 		// Check if the shard is empty. If it is, we can use the faster Load() method
 		// which doesn't check for duplicates. Otherwise, use Put() which handles
@@ -174,6 +190,8 @@ func (t *trackerStore) loadSnapshot(data []byte, now time.Time) error {
 		}
 		m.Unlock()
 		tenant.RUnlock()
+
+		returnRefs()
 	}
 	return nil
 }


### PR DESCRIPTION
#### What this PR does

Reduce usage-tracker memory spikes during rehash and snapshot loading.

- Split `rehash` into `rehashCompact` (reuses existing backing arrays in-place) and `rehashGrow` (pools arrays across shards via `sync.Pool`), so cleanup-triggered compaction no longer allocates fresh arrays.
- Pool `[]refTimestamp` buffers in snapshot loading and fix error-path pool leak.
- Fix `EnsureCapacity` in snapshot loading to account for entries already in the shard.
- Increase default initial shard capacity from 512 to 8192 to reduce early rehashes for no-limit tenants.

#### Benchstat results

```
goos: linux
goarch: amd64
cpu: Intel(R) Xeon(R) Platinum 8280 CPU @ 2.70GHz
                              │  main.txt   │           optimized.txt            │
                              │   sec/op    │   sec/op     vs base               │
MapRehashAllocs/compaction-16   12.16m ± 6%   14.77m ± 1%  +21.43% (p=0.002 n=6)
MapRehashAllocs/growth-16       15.59m ± 1%   16.35m ± 1%   +4.89% (p=0.002 n=6)

                              │   main.txt    │            optimized.txt             │
                              │     B/op      │     B/op       vs base               │
MapRehashAllocs/compaction-16   9920.0Ki ± 0%   801.4Ki ± 61%  -91.92% (p=0.002 n=6)
MapRehashAllocs/growth-16        23.86Mi ± 0%   23.87Mi ±  0%   +0.03% (p=0.002 n=6)

                              │  main.txt  │           optimized.txt            │
                              │ allocs/op  │ allocs/op   vs base                │
MapRehashAllocs/compaction-16   3.000 ± 0%   1.000 ± 0%   -66.67% (p=0.002 n=6)
MapRehashAllocs/growth-16       3.000 ± 0%   9.000 ± 0%  +200.00% (p=0.002 n=6)
```

Compaction: **-92% memory** (9.7 MiB → 801 KiB), +21% CPU (expected trade-off for avoiding allocation spike).
Growth: neutral on memory/CPU. The 9 allocs are cold-pool `*[]T` wrapper allocations that stabilize at 0 once the pool is warm.

#### Which issue(s) this PR fixes or relates to

*N/A*

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated.
- [ ] `about-versioning.md` updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the usage-tracker’s core shard map rehashing and snapshot reload paths; while tests were added, bugs here could cause incorrect series accounting or higher memory/CPU under load.
> 
> **Overview**
> Reduces usage-tracker memory spikes by changing shard map `rehash` to choose between an in-place **compaction** path (reuse existing backing arrays + pooled entry buffer) and a **growth** path that reuses large `index`/`keys`/`data` arrays across shards via `sync.Pool`.
> 
> Snapshot loading now pools temporary `[]refTimestamp` buffers (including fixing error-path pool returns) and sizes `EnsureCapacity` based on *existing + incoming* entries to avoid excess rehashing; the default initial shard capacity for no-limit tenants is also increased (512 → 8192).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 574ba92f9cd287dc369a76b1c51f849ae4f42b97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->