### PR TITLE
development: scrape correct store-gateway hosts in ingest compose

### DIFF
--- a/development/mimir-ingest-storage/config/grafana-agent.flow
+++ b/development/mimir-ingest-storage/config/grafana-agent.flow
@@ -50,21 +50,14 @@ prometheus.scrape "metrics_local_mimir_ingest_storage" {
                         namespace   = "mimir-ingest-storage",
                 }],
                 [{
-                        __address__ = "store-gateway-1:8080",
+                        __address__ = "store-gateway-zone-a-1:8080",
                         cluster     = "docker-compose",
                         container   = "store-gateway",
                         job         = "mimir-ingest-storage/store-gateway",
                         namespace   = "mimir-ingest-storage",
                 }],
                 [{
-                        __address__ = "store-gateway-2:8080",
-                        cluster     = "docker-compose",
-                        container   = "store-gateway",
-                        job         = "mimir-ingest-storage/store-gateway",
-                        namespace   = "mimir-ingest-storage",
-                }],
-                [{
-                        __address__ = "store-gateway-3:8080",
+                        __address__ = "store-gateway-zone-b-1:8080",
                         cluster     = "docker-compose",
                         container   = "store-gateway",
                         job         = "mimir-ingest-storage/store-gateway",


### PR DESCRIPTION
#### What this PR does

Adjust the Alloy/Grafana Agent configuration to scrape the correct store-gateway hosts when running the ingest-storage docker compose setup.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates local Grafana Agent/Alloy scrape target hostnames in a development docker-compose setup, with no production code or data-path changes.
> 
> **Overview**
> Updates `development/mimir-ingest-storage/config/grafana-agent.flow` to scrape metrics from the zoned store-gateway containers (`store-gateway-zone-a-1` and `store-gateway-zone-b-1`) instead of the previous `store-gateway-1/2/3` hostnames, dropping the extra third store-gateway target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a88d1d34c98ca8321a8679299321c3632b40a4c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->