### PR TITLE
Querier: fix HPA scaling and MimirAutoscalerKedaFailing alert misfiring when traffic not routed yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [ENHANCEMENT] MQE: Simplify `unless` and `or` operations where one side can be proven to be empty by inspecting the expression. #15198
 * [BUGFIX] Ingest storage: Fix `KafkaProducer.ProduceSync()` returning a single result with a nil record when the context is canceled, instead of one result per input record (with the record set) as the underlying franz-go client does. #15199
 * [BUGFIX] Distributor: Return HTTP 200 with OTLP partial-success when only some samples in an OTLP request are rejected by distributor-level validation (e.g. `too_far_in_past`). #15253
+* [BUGFIX] Querier: Fix querier ScaledObjects triggering `MimirAutoscalerKedaFailing` when queriers have no traffic because `cortex_querier_request_duration_seconds_sum` is not published until the first request is received. #15106
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * [ENHANCEMENT] MQE: Simplify `unless` and `or` operations where one side can be proven to be empty by inspecting the expression. #15198
 * [BUGFIX] Ingest storage: Fix `KafkaProducer.ProduceSync()` returning a single result with a nil record when the context is canceled, instead of one result per input record (with the record set) as the underlying franz-go client does. #15199
 * [BUGFIX] Distributor: Return HTTP 200 with OTLP partial-success when only some samples in an OTLP request are rejected by distributor-level validation (e.g. `too_far_in_past`). #15253
-* [BUGFIX] Querier: Fix querier ScaledObjects triggering `MimirAutoscalerKedaFailing` when queriers have no traffic because `cortex_querier_request_duration_seconds_sum` is not published until the first request is received. #15106
+* [BUGFIX] Querier: Fix querier ScaledObjects native histogram querying and triggering `MimirAutoscalerKedaFailing` when queriers have no traffic because `cortex_querier_request_duration_seconds_sum` is not published until the first request is received. #15106
 
 ### Mixin
 

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -2119,20 +2119,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "7"
     name: cortex_querier_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "7"
-    name: cortex_querier_hpa_default_requests_duration_nh
     type: prometheus
   - metadata:
       ignoreNullValues: "false"

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -2127,6 +2127,15 @@ spec:
     type: prometheus
   - metadata:
       ignoreNullValues: "false"
+      metricName: cortex_querier_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "7"
+    name: cortex_querier_hpa_default_requests_duration_nh
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_7d_offset
       query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5"}[30m]
         offset 6d23h30m) >= 0) or vector(0))

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -2118,7 +2118,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "7"
     name: cortex_querier_hpa_default_requests_duration

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -2110,7 +2110,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "7"
     name: cortex_querier_hpa_default
@@ -2127,8 +2128,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_7d_offset
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5"}[30m]
-        offset 6d23h30m))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5"}[30m]
+        offset 6d23h30m) >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "7"
     name: cortex_querier_hpa_default_7d_offset

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -2110,7 +2110,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default
@@ -2127,8 +2128,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_7d_offset
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5"}[30m]
-        offset 6d23h30m))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5"}[30m]
+        offset 6d23h30m) >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default_7d_offset

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -2118,7 +2118,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -2127,6 +2127,15 @@ spec:
     type: prometheus
   - metadata:
       ignoreNullValues: "false"
+      metricName: cortex_querier_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_hpa_default_requests_duration_nh
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_7d_offset
       query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5"}[30m]
         offset 6d23h30m) >= 0) or vector(0))

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -2119,20 +2119,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_hpa_default_requests_duration_nh
     type: prometheus
   - metadata:
       ignoreNullValues: "false"

--- a/operations/mimir-tests/test-multi-az-read-path-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-generated.yaml
@@ -4986,7 +4986,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
@@ -5033,7 +5034,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration

