### PR TITLE
MQE: Fix narrow selectors optimization pass to drop irrelevant matchers before passing to children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -266,6 +266,7 @@
 * [BUGFIX] Alertmanager: Fix deadlock when trying to broadcast after stopping a tenant #14922
 * [BUGFIX] Query-frontend: Fix max total query length limit (`-query-frontend.max-total-query-length`) not being enforced on instant queries with subqueries or range selectors. #14985
 * [BUGFIX] Compactor: Fix potential goroutine leak when compaction iteration exits early due to errors. #13420
+* [BUGFIX] MQE: Fix narrow selectors optimization pass to drop irrelevant matchers before passing to children  #15082
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -266,7 +266,7 @@
 * [BUGFIX] Alertmanager: Fix deadlock when trying to broadcast after stopping a tenant #14922
 * [BUGFIX] Query-frontend: Fix max total query length limit (`-query-frontend.max-total-query-length`) not being enforced on instant queries with subqueries or range selectors. #14985
 * [BUGFIX] Compactor: Fix potential goroutine leak when compaction iteration exits early due to errors. #13420
-* [BUGFIX] MQE: Fix narrow selectors optimization pass to drop irrelevant matchers before passing to children  #15082
+* [BUGFIX] MQE: Fix narrow selectors optimization pass to drop irrelevant matchers before passing to children.  #15082
 
 ### Mixin
 

--- a/pkg/streamingpromql/operators/binops/binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/binary_operation.go
@@ -777,6 +777,63 @@ type Hints struct {
 	Include []string
 }
 
+// filterMatchersForVectorMatching returns the subset of matchers that are relevant to the
+// matching labels of a binary operation, dropping any matchers for labels that are not part
+// of the match. This prevents a parent binary operation from incorrectly narrowing the series
+// returned by a child binary operation via matchers that don't apply to its matching labels.
+//
+// For an 'on' binary operation, only matchers for labels in the 'on' list are kept.
+// For a 'without' binary operation, matchers for the excluded labels are dropped.
+// For default (implied 'without ()') matching, all matchers are returned unchanged.
+func filterMatchersForVectorMatching(matchers types.Matchers, vm parser.VectorMatching) types.Matchers {
+	if len(matchers) == 0 {
+		return matchers
+	}
+
+	if vm.On {
+		if len(vm.MatchingLabels) == 0 {
+			// on () — nothing is a matching label, so no matchers are relevant.
+			return nil
+		}
+
+		matchingSet := make(map[string]struct{}, len(vm.MatchingLabels))
+		for _, l := range vm.MatchingLabels {
+			matchingSet[l] = struct{}{}
+		}
+
+		filtered := make(types.Matchers, 0, len(matchers))
+		for _, m := range matchers {
+			if _, ok := matchingSet[m.Name]; ok {
+				filtered = append(filtered, m)
+			}
+		}
+
+		return filtered
+	}
+
+	if len(vm.MatchingLabels) > 0 {
+		// 'without' case: all labels except those listed (and __name__) are matching labels.
+		excludeSet := make(map[string]struct{}, len(vm.MatchingLabels)+1)
+		excludeSet[model.MetricNameLabel] = struct{}{}
+		for _, l := range vm.MatchingLabels {
+			excludeSet[l] = struct{}{}
+		}
+
+		filtered := make(types.Matchers, 0, len(matchers))
+		for _, m := range matchers {
+			if _, ok := excludeSet[m.Name]; !ok {
+				filtered = append(filtered, m)
+			}
+		}
+
+		return filtered
+	}
+
+	// Default matching (implied 'without ()'): all non-__name__ labels are matching labels.
+	// Pass matchers through unchanged.
+	return matchers
+}
+
 const (
 	maxHintMatcherValues = 64
 )

