### PR TITLE
release 2.17.9: Update backward compatibility test

### DIFF
--- a/integration/backward_compatibility.go
+++ b/integration/backward_compatibility.go
@@ -11,7 +11,7 @@ var DefaultPreviousVersionImages = map[string]e2emimir.FlagMapper{
 		removePartitionRingFlags,
 		removeQuerierRingFlags,
 	),
-	"grafana/mimir:2.17.8": e2emimir.ChainFlagMappers(
+	"grafana/mimir:2.17.9": e2emimir.ChainFlagMappers(
 		removePartitionRingFlags,
 		removeQuerierRingFlags,
 	),


### PR DESCRIPTION
#### What this PR does

Update backward compatibility test for release 2.17.9

#### Which issue(s) this PR fixes or relates to

Part of https://github.com/grafana/mimir/issues/12039

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single version string bump for integration test coverage with no production logic changes.
> 
> **Overview**
> Backward-compatibility integration coverage is updated by replacing the previous image tag `grafana/mimir:2.17.8` with `grafana/mimir:2.17.9` in `DefaultPreviousVersionImages`, keeping the same flag-mapper removals for the test setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b51af1c1c32ae89d889cdab28216c9cbca0ce79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->