--- a/operations/mimir-tests/test-multi-az-read-path-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-generated.yaml
@@ -4987,20 +4987,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_zone_a_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_zone_a_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
@@ -5045,20 +5048,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_zone_b_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_zone_b_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-multi-az-read-path-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-generated.yaml
@@ -4993,6 +4993,15 @@ spec:
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_zone_a_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_zone_a_hpa_default_requests_duration_nh
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -5041,6 +5050,15 @@ spec:
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_zone_b_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_zone_b_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-multi-az-read-path-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-generated.yaml
@@ -4978,7 +4978,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default
@@ -5026,7 +5027,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-0-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-0-generated.yaml
@@ -3549,7 +3549,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-0-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-0-generated.yaml
@@ -3550,20 +3550,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-0-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-0-generated.yaml
@@ -3541,7 +3541,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-0-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-0-generated.yaml
@@ -3556,6 +3556,15 @@ spec:
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_hpa_default_requests_duration_nh
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-1-generated.yaml
@@ -6173,7 +6173,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
@@ -6220,7 +6221,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
@@ -6267,7 +6269,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-1-generated.yaml
@@ -6165,7 +6165,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod!~"(querier|query-scheduler)-zone.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default
@@ -6213,7 +6214,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default
@@ -6261,7 +6263,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-1-generated.yaml
@@ -6180,6 +6180,15 @@ spec:
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_hpa_default_requests_duration_nh
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -6229,6 +6238,15 @@ spec:
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_zone_a_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_zone_a_hpa_default_requests_duration_nh
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -6277,6 +6295,15 @@ spec:
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_zone_b_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_zone_b_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-1-generated.yaml
@@ -6174,20 +6174,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
@@ -6232,20 +6235,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_zone_a_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_zone_a_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
@@ -6290,20 +6296,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_zone_b_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_zone_b_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2-generated.yaml
@@ -6555,6 +6555,15 @@ spec:
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_hpa_default_requests_duration_nh
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -6604,6 +6613,15 @@ spec:
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_zone_a_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_zone_a_hpa_default_requests_duration_nh
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -6652,6 +6670,15 @@ spec:
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_zone_b_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_zone_b_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2-generated.yaml
@@ -6548,7 +6548,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
@@ -6595,7 +6596,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
@@ -6642,7 +6644,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2-generated.yaml
@@ -6549,20 +6549,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
@@ -6607,20 +6610,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_zone_a_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_zone_a_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
@@ -6665,20 +6671,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_zone_b_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_zone_b_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2-generated.yaml
@@ -6540,7 +6540,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod!~"(querier|query-scheduler)-zone.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default
@@ -6588,7 +6589,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default
@@ -6636,7 +6638,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2a-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2a-generated.yaml
@@ -6555,6 +6555,15 @@ spec:
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_hpa_default_requests_duration_nh
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -6604,6 +6613,15 @@ spec:
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_zone_a_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_zone_a_hpa_default_requests_duration_nh
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -6652,6 +6670,15 @@ spec:
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_zone_b_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_zone_b_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2a-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2a-generated.yaml
@@ -6548,7 +6548,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
@@ -6595,7 +6596,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
@@ -6642,7 +6644,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2a-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2a-generated.yaml
@@ -6549,20 +6549,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
@@ -6607,20 +6610,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_zone_a_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_zone_a_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
@@ -6665,20 +6671,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_zone_b_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_zone_b_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2a-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2a-generated.yaml
@@ -6540,7 +6540,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod!~"(querier|query-scheduler)-zone.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default
@@ -6588,7 +6589,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default
@@ -6636,7 +6638,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2b-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2b-generated.yaml
@@ -6553,20 +6553,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
@@ -6611,20 +6614,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_zone_a_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_zone_a_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
@@ -6669,20 +6675,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_zone_b_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_zone_b_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2b-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2b-generated.yaml
@@ -6544,7 +6544,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod!~"(querier|query-scheduler)-zone.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default
@@ -6592,7 +6593,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default
@@ -6640,7 +6642,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2b-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2b-generated.yaml
@@ -6559,6 +6559,15 @@ spec:
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_hpa_default_requests_duration_nh
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -6608,6 +6617,15 @@ spec:
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_zone_a_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_zone_a_hpa_default_requests_duration_nh
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -6656,6 +6674,15 @@ spec:
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_zone_b_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_zone_b_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2b-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2b-generated.yaml
@@ -6552,7 +6552,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
@@ -6599,7 +6600,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
@@ -6646,7 +6648,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2c-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2c-generated.yaml
@@ -6553,20 +6553,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
@@ -6611,20 +6614,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_zone_a_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_zone_a_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
@@ -6669,20 +6675,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_zone_b_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_zone_b_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2c-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2c-generated.yaml
@@ -6544,7 +6544,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod!~"(querier|query-scheduler)-zone.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default
@@ -6592,7 +6593,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default
@@ -6640,7 +6642,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2c-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2c-generated.yaml
@@ -6559,6 +6559,15 @@ spec:
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_hpa_default_requests_duration_nh
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -6608,6 +6617,15 @@ spec:
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_zone_a_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_zone_a_hpa_default_requests_duration_nh
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -6656,6 +6674,15 @@ spec:
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_zone_b_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_zone_b_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2c-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2c-generated.yaml
@@ -6552,7 +6552,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
@@ -6599,7 +6600,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
@@ -6646,7 +6648,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2d-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2d-generated.yaml
@@ -6565,20 +6565,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
@@ -6623,20 +6626,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_zone_a_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_zone_a_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
@@ -6681,20 +6687,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_zone_b_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_zone_b_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2d-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2d-generated.yaml
@@ -6564,7 +6564,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
@@ -6611,7 +6612,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
@@ -6658,7 +6660,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2d-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2d-generated.yaml
@@ -6571,6 +6571,15 @@ spec:
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_hpa_default_requests_duration_nh
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -6620,6 +6629,15 @@ spec:
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_zone_a_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_zone_a_hpa_default_requests_duration_nh
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -6668,6 +6686,15 @@ spec:
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_zone_b_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_zone_b_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2d-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2d-generated.yaml
@@ -6556,7 +6556,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod!~"(querier|query-scheduler)-zone.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default
@@ -6604,7 +6605,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default
@@ -6652,7 +6654,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2e-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2e-generated.yaml
@@ -6382,7 +6382,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod!~"(querier|query-scheduler)-zone.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default
@@ -6430,7 +6431,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default
@@ -6478,7 +6480,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2e-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2e-generated.yaml
@@ -6390,7 +6390,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
@@ -6437,7 +6438,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
@@ -6484,7 +6486,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2e-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2e-generated.yaml
@@ -6397,6 +6397,15 @@ spec:
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_hpa_default_requests_duration_nh
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -6446,6 +6455,15 @@ spec:
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_zone_a_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_zone_a_hpa_default_requests_duration_nh
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -6494,6 +6512,15 @@ spec:
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_zone_b_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_zone_b_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2e-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2e-generated.yaml
@@ -6391,20 +6391,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
@@ -6449,20 +6452,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_zone_a_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_zone_a_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
@@ -6507,20 +6513,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_zone_b_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_zone_b_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2f-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2f-generated.yaml
@@ -6404,20 +6404,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
@@ -6462,20 +6465,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_zone_a_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_zone_a_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
@@ -6520,20 +6526,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_zone_b_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_zone_b_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2f-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2f-generated.yaml
@@ -6410,6 +6410,15 @@ spec:
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_hpa_default_requests_duration_nh
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -6459,6 +6468,15 @@ spec:
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_zone_a_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_zone_a_hpa_default_requests_duration_nh
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -6507,6 +6525,15 @@ spec:
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_zone_b_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_zone_b_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2f-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2f-generated.yaml
@@ -6403,7 +6403,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
@@ -6450,7 +6451,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
@@ -6497,7 +6499,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2f-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2f-generated.yaml
@@ -6395,7 +6395,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod!~"(querier|query-scheduler)-zone.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default
@@ -6443,7 +6444,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default
@@ -6491,7 +6493,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-3-generated.yaml
@@ -6416,7 +6416,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
@@ -6463,7 +6464,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
@@ -6510,7 +6512,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-3-generated.yaml
@@ -6423,6 +6423,15 @@ spec:
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_hpa_default_requests_duration_nh
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -6472,6 +6481,15 @@ spec:
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_zone_a_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_zone_a_hpa_default_requests_duration_nh
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -6520,6 +6538,15 @@ spec:
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_zone_b_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_zone_b_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-3-generated.yaml
@@ -6417,20 +6417,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
@@ -6475,20 +6478,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_zone_a_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_zone_a_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
@@ -6533,20 +6539,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_zone_b_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_zone_b_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-3-generated.yaml
@@ -6408,7 +6408,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod!~"(querier|query-scheduler)-zone.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default
@@ -6456,7 +6457,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default
@@ -6504,7 +6506,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-4-generated.yaml
@@ -6416,7 +6416,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
@@ -6463,7 +6464,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
@@ -6510,7 +6512,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-4-generated.yaml
@@ -6423,6 +6423,15 @@ spec:
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_hpa_default_requests_duration_nh
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -6472,6 +6481,15 @@ spec:
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_zone_a_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_zone_a_hpa_default_requests_duration_nh
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -6520,6 +6538,15 @@ spec:
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_zone_b_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_zone_b_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-4-generated.yaml
@@ -6417,20 +6417,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
@@ -6475,20 +6478,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_zone_a_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_zone_a_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
@@ -6533,20 +6539,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_zone_b_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_zone_b_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-4-generated.yaml
@@ -6408,7 +6408,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod!~"(querier|query-scheduler)-zone.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default
@@ -6456,7 +6457,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default
@@ -6504,7 +6506,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-5-generated.yaml
@@ -6732,7 +6732,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
@@ -6779,7 +6780,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
@@ -6826,7 +6828,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-5-generated.yaml
@@ -6739,6 +6739,15 @@ spec:
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_hpa_default_requests_duration_nh
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -6788,6 +6797,15 @@ spec:
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_zone_a_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_zone_a_hpa_default_requests_duration_nh
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -6836,6 +6854,15 @@ spec:
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_zone_b_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_zone_b_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-5-generated.yaml
@@ -6724,7 +6724,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod!~"(querier|query-scheduler)-zone.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default
@@ -6772,7 +6773,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default
@@ -6820,7 +6822,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-5-generated.yaml
@@ -6733,20 +6733,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
@@ -6791,20 +6794,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_zone_a_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_zone_a_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
@@ -6849,20 +6855,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_zone_b_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_zone_b_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-6-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-6-generated.yaml
@@ -6732,7 +6732,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
@@ -6779,7 +6780,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
@@ -6826,7 +6828,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-6-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-6-generated.yaml
@@ -6739,6 +6739,15 @@ spec:
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_hpa_default_requests_duration_nh
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -6788,6 +6797,15 @@ spec:
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_zone_a_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_zone_a_hpa_default_requests_duration_nh
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -6836,6 +6854,15 @@ spec:
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_zone_b_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_zone_b_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-6-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-6-generated.yaml
@@ -6724,7 +6724,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod!~"(querier|query-scheduler)-zone.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default
@@ -6772,7 +6773,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default
@@ -6820,7 +6822,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-6-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-6-generated.yaml
@@ -6733,20 +6733,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
@@ -6791,20 +6794,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_zone_a_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_zone_a_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
@@ -6849,20 +6855,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_zone_b_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_zone_b_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-7-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-7-generated.yaml
@@ -6588,7 +6588,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
@@ -6635,7 +6636,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
@@ -6682,7 +6684,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-7-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-7-generated.yaml
@@ -6595,6 +6595,15 @@ spec:
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_hpa_default_requests_duration_nh
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -6644,6 +6653,15 @@ spec:
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_zone_a_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_zone_a_hpa_default_requests_duration_nh
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -6692,6 +6710,15 @@ spec:
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_zone_b_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_zone_b_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-7-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-7-generated.yaml
@@ -6580,7 +6580,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod!~"(querier|query-scheduler)-zone.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default
@@ -6628,7 +6629,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default
@@ -6676,7 +6678,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-7-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-7-generated.yaml
@@ -6589,20 +6589,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod!~"(querier|query-scheduler)-zone.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
@@ -6647,20 +6650,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_zone_a_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_zone_a_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
@@ -6705,20 +6711,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_zone_b_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_zone_b_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-8-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-8-generated.yaml
@@ -5384,20 +5384,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_zone_a_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_zone_a_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
@@ -5442,20 +5445,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_zone_b_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_zone_b_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-8-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-8-generated.yaml
@@ -5375,7 +5375,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default
@@ -5423,7 +5424,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-8-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-8-generated.yaml
@@ -5390,6 +5390,15 @@ spec:
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_zone_a_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_zone_a_hpa_default_requests_duration_nh
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -5438,6 +5447,15 @@ spec:
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_zone_b_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_zone_b_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-8-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-8-generated.yaml
@@ -5383,7 +5383,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
@@ -5430,7 +5431,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-final-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-final-generated.yaml
@@ -5384,20 +5384,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_zone_a_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_zone_a_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
@@ -5442,20 +5445,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_zone_b_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_zone_b_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-final-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-final-generated.yaml
@@ -5375,7 +5375,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default
@@ -5423,7 +5424,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-final-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-final-generated.yaml
@@ -5390,6 +5390,15 @@ spec:
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_zone_a_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_zone_a_hpa_default_requests_duration_nh
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -5438,6 +5447,15 @@ spec:
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_zone_b_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_zone_b_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-final-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-final-generated.yaml
@@ -5383,7 +5383,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
@@ -5430,7 +5431,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration

