### PR TITLE
MQE: introduce subset tracking to `OperatorEvaluationStats`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@
 * [FEATURE] Ingest storage: Add `-ingest-storage.kafka.tls*` flags to connect to Kafka using TLS. #14550
 * [FEATURE] Ingest storage: Add `-ingest-storage.ingestion-partition-tenant-write-shard-size` to limit the number of partitions used for writes independently from reads, allowing safely reducing the shard size without losing query coverage during the migration. #14780
 * [FEATURE] MQE: Add experimental support for splitting and caching intermediate results for functions over range vectors in instant queries. #13472 #14479 #14506 #14499 #14517 #14536 #14614 #14645 #14677 #14788
-* [FEATURE] MQE: Add experimental support for reporting the number of samples read per query. #14828 #14839
+* [FEATURE] MQE: Add experimental support for reporting the number of samples read per query. #14828 #14839 #14952
 * [FEATURE] Compactor: Add `-compactor.ooo-split-and-merge-shards` per-tenant limit to allow a separate shard count for blocks with the out-of-order external label. #14704
 * [ENHANCEMENT] Query-frontend: Add `minimum_step_size` filter to blocked queries config to reject range queries with a step smaller than the configured threshold. #14885
 * [ENHANCEMENT] Query-frontend: Add support for blocking queries exceeding a time range duration with `time_range_longer_than`. #14609

--- a/pkg/streamingpromql/operators/scalars/scalar_constant.go
+++ b/pkg/streamingpromql/operators/scalars/scalar_constant.go
@@ -71,7 +71,7 @@ func (s *ScalarConstant) Finalize(_ context.Context) error {
 }
 
 func (s *ScalarConstant) Stats(_ context.Context) (*types.OperatorEvaluationStats, error) {
-	return types.NewOperatorEvaluationStats(s.TimeRange, s.MemoryConsumptionTracker)
+	return types.NewOperatorEvaluationStats(s.TimeRange, s.MemoryConsumptionTracker, 0)
 }
 
 func (s *ScalarConstant) Close() {

--- a/pkg/streamingpromql/operators/selectors/instant_vector_selector.go
+++ b/pkg/streamingpromql/operators/selectors/instant_vector_selector.go
@@ -188,7 +188,7 @@ func (v *InstantVectorSelector) NextSeries(ctx context.Context) (types.InstantVe
 			// For consistency with Prometheus' engine, we convert each histogram point to an equivalent number of float points.
 			sampleCount := types.EquivalentFloatSampleCount(h)
 			v.QueryStats.IncrementSamples(sampleCount)
-			v.evaluationStats.TrackSampleForInstantVectorSelector(stepT, sampleCount)
+			v.evaluationStats.TrackSampleForInstantVectorSelector(stepT, sampleCount, nil)
 
 		} else {
 			// Only create the slice once we know the series is a histogram or not.
@@ -201,7 +201,7 @@ func (v *InstantVectorSelector) NextSeries(ctx context.Context) (types.InstantVe
 				}
 			}
 			v.QueryStats.IncrementSamples(1)
-			v.evaluationStats.TrackSampleForInstantVectorSelector(stepT, 1)
+			v.evaluationStats.TrackSampleForInstantVectorSelector(stepT, 1, nil)
 			data.Floats = append(data.Floats, promql.FPoint{T: stepT, F: f})
 		}
 	}
