### PR TITLE
MQE: add the ability to drop labels from series results

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -5322,6 +5322,39 @@
           ],
           "fieldValue": null,
           "fieldDefaultValue": null
+        },
+        {
+          "kind": "field",
+          "name": "enable_series_hash_head",
+          "required": false,
+          "desc": "Allow the TSDB head to remove unique ID from series before blocks are persisted and at query time when not needed. This is required if the unique ID is being generated or if it was in the past (within the range of the TSDB head).",
+          "fieldValue": null,
+          "fieldDefaultValue": false,
+          "fieldFlag": "ingester.enable-series-hash-head",
+          "fieldType": "boolean",
+          "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
+          "name": "enable_series_hash_write",
+          "required": false,
+          "desc": "Enables generating a unique ID for each series on ingestion.",
+          "fieldValue": null,
+          "fieldDefaultValue": false,
+          "fieldFlag": "ingester.enable-series-hash-write",
+          "fieldType": "boolean",
+          "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
+          "name": "enable_series_hash_read",
+          "required": false,
+          "desc": "Enables using a unique ID for the MQE projections optimization at query time.",
+          "fieldValue": null,
+          "fieldDefaultValue": false,
+          "fieldFlag": "ingester.enable-series-hash-read",
+          "fieldType": "boolean",
+          "fieldCategory": "experimental"
         }
       ],
       "fieldValue": null,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1635,6 +1635,12 @@ Usage of ./cmd/mimir/mimir:
     	[experimental] Minimum estimated series reduction percentage (0-100) required to trigger per-tenant early compaction. (default 15)
   -ingester.early-head-compaction-owned-series-threshold int
     	[experimental] When the number of owned series for a tenant across the cluster exceeds this threshold, trigger early head compaction. 0 to disable.
+  -ingester.enable-series-hash-head
+    	[experimental] Allow the TSDB head to remove unique ID from series before blocks are persisted and at query time when not needed. This is required if the unique ID is being generated or if it was in the past (within the range of the TSDB head).
+  -ingester.enable-series-hash-read
+    	[experimental] Enables using a unique ID for the MQE projections optimization at query time.
+  -ingester.enable-series-hash-write
+    	[experimental] Enables generating a unique ID for each series on ingestion.
   -ingester.error-sample-rate int
     	Each error will be logged once in this many times. Use 0 to log all of them. (default 10)
   -ingester.ignore-ooo-exemplars

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -1694,6 +1694,22 @@ read_reactive_limiter:
   # current inflight requests, after which all requests are rejected
   # CLI flag: -ingester.read-reactive-limiter.max-rejection-factor
   [max_rejection_factor: <float> | default = 3]
