### PR TITLE
remove humanizePercentage from MimirStoreGatewayTooManyFailedOperations

### DIFF
--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -268,7 +268,7 @@ spec:
               severity: warning
           - alert: MimirStoreGatewayTooManyFailedOperations
             annotations:
-              message: Mimir store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ $value | humanizePercentage }} errors while doing {{ $labels.operation }} on the object storage.
+              message: Mimir store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ $value }} errors while doing {{ $labels.operation }} on the object storage.
               runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstoregatewaytoomanyfailedoperations
             expr: |
               sum by(cluster, namespace, operation) (rate(thanos_objstore_bucket_operation_failures_total{component="store-gateway"}[1m])) > 0

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -256,7 +256,7 @@ groups:
             severity: warning
         - alert: MimirStoreGatewayTooManyFailedOperations
           annotations:
-            message: Mimir store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ $value | humanizePercentage }} errors while doing {{ $labels.operation }} on the object storage.
+            message: Mimir store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ $value }} errors while doing {{ $labels.operation }} on the object storage.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstoregatewaytoomanyfailedoperations
           expr: |
             sum by(cluster, namespace, operation) (rate(thanos_objstore_bucket_operation_failures_total{component="store-gateway"}[1m])) > 0

--- a/operations/mimir-mixin-compiled-gem/alerts.yaml
+++ b/operations/mimir-mixin-compiled-gem/alerts.yaml
@@ -256,7 +256,7 @@ groups:
             severity: warning
         - alert: MimirStoreGatewayTooManyFailedOperations
           annotations:
-            message: GEM store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ $value | humanizePercentage }} errors while doing {{ $labels.operation }} on the object storage.
+            message: GEM store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ $value }} errors while doing {{ $labels.operation }} on the object storage.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstoregatewaytoomanyfailedoperations
           expr: |
             sum by(cluster, namespace, operation) (rate(thanos_objstore_bucket_operation_failures_total{component="store-gateway"}[1m])) > 0

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -256,7 +256,7 @@ groups:
             severity: warning
         - alert: MimirStoreGatewayTooManyFailedOperations
           annotations:
-            message: Mimir store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ $value | humanizePercentage }} errors while doing {{ $labels.operation }} on the object storage.
+            message: Mimir store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ $value }} errors while doing {{ $labels.operation }} on the object storage.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstoregatewaytoomanyfailedoperations
           expr: |
             sum by(cluster, namespace, operation) (rate(thanos_objstore_bucket_operation_failures_total{component="store-gateway"}[1m])) > 0


### PR DESCRIPTION
`thanos_objstore_bucket_operation_failures_total > 0 ` query does not generate a ratio. Therefore using it with humanizePercentage causes invalid %



<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

replaces % number with raw `thanos_objstore_bucket_operation_failures_total` values from the alert query. 
The query is triggered when thanos_objstore_bucket_operation_failures_total is higher than 0. Therefore, the alert message will end up contain unusually large  %s. 

Example metric snapshot: 
<img width="1311" height="581" alt="Screenshot 2026-04-17 at 11 04 25 AM" src="https://github.com/user-attachments/assets/c90cbfdb-0ecd-429e-82d4-3b1a955c9152" />

Resulting message: 
`Mimir store-gateway in ABC is experiencing 1.177e+04% errors while doing get_range on the object storage.`

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes alert annotation text formatting for `MimirStoreGatewayTooManyFailedOperations` without altering any PromQL expressions or alert thresholds.
> 
> **Overview**
> Updates the `MimirStoreGatewayTooManyFailedOperations` alert message to **stop formatting `$value` as a percentage** and instead display the raw error rate value from `thanos_objstore_bucket_operation_failures_total`.
> 
> This change is applied consistently across the generated Helm metamonitoring rule output and the compiled Mimir mixin alert files (including GEM/baremetal variants).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3ca7bbcb0742986108966a45dac35a0b6bb88d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->