### PR TITLE
Ingester: enforce a minimum 10s delay between TSDB head compaction iterations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,7 @@
 * [ENHANCEMENT] Distributor: OTLP endpoint now returns partial success (HTTP 200) instead of HTTP 429 when the usage tracker rejects some series due to the active series limit but other series are successfully ingested. The `RejectedDataPoints` field reports the count of distributor-side rejections (usage tracker filtering). #14789
 * [ENHANCEMENT] MQE: Account for memory consumption of labels returned by binary operations in query memory consumption estimate earlier. #15033
 * [ENHANCEMENT] Query-frontend: Log the number of series and samples returned for queries in `query stats` log lines. #15044
+* [BUGFIX] Ingester: enforce a minimum 10s delay between TSDB head compaction iterations when an iteration approaches or exceeds the configured `-blocks-storage.tsdb.head-compaction-interval`, so ingestion is not starved by back-to-back compactions. #15061
 * [BUGFIX] Update to Go v1.25.9. #15030
 * [BUGFIX] Distributor: OTLP partial success responses now correctly populate `RejectedDataPoints` with the actual count of rejected samples, instead of always reporting 0. In classical architecture, this includes rejected samples propagated from the ingester. #14789
 * [BUGFIX] Distributor: Fix race condition where usage-tracker partition ring may not be initialized before the distributor service starts, causing `usage-tracker partition ring is required` error on startup. #14675

--- a/pkg/ingester/ingester_compaction.go
+++ b/pkg/ingester/ingester_compaction.go
@@ -22,6 +22,12 @@ import (
 	"github.com/grafana/mimir/pkg/util"
 )
 
