### PR TITLE
development: Disable ingester block shipping in ingest-storage Docker env.

### DIFF
--- a/development/mimir-ingest-storage/config/mimir.yaml
+++ b/development/mimir-ingest-storage/config/mimir.yaml
@@ -47,6 +47,7 @@ blocks_storage:
     bucket_name:       mimir-blocks
   tsdb:
     dir: /data
+    ship_interval: 0s # disable ingester block shipping; block-builder does that job.
     head_postings_for_matchers_cache_force: true
     block_postings_for_matchers_cache_force: true
 


### PR DESCRIPTION
#### What this PR does

Since block-builder runs in the ingest-storage docker environment, we stop shipping blocks from ingester. This is how the system is actually set up when running under ingest storage.

#### Checklist

- (n/a) Tests updated.
- (n/a) Documentation added.
- (n/a) `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- (n/a) [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that alters local ingest-storage Docker behavior by preventing ingesters from shipping blocks; risk is limited to development environment correctness if block-builder is not running.
> 
> **Overview**
> Disables ingester TSDB block shipping in the `development/mimir-ingest-storage` Docker configuration by setting `blocks_storage.tsdb.ship_interval: 0s`, delegating block shipping to the block-builder in this environment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a66f0ca9fc3440d0f0187f328cf27a7b7121264f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->