### PR TITLE
mixin: fix build failure when singleBinary is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -342,6 +342,7 @@
 * [BUGFIX] Dashboards: Fix issue where the "Tenant gateway requests" panels on Tenants dashboard would show data from all components. #13940
 * [BUGFIX] Dashboards: Fix issue where the MQE-related dashboard panels on the Queries dashboard would show data from both queriers and query-frontends, instead of just queriers. #14029
 * [BUGFIX] Alerts: Fix alert definitions with short range vector selectors that did not respect the configured `base_alerts_range_interval_minutes`. #15083
+* [BUGFIX] Dashboards: Fix mixin build failure when `singleBinary` is `true`. #15108
 
 ### Jsonnet
 

--- a/operations/mimir-mixin/dashboards/dashboard-queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-queries.libsonnet
@@ -28,8 +28,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
   // ncSumHistogramCountRateRatio builds native and classic queries for
   // sum(rate(<metric>_count{<selectors + extra_selector>}[ri])) / sum(rate(<metric>_count{<selectors>}[ri])).
   ncSumHistogramCountRateRatio(metric, selectors, extra_selector, rate_interval='$__rate_interval')::
-    local selectorsStr = $.toPrometheusSelector(selectors);
-    local extendedSelectorsStr = $.toPrometheusSelector(selectors + extra_selector);
+    local selectorsStr = utils.toPrometheusSelector(selectors);
+    local extendedSelectorsStr = utils.toPrometheusSelector(selectors + extra_selector);
     {
       classic: 'sum(rate(%(metric)s_count%(extendedSelectors)s[%(rateInterval)s])) /\nsum(rate(%(metric)s_count%(selectors)s[%(rateInterval)s]))' % {
         metric: metric,
@@ -48,7 +48,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
   // ncSumHistogramCountRate builds native and classic queries for
   // sum(rate(<metric>_count{<selectors>}[ri])).
   ncSumHistogramCountRate(metric, selectors, rate_interval='$__rate_interval')::
-    local selectorsStr = $.toPrometheusSelector(selectors);
+    local selectorsStr = utils.toPrometheusSelector(selectors);
     {
       classic: 'sum(rate(%(metric)s_count%(selectors)s[%(rateInterval)s]))' % {
         metric: metric,
@@ -65,7 +65,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
   ncAvgHistogramQuantile(quantile, metric, selectors, offset, rate_interval='$__rate_interval')::
     local labels = std.join('_', [matcher.label for matcher in selectors]);
     local metricStr = '%(labels)s:%(metric)s' % { labels: labels, metric: metric };
-    local selectorsStr = $.toPrometheusSelector(selectors);
+    local selectorsStr = utils.toPrometheusSelector(selectors);
     {
       classic: |||
         1 - (


### PR DESCRIPTION
#### What this PR does

The dashboard-queries helpers should use Mimir local `toPrometheusSelector` function, that is overwritten to support a special "noop" selector for a single binary build.

I've tested it by setting `$._config.singleBinary = true` and rebuilding the mixin.

#### Which issue(s) this PR fixes or relates to

Fixes #15069

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
