### PR TITLE
Slow queries dashboard: add configurable query blocking link to limits-operator

### DIFF
--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -221,6 +221,12 @@
     // Controls whether dashboards show classic or native latency histograms. Allowed values: 'classic' (default), 'native'.
     dashboards_default_latency_mode: 'classic',
 
+    // URL template for "Block this query in limits-operator" link in the slow queries table.
+    // Set to a non-empty string to enable the link. The URL can use Grafana variable interpolation
+    // (e.g. $namespace) and data field references (e.g. ${__data.fields["Tenant ID"]}, ${__data.fields.Query}).
+    // Example: 'https://example.com/directory-mimir/$namespace/limits-operator/tenant/${__data.fields["Tenant ID"]}/query-blocking?pattern=${__data.fields.Query:percentencode}&regex=true'
+    slow_queries_query_blocking_url: '',
+
     // Used to add extra labels to all alerts. Careful: takes precedence over default labels.
     alert_extra_labels: {},
 

--- a/operations/mimir-mixin/dashboards/slow-queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/slow-queries.libsonnet
@@ -319,7 +319,21 @@ local filename = 'mimir-slow-queries.json';
                   properties: [{ id: 'unit', value: 's' }],
                 }
                 for fieldName in secondsFields
-              ],
+              ] +
+              // Add a "Block this query in limits-operator" data link to the Query column if configured.
+              (if $._config.slow_queries_query_blocking_url != '' then [
+                 {
+                   matcher: { id: 'byName', options: 'Query' },
+                   properties: [{
+                     id: 'links',
+                     value: [{
+                       title: 'Block this query in limits-operator',
+                       url: $._config.slow_queries_query_blocking_url,
+                       targetBlank: true,
+                     }],
+                   }],
+                 },
+               ] else []),
           },
         },
       )


### PR DESCRIPTION
## What

Add a configurable "Block this query in limits-operator" data link to the Query column of the slow queries dashboard table.

When `slow_queries_query_blocking_url` is set in `_config`, each row in the slow queries table gets a clickable link on the Query column that opens the limits-operator query blocking page in a new tab. The URL template supports Grafana variable interpolation and data field references, allowing it to pre-fill the query pattern.

This works in conjunction with grafana/mimir-limits-operator#908 which adds support for pre-filling blocked query entries from URL parameters.

## Configuration

Set `slow_queries_query_blocking_url` in `_config` to enable the link. Example:

```jsonnet
{
  _config+:: {
    slow_queries_query_blocking_url: 'https://grafana.example.com/directory-mimir/$namespace/limits-operator/tenant/${__data.fields["Tenant ID"]}/query-blocking?pattern=${__data.fields.Query:percentencode}&regex=true',
  },
}
```

The default is an empty string (link disabled).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional Grafana table data link controlled by config, without changing queries, alerts, or backend behavior.
> 
> **Overview**
> Adds a new `_config.slow_queries_query_blocking_url` setting (default empty) to optionally enable a per-row data link in the Slow Queries dashboard.
> 
> When configured, the `Query` column in the slow queries table includes a "Block this query in limits-operator" link that opens the configured URL template in a new tab (supporting Grafana variable/data-field interpolation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5985a3838778e5dd4c8f85201c1d46f2071a2d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->