### PR TITLE
MQE: Add optimisation for and/unless binops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,7 +197,7 @@
   * `-ingest-storage.kafka.ingestion-concurrency-queue-capacity` from `5` to `3`
   * `-ingest-storage.kafka.ingestion-concurrency-target-flushes-per-shard` from `80` to `40`
   * `-ingest-storage.kafka.max-buffered-bytes` from `100MB` to `1GB`
-* [ENHANCEMENT] MQE: Enable narrow selectors optimisation and hints passing for `unless` binary operation. #15096
+* [ENHANCEMENT] MQE: Enable narrow selectors optimisation and hints passing for `and`/`unless` binary operation. #15096
 * [BUGFIX] Ingester: enforce a minimum 10s delay between TSDB head compaction iterations when an iteration approaches or exceeds the configured `-blocks-storage.tsdb.head-compaction-interval`, so ingestion is not starved by back-to-back compactions. #15061
 * [BUGFIX] Update to Go v1.25.9. #15030
 * [BUGFIX] Distributor: OTLP partial success responses now correctly populate `RejectedDataPoints` with the actual count of rejected samples, instead of always reporting 0. In classical architecture, this includes rejected samples propagated from the ingester. #14789

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,7 @@
   * `-ingest-storage.kafka.ingestion-concurrency-queue-capacity` from `5` to `3`
   * `-ingest-storage.kafka.ingestion-concurrency-target-flushes-per-shard` from `80` to `40`
   * `-ingest-storage.kafka.max-buffered-bytes` from `100MB` to `1GB`
+* [ENHANCEMENT] MQE: Enable narrow selectors optimisation and hints passing for `unless` binary operation. #15096
 * [BUGFIX] Ingester: enforce a minimum 10s delay between TSDB head compaction iterations when an iteration approaches or exceeds the configured `-blocks-storage.tsdb.head-compaction-interval`, so ingestion is not starved by back-to-back compactions. #15061
 * [BUGFIX] Update to Go v1.25.9. #15030
 * [BUGFIX] Distributor: OTLP partial success responses now correctly populate `RejectedDataPoints` with the actual count of rejected samples, instead of always reporting 0. In classical architecture, this includes rejected samples propagated from the ingester. #14789

--- a/pkg/streamingpromql/operators/binops/and_unless_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/and_unless_binary_operation.go
@@ -5,11 +5,13 @@ package binops
 import (
 	"context"
 
+	"github.com/go-kit/log"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/promql/parser/posrange"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
 	"github.com/grafana/mimir/pkg/util/limiter"
+	"github.com/grafana/mimir/pkg/util/spanlogger"
 )
 
 // AndUnlessBinaryOperation represents a logical 'and' or 'unless' between two vectors.