@@ -215,7 +215,7 @@ func (v *InstantVectorSelector) NextSeries(ctx context.Context) (types.InstantVe
 
 func (v *InstantVectorSelector) Prepare(ctx context.Context, params *types.PrepareParams) error {
 	var err error
-	v.evaluationStats, err = types.NewOperatorEvaluationStats(v.Selector.TimeRange, v.MemoryConsumptionTracker)
+	v.evaluationStats, err = types.NewOperatorEvaluationStats(v.Selector.TimeRange, v.MemoryConsumptionTracker, 0)
 	if err != nil {
 		return err
 	}

--- a/pkg/streamingpromql/operators/selectors/range_vector_selector.go
+++ b/pkg/streamingpromql/operators/selectors/range_vector_selector.go
@@ -162,7 +162,7 @@ func (m *RangeVectorSelector) NextStepSamples(ctx context.Context) (*types.Range
 	}
 
 	// Update query stats before we perform any mutations for the anchored or smoothed modifier.
-	m.evaluationStats.TrackSamplesForRangeVectorSelector(m.stepData.StepT, m.floats, m.histograms, originalRangeStart, originalRangeEnd)
+	m.evaluationStats.TrackSamplesForRangeVectorSelector(m.stepData.StepT, m.floats, m.histograms, originalRangeStart, originalRangeEnd, nil)
 
 	if m.Selector.Anchored || m.Selector.Smoothed {
 		// Histograms are not supported for these modified range queries
@@ -259,7 +259,7 @@ func (m *RangeVectorSelector) fillBuffer(floats *types.FPointRingBuffer, histogr
 
 func (m *RangeVectorSelector) Prepare(ctx context.Context, params *types.PrepareParams) error {
 	var err error
-	m.evaluationStats, err = types.NewOperatorEvaluationStats(m.Selector.TimeRange, m.MemoryConsumptionTracker)
+	m.evaluationStats, err = types.NewOperatorEvaluationStats(m.Selector.TimeRange, m.MemoryConsumptionTracker, 0)
 	if err != nil {
 		return err
 	}

--- a/pkg/streamingpromql/operators/string.go
+++ b/pkg/streamingpromql/operators/string.go
@@ -58,7 +58,7 @@ func (s *StringLiteral) Finalize(_ context.Context) error {
 }
 
 func (s *StringLiteral) Stats(_ context.Context) (*types.OperatorEvaluationStats, error) {
-	return types.NewOperatorEvaluationStats(s.timeRange, s.memoryConsumptionTracker)
+	return types.NewOperatorEvaluationStats(s.timeRange, s.memoryConsumptionTracker, 0)
 }
 
 func (s *StringLiteral) Close() {

--- a/pkg/streamingpromql/operators/time.go
+++ b/pkg/streamingpromql/operators/time.go
@@ -68,7 +68,7 @@ func (s *Time) Finalize(_ context.Context) error {
 }
 
 func (s *Time) Stats(_ context.Context) (*types.OperatorEvaluationStats, error) {
-	return types.NewOperatorEvaluationStats(s.TimeRange, s.MemoryConsumptionTracker)
+	return types.NewOperatorEvaluationStats(s.TimeRange, s.MemoryConsumptionTracker, 0)
 }
 
 func (s *Time) Close() {

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/instant_vector_operator.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/instant_vector_operator.go
@@ -459,13 +459,3 @@ func (d *InstantVectorDuplicationConsumer) Stats(ctx context.Context) (*types.Op
 func (d *InstantVectorDuplicationConsumer) Close() {
 	d.Buffer.CloseConsumer(d)
 }
-
-func matchesSeries(filters []*labels.Matcher, series labels.Labels) bool {
-	for _, filter := range filters {
-		if !filter.Matches(series.Get(filter.Name)) {
-			return false
-		}
-	}
-
-	return true
-}

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/operators.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/operators.go
@@ -23,7 +23,7 @@ func computeFilterBitmap(unfilteredSeries []types.SeriesMetadata, filters []*lab
 	unfilteredSeriesBitmap = unfilteredSeriesBitmap[:len(unfilteredSeries)]
 
 	for unfilteredSeriesIndex, series := range unfilteredSeries {
-		if !matchesSeries(filters, series.Labels) {
+		if !types.MatchersMatch(filters, series.Labels) {
 			continue
 		}
 

--- a/pkg/streamingpromql/types/data.go
+++ b/pkg/streamingpromql/types/data.go
@@ -323,3 +323,13 @@ func (q *QueryTimeRange) LastPointIndexAtOrBefore(t int64) int {
 	}
 	return idx
 }
+
+func MatchersMatch(matchers []*labels.Matcher, lbls labels.Labels) bool {
+	for _, matcher := range matchers {
+		if !matcher.Matches(lbls.Get(matcher.Name)) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/streamingpromql/types/stats.go
+++ b/pkg/streamingpromql/types/stats.go
@@ -90,7 +90,8 @@ func NewOperatorEvaluationStats(timeRange QueryTimeRange, memoryConsumptionTrack
 // TrackSampleForInstantVectorSelector should be called for each output step of an instant vector selector, even if
 // the same underlying sample is used for multiple output steps.
 //
-// lbls is the label set of the series the sample belongs to, used to determine which subsets (if any) it belongs to.
+// matchesSubsets must be a bitmap with a value for each subset tracked by this instance. true indicates the samples
+// should be added to the corresponding subset.
 func (s *OperatorEvaluationStats) TrackSampleForInstantVectorSelector(stepT int64, sampleCount int64, matchesSubsets []bool) {
 	if len(matchesSubsets) != len(s.subsets) {
 		panic(fmt.Errorf("expected %d subsets, got %d", len(s.subsets), len(matchesSubsets)))
@@ -115,7 +116,8 @@ func (s *OperatorEvaluationStats) TrackSampleForInstantVectorSelector(stepT int6
 // floats and histograms may contain samples beyond rangeEnd, these will be ignored.
 // floats and histograms must not contain samples before rangeStart.
 //
-// lbls is the label set of the series the samples belong to, used to determine which subsets (if any) they belong to.
+// matchesSubsets must be a bitmap with a value for each subset tracked by this instance. true indicates the samples
+// should be added to the corresponding subset.
 func (s *OperatorEvaluationStats) TrackSamplesForRangeVectorSelector(stepT int64, floats *FPointRingBuffer, histograms *HPointRingBuffer, rangeStart int64, rangeEnd int64, matchesSubsets []bool) {
 	if len(matchesSubsets) != len(s.subsets) {
 		panic(fmt.Errorf("expected %d subsets, got %d", len(s.subsets), len(matchesSubsets)))

--- a/pkg/streamingpromql/types/stats.go
+++ b/pkg/streamingpromql/types/stats.go
@@ -12,6 +12,7 @@ import (
 	"unsafe"
 
 	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/mimir/pkg/util/limiter"
 )
@@ -50,27 +51,37 @@ type OperatorEvaluationStats struct {
 	timeRange                QueryTimeRange
 	memoryConsumptionTracker *limiter.MemoryConsumptionTracker
 
-	samplesProcessedPerStep []int64
-	newSamplesReadPerStep   []int64
+	allSeries *statsTracker
+	subsets   []*subsetStats
 }
 
-func NewOperatorEvaluationStats(timeRange QueryTimeRange, memoryConsumptionTracker *limiter.MemoryConsumptionTracker) (*OperatorEvaluationStats, error) {
-	samplesProcessedPerStep, err := Int64SlicePool.Get(timeRange.StepCount, memoryConsumptionTracker)
+// NewOperatorEvaluationStats creates a new OperatorEvaluationStats for the given time range.
+//
+// subsetMatchers defines zero or more subsets of series to track independently.
+// Each subset is defined by a set of label matchers (AND semantics): a series belongs to a subset
+// if it matches all matchers in that subset's set.
+func NewOperatorEvaluationStats(timeRange QueryTimeRange, memoryConsumptionTracker *limiter.MemoryConsumptionTracker, subsetMatchers [][]*labels.Matcher) (*OperatorEvaluationStats, error) {
+	allSeries, err := newStatsTracker(timeRange, memoryConsumptionTracker)
 	if err != nil {
 		return nil, err
 	}
 
-	newSamplesReadPerStep, err := Int64SlicePool.Get(timeRange.StepCount, memoryConsumptionTracker)
-	if err != nil {
-		return nil, err
+	subsets := make([]*subsetStats, len(subsetMatchers))
+	for i, matchers := range subsetMatchers {
+		stats, err := newSubsetsStats(matchers, timeRange, memoryConsumptionTracker)
+		if err != nil {
+			return nil, err
+		}
+
+		subsets[i] = stats
 	}
 
 	return &OperatorEvaluationStats{
 		timeRange:                timeRange,
 		memoryConsumptionTracker: memoryConsumptionTracker,
 
-		samplesProcessedPerStep: samplesProcessedPerStep[:timeRange.StepCount],
-		newSamplesReadPerStep:   newSamplesReadPerStep[:timeRange.StepCount],
+		allSeries: allSeries,
+		subsets:   subsets,
 	}, nil
 }
 
@@ -80,11 +91,18 @@ func NewOperatorEvaluationStats(timeRange QueryTimeRange, memoryConsumptionTrack
 //
 // TrackSampleForInstantVectorSelector should be called for each output step of an instant vector selector, even if
 // the same underlying sample is used for multiple output steps.
-func (s *OperatorEvaluationStats) TrackSampleForInstantVectorSelector(stepT int64, sampleCount int64) {
+//
+// lbls is the label set of the series the sample belongs to, used to determine which subsets (if any) it belongs to.
+func (s *OperatorEvaluationStats) TrackSampleForInstantVectorSelector(stepT int64, sampleCount int64, lbls labels.Labels) {
 	i := s.timeRange.PointIndex(stepT)
 
-	s.samplesProcessedPerStep[i] += sampleCount
-	s.newSamplesReadPerStep[i] += sampleCount
+	s.allSeries.Add(i, sampleCount, sampleCount)
+
+	for _, subset := range s.subsets {
+		if subset.matches(lbls) {
+			subset.Add(i, sampleCount, sampleCount)
+		}
+	}
 }
 
 // TrackSamplesForRangeVectorSelector records samples for a range vector selector at output timestamp stepT.
@@ -94,17 +112,26 @@ func (s *OperatorEvaluationStats) TrackSampleForInstantVectorSelector(stepT int6
 //
 // floats and histograms may contain samples beyond rangeEnd, these will be ignored.
 // floats and histograms must not contain samples before rangeStart.
-func (s *OperatorEvaluationStats) TrackSamplesForRangeVectorSelector(stepT int64, floats *FPointRingBuffer, histograms *HPointRingBuffer, rangeStart int64, rangeEnd int64) {
+//
+// lbls is the label set of the series the samples belong to, used to determine which subsets (if any) they belong to.
+func (s *OperatorEvaluationStats) TrackSamplesForRangeVectorSelector(stepT int64, floats *FPointRingBuffer, histograms *HPointRingBuffer, rangeStart int64, rangeEnd int64, lbls labels.Labels) {
 	i := s.timeRange.PointIndex(stepT)
 
-	s.samplesProcessedPerStep[i] += int64(floats.CountUntil(rangeEnd)) + histograms.EquivalentFloatSampleCountUntil(rangeEnd)
+	samplesProcessed := int64(floats.CountUntil(rangeEnd)) + histograms.EquivalentFloatSampleCountUntil(rangeEnd)
 
 	newSampleRangeStart := rangeEnd - s.timeRange.IntervalMilliseconds
 	if s.timeRange.IsInstant {
 		newSampleRangeStart = rangeStart
 	}
+	newSamplesRead := int64(floats.CountBetween(newSampleRangeStart, rangeEnd)) + histograms.EquivalentFloatSampleCountBetween(newSampleRangeStart, rangeEnd)
 
-	s.newSamplesReadPerStep[i] += int64(floats.CountBetween(newSampleRangeStart, rangeEnd)) + histograms.EquivalentFloatSampleCountBetween(newSampleRangeStart, rangeEnd)
+	s.allSeries.Add(i, samplesProcessed, newSamplesRead)
+
+	for _, subset := range s.subsets {
+		if subset.matches(lbls) {
+			subset.Add(i, samplesProcessed, newSamplesRead)
+		}
+	}
 }
 
 // Add adds the statistics from other to this instance.
@@ -112,28 +139,49 @@ func (s *OperatorEvaluationStats) TrackSamplesForRangeVectorSelector(stepT int64
 // This instance is modified in-place.
 //
 // Both instances must be for the same time range.
+//
+// At most one of the two instances may have subsets. If both have subsets, an error is returned.
+// When one has subsets and the other does not, the overall statistics from the instance without subsets
+// are added to each subset in the instance with subsets.
 func (s *OperatorEvaluationStats) Add(other *OperatorEvaluationStats) error {
 	if !s.timeRange.Equal(other.timeRange) {
 		return errors.New("cannot add OperatorEvaluationStats with different time ranges")
 	}
 
-	for i := range s.samplesProcessedPerStep {
-		s.samplesProcessedPerStep[i] += other.samplesProcessedPerStep[i]
-		s.newSamplesReadPerStep[i] += other.newSamplesReadPerStep[i]
+	if len(s.subsets) > 0 && len(other.subsets) > 0 {
+		return errors.New("cannot add two OperatorEvaluationStats instances that both have subsets")
+	}
+
+	for i := range s.timeRange.StepCount {
+		s.allSeries.Add(int64(i), other.allSeries.samplesProcessedPerStep[i], other.allSeries.newSamplesReadPerStep[i])
+	}
+
+	for _, subset := range s.subsets {
+		for i := range subset.samplesProcessedPerStep {
+			subset.Add(int64(i), other.allSeries.samplesProcessedPerStep[i], other.allSeries.newSamplesReadPerStep[i])
+		}
 	}
 
 	return nil
 }
 
-// Clone returns a copy of this OperatorEvaluationStats instance.
+// Clone returns a copy of this OperatorEvaluationStats instance, including any subset definitions and their data.
 func (s *OperatorEvaluationStats) Clone() (*OperatorEvaluationStats, error) {
-	clone, err := NewOperatorEvaluationStats(s.timeRange, s.memoryConsumptionTracker)
+	subsetMatchers := make([][]*labels.Matcher, len(s.subsets))
+	for i, subset := range s.subsets {
+		subsetMatchers[i] = subset.matchers
+	}
+
+	clone, err := NewOperatorEvaluationStats(s.timeRange, s.memoryConsumptionTracker, subsetMatchers)
 	if err != nil {
 		return nil, err
 	}
 
-	copy(clone.samplesProcessedPerStep, s.samplesProcessedPerStep)
-	copy(clone.newSamplesReadPerStep, s.newSamplesReadPerStep)
+	clone.allSeries.CopyFrom(s.allSeries)
+
+	for i, subset := range s.subsets {
+		clone.subsets[i].CopyFrom(subset.statsTracker)
+	}
 
 	return clone, nil
 }
@@ -141,21 +189,28 @@ func (s *OperatorEvaluationStats) Clone() (*OperatorEvaluationStats, error) {
 // ExtendStepInvariantToFullRange calculates the equivalent statistics for a step invariant
 // operation that is used for multiple steps in a range query.
 //
+// Subset definitions and their data are preserved in the expanded instance.
+//
 // It is the caller's responsibility to call Close on the original OperatorEvaluationStats instance.
 func (s *OperatorEvaluationStats) ExtendStepInvariantToFullRange(timeRange QueryTimeRange) (*OperatorEvaluationStats, error) {
 	if !s.timeRange.IsInstant {
 		return nil, fmt.Errorf("cannot extend step invariant to full range for non-instant time range %v", s.timeRange)
 	}
 
-	expanded, err := NewOperatorEvaluationStats(timeRange, s.memoryConsumptionTracker)
+	subsetMatchers := make([][]*labels.Matcher, len(s.subsets))
+	for i, subset := range s.subsets {
+		subsetMatchers[i] = subset.matchers
+	}
+
+	expanded, err := NewOperatorEvaluationStats(timeRange, s.memoryConsumptionTracker, subsetMatchers)
 	if err != nil {
 		return nil, err
 	}
 
-	expanded.newSamplesReadPerStep[0] = s.newSamplesReadPerStep[0]
+	expanded.allSeries.SetFromStepInvariant(s.allSeries.samplesProcessedPerStep[0], s.allSeries.newSamplesReadPerStep[0])
 
-	for idx := range timeRange.StepCount {
-		expanded.samplesProcessedPerStep[idx] = s.samplesProcessedPerStep[0]
+	for i, subset := range s.subsets {
+		expanded.subsets[i].SetFromStepInvariant(subset.samplesProcessedPerStep[0], subset.newSamplesReadPerStep[0])
 	}
 
 	return expanded, nil
@@ -216,6 +271,76 @@ func (s *OperatorEvaluationStats) ComputeForSubquery(
 }
 
 func (s *OperatorEvaluationStats) Close() {
+	s.allSeries.Close()
+
+	for _, subset := range s.subsets {
+		subset.Close()
+	}
+}
+
+// subsetStats holds per-step tracking data for a single subset of series defined by a set of label matchers.
+type subsetStats struct {
+	*statsTracker
+	matchers []*labels.Matcher
+}
+
+func newSubsetsStats(matchers []*labels.Matcher, timeRange QueryTimeRange, memoryConsumptionTracker *limiter.MemoryConsumptionTracker) (*subsetStats, error) {
+	tracker, err := newStatsTracker(timeRange, memoryConsumptionTracker)
+	if err != nil {
+		return nil, err
+	}
+
+	return &subsetStats{statsTracker: tracker, matchers: matchers}, nil
+}
+
+// matches returns true if lbls satisfies all matchers in the subset (AND semantics).
+func (s *subsetStats) matches(lbls labels.Labels) bool {
+	return MatchersMatch(s.matchers, lbls)
+}
+
+type statsTracker struct {
+	samplesProcessedPerStep []int64
+	newSamplesReadPerStep   []int64
+
+	memoryConsumptionTracker *limiter.MemoryConsumptionTracker
+}
+
+func newStatsTracker(timeRange QueryTimeRange, memoryConsumptionTracker *limiter.MemoryConsumptionTracker) (*statsTracker, error) {
+	samplesProcessed, err := Int64SlicePool.Get(timeRange.StepCount, memoryConsumptionTracker)
+	if err != nil {
+		return nil, err
+	}
+
+	newSamplesRead, err := Int64SlicePool.Get(timeRange.StepCount, memoryConsumptionTracker)
+	if err != nil {
+		return nil, err
+	}
+
+	return &statsTracker{
+		samplesProcessedPerStep:  samplesProcessed[:timeRange.StepCount],
+		newSamplesReadPerStep:    newSamplesRead[:timeRange.StepCount],
+		memoryConsumptionTracker: memoryConsumptionTracker,
+	}, nil
+}
+
+func (s *statsTracker) Add(pointIndex int64, samplesProcessed int64, newSamplesRead int64) {
+	s.samplesProcessedPerStep[pointIndex] += samplesProcessed
+	s.newSamplesReadPerStep[pointIndex] += newSamplesRead
+}
+
+func (s *statsTracker) SetFromStepInvariant(samplesProcessed int64, newSamplesRead int64) {
+	s.newSamplesReadPerStep[0] = newSamplesRead
+	for idx := range s.samplesProcessedPerStep {
+		s.samplesProcessedPerStep[idx] = samplesProcessed
+	}
+}
+
+func (s *statsTracker) CopyFrom(source *statsTracker) {
+	copy(s.samplesProcessedPerStep, source.samplesProcessedPerStep)
+	copy(s.newSamplesReadPerStep, source.newSamplesReadPerStep)
+}
+
+func (s *statsTracker) Close() {
 	Int64SlicePool.Put(&s.samplesProcessedPerStep, s.memoryConsumptionTracker)
 	Int64SlicePool.Put(&s.newSamplesReadPerStep, s.memoryConsumptionTracker)
 }

--- a/pkg/streamingpromql/types/stats.go
+++ b/pkg/streamingpromql/types/stats.go
@@ -240,10 +240,10 @@ func (s *OperatorEvaluationStats) ComputeForSubquery(
 
 	lastNewSamplesIdxUsed := -1
 
-	for outerIdx := range int64(parentTimeRange.StepCount) {
-		outerT := parentTimeRange.IndexTime(outerIdx)
+	for parentIdx := range parentTimeRange.StepCount {
+		parentT := parentTimeRange.IndexTime(int64(parentIdx))
 
-		rangeEnd := outerT
+		rangeEnd := parentT
 		if subqueryTimestamp != nil {
 			rangeEnd = *subqueryTimestamp
 		}
@@ -251,19 +251,17 @@ func (s *OperatorEvaluationStats) ComputeForSubquery(
 		rangeStart := rangeEnd - subqueryRangeMilliseconds
 
 		// Find the range of inner steps in (rangeStart, rangeEnd].
-		firstIdx := s.timeRange.FirstPointIndexAfter(rangeStart)
-		lastIdx := s.timeRange.LastPointIndexAtOrBefore(rangeEnd)
+		firstInnerIdx := s.timeRange.FirstPointIndexAfter(rangeStart)
+		lastInnerIdx := s.timeRange.LastPointIndexAtOrBefore(rangeEnd)
+		firstNewSamplesInnerIdx := max(lastNewSamplesIdxUsed, firstInnerIdx)
 
-		for innerIdx := firstIdx; innerIdx <= lastIdx; innerIdx++ {
-			result.allSeries.samplesProcessedPerStep[outerIdx] += s.allSeries.samplesProcessedPerStep[innerIdx]
+		result.allSeries.SetFromSubquery(s.allSeries, parentIdx, firstInnerIdx, firstNewSamplesInnerIdx, lastInnerIdx)
+
+		for i, subset := range result.subsets {
+			subset.SetFromSubquery(s.subsets[i].statsTracker, parentIdx, firstInnerIdx, firstNewSamplesInnerIdx, lastInnerIdx)
 		}
 
-		firstNewIdx := max(lastNewSamplesIdxUsed, firstIdx)
-		for innerIdx := firstNewIdx; innerIdx <= lastIdx; innerIdx++ {
-			result.allSeries.newSamplesReadPerStep[outerIdx] += s.allSeries.newSamplesReadPerStep[innerIdx]
-		}
-
-		lastNewSamplesIdxUsed = lastIdx + 1
+		lastNewSamplesIdxUsed = lastInnerIdx + 1
 	}
 
 	return result, nil
@@ -325,6 +323,16 @@ func newStatsTracker(timeRange QueryTimeRange, memoryConsumptionTracker *limiter
 func (s *statsTracker) Add(pointIndex int64, samplesProcessed int64, newSamplesRead int64) {
 	s.samplesProcessedPerStep[pointIndex] += samplesProcessed
 	s.newSamplesReadPerStep[pointIndex] += newSamplesRead
+}
+
+func (s *statsTracker) SetFromSubquery(source *statsTracker, parentIdx, firstInnerIdx, firstNewSamplesInnerIdx, lastIdx int) {
+	for innerIdx := firstInnerIdx; innerIdx <= lastIdx; innerIdx++ {
+		s.samplesProcessedPerStep[parentIdx] += source.samplesProcessedPerStep[innerIdx]
+	}
+
+	for innerIdx := firstNewSamplesInnerIdx; innerIdx <= lastIdx; innerIdx++ {
+		s.newSamplesReadPerStep[parentIdx] += source.newSamplesReadPerStep[innerIdx]
+	}
 }
 
 func (s *statsTracker) SetFromStepInvariant(samplesProcessed int64, newSamplesRead int64) {

--- a/pkg/streamingpromql/types/stats.go
+++ b/pkg/streamingpromql/types/stats.go
@@ -165,14 +165,18 @@ func (s *OperatorEvaluationStats) Add(other *OperatorEvaluationStats) error {
 	return nil
 }
 
-// Clone returns a copy of this OperatorEvaluationStats instance, including any subset definitions and their data.
-func (s *OperatorEvaluationStats) Clone() (*OperatorEvaluationStats, error) {
+func (s *OperatorEvaluationStats) newEmptyInstanceWithSameMatchers(timeRange QueryTimeRange) (*OperatorEvaluationStats, error) {
 	subsetMatchers := make([][]*labels.Matcher, len(s.subsets))
 	for i, subset := range s.subsets {
 		subsetMatchers[i] = subset.matchers
 	}
 
-	clone, err := NewOperatorEvaluationStats(s.timeRange, s.memoryConsumptionTracker, subsetMatchers)
+	return NewOperatorEvaluationStats(timeRange, s.memoryConsumptionTracker, subsetMatchers)
+}
+
+// Clone returns a copy of this OperatorEvaluationStats instance, including any subset definitions and their data.
+func (s *OperatorEvaluationStats) Clone() (*OperatorEvaluationStats, error) {
+	clone, err := s.newEmptyInstanceWithSameMatchers(s.timeRange)
 	if err != nil {
 		return nil, err
 	}
@@ -197,12 +201,7 @@ func (s *OperatorEvaluationStats) ExtendStepInvariantToFullRange(timeRange Query
 		return nil, fmt.Errorf("cannot extend step invariant to full range for non-instant time range %v", s.timeRange)
 	}
 
-	subsetMatchers := make([][]*labels.Matcher, len(s.subsets))
-	for i, subset := range s.subsets {
-		subsetMatchers[i] = subset.matchers
-	}
-
-	expanded, err := NewOperatorEvaluationStats(timeRange, s.memoryConsumptionTracker, subsetMatchers)
+	expanded, err := s.newEmptyInstanceWithSameMatchers(timeRange)
 	if err != nil {
 		return nil, err
 	}
@@ -234,7 +233,7 @@ func (s *OperatorEvaluationStats) ComputeForSubquery(
 	subqueryTimestamp *int64,
 	subqueryOffsetMilliseconds int64,
 ) (*OperatorEvaluationStats, error) {
-	result, err := NewOperatorEvaluationStats(parentTimeRange, s.memoryConsumptionTracker)
+	result, err := s.newEmptyInstanceWithSameMatchers(parentTimeRange)
 	if err != nil {
 		return nil, err
 	}
@@ -256,12 +255,12 @@ func (s *OperatorEvaluationStats) ComputeForSubquery(
 		lastIdx := s.timeRange.LastPointIndexAtOrBefore(rangeEnd)
 
 		for innerIdx := firstIdx; innerIdx <= lastIdx; innerIdx++ {
-			result.samplesProcessedPerStep[outerIdx] += s.samplesProcessedPerStep[innerIdx]
+			result.allSeries.samplesProcessedPerStep[outerIdx] += s.allSeries.samplesProcessedPerStep[innerIdx]
 		}
 
 		firstNewIdx := max(lastNewSamplesIdxUsed, firstIdx)
 		for innerIdx := firstNewIdx; innerIdx <= lastIdx; innerIdx++ {
-			result.newSamplesReadPerStep[outerIdx] += s.newSamplesReadPerStep[innerIdx]
+			result.allSeries.newSamplesReadPerStep[outerIdx] += s.allSeries.newSamplesReadPerStep[innerIdx]
 		}
 
 		lastNewSamplesIdxUsed = lastIdx + 1

--- a/pkg/streamingpromql/types/stats.go
+++ b/pkg/streamingpromql/types/stats.go
@@ -12,7 +12,6 @@ import (
 	"unsafe"
 
 	"github.com/prometheus/prometheus/model/histogram"
-	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/mimir/pkg/util/limiter"
 )
@@ -52,28 +51,27 @@ type OperatorEvaluationStats struct {
 	memoryConsumptionTracker *limiter.MemoryConsumptionTracker
 
 	allSeries *statsTracker
-	subsets   []*subsetStats
+	subsets   []*statsTracker
 }
 
 // NewOperatorEvaluationStats creates a new OperatorEvaluationStats for the given time range.
 //
-// subsetMatchers defines zero or more subsets of series to track independently.
-// Each subset is defined by a set of label matchers (AND semantics): a series belongs to a subset
-// if it matches all matchers in that subset's set.
-func NewOperatorEvaluationStats(timeRange QueryTimeRange, memoryConsumptionTracker *limiter.MemoryConsumptionTracker, subsetMatchers [][]*labels.Matcher) (*OperatorEvaluationStats, error) {
+// subsetCount is the number of subsets to track. It is the caller's responsibility to track
+// which subset is which.
+func NewOperatorEvaluationStats(timeRange QueryTimeRange, memoryConsumptionTracker *limiter.MemoryConsumptionTracker, subsetCount int) (*OperatorEvaluationStats, error) {
 	allSeries, err := newStatsTracker(timeRange, memoryConsumptionTracker)
 	if err != nil {
 		return nil, err
 	}
 
-	subsets := make([]*subsetStats, len(subsetMatchers))
-	for i, matchers := range subsetMatchers {
-		stats, err := newSubsetsStats(matchers, timeRange, memoryConsumptionTracker)
+	subsets := make([]*statsTracker, 0, subsetCount)
+	for range subsetCount {
+		stats, err := newStatsTracker(timeRange, memoryConsumptionTracker)
 		if err != nil {
 			return nil, err
 		}
 
-		subsets[i] = stats
+		subsets = append(subsets, stats)
 	}
 
 	return &OperatorEvaluationStats{
@@ -93,14 +91,18 @@ func NewOperatorEvaluationStats(timeRange QueryTimeRange, memoryConsumptionTrack
 // the same underlying sample is used for multiple output steps.
 //
 // lbls is the label set of the series the sample belongs to, used to determine which subsets (if any) it belongs to.
-func (s *OperatorEvaluationStats) TrackSampleForInstantVectorSelector(stepT int64, sampleCount int64, lbls labels.Labels) {
-	i := s.timeRange.PointIndex(stepT)
+func (s *OperatorEvaluationStats) TrackSampleForInstantVectorSelector(stepT int64, sampleCount int64, matchesSubsets []bool) {
+	if len(matchesSubsets) != len(s.subsets) {
+		panic(fmt.Errorf("expected %d subsets, got %d", len(s.subsets), len(matchesSubsets)))
+	}
 
-	s.allSeries.Add(i, sampleCount, sampleCount)
+	pointIdx := s.timeRange.PointIndex(stepT)
 
-	for _, subset := range s.subsets {
-		if subset.matches(lbls) {
-			subset.Add(i, sampleCount, sampleCount)
+	s.allSeries.Add(pointIdx, sampleCount, sampleCount)
+
+	for subsetIdx, subset := range s.subsets {
+		if matchesSubsets[subsetIdx] {
+			subset.Add(pointIdx, sampleCount, sampleCount)
 		}
 	}
 }
@@ -114,8 +116,12 @@ func (s *OperatorEvaluationStats) TrackSampleForInstantVectorSelector(stepT int6
 // floats and histograms must not contain samples before rangeStart.
 //
 // lbls is the label set of the series the samples belong to, used to determine which subsets (if any) they belong to.
-func (s *OperatorEvaluationStats) TrackSamplesForRangeVectorSelector(stepT int64, floats *FPointRingBuffer, histograms *HPointRingBuffer, rangeStart int64, rangeEnd int64, lbls labels.Labels) {
-	i := s.timeRange.PointIndex(stepT)
+func (s *OperatorEvaluationStats) TrackSamplesForRangeVectorSelector(stepT int64, floats *FPointRingBuffer, histograms *HPointRingBuffer, rangeStart int64, rangeEnd int64, matchesSubsets []bool) {
+	if len(matchesSubsets) != len(s.subsets) {
+		panic(fmt.Errorf("expected %d subsets, got %d", len(s.subsets), len(matchesSubsets)))
+	}
+
+	pointIdx := s.timeRange.PointIndex(stepT)
 
 	samplesProcessed := int64(floats.CountUntil(rangeEnd)) + histograms.EquivalentFloatSampleCountUntil(rangeEnd)
 
@@ -125,11 +131,11 @@ func (s *OperatorEvaluationStats) TrackSamplesForRangeVectorSelector(stepT int64
 	}
 	newSamplesRead := int64(floats.CountBetween(newSampleRangeStart, rangeEnd)) + histograms.EquivalentFloatSampleCountBetween(newSampleRangeStart, rangeEnd)
 
-	s.allSeries.Add(i, samplesProcessed, newSamplesRead)
+	s.allSeries.Add(pointIdx, samplesProcessed, newSamplesRead)
 
-	for _, subset := range s.subsets {
-		if subset.matches(lbls) {
-			subset.Add(i, samplesProcessed, newSamplesRead)
+	for subsetIdx, subset := range s.subsets {
+		if matchesSubsets[subsetIdx] {
+			subset.Add(pointIdx, samplesProcessed, newSamplesRead)
 		}
 	}
 }
@@ -165,18 +171,13 @@ func (s *OperatorEvaluationStats) Add(other *OperatorEvaluationStats) error {
 	return nil
 }
 
-func (s *OperatorEvaluationStats) newEmptyInstanceWithSameMatchers(timeRange QueryTimeRange) (*OperatorEvaluationStats, error) {
-	subsetMatchers := make([][]*labels.Matcher, len(s.subsets))
-	for i, subset := range s.subsets {
-		subsetMatchers[i] = subset.matchers
-	}
-
-	return NewOperatorEvaluationStats(timeRange, s.memoryConsumptionTracker, subsetMatchers)
+func (s *OperatorEvaluationStats) newEmptyInstanceWithSameSubsets(timeRange QueryTimeRange) (*OperatorEvaluationStats, error) {
+	return NewOperatorEvaluationStats(timeRange, s.memoryConsumptionTracker, len(s.subsets))
 }
 
 // Clone returns a copy of this OperatorEvaluationStats instance, including any subset definitions and their data.
 func (s *OperatorEvaluationStats) Clone() (*OperatorEvaluationStats, error) {
-	clone, err := s.newEmptyInstanceWithSameMatchers(s.timeRange)
+	clone, err := s.newEmptyInstanceWithSameSubsets(s.timeRange)
 	if err != nil {
 		return nil, err
 	}
@@ -184,7 +185,7 @@ func (s *OperatorEvaluationStats) Clone() (*OperatorEvaluationStats, error) {
 	clone.allSeries.CopyFrom(s.allSeries)
 
 	for i, subset := range s.subsets {
-		clone.subsets[i].CopyFrom(subset.statsTracker)
+		clone.subsets[i].CopyFrom(subset)
 	}
 
 	return clone, nil
@@ -201,7 +202,7 @@ func (s *OperatorEvaluationStats) ExtendStepInvariantToFullRange(timeRange Query
 		return nil, fmt.Errorf("cannot extend step invariant to full range for non-instant time range %v", s.timeRange)
 	}
 
-	expanded, err := s.newEmptyInstanceWithSameMatchers(timeRange)
+	expanded, err := s.newEmptyInstanceWithSameSubsets(timeRange)
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +234,7 @@ func (s *OperatorEvaluationStats) ComputeForSubquery(
 	subqueryTimestamp *int64,
 	subqueryOffsetMilliseconds int64,
 ) (*OperatorEvaluationStats, error) {
-	result, err := s.newEmptyInstanceWithSameMatchers(parentTimeRange)
+	result, err := s.newEmptyInstanceWithSameSubsets(parentTimeRange)
 	if err != nil {
 		return nil, err
 	}
@@ -258,7 +259,7 @@ func (s *OperatorEvaluationStats) ComputeForSubquery(
 		result.allSeries.SetFromSubquery(s.allSeries, parentIdx, firstInnerIdx, firstNewSamplesInnerIdx, lastInnerIdx)
 
 		for i, subset := range result.subsets {
-			subset.SetFromSubquery(s.subsets[i].statsTracker, parentIdx, firstInnerIdx, firstNewSamplesInnerIdx, lastInnerIdx)
+			subset.SetFromSubquery(s.subsets[i], parentIdx, firstInnerIdx, firstNewSamplesInnerIdx, lastInnerIdx)
 		}
 
 		lastNewSamplesIdxUsed = lastInnerIdx + 1
@@ -273,26 +274,6 @@ func (s *OperatorEvaluationStats) Close() {
 	for _, subset := range s.subsets {
 		subset.Close()
 	}
-}
-
-// subsetStats holds per-step tracking data for a single subset of series defined by a set of label matchers.
-type subsetStats struct {
-	*statsTracker
-	matchers []*labels.Matcher
-}
-
-func newSubsetsStats(matchers []*labels.Matcher, timeRange QueryTimeRange, memoryConsumptionTracker *limiter.MemoryConsumptionTracker) (*subsetStats, error) {
-	tracker, err := newStatsTracker(timeRange, memoryConsumptionTracker)
-	if err != nil {
-		return nil, err
-	}
-
-	return &subsetStats{statsTracker: tracker, matchers: matchers}, nil
-}
-
-// matches returns true if lbls satisfies all matchers in the subset (AND semantics).
-func (s *subsetStats) matches(lbls labels.Labels) bool {
-	return MatchersMatch(s.matchers, lbls)
 }
 
 type statsTracker struct {

--- a/pkg/streamingpromql/types/stats_test.go
+++ b/pkg/streamingpromql/types/stats_test.go
@@ -838,6 +838,93 @@ func TestOperatorEvaluationStats_ComputeForSubquery(t *testing.T) {
 	})
 }
 
+func TestOperatorEvaluationStats_ComputeForSubquery_WithSubsets(t *testing.T) {
+	// Inner time range: steps at 0, 2, 4, 6, 8, 10 minutes (6 steps with 2 minute interval).
+	innerStep := 2 * time.Minute
+	innerStart := timestamp.Time(0)
+	innerEnd := innerStart.Add(5 * innerStep)
+	innerTimeRange := NewRangeQueryTimeRange(innerStart, innerEnd, innerStep)
+
+	ctx := context.Background()
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
+
+	subsetMatchers := [][]*labels.Matcher{
+		{labels.MustNewMatcher(labels.MatchEqual, "env", "prod")},
+	}
+
+	samplesProcessedAt := func(t int) int64 { return int64(10 + t*10) }
+	newSamplesReadAt := func(t int) int64 { return int64(5 + t*10) }
+	subsetSamplesProcessedAt := func(t int) int64 { return int64(2 + t*3) }
+	subsetNewSamplesReadAt := func(t int) int64 { return int64(1 + t*2) }
+
+	createInnerStats := func(t *testing.T) *OperatorEvaluationStats {
+		inner, err := NewOperatorEvaluationStats(innerTimeRange, memoryConsumptionTracker, subsetMatchers)
+		require.NoError(t, err)
+
+		for i := range innerTimeRange.StepCount {
+			inner.allSeries.samplesProcessedPerStep[i] = samplesProcessedAt(i)
+			inner.allSeries.newSamplesReadPerStep[i] = newSamplesReadAt(i)
+			inner.subsets[0].samplesProcessedPerStep[i] = subsetSamplesProcessedAt(i)
+			inner.subsets[0].newSamplesReadPerStep[i] = subsetNewSamplesReadAt(i)
+		}
+
+		return inner
+	}
+
+	t.Run("range query, outer ranges overlap", func(t *testing.T) {
+		parentStep := 4 * time.Minute
+		parentStart := innerStart.Add(6 * time.Minute)
+		parentEnd := parentStart.Add(parentStep)
+		parentTimeRange := NewRangeQueryTimeRange(parentStart, parentEnd, parentStep)
+
+		inner := createInnerStats(t)
+		subqueryRange := 6 * time.Minute
+		result, err := inner.ComputeForSubquery(parentTimeRange, subqueryRange.Milliseconds(), nil, 0)
+		require.NoError(t, err)
+
+		// At t=6min: inner steps in (0m, 6m] = {2m, 4m, 6m} (idx 1, 2, 3)
+		// new samples start after 0m, inner steps in (0m, 6m] = {2m, 4m, 6m} (idx 1, 2, 3)
+		//
+		// At t=10min: inner steps in (4m, 10m] = {6m, 8m, 10m} (idx 3, 4, 5)
+		// new samples start after 6m, inner steps in (6m, 10m] = {8m, 10m} (idx 4, 5)
+		require.Equal(t, []int64{samplesProcessedAt(1) + samplesProcessedAt(2) + samplesProcessedAt(3), samplesProcessedAt(3) + samplesProcessedAt(4) + samplesProcessedAt(5)}, result.allSeries.samplesProcessedPerStep)
+		require.Equal(t, []int64{newSamplesReadAt(1) + newSamplesReadAt(2) + newSamplesReadAt(3), newSamplesReadAt(4) + newSamplesReadAt(5)}, result.allSeries.newSamplesReadPerStep)
+
+		// Subset should be computed using the same time-range logic as allSeries.
+		require.Len(t, result.subsets, 1)
+		require.Equal(t, subsetMatchers[0], result.subsets[0].matchers)
+		require.Equal(t, []int64{subsetSamplesProcessedAt(1) + subsetSamplesProcessedAt(2) + subsetSamplesProcessedAt(3), subsetSamplesProcessedAt(3) + subsetSamplesProcessedAt(4) + subsetSamplesProcessedAt(5)}, result.subsets[0].samplesProcessedPerStep)
+		require.Equal(t, []int64{subsetNewSamplesReadAt(1) + subsetNewSamplesReadAt(2) + subsetNewSamplesReadAt(3), subsetNewSamplesReadAt(4) + subsetNewSamplesReadAt(5)}, result.subsets[0].newSamplesReadPerStep)
+
+		inner.Close()
+		result.Close()
+		require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
+	})
+
+	t.Run("instant query", func(t *testing.T) {
+		parentTimeRange := NewInstantQueryTimeRange(innerStart.Add(10 * time.Minute))
+
+		inner := createInnerStats(t)
+		subqueryRange := 6 * time.Minute
+		result, err := inner.ComputeForSubquery(parentTimeRange, subqueryRange.Milliseconds(), nil, 0)
+		require.NoError(t, err)
+
+		// At t=10m: inner steps in (4m, 10m] = {6m, 8m, 10m} (idx 3, 4, 5)
+		require.Equal(t, []int64{samplesProcessedAt(3) + samplesProcessedAt(4) + samplesProcessedAt(5)}, result.allSeries.samplesProcessedPerStep)
+		require.Equal(t, []int64{newSamplesReadAt(3) + newSamplesReadAt(4) + newSamplesReadAt(5)}, result.allSeries.newSamplesReadPerStep)
+
+		// Subset should be computed using the same time-range logic as allSeries.
+		require.Len(t, result.subsets, 1)
+		require.Equal(t, subsetMatchers[0], result.subsets[0].matchers)
+		require.Equal(t, []int64{subsetSamplesProcessedAt(3) + subsetSamplesProcessedAt(4) + subsetSamplesProcessedAt(5)}, result.subsets[0].samplesProcessedPerStep)
+		require.Equal(t, []int64{subsetNewSamplesReadAt(3) + subsetNewSamplesReadAt(4) + subsetNewSamplesReadAt(5)}, result.subsets[0].newSamplesReadPerStep)
+
+		inner.Close()
+		result.Close()
+		require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
+	})
+}
+
 func TestOperatorEvaluationStats_ExtendStepInvariant(t *testing.T) {
 	ctx := context.Background()
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)

--- a/pkg/streamingpromql/types/stats_test.go
+++ b/pkg/streamingpromql/types/stats_test.go
@@ -596,12 +596,12 @@ func TestOperatorEvaluationStats_ComputeForSubquery(t *testing.T) {
 	newSamplesReadAt := func(t int) int64 { return int64(5 + t*10) }
 
 	createInnerStats := func(t *testing.T) *OperatorEvaluationStats {
-		inner, err := NewOperatorEvaluationStats(innerTimeRange, memoryConsumptionTracker)
+		inner, err := NewOperatorEvaluationStats(innerTimeRange, memoryConsumptionTracker, nil)
 		require.NoError(t, err)
 
 		for i := range innerTimeRange.StepCount {
-			inner.samplesProcessedPerStep[i] = samplesProcessedAt(i)
-			inner.newSamplesReadPerStep[i] = newSamplesReadAt(i)
+			inner.allSeries.samplesProcessedPerStep[i] = samplesProcessedAt(i)
+			inner.allSeries.newSamplesReadPerStep[i] = newSamplesReadAt(i)
 		}
 
 		return inner
@@ -623,8 +623,8 @@ func TestOperatorEvaluationStats_ComputeForSubquery(t *testing.T) {
 		//
 		// At t=10min: inner steps in (4m, 10m] = {6m, 8m, 10m} (idx 3, 4, 5)
 		// new samples start after 6m, inner steps in (6m, 10m] = {8m, 10m} (idx 4, 5)
-		require.Equal(t, []int64{samplesProcessedAt(1) + samplesProcessedAt(2) + samplesProcessedAt(3), samplesProcessedAt(3) + samplesProcessedAt(4) + samplesProcessedAt(5)}, result.samplesProcessedPerStep)
-		require.Equal(t, []int64{newSamplesReadAt(1) + newSamplesReadAt(2) + newSamplesReadAt(3), newSamplesReadAt(4) + newSamplesReadAt(5)}, result.newSamplesReadPerStep)
+		require.Equal(t, []int64{samplesProcessedAt(1) + samplesProcessedAt(2) + samplesProcessedAt(3), samplesProcessedAt(3) + samplesProcessedAt(4) + samplesProcessedAt(5)}, result.allSeries.samplesProcessedPerStep)
+		require.Equal(t, []int64{newSamplesReadAt(1) + newSamplesReadAt(2) + newSamplesReadAt(3), newSamplesReadAt(4) + newSamplesReadAt(5)}, result.allSeries.newSamplesReadPerStep)
 
 		inner.Close()
 		result.Close()
@@ -647,8 +647,8 @@ func TestOperatorEvaluationStats_ComputeForSubquery(t *testing.T) {
 		//
 		// At t=8min: inner steps in (6m, 8m] = {8m} (idx 4)
 		// new samples start after 6m, inner steps in (6m, 8m] = {8m} (same)
-		require.Equal(t, []int64{samplesProcessedAt(3), samplesProcessedAt(4)}, result.samplesProcessedPerStep)
-		require.Equal(t, []int64{newSamplesReadAt(3), newSamplesReadAt(4)}, result.newSamplesReadPerStep)
+		require.Equal(t, []int64{samplesProcessedAt(3), samplesProcessedAt(4)}, result.allSeries.samplesProcessedPerStep)
+		require.Equal(t, []int64{newSamplesReadAt(3), newSamplesReadAt(4)}, result.allSeries.newSamplesReadPerStep)
 
 		inner.Close()
 		result.Close()
@@ -671,8 +671,8 @@ func TestOperatorEvaluationStats_ComputeForSubquery(t *testing.T) {
 		//
 		// At t=10min: inner steps in (7m, 10m] = {8m, 10m} (idx 4, 5)
 		// new samples start after 7m, inner steps in (7m, 10m] = {8m, 10m} (same)
-		require.Equal(t, []int64{samplesProcessedAt(1) + samplesProcessedAt(2), samplesProcessedAt(4) + samplesProcessedAt(5)}, result.samplesProcessedPerStep)
-		require.Equal(t, []int64{newSamplesReadAt(1) + newSamplesReadAt(2), newSamplesReadAt(4) + newSamplesReadAt(5)}, result.newSamplesReadPerStep)
+		require.Equal(t, []int64{samplesProcessedAt(1) + samplesProcessedAt(2), samplesProcessedAt(4) + samplesProcessedAt(5)}, result.allSeries.samplesProcessedPerStep)
+		require.Equal(t, []int64{newSamplesReadAt(1) + newSamplesReadAt(2), newSamplesReadAt(4) + newSamplesReadAt(5)}, result.allSeries.newSamplesReadPerStep)
 
 		inner.Close()
 		result.Close()
@@ -693,8 +693,8 @@ func TestOperatorEvaluationStats_ComputeForSubquery(t *testing.T) {
 
 		// For all steps, the inner steps are (2m, 8m] = {4m, 6m, 8m} (idx 2, 3, 4)
 		samplesProcessed := samplesProcessedAt(2) + samplesProcessedAt(3) + samplesProcessedAt(4)
-		require.Equal(t, []int64{samplesProcessed, samplesProcessed}, result.samplesProcessedPerStep)
-		require.Equal(t, []int64{newSamplesReadAt(2) + newSamplesReadAt(3) + newSamplesReadAt(4), 0}, result.newSamplesReadPerStep) // No new samples are read for subsequent steps.
+		require.Equal(t, []int64{samplesProcessed, samplesProcessed}, result.allSeries.samplesProcessedPerStep)
+		require.Equal(t, []int64{newSamplesReadAt(2) + newSamplesReadAt(3) + newSamplesReadAt(4), 0}, result.allSeries.newSamplesReadPerStep) // No new samples are read for subsequent steps.
 
 		inner.Close()
 		result.Close()
@@ -715,8 +715,8 @@ func TestOperatorEvaluationStats_ComputeForSubquery(t *testing.T) {
 
 		// At t=10min: inner steps in (0m, 6m] = {2m, 4m, 6m} (idx 1, 2, 3)
 		// At t=14min: inner steps in (4m, 10m] = {6m, 8m, 10m} (idx 3, 4, 5)
-		require.Equal(t, []int64{samplesProcessedAt(1) + samplesProcessedAt(2) + samplesProcessedAt(3), samplesProcessedAt(3) + samplesProcessedAt(4) + samplesProcessedAt(5)}, result.samplesProcessedPerStep)
-		require.Equal(t, []int64{newSamplesReadAt(1) + newSamplesReadAt(2) + newSamplesReadAt(3), newSamplesReadAt(4) + newSamplesReadAt(5)}, result.newSamplesReadPerStep)
+		require.Equal(t, []int64{samplesProcessedAt(1) + samplesProcessedAt(2) + samplesProcessedAt(3), samplesProcessedAt(3) + samplesProcessedAt(4) + samplesProcessedAt(5)}, result.allSeries.samplesProcessedPerStep)
+		require.Equal(t, []int64{newSamplesReadAt(1) + newSamplesReadAt(2) + newSamplesReadAt(3), newSamplesReadAt(4) + newSamplesReadAt(5)}, result.allSeries.newSamplesReadPerStep)
 
 		inner.Close()
 		result.Close()
@@ -738,8 +738,8 @@ func TestOperatorEvaluationStats_ComputeForSubquery(t *testing.T) {
 
 		// For all steps, the inner steps are (0m, 6m] = {2m, 4m, 6m} (idx 1, 2, 3)
 		samplesProcessed := samplesProcessedAt(1) + samplesProcessedAt(2) + samplesProcessedAt(3)
-		require.Equal(t, []int64{samplesProcessed, samplesProcessed}, result.samplesProcessedPerStep)
-		require.Equal(t, []int64{newSamplesReadAt(1) + newSamplesReadAt(2) + newSamplesReadAt(3), 0}, result.newSamplesReadPerStep)
+		require.Equal(t, []int64{samplesProcessed, samplesProcessed}, result.allSeries.samplesProcessedPerStep)
+		require.Equal(t, []int64{newSamplesReadAt(1) + newSamplesReadAt(2) + newSamplesReadAt(3), 0}, result.allSeries.newSamplesReadPerStep)
 
 		inner.Close()
 		result.Close()
@@ -757,8 +757,8 @@ func TestOperatorEvaluationStats_ComputeForSubquery(t *testing.T) {
 		result, err := inner.ComputeForSubquery(parentTimeRange, subqueryRange.Milliseconds(), nil, 0)
 		require.NoError(t, err)
 
-		require.Equal(t, []int64{0, 0}, result.samplesProcessedPerStep)
-		require.Equal(t, []int64{0, 0}, result.newSamplesReadPerStep)
+		require.Equal(t, []int64{0, 0}, result.allSeries.samplesProcessedPerStep)
+		require.Equal(t, []int64{0, 0}, result.allSeries.newSamplesReadPerStep)
 
 		inner.Close()
 		result.Close()
@@ -774,8 +774,8 @@ func TestOperatorEvaluationStats_ComputeForSubquery(t *testing.T) {
 		require.NoError(t, err)
 
 		// At t=10m: inner steps in (4m, 10m] = {6m, 8m, 10m} (idx 3, 4, 5)
-		require.Equal(t, []int64{samplesProcessedAt(3) + samplesProcessedAt(4) + samplesProcessedAt(5)}, result.samplesProcessedPerStep)
-		require.Equal(t, []int64{newSamplesReadAt(3) + newSamplesReadAt(4) + newSamplesReadAt(5)}, result.newSamplesReadPerStep)
+		require.Equal(t, []int64{samplesProcessedAt(3) + samplesProcessedAt(4) + samplesProcessedAt(5)}, result.allSeries.samplesProcessedPerStep)
+		require.Equal(t, []int64{newSamplesReadAt(3) + newSamplesReadAt(4) + newSamplesReadAt(5)}, result.allSeries.newSamplesReadPerStep)
 
 		inner.Close()
 		result.Close()
@@ -792,8 +792,8 @@ func TestOperatorEvaluationStats_ComputeForSubquery(t *testing.T) {
 		require.NoError(t, err)
 
 		// At t=10m, subquery timestamp is 8m: inner steps in (2m, 8m] = {4m, 6m, 8m} (idx 2, 3, 4)
-		require.Equal(t, []int64{samplesProcessedAt(2) + samplesProcessedAt(3) + samplesProcessedAt(4)}, result.samplesProcessedPerStep)
-		require.Equal(t, []int64{newSamplesReadAt(2) + newSamplesReadAt(3) + newSamplesReadAt(4)}, result.newSamplesReadPerStep)
+		require.Equal(t, []int64{samplesProcessedAt(2) + samplesProcessedAt(3) + samplesProcessedAt(4)}, result.allSeries.samplesProcessedPerStep)
+		require.Equal(t, []int64{newSamplesReadAt(2) + newSamplesReadAt(3) + newSamplesReadAt(4)}, result.allSeries.newSamplesReadPerStep)
 
 		inner.Close()
 		result.Close()
@@ -810,8 +810,8 @@ func TestOperatorEvaluationStats_ComputeForSubquery(t *testing.T) {
 		require.NoError(t, err)
 
 		// At t=12m: inner steps in (4m, 10m] = {6m, 8m, 10m} (idx 3, 4, 5)
-		require.Equal(t, []int64{samplesProcessedAt(3) + samplesProcessedAt(4) + samplesProcessedAt(5)}, result.samplesProcessedPerStep)
-		require.Equal(t, []int64{newSamplesReadAt(3) + newSamplesReadAt(4) + newSamplesReadAt(5)}, result.newSamplesReadPerStep)
+		require.Equal(t, []int64{samplesProcessedAt(3) + samplesProcessedAt(4) + samplesProcessedAt(5)}, result.allSeries.samplesProcessedPerStep)
+		require.Equal(t, []int64{newSamplesReadAt(3) + newSamplesReadAt(4) + newSamplesReadAt(5)}, result.allSeries.newSamplesReadPerStep)
 
 		inner.Close()
 		result.Close()
@@ -829,8 +829,8 @@ func TestOperatorEvaluationStats_ComputeForSubquery(t *testing.T) {
 		require.NoError(t, err)
 
 		// At t=12m, subquery timestamp is 10m-2m=8m: inner steps in (2m, 8m] = {4m, 6m, 8m} (idx 2, 3, 4)
-		require.Equal(t, []int64{samplesProcessedAt(2) + samplesProcessedAt(3) + samplesProcessedAt(4)}, result.samplesProcessedPerStep)
-		require.Equal(t, []int64{newSamplesReadAt(2) + newSamplesReadAt(3) + newSamplesReadAt(4)}, result.newSamplesReadPerStep)
+		require.Equal(t, []int64{samplesProcessedAt(2) + samplesProcessedAt(3) + samplesProcessedAt(4)}, result.allSeries.samplesProcessedPerStep)
+		require.Equal(t, []int64{newSamplesReadAt(2) + newSamplesReadAt(3) + newSamplesReadAt(4)}, result.allSeries.newSamplesReadPerStep)
 
 		inner.Close()
 		result.Close()

--- a/pkg/streamingpromql/types/stats_test.go
+++ b/pkg/streamingpromql/types/stats_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/prometheus/prometheus/model/histogram"
-	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/stretchr/testify/require"
@@ -25,25 +24,25 @@ func TestOperatorEvaluationStats_TrackSampleForInstantVectorSelector(t *testing.
 	ctx := context.Background()
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
-	stats, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, nil)
+	stats, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, 0)
 	require.NoError(t, err)
 
 	samplesProcessedPerStep := newPerStepTracker("samples processed", timeRange.StepCount)
 	newSamplesReadPerStep := newPerStepTracker("new samples read", timeRange.StepCount)
 
-	stats.TrackSampleForInstantVectorSelector(timestamp.FromTime(start), 1, labels.EmptyLabels())
+	stats.TrackSampleForInstantVectorSelector(timestamp.FromTime(start), 1, nil)
 	samplesProcessedPerStep.requireChange(t, stats.allSeries.samplesProcessedPerStep, 1, 0, 0)
 	newSamplesReadPerStep.requireChange(t, stats.allSeries.newSamplesReadPerStep, 1, 0, 0)
 
-	stats.TrackSampleForInstantVectorSelector(timestamp.FromTime(start), 2, labels.EmptyLabels())
+	stats.TrackSampleForInstantVectorSelector(timestamp.FromTime(start), 2, nil)
 	samplesProcessedPerStep.requireChange(t, stats.allSeries.samplesProcessedPerStep, 2, 0, 0)
 	newSamplesReadPerStep.requireChange(t, stats.allSeries.newSamplesReadPerStep, 2, 0, 0)
 
-	stats.TrackSampleForInstantVectorSelector(timestamp.FromTime(start.Add(step)), 1, labels.EmptyLabels())
+	stats.TrackSampleForInstantVectorSelector(timestamp.FromTime(start.Add(step)), 1, nil)
 	samplesProcessedPerStep.requireChange(t, stats.allSeries.samplesProcessedPerStep, 0, 1, 0)
 	newSamplesReadPerStep.requireChange(t, stats.allSeries.newSamplesReadPerStep, 0, 1, 0)
 
-	stats.TrackSampleForInstantVectorSelector(timestamp.FromTime(start.Add(2*step)), 4, labels.EmptyLabels())
+	stats.TrackSampleForInstantVectorSelector(timestamp.FromTime(start.Add(2*step)), 4, nil)
 	samplesProcessedPerStep.requireChange(t, stats.allSeries.samplesProcessedPerStep, 0, 0, 4)
 	newSamplesReadPerStep.requireChange(t, stats.allSeries.newSamplesReadPerStep, 0, 0, 4)
 
@@ -80,7 +79,7 @@ func TestOperatorEvaluationStats_TrackSamplesForRangeVectorSelector(t *testing.T
 			ctx := context.Background()
 			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
-			stats, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, nil)
+			stats, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, 0)
 			require.NoError(t, err)
 
 			samplesProcessedPerStep := newPerStepTracker("samples processed", timeRange.StepCount)
@@ -102,17 +101,17 @@ func TestOperatorEvaluationStats_TrackSamplesForRangeVectorSelector(t *testing.T
 			appendPoint(start)
 
 			// Samples from rangeStart up to and including rangeEnd should be included.
-			stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start), floats, histograms, timestamp.FromTime(start.Add(-4*time.Second)), timestamp.FromTime(start), labels.EmptyLabels())
+			stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start), floats, histograms, timestamp.FromTime(start.Add(-4*time.Second)), timestamp.FromTime(start), nil)
 			samplesProcessedPerStep.requireChange(t, stats.allSeries.samplesProcessedPerStep, 4*testCase.samplesPerPoint, 0, 0)
 			newSamplesReadPerStep.requireChange(t, stats.allSeries.newSamplesReadPerStep, 4*testCase.samplesPerPoint, 0, 0)
 
 			// Samples after rangeEnd should not be included.
-			stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start), floats, histograms, timestamp.FromTime(start.Add(-4*time.Second)), timestamp.FromTime(start.Add(-1*time.Second)), labels.EmptyLabels())
+			stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start), floats, histograms, timestamp.FromTime(start.Add(-4*time.Second)), timestamp.FromTime(start.Add(-1*time.Second)), nil)
 			samplesProcessedPerStep.requireChange(t, stats.allSeries.samplesProcessedPerStep, 3*testCase.samplesPerPoint, 0, 0)
 			newSamplesReadPerStep.requireChange(t, stats.allSeries.newSamplesReadPerStep, 3*testCase.samplesPerPoint, 0, 0)
 
 			// Should behave the same way for subsequent steps as well.
-			stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start.Add(step)), floats, histograms, timestamp.FromTime(start.Add(-4*time.Second)), timestamp.FromTime(start), labels.EmptyLabels())
+			stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start.Add(step)), floats, histograms, timestamp.FromTime(start.Add(-4*time.Second)), timestamp.FromTime(start), nil)
 			samplesProcessedPerStep.requireChange(t, stats.allSeries.samplesProcessedPerStep, 0, 4*testCase.samplesPerPoint, 0)
 			newSamplesReadPerStep.requireChange(t, stats.allSeries.newSamplesReadPerStep, 0, 4*testCase.samplesPerPoint, 0)
 
@@ -124,17 +123,17 @@ func TestOperatorEvaluationStats_TrackSamplesForRangeVectorSelector(t *testing.T
 			appendPoint(start.Add(-2 * time.Second))
 			appendPoint(start.Add(-time.Second))
 			appendPoint(start)
-			stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start), floats, histograms, timestamp.FromTime(start.Add(-3*step)), timestamp.FromTime(start), labels.EmptyLabels())
+			stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start), floats, histograms, timestamp.FromTime(start.Add(-3*step)), timestamp.FromTime(start), nil)
 			samplesProcessedPerStep.requireChange(t, stats.allSeries.samplesProcessedPerStep, 6*testCase.samplesPerPoint, 0, 0)
 			newSamplesReadPerStep.requireChange(t, stats.allSeries.newSamplesReadPerStep, 4*testCase.samplesPerPoint, 0, 0)
 
-			stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start.Add(step)), floats, histograms, timestamp.FromTime(start.Add(-3*step)), timestamp.FromTime(start), labels.EmptyLabels())
+			stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start.Add(step)), floats, histograms, timestamp.FromTime(start.Add(-3*step)), timestamp.FromTime(start), nil)
 			samplesProcessedPerStep.requireChange(t, stats.allSeries.samplesProcessedPerStep, 0, 6*testCase.samplesPerPoint, 0)
 			newSamplesReadPerStep.requireChange(t, stats.allSeries.newSamplesReadPerStep, 0, 4*testCase.samplesPerPoint, 0)
 
 			// Using empty buffers should not change anything.
 			clearPoints()
-			stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start), floats, histograms, timestamp.FromTime(start.Add(-4*time.Second)), timestamp.FromTime(start), labels.EmptyLabels())
+			stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start), floats, histograms, timestamp.FromTime(start.Add(-4*time.Second)), timestamp.FromTime(start), nil)
 			samplesProcessedPerStep.requireNoChange(t, stats.allSeries.samplesProcessedPerStep)
 			newSamplesReadPerStep.requireNoChange(t, stats.allSeries.newSamplesReadPerStep)
 
@@ -155,7 +154,7 @@ func TestOperatorEvaluationStats_TrackSamplesForRangeVectorSelector_FloatsAndHis
 	ctx := context.Background()
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
-	stats, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, nil)
+	stats, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, 0)
 	require.NoError(t, err)
 
 	samplesProcessedPerStep := newPerStepTracker("samples processed", timeRange.StepCount)
@@ -169,7 +168,7 @@ func TestOperatorEvaluationStats_TrackSamplesForRangeVectorSelector_FloatsAndHis
 	require.NoError(t, histograms.Append(promql.HPoint{T: timestamp.FromTime(start.Add(-2 * time.Second)), H: h}))
 	require.NoError(t, floats.Append(promql.FPoint{T: timestamp.FromTime(start.Add(-time.Second))}))
 
-	stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start), floats, histograms, timestamp.FromTime(start.Add(-4*time.Second)), timestamp.FromTime(start), labels.EmptyLabels())
+	stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start), floats, histograms, timestamp.FromTime(start.Add(-4*time.Second)), timestamp.FromTime(start), nil)
 	samplesProcessedPerStep.requireChange(t, stats.allSeries.samplesProcessedPerStep, 2+EquivalentFloatSampleCount(h), 0, 0)
 	newSamplesReadPerStep.requireChange(t, stats.allSeries.newSamplesReadPerStep, 2 + +EquivalentFloatSampleCount(h), 0, 0)
 
@@ -186,7 +185,7 @@ func TestOperatorEvaluationStats_TrackSamplesForRangeVectorSelector_InstantQuery
 	ctx := context.Background()
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
-	stats, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, nil)
+	stats, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, 0)
 	require.NoError(t, err)
 
 	samplesProcessedPerStep := newPerStepTracker("samples processed", timeRange.StepCount)
@@ -200,7 +199,7 @@ func TestOperatorEvaluationStats_TrackSamplesForRangeVectorSelector_InstantQuery
 	require.NoError(t, histograms.Append(promql.HPoint{T: timestamp.FromTime(queryT.Add(-2 * time.Second)), H: h}))
 	require.NoError(t, floats.Append(promql.FPoint{T: timestamp.FromTime(queryT.Add(-time.Second))}))
 
-	stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(queryT), floats, histograms, timestamp.FromTime(queryT.Add(-4*time.Second)), timestamp.FromTime(queryT), labels.EmptyLabels())
+	stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(queryT), floats, histograms, timestamp.FromTime(queryT.Add(-4*time.Second)), timestamp.FromTime(queryT), nil)
 	samplesProcessedPerStep.requireChange(t, stats.allSeries.samplesProcessedPerStep, 2+EquivalentFloatSampleCount(h))
 	newSamplesReadPerStep.requireChange(t, stats.allSeries.newSamplesReadPerStep, 2 + +EquivalentFloatSampleCount(h))
 
@@ -219,18 +218,9 @@ func TestOperatorEvaluationStats_Subsets_TrackSampleForInstantVectorSelector(t *
 	ctx := context.Background()
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
-	subsetMatchers := [][]*labels.Matcher{
-		{labels.MustNewMatcher(labels.MatchEqual, "env", "prod")},
-		{labels.MustNewMatcher(labels.MatchEqual, "env", "staging"), labels.MustNewMatcher(labels.MatchEqual, "region", "us-east")},
-	}
-	stats, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, subsetMatchers)
+	stats, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, 2)
 	require.NoError(t, err)
 	require.Len(t, stats.subsets, 2)
-
-	prodLabels := labels.FromStrings("env", "prod", "region", "us-east")
-	stagingUsEastLabels := labels.FromStrings("env", "staging", "region", "us-east")
-	stagingEuLabels := labels.FromStrings("env", "staging", "region", "eu-west")
-	noMatchLabels := labels.FromStrings("env", "dev")
 
 	overallProcessed := newPerStepTracker("overall samples processed", timeRange.StepCount)
 	overallRead := newPerStepTracker("overall new samples read", timeRange.StepCount)
@@ -239,8 +229,8 @@ func TestOperatorEvaluationStats_Subsets_TrackSampleForInstantVectorSelector(t *
 	subset1Processed := newPerStepTracker("subset[1] samples processed", timeRange.StepCount)
 	subset1Read := newPerStepTracker("subset[1] new samples read", timeRange.StepCount)
 
-	// prodLabels matches subset[0] (env=prod) only.
-	stats.TrackSampleForInstantVectorSelector(timestamp.FromTime(start), 3, prodLabels)
+	// Test series that matches first subset only.
+	stats.TrackSampleForInstantVectorSelector(timestamp.FromTime(start), 3, []bool{true, false})
 	overallProcessed.requireChange(t, stats.allSeries.samplesProcessedPerStep, 3, 0, 0)
 	overallRead.requireChange(t, stats.allSeries.newSamplesReadPerStep, 3, 0, 0)
 	subset0Processed.requireChange(t, stats.subsets[0].samplesProcessedPerStep, 3, 0, 0)
@@ -248,8 +238,8 @@ func TestOperatorEvaluationStats_Subsets_TrackSampleForInstantVectorSelector(t *
 	subset1Processed.requireNoChange(t, stats.subsets[1].samplesProcessedPerStep)
 	subset1Read.requireNoChange(t, stats.subsets[1].newSamplesReadPerStep)
 
-	// stagingUsEastLabels matches subset[1] (env=staging AND region=us-east) only.
-	stats.TrackSampleForInstantVectorSelector(timestamp.FromTime(start.Add(step)), 2, stagingUsEastLabels)
+	// Test series that matches second subset only.
+	stats.TrackSampleForInstantVectorSelector(timestamp.FromTime(start.Add(step)), 2, []bool{false, true})
 	overallProcessed.requireChange(t, stats.allSeries.samplesProcessedPerStep, 0, 2, 0)
 	overallRead.requireChange(t, stats.allSeries.newSamplesReadPerStep, 0, 2, 0)
 	subset0Processed.requireNoChange(t, stats.subsets[0].samplesProcessedPerStep)
@@ -257,19 +247,10 @@ func TestOperatorEvaluationStats_Subsets_TrackSampleForInstantVectorSelector(t *
 	subset1Processed.requireChange(t, stats.subsets[1].samplesProcessedPerStep, 0, 2, 0)
 	subset1Read.requireChange(t, stats.subsets[1].newSamplesReadPerStep, 0, 2, 0)
 
-	// stagingEuLabels matches neither subset (env=staging but region=eu-west, not us-east).
-	stats.TrackSampleForInstantVectorSelector(timestamp.FromTime(start.Add(2*step)), 1, stagingEuLabels)
+	// Test series that matches neither subset.
+	stats.TrackSampleForInstantVectorSelector(timestamp.FromTime(start.Add(2*step)), 1, []bool{false, false})
 	overallProcessed.requireChange(t, stats.allSeries.samplesProcessedPerStep, 0, 0, 1)
 	overallRead.requireChange(t, stats.allSeries.newSamplesReadPerStep, 0, 0, 1)
-	subset0Processed.requireNoChange(t, stats.subsets[0].samplesProcessedPerStep)
-	subset0Read.requireNoChange(t, stats.subsets[0].newSamplesReadPerStep)
-	subset1Processed.requireNoChange(t, stats.subsets[1].samplesProcessedPerStep)
-	subset1Read.requireNoChange(t, stats.subsets[1].newSamplesReadPerStep)
-
-	// noMatchLabels matches neither subset.
-	stats.TrackSampleForInstantVectorSelector(timestamp.FromTime(start), 5, noMatchLabels)
-	overallProcessed.requireChange(t, stats.allSeries.samplesProcessedPerStep, 5, 0, 0)
-	overallRead.requireChange(t, stats.allSeries.newSamplesReadPerStep, 5, 0, 0)
 	subset0Processed.requireNoChange(t, stats.subsets[0].samplesProcessedPerStep)
 	subset0Read.requireNoChange(t, stats.subsets[0].newSamplesReadPerStep)
 	subset1Processed.requireNoChange(t, stats.subsets[1].samplesProcessedPerStep)
@@ -288,10 +269,7 @@ func TestOperatorEvaluationStats_Subsets_TrackSamplesForRangeVectorSelector(t *t
 	ctx := context.Background()
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
-	subsetMatchers := [][]*labels.Matcher{
-		{labels.MustNewMatcher(labels.MatchEqual, "env", "prod")},
-	}
-	stats, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, subsetMatchers)
+	stats, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, 1)
 	require.NoError(t, err)
 
 	floats := NewFPointRingBuffer(memoryConsumptionTracker)
@@ -301,23 +279,20 @@ func TestOperatorEvaluationStats_Subsets_TrackSamplesForRangeVectorSelector(t *t
 	require.NoError(t, floats.Append(promql.FPoint{T: timestamp.FromTime(start.Add(-time.Second))}))
 	require.NoError(t, floats.Append(promql.FPoint{T: timestamp.FromTime(start)}))
 
-	prodLabels := labels.FromStrings("env", "prod")
-	otherLabels := labels.FromStrings("env", "dev")
-
 	overallProcessed := newPerStepTracker("overall samples processed", timeRange.StepCount)
 	overallRead := newPerStepTracker("overall new samples read", timeRange.StepCount)
 	subsetProcessed := newPerStepTracker("subset samples processed", timeRange.StepCount)
 	subsetRead := newPerStepTracker("subset new samples read", timeRange.StepCount)
 
 	// Matching series: both overall and subset should be updated.
-	stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start), floats, histograms, timestamp.FromTime(start.Add(-4*time.Second)), timestamp.FromTime(start), prodLabels)
+	stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start), floats, histograms, timestamp.FromTime(start.Add(-4*time.Second)), timestamp.FromTime(start), []bool{true})
 	overallProcessed.requireChange(t, stats.allSeries.samplesProcessedPerStep, 4, 0, 0)
 	overallRead.requireChange(t, stats.allSeries.newSamplesReadPerStep, 4, 0, 0)
 	subsetProcessed.requireChange(t, stats.subsets[0].samplesProcessedPerStep, 4, 0, 0)
 	subsetRead.requireChange(t, stats.subsets[0].newSamplesReadPerStep, 4, 0, 0)
 
 	// Non-matching series: only overall should be updated.
-	stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start.Add(step)), floats, histograms, timestamp.FromTime(start.Add(-4*time.Second)), timestamp.FromTime(start), otherLabels)
+	stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start.Add(step)), floats, histograms, timestamp.FromTime(start.Add(-4*time.Second)), timestamp.FromTime(start), []bool{false})
 	overallProcessed.requireChange(t, stats.allSeries.samplesProcessedPerStep, 0, 4, 0)
 	overallRead.requireChange(t, stats.allSeries.newSamplesReadPerStep, 0, 4, 0)
 	subsetProcessed.requireNoChange(t, stats.subsets[0].samplesProcessedPerStep)
@@ -363,9 +338,9 @@ func TestOperatorEvaluationStats_Add(t *testing.T) {
 	ctx := context.Background()
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
-	s1, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, nil)
+	s1, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, 0)
 	require.NoError(t, err)
-	s2, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, nil)
+	s2, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, 0)
 	require.NoError(t, err)
 
 	s1.allSeries.samplesProcessedPerStep[0] = 10
@@ -405,9 +380,9 @@ func TestOperatorEvaluationStats_Add_DifferentTimeRanges(t *testing.T) {
 	ctx := context.Background()
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
-	s1, err := NewOperatorEvaluationStats(timeRange1, memoryConsumptionTracker, nil)
+	s1, err := NewOperatorEvaluationStats(timeRange1, memoryConsumptionTracker, 0)
 	require.NoError(t, err)
-	s2, err := NewOperatorEvaluationStats(timeRange2, memoryConsumptionTracker, nil)
+	s2, err := NewOperatorEvaluationStats(timeRange2, memoryConsumptionTracker, 0)
 	require.NoError(t, err)
 
 	require.EqualError(t, s1.Add(s2), "cannot add OperatorEvaluationStats with different time ranges")
@@ -425,14 +400,10 @@ func TestOperatorEvaluationStats_Add_WithSubsets(t *testing.T) {
 	ctx := context.Background()
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
-	subsetMatchers := [][]*labels.Matcher{
-		{labels.MustNewMatcher(labels.MatchEqual, "env", "prod")},
-	}
-
 	t.Run("receiver has subsets, other does not", func(t *testing.T) {
-		withSubsets, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, subsetMatchers)
+		withSubsets, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, 1)
 		require.NoError(t, err)
-		withoutSubsets, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, nil)
+		withoutSubsets, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, 0)
 		require.NoError(t, err)
 
 		withSubsets.allSeries.samplesProcessedPerStep[0] = 10
@@ -462,9 +433,9 @@ func TestOperatorEvaluationStats_Add_WithSubsets(t *testing.T) {
 	})
 
 	t.Run("receiver has no subsets, other does", func(t *testing.T) {
-		withoutSubsets, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, nil)
+		withoutSubsets, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, 0)
 		require.NoError(t, err)
-		withSubsets, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, subsetMatchers)
+		withSubsets, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, 1)
 		require.NoError(t, err)
 
 		withoutSubsets.allSeries.samplesProcessedPerStep[0] = 10
@@ -488,9 +459,9 @@ func TestOperatorEvaluationStats_Add_WithSubsets(t *testing.T) {
 	})
 
 	t.Run("both have subsets returns error", func(t *testing.T) {
-		s1, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, subsetMatchers)
+		s1, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, 1)
 		require.NoError(t, err)
-		s2, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, subsetMatchers)
+		s2, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, 1)
 		require.NoError(t, err)
 
 		require.EqualError(t, s1.Add(s2), "cannot add two OperatorEvaluationStats instances that both have subsets")
@@ -511,7 +482,7 @@ func TestOperatorEvaluationStats_Clone(t *testing.T) {
 	ctx := context.Background()
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
-	original, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, nil)
+	original, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, 0)
 	require.NoError(t, err)
 
 	original.allSeries.samplesProcessedPerStep[0] = 10
@@ -549,10 +520,7 @@ func TestOperatorEvaluationStats_Clone_WithSubsets(t *testing.T) {
 	ctx := context.Background()
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
-	subsetMatchers := [][]*labels.Matcher{
-		{labels.MustNewMatcher(labels.MatchEqual, "env", "prod")},
-	}
-	original, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, subsetMatchers)
+	original, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, 1)
 	require.NoError(t, err)
 
 	original.allSeries.samplesProcessedPerStep[0] = 10
@@ -567,7 +535,6 @@ func TestOperatorEvaluationStats_Clone_WithSubsets(t *testing.T) {
 	require.Equal(t, original.allSeries.samplesProcessedPerStep, clone.allSeries.samplesProcessedPerStep)
 	require.Equal(t, original.allSeries.newSamplesReadPerStep, clone.allSeries.newSamplesReadPerStep)
 	require.Len(t, clone.subsets, 1)
-	require.Equal(t, original.subsets[0].matchers, clone.subsets[0].matchers)
 	require.Equal(t, original.subsets[0].samplesProcessedPerStep, clone.subsets[0].samplesProcessedPerStep)
 	require.Equal(t, original.subsets[0].newSamplesReadPerStep, clone.subsets[0].newSamplesReadPerStep)
 
@@ -596,7 +563,7 @@ func TestOperatorEvaluationStats_ComputeForSubquery(t *testing.T) {
 	newSamplesReadAt := func(t int) int64 { return int64(5 + t*10) }
 
 	createInnerStats := func(t *testing.T) *OperatorEvaluationStats {
-		inner, err := NewOperatorEvaluationStats(innerTimeRange, memoryConsumptionTracker, nil)
+		inner, err := NewOperatorEvaluationStats(innerTimeRange, memoryConsumptionTracker, 0)
 		require.NoError(t, err)
 
 		for i := range innerTimeRange.StepCount {
@@ -848,17 +815,13 @@ func TestOperatorEvaluationStats_ComputeForSubquery_WithSubsets(t *testing.T) {
 	ctx := context.Background()
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
-	subsetMatchers := [][]*labels.Matcher{
-		{labels.MustNewMatcher(labels.MatchEqual, "env", "prod")},
-	}
-
 	samplesProcessedAt := func(t int) int64 { return int64(10 + t*10) }
 	newSamplesReadAt := func(t int) int64 { return int64(5 + t*10) }
 	subsetSamplesProcessedAt := func(t int) int64 { return int64(2 + t*3) }
 	subsetNewSamplesReadAt := func(t int) int64 { return int64(1 + t*2) }
 
 	createInnerStats := func(t *testing.T) *OperatorEvaluationStats {
-		inner, err := NewOperatorEvaluationStats(innerTimeRange, memoryConsumptionTracker, subsetMatchers)
+		inner, err := NewOperatorEvaluationStats(innerTimeRange, memoryConsumptionTracker, 1)
 		require.NoError(t, err)
 
 		for i := range innerTimeRange.StepCount {
@@ -892,7 +855,6 @@ func TestOperatorEvaluationStats_ComputeForSubquery_WithSubsets(t *testing.T) {
 
 		// Subset should be computed using the same time-range logic as allSeries.
 		require.Len(t, result.subsets, 1)
-		require.Equal(t, subsetMatchers[0], result.subsets[0].matchers)
 		require.Equal(t, []int64{subsetSamplesProcessedAt(1) + subsetSamplesProcessedAt(2) + subsetSamplesProcessedAt(3), subsetSamplesProcessedAt(3) + subsetSamplesProcessedAt(4) + subsetSamplesProcessedAt(5)}, result.subsets[0].samplesProcessedPerStep)
 		require.Equal(t, []int64{subsetNewSamplesReadAt(1) + subsetNewSamplesReadAt(2) + subsetNewSamplesReadAt(3), subsetNewSamplesReadAt(4) + subsetNewSamplesReadAt(5)}, result.subsets[0].newSamplesReadPerStep)
 
@@ -915,7 +877,6 @@ func TestOperatorEvaluationStats_ComputeForSubquery_WithSubsets(t *testing.T) {
 
 		// Subset should be computed using the same time-range logic as allSeries.
 		require.Len(t, result.subsets, 1)
-		require.Equal(t, subsetMatchers[0], result.subsets[0].matchers)
 		require.Equal(t, []int64{subsetSamplesProcessedAt(3) + subsetSamplesProcessedAt(4) + subsetSamplesProcessedAt(5)}, result.subsets[0].samplesProcessedPerStep)
 		require.Equal(t, []int64{subsetNewSamplesReadAt(3) + subsetNewSamplesReadAt(4) + subsetNewSamplesReadAt(5)}, result.subsets[0].newSamplesReadPerStep)
 
@@ -930,7 +891,7 @@ func TestOperatorEvaluationStats_ExtendStepInvariant(t *testing.T) {
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
 	// Create a set of stats corresponding to the single evaluated step.
-	stepInvariant, err := NewOperatorEvaluationStats(NewInstantQueryTimeRange(timestamp.Time(10000)), memoryConsumptionTracker, nil)
+	stepInvariant, err := NewOperatorEvaluationStats(NewInstantQueryTimeRange(timestamp.Time(10000)), memoryConsumptionTracker, 0)
 	require.NoError(t, err)
 
 	stepInvariant.allSeries.samplesProcessedPerStep[0] = 100
@@ -957,10 +918,7 @@ func TestOperatorEvaluationStats_ExtendStepInvariant_WithSubsets(t *testing.T) {
 	ctx := context.Background()
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
-	subsetMatchers := [][]*labels.Matcher{
-		{labels.MustNewMatcher(labels.MatchEqual, "env", "prod")},
-	}
-	stepInvariant, err := NewOperatorEvaluationStats(NewInstantQueryTimeRange(timestamp.Time(10000)), memoryConsumptionTracker, subsetMatchers)
+	stepInvariant, err := NewOperatorEvaluationStats(NewInstantQueryTimeRange(timestamp.Time(10000)), memoryConsumptionTracker, 1)
 	require.NoError(t, err)
 
 	stepInvariant.allSeries.samplesProcessedPerStep[0] = 100
@@ -981,7 +939,6 @@ func TestOperatorEvaluationStats_ExtendStepInvariant_WithSubsets(t *testing.T) {
 
 	// Subset stats should be expanded the same way.
 	require.Len(t, extended.subsets, 1)
-	require.Equal(t, subsetMatchers[0], extended.subsets[0].matchers)
 	require.Equal(t, []int64{60, 60, 60}, extended.subsets[0].samplesProcessedPerStep)
 	require.Equal(t, []int64{25, 0, 0}, extended.subsets[0].newSamplesReadPerStep)
 

--- a/pkg/streamingpromql/types/stats_test.go
+++ b/pkg/streamingpromql/types/stats_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/stretchr/testify/require"
@@ -24,27 +25,27 @@ func TestOperatorEvaluationStats_TrackSampleForInstantVectorSelector(t *testing.
 	ctx := context.Background()
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
-	stats, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker)
+	stats, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, nil)
 	require.NoError(t, err)
 
 	samplesProcessedPerStep := newPerStepTracker("samples processed", timeRange.StepCount)
 	newSamplesReadPerStep := newPerStepTracker("new samples read", timeRange.StepCount)
 
-	stats.TrackSampleForInstantVectorSelector(timestamp.FromTime(start), 1)
-	samplesProcessedPerStep.requireChange(t, stats.samplesProcessedPerStep, 1, 0, 0)
-	newSamplesReadPerStep.requireChange(t, stats.newSamplesReadPerStep, 1, 0, 0)
+	stats.TrackSampleForInstantVectorSelector(timestamp.FromTime(start), 1, labels.EmptyLabels())
+	samplesProcessedPerStep.requireChange(t, stats.allSeries.samplesProcessedPerStep, 1, 0, 0)
+	newSamplesReadPerStep.requireChange(t, stats.allSeries.newSamplesReadPerStep, 1, 0, 0)
 
-	stats.TrackSampleForInstantVectorSelector(timestamp.FromTime(start), 2)
-	samplesProcessedPerStep.requireChange(t, stats.samplesProcessedPerStep, 2, 0, 0)
-	newSamplesReadPerStep.requireChange(t, stats.newSamplesReadPerStep, 2, 0, 0)
+	stats.TrackSampleForInstantVectorSelector(timestamp.FromTime(start), 2, labels.EmptyLabels())
+	samplesProcessedPerStep.requireChange(t, stats.allSeries.samplesProcessedPerStep, 2, 0, 0)
+	newSamplesReadPerStep.requireChange(t, stats.allSeries.newSamplesReadPerStep, 2, 0, 0)
 
-	stats.TrackSampleForInstantVectorSelector(timestamp.FromTime(start.Add(step)), 1)
-	samplesProcessedPerStep.requireChange(t, stats.samplesProcessedPerStep, 0, 1, 0)
-	newSamplesReadPerStep.requireChange(t, stats.newSamplesReadPerStep, 0, 1, 0)
+	stats.TrackSampleForInstantVectorSelector(timestamp.FromTime(start.Add(step)), 1, labels.EmptyLabels())
+	samplesProcessedPerStep.requireChange(t, stats.allSeries.samplesProcessedPerStep, 0, 1, 0)
+	newSamplesReadPerStep.requireChange(t, stats.allSeries.newSamplesReadPerStep, 0, 1, 0)
 
-	stats.TrackSampleForInstantVectorSelector(timestamp.FromTime(start.Add(2*step)), 4)
-	samplesProcessedPerStep.requireChange(t, stats.samplesProcessedPerStep, 0, 0, 4)
-	newSamplesReadPerStep.requireChange(t, stats.newSamplesReadPerStep, 0, 0, 4)
+	stats.TrackSampleForInstantVectorSelector(timestamp.FromTime(start.Add(2*step)), 4, labels.EmptyLabels())
+	samplesProcessedPerStep.requireChange(t, stats.allSeries.samplesProcessedPerStep, 0, 0, 4)
+	newSamplesReadPerStep.requireChange(t, stats.allSeries.newSamplesReadPerStep, 0, 0, 4)
 
 	stats.Close()
 	require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
@@ -79,7 +80,7 @@ func TestOperatorEvaluationStats_TrackSamplesForRangeVectorSelector(t *testing.T
 			ctx := context.Background()
 			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
-			stats, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker)
+			stats, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, nil)
 			require.NoError(t, err)
 
 			samplesProcessedPerStep := newPerStepTracker("samples processed", timeRange.StepCount)
@@ -101,19 +102,19 @@ func TestOperatorEvaluationStats_TrackSamplesForRangeVectorSelector(t *testing.T
 			appendPoint(start)
 
 			// Samples from rangeStart up to and including rangeEnd should be included.
-			stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start), floats, histograms, timestamp.FromTime(start.Add(-4*time.Second)), timestamp.FromTime(start))
-			samplesProcessedPerStep.requireChange(t, stats.samplesProcessedPerStep, 4*testCase.samplesPerPoint, 0, 0)
-			newSamplesReadPerStep.requireChange(t, stats.newSamplesReadPerStep, 4*testCase.samplesPerPoint, 0, 0)
+			stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start), floats, histograms, timestamp.FromTime(start.Add(-4*time.Second)), timestamp.FromTime(start), labels.EmptyLabels())
+			samplesProcessedPerStep.requireChange(t, stats.allSeries.samplesProcessedPerStep, 4*testCase.samplesPerPoint, 0, 0)
+			newSamplesReadPerStep.requireChange(t, stats.allSeries.newSamplesReadPerStep, 4*testCase.samplesPerPoint, 0, 0)
 
 			// Samples after rangeEnd should not be included.
-			stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start), floats, histograms, timestamp.FromTime(start.Add(-4*time.Second)), timestamp.FromTime(start.Add(-1*time.Second)))
-			samplesProcessedPerStep.requireChange(t, stats.samplesProcessedPerStep, 3*testCase.samplesPerPoint, 0, 0)
-			newSamplesReadPerStep.requireChange(t, stats.newSamplesReadPerStep, 3*testCase.samplesPerPoint, 0, 0)
+			stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start), floats, histograms, timestamp.FromTime(start.Add(-4*time.Second)), timestamp.FromTime(start.Add(-1*time.Second)), labels.EmptyLabels())
+			samplesProcessedPerStep.requireChange(t, stats.allSeries.samplesProcessedPerStep, 3*testCase.samplesPerPoint, 0, 0)
+			newSamplesReadPerStep.requireChange(t, stats.allSeries.newSamplesReadPerStep, 3*testCase.samplesPerPoint, 0, 0)
 
 			// Should behave the same way for subsequent steps as well.
-			stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start.Add(step)), floats, histograms, timestamp.FromTime(start.Add(-4*time.Second)), timestamp.FromTime(start))
-			samplesProcessedPerStep.requireChange(t, stats.samplesProcessedPerStep, 0, 4*testCase.samplesPerPoint, 0)
-			newSamplesReadPerStep.requireChange(t, stats.newSamplesReadPerStep, 0, 4*testCase.samplesPerPoint, 0)
+			stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start.Add(step)), floats, histograms, timestamp.FromTime(start.Add(-4*time.Second)), timestamp.FromTime(start), labels.EmptyLabels())
+			samplesProcessedPerStep.requireChange(t, stats.allSeries.samplesProcessedPerStep, 0, 4*testCase.samplesPerPoint, 0)
+			newSamplesReadPerStep.requireChange(t, stats.allSeries.newSamplesReadPerStep, 0, 4*testCase.samplesPerPoint, 0)
 
 			// If the range is greater than the step, then only samples since the previous step should be counted as new.
 			clearPoints()
@@ -123,19 +124,19 @@ func TestOperatorEvaluationStats_TrackSamplesForRangeVectorSelector(t *testing.T
 			appendPoint(start.Add(-2 * time.Second))
 			appendPoint(start.Add(-time.Second))
 			appendPoint(start)
-			stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start), floats, histograms, timestamp.FromTime(start.Add(-3*step)), timestamp.FromTime(start))
-			samplesProcessedPerStep.requireChange(t, stats.samplesProcessedPerStep, 6*testCase.samplesPerPoint, 0, 0)
-			newSamplesReadPerStep.requireChange(t, stats.newSamplesReadPerStep, 4*testCase.samplesPerPoint, 0, 0)
+			stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start), floats, histograms, timestamp.FromTime(start.Add(-3*step)), timestamp.FromTime(start), labels.EmptyLabels())
+			samplesProcessedPerStep.requireChange(t, stats.allSeries.samplesProcessedPerStep, 6*testCase.samplesPerPoint, 0, 0)
+			newSamplesReadPerStep.requireChange(t, stats.allSeries.newSamplesReadPerStep, 4*testCase.samplesPerPoint, 0, 0)
 
-			stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start.Add(step)), floats, histograms, timestamp.FromTime(start.Add(-3*step)), timestamp.FromTime(start))
-			samplesProcessedPerStep.requireChange(t, stats.samplesProcessedPerStep, 0, 6*testCase.samplesPerPoint, 0)
-			newSamplesReadPerStep.requireChange(t, stats.newSamplesReadPerStep, 0, 4*testCase.samplesPerPoint, 0)
+			stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start.Add(step)), floats, histograms, timestamp.FromTime(start.Add(-3*step)), timestamp.FromTime(start), labels.EmptyLabels())
+			samplesProcessedPerStep.requireChange(t, stats.allSeries.samplesProcessedPerStep, 0, 6*testCase.samplesPerPoint, 0)
+			newSamplesReadPerStep.requireChange(t, stats.allSeries.newSamplesReadPerStep, 0, 4*testCase.samplesPerPoint, 0)
 
 			// Using empty buffers should not change anything.
 			clearPoints()
-			stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start), floats, histograms, timestamp.FromTime(start.Add(-4*time.Second)), timestamp.FromTime(start))
-			samplesProcessedPerStep.requireNoChange(t, stats.samplesProcessedPerStep)
-			newSamplesReadPerStep.requireNoChange(t, stats.newSamplesReadPerStep)
+			stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start), floats, histograms, timestamp.FromTime(start.Add(-4*time.Second)), timestamp.FromTime(start), labels.EmptyLabels())
+			samplesProcessedPerStep.requireNoChange(t, stats.allSeries.samplesProcessedPerStep)
+			newSamplesReadPerStep.requireNoChange(t, stats.allSeries.newSamplesReadPerStep)
 
 			stats.Close()
 			floats.Close()
@@ -154,7 +155,7 @@ func TestOperatorEvaluationStats_TrackSamplesForRangeVectorSelector_FloatsAndHis
 	ctx := context.Background()
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
-	stats, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker)
+	stats, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, nil)
 	require.NoError(t, err)
 
 	samplesProcessedPerStep := newPerStepTracker("samples processed", timeRange.StepCount)
@@ -168,9 +169,9 @@ func TestOperatorEvaluationStats_TrackSamplesForRangeVectorSelector_FloatsAndHis
 	require.NoError(t, histograms.Append(promql.HPoint{T: timestamp.FromTime(start.Add(-2 * time.Second)), H: h}))
 	require.NoError(t, floats.Append(promql.FPoint{T: timestamp.FromTime(start.Add(-time.Second))}))
 
-	stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start), floats, histograms, timestamp.FromTime(start.Add(-4*time.Second)), timestamp.FromTime(start))
-	samplesProcessedPerStep.requireChange(t, stats.samplesProcessedPerStep, 2+EquivalentFloatSampleCount(h), 0, 0)
-	newSamplesReadPerStep.requireChange(t, stats.newSamplesReadPerStep, 2 + +EquivalentFloatSampleCount(h), 0, 0)
+	stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start), floats, histograms, timestamp.FromTime(start.Add(-4*time.Second)), timestamp.FromTime(start), labels.EmptyLabels())
+	samplesProcessedPerStep.requireChange(t, stats.allSeries.samplesProcessedPerStep, 2+EquivalentFloatSampleCount(h), 0, 0)
+	newSamplesReadPerStep.requireChange(t, stats.allSeries.newSamplesReadPerStep, 2 + +EquivalentFloatSampleCount(h), 0, 0)
 
 	stats.Close()
 	floats.Close()
