### PR TITLE
Ingester: allow /ingester/flush endpoint while the ingester is starting up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,7 @@
 * [ENHANCEMENT] Ingester: reduce heap usage during streaming chunk queries by releasing series label memory after each batch is sent rather than holding it until chunk streaming completes. #14422
 * [ENHANCEMENT] Ingester: Eliminate 20-minute active series metrics loading period when custom tracker or cost attribution configuration changes. Active series counts are now immediately correct after a config reload. #14537
 * [ENHANCEMENT] Ingester: Export `cortex_ingester_active_series_loading` gauge metric that is `1` while active series counts are still warming up after ingester startup, and `0` once they are accurate (after IdleTimeout has elapsed). #14783
+* [ENHANCEMENT] Ingester: Allow `/ingester/flush` endpoint to be called while the ingester is starting up. This is useful during incidents where ingesters are stuck replaying from Kafka because they hit the max series limit, and an operator needs to manually trigger TSDB head compaction to free up in-memory series. #15065
 * [ENHANCEMENT] Ingest storage: Skip kotel tracing hooks for unsampled traces in the franz-go Kafka client, significantly reducing CPU and memory overhead. #14852
 * [ENHANCEMENT] Distributor: Reduced CPU utilization when writing to ingest storage with a large number of partitions by batching all partitions into a single Kafka produce call instead of one per partition. #14898
 * [ENHANCEMENT] Ingest storage: Allow configuring multiple Kafka seed brokers via `-ingest-storage.kafka.address` (comma-separated). #14328

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -281,6 +281,7 @@ type Ingester struct {
 	subservicesWatcher    *services.FailureWatcher
 	ownedSeriesService    *ownedSeriesService
 	compactionService     services.Service
+	shippingService       services.Service
 	metricsUpdaterService services.Service
 	metadataPurgerService services.Service
 	statisticsService     services.Service
@@ -577,6 +578,11 @@ func New(cfg Config, limits *validation.Overrides, ingestersRing ring.ReadRing, 
 	i.compactionService = services.NewBasicService(nil, i.compactionServiceRunning, nil).WithName("ingester-compaction")
 	i.subservicesWatcher.WatchService(i.compactionService)
 
+	// Init shipping service, responsible to periodically ship TSDB blocks to long-term storage.
+	if cfg.BlocksStorageConfig.TSDB.IsBlocksShippingEnabled() {
+		i.shippingService = services.NewBasicService(nil, i.shipBlocksLoop, nil).WithName("ingester-shipping")
+	}
+
 	// Init metrics updater service, responsible to periodically update ingester metrics and stats.
 	i.metricsUpdaterService = services.NewBasicService(nil, i.metricsUpdaterServiceRunning, nil).WithName("ingester-metrics-updater")
 	i.subservicesWatcher.WatchService(i.metricsUpdaterService)
@@ -709,9 +715,8 @@ func (i *Ingester) starting(ctx context.Context) (err error) {
 	// Finally we start all services that should run after the ingester ring lifecycler.
 	var servs []services.Service
 
-	if i.cfg.BlocksStorageConfig.TSDB.IsBlocksShippingEnabled() {
-		shippingService := services.NewBasicService(nil, i.shipBlocksLoop, nil)
-		servs = append(servs, shippingService)
+	if i.shippingService != nil {
+		servs = append(servs, i.shippingService)
 	}
 
 	if i.cfg.BlocksStorageConfig.TSDB.IndexLookupPlanning.Enabled {

--- a/pkg/ingester/ingester_http.go
+++ b/pkg/ingester/ingester_http.go
@@ -51,15 +51,25 @@ const (
 	waitParam   = "wait"
 )
 
-// Blocks version of Flush handler. It force-compacts blocks, and triggers shipping.
+// FlushHandler force-compacts blocks, and triggers shipping.
 func (i *Ingester) FlushHandler(w http.ResponseWriter, r *http.Request) {
-	// Don't allow callers to flush TSDB while we're in the middle of starting or shutting down.
-	if ingesterState := i.State(); ingesterState != services.Running {
+	// Allow flush during Starting state (useful when the ingester is stuck replaying from ingest
+	// storage because it hit the max series limit) and Running state.
+	if ingesterState := i.State(); ingesterState != services.Running && ingesterState != services.Starting {
 		err := newUnavailableError(ingesterState)
 		level.Warn(i.logger).Log("msg", "flushing TSDB blocks is not allowed", "err", err)
 
 		w.WriteHeader(http.StatusServiceUnavailable)
 		_, _ = w.Write([]byte(err.Error()))
+		return
+	}
+
+	// Flushing is only possible after the compaction service has started (see starting()),
+	// because the compaction loop consumes from forceCompactTrigger.
+	if i.compactionService.State() != services.Running {
+		level.Warn(i.logger).Log("msg", "flushing TSDB blocks is not allowed because compaction service is not running yet")
+
+		http.Error(w, "compaction service is not running", http.StatusServiceUnavailable)
 		return
 	}
 
@@ -105,7 +115,9 @@ func (i *Ingester) FlushHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		if i.cfg.BlocksStorageConfig.TSDB.IsBlocksShippingEnabled() {
+		// Only trigger shipping if the shipping service is running, otherwise the following code
+		// will block forever because no shipping will actually occur.
+		if i.shippingService != nil && i.shippingService.State() == services.Running {
 			shippingCallbackCh := make(chan struct{}) // must be new channel, as compactionCallbackCh is closed now.
 
 			level.Info(i.logger).Log("msg", "flushing TSDB blocks: triggering shipping")

--- a/pkg/ingester/ingester_http_test.go
+++ b/pkg/ingester/ingester_http_test.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package ingester
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/services"
+	"github.com/grafana/dskit/test"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kmsg"
+	"go.uber.org/atomic"
+
+	"github.com/grafana/mimir/pkg/mimirpb"
+	"github.com/grafana/mimir/pkg/storage/ingest"
+	util_test "github.com/grafana/mimir/pkg/util/test"
+	"github.com/grafana/mimir/pkg/util/validation"
+)
+
+func TestIngester_FlushHandler_WhileStarting(t *testing.T) {
+	var (
+		ctx                = context.Background()
+		cfg                = defaultIngesterTestConfig(t)
+		reg                = prometheus.NewRegistry()
+		fetchRequestsCount = atomic.NewInt64(0)
+		series1            = mimirpb.PreallocTimeseries{TimeSeries: &mimirpb.TimeSeries{
+			Labels:  mimirpb.FromLabelsToLabelAdapters(labels.FromStrings(model.MetricNameLabel, "series_1")),
+			Samples: []mimirpb.Sample{{TimestampMs: 1000, Value: 10}},
+		}}
+	)
+
+	const expectedSeriesToReplay = 2
+
+	cfg.BlocksStorageConfig.TSDB.HeadCompactionInterval = time.Minute
+	cfg.BlocksStorageConfig.TSDB.HeadCompactionIntervalWhileStarting = 100 * time.Millisecond
+	cfg.BlocksStorageConfig.TSDB.HeadCompactionIntervalJitterEnabled = false
+
+	overrides := validation.NewOverrides(defaultLimitsTestConfig(), nil)
+	ingester, kafkaCluster, _ := createTestIngesterWithIngestStorage(t, &cfg, overrides, nil, reg, util_test.NewTestingLogger(t))
+
+	// Mock the Kafka cluster to count Fetch requests and return a "last produced offset" in the future,
+	// so that the ingester will be stuck replaying the partition.
+	kafkaCluster.ControlKey(int16(kmsg.Fetch), func(kmsg.Request) (kmsg.Response, error, bool) {
+		kafkaCluster.KeepControl()
+		fetchRequestsCount.Inc()
+		return nil, nil, false
+	})
+
+	kafkaCluster.ControlKey(int16(kmsg.ListOffsets), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+		kafkaCluster.KeepControl()
+
+		req := kreq.(*kmsg.ListOffsetsRequest)
+		for _, topic := range req.Topics {
+			for _, partition := range topic.Partitions {
+				if partition.Timestamp != -1 {
+					return nil, nil, false
+				}
+			}
+		}
+
+		res := req.ResponseKind().(*kmsg.ListOffsetsResponse)
+		res.Topics = []kmsg.ListOffsetsResponseTopic{{
+			Topic: cfg.IngestStorageConfig.KafkaConfig.Topic,
+			Partitions: []kmsg.ListOffsetsResponseTopicPartition{{
+				Partition: ingester.ingestPartitionID,
+				ErrorCode: 0,
+				Offset:    expectedSeriesToReplay,
+			}},
+		}}
+
+		return res, nil, true
+	})
+
+	// Write a series to Kafka.
+	writer := ingest.NewWriter(cfg.IngestStorageConfig.KafkaConfig, log.NewNopLogger(), nil)
+	require.NoError(t, services.StartAndAwaitRunning(ctx, writer))
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, writer))
+	})
+
+	partitionID, err := ingest.IngesterPartitionID(cfg.IngesterRing.InstanceID)
+	require.NoError(t, err)
+	require.NoError(t, writer.WriteSync(ctx, cfg.IngestStorageConfig.KafkaConfig.Topic, partitionID, userID, &mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series1}, Source: mimirpb.API}))
+
+	// Start the ingester.
+	require.NoError(t, ingester.StartAsync(ctx))
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, ingester))
+	})
+
+	// Wait until the ingester is stuck in Starting state replaying the partition.
+	test.Poll(t, 5*time.Second, true, func() interface{} {
+		return fetchRequestsCount.Load() > 0
+	})
+	assert.Equal(t, services.Starting, ingester.State())
+	assert.Equal(t, services.Running, ingester.compactionService.State())
+
+	// Call FlushHandler while the ingester is starting. It should succeed.
+	rec := httptest.NewRecorder()
+	ingester.FlushHandler(rec, httptest.NewRequest("POST", "/ingester/flush?wait=true", nil))
+	assert.Equal(t, http.StatusNoContent, rec.Result().StatusCode)
+
+	// Unblock the ingester by writing the remaining series to Kafka.
+	series2 := mimirpb.PreallocTimeseries{TimeSeries: &mimirpb.TimeSeries{
+		Labels:  mimirpb.FromLabelsToLabelAdapters(labels.FromStrings(model.MetricNameLabel, "series_2")),
+		Samples: []mimirpb.Sample{{TimestampMs: 1000, Value: 10}},
+	}}
+	require.NoError(t, writer.WriteSync(ctx, cfg.IngestStorageConfig.KafkaConfig.Topic, partitionID, userID, &mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{series2}, Source: mimirpb.API}))
+
+	// Wait for the ingester to transition to Running state.
+	test.Poll(t, 5*time.Second, services.Running, func() interface{} {
+		return ingester.State()
+	})
+}

