### PR TITLE
operations: Add formal controls around query-ingesters-within, disconnect ingester downscale window from querier config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -354,6 +354,7 @@
   * `$._config.shuffle_sharding.store_gateway_shard_size_per_zone_overrides_enabled` (takes precedence over `store_gateway_shard_size_per_zone_enabled`)
 * [FEATURE] Ruler: Add `$._config.multi_zone_ruler_balanced_autoscaling_enabled` option to ensure equally balanced replica counts across ruler zones in multi-AZ deployments by using aggregate metrics for autoscaling. #14198
 * [FEATURE] Add `query_engine_range_vector_splitting_enabled` configuration option to enable experimental range vector splitting with memcached cache. #14435
+* [FEATURE] Jsonnet: Add `_config` fields `querier_query_ingesters_within`, `querier_query_store_after`, and `store_gateway_ignore_blocks_within`, matching `-querier.query-ingesters-within`, `-querier.query-store-after`, and `-blocks-storage.bucket-store.ignore-blocks-within`. #15002
 * [CHANGE] Memberlist bridge: Changed default value of `memberlist_bridge_replicas_per_zone` from 2 to 3. #14667
 * [ENHANCEMENT] Ruler querier and query-frontend: Add support for newly-introduced querier ring, which is used when performing query planning in query-frontends and distributing portions of the plan to queriers for execution. #13017
 * [ENHANCEMENT] Ingester: Increase `$._config.ingester_tsdb_head_early_compaction_min_in_memory_series` default when Mimir is running with the ingest storage architecture. #13450

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -354,7 +354,7 @@
   * `$._config.shuffle_sharding.store_gateway_shard_size_per_zone_overrides_enabled` (takes precedence over `store_gateway_shard_size_per_zone_enabled`)
 * [FEATURE] Ruler: Add `$._config.multi_zone_ruler_balanced_autoscaling_enabled` option to ensure equally balanced replica counts across ruler zones in multi-AZ deployments by using aggregate metrics for autoscaling. #14198
 * [FEATURE] Add `query_engine_range_vector_splitting_enabled` configuration option to enable experimental range vector splitting with memcached cache. #14435
-* [FEATURE] Jsonnet: Add `_config` fields `querier_query_ingesters_within`, `querier_query_store_after`, and `store_gateway_ignore_blocks_within`, matching `-querier.query-ingesters-within`, `-querier.query-store-after`, and `-blocks-storage.bucket-store.ignore-blocks-within`. #15002
+* [FEATURE] Jsonnet: Add `_config` fields `querier_query_ingesters_within`, `querier_query_store_after`, and `store_gateway_ignore_blocks_within`, matching `-querier.query-ingesters-within`, `-querier.query-store-after`, and `-blocks-storage.bucket-store.ignore-blocks-within`. #15009
 * [CHANGE] Memberlist bridge: Changed default value of `memberlist_bridge_replicas_per_zone` from 2 to 3. #14667
 * [ENHANCEMENT] Ruler querier and query-frontend: Add support for newly-introduced querier ring, which is used when performing query planning in query-frontends and distributing portions of the plan to queriers for execution. #13017
 * [ENHANCEMENT] Ingester: Increase `$._config.ingester_tsdb_head_early_compaction_min_in_memory_series` default when Mimir is running with the ingest storage architecture. #13450

--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -39,9 +39,11 @@
     // Controls the ingester data-window.
     querier_query_ingesters_within: '13h',
     querier_query_store_after: $.util.formatDuration($.util.parseDuration(self.querier_query_ingesters_within) - 3600),
+    store_gateway_ignore_blocks_within: '10h',
 
     assert $.util.parseDuration(self.querier_query_store_after) < $.util.parseDuration(self.querier_query_ingesters_within) : 'querier_query_store_after must be strictly less than querier_query_ingesters_within.',
     assert $.util.parseDuration(self.querier_query_ingesters_within) >= 3600 : 'querier_query_ingesters_within must be greater than or equal to 1h.',
+    assert $.util.parseDuration(self.store_gateway_ignore_blocks_within) < $.util.parseDuration(self.querier_query_store_after) : 'store_gateway_ignore_blocks_within must be strictly less than querier_query_store_after.',
 
     test_exporter_enabled: false,
     test_exporter_start_time: error 'must specify test exporter start time',

--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -36,6 +36,10 @@
     querier_max_concurrency: 8,
     ruler_querier_max_concurrency: $._config.querier_max_concurrency,
 
+    // Controls the ingester data-window.
+    querier_query_ingesters_within: '13h',
+    querier_query_store_after: $.util.formatDuration($.util.parseDuration($._config.querier_query_ingesters_within) - 3600),
+
     test_exporter_enabled: false,
     test_exporter_start_time: error 'must specify test exporter start time',
     test_exporter_user_id: error 'must specify test exporter used id',

