### PR TITLE
ruler: Fix rule expressions with leading newlines failing to parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,7 @@
 * [BUGFIX] Query-scheduler: Fix issue where queries executed with remote execution could time out rather than fail immediately if the querier evaluating the request crashes after receiving the query from the query-scheduler. #13742
 * [BUGFIX] Query-frontend: Fix silent panic when executing a remote read API request if the request has no matchers. #13745
 * [BUGFIX] Ruler: Fixed `-ruler.max-rule-groups-per-tenant-by-namespace` to only count rule groups in the specified namespace instead of all namespaces. #13743
+* [BUGFIX] Ruler: Fixed rule expressions with leading newlines failing to parse. #14947
 * [BUGFIX] Query-frontend: Fix race condition that could sometimes cause unnecessary resharding of queriers if querier shuffle sharding and remote execution is enabled. #13794 #13838
 * [BUGFIX] Query-frontend: Fix `step()` duration expression returning 1000x larger value. #13920
 * [BUGFIX] Store-gateway: Fix parent-child relationship in LabelNames and LabelValues trace spans. #13932

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,7 +216,7 @@
 * [BUGFIX] Query-scheduler: Fix issue where queries executed with remote execution could time out rather than fail immediately if the querier evaluating the request crashes after receiving the query from the query-scheduler. #13742
 * [BUGFIX] Query-frontend: Fix silent panic when executing a remote read API request if the request has no matchers. #13745
 * [BUGFIX] Ruler: Fixed `-ruler.max-rule-groups-per-tenant-by-namespace` to only count rule groups in the specified namespace instead of all namespaces. #13743
-* [BUGFIX] Ruler: Fixed rule expressions with leading newlines failing to parse. #14947
+* [BUGFIX] Ruler: Fix parsing of rule expressions with leading newlines. #14947
 * [BUGFIX] Query-frontend: Fix race condition that could sometimes cause unnecessary resharding of queriers if querier shuffle sharding and remote execution is enabled. #13794 #13838
 * [BUGFIX] Query-frontend: Fix `step()` duration expression returning 1000x larger value. #13920
 * [BUGFIX] Store-gateway: Fix parent-child relationship in LabelNames and LabelValues trace spans. #13932

--- a/pkg/ruler/mapper.go
+++ b/pkg/ruler/mapper.go
@@ -149,7 +149,7 @@ func (m *mapper) writeRuleGroupsIfNewer(groups []rulefmt.RuleGroup, filename str
 		return strings.Compare(b.Name, a.Name)
 	})
 
-	rgs := rulefmt.RuleGroups{Groups: groups}
+	rgs := rulefmt.RuleGroups{Groups: cleanRuleGroupExprs(groups)}
 
 	d, err := yaml.Marshal(&rgs)
 	if err != nil {
@@ -211,4 +211,21 @@ func (f FSLoader) parseFile(fs afero.Fs, file string, ignoreUnknownFields bool, 
 		errs[i] = fmt.Errorf("%s: %w", file, errs[i])
 	}
 	return rgs, errs
+}
+
+// cleanRuleGroupExprs returns a copy of groups with leading/trailing whitespace
+// trimmed from rule expressions. This avoids yaml.v3 emitting explicit
+// indentation indicators (e.g. "|4") for expressions that start with newlines
+// or whitespace, which can cause parsing failures when the file is read back.
+func cleanRuleGroupExprs(groups []rulefmt.RuleGroup) []rulefmt.RuleGroup {
+	cleaned := make([]rulefmt.RuleGroup, len(groups))
+	for i, g := range groups {
+		cleaned[i] = g
+		cleaned[i].Rules = make([]rulefmt.Rule, len(g.Rules))
+		for j, r := range g.Rules {
+			cleaned[i].Rules[j] = r
+			cleaned[i].Rules[j].Expr = strings.TrimSpace(r.Expr)
+		}
+	}
+	return cleaned
 }

--- a/pkg/ruler/mapper_test.go
+++ b/pkg/ruler/mapper_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	util_log "github.com/grafana/mimir/pkg/util/log"
 )

--- a/pkg/ruler/mapper_test.go
+++ b/pkg/ruler/mapper_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
 	util_log "github.com/grafana/mimir/pkg/util/log"
 )
@@ -489,6 +490,45 @@ func Test_mapper_users(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, result)
 	})