@@ -185,7 +186,7 @@ func TestOperatorEvaluationStats_TrackSamplesForRangeVectorSelector_InstantQuery
 	ctx := context.Background()
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
-	stats, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker)
+	stats, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, nil)
 	require.NoError(t, err)
 
 	samplesProcessedPerStep := newPerStepTracker("samples processed", timeRange.StepCount)
@@ -199,9 +200,128 @@ func TestOperatorEvaluationStats_TrackSamplesForRangeVectorSelector_InstantQuery
 	require.NoError(t, histograms.Append(promql.HPoint{T: timestamp.FromTime(queryT.Add(-2 * time.Second)), H: h}))
 	require.NoError(t, floats.Append(promql.FPoint{T: timestamp.FromTime(queryT.Add(-time.Second))}))
 
-	stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(queryT), floats, histograms, timestamp.FromTime(queryT.Add(-4*time.Second)), timestamp.FromTime(queryT))
-	samplesProcessedPerStep.requireChange(t, stats.samplesProcessedPerStep, 2+EquivalentFloatSampleCount(h))
-	newSamplesReadPerStep.requireChange(t, stats.newSamplesReadPerStep, 2 + +EquivalentFloatSampleCount(h))
+	stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(queryT), floats, histograms, timestamp.FromTime(queryT.Add(-4*time.Second)), timestamp.FromTime(queryT), labels.EmptyLabels())
+	samplesProcessedPerStep.requireChange(t, stats.allSeries.samplesProcessedPerStep, 2+EquivalentFloatSampleCount(h))
+	newSamplesReadPerStep.requireChange(t, stats.allSeries.newSamplesReadPerStep, 2 + +EquivalentFloatSampleCount(h))
+
+	stats.Close()
+	floats.Close()
+	histograms.Close()
+	require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
+}
+
+func TestOperatorEvaluationStats_Subsets_TrackSampleForInstantVectorSelector(t *testing.T) {
+	start := timestamp.Time(0)
+	step := time.Minute
+	end := start.Add(2 * step)
+	timeRange := NewRangeQueryTimeRange(start, end, step)
+
+	ctx := context.Background()
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
+
+	subsetMatchers := [][]*labels.Matcher{
+		{labels.MustNewMatcher(labels.MatchEqual, "env", "prod")},
+		{labels.MustNewMatcher(labels.MatchEqual, "env", "staging"), labels.MustNewMatcher(labels.MatchEqual, "region", "us-east")},
+	}
+	stats, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, subsetMatchers)
+	require.NoError(t, err)
+	require.Len(t, stats.subsets, 2)
+
+	prodLabels := labels.FromStrings("env", "prod", "region", "us-east")
+	stagingUsEastLabels := labels.FromStrings("env", "staging", "region", "us-east")
+	stagingEuLabels := labels.FromStrings("env", "staging", "region", "eu-west")
+	noMatchLabels := labels.FromStrings("env", "dev")
+
+	overallProcessed := newPerStepTracker("overall samples processed", timeRange.StepCount)
+	overallRead := newPerStepTracker("overall new samples read", timeRange.StepCount)
+	subset0Processed := newPerStepTracker("subset[0] samples processed", timeRange.StepCount)
+	subset0Read := newPerStepTracker("subset[0] new samples read", timeRange.StepCount)
+	subset1Processed := newPerStepTracker("subset[1] samples processed", timeRange.StepCount)
+	subset1Read := newPerStepTracker("subset[1] new samples read", timeRange.StepCount)
+
+	// prodLabels matches subset[0] (env=prod) only.
+	stats.TrackSampleForInstantVectorSelector(timestamp.FromTime(start), 3, prodLabels)
+	overallProcessed.requireChange(t, stats.allSeries.samplesProcessedPerStep, 3, 0, 0)
+	overallRead.requireChange(t, stats.allSeries.newSamplesReadPerStep, 3, 0, 0)
+	subset0Processed.requireChange(t, stats.subsets[0].samplesProcessedPerStep, 3, 0, 0)
+	subset0Read.requireChange(t, stats.subsets[0].newSamplesReadPerStep, 3, 0, 0)
+	subset1Processed.requireNoChange(t, stats.subsets[1].samplesProcessedPerStep)
+	subset1Read.requireNoChange(t, stats.subsets[1].newSamplesReadPerStep)
+
+	// stagingUsEastLabels matches subset[1] (env=staging AND region=us-east) only.
+	stats.TrackSampleForInstantVectorSelector(timestamp.FromTime(start.Add(step)), 2, stagingUsEastLabels)
+	overallProcessed.requireChange(t, stats.allSeries.samplesProcessedPerStep, 0, 2, 0)
+	overallRead.requireChange(t, stats.allSeries.newSamplesReadPerStep, 0, 2, 0)
+	subset0Processed.requireNoChange(t, stats.subsets[0].samplesProcessedPerStep)
+	subset0Read.requireNoChange(t, stats.subsets[0].newSamplesReadPerStep)
+	subset1Processed.requireChange(t, stats.subsets[1].samplesProcessedPerStep, 0, 2, 0)
+	subset1Read.requireChange(t, stats.subsets[1].newSamplesReadPerStep, 0, 2, 0)
+
+	// stagingEuLabels matches neither subset (env=staging but region=eu-west, not us-east).
+	stats.TrackSampleForInstantVectorSelector(timestamp.FromTime(start.Add(2*step)), 1, stagingEuLabels)
+	overallProcessed.requireChange(t, stats.allSeries.samplesProcessedPerStep, 0, 0, 1)
+	overallRead.requireChange(t, stats.allSeries.newSamplesReadPerStep, 0, 0, 1)
+	subset0Processed.requireNoChange(t, stats.subsets[0].samplesProcessedPerStep)
+	subset0Read.requireNoChange(t, stats.subsets[0].newSamplesReadPerStep)
+	subset1Processed.requireNoChange(t, stats.subsets[1].samplesProcessedPerStep)
+	subset1Read.requireNoChange(t, stats.subsets[1].newSamplesReadPerStep)
+
+	// noMatchLabels matches neither subset.
+	stats.TrackSampleForInstantVectorSelector(timestamp.FromTime(start), 5, noMatchLabels)
+	overallProcessed.requireChange(t, stats.allSeries.samplesProcessedPerStep, 5, 0, 0)
+	overallRead.requireChange(t, stats.allSeries.newSamplesReadPerStep, 5, 0, 0)
+	subset0Processed.requireNoChange(t, stats.subsets[0].samplesProcessedPerStep)
+	subset0Read.requireNoChange(t, stats.subsets[0].newSamplesReadPerStep)
+	subset1Processed.requireNoChange(t, stats.subsets[1].samplesProcessedPerStep)
+	subset1Read.requireNoChange(t, stats.subsets[1].newSamplesReadPerStep)
+
+	stats.Close()
+	require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
+}
+
+func TestOperatorEvaluationStats_Subsets_TrackSamplesForRangeVectorSelector(t *testing.T) {
+	start := timestamp.Time(0)
+	step := time.Minute
+	end := start.Add(2 * step)
+	timeRange := NewRangeQueryTimeRange(start, end, step)
+
+	ctx := context.Background()
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
+
+	subsetMatchers := [][]*labels.Matcher{
+		{labels.MustNewMatcher(labels.MatchEqual, "env", "prod")},
+	}
+	stats, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, subsetMatchers)
+	require.NoError(t, err)
+
+	floats := NewFPointRingBuffer(memoryConsumptionTracker)
+	histograms := NewHPointRingBuffer(memoryConsumptionTracker)
+	require.NoError(t, floats.Append(promql.FPoint{T: timestamp.FromTime(start.Add(-3 * time.Second))}))
+	require.NoError(t, floats.Append(promql.FPoint{T: timestamp.FromTime(start.Add(-2 * time.Second))}))
+	require.NoError(t, floats.Append(promql.FPoint{T: timestamp.FromTime(start.Add(-time.Second))}))
+	require.NoError(t, floats.Append(promql.FPoint{T: timestamp.FromTime(start)}))
+
+	prodLabels := labels.FromStrings("env", "prod")
+	otherLabels := labels.FromStrings("env", "dev")
+
+	overallProcessed := newPerStepTracker("overall samples processed", timeRange.StepCount)
+	overallRead := newPerStepTracker("overall new samples read", timeRange.StepCount)
+	subsetProcessed := newPerStepTracker("subset samples processed", timeRange.StepCount)
+	subsetRead := newPerStepTracker("subset new samples read", timeRange.StepCount)
+
+	// Matching series: both overall and subset should be updated.
+	stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start), floats, histograms, timestamp.FromTime(start.Add(-4*time.Second)), timestamp.FromTime(start), prodLabels)
+	overallProcessed.requireChange(t, stats.allSeries.samplesProcessedPerStep, 4, 0, 0)
+	overallRead.requireChange(t, stats.allSeries.newSamplesReadPerStep, 4, 0, 0)
+	subsetProcessed.requireChange(t, stats.subsets[0].samplesProcessedPerStep, 4, 0, 0)
+	subsetRead.requireChange(t, stats.subsets[0].newSamplesReadPerStep, 4, 0, 0)
+
+	// Non-matching series: only overall should be updated.
+	stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start.Add(step)), floats, histograms, timestamp.FromTime(start.Add(-4*time.Second)), timestamp.FromTime(start), otherLabels)
+	overallProcessed.requireChange(t, stats.allSeries.samplesProcessedPerStep, 0, 4, 0)
+	overallRead.requireChange(t, stats.allSeries.newSamplesReadPerStep, 0, 4, 0)
+	subsetProcessed.requireNoChange(t, stats.subsets[0].samplesProcessedPerStep)
+	subsetRead.requireNoChange(t, stats.subsets[0].newSamplesReadPerStep)
 
 	stats.Close()
 	floats.Close()
