### PR TITLE
MQE: fix issues where "remove statically empty expressions" behaves incorrectly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,7 +181,7 @@
 * [ENHANCEMENT] Query-frontend: Stream JSON encoding directly to the response body to avoid a full-copy allocation of the serialized payload. #14840
 * [ENHANCEMENT] Activity tracker: Added `activity_tracker_unfinished_activities_loaded` metric to report the number of unfinished activities detected on startup. #14860
 * [ENHANCEMENT] Distributor now uses record validation time as Kafka record timestamp to reduce rejections among consumers. #14921
-* [ENHANCEMENT] MQE: Add optimisation pass to optimise away expressions containing comparisons with `timestamp()` that can't produce results due to the query time range. #14989
+* [ENHANCEMENT] MQE: Add optimisation pass to optimise away expressions containing comparisons with `timestamp()` that can't produce results due to the query time range. #14989 #15014
 * [ENHANCEMENT] Distributor: OTLP endpoint now returns partial success (HTTP 200) instead of HTTP 429 when the usage tracker rejects some series due to the active series limit but other series are successfully ingested. The `RejectedDataPoints` field reports the count of distributor-side rejections (usage tracker filtering). #14789
 * [BUGFIX] Distributor: OTLP partial success responses now correctly populate `RejectedDataPoints` with the actual count of rejected samples, instead of always reporting 0. In classical architecture, this includes rejected samples propagated from the ingester. #14789
 * [BUGFIX] Distributor: Fix race condition where usage-tracker partition ring may not be initialized before the distributor service starts, causing `usage-tracker partition ring is required` error on startup. #14675

--- a/pkg/streamingpromql/config.go
+++ b/pkg/streamingpromql/config.go
@@ -120,13 +120,14 @@ func NewTestEngineOpts() EngineOpts {
 		Logger:   log.NewNopLogger(),
 		Limits:   NewStaticQueryLimitsProvider(),
 
-		EnablePruneToggles:                   true,
-		EnableCommonSubexpressionElimination: true,
-		EnableSubsetSelectorElimination:      true,
-		EnableNarrowBinarySelectors:          true,
-		EnableEliminateDeduplicateAndMerge:   true,
-		EnableReduceMatchers:                 true,
-		EnableProjectionPushdown:             true,
-		EnableMultiAggregation:               true,
+		EnablePruneToggles:                     true,
+		EnableCommonSubexpressionElimination:   true,
+		EnableSubsetSelectorElimination:        true,
+		EnableNarrowBinarySelectors:            true,
+		EnableEliminateDeduplicateAndMerge:     true,
+		EnableReduceMatchers:                   true,
+		EnableProjectionPushdown:               true,
+		EnableMultiAggregation:                 true,
+		EnableRemoveStaticallyEmptyExpressions: true,
 	}
 }