--- a/pkg/streamingpromql/operators/binops/binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/binary_operation.go
@@ -784,7 +784,7 @@ type Hints struct {
 //
 // For an 'on' binary operation, only matchers for labels in the 'on' list are kept.
 // For a 'without' binary operation, matchers for the excluded labels are dropped.
-// For default (implied 'without ()') matching, all matchers are returned unchanged.
+// For default (implied 'without ()') matching, all matchers except __name__ are returned.
 func filterMatchersForVectorMatching(matchers types.Matchers, vm parser.VectorMatching) types.Matchers {
 	if len(matchers) == 0 {
 		return matchers
@@ -830,8 +830,14 @@ func filterMatchersForVectorMatching(matchers types.Matchers, vm parser.VectorMa
 	}
 
 	// Default matching (implied 'without ()'): all non-__name__ labels are matching labels.
-	// Pass matchers through unchanged.
-	return matchers
+	// Drop any __name__ matchers, as __name__ is not a matching label in this case.
+	filtered := make(types.Matchers, 0, len(matchers))
+	for _, m := range matchers {
+		if m.Name != model.MetricNameLabel {
+			filtered = append(filtered, m)
+		}
+	}
+	return filtered
 }
 
 const (

--- a/pkg/streamingpromql/operators/binops/binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/binary_operation_test.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
@@ -106,6 +108,56 @@ func generateSeriesMetadata(name string, num int) []types.SeriesMetadata {
 	}
 
 	return out
+}
+
+func TestFilterMatchersForVectorMatching(t *testing.T) {
+	regionMatcher := types.Matcher{Type: labels.MatchEqual, Name: "region", Value: "us"}
+	zoneMatcher := types.Matcher{Type: labels.MatchEqual, Name: "zone", Value: "1"}
+	nameMatcher := types.Matcher{Type: labels.MatchEqual, Name: model.MetricNameLabel, Value: "foo"}
+
+	testCases := map[string]struct {
+		matchers       types.Matchers
+		vectorMatching parser.VectorMatching
+		expected       types.Matchers
+	}{
+		"nil matchers returns nil unchanged": {
+			matchers:       nil,
+			vectorMatching: parser.VectorMatching{On: true, MatchingLabels: []string{"zone"}},
+			expected:       nil,
+		},
+		"on() with matchers returns nil (no labels match)": {
+			matchers:       types.Matchers{regionMatcher, zoneMatcher},
+			vectorMatching: parser.VectorMatching{On: true, MatchingLabels: []string{}},
+			expected:       nil,
+		},
+		"on(zone) keeps only zone matchers": {
+			matchers:       types.Matchers{regionMatcher, zoneMatcher},
+			vectorMatching: parser.VectorMatching{On: true, MatchingLabels: []string{"zone"}},
+			expected:       types.Matchers{zoneMatcher},
+		},
+		"on(zone) with no matching matchers in input returns empty": {
+			matchers:       types.Matchers{regionMatcher},
+			vectorMatching: parser.VectorMatching{On: true, MatchingLabels: []string{"zone"}},
+			expected:       types.Matchers{},
+		},
+		"without(zone) drops zone and __name__ matchers, keeps others": {
+			matchers:       types.Matchers{regionMatcher, zoneMatcher, nameMatcher},
+			vectorMatching: parser.VectorMatching{On: false, MatchingLabels: []string{"zone"}},
+			expected:       types.Matchers{regionMatcher},
+		},
+		"without() default matching passes all matchers through unchanged": {
+			matchers:       types.Matchers{regionMatcher, zoneMatcher},
+			vectorMatching: parser.VectorMatching{On: false, MatchingLabels: []string{}},
+			expected:       types.Matchers{regionMatcher, zoneMatcher},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			result := filterMatchersForVectorMatching(tc.matchers, tc.vectorMatching)
+			require.Equal(t, tc.expected, result)
+		})
+	}
 }
 
 func BenchmarkBuildMatchers(b *testing.B) {

--- a/pkg/streamingpromql/operators/binops/binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/binary_operation_test.go
@@ -145,10 +145,15 @@ func TestFilterMatchersForVectorMatching(t *testing.T) {
 			vectorMatching: parser.VectorMatching{On: false, MatchingLabels: []string{"zone"}},
 			expected:       types.Matchers{regionMatcher},
 		},
-		"without() default matching passes all matchers through unchanged": {
+		"without() default matching passes non-__name__ matchers through": {
 			matchers:       types.Matchers{regionMatcher, zoneMatcher},
 			vectorMatching: parser.VectorMatching{On: false, MatchingLabels: []string{}},
 			expected:       types.Matchers{regionMatcher, zoneMatcher},
+		},
+		"without() default matching drops __name__ matchers": {
+			matchers:       types.Matchers{regionMatcher, nameMatcher},
+			vectorMatching: parser.VectorMatching{On: false, MatchingLabels: []string{}},
+			expected:       types.Matchers{regionMatcher},
 		},
 	}
 

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
@@ -244,8 +244,13 @@ func (g *GroupedVectorVectorBinaryOperation) loadSeriesMetadata(ctx context.Cont
 	// We retain the series labels for later so we can use them to generate error messages.
 	// We'll return them to the pool in Close().
 
+	// Only pass matchers for labels that are part of this operation's matching to child
+	// operators. See the equivalent comment in OneToOneVectorVectorBinaryOperation.SeriesMetadata
+	// for the full rationale.
+	filteredMatchers := filterMatchersForVectorMatching(matchers, g.VectorMatching)
+
 	var err error
-	g.oneSideMetadata, err = g.oneSide.SeriesMetadata(ctx, matchers)
+	g.oneSideMetadata, err = g.oneSide.SeriesMetadata(ctx, filteredMatchers)
 	if err != nil {
 		return false, err
 	}
@@ -255,7 +260,7 @@ func (g *GroupedVectorVectorBinaryOperation) loadSeriesMetadata(ctx context.Cont
 		return false, nil
 	}
 
-	g.manySideMetadata, err = g.manySide.SeriesMetadata(ctx, matchers)
+	g.manySideMetadata, err = g.manySide.SeriesMetadata(ctx, filteredMatchers)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/streamingpromql/operators/binops/matcher_propagation_test.go
+++ b/pkg/streamingpromql/operators/binops/matcher_propagation_test.go
@@ -28,13 +28,13 @@ import (
 // with a different region but the same zone to be discarded.
 func TestOneToOneVectorVectorBinaryOperation_MatcherPropagation(t *testing.T) {
 	testCases := map[string]struct {
-		vectorMatching  parser.VectorMatching
-		parentMatchers  types.Matchers
-		leftSeries      []labels.Labels
-		rightSeries     []labels.Labels
-		expectedLHS     types.Matchers
-		expectedRHS     types.Matchers
-		expectedSeries  int
+		vectorMatching parser.VectorMatching
+		parentMatchers types.Matchers
+		leftSeries     []labels.Labels
+		rightSeries    []labels.Labels
+		expectedLHS    types.Matchers
+		expectedRHS    types.Matchers
+		expectedSeries int
 	}{
 		"on(zone): region matcher is filtered out before reaching children": {
 			vectorMatching: parser.VectorMatching{On: true, MatchingLabels: []string{"zone"}},
@@ -283,11 +283,11 @@ func TestAndUnlessBinaryOperation_MatcherPropagation(t *testing.T) {
 			expectedSeries: 1,
 		},
 		"and: nil parent matchers propagate as nil to both sides": {
-			isUnless:       false,
-			vectorMatching: parser.VectorMatching{On: true, MatchingLabels: []string{"zone"}},
-			parentMatchers: nil,
-			leftSeries:     []labels.Labels{labels.FromStrings("zone", "1")},
-			rightSeries:    []labels.Labels{labels.FromStrings("zone", "1")},
+			isUnless:            false,
+			vectorMatching:      parser.VectorMatching{On: true, MatchingLabels: []string{"zone"}},
+			parentMatchers:      nil,
+			leftSeries:          []labels.Labels{labels.FromStrings("zone", "1")},
+			rightSeries:         []labels.Labels{labels.FromStrings("zone", "1")},
 			expectedLHSMatchers: nil,
 			expectedSeries:      1,
 		},

--- a/pkg/streamingpromql/operators/binops/matcher_propagation_test.go
+++ b/pkg/streamingpromql/operators/binops/matcher_propagation_test.go
@@ -1,0 +1,333 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package binops
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/promql/parser/posrange"
+	"github.com/prometheus/prometheus/util/annotations"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/streamingpromql/operators"
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+	"github.com/grafana/mimir/pkg/util/limiter"
+)
+
+// TestOneToOneVectorVectorBinaryOperation_MatcherPropagation verifies that when a parent
+// binary operation passes matchers to a 1:1 binary operation, only the matchers relevant
+// to the operation's matching labels are forwarded to child operators (Bug 1 fix).
+//
+// Without the fix, if a parent passes matchers for labels outside the 'on' set (e.g., region=us
+// for an 'on(zone)' operation), those matchers would incorrectly filter the RHS, causing series
+// with a different region but the same zone to be discarded.
+func TestOneToOneVectorVectorBinaryOperation_MatcherPropagation(t *testing.T) {
+	testCases := map[string]struct {
+		vectorMatching  parser.VectorMatching
+		parentMatchers  types.Matchers
+		leftSeries      []labels.Labels
+		rightSeries     []labels.Labels
+		expectedLHS     types.Matchers
+		expectedRHS     types.Matchers
+		expectedSeries  int
+	}{
+		"on(zone): region matcher is filtered out before reaching children": {
+			vectorMatching: parser.VectorMatching{On: true, MatchingLabels: []string{"zone"}},
+			parentMatchers: types.Matchers{
+				{Type: labels.MatchEqual, Name: "region", Value: "us"},
+				{Type: labels.MatchEqual, Name: "zone", Value: "1"},
+			},
+			// LHS matches zone=1, RHS has different region but same zone.
+			// Without the fix, region=us would be forwarded to RHS, filtering out b{region=eu}.
+			leftSeries:  []labels.Labels{labels.FromStrings("region", "us", "zone", "1")},
+			rightSeries: []labels.Labels{labels.FromStrings("region", "eu", "zone", "1")},
+			// Only zone=1 should reach both sides.
+			expectedLHS:    types.Matchers{{Type: labels.MatchEqual, Name: "zone", Value: "1"}},
+			expectedRHS:    types.Matchers{{Type: labels.MatchEqual, Name: "zone", Value: "1"}},
+			expectedSeries: 1, // they match on zone=1 even though region differs
+		},
+		"on(): no matchers reach children": {
+			vectorMatching: parser.VectorMatching{On: true, MatchingLabels: []string{}},
+			parentMatchers: types.Matchers{
+				{Type: labels.MatchEqual, Name: "region", Value: "us"},
+			},
+			leftSeries:     []labels.Labels{labels.FromStrings("region", "us")},
+			rightSeries:    []labels.Labels{labels.FromStrings("region", "eu")},
+			expectedLHS:    nil,
+			expectedRHS:    nil,
+			expectedSeries: 1, // on() matches everything to everything
+		},
+		"without(region): region matcher is filtered out, zone passes through": {
+			vectorMatching: parser.VectorMatching{On: false, MatchingLabels: []string{"region"}},
+			parentMatchers: types.Matchers{
+				{Type: labels.MatchEqual, Name: "region", Value: "us"},
+				{Type: labels.MatchEqual, Name: "zone", Value: "1"},
+			},
+			leftSeries:  []labels.Labels{labels.FromStrings("region", "us", "zone", "1")},
+			rightSeries: []labels.Labels{labels.FromStrings("region", "eu", "zone", "1")},
+			// region is excluded label in without, so region matcher is dropped.
+			expectedLHS:    types.Matchers{{Type: labels.MatchEqual, Name: "zone", Value: "1"}},
+			expectedRHS:    types.Matchers{{Type: labels.MatchEqual, Name: "zone", Value: "1"}},
+			expectedSeries: 1,
+		},
+		"no parent matchers: both sides receive nil": {
+			vectorMatching: parser.VectorMatching{On: true, MatchingLabels: []string{"zone"}},
+			parentMatchers: nil,
+			leftSeries:     []labels.Labels{labels.FromStrings("zone", "1")},
+			rightSeries:    []labels.Labels{labels.FromStrings("zone", "1")},
+			expectedLHS:    nil,
+			expectedRHS:    nil,
+			expectedSeries: 1,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			timeRange := types.NewInstantQueryTimeRange(time.Now())
+			memTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+
+			left := &operators.TestOperator{
+				Series:                   tc.leftSeries,
+				Data:                     make([]types.InstantVectorSeriesData, len(tc.leftSeries)),
+				MemoryConsumptionTracker: memTracker,
+			}
+			right := &operators.TestOperator{
+				Series:                   tc.rightSeries,
+				Data:                     make([]types.InstantVectorSeriesData, len(tc.rightSeries)),
+				MemoryConsumptionTracker: memTracker,
+			}
+
+			op, err := NewOneToOneVectorVectorBinaryOperation(
+				left, right, tc.vectorMatching, parser.ADD, false,
+				memTracker, annotations.New(), posrange.PositionRange{}, timeRange, nil, log.NewNopLogger(),
+			)
+			require.NoError(t, err)
+
+			outputSeries, err := op.SeriesMetadata(ctx, tc.parentMatchers)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expectedLHS, left.MatchersProvided, "LHS should receive filtered matchers")
+			require.Equal(t, tc.expectedRHS, right.MatchersProvided, "RHS should receive filtered matchers")
+			require.Len(t, outputSeries, tc.expectedSeries, "unexpected number of output series")
+
+			require.NoError(t, op.Finalize(ctx))
+			op.Close()
+		})
+	}
+}
+
+// TestGroupedVectorVectorBinaryOperation_MatcherPropagation verifies that matchers are
+// filtered to the operation's matching labels before being forwarded to child operators
+// in a grouped (many-to-one or one-to-many) binary operation (Bug 1 fix).
+func TestGroupedVectorVectorBinaryOperation_MatcherPropagation(t *testing.T) {
+	testCases := map[string]struct {
+		vectorMatching parser.VectorMatching
+		parentMatchers types.Matchers
+		leftSeries     []labels.Labels
+		rightSeries    []labels.Labels
+		expectedLHS    types.Matchers
+		expectedRHS    types.Matchers
+		expectedSeries int
+	}{
+		"on(zone) group_left: region matcher filtered out before reaching children": {
+			vectorMatching: parser.VectorMatching{
+				On:             true,
+				MatchingLabels: []string{"zone"},
+				Card:           parser.CardManyToOne,
+			},
+			parentMatchers: types.Matchers{
+				{Type: labels.MatchEqual, Name: "region", Value: "us"},
+				{Type: labels.MatchEqual, Name: "zone", Value: "1"},
+			},
+			// Multiple left series with zone=1, one right series with different region but same zone.
+			// Without the fix, region=us would filter out the right series.
+			leftSeries: []labels.Labels{
+				labels.FromStrings("region", "us", "zone", "1"),
+				labels.FromStrings("region", "us", "zone", "2"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("region", "eu", "zone", "1"),
+			},
+			expectedLHS: types.Matchers{{Type: labels.MatchEqual, Name: "zone", Value: "1"}},
+			expectedRHS: types.Matchers{{Type: labels.MatchEqual, Name: "zone", Value: "1"}},
+			// left[zone=1] matches right[zone=1]; left[zone=2] has no match.
+			expectedSeries: 1,
+		},
+		"no parent matchers: both sides receive nil": {
+			vectorMatching: parser.VectorMatching{
+				On:             true,
+				MatchingLabels: []string{"zone"},
+				Card:           parser.CardManyToOne,
+			},
+			parentMatchers: nil,
+			leftSeries: []labels.Labels{
+				labels.FromStrings("zone", "1"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("zone", "1"),
+			},
+			expectedLHS:    nil,
+			expectedRHS:    nil,
+			expectedSeries: 1,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			timeRange := types.NewInstantQueryTimeRange(time.Now())
+			memTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+
+			left := &operators.TestOperator{
+				Series:                   tc.leftSeries,
+				Data:                     make([]types.InstantVectorSeriesData, len(tc.leftSeries)),
+				MemoryConsumptionTracker: memTracker,
+			}
+			right := &operators.TestOperator{
+				Series:                   tc.rightSeries,
+				Data:                     make([]types.InstantVectorSeriesData, len(tc.rightSeries)),
+				MemoryConsumptionTracker: memTracker,
+			}
+
+			op, err := NewGroupedVectorVectorBinaryOperation(
+				left, right, tc.vectorMatching, parser.ADD, false,
+				memTracker, annotations.New(), posrange.PositionRange{}, timeRange,
+			)
+			require.NoError(t, err)
+
+			outputSeries, err := op.SeriesMetadata(ctx, tc.parentMatchers)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expectedLHS, left.MatchersProvided, "LHS should receive filtered matchers")
+			require.Equal(t, tc.expectedRHS, right.MatchersProvided, "RHS should receive filtered matchers")
+			require.Len(t, outputSeries, tc.expectedSeries, "unexpected number of output series")
+
+			require.NoError(t, op.Finalize(ctx))
+			op.Close()
+		})
+	}
+}
+
+// TestAndUnlessBinaryOperation_MatcherPropagation verifies two behaviors introduced by the
+// bug fixes:
+//
+//  1. (Bug 2 fix) The RHS of an 'and'/'unless' operation always receives nil matchers,
+//     regardless of what the parent passes. The RHS acts only as a presence filter; passing
+//     parent matchers to it can cause wrong results when those matchers cover labels outside
+//     the operation's matching set.
+//
+//  2. (Correctness) An 'and on(zone)' correctly matches LHS and RHS series that share the
+//     same zone value even when other labels (e.g., region) differ, because the RHS is not
+//     narrowed by the parent's region matchers.
+func TestAndUnlessBinaryOperation_MatcherPropagation(t *testing.T) {
+	testCases := map[string]struct {
+		isUnless       bool
+		vectorMatching parser.VectorMatching
+		parentMatchers types.Matchers
+		leftSeries     []labels.Labels
+		rightSeries    []labels.Labels
+		// expectedLHSMatchers: what the LHS should receive (full parent matchers, unchanged).
+		expectedLHSMatchers types.Matchers
+		// RHS always receives nil (Bug 2 fix).
+		expectedSeries int
+	}{
+		"and on(zone): parent region=us matcher does not filter RHS": {
+			isUnless:       false,
+			vectorMatching: parser.VectorMatching{On: true, MatchingLabels: []string{"zone"}},
+			parentMatchers: types.Matchers{
+				{Type: labels.MatchEqual, Name: "region", Value: "us"},
+			},
+			// LHS filtered by region=us (it has region=us → kept).
+			leftSeries: []labels.Labels{
+				labels.FromStrings("region", "us", "zone", "1"),
+			},
+			// RHS has a different region. Without the fix, region=us would be forwarded to
+			// the RHS, filtering out b{region=eu,zone=1} and causing a{region=us,zone=1} to
+			// have no match in the 'and', resulting in empty output.
+			rightSeries: []labels.Labels{
+				labels.FromStrings("region", "eu", "zone", "1"),
+			},
+			expectedLHSMatchers: types.Matchers{
+				{Type: labels.MatchEqual, Name: "region", Value: "us"},
+			},
+			// a{region=us,zone=1} matches b{region=eu,zone=1} on zone=1 → output is a{region=us,zone=1}
+			expectedSeries: 1,
+		},
+		"unless on(zone): parent region=us matcher does not filter RHS": {
+			isUnless:       true,
+			vectorMatching: parser.VectorMatching{On: true, MatchingLabels: []string{"zone"}},
+			parentMatchers: types.Matchers{
+				{Type: labels.MatchEqual, Name: "region", Value: "us"},
+			},
+			leftSeries: []labels.Labels{
+				labels.FromStrings("region", "us", "zone", "1"),
+			},
+			// RHS has a different region. Without the fix, region=us would filter out
+			// b{region=eu,zone=1}, so the 'unless' would incorrectly keep a{region=us,zone=1}
+			// (since b appears absent). With the fix, b is kept and will filter out a at data
+			// level (verified by the e2e test in binary_operators.test).
+			rightSeries: []labels.Labels{
+				labels.FromStrings("region", "eu", "zone", "1"),
+			},
+			expectedLHSMatchers: types.Matchers{
+				{Type: labels.MatchEqual, Name: "region", Value: "us"},
+			},
+			// 'unless' metadata always returns all LHS series; data-level filtering happens
+			// in NextSeries. The key check here is that RHS receives nil (not region=us).
+			expectedSeries: 1,
+		},
+		"and: nil parent matchers propagate as nil to both sides": {
+			isUnless:       false,
+			vectorMatching: parser.VectorMatching{On: true, MatchingLabels: []string{"zone"}},
+			parentMatchers: nil,
+			leftSeries:     []labels.Labels{labels.FromStrings("zone", "1")},
+			rightSeries:    []labels.Labels{labels.FromStrings("zone", "1")},
+			expectedLHSMatchers: nil,
+			expectedSeries:      1,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			timeRange := types.NewInstantQueryTimeRange(time.Now())
+			memTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+
+			left := &operators.TestOperator{
+				Series:                   tc.leftSeries,
+				Data:                     make([]types.InstantVectorSeriesData, len(tc.leftSeries)),
+				MemoryConsumptionTracker: memTracker,
+			}
+			right := &operators.TestOperator{
+				Series:                   tc.rightSeries,
+				Data:                     make([]types.InstantVectorSeriesData, len(tc.rightSeries)),
+				MemoryConsumptionTracker: memTracker,
+			}
+
+			op := NewAndUnlessBinaryOperation(
+				left, right, tc.vectorMatching, memTracker, tc.isUnless, timeRange, posrange.PositionRange{},
+			)
+
+			outputSeries, err := op.SeriesMetadata(ctx, tc.parentMatchers)
+			require.NoError(t, err)
+
+			// LHS receives the full parent matchers unchanged.
+			require.Equal(t, tc.expectedLHSMatchers, left.MatchersProvided, "LHS should receive full parent matchers")
+
+			// RHS always receives nil (Bug 2 fix): the RHS is a presence filter and must not
+			// be narrowed by parent matchers that cover labels outside the matching set.
+			require.Nil(t, right.MatchersProvided, "RHS should always receive nil matchers")
+
+			require.Len(t, outputSeries, tc.expectedSeries, "unexpected number of output series")
+
+			require.NoError(t, op.Finalize(ctx))
+			op.Close()
+		})
+	}
+}

--- a/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation.go
@@ -179,7 +179,16 @@ func (b *OneToOneVectorVectorBinaryOperation) ExpressionPosition() posrange.Posi
 // avoid.)
 func (b *OneToOneVectorVectorBinaryOperation) SeriesMetadata(ctx context.Context, matchers types.Matchers) ([]types.SeriesMetadata, error) {
 	var err error
-	b.leftMetadata, err = b.Left.SeriesMetadata(ctx, matchers)
+
+	// Only pass matchers for labels that are part of this operation's matching to child
+	// operators. Matchers from a parent binary operation may refer to labels that are not
+	// matching labels here, and passing them through could incorrectly filter out series
+	// that are needed (e.g. a parent using on(region) generating region=us matchers, passed
+	// to a child using on(zone), where b{region=eu,zone=1} could legitimately match
+	// a{region=us,zone=1} on zone).
+	lhsMatchers := filterMatchersForVectorMatching(matchers, b.VectorMatching)
+
+	b.leftMetadata, err = b.Left.SeriesMetadata(ctx, lhsMatchers)
 	if err != nil {
 		return nil, err
 	} else if len(b.leftMetadata) == 0 {
@@ -191,28 +200,26 @@ func (b *OneToOneVectorVectorBinaryOperation) SeriesMetadata(ctx context.Context
 		return nil, nil
 	}
 
-	// If there are labels that this binary operation selects on or aggregations being done
-	// on the LHS, we can use the series and their values for those labels to reduce the amount
-	// of data fetched on the RHS.
+	// Use the LHS series to narrow the data we need to fetch on the RHS.
+	// When hints have been set by the optimization pass, use them to build matchers from the
+	// LHS metadata (e.g. for aggregation-based hints). Otherwise fall back to the same
+	// filtered matchers used for the LHS.
+	var rhsMatchers types.Matchers
 	if b.hints != nil {
-		// Note we are reassigning `matchers` here before passing to the RHS and dropping any
-		// other extra matchers passed to this binary operation. Hints from the optimization
-		// pass are set specifically for each binary operation and include only fields that are
-		// valid to be passed to its RHS. We drop existing extra matchers since they may refer
-		// to labels that don't exist on the RHS of this binary operation.
-		ignored := matchers
-		matchers = BuildMatchers(b.leftMetadata, b.hints)
+		rhsMatchers = BuildMatchers(b.leftMetadata, b.hints)
 
 		sl := spanlogger.FromContext(ctx, b.logger)
 		sl.DebugLog(
 			"msg", "binary operator passing additional matchers to RHS",
 			"fields", b.hints.Include,
-			"hint_matchers", len(matchers),
-			"ignored_matchers", len(ignored),
+			"hint_matchers", len(rhsMatchers),
+			"ignored_matchers", len(matchers),
 		)
+	} else {
+		rhsMatchers = lhsMatchers
 	}
 
-	b.rightMetadata, err = b.Right.SeriesMetadata(ctx, matchers)
+	b.rightMetadata, err = b.Right.SeriesMetadata(ctx, rhsMatchers)
 	if err != nil {
 		return nil, err
 	} else if len(b.rightMetadata) == 0 {


### PR DESCRIPTION
#### What this PR does
When a parent binary operation passed label matchers down to a child binary operation with the narrow selector optimisation, the child would forward those matchers to both its LHS and RHS. If the parent's matchers referred to labels outside the child's matching set these irrelevant matchers would filter out series that should have been matched leading to potentially incorrect results.

Added a `filterMatchersForVectorMatching()` function that drops matchers that aren't relevant to a binop's matching labels before passing them down to the children.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes matcher propagation in streaming PromQL binary operators, which can affect query results and series selection; logic is localized and covered by new unit tests but touches correctness-critical query execution.
> 
> **Overview**
> Fixes incorrect matcher propagation in streaming PromQL binary operations when the narrow-selectors optimization is used.
> 
> Adds `filterMatchersForVectorMatching()` and uses it in `OneToOneVectorVectorBinaryOperation` and `GroupedVectorVectorBinaryOperation` so only match-relevant label matchers are forwarded to child operators (preventing parents from over-filtering children). Adjusts RHS matcher handling so hint-derived matchers are applied *instead of* unrelated parent matchers, and adds focused tests (including a new `matcher_propagation_test.go`) plus a changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff0b44a5a2c3886fbbc0e85737891974806bb168. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->