--- a/operations/mimir-tests/test-range-vector-splitting-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-range-vector-splitting-multi-zone-generated.yaml
@@ -5243,6 +5243,15 @@ spec:
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
     type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_zone_a_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_zone_a_hpa_default_requests_duration_nh
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -5291,6 +5300,15 @@ spec:
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_querier_zone_b_hpa_default_requests_duration_nh
+      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])))
+        or vector(0))
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "6"
+    name: cortex_querier_zone_b_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-range-vector-splitting-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-range-vector-splitting-multi-zone-generated.yaml
@@ -5237,20 +5237,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_zone_a_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_zone_a_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
@@ -5295,20 +5298,23 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
-      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
-        or vector(0))
+      query: |
+        max without(source) (
+          # classic histograms; label_replace gives each a distinct label so or acts as union
+          label_replace(
+            sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])) or vector(0),
+            "source", "classic", "", ""
+          )
+          or
+          # native histograms
+          label_replace(
+            sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))) or vector(0),
+            "source", "native", "", ""
+          )
+        )
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration
-    type: prometheus
-  - metadata:
-      ignoreNullValues: "false"
-      metricName: cortex_querier_zone_b_hpa_default_requests_duration_nh
-      query: (sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])))
-        or vector(0))
-      serverAddress: http://prometheus.default:9090/prometheus
-      threshold: "6"
-    name: cortex_querier_zone_b_hpa_default_requests_duration_nh
     type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1

