### PR TITLE
jsonnet: upstream configuration for autoscaling store-gateways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -346,6 +346,7 @@
 * [CHANGE] Ingester: Change default ingestion concurrency configuration used by ingest storage architecture, to maximize throughput when consuming records from Kafka. #14668
 * [CHANGE] Memberlist: when the multi-zone memberlist bridge is enabled (`multi_zone_memberlist_bridge_enabled`), Mimir components now use memberlist-bridge pods as seed nodes by default, instead of the shared gossip ring service. This reduces inter-AZ data transfer. The new `memberlist_bridge_seed_nodes_enabled` configuration option can be used to disable this behavior. #14994
 * [CHANGE] Ruler remote evaluation: Split the ruler-query-frontend service into a ClusterIP service (for HTTP load balancing) and a headless service (for gRPC client-side load balancing by rulers). The ruler now connects to the headless service. #15001
+* [CHANGE] Memberlist bridge: Changed default value of `memberlist_bridge_replicas_per_zone` from 2 to 3. #14667
 * [FEATURE] Add multi-zone support for read path components (memcached, querier, query-frontend, query-scheduler, ruler, and ruler remote evaluation stack). Add multi-AZ support for ingester and store-gateway multi-zone deployments. Add memberlist-bridge support for zone-aware memberlist routing. #13559 #13628 #13636 #13915 #14260 #14301
 * [FEATURE] Add deletion protection support for ingesters and store-gateways StatefulSet. It can be enabled by setting `ingester_deletion_protection_enabled` and `store_gateway_deletion_protection_enabled` in the `_config` block. #13819
 * [FEATURE] Shuffle sharding: Add the following configuration options to enable the experimental per-zone store-gateway shard size: #13908 #13941
@@ -354,7 +355,11 @@
   * `$._config.shuffle_sharding.store_gateway_shard_size_per_zone_overrides_enabled` (takes precedence over `store_gateway_shard_size_per_zone_enabled`)
 * [FEATURE] Ruler: Add `$._config.multi_zone_ruler_balanced_autoscaling_enabled` option to ensure equally balanced replica counts across ruler zones in multi-AZ deployments by using aggregate metrics for autoscaling. #14198
 * [FEATURE] Add `query_engine_range_vector_splitting_enabled` configuration option to enable experimental range vector splitting with memcached cache. #14435
-* [CHANGE] Memberlist bridge: Changed default value of `memberlist_bridge_replicas_per_zone` from 2 to 3. #14667
+* [FEATURE] Store-gateway: Add the ability to autoscale store-gateways based on disk usage when automated downscale is enabled. #15019
+  * `$._config.autoscaling_store_gateway_enabled`
+  * `$._config.autoscaling_store_gateway_disk_usage_threshold`
+  * `$._config.autoscaling_store_gateway_min_replicas_per_zone`
+  * `$._config.autoscaling_store_gateway_max_replicas_per_zone`
 * [ENHANCEMENT] Ruler querier and query-frontend: Add support for newly-introduced querier ring, which is used when performing query planning in query-frontends and distributing portions of the plan to queriers for execution. #13017
 * [ENHANCEMENT] Ingester: Increase `$._config.ingester_tsdb_head_early_compaction_min_in_memory_series` default when Mimir is running with the ingest storage architecture. #13450
 * [ENHANCEMENT] Memberlist bridge: Add `memberlist_bridge_replicas_per_zone` configuration option (default: 2). #13727

--- a/operations/mimir-tests/test-autoscaling-store-gateway-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-store-gateway-generated.yaml
@@ -2030,7 +2030,6 @@ metadata:
   namespace: default
 spec:
   podManagementPolicy: Parallel
-  replicas: 1
   selector:
     matchLabels:
       name: store-gateway-zone-a