+}
+
+func Test_mapper_ExprWithLeadingNewlines(t *testing.T) {
+	m := &mapper{
+		Path:   "/rules",
+		FS:     afero.NewMemMapFs(),
+		logger: log.NewNopLogger(),
+	}
+
+	ruleConfigs := map[string][]rulefmt.RuleGroup{
+		"rules.yaml": {
+			{
+				Name: "test_group",
+				Rules: []rulefmt.Rule{
+					{
+						Record: "test_rule",
+						Expr:   "\n\n# comment\nup > 0\n",
+					},
+				},
+			},
+		},
+	}
+
+	updated, files, err := m.MapRules("user1", ruleConfigs)
+	require.NoError(t, err)
+	require.True(t, updated)
+	require.Len(t, files, 1)
+
+	// Verify the written file can be parsed back by the rulefmt parser.
+	content, err := afero.ReadFile(m.FS, files[0])
+	require.NoError(t, err)
+
+	var rgs rulefmt.RuleGroups
+	err = yaml.Unmarshal(content, &rgs)
+	require.NoError(t, err)
+	require.Len(t, rgs.Groups, 1)
+	require.Len(t, rgs.Groups[0].Rules, 1)
+	// Leading/trailing whitespace should be trimmed.
+	require.Equal(t, "# comment\nup > 0", rgs.Groups[0].Rules[0].Expr)
 }
 
 func Test_FSLoader_LoadRules(t *testing.T) {

--- a/pkg/ruler/mapper_test.go
+++ b/pkg/ruler/mapper_test.go
@@ -531,6 +531,26 @@ func Test_mapper_ExprWithLeadingNewlines(t *testing.T) {
 	require.Equal(t, "# comment\nup > 0", rgs.Groups[0].Rules[0].Expr)
 }
 
+func Test_cleanRuleGroupExprs(t *testing.T) {
+	groups := []rulefmt.RuleGroup{
+		{
+			Name: "group1",
+			Rules: []rulefmt.Rule{
+				{Record: "r1", Expr: "\n\n  up > 0\n"},
+				{Record: "r2", Expr: "rate(foo[5m])"},
+			},
+		},
+	}
+
+	cleaned := cleanRuleGroupExprs(groups)
+
+	// Cleaned expressions should have whitespace trimmed.
+	require.Equal(t, "up > 0", cleaned[0].Rules[0].Expr)
+	require.Equal(t, "rate(foo[5m])", cleaned[0].Rules[1].Expr)
+	// Original should be unmodified.
+	require.Equal(t, "\n\n  up > 0\n", groups[0].Rules[0].Expr)
+}
+
 func Test_FSLoader_LoadRules(t *testing.T) {
 	l := util_log.MakeLeveledLogger(os.Stdout, "info")
 	setupRuleSets()


### PR DESCRIPTION
#### What this PR does

When a ruler rule expression starts with whitespace (e.g. a leading newline before a comment), `yaml.v3` emits an explicit indentation indicator in the serialized output (e.g. `|4`). This causes the YAML to fail parsing when the file is read back by the `rulefmt` parser.

This PR fixes the issue by trimming leading whitespace from rule expressions before marshaling them to YAML in `writeRuleGroupsIfNewer`.

##### Changes

- `pkg/ruler/mapper.go`: Added `cleanRuleGroupExprs` helper that returns a deep-copied slice of rule groups with all rule expressions trimmed. Called at the point of serialization, so the in-memory representation is unaffected.
- `pkg/ruler/mapper_test.go`: Added two tests:
  - `Test_mapper_ExprWithLeadingNewlines` — end-to-end test verifying that rules with leading newlines round-trip correctly through write and parse.
  - `Test_cleanRuleGroupExprs` — unit test verifying trimming behavior and that the original groups are not mutated.

##### Why

Rule expressions submitted via the API can include leading newlines (e.g. a multiline expr starting with a blank line or comment). This is valid PromQL but breaks the YAML serialization round-trip used by the ruler's file-based storage layer.

#### Which issue(s) this PR fixes or relates to

Fixes #6763 (tested locally with docker-compose with the example rules file there)

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk bugfix confined to ruler rule-file serialization; the main behavior change is trimming leading/trailing whitespace in rule expressions, which should not affect valid PromQL but could slightly alter stored formatting.
> 
> **Overview**
> Fixes a ruler YAML round-trip bug where rule expressions starting with whitespace/newlines could be re-serialized with explicit indentation indicators and then fail `rulefmt` parsing.
> 
> Rule groups are now deep-copied and each rule `Expr` is `strings.TrimSpace`’d right before YAML marshaling in `writeRuleGroupsIfNewer`, and new tests cover end-to-end parsing of leading-newline expressions plus the non-mutating trim helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bc20ea1c1e5253bf2a23763ddebe98482d20db5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->