@@ -22,6 +24,8 @@ type AndUnlessBinaryOperation struct {
 
 	timeRange                  types.QueryTimeRange
 	expressionPosition         posrange.PositionRange
+	hints                      *Hints
+	logger                     log.Logger
 	leftSeriesGroups           []*andGroup
 	rightSeriesGroups          []*andGroup
 	nextRightSeriesIndex       int
@@ -40,6 +44,8 @@ func NewAndUnlessBinaryOperation(
 	isUnless bool,
 	timeRange types.QueryTimeRange,
 	expressionPosition posrange.PositionRange,
+	hints *Hints,
+	logger log.Logger,
 ) *AndUnlessBinaryOperation {
 	return &AndUnlessBinaryOperation{
 		Left:                     left,
@@ -49,6 +55,8 @@ func NewAndUnlessBinaryOperation(
 		IsUnless:                 isUnless,
 		timeRange:                timeRange,
 		expressionPosition:       expressionPosition,
+		hints:                    hints,
+		logger:                   logger,
 
 		lastLeftSeriesIndexToRead:  -1,
 		lastRightSeriesIndexToRead: -1,
@@ -90,12 +98,20 @@ func (a *AndUnlessBinaryOperation) computeSeriesMetadata(ctx context.Context, ma
 		return nil, nil
 	}
 
-	// Do not pass the parent's matchers to the RHS. For 'and' and 'unless', the RHS acts as
-	// a presence filter on the LHS: only the LHS series are returned. Passing matchers from a
-	// parent binary operation to the RHS could incorrectly exclude RHS series that would
-	// otherwise filter out (for 'unless') or include (for 'and') LHS series, producing wrong
-	// results when the parent's matchers cover labels not in this operation's matching set.
-	rightMetadata, err := a.Right.SeriesMetadata(ctx, nil)
+	// Build RHS matchers: when hints are set, build matchers from LHS metadata to narrow
+	// the RHS series fetch. When no hints are available, pass nil (do not apply parent matchers
+	// to the RHS — see SeriesMetadata for why).
+	var rhsMatchers types.Matchers
+	if a.hints != nil {
+		rhsMatchers = BuildMatchers(leftMetadata, a.hints)
+		sl := spanlogger.FromContext(ctx, a.logger)
+		sl.DebugLog(
+			"msg", "binary operator passing additional matchers to RHS",
+			"fields", a.hints.Include,
+			"hint_matchers", len(rhsMatchers),
+		)
+	}
+	rightMetadata, err := a.Right.SeriesMetadata(ctx, rhsMatchers)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/streamingpromql/operators/binops/and_unless_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/and_unless_binary_operation_test.go
@@ -109,7 +109,7 @@ func TestAndUnlessBinaryOperation_PassesHintMatchersToRHS(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := context.Background()
 			timeRange := types.NewInstantQueryTimeRange(time.Now())
-			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 			left := &operators.TestOperator{Series: testCase.leftSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.leftSeries)), MemoryConsumptionTracker: memoryConsumptionTracker}
 			right := &operators.TestOperator{Series: testCase.rightSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.rightSeries)), MemoryConsumptionTracker: memoryConsumptionTracker}
 			vectorMatching := parser.VectorMatching{On: true, MatchingLabels: []string{"env"}}

--- a/pkg/streamingpromql/operators/binops/and_unless_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/and_unless_binary_operation_test.go
@@ -110,7 +110,7 @@ func TestAndUnlessBinaryOperation_PassesHintMatchersToRHS(t *testing.T) {
 			ctx := context.Background()
 			timeRange := types.NewInstantQueryTimeRange(time.Now())
 			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
-			left := &operators.TestOperator{Series: testCase.leftSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.leftSeries)), MemoryConsumptionTracker: memoryConsumptionTracker}
+			left := &operators.TestOperator{Series: testCase.leftSeries, MemoryConsumptionTracker: memoryConsumptionTracker}
 			right := &operators.TestOperator{Series: testCase.rightSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.rightSeries)), MemoryConsumptionTracker: memoryConsumptionTracker}
 			vectorMatching := parser.VectorMatching{On: true, MatchingLabels: []string{"env"}}
 			o := NewAndUnlessBinaryOperation(left, right, vectorMatching, memoryConsumptionTracker, testCase.isUnless, timeRange, posrange.PositionRange{}, testCase.hints, log.NewNopLogger())

--- a/pkg/streamingpromql/operators/binops/and_unless_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/and_unless_binary_operation_test.go
@@ -42,7 +42,7 @@ func TestAndUnlessBinaryOperation_PassesHintMatchersToRHS(t *testing.T) {
 			},
 			rightSeries: []labels.Labels{
 				labels.FromStrings("env", "prod", "series", "right-1"),
-				labels.FromStrings("env", "staging", "series", "right-2"), // these labels will be filtered out by hint matcher becuase theyre not in RHS
+				labels.FromStrings("env", "staging", "series", "right-2"), // these labels will be filtered out by hint matcher because they're not in RHS
 			},
 			expectedRHSMatchers: types.Matchers{
 				{Type: labels.MatchRegexp, Name: "env", Value: "prod"},

--- a/pkg/streamingpromql/operators/binops/and_unless_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/and_unless_binary_operation_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/log"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/promql/parser/posrange"
@@ -315,7 +316,7 @@ func TestAndUnlessBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *tes
 			left := &operators.TestOperator{Series: testCase.leftSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.leftSeries)), MemoryConsumptionTracker: memoryConsumptionTracker}
 			right := &operators.TestOperator{Series: testCase.rightSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.rightSeries)), MemoryConsumptionTracker: memoryConsumptionTracker}
 			vectorMatching := parser.VectorMatching{On: true, MatchingLabels: []string{"group"}}
