### PR TITLE
Revert "HA dedup on every sample (#13665)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,7 +171,6 @@
 * [ENHANCEMENT] Store-gateway: Add experimental flag `blocks-storage.bucket-store.partitioner-max-gap-bytes-chunks` to specify the gap size for the chunks partitioner. #14649
 * [ENHANCEMENT] Compactor: Add expermental `-compactor.first-level-compaction-ooo-wait-period` to configure a separate compaction wait period for out-of-order blocks. It's an analogue of `-compactor.first-level-compaction-wait-period`, which currently ignores out-of-order blocks. #14627
 * [ENHANCEMENT] Block-builder: Support for experimental `-blocks-storage.tsdb.early-head-compaction-min-in-memory-series` to enforce early head compaction, if in-memory series reach threshold. #14678
-* [ENHANCEMENT] HA: Deduplicate per sample instead of per batch. #13665
 * [ENHANCEMENT] Usage-tracker: Improve performance of TrackSeriesBatch by preprocessing input data. #14702 #14734
 * [ENHANCEMENT] MQE: Improve per-query memory consumption limit enforcement in histogram function evaluations. #14691
 * [ENHANCEMENT] MQE: Improve per-query memory consumption limit enforcement within aggregation operations. #14735

--- a/docs/sources/mimir/configure/configure-high-availability-deduplication.md
+++ b/docs/sources/mimir/configure/configure-high-availability-deduplication.md
@@ -45,14 +45,7 @@ Incoming samples are considered duplicated (and thus dropped) if they are receiv
 
 If the HA tracker is enabled but incoming samples contain only one or none of the cluster and replica labels, these samples are accepted by default and never deduplicated.
 