+
+# (experimental) Allow the TSDB head to remove unique ID from series before
+# blocks are persisted and at query time when not needed. This is required if
+# the unique ID is being generated or if it was in the past (within the range of
+# the TSDB head).
+# CLI flag: -ingester.enable-series-hash-head
+[enable_series_hash_head: <boolean> | default = false]
+
+# (experimental) Enables generating a unique ID for each series on ingestion.
+# CLI flag: -ingester.enable-series-hash-write
+[enable_series_hash_write: <boolean> | default = false]
+
+# (experimental) Enables using a unique ID for the MQE projections optimization
+# at query time.
+# CLI flag: -ingester.enable-series-hash-read
+[enable_series_hash_read: <boolean> | default = false]
 ```
 
 ### querier

--- a/go.mod
+++ b/go.mod
@@ -350,7 +350,8 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20260417154702-07bf9a9e74e9
+//replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20260417154702-07bf9a9e74e9
+replace github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20260420161723-12ee99bf6a0f
 
 // Replace memberlist with our fork which includes some changes that haven't been
 // merged upstream yet for years and we don't expect to change anytime soon.

--- a/go.sum
+++ b/go.sum
@@ -599,8 +599,8 @@ github.com/grafana/memberlist v0.3.1-0.20251126142931-6f9f62ab6f86 h1:aTwfQuroOm
 github.com/grafana/memberlist v0.3.1-0.20251126142931-6f9f62ab6f86/go.mod h1:h60o12SZn/ua/j0B6iKAZezA4eDaGsIuPO70eOaJ6WE=
 github.com/grafana/mimir-otlptranslator v0.0.0-20251017074411-ea1e8f863e1d h1:k4NIVPYPP0sLJoGNzGwoQs2MpnWTvTcgbWPCzfdX66c=
 github.com/grafana/mimir-otlptranslator v0.0.0-20251017074411-ea1e8f863e1d/go.mod h1:vRYWnXvI6aWGpsdY/mOT/cbeVRBlPWtBNDb7kGR3uKM=
-github.com/grafana/mimir-prometheus v1.8.2-0.20260417154702-07bf9a9e74e9 h1:xF1l6jfWyB1m35y7L+FaoQGzROrIN2O6ofIoyq2UiMw=
-github.com/grafana/mimir-prometheus v1.8.2-0.20260417154702-07bf9a9e74e9/go.mod h1:5QklNrg9sNn75Zz3kMfJl9d/35Fgi4SzHIa1IdvF0K0=
+github.com/grafana/mimir-prometheus v1.8.2-0.20260420161723-12ee99bf6a0f h1:vC+W3yffFl2Tv27lc82hbgQzAypVc68ifu2IagTmmVg=
+github.com/grafana/mimir-prometheus v1.8.2-0.20260420161723-12ee99bf6a0f/go.mod h1:5QklNrg9sNn75Zz3kMfJl9d/35Fgi4SzHIa1IdvF0K0=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956 h1:em1oddjXL8c1tL0iFdtVtPloq2hRPen2MJQKoAWpxu0=
 github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
 github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF3YH66t4qL8=

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -188,6 +188,10 @@ type Config struct {
 
 	PushGrpcMethodEnabled bool `yaml:"push_grpc_method_enabled" category:"experimental" doc:"hidden"`
 
+	EnableSeriesHashHead  bool `yaml:"enable_series_hash_head" category:"experimental"`
+	EnableSeriesHashWrite bool `yaml:"enable_series_hash_write" category:"experimental"`
+	EnableSeriesHashRead  bool `yaml:"enable_series_hash_read" category:"experimental"`
+
 	// This config is dynamically injected because defined outside the ingester config.
 	IngestStorageConfig ingest.Config `yaml:"-"`
 
@@ -218,6 +222,9 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.BoolVar(&cfg.UpdateIngesterOwnedSeries, "ingester.track-ingester-owned-series", false, "This option enables tracking of ingester-owned series based on ring state, even if -ingester.use-ingester-owned-series-for-limits is disabled.")
 	f.DurationVar(&cfg.OwnedSeriesUpdateInterval, "ingester.owned-series-update-interval", 15*time.Second, "How often to check for ring changes and possibly recompute owned series as a result of detected change.")
 	f.BoolVar(&cfg.PushGrpcMethodEnabled, "ingester.push-grpc-method-enabled", true, "Enables Push gRPC method on ingester. Can be only disabled when using ingest-storage to make sure ingesters only receive data from Kafka.")
+	f.BoolVar(&cfg.EnableSeriesHashHead, "ingester.enable-series-hash-head", false, "Allow the TSDB head to remove unique ID from series before blocks are persisted and at query time when not needed. This is required if the unique ID is being generated or if it was in the past (within the range of the TSDB head).")
+	f.BoolVar(&cfg.EnableSeriesHashWrite, "ingester.enable-series-hash-write", false, "Enables generating a unique ID for each series on ingestion.")
+	f.BoolVar(&cfg.EnableSeriesHashRead, "ingester.enable-series-hash-read", false, "Enables using a unique ID for the MQE projections optimization at query time.")
 
 	// Hardcoded config (can only be overridden in tests).
 	cfg.limitMetricsUpdatePeriod = time.Second * 15

--- a/pkg/ingester/ingester_push.go
+++ b/pkg/ingester/ingester_push.go
@@ -8,6 +8,7 @@ package ingester
 import (
 	"context"
 	"math"
+	"slices"
 	"time"
 
 	"github.com/failsafe-go/failsafe-go/adaptivelimiter"
@@ -24,6 +25,7 @@ import (
 	"github.com/grafana/mimir/pkg/ingester/activeseries"
 	"github.com/grafana/mimir/pkg/mimirpb"
 	mimir_storage "github.com/grafana/mimir/pkg/storage"
+	"github.com/grafana/mimir/pkg/storage/series"
 	"github.com/grafana/mimir/pkg/util/globalerror"
 	util_log "github.com/grafana/mimir/pkg/util/log"
 	"github.com/grafana/mimir/pkg/util/spanlogger"
@@ -542,7 +544,18 @@ func (i *Ingester) pushSamplesToAppender(
 	idx := i.getTSDB(userID).Head().MustIndex()
 	defer idx.Close()
 
+	hasher := series.NewProjectionHasher()
+
 	for _, ts := range timeseries {
+		// TODO(56quarters): Explain
+		if i.cfg.EnableSeriesHashWrite {
+			h, pos := hasher.SeriesHash(ts.Labels)
+			ts.SetLabels(slices.Insert(ts.Labels, pos, mimirpb.LabelAdapter{
+				Name:  series.HashLabelName,
+				Value: h,
+			}))
+		}
+
 		// Fast path in case we only have samples and they are all out of bound
 		// and out-of-order support is not enabled.
 		// TODO(jesus.vazquez) If we had too many old samples we might want to

--- a/pkg/ingester/ingester_query.go
+++ b/pkg/ingester/ingester_query.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/dskit/tenant"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
@@ -573,7 +574,33 @@ func (i *Ingester) QueryStream(req *client.QueryRequest, stream client.Ingester_
 
 	selectHints := initSelectHints(int64(from), int64(through))
 	selectHints = configSelectHintsWithShard(selectHints, shard)
-	selectHints = configSelectHintsWithProjections(selectHints, req.ProjectionInclude, req.ProjectionLabels)
+
+	// We can only use projections when the range of the entire query can be served
+	// from the TSDB head. Otherwise, we ignore them since we'd be adding __series_hash__
+	// to series which the same series in the local blocks or blocks in object storage
+	// won't have.
+	head := db.Head()
+	headMinT := model.Time(head.MinTime())
+
+	// Projection parameters are potentially set on the request by the querier if this query
+	// only touches ingesters. We need to do additional validation here to ensure we only pass
+	// the hints along when the query only touches the HEAD.
+	projectionsMsg := "skipping projections for query"
+	if i.cfg.EnableSeriesHashWrite && i.cfg.EnableSeriesHashRead && from.After(headMinT) {
+		selectHints = configSelectHintsWithProjections(selectHints, req.ProjectionInclude, req.ProjectionLabels)
+		projectionsMsg = "propagating projections for query via hints"
+	}
+
+	spanlog.DebugLog(
+		"msg", projectionsMsg,
+		"enabled_write", i.cfg.EnableSeriesHashWrite,
+		"enabled_read", i.cfg.EnableSeriesHashRead,
+		"min_time", from.Time(),
+		"head_min_time", headMinT.Time(),
+		"include", req.ProjectionInclude,
+		"labels", fmt.Sprintf("%+v", req.ProjectionLabels),
+	)
+
 	// Disable chunks trimming, so that we don't have to rewrite chunks which have samples outside
 	// the requested from/through range. PromQL engine can handle it.
 	selectHints = configSelectHintsWithDisabledTrimming(selectHints)
@@ -596,11 +623,15 @@ func (i *Ingester) QueryStream(req *client.QueryRequest, stream client.Ingester_
 func (i *Ingester) executeStreamingQuery(ctx context.Context, db *userTSDB, hints *storage.SelectHints, matchers []*labels.Matcher, stream client.Ingester_QueryStreamServer, batchSize uint64, spanlog *spanlogger.SpanLogger) (numSeries, numSamples int, _ error) {
 	var q storage.ChunkQuerier
 	var err error
-	if i.limits.OutOfOrderTimeWindow(db.userID) > 0 {
+
+	if hints.ProjectionInclude {
+		q, err = db.ChunkQuerierForProjections(hints.Start, hints.End)
+	} else if i.limits.OutOfOrderTimeWindow(db.userID) > 0 {
 		q, err = db.UnorderedChunkQuerier(hints.Start, hints.End)
 	} else {
 		q, err = db.ChunkQuerier(hints.Start, hints.End)
 	}
+
 	if err != nil {
 		return 0, 0, err
 	}
@@ -717,10 +748,8 @@ func (i *Ingester) sendStreamingQuerySeries(ctx context.Context, q storage.Chunk
 
 		if hints.ProjectionInclude {
 			originalLabelBytes += lbls.ByteSize()
-			reduced := projections.Reduce(lbls)
-			// Estimate the size of the series hash label and value since we aren't generating
-			// series hash on ingest currently.
-			reducedLabelBytes += reduced.ByteSize() + uint64(len(series.HashLabelName)) + 42 /* 256-bit hash as base64 */
+			lbls = projections.Reduce(lbls)
+			reducedLabelBytes += lbls.ByteSize()
 		} else {
 			skippedLabelBytes += lbls.ByteSize()
 		}

--- a/pkg/ingester/ingester_tsdb.go
+++ b/pkg/ingester/ingester_tsdb.go
@@ -208,8 +208,9 @@ func (i *Ingester) createTSDB(userID string, walReplayConcurrency int) (*userTSD
 		EnableBiggerOOOBlockForOldSamples:    i.cfg.BlocksStorageConfig.TSDB.BiggerOutOfOrderBlocksForOldSamples,
 		IsolationDisabled:                    true,
 		HeadChunksWriteQueueSize:             i.cfg.BlocksStorageConfig.TSDB.HeadChunksWriteQueueSize,
-		EnableOverlappingCompaction:          false,                // always false since Mimir only uploads lvl 1 compacted blocks
-		EnableSharding:                       true,                 // Always enable query sharding support.
+		EnableOverlappingCompaction:          false, // always false since Mimir only uploads lvl 1 compacted blocks
+		EnableSharding:                       true,  // Always enable query sharding support.
+		EnableSeriesHash:                     i.cfg.EnableSeriesHashHead,
 		OutOfOrderTimeWindow:                 oooTW.Milliseconds(), // The unit must be same as our timestamps.
 		OutOfOrderCapMax:                     int64(i.cfg.BlocksStorageConfig.TSDB.OutOfOrderCapacityMax),
 		TimelyCompaction:                     i.cfg.BlocksStorageConfig.TSDB.TimelyHeadCompaction,

--- a/pkg/ingester/user_tsdb.go
+++ b/pkg/ingester/user_tsdb.go
@@ -203,6 +203,10 @@ func (u *userTSDB) Querier(mint, maxt int64) (storage.Querier, error) {
 	return u.db.Querier(mint, maxt)
 }
 
+func (u *userTSDB) ChunkQuerierForProjections(mint, maxt int64) (storage.ChunkQuerier, error) {
+	return u.db.ChunkQuerierForProjections(mint, maxt)
+}
+
 func (u *userTSDB) ChunkQuerier(mint, maxt int64) (storage.ChunkQuerier, error) {
 	return u.db.ChunkQuerier(mint, maxt)
 }

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -295,8 +295,9 @@ type multiQuerier struct {
 	queryMetrics *stats.QueryMetrics
 	cfg          Config
 	minT, maxT   int64
-	queriers     []storage.Querier
-	queriersMtx  sync.Mutex
+
+	queriers    []storage.Querier
+	queriersMtx sync.Mutex
 
 	limits *validation.Overrides
 
@@ -305,7 +306,7 @@ type multiQuerier struct {
 
 // getQueriers returns a context with per-tenant query limits applied, queriers applicable to the provided
 // time range, and the possibly adjusted min and max times.
-func (mq *multiQuerier) getQueriers(ctx context.Context, minT, maxT int64) (context.Context, []storage.Querier, int64, int64, error) {
+func (mq *multiQuerier) getQueriers(ctx context.Context, minT, maxT int64) (context.Context, []storage.Querier, int64, int64, bool, error) {
 	spanLog, ctx := spanlogger.New(ctx, mq.logger, tracer, "multiQuerier.getQueriers")
 	defer spanLog.Finish()
 
@@ -313,7 +314,7 @@ func (mq *multiQuerier) getQueriers(ctx context.Context, minT, maxT int64) (cont
 
 	tenantID, err := tenant.TenantID(ctx)
 	if err != nil {
-		return nil, nil, 0, 0, err
+		return nil, nil, 0, 0, false, err
 	}
 
 	ctx = limiter.AddQueryLimiterToContext(ctx, limiter.NewQueryLimiter(
@@ -326,26 +327,32 @@ func (mq *multiQuerier) getQueriers(ctx context.Context, minT, maxT int64) (cont
 
 	minT, maxT, err = validateQueryTimeRange(tenantID, minT, maxT, now.UnixMilli(), mq.limits, spanlogger.FromContext(ctx, mq.logger))
 	if err != nil {
-		return nil, nil, 0, 0, err
+		return nil, nil, 0, 0, false, err
 	}
 
-	var queriers []storage.Querier
+	var (
+		queriers        []storage.Querier
+		queryIngesters  bool
+		queryBlockStore bool
+	)
 
 	if mq.distributor != nil && ShouldQueryIngesters(mq.limits.QueryIngestersWithin(tenantID), now, maxT) {
 		q, err := mq.distributor.Querier(minT, maxT)
 		if err != nil {
-			return nil, nil, 0, 0, err
+			return nil, nil, 0, 0, false, err
 		}
 		queriers = append(queriers, q)
+		queryIngesters = true
 		mq.queryMetrics.QueriesExecutedTotal.WithLabelValues("ingester").Inc()
 	}
 
 	if mq.blockStore != nil && ShouldQueryBlockStore(mq.cfg.QueryStoreAfter, now, minT) {
 		q, err := mq.blockStore.Querier(minT, maxT)
 		if err != nil {
-			return nil, nil, 0, 0, err
+			return nil, nil, 0, 0, false, err
 		}
 		queriers = append(queriers, q)
+		queryBlockStore = true
 		mq.queryMetrics.QueriesExecutedTotal.WithLabelValues("store-gateway").Inc()
 	}
 
@@ -355,7 +362,7 @@ func (mq *multiQuerier) getQueriers(ctx context.Context, minT, maxT int64) (cont
 	// when methods are initially called: we need to wait until the results are
 	// consumed and the caller of this querier closes it.
 	mq.storeQueriers(queriers)
-	return ctx, queriers, minT, maxT, nil
+	return ctx, queriers, minT, maxT, queryIngesters && !queryBlockStore, nil
 }
 
 // Select implements storage.Querier interface.
@@ -364,7 +371,7 @@ func (mq *multiQuerier) Select(ctx context.Context, _ bool, sp *storage.SelectHi
 	spanLog, ctx := spanlogger.New(ctx, mq.logger, tracer, "multiQuerier.Select")
 	defer spanLog.Finish()
 
-	ctx, queriers, minT, maxT, err := mq.getQueriers(ctx, mq.minT, mq.maxT)
+	ctx, queriers, minT, maxT, ingesterOnly, err := mq.getQueriers(ctx, mq.minT, mq.maxT)
 	if errors.Is(err, errEmptyTimeRange) {
 		return storage.EmptySeriesSet()
 	}
@@ -382,6 +389,13 @@ func (mq *multiQuerier) Select(ctx context.Context, _ bool, sp *storage.SelectHi
 		scp := *sp
 		sp = &scp
 	}
+
+	// TODO(56quarters): Terrible
+	if !ingesterOnly {
+		sp.ProjectionInclude = false
+		sp.ProjectionLabels = nil
+	}
+
 	now := time.Now()
 
 	level.Debug(spanLog).Log(
@@ -528,7 +542,7 @@ func (mq *multiQuerier) LabelValues(ctx context.Context, name string, hints *sto
 	spanLog, ctx := spanlogger.New(ctx, mq.logger, tracer, "multiQuerier.LabelValues")
 	defer spanLog.Finish()
 
-	ctx, queriers, _, _, err := mq.getQueriers(ctx, mq.minT, mq.maxT)
+	ctx, queriers, _, _, _, err := mq.getQueriers(ctx, mq.minT, mq.maxT)
 	if errors.Is(err, errEmptyTimeRange) {
 		return nil, nil, nil
 	}
@@ -595,7 +609,7 @@ func (mq *multiQuerier) LabelNames(ctx context.Context, hints *storage.LabelHint
 	spanLog, ctx := spanlogger.New(ctx, mq.logger, tracer, "multiQuerier.LabelNames")
 	defer spanLog.Finish()
 
-	ctx, queriers, _, _, err := mq.getQueriers(ctx, mq.minT, mq.maxT)
+	ctx, queriers, _, _, _, err := mq.getQueriers(ctx, mq.minT, mq.maxT)
 	if errors.Is(err, errEmptyTimeRange) {
 		return nil, nil, nil
 	}

--- a/pkg/storage/series/projections.go
+++ b/pkg/storage/series/projections.go
@@ -3,11 +3,49 @@
 package series
 
 import (
+	"crypto/sha3"
+	"encoding/base64"
+
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/grafana/mimir/pkg/mimirpb"
 )
 
-const HashLabelName = "__series_hash__"
+const (
+	HashLabelName = "__series_hash__"
+
+	hashOutputSize = 16
+)
+
+type ProjectionHasher struct {
+	buf  []byte
+	hash *sha3.SHAKE
+}
+
+func NewProjectionHasher() *ProjectionHasher {
+	return &ProjectionHasher{
+		buf:  make([]byte, hashOutputSize),
+		hash: sha3.NewSHAKE256(),
+	}
+}
+
+func (p *ProjectionHasher) SeriesHash(lbls []mimirpb.LabelAdapter) (string, int) {
+	p.hash.Reset()
+	pos := 0
+
+	for labelIdx, l := range lbls {
+		if l.Name < HashLabelName {
+			pos = labelIdx
+		}
+
+		_, _ = p.hash.Write([]byte(l.Name))
+		_, _ = p.hash.Write([]byte(l.Value))
+	}
+
+	_, _ = p.hash.Read(p.buf)
+	return base64.RawURLEncoding.EncodeToString(p.buf), pos + 1
+}
 
 // ProjectionLabels modifies label sets for series to only retain labels required
 // for a query and to ensure the set of labels continues to sort correctly compared

--- a/vendor/github.com/prometheus/prometheus/tsdb/db.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/db.go
@@ -59,6 +59,9 @@ const (
 	// DefaultCompactionDelayMaxPercent in percentage.
 	DefaultCompactionDelayMaxPercent = 10
 
+	// SeriesHashLabel is the label used for unique per-series IDs to support the projections optimization.
+	SeriesHashLabel = "__series_hash__"
+
 	// Block dir suffixes to make deletion and creation operations atomic.
 	// We decided to do suffixes instead of creating meta.json as last (or delete as first) one,
 	// because in error case you still can recover meta.json from the block content within local TSDB dir.
@@ -72,6 +75,8 @@ const (
 
 // ErrNotReady is returned if the underlying storage is not ready yet.
 var ErrNotReady = errors.New("TSDB not ready")
+
+var ErrInvalidTimeRangeForProjections = errors.New("time range cannot be used with projections")
 
 // DefaultOptions used for the DB. They are reasonable for setups using
 // millisecond precision timestamps.
@@ -92,6 +97,7 @@ func DefaultOptions() *Options {
 		OutOfOrderCapMax:                         DefaultOutOfOrderCapMax,
 		EnableOverlappingCompaction:              true,
 		EnableSharding:                           false,
+		EnableSeriesHash:                         false,
 		EnableDelayedCompaction:                  false,
 		CompactionDelayMaxPercent:                DefaultCompactionDelayMaxPercent,
 		CompactionDelay:                          time.Duration(0),
@@ -234,6 +240,9 @@ type Options struct {
 
 	// EnableSharding enables query sharding support in TSDB.
 	EnableSharding bool
+
+	// EnableSeriesHash enables support for the projections optimization in TSDB via a unique per-series ID.
+	EnableSeriesHash bool
 
 	// EnableDelayedCompaction, when set to true, assigns a random value to CompactionDelay during DB opening.
 	// When set to false, delayed compaction is disabled, unless CompactionDelay is set directly.
@@ -1227,6 +1236,7 @@ func open(dir string, l *slog.Logger, r prometheus.Registerer, opts *Options, rn
 	headOpts.OutOfOrderTimeWindow.Store(opts.OutOfOrderTimeWindow)
 	headOpts.OutOfOrderCapMax.Store(opts.OutOfOrderCapMax)
 	headOpts.EnableSharding = opts.EnableSharding
+	headOpts.EnableSeriesHash = opts.EnableSeriesHash
 	headOpts.TimelyCompaction = opts.TimelyCompaction
 	if opts.HeadPostingsForMatchersCacheFactory != nil {
 		headOpts.PostingsForMatchersCacheFactory = opts.HeadPostingsForMatchersCacheFactory
@@ -2672,6 +2682,54 @@ func (db *DB) blockChunkQuerierForRange(mint, maxt int64) (_ []storage.ChunkQuer
 	}
 
 	return blockQueriers, nil
+}
+
+func (db *DB) ChunkQuerierForProjections(mint, maxt int64) (storage.ChunkQuerier, error) {
+	db.mtx.RLock()
+	defer db.mtx.RUnlock()
+
+	for _, b := range db.blocks {
+		if b.OverlapsClosedInterval(mint, maxt) {
+			return nil, fmt.Errorf("%w: existing block overlaps the range. mint: %d, maxt: %d", ErrInvalidTimeRangeForProjections, mint, maxt)
+		}
+	}
+
+	// We can only use the projections optimization (including __series_hash__  unique ID) when
+	// the query touches only the head since we need to ensure results are sorted correctly based
+	// on the labels returned. This is only possible for the in-memory head.
+	headMinT := db.head.MinTime()
+	if mint < headMinT {
+		return nil, fmt.Errorf("%w: range mint %d precedes head mint %d", ErrInvalidTimeRangeForProjections, mint, headMinT)
+	}
+
+	rh := NewProjectionsRangeHead(db.head, mint, maxt)
+	headQuerier, err := db.blockChunkQuerierFunc(rh, mint, maxt)
+	if err != nil {
+		return nil, fmt.Errorf("open querier for head %s: %w", rh, err)
+	}
+
+	// Getting the querier above registers itself in the queue that the truncation waits on.
+	// If the querier is currently not colliding with any truncation, we can continue to use it
+	// for this projections optimized query. If it _is_ colliding return an error since we would
+	// rather not block truncation. In the normal query path, we adjust the range queried from
+	// the head but, we can't do that with projections since we need to be able to sort the entire
+	// result based on labels returned.
+	if shouldClose, _, _ := db.head.IsQuerierCollidingWithTruncation(mint, maxt); shouldClose {
+		if err = headQuerier.Close(); err != nil {
+			return nil, fmt.Errorf("closing head querier %s: %w", rh, err)
+		}
+
+		return nil, fmt.Errorf("%w: range mint %d to maxt %d overlaps truncation", ErrInvalidTimeRangeForProjections, mint, maxt)
+	}
+
+	overlapsOOO := overlapsClosedInterval(mint, maxt, db.head.MinOOOTime(), db.head.MaxOOOTime())
+	if overlapsOOO {
+		// We need to fetch from in-order and out-of-order chunks: wrap the headQuerier.
+		isoState := db.head.oooIso.TrackReadAfter(db.lastGarbageCollectedMmapRef)
+		headQuerier = NewHeadAndOOOChunkQuerier(headMinT, mint, maxt, db.head, isoState, headQuerier)
+	}
+
+	return headQuerier, nil
 }
 
 // ChunkQuerier returns a new chunk querier over the data partition for the given time range.

--- a/vendor/github.com/prometheus/prometheus/tsdb/head.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/head.go
@@ -208,6 +208,9 @@ type HeadOptions struct {
 	// EnableSharding enables ShardedPostings() support in the Head.
 	EnableSharding bool
 
+	// EnableSeriesHash enables support for the projections optimization in the Head via a unique per-series ID.
+	EnableSeriesHash bool
+
 	// IndexLookupPlannerFunc can be optionally used when querying the index of the Head.
 	IndexLookupPlannerFunc IndexLookupPlannerFunc
 
@@ -1616,7 +1619,7 @@ func NewRangeHeadWithIsolationDisabled(head *Head, mint, maxt int64) *RangeHead 
 }
 
 func (h *RangeHead) Index() (IndexReader, error) {
-	return h.head.indexRange(h.mint, h.maxt), nil
+	return h.head.indexRange(h.mint, h.maxt, false), nil
 }
 
 func (h *RangeHead) Chunks() (ChunkReader, error) {
@@ -1672,6 +1675,27 @@ func (h *RangeHead) String() string {
 	return fmt.Sprintf("range head (mint: %d, maxt: %d)", h.MinTime(), h.MaxTime())
 }
 
+// ProjectionsRangeHead allows querying Head via an IndexReader, ChunkReader and tombstones.Reader
+// but only within a restricted range. Used for queries that have requested the projections optimization,
+// adding a __series_hash__ unique ID to each series so that a subset of other labels may be returned.
+type ProjectionsRangeHead struct {
+	RangeHead
+}
+
+func NewProjectionsRangeHead(head *Head, mint, maxt int64) *ProjectionsRangeHead {
+	return &ProjectionsRangeHead{
+		RangeHead: RangeHead{
+			head: head,
+			mint: mint,
+			maxt: maxt,
+		},
+	}
+}
+
+func (h *ProjectionsRangeHead) Index() (IndexReader, error) {
+	return h.head.indexRange(h.mint, h.maxt, true), nil
+}
+
 // StaleHead allows querying the stale series in the Head via an IndexReader, ChunkReader and tombstones.Reader.
 // Used only for compactions.
 type StaleHead struct {
@@ -1725,7 +1749,7 @@ func (h *Head) Delete(ctx context.Context, mint, maxt int64, ms ...*labels.Match
 	// Do not delete anything beyond the currently valid range.
 	mint, maxt = clampInterval(mint, maxt, h.MinTime(), h.MaxTime())
 
-	ir := h.indexRange(mint, maxt)
+	ir := h.indexRange(mint, maxt, false)
 
 	p, err := ir.PostingsForMatchers(ctx, false, ms...)
 	if err != nil {
@@ -1956,6 +1980,7 @@ func (h *Head) getOrCreateWithOptionalID(id chunks.HeadSeriesRef, hash uint64, l
 	if h.opts.EnableSharding {
 		shardHash = labels.StableHash(lset)
 	}
+
 	optimisticallyCreatedSeries := newMemSeries(lset, id, shardHash, h.secondaryHashFunc(lset), h.opts.ChunkEndTimeVariance, h.opts.IsolationDisabled, pendingCommit)
 
 	s, created := h.series.setUnlessAlreadySet(hash, lset, optimisticallyCreatedSeries)

--- a/vendor/github.com/prometheus/prometheus/tsdb/head_read.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/head_read.go
@@ -35,19 +35,20 @@ func (h *Head) ExemplarQuerier(ctx context.Context) (storage.ExemplarQuerier, er
 
 // Index returns an IndexReader against the block.
 func (h *Head) Index() (IndexReader, error) {
-	return h.indexRange(math.MinInt64, math.MaxInt64), nil
+	return h.indexRange(math.MinInt64, math.MaxInt64, false), nil
 }
 
-func (h *Head) indexRange(mint, maxt int64) *headIndexReader {
+func (h *Head) indexRange(mint, maxt int64, includeSeriesHash bool) *headIndexReader {
 	if hmin := h.MinTime(); hmin > mint {
 		mint = hmin
 	}
-	return &headIndexReader{head: h, mint: mint, maxt: maxt}
+	return &headIndexReader{head: h, mint: mint, maxt: maxt, includeSeriesHash: includeSeriesHash}
 }
 
 type headIndexReader struct {
-	head       *Head
-	mint, maxt int64
+	head              *Head
+	mint, maxt        int64
+	includeSeriesHash bool
 }
 
 func (*headIndexReader) Close() error {
@@ -139,9 +140,16 @@ func (h *headIndexReader) SortedPostings(p index.Postings) index.Postings {
 		return index.ErrPostings(fmt.Errorf("expand postings: %w", err))
 	}
 
-	slices.SortFunc(series, func(a, b *memSeries) int {
-		return labels.Compare(a.labels(), b.labels())
-	})
+	// If the memSeries have a series hash label set and we haven't been
+	// told to include it in the output (when projections aren't being used)
+	// then we need to remove it from the label sets before sorting them.
+	// Otherwise, the label sets don't have the series hash or, we should
+	// include it so we don't remove anything.
+	if h.head.opts.EnableSeriesHash && !h.includeSeriesHash {
+		slices.SortFunc(series, compareWithoutSeriesHash)
+	} else {
+		slices.SortFunc(series, compareWithSeriesHash)
+	}
 
 	// Convert back to list.
 	ep := make([]storage.SeriesRef, 0, len(series))
@@ -149,6 +157,22 @@ func (h *headIndexReader) SortedPostings(p index.Postings) index.Postings {
 		ep = append(ep, storage.SeriesRef(p.ref))
 	}
 	return index.NewListPostings(ep)
+}
+
+func compareWithSeriesHash(a, b *memSeries) int {
+	return labels.Compare(a.labels(), b.labels())
+}
+
+func compareWithoutSeriesHash(a, b *memSeries) int {
+	lsetA := a.labels().DropReserved(func(name string) bool {
+		return name == SeriesHashLabel
+	})
+
+	lsetB := b.labels().DropReserved(func(name string) bool {
+		return name == SeriesHashLabel
+	})
+
+	return labels.Compare(lsetA, lsetB)
 }
 
 // ShardedPostings implements IndexReader. This function returns an failing postings list if sharding
@@ -202,7 +226,14 @@ func (h *headIndexReader) Series(ref storage.SeriesRef, builder *labels.ScratchB
 		h.head.metrics.seriesNotFound.Inc()
 		return storage.ErrNotFound
 	}
-	builder.Assign(s.labels())
+
+	if h.head.opts.EnableSeriesHash && !h.includeSeriesHash {
+		builder.Assign(s.labels().DropReserved(func(name string) bool {
+			return name == SeriesHashLabel
+		}))
+	} else {
+		builder.Assign(s.labels())
+	}
 
 	if chks == nil {
 		return nil
@@ -219,7 +250,7 @@ func (h *headIndexReader) Series(ref storage.SeriesRef, builder *labels.ScratchB
 
 func (h *Head) staleIndex(mint, maxt int64, staleSeriesRefs []storage.SeriesRef) (*headStaleIndexReader, error) {
 	return &headStaleIndexReader{
-		headIndexReader: h.indexRange(mint, maxt),
+		headIndexReader: h.indexRange(mint, maxt, false),
 		staleSeriesRefs: staleSeriesRefs,
 	}, nil
 }

--- a/vendor/github.com/prometheus/prometheus/tsdb/head_read_mimir.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/head_read_mimir.go
@@ -13,8 +13,10 @@
 
 package tsdb
 
-import "math"
+import (
+	"math"
+)
 
 func (h *Head) MustIndex() IndexReader {
-	return h.indexRange(math.MinInt64, math.MaxInt64)
+	return h.indexRange(math.MinInt64, math.MaxInt64, false)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1156,7 +1156,7 @@ github.com/prometheus/otlptranslator
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v1.8.2-0.20260417154702-07bf9a9e74e9
+# github.com/prometheus/prometheus v1.99.0 => github.com/grafana/mimir-prometheus v1.8.2-0.20260420161723-12ee99bf6a0f
 ## explicit; go 1.25.0
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -2177,7 +2177,7 @@ sigs.k8s.io/structured-merge-diff/v6/value
 # sigs.k8s.io/yaml v1.6.0
 ## explicit; go 1.22
 sigs.k8s.io/yaml
-# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20260417154702-07bf9a9e74e9
+# github.com/prometheus/prometheus => github.com/grafana/mimir-prometheus v1.8.2-0.20260420161723-12ee99bf6a0f
 # github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20251126142931-6f9f62ab6f86
 # go.yaml.in/yaml/v3 => github.com/grafana/go-yaml/v3 v3.0.0-20260130164322-e3c24e8f4c87
 # github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20250905101755-5eb4f3acbf71


### PR DESCRIPTION
#### What this PR does

Add the ability to drop unused labels from series returned from
ingesters when projections are in use and the query only requires
data from the TSDB head.

#### Which issue(s) this PR fixes or relates to

Part of https://github.com/grafana/mimir/issues/13863

Related https://github.com/grafana/mimir-prometheus/pull/1142

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
