### PR TITLE
Fix flaky integration tests

### DIFF
--- a/integration/distributor_test.go
+++ b/integration/distributor_test.go
@@ -1254,8 +1254,10 @@ func testDistributorCases(t *testing.T, cachingUnmarshalDataEnabled bool, rwVers
 				if !tc.shouldReject {
 					requestCount += len(tc.rw1request)
 				}
-				err = distributor.WaitSumMetricsWithOptions(e2e.Equals(float64(requestCount)), []string{"cortex_distributor_requests_in_total"}, e2e.WithLabelMatchers(
-					labels.MustNewMatcher(labels.MatchEqual, "version", "1.0")))
+				err = distributor.WaitSumMetricsWithOptions(e2e.Equals(float64(requestCount)), []string{"cortex_distributor_requests_in_total"},
+					e2e.WithLabelMatchers(labels.MustNewMatcher(labels.MatchEqual, "version", "1.0")),
+					// The version label is only added on the first successfully-decoded request, so if every request so far has been rejected the label may not exist yet.
+					skipMissingMetricsIfZero(float64(requestCount)))
 				require.NoError(t, err)
 
 			case "rw2":
@@ -1275,8 +1277,10 @@ func testDistributorCases(t *testing.T, cachingUnmarshalDataEnabled bool, rwVers
 				if !tc.shouldReject {
 					requestCount += len(tc.rw2request)
 				}
-				err = distributor.WaitSumMetricsWithOptions(e2e.Equals(float64(requestCount)), []string{"cortex_distributor_requests_in_total"}, e2e.WithLabelMatchers(
-					labels.MustNewMatcher(labels.MatchEqual, "version", "2.0")))
+				err = distributor.WaitSumMetricsWithOptions(e2e.Equals(float64(requestCount)), []string{"cortex_distributor_requests_in_total"},
+					e2e.WithLabelMatchers(labels.MustNewMatcher(labels.MatchEqual, "version", "2.0")),
+					// The version label is only added on the first successfully-decoded request, so if every request so far has been rejected the label may not exist yet.
+					skipMissingMetricsIfZero(float64(requestCount)))
 				require.NoError(t, err)
 
 			default:

--- a/integration/util.go
+++ b/integration/util.go
@@ -38,6 +38,15 @@ var (
 // generateSeriesFunc defines what kind of series (and expected vectors/matrices) to generate - float samples or native histograms
 type generateSeriesFunc func(name string, ts time.Time, additionalLabels ...prompb.Label) (series []prompb.TimeSeries, vector model.Vector, matrix model.Matrix)
 
+// skipMissingMetricsIfZero returns e2e.SkipMissingMetrics when value == 0, otherwise a no-op.
+func skipMissingMetricsIfZero(value float64) e2e.MetricsOption {
+	return func(opts *e2e.MetricsOptions) {
+		if value == 0 {
+			opts.SkipMissingMetrics = true
+		}
+	}
+}
+
 func generateFloatSeriesModel(name string, ts time.Time, additionalLabels ...prompb.Label) prompb.TimeSeries {
 	series, _, _ := generateFloatSeries(name, ts, additionalLabels...)
 	return series[0]

--- a/pkg/ingester/ingester_tsdb.go
+++ b/pkg/ingester/ingester_tsdb.go
@@ -173,9 +173,9 @@ func (i *Ingester) createTSDB(userID string, walReplayConcurrency int) (*userTSD
 		userDB.plannerProvider = newPlannerProvider(plannerFactory)
 	}
 
-	userDBHasDB := atomic.NewBool(false)
+	userDBReady := atomic.NewBool(false)
 	blocksToDelete := func(blocks []*tsdb.Block) map[ulid.ULID]struct{} {
-		if !userDBHasDB.Load() {
+		if !userDBReady.Load() {
 			return nil
 		}
 		return userDB.blocksToDelete(blocks)
@@ -242,7 +242,6 @@ func (i *Ingester) createTSDB(userID string, walReplayConcurrency int) (*userTSD
 	}
 
 	userDB.db = db
-	userDBHasDB.Store(true)
 	// We set the limiter here because we don't want to limit
 	// series during WAL replay.
 	userDB.limiter = i.limiter
@@ -293,6 +292,10 @@ func (i *Ingester) createTSDB(userID string, walReplayConcurrency int) (*userTSD
 			level.Error(userLogger).Log("msg", "failed to generate initial TSDB head statistics", "err", err)
 		}
 	}
+
+	// Must be the last statement: once flipped, blocksToDelete can run against userDB from
+	// the goroutine tsdb.Open started, so every field it reads must already be initialised.
+	userDBReady.Store(true)
 
 	return userDB, nil
 }


### PR DESCRIPTION
## What this PR does

Fixes two pre-existing issues that caused integration tests to fail intermittently in CI, and that I've seen here:
- https://github.com/grafana/mimir/actions/runs/24659907428/job/72103479125?pr=15065
- https://github.com/grafana/mimir/actions/runs/24659649618/job/72102625947?pr=15061

### 1. Data race in `createTSDB` between `userDB.shipper` assignment and the `blocksToDelete` callback (ingester halt)

`tsdb.Open()` spawns a background `DB.run()` goroutine that periodically calls `reloadBlocks` → the `BlocksToDelete` callback → `userTSDB.blocksToDelete()`, which reads `u.shipper`. The callback was gated by an atomic flag (`userDBHasDB`) that was set after `userDB.db` was assigned, but other fields read by `blocksToDelete` — notably `userDB.shipper` — were assigned *after* the gate flipped. This produced a genuine data race.

CI runs the race-enabled ingester with `GORACE=halt_on_error=1` (see `.github/workflows/scripts/run-integration-tests-group.sh`), so hitting the race halts the ingester process and subsequent queries from the distributor fail with `500`. That's what caused `TestDistributor/caching_unmarshal_data_enabled/rw2/wrong_labels_order` to fail in the CI run linked in the issue.

**Fix:** rename the gate to `userDBReady` to reflect the broader invariant and move `userDBReady.Store(true)` to the very end of `createTSDB`, after every field `blocksToDelete` reads has been initialised. The rest of `createTSDB` keeps its original structure; only the gate's position changes.

### 2. `TestDistributor` flake: "metric not found" when the first rw1/rw2 subtest is a rejection

The distributor's `metricsMiddleware` increments `cortex_distributor_requests_in_total{version="1.0"|"2.0"}` only after a successful `pushReq.WriteRequest()` unmarshal. When a request is rejected during decoding (e.g. the `invalid_rw2_symbols` subtest, which triggers "Remote Write 2.0 symbols must start with empty string"), the counter is never incremented and the label combination is never created.

`testCases` in `TestDistributor` is a Go `map`, so subtest order is randomised. When a rejection-only subtest happens to run first, `WaitSumMetricsWithOptions(e2e.Equals(0), ...)` fails immediately with `metric not found` instead of treating the missing metric as a value of 0.

**Fix:** added a small helper `skipMissingMetricsIfZero(value)` in `integration/util.go` that returns `e2e.SkipMissingMetrics` only when the expected value is 0 (and a no-op otherwise). When `requestCount > 0` we still require the metric to exist and match, so the check is only relaxed when the value `0` is trivially equivalent to "metric absent".

## Which issue(s) this PR fixes or relates to

N/A

## Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated — N/A (bugfix in test/ingester startup plumbing, no user-visible behaviour change).
- [ ] `about-versioning.md` updated with experimental features.
