### PR TITLE
Query-frontend: rename Blocked Queries filter minimum_step_size to step_size_shorter_than

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Grafana Mimir
 
+* [CHANGE] Query-frontend: Renamed `minimum_step_size` filter in `blocked_queries` configuration to `step_size_shorter_than` to follow the naming convention of `time_range_longer_than`. Users with `minimum_step_size` in their runtime configuration must rename the field. #15081
 * [CHANGE] Query-frontend: `blocked_queries` configuration is now validated at load time; a configuration error is returned if a rule has an empty `pattern`, or has `regex: true` with a `pattern` that is not a valid regular expression. #14978
 * [CHANGE] Ingester: Changed default value of `-include-tenant-id-in-profile-labels` from false to true. #13375
 * [CHANGE] Hash ring: removed experimental support for disabling heartbeats (setting `-*.ring.heartbeat-period=0`) and heartbeat timeouts (setting `-*.ring.heartbeat-timeout=0`). These configurations are now invalid. #13104

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -6120,9 +6120,9 @@
               },
               {
                 "kind": "field",
-                "name": "minimum_step_size",
+                "name": "step_size_shorter_than",
                 "required": false,
-                "desc": "Block queries where the step is smaller than this duration. Instant queries and queries with no step are not blocked. Set to 0 to disable.",
+                "desc": "Block queries where the step is shorter than this duration. Instant queries and queries with no step are not blocked. Set to 0 to disable.",
                 "fieldValue": null,
                 "fieldDefaultValue": null,
                 "fieldType": "duration"

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -4571,9 +4571,9 @@ blocked_queries:
     # disable.
     [time_range_longer_than: <duration> | default = ]
 
-    # Block queries where the step is smaller than this duration. Instant
+    # Block queries where the step is shorter than this duration. Instant
     # queries and queries with no step are not blocked. Set to 0 to disable.
-    [minimum_step_size: <duration> | default = ]
+    [step_size_shorter_than: <duration> | default = ]
 
 # (experimental) List of queries to limit and duration to limit them for.
 # Example:

--- a/docs/sources/mimir/configure/configure-blocked-queries.md
+++ b/docs/sources/mimir/configure/configure-blocked-queries.md
@@ -13,7 +13,7 @@ your service.
 Each rule must include a `pattern` field; rules without a pattern are a configuration error.
 Rules with `regex: true` must have a valid regular expression pattern; an invalid pattern is also a configuration error.
 To match all queries, use `pattern: ".*"` with `regex: true`.
-Optional filter conditions (`time_range_longer_than`, `minimum_step_size`, `unaligned_range_queries`) narrow which matching queries are blocked; all configured conditions must be satisfied to block.
+Optional filter conditions (`time_range_longer_than`, `step_size_shorter_than`, `unaligned_range_queries`) narrow which matching queries are blocked; all configured conditions must be satisfied to block.
 
 You can block queries using [per-tenant overrides](../about-runtime-configuration/):
 
@@ -40,10 +40,10 @@ overrides:
         time_range_longer_than: 24h
         reason: "expensive queries over 1 day are blocked"
 
-      # match all queries with a step smaller than 1 minute
+      # match all queries with a step shorter than 1 minute
       - pattern: ".*"
         regex: true
-        minimum_step_size: 1m
+        step_size_shorter_than: 1m
         reason: "step resolution too fine-grained"
 
       # match this query only when the time range is not a multiple of the step
@@ -58,8 +58,8 @@ For instant and range queries, the pattern is evaluated against the query. For r
 Setting `time_range_longer_than` on a rule blocks queries where the time range duration (calculated as `end - start`) exceeds the specified threshold.
 `time_range_longer_than` does not apply to instant queries.
 
-Setting `minimum_step_size` on a rule blocks queries where the step is smaller than the configured duration.
-`minimum_step_size` does not apply to instant queries or queries without a step.
+Setting `step_size_shorter_than` on a rule blocks queries where the step is shorter than the configured duration.
+`step_size_shorter_than` does not apply to instant queries or queries without a step.
 
 Setting `unaligned_range_queries: true` on a rule limits it to range queries where the time range is not a multiple of the step.
 Such queries are not eligible for [range query result caching](https://grafana.com/docs/mimir/latest/references/architecture/components/query-frontend/#caching) by default.

--- a/pkg/frontend/querymiddleware/query_blocker.go
+++ b/pkg/frontend/querymiddleware/query_blocker.go
@@ -101,8 +101,8 @@ func (qb *queryBlockerMiddleware) isBlocked(tenant string, req MetricsQueryReque
 			continue
 		}
 
-		if block.MinimumStepSize > 0 &&
-			(stepMs == 0 || stepDuration >= time.Duration(block.MinimumStepSize)) {
+		if block.StepSizeShorterThan > 0 &&
+			(stepMs == 0 || stepDuration >= time.Duration(block.StepSizeShorterThan)) {
 			continue
 		}
 

--- a/pkg/frontend/querymiddleware/query_blocker_test.go
+++ b/pkg/frontend/querymiddleware/query_blocker_test.go
@@ -551,7 +551,7 @@ blocked_queries:
 	}
 }
 
-// TestQueryBlockerMiddleware_StepSize verifies minimum_step_size: the step must be below the
+// TestQueryBlockerMiddleware_StepSize verifies step_size_shorter_than: the step must be below the
 // threshold to block; instant queries and queries with no step are never blocked by this filter.
 func TestQueryBlockerMiddleware_StepSize(t *testing.T) {
 	now := time.Now()
@@ -589,7 +589,7 @@ func TestQueryBlockerMiddleware_StepSize(t *testing.T) {
 			name: "no pattern",
 			limitsYAML: `
 blocked_queries:
-  - minimum_step_size: "1m"
+  - step_size_shorter_than: "1m"
     reason: "step too small"
 `,
 			makeReq:         rangeReq("rate(expensive_metric[5m])", step30s),
@@ -601,7 +601,7 @@ blocked_queries:
 blocked_queries:
   - pattern: ".*"
     regex: true
-    minimum_step_size: "1m"
+    step_size_shorter_than: "1m"
     reason: "step too small"
 `,
 			makeReq:         rangeReq("rate(expensive_metric[5m])", step30s),
@@ -613,7 +613,7 @@ blocked_queries:
 blocked_queries:
   - pattern: ".*"
     regex: true
-    minimum_step_size: "1m"
+    step_size_shorter_than: "1m"
 `,
 			makeReq:         rangeReq("rate(expensive_metric[5m])", step1m),
 			expectedBlocked: false,
@@ -624,7 +624,7 @@ blocked_queries:
 blocked_queries:
   - pattern: ".*"
     regex: true
-    minimum_step_size: "1m"
+    step_size_shorter_than: "1m"
 `,
 			makeReq:         rangeReq("rate(expensive_metric[5m])", step5m),
 			expectedBlocked: false,
@@ -635,7 +635,7 @@ blocked_queries:
 blocked_queries:
   - pattern: ".*"
     regex: true
-    minimum_step_size: "1m"
+    step_size_shorter_than: "1m"
 `,
 			makeReq:         instantReq("rate(expensive_metric[5m])"),
 			expectedBlocked: false,
@@ -681,7 +681,7 @@ blocked_queries:
   - pattern: ".*expensive.*"
     regex: true
     time_range_longer_than: "24h"
-    minimum_step_size: "1m"
+    step_size_shorter_than: "1m"
     reason: "all three conditions met"
 `,
 			makeReq:         rangeReq("rate(expensive_metric[5m])", now.Add(-48*time.Hour), step30s),
@@ -694,7 +694,7 @@ blocked_queries:
   - pattern: ".*expensive.*"
     regex: true
     time_range_longer_than: "24h"
-    minimum_step_size: "1m"
+    step_size_shorter_than: "1m"
 `,
 			makeReq:         rangeReq("rate(cheap_metric[5m])", now.Add(-48*time.Hour), step30s),
 			expectedBlocked: false,
@@ -706,7 +706,7 @@ blocked_queries:
   - pattern: ".*expensive.*"
     regex: true
     time_range_longer_than: "24h"
-    minimum_step_size: "1m"
+    step_size_shorter_than: "1m"
 `,
 			makeReq:         rangeReq("rate(expensive_metric[5m])", now.Add(-12*time.Hour), step30s),
 			expectedBlocked: false,
@@ -718,7 +718,7 @@ blocked_queries:
   - pattern: ".*expensive.*"
     regex: true
     time_range_longer_than: "24h"
-    minimum_step_size: "1m"
+    step_size_shorter_than: "1m"
 `,
 			makeReq:         rangeReq("rate(expensive_metric[5m])", now.Add(-48*time.Hour), step5m),
 			expectedBlocked: false,
@@ -738,7 +738,7 @@ blocked_queries:
 // LabelMatchersToString — never PromQL syntax. Non-regex matching is a raw string compare
 // with no canonicalization on the query side, so matcher order is significant (unlike range/instant
 // queries where both sides are canonicalized via the PromQL parser).
-// minimum_step_size never applies because GetStep always returns 0 for remote reads.
+// step_size_shorter_than never applies because GetStep always returns 0 for remote reads.
 func TestQueryBlockerMiddleware_RemoteRead(t *testing.T) {
 	remoteReadReq := func(matchers ...*prompb.LabelMatcher) func(t *testing.T) MetricsQueryRequest {
 		req := mustSucceed(remoteReadToMetricsQueryRequest(remoteReadPathSuffix, &prompb.Query{Matchers: matchers}))

--- a/pkg/util/validation/blocked_query.go
+++ b/pkg/util/validation/blocked_query.go
@@ -17,7 +17,7 @@ type BlockedQuery struct {
 	Reason                string         `yaml:"reason" doc:"description=Reason returned to clients when rejecting matching queries."`
 	UnalignedRangeQueries bool           `yaml:"unaligned_range_queries,omitempty" doc:"description=If true, only block the query if the query time range is not aligned to the step, meaning the query is not eligible for range query result caching. If enabled, instant queries and remote read requests will not be blocked."`
 	TimeRangeLongerThan   model.Duration `yaml:"time_range_longer_than,omitempty" doc:"description=Block queries with time range longer than this duration. Set to 0 to disable."`
-	MinimumStepSize       model.Duration `yaml:"minimum_step_size,omitempty" doc:"description=Block queries where the step is smaller than this duration. Instant queries and queries with no step are not blocked. Set to 0 to disable."`
+	StepSizeShorterThan   model.Duration `yaml:"step_size_shorter_than,omitempty" doc:"description=Block queries where the step is shorter than this duration. Instant queries and queries with no step are not blocked. Set to 0 to disable."`
 }
 
 type BlockedQueriesConfig []BlockedQuery


### PR DESCRIPTION
#### What this PR does

Renames `minimum_step_size` introduced in #14885 to `step_size_shorter_than` per
https://github.com/grafana/mimir/pull/14978#discussion_r3084104508.

The new name follows the `<subject>_<adjective>_than` convention of the existing
`time_range_longer_than` field — both compare durations and shorter/longer are
natural antonyms.

An alternative would be either `xyz_min|max_period` or `xyz_min|max_duration`.

Before:
```
blocked_queries:
- pattern: ".*" 
  regex: true
  minimum_step_size: 1m
```

After:
```
blocked_queries:
- pattern: ".*"
  regex: true
  step_size_shorter_than: 1m
```

Breaking change:

Users must update their runtime configuration. The field was introduced in
#14885 which has not yet shipped in a stable release.

#### Which issue(s) this PR fixes or relates to

- #14885
- https://github.com/grafana/mimir/pull/14978#discussion_r3084104508

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for runtime configuration: `blocked_queries.minimum_step_size` is renamed and older configs will fail unless updated. Code changes are localized to query-blocking logic and docs/tests, so behavioral risk beyond the rename is limited.
> 
> **Overview**
> Renames the `blocked_queries` filter field from `minimum_step_size` to `step_size_shorter_than` to align with the existing `*_than` naming convention.
> 
> Updates the query-blocking middleware to read the new field, and refreshes the config descriptor, documentation examples, tests, and `CHANGELOG.md` to reflect the new key (users must rename the field in runtime overrides).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa0e491a4d52e362772b0977cff2e2e7821f5dd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->