--- a/operations/mimir-tests/test-range-vector-splitting-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-range-vector-splitting-multi-zone-generated.yaml
@@ -5236,7 +5236,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default_requests_duration
@@ -5283,7 +5284,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default_requests_duration
-      query: sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(rate(cortex_querier_request_duration_seconds_sum{container="querier",namespace="default",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+        or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default_requests_duration

--- a/operations/mimir-tests/test-range-vector-splitting-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-range-vector-splitting-multi-zone-generated.yaml
@@ -5228,7 +5228,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_a_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-a.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_a_hpa_default
@@ -5276,7 +5277,8 @@ spec:
   - metadata:
       ignoreNullValues: "false"
       metricName: cortex_querier_zone_b_hpa_default
-      query: sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m]))
+      query: (sum(max_over_time(cortex_query_scheduler_inflight_requests{container="query-scheduler",namespace="default",quantile="0.5",pod=~"(querier|query-scheduler)-zone-b.*"}[1m])
+        >= 0) or vector(0))
       serverAddress: http://prometheus.default:9090/prometheus
       threshold: "6"
     name: cortex_querier_zone_b_hpa_default

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -220,7 +220,7 @@
             //
             // This metric covers the case queries are not necessarily piling up in the query-scheduler queue,
             // but queriers are busy.