--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -579,6 +579,13 @@
     service_ignored_labels:: [self.gossip_member_label],
   },
 
+  // Matches rollout-operator delayed ingester downscale (query window + optional extra delay).
+  // Used for partition-ring inactive partition cleanup when ingest storage is enabled.
+  ingester_rollout_downscale_delay:: $.util.formatDuration(
+    $.util.parseDuration($._config.querier_query_ingesters_within) +
+    $.util.parseDuration($._config.ingester_extra_downscale_delay)
+  ),
+
   local configMap = $.core.v1.configMap,
 
   overrides_config:

--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -36,10 +36,12 @@
     querier_max_concurrency: 8,
     ruler_querier_max_concurrency: $._config.querier_max_concurrency,
 
-    // Controls the ingester data-window.
+    // Controls the ingester data window.
     querier_query_ingesters_within: '13h',
     querier_query_store_after: $.util.formatDuration($.util.parseDuration(self.querier_query_ingesters_within) - 3600),
     store_gateway_ignore_blocks_within: '10h',
+    // Allows ingesters to stick around longer than their data window, for evaluation purposes.
+    ingester_extra_downscale_delay: '0h',
 
     assert $.util.parseDuration(self.querier_query_store_after) < $.util.parseDuration(self.querier_query_ingesters_within) : 'querier_query_store_after must be strictly less than querier_query_ingesters_within.',
     assert $.util.parseDuration(self.querier_query_ingesters_within) >= 3600 : 'querier_query_ingesters_within must be greater than or equal to 1h.',

--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -45,7 +45,7 @@
 
     assert $.util.parseDuration(self.querier_query_store_after) < $.util.parseDuration(self.querier_query_ingesters_within) : 'querier_query_store_after must be strictly less than querier_query_ingesters_within.',
     assert $.util.parseDuration(self.querier_query_ingesters_within) >= 3600 : 'querier_query_ingesters_within must be greater than or equal to 1h.',
-    assert $.util.parseDuration(self.store_gateway_ignore_blocks_within) < $.util.parseDuration(self.querier_query_store_after) : 'store_gateway_ignore_blocks_within must be strictly less than querier_query_store_after.',
+    assert $.util.parseDuration(self.store_gateway_ignore_blocks_within) <= $.util.parseDuration(self.querier_query_store_after) : 'store_gateway_ignore_blocks_within must be less than or equal to querier_query_store_after.',
 
     test_exporter_enabled: false,
     test_exporter_start_time: error 'must specify test exporter start time',

--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -579,8 +579,6 @@
     service_ignored_labels:: [self.gossip_member_label],
   },
 
