### PR TITLE
Alertmanager: Remove -alertmanager.grafana-alertmanager-compatibility-enabled from about-versioning.md

### DIFF
--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -59,8 +59,6 @@ The following features are currently experimental:
   - Configure the cost attribution cleanup process run interval
     - `-cost-attribution.cleanup-interval`
 - Alertmanager
-  - Enable a set of experimental API endpoints to help support the migration of the Grafana Alertmanager to the Mimir Alertmanager.
-    - `-alertmanager.grafana-alertmanager-compatibility-enabled`
   - Health check grace period for connections to other replicas (`-alertmanager.alertmanager-client.health-check-grace-period`)
 - Compactor
   - Limit blocks processed in each compaction cycle. Blocks uploaded prior to the maximum lookback aren't processed.


### PR DESCRIPTION
This feature was removed from the Mimir Alertmanager.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that removes a reference to an Alertmanager experimental flag; no runtime behavior or APIs are affected.
> 
> **Overview**
> Removes the `-alertmanager.grafana-alertmanager-compatibility-enabled` entry from the *Experimental features* list in `about-versioning.md`, reflecting that this Grafana Alertmanager compatibility toggle is no longer available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e06fd133a23ee833777a129a6795cc1aa5fbfe4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->