-            query: queryWithWeight('sum(rate(cortex_querier_request_duration_seconds_sum{container="%(querier_container_name)s",namespace="%(namespace)s"%(extra_matchers)s}[1m]))' % queryParams, weight),
+            query: queryWithWeight('(sum(rate(cortex_querier_request_duration_seconds_sum{container="%(querier_container_name)s",namespace="%(namespace)s"%(extra_matchers)s}[1m])) or vector(0))' % queryParams, weight),
 
             threshold: '%d' % std.floor(querier_max_concurrent * target_utilization),
             // We only need to pass ignore_null_values if it's false

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -229,26 +229,21 @@
             // received traffic yet (e.g. during a migration before routing is switched).
             // Without it, the histogram counter is absent from Prometheus until the first request,
             // causing KEDA to error with ignoreNullValues=false and triggering MimirAutoscalerKedaFailing.
-            query: queryWithWeight('(sum(rate(cortex_querier_request_duration_seconds_sum{container="%(querier_container_name)s",namespace="%(namespace)s"%(extra_matchers)s}[1m])) or vector(0))' % queryParams, weight),
-
-            threshold: '%d' % std.floor(querier_max_concurrent * target_utilization),
-            // We only need to pass ignore_null_values if it's false
-            [if !ignore_null_values then 'ignore_null_values']: ignore_null_values,
-          },
-          {
-            metric_name: 'cortex_%s_hpa_%s_requests_duration_nh' % [std.strReplace(name, '-', '_'), $._config.namespace],
-
-            // The total requests duration / second is a good approximation of the number of querier workers used.
-            // This trigger uses the native histogram variant of the metric.
-            //
-            // This metric covers the case queries are not necessarily piling up in the query-scheduler queue,
-            // but queriers are busy.
-            //
-            // or vector(0) ensures KEDA receives a numeric result when queriers exist but have NOT
-            // received traffic yet (e.g. during a migration before routing is switched).
-            // Without it, the native histogram metric is absent from Prometheus until the first request,
-            // causing KEDA to error with ignoreNullValues=false and triggering MimirAutoscalerKedaFailing.
-            query: queryWithWeight('(sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="%(querier_container_name)s",namespace="%(namespace)s"%(extra_matchers)s}[1m]))) or vector(0))' % queryParams, weight),
+            query: queryWithWeight(|||
+              max without(source) (
+                # classic histograms; label_replace gives each a distinct label so or acts as union
+                label_replace(
+                  sum(rate(cortex_querier_request_duration_seconds_sum{container="%(querier_container_name)s",namespace="%(namespace)s"%(extra_matchers)s}[1m])) or vector(0),
+                  "source", "classic", "", ""
+                )
+                or
+                # native histograms
+                label_replace(
+                  sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="%(querier_container_name)s",namespace="%(namespace)s"%(extra_matchers)s}[1m]))) or vector(0),
+                  "source", "native", "", ""
+                )
+              )
+            ||| % queryParams, weight),
 
             threshold: '%d' % std.floor(querier_max_concurrent * target_utilization),
             // We only need to pass ignore_null_values if it's false

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -220,6 +220,11 @@
             //
             // This metric covers the case queries are not necessarily piling up in the query-scheduler queue,
             // but queriers are busy.