@@ -243,32 +363,32 @@ func TestOperatorEvaluationStats_Add(t *testing.T) {
 	ctx := context.Background()
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
-	s1, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker)
+	s1, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, nil)
 	require.NoError(t, err)
-	s2, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker)
+	s2, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, nil)
 	require.NoError(t, err)
 
-	s1.samplesProcessedPerStep[0] = 10
-	s1.samplesProcessedPerStep[1] = 20
-	s1.samplesProcessedPerStep[2] = 30
-	s1.newSamplesReadPerStep[0] = 1
-	s1.newSamplesReadPerStep[1] = 2
-	s1.newSamplesReadPerStep[2] = 3
+	s1.allSeries.samplesProcessedPerStep[0] = 10
+	s1.allSeries.samplesProcessedPerStep[1] = 20
+	s1.allSeries.samplesProcessedPerStep[2] = 30
+	s1.allSeries.newSamplesReadPerStep[0] = 1
+	s1.allSeries.newSamplesReadPerStep[1] = 2
+	s1.allSeries.newSamplesReadPerStep[2] = 3
 
-	s2.samplesProcessedPerStep[0] = 40
-	s2.samplesProcessedPerStep[1] = 50
-	s2.samplesProcessedPerStep[2] = 60
-	s2.newSamplesReadPerStep[0] = 4
-	s2.newSamplesReadPerStep[1] = 5
-	s2.newSamplesReadPerStep[2] = 6
+	s2.allSeries.samplesProcessedPerStep[0] = 40
+	s2.allSeries.samplesProcessedPerStep[1] = 50
+	s2.allSeries.samplesProcessedPerStep[2] = 60
+	s2.allSeries.newSamplesReadPerStep[0] = 4
+	s2.allSeries.newSamplesReadPerStep[1] = 5
+	s2.allSeries.newSamplesReadPerStep[2] = 6
 
 	require.NoError(t, s1.Add(s2))