--- a/pkg/ingester/ingester_http_test.go
+++ b/pkg/ingester/ingester_http_test.go
@@ -3,7 +3,6 @@
 package ingester
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -28,7 +27,7 @@ import (
 
 func TestIngester_FlushHandler_WhileStarting(t *testing.T) {
 	var (
-		ctx                = context.Background()
+		ctx                = t.Context()
 		cfg                = defaultIngesterTestConfig(t)
 		reg                = prometheus.NewRegistry()
 		fetchRequestsCount = atomic.NewInt64(0)

--- a/pkg/ingester/ingester_http_test.go
+++ b/pkg/ingester/ingester_http_test.go
@@ -3,6 +3,7 @@
 package ingester
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -27,7 +28,7 @@ import (
 
 func TestIngester_FlushHandler_WhileStarting(t *testing.T) {
 	var (
-		ctx                = t.Context()
+		ctx                = context.Background()
 		cfg                = defaultIngesterTestConfig(t)
 		reg                = prometheus.NewRegistry()
 		fetchRequestsCount = atomic.NewInt64(0)


### PR DESCRIPTION
#### What this PR does

Allow the `/ingester/flush` endpoint to be called while the ingester is in `Starting` state, not just `Running`.

During incidents, ingesters can get stuck replaying from ingest storage (Kafka) because they hit the max series per ingester limit. In this situation, being able to manually trigger a TSDB head compaction via `/ingester/flush` helps free up in-memory series and unblock the replay.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.