### PR TITLE
Log the number of series and samples returned in responses from query-frontends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,7 @@
 * [ENHANCEMENT] MQE: Add optimisation pass to optimise away expressions containing comparisons with `timestamp()` that can't produce results due to the query time range. #14989
 * [ENHANCEMENT] Distributor: OTLP endpoint now returns partial success (HTTP 200) instead of HTTP 429 when the usage tracker rejects some series due to the active series limit but other series are successfully ingested. The `RejectedDataPoints` field reports the count of distributor-side rejections (usage tracker filtering). #14789
 * [ENHANCEMENT] MQE: Account for memory consumption of labels returned by binary operations in query memory consumption estimate earlier. #15033
+* [ENHANCEMENT] Query-frontend: Log the number of series and samples returned for queries in `query stats` log lines. #15044
 * [BUGFIX] Update to Go v1.25.9. #15030
 * [BUGFIX] Distributor: OTLP partial success responses now correctly populate `RejectedDataPoints` with the actual count of rejected samples, instead of always reporting 0. In classical architecture, this includes rejected samples propagated from the ingester. #14789
 * [BUGFIX] Distributor: Fix race condition where usage-tracker partition ring may not be initialized before the distributor service starts, causing `usage-tracker partition ring is required` error on startup. #14675

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -3861,6 +3861,8 @@ When looking at `msg="query stats"` consider the following attributes;
 - status_code - the http response status code
 - response_time — total wall-clock time from request received to response sent
 - response_size_bytes — size of the HTTP response body
+- response_series_count — total number of series in the response
+- response_samples_count — total number of samples in the response
 - queue_time_seconds — time spent waiting in the query scheduler queue
 - query_wall_time_seconds — time spent actually executing the query
 - encode_time_seconds — time spent serialising the result to JSON

--- a/pkg/frontend/querymiddleware/stats.go
+++ b/pkg/frontend/querymiddleware/stats.go
@@ -65,7 +65,11 @@ func (s queryStatsMiddleware) Do(ctx context.Context, req MetricsQueryRequest) (
 	s.trackQueryExpressionSize(ctx, req)
 	s.populateQueryDetails(ctx, req)
 
-	return s.next.Do(ctx, req)
+	resp, err := s.next.Do(ctx, req)
+	if err == nil {
+		s.populateResponseDetails(ctx, resp)
+	}
+	return resp, err
 }
 
 func (s queryStatsMiddleware) trackRegexpMatchers(req MetricsQueryRequest) {
@@ -133,6 +137,21 @@ func (s queryStatsMiddleware) populateQueryDetails(ctx context.Context, req Metr
 	}
 }
 
+func (s queryStatsMiddleware) populateResponseDetails(ctx context.Context, resp Response) {
+	details := QueryDetailsFromContext(ctx)
+	if details == nil || resp == nil {
+		return
+	}
+	pr, ok := resp.GetPrometheusResponse()
+	if !ok || pr == nil || pr.Data == nil {
+		return
+	}
+	details.ResponseSeriesCount += len(pr.Data.Result)
+	for _, stream := range pr.Data.Result {
+		details.ResponseSamplesCount += len(stream.Samples) + len(stream.Histograms)
+	}
+}
+
 func (s queryStatsMiddleware) trackReadConsistency(ctx context.Context) {
 	consistency, ok := api.ReadConsistencyLevelFromContext(ctx)
 	if !ok {
@@ -158,6 +177,11 @@ type QueryDetails struct {
 
 	ResultsCacheMissBytes int
 	ResultsCacheHitBytes  int
+
+	// ResponseSeriesCount is the number of series in the query response.
+	ResponseSeriesCount int
+	// ResponseSamplesCount is the total number of samples (floats or histograms) across all series in the query response.
+	ResponseSamplesCount int
 }
 
 type contextKey int

--- a/pkg/frontend/querymiddleware/stats_test.go
+++ b/pkg/frontend/querymiddleware/stats_test.go
@@ -11,11 +11,13 @@ import (
 	"github.com/grafana/dskit/user"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/mimir/pkg/mimirpb"
 	querierapi "github.com/grafana/mimir/pkg/querier/api"
 	querier_stats "github.com/grafana/mimir/pkg/querier/stats"
 	"github.com/grafana/mimir/pkg/util"
@@ -257,6 +259,126 @@ func Test_queryStatsMiddleware_Do(t *testing.T) {
 				assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(tt.expectedMetrics)))
 				assert.Equal(t, tt.expectedQueryDetails, *actualDetails)
 			})
