### PR TITLE
chore(storegateway): remove stale TODO and fix help text for cached postings compressions metric

### DIFF
--- a/pkg/storegateway/bucket_store_metrics.go
+++ b/pkg/storegateway/bucket_store_metrics.go
@@ -128,7 +128,7 @@ func NewBucketStoreMetrics(reg prometheus.Registerer) *BucketStoreMetrics {
 
 	m.cachedPostingsCompressions = promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 		Name: "cortex_bucket_store_cached_postings_compressions_total",
-		Help: "Number of postings compressions and decompressions when storing to index cache.", // TODO also decompressions?
+		Help: "Number of postings compressions (op=encode) and decompressions (op=decode) when interacting with the index cache.",
 	}, []string{"op"})
 	m.cachedPostingsCompressions.WithLabelValues(labelEncode)
 	m.cachedPostingsCompressions.WithLabelValues(labelDecode)


### PR DESCRIPTION
#### What this PR does

The `cortex_bucket_store_cached_postings_compressions_total` metric already tracks both compressions and decompressions via the `op` label (`encode`/`decode`). The inline `// TODO also decompressions?` comment was stale — decompressions have been tracked since the `op=decode` label value was wired up.

Also fixes the help text: it said "when storing to index cache" but decompressions (decode) happen when reading *from* the cache, not storing to it.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change: updates Prometheus metric help text to correctly describe `encode`/`decode` operations; no behavior or data-path logic changes.
> 
> **Overview**
> Clarifies the `cortex_bucket_store_cached_postings_compressions_total` metric description to explicitly cover both compression (`op=encode`) and decompression (`op=decode`) when interacting with the index cache, and removes the stale TODO implying decompressions were not tracked.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd2ec24c186c2ac9ea005ddc56d054f91751113d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->