### PR TITLE
docker-compose microservices: Allow running delve for specific targets only

### DIFF
--- a/development/mimir-microservices-mode/docker-compose.jsonnet
+++ b/development/mimir-microservices-mode/docker-compose.jsonnet
@@ -1,11 +1,12 @@
 std.manifestYamlDoc({
   _config:: {
-    // If true, all Mimir services are run under Delve debugger (that can be attached to via remote-debugging
-    // session) and debug_targets is ignored.
+    // If true, Mimir services are run under Delve debugger, that can be attached to via remote-debugging session.
     // Note that Delve doesn't forward signals to the Mimir process, so Mimir components don't shutdown cleanly.
     debug: false,
 
-    // When debug is false, only these specific targets are run under Delve.
+    // When debug is true, controls which targets run under Delve.
+    // If empty, all components run under Delve.
+    // If non-empty, only the listed components run under Delve.
     // Example: ['querier', 'ingester'] to debug only querier and ingester.
     // Available targets: distributor, ingester, querier, query-frontend, query-scheduler, compactor, ruler, alertmanager, store-gateway, continuous-test.
     debug_targets: [],
@@ -256,7 +257,7 @@ std.manifestYamlDoc({
     local command = if isLocalImage then ['/bin/sh', '-c', std.join(' ', [
       // some of the following expressions use "... else null", which std.join seem to ignore.
       (if $._config.sleep_seconds > 0 then 'sleep %d &&' % [$._config.sleep_seconds] else null),
-      (if $._config.debug || std.member($._config.debug_targets, options.target) then 'exec /bin/dlv exec /bin/mimir --listen=:%(debugPort)d --headless=true --api-version=2 --accept-multiclient --continue -- ' % options else 'exec /bin/mimir'),
+      (if $._config.debug && (std.length($._config.debug_targets) == 0 || std.member($._config.debug_targets, options.target)) then 'exec /bin/dlv exec /bin/mimir --listen=:%(debugPort)d --headless=true --api-version=2 --accept-multiclient --continue -- ' % options else 'exec /bin/mimir'),
     ] + flags)] else flags,
 
     build: if isLocalImage then {
@@ -270,7 +271,7 @@ std.manifestYamlDoc({
     // Only publish HTTP and debug port, but not gRPC one.
     ports: ['%d:%d' % [options.httpPort, options.httpPort]] +
            ['%d:%d' % [options.memberlistBindPort, options.memberlistBindPort]] +
-           if $._config.debug || std.member($._config.debug_targets, options.target) then [
+           if $._config.debug && (std.length($._config.debug_targets) == 0 || std.member($._config.debug_targets, options.target)) then [
              '%d:%d' % [options.debugPort, options.debugPort],
            ] else [],
     depends_on: options.dependsOn,

--- a/development/mimir-microservices-mode/docker-compose.jsonnet
+++ b/development/mimir-microservices-mode/docker-compose.jsonnet
@@ -1,8 +1,14 @@
 std.manifestYamlDoc({
   _config:: {
-    // If true, Mimir services are run under Delve debugger, that can be attached to via remote-debugging session.
+    // If true, all Mimir services are run under Delve debugger (that can be attached to via remote-debugging
+    // session) and debug_targets is ignored.
     // Note that Delve doesn't forward signals to the Mimir process, so Mimir components don't shutdown cleanly.
     debug: false,
+
+    // When debug is false, only these specific targets are run under Delve.
+    // Example: ['querier', 'ingester'] to debug only querier and ingester.
+    // Available targets: distributor, ingester, querier, query-frontend, query-scheduler, compactor, ruler, alertmanager, store-gateway, continuous-test.
+    debug_targets: [],
 
     // How long should Mimir docker containers sleep before Mimir is started.
     sleep_seconds: 3,
@@ -250,7 +256,7 @@ std.manifestYamlDoc({
     local command = if isLocalImage then ['/bin/sh', '-c', std.join(' ', [
       // some of the following expressions use "... else null", which std.join seem to ignore.
       (if $._config.sleep_seconds > 0 then 'sleep %d &&' % [$._config.sleep_seconds] else null),
-      (if $._config.debug then 'exec /bin/dlv exec /bin/mimir --listen=:%(debugPort)d --headless=true --api-version=2 --accept-multiclient --continue -- ' % options else 'exec /bin/mimir'),
+      (if $._config.debug || std.member($._config.debug_targets, options.target) then 'exec /bin/dlv exec /bin/mimir --listen=:%(debugPort)d --headless=true --api-version=2 --accept-multiclient --continue -- ' % options else 'exec /bin/mimir'),
     ] + flags)] else flags,
 
     build: if isLocalImage then {
@@ -264,7 +270,7 @@ std.manifestYamlDoc({
     // Only publish HTTP and debug port, but not gRPC one.
     ports: ['%d:%d' % [options.httpPort, options.httpPort]] +
            ['%d:%d' % [options.memberlistBindPort, options.memberlistBindPort]] +
-           if $._config.debug then [
+           if $._config.debug || std.member($._config.debug_targets, options.target) then [
              '%d:%d' % [options.debugPort, options.debugPort],
            ] else [],
     depends_on: options.dependsOn,

--- a/development/mimir-microservices-mode/docker-compose.jsonnet
+++ b/development/mimir-microservices-mode/docker-compose.jsonnet
@@ -241,6 +241,7 @@ std.manifestYamlDoc({
     // and has `/bin/mimir` set as an entrypoint. That requires passing CLI flags in 'command' instead
     // of a string that will be passed to a shell.
     local isLocalImage = options.image == 'mimir',
+    local useDelve = $._config.debug && (std.length($._config.debug_targets) == 0 || std.member($._config.debug_targets, options.target)),
     local flags = [
       '-config.file=/etc/mimir/mimir.yaml',
       '-target=%(target)s' % options,
@@ -257,7 +258,7 @@ std.manifestYamlDoc({
     local command = if isLocalImage then ['/bin/sh', '-c', std.join(' ', [
       // some of the following expressions use "... else null", which std.join seem to ignore.
       (if $._config.sleep_seconds > 0 then 'sleep %d &&' % [$._config.sleep_seconds] else null),
-      (if $._config.debug && (std.length($._config.debug_targets) == 0 || std.member($._config.debug_targets, options.target)) then 'exec /bin/dlv exec /bin/mimir --listen=:%(debugPort)d --headless=true --api-version=2 --accept-multiclient --continue -- ' % options else 'exec /bin/mimir'),
+      (if useDelve then 'exec /bin/dlv exec /bin/mimir --listen=:%(debugPort)d --headless=true --api-version=2 --accept-multiclient --continue -- ' % options else 'exec /bin/mimir'),
     ] + flags)] else flags,
 
     build: if isLocalImage then {
@@ -271,7 +272,7 @@ std.manifestYamlDoc({
     // Only publish HTTP and debug port, but not gRPC one.
     ports: ['%d:%d' % [options.httpPort, options.httpPort]] +
            ['%d:%d' % [options.memberlistBindPort, options.memberlistBindPort]] +
-           if $._config.debug && (std.length($._config.debug_targets) == 0 || std.member($._config.debug_targets, options.target)) then [
+           if useDelve then [
              '%d:%d' % [options.debugPort, options.debugPort],
            ] else [],
     depends_on: options.dependsOn,


### PR DESCRIPTION
#### What this PR does

Lets you run a debugger for only specific components, more lightweight if you don't need all of them.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

Not user-facing, only affects docker-compose for devs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes dev `docker-compose.jsonnet` behavior and simply gates Delve wrapping/port publishing by a new config list.
> 
> **Overview**
> Adds a `debug_targets` config option to `development/mimir-microservices-mode/docker-compose.jsonnet` so Delve can be enabled for *only* specified Mimir component targets.
> 
> Updates service generation to compute `useDelve` per service and uses it to decide whether to wrap the command with `dlv` and whether to publish the debug port, while preserving existing behavior when `debug_targets` is empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35b72d84d033030080b747290e5672b68e07ef58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->