### PR TITLE
ci: Fetch all origin tags when deciding to push image as :latest

### DIFF
--- a/.github/workflows/scripts/push-images.sh
+++ b/.github/workflows/scripts/push-images.sh
@@ -11,9 +11,12 @@ TAG="$3"
 
 # If image is the latest stable git tag, also push :latest image.
 # Do not tag with latest any release candidate (tag ends with "-rc.*").
+LATEST_TAG="$(git ls-remote --tags origin | awk '{print $2}' | grep -E '^refs/tags/mimir-[0-9]+\.[0-9]+\.[0-9]+$' | grep -Eo 'mimir-.*' | sort -V | tail -n 1)"
 EXTRA_TAG=""
-if [[ "$(git tag | grep -E '^mimir-[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1)" == "mimir-${TAG}" ]]; then
+if [[ "$LATEST_TAG" == "mimir-${TAG}" ]]; then
   EXTRA_TAG="latest"
+else
+  echo "Latest stable git tag is $LATEST_TAG, while we're pushing $TAG. Not pushing :latest"
 fi
 
 # Push images from OCI archives to docker registry.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

While publishing 2.17.10, I noticed it was also pushed as `grafana/mimir:latest`. This is incorrect, as only the 3.x versions should be latest

The issue is that the push script list tags with `git tag` to look up the latest release. But `git tag` only lists local tags, and CI checks out the repo sparsely.

With this change, tags are listed with `git ls-remote` instead, which lists all tags in the remote repository without fetching them.

#### Which issue(s) this PR fixes or relates to

—

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small CI scripting change that only affects when images are additionally pushed as `:latest`, with minimal impact outside release publishing behavior.
> 
> **Overview**
> Fixes `:latest` image tagging during releases by determining the latest stable `mimir-x.y.z` tag from `origin` via `git ls-remote` (instead of local `git tag`, which can be incomplete in CI).
> 
> When the pushed `TAG` is not the latest stable tag, the script now skips pushing `:latest` and logs which remote tag was considered latest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a2d5abb74f26346379fab7cc457d3199130dfed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->