+		})
+	}
+}
+
+func Test_queryStatsMiddleware_ResponseDetails(t *testing.T) {
+	const tenantID = "test"
+	req := &PrometheusRangeQueryRequest{
+		path:      "/query_range",
+		start:     util.TimeToMillis(start),
+		end:       util.TimeToMillis(end),
+		step:      step.Milliseconds(),
+		queryExpr: parseQuery(t, `metric`),
+	}
+
+	tests := map[string]struct {
+		resp                         *PrometheusResponse
+		expectedResponseSeriesCount  int
+		expectedResponseSamplesCount int
+	}{
+		"nil response": {
+			resp:                         nil,
+			expectedResponseSeriesCount:  0,
+			expectedResponseSamplesCount: 0,
+		},
+		"empty response": {
+			resp: &PrometheusResponse{
+				Status: statusSuccess,
+				Data:   &PrometheusData{ResultType: model.ValMatrix.String(), Result: []SampleStream{}},
+			},
+			expectedResponseSeriesCount:  0,
+			expectedResponseSamplesCount: 0,
+		},
+		"matrix response with samples": {
+			resp: &PrometheusResponse{
+				Status: statusSuccess,
+				Data: &PrometheusData{
+					ResultType: model.ValMatrix.String(),
+					Result: []SampleStream{
+						{Samples: []mimirpb.Sample{{TimestampMs: 0, Value: 1}, {TimestampMs: 1000, Value: 2}}},
+						{Samples: []mimirpb.Sample{{TimestampMs: 0, Value: 3}}},
+					},
+				},
+			},
+			expectedResponseSeriesCount:  2,
+			expectedResponseSamplesCount: 3,
+		},
+		"vector response with histograms": {
+			resp: &PrometheusResponse{
+				Status: statusSuccess,
+				Data: &PrometheusData{
+					ResultType: model.ValVector.String(),
+					Result: []SampleStream{
+						{Histograms: []mimirpb.FloatHistogramPair{{TimestampMs: 0}}},
+						{Histograms: []mimirpb.FloatHistogramPair{{TimestampMs: 0}}},
+						{Histograms: []mimirpb.FloatHistogramPair{{TimestampMs: 0}}},
+					},
+				},
+			},
+			expectedResponseSeriesCount:  3,
+			expectedResponseSamplesCount: 3,
+		},
+		"response with mixed samples and histograms": {
+			resp: &PrometheusResponse{
+				Status: statusSuccess,
+				Data: &PrometheusData{
+					ResultType: model.ValMatrix.String(),
+					Result: []SampleStream{
+						{
+							Samples:    []mimirpb.Sample{{TimestampMs: 0, Value: 1}},
+							Histograms: []mimirpb.FloatHistogramPair{{TimestampMs: 1000}},
+						},
+					},
+				},
+			},
+			expectedResponseSeriesCount:  1,
+			expectedResponseSamplesCount: 2,
+		},
+		"string response": {
+			resp: &PrometheusResponse{
+				Status: statusSuccess,
+				Data: &PrometheusData{
+					ResultType: model.ValString.String(),
+					Result: []SampleStream{
+						{
+							Labels:  []mimirpb.LabelAdapter{{Name: "value", Value: "foo"}},
+							Samples: []mimirpb.Sample{{TimestampMs: 1_500}},
+						},
+					},
+				},
+			},
+			expectedResponseSeriesCount:  1,
+			expectedResponseSamplesCount: 1,
+		},
+		"scalar response": {
+			resp: &PrometheusResponse{
+				Status: statusSuccess,
+				Data: &PrometheusData{
+					ResultType: model.ValScalar.String(),
+					Result: []SampleStream{
+						{Samples: []mimirpb.Sample{{TimestampMs: 1_000, Value: 200}}},
+					},
+				},
+			},
+			expectedResponseSeriesCount:  1,
+			expectedResponseSamplesCount: 1,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			reg := prometheus.NewPedanticRegistry()
+			mw := newQueryStatsMiddleware(reg)
+			actualDetails, ctx := ContextWithEmptyDetails(context.Background())
+			ctx = user.InjectOrgID(ctx, tenantID)
+
+			_, err := mw.Wrap(mockHandlerWith(tt.resp, nil)).Do(ctx, req)
+			require.NoError(t, err)
+
+			require.Equal(t, tt.expectedResponseSeriesCount, actualDetails.ResponseSeriesCount)
+			require.Equal(t, tt.expectedResponseSamplesCount, actualDetails.ResponseSamplesCount)
 		})
 	}
 }

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -375,6 +375,8 @@ func (f *Handler) reportQueryStats(
 		logMessage = append(logMessage,
 			resultsCacheHitBytes, details.ResultsCacheHitBytes,
 			resultsCacheMissBytes, details.ResultsCacheMissBytes,
+			"response_series_count", details.ResponseSeriesCount,
+			"response_samples_count", details.ResponseSamplesCount,
 		)
 	}
 

