### PR TITLE
Bump latest versions in backward compatibility tests

### DIFF
--- a/integration/backward_compatibility.go
+++ b/integration/backward_compatibility.go
@@ -11,11 +11,11 @@ var DefaultPreviousVersionImages = map[string]e2emimir.FlagMapper{
 		removePartitionRingFlags,
 		removeQuerierRingFlags,
 	),
-	"grafana/mimir:2.17.9": e2emimir.ChainFlagMappers(
+	"grafana/mimir:2.17.10": e2emimir.ChainFlagMappers(
 		removePartitionRingFlags,
 		removeQuerierRingFlags,
 	),
-	"grafana/mimir:3.0.4": e2emimir.ChainFlagMappers(
+	"grafana/mimir:3.0.6": e2emimir.ChainFlagMappers(
 		removePartitionRingFlags,
 		removeQuerierRingFlags,
 	),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Bumps image versions in `DefaultPreviousVersionImages` to the latest patch releases.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/issues/13063#issuecomment-4281950373

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the referenced `grafana/mimir` image tags used in compatibility tests/pre-pull tooling, with no production code or logic changes.
> 
> **Overview**
> Bumps the `grafana/mimir` image versions used by `DefaultPreviousVersionImages` for backward-compatibility testing and `tools/pre-pull-images` (2.17.9 → 2.17.10 and 3.0.4 → 3.0.6).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 040c356eac31aeec506dc29c402b73f87f3f932b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->