### PR TITLE
[release 2.17] Backport of ruler: Fix rule expressions with leading newlines failing to parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Grafana Mimir
 
-* [BUGFIX] Ruler: Fix parsing of rule expressions with leading newlines. #14947
+* [BUGFIX] Ruler: Fix parsing of rule expressions with leading newlines. #14947 #15032
 
 ## 2.17.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## unreleased
+
+### Grafana Mimir
+
+* [BUGFIX] Ruler: Fix parsing of rule expressions with leading newlines. #14947
+
 ## 2.17.9
 
 ### Grafana Mimir

--- a/pkg/ruler/mapper.go
+++ b/pkg/ruler/mapper.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -143,7 +144,7 @@ func (m *mapper) writeRuleGroupsIfNewer(groups []rulefmt.RuleGroup, filename str
 		return groups[i].Name > groups[j].Name
 	})
 
-	rgs := rulefmt.RuleGroups{Groups: groups}
+	rgs := rulefmt.RuleGroups{Groups: cleanRuleGroupExprs(groups)}
 
 	d, err := yaml.Marshal(&rgs)
 	if err != nil {
@@ -170,4 +171,21 @@ func (m *mapper) writeRuleGroupsIfNewer(groups []rulefmt.RuleGroup, filename str
 	}
 
 	return true, nil
+}
+
+// cleanRuleGroupExprs returns a copy of groups with leading/trailing whitespace
+// trimmed from rule expressions. This avoids yaml.v3 emitting explicit
+// indentation indicators (e.g. "|4") for expressions that start with newlines
+// or whitespace, which can cause parsing failures when the file is read back.
+func cleanRuleGroupExprs(groups []rulefmt.RuleGroup) []rulefmt.RuleGroup {
+	cleaned := make([]rulefmt.RuleGroup, len(groups))
+	for i, g := range groups {
+		cleaned[i] = g
+		cleaned[i].Rules = make([]rulefmt.Rule, len(g.Rules))
+		for j, r := range g.Rules {
+			cleaned[i].Rules[j] = r
+			cleaned[i].Rules[j].Expr = strings.TrimSpace(r.Expr)
+		}
+	}
+	return cleaned
 }

--- a/pkg/ruler/mapper_test.go
+++ b/pkg/ruler/mapper_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
 
 	util_log "github.com/grafana/mimir/pkg/util/log"
 )
@@ -404,4 +405,63 @@ func sliceContains(t *testing.T, find string, in []string) bool {
 	}
 
 	return false
+}
+
+func Test_mapper_ExprWithLeadingNewlines(t *testing.T) {
+	m := &mapper{
+		Path:   "/rules",
+		FS:     afero.NewMemMapFs(),
+		logger: log.NewNopLogger(),
+	}
+
+	ruleConfigs := map[string][]rulefmt.RuleGroup{
+		"rules.yaml": {
+			{
+				Name: "test_group",
+				Rules: []rulefmt.Rule{
+					{
+						Record: "test_rule",
+						Expr:   "\n\n# comment\nup > 0\n",
+					},
+				},
+			},
+		},
+	}
+
+	updated, files, err := m.MapRules("user1", ruleConfigs)
+	require.NoError(t, err)
+	require.True(t, updated)
+	require.Len(t, files, 1)
+
+	// Verify the written file can be parsed back by the rulefmt parser.
+	content, err := afero.ReadFile(m.FS, files[0])
+	require.NoError(t, err)
+
+	var rgs rulefmt.RuleGroups
+	err = yaml.Unmarshal(content, &rgs)
+	require.NoError(t, err)
+	require.Len(t, rgs.Groups, 1)
+	require.Len(t, rgs.Groups[0].Rules, 1)
+	// Leading/trailing whitespace should be trimmed.
+	require.Equal(t, "# comment\nup > 0", rgs.Groups[0].Rules[0].Expr)
+}
+
+func Test_cleanRuleGroupExprs(t *testing.T) {
+	groups := []rulefmt.RuleGroup{
+		{
+			Name: "group1",
+			Rules: []rulefmt.Rule{
+				{Record: "r1", Expr: "\n\n  up > 0\n"},
+				{Record: "r2", Expr: "rate(foo[5m])"},
+			},
+		},
+	}
+
+	cleaned := cleanRuleGroupExprs(groups)
+
+	// Cleaned expressions should have whitespace trimmed.
+	require.Equal(t, "up > 0", cleaned[0].Rules[0].Expr)
+	require.Equal(t, "rate(foo[5m])", cleaned[0].Rules[1].Expr)
+	// Original should be unmodified.
+	require.Equal(t, "\n\n  up > 0\n", groups[0].Rules[0].Expr)
 }

--- a/pkg/ruler/mapper_test.go
+++ b/pkg/ruler/mapper_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/prometheus/prometheus/model/rulefmt"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v3"
+	"gopkg.in/yaml.v3"
 
 	util_log "github.com/grafana/mimir/pkg/util/log"
 )


### PR DESCRIPTION
#### What this PR does

Backport https://github.com/grafana/mimir/pull/14947 to release 2.17 so we can include this in GEM.

#### Which issue(s) this PR fixes or relates to

See the support escalation linked below.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to rule-file serialization that only trims surrounding whitespace in expressions; low likelihood of impacting rule semantics but could affect users relying on preserved formatting.
> 
> **Overview**
> Fixes a ruler rule-file roundtrip bug where rule expressions starting with newlines/whitespace could be YAML-marshaled with indentation indicators (e.g. `|4`) and then fail to parse when read back.
> 
> Rule group mapping now trims leading/trailing whitespace from each rule `Expr` before marshaling, and adds regression tests covering expressions with leading newlines plus a unit test for the trimming helper; `CHANGELOG.md` is updated with an unreleased bugfix entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e530079b96004ec059a1272e42f5c80dec6e4f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->