### PR TITLE
query-frontend: Enforce max total query length using effective time range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,6 +244,7 @@
 * [BUGFIX] MQE: Fix and/unless functions to not pass matchers to RHS as it can result in incorrect filtering. #14902
 * [BUGFIX] MQE: Fix internal error when executing a subquery with delayed name removal enabled. #14946
 * [BUGFIX] Alertmanager: Fix deadlock when trying to broadcast after stopping a tenant #14922
+* [BUGFIX] Query-frontend: Fix subquery spin-off not enforcing the max total query length limit (`-query-frontend.max-total-query-length`) on spun-off range queries. #14983
 
 ### Mixin
 

--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -203,8 +203,10 @@ func (l limitsMiddleware) Do(ctx context.Context, r MetricsQueryRequest) (Respon
 	}
 
 	// Enforce the max query length.
+	// Use GetMinT/GetMaxT which account for range selectors, subqueries, offsets, and lookback delta.
+	// This ensures instant queries with large subquery ranges (e.g. [30d:1m]) are also checked.
 	if maxQueryLength := validation.SmallestPositiveNonZeroDurationPerTenant(tenantIDs, l.MaxTotalQueryLength); maxQueryLength > 0 {
-		queryLen := timestamp.Time(r.GetEnd()).Sub(timestamp.Time(r.GetStart()))
+		queryLen := timestamp.Time(r.GetMaxT()).Sub(timestamp.Time(r.GetMinT()))
 		if queryLen > maxQueryLength {
 			return nil, newMaxTotalQueryLengthError(queryLen, maxQueryLength)
 		}

--- a/pkg/frontend/querymiddleware/limits_test.go
+++ b/pkg/frontend/querymiddleware/limits_test.go
@@ -547,12 +547,12 @@ func TestLimitsMiddleware_MaxQueryLength(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			// NOTE: instant queries are not tested because they don't have a time range.
+			// NOTE: instant queries are not tested here because their start==end; they are
+			// covered separately by TestLimitsMiddleware_MaxQueryLength_InstantQueryWithSubquery.
 			reqs := map[string]MetricsQueryRequest{
-				"range query": &PrometheusRangeQueryRequest{
-					start: util.TimeToMillis(testData.reqStartTime),
-					end:   util.TimeToMillis(testData.reqEndTime),
-				},
+				"range query": NewPrometheusRangeQueryRequest(
+					"/query_range", nil, util.TimeToMillis(testData.reqStartTime), util.TimeToMillis(testData.reqEndTime), 0, 0, nil, Options{}, nil, "",
+				),
 				"remote read": &remoteReadQueryRequest{
 					path: remoteReadPathSuffix,
 					query: &prompb.Query{
@@ -591,6 +591,69 @@ func TestLimitsMiddleware_MaxQueryLength(t *testing.T) {
 						assert.Equal(t, util.TimeToMillis(testData.reqEndTime), inner.Calls[0].Arguments.Get(1).(MetricsQueryRequest).GetEnd())
 					}
 				})
+			}
+		})
+	}
+}
+
+func TestLimitsMiddleware_MaxQueryLength_InstantQueryWithSubquery(t *testing.T) {
+	now := time.Now()
+
+	tests := map[string]struct {
+		query              string
+		maxTotalQueryLength time.Duration
+		expectedErr        string
+	}{
+		"should fail when subquery range exceeds the limit": {
+			query:              `max_over_time(rate(metric_counter[1m])[2h:1m])`,
+			maxTotalQueryLength: 1 * time.Hour,
+			expectedErr:        "the total query time range exceeds the limit",
+		},
+		"should succeed when subquery range is within the limit": {
+			query:              `max_over_time(rate(metric_counter[1m])[2h:1m])`,
+			maxTotalQueryLength: 3 * time.Hour,
+		},
+		"should succeed when limit is disabled": {
+			query:              `max_over_time(rate(metric_counter[1m])[30d:1m])`,
+			maxTotalQueryLength: 0,
+		},
+		"should fail when range selector exceeds the limit": {
+			query:              `rate(metric_counter[2h])`,
+			maxTotalQueryLength: 1 * time.Hour,
+			expectedErr:        "the total query time range exceeds the limit",
+		},
+		"should succeed for simple instant query without subquery": {
+			query:              `metric_counter`,
+			maxTotalQueryLength: 1 * time.Hour,
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			queryTime := util.TimeToMillis(now)
+			req := NewPrometheusInstantQueryRequest(
+				"/query", nil, queryTime, 0, parseQuery(t, testData.query), Options{}, nil, "",
+			)
+
+			limits := mockLimits{maxTotalQueryLength: testData.maxTotalQueryLength}
+			middleware := newLimitsMiddleware(limits, log.NewNopLogger())
+
+			innerRes := NewEmptyPrometheusResponse()
+			inner := &mockHandler{}
+			inner.On("Do", mock.Anything, mock.Anything).Return(innerRes, nil)
+
+			ctx := user.InjectOrgID(context.Background(), "test")
+			outer := middleware.Wrap(inner)
+			res, err := outer.Do(ctx, req)
+
+			if testData.expectedErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), testData.expectedErr)
+				assert.Nil(t, res)
+				assert.Len(t, inner.Calls, 0)
+			} else {
+				require.NoError(t, err)
+				assert.Same(t, innerRes, res)
 			}
 		})
 	}


### PR DESCRIPTION
#### What this PR does

The limits middleware now uses `promql.FindMinMaxTime()` to compute the effective time range of a query when checking against `MaxTotalQueryLength`. This accounts for range selectors, subqueries, offsets, and the lookback delta.

Previously, only the explicit `start`/`end` range was checked. For instant queries (`start == end`), this meant the query length was always 0, so queries with large subquery ranges like `max_over_time(rate(foo[1m])[30d:1m])` bypassed the limit entirely.

#### Checklist

- [x] Tests updated.
- [x] `CHANGELOG.md` updated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens query-length enforcement by switching from explicit `start`/`end` to effective `minT`/`maxT`, which may cause previously-accepted instant/subquery queries to be rejected for some tenants.
> 
> **Overview**
> **Fixes query-length limit enforcement in the query-frontend.** The limits middleware now computes total query time range using `MetricsQueryRequest.GetMinT()`/`GetMaxT()` (accounting for subqueries, range selectors, offsets, and lookback delta) instead of only `start`/`end`.
> 
> Tests are updated to construct range requests via helpers and a new test covers instant queries with subqueries to ensure `-query-frontend.max-total-query-length` is enforced; `CHANGELOG.md` documents the bugfix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 449426233f3d1009fd3387e6cf0fbd00461a0ffd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->