### PR TITLE
[3.0] ci: Fetch all origin tags when deciding to push image as :latest

### DIFF
--- a/.github/workflows/scripts/push-images.sh
+++ b/.github/workflows/scripts/push-images.sh
@@ -11,9 +11,12 @@ TAG="$3"
 
 # If image is the latest stable git tag, also push :latest image.
 # Do not tag with latest any release candidate (tag ends with "-rc.*").
+LATEST_TAG="$(git ls-remote --tags origin | awk '{print $2}' | grep -E '^refs/tags/mimir-[0-9]+\.[0-9]+\.[0-9]+$' | grep -Eo 'mimir-.*' | sort -V | tail -n 1)"
 EXTRA_TAG=""
-if [[ "$(git tag | grep -E '^mimir-[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1)" == "mimir-${TAG}" ]]; then
+if [[ "$LATEST_TAG" == "mimir-${TAG}" ]]; then
   EXTRA_TAG="latest"
+else
+  echo "Latest stable git tag is $LATEST_TAG, while we're pushing $TAG. Not pushing :latest"
 fi
 
 # Push images from OCI archives to docker registry.


### PR DESCRIPTION
Backport of #15087

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small CI script change that only affects whether Docker images are additionally pushed as `:latest` based on the remote tag set.
> 
> **Overview**
> Updates the image-push workflow script to decide whether to also publish Docker images as `:latest` by computing the *latest stable* `mimir-x.y.z` tag from `origin` via `git ls-remote --tags`, instead of relying on locally available tags.
> 
> When the pushed `TAG` is not the latest stable remote tag, it now logs an explicit message and skips the `:latest` tagging step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce3faffd7007d5832e9a8c057185ca97292b9469. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->