### PR TITLE
query-frontend: Enforce max total query length using effective time range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,6 +244,7 @@
 * [BUGFIX] MQE: Fix and/unless functions to not pass matchers to RHS as it can result in incorrect filtering. #14902
 * [BUGFIX] MQE: Fix internal error when executing a subquery with delayed name removal enabled. #14946
 * [BUGFIX] Alertmanager: Fix deadlock when trying to broadcast after stopping a tenant #14922
+* [BUGFIX] Query-frontend: Fix max total query length limit (`-query-frontend.max-total-query-length`) not being enforced on instant queries with subqueries or range selectors. #14985
 
 ### Mixin
 

--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -204,7 +204,14 @@ func (l limitsMiddleware) Do(ctx context.Context, r MetricsQueryRequest) (Respon
 
 	// Enforce the max query length.
 	if maxQueryLength := validation.SmallestPositiveNonZeroDurationPerTenant(tenantIDs, l.MaxTotalQueryLength); maxQueryLength > 0 {
-		queryLen := timestamp.Time(r.GetEnd()).Sub(timestamp.Time(r.GetStart()))
+		// For range queries, use the explicit start/end for backwards compatibility.
+		// For instant queries (start == end), use GetMinT/GetMaxT which account for range selectors,
+		// subqueries, offsets, and lookback delta, so that queries like [30d:1m] are also checked.
+		minT, maxT := r.GetStart(), r.GetEnd()
+		if minT == maxT {
+			minT, maxT = r.GetMinT(), r.GetMaxT()
+		}
+		queryLen := timestamp.Time(maxT).Sub(timestamp.Time(minT))
 		if queryLen > maxQueryLength {
 			return nil, newMaxTotalQueryLengthError(queryLen, maxQueryLength)
 		}

--- a/pkg/frontend/querymiddleware/limits_test.go
+++ b/pkg/frontend/querymiddleware/limits_test.go
@@ -547,7 +547,8 @@ func TestLimitsMiddleware_MaxQueryLength(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			// NOTE: instant queries are not tested because they don't have a time range.
+			// NOTE: instant queries are not tested here because their start==end; they are
+			// covered separately by TestLimitsMiddleware_MaxQueryLength_InstantQueryWithSubquery.
 			reqs := map[string]MetricsQueryRequest{
 				"range query": &PrometheusRangeQueryRequest{
 					start: util.TimeToMillis(testData.reqStartTime),
@@ -591,6 +592,69 @@ func TestLimitsMiddleware_MaxQueryLength(t *testing.T) {
 						assert.Equal(t, util.TimeToMillis(testData.reqEndTime), inner.Calls[0].Arguments.Get(1).(MetricsQueryRequest).GetEnd())
 					}
 				})
+			}
+		})
+	}
+}
+
+func TestLimitsMiddleware_MaxQueryLength_InstantQueryWithSubquery(t *testing.T) {
+	now := time.Now()
+
+	tests := map[string]struct {
+		query               string
+		maxTotalQueryLength time.Duration
+		expectedErr         string
+	}{
+		"should fail when subquery range exceeds the limit": {
+			query:               `max_over_time(rate(metric_counter[1m])[2h:1m])`,
+			maxTotalQueryLength: 1 * time.Hour,
+			expectedErr:         "the total query time range exceeds the limit",
+		},
+		"should succeed when subquery range is within the limit": {
+			query:               `max_over_time(rate(metric_counter[1m])[2h:1m])`,
+			maxTotalQueryLength: 3 * time.Hour,
+		},
+		"should succeed when limit is disabled": {
+			query:               `max_over_time(rate(metric_counter[1m])[30d:1m])`,
+			maxTotalQueryLength: 0,
+		},
+		"should fail when range selector exceeds the limit": {
+			query:               `rate(metric_counter[2h])`,
+			maxTotalQueryLength: 1 * time.Hour,
+			expectedErr:         "the total query time range exceeds the limit",
+		},
+		"should succeed for simple instant query without subquery": {
+			query:               `metric_counter`,
+			maxTotalQueryLength: 1 * time.Hour,
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			queryTime := util.TimeToMillis(now)
+			req := NewPrometheusInstantQueryRequest(
+				"/query", nil, queryTime, 0, parseQuery(t, testData.query), Options{}, nil, "",
+			)
+
+			limits := mockLimits{maxTotalQueryLength: testData.maxTotalQueryLength}
+			middleware := newLimitsMiddleware(limits, log.NewNopLogger())
+
+			innerRes := NewEmptyPrometheusResponse()
+			inner := &mockHandler{}
+			inner.On("Do", mock.Anything, mock.Anything).Return(innerRes, nil)
+
+			ctx := user.InjectOrgID(context.Background(), "test")
+			outer := middleware.Wrap(inner)
+			res, err := outer.Do(ctx, req)
+
+			if testData.expectedErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), testData.expectedErr)
+				assert.Nil(t, res)
+				assert.Len(t, inner.Calls, 0)
+			} else {
+				require.NoError(t, err)
+				assert.Same(t, innerRes, res)
 			}
 		})
 	}