@@ -2478,6 +2477,46 @@ webhooks:
     scope: Namespaced
   sideEffects: NoneOnDryRun
   timeoutSeconds: 10
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: store-gateway-zone-a
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 600
+            type: Pods
+            value: 1
+          stabilizationWindowSeconds: 3600
+        scaleUp:
+          policies:
+          - periodSeconds: 600
+            type: Percent
+            value: 50
+          stabilizationWindowSeconds: 1800
+  maxReplicaCount: 6
+  minReplicaCount: 1
+  pollingInterval: 10
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: store-gateway-zone-a
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: mimir_store_gateway_zone_a_replicas_hpa_default
+      query: (1 - (min(kubelet_volume_stats_available_bytes{namespace="default", persistentvolumeclaim=~"store-gateway-.*"}/kubelet_volume_stats_capacity_bytes{namespace="default",
+        persistentvolumeclaim=~"store-gateway-.*"}))) * 100
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "77"
+    metricType: Value
+    name: mimir_store_gateway_zone_a_replicas_hpa_default
+    type: prometheus
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/operations/mimir-tests/test-autoscaling-store-gateway.jsonnet
+++ b/operations/mimir-tests/test-autoscaling-store-gateway.jsonnet
@@ -22,6 +22,10 @@ mimir {
     multi_zone_store_gateway_enabled: true,
     multi_zone_store_gateway_replicas: 3,
 
+    autoscaling_store_gateway_enabled: true,
+    autoscaling_store_gateway_min_replicas_per_zone: 1,
+    autoscaling_store_gateway_max_replicas_per_zone: 6,
+
     // not relevant to this test
     zpdb_custom_resource_definition_enabled: false,
   },

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -61,6 +61,10 @@
     autoscaling_alertmanager_memory_target_utilization: 1,
   },
 
+  // Utility used to override a field only if exists in super.
+  local overrideSuperIfExists(name, override) = if !( name in super) || super[name] == null || super[name] == {} then null else
+    super[name] + override,
+
   // KEDA defaults to apiVersion: apps/v1 and kind: Deployment for scaleTargetRef, this function
   // avoids specifying apiVersion and kind if they are at their defaults.
   local scaleTargetRef(apiVersion, kind, name) = if apiVersion != 'apps/v1' || kind != 'Deployment' then {
@@ -800,9 +804,9 @@
     if !$._config.autoscaling_ruler_enabled then {} else $.removeReplicasFromSpec
   ),
 
-  // Utility used to override a field only if exists in super.
-  local overrideSuperIfExists(name, override) = if !( name in super) || super[name] == null || super[name] == {} then null else
-    super[name] + override,
+  //
+  // Alertmanagers
+  //
 
   alertmanager_scaled_object: if !$._config.autoscaling_alertmanager_enabled then null else
     $.newResourceScaledObject(
@@ -826,4 +830,9 @@
     'alertmanager_statefulset',
     if !$._config.autoscaling_alertmanager_enabled then {} else $.removeReplicasFromSpec
   ),
+
+  //
+  // Store-gateway autoscaling is in store-gateway-autoscaling.libsonnet due to needing
+  // to be applied after multi-zone configuration.
+  //
 }

--- a/operations/mimir/jsonnetfile.json
+++ b/operations/mimir/jsonnetfile.json
@@ -45,6 +45,16 @@
         }
       },
       "version": "master"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/jsonnet-libs/keda-libsonnet.git",
+          "subdir": "2.15"
+        }
+      },
+      "version": "main",
+      "name": "keda-libsonnet"
     }
   ],
   "legacyImports": true

--- a/operations/mimir/mimir.libsonnet
+++ b/operations/mimir/mimir.libsonnet
@@ -1,4 +1,5 @@
 (import 'ksonnet-util/kausal.libsonnet') +
+(import 'keda-libsonnet/main.libsonnet') +
 (import 'images.libsonnet') +
 (import 'common.libsonnet') +
 (import 'tracing.libsonnet') +
@@ -47,7 +48,7 @@
 // Automated downscale of ingesters and store-gateways
 (import 'ingester-automated-downscale.libsonnet') +
 (import 'ingester-automated-downscale-v2.libsonnet') +
-(import 'store-gateway-automated-downscale.libsonnet') +
+(import 'store-gateway-autoscaling.libsonnet') +
 
 // Automatic cleanup of unused PVCs after scaling down
 (import 'pvc-auto-deletion.libsonnet') +

