### PR TITLE
Distributor: add per-tenant configurable HTTP response code for active series limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 * [FEATURE] MQE: Add experimental support for splitting and caching intermediate results for functions over range vectors in instant queries. #13472 #14479 #14506 #14499 #14517 #14536 #14614 #14645 #14677 #14788
 * [FEATURE] MQE: Add experimental support for reporting the number of samples read per query. #14828 #14839
 * [FEATURE] Compactor: Add `-compactor.ooo-split-and-merge-shards` per-tenant limit to allow a separate shard count for blocks with the out-of-order external label. #14704
+* [ENHANCEMENT] Distributor: Add per-tenant `-distributor.active-series-limit-response-code` override to configure the HTTP response code returned when rejecting series due to the active series limit. Defaults to 429 (Too Many Requests). Set to 400 (Bad Request) to prevent clients from retrying rejected requests. #14981
 * [ENHANCEMENT] Query-frontend: Add `minimum_step_size` filter to blocked queries config to reject range queries with a step smaller than the configured threshold. #14885
 * [ENHANCEMENT] Query-frontend: Add support for blocking queries exceeding a time range duration with `time_range_longer_than`. #14609
 * [ENHANCEMENT] Distributor: Add zone-aware rate limiting via `-distributor.ring.instance-availability-zone`. When configured the global ingestion rate limit is divided by the number of zones and the number of distributors in the local zone, instead of the total number of distributors. #14515

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1931,7 +1931,7 @@ func (d *Distributor) prePushMaxSeriesLimitMiddleware(next PushFunc) PushFunc {
 
 		if len(req.Timeseries) == 0 {
 			// All series have been rejected, no need to talk to ingesters.
-			return newActiveSeriesLimitedError(totalTimeseries, len(rejectedHashes), d.limits.MaxActiveOrGlobalSeriesPerUser(limitsKey))
+			return newActiveSeriesLimitedError(totalTimeseries, len(rejectedHashes), d.limits.MaxActiveOrGlobalSeriesPerUser(limitsKey), d.limits.ActiveSeriesLimitResponseCode(limitsKey))
 		}
 
 		// If there's an error coming from the ingesters, prioritize that one.
@@ -1940,7 +1940,7 @@ func (d *Distributor) prePushMaxSeriesLimitMiddleware(next PushFunc) PushFunc {
 		}
 
 		if len(rejectedHashes) > 0 {
-			return newActiveSeriesLimitedError(totalTimeseries, len(rejectedHashes), d.limits.MaxActiveOrGlobalSeriesPerUser(limitsKey))
+			return newActiveSeriesLimitedError(totalTimeseries, len(rejectedHashes), d.limits.MaxActiveOrGlobalSeriesPerUser(limitsKey), d.limits.ActiveSeriesLimitResponseCode(limitsKey))
 		}
 
 		return nil

--- a/pkg/distributor/distributor_max_series_limit_test.go
+++ b/pkg/distributor/distributor_max_series_limit_test.go
@@ -65,6 +65,7 @@ func TestDistributor_Push_ShouldEnforceMaxSeriesLimits(t *testing.T) {
 		expectedResourceExhaustedErrorCode    bool
 		expectedFailedToEnforceSeriesLimitErr bool
 		canTrackAsync                         bool
+		activeSeriesLimitResponseCode         int
 	}{
 		"no series rejected": {
 			expectedAcceptedSeries:             []string{"series_1", "series_2", "series_3", "series_4", "series_5"},
@@ -82,6 +83,20 @@ func TestDistributor_Push_ShouldEnforceMaxSeriesLimits(t *testing.T) {
 			expectedAcceptedSeries:             []string{},
 			expectedResourceExhaustedErrorCode: true,
 			canTrackAsync:                      false,
+		},
+		"some series rejected with 400 response code": {
+			trackSeriesRejectedHashes:          []uint64{series4Hash, series2Hash},
+			expectedAcceptedSeries:             []string{"series_1", "series_3", "series_5"},
+			expectedResourceExhaustedErrorCode: true,
+			canTrackAsync:                      false,
+			activeSeriesLimitResponseCode:      400,
+		},
+		"all series rejected with 400 response code": {
+			trackSeriesRejectedHashes:          []uint64{series1Hash, series2Hash, series3Hash, series4Hash, series5Hash},
+			expectedAcceptedSeries:             []string{},
+			expectedResourceExhaustedErrorCode: true,
+			canTrackAsync:                      false,
+			activeSeriesLimitResponseCode:      400,
 		},
 		"failed to track series via usage-tracker": {
 			trackSeriesErr:                        errors.New("usage-tracker service is unavailable"),
@@ -141,11 +156,16 @@ func TestDistributor_Push_ShouldEnforceMaxSeriesLimits(t *testing.T) {
 				metricUserID = userID
 			}
 
+			limits := prepareDefaultLimits()
+			if testData.activeSeriesLimitResponseCode > 0 {
+				limits.ActiveSeriesLimitResponseCode = testData.activeSeriesLimitResponseCode
+			}
+
 			testConfig := prepConfig{
 				numDistributors:         1,
 				ingestStorageEnabled:    true,
 				ingestStoragePartitions: 1,
-				limits:                  prepareDefaultLimits(),
+				limits:                  limits,
 			}
 
 			distributors, _, regs, kafkaCluster := prepare(t, testConfig)

--- a/pkg/distributor/errors.go
+++ b/pkg/distributor/errors.go
@@ -67,6 +67,12 @@ type Error interface {
 	IsSoft() bool
 }
 
+// ErrorWithHTTPStatusCode is an optional interface that errors can implement
+// to override the default HTTP status code derived from the error cause.
+type ErrorWithHTTPStatusCode interface {
+	HTTPStatusCode() int
+}
+
 // replicasDidNotMatchError is an error stating that replicas do not match.
 type replicasDidNotMatchError struct {
 	replica, elected string
@@ -165,11 +171,12 @@ func (e reactiveLimiterExceededError) IsSoft() bool {
 
 var _ Error = reactiveLimiterExceededError{}
 
-func newActiveSeriesLimitedError(totalSeriesInThisRequest, rejectedSeriesFromThisRequest, limit int) activeSeriesLimitedError {
+func newActiveSeriesLimitedError(totalSeriesInThisRequest, rejectedSeriesFromThisRequest, limit, httpStatusCode int) activeSeriesLimitedError {
 	return activeSeriesLimitedError{
 		totalSeriesInThisRequest:      totalSeriesInThisRequest,
 		rejectedSeriesFromThisRequest: rejectedSeriesFromThisRequest,
 		limit:                         limit,
+		httpStatusCode:                httpStatusCode,
 	}
 }
 
@@ -177,6 +184,7 @@ type activeSeriesLimitedError struct {
 	totalSeriesInThisRequest      int
 	rejectedSeriesFromThisRequest int
 	limit                         int
+	httpStatusCode                int
 }
 
 func (e activeSeriesLimitedError) Error() string {
@@ -191,8 +199,13 @@ func (e activeSeriesLimitedError) IsSoft() bool {
 	return false
 }
 
-// Ensure that activeSeriesLimitedError implements Error.
+func (e activeSeriesLimitedError) HTTPStatusCode() int {
+	return e.httpStatusCode
+}
+
+// Ensure that activeSeriesLimitedError implements Error and ErrorWithHTTPStatusCode.
 var _ Error = activeSeriesLimitedError{}
+var _ ErrorWithHTTPStatusCode = activeSeriesLimitedError{}
 
 // ingestionRateLimitedError is an error used to represent the ingestion rate limited error.
 type ingestionRateLimitedError struct {

--- a/pkg/distributor/errors_test.go
+++ b/pkg/distributor/errors_test.go
@@ -638,11 +638,43 @@ func TestErrorCauseToHTTPStatusCode(t *testing.T) {
 			errorCause:         mimirpb.ERROR_CAUSE_TSDB_UNAVAILABLE,
 			expectedHTTPStatus: http.StatusServiceUnavailable,
 		},
+		"an ACTIVE_SERIES_LIMITED error cause gets translated into a HTTP 429": {
+			errorCause:         mimirpb.ERROR_CAUSE_ACTIVE_SERIES_LIMITED,
+			expectedHTTPStatus: http.StatusTooManyRequests,
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			status := errorCauseToHTTPStatusCode(tc.errorCause)
 			assert.Equal(t, tc.expectedHTTPStatus, status)
+		})
+	}
+}
+
+func TestActiveSeriesLimitedErrorHTTPStatusCode(t *testing.T) {
+	tests := map[string]struct {
+		httpStatusCode     int
+		expectedHTTPStatus int
+	}{
+		"default 429": {
+			httpStatusCode:     http.StatusTooManyRequests,
+			expectedHTTPStatus: http.StatusTooManyRequests,
+		},
+		"overridden to 400": {
+			httpStatusCode:     http.StatusBadRequest,
+			expectedHTTPStatus: http.StatusBadRequest,
+		},
+		"arbitrary code": {
+			httpStatusCode:     http.StatusServiceUnavailable,
+			expectedHTTPStatus: http.StatusServiceUnavailable,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := newActiveSeriesLimitedError(100, 25, 50, tc.httpStatusCode)
+			assert.Equal(t, tc.expectedHTTPStatus, err.HTTPStatusCode())
+			assert.Equal(t, mimirpb.ERROR_CAUSE_ACTIVE_SERIES_LIMITED, err.Cause())
+			assert.False(t, err.IsSoft())
 		})
 	}
 }

--- a/pkg/distributor/influx.go
+++ b/pkg/distributor/influx.go
@@ -120,12 +120,17 @@ func InfluxHandler(
 				httpCode = int(st.Code())
 				errorMsg = st.Message()
 			} else {
-				var distributorErr Error
 				errorMsg = err.Error()
-				if errors.Is(err, context.DeadlineExceeded) || !errors.As(err, &distributorErr) {
-					httpCode = http.StatusServiceUnavailable
+				var httpStatusErr ErrorWithHTTPStatusCode
+				if errors.As(err, &httpStatusErr) {
+					httpCode = httpStatusErr.HTTPStatusCode()
 				} else {
-					httpCode = errorCauseToHTTPStatusCode(distributorErr.Cause())
+					var distributorErr Error
+					if errors.Is(err, context.DeadlineExceeded) || !errors.As(err, &distributorErr) {
+						httpCode = http.StatusServiceUnavailable
+					} else {
+						httpCode = errorCauseToHTTPStatusCode(distributorErr.Cause())
+					}
 				}
 			}
 			if httpCode != 202 {

--- a/pkg/distributor/otel.go
+++ b/pkg/distributor/otel.go
@@ -464,7 +464,15 @@ func toOtlpGRPCHTTPStatus(pushErr error) (codes.Code, int, bool) {
 	}
 
 	grpcStatusCode := errorCauseToGRPCStatusCode(distributorErr.Cause())
-	httpStatusCode := errorCauseToHTTPStatusCode(distributorErr.Cause())
+
+	var httpStatusCode int
+	var httpStatusErr ErrorWithHTTPStatusCode
+	if errors.As(pushErr, &httpStatusErr) {
+		httpStatusCode = httpStatusErr.HTTPStatusCode()
+	} else {
+		httpStatusCode = errorCauseToHTTPStatusCode(distributorErr.Cause())
+	}
+
 	return grpcStatusCode, httpRetryableToOTLPRetryable(httpStatusCode), distributorErr.IsSoft()
 }
 

--- a/pkg/distributor/otel_test.go
+++ b/pkg/distributor/otel_test.go
@@ -2174,6 +2174,18 @@ func TestHandler_toOtlpGRPCHTTPStatus(t *testing.T) {
 			expectedGRPCStatus: codes.InvalidArgument,
 			expectedSoft:       true,
 		},
+		"an activeSeriesLimitedError with default 429 gets translated into gRPC codes.ResourceExhausted and HTTP 429 statuses": {
+			err:                newActiveSeriesLimitedError(100, 25, 50, http.StatusTooManyRequests),
+			expectedHTTPStatus: http.StatusTooManyRequests,
+			expectedGRPCStatus: codes.ResourceExhausted,
+			expectedSoft:       false,
+		},
+		"an activeSeriesLimitedError with overridden 400 gets translated into gRPC codes.ResourceExhausted and HTTP 400 statuses": {
+			err:                newActiveSeriesLimitedError(100, 25, 50, http.StatusBadRequest),
+			expectedHTTPStatus: http.StatusBadRequest,
+			expectedGRPCStatus: codes.ResourceExhausted,
+			expectedSoft:       false,
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/distributor/push.go
+++ b/pkg/distributor/push.go
@@ -372,6 +372,11 @@ func toHTTPStatus(pushErr error) int {
 		return http.StatusInternalServerError
 	}
 
+	var httpStatusErr ErrorWithHTTPStatusCode
+	if errors.As(pushErr, &httpStatusErr) {
+		return httpStatusErr.HTTPStatusCode()
+	}
+
 	var distributorErr Error
 	if errors.As(pushErr, &distributorErr) {
 		return errorCauseToHTTPStatusCode(distributorErr.Cause())

--- a/pkg/distributor/push_test.go
+++ b/pkg/distributor/push_test.go
@@ -1107,6 +1107,14 @@ func TestHandler_toHTTPStatus(t *testing.T) {
 			err:                errors.Wrap(newIngesterPushError(createStatusWithDetails(t, codes.Unavailable, originalMsg, mimirpb.ERROR_CAUSE_CIRCUIT_BREAKER_OPEN), ingesterID), "wrapped"),
 			expectedHTTPStatus: http.StatusServiceUnavailable,
 		},
+		"an activeSeriesLimitedError with default 429 gets translated into an HTTP 429": {
+			err:                newActiveSeriesLimitedError(100, 25, 50, http.StatusTooManyRequests),
+			expectedHTTPStatus: http.StatusTooManyRequests,
+		},
+		"an activeSeriesLimitedError with overridden 400 gets translated into an HTTP 400": {
+			err:                newActiveSeriesLimitedError(100, 25, 50, http.StatusBadRequest),
+			expectedHTTPStatus: http.StatusBadRequest,
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -63,6 +63,7 @@ const (
 	MaxTotalQueryLengthFlag                     = "query-frontend.max-total-query-length"
 	MaxQueryExpressionSizeBytesFlag             = "query-frontend.max-query-expression-size-bytes"
 	MaxActiveSeriesPerUserFlag                  = "distributor.max-active-series-per-user"
+	ActiveSeriesLimitResponseCodeFlag           = "distributor.active-series-limit-response-code"
 	RequestRateFlag                             = "distributor.request-rate-limit"
 	RequestBurstSizeFlag                        = "distributor.request-burst-size"
 	IngestionRateFlag                           = "distributor.ingestion-rate-limit"
@@ -119,16 +120,17 @@ func IsLimitError(err error) bool {
 // limits via flags, or per-user limits via yaml config.
 type Limits struct {
 	// Distributor enforced limits.
-	MaxActiveSeriesPerUser int     `yaml:"max_active_series_per_user" json:"max_active_series_per_user" category:"experimental" doc:"hidden"`
-	RequestRate            float64 `yaml:"request_rate" json:"request_rate"`
-	RequestBurstSize       int     `yaml:"request_burst_size" json:"request_burst_size"`
-	IngestionRate          float64 `yaml:"ingestion_rate" json:"ingestion_rate"`
-	IngestionBurstSize     int     `yaml:"ingestion_burst_size" json:"ingestion_burst_size"`
-	IngestionBurstFactor   float64 `yaml:"ingestion_burst_factor" json:"ingestion_burst_factor" category:"experimental"`
-	AcceptHASamples        bool    `yaml:"accept_ha_samples" json:"accept_ha_samples"`
-	HAClusterLabel         string  `yaml:"ha_cluster_label" json:"ha_cluster_label"`
-	HAReplicaLabel         string  `yaml:"ha_replica_label" json:"ha_replica_label"`
-	HAMaxClusters          int     `yaml:"ha_max_clusters" json:"ha_max_clusters"`
+	MaxActiveSeriesPerUser        int     `yaml:"max_active_series_per_user" json:"max_active_series_per_user" category:"experimental" doc:"hidden"`
+	ActiveSeriesLimitResponseCode int     `yaml:"active_series_limit_response_code" json:"active_series_limit_response_code" category:"experimental" doc:"hidden"`
+	RequestRate                   float64 `yaml:"request_rate" json:"request_rate"`
+	RequestBurstSize              int     `yaml:"request_burst_size" json:"request_burst_size"`
+	IngestionRate                 float64 `yaml:"ingestion_rate" json:"ingestion_rate"`
+	IngestionBurstSize            int     `yaml:"ingestion_burst_size" json:"ingestion_burst_size"`
+	IngestionBurstFactor          float64 `yaml:"ingestion_burst_factor" json:"ingestion_burst_factor" category:"experimental"`
+	AcceptHASamples               bool    `yaml:"accept_ha_samples" json:"accept_ha_samples"`
+	HAClusterLabel                string  `yaml:"ha_cluster_label" json:"ha_cluster_label"`
+	HAReplicaLabel                string  `yaml:"ha_replica_label" json:"ha_replica_label"`
+	HAMaxClusters                 int     `yaml:"ha_max_clusters" json:"ha_max_clusters"`
 	// We should only update the timestamp if the difference
 	// between the stored timestamp and the time we received a sample at
 	// is more than this duration.
@@ -332,6 +334,7 @@ type Limits struct {
 // RegisterFlags adds the flags required to config this to the given FlagSet
 func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.MaxActiveSeriesPerUser, MaxActiveSeriesPerUserFlag, 0, "Maximum number of active series per user. 0 means no limit. This limit only applies with ingest storage enabled.")
+	f.IntVar(&l.ActiveSeriesLimitResponseCode, ActiveSeriesLimitResponseCodeFlag, 429, "HTTP response code to use when rejecting series due to the active series limit.")
 	f.IntVar(&l.IngestionTenantShardSize, "distributor.ingestion-tenant-shard-size", 0, "The tenant's shard size used by shuffle-sharding. This value is the total size of the shard (ie. it is not the number of ingesters in the shard per zone, but the number of ingesters in the shard across all zones, if zone-awareness is enabled). Must be set both on ingesters and distributors. 0 disables shuffle sharding.")
 	f.Float64Var(&l.RequestRate, RequestRateFlag, 0, "Per-tenant push request rate limit in requests per second. 0 to disable.")
 	f.IntVar(&l.RequestBurstSize, RequestBurstSizeFlag, 0, "Per-tenant allowed push request burst size. 0 to disable.")
@@ -907,6 +910,11 @@ func (o *Overrides) MaxActiveOrGlobalSeriesPerUser(limitsKey string) int {
 		return maxActive
 	}
 	return overrides.MaxGlobalSeriesPerUser
+}
+
+// ActiveSeriesLimitResponseCode returns the HTTP status code to use when rejecting series due to the active series limit.
+func (o *Overrides) ActiveSeriesLimitResponseCode(limitsKey string) int {
+	return o.getOverridesForLimitsKey(limitsKey).ActiveSeriesLimitResponseCode
 }
 
 // MaxGlobalSeriesPerUser returns the maximum number of series a user is allowed to store across the cluster.
@@ -1725,6 +1733,9 @@ func mergeLimits(dst, overlay *Limits) *Limits {
 	}
 	if overlay.MaxActiveSeriesPerUser > 0 {
 		dst.MaxActiveSeriesPerUser = overlay.MaxActiveSeriesPerUser
+	}
+	if overlay.ActiveSeriesLimitResponseCode > 0 {
+		dst.ActiveSeriesLimitResponseCode = overlay.ActiveSeriesLimitResponseCode
 	}
 	if overlay.IngestionRate > 0 {
 		dst.IngestionRate = overlay.IngestionRate

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -2202,11 +2202,12 @@ func TestExtensionMarshalling(t *testing.T) {
         foo: 0
     test_extension_string: ""
     max_active_series_per_user: 0
+    active_series_limit_response_code: 0
     request_rate: 0`)
 
 		val, err = json.Marshal(overrides)
 		require.NoError(t, err)
-		require.Contains(t, string(val), `{"test":{"test_extension_struct":{"foo":0},"test_extension_string":"","max_active_series_per_user":0,`)
+		require.Contains(t, string(val), `{"test":{"test_extension_struct":{"foo":0},"test_extension_string":"","max_active_series_per_user":0,"active_series_limit_response_code":0,`)
 	})
 
 	t.Run("marshal limits with partial extension values", func(t *testing.T) {
@@ -2226,12 +2227,13 @@ func TestExtensionMarshalling(t *testing.T) {
         foo: 421237
     test_extension_string: ""
     max_active_series_per_user: 0
+    active_series_limit_response_code: 0
     request_rate: 0
     request_burst_size: 0`)
 
 		val, err = json.Marshal(overrides)
 		require.NoError(t, err)
-		require.Contains(t, string(val), `{"test":{"test_extension_struct":{"foo":421237},"test_extension_string":"","max_active_series_per_user":0,"request_rate":0,`)
+		require.Contains(t, string(val), `{"test":{"test_extension_struct":{"foo":421237},"test_extension_string":"","max_active_series_per_user":0,"active_series_limit_response_code":0,"request_rate":0,`)
 	})
 
 	t.Run("marshal limits with default extension values", func(t *testing.T) {
@@ -2246,12 +2248,13 @@ func TestExtensionMarshalling(t *testing.T) {
         foo: 42
     test_extension_string: default string extension value
     max_active_series_per_user: 0
+    active_series_limit_response_code: 429
     request_rate: 0
     request_burst_size: 0`)
 
 		val, err = json.Marshal(overrides)
 		require.NoError(t, err)
-		require.Contains(t, string(val), `{"user":{"test_extension_struct":{"foo":42},"test_extension_string":"default string extension value","max_active_series_per_user":0,"request_rate":0,`)
+		require.Contains(t, string(val), `{"user":{"test_extension_struct":{"foo":42},"test_extension_string":"default string extension value","max_active_series_per_user":0,"active_series_limit_response_code":429,"request_rate":0,`)
 	})
 }
 


### PR DESCRIPTION
#### What this PR does

Adds a new per-tenant override `active_series_limit_response_code` (flag: `-distributor.active-series-limit-response-code`, default: `429`) that controls the HTTP status code returned when the distributor rejects series due to the max active series limit.

Currently the active series limit always returns HTTP 429 (Too Many Requests). Prometheus remote-write does not retry 429 by default (requires `retry_on_http_429: true`), but OTel Collector retries 429 automatically. For tenants that are persistently over their series limit, these retries amplify load without benefit.

Setting this to `400` causes clients to drop rejected data immediately without retrying, which is the desired behavior for some tenants.

The gRPC error code (`ResourceExhausted`) and error cause (`ACTIVE_SERIES_LIMITED`) remain unchanged regardless of the HTTP status code, so metrics and observability are not affected. The `Retry-After` header is only sent for 429/5xx responses, so it is naturally omitted when the response code is 400.

#### Which issue(s) this PR fixes or relates to

*N/A*

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes distributor error-to-HTTP status behavior for active-series-limit rejections across remote-write, OTLP, and Influx paths; while default remains 429, misconfiguration or unhandled edge cases could alter client retry behavior.
> 
> **Overview**
> Adds a new per-tenant limit/flag `-distributor.active-series-limit-response-code` (default `429`) to control which HTTP status code is returned when series are rejected due to the active series limit.
> 
> Implements an optional `ErrorWithHTTPStatusCode` interface and updates push status mapping (`toHTTPStatus`, OTLP `toOtlpGRPCHTTPStatus`, and Influx handler) so `activeSeriesLimitedError` can override the default cause-derived status while keeping the gRPC code/cause unchanged. Updates limits merging/marshalling and expands unit tests + changelog entry to cover the new override and 400/429 behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb6b9600e4ea866e34e22476efb055fe8b448541. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->