--- a/pkg/frontend/querymiddleware/model_extra.go
+++ b/pkg/frontend/querymiddleware/model_extra.go
@@ -160,12 +160,18 @@ func (r *PrometheusRangeQueryRequest) GetParsedQuery() parser.Expr {
 // GetMinT returns the minimum timestamp in milliseconds of data to be queried,
 // as determined from the start timestamp and any range vector or offset in the query.
 func (r *PrometheusRangeQueryRequest) GetMinT() int64 {
+	if r.minT == 0 {
+		r.updateMinMaxT()
+	}
 	return r.minT
 }
 
 // GetMaxT returns the maximum timestamp in milliseconds of data to be queried,
 // as determined from the end timestamp and any offset in the query.
 func (r *PrometheusRangeQueryRequest) GetMaxT() int64 {
+	if r.maxT == 0 {
+		r.updateMinMaxT()
+	}
 	return r.maxT
 }
 
@@ -389,12 +395,18 @@ func (r *PrometheusInstantQueryRequest) GetStep() int64 {
 // GetMinT returns the minimum timestamp in milliseconds of data to be queried,
 // as determined from the start timestamp and any range vector or offset in the query.
 func (r *PrometheusInstantQueryRequest) GetMinT() int64 {
+	if r.minT == 0 {
+		r.updateMinMaxT()
+	}
 	return r.minT
 }
 
 // GetMaxT returns the maximum timestamp in milliseconds of data to be queried,
 // as determined from the end timestamp and any offset in the query.
 func (r *PrometheusInstantQueryRequest) GetMaxT() int64 {
+	if r.maxT == 0 {
+		r.updateMinMaxT()
+	}
 	return r.maxT
 }
 


### PR DESCRIPTION
#### What this PR does

The limits middleware now uses `GetMinT()`/`GetMaxT()` (which account for range selectors, subqueries, offsets, and lookback delta) when checking against `MaxTotalQueryLength`. Previously, only the explicit `start`/`end` range was checked, which meant instant queries with large subquery ranges like `max_over_time(rate(foo[1m])[30d:1m])` bypassed the limit entirely since `start == end` for instant queries.

#### Checklist

- [x] Tests updated.
- [x] `CHANGELOG.md` updated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes limit enforcement logic in the query-frontend, which can newly reject previously-accepted instant queries with subqueries/range selectors; scope is small but affects request validation behavior.
> 
> **Overview**
> Fixes `-query-frontend.max-total-query-length` enforcement to use the *effective* query time range for instant queries (via `GetMinT()`/`GetMaxT()`), preventing subqueries/range selectors/offsets/lookback from bypassing the limit when `start == end`.
> 
> Adds targeted tests for instant queries with subqueries/range selectors and makes `GetMinT()`/`GetMaxT()` lazily recompute min/max times if unset; documents the bugfix in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd3cabb6210632744e2fc7dbfc583188ad002562. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->