--- a/operations/mimir/store-gateway-autoscaling.libsonnet
+++ b/operations/mimir/store-gateway-autoscaling.libsonnet
@@ -49,7 +49,7 @@
           metric_name: 'mimir_%s_replicas_hpa_%s' % [std.strReplace(name_and_zone, '-', '_'), std.strReplace($._config.namespace, '-', '_')],
           query: qry % {
             namespace: $._config.namespace,
-            extra_matchers: extra_matchers,
+            extra_matchers: if extra_matchers == '' then '' else ',%s' % extra_matchers,
             pvc_name_pattern: pat,
           },
           metric_type: 'Value',

--- a/operations/mimir/store-gateway-autoscaling.libsonnet
+++ b/operations/mimir/store-gateway-autoscaling.libsonnet
@@ -10,7 +10,6 @@
 
   _config+: {
     store_gateway_automated_downscale_enabled: false,
-
     // Allow to selectively enable it on a per-zone basis.
     store_gateway_automated_downscale_zone_a_enabled: $._config.store_gateway_automated_downscale_enabled,
     store_gateway_automated_downscale_zone_b_enabled: $._config.store_gateway_automated_downscale_enabled,
@@ -18,9 +17,65 @@
     store_gateway_automated_downscale_zone_a_backup_enabled: $._config.store_gateway_automated_downscale_enabled,
     store_gateway_automated_downscale_zone_b_backup_enabled: $._config.store_gateway_automated_downscale_enabled,
 
+    autoscaling_store_gateway_enabled: false,
+    // With a tolerance of +/- 10%, 77% disk usage will trigger scaling when the worst case pod hits 85% disk usage.
+    autoscaling_store_gateway_disk_usage_threshold: 77,
+    autoscaling_store_gateway_min_replicas_per_zone: error 'you must set autoscaling_store_gateway_min_replicas_per_zone in the _config',
+    autoscaling_store_gateway_max_replicas_per_zone: error 'you must set autoscaling_store_gateway_max_replicas_per_zone in the _config',
+
     // Give more time if lazy-loading is disabled.
     store_gateway_automated_downscale_min_time_between_zones: if $._config.store_gateway_lazy_loading_enabled then '15m' else '60m',
   },
+
+  local keda = $.keda.v1alpha1,
+  local scaledObject = keda.scaledObject,
+  local scaleDown = scaledObject.spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleDown,
+  local scaleDownPolicies = scaleDown.policies,
+  local scaleUp = scaledObject.spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleUp,
+  local scaleUpPolicies = scaleUp.policies,
+
+  // Create a KEDA scaled object for the leader zone (zone A). The replica count for other
+  // zones will follow zone A using the rollout-operator.
+  newLeaderStoreGatewayScaledObject(name_and_zone, min_replicas, max_replicas, usage_threshold, pvc_name_pattern=null, extra_matchers='')::
+    local pat = if pvc_name_pattern != null then pvc_name_pattern else 'store-gateway-.*';
+    local qry = '(1 - (min(kubelet_volume_stats_available_bytes{namespace="%(namespace)s", persistentvolumeclaim=~"%(pvc_name_pattern)s"%(extra_matchers)s}/kubelet_volume_stats_capacity_bytes{namespace="%(namespace)s", persistentvolumeclaim=~"%(pvc_name_pattern)s"%(extra_matchers)s}))) * 100';
+
+    self.newScaledObject(name_and_zone, $._config.namespace, {
+      min_replica_count: min_replicas,
+      max_replica_count: max_replicas,
+      // see https://keda.sh/docs/2.9/concepts/scaling-deployments/#triggers
+      triggers: [
+        {
+          metric_name: 'mimir_%s_replicas_hpa_%s' % [std.strReplace(name_and_zone, '-', '_'), std.strReplace($._config.namespace, '-', '_')],
+          query: qry % {
+            namespace: $._config.namespace,
+            extra_matchers: extra_matchers,
+            pvc_name_pattern: pat,
+          },
+          metric_type: 'Value',
+          threshold: std.toString(usage_threshold),
+          // Disable ignoring null values. This allows HPAs to effectively pause when metrics are unavailable rather than scaling
+          // up or down unexpectedly. See https://keda.sh/docs/2.13/scalers/prometheus/ for more info.
+          ignore_null_values: false,
+        },
+      ],
+    }, kind='StatefulSet') +
+
+    // Allow 50% increase of pods - this larger percentage is due to replica counts being divided by zones
+    // check every 10 minutes with a cooldown of 1h after scaling
+    scaleUp.withPolicies(
+      scaleUpPolicies.withType('Percent') +
+      scaleUpPolicies.withValue(50) +
+      scaleUpPolicies.withPeriodSeconds(600)
+    ) + scaleUp.withStabilizationWindowSeconds(1800) +  // long stabilization period to reduce risk of flapping
+
+    // Allow 1 pod per leader zone downscaling of pods
+    // check every 10 minutes with a 1h cooldown after scaling
+    scaleDown.withPolicies(
+      scaleDownPolicies.withType('Pods') +
+      scaleDownPolicies.withValue(1) +
+      scaleDownPolicies.withPeriodSeconds(600)
+    ) + scaleDown.withStabilizationWindowSeconds(3600),  // long stabilization period to reduce risk of flapping
 
   // Utility used to override a field only if exists in super.
   local overrideSuperIfExists(name, override) = if !( name in super) || super[name] == null || super[name] == {} then null else