-	require.Equal(t, []int64{50, 70, 90}, s1.samplesProcessedPerStep)
-	require.Equal(t, []int64{5, 7, 9}, s1.newSamplesReadPerStep)
+	require.Equal(t, []int64{50, 70, 90}, s1.allSeries.samplesProcessedPerStep)
+	require.Equal(t, []int64{5, 7, 9}, s1.allSeries.newSamplesReadPerStep)
 
 	// s2 should be unchanged.
-	require.Equal(t, []int64{40, 50, 60}, s2.samplesProcessedPerStep)
-	require.Equal(t, []int64{4, 5, 6}, s2.newSamplesReadPerStep)
+	require.Equal(t, []int64{40, 50, 60}, s2.allSeries.samplesProcessedPerStep)
+	require.Equal(t, []int64{4, 5, 6}, s2.allSeries.newSamplesReadPerStep)
 
 	s1.Close()
 	s2.Close()
@@ -285,12 +405,101 @@ func TestOperatorEvaluationStats_Add_DifferentTimeRanges(t *testing.T) {
 	ctx := context.Background()
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
-	s1, err := NewOperatorEvaluationStats(timeRange1, memoryConsumptionTracker)
+	s1, err := NewOperatorEvaluationStats(timeRange1, memoryConsumptionTracker, nil)
 	require.NoError(t, err)
-	s2, err := NewOperatorEvaluationStats(timeRange2, memoryConsumptionTracker)
+	s2, err := NewOperatorEvaluationStats(timeRange2, memoryConsumptionTracker, nil)
 	require.NoError(t, err)
 
 	require.EqualError(t, s1.Add(s2), "cannot add OperatorEvaluationStats with different time ranges")
+
+	s1.Close()
+	s2.Close()
+}
+
+func TestOperatorEvaluationStats_Add_WithSubsets(t *testing.T) {
+	start := timestamp.Time(0)
+	step := time.Minute
+	end := start.Add(2 * step)
+	timeRange := NewRangeQueryTimeRange(start, end, step)
+
+	ctx := context.Background()
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
+
+	subsetMatchers := [][]*labels.Matcher{
+		{labels.MustNewMatcher(labels.MatchEqual, "env", "prod")},
+	}
+
+	t.Run("receiver has subsets, other does not", func(t *testing.T) {
+		withSubsets, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, subsetMatchers)
+		require.NoError(t, err)
+		withoutSubsets, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, nil)
+		require.NoError(t, err)
+
+		withSubsets.allSeries.samplesProcessedPerStep[0] = 10
+		withSubsets.allSeries.samplesProcessedPerStep[1] = 20
+		withSubsets.allSeries.newSamplesReadPerStep[0] = 1
+		withSubsets.allSeries.newSamplesReadPerStep[1] = 2
+		withSubsets.subsets[0].samplesProcessedPerStep[0] = 5
+		withSubsets.subsets[0].newSamplesReadPerStep[0] = 3
+
+		withoutSubsets.allSeries.samplesProcessedPerStep[0] = 40
+		withoutSubsets.allSeries.samplesProcessedPerStep[1] = 50
+		withoutSubsets.allSeries.newSamplesReadPerStep[0] = 4
+		withoutSubsets.allSeries.newSamplesReadPerStep[1] = 5
+
+		require.NoError(t, withSubsets.Add(withoutSubsets))
+
+		// Overall stats should be summed.
+		require.Equal(t, []int64{50, 70, 0}, withSubsets.allSeries.samplesProcessedPerStep)
+		require.Equal(t, []int64{5, 7, 0}, withSubsets.allSeries.newSamplesReadPerStep)
+
+		// other's overall should be added to each subset.
+		require.Equal(t, []int64{45, 50, 0}, withSubsets.subsets[0].samplesProcessedPerStep)
+		require.Equal(t, []int64{7, 5, 0}, withSubsets.subsets[0].newSamplesReadPerStep)
+
+		withSubsets.Close()
+		withoutSubsets.Close()
+	})
+
+	t.Run("receiver has no subsets, other does", func(t *testing.T) {
+		withoutSubsets, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, nil)
+		require.NoError(t, err)
+		withSubsets, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, subsetMatchers)
+		require.NoError(t, err)
+
+		withoutSubsets.allSeries.samplesProcessedPerStep[0] = 10
+		withoutSubsets.allSeries.newSamplesReadPerStep[0] = 1
+
+		withSubsets.allSeries.samplesProcessedPerStep[0] = 40
+		withSubsets.allSeries.samplesProcessedPerStep[1] = 50
+		withSubsets.allSeries.newSamplesReadPerStep[0] = 4
+		withSubsets.allSeries.newSamplesReadPerStep[1] = 5
+		withSubsets.subsets[0].samplesProcessedPerStep[0] = 30
+		withSubsets.subsets[0].newSamplesReadPerStep[0] = 3
+
+		require.NoError(t, withoutSubsets.Add(withSubsets))
+
+		// Only overall stats are updated; withoutSubsets has no subsets to carry over.
+		require.Equal(t, []int64{50, 50, 0}, withoutSubsets.allSeries.samplesProcessedPerStep)
+		require.Equal(t, []int64{5, 5, 0}, withoutSubsets.allSeries.newSamplesReadPerStep)
+
+		withoutSubsets.Close()
+		withSubsets.Close()
+	})
+
+	t.Run("both have subsets returns error", func(t *testing.T) {
+		s1, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, subsetMatchers)
+		require.NoError(t, err)
+		s2, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, subsetMatchers)
+		require.NoError(t, err)
+
+		require.EqualError(t, s1.Add(s2), "cannot add two OperatorEvaluationStats instances that both have subsets")
+
+		s1.Close()
+		s2.Close()
+	})
+
+	require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
 }
 
 func TestOperatorEvaluationStats_Clone(t *testing.T) {
@@ -302,29 +511,71 @@ func TestOperatorEvaluationStats_Clone(t *testing.T) {
 	ctx := context.Background()
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
-	original, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker)
+	original, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, nil)
 	require.NoError(t, err)
 
