### PR TITLE
Compactor dashboard: make autoscaling panels work with other scaling metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 * [ENHANCEMENT] Distributor: Add zone-aware rate limiting via `-distributor.ring.instance-availability-zone`. When configured the global ingestion rate limit is divided by the number of zones and the number of distributors in the local zone, instead of the total number of distributors. #14515
 * [ENHANCEMENT] Memberlist: Add experimental propagation delay tracker to measure gossip propagation delay across the memberlist cluster. Enable with `-memberlist.propagation-delay-tracker.enabled=true`. #14312 #14406
 * [ENHANCEMENT] Memberlist: Add `-memberlist.received-messages-queue-size` to configure the size of the internal queue for messages received from other nodes. Increasing this value may help to avoid dropping messages when the node is processing a large number of messages from other nodes. #14995
+* [ENHANCEMENT] Compactor: Make the compactor dashboard autoscaling panel work with non-CPU scaling metrics. #15017
 * [ENHANCEMENT] Compactor: Add 0-100% jitter to the first compaction interval to spread compactions when multiple compactors start simultaneously. #14280
 * [ENHANCEMENT] Compactor, Store-gateway: Remove experimental setting `-compactor.upload-sparse-index-headers` and always upload sparse index-headers. This improves lazy loading performance in the store-gateway. #13089 #13882
 * [ENHANCEMENT] Querier: Reduce memory consumption of queries samples for a single series are retrieved from multiple ingesters or store-gateways. #13806

--- a/operations/mimir-mixin/dashboards/compactor.libsonnet
+++ b/operations/mimir-mixin/dashboards/compactor.libsonnet
@@ -484,6 +484,15 @@ local fixTargetsForTransformations(panel, refIds) = panel {
     )
     .addRowIf(
       $._config.autoscaling.compactor.enabled,
-      $.cpuBasedAutoScalingRow('Compactor'),
+      $.row('Compactor – autoscaling')
+      .addPanel(
+        $.autoScalingActualReplicas('compactor')
+      )
+      .addPanel(
+        $.autoScalingDesiredReplicasByAverageValueScalingMetricPanel('compactor', scalingMetricName='', scalingMetricID='')
+      )
+      .addPanel(
+        $.autoScalingFailuresPanel('compactor')
+      )
     ),
 }

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -944,19 +944,6 @@ local utils = import 'mixin-utils/utils.libsonnet';
       |||
     ),
 
-  cpuBasedAutoScalingRow(componentTitle)::
-    local componentName = std.strReplace(std.asciiLower(componentTitle), '-', '_');
-    super.row('%s – autoscaling' % [componentTitle])
-    .addPanel(
-      $.autoScalingActualReplicas(componentName)
-    )
-    .addPanel(
-      $.autoScalingDesiredReplicasByAverageValueScalingMetricPanel(componentName, 'CPU', 'cpu')
-    )
-    .addPanel(
-      $.autoScalingFailuresPanel(componentName)
-    ),
-
   cpuAndMemoryBasedAutoScalingRow(componentTitle)::
     local componentName = std.strReplace(std.asciiLower(componentTitle), '-', '_');
     super.row('%s – autoscaling' % [componentTitle])


### PR DESCRIPTION
#### What this PR does

Makes the compactor dashboard autoscaling row work with any KEDA scaler for the compactor HPA, not just for ones matching the `.*cpu.*` filter. 

As part of the compactor scheduler work, at Grafana Labs we are experimenting with a new autoscaler based on the scheduler's queue work. This adds support for displaying that signal here.

Preview:

<details>
<summary>Before</summary>

<img width="1843" height="477" alt="image" src="https://github.com/user-attachments/assets/7e5984bb-634d-4ee8-aa91-edd7f128bcb8" />

</details>

<details>
<summary>Now (cell without new autoscaler)</summary>

<img width="1848" height="484" alt="image" src="https://github.com/user-attachments/assets/c0a58744-a697-4105-bb48-b122c03bfb88" />


</details>

<details>
<summary>Now (cell with new autoscaler)</summary>

<img width="1846" height="491" alt="image" src="https://github.com/user-attachments/assets/cb7fd049-26a3-4508-bd20-259305c3da18" />


</details>

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dashboard-only change: updates Jsonnet mixin panels and removes a helper; risk is limited to Grafana/KEDA metric display correctness for compactor autoscaling.
> 
> **Overview**
> Updates the compactor Grafana dashboard autoscaling row to work with *any* KEDA scaling metric, not just CPU-based scalers, by switching from the CPU-specific `cpuBasedAutoScalingRow` helper to an explicit row that uses `autoScalingDesiredReplicasByAverageValueScalingMetricPanel` without a `cpu` scaler filter.
> 
> Removes the now-unused `cpuBasedAutoScalingRow` helper from `dashboard-utils.libsonnet`, and adds a corresponding `CHANGELOG.md` enhancement entry for the compactor dashboard autoscaling panel fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1279f830383c2f765c99fae95d8d7793ae46c82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->