@@ -39,11 +94,20 @@
       'grafana.com/prepare-downscale-http-port': '80',
     }),
 
+  store_gateway_zone_a_scaled_object: if !$._config.autoscaling_store_gateway_enabled || !$._config.multi_zone_store_gateway_enabled || !$._config.store_gateway_automated_downscale_zone_a_enabled then null else
+    $.newLeaderStoreGatewayScaledObject(
+      'store-gateway-zone-a',
+      $._config.autoscaling_store_gateway_min_replicas_per_zone,
+      $._config.autoscaling_store_gateway_max_replicas_per_zone,
+      $._config.autoscaling_store_gateway_disk_usage_threshold,
+      null,
+    ),
+
   // Store-gateway prepare-downscale configuration
   store_gateway_zone_a_statefulset: overrideSuperIfExists(
     'store_gateway_zone_a_statefulset',
     if !$._config.store_gateway_automated_downscale_zone_a_enabled || !$._config.multi_zone_store_gateway_enabled then {} else
-      prepareDownscaleLabelsAnnotations
+      prepareDownscaleLabelsAnnotations + (if !$._config.autoscaling_store_gateway_enabled then {} else $.removeReplicasFromSpec)
   ),
 
   store_gateway_zone_b_statefulset: overrideSuperIfExists(
@@ -115,5 +179,4 @@
   store_gateway_zone_b_backup_args+:: if !$._config.store_gateway_automated_downscale_zone_b_backup_enabled || !$._config.multi_zone_store_gateway_enabled then {} else {
     'store-gateway.sharding-ring.auto-forget-enabled': false,
   },
-
 }


### PR DESCRIPTION
#### What this PR does

This change adds jsonnet that we have been using internally to autoscale store-gateways based on disk usage.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new autoscaling behavior for multi-zone store-gateways (replica counts now controlled by a KEDA `ScaledObject` when enabled), which can affect capacity and availability if thresholds/limits are misconfigured.
> 
> **Overview**
> Adds **disk-usage-based autoscaling for multi-zone store-gateways** by generating a KEDA `ScaledObject` for the leader zone (`store-gateway-zone-a`) that scales a StatefulSet based on PVC usage PromQL, with explicit scale-up/down policies and `ignoreNullValues=false`.
> 
> Wires in new `_config` flags (`autoscaling_store_gateway_enabled`, disk usage threshold, min/max replicas per zone), removes `replicas` from the zone A StatefulSet spec when autoscaling is enabled so HPA/KEDA controls it, and vendors the `keda-libsonnet` dependency + import. Updates the autoscaling store-gateway golden test output and adds a changelog feature entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bac2fe00ebfb83d94f737b2c7011d0d6b6d7a5c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->