-			o := NewAndUnlessBinaryOperation(left, right, vectorMatching, memoryConsumptionTracker, testCase.isUnless, timeRange, posrange.PositionRange{})
+			o := NewAndUnlessBinaryOperation(left, right, vectorMatching, memoryConsumptionTracker, testCase.isUnless, timeRange, posrange.PositionRange{}, nil, log.NewNopLogger())
 
 			outputSeries, err := o.SeriesMetadata(ctx, nil)
 			require.NoError(t, err)
@@ -450,7 +451,7 @@ func TestAndUnlessBinaryOperation_ReleasesIntermediateStateIfClosedEarly(t *test
 					left := &operators.TestOperator{Series: testCase.leftSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.leftSeries)), MemoryConsumptionTracker: memoryConsumptionTracker}
 					right := &operators.TestOperator{Series: testCase.rightSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.rightSeries)), MemoryConsumptionTracker: memoryConsumptionTracker}
 					vectorMatching := parser.VectorMatching{On: true, MatchingLabels: []string{"group"}}
-					o := NewAndUnlessBinaryOperation(left, right, vectorMatching, memoryConsumptionTracker, isUnless, timeRange, posrange.PositionRange{})
+					o := NewAndUnlessBinaryOperation(left, right, vectorMatching, memoryConsumptionTracker, isUnless, timeRange, posrange.PositionRange{}, nil, log.NewNopLogger())
 
 					outputSeries, err := o.SeriesMetadata(ctx, nil)
 					require.NoError(t, err)

--- a/pkg/streamingpromql/operators/binops/and_unless_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/and_unless_binary_operation_test.go
@@ -19,6 +19,116 @@ import (
 	"github.com/grafana/mimir/pkg/util/limiter"
 )
 
