### PR TITLE
chore: query-frontend: default to active series sharding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [CHANGE] Query-frontend: Removed support for calculating 'cache-adjusted samples processed' query statistic. The `-query-frontend.cache-samples-processed-stats` CLI flag has been deprecated and will be removed in a future release. Setting it has now no effect. #13582
 * [CHANGE] Querier: Renamed experimental flag `-querier.prefer-availability-zone` to `-querier.prefer-availability-zones` and changed it to accept a comma-separated list of availability zones. All zones in the list are given equal priority when querying ingesters and store-gateways. #13756 #13758
 * [CHANGE] Ingester: Stabilize experimental flag `-ingest-storage.write-logs-fsync-before-kafka-commit-concurrency` to fsync write logs before the offset is committed to Kafka. Remove `-ingest-storage.write-logs-fsync-before-kafka-commit-enabled` since this is always enabled now. #13591
+* [CHANGE] Query-frontend: Remove experimental flags `-query-frontend.shard-active-series-queries`, `-query-frontend.use-active-series-decoder`. These settings are always enabled now. #15091
 * [CHANGE] Ingester: Remove metric `cortex_ingester_owned_target_info_series`; if needed this is better done as a custom active series tracker. #13831
 * [CHANGE] Querier: Remove experimental flag `-querier.response-streaming-enabled`, active series responses are now always streamed to query-frontends. #14095 #14114
 * [CHANGE] Store-gateway: Warn when loading index headers based on TSDB blocks that use v1 of the index file format. #13834

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -8651,28 +8651,6 @@
         },
         {
           "kind": "field",
-          "name": "shard_active_series_queries",
-          "required": false,
-          "desc": "True to enable sharding of active series queries.",
-          "fieldValue": null,
-          "fieldDefaultValue": false,
-          "fieldFlag": "query-frontend.shard-active-series-queries",
-          "fieldType": "boolean",
-          "fieldCategory": "experimental"
-        },
-        {
-          "kind": "field",
-          "name": "use_active_series_decoder",
-          "required": false,
-          "desc": "Set to true to use the zero-allocation response decoder for active series queries.",
-          "fieldValue": null,
-          "fieldDefaultValue": false,
-          "fieldFlag": "query-frontend.use-active-series-decoder",
-          "fieldType": "boolean",
-          "fieldCategory": "experimental"
-        },
-        {
-          "kind": "field",
           "name": "extra_propagated_headers",
           "required": false,
           "desc": "Comma-separated list of request header names to allow to pass through to the rest of the query path. This is in addition to a list of required headers that the read path needs.",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2655,14 +2655,10 @@ Usage of ./cmd/mimir/mimir:
     	How often to resolve the scheduler-address, in order to look for new query-scheduler instances. (default 10s)
   -query-frontend.scheduler-worker-concurrency int
     	Number of concurrent workers forwarding queries to single query-scheduler. (default 5)
-  -query-frontend.shard-active-series-queries
-    	[experimental] True to enable sharding of active series queries.
   -query-frontend.split-queries-by-interval duration
     	Split range queries by an interval and execute in parallel. You should use a multiple of 24 hours to optimize querying blocks. 0 to disable it. (default 24h0m0s)
   -query-frontend.subquery-spin-off-enabled
     	[experimental] Enable spinning off subqueries from instant queries as range queries to optimize their performance.
-  -query-frontend.use-active-series-decoder
-    	[experimental] Set to true to use the zero-allocation response decoder for active series queries.
   -query-frontend.use-mimir-query-engine-for-sharding
     	[experimental] Set to true to enable performing query sharding inside the Mimir query engine (MQE). This setting has no effect if sharding is disabled. Requires remote execution and MQE to be enabled.
   -query-scheduler.grpc-client-config.backoff-max-period duration

--- a/development/mimir-microservices-mode/config/mimir.yaml
+++ b/development/mimir-microservices-mode/config/mimir.yaml
@@ -149,7 +149,6 @@ frontend:
   parallelize_shardable_queries: true
   cache_results: true
   cache_errors: true
-  shard_active_series_queries: true
 
   # Uncomment when using "dns" service discovery mode for query-scheduler.
   # scheduler_address: "query-scheduler:9008"

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -2258,15 +2258,6 @@ results_cache:
 # CLI flag: -query-frontend.query-sharding-target-series-per-shard
 [query_sharding_target_series_per_shard: <int> | default = 0]
 
-# (experimental) True to enable sharding of active series queries.
-# CLI flag: -query-frontend.shard-active-series-queries
-[shard_active_series_queries: <boolean> | default = false]
-
-# (experimental) Set to true to use the zero-allocation response decoder for
-# active series queries.
-# CLI flag: -query-frontend.use-active-series-decoder
-[use_active_series_decoder: <boolean> | default = false]
-
 # (advanced) Comma-separated list of request header names to allow to pass
 # through to the rest of the query path. This is in addition to a list of
 # required headers that the read path needs.

--- a/integration/query_frontend_active_series_test.go
+++ b/integration/query_frontend_active_series_test.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"fmt"
 	"net/http"
 	"strconv"
 	"testing"
@@ -21,43 +20,32 @@ import (
 )
 
 func TestActiveSeriesWithQuerySharding(t *testing.T) {
-	for _, tc := range []struct {
-		shardingEnabled bool
-	}{
-		{false},
-		{true},
-	} {
-		config := queryFrontendTestConfig{
-			queryStatsEnabled:           true,
-			shardActiveSeriesQueries:    tc.shardingEnabled,
-			querySchedulerDiscoveryMode: "ring",
-			setup: func(t *testing.T, s *e2e.Scenario) (string, map[string]string) {
-				flags := mergeFlags(BlocksStorageFlags(), BlocksStorageS3Flags())
-				minio := e2edb.NewMinio(9000, flags["-blocks-storage.s3.bucket-name"])
-				require.NoError(t, s.StartAndWaitReady(minio))
+	config := queryFrontendTestConfig{
+		queryStatsEnabled:           true,
+		querySchedulerDiscoveryMode: "ring",
+		setup: func(t *testing.T, s *e2e.Scenario) (string, map[string]string) {
+			flags := mergeFlags(BlocksStorageFlags(), BlocksStorageS3Flags())
+			minio := e2edb.NewMinio(9000, flags["-blocks-storage.s3.bucket-name"])
+			require.NoError(t, s.StartAndWaitReady(minio))
 
-				return "", flags
-			},
-		}
-
-		testName := fmt.Sprintf("query query_sharding=%v",
-			tc.shardingEnabled,
-		)
-		t.Run("active series/"+testName, func(t *testing.T) {
-			runTestActiveSeriesWithQueryShardingHTTPTest(t, config)
-		})
-
-		t.Run("active native histograms/"+testName, func(t *testing.T) {
-			runTestActiveNativeHistogramMetricsWithQueryShardingHTTPTest(t, config)
-		})
+			return "", flags
+		},
 	}
+
+	t.Run("active series", func(t *testing.T) {
+		runTestActiveSeriesHTTPTest(t, config)
+	})
+
+	t.Run("active native histograms", func(t *testing.T) {
+		runTestActiveNativeHistogramMetricsHTTPTest(t, config)
+	})
 }
 
 const (
 	metricName = "test_metric"
 )
 
-func runTestActiveSeriesWithQueryShardingHTTPTest(t *testing.T, cfg queryFrontendTestConfig) {
+func runTestActiveSeriesHTTPTest(t *testing.T, cfg queryFrontendTestConfig) {
 	numSeries := 100
 	s, c := setupComponentsForActiveSeriesTest(t, cfg, numSeries)
 	defer s.Close()
@@ -76,17 +64,12 @@ func runTestActiveSeriesWithQueryShardingHTTPTest(t *testing.T, cfg queryFronten
 		require.Len(t, response.Data, numSeries)
 	}
 
-	var err error
-	_, err = c.ActiveSeries(metricName, e2emimir.WithQueryShards(512))
-	if cfg.shardActiveSeriesQueries {
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "shard count 512 exceeds allowed maximum (128)")
-	} else {
-		require.NoError(t, err)
-	}
+	_, err := c.ActiveSeries(metricName, e2emimir.WithQueryShards(512))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "shard count 512 exceeds allowed maximum (128)")
 }
 
-func runTestActiveNativeHistogramMetricsWithQueryShardingHTTPTest(t *testing.T, cfg queryFrontendTestConfig) {
+func runTestActiveNativeHistogramMetricsHTTPTest(t *testing.T, cfg queryFrontendTestConfig) {
 	numSeries := 100
 	s, c := setupComponentsForActiveSeriesTest(t, cfg, numSeries)
 	defer s.Close()
@@ -113,14 +96,9 @@ func runTestActiveNativeHistogramMetricsWithQueryShardingHTTPTest(t *testing.T, 
 		})
 	}
 
-	var err error
-	_, err = c.ActiveNativeHistogramMetrics(metricName, e2emimir.WithQueryShards(512))
-	if cfg.shardActiveSeriesQueries {
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "shard count 512 exceeds allowed maximum (128)")
-	} else {
-		require.NoError(t, err)
-	}
+	_, err := c.ActiveNativeHistogramMetrics(metricName, e2emimir.WithQueryShards(512))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "shard count 512 exceeds allowed maximum (128)")
 }
 
 func setupComponentsForActiveSeriesTest(t *testing.T, cfg queryFrontendTestConfig, numSeries int) (*e2e.Scenario, *e2emimir.Client) {
@@ -158,10 +136,6 @@ func setupComponentsForActiveSeriesTest(t *testing.T, cfg queryFrontendTestConfi
 		require.NoError(t, s.StartAndWaitReady(queryScheduler))
 		flags["-query-frontend.scheduler-address"] = queryScheduler.NetworkGRPCEndpoint()
 		flags["-querier.scheduler-address"] = queryScheduler.NetworkGRPCEndpoint()
-	}
-
-	if cfg.shardActiveSeriesQueries {
-		flags["-query-frontend.shard-active-series-queries"] = "true"
 	}
 
 	// Start the query-frontend.

--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -41,7 +41,6 @@ type queryFrontendTestConfig struct {
 	queryStatsEnabled           bool
 	setup                       func(t *testing.T, s *e2e.Scenario) (configFile string, flags map[string]string)
 	withHistograms              bool
-	shardActiveSeriesQueries    bool
 	remoteExecutionEnabled      bool
 }
 

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -73,8 +73,6 @@ type Config struct {
 	RewriteQueriesHistogram                   bool               `yaml:"rewrite_histogram_queries" category:"experimental"`
 	RewriteQueriesPropagateMatchers           bool               `yaml:"rewrite_propagate_matchers" category:"experimental"`
 	TargetSeriesPerShard                      uint64             `yaml:"query_sharding_target_series_per_shard" category:"advanced"`
-	ShardActiveSeriesQueries                  bool               `yaml:"shard_active_series_queries" category:"experimental"`
-	UseActiveSeriesDecoder                    bool               `yaml:"use_active_series_decoder" category:"experimental"`
 
 	// CacheKeyGenerator allows to inject a CacheKeyGenerator to use for generating cache keys.
 	// If nil, the querymiddleware package uses a DefaultCacheKeyGenerator with SplitQueriesByInterval.
@@ -114,8 +112,6 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.Uint64Var(&cfg.TargetSeriesPerShard, "query-frontend.query-sharding-target-series-per-shard", 0, "How many series a single sharded partial query should load at most. This is not a strict requirement guaranteed to be honoured by query sharding, but a hint given to the query sharding when the query execution is initially planned. 0 to disable cardinality-based hints.")
 	f.Var(&cfg.ExtraPropagateHeaders, "query-frontend.extra-propagated-headers", "Comma-separated list of request header names to allow to pass through to the rest of the query path. This is in addition to a list of required headers that the read path needs.")
 	f.StringVar(&cfg.QueryResultResponseFormat, "query-frontend.query-result-response-format", formatProtobuf, fmt.Sprintf("Format to use when retrieving query results from queriers. Supported values: %s", strings.Join(allFormats, ", ")))
-	f.BoolVar(&cfg.ShardActiveSeriesQueries, "query-frontend.shard-active-series-queries", false, "True to enable sharding of active series queries.")
-	f.BoolVar(&cfg.UseActiveSeriesDecoder, "query-frontend.use-active-series-decoder", false, "Set to true to use the zero-allocation response decoder for active series queries.")
 	f.BoolVar(&cfg.CacheSamplesProcessedStats, "query-frontend.cache-samples-processed-stats", false, "Cache statistics of processed samples on results cache. Deprecated: has no effect.")
 	cfg.ResultsCache.RegisterFlags(f)
 
@@ -332,10 +328,9 @@ func newQueryTripperware(
 			activeSeries = newRetryRoundTripper(series, log, cfg.MaxRetries, retryMetrics)
 		}
 
-		if cfg.ShardActiveSeriesQueries {
-			activeSeries = newShardActiveSeriesMiddleware(activeSeries, cfg.UseActiveSeriesDecoder, limits, log)
-			activeNativeHistogramMetrics = newShardActiveNativeHistogramMetricsMiddleware(activeNativeHistogramMetrics, limits, log)
-		}
+		// Shard active series requests using special middleware.
+		activeSeries = newShardActiveSeriesMiddleware(activeSeries, limits, log)
+		activeNativeHistogramMetrics = newShardActiveNativeHistogramMetricsMiddleware(activeNativeHistogramMetrics, limits, log)
 
 		// Enforce read consistency after caching.
 		if len(ingestStorageTopicOffsetsReaders) > 0 {

--- a/pkg/frontend/querymiddleware/shard_active_series.go
+++ b/pkg/frontend/querymiddleware/shard_active_series.go
@@ -17,7 +17,6 @@ import (
 	jsoniter "github.com/json-iterator/go"
 	"github.com/klauspost/compress/s2"
 	"github.com/pkg/errors"
-	"github.com/prometheus/prometheus/model/labels"
 	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/sync/errgroup"
 
@@ -36,12 +35,6 @@ var (
 			return &buf
 		},
 	}
-
-	labelBuilderPool = sync.Pool{
-		New: func() any {
-			return labels.NewBuilder(labels.EmptyLabels())
-		},
-	}
 )
 
 var snappyWriterPool sync.Pool
@@ -58,31 +51,21 @@ func getSnappyWriter(w io.Writer) *s2.Writer {
 
 type shardActiveSeriesMiddleware struct {
 	shardBySeriesBase
-	useZeroAllocationDecoder bool
 }
 
-func newShardActiveSeriesMiddleware(upstream http.RoundTripper, useZeroAllocationDecoder bool, limits Limits, logger log.Logger) http.RoundTripper {
+func newShardActiveSeriesMiddleware(upstream http.RoundTripper, limits Limits, logger log.Logger) http.RoundTripper {
 	return &shardActiveSeriesMiddleware{shardBySeriesBase{
 		upstream: upstream,
 		limits:   limits,
 		logger:   logger,
-	}, useZeroAllocationDecoder}
+	}}
 }
 
 func (s *shardActiveSeriesMiddleware) RoundTrip(r *http.Request) (*http.Response, error) {
 	spanLog, ctx := spanlogger.New(r.Context(), s.logger, tracer, "shardActiveSeries.RoundTrip")
 	defer spanLog.Finish()
 
-	var (
-		resp *http.Response
-		err  error
-	)
-	if s.useZeroAllocationDecoder {
-		resp, err = s.shardBySeriesSelector(ctx, spanLog, r, s.mergeResponsesWithZeroAllocationDecoder)
-	} else {
-		resp, err = s.shardBySeriesSelector(ctx, spanLog, r, s.mergeResponses)
-	}
-
+	resp, err := s.shardBySeriesSelector(ctx, spanLog, r, s.mergeResponses)
 	if err != nil {
 		return nil, err
 	}
@@ -90,93 +73,6 @@ func (s *shardActiveSeriesMiddleware) RoundTrip(r *http.Request) (*http.Response
 }
 
 func (s *shardActiveSeriesMiddleware) mergeResponses(ctx context.Context, responses []*http.Response, encoding string) *http.Response {
-	reader, writer := io.Pipe()
-
-	items := make(chan *labels.Builder, len(responses))
-
-	g := new(errgroup.Group)
-	for _, res := range responses {
-		if res == nil {
-			continue
-		}
-		r := res
-		g.Go(func() error {
-			defer func(body io.ReadCloser) {
-				// drain body reader
-				_, _ = io.Copy(io.Discard, body)
-				_ = body.Close()
-			}(r.Body)
-
-			bufPtr := jsoniterBufferPool.Get().(*[]byte)
-			defer jsoniterBufferPool.Put(bufPtr)
-
-			it := jsoniter.ConfigFastest.BorrowIterator(*bufPtr)
-			it.Reset(r.Body)
-			defer func() {
-				jsoniter.ConfigFastest.ReturnIterator(it)
-			}()
-
-			// Iterate over fields until we find data or error fields
-			foundDataField := false
-			for it.Error == nil {
-				field := it.ReadObject()
-				if field == "error" {
-					return fmt.Errorf("error in partial response: %s", it.ReadString())
-				}
-				if field == "data" {
-					foundDataField = true
-					break
-				}
-				// If the field is neither data nor error, we skip it.
-				it.ReadAny()
-			}
-			if !foundDataField {
-				return fmt.Errorf("expected data field at top level, found %s", it.CurrentBuffer())
-			}
-
-			if it.WhatIsNext() != jsoniter.ArrayValue {
-				err := errors.New("expected data field to contain an array")
-				return err
-			}
-
-			for it.ReadArray() {
-				if err := ctx.Err(); err != nil {
-					if cause := context.Cause(ctx); cause != nil {
-						return fmt.Errorf("aborted streaming because context was cancelled: %w", cause)
-					}
-					return ctx.Err()
-				}
-
-				item := labelBuilderPool.Get().(*labels.Builder)
-				it.ReadMapCB(func(iterator *jsoniter.Iterator, s string) bool {
-					item.Set(s, iterator.ReadString())
-					return true
-				})
-				items <- item
-			}
-
-			return it.Error
-		})
-	}
-
-	go func() {
-		// We ignore the error from the errgroup because it will be checked again later.
-		_ = g.Wait()
-		close(items)
-	}()
-
-	resp := &http.Response{Body: reader, StatusCode: http.StatusOK, Header: http.Header{}}
-	resp.Header.Set("Content-Type", "application/json")
-	if encoding == encodingTypeSnappyFramed {
-		resp.Header.Set("Content-Encoding", encodingTypeSnappyFramed)
-	}
-
-	go s.writeMergedResponse(ctx, g.Wait, writer, items, encoding)
-
-	return resp
-}
-
-func (s *shardActiveSeriesMiddleware) mergeResponsesWithZeroAllocationDecoder(ctx context.Context, responses []*http.Response, encoding string) *http.Response {
 	reader, writer := io.Pipe()
 
 	streamCh := make(chan *bytes.Buffer)
@@ -213,94 +109,15 @@ func (s *shardActiveSeriesMiddleware) mergeResponsesWithZeroAllocationDecoder(ct
 		resp.Header.Set("Content-Encoding", encodingTypeSnappyFramed)
 	}
 
-	go s.writeMergedResponseWithZeroAllocationDecoder(gCtx, g.Wait, writer, streamCh, encoding)
+	go s.writeMergedResponse(gCtx, g.Wait, writer, streamCh, encoding)
 
 	return resp
 }
 
-func (s *shardActiveSeriesMiddleware) writeMergedResponse(ctx context.Context, check func() error, w io.WriteCloser, items <-chan *labels.Builder, encoding string) {
+func (s *shardActiveSeriesMiddleware) writeMergedResponse(ctx context.Context, check func() error, w io.WriteCloser, streamCh chan *bytes.Buffer, encoding string) {
 	defer w.Close()
 
 	_, span := tracer.Start(ctx, "shardActiveSeries.writeMergedResponse")
-	defer span.End()
-
-	var out io.Writer = w
-	if encoding == encodingTypeSnappyFramed {
-		span.SetAttributes(attribute.String("encoding", encodingTypeSnappyFramed))
-		enc := getSnappyWriter(w)
-		out = enc
-		defer func() {
-			enc.Close()
-			// Reset the encoder before putting it back to pool to avoid it to hold the writer.
-			enc.Reset(nil)
-			snappyWriterPool.Put(enc)
-		}()
-	} else {
-		span.SetAttributes(attribute.String("encoding", "none"))
-	}
-
-	stream := jsoniter.ConfigFastest.BorrowStream(out)
-	defer func(stream *jsoniter.Stream) {
-		_ = stream.Flush()
-
-		if cap(stream.Buffer()) > jsoniterMaxBufferSize {
-			return
-		}
-		jsoniter.ConfigFastest.ReturnStream(stream)
-	}(stream)
-
-	stream.WriteObjectStart()
-	stream.WriteObjectField("data")
-	stream.WriteArrayStart()
-	firstItem := true
-	for item := range items {
-		if firstItem {
-			firstItem = false
-		} else {
-			stream.WriteMore()
-		}
-		stream.WriteObjectStart()
-		firstField := true
-
-		item.Range(func(l labels.Label) {
-			if firstField {
-				firstField = false
-			} else {
-				stream.WriteMore()
-			}
-			stream.WriteObjectField(l.Name)
-			stream.WriteString(l.Value)
-		})
-		stream.WriteObjectEnd()
-
-		item.Reset(labels.EmptyLabels())
-		labelBuilderPool.Put(item)
-
-		// Flush the stream buffer if it's getting too large.
-		if stream.Buffered() > jsoniterMaxBufferSize {
-			_ = stream.Flush()
-		}
-	}
-	stream.WriteArrayEnd()
-
-	if err := check(); err != nil {
-		level.Error(s.logger).Log("msg", "error merging partial responses", "err", err.Error())
-		span.RecordError(err)
-		stream.WriteMore()
-		stream.WriteObjectField("status")
-		stream.WriteString("error")
-		stream.WriteMore()
-		stream.WriteObjectField("error")
-		stream.WriteString(fmt.Sprintf("error merging partial responses: %s", err.Error()))
-	}
-
-	stream.WriteObjectEnd()
-}
-
-func (s *shardActiveSeriesMiddleware) writeMergedResponseWithZeroAllocationDecoder(ctx context.Context, check func() error, w io.WriteCloser, streamCh chan *bytes.Buffer, encoding string) {
-	defer w.Close()
-
-	_, span := tracer.Start(ctx, "shardActiveSeries.writeMergedResponseWithZeroAllocationDecoder")
 	defer span.End()
 
 	var out io.Writer = w

--- a/pkg/frontend/querymiddleware/shard_active_series_test.go
+++ b/pkg/frontend/querymiddleware/shard_active_series_test.go
@@ -32,14 +32,6 @@ import (
 )
 
 func Test_shardActiveSeriesMiddleware_RoundTrip(t *testing.T) {
-	for _, useZeroAllocationDecoder := range []bool{false, true} {
-		t.Run(fmt.Sprintf("useZeroAllocationDecoder=%t", useZeroAllocationDecoder), func(t *testing.T) {
-			runTestShardActiveSeriesMiddlewareRoundTrip(t, useZeroAllocationDecoder)
-		})
-	}
-}
-
-func runTestShardActiveSeriesMiddlewareRoundTrip(t *testing.T, useZeroAllocationDecoder bool) {
 	const tenantShardCount = 4
 	const tenantMaxShardCount = 128
 
@@ -367,14 +359,6 @@ func runTestShardActiveSeriesMiddlewareRoundTrip(t *testing.T, useZeroAllocation
 }
 
 func Test_shardActiveSeriesMiddleware_RoundTrip_concurrent(t *testing.T) {
-	for _, useZeroAllocationDecoder := range []bool{false, true} {
-		t.Run(fmt.Sprintf("useZeroAllocationDecoder=%t", useZeroAllocationDecoder), func(t *testing.T) {
-			runTestShardActiveSeriesMiddlewareRoundTripConcurrent(t, useZeroAllocationDecoder)
-		})
-	}
-}
-
-func runTestShardActiveSeriesMiddlewareRoundTripConcurrent(t *testing.T, useZeroAllocationDecoder bool) {
 	const shardCount = 4
 
 	upstream := RoundTripFunc(func(r *http.Request) (*http.Response, error) {
@@ -443,14 +427,6 @@ func runTestShardActiveSeriesMiddlewareRoundTripConcurrent(t *testing.T, useZero
 }
 
 func Test_shardActiveSeriesMiddleware_mergeResponse_contextCancellation(t *testing.T) {
-	for _, useZeroAllocationDecoder := range []bool{false, true} {
-		t.Run(fmt.Sprintf("useZeroAllocationDecoder=%t", useZeroAllocationDecoder), func(t *testing.T) {
-			runTestShardActiveSeriesMiddlewareMergeResponseContextCancellation(t, useZeroAllocationDecoder)
-		})
-	}
-}
-
-func runTestShardActiveSeriesMiddlewareMergeResponseContextCancellation(t *testing.T, useZeroAllocationDecoder bool) {
 	s := newShardActiveSeriesMiddleware(nil, mockLimits{}, log.NewNopLogger()).(*shardActiveSeriesMiddleware)
 	ctx, cancel := context.WithCancelCause(context.Background())
 	defer cancel(fmt.Errorf("test ran to completion"))
@@ -467,18 +443,8 @@ func runTestShardActiveSeriesMiddlewareMergeResponseContextCancellation(t *testi
 		{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(body))},
 		{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(body))},
 	}
-	var resp *http.Response
 
-	if useZeroAllocationDecoder {
-		resp = s.mergeResponses(ctx, responses, "")
-	} else {
-		defer func() {
-			_, _ = io.Copy(io.Discard, resp.Body)
-			_ = resp.Body.Close()
-		}()
-
-		resp = s.mergeResponses(ctx, responses, "")
-	}
+	resp := s.mergeResponses(ctx, responses, "")
 
 	var buf bytes.Buffer
 	_, err = io.CopyN(&buf, resp.Body, int64(os.Getpagesize()))

--- a/pkg/frontend/querymiddleware/shard_active_series_test.go
+++ b/pkg/frontend/querymiddleware/shard_active_series_test.go
@@ -323,7 +323,6 @@ func runTestShardActiveSeriesMiddlewareRoundTrip(t *testing.T, useZeroAllocation
 			// Run the request through the middleware.
 			s := newShardActiveSeriesMiddleware(
 				upstream,
-				useZeroAllocationDecoder,
 				mockLimits{maxShardedQueries: tenantMaxShardCount, totalShards: tenantShardCount},
 				log.NewNopLogger(),
 			)
@@ -393,7 +392,6 @@ func runTestShardActiveSeriesMiddlewareRoundTripConcurrent(t *testing.T, useZero
 
 	s := newShardActiveSeriesMiddleware(
 		upstream,
-		useZeroAllocationDecoder,
 		mockLimits{maxShardedQueries: shardCount, totalShards: shardCount},
 		log.NewNopLogger(),
 	)
@@ -453,7 +451,7 @@ func Test_shardActiveSeriesMiddleware_mergeResponse_contextCancellation(t *testi
 }
 
 func runTestShardActiveSeriesMiddlewareMergeResponseContextCancellation(t *testing.T, useZeroAllocationDecoder bool) {
-	s := newShardActiveSeriesMiddleware(nil, true, mockLimits{}, log.NewNopLogger()).(*shardActiveSeriesMiddleware)
+	s := newShardActiveSeriesMiddleware(nil, mockLimits{}, log.NewNopLogger()).(*shardActiveSeriesMiddleware)
 	ctx, cancel := context.WithCancelCause(context.Background())
 	defer cancel(fmt.Errorf("test ran to completion"))
 
@@ -472,7 +470,7 @@ func runTestShardActiveSeriesMiddlewareMergeResponseContextCancellation(t *testi
 	var resp *http.Response
 
 	if useZeroAllocationDecoder {
-		resp = s.mergeResponsesWithZeroAllocationDecoder(ctx, responses, "")
+		resp = s.mergeResponses(ctx, responses, "")
 	} else {
 		defer func() {
 			_, _ = io.Copy(io.Discard, resp.Body)
@@ -548,13 +546,13 @@ func benchmarkActiveSeriesMiddlewareMergeResponses(b *testing.B, encoding string
 				benchResponses[i] = responses
 			}
 
-			s := newShardActiveSeriesMiddleware(nil, true, mockLimits{}, log.NewNopLogger()).(*shardActiveSeriesMiddleware)
+			s := newShardActiveSeriesMiddleware(nil, mockLimits{}, log.NewNopLogger()).(*shardActiveSeriesMiddleware)
 
 			b.ResetTimer()
 			b.ReportAllocs()
 
 			for i := 0; i < b.N; i++ {
-				resp := s.mergeResponsesWithZeroAllocationDecoder(context.Background(), benchResponses[i], encoding)
+				resp := s.mergeResponses(context.Background(), benchResponses[i], encoding)
 
 				_, _ = io.Copy(io.Discard, resp.Body)
 				_ = resp.Body.Close()


### PR DESCRIPTION
#### What this PR does

Remove experimental settings for enabling/disabling active series sharding and use of a zero-allocation decoder. These have been enabled in Grafana Cloud for a over a year, they're not experimental anymore.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes query-frontend behavior by making active series sharding (and its new streaming merge path) unconditional, which could affect performance and error handling for cardinality endpoints in production. Risk is limited to the active-series query path and removes configuration rollback knobs.
> 
> **Overview**
> **Active series query sharding is now always on in the query-frontend.** The experimental flags/config fields `-query-frontend.shard-active-series-queries` and `-query-frontend.use-active-series-decoder` are removed from CLI help, config docs/descriptors, and example configs.
> 
> The query-frontend middleware chain now always wraps `active_series` and `active_native_histogram_metrics` requests with the sharding middlewares, and the active-series sharding implementation is simplified to a single streaming merge/decoder path (dropping the legacy merge and related pooling). Integration/unit tests are updated to reflect the removal of the toggle and to always expect shard-limit enforcement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32252da8441f0b3b09541ff44b3636123728409d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->