### PR TITLE
fix: dropped error in tools/ulidtime

### DIFF
--- a/tools/ulidtime/main.go
+++ b/tools/ulidtime/main.go
@@ -71,6 +71,9 @@ func main() {
 		}
 	}
 
-	tw.Flush()
+	err = tw.Flush()
+	if err != nil {
+		log.Fatal(err)
+	}
 	os.Exit(exit)
 }


### PR DESCRIPTION
This picks up and logs a dropped error in `toolds/ulidtime`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds error handling for `tabwriter.Writer.Flush()` in a CLI tool, changing behavior only when output flushing fails.
> 
> **Overview**
> The `tools/ulidtime` CLI now checks and handles the error returned by `tw.Flush()` instead of dropping it.
> 
> On flush failure, it exits via `log.Fatal`, making output/IO errors visible and preventing silent failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed4d5682e23772ccac9e87f717fc870c32bfe59e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->