-	original.samplesProcessedPerStep[0] = 10
-	original.samplesProcessedPerStep[1] = 20
-	original.samplesProcessedPerStep[2] = 30
-	original.newSamplesReadPerStep[0] = 1
-	original.newSamplesReadPerStep[1] = 2
-	original.newSamplesReadPerStep[2] = 3
+	original.allSeries.samplesProcessedPerStep[0] = 10
+	original.allSeries.samplesProcessedPerStep[1] = 20
+	original.allSeries.samplesProcessedPerStep[2] = 30
+	original.allSeries.newSamplesReadPerStep[0] = 1
+	original.allSeries.newSamplesReadPerStep[1] = 2
+	original.allSeries.newSamplesReadPerStep[2] = 3
 
 	clone, err := original.Clone()
 	require.NoError(t, err)
 
 	// Clone should have the same values.
-	require.Equal(t, original.samplesProcessedPerStep, clone.samplesProcessedPerStep)
-	require.Equal(t, original.newSamplesReadPerStep, clone.newSamplesReadPerStep)
+	require.Equal(t, original.allSeries.samplesProcessedPerStep, clone.allSeries.samplesProcessedPerStep)
+	require.Equal(t, original.allSeries.newSamplesReadPerStep, clone.allSeries.newSamplesReadPerStep)
 	require.Equal(t, original.timeRange, clone.timeRange)
 
 	// Modifying the clone should not affect the original.