-  // Matches rollout-operator delayed ingester downscale (query window + optional extra delay).
-  // Used for partition-ring inactive partition cleanup when ingest storage is enabled.
   ingester_rollout_downscale_delay:: $.util.formatDuration(
     $.util.parseDuration($._config.querier_query_ingesters_within) +
     $.util.parseDuration($._config.ingester_extra_downscale_delay)

--- a/operations/mimir/config.libsonnet
+++ b/operations/mimir/config.libsonnet
@@ -38,7 +38,10 @@
 
     // Controls the ingester data-window.
     querier_query_ingesters_within: '13h',
-    querier_query_store_after: $.util.formatDuration($.util.parseDuration($._config.querier_query_ingesters_within) - 3600),
+    querier_query_store_after: $.util.formatDuration($.util.parseDuration(self.querier_query_ingesters_within) - 3600),
+
+    assert $.util.parseDuration(self.querier_query_store_after) < $.util.parseDuration(self.querier_query_ingesters_within) : 'querier_query_store_after must be strictly less than querier_query_ingesters_within.',
+    assert $.util.parseDuration(self.querier_query_ingesters_within) >= 3600 : 'querier_query_ingesters_within must be greater than or equal to 1h.',
 
     test_exporter_enabled: false,
     test_exporter_start_time: error 'must specify test exporter start time',

--- a/operations/mimir/ingest-storage-ingester-autoscaling.libsonnet
+++ b/operations/mimir/ingest-storage-ingester-autoscaling.libsonnet
@@ -18,11 +18,11 @@
       1800000,
 
     // How long to wait before terminating an ingester after it has been notified about the scale down.
-    ingest_storage_ingester_downscale_delay: if 'querier.query-ingesters-within' in $.querier_args then
-      $.querier_args['querier.query-ingesters-within']
-    else
-      // The default -querier.query-ingesters-within in Mimir is 13 hours.
-      '13h',
+    ingest_storage_ingester_downscale_delay:
+      $.util.formatDuration(
+        $.util.parseDuration($._config.querier_query_ingesters_within) +
+        $.util.parseDuration($._config.ingester_extra_downscale_delay)
+      ),
 
     // Allow to fine-tune which components gets deployed. This is useful when following the procedure
     // to rollout ingesters autoscaling with no downtime.

--- a/operations/mimir/ingest-storage-ingester-autoscaling.libsonnet
+++ b/operations/mimir/ingest-storage-ingester-autoscaling.libsonnet
@@ -18,11 +18,7 @@
       1800000,
 
     // How long to wait before terminating an ingester after it has been notified about the scale down.
-    ingest_storage_ingester_downscale_delay:
-      $.util.formatDuration(
-        $.util.parseDuration($._config.querier_query_ingesters_within) +
-        $.util.parseDuration($._config.ingester_extra_downscale_delay)
-      ),
+    ingest_storage_ingester_downscale_delay: $.ingester_rollout_downscale_delay,
 
     // Allow to fine-tune which components gets deployed. This is useful when following the procedure
     // to rollout ingesters autoscaling with no downtime.

--- a/operations/mimir/ingest-storage.libsonnet
+++ b/operations/mimir/ingest-storage.libsonnet
@@ -116,10 +116,7 @@
     $.ingest_storage_ingester_args +
     {
       // How long to wait before deleting an inactive partition, that doesn't have an owner.
-      'ingester.partition-ring.delete-inactive-partition-after': if 'querier.query-ingesters-within' in $.querier_args then
-        $.querier_args['querier.query-ingesters-within']
-      else
-        '13h',  // The default -querier.query-ingesters-within in Mimir is 13 hours.
+      'ingester.partition-ring.delete-inactive-partition-after': $._config.querier_query_ingesters_within,
     } + (
       if $._config.ingest_storage_ingester_ring_tokens_enabled then {} else {
         'ingester.ring.num-tokens': 0,

--- a/operations/mimir/ingest-storage.libsonnet
+++ b/operations/mimir/ingest-storage.libsonnet
@@ -116,7 +116,7 @@
     $.ingest_storage_ingester_args +
     {
       // How long to wait before deleting an inactive partition, that doesn't have an owner.
-      'ingester.partition-ring.delete-inactive-partition-after': $._config.querier_query_ingesters_within,
+      'ingester.partition-ring.delete-inactive-partition-after': $.ingester_rollout_downscale_delay,
     } + (
       if $._config.ingest_storage_ingester_ring_tokens_enabled then {} else {
         'ingester.ring.num-tokens': 0,

--- a/operations/mimir/ingester-automated-downscale-v2.libsonnet
+++ b/operations/mimir/ingester-automated-downscale-v2.libsonnet
@@ -25,11 +25,11 @@
     ingester_automated_downscale_v2_replicas_per_zone: std.ceil($._config.multi_zone_ingester_replicas / $._config.ingester_automated_downscale_v2_ingester_zones),
 
     // How long to wait before terminating an ingester after it has been notified about the scale down.
-    ingester_automated_downscale_v2_delay: if 'querier.query-ingesters-within' in $.querier_args then
-      $.querier_args['querier.query-ingesters-within']
-    else
-      // The default -querier.query-ingesters-within in Mimir is 13 hours.
-      '13h',
+    ingester_automated_downscale_v2_delay:
+      $.util.formatDuration(
+        $.util.parseDuration($._config.querier_query_ingesters_within) +
+        $.util.parseDuration($._config.ingester_extra_downscale_delay)
+      ),
   },
 
   // Validate the configuration.

--- a/operations/mimir/ingester-automated-downscale-v2.libsonnet
+++ b/operations/mimir/ingester-automated-downscale-v2.libsonnet
@@ -25,11 +25,7 @@
     ingester_automated_downscale_v2_replicas_per_zone: std.ceil($._config.multi_zone_ingester_replicas / $._config.ingester_automated_downscale_v2_ingester_zones),
 
     // How long to wait before terminating an ingester after it has been notified about the scale down.
-    ingester_automated_downscale_v2_delay:
-      $.util.formatDuration(
-        $.util.parseDuration($._config.querier_query_ingesters_within) +
-        $.util.parseDuration($._config.ingester_extra_downscale_delay)
-      ),
+    ingester_automated_downscale_v2_delay: $.ingester_rollout_downscale_delay,
   },
 
   // Validate the configuration.

--- a/operations/mimir/querier.libsonnet
+++ b/operations/mimir/querier.libsonnet
@@ -30,6 +30,9 @@
       'mem-ballast-size-bytes': 1 << 28,  // 256M
 
       'querier.store-gateway-client.grpc-max-recv-msg-size': $._config.store_gateway_grpc_max_query_response_size_bytes,
+
+      'querier.query-ingesters-within': $._config.querier_query_ingesters_within,
+      'querier.query-store-after': $._config.querier_query_store_after,
     },
 
   // CLI flags that are applied only to queriers, and not ruler-queriers.

--- a/operations/mimir/querier.libsonnet
+++ b/operations/mimir/querier.libsonnet
@@ -30,10 +30,19 @@
       'mem-ballast-size-bytes': 1 << 28,  // 256M
 
       'querier.store-gateway-client.grpc-max-recv-msg-size': $._config.store_gateway_grpc_max_query_response_size_bytes,
-
-      'querier.query-ingesters-within': $._config.querier_query_ingesters_within,
-      'querier.query-store-after': $._config.querier_query_store_after,
-    },
+    } + (
+      local s = $.util.parseDuration($._config.querier_query_ingesters_within);
+      local d = $.util.getFlagDefaultSeconds('querier.query-ingesters-within');
+      if d == null || s != d then
+        { 'querier.query-ingesters-within': $._config.querier_query_ingesters_within }
+      else {}
+    ) + (
+      local s = $.util.parseDuration($._config.querier_query_store_after);
+      local d = $.util.getFlagDefaultSeconds('querier.query-store-after');
+      if d == null || s != d then
+        { 'querier.query-store-after': $._config.querier_query_store_after }
+      else {}
+    ),
 
   // CLI flags that are applied only to queriers, and not ruler-queriers.
   // Values take precedence over querier_args.

