### PR TITLE
[2.17] ci: Fetch all origin tags when deciding to push image as :latest

### DIFF
--- a/.github/workflows/scripts/push-images.sh
+++ b/.github/workflows/scripts/push-images.sh
@@ -11,9 +11,12 @@ TAG="$3"
 
 # If image is the latest stable git tag, also push :latest image.
 # Do not tag with latest any release candidate (tag ends with "-rc.*").
+LATEST_TAG="$(git ls-remote --tags origin | awk '{print $2}' | grep -E '^refs/tags/mimir-[0-9]+\.[0-9]+\.[0-9]+$' | grep -Eo 'mimir-.*' | sort -V | tail -n 1)"
 EXTRA_TAG=""
-if [[ "$(git tag | grep -E '^mimir-[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1)" == "mimir-${TAG}" ]]; then
+if [[ "$LATEST_TAG" == "mimir-${TAG}" ]]; then
   EXTRA_TAG="latest"
+else
+  echo "Latest stable git tag is $LATEST_TAG, while we're pushing $TAG. Not pushing :latest"
 fi
 
 # Push images from OCI archives to docker registry.


### PR DESCRIPTION
Backport of #15087

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI scripting change that only affects when images are additionally tagged as `:latest`; main risk is mis-detecting the latest stable tag if tag naming/remote access differs in CI.
> 
> **Overview**
> The `push-images.sh` workflow script now computes the latest stable release tag by querying `origin` tags (`git ls-remote --tags origin`) and only pushes the `:latest` image when the pushed `TAG` matches that remote latest stable tag.
> 
> When the tag does not match, it logs a message explaining why `:latest` is not being pushed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ff53146650b979a04c5b13a1ede6f7d31036bb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->