### PR TITLE
query-frontend: Enforce max total query length on subquery spin-off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,6 +244,7 @@
 * [BUGFIX] MQE: Fix and/unless functions to not pass matchers to RHS as it can result in incorrect filtering. #14902
 * [BUGFIX] MQE: Fix internal error when executing a subquery with delayed name removal enabled. #14946
 * [BUGFIX] Alertmanager: Fix deadlock when trying to broadcast after stopping a tenant #14922
+* [BUGFIX] Query-frontend: Fix subquery spin-off not enforcing the max total query length limit (`-query-frontend.max-total-query-length`) on spun-off range queries. #14983
 
 ### Mixin
 

--- a/pkg/frontend/querymiddleware/spin_off_subqueries.go
+++ b/pkg/frontend/querymiddleware/spin_off_subqueries.go
@@ -192,7 +192,8 @@ func (s *spinOffSubqueriesMiddleware) Do(ctx context.Context, req MetricsQueryRe
 
 	annotationAccumulator := NewAnnotationAccumulator()
 
-	queryable := newSpinOffSubqueriesQueryable(req, annotationAccumulator, s.next, s.rangeNext)
+	maxTotalQueryLength := validation.SmallestPositiveNonZeroDurationPerTenant(tenantIDs, s.limits.MaxTotalQueryLength)
+	queryable := newSpinOffSubqueriesQueryable(req, annotationAccumulator, s.next, s.rangeNext, maxTotalQueryLength)
 
 	qry, err := newQuery(ctx, req, s.engine, lazyquery.NewLazyQueryable(queryable))
 	if err != nil {

--- a/pkg/frontend/querymiddleware/spin_off_subqueries_queryable.go
+++ b/pkg/frontend/querymiddleware/spin_off_subqueries_queryable.go
@@ -25,15 +25,17 @@ type spinOffSubqueriesQueryable struct {
 	responseHeaders       *responseHeadersTracker
 	handler               MetricsQueryHandler
 	rangeHandler          MetricsQueryHandler
+	maxTotalQueryLength   time.Duration
 }
 
-func newSpinOffSubqueriesQueryable(req MetricsQueryRequest, annotationAccumulator *AnnotationAccumulator, next MetricsQueryHandler, rangeHandler MetricsQueryHandler) *spinOffSubqueriesQueryable {
+func newSpinOffSubqueriesQueryable(req MetricsQueryRequest, annotationAccumulator *AnnotationAccumulator, next MetricsQueryHandler, rangeHandler MetricsQueryHandler, maxTotalQueryLength time.Duration) *spinOffSubqueriesQueryable {
 	return &spinOffSubqueriesQueryable{
 		req:                   req,
 		annotationAccumulator: annotationAccumulator,
 		handler:               next,
 		rangeHandler:          rangeHandler,
 		responseHeaders:       newResponseHeadersTracker(),
+		maxTotalQueryLength:   maxTotalQueryLength,
 	}
 }
 
@@ -44,6 +46,7 @@ func (q *spinOffSubqueriesQueryable) Querier(_, _ int64) (storage.Querier, error
 		handler:               q.handler,
 		rangeHandler:          q.rangeHandler,
 		responseHeaders:       q.responseHeaders,
+		maxTotalQueryLength:   q.maxTotalQueryLength,
 	}, nil
 }
 
@@ -58,6 +61,7 @@ type spinOffSubqueriesQuerier struct {
 	annotationAccumulator *AnnotationAccumulator
 	handler               MetricsQueryHandler
 	rangeHandler          MetricsQueryHandler
+	maxTotalQueryLength   time.Duration
 
 	// Keep track of response headers received when running embedded queries.
 	responseHeaders *responseHeadersTracker
@@ -125,6 +129,9 @@ func (q *spinOffSubqueriesQuerier) Select(ctx context.Context, _ bool, hints *st
 		queryRange, err := time.ParseDuration(rangeStr)
 		if err != nil {
 			return storage.ErrSeriesSet(errors.Wrap(err, "failed to parse subquery range"))
+		}
+		if q.maxTotalQueryLength > 0 && queryRange > q.maxTotalQueryLength {
+			return storage.ErrSeriesSet(newMaxTotalQueryLengthError(queryRange, q.maxTotalQueryLength))
 		}
 		queryStep, err := time.ParseDuration(stepStr)
 		if err != nil {

--- a/pkg/frontend/querymiddleware/spin_off_subqueries_test.go
+++ b/pkg/frontend/querymiddleware/spin_off_subqueries_test.go
@@ -200,6 +200,72 @@ func TestSubquerySpinOff_ShouldReturnErrorOnDownstreamHandlerFailure(t *testing.
 	})
 }
 
+func TestSubquerySpinOff_ShouldReturnErrorIfSubqueryRangeExceedsMaxTotalQueryLength(t *testing.T) {
+	// The subquery has a 2h range, so setting the limit to 1h should cause an error.
+	req := &PrometheusInstantQueryRequest{
+		path:      "/query",
+		time:      util.TimeToMillis(end),
+		queryExpr: parseQuery(t, `max_over_time(rate(metric_counter[1m])[2h:1m])`),
+	}
+
+	queryable := setupSubquerySpinOffTestSeries(t, 2*time.Hour)
+
+	runForEngines(t, func(t *testing.T, opts promql.EngineOpts, eng promql.QueryEngine) {
+		downstream := &downstreamHandler{engine: eng, queryable: queryable}
+
+		spinoffMiddleware := newSpinOffSubqueriesMiddleware(
+			mockLimits{
+				subquerySpinOffEnabled: true,
+				maxTotalQueryLength:    1 * time.Hour,
+			},
+			log.NewNopLogger(),
+			eng,
+			nil,
+			nil,
+			defaultStepFunc,
+		)
+
+		ctx := user.InjectOrgID(context.Background(), "test")
+		_, err := spinoffMiddleware.Wrap(downstream).Do(ctx, req)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "the total query time range exceeds the limit")
+	})
+}
+
+func TestSubquerySpinOff_ShouldSucceedIfSubqueryRangeWithinMaxTotalQueryLength(t *testing.T) {
+	// The subquery has a 2h range, and the limit is 3h, so this should succeed.
+	req := &PrometheusInstantQueryRequest{
+		path:      "/query",
+		time:      util.TimeToMillis(end),
+		queryExpr: parseQuery(t, `max_over_time(rate(metric_counter[1m])[2h:1m])`),
+	}
+
+	queryable := setupSubquerySpinOffTestSeries(t, 2*time.Hour)
+
+	runForEngines(t, func(t *testing.T, opts promql.EngineOpts, eng promql.QueryEngine) {
+		downstream := &downstreamHandler{engine: eng, queryable: queryable}
+
+		spinoffMiddleware := newSpinOffSubqueriesMiddleware(
+			mockLimits{
+				subquerySpinOffEnabled: true,
+				maxTotalQueryLength:    3 * time.Hour,
+			},
+			log.NewNopLogger(),
+			eng,
+			nil,
+			nil,
+			defaultStepFunc,
+		)
+
+		ctx := user.InjectOrgID(context.Background(), "test")
+		res, err := spinoffMiddleware.Wrap(downstream).Do(ctx, req)
+		require.NoError(t, err)
+		promRes, ok := res.GetPrometheusResponse()
+		require.True(t, ok)
+		require.NotEmpty(t, promRes.Data.Result)
+	})
+}
+
 var defaultStepFunc = func(int64) int64 {
 	return (1 * time.Minute).Milliseconds()
 }


### PR DESCRIPTION
#### What this PR does

When the subquery spin-off feature converts subqueries into range queries, those range queries bypassed the `MaxTotalQueryLength` limit check (configured via `-query-frontend.max-total-query-length`). The limits middleware runs earlier in the middleware chain and only checks the original instant query's time range (which is zero for instant queries), so the spun-off range queries were never validated.

This adds enforcement of the max total query length limit on the subquery range inside the spin-off queryable, before creating the range queries.

#### Checklist

- [x] Tests updated.
- [x] `CHANGELOG.md` updated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes query-frontend enforcement for `-query-frontend.max-total-query-length` by rejecting spun-off subquery range queries that exceed the limit, which may cause new user-visible errors for previously accepted queries. Scope is contained to subquery spin-off path and covered by new unit tests.
> 
> **Overview**
> Ensures subquery spin-off enforces the per-tenant `MaxTotalQueryLength` limit by passing the computed limit into the spin-off `Queryable` and validating the parsed subquery range before issuing spun-off range queries.
> 
> Adds regression tests covering both failure (subquery range exceeds limit) and success (within limit) cases, and documents the bugfix in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4293cc05108f85a5ebeda4f241b657e8df53abd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->