-> Note: the HA tracker checks the cluster and replica label of every series in the request to determine whether each series in the request should be deduplicated.
-
-### Error responses
-
-When the HA tracker drops samples, Mimir returns one of the following errors depending on the reason:
-
-- **Replicas did not match**: When samples are received from a non-elected replica, Mimir returns an HTTP `202 Accepted` response with the message `replicas did not match, rejecting sample: replica=<replica>, elected=<elected>`. This indicates that the samples were successfully deduplicated and can be safely ignored.
-- **Too many HA clusters**: When the number of HA clusters for a tenant exceeds the configured limit, Mimir returns an HTTP `400 Bad Request` response with the error ID `err-mimir-tenant-too-many-ha-clusters`. To adjust this limit, configure `-distributor.ha-tracker.max-clusters` or contact your service administrator.
+> Note: for performance reasons, the HA tracker only checks the cluster and replica label of the first series in the request to determine whether all series in the request should be deduplicated. This assumes that all series inside the request have the same cluster and replica labels, which is typically true when Prometheus is configured with external labels. Ensure this requirement is honored if you have a non-standard Prometheus setup (for example, you're using Prometheus federation or have a metrics proxy in between).
 
 ## Configuration
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -29,7 +29,6 @@ import (
 	"github.com/grafana/dskit/limiter"
 	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/mtime"
-	"github.com/grafana/dskit/multierror"
 	"github.com/grafana/dskit/ring"
 	ring_client "github.com/grafana/dskit/ring/client"
 	"github.com/grafana/dskit/services"
@@ -1176,162 +1175,6 @@ func (d *Distributor) wrapPushWithMiddlewares(next PushFunc) PushFunc {
 
 }
 
-type replicaState int
-
-const (
-	// replicaRejectedUnknown sample is rejected due to an unknown error.
-	replicaRejectedUnknown replicaState = 0
-	// replicaIsPrimary sample is from the elected primary replica and should be accepted.
-	replicaIsPrimary replicaState = 1 << iota
-	// replicaNotHA sample doesn't have both HA labels and should be accepted.
-	replicaNotHA
-	// replicaDeduped sample is from a non-primary replica and should be deduplicated.
-	replicaDeduped
-	// replicaRejectedTooManyClusters sample is rejected because the tenant has too many HA clusters.
-	replicaRejectedTooManyClusters
-
-	replicaAccepted = replicaIsPrimary | replicaNotHA
-)
-
-func (r replicaState) equals(other replicaState) bool {
-	if other == replicaRejectedUnknown {
-		return r == replicaRejectedUnknown
-	}
-	return r&other != 0
-}
-
-type haReplica struct {
-	cluster, replica string
-}
-
-type replicaInfo struct {
-	state       replicaState
-	sampleCount int
-}
-
-// replicaObserved checks if a sample from a given replica should be accepted for ingestion based on HA deduplication rules.
-func (d *Distributor) replicaObserved(ctx context.Context, userID string, replica haReplica, ts int64) (replicaState, error) {
-	isAccepted, err := d.checkSample(ctx, userID, replica.cluster, replica.replica, ts)
-	if err != nil {
-		var replicasDidNotMatch *replicasDidNotMatchError
-		var tooManyClusters *tooManyClustersError
-		switch {
-		case errors.As(err, &replicasDidNotMatch):
-			// These samples have been deduped.
-			return replicaDeduped, err
-		case errors.As(err, &tooManyClusters):
-			return replicaRejectedTooManyClusters, err
-		default:
-			return replicaRejectedUnknown, err
-		}
-	}
-
-	if isAccepted {
-		return replicaIsPrimary, nil
-	}
-	// If there wasn't an error but isAccepted is false that means we didn't find both HA labels.
-	return replicaNotHA, nil
-}
-
-func getEarliestSampleTimestamp(req *mimirpb.WriteRequest, defaultTimestamp int64) int64 {
-	earliestSampleTimestamp := defaultTimestamp
-	for _, ts := range req.Timeseries {
-		if len(ts.Samples) > 0 {
-			tsms := ts.Samples[0].TimestampMs
-			if tsms < earliestSampleTimestamp {
-				earliestSampleTimestamp = tsms
-			}
-		}
-		if len(ts.Histograms) > 0 {
-			tsms := ts.Histograms[0].Timestamp
-			if tsms < earliestSampleTimestamp {
-				earliestSampleTimestamp = tsms
-			}
-		}
-	}
-	return earliestSampleTimestamp
-}
-
-func (d *Distributor) processHaReplicas(ctx context.Context, userID string, sampleTimestamp int64, replicaInfos map[haReplica]*replicaInfo) (map[replicaState]int, error) {
-	var rejectionErrs, dedupErrs multierror.MultiError
-	samplesPerState := make(map[replicaState]int)
-	for replicaKey, info := range replicaInfos {
-		if info.state.equals(replicaRejectedUnknown) {
-			state, replicaErr := d.replicaObserved(ctx, userID, replicaKey, sampleTimestamp)
-			if replicaErr != nil {
-				// Collect rejection errors before dedup errors so that toErrorWithGRPCStatus
-				// deterministically picks the higher-severity gRPC status code.
-				if state == replicaDeduped {
-					dedupErrs.Add(replicaErr)
-				} else {
-					rejectionErrs.Add(replicaErr)
-				}
-			}
-			info.state = state
-		}
-		samplesPerState[info.state] += info.sampleCount
-	}
-
-	var errs multierror.MultiError
-	for _, err := range rejectionErrs {
-		errs.Add(err)
-	}
-	for _, err := range dedupErrs {
-		errs.Add(err)
-	}
-	return samplesPerState, errs.Err()
-}
-
-var haReplicaSlicePool = sync.Pool{
-	New: func() interface{} {
-		s := make([]haReplica, 0, 2500)
-		return &s
-	},
-}
-
-func getReplicasAndInfos(req *mimirpb.WriteRequest, haReplicaLabel, haClusterLabel string) (*[]haReplica, map[haReplica]*replicaInfo) {
-	count := len(req.Timeseries)
-	replicasPtr := haReplicaSlicePool.Get().(*[]haReplica)
-	if cap(*replicasPtr) < count {
-		*replicasPtr = make([]haReplica, count)
-	} else {
-		*replicasPtr = (*replicasPtr)[:count]
-	}
-
-	replicas := *replicasPtr
-	replicaInfos := make(map[haReplica]*replicaInfo)
-
-	var previousReplica haReplica
-	var previousInfo *replicaInfo
-
-	for i, ts := range req.Timeseries {
-		currentReplica := findHALabels(haReplicaLabel, haClusterLabel, ts.Labels)
-		replicas[i] = currentReplica
-
-		// If the current replica is the same as the previous one
-		// we skip the map lookup and update the count directly.
-		if i > 0 && currentReplica == previousReplica {
-			previousInfo.sampleCount += len(ts.Samples) + len(ts.Histograms)
-			continue
-		}
-
-		info, found := replicaInfos[currentReplica]
-		if !found {
-			// The replica info is stored in a map where the key is the replica itself.
-			// The replica labels are references to the request buffer, which will be reused.
-			// To safely use the replica as map key, we need to clone its labels.
-			currentReplica.cluster = strings.Clone(currentReplica.cluster)
-			currentReplica.replica = strings.Clone(currentReplica.replica)
-			info = &replicaInfo{}
-			replicaInfos[currentReplica] = info
-		}
-		info.sampleCount += len(ts.Samples) + len(ts.Histograms)
-		previousReplica = currentReplica
-		previousInfo = info
-	}
-	return replicasPtr, replicaInfos
-}
-
 func (d *Distributor) prePushHaDedupeMiddleware(next PushFunc) PushFunc {
 	return WithCleanup(next, func(next PushFunc, ctx context.Context, pushReq *Request) error {
 		req, err := pushReq.WriteRequest()
@@ -1349,176 +1192,75 @@ func (d *Distributor) prePushHaDedupeMiddleware(next PushFunc) PushFunc {
 		}
 
 		haReplicaLabel := d.limits.HAReplicaLabel(userID)
-		haClusterLabel := d.limits.HAClusterLabel(userID)
-
-		replicasPtr, replicaInfos := getReplicasAndInfos(req, haReplicaLabel, haClusterLabel)
-		replicas := *replicasPtr
-		defer func() {
-			var zero haReplica
-			for i := range replicas {
-				replicas[i] = zero
-			}
-			haReplicaSlicePool.Put(replicasPtr)
-		}()
+		cluster, replica := findHALabels(haReplicaLabel, d.limits.HAClusterLabel(userID), req.Timeseries[0].Labels)
+		// Make a copy of these, since they may be retained as labels on our metrics, e.g. dedupedSamples.
+		cluster, replica = strings.Clone(cluster), strings.Clone(replica)
 
 		span := trace.SpanFromContext(ctx)
+		span.SetAttributes(
+			attribute.String("cluster", cluster),
+			attribute.String("replica", replica),
+		)
 
+		numSamples := 0
 		now := time.Now()
-
 		group := d.activeGroups.UpdateActiveGroupTimestamp(userID, validation.GroupLabel(d.limits, userID, req.Timeseries), now)
 		sampleTimestamp := timestamp.FromTime(now)
 		if d.limits.HATrackerUseSampleTimeForFailover(userID) {
-			sampleTimestamp = getEarliestSampleTimestamp(req, sampleTimestamp)
-		}
-
-		var errs multierror.MultiError
-
-		if span.IsRecording() {
-			var clustersAsStrings, replicasAsStrings strings.Builder
-			isFirst := true
-			for replicaKey := range replicaInfos {
-				if !isFirst {
-					clustersAsStrings.WriteString(", ")
-					replicasAsStrings.WriteString(", ")
+			earliestSampleTimestamp := sampleTimestamp
+			for _, ts := range req.Timeseries {
+				if len(ts.Samples) > 0 {
+					tsms := ts.Samples[0].TimestampMs
+					if tsms < earliestSampleTimestamp {
+						earliestSampleTimestamp = tsms
+					}
 				}
-				clustersAsStrings.WriteString(replicaKey.cluster)
-				replicasAsStrings.WriteString(replicaKey.replica)
-				isFirst = false
+				if len(ts.Histograms) > 0 {
+					tsms := ts.Histograms[0].Timestamp
+					if tsms < earliestSampleTimestamp {
+						earliestSampleTimestamp = tsms
+					}
+				}
 			}
-			span.SetAttributes(
-				attribute.String("clusters", clustersAsStrings.String()),
-				attribute.String("replicas", replicasAsStrings.String()),
-			)
+			sampleTimestamp = earliestSampleTimestamp
+		}
+		for _, ts := range req.Timeseries {
+			numSamples += len(ts.Samples) + len(ts.Histograms)
 		}
 
-		samplesPerState, processErr := d.processHaReplicas(ctx, userID, sampleTimestamp, replicaInfos)
-		if processErr != nil {
-			errs.Add(processErr)
-		}
-
-		// Capture labels before sortByAccepted reorders timeseries and mixes rejection types.
-		var tooManyClustersLabels []mimirpb.LabelAdapter
-		if samplesPerState[replicaRejectedTooManyClusters] > 0 {
-			tooManyClustersLabels = findLabelsForRejectedTooManyClusters(replicaInfos, replicas, req)
-		}
-
-		lastAccepted := sortByAccepted(req, replicaInfos, replicas)
-		removeHAReplicaLabels(req, lastAccepted, replicas, replicaInfos, haReplicaLabel)
-
-		// We don't want to send samples beyond the last accepted sample - that was deduplicated
-		d.updateHADedupeMetrics(userID, group, replicaInfos, samplesPerState, tooManyClustersLabels)
-
-		// Free the unaccepted (deduplicated/rejected) timeseries immediately and truncate
-		// the slice so downstream middleware only sees accepted timeseries. We must NOT
-		// defer restoration of the original slice header because downstream middleware
-		// (e.g., validation, relabeling) may compact req.Timeseries via RemoveSliceIndexes,
-		// which shifts elements in the backing array. Restoring the original header would
-		// then expose duplicate references, causing double-frees when ReuseSlice runs.
-		for i := lastAccepted + 1; i < len(req.Timeseries); i++ {
-			mimirpb.ReusePreallocTimeseries(&req.Timeseries[i])
-		}
-		req.Timeseries = req.Timeseries[:lastAccepted+1]
-
-		if len(req.Timeseries) > 0 {
-			if pushErr := next(ctx, pushReq); pushErr != nil {
-				// Return only the push error: combining it with dedup errors in a multierror
-				// would let errors.As find replicasDidNotMatchError first, masking 5xx with 202.
-				return pushErr
+		removeReplica, err := d.checkSample(ctx, userID, cluster, replica, sampleTimestamp)
+		if err != nil {
+			if errors.As(err, &replicasDidNotMatchError{}) {
+				// These samples have been deduped.
+				d.dedupedSamples.WithLabelValues(userID, cluster).Add(float64(numSamples))
 			}
+
+			if errors.As(err, &tooManyClustersError{}) {
+				d.discardedSamplesTooManyHaClusters.WithLabelValues(userID, group).Add(float64(numSamples))
+				d.costAttributionMgr.SampleTracker(userID).IncrementDiscardedSamples(req.Timeseries[0].Labels, float64(numSamples), reasonTooManyHAClusters, now)
+			}
+
+			return err
 		}
 
-		return errs.Err()
+		if removeReplica {
+			// If we found both the cluster and replica labels, we only want to include the cluster label when
+			// storing series in Mimir. If we kept the replica label we would end up with another series for the same
+			// series we're trying to dedupe when HA tracking moves over to a different replica.
+			for ix := range req.Timeseries {
+				req.Timeseries[ix].RemoveLabel(haReplicaLabel)
+			}
+		} else {
+			// If there wasn't an error but removeReplica is false that means we didn't find both HA labels.
+			d.nonHASamples.WithLabelValues(userID).Add(float64(numSamples))
+		}
+
+		return next(ctx, pushReq)
 	})
-}
-
-func removeHAReplicaLabels(req *mimirpb.WriteRequest, lastAccepted int, replicas []haReplica, replicaInfos map[haReplica]*replicaInfo, haReplicaLabel string) {
-	for i := 0; i <= lastAccepted; i++ {
-		r := replicas[i]
-		if !replicaInfos[r].state.equals(replicaIsPrimary) {
-			continue
-		}
-		// If we found both the cluster and replica labels, we only want to include the cluster label when
-		// storing series in Mimir. If we kept the replica label we would end up with another series for the same
-		// series we're trying to dedupe when HA tracking moves over to a different replica.
-		req.Timeseries[i].RemoveLabel(haReplicaLabel)
-	}
-}
-
-// updateHADedupeMetrics updates metrics related to HA deduplication.
-func (d *Distributor) updateHADedupeMetrics(userID, group string, replicaInfos map[haReplica]*replicaInfo, samplesPerState map[replicaState]int, tooManyClustersLabels []mimirpb.LabelAdapter) {
-	for replica, info := range replicaInfos {
-		if info.state.equals(replicaDeduped) && info.sampleCount > 0 {
-			cluster := strings.Clone(replica.cluster) // Make a copy of this, since it may be retained as labels on our metrics
-			d.dedupedSamples.WithLabelValues(userID, cluster).Add(float64(info.sampleCount))
-		}
-	}
-	if samplesPerState[replicaNotHA] > 0 {
-		d.nonHASamples.WithLabelValues(userID).Add(float64(samplesPerState[replicaNotHA]))
-	}
-	if samplesPerState[replicaRejectedTooManyClusters] > 0 {
-		d.costAttributionMgr.SampleTracker(userID).IncrementDiscardedSamples(tooManyClustersLabels, float64(samplesPerState[replicaRejectedTooManyClusters]), reasonTooManyHAClusters, time.Now())
-		d.discardedSamplesTooManyHaClusters.WithLabelValues(userID, group).Add(float64(samplesPerState[replicaRejectedTooManyClusters]))
-	}
-}
-
-// findLabelsForRejectedTooManyClusters finds labels from a timeseries whose replica was rejected for too many clusters.
-func findLabelsForRejectedTooManyClusters(replicaInfos map[haReplica]*replicaInfo, replicas []haReplica, req *mimirpb.WriteRequest) []mimirpb.LabelAdapter {
-	var rejectedReplica haReplica
-	for replica, info := range replicaInfos {
-		if info.state.equals(replicaRejectedTooManyClusters) {
-			rejectedReplica = replica
-			break
-		}
-	}
-	for i, r := range replicas {
-		if r == rejectedReplica {
-			return req.Timeseries[i].Labels
-		}
-	}
-	return nil
-}
-
-// sortByAccepted returns the index of the last accepted timeseries in the write request based on the ha dedup states of the replicas
-func sortByAccepted(req *mimirpb.WriteRequest, replicaInfos map[haReplica]*replicaInfo, replicas []haReplica) int {
-	left := 0
-	right := len(replicas) - 1
-	for left < right {
-		for left < right && replicaInfos[replicas[left]].state.equals(replicaAccepted) {
-			left++
-		}
-		for right > left && !replicaInfos[replicas[right]].state.equals(replicaAccepted) {
-			right--
-		}
-		if left == right {
-			break
-		}
-		req.Timeseries[left], req.Timeseries[right] = req.Timeseries[right], req.Timeseries[left]
-		replicas[left], replicas[right] = replicas[right], replicas[left]
-		left++
-		right--
-	}
-
-	// At this point:
-	// - All elements before left are accepted
-	// - All elements after right are rejected
-	// - If left == right, we need to check that element
-	// - If left > right, partition is complete and right is the last accepted index
-
-	if left == right {
-		// Check the element at the meeting point
-		if replicaInfos[replicas[left]].state.equals(replicaAccepted) {
-			return left
-		}
-		return left - 1
-	}
-
-	// left > right, so right is the index of the last accepted element
-	return right
 }
 
 func (d *Distributor) prePushRelabelMiddleware(next PushFunc) PushFunc {
 	return WithCleanup(next, func(next PushFunc, ctx context.Context, pushReq *Request) error {
-
 		req, err := pushReq.WriteRequest()
 		if err != nil {
 			return err

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"math"
 	"math/rand"
-	"net/http"
 	"path/filepath"
 	"slices"
 	"sort"
@@ -2231,7 +2230,7 @@ func mkLabels(n int, extra ...string) []mimirpb.LabelAdapter {
 
 func BenchmarkDistributor_Push(b *testing.B) {
 	const (
-		numSeriesPerRequest = 1024
+		numSeriesPerRequest = 1000
 	)
 	ctx := user.InjectOrgID(context.Background(), "user")
 
@@ -2379,83 +2378,6 @@ func BenchmarkDistributor_Push(b *testing.B) {
 
 				for i := 0; i < numSeriesPerRequest; i++ {
 					metrics[i] = mkLabels(10, "team", strconv.Itoa(i%4))
-					samples[i] = mimirpb.Sample{
-						Value:       float64(i),
-						TimestampMs: time.Now().UnixNano() / int64(time.Millisecond),
-					}
-				}
-
-				return metrics, samples
-			},
-			expectedErr: "",
-		},
-		"HA dedup; no HA samples in the request": {
-			prepareConfig: func(limits *validation.Limits) {
-				limits.AcceptHASamples = true
-			},
-			prepareSeries: func() ([][]mimirpb.LabelAdapter, []mimirpb.Sample) {
-				metrics := make([][]mimirpb.LabelAdapter, numSeriesPerRequest)
-				samples := make([]mimirpb.Sample, numSeriesPerRequest)
-
-				for i := 0; i < numSeriesPerRequest; i++ {
-					metrics[i] = mkLabels(25, "team", strconv.Itoa(i%4))
-					samples[i] = mimirpb.Sample{
-						Value:       float64(i),
-						TimestampMs: time.Now().UnixNano() / int64(time.Millisecond),
-					}
-				}
-
-				return metrics, samples
-			},
-			expectedErr: "",
-		},
-		"HA dedup; all samples same replica": {
-			prepareConfig: func(limits *validation.Limits) {
-				limits.AcceptHASamples = true
-				limits.HAMaxClusters = 100
-			},
-			prepareSeries: func() ([][]mimirpb.LabelAdapter, []mimirpb.Sample) {
-				metrics := make([][]mimirpb.LabelAdapter, numSeriesPerRequest)
-				samples := make([]mimirpb.Sample, numSeriesPerRequest)
-
-				for i := 0; i < numSeriesPerRequest; i++ {
-					lbls := labels.NewBuilder(labels.FromStrings(model.MetricNameLabel, "foo"))
-					for i := 0; i < 25; i++ {
-						lbls.Set(fmt.Sprintf("name_%d", i), fmt.Sprintf("value_%d", i))
-					}
-					lbls.Set("cluster", "c1")
-					lbls.Set("__replica__", "r1")
-
-					metrics[i] = mimirpb.FromLabelsToLabelAdapters(lbls.Labels())
-					samples[i] = mimirpb.Sample{
-						Value:       float64(i),
-						TimestampMs: time.Now().UnixNano() / int64(time.Millisecond),
-					}
-				}
-
-				return metrics, samples
-			},
-			expectedErr: "",
-		},
-		"HA dedup; 512 clusters 2 replicas evenly split": {
-			prepareConfig: func(limits *validation.Limits) {
-				limits.AcceptHASamples = true
-				limits.HAMaxClusters = 100
-			},
-			prepareSeries: func() ([][]mimirpb.LabelAdapter, []mimirpb.Sample) {
-				metrics := make([][]mimirpb.LabelAdapter, numSeriesPerRequest)
-				samples := make([]mimirpb.Sample, numSeriesPerRequest)
-
-				for i := 0; i < numSeriesPerRequest; i++ {
-					lbls := labels.NewBuilder(labels.FromStrings(model.MetricNameLabel, "foo"))
-					for i := 0; i < 25; i++ {
-						lbls.Set(fmt.Sprintf("name_%d", i), fmt.Sprintf("value_%d", i))
-					}
-					cluster, replica := i/2+1, i%2+1
-					lbls.Set("cluster", strconv.Itoa(cluster))
-					lbls.Set("__replica__", strconv.Itoa(replica))
-
-					metrics[i] = mimirpb.FromLabelsToLabelAdapters(lbls.Labels())
 					samples[i] = mimirpb.Sample{
 						Value:       float64(i),
 						TimestampMs: time.Now().UnixNano() / int64(time.Millisecond),
@@ -5163,7 +5085,6 @@ func TestHaDedupeMiddleware(t *testing.T) {
 		ctx               context.Context
 		enableHaTracker   bool
 		acceptHaSamples   bool
-		haMaxClusters     int
 		reqs              []*mimirpb.WriteRequest
 		expectedReqs      []*mimirpb.WriteRequest
 		expectedNextCalls int
@@ -5219,17 +5140,13 @@ func TestHaDedupeMiddleware(t *testing.T) {
 			},
 			expectedReqs:      []*mimirpb.WriteRequest{makeWriteRequestForGenerators(5, labelSetGenWithCluster(cluster1), nil, nil)},
 			expectedNextCalls: 1,
-			expectErrs: []*status.Status{
-				nil,
-				status.New(codes.AlreadyExists, newReplicasDidNotMatchError(replica2, replica1).Error()),
-			},
-			expectDetails: []*mimirpb.ErrorDetails{nil, replicasDidNotMatchDetails},
+			expectErrs:        []*status.Status{nil, status.New(codes.AlreadyExists, newReplicasDidNotMatchError(replica2, replica1).Error())},
+			expectDetails:     []*mimirpb.ErrorDetails{nil, replicasDidNotMatchDetails},
 		}, {
 			name:            "exceed max ha clusters limit",
 			ctx:             ctxWithUser,
 			enableHaTracker: true,
 			acceptHaSamples: true,
-			haMaxClusters:   1,
 			reqs: []*mimirpb.WriteRequest{
 				makeWriteRequestForGenerators(5, labelSetGenWithReplicaAndCluster(replica1, cluster1), nil, nil),
 				makeWriteRequestForGenerators(5, labelSetGenWithReplicaAndCluster(replica2, cluster1), nil, nil),
@@ -5245,145 +5162,6 @@ func TestHaDedupeMiddleware(t *testing.T) {
 				status.New(codes.FailedPrecondition, newTooManyClustersError(1).Error()),
 			},
 			expectDetails: []*mimirpb.ErrorDetails{nil, replicasDidNotMatchDetails, tooManyClusterDetails, tooManyClusterDetails},
-		}, {
-			name:            "perform partial HA deduplication",
-			ctx:             ctxWithUser,
-			enableHaTracker: true,
-			acceptHaSamples: true,
-			reqs: func() []*mimirpb.WriteRequest {
-				r1 := makeWriteRequestForGenerators(1, labelSetGenWithReplicaAndCluster(replica1, cluster1), nil, nil)
-
-				r2 := makeWriteRequestForGenerators(1, labelSetGenWithReplicaAndCluster(replica2, cluster1), nil, nil)
-				r3 := makeWriteRequestForGenerators(1, labelSetGenWithReplicaAndCluster(replica1, cluster2), nil, nil)
-				r2.Timeseries = append(r2.Timeseries, r3.Timeseries...)
-
-				return []*mimirpb.WriteRequest{r1, r2}
-			}(),
-			expectedReqs: func() []*mimirpb.WriteRequest {
-				c1 := makeWriteRequestForGenerators(1, labelSetGenWithCluster(cluster1), nil, nil)
-				c2 := makeWriteRequestForGenerators(1, labelSetGenWithCluster(cluster2), nil, nil)
-
-				return []*mimirpb.WriteRequest{c1, c2}
-			}(),
-			expectedNextCalls: 2,
-			expectErrs:        []*status.Status{nil, status.New(codes.AlreadyExists, newReplicasDidNotMatchError(replica2, replica1).Error())},
-			expectDetails:     []*mimirpb.ErrorDetails{nil, replicasDidNotMatchDetails},
-		}, {
-			name:            "mixed series from multiple primary replicas in single request",
-			ctx:             ctxWithUser,
-			enableHaTracker: true,
-			acceptHaSamples: true,
-			reqs: func() []*mimirpb.WriteRequest {
-				// Both replicas are primary for their respective clusters
-				r1 := makeWriteRequestForGenerators(2, labelSetGenWithReplicaAndCluster(replica1, cluster1), nil, nil)
-				r2 := makeWriteRequestForGenerators(2, labelSetGenWithReplicaAndCluster(replica1, cluster2), nil, nil)
-				r1.Timeseries = append(r1.Timeseries, r2.Timeseries...)
-
-				return []*mimirpb.WriteRequest{r1}
-			}(),
-			expectedReqs: func() []*mimirpb.WriteRequest {
-				c1 := makeWriteRequestForGenerators(2, labelSetGenWithCluster(cluster1), nil, nil)
-				c2 := makeWriteRequestForGenerators(2, labelSetGenWithCluster(cluster2), nil, nil)
-				c1.Timeseries = append(c1.Timeseries, c2.Timeseries...)
-
-				return []*mimirpb.WriteRequest{c1}
-			}(),
-			expectedNextCalls: 1,
-			expectErrs:        []*status.Status{nil},
-		}, {
-			name:            "mixed series with and without cluster labels in single request",
-			ctx:             ctxWithUser,
-			enableHaTracker: true,
-			acceptHaSamples: true,
-			reqs: func() []*mimirpb.WriteRequest {
-				r1 := makeWriteRequestForGenerators(2, labelSetGenWithReplicaAndCluster(replica1, cluster1), nil, nil)
-				// Series without cluster/replica labels
-				r2 := makeWriteRequestForGenerators(2, labelSetGenForStringPairs(t, "__name__", "metric_%d", "label", "value"), nil, nil)
-				r1.Timeseries = append(r1.Timeseries, r2.Timeseries...)
-
-				return []*mimirpb.WriteRequest{r1}
-			}(),
-			expectedReqs: func() []*mimirpb.WriteRequest {
-				c1 := makeWriteRequestForGenerators(2, labelSetGenWithCluster(cluster1), nil, nil)
-				c2 := makeWriteRequestForGenerators(2, labelSetGenForStringPairs(t, "__name__", "metric_%d", "label", "value"), nil, nil)
-				c1.Timeseries = append(c1.Timeseries, c2.Timeseries...)
-
-				return []*mimirpb.WriteRequest{c1}
-			}(),
-			expectedNextCalls: 1,
-			expectErrs:        []*status.Status{nil},
-		}, {
-			name:            "mixed primary and non-primary replicas with non-HA series in single request",
-			ctx:             ctxWithUser,
-			enableHaTracker: true,
-			acceptHaSamples: true,
-			reqs: func() []*mimirpb.WriteRequest {
-				// First establish replica1 as primary for cluster1
-				r1 := makeWriteRequestForGenerators(1, labelSetGenWithReplicaAndCluster(replica1, cluster1), nil, nil)
-
-				// Then send mixed request: primary replica, non-primary replica, and non-HA series
-				r2 := makeWriteRequestForGenerators(1, labelSetGenWithReplicaAndCluster(replica1, cluster1), nil, nil)
-				r3 := makeWriteRequestForGenerators(1, labelSetGenWithReplicaAndCluster(replica2, cluster1), nil, nil)
-				r4 := makeWriteRequestForGenerators(1, labelSetGenForStringPairs(t, "__name__", "no_ha_metric", "label", "value"), nil, nil)
-				r2.Timeseries = append(r2.Timeseries, r3.Timeseries...)
-				r2.Timeseries = append(r2.Timeseries, r4.Timeseries...)
-
-				return []*mimirpb.WriteRequest{r1, r2}
-			}(),
-			expectedReqs: func() []*mimirpb.WriteRequest {
-				c1 := makeWriteRequestForGenerators(1, labelSetGenWithCluster(cluster1), nil, nil)
-				c2 := makeWriteRequestForGenerators(1, labelSetGenWithCluster(cluster1), nil, nil)
-				c3 := makeWriteRequestForGenerators(1, labelSetGenForStringPairs(t, "__name__", "no_ha_metric", "label", "value"), nil, nil)
-				c2.Timeseries = append(c2.Timeseries, c3.Timeseries...)
-
-				return []*mimirpb.WriteRequest{c1, c2}
-			}(),
-			expectedNextCalls: 2,
-			expectErrs:        []*status.Status{nil, status.New(codes.AlreadyExists, newReplicasDidNotMatchError(replica2, replica1).Error())},
-			expectDetails:     []*mimirpb.ErrorDetails{nil, replicasDidNotMatchDetails},
-		}, {
-			name:            "series with only cluster label (no replica label)",
-			ctx:             ctxWithUser,
-			enableHaTracker: true,
-			acceptHaSamples: true,
-			reqs: func() []*mimirpb.WriteRequest {
-				// Series with cluster but no replica - should be treated as non-HA
-				r1 := makeWriteRequestForGenerators(2, labelSetGenWithCluster(cluster1), nil, nil)
-
-				return []*mimirpb.WriteRequest{r1}
-			}(),
-			expectedReqs: func() []*mimirpb.WriteRequest {
-				c1 := makeWriteRequestForGenerators(2, labelSetGenWithCluster(cluster1), nil, nil)
-
-				return []*mimirpb.WriteRequest{c1}
-			}(),
-			expectedNextCalls: 1,
-			expectErrs:        []*status.Status{nil},
-		}, {
-			name:            "empty timeseries after deduplication - all samples from non-primary replica",
-			ctx:             ctxWithUser,
-			enableHaTracker: true,
-			acceptHaSamples: true,
-			reqs: func() []*mimirpb.WriteRequest {
-				// First establish replica1 as primary
-				r1 := makeWriteRequestForGenerators(3, labelSetGenWithReplicaAndCluster(replica1, cluster1), nil, nil)
-
-				// Then send request with only non-primary replica - all should be deduplicated
-				r2 := makeWriteRequestForGenerators(3, labelSetGenWithReplicaAndCluster(replica2, cluster1), nil, nil)
-
-				return []*mimirpb.WriteRequest{r1, r2}
-			}(),
-			expectedReqs: func() []*mimirpb.WriteRequest {
-				c1 := makeWriteRequestForGenerators(3, labelSetGenWithCluster(cluster1), nil, nil)
-
-				return []*mimirpb.WriteRequest{c1}
-			}(),
-			expectedNextCalls: 1, // next() should not be called for the second request since all samples are deduplicated
-			expectErrs: []*status.Status{
-				nil,
-				status.New(codes.AlreadyExists, newReplicasDidNotMatchError(replica2, replica1).Error()),
-			},
-			expectDetails: []*mimirpb.ErrorDetails{nil, replicasDidNotMatchDetails},
 		},
 	}
 
@@ -5406,8 +5184,7 @@ func TestHaDedupeMiddleware(t *testing.T) {
 				nextCallCount++
 				req, err := pushReq.WriteRequest()
 				require.NoError(t, err)
-				reqCopy := *req // make a copy of the request to retain the slices as they were at the time of the request
-				gotReqs = append(gotReqs, &reqCopy)
+				gotReqs = append(gotReqs, req)
 				pushReq.CleanUp()
 				pushReq.AddCleanup(duplicateCleanup)
 				return nil
@@ -5417,7 +5194,7 @@ func TestHaDedupeMiddleware(t *testing.T) {
 			flagext.DefaultValues(&limits)
 			limits.AcceptHASamples = tc.acceptHaSamples
 			limits.MaxLabelValueLength = 15
-			limits.HAMaxClusters = tc.haMaxClusters
+			limits.HAMaxClusters = 1
 
 			ds, _, _, _ := prepare(t, prepConfig{
 				numDistributors: 1,
@@ -5439,20 +5216,13 @@ func TestHaDedupeMiddleware(t *testing.T) {
 				gotErrs = append(gotErrs, handledErr)
 			}
 
-			assert.Len(t, gotReqs, len(tc.expectedReqs))
-			for i := range gotReqs {
-				assert.ElementsMatch(t, tc.expectedReqs[i].Timeseries, gotReqs[i].Timeseries)
-				assert.ElementsMatch(t, tc.expectedReqs[i].Metadata, gotReqs[i].Metadata)
-				assert.Equal(t, tc.expectedReqs[i].Source, gotReqs[i].Source)
-			}
+			assert.Equal(t, tc.expectedReqs, gotReqs)
 			assert.Len(t, gotErrs, len(tc.expectErrs))
 			for errIdx, expectErr := range tc.expectErrs {
-				if expectErr != nil {
-					// Expect a gRPC error.
-					checkGRPCError(t, expectErr, tc.expectDetails[errIdx], gotErrs[errIdx])
+				if expectErr == nil {
+					assert.NoError(t, gotErrs[errIdx])
 				} else {
-					// Expect no error.
-					assert.Nil(t, gotErrs[errIdx])
+					checkGRPCError(t, expectErr, tc.expectDetails[errIdx], gotErrs[errIdx])
 				}
 			}
 
@@ -5461,59 +5231,6 @@ func TestHaDedupeMiddleware(t *testing.T) {
 			assert.Equal(t, tc.expectedNextCalls, nextCallCount)
 		})
 	}
-}
-
-func TestHaDedupeMiddleware_PushErrorNotMaskedByDedupError(t *testing.T) {
-	ctx := user.InjectOrgID(context.Background(), "user")
-	const replica1 = "replicaA"
-	const replica2 = "replicaB"
-	const cluster1 = "clusterA"
-
-	var limits validation.Limits
-	flagext.DefaultValues(&limits)
-	limits.AcceptHASamples = true
-	limits.MaxLabelValueLength = 15
-
-	ds, _, _, _ := prepare(t, prepConfig{
-		numDistributors: 1,
-		limits:          &limits,
-		enableTracker:   true,
-	})
-
-	pushErr := ingesterPushError{message: "failed pushing to ingester", cause: mimirpb.ERROR_CAUSE_UNKNOWN}
-	callCount := 0
-	next := func(_ context.Context, pushReq *Request) error {
-		callCount++
-		if callCount > 1 {
-			return pushErr
-		}
-		return nil
-	}
-
-	middleware := ds[0].prePushHaDedupeMiddleware(next)
-
-	// Establish replica1 as primary.
-	r1 := makeWriteRequestForGenerators(3, labelSetGenWithReplicaAndCluster(replica1, cluster1), nil, nil)
-	pushReq1 := NewParsedRequest(r1, r1.Size())
-	pushReq1.AddCleanup(func() {})
-	err := middleware(ctx, pushReq1)
-	require.NoError(t, err)
-
-	// Send a mixed request: some series from replica1 (accepted) and some from replica2 (deduped).
-	// The push of accepted series will fail. The returned error must reflect the push failure, not the dedup.
-	r2 := makeWriteRequestForGenerators(2, labelSetGenWithReplicaAndCluster(replica1, cluster1), nil, nil)
-	r3 := makeWriteRequestForGenerators(2, labelSetGenWithReplicaAndCluster(replica2, cluster1), nil, nil)
-	r2.Timeseries = append(r2.Timeseries, r3.Timeseries...)
-
-	pushReq2 := NewParsedRequest(r2, r2.Size())
-	pushReq2.AddCleanup(func() {})
-	err = middleware(ctx, pushReq2)
-	require.Error(t, err)
-
-	handledErr := ds[0].handlePushError(err)
-	stat, ok := grpcutil.ErrorToStatus(handledErr)
-	require.True(t, ok)
-	require.Equal(t, codes.Internal, stat.Code(), "push error must not be masked by dedup error (AlreadyExists/202)")
 }
 
 func TestInstanceLimitsBeforeHaDedupe(t *testing.T) {
@@ -5805,87 +5522,6 @@ func TestSortAndFilterMiddleware(t *testing.T) {
 
 			// Cleanup must have been called once per request.
 			assert.Equal(t, len(tc.reqs), cleanupCallCount)
-		})
-	}
-}
-
-func TestSortByAccepted(t *testing.T) {
-	tests := []struct {
-		name             string
-		states           []replicaState
-		expectedAccepted int
-	}{
-		{
-			name:             "empty request",
-			states:           []replicaState{},
-			expectedAccepted: 0,
-		},
-		{
-			name:             "all accepted (primary)",
-			states:           []replicaState{replicaIsPrimary, replicaIsPrimary, replicaIsPrimary},
-			expectedAccepted: 3,
-		},
-		{
-			name:             "all accepted (not HA)",
-			states:           []replicaState{replicaNotHA, replicaNotHA},
-			expectedAccepted: 2,
-		},
-		{
-			name:             "all rejected (deduped)",
-			states:           []replicaState{replicaDeduped, replicaDeduped},
-			expectedAccepted: 0,
-		},
-		{
-			name:             "mixed: accept, reject, accept",
-			states:           []replicaState{replicaIsPrimary, replicaDeduped, replicaIsPrimary},
-			expectedAccepted: 2,
-		},
-		{
-			name:             "mixed: reject, accept, reject",
-			states:           []replicaState{replicaDeduped, replicaIsPrimary, replicaDeduped},
-			expectedAccepted: 1,
-		},
-		{
-			name:             "mixed: reject, reject, accept",
-			states:           []replicaState{replicaDeduped, replicaDeduped, replicaIsPrimary},
-			expectedAccepted: 1,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			count := len(tc.states)
-			req := &mimirpb.WriteRequest{
-				Timeseries: make([]mimirpb.PreallocTimeseries, count),
-			}
-			replicas := make([]haReplica, count)
-			replicaInfos := make(map[haReplica]*replicaInfo)
-
-			for i, state := range tc.states {
-				req.Timeseries[i] = mimirpb.PreallocTimeseries{
-					TimeSeries: &mimirpb.TimeSeries{
-						Labels: []mimirpb.LabelAdapter{{Name: "id", Value: fmt.Sprintf("%d", i)}},
-					},
-				}
-				r := haReplica{cluster: "c", replica: fmt.Sprintf("%d", i)}
-				replicas[i] = r
-				replicaInfos[r] = &replicaInfo{state: state}
-			}
-
-			lastAcceptedIdx := sortByAccepted(req, replicaInfos, replicas)
-			require.Equal(t, tc.expectedAccepted-1, lastAcceptedIdx)
-
-			for i := 0; i < count; i++ {
-				r := replicas[i]
-				info := replicaInfos[r]
-				isAccepted := info.state.equals(replicaAccepted)
-
-				if i <= lastAcceptedIdx {
-					require.True(t, isAccepted, "index %d should be accepted, state: %v", i, info.state)
-				} else {
-					require.False(t, isAccepted, "index %d should be rejected, state: %v", i, info.state)
-				}
-			}
 		})
 	}
 }
@@ -7580,12 +7216,6 @@ func (i *noopIngester) Close() error {
 
 func (i *noopIngester) Push(context.Context, *mimirpb.WriteRequest, ...grpc.CallOption) (*mimirpb.WriteResponse, error) {
 	return nil, nil
-}
-
-func (*noopIngester) Check(ctx context.Context, in *grpc_health_v1.HealthCheckRequest, opts ...grpc.CallOption) (*grpc_health_v1.HealthCheckResponse, error) {
-	return &grpc_health_v1.HealthCheckResponse{
-		Status: grpc_health_v1.HealthCheckResponse_SERVING,
-	}, nil
 }
 
 type stream struct {
@@ -9657,214 +9287,4 @@ func (m *MockTimeSource) Sleep(d time.Duration) {
 
 func (m *MockTimeSource) Add(d time.Duration) {
 	m.CurrentTime = m.CurrentTime.Add(d)
-}
-
-func BenchmarkDistributor_HaDedupMiddleware(b *testing.B) {
-	var (
-		now                 = time.Now()
-		userID              = "user-1"
-		ctx                 = user.InjectOrgID(context.Background(), userID)
-		numSeriesPerRequest = 1024
-		cluster             = "test-cluster"
-		replica             = "replica-1"
-	)
-
-	testCases := map[string]struct {
-		numClusters  int
-		numReplicas  int
-		acceptedOnly bool
-	}{
-		"1 cluster 1 replica all accepted": {
-			numClusters:  1,
-			numReplicas:  1,
-			acceptedOnly: true,
-		},
-		"1 cluster 2 replicas with deduped": {
-			numClusters:  1,
-			numReplicas:  2,
-			acceptedOnly: false,
-		},
-	}
-
-	for testName, tc := range testCases {
-		b.Run(testName, func(b *testing.B) {
-			var limits validation.Limits
-			flagext.DefaultValues(&limits)
-			limits.AcceptHASamples = true
-			limits.HAMaxClusters = tc.numClusters
-
-			testConfig := prepConfig{
-				numDistributors: 1,
-				enableTracker:   true,
-				limits:          &limits,
-			}
-
-			// Create a distributor.
-			distributors, _, _, _ := prepare(b, testConfig)
-			require.Len(b, distributors, 1)
-
-			// Pre-register the accepted replica so the HA tracker knows which replica to accept.
-			if tc.acceptedOnly {
-				err := distributors[0].HATracker.checkReplica(ctx, userID, cluster, replica, now, now)
-				require.NoError(b, err)
-			}
-
-			// Pre-generate all write requests that will be used in this test.
-			reqs := make([]*mimirpb.WriteRequest, 0, b.N)
-			for r := 0; r < b.N; r++ {
-				req := &mimirpb.WriteRequest{
-					Timeseries: make([]mimirpb.PreallocTimeseries, 0, numSeriesPerRequest),
-				}
-
-				seriesPerReplica := numSeriesPerRequest / (tc.numClusters * tc.numReplicas)
-				for c := 0; c < tc.numClusters; c++ {
-					for rep := 0; rep < tc.numReplicas; rep++ {
-						replicaName := replica
-						if rep > 0 {
-							replicaName = fmt.Sprintf("replica-%d", rep+1)
-						}
-						clusterName := cluster
-						if c > 0 {
-							clusterName = fmt.Sprintf("cluster-%d", c+1)
-						}
-						for s := 0; s < seriesPerReplica; s++ {
-							req.Timeseries = append(req.Timeseries, makeTimeseries(
-								[]string{model.MetricNameLabel, fmt.Sprintf("series_%d", s), "__replica__", replicaName, "cluster", clusterName},
-								makeSamples(now.UnixMilli(), float64(s)), nil, nil,
-							))
-						}
-					}
-				}
-
-				reqs = append(reqs, req)
-			}
-
-			// Get the middleware function.
-			noop := func(_ context.Context, _ *Request) error { return nil }
-			fn := distributors[0].prePushHaDedupeMiddleware(noop)
-
-			b.ResetTimer()
-
-			for n := 0; n < b.N; n++ {
-				err := fn(ctx, newRequest(func() (req *mimirpb.WriteRequest, cleanup func(), uncompressedBodySize int, err error) {
-					return reqs[n], func() {}, 0, nil
-				}))
-				if tc.acceptedOnly {
-					require.NoError(b, err)
-				} else {
-					var replicasErr replicasDidNotMatchError
-					require.ErrorAs(b, err, &replicasErr)
-				}
-			}
-		})
-	}
-}
-
-// mockHATracker is a mock implementation of haTracker for testing
-type mockHATracker struct {
-	services.Service
-	http.Handler
-	errToReturn error
-}
-
-func (m *mockHATracker) checkReplica(ctx context.Context, userID, cluster, replica string, _ time.Time, _ time.Time) error {
-	return m.errToReturn
-}
-
-func (m *mockHATracker) cleanupHATrackerMetricsForUser(userID string) {
-	// No-op for mock
-}
-
-func TestDistributor_replicaObserved(t *testing.T) {
-	userID := "test-user"
-	cluster := "c1"
-	replica := "r1"
-	now := time.Now()
-	ts := now.Unix()
-	ctx := user.InjectOrgID(context.Background(), userID)
-
-	testConfig := prepConfig{numDistributors: 1, enableTracker: true}
-
-	replicasDidNotMatch := &replicasDidNotMatchError{}
-	tooManyClusters := &tooManyClustersError{}
-	unknownErr := errors.New("unknown")
-
-	tests := []struct {
-		name         string
-		cluster      string
-		replica      string
-		haTrackerErr error
-		wantState    replicaState
-		wantErr      error
-	}{
-		{
-			name:         "primary replica",
-			cluster:      cluster,
-			replica:      replica,
-			haTrackerErr: nil,
-			wantState:    replicaIsPrimary,
-			wantErr:      nil,
-		},
-		{
-			name:         "deduped replica",
-			cluster:      cluster,
-			replica:      replica,
-			haTrackerErr: replicasDidNotMatch,
-			wantState:    replicaDeduped,
-			wantErr:      replicasDidNotMatch,
-		},
-		{
-			name:         "too many clusters",
-			cluster:      cluster,
-			replica:      replica,
-			haTrackerErr: tooManyClusters,
-			wantState:    replicaRejectedTooManyClusters,
-			wantErr:      tooManyClusters,
-		},
-		{
-			name:         "unknown error",
-			cluster:      cluster,
-			replica:      replica,
-			haTrackerErr: unknownErr,
-			wantState:    replicaRejectedUnknown,
-			wantErr:      unknownErr,
-		},
-		{
-			name:         "missing cluster label",
-			cluster:      "",
-			replica:      replica,
-			haTrackerErr: nil,
-			wantState:    replicaNotHA,
-			wantErr:      nil,
-		},
-		{
-			name:         "missing replica label",
-			cluster:      cluster,
-			replica:      "",
-			haTrackerErr: nil,
-			wantState:    replicaNotHA,
-			wantErr:      nil,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			d, _, _, _ := prepare(t, testConfig)
-			require.Len(t, d, 1)
-
-			// Mock HA tracker behavior
-			mockHATracker := &mockHATracker{
-				errToReturn: tc.haTrackerErr,
-			}
-			d[0].HATracker = mockHATracker
-
-			state, err := d[0].replicaObserved(ctx, userID, haReplica{cluster: tc.cluster, replica: tc.replica}, ts)
-			assert.Equal(t, tc.wantState, state)
-			if tc.wantErr != nil {
-				assert.ErrorIs(t, err, tc.wantErr)
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
 }

--- a/pkg/distributor/ha_tracker.go
+++ b/pkg/distributor/ha_tracker.go
@@ -721,25 +721,20 @@ func (h *defaultHaTrackerForUser) updateKVStore(ctx context.Context, cluster, re
 	return err
 }
 
-func findHALabels(replicaLabel, clusterLabel string, labels []mimirpb.LabelAdapter) haReplica {
-	var r haReplica
+func findHALabels(replicaLabel, clusterLabel string, labels []mimirpb.LabelAdapter) (string, string) {
+	var cluster, replica string
+	var pair mimirpb.LabelAdapter
 
-	for _, pair := range labels {
-		switch pair.Name {
-		case replicaLabel:
-			r.replica = pair.Value
-			if r.cluster != "" {
-				return r
-			}
-		case clusterLabel:
-			r.cluster = pair.Value
-			if r.replica != "" {
-				return r
-			}
+	for _, pair = range labels {
+		if pair.Name == replicaLabel {
+			replica = pair.Value
+		}
+		if pair.Name == clusterLabel {
+			cluster = pair.Value
 		}
 	}
 
-	return r
+	return cluster, replica
 }
 
 func (h *defaultHaTracker) cleanupHATrackerMetricsForUser(userID string) {

--- a/pkg/distributor/ha_tracker_test.go
+++ b/pkg/distributor/ha_tracker_test.go
@@ -928,9 +928,13 @@ func TestHATrackerCheckReplicaUpdateTimeoutJitter(t *testing.T) {
 
 func TestHATrackerFindHALabels(t *testing.T) {
 	replicaLabel, clusterLabel := "replica", "cluster"
+	type expectedOutput struct {
+		cluster string
+		replica string
+	}
 	cases := []struct {
 		labelsIn []mimirpb.LabelAdapter
-		expected haReplica
+		expected expectedOutput
 	}{
 		{
 			[]mimirpb.LabelAdapter{
@@ -939,7 +943,7 @@ func TestHATrackerFindHALabels(t *testing.T) {
 				{Name: "sample", Value: "1"},
 				{Name: replicaLabel, Value: "1"},
 			},
-			haReplica{cluster: "", replica: "1"},
+			expectedOutput{cluster: "", replica: "1"},
 		},
 		{
 			[]mimirpb.LabelAdapter{
@@ -948,7 +952,7 @@ func TestHATrackerFindHALabels(t *testing.T) {
 				{Name: "sample", Value: "1"},
 				{Name: clusterLabel, Value: "cluster-2"},
 			},
-			haReplica{cluster: "cluster-2", replica: ""},
+			expectedOutput{cluster: "cluster-2", replica: ""},
 		},
 		{
 			[]mimirpb.LabelAdapter{
@@ -958,22 +962,14 @@ func TestHATrackerFindHALabels(t *testing.T) {
 				{Name: replicaLabel, Value: "3"},
 				{Name: clusterLabel, Value: "cluster-3"},
 			},
-			haReplica{cluster: "cluster-3", replica: "3"},
-		},
-		{
-			[]mimirpb.LabelAdapter{
-				{Name: replicaLabel, Value: "r1"},
-				{Name: clusterLabel, Value: "c1"},
-				{Name: replicaLabel, Value: "r2"}, // Should be ignored due to fast path
-				{Name: clusterLabel, Value: "c2"}, // Should be ignored due to fast path
-			},
-			haReplica{cluster: "c1", replica: "r1"},
+			expectedOutput{cluster: "cluster-3", replica: "3"},
 		},
 	}
 
 	for _, c := range cases {
-		r := findHALabels(replicaLabel, clusterLabel, c.labelsIn)
-		assert.Equal(t, c.expected, r)
+		cluster, replica := findHALabels(replicaLabel, clusterLabel, c.labelsIn)
+		assert.Equal(t, c.expected.cluster, cluster)
+		assert.Equal(t, c.expected.replica, replica)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This reverts commit 94d6d300e89f210654c89c9f3eb3c22414b9224f (https://github.com/grafana/mimir/pull/13665).

While the enhancement is a valid one, there is no mechanism to control its rollout, and the change in behavior can break existing working setups. Revert for now and bring it back in a more controlled fashion.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes HA deduplication behavior in the distributor to assume a single cluster/replica per write request, which can alter ingestion results for mixed-label or proxy/federation setups and impact dedupe/too-many-clusters handling.
> 
> **Overview**
> Reverts the recent change to **deduplicate HA samples per-series within a single remote-write request**, returning the distributor HA dedupe middleware to a *per-request* decision based only on the first timeseries’ cluster/replica labels.
> 
> This removes the previous logic that partitioned accepted vs deduped/rejected series within one request (and its associated benchmarks/tests), updates `findHALabels` to return simple `(cluster, replica)` strings, and adjusts docs/changelog to reflect the restored assumption that all series in a request share the same HA labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d06d7ca034cd78f098fcc40ce583aabb3393e8c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->