--- a/pkg/frontend/transport/handler_test.go
+++ b/pkg/frontend/transport/handler_test.go
@@ -496,6 +496,8 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				require.EqualValues(t, 0, msg["estimated_series_count"])
 				require.EqualValues(t, 0, msg["queue_time_seconds"])
 				require.EqualValues(t, 0, msg["remote_execution_request_count"])
+				require.EqualValues(t, 0, msg["response_series_count"])
+				require.EqualValues(t, 0, msg["response_samples_count"])
 
 				if tt.expectedStatusCode >= 200 && tt.expectedStatusCode < 300 {
 					require.Equal(t, "success", msg["status"])
@@ -795,6 +797,18 @@ func TestHandler_LogsFormattedQueryDetails(t *testing.T) {
 				"results_cache_miss_bytes": "10",
 				"results_cache_hit_bytes":  "200",
 				"header_cache_control":     "",
+			},
+		},
+		{
+			name:              "response series and samples count",
+			requestFormFields: []string{},
+			setQueryDetails: func(d *querymiddleware.QueryDetails) {
+				d.ResponseSeriesCount = 42
+				d.ResponseSamplesCount = 1234
+			},
+			expectedLoggedFields: map[string]string{
+				"response_series_count":  "42",
+				"response_samples_count": "1234",
 			},
 		},
 		{


### PR DESCRIPTION
#### What this PR does

This PR extends the `query stats` log lines emitted by query-frontends to include the number of series and samples included in the response payload.

The number of series and number of samples is helpful for gauging the size of the response, and also for evaluating the efficiency of queries.

These are also useful when investigating a query where the result is flapping from one result to another.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds additional logging fields and lightweight response counting; minimal behavioral impact beyond small per-request overhead and log output changes.
> 
> **Overview**
> Query-frontend `query stats` logs now include `response_series_count` and `response_samples_count`, computed from the returned Prometheus response and stored on `QueryDetails`.
> 
> This threads response-aware accounting through `queryStatsMiddleware` (populating counts only on successful downstream responses), updates handler logging accordingly, and extends unit tests plus runbook/changelog documentation to cover the new fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd5b08db73243c5d840e4d16e69ebfcc256b75a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->