+// minCompactionLoopDelay is the minimum delay enforced between TSDB head
+// compaction iterations, so the loop cannot run continuously and starve
+// other ingester work when a single iteration approaches or exceeds the
+// configured compaction interval.
+const minCompactionLoopDelay = 10 * time.Second
+
 func (i *Ingester) shipBlocksLoop(ctx context.Context) error {
 	// We add a slight jitter to make sure that if the head compaction interval and ship interval are set to the same
 	// value they don't clash (if they both continuously run at the same exact time, the head compaction may not run
@@ -132,6 +138,8 @@ func (i *Ingester) compactionServiceRunning(ctx context.Context) error {
 	for ctx.Err() == nil {
 		select {
 		case <-tickerChan:
+			iterationStart := time.Now()
+
 			// Count the number of compactions in progress to keep the downscale handler from
 			// clearing the read-only mode. See [Ingester.PrepareInstanceRingDownscaleHandler]
 			i.numCompactionsInProgress.Inc()
@@ -147,6 +155,24 @@ func (i *Ingester) compactionServiceRunning(ctx context.Context) error {
 
 			// Decrement the counter after compaction is complete
 			i.numCompactionsInProgress.Dec()
+
+			// Ensure the gap between iterations is always at least minCompactionLoopDelay,
+			// so the compaction loop can't run continuously when iterations are slow and
+			// starve other ingester work (e.g. ingestion offset commits).
+			iterationDuration := time.Since(iterationStart)
+			if extraDelay := compactionLoopExtraDelay(iterationDuration, standardInterval, minCompactionLoopDelay); extraDelay > 0 {
+				level.Warn(i.logger).Log(
+					"msg", "enforcing minimum delay between TSDB head compaction iterations because the previous iteration approached or exceeded the configured interval",
+					"iteration_duration", iterationDuration,
+					"configured_interval", standardInterval,
+					"extra_delay", extraDelay,
+				)
+				select {
+				case <-time.After(extraDelay):
+				case <-ctx.Done():
+					return nil
+				}
+			}
 
 			// If the ingester state is no longer "Starting", we switch to a different interval.
 			// We only compare the standard interval because the first interval may be random due to jittering.
@@ -619,4 +645,25 @@ func timeUntilCompaction(now time.Time, compactionInterval, zoneOffset time.Dura
 	}
 
 	return compactionInterval - timeSinceLastCompaction
+}
+
+// compactionLoopExtraDelay returns how long the compaction loop should sleep
+// after an iteration, on top of the natural wait for the next ticker tick,
+// to guarantee a gap of at least minDelay between iterations. Returns 0 when
+// the natural wait (standardInterval - iterationDuration) is already >= minDelay.
+//
+// When an iteration overruns the configured interval, the extra delay is capped
+// at minDelay so that a pathologically long iteration does not translate into
+// an equally long sleep — the goal is just to prevent the loop from spinning
+// continuously.
+func compactionLoopExtraDelay(iterationDuration, standardInterval, minDelay time.Duration) time.Duration {
+	remaining := standardInterval - iterationDuration
+	if remaining >= minDelay {
+		return 0
+	}
+	extraDelay := minDelay - remaining
+	if extraDelay > minDelay {
+		extraDelay = minDelay
+	}
+	return extraDelay
 }

--- a/pkg/ingester/ingester_compaction.go
+++ b/pkg/ingester/ingester_compaction.go
@@ -648,22 +648,19 @@ func timeUntilCompaction(now time.Time, compactionInterval, zoneOffset time.Dura
 }
 
 // compactionLoopExtraDelay returns how long the compaction loop should sleep
-// after an iteration, on top of the natural wait for the next ticker tick,
-// to guarantee a gap of at least minDelay between iterations. Returns 0 when
-// the natural wait (standardInterval - iterationDuration) is already >= minDelay.
+// after an iteration to guarantee a gap of at least minDelay between iterations.
+// Returns 0 when the natural wait for the next ticker tick
+// (standardInterval - iterationDuration) is already >= minDelay.
 //
-// When an iteration overruns the configured interval, the extra delay is capped
-// at minDelay so that a pathologically long iteration does not translate into
-// an equally long sleep — the goal is just to prevent the loop from spinning
-// continuously.
+// When the natural wait is shorter, the function returns minDelay — not
+// minDelay - remaining. That is because the sleep does NOT add to the ticker
+// countdown: both run against wall-clock time, so the effective gap is
+// max(sleep, naturalWait). To push the max above minDelay, the sleep itself
+// must be at least minDelay. Returning minDelay also handles the overrun case
+// (naturalWait <= 0, tick already buffered) with the same value.
 func compactionLoopExtraDelay(iterationDuration, standardInterval, minDelay time.Duration) time.Duration {
-	remaining := standardInterval - iterationDuration
-	if remaining >= minDelay {
+	if standardInterval-iterationDuration >= minDelay {
 		return 0
 	}
-	extraDelay := minDelay - remaining
-	if extraDelay > minDelay {
-		extraDelay = minDelay
-	}
-	return extraDelay
+	return minDelay
 }

--- a/pkg/ingester/ingester_compaction_test.go
+++ b/pkg/ingester/ingester_compaction_test.go
@@ -27,23 +27,23 @@ func TestCompactionLoopExtraDelay(t *testing.T) {
 			iterationDuration: standardInterval - minDelay,
 			expected:          0,
 		},
-		"iteration just past the boundary: small extra delay": {
+		"iteration just past the boundary: extra delay equals minDelay": {
 			iterationDuration: standardInterval - minDelay + time.Second,
-			expected:          time.Second,
+			expected:          minDelay,
 		},
-		"iteration near the full interval: extra delay close to minDelay": {
+		"iteration near the full interval: extra delay equals minDelay": {
 			iterationDuration: standardInterval - time.Second,
-			expected:          minDelay - time.Second,
+			expected:          minDelay,
 		},
 		"iteration exactly at the interval: extra delay equals minDelay": {
 			iterationDuration: standardInterval,
 			expected:          minDelay,
 		},
-		"iteration overruns the interval: extra delay capped at minDelay": {
+		"iteration overruns the interval: extra delay equals minDelay": {
 			iterationDuration: standardInterval + time.Second,
 			expected:          minDelay,
 		},
-		"iteration far overruns the interval: extra delay still capped at minDelay": {
+		"iteration far overruns the interval: extra delay equals minDelay": {
 			iterationDuration: 10 * standardInterval,
 			expected:          minDelay,
 		},

--- a/pkg/ingester/ingester_compaction_test.go
+++ b/pkg/ingester/ingester_compaction_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package ingester
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCompactionLoopExtraDelay(t *testing.T) {
+	const (
+		standardInterval = time.Minute
+		minDelay         = 10 * time.Second
+	)
+
+	tests := map[string]struct {
+		iterationDuration time.Duration
+		expected          time.Duration
+	}{
+		"fast iteration well below interval: no extra delay": {
+			iterationDuration: 5 * time.Second,
+			expected:          0,
+		},
+		"iteration exactly at the boundary: no extra delay": {
+			iterationDuration: standardInterval - minDelay,
+			expected:          0,
+		},
+		"iteration just past the boundary: small extra delay": {
+			iterationDuration: standardInterval - minDelay + time.Second,
+			expected:          time.Second,
+		},
+		"iteration near the full interval: extra delay close to minDelay": {
+			iterationDuration: standardInterval - time.Second,
+			expected:          minDelay - time.Second,
+		},
+		"iteration exactly at the interval: extra delay equals minDelay": {
+			iterationDuration: standardInterval,
+			expected:          minDelay,
+		},
+		"iteration overruns the interval: extra delay capped at minDelay": {
+			iterationDuration: standardInterval + time.Second,
+			expected:          minDelay,
+		},
+		"iteration far overruns the interval: extra delay still capped at minDelay": {
+			iterationDuration: 10 * standardInterval,
+			expected:          minDelay,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := compactionLoopExtraDelay(tc.iterationDuration, standardInterval, minDelay)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does

Adds a safety guard in the ingester's TSDB head compaction loop that enforces a minimum gap between iterations, so the loop cannot run continuously and starve other ingester work (e.g. ingest-storage offset commits) when a single iteration approaches or exceeds the configured `-blocks-storage.tsdb.head-compaction-interval`.

This prevents an edge case where the ingestion is stuck forever just because the TSDB early compaction is always in progress, while catching up from Kafka.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