+func TestAndUnlessBinaryOperation_PassesHintMatchersToRHS(t *testing.T) {
+	// Test that when hints are provided, matchers derived from the LHS series' label values are
+	// passed to the RHS SeriesMetadata call to narrow what the RHS fetches. When hints are nil,
+	// the RHS receives nil matchers (which is what happened before).
+	testCases := map[string]struct {
+		isUnless bool
+		hints    *Hints
+
+		leftSeries  []labels.Labels
+		rightSeries []labels.Labels
+
+		expectedRHSMatchers  types.Matchers
+		expectedOutputSeries []labels.Labels
+	}{
+		"and op with hints: RHS receives matcher derived from LHS label values, filtering non-matching RHS series": {
+			isUnless: false,
+			hints:    &Hints{Include: []string{"env"}},
+			leftSeries: []labels.Labels{
+				labels.FromStrings("env", "prod", "series", "left-1"),
+				labels.FromStrings("env", "prod", "series", "left-2"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("env", "prod", "series", "right-1"),
+				labels.FromStrings("env", "staging", "series", "right-2"), // these labels will be filtered out by hint matcher becuase theyre not in RHS
+			},
+			expectedRHSMatchers: types.Matchers{
+				{Type: labels.MatchRegexp, Name: "env", Value: "prod"},
+			},
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("env", "prod", "series", "left-1"),
+				labels.FromStrings("env", "prod", "series", "left-2"),
+			},
+		},
+		"unless op with hints: RHS receives matchers for all LHS env values; RHS series not in LHS env values are filtered out": {
+			isUnless: true,
+			hints:    &Hints{Include: []string{"env"}},
+			leftSeries: []labels.Labels{
+				labels.FromStrings("env", "prod", "series", "left-1"),
+				labels.FromStrings("env", "staging", "series", "left-2"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("env", "prod", "series", "right-1"),
+				labels.FromStrings("env", "dev", "series", "right-2"), // filtered out by hint matcher like above
+			},
+			expectedRHSMatchers: types.Matchers{
+				{Type: labels.MatchRegexp, Name: "env", Value: "prod|staging"},
+			},
+			// the SeriesMetadata for unless should always returns all of the LHS series, filtering happens in a different part of the pipeline
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("env", "prod", "series", "left-1"),
+				labels.FromStrings("env", "staging", "series", "left-2"),
+			},
+		},
+		"and op with no hints: RHS receives nil matchers": {
+			isUnless: false,
+			hints:    nil,
+			leftSeries: []labels.Labels{
+				labels.FromStrings("env", "prod", "series", "left-1"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("env", "prod", "series", "right-1"),
+			},
+			expectedRHSMatchers: nil,
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("env", "prod", "series", "left-1"),
+			},
+		},
+		"unless op with no hints: RHS receives nil matchers": {
+			isUnless: true,
+			hints:    nil,
+			leftSeries: []labels.Labels{
+				labels.FromStrings("env", "prod", "series", "left-1"),
+				labels.FromStrings("env", "staging", "series", "left-2"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("env", "prod", "series", "right-1"),
+			},
+			expectedRHSMatchers: nil,
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("env", "prod", "series", "left-1"),
+				// the SeriesMetadata for unless should always returns all of the LHS series, filtering happens in a different part of the pipeline
+				labels.FromStrings("env", "staging", "series", "left-2"),
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			timeRange := types.NewInstantQueryTimeRange(time.Now())
+			memoryConsumptionTracker := limiter.NewMemoryConsumptionTracker(ctx, 0, nil, "")
+			left := &operators.TestOperator{Series: testCase.leftSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.leftSeries)), MemoryConsumptionTracker: memoryConsumptionTracker}
+			right := &operators.TestOperator{Series: testCase.rightSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.rightSeries)), MemoryConsumptionTracker: memoryConsumptionTracker}
+			vectorMatching := parser.VectorMatching{On: true, MatchingLabels: []string{"env"}}
+			o := NewAndUnlessBinaryOperation(left, right, vectorMatching, memoryConsumptionTracker, testCase.isUnless, timeRange, posrange.PositionRange{}, testCase.hints, log.NewNopLogger())
+
+			outputSeries, err := o.SeriesMetadata(ctx, nil)
+			require.NoError(t, err)
+
+			require.Equal(t, testCase.expectedRHSMatchers, right.MatchersProvided, "matchers passed to RHS")
+
+			require.Equal(t, testutils.LabelsToSeriesMetadata(testCase.expectedOutputSeries), outputSeries)
+
+			types.SeriesMetadataSlicePool.Put(&outputSeries, memoryConsumptionTracker)
+			require.NoError(t, o.Finalize(ctx))
+			o.Close()
+		})
+	}
+}
+
 func TestAndUnlessBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *testing.T) {
 	testCases := map[string]struct {
 		isUnless    bool

--- a/pkg/streamingpromql/optimize/plan/narrow_selectors.go
+++ b/pkg/streamingpromql/optimize/plan/narrow_selectors.go
@@ -17,8 +17,7 @@ import (
 )
 
 var disallowedOperations = map[core.BinaryOperation]struct{}{
-	core.BINARY_LOR:     {},
-	core.BINARY_LUNLESS: {},
+	core.BINARY_LOR: {},
 }
 
 // NarrowSelectorsOptimizationPass examines a QueryPlan to determine if there are any

--- a/pkg/streamingpromql/optimize/plan/narrow_selectors_test.go
+++ b/pkg/streamingpromql/optimize/plan/narrow_selectors_test.go
@@ -427,19 +427,19 @@ func TestNarrowSelectorsOptimizationPass(t *testing.T) {
 			expectedAttempts: 1,
 			expectedModified: 0,
 		},
-		"logical unless binary expression should not have hints added": {
+		"logical unless binary expression should have hints added": {
 			expr: `
 				first_metric
 				unless on (env, region)
 				second_metric
 			`,
 			expectedPlan: `
-				- BinaryExpression: LHS unless on (env, region) RHS
+				- BinaryExpression: LHS unless on (env, region) RHS, hints (env, region)
 					- LHS: VectorSelector: {__name__="first_metric"}
 					- RHS: VectorSelector: {__name__="second_metric"}
 			`,
 			expectedAttempts: 1,
-			expectedModified: 0,
+			expectedModified: 1,
 		},
 	}
 

--- a/pkg/streamingpromql/planning/core/binary_expression.go
+++ b/pkg/streamingpromql/planning/core/binary_expression.go
@@ -254,7 +254,7 @@ func (b *BinaryExpression) getChildOperator(node planning.Node, timeRange types.
 func (b *BinaryExpression) createVectorVectorOperator(lhs, rhs types.InstantVectorOperator, op parser.ItemType, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (types.InstantVectorOperator, error) {
 	switch op {
 	case parser.LAND, parser.LUNLESS:
-		return binops.NewAndUnlessBinaryOperation(lhs, rhs, *b.VectorMatching.ToPrometheusType(), params.MemoryConsumptionTracker, op == parser.LUNLESS, timeRange, b.GetExpressionPosition().ToPrometheusType()), nil
+		return binops.NewAndUnlessBinaryOperation(lhs, rhs, *b.VectorMatching.ToPrometheusType(), params.MemoryConsumptionTracker, op == parser.LUNLESS, timeRange, b.GetExpressionPosition().ToPrometheusType(), b.Hints.ToOperatorType(), params.Logger), nil
 	case parser.LOR:
 		return binops.NewOrBinaryOperation(lhs, rhs, *b.VectorMatching.ToPrometheusType(), params.MemoryConsumptionTracker, timeRange, b.GetExpressionPosition().ToPrometheusType()), nil
 	default:

--- a/pkg/streamingpromql/testdata/ours/binary_operators.test
+++ b/pkg/streamingpromql/testdata/ours/binary_operators.test
@@ -1870,3 +1870,28 @@ load 1m
 
 eval instant at 0m c * on(region) (a unless on(zone) b)
   # a{region=us,zone=1} is suppressed by b{region=eu,zone=1} matching on zone=1 → inner returns empty → no result
+
+clear
+
+# Test that the hints-based narrowing optimisation for 'and'/'unless' produces correct results
+# when the RHS contains series whose matching-label values are absent from the LHS.
+# The optimisation builds a matcher from LHS label values (e.g. env=~"prod") and passes it to
+# the RHS, which should filter out irrelevant RHS series without affecting correctness.
+load 6m
+  left{env="prod",  pod="a"} 1 2 3 4
+  left{env="prod",  pod="b"} 5 6 7 8
+  right{env="prod",    idx="1"} 10 _ 30 _
+  right{env="staging", idx="2"} _  _ _  _
+
+# and on(env): env="staging" RHS series is narrowed away by hint matcher, but the result is
+# identical to what it would be without narrowing (env="staging" would never match LHS anyway).
+# RHS right{env="prod"} has data at t=0 and t=12 only, so those are the only steps returned.
+eval range from 0 to 18m step 6m left and on(env) right
+  left{env="prod", pod="a"} 1 _ 3 _
+  left{env="prod", pod="b"} 5 _ 7 _
+
+# unless on(env): same narrowing applies; env="prod" LHS series are suppressed at steps where
+# env="prod" RHS has data (t=0, t=12), and returned at steps where it doesn't (t=6, t=18).
+eval range from 0 to 18m step 6m left unless on(env) right
+  left{env="prod", pod="a"} _ 2 _ 4
+  left{env="prod", pod="b"} _ 6 _ 8


### PR DESCRIPTION
#### What this PR does
This PR enables narrow selectors optimisation pass for and/unless binary operations and passes hints down to hopefully reduce some data fetching. This optimisation already existed for `and`, this just makes it work for `unless` too.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes query-planning and `and`/`unless` series-metadata fetching to add and apply hints-based RHS matcher narrowing, which could affect query correctness or performance if matcher derivation is wrong. Test coverage is expanded, but this touches core query execution paths.
> 
> **Overview**
> Enables the *narrow selectors* optimization for logical `unless` (in addition to existing support), allowing binary expressions to carry hints for `and`/`unless`.
> 
> Updates `AndUnlessBinaryOperation` to accept hints and a logger, derive additional RHS matchers from LHS series metadata via `BuildMatchers`, and pass those matchers to the RHS `SeriesMetadata` call (with debug logging) to reduce unnecessary RHS data fetches without applying parent matchers.
> 
> Adds unit tests and promql testdata to verify RHS matcher passing and correctness for `and`/`unless`, including cases where RHS has extra label values; updates planner tests and `CHANGELOG.md` accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 030a53598db170944a932200ec55311069ca99b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->