--- a/operations/mimir/store-gateway.libsonnet
+++ b/operations/mimir/store-gateway.libsonnet
@@ -45,7 +45,14 @@
     $.blocks_chunks_caching_config +
     $.blocks_metadata_caching_config +
     $.bucket_index_config +
-    $.mimirRuntimeConfigFile,
+    $.mimirRuntimeConfigFile +
+    (
+      local s = $.util.parseDuration($._config.store_gateway_ignore_blocks_within);
+      local d = $.util.getFlagDefaultSeconds('blocks-storage.bucket-store.ignore-blocks-within');
+      if d == null || s != d then
+        { 'blocks-storage.bucket-store.ignore-blocks-within': $._config.store_gateway_ignore_blocks_within }
+      else {}
+    ),
 
   store_gateway_ports:: $.util.defaultPorts,
 


### PR DESCRIPTION
#### What this PR does

As we move toward defaulting to a lower ingester data window, we add formal jsonnet controls for manipulating it and its related flags.

`_config.querier_query_ingesters_within` controls `-querier.query-ingesters-within`
`_config.querier_query_store_after` controls `-querier.query-store-after`
`_config.store_gateway_ignore_blocks_within` controls `-blocks-storage.bucket-store.ignore-blocks-within`

We add a new feature, `_config.ingester_extra_downscale_delay`, which allows keeping ingesters around for a specified time longer than their query window. For example, with `query_ingesters_within` of 6h and `ingester_extra_downscale_delay` of 2h, ingesters will wait 8 hours to scale down, despite queries not being served to them. This allows for a verification step - query window can be safely controlled without affecting partition layout and data residency.

We also add extra QoL features, such as automatically deriving settings where we can, and adding assertion guards against configuration that might break reads.

#### Which issue(s) this PR fixes or relates to

contrib https://github.com/grafana/mimir-squad/issues/3373

#### Checklist

- [x] Tests updated. (This change is careful to not affect existing manifests)
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches query-window and block-selection CLI flags plus ingester downscale timing, which can affect query correctness and rollout behavior if misconfigured. Risk is mitigated by validation asserts and by only emitting flags when diverging from Mimir defaults.
> 
> **Overview**
> Introduces new `_config` knobs to control read-path time windows via Jsonnet: `querier_query_ingesters_within`, derived `querier_query_store_after`, and `store_gateway_ignore_blocks_within`, with guardrail assertions to prevent unsafe combinations.
> 
> Updates `querier` and `store-gateway` manifests to **only** emit `-querier.query-ingesters-within`, `-querier.query-store-after`, and `-blocks-storage.bucket-store.ignore-blocks-within` when the configured values differ from upstream flag defaults.
> 
> Decouples ingester scale-down/partition-retention timing from `querier_args` by adding a shared `ingester_rollout_downscale_delay` (query window + optional `ingester_extra_downscale_delay`) and wiring it into ingest-storage ingester autoscaling, ingest-storage partition deletion (`ingester.partition-ring.delete-inactive-partition-after`), and `ingester-automated-downscale-v2` delays.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d21d58c246a5df9b1e0543d643bafdfe64bf4c44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->