### PR TITLE
mimir-mixin: add disk utilization panels to block-builder dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -317,6 +317,7 @@
 * [ENHANCEMENT] Recording rules: add a low-cardinality recorded version of usage_tracker_active_series. #14901
 * [ENHANCEMENT] Alerts: Fix `MimirSchedulerQueriesStuck` false positives by only looking for cases where the number of enqueued queries doesn't decrease. #14943
 * [ENHANCEMENT] Dashboards: Add ephemeral storage panels to "Resources" dashboards. #14999
+* [ENHANCEMENT] Dashboards: Add disk utilization panels to experimental Block-builder dashboard. #15029
 * [BUGFIX] Dashboards: Fix compactor dashboard to exclude instances without the last successful run metric in the "Last successful run per-compactor replica" table. #14784
 * [BUGFIX] Dashboards: Fix issue where throughput dashboard panels would group all gRPC requests that resulted in a status containing an underscore into one series with no name. #13184
 * [BUGFIX] Dashboards: Filter out 0s from `max_series` limit on Writes Resources > Ingester > In-memory series panel. #13419

--- a/operations/mimir-mixin/dashboards/block-builder.libsonnet
+++ b/operations/mimir-mixin/dashboards/block-builder.libsonnet
@@ -218,6 +218,18 @@ local filename = 'mimir-block-builder.json';
       )
       .splitIntoLines([4, 1])  // Puts "in-memory series" panel below the rest of the resources
     )
+    .addRow(
+      $.row('')
+      .addPanel(
+        $.containerDiskWritesPanelByComponent('block_builder')
+      )
+      .addPanel(
+        $.containerDiskReadsPanelByComponent('block_builder')
+      )
+      .addPanel(
+        $.containerDiskSpaceUtilizationPanelByComponent('block_builder'),
+      )
+    )
     .addRowIf(
       $._config.autoscaling.block_builder.enabled,
       $.row('Block builder - autoscaling')


### PR DESCRIPTION
#### What this PR does

While testing block-builder we've noticed that it's disk utilization is currently a blind spot. This PR adds a set of panels to the Block-builder dashboard, to show the utilization by block-builder instance.

Example:

<img width="1463" height="306" alt="Screenshot 2026-04-15 at 13 09 37" src="https://github.com/user-attachments/assets/ca3449f2-5c47-45a1-b7b0-b926a2047aa3" />