### PR TITLE
MQE: account for memory consumption of labels from binary operations earlier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,7 @@
 * [ENHANCEMENT] Distributor now uses record validation time as Kafka record timestamp to reduce rejections among consumers. #14921
 * [ENHANCEMENT] MQE: Add optimisation pass to optimise away expressions containing comparisons with `timestamp()` that can't produce results due to the query time range. #14989
 * [ENHANCEMENT] Distributor: OTLP endpoint now returns partial success (HTTP 200) instead of HTTP 429 when the usage tracker rejects some series due to the active series limit but other series are successfully ingested. The `RejectedDataPoints` field reports the count of distributor-side rejections (usage tracker filtering). #14789
+* [ENHANCEMENT] MQE: Account for memory consumption of labels returned by binary operations in query memory consumption estimate earlier. #15033
 * [BUGFIX] Update to Go v1.25.9. #15030
 * [BUGFIX] Distributor: OTLP partial success responses now correctly populate `RejectedDataPoints` with the actual count of rejected samples, instead of always reporting 0. In classical architecture, this includes rejected samples propagated from the ingester. #14789
 * [BUGFIX] Distributor: Fix race condition where usage-tracker partition ring may not be initialized before the distributor service starts, causing `usage-tracker partition ring is required` error on startup. #14675

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
@@ -366,6 +366,14 @@ func (g *GroupedVectorVectorBinaryOperation) computeOutputSeries() ([]types.Seri
 				oneSide.outputSeriesCount++
 				thisManySide.outputSeriesCount++
 
+				// Account for the memory consumption from the labels now. This helps protect against
+				// queries that return many series from this operator.
+				// All series in outputSeriesMap will be returned, so this doesn't lead to over-counting
+				// of memory consumption.
+				if err := g.MemoryConsumptionTracker.IncreaseMemoryConsumptionForLabels(l); err != nil {
+					return nil, nil, nil, -1, nil, -1, err
+				}
+
 				outputSeriesMap[string(l.Bytes(buf))] = groupedBinaryOperationOutputSeriesWithLabels{
 					labels: l,
 					outputSeries: &groupedBinaryOperationOutputSeries{
@@ -418,11 +426,9 @@ func (g *GroupedVectorVectorBinaryOperation) computeOutputSeries() ([]types.Seri
 	outputSeries := make([]*groupedBinaryOperationOutputSeries, 0, len(outputSeriesMap))
 
 	for _, o := range outputSeriesMap {
-		outputMetadata, err = types.AppendSeriesMetadata(g.MemoryConsumptionTracker, outputMetadata, types.SeriesMetadata{Labels: o.labels})
-		if err != nil {
-			return nil, nil, nil, -1, nil, -1, err
-		}
-
+		// Note that we deliberately don't use types.AppendSeriesMetadata here as we've already
+		// accounted for the memory consumption of every set of labels in outputSeriesMap above.
+		outputMetadata = append(outputMetadata, types.SeriesMetadata{Labels: o.labels})
 		outputSeries = append(outputSeries, o.outputSeries)
 	}
 

--- a/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation.go
@@ -321,6 +321,14 @@ func (b *OneToOneVectorVectorBinaryOperation) computeOutputSeries() ([]types.Ser
 
 			rightSide.outputSeriesCount++
 
+			// Account for the memory consumption from the labels now. This helps protect against
+			// queries that return many series from this operator.
+			// All series in outputSeriesMap will be returned, so this doesn't lead to over-counting
+			// of memory consumption.
+			if err := b.MemoryConsumptionTracker.IncreaseMemoryConsumptionForLabels(outputSeriesLabels); err != nil {
+				return nil, nil, nil, -1, nil, -1, err
+			}
+
 			outputSeries = oneToOneBinaryOperationOutputSeriesWithLabels{
 				labels: outputSeriesLabels,
 				series: &oneToOneBinaryOperationOutputSeries{rightSide: rightSide},
@@ -342,11 +350,9 @@ func (b *OneToOneVectorVectorBinaryOperation) computeOutputSeries() ([]types.Ser
 	allSeries := make([]*oneToOneBinaryOperationOutputSeries, 0, len(outputSeriesMap))
 
 	for _, outputSeries := range outputSeriesMap {
-		allMetadata, err = types.AppendSeriesMetadata(b.MemoryConsumptionTracker, allMetadata, types.SeriesMetadata{Labels: outputSeries.labels})
-		if err != nil {
-			return nil, nil, nil, -1, nil, -1, err
-		}
-
+		// Note that we deliberately don't use types.AppendSeriesMetadata here as we've already
+		// accounted for the memory consumption of every set of labels in outputSeriesMap above.
+		allMetadata = append(allMetadata, types.SeriesMetadata{Labels: outputSeries.labels})
 		allSeries = append(allSeries, outputSeries.series)
 	}
 


### PR DESCRIPTION
#### What this PR does

This PR changes the behaviour of the one-to-one and one-to-many/many-to-one binary operation operators to track the memory consumed by output series' labels as soon as each is created, rather than once all of them have been computed.

This ensures that queries that return a large number of series from binary operations fail earlier if they would exceed the query memory consumption limit, reducing the likelihood that a single query can consume a large amount of memory.

The same change does not apply to the other kinds of binary operations (logical operations and operations involving scalars on one side) as these already either return the input series as-is, or already account for the memory consumption from labels as they are mutated from the input series.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes query memory accounting and failure timing for binary operations; behavior should be functionally equivalent but could alter when/which queries are rejected under tight memory limits.
> 
> **Overview**
> Improves MQE per-query memory limit enforcement for vector-vector binary operations by charging label memory *when each output series is created* in `GroupedVectorVectorBinaryOperation` and `OneToOneVectorVectorBinaryOperation`, rather than after all output series have been computed.
> 
> To avoid double-counting, output metadata construction now appends `types.SeriesMetadata` directly instead of using `types.AppendSeriesMetadata`. The changelog is updated to document the enhancement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8482b10cc6a867f8fa7841f701283fa1cf86d51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->