### PR TITLE
MQE: use `MatchersMatch` in `MultiAggregatorInstanceOperator`

### DIFF
--- a/pkg/streamingpromql/optimize/plan/multiaggregation/operator.go
+++ b/pkg/streamingpromql/optimize/plan/multiaggregation/operator.go
@@ -287,13 +287,7 @@ func (m *MultiAggregatorInstanceOperator) computeGroups(unfilteredSeries []types
 }
 
 func (m *MultiAggregatorInstanceOperator) matchesSeries(series labels.Labels) bool {
-	for _, filter := range m.filters {
-		if !filter.Matches(series.Get(filter.Name)) {
-			return false
-		}
-	}
-
-	return true
+	return types.MatchersMatch(m.filters, series)
 }
 
 func (m *MultiAggregatorInstanceOperator) NextSeries(ctx context.Context) (types.InstantVectorSeriesData, error) {


### PR DESCRIPTION
#### What this PR does

This PR addresses some post-merge feedback on https://github.com/grafana/mimir/pull/14952:  https://github.com/grafana/mimir/pull/14952#discussion_r3061435989

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/pull/14952#discussion_r3061435989

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes matcher evaluation; behavior should remain the same aside from any subtle differences in `MatchersMatch` semantics.
> 
> **Overview**
> Simplifies `MultiAggregatorInstanceOperator.matchesSeries` by replacing its manual per-matcher label check with a call to the shared `types.MatchersMatch` helper, centralizing matcher-evaluation logic for multi-aggregation filtering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 115971cbfa367ae0ca1556ae7a76949179101d55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->