### PR TITLE
alertmanager: register config API under alertmanager HTTP prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Grafana Mimir
 
+* [BUGFIX] Alertmanager: register the Mimir alertmanager config API (`/api/v1/alerts`) also under the alertmanager HTTP prefix path so that users who include the prefix in their `--address` (e.g. `http://host:port/alertmanager`) receive the correct response instead of a `410 Gone` from the embedded Prometheus Alertmanager. #14928
 * [CHANGE] Ingester: Changed default value of `-include-tenant-id-in-profile-labels` from false to true. #13375
 * [CHANGE] Hash ring: removed experimental support for disabling heartbeats (setting `-*.ring.heartbeat-period=0`) and heartbeat timeouts (setting `-*.ring.heartbeat-timeout=0`). These configurations are now invalid. #13104
 * [CHANGE] Distributor: removed experimental flag `-distributor.metric-relabeling-enabled`. #13143

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -245,6 +245,16 @@ func (a *API) RegisterAlertmanager(am *alertmanager.MultitenantAlertmanager, api
 	a.RegisterRoute("/multitenant_alertmanager/delete_tenant_config", http.HandlerFunc(am.DeleteUserConfig), true, true, "POST")
 	a.RegisterRoute(path.Join(a.cfg.AlertmanagerHTTPPrefix, "/api/v1/status/buildinfo"), buildInfoHandler, false, true, "GET")
 
+	// MultiTenant Alertmanager API routes - register before the prefix handler so they take
+	// priority over the embedded Prometheus Alertmanager handler. This ensures requests to
+	// {alertmanagerHTTPPrefix}/api/v1/alerts are served by Mimir's config API regardless of
+	// whether the user includes the alertmanager path prefix in their --address.
+	if apiEnabled {
+		a.RegisterRoute(path.Join(a.cfg.AlertmanagerHTTPPrefix, "/api/v1/alerts"), http.HandlerFunc(am.GetUserConfig), true, true, "GET")
+		a.RegisterRoute(path.Join(a.cfg.AlertmanagerHTTPPrefix, "/api/v1/alerts"), http.HandlerFunc(am.SetUserConfig), true, true, "POST")
+		a.RegisterRoute(path.Join(a.cfg.AlertmanagerHTTPPrefix, "/api/v1/alerts"), http.HandlerFunc(am.DeleteUserConfig), true, true, "DELETE")
+	}
+
 	// UI components lead to a large number of routes to support, utilize a path prefix instead
 	a.RegisterRoutesWithPrefix(a.cfg.AlertmanagerHTTPPrefix, am, true, true, 0)
 	level.Debug(a.logger).Log("msg", "api: registering alertmanager", "path_prefix", a.cfg.AlertmanagerHTTPPrefix)

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -375,6 +376,68 @@ func TestNewRouteMaxBodySize(t *testing.T) {
 				var maxBytesErr *http.MaxBytesError
 				require.ErrorAs(t, handlerBodyErr, &maxBytesErr)
 			}
+		})
+	}
+}
+
+// TestAlertmanagerConfigRoutePriority verifies that Mimir's alertmanager config API routes
+// registered at {alertmanagerHTTPPrefix}/api/v1/alerts take priority over the broader
+// alertmanager prefix handler. This ensures users who include the alertmanager path prefix
+// in their mimirtool --address (e.g. http://host:port/alertmanager) are served by Mimir's
+// config API rather than the embedded Prometheus Alertmanager, whose /api/v1/alerts
+// endpoint was removed in upstream 0.28.0 and returns 410 Gone.
+func TestAlertmanagerConfigRoutePriority(t *testing.T) {
+	const alertmanagerPrefix = "/alertmanager"
+
+	cfg := Config{AlertmanagerHTTPPrefix: alertmanagerPrefix}
+	federationCfg := tenantfederation.Config{}
+	serverCfg := getServerConfig(t)
+	serverCfg.MetricsNamespace = "alertmanager_route_priority"
+	srv, err := server.New(serverCfg)
+	require.NoError(t, err)
+
+	api, err := New(cfg, federationCfg, serverCfg, srv, log.NewNopLogger(), nil)
+	require.NoError(t, err)
+
+	const (
+		responseConfig = "config-handler"
+		responsePrefix = "prefix-handler"
+	)
+
+	configHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(responseConfig))
+	})
+	prefixHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(responsePrefix))
+	})
+
+	// Mirrors RegisterAlertmanager: specific routes registered before the prefix handler.
+	api.RegisterRoute(path.Join(alertmanagerPrefix, "/api/v1/alerts"), configHandler, false, false, "GET")
+	api.RegisterRoutesWithPrefix(alertmanagerPrefix, prefixHandler, false, false, 0)
+	api.RegisterRoute("/api/v1/alerts", configHandler, false, false, "GET")
+
+	for _, tc := range []struct {
+		requestPath      string
+		expectedResponse string
+	}{
+		{
+			requestPath:      "/api/v1/alerts",
+			expectedResponse: responseConfig,
+		},
+		{
+			requestPath:      "/alertmanager/api/v1/alerts",
+			expectedResponse: responseConfig,
+		},
+		{
+			requestPath:      "/alertmanager/api/v2/alerts",
+			expectedResponse: responsePrefix,
+		},
+	} {
+		t.Run(tc.requestPath, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.requestPath, nil)
+			w := httptest.NewRecorder()
+			api.server.HTTP.ServeHTTP(w, req)
+			require.Equal(t, tc.expectedResponse, w.Body.String())
 		})
 	}
 }


### PR DESCRIPTION
#### What this PR does

Users who set `--address=http://host:port/alertmanager` in mimirtool have requests routed to `/alertmanager/api/v1/alerts`, which hits the embedded Prometheus Alertmanager handler rather than Mimir's config API. The Prometheus Alertmanager removed its `/api/v1/alerts` endpoint in 0.28.0 and returns `410 Gone`, causing `mimirtool alertmanager get/load/delete` to fail in any deployment where users include the alertmanager HTTP prefix in their address.

The fix registers Mimir's config API handlers (`GetUserConfig`, `SetUserConfig`, `DeleteUserConfig`) also at `{alertmanagerHTTPPrefix}/api/v1/alerts`, placed before the broad `RegisterRoutesWithPrefix` call so the specific route takes priority in gorilla/mux's first-match evaluation.

Both `/api/v1/alerts` and `/alertmanager/api/v1/alerts` now correctly serve the Mimir config API, while all other `/alertmanager/*` paths continue to route to the embedded Prometheus Alertmanager as before.

#### Which issue(s) this PR fixes or relates to

Fixes #11676

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes HTTP route registration order/paths for Alertmanager so requests under the configured prefix hit Mimir’s config API instead of the embedded Alertmanager; incorrect routing could affect some Alertmanager endpoints if mis-ordered. Scope is small and covered by a new routing-priority test.
> 
> **Overview**
> Fixes Alertmanager config API routing when clients include the Alertmanager HTTP prefix in their base address.
> 
> `/api/v1/alerts` handlers (`GetUserConfig`/`SetUserConfig`/`DeleteUserConfig`) are now also registered at `{alertmanagerHTTPPrefix}/api/v1/alerts` *before* the broader `RegisterRoutesWithPrefix` handler, preventing requests like `/alertmanager/api/v1/alerts` from falling through to the embedded Prometheus Alertmanager (which returns `410 Gone`). Adds a focused unit test asserting route precedence and documents the bugfix in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72faacff0aba5c34c670614a5f81525f18e66b85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->