### PR TITLE
chore: typo `nonexistant` -> `nonexistent` in alertmanager template test name

### DIFF
--- a/pkg/alertmanager/alertmanager_template_test.go
+++ b/pkg/alertmanager/alertmanager_template_test.go
@@ -117,7 +117,7 @@ func Test_loadTemplates(t *testing.T) {
 			exp:    "My Template 1",
 		},
 		{
-			name: "fails to reference nonexistant templates",
+			name: "fails to reference nonexistent templates",
 			loaded: []string{
 				`
 {{ define "my_tmpl_1" }}My Template 1{{ end }}


### PR DESCRIPTION
One-character typo fix inside `pkg/alertmanager/alertmanager_template_test.go:120` (test case name). No functional change.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes a test description string with no behavior or logic impact.
> 
> **Overview**
> Fixes a typo in `pkg/alertmanager/alertmanager_template_test.go` by renaming a test case from *nonexistant* to *nonexistent*; no functional changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a2ed5a1e50260438f1478cbabbcf778f5fbe26b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->