-	clone.samplesProcessedPerStep[0] = 99
-	clone.newSamplesReadPerStep[0] = 99
-	require.Equal(t, int64(10), original.samplesProcessedPerStep[0])
-	require.Equal(t, int64(1), original.newSamplesReadPerStep[0])
+	clone.allSeries.samplesProcessedPerStep[0] = 99
+	clone.allSeries.newSamplesReadPerStep[0] = 99
+	require.Equal(t, int64(10), original.allSeries.samplesProcessedPerStep[0])
+	require.Equal(t, int64(1), original.allSeries.newSamplesReadPerStep[0])
+
+	original.Close()
+	clone.Close()
+	require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
+}
+
+func TestOperatorEvaluationStats_Clone_WithSubsets(t *testing.T) {
+	start := timestamp.Time(0)
+	step := time.Minute
+	end := start.Add(2 * step)
+	timeRange := NewRangeQueryTimeRange(start, end, step)
+
+	ctx := context.Background()
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
+
+	subsetMatchers := [][]*labels.Matcher{
+		{labels.MustNewMatcher(labels.MatchEqual, "env", "prod")},
+	}
+	original, err := NewOperatorEvaluationStats(timeRange, memoryConsumptionTracker, subsetMatchers)
+	require.NoError(t, err)
+
+	original.allSeries.samplesProcessedPerStep[0] = 10
+	original.allSeries.newSamplesReadPerStep[0] = 1
+	original.subsets[0].samplesProcessedPerStep[0] = 7
+	original.subsets[0].newSamplesReadPerStep[0] = 4
+
+	clone, err := original.Clone()
+	require.NoError(t, err)
+
+	// Clone should have the same values including subsets.
+	require.Equal(t, original.allSeries.samplesProcessedPerStep, clone.allSeries.samplesProcessedPerStep)
+	require.Equal(t, original.allSeries.newSamplesReadPerStep, clone.allSeries.newSamplesReadPerStep)
+	require.Len(t, clone.subsets, 1)
+	require.Equal(t, original.subsets[0].matchers, clone.subsets[0].matchers)
+	require.Equal(t, original.subsets[0].samplesProcessedPerStep, clone.subsets[0].samplesProcessedPerStep)
+	require.Equal(t, original.subsets[0].newSamplesReadPerStep, clone.subsets[0].newSamplesReadPerStep)
+
+	// Modifying the clone's subset should not affect the original.
+	clone.subsets[0].samplesProcessedPerStep[0] = 99
+	clone.subsets[0].newSamplesReadPerStep[0] = 99
+	require.Equal(t, int64(7), original.subsets[0].samplesProcessedPerStep[0])
+	require.Equal(t, int64(4), original.subsets[0].newSamplesReadPerStep[0])
 
 	original.Close()
 	clone.Close()
@@ -592,11 +843,11 @@ func TestOperatorEvaluationStats_ExtendStepInvariant(t *testing.T) {
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
 	// Create a set of stats corresponding to the single evaluated step.
-	stepInvariant, err := NewOperatorEvaluationStats(NewInstantQueryTimeRange(timestamp.Time(10000)), memoryConsumptionTracker)
+	stepInvariant, err := NewOperatorEvaluationStats(NewInstantQueryTimeRange(timestamp.Time(10000)), memoryConsumptionTracker, nil)
 	require.NoError(t, err)
 
-	stepInvariant.samplesProcessedPerStep[0] = 100
-	stepInvariant.newSamplesReadPerStep[0] = 40
+	stepInvariant.allSeries.samplesProcessedPerStep[0] = 100
+	stepInvariant.allSeries.newSamplesReadPerStep[0] = 40
 
 	// Extend it to the full time range.
 	start := timestamp.Time(20000)
@@ -606,10 +857,47 @@ func TestOperatorEvaluationStats_ExtendStepInvariant(t *testing.T) {
 	extended, err := stepInvariant.ExtendStepInvariantToFullRange(timeRange)
 	require.NoError(t, err)
 
-	require.Equal(t, []int64{100, 100, 100}, extended.samplesProcessedPerStep)
-	require.Equal(t, []int64{40, 0, 0}, extended.newSamplesReadPerStep)
+	require.Equal(t, []int64{100, 100, 100}, extended.allSeries.samplesProcessedPerStep)
+	require.Equal(t, []int64{40, 0, 0}, extended.allSeries.newSamplesReadPerStep)
 
 	// Make sure everything was returned to the pool.
+	extended.Close()
+	stepInvariant.Close()
+	require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
+}
+
+func TestOperatorEvaluationStats_ExtendStepInvariant_WithSubsets(t *testing.T) {
+	ctx := context.Background()
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
+
+	subsetMatchers := [][]*labels.Matcher{
+		{labels.MustNewMatcher(labels.MatchEqual, "env", "prod")},
+	}
+	stepInvariant, err := NewOperatorEvaluationStats(NewInstantQueryTimeRange(timestamp.Time(10000)), memoryConsumptionTracker, subsetMatchers)
+	require.NoError(t, err)
+
+	stepInvariant.allSeries.samplesProcessedPerStep[0] = 100
+	stepInvariant.allSeries.newSamplesReadPerStep[0] = 40
+	stepInvariant.subsets[0].samplesProcessedPerStep[0] = 60
+	stepInvariant.subsets[0].newSamplesReadPerStep[0] = 25
+
+	start := timestamp.Time(20000)
+	step := time.Minute
+	end := start.Add(2 * step)
+	timeRange := NewRangeQueryTimeRange(start, end, step)
+	extended, err := stepInvariant.ExtendStepInvariantToFullRange(timeRange)
+	require.NoError(t, err)
+
+	// Overall stats should be expanded as normal.
+	require.Equal(t, []int64{100, 100, 100}, extended.allSeries.samplesProcessedPerStep)
+	require.Equal(t, []int64{40, 0, 0}, extended.allSeries.newSamplesReadPerStep)
+
+	// Subset stats should be expanded the same way.
+	require.Len(t, extended.subsets, 1)
+	require.Equal(t, subsetMatchers[0], extended.subsets[0].matchers)
+	require.Equal(t, []int64{60, 60, 60}, extended.subsets[0].samplesProcessedPerStep)
+	require.Equal(t, []int64{25, 0, 0}, extended.subsets[0].newSamplesReadPerStep)
+
 	extended.Close()
 	stepInvariant.Close()
 	require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())


### PR DESCRIPTION
#### What this PR does

This PR extends `OperatorEvaluationStats` to support tracking subsets of all series.

This will be used to implement correct stats tracking for queries where subset selector elimination applies.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/pull/14828

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors core query evaluation statistics accounting and changes tracking method signatures (now requiring subset bitmaps), which could affect query stats correctness or trigger panics if callers pass mismatched subset state.
> 
> **Overview**
> **Adds subset-aware query evaluation stats.** `OperatorEvaluationStats` is refactored to track per-step `samplesProcessed`/`newSamplesRead` for *all series* plus N optional *subsets*, and updates `TrackSample*`/`TrackSamples*`, `Add`, `Clone`, `ExtendStepInvariantToFullRange`, and `ComputeForSubquery` to propagate subset data.
> 
> Call sites (eg `InstantVectorSelector`, `RangeVectorSelector`, scalar/string/time literals) are updated to use the new constructor signature (`subsetCount`) and pass a subset-match bitmap (currently `nil` where no subsets are tracked). CSE filtering drops a local `matchesSeries` helper in favor of new shared `types.MatchersMatch`, and tests are expanded to cover subset behavior; `CHANGELOG.md` notes the related MQE feature update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f82851ba06eecb1eb2db27adf83c16a39bdeead. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->