--- a/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
+++ b/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
@@ -217,7 +217,7 @@ func unwrap(node planning.Node) planning.Node {
 		case *core.StepInvariantExpression:
 			node = n.Inner
 		case *core.FunctionCall:
-			if n.Function == functions.FUNCTION_ADAPTIVE_METRICS_RESERVED_1 || n.Function == functions.FUNCTION_ADAPTIVE_METRICS_RESERVED_2 {
+			if (n.Function == functions.FUNCTION_ADAPTIVE_METRICS_RESERVED_1 || n.Function == functions.FUNCTION_ADAPTIVE_METRICS_RESERVED_2) && len(n.Args) > 0 {
 				// The Adaptive Metrics query rewriting can wrap a timestamp() call (eg. expression becomes wrapper(timestamp(...)) < T), so unwrap it.
 				node = n.Args[0]
 			} else {

--- a/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
+++ b/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
@@ -60,7 +60,7 @@ func NewRemoveStaticallyEmptyExpressionsOptimizationPass(reg prometheus.Register
 }
 
 func (s *RemoveStaticallyEmptyExpressionsOptimizationPass) Name() string {
-	return "remove statically empty expressions"
+	return "Remove statically empty expressions"
 }
 
 func (s *RemoveStaticallyEmptyExpressionsOptimizationPass) Apply(ctx context.Context, plan *planning.QueryPlan, maximumSupportedQueryPlanVersion planning.QueryPlanVersion) (*planning.QueryPlan, error) {

--- a/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
+++ b/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
@@ -216,6 +216,13 @@ func unwrap(node planning.Node) planning.Node {
 			node = n.Inner
 		case *core.StepInvariantExpression:
 			node = n.Inner
+		case *core.FunctionCall:
+			if n.Function == functions.FUNCTION_ADAPTIVE_METRICS_RESERVED_1 || n.Function == functions.FUNCTION_ADAPTIVE_METRICS_RESERVED_2 {
+				// The Adaptive Metrics query rewriting can wrap a timestamp() call (eg. expression becomes wrapper(timestamp(...)) < T), so unwrap it.
+				node = n.Args[0]
+			} else {
+				return node
+			}
 		default:
 			return node
 		}

--- a/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
+++ b/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
@@ -4,10 +4,12 @@ package plan
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/prometheus/model/timestamp"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/operators/functions"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning"
@@ -117,7 +119,9 @@ func (s *RemoveStaticallyEmptyExpressionsOptimizationPass) apply(node planning.N
 		}
 	}
 
-	if isAlwaysEmpty(node, params) {
+	if empty, err := isAlwaysEmpty(node, params); err != nil {
+		return nil, false, err
+	} else if empty {
 		noOp := &core.NoOp{NoOpDetails: &core.NoOpDetails{}}
 		return noOp, true, nil
 	}
@@ -127,83 +131,134 @@ func (s *RemoveStaticallyEmptyExpressionsOptimizationPass) apply(node planning.N
 
 // isAlwaysEmpty returns true if node can be statically determined to produce an empty instant
 // vector for the entire query time range described by params.
-func isAlwaysEmpty(node planning.Node, params *planning.QueryParameters) bool {
+func isAlwaysEmpty(node planning.Node, params *planning.QueryParameters) (bool, error) {
 	node = unwrap(node)
 
 	switch node := node.(type) {
 	case *core.NoOp:
-		return true
+		return true, nil
 	case *core.BinaryExpression:
 		return isAlwaysEmptyBinaryExpression(node, params)
 	default:
-		return false
+		return false, nil
 	}
 }
 
-func isAlwaysEmptyBinaryExpression(node *core.BinaryExpression, params *planning.QueryParameters) bool {
-	earliestPossibleTimestampValueInMilliseconds := float64(params.TimeRange.StartT - params.LookbackDelta.Milliseconds())
-
+func isAlwaysEmptyBinaryExpression(node *core.BinaryExpression, params *planning.QueryParameters) (bool, error) {
 	if node.ReturnBool {
-		return false
+		return false, nil
 	}
 
 	switch node.Op {
 	case core.BINARY_LAND:
-		return isAlwaysEmpty(node.LHS, params) || isAlwaysEmpty(node.RHS, params)
+		lhsEmpty, err := isAlwaysEmpty(node.LHS, params)
+		if err != nil {
+			return false, err
+		}
+
+		if lhsEmpty {
+			return true, nil
+		}
+
+		return isAlwaysEmpty(node.RHS, params)
 
 	case core.BINARY_LSS:
-		// timestamp(v) < C: always empty when C <= the earliest value that timestamp() could return
-		// timestamp() returns the value in seconds since the epoch, so we need to convert to milliseconds.
-		if constant, ok := isTimestampComparison(node.LHS, node.RHS); ok {
-			return constant*1000 <= earliestPossibleTimestampValueInMilliseconds
-		}
+		// Check for timestamp(v) < C.
+		return isAlwaysEmptyTimestampComparison(node.LHS, node.RHS, false, params)
 
 	case core.BINARY_LTE:
-		// timestamp(v) <= C: always empty when C < the earliest value that timestamp() could return
-		if constant, ok := isTimestampComparison(node.LHS, node.RHS); ok {
-			return constant*1000 < earliestPossibleTimestampValueInMilliseconds
-		}
+		// Check for timestamp(v) <= C.
+		return isAlwaysEmptyTimestampComparison(node.LHS, node.RHS, true, params)
 
 	case core.BINARY_GTR:
-		// C > timestamp(v): equivalent to timestamp(v) < C.
-		if constant, ok := isTimestampComparison(node.RHS, node.LHS); ok {
-			return constant*1000 <= earliestPossibleTimestampValueInMilliseconds
-		}
+		// Check for C > timestamp(v), equivalent to timestamp(v) < C.
+		return isAlwaysEmptyTimestampComparison(node.RHS, node.LHS, false, params)
 
 	case core.BINARY_GTE:
-		// C >= timestamp(v): equivalent to timestamp(v) <= C.
-		if constant, ok := isTimestampComparison(node.RHS, node.LHS); ok {
-			return constant*1000 < earliestPossibleTimestampValueInMilliseconds
-		}
+		// Check for C >= timestamp(v), equivalent to timestamp(v) <= C.
+		return isAlwaysEmptyTimestampComparison(node.RHS, node.LHS, true, params)
 	}
 
-	return false
+	return false, nil
 }
 
-// isTimestampComparison checks whether timestampSide is (or wraps) a timestamp()
-// function call and constantSide is (or wraps) a NumberLiteral. If so, it returns the constant
-// value and true.
-func isTimestampComparison(timestampSide, constantSide planning.Node) (float64, bool) {
-	if !isTimestampCall(timestampSide) {
-		return 0, false
-	}
-
-	constantSide = unwrap(constantSide)
-	literal, ok := constantSide.(*core.NumberLiteral)
+// isAlwaysEmptyTimestampComparison returns true if timestampSide and constantSide represent
+// a timestamp(...) invocation and number literal respectively, and the value of constantSide
+// is such that the expression timestampSide < constantSide (inclusive=false) or
+// timestampSide <= constantSide (inclusive=true) can never return any results.
+func isAlwaysEmptyTimestampComparison(timestampSide, constantSide planning.Node, inclusive bool, params *planning.QueryParameters) (bool, error) {
+	timestampCall, ok := findTimestampCall(timestampSide)
 	if !ok {
-		return 0, false
+		return false, nil
 	}
 
-	return literal.Value, true
+	constant, ok := findConstant(constantSide)
+	if !ok {
+		return false, nil
+	}
+
+	if len(timestampCall.Args) < 1 {
+		// Should never happen, but check to avoid panicking here.
+		return false, fmt.Errorf("expected at least one argument in call to timestamp(), got %d", len(timestampCall.Args))
+	}
+
+	selector, timestampWrapsSelector := timestampCall.Args[0].(*core.VectorSelector)
+
+	// The expression timestamp(X) < C is guaranteed to return no results if the lowest possible
+	// value of timestamp(X) is greater than or equal to C.
+	//
+	// The expression timestamp(X) <= C is guaranteed to return no results if the lowest possible
+	// value of timestamp is greater than C.
+	//
+	// If X is a selector, then timestamp(X) will return the timestamps of the underlying samples, so we need to check
+	// the time range queried to account for the lookback window, offsets and @ modifiers.
+	//
+	// If X is not a selector, then timestamp(X) can only return timestamps of the steps in the query time range.
+
+	var earliestPossibleTimestampValueInMilliseconds float64
+	if timestampWrapsSelector {
+		timeRange, err := selector.QueriedTimeRange(params.TimeRange, params.LookbackDelta)
+		if err != nil {
+			return false, err
+		}
+		earliestPossibleTimestampValueInMilliseconds = float64(timestamp.FromTime(timeRange.MinT))
+	} else {
+		earliestPossibleTimestampValueInMilliseconds = float64(params.TimeRange.StartT)
+	}
+
+	constantInMilliseconds := constant.Value * 1000
+
+	if inclusive {
+		return earliestPossibleTimestampValueInMilliseconds > constantInMilliseconds, nil
+	}
+
+	return earliestPossibleTimestampValueInMilliseconds >= constantInMilliseconds, nil
 }
 
-// isTimestampCall returns true if node is (or wraps) a FunctionCall for the timestamp() function.
+// findTimestampCall returns the function node and true if node is (or wraps) a FunctionCall for the timestamp() function.
 // It unwraps DeduplicateAndMerge, DropName, and StepInvariantExpression layers transparently.
-func isTimestampCall(node planning.Node) bool {
+func findTimestampCall(node planning.Node) (*core.FunctionCall, bool) {
 	node = unwrap(node)
 
-	fc, ok := node.(*core.FunctionCall)
-	return ok && fc.Function == functions.FUNCTION_TIMESTAMP
+	f, ok := node.(*core.FunctionCall)
+	if !ok {
+		return nil, false
+	}
+
+	if f.Function == functions.FUNCTION_TIMESTAMP {
+		return f, true
+	}
+
+	return nil, false
+}
+
+// findConstant returns the number literal node and true if node is (or wraps) a NumberLiteral.
+// It unwraps DeduplicateAndMerge, DropName, and StepInvariantExpression layers transparently.
+func findConstant(node planning.Node) (*core.NumberLiteral, bool) {
+	node = unwrap(node)
+
+	literal, ok := node.(*core.NumberLiteral)
+	return literal, ok
 }
 
 // unwrap removes transparent wrapper nodes returning the innermost non-wrapper node.

--- a/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions_test.go
+++ b/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions_test.go
@@ -13,11 +13,16 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/streamingpromql"
+	"github.com/grafana/mimir/pkg/streamingpromql/operators/functions"
 	"github.com/grafana/mimir/pkg/streamingpromql/optimize/plan"
+	"github.com/grafana/mimir/pkg/streamingpromql/planning"
+	"github.com/grafana/mimir/pkg/streamingpromql/planning/core"
 	"github.com/grafana/mimir/pkg/streamingpromql/testutils"
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
 )
@@ -213,5 +218,70 @@ func TestRemoveStaticallyEmptyExpressionsOptimizationPass(t *testing.T) {
 				`, expectedModified)), "cortex_mimir_query_engine_remove_statically_empty_expressions_attempted_total", "cortex_mimir_query_engine_remove_statically_empty_expressions_modified_total",
 			))
 		})
+	}
+}
+
+func TestRemoveStaticallyEmptyExpressions_AdaptiveMetrics(t *testing.T) {
+	// This test confirms that expressions rewritten by Adaptive Metrics are correctly optimised away.
+	// Expressions like timestamp(foo) < C are rewritten to wrapper(timestamp(foo)) < C.
+
+	reg := prometheus.NewPedanticRegistry()
+	opts := streamingpromql.NewTestEngineOpts()
+	optimizationPass := plan.NewRemoveStaticallyEmptyExpressionsOptimizationPass(reg, opts.Logger)
+
+	for _, function := range []functions.Function{functions.FUNCTION_ADAPTIVE_METRICS_RESERVED_1, functions.FUNCTION_ADAPTIVE_METRICS_RESERVED_2} {
+		// We have to manually create the query plan instead of parsing it from an expression because the Adaptive Metrics wrapper
+		// functions aren't registered in open source Mimir.
+		selector := &core.VectorSelector{
+			VectorSelectorDetails: &core.VectorSelectorDetails{
+				Matchers: []*core.LabelMatcher{
+					{
+						Type:  labels.MatchEqual,
+						Name:  model.MetricNameLabel,
+						Value: "metric",
+					},
+				},
+			},
+		}
+
+		timestampFunctionCall := &core.FunctionCall{
+			FunctionCallDetails: &core.FunctionCallDetails{
+				Function: functions.FUNCTION_TIMESTAMP,
+			},
+			Args: []planning.Node{selector},
+		}
+
+		adaptiveMetricsWrapper := &core.FunctionCall{
+			FunctionCallDetails: &core.FunctionCallDetails{
+				Function: function,
+			},
+			Args: []planning.Node{
+				timestampFunctionCall,
+			},
+		}
+
+		scalar := &core.NumberLiteral{
+			NumberLiteralDetails: &core.NumberLiteralDetails{
+				Value: 1000,
+			},
+		}
+
+		queryPlan := &planning.QueryPlan{
+			Root: &core.BinaryExpression{
+				LHS: adaptiveMetricsWrapper,
+				RHS: scalar,
+				BinaryExpressionDetails: &core.BinaryExpressionDetails{
+					Op: core.BINARY_LTE,
+				},
+			},
+			Parameters: &planning.QueryParameters{
+				TimeRange: types.NewInstantQueryTimeRange(time.Unix(2000, 0)),
+			},
+		}
+
+		optimizedPlan, err := optimizationPass.Apply(context.Background(), queryPlan, planning.MaximumSupportedQueryPlanVersion)
+		require.NoError(t, err)
+
+		require.Equal(t, "- NoOp", optimizedPlan.String())
 	}
 }

--- a/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions_test.go
+++ b/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions_test.go
@@ -5,7 +5,6 @@ package plan_test
 import (
 	"context"
 	"fmt"
-	"math"
 	"strconv"
 	"strings"
 	"testing"
@@ -15,7 +14,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
-	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/streamingpromql"
@@ -30,7 +28,8 @@ import (
 func TestRemoveStaticallyEmptyExpressionsOptimizationPass(t *testing.T) {
 	const lookbackDelta = 5 * time.Minute
 	const constant = 1000
-	thresholdMs := (constant*time.Second + lookbackDelta).Milliseconds()
+	selectorThresholdMs := (constant*time.Second + lookbackDelta).Milliseconds() // Note that the lookback window is left-open.
+	nonSelectorThresholdMs := (constant * time.Second).Milliseconds()
 
 	testCases := map[string]struct {
 		expr            string
@@ -40,80 +39,137 @@ func TestRemoveStaticallyEmptyExpressionsOptimizationPass(t *testing.T) {
 	}{
 		"timestamp(v) < C: query time range is on threshold, should optimize": {
 			expr:       "timestamp(metric) < CONSTANT",
-			queryStart: time.UnixMilli(thresholdMs),
+			queryStart: time.UnixMilli(selectorThresholdMs - 1),
 			expectedPlan: `
 				- NoOp
 			`,
 		},
 		"timestamp(v) < bool C: would optimise because query time range is on threshold, but skipped due to bool modifier": {
 			expr:            "timestamp(metric) < bool CONSTANT",
-			queryStart:      time.UnixMilli(thresholdMs),
+			queryStart:      time.UnixMilli(selectorThresholdMs - 1),
 			expectUnchanged: true,
 		},
 		"timestamp(v) < C: query time range overlaps threshold, should not optimize": {
 			expr:            "timestamp(metric) < CONSTANT",
-			queryStart:      time.UnixMilli(thresholdMs - 1),
+			queryStart:      time.UnixMilli(selectorThresholdMs - 2),
 			expectUnchanged: true,
 		},
+		"timestamp(v offset -1ms) < C: query time range does not overlaps threshold, should optimize": {
+			expr:       "timestamp(metric offset -1ms) < CONSTANT",
+			queryStart: time.UnixMilli(selectorThresholdMs - 1),
+			expectedPlan: `
+				- NoOp
+			`,
+		},
+		"timestamp(v offset 1ms) < C: query time range overlaps threshold, should not optimize": {
+			expr:            "timestamp(metric offset 1ms) < CONSTANT",
+			queryStart:      time.UnixMilli(selectorThresholdMs - 1),
+			expectUnchanged: true,
+		},
+		"timestamp(abs(v)) < C: query time range is on threshold, should optimize": {
+			expr:       "timestamp(abs(v)) < CONSTANT",
+			queryStart: time.UnixMilli(nonSelectorThresholdMs),
+			expectedPlan: `
+				- NoOp
+			`,
+		},
+		"timestamp(abs(v)) < C: query time range is above threshold, should optimize": {
+			expr:       "timestamp(abs(v)) < CONSTANT",
+			queryStart: time.UnixMilli(nonSelectorThresholdMs + 1),
+			expectedPlan: `
+				- NoOp
+			`,
+		},
+		"timestamp(abs(v offset 1ms)) < C: query time range is above threshold, should optimize (offset and lookback delta ignored)": {
+			expr:       "timestamp(abs(v offset 1ms)) < CONSTANT",
+			queryStart: time.UnixMilli(nonSelectorThresholdMs + 1),
+			expectedPlan: `
+				- NoOp
+			`,
+		},
+
 		"timestamp(v) <= C: query range starts just above threshold, should optimize": {
 			expr:       "timestamp(metric) <= CONSTANT",
-			queryStart: time.UnixMilli(thresholdMs + 1),
+			queryStart: time.UnixMilli(selectorThresholdMs + 1),
 			expectedPlan: `
 				- NoOp
 			`,
 		},
-		"timestamp(v) <= C: query range starts exactly at threshold, should not optimize": {
+		"timestamp(v) <= C: query range starts exactly at threshold, should optimize": {
+			expr:       "timestamp(metric) <= CONSTANT",
+			queryStart: time.UnixMilli(selectorThresholdMs),
+			expectedPlan: `
+				- NoOp
+			`,
+		},
+		"timestamp(v) <= C: query range starts below threshold, should not optimize": {
 			expr:            "timestamp(metric) <= CONSTANT",
-			queryStart:      time.UnixMilli(thresholdMs),
+			queryStart:      time.UnixMilli(selectorThresholdMs - 1),
 			expectUnchanged: true,
 		},
-		"C > timestamp(v): query range at threshold, should optimize": {
-			expr:       "metric and CONSTANT > timestamp(metric)",
-			queryStart: time.UnixMilli(thresholdMs),
+		"C > timestamp(v): query range starts at threshold, should optimize": {
+			expr:       "CONSTANT > timestamp(metric)",
+			queryStart: time.UnixMilli(selectorThresholdMs),
 			expectedPlan: `
 				- NoOp
 			`,
 		},
-		"C > timestamp(v): query range before threshold, should not optimize": {
-			expr:            "metric and CONSTANT > timestamp(metric)",
-			queryStart:      time.UnixMilli(thresholdMs - 1),
-			expectUnchanged: true,
-		},
-		"C >= timestamp(v): query range just above threshold, should optimize": {
-			expr:       "metric and CONSTANT >= timestamp(metric)",
-			queryStart: time.UnixMilli(thresholdMs + 1),
+		"C > timestamp(v): query range starts before threshold, should optimize": {
+			expr:       "CONSTANT > timestamp(metric)",
+			queryStart: time.UnixMilli(selectorThresholdMs - 1),
 			expectedPlan: `
 				- NoOp
 			`,
 		},
-		"C >= timestamp(v): query range exactly at threshold, should not optimize": {
-			expr:            "metric and CONSTANT >= timestamp(metric)",
-			queryStart:      time.UnixMilli(thresholdMs),
+		"C >= timestamp(v): query range starts just above threshold, should optimize": {
+			expr:       "CONSTANT >= timestamp(metric)",
+			queryStart: time.UnixMilli(selectorThresholdMs + 1),
+			expectedPlan: `
+				- NoOp
+			`,
+		},
+		"C >= timestamp(v): query range starts exactly at threshold, should optimize": {
+			expr:       "CONSTANT >= timestamp(metric)",
+			queryStart: time.UnixMilli(selectorThresholdMs),
+			expectedPlan: `
+				- NoOp
+			`,
+		},
+		"C >= timestamp(v): query range starts just below threshold, should not optimize": {
+			expr:            "CONSTANT >= timestamp(metric)",
+			queryStart:      time.UnixMilli(selectorThresholdMs - 1),
 			expectUnchanged: true,
 		},
 
 		"non-timestamp comparison: should not optimize": {
 			expr:            "metric2 < CONSTANT",
-			queryStart:      time.UnixMilli(thresholdMs),
+			queryStart:      time.UnixMilli(selectorThresholdMs),
 			expectUnchanged: true,
 		},
 
-		"timestamp(v) < C with and: query range starts exactly at threshold, should optimize": {
+		"timestamp(v) < C with and: query range starts after threshold, should optimize": {
 			expr:       "metric and timestamp(metric) < CONSTANT",
-			queryStart: time.UnixMilli(thresholdMs),
+			queryStart: time.UnixMilli(selectorThresholdMs),
 			expectedPlan: `
 				- NoOp
 			`,
 		},
-		"timestamp(v) < C with and: query range starts just before before threshold, should not optimize": {
+		"timestamp(v) < C with and: query range starts at threshold, should optimize": {
+			expr:       "metric and timestamp(metric) < CONSTANT",
+			queryStart: time.UnixMilli(selectorThresholdMs - 1),
+			expectedPlan: `
+				- NoOp
+			`,
+		},
+		"timestamp(v) < C with and: query range starts before threshold, should not optimize": {
 			expr:            "metric and timestamp(metric) < CONSTANT",
-			queryStart:      time.UnixMilli(thresholdMs - 1),
+			queryStart:      time.UnixMilli(selectorThresholdMs - 2),
 			expectUnchanged: true,
 		},
 
 		"timestamp condition on LHS of and: should optimize": {
 			expr:       "timestamp(metric) < CONSTANT and metric",
-			queryStart: time.UnixMilli(thresholdMs),
+			queryStart: time.UnixMilli(selectorThresholdMs),
 			expectedPlan: `
 				- NoOp
 			`,
@@ -123,19 +179,19 @@ func TestRemoveStaticallyEmptyExpressionsOptimizationPass(t *testing.T) {
 			// The inner "and" has the timestamp filter → replaced with NoOp.
 			// The outer "and" then has NoOp as its LHS → also replaced with NoOp.
 			expr:       "(metric and timestamp(metric) < CONSTANT) and metric2",
-			queryStart: time.UnixMilli(thresholdMs),
+			queryStart: time.UnixMilli(selectorThresholdMs),
 			expectedPlan: `
 				- NoOp
 			`,
 		},
 		"nested and expressions: inner not optimized because not a no-op": {
 			expr:            "(metric and timestamp(metric) < CONSTANT) and metric2",
-			queryStart:      time.UnixMilli(thresholdMs - 1),
+			queryStart:      time.UnixMilli(selectorThresholdMs - 2),
 			expectUnchanged: true,
 		},
 		"nested and expressions: should optimize as far as possible": {
 			expr:       "(metric and timestamp(metric) < CONSTANT) or metric2",
-			queryStart: time.UnixMilli(thresholdMs),
+			queryStart: time.UnixMilli(selectorThresholdMs),
 			expectedPlan: `
 				- DeduplicateAndMerge
 					- BinaryExpression: LHS or RHS
@@ -146,14 +202,14 @@ func TestRemoveStaticallyEmptyExpressionsOptimizationPass(t *testing.T) {
 
 		"complex expression inside timestamp() that is a no-op: should optimize": {
 			expr:       `foo and timestamp(sum(metric)) < CONSTANT`,
-			queryStart: time.UnixMilli(thresholdMs),
+			queryStart: time.UnixMilli(nonSelectorThresholdMs),
 			expectedPlan: `
 				- NoOp
 			`,
 		},
 		"complex expression inside timestamp() that is not a no-op: should not optimize": {
 			expr:            `foo and timestamp(sum(metric)) < CONSTANT`,
-			queryStart:      time.UnixMilli(thresholdMs - 1),
+			queryStart:      time.UnixMilli(nonSelectorThresholdMs - 1),
 			expectUnchanged: true,
 		},
 
@@ -161,7 +217,7 @@ func TestRemoveStaticallyEmptyExpressionsOptimizationPass(t *testing.T) {
 			// The "and timestamp(metric) < CONSTANT" is outside the subquery, so it is evaluated
 			// at the outer query time range, which is after the threshold.
 			expr:       "avg_over_time(metric[5m:1m]) and timestamp(metric) < CONSTANT",
-			queryStart: time.UnixMilli(thresholdMs),
+			queryStart: time.UnixMilli(selectorThresholdMs),
 			expectedPlan: `
 				- NoOp
 			`,
@@ -196,7 +252,7 @@ func TestRemoveStaticallyEmptyExpressionsOptimizationPass(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			testCase.expr = strings.ReplaceAll(testCase.expr, "CONSTANT", strconv.Itoa(constant))
 
-			timeRange := types.NewRangeQueryTimeRange(testCase.queryStart, timestamp.Time(math.MaxInt64), time.Minute)
+			timeRange := types.NewRangeQueryTimeRange(testCase.queryStart, testCase.queryStart.Add(24*time.Hour), time.Minute)
 			expectedModified := 1
 
 			if testCase.expectUnchanged {

--- a/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions_test.go
+++ b/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions_test.go
@@ -28,7 +28,7 @@ import (
 func TestRemoveStaticallyEmptyExpressionsOptimizationPass(t *testing.T) {
 	const lookbackDelta = 5 * time.Minute
 	const constant = 1000
-	selectorThresholdMs := (constant*time.Second + lookbackDelta).Milliseconds() // Note that the lookback window is left-open.
+	selectorThresholdMs := (constant*time.Second + lookbackDelta).Milliseconds() - 1 // -1 because the lookback window is left-open.
 	nonSelectorThresholdMs := (constant * time.Second).Milliseconds()
 
 	testCases := map[string]struct {
@@ -39,31 +39,31 @@ func TestRemoveStaticallyEmptyExpressionsOptimizationPass(t *testing.T) {
 	}{
 		"timestamp(v) < C: query time range is on threshold, should optimize": {
 			expr:       "timestamp(metric) < CONSTANT",
-			queryStart: time.UnixMilli(selectorThresholdMs - 1),
+			queryStart: time.UnixMilli(selectorThresholdMs),
 			expectedPlan: `
 				- NoOp
 			`,
 		},
 		"timestamp(v) < bool C: would optimise because query time range is on threshold, but skipped due to bool modifier": {
 			expr:            "timestamp(metric) < bool CONSTANT",
-			queryStart:      time.UnixMilli(selectorThresholdMs - 1),
+			queryStart:      time.UnixMilli(selectorThresholdMs),
 			expectUnchanged: true,
 		},
 		"timestamp(v) < C: query time range overlaps threshold, should not optimize": {
 			expr:            "timestamp(metric) < CONSTANT",
-			queryStart:      time.UnixMilli(selectorThresholdMs - 2),
+			queryStart:      time.UnixMilli(selectorThresholdMs - 1),
 			expectUnchanged: true,
 		},
 		"timestamp(v offset -1ms) < C: query time range does not overlaps threshold, should optimize": {
 			expr:       "timestamp(metric offset -1ms) < CONSTANT",
-			queryStart: time.UnixMilli(selectorThresholdMs - 1),
+			queryStart: time.UnixMilli(selectorThresholdMs),
 			expectedPlan: `
 				- NoOp
 			`,
 		},
 		"timestamp(v offset 1ms) < C: query time range overlaps threshold, should not optimize": {
 			expr:            "timestamp(metric offset 1ms) < CONSTANT",
-			queryStart:      time.UnixMilli(selectorThresholdMs - 1),
+			queryStart:      time.UnixMilli(selectorThresholdMs),
 			expectUnchanged: true,
 		},
 		"timestamp(abs(v)) < C: query time range is on threshold, should optimize": {
@@ -90,86 +90,86 @@ func TestRemoveStaticallyEmptyExpressionsOptimizationPass(t *testing.T) {
 
 		"timestamp(v) <= C: query range starts just above threshold, should optimize": {
 			expr:       "timestamp(metric) <= CONSTANT",
-			queryStart: time.UnixMilli(selectorThresholdMs + 1),
+			queryStart: time.UnixMilli(selectorThresholdMs + 2),
 			expectedPlan: `
 				- NoOp
 			`,
 		},
 		"timestamp(v) <= C: query range starts exactly at threshold, should optimize": {
 			expr:       "timestamp(metric) <= CONSTANT",
-			queryStart: time.UnixMilli(selectorThresholdMs),
+			queryStart: time.UnixMilli(selectorThresholdMs + 1),
 			expectedPlan: `
 				- NoOp
 			`,
 		},
 		"timestamp(v) <= C: query range starts below threshold, should not optimize": {
 			expr:            "timestamp(metric) <= CONSTANT",
-			queryStart:      time.UnixMilli(selectorThresholdMs - 1),
+			queryStart:      time.UnixMilli(selectorThresholdMs),
 			expectUnchanged: true,
 		},
 		"C > timestamp(v): query range starts at threshold, should optimize": {
 			expr:       "CONSTANT > timestamp(metric)",
-			queryStart: time.UnixMilli(selectorThresholdMs),
+			queryStart: time.UnixMilli(selectorThresholdMs + 1),
 			expectedPlan: `
 				- NoOp
 			`,
 		},
 		"C > timestamp(v): query range starts before threshold, should optimize": {
 			expr:       "CONSTANT > timestamp(metric)",
-			queryStart: time.UnixMilli(selectorThresholdMs - 1),
+			queryStart: time.UnixMilli(selectorThresholdMs),
 			expectedPlan: `
 				- NoOp
 			`,
 		},
 		"C >= timestamp(v): query range starts just above threshold, should optimize": {
 			expr:       "CONSTANT >= timestamp(metric)",
-			queryStart: time.UnixMilli(selectorThresholdMs + 1),
+			queryStart: time.UnixMilli(selectorThresholdMs + 2),
 			expectedPlan: `
 				- NoOp
 			`,
 		},
 		"C >= timestamp(v): query range starts exactly at threshold, should optimize": {
 			expr:       "CONSTANT >= timestamp(metric)",
-			queryStart: time.UnixMilli(selectorThresholdMs),
+			queryStart: time.UnixMilli(selectorThresholdMs + 1),
 			expectedPlan: `
 				- NoOp
 			`,
 		},
 		"C >= timestamp(v): query range starts just below threshold, should not optimize": {
 			expr:            "CONSTANT >= timestamp(metric)",
-			queryStart:      time.UnixMilli(selectorThresholdMs - 1),
+			queryStart:      time.UnixMilli(selectorThresholdMs),
 			expectUnchanged: true,
 		},
 
 		"non-timestamp comparison: should not optimize": {
 			expr:            "metric2 < CONSTANT",
-			queryStart:      time.UnixMilli(selectorThresholdMs),
+			queryStart:      time.UnixMilli(selectorThresholdMs + 1),
 			expectUnchanged: true,
 		},
 
 		"timestamp(v) < C with and: query range starts after threshold, should optimize": {
 			expr:       "metric and timestamp(metric) < CONSTANT",
-			queryStart: time.UnixMilli(selectorThresholdMs),
+			queryStart: time.UnixMilli(selectorThresholdMs + 1),
 			expectedPlan: `
 				- NoOp
 			`,
 		},
 		"timestamp(v) < C with and: query range starts at threshold, should optimize": {
 			expr:       "metric and timestamp(metric) < CONSTANT",
-			queryStart: time.UnixMilli(selectorThresholdMs - 1),
+			queryStart: time.UnixMilli(selectorThresholdMs),
 			expectedPlan: `
 				- NoOp
 			`,
 		},
 		"timestamp(v) < C with and: query range starts before threshold, should not optimize": {
 			expr:            "metric and timestamp(metric) < CONSTANT",
-			queryStart:      time.UnixMilli(selectorThresholdMs - 2),
+			queryStart:      time.UnixMilli(selectorThresholdMs - 1),
 			expectUnchanged: true,
 		},
 
 		"timestamp condition on LHS of and: should optimize": {
 			expr:       "timestamp(metric) < CONSTANT and metric",
-			queryStart: time.UnixMilli(selectorThresholdMs),
+			queryStart: time.UnixMilli(selectorThresholdMs + 1),
 			expectedPlan: `
 				- NoOp
 			`,
@@ -179,19 +179,19 @@ func TestRemoveStaticallyEmptyExpressionsOptimizationPass(t *testing.T) {
 			// The inner "and" has the timestamp filter → replaced with NoOp.
 			// The outer "and" then has NoOp as its LHS → also replaced with NoOp.
 			expr:       "(metric and timestamp(metric) < CONSTANT) and metric2",
-			queryStart: time.UnixMilli(selectorThresholdMs),
+			queryStart: time.UnixMilli(selectorThresholdMs + 1),
 			expectedPlan: `
 				- NoOp
 			`,
 		},
 		"nested and expressions: inner not optimized because not a no-op": {
 			expr:            "(metric and timestamp(metric) < CONSTANT) and metric2",
-			queryStart:      time.UnixMilli(selectorThresholdMs - 2),
+			queryStart:      time.UnixMilli(selectorThresholdMs - 1),
 			expectUnchanged: true,
 		},
 		"nested and expressions: should optimize as far as possible": {
 			expr:       "(metric and timestamp(metric) < CONSTANT) or metric2",
-			queryStart: time.UnixMilli(selectorThresholdMs),
+			queryStart: time.UnixMilli(selectorThresholdMs + 1),
 			expectedPlan: `
 				- DeduplicateAndMerge
 					- BinaryExpression: LHS or RHS
@@ -217,7 +217,7 @@ func TestRemoveStaticallyEmptyExpressionsOptimizationPass(t *testing.T) {
 			// The "and timestamp(metric) < CONSTANT" is outside the subquery, so it is evaluated
 			// at the outer query time range, which is after the threshold.
 			expr:       "avg_over_time(metric[5m:1m]) and timestamp(metric) < CONSTANT",
-			queryStart: time.UnixMilli(selectorThresholdMs),
+			queryStart: time.UnixMilli(selectorThresholdMs + 1),
 			expectedPlan: `
 				- NoOp
 			`,

--- a/pkg/streamingpromql/testdata/ours/functions.test
+++ b/pkg/streamingpromql/testdata/ours/functions.test
@@ -1531,3 +1531,53 @@ eval instant at 70s mad_over_time(metric_histogram{type="mix"}[70s])
   {type="mix"} 0
 
 clear
+
+# Test the "remove statically empty expressions" optimization pass doesn't cause incorrect results.
+# Note that these tests aren't sufficient to test that the optimisation pass applies when it should -
+# just that the optimisation pass doesn't apply when it shouldn't.
+
+load 1s
+  metric_1 1+1x2000
+
+load 500ms
+  metric_2 0 0.5 1 1.5 2 2.5 3 3.5 4 4.5 _x600 305
+  metric_3 0 0.5 1 1.5 2 2.5 3 3.5 4 4.5 5 _x599 305
+
+# Test the simple case first: selector wrapped in another function, so timestamp() can only return the evaluation timestamp.
+eval instant at 0s timestamp(abs(metric_1)) < 1000
+  {} 0
+
+eval instant at 999s timestamp(abs(metric_1)) < 1000
+  {} 999
+
+eval instant at 1000s timestamp(abs(metric_1)) < 1000
+  # Should be empty.
+
+eval instant at 999s timestamp(abs(metric_1)) <= 1000
+  {} 999
+
+eval instant at 1000s timestamp(abs(metric_1)) <= 1000
+  {} 1000
+
+eval instant at 1001s timestamp(abs(metric_1)) <= 1000
+  # Should be empty.
+
+# More complex case: timestamp() directly over a selector, so need to consider the lookback window.
+# At T=305s, the range of samples that could be selected is (305-(5*60), 305] = (5, 305] (the lookback window is not inclusive).
+eval instant at 0s timestamp(metric_2) < 5
+  {} 0
+
+eval instant at 304s timestamp(metric_2) < 5
+  {} 4.5
+
+eval instant at 305s timestamp(metric_2) < 5
+  # Should be empty
+
+eval instant at 304s timestamp(metric_3) <= 5
+  {} 5
+
+eval instant at 305s timestamp(metric_3) <= 5
+  # Should be empty
+
+eval instant at 306s timestamp(metric_3) <= 5
+  # Should be empty


### PR DESCRIPTION
#### What this PR does

This PR fixes two issues in the "remove statically empty expressions" optimisation pass:

* it is ineffective when applied to queries rewritten by Grafana Cloud's Adaptive Metrics feature
* it can incorrectly determine that an expression is empty if the expression is a `timestamp()` function call directly on a selector and that selector contains an offset or @ modifier

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/pull/14989

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches query-planning optimization logic for `timestamp()` comparisons; mistakes could change whether parts of queries are skipped, but the change is narrowly scoped and backed by expanded tests.
> 
> **Overview**
> Fixes the MQE `RemoveStaticallyEmptyExpressions` optimization so it no longer misclassifies `timestamp()` comparisons as empty when `timestamp()` wraps a selector with `offset`/`@` (now derives the earliest possible sample time via the selector’s queried time range), while still optimizing non-selector `timestamp(<expr>)` comparisons based only on the evaluation start.
> 
> Makes the optimization effective for Grafana Cloud Adaptive Metrics rewrites by unwrapping the reserved wrapper functions around `timestamp()` calls, adds defensive error handling, and expands unit/integration tests plus a changelog reference update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2342b78a2503262ce593f897885d792ce5134584. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->