### PR TITLE
copyblocks: support resolving S3 credentials from the environment (IRSA, ECS, EC2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -417,6 +417,7 @@
 * [FEATURE] kafkatool: Add `create-topic` command to create a Kafka topic with a specified number of partitions. #14639
 * [FEATURE] kafkatool: Add `list-topics` command to list all Kafka topics and their partition counts. #14639
 * [ENHANCEMENT] mimir-tool: Add `__ignore_usage__=""` label selector to queries used in `analyze prometheus` command, so that Adaptive Metrics' recommendations service ignores them. #14474
+* [ENHANCEMENT] copyblocks: Support resolving S3 credentials from the environment (IAM roles for service accounts, ECS task roles, and EC2 instance metadata) when `-s3.<source|destination>.access-key-id` and `-s3.<source|destination>.secret-access-key` are omitted. #15075
 * [BUGFIX] mimir-tool-action: Fix base image of the Github action. #13303
 * [BUGFIX] mimir-tool: do not fail on `$latency_metrics` dashboard variable, documented for native histograms migrations. #13526
 * [BUGFIX] kafkatool: Fix `kafkatool dump print` to support RW2 records. #13848

--- a/pkg/util/objtools/s3.go
+++ b/pkg/util/objtools/s3.go
@@ -25,8 +25,8 @@ type S3ClientConfig struct {
 func (c *S3ClientConfig) RegisterFlags(prefix string, f *flag.FlagSet) {
 	f.StringVar(&c.BucketName, prefix+"bucket-name", "", "The name of the bucket (not prefixed by a scheme).")
 	f.StringVar(&c.Endpoint, prefix+"endpoint", "", "The endpoint to contact when accessing the bucket.")
-	f.StringVar(&c.AccessKeyID, prefix+"access-key-id", "", "The access key ID used in AWS Signature Version 4 authentication.")
-	f.StringVar(&c.SecretAccessKey, prefix+"secret-access-key", "", "The secret access key used in AWS Signature Version 4 authentication.")
+	f.StringVar(&c.AccessKeyID, prefix+"access-key-id", "", "The access key ID used in AWS Signature Version 4 authentication. If unset along with "+prefix+"secret-access-key, credentials are resolved from the environment (IAM roles for service accounts, ECS task roles, or EC2 instance metadata).")
+	f.StringVar(&c.SecretAccessKey, prefix+"secret-access-key", "", "The secret access key used in AWS Signature Version 4 authentication. If unset along with "+prefix+"access-key-id, credentials are resolved from the environment (IAM roles for service accounts, ECS task roles, or EC2 instance metadata).")
 	f.BoolVar(&c.Secure, prefix+"secure", true, "If true (default), use HTTPS when connecting to the bucket. If false, insecure HTTP is used.")
 	f.Uint64Var(&c.PartSize, prefix+"part-size", 0, "If 0, and object's size is known and optimal for multipart upload, the default value is the minimum allowed size 16MiB.")
 }
@@ -38,18 +38,22 @@ func (c *S3ClientConfig) Validate(prefix string) error {
 	if c.Endpoint == "" {
 		return errors.New(prefix + "endpoint is missing")
 	}
-	if c.AccessKeyID == "" {
-		return errors.New(prefix + "access-key-id is missing")
-	}
-	if c.SecretAccessKey == "" {
-		return errors.New(prefix + "secret-access-key is missing")
+	if (c.AccessKeyID == "") != (c.SecretAccessKey == "") {
+		return errors.New(prefix + "access-key-id and " + prefix + "secret-access-key must be set together, or both left empty to use credentials from the environment")
 	}
 	return nil
 }
 
 func (c *S3ClientConfig) ToBucket() (Bucket, error) {
+	var creds *credentials.Credentials
+	if c.AccessKeyID != "" {
+		creds = credentials.NewStaticV4(c.AccessKeyID, c.SecretAccessKey, "")
+	} else {
+		// Resolves IAM roles for service accounts (IRSA), ECS task roles and EC2 instance metadata from standard AWS environment variables.
+		creds = credentials.NewIAM("")
+	}
 	client, err := minio.New(c.Endpoint, &minio.Options{
-		Creds:  credentials.NewStaticV4(c.AccessKeyID, c.SecretAccessKey, ""),
+		Creds:  creds,
 		Secure: c.Secure,
 	})
 	if err != nil {

--- a/tools/copyblocks/README.md
+++ b/tools/copyblocks/README.md
@@ -72,6 +72,8 @@ Consider passing `--client-side-copy` to avoid having to deal with that.
   --dry-run
 ```
 
+If both `--s3.<source|destination>.access-key-id` and `--s3.<source|destination>.secret-access-key` are omitted, credentials are resolved from the environment. This supports IAM roles for service accounts (IRSA) on EKS, ECS task roles, and EC2 instance metadata, and lets a single role that has access to both buckets authenticate the source and destination clients without passing static credentials.
+
 ### Example for copying between different providers
 
 Combine the relevant source and destination configuration options using the above examples as a guide.


### PR DESCRIPTION
#### What this PR does

Adds support for AWS IRSA (IAM roles for service accounts), ECS task roles, and EC2 instance metadata to the S3 client used by `copyblocks` (and any other consumer of `objtools.S3ClientConfig`).

Previously, `S3ClientConfig` required static access key / secret pairs and wired them directly into `credentials.NewStaticV4`, so there was no way to run the tool with a pod-level role.

With this change:

- When both `-s3.<source|destination>.access-key-id` and `-s3.<source|destination>.secret-access-key` are omitted, credentials are resolved via minio-go's `credentials.NewIAM("")`, which in turn reads the standard AWS env vars set by EKS (`AWS_WEB_IDENTITY_TOKEN_FILE`, `AWS_ROLE_ARN`), ECS (`AWS_CONTAINER_CREDENTIALS_*`), or falls back to EC2 instance metadata.
- Static credentials keep working exactly as before.
- Passing only one of the two keys is now a validation error to avoid silently falling back to env credentials when a misconfiguration is more likely.
- `copyblocks/README.md` documents how to use a single IRSA-backed role with access to both the source and destination buckets.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes S3 credential resolution behavior by allowing implicit environment-based IAM auth, which can affect runtime access and failure modes if deployments relied on required static keys. Validation tightening reduces misconfiguration risk but may break setups that previously passed only one key.
> 
> **Overview**
> `copyblocks` (via `objtools.S3ClientConfig`) now supports S3 authentication using **environment-resolved IAM credentials** (IRSA/ECS/EC2 metadata) when both `access-key-id` and `secret-access-key` are omitted, instead of always requiring static keys.
> 
> Flag help, validation, and the `copyblocks` README are updated: supplying only one of the two keys is now an error, and documentation explains running without static credentials. The change is also recorded in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67fac3b69be716723bbd55901e01a681a9c4635a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->