### PR TITLE
fix(store-gateway): run all index header bucket reads through GetRange interface

### DIFF
--- a/pkg/storage/indexheader/encoding/bucket_factory.go
+++ b/pkg/storage/indexheader/encoding/bucket_factory.go
@@ -57,6 +57,7 @@ func (bf *BucketDecbufFactory) NewDecbufAtChecked(offset int, table *crc32.Table
 		lengthBytes := make([]byte, numLenBytes)
 		n, err := metaReader.Read(lengthBytes)
 		if err != nil {
+			bf.mu.Unlock()
 			return Decbuf{E: err}
 		}
 		if n != numLenBytes {
@@ -74,6 +75,7 @@ func (bf *BucketDecbufFactory) NewDecbufAtChecked(offset int, table *crc32.Table
 	// bufReader is expected start at base offset + 4 after consuming length bytes
 	err = bufReader.Skip(numLenBytes)
 	if err != nil {
+		_ = bufReader.Close()
 		return Decbuf{E: err}
 	}
 	d := Decbuf{r: bufReader}

--- a/pkg/storage/indexheader/encoding/bucket_factory.go
+++ b/pkg/storage/indexheader/encoding/bucket_factory.go
@@ -13,7 +13,7 @@ import (
 )
 
 // BucketDecbufFactory creates new bucket-reader-backed Decbuf instances
-// for a specific index-header file in object storage
+// for a specific index file in object storage
 type BucketDecbufFactory struct {
 	ctx             context.Context
 	bkt             objstore.BucketReader
@@ -109,4 +109,12 @@ func (bf *BucketDecbufFactory) NewRawDecbuf() Decbuf {
 	)
 	d := Decbuf{r: r}
 	return d
+}
+
+// Close cleans up resources associated with this BucketDecbufFactory.
+// For bucket-based implementation, there are no resources to clean up;
+// the bucket client lifecycle is managed by parent components.
+func (bf *BucketDecbufFactory) Close() error {
+	// Nothing to do for bucket-based implementation
+	return nil
 }

--- a/pkg/storage/indexheader/encoding/bucket_factory.go
+++ b/pkg/storage/indexheader/encoding/bucket_factory.go
@@ -3,13 +3,10 @@
 package encoding
 
 import (
-	"bufio"
 	"context"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"hash/crc32"
-	"io"
 	"sync"
 
 	"github.com/thanos-io/objstore"
@@ -18,9 +15,11 @@ import (
 // BucketDecbufFactory creates new bucket-reader-backed Decbuf instances
 // for a specific index-header file in object storage
 type BucketDecbufFactory struct {
-	ctx        context.Context
-	bkt        objstore.BucketReader
-	objectPath string // Path to index file in bucket
+	ctx             context.Context
+	bkt             objstore.BucketReader
+	objectPath      string // Path to index file in bucket
+	sectionLenCache map[int]int
+	mu              sync.Mutex
 }
 
 // NewBucketDecbufFactory creates a new BucketDecbufFactory for the given object path.
@@ -29,52 +28,57 @@ func NewBucketDecbufFactory(ctx context.Context, bkt objstore.BucketReader, obje
 		ctx:        ctx,
 		bkt:        bkt,
 		objectPath: objectPath,
+		// Allocate cache to hold the start offsets of Symbols and Postings Offsets tables.
+		sectionLenCache: make(map[int]int, 2),
 	}
 }
 
 func (bf *BucketDecbufFactory) NewDecbufAtChecked(offset int, table *crc32.Table) Decbuf {
-	// At this point we don't know the length of the section (length is -1).
-	rc, err := bf.bkt.GetRange(bf.ctx, bf.objectPath, int64(offset), -1)
+	attrs, err := bf.bkt.Attributes(bf.ctx, bf.objectPath)
 	if err != nil {
-		return Decbuf{E: fmt.Errorf("get range from %s at offset %d: %w", bf.objectPath, offset, err)}
+		return Decbuf{E: fmt.Errorf("get size from %s: %w", bf.objectPath, err)}
+	}
+	if offset > int(attrs.Size) {
+		return Decbuf{E: fmt.Errorf("offset greater than object size of %s: %w", bf.objectPath, err)}
 	}
 
-	closeReader := true
-	defer func() {
-		if closeReader {
-			rc.Close()
-		}
-	}()
+	// We do not know section length yet;
+	// use the lower-level BucketReader to scan the length data
+	metaReader := NewBucketReader(
+		bf.ctx, bf.bkt, bf.objectPath, offset, int(attrs.Size),
+	)
 
-	// Consume 4-byte length prefix of the section.
-	lengthBytes := make([]byte, 4)
-	n, err := io.ReadFull(rc, lengthBytes)
-	if err != nil {
-		return Decbuf{E: fmt.Errorf("read section length from %s at offset %d: %w", bf.objectPath, offset, err)}
-	}
-	if n != 4 {
-		return Decbuf{E: fmt.Errorf(
-			"insufficient bytes read from %s for section length at offset %d (got %d, wanted %d): %w",
-			bf.objectPath, offset, n, 4, ErrInvalidSize,
-		)}
-	}
+	// TODO: A particular index-header only has symbols and posting offsets. We should only need to read
+	//  the length of each of those a single time per index-header (DecbufFactory). Should the factory
+	//  cache the length? Should the table of contents be passed to the factory?
 
-	contentLength := int(binary.BigEndian.Uint32(lengthBytes))
-	bufLength := len(lengthBytes) + contentLength + crc32.Size
-
-	r := newStreamReader(rc, len(lengthBytes), bufLength)
-	r.seekReader = func(off int) error {
-		rc, err := bf.bkt.GetRange(bf.ctx, bf.objectPath, int64(offset+off), -1)
+	var contentLength int
+	bf.mu.Lock()
+	if cachedContentLength, ok := bf.sectionLenCache[offset]; ok {
+		contentLength = cachedContentLength
+	} else {
+		lengthBytes := make([]byte, 4)
+		n, err := metaReader.Read(lengthBytes)
 		if err != nil {
-			return err
+			return Decbuf{E: err}
 		}
-		r.rc.Close()
-		r.rc = rc
-		return nil
+		if n != 4 {
+			return Decbuf{E: fmt.Errorf("insufficient bytes read for size (got %d, wanted %d): %w", n, 4, ErrInvalidSize)}
+		}
+		contentLength = int(binary.BigEndian.Uint32(lengthBytes))
+		bf.sectionLenCache[offset] = contentLength
 	}
+	bf.mu.Unlock()
 
-	d := Decbuf{r: r}
-	closeReader = false
+	bufferLength := 4 + contentLength + crc32.Size
+
+	bufReader := NewBucketBufReader(bf.ctx, bf.bkt, bf.objectPath, offset, bufferLength)
+	// bufReader is expected start at base offset + 4 after consuming length bytes
+	err = bufReader.Skip(4)
+	if err != nil {
+		return Decbuf{E: err}
+	}
+	d := Decbuf{r: bufReader}
 
 	if table != nil {
 		if d.CheckCrc32(table); d.Err() != nil {
@@ -95,178 +99,14 @@ func (bf *BucketDecbufFactory) NewDecbufAtUnchecked(offset int) Decbuf {
 func (bf *BucketDecbufFactory) NewRawDecbuf() Decbuf {
 	const offset = 0
 
-	rc, err := bf.bkt.GetRange(bf.ctx, bf.objectPath, offset, -1)
-	if err != nil {
-		return Decbuf{E: fmt.Errorf("get range from %s at offset %d: %w", bf.objectPath, offset, err)}
-	}
-
-	closeReader := true
-	defer func() {
-		if closeReader {
-			rc.Close()
-		}
-	}()
-
 	attrs, err := bf.bkt.Attributes(bf.ctx, bf.objectPath)
 	if err != nil {
 		return Decbuf{E: fmt.Errorf("get size from %s: %w", bf.objectPath, err)}
 	}
-
-	r := newStreamReader(rc, offset, int(attrs.Size))
-	r.seekReader = func(_ int) error {
-		// Create reader from full file range
-		rc, err := bf.bkt.GetRange(bf.ctx, bf.objectPath, offset, attrs.Size)
-		if err != nil {
-			return err
-		}
-		r.rc.Close()
-		r.rc = rc
-		return nil
-	}
-
-	closeReader = false
-	return Decbuf{r: r}
-}
-
-// Close cleans up resources associated with this BucketDecbufFactory.
-// For bucket-based implementation, there are no resources to clean up;
-// the bucket client lifecycle is managed by parent components.
-func (bf *BucketDecbufFactory) Close() error {
-	// Nothing to do for bucket-based implementation
-	return nil
-}
-
-// streamReader implements BufReader with a bucket-based io.ReadCloser
-type streamReader struct {
-	rc     io.ReadCloser
-	buf    *bufio.Reader
-	pos    int
-	length int
-
-	seekReader func(off int) error
-}
-
-var netbufPool = sync.Pool{
-	New: func() any {
-		// 1MiB buffer chosen as starting point;
-		// we could make this configurable and benchmark.
-		return bufio.NewReaderSize(nil, 1<<20)
-	},
-}
-
-// newStreamReader creates a new streamReader that wraps the given io.ReadCloser.
-func newStreamReader(rc io.ReadCloser, pos, length int) *streamReader {
-	r := &streamReader{
-		rc:     rc,
-		buf:    netbufPool.Get().(*bufio.Reader),
-		pos:    pos,
-		length: length,
-	}
-	r.buf.Reset(r.rc)
-	return r
-}
-
-func (r *streamReader) Reset() error {
-	return r.ResetAt(0)
-}
-
-func (r *streamReader) ResetAt(off int) error {
-	if off > r.length {
-		return ErrInvalidSize
-	}
-
-	if dist := off - r.pos; dist > 0 && dist < r.Buffered() {
-		// skip ahead by discarding the distance bytes
-		return r.Skip(dist)
-	}
-
-	// Objstore hides the io.ReadSeekCloser, that the underlying bucket clients implement.
-	// So we reimplement it ourselves:
-	// 1. Close the r.rc
-	// 2. Re-read the object from new offset
-	// 3. Reset the r.buf and the rest of the state.
-	// TODO: evaluate if we need a more efficient approach
-	if err := r.seekReader(off); err != nil {
-		return err
-	}
-
-	r.buf.Reset(r.rc)
-	r.pos = off
-
-	return nil
-}
-
-func (r *streamReader) Skip(l int) error {
-	if l > r.Len() {
-		return ErrInvalidSize
-	}
-
-	// TODO: how to make sure we don't trash the cache when skipping
-	n, err := r.buf.Discard(l)
-	if n > 0 {
-		r.pos += n
-	}
-
-	return err
-}
-
-func (r *streamReader) Peek(n int) ([]byte, error) {
-	b, err := r.buf.Peek(n)
-	if err != nil && !errors.Is(err, io.EOF) {
-		return nil, err
-	}
-
-	if len(b) > 0 {
-		return b, nil
-	}
-
-	return nil, nil
-}
-
-func (r *streamReader) Read(n int) ([]byte, error) {
-	b := make([]byte, n)
-
-	err := r.ReadInto(b)
-	if err != nil {
-		return nil, err
-	}
-
-	return b, nil
-}
-
-func (r *streamReader) ReadInto(b []byte) error {
-	n, err := io.ReadFull(r.buf, b)
-	if n > 0 {
-		r.pos += n
-	}
-
-	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
-		return fmt.Errorf("%w reading %d bytes: %s", ErrInvalidSize, len(b), err)
-	} else if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (r *streamReader) Offset() int {
-	return r.pos
-}
-
-func (r *streamReader) Len() int {
-	return r.length - r.pos
-}
-
-func (r *streamReader) Size() int {
-	return r.buf.Size()
-}
-
-func (r *streamReader) Buffered() int {
-	return r.buf.Buffered()
-}
-
-func (r *streamReader) Close() error {
-	err := r.rc.Close()
-	netbufPool.Put(r.buf)
-	return err
+	// Create reader from full file range
+	r := NewBucketBufReader(
+		bf.ctx, bf.bkt, bf.objectPath, offset, int(attrs.Size),
+	)
+	d := Decbuf{r: r}
+	return d
 }

--- a/pkg/storage/indexheader/encoding/bucket_factory.go
+++ b/pkg/storage/indexheader/encoding/bucket_factory.go
@@ -44,7 +44,6 @@ func (bf *BucketDecbufFactory) NewDecbufAtChecked(offset int, table *crc32.Table
 
 	var contentLength int
 	bf.mu.Lock()
-	defer bf.mu.Unlock()
 	if cachedContentLength, ok := bf.sectionLenCache[offset]; ok {
 		// Section length is cached
 		contentLength = cachedContentLength
@@ -52,7 +51,7 @@ func (bf *BucketDecbufFactory) NewDecbufAtChecked(offset int, table *crc32.Table
 		// We do not know section length yet;
 		// use the lower-level BucketReader to scan the length data
 		metaReader := NewBucketReader(
-			bf.ctx, bf.bkt, bf.objectPath, offset, int(attrs.Size),
+			bf.ctx, bf.bkt, bf.objectPath, offset, int(attrs.Size)-offset,
 		)
 
 		lengthBytes := make([]byte, numLenBytes)
@@ -61,11 +60,13 @@ func (bf *BucketDecbufFactory) NewDecbufAtChecked(offset int, table *crc32.Table
 			return Decbuf{E: err}
 		}
 		if n != numLenBytes {
+			bf.mu.Unlock()
 			return Decbuf{E: fmt.Errorf("insufficient bytes read for size (got %d, wanted %d): %w", n, numLenBytes, ErrInvalidSize)}
 		}
 		contentLength = int(binary.BigEndian.Uint32(lengthBytes))
 		bf.sectionLenCache[offset] = contentLength
 	}
+	bf.mu.Unlock()
 
 	bufferLength := numLenBytes + contentLength + crc32.Size
 

--- a/pkg/storage/indexheader/encoding/bucket_factory.go
+++ b/pkg/storage/indexheader/encoding/bucket_factory.go
@@ -39,11 +39,12 @@ func (bf *BucketDecbufFactory) NewDecbufAtChecked(offset int, table *crc32.Table
 		return Decbuf{E: fmt.Errorf("get size from %s: %w", bf.objectPath, err)}
 	}
 	if offset > int(attrs.Size) {
-		return Decbuf{E: fmt.Errorf("offset greater than object size of %s: %w", bf.objectPath, err)}
+		return Decbuf{E: fmt.Errorf("offset greater than object size of %s", bf.objectPath)}
 	}
 
 	var contentLength int
 	bf.mu.Lock()
+	defer bf.mu.Unlock()
 	if cachedContentLength, ok := bf.sectionLenCache[offset]; ok {
 		// Section length is cached
 		contentLength = cachedContentLength
@@ -65,7 +66,6 @@ func (bf *BucketDecbufFactory) NewDecbufAtChecked(offset int, table *crc32.Table
 		contentLength = int(binary.BigEndian.Uint32(lengthBytes))
 		bf.sectionLenCache[offset] = contentLength
 	}
-	bf.mu.Unlock()
 
 	bufferLength := numLenBytes + contentLength + crc32.Size
 

--- a/pkg/storage/indexheader/encoding/bucket_factory.go
+++ b/pkg/storage/indexheader/encoding/bucket_factory.go
@@ -42,39 +42,36 @@ func (bf *BucketDecbufFactory) NewDecbufAtChecked(offset int, table *crc32.Table
 		return Decbuf{E: fmt.Errorf("offset greater than object size of %s: %w", bf.objectPath, err)}
 	}
 
-	// We do not know section length yet;
-	// use the lower-level BucketReader to scan the length data
-	metaReader := NewBucketReader(
-		bf.ctx, bf.bkt, bf.objectPath, offset, int(attrs.Size),
-	)
-
-	// TODO: A particular index-header only has symbols and posting offsets. We should only need to read
-	//  the length of each of those a single time per index-header (DecbufFactory). Should the factory
-	//  cache the length? Should the table of contents be passed to the factory?
-
 	var contentLength int
 	bf.mu.Lock()
 	if cachedContentLength, ok := bf.sectionLenCache[offset]; ok {
+		// Section length is cached
 		contentLength = cachedContentLength
 	} else {
-		lengthBytes := make([]byte, 4)
+		// We do not know section length yet;
+		// use the lower-level BucketReader to scan the length data
+		metaReader := NewBucketReader(
+			bf.ctx, bf.bkt, bf.objectPath, offset, int(attrs.Size),
+		)
+
+		lengthBytes := make([]byte, numLenBytes)
 		n, err := metaReader.Read(lengthBytes)
 		if err != nil {
 			return Decbuf{E: err}
 		}
-		if n != 4 {
-			return Decbuf{E: fmt.Errorf("insufficient bytes read for size (got %d, wanted %d): %w", n, 4, ErrInvalidSize)}
+		if n != numLenBytes {
+			return Decbuf{E: fmt.Errorf("insufficient bytes read for size (got %d, wanted %d): %w", n, numLenBytes, ErrInvalidSize)}
 		}
 		contentLength = int(binary.BigEndian.Uint32(lengthBytes))
 		bf.sectionLenCache[offset] = contentLength
 	}
 	bf.mu.Unlock()
 
-	bufferLength := 4 + contentLength + crc32.Size
+	bufferLength := numLenBytes + contentLength + crc32.Size
 
 	bufReader := NewBucketBufReader(bf.ctx, bf.bkt, bf.objectPath, offset, bufferLength)
 	// bufReader is expected start at base offset + 4 after consuming length bytes
-	err = bufReader.Skip(4)
+	err = bufReader.Skip(numLenBytes)
 	if err != nil {
 		return Decbuf{E: err}
 	}
@@ -86,7 +83,7 @@ func (bf *BucketDecbufFactory) NewDecbufAtChecked(offset int, table *crc32.Table
 		}
 
 		// reset to the beginning of the content after reading it all for the CRC.
-		d.ResetAt(4)
+		d.ResetAt(numLenBytes)
 	}
 
 	return d

--- a/pkg/storage/indexheader/encoding/bucket_reader.go
+++ b/pkg/storage/indexheader/encoding/bucket_reader.go
@@ -88,6 +88,8 @@ type BucketBufReader struct {
 	r           *BucketReader
 	resetReader func(off int) error
 	buf         *bufio.Reader
+	// Hold a reference to the pool for returning on Close - allows tests to use different pool.
+	bufPool *sync.Pool
 }
 
 func resetReaderFunc(bufReader *BucketBufReader) func(off int) error {
@@ -116,13 +118,14 @@ func newBucketBufReader(
 	bufioReader.Reset(reader)
 
 	bufReader := &BucketBufReader{
-		ctx:    ctx,
-		bkt:    bkt,
-		name:   name,
-		base:   base,
-		length: length,
-		r:      reader,
-		buf:    bufioReader,
+		ctx:     ctx,
+		bkt:     bkt,
+		name:    name,
+		base:    base,
+		length:  length,
+		r:       reader,
+		buf:     bufioReader,
+		bufPool: bufioPool,
 	}
 
 	bufReader.resetReader = resetReaderFunc(bufReader)
@@ -226,7 +229,7 @@ func (bbr *BucketBufReader) Buffered() int {
 func (bbr *BucketBufReader) Close() error {
 	// Note that we don't do anything to clean up the buffer before returning it to the pool here:
 	// we reset the buffer when we retrieve it from the pool instead.
-	bucketBufPool.Put(bbr.buf)
+	bbr.bufPool.Put(bbr.buf)
 	// The BucketReader does not need closed -
 	// it closes the reader generated from bkt.GetRange on each Read call.
 	return nil

--- a/pkg/storage/indexheader/encoding/bucket_reader.go
+++ b/pkg/storage/indexheader/encoding/bucket_reader.go
@@ -113,7 +113,7 @@ func (bbr *BucketBufReader) ResetAt(off int) error {
 	if off > bbr.length {
 		return ErrInvalidSize
 	}
-	
+
 	if err := bbr.resetReader(off); err != nil {
 		return err
 	}

--- a/pkg/storage/indexheader/encoding/bucket_reader.go
+++ b/pkg/storage/indexheader/encoding/bucket_reader.go
@@ -59,6 +59,17 @@ func (r *BucketReader) Read(p []byte) (n int, err error) {
 	return n, err
 }
 
+func (r *BucketReader) Seek(offset int64, whence int) (int64, error) {
+	if whence != io.SeekStart {
+		return 0, fmt.Errorf("invalid Seek whence: %d", whence)
+	}
+	if offset < 0 {
+		return 0, fmt.Errorf("seek to negative offset %d", offset)
+	}
+	r.off = int(offset)
+	return offset, nil
+}
+
 var bucketBufPool = sync.Pool{
 	New: func() any {
 		// 1MiB buffer chosen as starting point;
@@ -97,7 +108,11 @@ func NewBucketBufReader(
 	}
 
 	resetReader := func(off int) error {
-		r := NewBucketReader(ctx, bkt, name, base+off, length)
+		r := NewBucketReader(ctx, bkt, name, base, length)
+		_, err := r.Seek(int64(off), io.SeekStart)
+		if err != nil {
+			return err
+		}
 		bufReader.r = r
 		return nil
 	}

--- a/pkg/storage/indexheader/encoding/bucket_reader.go
+++ b/pkg/storage/indexheader/encoding/bucket_reader.go
@@ -90,11 +90,29 @@ type BucketBufReader struct {
 	buf         *bufio.Reader
 }
 
+func resetReaderFunc(bufReader *BucketBufReader) func(off int) error {
+	return func(off int) error {
+		r := NewBucketReader(bufReader.ctx, bufReader.bkt, bufReader.name, bufReader.base, bufReader.length)
+		_, err := r.Seek(int64(off), io.SeekStart)
+		if err != nil {
+			return err
+		}
+		bufReader.r = r
+		return nil
+	}
+}
+
 func NewBucketBufReader(
 	ctx context.Context, bkt objstore.BucketReader, name string, base int, length int,
 ) *BucketBufReader {
+	return newBucketBufReader(ctx, &bucketBufPool, bkt, name, base, length)
+}
+
+func newBucketBufReader(
+	ctx context.Context, bufioPool *sync.Pool, bkt objstore.BucketReader, name string, base int, length int,
+) *BucketBufReader {
 	reader := NewBucketReader(ctx, bkt, name, base, length)
-	bufioReader := bucketBufPool.Get().(*bufio.Reader)
+	bufioReader := bufioPool.Get().(*bufio.Reader)
 	bufioReader.Reset(reader)
 
 	bufReader := &BucketBufReader{
@@ -107,16 +125,7 @@ func NewBucketBufReader(
 		buf:    bufioReader,
 	}
 
-	resetReader := func(off int) error {
-		r := NewBucketReader(ctx, bkt, name, base, length)
-		_, err := r.Seek(int64(off), io.SeekStart)
-		if err != nil {
-			return err
-		}
-		bufReader.r = r
-		return nil
-	}
-	bufReader.resetReader = resetReader
+	bufReader.resetReader = resetReaderFunc(bufReader)
 	return bufReader
 }
 
@@ -127,6 +136,11 @@ func (bbr *BucketBufReader) Reset() error {
 func (bbr *BucketBufReader) ResetAt(off int) error {
 	if off > bbr.length {
 		return ErrInvalidSize
+	}
+
+	if dist := off - bbr.off; dist > 0 && dist < bbr.Buffered() {
+		// skip ahead by discarding the distance bytes
+		return bbr.Skip(dist)
 	}
 
 	if err := bbr.resetReader(off); err != nil {

--- a/pkg/storage/indexheader/encoding/bucket_reader.go
+++ b/pkg/storage/indexheader/encoding/bucket_reader.go
@@ -113,13 +113,7 @@ func (bbr *BucketBufReader) ResetAt(off int) error {
 	if off > bbr.length {
 		return ErrInvalidSize
 	}
-
-	// Objstore hides the io.ReadSeekCloser, that the underlying bucket clients implement.
-	// So we reimplement it ourselves:
-	// 1. Close the r.rc
-	// 2. Re-read the object from new offset
-	// 3. Reset the r.buf and the rest of the state.
-	// TODO: evaluate if we need a more efficient approach
+	
 	if err := bbr.resetReader(off); err != nil {
 		return err
 	}

--- a/pkg/storage/indexheader/encoding/bucket_reader.go
+++ b/pkg/storage/indexheader/encoding/bucket_reader.go
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package encoding
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/thanos-io/objstore"
+)
+
+type BucketReader struct {
+	ctx    context.Context
+	bkt    objstore.BucketReader
+	name   string
+	base   int
+	length int
+	off    int
+}
+
+func NewBucketReader(
+	ctx context.Context, bkt objstore.BucketReader, name string, base int, length int,
+) *BucketReader {
+	return &BucketReader{
+		ctx:    ctx,
+		bkt:    bkt,
+		name:   name,
+		base:   base,
+		length: length,
+	}
+}
+
+func (r *BucketReader) Read(p []byte) (n int, err error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if r.off >= r.length {
+		return 0, io.EOF
+	}
+	toRead := len(p)
+	remaining := r.length - r.off
+	if toRead > remaining {
+		toRead = remaining
+	}
+	rc, err := r.bkt.GetRange(r.ctx, r.name, int64(r.base+r.off), int64(toRead))
+	if err != nil {
+		return 0, err
+	}
+	defer rc.Close()
+	n, err = io.ReadFull(rc, p[:toRead])
+	r.off += n
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		err = io.EOF
+	}
+	return n, err
+}
+
+var bucketBufPool = sync.Pool{
+	New: func() any {
+		// 1MiB buffer chosen as starting point;
+		// we could make this configurable and benchmark.
+		return bufio.NewReaderSize(nil, 1<<20)
+	},
+}
+
+type BucketBufReader struct {
+	ctx         context.Context
+	bkt         objstore.BucketReader
+	name        string
+	base        int
+	length      int
+	off         int
+	r           *BucketReader
+	resetReader func(off int) error
+	buf         *bufio.Reader
+}
+
+func NewBucketBufReader(
+	ctx context.Context, bkt objstore.BucketReader, name string, base int, length int,
+) *BucketBufReader {
+	reader := NewBucketReader(ctx, bkt, name, base, length)
+	bufioReader := bucketBufPool.Get().(*bufio.Reader)
+	bufioReader.Reset(reader)
+
+	bufReader := &BucketBufReader{
+		ctx:    ctx,
+		bkt:    bkt,
+		name:   name,
+		base:   base,
+		length: length,
+		r:      reader,
+		buf:    bufioReader,
+	}
+
+	resetReader := func(off int) error {
+		r := NewBucketReader(ctx, bkt, name, base+off, length)
+		bufReader.r = r
+		return nil
+	}
+	bufReader.resetReader = resetReader
+	return bufReader
+}
+
+func (bbr *BucketBufReader) Reset() error {
+	return bbr.ResetAt(0)
+}
+
+func (bbr *BucketBufReader) ResetAt(off int) error {
+	if off > bbr.length {
+		return ErrInvalidSize
+	}
+
+	// Objstore hides the io.ReadSeekCloser, that the underlying bucket clients implement.
+	// So we reimplement it ourselves:
+	// 1. Close the r.rc
+	// 2. Re-read the object from new offset
+	// 3. Reset the r.buf and the rest of the state.
+	// TODO: evaluate if we need a more efficient approach
+	if err := bbr.resetReader(off); err != nil {
+		return err
+	}
+
+	bbr.buf.Reset(bbr.r)
+	bbr.off = off
+
+	return nil
+}
+
+func (bbr *BucketBufReader) Skip(l int) error {
+	if l > bbr.Len() {
+		return ErrInvalidSize
+	}
+
+	n, err := bbr.buf.Discard(l)
+	if n > 0 {
+		bbr.off += n
+	}
+
+	return err
+}
+
+func (bbr *BucketBufReader) Peek(n int) ([]byte, error) {
+	b, err := bbr.buf.Peek(n)
+	// bufio.Reader still returns what it Read when it hits EOF and callers
+	// expect to be able to peek past the end of a file.
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, err
+	}
+
+	if len(b) > 0 {
+		return b, nil
+	}
+
+	return nil, nil
+}
+
+func (bbr *BucketBufReader) Read(n int) ([]byte, error) {
+	b := make([]byte, n)
+
+	err := bbr.ReadInto(b)
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+func (bbr *BucketBufReader) ReadInto(b []byte) error {
+	n, err := io.ReadFull(bbr.buf, b)
+	if n > 0 {
+		bbr.off += n
+	}
+
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return fmt.Errorf("%w reading %d bytes: %s", ErrInvalidSize, len(b), err)
+	} else if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (bbr *BucketBufReader) Size() int {
+	return bbr.buf.Size()
+}
+
+func (bbr *BucketBufReader) Len() int {
+	return bbr.length - bbr.off
+}
+
+func (bbr *BucketBufReader) Offset() int {
+	return bbr.off
+}
+
+func (bbr *BucketBufReader) Buffered() int {
+	return bbr.buf.Buffered()
+}
+
+func (bbr *BucketBufReader) Close() error {
+	// Note that we don't do anything to clean up the buffer before returning it to the pool here:
+	// we reset the buffer when we retrieve it from the pool instead.
+	bucketBufPool.Put(bbr.buf)
+	// The BucketReader does not need closed -
+	// it closes the reader generated from bkt.GetRange on each Read call.
+	return nil
+}

--- a/pkg/storage/indexheader/encoding/bucket_reader_test.go
+++ b/pkg/storage/indexheader/encoding/bucket_reader_test.go
@@ -1,0 +1,406 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package encoding
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
+)
+
+// testBucketContents is the 36-byte payload used throughout bucket reader tests.
+// 36 bytes selected to allow two full buffer fills of size 16 and one partial buffer fill to complete.
+var testBucketContents = []byte("abcdefghijklmnopqrstuvwxyz1234567890")
+
+const testBucketObjectName = "test-object"
+
+// trackingBucket wraps an InstrumentedBucketReader and records every GetRange call.
+type trackingBucket struct {
+	objstore.InstrumentedBucketReader
+	calls []rangeCall
+}
+
+type rangeCall struct {
+	off    int64
+	length int64
+}
+
+func (b *trackingBucket) GetRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {
+	b.calls = append(b.calls, rangeCall{off, length})
+	return b.InstrumentedBucketReader.GetRange(ctx, name, off, length)
+}
+
+// newTrackingBucket uploads objectData to an in-memory bucket and returns a
+// tracking wrapper around it.
+func newTrackingBucket(t *testing.T, objectData []byte) *trackingBucket {
+	t.Helper()
+	inmem := objstore.NewInMemBucket()
+	require.NoError(t, inmem.Upload(context.Background(), testBucketObjectName, bytes.NewReader(objectData)))
+	return &trackingBucket{InstrumentedBucketReader: objstore.WithNoopInstr(inmem)}
+}
+
+const testBufPoolSize = 16 // Equal to minReadBufferSize for bufio.Reader; cannot init with smaller size
+
+var testBucketBufPool = sync.Pool{
+	New: func() any {
+		// 1MiB buffer chosen as starting point;
+		// we could make this configurable and benchmark.
+		return bufio.NewReaderSize(nil, testBufPoolSize)
+	},
+}
+
+// newTestReader returns a BucketBufReader whose data segment is testBucketContents,
+// starting at base bytes into the object.
+func newTestReader(t *testing.T, base, length int) (*BucketBufReader, *trackingBucket) {
+	t.Helper()
+	ctx := context.Background()
+
+	objectData := make([]byte, 0, length)
+	objectData = append(objectData, testBucketContents...)
+	bkt := newTrackingBucket(t, objectData)
+
+	reader := NewBucketReader(ctx, bkt, testBucketObjectName, base, length)
+	bufioReader := testBucketBufPool.Get().(*bufio.Reader)
+	bufioReader.Reset(reader)
+
+	bufReader := &BucketBufReader{
+		ctx:    ctx,
+		bkt:    bkt,
+		name:   testBucketObjectName,
+		base:   base,
+		length: length,
+		r:      reader,
+		buf:    bufioReader,
+	}
+
+	resetReader := func(off int) error {
+		r := NewBucketReader(ctx, bkt, testBucketObjectName, base+off, length)
+		bufReader.r = r
+		return nil
+	}
+	bufReader.resetReader = resetReader
+	return bufReader, bkt
+}
+
+// failingBucket is an InstrumentedBucketReader whose GetRange always returns an error.
+type failingBucket struct {
+	err error
+}
+
+func (b *failingBucket) GetRange(_ context.Context, _ string, _, _ int64) (io.ReadCloser, error) {
+	return nil, b.err
+}
+
+func (b *failingBucket) Get(_ context.Context, _ string) (io.ReadCloser, error) {
+	return nil, b.err
+}
+
+func (b *failingBucket) Iter(_ context.Context, _ string, _ func(string) error, _ ...objstore.IterOption) error {
+	return b.err
+}
+
+func (b *failingBucket) IterWithAttributes(_ context.Context, _ string, _ func(objstore.IterObjectAttributes) error, _ ...objstore.IterOption) error {
+	return b.err
+}
+
+func (b *failingBucket) SupportedIterOptions() []objstore.IterOptionType { return nil }
+
+func (b *failingBucket) Exists(_ context.Context, _ string) (bool, error) { return false, b.err }
+
+func (b *failingBucket) Attributes(_ context.Context, _ string) (objstore.ObjectAttributes, error) {
+	return objstore.ObjectAttributes{}, b.err
+}
+
+func (b *failingBucket) IsObjNotFoundErr(_ error) bool  { return false }
+func (b *failingBucket) IsAccessDeniedErr(_ error) bool { return false }
+func (b *failingBucket) Name() string                   { return "failing" }
+func (b *failingBucket) Close() error                   { return nil }
+
+func (b *failingBucket) ReaderWithExpectedErrs(_ objstore.IsOpFailureExpectedFunc) objstore.BucketReader {
+	return b
+}
+
+// newFailingBufReader returns a BucketBufReader backed by a failingBucket.
+func newFailingBufReader(t *testing.T, sentinel error) *BucketBufReader {
+	t.Helper()
+	bkt := &failingBucket{err: sentinel}
+	ctx := context.Background()
+	reader := NewBucketReader(ctx, bkt, "obj", 0, 10)
+	bufioReader := testBucketBufPool.Get().(*bufio.Reader)
+	bufioReader.Reset(reader)
+	return &BucketBufReader{
+		ctx:    ctx,
+		bkt:    bkt,
+		name:   "obj",
+		base:   0,
+		length: 10,
+		r:      reader,
+		buf:    bufioReader,
+	}
+}
+
+// ---- BucketBufReader --------------------------------------------------------
+
+func TestBucketBufReader_Read_Sequential(t *testing.T) {
+	r, _ := newTestReader(t, 0, len(testBucketContents))
+
+	b, err := r.Read(5)
+	require.NoError(t, err)
+	require.Equal(t, testBucketContents[:5], b)
+	require.Equal(t, 5, r.Offset())
+
+	b, err = r.Read(5)
+	require.NoError(t, err)
+	require.Equal(t, testBucketContents[5:10], b)
+	require.Equal(t, 10, r.Offset())
+}
+
+func TestBucketBufReader_Read_ExactLength(t *testing.T) {
+	r, _ := newTestReader(t, 0, len(testBucketContents))
+
+	b, err := r.Read(len(testBucketContents))
+	require.NoError(t, err)
+	require.Equal(t, testBucketContents, b)
+	require.Equal(t, len(testBucketContents), r.Offset())
+	require.Equal(t, 0, r.Len())
+}
+
+func TestBucketBufReader_Read_BeyondEnd(t *testing.T) {
+	const segmentLen = 10
+	r, _ := newTestReader(t, 0, segmentLen)
+
+	b, err := r.Read(segmentLen + 1)
+	require.ErrorIs(t, err, ErrInvalidSize)
+	require.Nil(t, b)
+	require.Equal(t, segmentLen, r.Offset(), "cursor advanced to end")
+}
+
+func TestBucketBufReader_Read_BeyondEndAfterPartialConsumption(t *testing.T) {
+	const segmentLen = 10
+	r, _ := newTestReader(t, 0, segmentLen)
+
+	_, err := r.Read(3)
+	require.NoError(t, err)
+
+	// 7 remain; attempt to read 8
+	b, err := r.Read(8)
+	require.ErrorIs(t, err, ErrInvalidSize)
+	require.Nil(t, b)
+	require.Equal(t, segmentLen, r.Offset(), "cursor advanced to end")
+}
+
+func TestBucketBufReader_ReadInto_Basic(t *testing.T) {
+	r, _ := newTestReader(t, 0, len(testBucketContents))
+
+	buf := make([]byte, 5)
+	require.NoError(t, r.ReadInto(buf))
+	require.Equal(t, testBucketContents[:5], buf)
+	require.Equal(t, 5, r.Offset())
+}
+
+func TestBucketBufReader_ReadInto_BeyondEnd(t *testing.T) {
+	const segmentLen = 5
+	r, _ := newTestReader(t, 0, segmentLen)
+
+	buf := make([]byte, segmentLen+1)
+	err := r.ReadInto(buf)
+	require.ErrorIs(t, err, ErrInvalidSize)
+	require.Equal(t, segmentLen, r.Offset(), "cursor advanced to end")
+}
+
+func TestBucketBufReader_Skip_Basic(t *testing.T) {
+	r, _ := newTestReader(t, 0, len(testBucketContents))
+
+	require.NoError(t, r.Skip(10))
+	require.Equal(t, 10, r.Offset())
+	require.Equal(t, len(testBucketContents)-10, r.Len())
+
+	b, err := r.Read(3)
+	require.NoError(t, err)
+	require.Equal(t, testBucketContents[10:13], b)
+}
+
+func TestBucketBufReader_Skip_ToEnd(t *testing.T) {
+	const segmentLen = 10
+	r, _ := newTestReader(t, 0, segmentLen)
+
+	require.NoError(t, r.Skip(segmentLen))
+	require.Equal(t, segmentLen, r.Offset())
+	require.Equal(t, 0, r.Len())
+}
+
+func TestBucketBufReader_Skip_BeyondEnd(t *testing.T) {
+	const segmentLen = 10
+	r, _ := newTestReader(t, 0, segmentLen)
+
+	err := r.Skip(segmentLen + 1)
+	require.ErrorIs(t, err, ErrInvalidSize)
+}
+
+func TestBucketBufReader_Peek_Basic(t *testing.T) {
+	r, _ := newTestReader(t, 0, len(testBucketContents))
+
+	b, err := r.Peek(5)
+	require.NoError(t, err)
+	require.Equal(t, testBucketContents[:5], b)
+	require.Equal(t, 0, r.Offset(), "cursor must not advance after Peek")
+
+	// Read should return the same bytes.
+	got, err := r.Read(5)
+	require.NoError(t, err)
+	require.Equal(t, testBucketContents[:5], got)
+}
+
+func TestBucketBufReader_Peek_PastSegmentEnd(t *testing.T) {
+	// segmentLen must be smaller than testBufPoolSize so bufio can attempt to fill
+	// but hits EOF before reaching n; this exercises the EOF-suppression in Peek.
+	const segmentLen = 5
+	r, _ := newTestReader(t, 0, segmentLen)
+
+	b, err := r.Peek(segmentLen + 5)
+	require.NoError(t, err)
+	require.Equal(t, testBucketContents[:segmentLen], b)
+	require.Equal(t, 0, r.Offset(), "cursor must not advance after Peek")
+}
+
+func TestBucketBufReader_Peek_AtEnd(t *testing.T) {
+	const segmentLen = 5
+	r, _ := newTestReader(t, 0, segmentLen)
+	require.NoError(t, r.Skip(segmentLen))
+
+	b, err := r.Peek(1)
+	require.NoError(t, err)
+	require.Nil(t, b)
+}
+
+func TestBucketBufReader_Reset(t *testing.T) {
+	r, _ := newTestReader(t, 0, len(testBucketContents))
+
+	first, err := r.Read(10)
+	require.NoError(t, err)
+	require.Equal(t, testBucketContents[:10], first)
+
+	require.NoError(t, r.Reset())
+	require.Equal(t, 0, r.Offset())
+	require.Equal(t, len(testBucketContents), r.Len())
+
+	second, err := r.Read(10)
+	require.NoError(t, err)
+	require.Equal(t, testBucketContents[:10], second)
+}
+
+func TestBucketBufReader_ResetAt_Middle(t *testing.T) {
+	r, _ := newTestReader(t, 0, len(testBucketContents))
+
+	require.NoError(t, r.ResetAt(10))
+	require.Equal(t, 10, r.Offset())
+	require.Equal(t, len(testBucketContents)-10, r.Len())
+
+	b, err := r.Read(5)
+	require.NoError(t, err)
+	require.Equal(t, testBucketContents[10:15], b)
+}
+
+func TestBucketBufReader_ResetAt_End(t *testing.T) {
+	const segmentLen = 10
+	r, _ := newTestReader(t, 0, segmentLen)
+
+	require.NoError(t, r.ResetAt(segmentLen))
+	require.Equal(t, segmentLen, r.Offset())
+	require.Equal(t, 0, r.Len())
+}
+
+func TestBucketBufReader_ResetAt_BeyondEnd(t *testing.T) {
+	const segmentLen = 10
+	r, _ := newTestReader(t, 0, segmentLen)
+
+	err := r.ResetAt(segmentLen + 1)
+	require.ErrorIs(t, err, ErrInvalidSize)
+}
+
+func TestBucketBufReader_Len(t *testing.T) {
+	r, _ := newTestReader(t, 0, len(testBucketContents))
+
+	require.Equal(t, len(testBucketContents), r.Len())
+	require.NoError(t, r.Skip(10))
+	require.Equal(t, len(testBucketContents)-10, r.Len())
+	_, err := r.Read(5)
+	require.NoError(t, err)
+	require.Equal(t, len(testBucketContents)-15, r.Len())
+}
+
+func TestBucketBufReader_Size(t *testing.T) {
+	r, _ := newTestReader(t, 0, len(testBucketContents))
+	require.Equal(t, testBufPoolSize, r.Size())
+}
+
+func TestBucketBufReader_Buffered(t *testing.T) {
+	r, _ := newTestReader(t, 0, len(testBucketContents))
+	require.Equal(t, 0, r.Buffered())
+
+	// Reading 1 byte causes bufio to fill its full buffer; the remaining
+	// testBufPoolSize-1 bytes stay in memory.
+	_, err := r.Read(1)
+	require.NoError(t, err)
+	require.Equal(t, testBufPoolSize-1, r.Buffered())
+}
+
+func TestBucketBufReader_Close(t *testing.T) {
+	r, _ := newTestReader(t, 0, len(testBucketContents))
+	require.NoError(t, r.Close())
+}
+
+func TestBucketBufReader_GetRangeCalls_Buffering(t *testing.T) {
+	r, bkt := newTestReader(t, 0, len(testBucketContents))
+
+	// Reading one byte at a time: bufio fills its entire buffer (testBufPoolSize bytes)
+	// on the first underlying Read, so all testBufPoolSize single-byte reads cost one
+	// GetRange call.
+	for i := 0; i < testBufPoolSize; i++ {
+		_, err := r.Read(1)
+		require.NoError(t, err)
+	}
+	require.Len(t, bkt.calls, 1, "all reads within first buffer window should share one GetRange call")
+
+	// One more byte crosses into the next buffer window.
+	_, err := r.Read(1)
+	require.NoError(t, err)
+	require.Len(t, bkt.calls, 2, "crossing buffer boundary triggers a second GetRange call")
+}
+
+func TestBucketBufReader_GetRangeCalls_ResetRefetches(t *testing.T) {
+	r, bkt := newTestReader(t, 0, len(testBucketContents))
+
+	_, err := r.Read(1)
+	require.NoError(t, err)
+	require.Len(t, bkt.calls, 1)
+
+	// After Reset the buffer is discarded; the next read must refetch from the bucket.
+	require.NoError(t, r.Reset())
+	_, err = r.Read(1)
+	require.NoError(t, err)
+	require.Len(t, bkt.calls, 2)
+}
+
+func TestBucketBufReader_Read_GetRangeError(t *testing.T) {
+	sentinel := errors.New("storage error")
+	r := newFailingBufReader(t, sentinel)
+
+	_, err := r.Read(5)
+	require.ErrorIs(t, err, sentinel)
+}
+
+func TestBucketBufReader_ReadInto_GetRangeError(t *testing.T) {
+	sentinel := errors.New("storage error")
+	r := newFailingBufReader(t, sentinel)
+
+	err := r.ReadInto(make([]byte, 5))
+	require.ErrorIs(t, err, sentinel)
+}

--- a/pkg/storage/indexheader/encoding/bucket_reader_test.go
+++ b/pkg/storage/indexheader/encoding/bucket_reader_test.go
@@ -21,44 +21,17 @@ var testBucketContents = []byte("abcdefghijklmnopqrstuvwxyz1234567890")
 
 const testBucketObjectName = "test-object"
 
-// trackingBucket wraps an InstrumentedBucketReader and records every GetRange call.
-type trackingBucket struct {
-	objstore.InstrumentedBucketReader
-	calls []rangeCall
-}
-
-type rangeCall struct {
-	off    int64
-	length int64
-}
-
-func (b *trackingBucket) GetRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {
-	b.calls = append(b.calls, rangeCall{off, length})
-	return b.InstrumentedBucketReader.GetRange(ctx, name, off, length)
-}
-
-// newTrackingBucket uploads objectData to an in-memory bucket and returns a
-// tracking wrapper around it.
-func newTrackingBucket(t *testing.T, objectData []byte) *trackingBucket {
-	t.Helper()
-	inmem := objstore.NewInMemBucket()
-	require.NoError(t, inmem.Upload(context.Background(), testBucketObjectName, bytes.NewReader(objectData)))
-	return &trackingBucket{InstrumentedBucketReader: objstore.WithNoopInstr(inmem)}
-}
-
-const testBufPoolSize = 16 // Equal to minReadBufferSize for bufio.Reader; cannot init with smaller size
+// Equal to minReadBufferSize for bufio.Reader; cannot init with smaller size.
+// Small buffer is used to force multiple bufio.Reader fill operations to read full testBucketContents.
+const testBufPoolSize = 16
 
 var testBucketBufPool = sync.Pool{
 	New: func() any {
-		// 1MiB buffer chosen as starting point;
-		// we could make this configurable and benchmark.
 		return bufio.NewReaderSize(nil, testBufPoolSize)
 	},
 }
 
-// newTestReader returns a BucketBufReader whose data segment is testBucketContents,
-// starting at base bytes into the object.
-func newTestReader(t *testing.T, base, length int) (*BucketBufReader, *trackingBucket) {
+func newTestBufReader(t *testing.T, base, length int) (*BucketBufReader, *trackingBucket) {
 	t.Helper()
 	ctx := context.Background()
 
@@ -87,6 +60,303 @@ func newTestReader(t *testing.T, base, length int) (*BucketBufReader, *trackingB
 	}
 	bufReader.resetReader = resetReader
 	return bufReader, bkt
+}
+
+func newFailingBufReader(t *testing.T, sentinel error) *BucketBufReader {
+	t.Helper()
+	bkt := &failingBucket{err: sentinel}
+	ctx := context.Background()
+	reader := NewBucketReader(ctx, bkt, "obj", 0, 10)
+	bufioReader := testBucketBufPool.Get().(*bufio.Reader)
+	bufioReader.Reset(reader)
+	return &BucketBufReader{
+		ctx:    ctx,
+		bkt:    bkt,
+		name:   "obj",
+		base:   0,
+		length: 10,
+		r:      reader,
+		buf:    bufioReader,
+	}
+}
+
+func TestBucketBufReader_Read_Sequential(t *testing.T) {
+	r, _ := newTestBufReader(t, 0, len(testBucketContents))
+
+	b, err := r.Read(5)
+	require.NoError(t, err)
+	require.Equal(t, testBucketContents[:5], b)
+	require.Equal(t, 5, r.Offset())
+
+	b, err = r.Read(5)
+	require.NoError(t, err)
+	require.Equal(t, testBucketContents[5:10], b)
+	require.Equal(t, 10, r.Offset())
+}
+
+func TestBucketBufReader_Read_ExactLength(t *testing.T) {
+	r, _ := newTestBufReader(t, 0, len(testBucketContents))
+
+	b, err := r.Read(len(testBucketContents))
+	require.NoError(t, err)
+	require.Equal(t, testBucketContents, b)
+	require.Equal(t, len(testBucketContents), r.Offset())
+	require.Equal(t, 0, r.Len())
+}
+
+func TestBucketBufReader_Read_BeyondEnd(t *testing.T) {
+	const sectionLen = 10
+	r, _ := newTestBufReader(t, 0, sectionLen)
+
+	b, err := r.Read(sectionLen + 1)
+	require.ErrorIs(t, err, ErrInvalidSize)
+	require.Nil(t, b)
+	require.Equal(t, sectionLen, r.Offset())
+}
+
+func TestBucketBufReader_Read_BeyondEndAfterPartialConsumption(t *testing.T) {
+	const sectionLen = 10
+	r, _ := newTestBufReader(t, 0, sectionLen)
+
+	_, err := r.Read(3)
+	require.NoError(t, err)
+
+	// 7 remain; attempt to read 8
+	b, err := r.Read(8)
+	require.ErrorIs(t, err, ErrInvalidSize)
+	require.Nil(t, b)
+	require.Equal(t, sectionLen, r.Offset(), "cursor advanced to end")
+}
+
+func TestBucketBufReader_ReadInto_Basic(t *testing.T) {
+	r, _ := newTestBufReader(t, 0, len(testBucketContents))
+
+	buf := make([]byte, 5)
+	require.NoError(t, r.ReadInto(buf))
+	require.Equal(t, testBucketContents[:5], buf)
+	require.Equal(t, 5, r.Offset())
+}
+
+func TestBucketBufReader_ReadInto_BeyondEnd(t *testing.T) {
+	const sectionLen = 5
+	r, _ := newTestBufReader(t, 0, sectionLen)
+
+	buf := make([]byte, sectionLen+1)
+	err := r.ReadInto(buf)
+	require.ErrorIs(t, err, ErrInvalidSize)
+	require.Equal(t, sectionLen, r.Offset(), "cursor advanced to end")
+}
+
+func TestBucketBufReader_Skip_Basic(t *testing.T) {
+	r, _ := newTestBufReader(t, 0, len(testBucketContents))
+
+	require.NoError(t, r.Skip(10))
+	require.Equal(t, 10, r.Offset())
+	require.Equal(t, len(testBucketContents)-10, r.Len())
+
+	b, err := r.Read(3)
+	require.NoError(t, err)
+	require.Equal(t, testBucketContents[10:13], b)
+}
+
+func TestBucketBufReader_Skip_ToEnd(t *testing.T) {
+	const sectionLen = 10
+	r, _ := newTestBufReader(t, 0, sectionLen)
+
+	require.NoError(t, r.Skip(sectionLen))
+	require.Equal(t, sectionLen, r.Offset())
+	require.Equal(t, 0, r.Len())
+}
+
+func TestBucketBufReader_Skip_BeyondEnd(t *testing.T) {
+	const sectionLen = 10
+	r, _ := newTestBufReader(t, 0, sectionLen)
+
+	err := r.Skip(sectionLen + 1)
+	require.ErrorIs(t, err, ErrInvalidSize)
+}
+
+func TestBucketBufReader_Peek_Basic(t *testing.T) {
+	r, _ := newTestBufReader(t, 0, len(testBucketContents))
+
+	b, err := r.Peek(5)
+	require.NoError(t, err)
+	require.Equal(t, testBucketContents[:5], b)
+	require.Equal(t, 0, r.Offset())
+
+	// Read should return the same bytes.
+	got, err := r.Read(5)
+	require.NoError(t, err)
+	require.Equal(t, testBucketContents[:5], got)
+}
+
+func TestBucketBufReader_Peek_PastSegmentEnd(t *testing.T) {
+	// Peek must return the bytes read and suppress the EOF error
+	// when peeking past the configured length or peeking beyond the true end of the file/object.
+	const sectionLen = 5
+	r, _ := newTestBufReader(t, 0, sectionLen)
+
+	b, err := r.Peek(sectionLen + 5)
+	require.NoError(t, err)
+	require.Equal(t, testBucketContents[:sectionLen], b)
+	require.Equal(t, 0, r.Offset())
+}
+
+func TestBucketBufReader_Peek_AtEnd(t *testing.T) {
+	const sectionLen = 5
+	r, _ := newTestBufReader(t, 0, sectionLen)
+	require.NoError(t, r.Skip(sectionLen))
+
+	b, err := r.Peek(1)
+	require.NoError(t, err)
+	require.Nil(t, b)
+}
+
+func TestBucketBufReader_Reset(t *testing.T) {
+	r, _ := newTestBufReader(t, 0, len(testBucketContents))
+
+	first, err := r.Read(10)
+	require.NoError(t, err)
+	require.Equal(t, testBucketContents[:10], first)
+
+	require.NoError(t, r.Reset())
+	require.Equal(t, 0, r.Offset())
+	require.Equal(t, len(testBucketContents), r.Len())
+
+	second, err := r.Read(10)
+	require.NoError(t, err)
+	require.Equal(t, testBucketContents[:10], second)
+}
+
+func TestBucketBufReader_ResetAt_Middle(t *testing.T) {
+	r, _ := newTestBufReader(t, 0, len(testBucketContents))
+
+	require.NoError(t, r.ResetAt(10))
+	require.Equal(t, 10, r.Offset())
+	require.Equal(t, len(testBucketContents)-10, r.Len())
+
+	b, err := r.Read(5)
+	require.NoError(t, err)
+	require.Equal(t, testBucketContents[10:15], b)
+}
+
+func TestBucketBufReader_ResetAt_End(t *testing.T) {
+	const sectionLen = 10
+	r, _ := newTestBufReader(t, 0, sectionLen)
+
+	require.NoError(t, r.ResetAt(sectionLen))
+	require.Equal(t, sectionLen, r.Offset())
+	require.Equal(t, 0, r.Len())
+}
+
+func TestBucketBufReader_ResetAt_BeyondEnd(t *testing.T) {
+	const sectionLen = 10
+	r, _ := newTestBufReader(t, 0, sectionLen)
+
+	err := r.ResetAt(sectionLen + 1)
+	require.ErrorIs(t, err, ErrInvalidSize)
+}
+
+func TestBucketBufReader_Len(t *testing.T) {
+	r, _ := newTestBufReader(t, 0, len(testBucketContents))
+
+	require.Equal(t, len(testBucketContents), r.Len())
+	require.NoError(t, r.Skip(10))
+	require.Equal(t, len(testBucketContents)-10, r.Len())
+	_, err := r.Read(5)
+	require.NoError(t, err)
+	require.Equal(t, len(testBucketContents)-15, r.Len())
+}
+
+func TestBucketBufReader_Size(t *testing.T) {
+	r, _ := newTestBufReader(t, 0, len(testBucketContents))
+	require.Equal(t, testBufPoolSize, r.Size())
+}
+
+func TestBucketBufReader_Buffered(t *testing.T) {
+	r, _ := newTestBufReader(t, 0, len(testBucketContents))
+	require.Equal(t, 0, r.Buffered())
+
+	// The first read operation causes bufio to fill its buffer.
+	// The read bytes will not count towards the buffer length after the call.
+	_, err := r.Read(1)
+	require.NoError(t, err)
+	require.Equal(t, testBufPoolSize-1, r.Buffered())
+}
+
+func TestBucketBufReader_Close(t *testing.T) {
+	r, _ := newTestBufReader(t, 0, len(testBucketContents))
+	require.NoError(t, r.Close())
+}
+
+func TestBucketBufReader_GetRangeCalls_Buffering(t *testing.T) {
+	r, bkt := newTestBufReader(t, 0, len(testBucketContents))
+
+	// The first read operation causes bufio to fill its buffer.
+	// The first testBufPoolSize bytes read will be covered by a single GetRange call.
+	for i := 0; i < testBufPoolSize; i++ {
+		_, err := r.Read(1)
+		require.NoError(t, err)
+	}
+	require.Len(t, bkt.calls, 1)
+
+	// Buffer depleted; next read operation triggers another bufio fill and GetRange call.
+	_, err := r.Read(1)
+	require.NoError(t, err)
+	require.Len(t, bkt.calls, 2)
+}
+
+func TestBucketBufReader_GetRangeCalls_ResetRefetches(t *testing.T) {
+	r, bkt := newTestBufReader(t, 0, len(testBucketContents))
+
+	_, err := r.Read(1)
+	require.NoError(t, err)
+	require.Len(t, bkt.calls, 1)
+
+	// After Reset the buffer is discarded; the next read must refetch from the bucket.
+	require.NoError(t, r.Reset())
+	_, err = r.Read(1)
+	require.NoError(t, err)
+	require.Len(t, bkt.calls, 2)
+}
+
+func TestBucketBufReader_Read_GetRangeError(t *testing.T) {
+	sentinel := errors.New("storage error")
+	r := newFailingBufReader(t, sentinel)
+
+	_, err := r.Read(5)
+	require.ErrorIs(t, err, sentinel)
+}
+
+func TestBucketBufReader_ReadInto_GetRangeError(t *testing.T) {
+	sentinel := errors.New("storage error")
+	r := newFailingBufReader(t, sentinel)
+
+	err := r.ReadInto(make([]byte, 5))
+	require.ErrorIs(t, err, sentinel)
+}
+
+// trackingBucket wraps an InstrumentedBucketReader and records every GetRange call.
+type trackingBucket struct {
+	objstore.InstrumentedBucketReader
+	calls []rangeCall
+}
+
+type rangeCall struct {
+	off    int64
+	length int64
+}
+
+func (b *trackingBucket) GetRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {
+	b.calls = append(b.calls, rangeCall{off, length})
+	return b.InstrumentedBucketReader.GetRange(ctx, name, off, length)
+}
+
+func newTrackingBucket(t *testing.T, objectData []byte) *trackingBucket {
+	t.Helper()
+	inmem := objstore.NewInMemBucket()
+	require.NoError(t, inmem.Upload(context.Background(), testBucketObjectName, bytes.NewReader(objectData)))
+	return &trackingBucket{InstrumentedBucketReader: objstore.WithNoopInstr(inmem)}
 }
 
 // failingBucket is an InstrumentedBucketReader whose GetRange always returns an error.
@@ -125,282 +395,4 @@ func (b *failingBucket) Close() error                   { return nil }
 
 func (b *failingBucket) ReaderWithExpectedErrs(_ objstore.IsOpFailureExpectedFunc) objstore.BucketReader {
 	return b
-}
-
-// newFailingBufReader returns a BucketBufReader backed by a failingBucket.
-func newFailingBufReader(t *testing.T, sentinel error) *BucketBufReader {
-	t.Helper()
-	bkt := &failingBucket{err: sentinel}
-	ctx := context.Background()
-	reader := NewBucketReader(ctx, bkt, "obj", 0, 10)
-	bufioReader := testBucketBufPool.Get().(*bufio.Reader)
-	bufioReader.Reset(reader)
-	return &BucketBufReader{
-		ctx:    ctx,
-		bkt:    bkt,
-		name:   "obj",
-		base:   0,
-		length: 10,
-		r:      reader,
-		buf:    bufioReader,
-	}
-}
-
-// ---- BucketBufReader --------------------------------------------------------
-
-func TestBucketBufReader_Read_Sequential(t *testing.T) {
-	r, _ := newTestReader(t, 0, len(testBucketContents))
-
-	b, err := r.Read(5)
-	require.NoError(t, err)
-	require.Equal(t, testBucketContents[:5], b)
-	require.Equal(t, 5, r.Offset())
-
-	b, err = r.Read(5)
-	require.NoError(t, err)
-	require.Equal(t, testBucketContents[5:10], b)
-	require.Equal(t, 10, r.Offset())
-}
-
-func TestBucketBufReader_Read_ExactLength(t *testing.T) {
-	r, _ := newTestReader(t, 0, len(testBucketContents))
-
-	b, err := r.Read(len(testBucketContents))
-	require.NoError(t, err)
-	require.Equal(t, testBucketContents, b)
-	require.Equal(t, len(testBucketContents), r.Offset())
-	require.Equal(t, 0, r.Len())
-}
-
-func TestBucketBufReader_Read_BeyondEnd(t *testing.T) {
-	const segmentLen = 10
-	r, _ := newTestReader(t, 0, segmentLen)
-
-	b, err := r.Read(segmentLen + 1)
-	require.ErrorIs(t, err, ErrInvalidSize)
-	require.Nil(t, b)
-	require.Equal(t, segmentLen, r.Offset(), "cursor advanced to end")
-}
-
-func TestBucketBufReader_Read_BeyondEndAfterPartialConsumption(t *testing.T) {
-	const segmentLen = 10
-	r, _ := newTestReader(t, 0, segmentLen)
-
-	_, err := r.Read(3)
-	require.NoError(t, err)
-
-	// 7 remain; attempt to read 8
-	b, err := r.Read(8)
-	require.ErrorIs(t, err, ErrInvalidSize)
-	require.Nil(t, b)
-	require.Equal(t, segmentLen, r.Offset(), "cursor advanced to end")
-}
-
-func TestBucketBufReader_ReadInto_Basic(t *testing.T) {
-	r, _ := newTestReader(t, 0, len(testBucketContents))
-
-	buf := make([]byte, 5)
-	require.NoError(t, r.ReadInto(buf))
-	require.Equal(t, testBucketContents[:5], buf)
-	require.Equal(t, 5, r.Offset())
-}
-
-func TestBucketBufReader_ReadInto_BeyondEnd(t *testing.T) {
-	const segmentLen = 5
-	r, _ := newTestReader(t, 0, segmentLen)
-
-	buf := make([]byte, segmentLen+1)
-	err := r.ReadInto(buf)
-	require.ErrorIs(t, err, ErrInvalidSize)
-	require.Equal(t, segmentLen, r.Offset(), "cursor advanced to end")
-}
-
-func TestBucketBufReader_Skip_Basic(t *testing.T) {
-	r, _ := newTestReader(t, 0, len(testBucketContents))
-
-	require.NoError(t, r.Skip(10))
-	require.Equal(t, 10, r.Offset())
-	require.Equal(t, len(testBucketContents)-10, r.Len())
-
-	b, err := r.Read(3)
-	require.NoError(t, err)
-	require.Equal(t, testBucketContents[10:13], b)
-}
-
-func TestBucketBufReader_Skip_ToEnd(t *testing.T) {
-	const segmentLen = 10
-	r, _ := newTestReader(t, 0, segmentLen)
-
-	require.NoError(t, r.Skip(segmentLen))
-	require.Equal(t, segmentLen, r.Offset())
-	require.Equal(t, 0, r.Len())
-}
-
-func TestBucketBufReader_Skip_BeyondEnd(t *testing.T) {
-	const segmentLen = 10
-	r, _ := newTestReader(t, 0, segmentLen)
-
-	err := r.Skip(segmentLen + 1)
-	require.ErrorIs(t, err, ErrInvalidSize)
-}
-
-func TestBucketBufReader_Peek_Basic(t *testing.T) {
-	r, _ := newTestReader(t, 0, len(testBucketContents))
-
-	b, err := r.Peek(5)
-	require.NoError(t, err)
-	require.Equal(t, testBucketContents[:5], b)
-	require.Equal(t, 0, r.Offset(), "cursor must not advance after Peek")
-
-	// Read should return the same bytes.
-	got, err := r.Read(5)
-	require.NoError(t, err)
-	require.Equal(t, testBucketContents[:5], got)
-}
-
-func TestBucketBufReader_Peek_PastSegmentEnd(t *testing.T) {
-	// segmentLen must be smaller than testBufPoolSize so bufio can attempt to fill
-	// but hits EOF before reaching n; this exercises the EOF-suppression in Peek.
-	const segmentLen = 5
-	r, _ := newTestReader(t, 0, segmentLen)
-
-	b, err := r.Peek(segmentLen + 5)
-	require.NoError(t, err)
-	require.Equal(t, testBucketContents[:segmentLen], b)
-	require.Equal(t, 0, r.Offset(), "cursor must not advance after Peek")
-}
-
-func TestBucketBufReader_Peek_AtEnd(t *testing.T) {
-	const segmentLen = 5
-	r, _ := newTestReader(t, 0, segmentLen)
-	require.NoError(t, r.Skip(segmentLen))
-
-	b, err := r.Peek(1)
-	require.NoError(t, err)
-	require.Nil(t, b)
-}
-
-func TestBucketBufReader_Reset(t *testing.T) {
-	r, _ := newTestReader(t, 0, len(testBucketContents))
-
-	first, err := r.Read(10)
-	require.NoError(t, err)
-	require.Equal(t, testBucketContents[:10], first)
-
-	require.NoError(t, r.Reset())
-	require.Equal(t, 0, r.Offset())
-	require.Equal(t, len(testBucketContents), r.Len())
-
-	second, err := r.Read(10)
-	require.NoError(t, err)
-	require.Equal(t, testBucketContents[:10], second)
-}
-
-func TestBucketBufReader_ResetAt_Middle(t *testing.T) {
-	r, _ := newTestReader(t, 0, len(testBucketContents))
-
-	require.NoError(t, r.ResetAt(10))
-	require.Equal(t, 10, r.Offset())
-	require.Equal(t, len(testBucketContents)-10, r.Len())
-
-	b, err := r.Read(5)
-	require.NoError(t, err)
-	require.Equal(t, testBucketContents[10:15], b)
-}
-
-func TestBucketBufReader_ResetAt_End(t *testing.T) {
-	const segmentLen = 10
-	r, _ := newTestReader(t, 0, segmentLen)
-
-	require.NoError(t, r.ResetAt(segmentLen))
-	require.Equal(t, segmentLen, r.Offset())
-	require.Equal(t, 0, r.Len())
-}
-
-func TestBucketBufReader_ResetAt_BeyondEnd(t *testing.T) {
-	const segmentLen = 10
-	r, _ := newTestReader(t, 0, segmentLen)
-
-	err := r.ResetAt(segmentLen + 1)
-	require.ErrorIs(t, err, ErrInvalidSize)
-}
-
-func TestBucketBufReader_Len(t *testing.T) {
-	r, _ := newTestReader(t, 0, len(testBucketContents))
-
-	require.Equal(t, len(testBucketContents), r.Len())
-	require.NoError(t, r.Skip(10))
-	require.Equal(t, len(testBucketContents)-10, r.Len())
-	_, err := r.Read(5)
-	require.NoError(t, err)
-	require.Equal(t, len(testBucketContents)-15, r.Len())
-}
-
-func TestBucketBufReader_Size(t *testing.T) {
-	r, _ := newTestReader(t, 0, len(testBucketContents))
-	require.Equal(t, testBufPoolSize, r.Size())
-}
-
-func TestBucketBufReader_Buffered(t *testing.T) {
-	r, _ := newTestReader(t, 0, len(testBucketContents))
-	require.Equal(t, 0, r.Buffered())
-
-	// Reading 1 byte causes bufio to fill its full buffer; the remaining
-	// testBufPoolSize-1 bytes stay in memory.
-	_, err := r.Read(1)
-	require.NoError(t, err)
-	require.Equal(t, testBufPoolSize-1, r.Buffered())
-}
-
-func TestBucketBufReader_Close(t *testing.T) {
-	r, _ := newTestReader(t, 0, len(testBucketContents))
-	require.NoError(t, r.Close())
-}
-
-func TestBucketBufReader_GetRangeCalls_Buffering(t *testing.T) {
-	r, bkt := newTestReader(t, 0, len(testBucketContents))
-
-	// Reading one byte at a time: bufio fills its entire buffer (testBufPoolSize bytes)
-	// on the first underlying Read, so all testBufPoolSize single-byte reads cost one
-	// GetRange call.
-	for i := 0; i < testBufPoolSize; i++ {
-		_, err := r.Read(1)
-		require.NoError(t, err)
-	}
-	require.Len(t, bkt.calls, 1, "all reads within first buffer window should share one GetRange call")
-
-	// One more byte crosses into the next buffer window.
-	_, err := r.Read(1)
-	require.NoError(t, err)
-	require.Len(t, bkt.calls, 2, "crossing buffer boundary triggers a second GetRange call")
-}
-
-func TestBucketBufReader_GetRangeCalls_ResetRefetches(t *testing.T) {
-	r, bkt := newTestReader(t, 0, len(testBucketContents))
-
-	_, err := r.Read(1)
-	require.NoError(t, err)
-	require.Len(t, bkt.calls, 1)
-
-	// After Reset the buffer is discarded; the next read must refetch from the bucket.
-	require.NoError(t, r.Reset())
-	_, err = r.Read(1)
-	require.NoError(t, err)
-	require.Len(t, bkt.calls, 2)
-}
-
-func TestBucketBufReader_Read_GetRangeError(t *testing.T) {
-	sentinel := errors.New("storage error")
-	r := newFailingBufReader(t, sentinel)
-
-	_, err := r.Read(5)
-	require.ErrorIs(t, err, sentinel)
-}
-
-func TestBucketBufReader_ReadInto_GetRangeError(t *testing.T) {
-	sentinel := errors.New("storage error")
-	r := newFailingBufReader(t, sentinel)
-
-	err := r.ReadInto(make([]byte, 5))
-	require.ErrorIs(t, err, sentinel)
 }

--- a/pkg/storage/indexheader/encoding/bucket_reader_test.go
+++ b/pkg/storage/indexheader/encoding/bucket_reader_test.go
@@ -39,27 +39,7 @@ func newTestBufReader(t *testing.T, base, length int) (*BucketBufReader, *tracki
 	objectData = append(objectData, testBucketContents...)
 	bkt := newTrackingBucket(t, objectData)
 
-	reader := NewBucketReader(ctx, bkt, testBucketObjectName, base, length)
-	bufioReader := testBucketBufPool.Get().(*bufio.Reader)
-	bufioReader.Reset(reader)
-
-	bufReader := &BucketBufReader{
-		ctx:    ctx,
-		bkt:    bkt,
-		name:   testBucketObjectName,
-		base:   base,
-		length: length,
-		r:      reader,
-		buf:    bufioReader,
-	}
-
-	resetReader := func(off int) error {
-		r := NewBucketReader(ctx, bkt, testBucketObjectName, base+off, length)
-		bufReader.r = r
-		return nil
-	}
-	bufReader.resetReader = resetReader
-	return bufReader, bkt
+	return newBucketBufReader(ctx, &testBucketBufPool, bkt, testBucketObjectName, base, length), bkt
 }
 
 func newFailingBufReader(t *testing.T, sentinel error) *BucketBufReader {

--- a/pkg/storage/indexheader/encoding/factory.go
+++ b/pkg/storage/indexheader/encoding/factory.go
@@ -3,12 +3,11 @@
 package encoding
 
 import (
-	"encoding/binary"
 	"hash/crc32"
+)
 
-	"github.com/pkg/errors"
-
-	"github.com/grafana/mimir/pkg/util/filepool"
+const (
+	numLenBytes = 4 // Index sections use a 4-byte big-endian uint32 to mark the byte length of the section.
 )
 
 type DecbufFactory interface {
@@ -34,117 +33,4 @@ type DecbufFactory interface {
 	NewRawDecbuf() Decbuf
 
 	Close() error
-}
-
-// FilePoolDecbufFactory creates new file-backed Decbuf instances
-// for a specific index-header file on local disk.
-type FilePoolDecbufFactory struct {
-	files *filepool.FilePool
-}
-
-func NewFilePoolDecbufFactory(
-	path string,
-	maxIdleFileHandles uint,
-	metrics *filepool.FilePoolMetrics,
-) *FilePoolDecbufFactory {
-	return &FilePoolDecbufFactory{
-		files: filepool.NewFilePool(
-			path,
-			maxIdleFileHandles,
-			metrics,
-		),
-	}
-}
-
-func (df *FilePoolDecbufFactory) NewDecbufAtChecked(offset int, table *crc32.Table) Decbuf {
-	f, err := df.files.Get()
-	if err != nil {
-		return Decbuf{E: errors.Wrap(err, "open file for decbuf")}
-	}
-
-	// If we return early and don't include a BufReader for our Decbuf, we are responsible
-	// for putting the file handle back in the pool.
-	closeFile := true
-	defer func() {
-		if closeFile {
-			_ = df.files.Put(f)
-		}
-	}()
-
-	// TODO: A particular index-header only has symbols and posting offsets. We should only need to read
-	//  the length of each of those a single time per index-header (DecbufFactory). Should the factory
-	//  cache the length? Should the table of contents be passed to the factory?
-	lengthBytes := make([]byte, 4)
-	n, err := f.ReadAt(lengthBytes, int64(offset))
-	if err != nil {
-		return Decbuf{E: err}
-	}
-	if n != 4 {
-		return Decbuf{E: errors.Wrapf(ErrInvalidSize, "insufficient bytes read for size (got %d, wanted %d)", n, 4)}
-	}
-
-	contentLength := int(binary.BigEndian.Uint32(lengthBytes))
-	bufferLength := len(lengthBytes) + contentLength + crc32.Size
-	r, err := NewFileReader(f, offset, bufferLength, df.files)
-	if err != nil {
-		return Decbuf{E: errors.Wrap(err, "create file reader")}
-	}
-
-	closeFile = false
-	d := Decbuf{r: r}
-
-	if d.ResetAt(4); d.Err() != nil {
-		return d
-	}
-
-	if table != nil {
-		if d.CheckCrc32(table); d.Err() != nil {
-			return d
-		}
-
-		// reset to the beginning of the content after reading it all for the CRC.
-		d.ResetAt(4)
-	}
-
-	return d
-}
-
-func (df *FilePoolDecbufFactory) NewDecbufAtUnchecked(offset int) Decbuf {
-	return df.NewDecbufAtChecked(offset, nil)
-}
-
-func (df *FilePoolDecbufFactory) NewRawDecbuf() Decbuf {
-	f, err := df.files.Get()
-	if err != nil {
-		return Decbuf{E: errors.Wrap(err, "open file for decbuf")}
-	}
-
-	// If we return early and don't include a BufReader for our Decbuf, we are responsible
-	// for putting the file handle back in the pool.
-	closeFile := true
-	defer func() {
-		if closeFile {
-			_ = df.files.Put(f)
-		}
-	}()
-
-	stat, err := f.Stat()
-	if err != nil {
-		return Decbuf{E: errors.Wrap(err, "stat file for decbuf")}
-	}
-
-	fileSize := stat.Size()
-	reader, err := NewFileReader(f, 0, int(fileSize), df.files)
-	if err != nil {
-		return Decbuf{E: errors.Wrap(err, "file reader for decbuf")}
-	}
-
-	closeFile = false
-	return Decbuf{r: reader}
-}
-
-// Close cleans up resources associated with this DecbufFactory
-func (df *FilePoolDecbufFactory) Close() error {
-	df.files.Stop()
-	return nil
 }

--- a/pkg/storage/indexheader/encoding/file_factory.go
+++ b/pkg/storage/indexheader/encoding/file_factory.go
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package encoding
+
+import (
+	"encoding/binary"
+
+	"hash/crc32"
+
+	"github.com/pkg/errors"
+
+	"github.com/grafana/mimir/pkg/util/filepool"
+)
+
+// FilePoolDecbufFactory creates new file-backed Decbuf instances
+// for a specific index-header file on local disk.
+type FilePoolDecbufFactory struct {
+	files *filepool.FilePool
+}
+
+func NewFilePoolDecbufFactory(
+	path string,
+	maxIdleFileHandles uint,
+	metrics *filepool.FilePoolMetrics,
+) *FilePoolDecbufFactory {
+	return &FilePoolDecbufFactory{
+		files: filepool.NewFilePool(
+			path,
+			maxIdleFileHandles,
+			metrics,
+		),
+	}
+}
+
+func (df *FilePoolDecbufFactory) NewDecbufAtChecked(offset int, table *crc32.Table) Decbuf {
+	f, err := df.files.Get()
+	if err != nil {
+		return Decbuf{E: errors.Wrap(err, "open file for decbuf")}
+	}
+
+	// If we return early and don't include a BufReader for our Decbuf, we are responsible
+	// for putting the file handle back in the pool.
+	closeFile := true
+	defer func() {
+		if closeFile {
+			_ = df.files.Put(f)
+		}
+	}()
+
+	// TODO: A particular index-header only has symbols and posting offsets. We should only need to read
+	//  the length of each of those a single time per index-header (DecbufFactory). Should the factory
+	//  cache the length? Should the table of contents be passed to the factory?
+	lengthBytes := make([]byte, numLenBytes)
+	n, err := f.ReadAt(lengthBytes, int64(offset))
+	if err != nil {
+		return Decbuf{E: err}
+	}
+	if n != numLenBytes {
+		return Decbuf{E: errors.Wrapf(ErrInvalidSize, "insufficient bytes read for size (got %d, wanted %d)", n, numLenBytes)}
+	}
+
+	contentLength := int(binary.BigEndian.Uint32(lengthBytes))
+	bufferLength := len(lengthBytes) + contentLength + crc32.Size
+	r, err := NewFileReader(f, offset, bufferLength, df.files)
+	if err != nil {
+		return Decbuf{E: errors.Wrap(err, "create file reader")}
+	}
+
+	closeFile = false
+	d := Decbuf{r: r}
+
+	if d.ResetAt(numLenBytes); d.Err() != nil {
+		return d
+	}
+
+	if table != nil {
+		if d.CheckCrc32(table); d.Err() != nil {
+			return d
+		}
+
+		// reset to the beginning of the content after reading it all for the CRC.
+		d.ResetAt(numLenBytes)
+	}
+
+	return d
+}
+
+func (df *FilePoolDecbufFactory) NewDecbufAtUnchecked(offset int) Decbuf {
+	return df.NewDecbufAtChecked(offset, nil)
+}
+
+func (df *FilePoolDecbufFactory) NewRawDecbuf() Decbuf {
+	f, err := df.files.Get()
+	if err != nil {
+		return Decbuf{E: errors.Wrap(err, "open file for decbuf")}
+	}
+
+	// If we return early and don't include a BufReader for our Decbuf, we are responsible
+	// for putting the file handle back in the pool.
+	closeFile := true
+	defer func() {
+		if closeFile {
+			_ = df.files.Put(f)
+		}
+	}()
+
+	stat, err := f.Stat()
+	if err != nil {
+		return Decbuf{E: errors.Wrap(err, "stat file for decbuf")}
+	}
+
+	fileSize := stat.Size()
+	reader, err := NewFileReader(f, 0, int(fileSize), df.files)
+	if err != nil {
+		return Decbuf{E: errors.Wrap(err, "file reader for decbuf")}
+	}
+
+	closeFile = false
+	return Decbuf{r: reader}
+}
+
+// Close cleans up resources associated with this DecbufFactory
+func (df *FilePoolDecbufFactory) Close() error {
+	df.files.Stop()
+	return nil
+}

--- a/pkg/storage/indexheader/encoding/file_factory.go
+++ b/pkg/storage/indexheader/encoding/file_factory.go
@@ -4,7 +4,6 @@ package encoding
 
 import (
 	"encoding/binary"
-
 	"hash/crc32"
 
 	"github.com/pkg/errors"

--- a/pkg/storage/indexheader/encoding/reader.go
+++ b/pkg/storage/indexheader/encoding/reader.go
@@ -10,6 +10,10 @@ type BufReader interface {
 
 	// ResetAt moves the cursor to the given offset in the data segment owned by the reader,
 	// relative to the base offset configured at reader initialization.
+	// CAUTION: This operation may be very expensive and result in the discard of buffered data.
+	// Use Skip to move forward to avoid unnecessary buffer discard.
+	// ResetAt should only be used to move backwards.
+	//
 	// Attempting to ResetAt to the end of the data segment is valid.
 	// Attempting to ResetAt _beyond_ the end of the data segment will return an error.
 	ResetAt(off int) error

--- a/pkg/storage/indexheader/lazy_binary_reader.go
+++ b/pkg/storage/indexheader/lazy_binary_reader.go
@@ -146,11 +146,9 @@ func NewLazyBinaryReader(
 	}
 
 	g := errgroup.Group{}
-	if !cfg.BucketReader.Enabled {
-		g.Go(func() error {
-			return ensureIndexHeaderOnDisk(ctx, id, bkt, localDir, logger)
-		})
-	}
+	g.Go(func() error {
+		return ensureIndexHeaderOnDisk(ctx, id, bkt, localDir, logger)
+	})
 
 	g.Go(func() error {
 		err := downloadSparseHeaderToDisk(ctx, id, bkt, localDir, logger)

--- a/pkg/storage/indexheader/reader_benchmarks_test.go
+++ b/pkg/storage/indexheader/reader_benchmarks_test.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"path/filepath"
 	"slices"
+	"sort"
 	"testing"
 	"time"
 
@@ -30,9 +31,8 @@ func BenchmarkLookupSymbol(b *testing.B) {
 	bucketDir := b.TempDir()
 	bkt, err := filesystem.NewBucket(filepath.Join(bucketDir, "bkt"))
 	require.NoError(b, err)
-	instrBkt := objstore.WithNoopInstr(bkt)
 	b.Cleanup(func() {
-		require.NoError(b, instrBkt.Close())
+		require.NoError(b, bkt.Close())
 	})
 
 	// TODO: are the number of name and value symbols representative?
@@ -51,14 +51,14 @@ func BenchmarkLookupSymbol(b *testing.B) {
 		// TODO: are these sensible value for name lookup percentage?
 		for _, percentageNameLookups := range []int{20, 40, 50, 60, 80} {
 			b.Run(fmt.Sprintf("NameLookups%v%%-Parallelism%v", percentageNameLookups, parallelism), func(b *testing.B) {
-				benchmarkLookupSymbol(ctx, b, instrBkt, bucketDir, idIndexV2, parallelism, percentageNameLookups, nameSymbols, valueSymbols)
+				benchmarkLookupSymbol(ctx, b, bucketDir, idIndexV2, parallelism, percentageNameLookups, nameSymbols, valueSymbols)
 			})
 		}
 	}
 }
 
-func benchmarkLookupSymbol(ctx context.Context, b *testing.B, bkt objstore.InstrumentedBucketReader, bucketDir string, id ulid.ULID, parallelism int, percentageNameLookups int, nameSymbols []string, valueSymbols []string) {
-	binaryReader, err := NewStreamBinaryReader(ctx, id, bkt, bucketDir, Config{}, 32, log.NewNopLogger(), NewStreamBinaryReaderMetrics(nil))
+func benchmarkLookupSymbol(ctx context.Context, b *testing.B, bucketDir string, id ulid.ULID, parallelism int, percentageNameLookups int, nameSymbols []string, valueSymbols []string) {
+	binaryReader, err := NewStreamBinaryReader(ctx, id, nil, bucketDir, Config{}, 32, log.NewNopLogger(), NewStreamBinaryReaderMetrics(nil))
 	require.NoError(b, err)
 	b.Cleanup(func() { require.NoError(b, binaryReader.Close()) })
 
@@ -246,54 +246,74 @@ func BenchmarkLabelValuesOffsetsIndexV2_WithPrefix(b *testing.B) {
 	ctx := context.Background()
 	tests, blockID, blockDir, bkt := labelValuesTestCases(test.NewTB(b))
 
-	bucketReg := prometheus.NewPedanticRegistry()
-	instrBkt := objstore.WrapWithMetrics(objstore.WithNoopInstr(bkt), prometheus.WrapRegistererWithPrefix("thanos_", bucketReg), "")
-	b.Cleanup(func() {
-		require.NoError(b, bkt.Close())
-	})
-
-	// Initialize the first index-header reader,
-	// configured to read all index-header sections from the on-disk index-header.
-	// This first call to create a reader also builds the index-header and sparse index-header from the block.
-	diskReaderCfg := Config{}
-	diskReader, err := NewStreamBinaryReader(ctx, blockID, instrBkt, blockDir, diskReaderCfg, 32, log.NewNopLogger(), NewStreamBinaryReaderMetrics(nil))
-	require.NoError(b, err)
-	b.Cleanup(func() { require.NoError(b, diskReader.Close()) })
-
-	// Initialize the second index-header reader,
-	// configured to read symbols from disk and postings offsets from bucket.
-	bucketCacheCfg := bucketcache.NewCachingBucketConfig() // Caches nothing by default
-	cachingBucket, err := bucketcache.NewCachingBucket("test", instrBkt, bucketCacheCfg, log.NewNopLogger(), bucketReg)
-	require.NoError(b, err)
-
-	splitReaderCfg := Config{
-		BucketReader: BucketReaderConfig{
-			Enabled:             true,
-			BucketIndexSections: SectionPostingsOffsetsTable,
-		},
-	}
-	splitReader, err := NewStreamBinaryReader(ctx, blockID, cachingBucket, blockDir, splitReaderCfg, 32, log.NewNopLogger(), NewStreamBinaryReaderMetrics(nil))
-	require.NoError(b, err)
-	b.Cleanup(func() { require.NoError(b, splitReader.Close()) })
-
-	diskNames, err := diskReader.LabelNames(ctx)
-	require.NoError(b, err)
-	bucketReaderNames, err := splitReader.LabelNames(ctx)
-	require.NoError(b, err)
-	require.Equal(b, diskNames, bucketReaderNames)
-
-	readers := []struct {
+	sortedTests := make([]struct {
 		name string
-		Reader
-	}{
-		{"disk", diskReader},
-		{"split", splitReader},
-	}
-
-	b.ResetTimer()
+		tcs  []labelValuesTestCase
+	}, 0, len(tests))
 
 	for lbl, tcs := range tests {
-		for _, tc := range tcs {
+		sortedTests = append(sortedTests,
+			struct {
+				name string
+				tcs  []labelValuesTestCase
+			}{name: lbl, tcs: tcs},
+		)
+	}
+	// Sorting tests allows for deterministic behavior across test runs
+	// w.r.t when the index-header's underlying readers need to rewind/reset
+	// to continue reading from a different offset.
+	sort.Slice(sortedTests, func(i, j int) bool {
+		return sortedTests[i].name < sortedTests[j].name
+	})
+
+	for _, sortedTest := range sortedTests {
+		lbl := sortedTest.name
+		for _, tc := range sortedTest.tcs {
+			bucketReg := prometheus.NewPedanticRegistry()
+			instrBkt := objstore.WrapWithMetrics(objstore.WithNoopInstr(bkt), prometheus.WrapRegistererWithPrefix("thanos_", bucketReg), "")
+			b.Cleanup(func() {
+				require.NoError(b, bkt.Close())
+			})
+
+			// Initialize the first index-header reader,
+			// configured to read all index-header sections from the on-disk index-header.
+			// This first call to create a reader also builds the index-header and sparse index-header from the block.
+			diskReaderCfg := Config{}
+			diskReader, err := NewStreamBinaryReader(ctx, blockID, instrBkt, blockDir, diskReaderCfg, 32, log.NewNopLogger(), NewStreamBinaryReaderMetrics(nil))
+			require.NoError(b, err)
+			b.Cleanup(func() { require.NoError(b, diskReader.Close()) })
+
+			// Initialize the second index-header reader,
+			// configured to read symbols from disk and postings offsets from bucket.
+			bucketCacheCfg := bucketcache.NewCachingBucketConfig() // Caches nothing by default
+			cachingBucket, err := bucketcache.NewCachingBucket("test", instrBkt, bucketCacheCfg, log.NewNopLogger(), bucketReg)
+			require.NoError(b, err)
+
+			splitReaderCfg := Config{
+				BucketReader: BucketReaderConfig{
+					Enabled:             true,
+					BucketIndexSections: SectionPostingsOffsetsTable,
+				},
+			}
+			splitReader, err := NewStreamBinaryReader(ctx, blockID, cachingBucket, blockDir, splitReaderCfg, 32, log.NewNopLogger(), NewStreamBinaryReaderMetrics(nil))
+			require.NoError(b, err)
+			b.Cleanup(func() { require.NoError(b, splitReader.Close()) })
+
+			diskNames, err := diskReader.LabelNames(ctx)
+			require.NoError(b, err)
+			bucketReaderNames, err := splitReader.LabelNames(ctx)
+			require.NoError(b, err)
+			require.Equal(b, diskNames, bucketReaderNames)
+
+			readers := []struct {
+				name string
+				Reader
+			}{
+				{"disk", diskReader},
+				{"split", splitReader},
+			}
+
+			b.ResetTimer()
 			for _, reader := range readers {
 				b.Run(fmt.Sprintf("Label=%s/Prefix='%s'/Desc=%s/Reader=%s", lbl, tc.prefix, tc.desc, reader.name), func(b *testing.B) {
 					b.ReportAllocs()

--- a/pkg/storage/indexheader/reader_benchmarks_test.go
+++ b/pkg/storage/indexheader/reader_benchmarks_test.go
@@ -31,8 +31,9 @@ func BenchmarkLookupSymbol(b *testing.B) {
 	bucketDir := b.TempDir()
 	bkt, err := filesystem.NewBucket(filepath.Join(bucketDir, "bkt"))
 	require.NoError(b, err)
+	instrBkt := objstore.WithNoopInstr(bkt)
 	b.Cleanup(func() {
-		require.NoError(b, bkt.Close())
+		require.NoError(b, instrBkt.Close())
 	})
 
 	// TODO: are the number of name and value symbols representative?
@@ -51,14 +52,14 @@ func BenchmarkLookupSymbol(b *testing.B) {
 		// TODO: are these sensible value for name lookup percentage?
 		for _, percentageNameLookups := range []int{20, 40, 50, 60, 80} {
 			b.Run(fmt.Sprintf("NameLookups%v%%-Parallelism%v", percentageNameLookups, parallelism), func(b *testing.B) {
-				benchmarkLookupSymbol(ctx, b, bucketDir, idIndexV2, parallelism, percentageNameLookups, nameSymbols, valueSymbols)
+				benchmarkLookupSymbol(ctx, b, instrBkt, bucketDir, idIndexV2, parallelism, percentageNameLookups, nameSymbols, valueSymbols)
 			})
 		}
 	}
 }
 
-func benchmarkLookupSymbol(ctx context.Context, b *testing.B, bucketDir string, id ulid.ULID, parallelism int, percentageNameLookups int, nameSymbols []string, valueSymbols []string) {
-	binaryReader, err := NewStreamBinaryReader(ctx, id, nil, bucketDir, Config{}, 32, log.NewNopLogger(), NewStreamBinaryReaderMetrics(nil))
+func benchmarkLookupSymbol(ctx context.Context, b *testing.B, bkt objstore.InstrumentedBucketReader, bucketDir string, id ulid.ULID, parallelism int, percentageNameLookups int, nameSymbols []string, valueSymbols []string) {
+	binaryReader, err := NewStreamBinaryReader(ctx, id, bkt, bucketDir, Config{}, 32, log.NewNopLogger(), NewStreamBinaryReaderMetrics(nil))
 	require.NoError(b, err)
 	b.Cleanup(func() { require.NoError(b, binaryReader.Close()) })
 

--- a/pkg/storage/indexheader/reader_benchmarks_test.go
+++ b/pkg/storage/indexheader/reader_benchmarks_test.go
@@ -246,6 +246,9 @@ func BenchmarkLabelValuesOffsetsIndexV2(b *testing.B) {
 func BenchmarkLabelValuesOffsetsIndexV2_WithPrefix(b *testing.B) {
 	ctx := context.Background()
 	tests, blockID, blockDir, bkt := labelValuesTestCases(test.NewTB(b))
+	b.Cleanup(func() {
+		require.NoError(b, bkt.Close())
+	})
 
 	sortedTests := make([]struct {
 		name string
@@ -272,9 +275,6 @@ func BenchmarkLabelValuesOffsetsIndexV2_WithPrefix(b *testing.B) {
 		for _, tc := range sortedTest.tcs {
 			bucketReg := prometheus.NewPedanticRegistry()
 			instrBkt := objstore.WrapWithMetrics(objstore.WithNoopInstr(bkt), prometheus.WrapRegistererWithPrefix("thanos_", bucketReg), "")
-			b.Cleanup(func() {
-				require.NoError(b, bkt.Close())
-			})
 
 			// Initialize the first index-header reader,
 			// configured to read all index-header sections from the on-disk index-header.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Previous Bucket-based decbuf implementation did not send all of its reads through the thanos objstore `GetRange` interface - we fix this for two reasons:
1. Only the `GetRange` interface can be counted on to track bucket operation metrics correctly
2. The `GetRange` interface is required to use our bucket reads caching

This PR also now caches the Postings Offsets section length in the `BucketDecBufFactory` so after the first read it will make one less `GetRange` call each time it is initialized.

Other minor changes:
* Moved the filepool-backed decbuf factory to its own file. Previously `factory.go`, had the interface definition and the file-backed factory, while the bucket-backed factory was separate. I followed the pattern in the package for thre readers, where the interface gets its own file and then each impl gets its own file.
*  Introduce a constant `numLenBytes` isntead of writing `4` everywhere
* Fix lazy reader init logic for bucket reader

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches low-level index-header reading/rewind behavior and request patterns against object storage; regressions could surface as incorrect reads, CRC failures, or increased bucket calls under certain access patterns.
> 
> **Overview**
> **Refactors bucket-backed index-header decoding to consistently use `objstore.BucketReader.GetRange`** by replacing the bespoke `streamReader` logic with new `BucketReader`/`BucketBufReader` implementations, enabling accurate bucket metrics and compatibility with bucket-cache behavior.
> 
> `BucketDecbufFactory` now reads section length via a small `GetRange`-based reader and **caches section lengths by offset** to avoid repeated length-prefix fetches; the file-backed factory is moved into `file_factory.go` and both paths use a shared `numLenBytes` constant. Also removes the conditional that skipped `ensureIndexHeaderOnDisk` when bucket reading was enabled, and updates benchmarks to run deterministically by sorting test cases; adds comprehensive unit tests for the new bucket readers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c91b2823b68d7886730dcfbce44482bac6a56715. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->