+            //
+            // or vector(0) ensures KEDA receives a numeric result when queriers exist but have NOT
+            // received traffic yet (e.g. during a migration before routing is switched).
+            // Without it, the histogram counter is absent from Prometheus until the first request,
+            // causing KEDA to error with ignoreNullValues=false and triggering MimirAutoscalerKedaFailing.
             query: queryWithWeight('(sum(rate(cortex_querier_request_duration_seconds_sum{container="%(querier_container_name)s",namespace="%(namespace)s"%(extra_matchers)s}[1m])) or vector(0))' % queryParams, weight),
 
             threshold: '%d' % std.floor(querier_max_concurrent * target_utilization),

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -235,6 +235,25 @@
             // We only need to pass ignore_null_values if it's false
             [if !ignore_null_values then 'ignore_null_values']: ignore_null_values,
           },
+          {
+            metric_name: 'cortex_%s_hpa_%s_requests_duration_nh' % [std.strReplace(name, '-', '_'), $._config.namespace],
+
+            // The total requests duration / second is a good approximation of the number of querier workers used.
+            // This trigger uses the native histogram variant of the metric.
+            //
+            // This metric covers the case queries are not necessarily piling up in the query-scheduler queue,
+            // but queriers are busy.
+            //
+            // or vector(0) ensures KEDA receives a numeric result when queriers exist but have NOT
+            // received traffic yet (e.g. during a migration before routing is switched).
+            // Without it, the native histogram metric is absent from Prometheus until the first request,
+            // causing KEDA to error with ignoreNullValues=false and triggering MimirAutoscalerKedaFailing.
+            query: queryWithWeight('(sum(histogram_sum(rate(cortex_querier_request_duration_seconds{container="%(querier_container_name)s",namespace="%(namespace)s"%(extra_matchers)s}[1m]))) or vector(0))' % queryParams, weight),
+
+            threshold: '%d' % std.floor(querier_max_concurrent * target_utilization),
+            // We only need to pass ignore_null_values if it's false
+            [if !ignore_null_values then 'ignore_null_values']: ignore_null_values,
+          },
         ]
         + if !$._config.autoscaling_querier_predictive_scaling_enabled then [] else [
           {

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -207,7 +207,11 @@
             // to have enough querier workers to run the max observed inflight requests 50% of time.
             //
             // This metric covers the case queries are piling up in the query-scheduler queue.
-            query: queryWithWeight('sum(max_over_time(cortex_query_scheduler_inflight_requests{container="%(query_scheduler_container_name)s",namespace="%(namespace)s",quantile="0.5"%(extra_matchers)s}[1m]))' % queryParams, weight),
+            //
+            // The Prometheus Summary emits NaN for quantile values before the first Observe() call.
+            // >= 0 drops NaN samples (any comparison with NaN is false) before sum, leaving an empty
+            // vector so that or vector(0) can replace it with 0, giving KEDA a well-defined value.
+            query: queryWithWeight('(sum(max_over_time(cortex_query_scheduler_inflight_requests{container="%(query_scheduler_container_name)s",namespace="%(namespace)s",quantile="0.5"%(extra_matchers)s}[1m]) >= 0) or vector(0))' % queryParams, weight),
 
             threshold: '%d' % std.floor(querier_max_concurrent * target_utilization),
             // We only need to pass ignore_null_values if it's false
@@ -238,7 +242,11 @@
 
             // Scale queriers according to how many queriers would have been sufficient to handle the load $period ago.
             // We use the query scheduler metric which includes active queries and queries in the queue.
-            query: queryWithWeight('sum(max_over_time(cortex_query_scheduler_inflight_requests{container="%(query_scheduler_container_name)s",namespace="%(namespace)s",quantile="0.5"%(extra_matchers)s}[%(lookback)s] offset %(period)s))' % (
+            //
+            // >= 0 drops NaN samples (emitted by the Prometheus Summary before the first Observe() call)
+            // before sum; or vector(0) handles the absent case when the zone is newer than the offset
+            // period, or when the lookback window aligns with the first NaN scrape at deployment time.
+            query: queryWithWeight('(sum(max_over_time(cortex_query_scheduler_inflight_requests{container="%(query_scheduler_container_name)s",namespace="%(namespace)s",quantile="0.5"%(extra_matchers)s}[%(lookback)s] offset %(period)s) >= 0) or vector(0))' % (
               queryParams {
                 lookback: $._config.autoscaling_querier_predictive_scaling_lookback,
                 period: $._config.autoscaling_querier_predictive_scaling_period,


### PR DESCRIPTION
#### What this PR does

##### Part 1 - Native Histogram support

When native histograms are used, the `ScaledObject` query needs to change from `sum(rate(...seconds_sum{}))` to `sum(histogram_sum(rate(..._seconds{})))` per https://prometheus.io/docs/practices/histograms/#count-and-sum-of-observations

Added an extra metric leg to query on. 

##### Part 2 - Fix misfiring alert when traffic not yet routed to zonal queriers

`cortex_querier_request_duration_seconds_sum` is a histogram counter that only emits once the querier receives its first request. 
During migration to the multi-az read path, querier zone `ScaledObjects` fail because this metric doesn't exist yet, and `ignoreNullValues=false` causes KEDA to error on empty results.

Adding `or vector(0)` to the PromQL query ensures KEDA always receives a numeric value (0 when no traffic) rather than an empty result. 
This keeps `ignoreNullValues=false` intact, so a Prometheus connectivity failure still causes a scaler error and the HPA freezes rather than making decisions on stale/missing data.

The first trigger (`cortex_query_scheduler_inflight_requests`) is a `Summary` observed every 250ms by the `query-scheduler`, so it emits quantile values immediately on startup and doesn't require this fix.

Scenario                        | Trigger 1 (inflight_requests) | Trigger 2 (duration + or vector(0))  | HPA
--------------------------------|-------------------------------|--------------------------------------|----
Migration, no traffic           | 0 (scheduler samples at idle) | 0 (metric missing, vector(0) fires)  | min_replicas
Normal operation                | actual load                   | actual rate                          | max → correct
Querier pods crash              | HIGH (requests pile up)       | 0 (metric disappears)                | max(HIGH, 0) → scale up
Prometheus down                 | connection error              | connection error                     | ScaledObject fails, HPA freezes (same as before)
Prometheus can't scrape querier | unchanged                     | stale → 0 after 5 min                | trigger 1 still reflects load
weight != 1                     | correctly multiplied          | (0) * w = 0                          | correct


#### Which issue(s) this PR fixes or relates to

HPA scaling support for Native Histograms.

Fixes mis-firing `MimirAutoscalerKedaFailing` alerts when traffic isn't yet routed to zonal queriers.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PromQL used by querier KEDA `ScaledObject` triggers, which can affect autoscaling behavior and alerting if the new queries behave unexpectedly across Prometheus versions and histogram types.
> 
> **Overview**
> Fixes querier autoscaling metrics used by KEDA to avoid `ScaledObject` failures and misfiring `MimirAutoscalerKedaFailing` when queriers have no traffic yet.
> 
> Updates the querier request-duration trigger to support *native histograms* (adds `histogram_sum(rate(cortex_querier_request_duration_seconds{...}))` alongside classic `..._sum`) and wraps both with `or vector(0)` so empty results resolve to 0.
> 
> Hardens query-scheduler inflight-request triggers (including predictive scaling offset queries) by filtering out pre-`Observe()` NaNs via `>= 0` and defaulting to 0 with `or vector(0)`, and regenerates the affected `operations/mimir-tests/*-generated.yaml` fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ad53e95574ce9e03ca72635c62c177fee0493a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->