### PR TITLE
Mixin: fix MimirInconsistentRuntimeConfig false positive for newly rolled-out configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -314,7 +314,7 @@
 * [ENHANCEMENT] Dashboards: Split the "All series" panel in the Tenants dashboard into "Active series" and "Owned & in-memory series" panels, and added the active series limit. #14648 #14771
 * [ENHANCEMENT] Dashboards: Add "In memory series" panel to experimental "Mimir / Block-builder" dashboard. #14700
 * [ENHANCEMENT] Dashboards: Unify object store rows into a single collapsible row across Alertmanager, Compactor, Reads, and Ruler dashboards. #14850
-* [ENHANCEMENT] Alerts: Make `MimirInconsistentRuntimeConfig` alert less flaky when performing multiple configuration changes in a row in a large Kubernetes cluster. #14743 #14933
+* [ENHANCEMENT] Alerts: Make `MimirInconsistentRuntimeConfig` alert less flaky when performing multiple configuration changes in a row in a large Kubernetes cluster. #14743 #14933 #15051
 * [ENHANCEMENT] Alerts: Suppress `MimirRingMembersMismatch` alert during ingester rollouts. The alert now uses an `unless` clause to avoid false positives when ingester statefulsets are being updated. #14895
 * [ENHANCEMENT] Recording rules: add a low-cardinality recorded version of usage_tracker_active_series. #14901
 * [ENHANCEMENT] Alerts: Fix `MimirSchedulerQueriesStuck` false positives by only looking for cases where the number of enqueued queries doesn't decrease. #14943

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -83,6 +83,11 @@ spec:
                   # Kubernetes configmap propagation can be slow,
                   # and in large cells we may deploy a new configmap when the previous one isn't still propagated everywhere.
                   (changes((count by (cluster, namespace, sha256) (cortex_runtime_config_hash))[10m:]) > 0)
+                  # Don't include configs that didn't exist one minute ago.
+                  # changes() == 0 for metrics appearing for the first time,
+                  # but this is still a "we're rolling out a new config" scenario.
+                  and on (cluster, namespace, sha256)
+                  group by (cluster, namespace, sha256) (cortex_runtime_config_hash offset 1m)
               )  > 1
             for: 1h
             labels:

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -71,6 +71,11 @@ groups:
                 # Kubernetes configmap propagation can be slow,
                 # and in large cells we may deploy a new configmap when the previous one isn't still propagated everywhere.
                 (changes((count by (cluster, namespace, sha256) (cortex_runtime_config_hash))[10m:]) > 0)
+                # Don't include configs that didn't exist one minute ago.
+                # changes() == 0 for metrics appearing for the first time,
+                # but this is still a "we're rolling out a new config" scenario.
+                and on (cluster, namespace, sha256)
+                group by (cluster, namespace, sha256) (cortex_runtime_config_hash offset 1m)
             )  > 1
           for: 1h
           labels:

--- a/operations/mimir-mixin-compiled-gem/alerts.yaml
+++ b/operations/mimir-mixin-compiled-gem/alerts.yaml
@@ -71,6 +71,11 @@ groups:
                 # Kubernetes configmap propagation can be slow,
                 # and in large cells we may deploy a new configmap when the previous one isn't still propagated everywhere.
                 (changes((count by (cluster, namespace, sha256) (cortex_runtime_config_hash))[10m:]) > 0)
+                # Don't include configs that didn't exist one minute ago.
+                # changes() == 0 for metrics appearing for the first time,
+                # but this is still a "we're rolling out a new config" scenario.
+                and on (cluster, namespace, sha256)
+                group by (cluster, namespace, sha256) (cortex_runtime_config_hash offset 1m)
             )  > 1
           for: 1h
           labels:

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -71,6 +71,11 @@ groups:
                 # Kubernetes configmap propagation can be slow,
                 # and in large cells we may deploy a new configmap when the previous one isn't still propagated everywhere.
                 (changes((count by (cluster, namespace, sha256) (cortex_runtime_config_hash))[10m:]) > 0)
+                # Don't include configs that didn't exist one minute ago.
+                # changes() == 0 for metrics appearing for the first time,
+                # but this is still a "we're rolling out a new config" scenario.
+                and on (cluster, namespace, sha256)
+                group by (cluster, namespace, sha256) (cortex_runtime_config_hash offset 1m)
             )  > 1
           for: 1h
           labels:

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -182,6 +182,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
                 # Kubernetes configmap propagation can be slow,
                 # and in large cells we may deploy a new configmap when the previous one isn't still propagated everywhere.
                 (changes((count by (%(alert_aggregation_labels)s, sha256) (cortex_runtime_config_hash))[10m:]) > 0)
+                # Don't include configs that didn't exist one minute ago.
+                # changes() == 0 for metrics appearing for the first time,
+                # but this is still a "we're rolling out a new config" scenario.
+                and on (%(alert_aggregation_labels)s, sha256)
+                group by (%(alert_aggregation_labels)s, sha256) (cortex_runtime_config_hash offset 1m)
             )  > 1
           ||| % $._config,
           'for': '1h',


### PR DESCRIPTION
#### What this PR does

`MimirInconsistentRuntimeConfig` suppresses alerting for sha256 variants that are currently rolling out by filtering out variants where `changes(cortex_runtime_config_hash) > 0`. `changes()` returns 0 for a series with a single data point, so a brand-new sha256 that has just appeared bypasses the suppression and triggers a false-positive alert during rollouts in large clusters.

The alert now additionally intersects (`and on (...)`) the post-`unless` set with the set of sha256 variants that already existed 1m ago. Variants that appeared within the last minute are therefore excluded from the consistency count until they have at least two data points, at which point the existing `changes()`-based suppression takes over.

#### Which issue(s) this PR fixes or relates to

Follow-up to #14743 / #14933.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts PromQL logic for a critical alert; while intended to reduce rollout noise, it could also delay detection of real inconsistencies for very new `sha256` series.
> 
> **Overview**
> Updates the `MimirInconsistentRuntimeConfig` mixin alert expression to further suppress rollout-related noise by excluding `cortex_runtime_config_hash` `sha256` variants that did not exist 1 minute ago (via an `and on (...)` join with an `offset 1m` selector).
> 
> Regenerates the compiled alert YAMLs (mixin outputs and Helm metamonitoring golden file) to reflect the new PromQL, and updates `CHANGELOG.md` to reference the additional fix PR (`#15051`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4212a6930be5c273a5d4327cd13a0f218b9f66ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->