### PR TITLE
Compactor scheduler: add dedicated metric for incomplete plan jobs

### DIFF
--- a/pkg/compactor/scheduler/job_tracker_test.go
+++ b/pkg/compactor/scheduler/job_tracker_test.go
@@ -272,6 +272,43 @@ func TestJobTracker_ByteTracking(t *testing.T) {
 	assertTrackerBytes(t, reg, "merge job complete", 0, 0)
 }
 
+func TestJobTracker_PlanJobTracking(t *testing.T) {
+	clk := clock.NewMock()
+	clk.Set(at(3, 0))
+	jt, reg := newTestJobTracker(clk)
+
+	assertIncompletePlanJobs := func(label string, expected int) {
+		t.Helper()
+		require.NoError(t, prom_testutil.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
+			# HELP cortex_compactor_incomplete_plan_jobs The total number of plan jobs that have not yet completed (pending or active).
+			# TYPE cortex_compactor_incomplete_plan_jobs gauge
+			cortex_compactor_incomplete_plan_jobs %d
+		`, expected)), "cortex_compactor_incomplete_plan_jobs"), label)
+	}
+
+	assertIncompletePlanJobs("no plan jobs yet", 0)
+
+	_, err := jt.Maintenance(time.Minute, false, true, time.Hour, 0)
+	require.NoError(t, err)
+	assertIncompletePlanJobs("plan job pending", 1)
+
+	leaseResp, _, err := jt.Lease()
+	require.NoError(t, err)
+	require.Equal(t, planJobId, leaseResp.Key.Id)
+	assertIncompletePlanJobs("plan job active (still incomplete)", 1)
+
+	canceled, _, err := jt.CancelLease(leaseResp.Key.Id, leaseResp.Key.Epoch)
+	require.NoError(t, err)
+	require.True(t, canceled)
+	assertIncompletePlanJobs("plan job revived to pending (unchanged)", 1)
+
+	leaseResp, _, err = jt.Lease()
+	require.NoError(t, err)
+	_, _, err = jt.Remove(leaseResp.Key.Id, leaseResp.Key.Epoch, true)
+	require.NoError(t, err)
+	assertIncompletePlanJobs("plan job complete", 0)
+}
+
 func TestJobTracker_Cleanup(t *testing.T) {
 	clk := clock.NewMock()
 	reg := prometheus.NewPedanticRegistry()

--- a/pkg/compactor/scheduler/job_tracker_test.go
+++ b/pkg/compactor/scheduler/job_tracker_test.go
@@ -274,10 +274,11 @@ func TestJobTracker_ByteTracking(t *testing.T) {
 
 func TestJobTracker_Cleanup(t *testing.T) {
 	clk := clock.NewMock()
+	clk.Set(at(3, 0))
 	reg := prometheus.NewPedanticRegistry()
 	sm := newSchedulerMetrics(reg)
 
-	// Two tenants share the same incompleteJobsBytes gauge
+	// Two tenants share the same incompleteJobsBytes and incompletePlanJobs gauges.
 	jt1 := NewJobTracker(&NopJobPersister{}, "tenant1", clk, infiniteLeases, infiniteLeases, sm.newTrackerMetricsForTenant("tenant1"), log.NewNopLogger())
 	jt2 := NewJobTracker(&NopJobPersister{}, "tenant2", clk, infiniteLeases, infiniteLeases, sm.newTrackerMetricsForTenant("tenant2"), log.NewNopLogger())
 
@@ -289,15 +290,31 @@ func TestJobTracker_Cleanup(t *testing.T) {
 	}, nil)
 	assertTrackerBytes(t, reg, "both tenants contributing before cleanup", 100, 200)
 
-	// Cleaning up tenant1 should only subtract its bytes, not zero the shared gauge
+	_, err := jt1.Maintenance(time.Minute, false, true, time.Hour, 0)
+	require.NoError(t, err)
+	_, err = jt2.Maintenance(time.Minute, false, true, time.Hour, 0)
+	require.NoError(t, err)
+
+	require.NoError(t, prom_testutil.GatherAndCompare(reg, strings.NewReader(`
+		# HELP cortex_compactor_incomplete_plan_jobs The total number of plan jobs that have not yet completed (pending or active).
+		# TYPE cortex_compactor_incomplete_plan_jobs gauge
+		cortex_compactor_incomplete_plan_jobs 2
+	`), "cortex_compactor_incomplete_plan_jobs"), "both tenants have a pending plan job")
+
+	// Cleaning up tenant1 should only subtract its contribution, not zero the shared gauges.
 	jt1.CleanupMetrics()
 	assertTrackerBytes(t, reg, "only tenant1 bytes removed", 0, 200)
 	require.NoError(t, prom_testutil.GatherAndCompare(reg, strings.NewReader(`
 		# HELP cortex_compactor_scheduler_pending_jobs The number of queued pending jobs.
 		# TYPE cortex_compactor_scheduler_pending_jobs gauge
 		cortex_compactor_scheduler_pending_jobs{job_type="compaction",user="tenant2"} 1
-		cortex_compactor_scheduler_pending_jobs{job_type="plan",user="tenant2"} 0
+		cortex_compactor_scheduler_pending_jobs{job_type="plan",user="tenant2"} 1
 	`), "cortex_compactor_scheduler_pending_jobs"), "only tenant2 pending jobs remain")
+	require.NoError(t, prom_testutil.GatherAndCompare(reg, strings.NewReader(`
+		# HELP cortex_compactor_incomplete_plan_jobs The total number of plan jobs that have not yet completed (pending or active).
+		# TYPE cortex_compactor_incomplete_plan_jobs gauge
+		cortex_compactor_incomplete_plan_jobs 1
+	`), "cortex_compactor_incomplete_plan_jobs"), "only tenant2 plan job remains")
 }
 
 func TestJobTracker_CancelLease_PlanJobAlwaysRevives(t *testing.T) {

--- a/pkg/compactor/scheduler/job_tracker_test.go
+++ b/pkg/compactor/scheduler/job_tracker_test.go
@@ -307,8 +307,7 @@ func TestJobTracker_Cleanup(t *testing.T) {
 	require.NoError(t, prom_testutil.GatherAndCompare(reg, strings.NewReader(`
 		# HELP cortex_compactor_scheduler_pending_jobs The number of queued pending jobs.
 		# TYPE cortex_compactor_scheduler_pending_jobs gauge
-		cortex_compactor_scheduler_pending_jobs{job_type="compaction",user="tenant2"} 1
-		cortex_compactor_scheduler_pending_jobs{job_type="plan",user="tenant2"} 1
+		cortex_compactor_scheduler_pending_jobs{user="tenant2"} 2
 	`), "cortex_compactor_scheduler_pending_jobs"), "only tenant2 pending jobs remain")
 	require.NoError(t, prom_testutil.GatherAndCompare(reg, strings.NewReader(`
 		# HELP cortex_compactor_incomplete_plan_jobs The total number of plan jobs that have not yet completed (pending or active).

--- a/pkg/compactor/scheduler/job_tracker_test.go
+++ b/pkg/compactor/scheduler/job_tracker_test.go
@@ -274,7 +274,6 @@ func TestJobTracker_ByteTracking(t *testing.T) {
 
 func TestJobTracker_Cleanup(t *testing.T) {
 	clk := clock.NewMock()
-	clk.Set(at(3, 0))
 	reg := prometheus.NewPedanticRegistry()
 	sm := newSchedulerMetrics(reg)
 
@@ -290,6 +289,8 @@ func TestJobTracker_Cleanup(t *testing.T) {
 	}, nil)
 	assertTrackerBytes(t, reg, "both tenants contributing before cleanup", 100, 200)
 
+	// Set time past the first planning window to force planning on Maintenance()
+	clk.Set(at(3, 0))
 	_, err := jt1.Maintenance(time.Minute, false, true, time.Hour, 0)
 	require.NoError(t, err)
 	_, err = jt2.Maintenance(time.Minute, false, true, time.Hour, 0)

--- a/pkg/compactor/scheduler/metrics.go
+++ b/pkg/compactor/scheduler/metrics.go
@@ -126,10 +126,6 @@ func (q *queueMetrics) Pending(j TrackedJob) {
 
 func (q *queueMetrics) Leased(j TrackedJob) {
 	q.pendingJobs.Dec()
-	if j.ID() == planJobId {
-		q.incompletePlanJobs.Dec()
-		q.planJobCount--
-	}
 	q.activeJobs.Inc()
 }
 
@@ -146,7 +142,10 @@ func (q *queueMetrics) Recover(pending, leased []TrackedJob) {
 	}
 	for _, j := range leased {
 		q.activeJobs.Inc()
-		if cj, ok := j.(*TrackedCompactionJob); ok {
+		if j.ID() == planJobId {
+			q.incompletePlanJobs.Inc()
+			q.planJobCount++
+		} else if cj, ok := j.(*TrackedCompactionJob); ok {
 			q.addBytes(cj)
 		}
 	}
@@ -156,16 +155,15 @@ func (q *queueMetrics) Recover(pending, leased []TrackedJob) {
 func (q *queueMetrics) Revive(j TrackedJob) {
 	q.activeJobs.Dec()
 	q.pendingJobs.Inc()
-	if j.ID() == planJobId {
-		q.incompletePlanJobs.Inc()
-		q.planJobCount++
-	}
 }
 
 // Complete records a job leaving the system from the active queue (success or failure).
 func (q *queueMetrics) Complete(j TrackedJob) {
 	q.activeJobs.Dec()
-	if cj, ok := j.(*TrackedCompactionJob); ok {
+	if j.ID() == planJobId {
+		q.incompletePlanJobs.Dec()
+		q.planJobCount--
+	} else if cj, ok := j.(*TrackedCompactionJob); ok {
 		q.subBytes(cj)
 	}
 }

--- a/pkg/compactor/scheduler/metrics.go
+++ b/pkg/compactor/scheduler/metrics.go
@@ -29,7 +29,7 @@ func newSchedulerMetrics(reg prometheus.Registerer) *schedulerMetrics {
 		pendingJobs: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cortex_compactor_scheduler_pending_jobs",
 			Help: "The number of queued pending jobs.",
-		}, []string{"user", "job_type"}),
+		}, []string{"user"}),
 		incompleteJobsBytes: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cortex_compactor_scheduler_incomplete_compaction_jobs_bytes",
 			Help: "The total bytes of blocks in compaction jobs that have not yet completed (pending or active).",
@@ -62,15 +62,13 @@ func newSchedulerMetrics(reg prometheus.Registerer) *schedulerMetrics {
 func (s *schedulerMetrics) newTrackerMetricsForTenant(tenant string) *trackerMetrics {
 	return &trackerMetrics{
 		queue: &queueMetrics{
-			pendingPlanJobs:       s.pendingJobs.WithLabelValues(tenant, jobTypePlan),
-			pendingCompactionJobs: s.pendingJobs.WithLabelValues(tenant, jobTypeCompaction),
-			activeJobs:            s.activeJobs.WithLabelValues(tenant),
-			incompleteSplitBytes:  s.incompleteJobsBytes.WithLabelValues(compactionTypeSplit),
-			incompleteMergeBytes:  s.incompleteJobsBytes.WithLabelValues(compactionTypeMerge),
-			incompletePlanJobs:    s.incompletePlanJobs,
+			pendingJobs:          s.pendingJobs.WithLabelValues(tenant),
+			activeJobs:           s.activeJobs.WithLabelValues(tenant),
+			incompleteSplitBytes: s.incompleteJobsBytes.WithLabelValues(compactionTypeSplit),
+			incompleteMergeBytes: s.incompleteJobsBytes.WithLabelValues(compactionTypeMerge),
+			incompletePlanJobs:   s.incompletePlanJobs,
 			clear: func() {
-				s.pendingJobs.DeleteLabelValues(tenant, jobTypePlan)
-				s.pendingJobs.DeleteLabelValues(tenant, jobTypeCompaction)
+				s.pendingJobs.DeleteLabelValues(tenant)
 				s.activeJobs.DeleteLabelValues(tenant)
 			},
 		},
@@ -100,9 +98,8 @@ func (m *trackerMetrics) Clear() {
 // Callers are responsible for making valid transitions. Invalid calls (e.g. DropPending on an
 // empty queue) will produce incorrect gauge values. Methods are not thread-safe.
 type queueMetrics struct {
-	pendingPlanJobs       prometheus.Gauge
-	pendingCompactionJobs prometheus.Gauge
-	activeJobs            prometheus.Gauge
+	pendingJobs prometheus.Gauge
+	activeJobs  prometheus.Gauge
 
 	// shared across tenants
 	incompleteSplitBytes prometheus.Gauge
@@ -118,23 +115,20 @@ type queueMetrics struct {
 }
 
 func (q *queueMetrics) Pending(j TrackedJob) {
+	q.pendingJobs.Inc()
 	if j.ID() == planJobId {
-		q.pendingPlanJobs.Inc()
 		q.incompletePlanJobs.Inc()
 		q.planJobCount++
 	} else {
-		q.pendingCompactionJobs.Inc()
 		q.addBytes(j.(*TrackedCompactionJob))
 	}
 }
 
 func (q *queueMetrics) Leased(j TrackedJob) {
+	q.pendingJobs.Dec()
 	if j.ID() == planJobId {
-		q.pendingPlanJobs.Dec()
 		q.incompletePlanJobs.Dec()
 		q.planJobCount--
-	} else {
-		q.pendingCompactionJobs.Dec()
 	}
 	q.activeJobs.Inc()
 }
@@ -142,12 +136,11 @@ func (q *queueMetrics) Leased(j TrackedJob) {
 // Recover records jobs restored from persisted state on startup.
 func (q *queueMetrics) Recover(pending, leased []TrackedJob) {
 	for _, j := range pending {
+		q.pendingJobs.Inc()
 		if j.ID() == planJobId {
-			q.pendingPlanJobs.Inc()
 			q.incompletePlanJobs.Inc()
 			q.planJobCount++
 		} else {
-			q.pendingCompactionJobs.Inc()
 			q.addBytes(j.(*TrackedCompactionJob))
 		}
 	}
@@ -162,12 +155,10 @@ func (q *queueMetrics) Recover(pending, leased []TrackedJob) {
 // Revive records a job moving from active back to pending (lease expired or cancelled).
 func (q *queueMetrics) Revive(j TrackedJob) {
 	q.activeJobs.Dec()
+	q.pendingJobs.Inc()
 	if j.ID() == planJobId {
-		q.pendingPlanJobs.Inc()
 		q.incompletePlanJobs.Inc()
 		q.planJobCount++
-	} else {
-		q.pendingCompactionJobs.Inc()
 	}
 }
 
@@ -181,12 +172,11 @@ func (q *queueMetrics) Complete(j TrackedJob) {
 
 // DropPending records a job leaving the system from the pending queue.
 func (q *queueMetrics) DropPending(j TrackedJob) {
+	q.pendingJobs.Dec()
 	if j.ID() == planJobId {
-		q.pendingPlanJobs.Dec()
 		q.incompletePlanJobs.Dec()
 		q.planJobCount--
 	} else {
-		q.pendingCompactionJobs.Dec()
 		q.subBytes(j.(*TrackedCompactionJob))
 	}
 }

--- a/pkg/compactor/scheduler/metrics.go
+++ b/pkg/compactor/scheduler/metrics.go
@@ -18,6 +18,7 @@ const (
 type schedulerMetrics struct {
 	pendingJobs         *prometheus.GaugeVec
 	incompleteJobsBytes *prometheus.GaugeVec
+	incompletePlanJobs  prometheus.Gauge
 	activeJobs          *prometheus.GaugeVec
 	jobsCompleted       *prometheus.CounterVec
 	repeatedJobFailures prometheus.Counter
@@ -33,6 +34,10 @@ func newSchedulerMetrics(reg prometheus.Registerer) *schedulerMetrics {
 			Name: "cortex_compactor_scheduler_incomplete_compaction_jobs_bytes",
 			Help: "The total bytes of blocks in compaction jobs that have not yet completed (pending or active).",
 		}, []string{"compaction_type"}),
+		incompletePlanJobs: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Name: "cortex_compactor_incomplete_plan_jobs",
+			Help: "The total number of plan jobs that have not yet completed (pending or active).",
+		}),
 		activeJobs: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cortex_compactor_scheduler_active_jobs",
 			Help: "The number of jobs active in workers.",
@@ -62,6 +67,7 @@ func (s *schedulerMetrics) newTrackerMetricsForTenant(tenant string) *trackerMet
 			activeJobs:            s.activeJobs.WithLabelValues(tenant),
 			incompleteSplitBytes:  s.incompleteJobsBytes.WithLabelValues(compactionTypeSplit),
 			incompleteMergeBytes:  s.incompleteJobsBytes.WithLabelValues(compactionTypeMerge),
+			incompletePlanJobs:    s.incompletePlanJobs,
 			clear: func() {
 				s.pendingJobs.DeleteLabelValues(tenant, jobTypePlan)
 				s.pendingJobs.DeleteLabelValues(tenant, jobTypeCompaction)
@@ -77,13 +83,15 @@ type trackerMetrics struct {
 	repeatedJobFailures prometheus.Counter
 }
 
-// Clear deletes all per-tenant label values and subtracts this tenant's byte contribution from the
-// shared gauge. Must be called when a tenant is removed.
+// Clear deletes all per-tenant label values and subtracts this tenant's contribution from the
+// shared gauges. Must be called when a tenant is removed.
 func (m *trackerMetrics) Clear() {
 	m.queue.incompleteSplitBytes.Sub(float64(m.queue.splitBytes))
 	m.queue.incompleteMergeBytes.Sub(float64(m.queue.mergeBytes))
+	m.queue.incompletePlanJobs.Sub(float64(m.queue.planJobCount))
 	m.queue.splitBytes = 0
 	m.queue.mergeBytes = 0
+	m.queue.planJobCount = 0
 	m.queue.clear()
 }
 
@@ -99,17 +107,21 @@ type queueMetrics struct {
 	// shared across tenants
 	incompleteSplitBytes prometheus.Gauge
 	incompleteMergeBytes prometheus.Gauge
+	incompletePlanJobs   prometheus.Gauge
 
-	// splitBytes and mergeBytes track this tenant's contribution to the shared incomplete bytes
-	// so we can subtract exactly the right amount on tenant removal.
-	splitBytes uint64
-	mergeBytes uint64
-	clear      func()
+	// splitBytes, mergeBytes, and planJobCount track this tenant's contribution to the shared
+	// incomplete gauges so we can subtract exactly the right amount on tenant removal.
+	splitBytes   uint64
+	mergeBytes   uint64
+	planJobCount int
+	clear        func()
 }
 
 func (q *queueMetrics) Pending(j TrackedJob) {
 	if j.ID() == planJobId {
 		q.pendingPlanJobs.Inc()
+		q.incompletePlanJobs.Inc()
+		q.planJobCount++
 	} else {
 		q.pendingCompactionJobs.Inc()
 		q.addBytes(j.(*TrackedCompactionJob))
@@ -119,6 +131,8 @@ func (q *queueMetrics) Pending(j TrackedJob) {
 func (q *queueMetrics) Leased(j TrackedJob) {
 	if j.ID() == planJobId {
 		q.pendingPlanJobs.Dec()
+		q.incompletePlanJobs.Dec()
+		q.planJobCount--
 	} else {
 		q.pendingCompactionJobs.Dec()
 	}
@@ -130,6 +144,8 @@ func (q *queueMetrics) Recover(pending, leased []TrackedJob) {
 	for _, j := range pending {
 		if j.ID() == planJobId {
 			q.pendingPlanJobs.Inc()
+			q.incompletePlanJobs.Inc()
+			q.planJobCount++
 		} else {
 			q.pendingCompactionJobs.Inc()
 			q.addBytes(j.(*TrackedCompactionJob))
@@ -148,6 +164,8 @@ func (q *queueMetrics) Revive(j TrackedJob) {
 	q.activeJobs.Dec()
 	if j.ID() == planJobId {
 		q.pendingPlanJobs.Inc()
+		q.incompletePlanJobs.Inc()
+		q.planJobCount++
 	} else {
 		q.pendingCompactionJobs.Inc()
 	}
@@ -165,6 +183,8 @@ func (q *queueMetrics) Complete(j TrackedJob) {
 func (q *queueMetrics) DropPending(j TrackedJob) {
 	if j.ID() == planJobId {
 		q.pendingPlanJobs.Dec()
+		q.incompletePlanJobs.Dec()
+		q.planJobCount--
 	} else {
 		q.pendingCompactionJobs.Dec()
 		q.subBytes(j.(*TrackedCompactionJob))


### PR DESCRIPTION
#### What this PR does

Two changes:
- Remove the `job_type` from `cortex_compactor_scheduler_pending_jobs`
- Add new `cortex_compactor_incomplete_plan_jobs` metric, not labelled by user as opposed to the one above

##### Why

The `job_type` in `cortex_compactor_scheduler_pending_jobs` was originally introduced in https://github.com/grafana/mimir/pull/14945 for autoscaling purposes, specifically to know the number of outstanding plan jobs. But I later realized `cortex_compactor_scheduler_pending_jobs` was going to be of too high cardinality to be used in a critical autoscaling system. The new `cortex_compactor_incomplete_plan_jobs` metric does not have such high cardinality, and additionally also tracks the "active" plan jobs, just like how `cortex_compactor_scheduler_incomplete_compaction_jobs_bytes` does.

The `job_type` from `cortex_compactor_scheduler_pending_jobs` I'm removing because it doubles what is already high cardinality for no interesting reason. We can extract good enough information from other metrics for now.


#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Prometheus metric shape/semantics (removes `job_type` label and adds new global gauge), which can break existing dashboards/alerts/autoscalers if not updated; functional scheduler logic is otherwise minimally affected.
> 
> **Overview**
> Adds a new global Prometheus gauge `cortex_compactor_incomplete_plan_jobs` to track *all* plan jobs that are not yet complete (pending or active), and ensures per-tenant cleanup subtracts only that tenant’s contribution.
> 
> Simplifies `cortex_compactor_scheduler_pending_jobs` by removing the `job_type` label and reporting a single per-tenant pending-job count; tests are updated to validate the new metrics behavior across multiple tenants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ca9e5b13d687e2401c503e7d8d529e171c79582. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->