### PR TITLE
compactor scheduler: rework active and pending job metrics

### DIFF
--- a/pkg/compactor/scheduler/job_tracker_test.go
+++ b/pkg/compactor/scheduler/job_tracker_test.go
@@ -341,7 +341,8 @@ func TestJobTracker_Cleanup(t *testing.T) {
 	require.NoError(t, prom_testutil.GatherAndCompare(reg, strings.NewReader(`
 		# HELP cortex_compactor_scheduler_pending_jobs The number of queued pending jobs.
 		# TYPE cortex_compactor_scheduler_pending_jobs gauge
-		cortex_compactor_scheduler_pending_jobs 4
+		cortex_compactor_scheduler_pending_jobs{job_type="compaction"} 2
+		cortex_compactor_scheduler_pending_jobs{job_type="plan"} 2
 	`), "cortex_compactor_scheduler_pending_jobs"), "aggregate pending jobs across both tenants")
 
 	// Cleaning up tenant1 should only subtract its contribution, not zero the shared gauges.
@@ -355,7 +356,8 @@ func TestJobTracker_Cleanup(t *testing.T) {
 	require.NoError(t, prom_testutil.GatherAndCompare(reg, strings.NewReader(`
 		# HELP cortex_compactor_scheduler_pending_jobs The number of queued pending jobs.
 		# TYPE cortex_compactor_scheduler_pending_jobs gauge
-		cortex_compactor_scheduler_pending_jobs 2
+		cortex_compactor_scheduler_pending_jobs{job_type="compaction"} 1
+		cortex_compactor_scheduler_pending_jobs{job_type="plan"} 1
 	`), "cortex_compactor_scheduler_pending_jobs"), "aggregate pending jobs drops to tenant2's contribution")
 	require.NoError(t, prom_testutil.GatherAndCompare(reg, strings.NewReader(`
 		# HELP cortex_compactor_scheduler_incomplete_plan_jobs The total number of plan jobs that have not yet completed (pending or active).

--- a/pkg/compactor/scheduler/job_tracker_test.go
+++ b/pkg/compactor/scheduler/job_tracker_test.go
@@ -280,10 +280,10 @@ func TestJobTracker_PlanJobTracking(t *testing.T) {
 	assertIncompletePlanJobs := func(label string, expected int) {
 		t.Helper()
 		require.NoError(t, prom_testutil.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
-			# HELP cortex_compactor_incomplete_plan_jobs The total number of plan jobs that have not yet completed (pending or active).
-			# TYPE cortex_compactor_incomplete_plan_jobs gauge
-			cortex_compactor_incomplete_plan_jobs %d
-		`, expected)), "cortex_compactor_incomplete_plan_jobs"), label)
+			# HELP cortex_compactor_scheduler_incomplete_plan_jobs The total number of plan jobs that have not yet completed (pending or active).
+			# TYPE cortex_compactor_scheduler_incomplete_plan_jobs gauge
+			cortex_compactor_scheduler_incomplete_plan_jobs %d
+		`, expected)), "cortex_compactor_scheduler_incomplete_plan_jobs"), label)
 	}
 
 	assertIncompletePlanJobs("no plan jobs yet", 0)
@@ -334,24 +334,34 @@ func TestJobTracker_Cleanup(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, prom_testutil.GatherAndCompare(reg, strings.NewReader(`
-		# HELP cortex_compactor_incomplete_plan_jobs The total number of plan jobs that have not yet completed (pending or active).
-		# TYPE cortex_compactor_incomplete_plan_jobs gauge
-		cortex_compactor_incomplete_plan_jobs 2
-	`), "cortex_compactor_incomplete_plan_jobs"), "both tenants have a pending plan job")
+		# HELP cortex_compactor_scheduler_incomplete_plan_jobs The total number of plan jobs that have not yet completed (pending or active).
+		# TYPE cortex_compactor_scheduler_incomplete_plan_jobs gauge
+		cortex_compactor_scheduler_incomplete_plan_jobs 2
+	`), "cortex_compactor_scheduler_incomplete_plan_jobs"), "both tenants have a pending plan job")
+	require.NoError(t, prom_testutil.GatherAndCompare(reg, strings.NewReader(`
+		# HELP cortex_compactor_scheduler_pending_jobs The number of queued pending jobs.
+		# TYPE cortex_compactor_scheduler_pending_jobs gauge
+		cortex_compactor_scheduler_pending_jobs 4
+	`), "cortex_compactor_scheduler_pending_jobs"), "aggregate pending jobs across both tenants")
 
 	// Cleaning up tenant1 should only subtract its contribution, not zero the shared gauges.
 	jt1.CleanupMetrics()
 	assertTrackerBytes(t, reg, "only tenant1 bytes removed", 0, 200)
 	require.NoError(t, prom_testutil.GatherAndCompare(reg, strings.NewReader(`
+		# HELP cortex_compactor_scheduler_pending_jobs_by_user The number of queued pending jobs, broken down by user.
+		# TYPE cortex_compactor_scheduler_pending_jobs_by_user gauge
+		cortex_compactor_scheduler_pending_jobs_by_user{user="tenant2"} 2
+	`), "cortex_compactor_scheduler_pending_jobs_by_user"), "only tenant2 pending jobs remain")
+	require.NoError(t, prom_testutil.GatherAndCompare(reg, strings.NewReader(`
 		# HELP cortex_compactor_scheduler_pending_jobs The number of queued pending jobs.
 		# TYPE cortex_compactor_scheduler_pending_jobs gauge
-		cortex_compactor_scheduler_pending_jobs{user="tenant2"} 2
-	`), "cortex_compactor_scheduler_pending_jobs"), "only tenant2 pending jobs remain")
+		cortex_compactor_scheduler_pending_jobs 2
+	`), "cortex_compactor_scheduler_pending_jobs"), "aggregate pending jobs drops to tenant2's contribution")
 	require.NoError(t, prom_testutil.GatherAndCompare(reg, strings.NewReader(`
-		# HELP cortex_compactor_incomplete_plan_jobs The total number of plan jobs that have not yet completed (pending or active).
-		# TYPE cortex_compactor_incomplete_plan_jobs gauge
-		cortex_compactor_incomplete_plan_jobs 1
-	`), "cortex_compactor_incomplete_plan_jobs"), "only tenant2 plan job remains")
+		# HELP cortex_compactor_scheduler_incomplete_plan_jobs The total number of plan jobs that have not yet completed (pending or active).
+		# TYPE cortex_compactor_scheduler_incomplete_plan_jobs gauge
+		cortex_compactor_scheduler_incomplete_plan_jobs 1
+	`), "cortex_compactor_scheduler_incomplete_plan_jobs"), "only tenant2 plan job remains")
 }
 
 func TestJobTracker_CancelLease_PlanJobAlwaysRevives(t *testing.T) {

--- a/pkg/compactor/scheduler/job_tracker_test.go
+++ b/pkg/compactor/scheduler/job_tracker_test.go
@@ -277,36 +277,41 @@ func TestJobTracker_PlanJobTracking(t *testing.T) {
 	clk.Set(at(3, 0))
 	jt, reg := newTestJobTracker(clk)
 
-	assertIncompletePlanJobs := func(label string, expected int) {
+	assertPlanJobLocation := func(label string, pending, active int) {
 		t.Helper()
 		require.NoError(t, prom_testutil.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
-			# HELP cortex_compactor_scheduler_incomplete_plan_jobs The total number of plan jobs that have not yet completed (pending or active).
-			# TYPE cortex_compactor_scheduler_incomplete_plan_jobs gauge
-			cortex_compactor_scheduler_incomplete_plan_jobs %d
-		`, expected)), "cortex_compactor_scheduler_incomplete_plan_jobs"), label)
+			# HELP cortex_compactor_scheduler_pending_jobs The number of queued pending jobs.
+			# TYPE cortex_compactor_scheduler_pending_jobs gauge
+			cortex_compactor_scheduler_pending_jobs{job_type="compaction"} 0
+			cortex_compactor_scheduler_pending_jobs{job_type="plan"} %d
+			# HELP cortex_compactor_scheduler_active_jobs The number of jobs active in workers.
+			# TYPE cortex_compactor_scheduler_active_jobs gauge
+			cortex_compactor_scheduler_active_jobs{job_type="compaction"} 0
+			cortex_compactor_scheduler_active_jobs{job_type="plan"} %d
+		`, pending, active)), "cortex_compactor_scheduler_pending_jobs", "cortex_compactor_scheduler_active_jobs"), label)
 	}
 
-	assertIncompletePlanJobs("no plan jobs yet", 0)
+	assertPlanJobLocation("no plan jobs yet", 0, 0)
 
 	_, err := jt.Maintenance(time.Minute, false, true, time.Hour, 0)
 	require.NoError(t, err)
-	assertIncompletePlanJobs("plan job pending", 1)
+	assertPlanJobLocation("plan job pending", 1, 0)
 
 	leaseResp, _, err := jt.Lease()
 	require.NoError(t, err)
 	require.Equal(t, planJobId, leaseResp.Key.Id)
-	assertIncompletePlanJobs("plan job active (still incomplete)", 1)
+	assertPlanJobLocation("plan job active", 0, 1)
 
 	canceled, _, err := jt.CancelLease(leaseResp.Key.Id, leaseResp.Key.Epoch)
 	require.NoError(t, err)
 	require.True(t, canceled)
-	assertIncompletePlanJobs("plan job revived to pending (unchanged)", 1)
+	assertPlanJobLocation("plan job revived to pending", 1, 0)
 
 	leaseResp, _, err = jt.Lease()
 	require.NoError(t, err)
 	_, _, err = jt.Remove(leaseResp.Key.Id, leaseResp.Key.Epoch, true)
 	require.NoError(t, err)
-	assertIncompletePlanJobs("plan job complete", 0)
+	assertPlanJobLocation("plan job complete", 0, 0)
 }
 
 func TestJobTracker_Cleanup(t *testing.T) {
@@ -314,7 +319,7 @@ func TestJobTracker_Cleanup(t *testing.T) {
 	reg := prometheus.NewPedanticRegistry()
 	sm := newSchedulerMetrics(reg)
 
-	// Two tenants share the same incompleteJobsBytes and incompletePlanJobs gauges.
+	// Two tenants share the same aggregate gauges (incompleteJobsBytes, pendingJobs, activeJobs).
 	jt1 := NewJobTracker(&NopJobPersister{}, "tenant1", clk, infiniteLeases, infiniteLeases, sm.newTrackerMetricsForTenant("tenant1"), log.NewNopLogger())
 	jt2 := NewJobTracker(&NopJobPersister{}, "tenant2", clk, infiniteLeases, infiniteLeases, sm.newTrackerMetricsForTenant("tenant2"), log.NewNopLogger())
 
@@ -333,11 +338,6 @@ func TestJobTracker_Cleanup(t *testing.T) {
 	_, err = jt2.Maintenance(time.Minute, false, true, time.Hour, 0)
 	require.NoError(t, err)
 
-	require.NoError(t, prom_testutil.GatherAndCompare(reg, strings.NewReader(`
-		# HELP cortex_compactor_scheduler_incomplete_plan_jobs The total number of plan jobs that have not yet completed (pending or active).
-		# TYPE cortex_compactor_scheduler_incomplete_plan_jobs gauge
-		cortex_compactor_scheduler_incomplete_plan_jobs 2
-	`), "cortex_compactor_scheduler_incomplete_plan_jobs"), "both tenants have a pending plan job")
 	require.NoError(t, prom_testutil.GatherAndCompare(reg, strings.NewReader(`
 		# HELP cortex_compactor_scheduler_pending_jobs The number of queued pending jobs.
 		# TYPE cortex_compactor_scheduler_pending_jobs gauge
@@ -359,11 +359,6 @@ func TestJobTracker_Cleanup(t *testing.T) {
 		cortex_compactor_scheduler_pending_jobs{job_type="compaction"} 1
 		cortex_compactor_scheduler_pending_jobs{job_type="plan"} 1
 	`), "cortex_compactor_scheduler_pending_jobs"), "aggregate pending jobs drops to tenant2's contribution")
-	require.NoError(t, prom_testutil.GatherAndCompare(reg, strings.NewReader(`
-		# HELP cortex_compactor_scheduler_incomplete_plan_jobs The total number of plan jobs that have not yet completed (pending or active).
-		# TYPE cortex_compactor_scheduler_incomplete_plan_jobs gauge
-		cortex_compactor_scheduler_incomplete_plan_jobs 1
-	`), "cortex_compactor_scheduler_incomplete_plan_jobs"), "only tenant2 plan job remains")
 }
 
 func TestJobTracker_CancelLease_PlanJobAlwaysRevives(t *testing.T) {

--- a/pkg/compactor/scheduler/job_tracker_test.go
+++ b/pkg/compactor/scheduler/job_tracker_test.go
@@ -338,12 +338,22 @@ func TestJobTracker_Cleanup(t *testing.T) {
 	_, err = jt2.Maintenance(time.Minute, false, true, time.Hour, 0)
 	require.NoError(t, err)
 
+	// Lease both of tenant1's jobs
+	for range 2 {
+		_, _, err := jt1.Lease()
+		require.NoError(t, err)
+	}
+
 	require.NoError(t, prom_testutil.GatherAndCompare(reg, strings.NewReader(`
 		# HELP cortex_compactor_scheduler_pending_jobs The number of queued pending jobs.
 		# TYPE cortex_compactor_scheduler_pending_jobs gauge
-		cortex_compactor_scheduler_pending_jobs{job_type="compaction"} 2
-		cortex_compactor_scheduler_pending_jobs{job_type="plan"} 2
-	`), "cortex_compactor_scheduler_pending_jobs"), "aggregate pending jobs across both tenants")
+		cortex_compactor_scheduler_pending_jobs{job_type="compaction"} 1
+		cortex_compactor_scheduler_pending_jobs{job_type="plan"} 1
+		# HELP cortex_compactor_scheduler_active_jobs The number of jobs active in workers.
+		# TYPE cortex_compactor_scheduler_active_jobs gauge
+		cortex_compactor_scheduler_active_jobs{job_type="compaction"} 1
+		cortex_compactor_scheduler_active_jobs{job_type="plan"} 1
+	`), "cortex_compactor_scheduler_pending_jobs", "cortex_compactor_scheduler_active_jobs"), "tenant1 active, tenant2 pending")
 
 	// Cleaning up tenant1 should only subtract its contribution, not zero the shared gauges.
 	jt1.CleanupMetrics()
@@ -358,7 +368,11 @@ func TestJobTracker_Cleanup(t *testing.T) {
 		# TYPE cortex_compactor_scheduler_pending_jobs gauge
 		cortex_compactor_scheduler_pending_jobs{job_type="compaction"} 1
 		cortex_compactor_scheduler_pending_jobs{job_type="plan"} 1
-	`), "cortex_compactor_scheduler_pending_jobs"), "aggregate pending jobs drops to tenant2's contribution")
+		# HELP cortex_compactor_scheduler_active_jobs The number of jobs active in workers.
+		# TYPE cortex_compactor_scheduler_active_jobs gauge
+		cortex_compactor_scheduler_active_jobs{job_type="compaction"} 0
+		cortex_compactor_scheduler_active_jobs{job_type="plan"} 0
+	`), "cortex_compactor_scheduler_pending_jobs", "cortex_compactor_scheduler_active_jobs"), "tenant1's active contribution removed, tenant2's pending preserved")
 }
 
 func TestJobTracker_CancelLease_PlanJobAlwaysRevives(t *testing.T) {

--- a/pkg/compactor/scheduler/metrics.go
+++ b/pkg/compactor/scheduler/metrics.go
@@ -16,11 +16,11 @@ const (
 )
 
 type schedulerMetrics struct {
-	pendingJobs         prometheus.Gauge
+	pendingJobs         *prometheus.GaugeVec
 	pendingJobsByUser   *prometheus.GaugeVec
 	incompleteJobsBytes *prometheus.GaugeVec
 	incompletePlanJobs  prometheus.Gauge
-	activeJobs          prometheus.Gauge
+	activeJobs          *prometheus.GaugeVec
 	activeJobsByUser    *prometheus.GaugeVec
 	jobsCompleted       *prometheus.CounterVec
 	repeatedJobFailures prometheus.Counter
@@ -28,10 +28,10 @@ type schedulerMetrics struct {
 
 func newSchedulerMetrics(reg prometheus.Registerer) *schedulerMetrics {
 	m := &schedulerMetrics{
-		pendingJobs: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+		pendingJobs: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cortex_compactor_scheduler_pending_jobs",
 			Help: "The number of queued pending jobs.",
-		}),
+		}, []string{"job_type"}),
 		pendingJobsByUser: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cortex_compactor_scheduler_pending_jobs_by_user",
 			Help: "The number of queued pending jobs, broken down by user.",
@@ -44,10 +44,10 @@ func newSchedulerMetrics(reg prometheus.Registerer) *schedulerMetrics {
 			Name: "cortex_compactor_scheduler_incomplete_plan_jobs",
 			Help: "The total number of plan jobs that have not yet completed (pending or active).",
 		}),
-		activeJobs: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+		activeJobs: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cortex_compactor_scheduler_active_jobs",
 			Help: "The number of jobs active in workers.",
-		}),
+		}, []string{"job_type"}),
 		activeJobsByUser: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cortex_compactor_scheduler_active_jobs_by_user",
 			Help: "The number of jobs active in workers, broken down by user.",
@@ -64,6 +64,10 @@ func newSchedulerMetrics(reg prometheus.Registerer) *schedulerMetrics {
 	// Pre-initialize job type labels so we get zeros instead of no data.
 	m.jobsCompleted.WithLabelValues(jobTypePlan)
 	m.jobsCompleted.WithLabelValues(jobTypeCompaction)
+	m.pendingJobs.WithLabelValues(jobTypePlan)
+	m.pendingJobs.WithLabelValues(jobTypeCompaction)
+	m.activeJobs.WithLabelValues(jobTypePlan)
+	m.activeJobs.WithLabelValues(jobTypeCompaction)
 	m.incompleteJobsBytes.WithLabelValues(compactionTypeSplit)
 	m.incompleteJobsBytes.WithLabelValues(compactionTypeMerge)
 	return m
@@ -72,10 +76,16 @@ func newSchedulerMetrics(reg prometheus.Registerer) *schedulerMetrics {
 func (s *schedulerMetrics) newTrackerMetricsForTenant(tenant string) *trackerMetrics {
 	return &trackerMetrics{
 		queue: &queueMetrics{
-			pendingJobs:          s.pendingJobs,
-			pendingJobsByUser:    s.pendingJobsByUser.WithLabelValues(tenant),
-			activeJobs:           s.activeJobs,
-			activeJobsByUser:     s.activeJobsByUser.WithLabelValues(tenant),
+			pendingJobsByUser: s.pendingJobsByUser.WithLabelValues(tenant),
+			activeJobsByUser:  s.activeJobsByUser.WithLabelValues(tenant),
+			pendingJobs: perJobTypeGauges{
+				plan:       s.pendingJobs.WithLabelValues(jobTypePlan),
+				compaction: s.pendingJobs.WithLabelValues(jobTypeCompaction),
+			},
+			activeJobs: perJobTypeGauges{
+				plan:       s.activeJobs.WithLabelValues(jobTypePlan),
+				compaction: s.activeJobs.WithLabelValues(jobTypeCompaction),
+			},
 			incompleteSplitBytes: s.incompleteJobsBytes.WithLabelValues(compactionTypeSplit),
 			incompleteMergeBytes: s.incompleteJobsBytes.WithLabelValues(compactionTypeMerge),
 			incompletePlanJobs:   s.incompletePlanJobs,
@@ -99,14 +109,48 @@ func (m *trackerMetrics) Clear() {
 	m.queue.incompleteSplitBytes.Sub(float64(m.queue.splitBytes))
 	m.queue.incompleteMergeBytes.Sub(float64(m.queue.mergeBytes))
 	m.queue.incompletePlanJobs.Sub(float64(m.queue.planJobCount))
-	m.queue.pendingJobs.Sub(float64(m.queue.pendingJobsCount))
-	m.queue.activeJobs.Sub(float64(m.queue.activeJobsCount))
+	m.queue.pendingJobs.clear()
+	m.queue.activeJobs.clear()
 	m.queue.splitBytes = 0
 	m.queue.mergeBytes = 0
 	m.queue.planJobCount = 0
-	m.queue.pendingJobsCount = 0
-	m.queue.activeJobsCount = 0
 	m.queue.clear()
+}
+
+// perJobTypeGauges holds references to a pair of shared {plan,compaction} gauges together with
+// this tenant's per-type contribution, so Clear() can subtract exactly the right amount.
+type perJobTypeGauges struct {
+	plan            prometheus.Gauge
+	compaction      prometheus.Gauge
+	planCount       int
+	compactionCount int
+}
+
+func (g *perJobTypeGauges) inc(isPlan bool) {
+	if isPlan {
+		g.plan.Inc()
+		g.planCount++
+	} else {
+		g.compaction.Inc()
+		g.compactionCount++
+	}
+}
+
+func (g *perJobTypeGauges) dec(isPlan bool) {
+	if isPlan {
+		g.plan.Dec()
+		g.planCount--
+	} else {
+		g.compaction.Dec()
+		g.compactionCount--
+	}
+}
+
+func (g *perJobTypeGauges) clear() {
+	g.plan.Sub(float64(g.planCount))
+	g.compaction.Sub(float64(g.compactionCount))
+	g.planCount = 0
+	g.compactionCount = 0
 }
 
 // queueMetrics encapsulates queue-level metrics for one tenant, allowing the caller to ignore
@@ -118,25 +162,25 @@ type queueMetrics struct {
 	activeJobsByUser  prometheus.Gauge
 
 	// shared across tenants
-	pendingJobs          prometheus.Gauge
-	activeJobs           prometheus.Gauge
+	pendingJobs          perJobTypeGauges
+	activeJobs           perJobTypeGauges
 	incompleteSplitBytes prometheus.Gauge
 	incompleteMergeBytes prometheus.Gauge
 	incompletePlanJobs   prometheus.Gauge
 
-	// Per-tenant contribution to the shared gauges, tracked so we can subtract exactly the right
-	// amount on tenant removal.
-	splitBytes       uint64
-	mergeBytes       uint64
-	planJobCount     int
-	pendingJobsCount int
-	activeJobsCount  int
-	clear            func()
+	// splitBytes, mergeBytes, and planJobCount track this tenant's contribution to the shared
+	// incomplete gauges so we can subtract exactly the right amount on tenant removal.
+	splitBytes   uint64
+	mergeBytes   uint64
+	planJobCount int
+	clear        func()
 }
 
 func (q *queueMetrics) Pending(j TrackedJob) {
-	q.incPending()
-	if j.ID() == planJobId {
+	isPlan := j.ID() == planJobId
+	q.pendingJobsByUser.Inc()
+	q.pendingJobs.inc(isPlan)
+	if isPlan {
 		q.incompletePlanJobs.Inc()
 		q.planJobCount++
 	} else {
@@ -145,15 +189,20 @@ func (q *queueMetrics) Pending(j TrackedJob) {
 }
 
 func (q *queueMetrics) Leased(j TrackedJob) {
-	q.decPending()
-	q.incActive()
+	isPlan := j.ID() == planJobId
+	q.pendingJobsByUser.Dec()
+	q.pendingJobs.dec(isPlan)
+	q.activeJobsByUser.Inc()
+	q.activeJobs.inc(isPlan)
 }
 
 // Recover records jobs restored from persisted state on startup.
 func (q *queueMetrics) Recover(pending, leased []TrackedJob) {
 	for _, j := range pending {
-		q.incPending()
-		if j.ID() == planJobId {
+		isPlan := j.ID() == planJobId
+		q.pendingJobsByUser.Inc()
+		q.pendingJobs.inc(isPlan)
+		if isPlan {
 			q.incompletePlanJobs.Inc()
 			q.planJobCount++
 		} else {
@@ -161,8 +210,10 @@ func (q *queueMetrics) Recover(pending, leased []TrackedJob) {
 		}
 	}
 	for _, j := range leased {
-		q.incActive()
-		if j.ID() == planJobId {
+		isPlan := j.ID() == planJobId
+		q.activeJobsByUser.Inc()
+		q.activeJobs.inc(isPlan)
+		if isPlan {
 			q.incompletePlanJobs.Inc()
 			q.planJobCount++
 		} else if cj, ok := j.(*TrackedCompactionJob); ok {
@@ -173,14 +224,19 @@ func (q *queueMetrics) Recover(pending, leased []TrackedJob) {
 
 // Revive records a job moving from active back to pending (lease expired or cancelled).
 func (q *queueMetrics) Revive(j TrackedJob) {
-	q.decActive()
-	q.incPending()
+	isPlan := j.ID() == planJobId
+	q.activeJobsByUser.Dec()
+	q.activeJobs.dec(isPlan)
+	q.pendingJobsByUser.Inc()
+	q.pendingJobs.inc(isPlan)
 }
 
 // Complete records a job leaving the system from the active queue (success or failure).
 func (q *queueMetrics) Complete(j TrackedJob) {
-	q.decActive()
-	if j.ID() == planJobId {
+	isPlan := j.ID() == planJobId
+	q.activeJobsByUser.Dec()
+	q.activeJobs.dec(isPlan)
+	if isPlan {
 		q.incompletePlanJobs.Dec()
 		q.planJobCount--
 	} else if cj, ok := j.(*TrackedCompactionJob); ok {
@@ -190,37 +246,15 @@ func (q *queueMetrics) Complete(j TrackedJob) {
 
 // DropPending records a job leaving the system from the pending queue.
 func (q *queueMetrics) DropPending(j TrackedJob) {
-	q.decPending()
-	if j.ID() == planJobId {
+	isPlan := j.ID() == planJobId
+	q.pendingJobsByUser.Dec()
+	q.pendingJobs.dec(isPlan)
+	if isPlan {
 		q.incompletePlanJobs.Dec()
 		q.planJobCount--
 	} else {
 		q.subBytes(j.(*TrackedCompactionJob))
 	}
-}
-
-func (q *queueMetrics) incPending() {
-	q.pendingJobsByUser.Inc()
-	q.pendingJobs.Inc()
-	q.pendingJobsCount++
-}
-
-func (q *queueMetrics) decPending() {
-	q.pendingJobsByUser.Dec()
-	q.pendingJobs.Dec()
-	q.pendingJobsCount--
-}
-
-func (q *queueMetrics) incActive() {
-	q.activeJobsByUser.Inc()
-	q.activeJobs.Inc()
-	q.activeJobsCount++
-}
-
-func (q *queueMetrics) decActive() {
-	q.activeJobsByUser.Dec()
-	q.activeJobs.Dec()
-	q.activeJobsCount--
 }
 
 func (q *queueMetrics) addBytes(cj *TrackedCompactionJob) {

--- a/pkg/compactor/scheduler/metrics.go
+++ b/pkg/compactor/scheduler/metrics.go
@@ -19,7 +19,6 @@ type schedulerMetrics struct {
 	pendingJobs         *prometheus.GaugeVec
 	pendingJobsByUser   *prometheus.GaugeVec
 	incompleteJobsBytes *prometheus.GaugeVec
-	incompletePlanJobs  prometheus.Gauge
 	activeJobs          *prometheus.GaugeVec
 	activeJobsByUser    *prometheus.GaugeVec
 	jobsCompleted       *prometheus.CounterVec
@@ -40,10 +39,6 @@ func newSchedulerMetrics(reg prometheus.Registerer) *schedulerMetrics {
 			Name: "cortex_compactor_scheduler_incomplete_compaction_jobs_bytes",
 			Help: "The total bytes of blocks in compaction jobs that have not yet completed (pending or active).",
 		}, []string{"compaction_type"}),
-		incompletePlanJobs: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
-			Name: "cortex_compactor_scheduler_incomplete_plan_jobs",
-			Help: "The total number of plan jobs that have not yet completed (pending or active).",
-		}),
 		activeJobs: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cortex_compactor_scheduler_active_jobs",
 			Help: "The number of jobs active in workers.",
@@ -76,19 +71,14 @@ func newSchedulerMetrics(reg prometheus.Registerer) *schedulerMetrics {
 func (s *schedulerMetrics) newTrackerMetricsForTenant(tenant string) *trackerMetrics {
 	return &trackerMetrics{
 		queue: &queueMetrics{
-			pendingJobsByUser: s.pendingJobsByUser.WithLabelValues(tenant),
-			activeJobsByUser:  s.activeJobsByUser.WithLabelValues(tenant),
-			pendingJobs: perJobTypeGauges{
-				plan:       s.pendingJobs.WithLabelValues(jobTypePlan),
-				compaction: s.pendingJobs.WithLabelValues(jobTypeCompaction),
-			},
-			activeJobs: perJobTypeGauges{
-				plan:       s.activeJobs.WithLabelValues(jobTypePlan),
-				compaction: s.activeJobs.WithLabelValues(jobTypeCompaction),
-			},
-			incompleteSplitBytes: s.incompleteJobsBytes.WithLabelValues(compactionTypeSplit),
-			incompleteMergeBytes: s.incompleteJobsBytes.WithLabelValues(compactionTypeMerge),
-			incompletePlanJobs:   s.incompletePlanJobs,
+			pendingJobsByUser:     s.pendingJobsByUser.WithLabelValues(tenant),
+			activeJobsByUser:      s.activeJobsByUser.WithLabelValues(tenant),
+			pendingPlanJobs:       s.pendingJobs.WithLabelValues(jobTypePlan),
+			pendingCompactionJobs: s.pendingJobs.WithLabelValues(jobTypeCompaction),
+			activePlanJobs:        s.activeJobs.WithLabelValues(jobTypePlan),
+			activeCompactionJobs:  s.activeJobs.WithLabelValues(jobTypeCompaction),
+			incompleteSplitBytes:  s.incompleteJobsBytes.WithLabelValues(compactionTypeSplit),
+			incompleteMergeBytes:  s.incompleteJobsBytes.WithLabelValues(compactionTypeMerge),
 			clear: func() {
 				s.pendingJobsByUser.DeleteLabelValues(tenant)
 				s.activeJobsByUser.DeleteLabelValues(tenant)
@@ -106,51 +96,20 @@ type trackerMetrics struct {
 // Clear deletes all per-tenant label values and subtracts this tenant's contribution from the
 // shared gauges. Must be called when a tenant is removed.
 func (m *trackerMetrics) Clear() {
-	m.queue.incompleteSplitBytes.Sub(float64(m.queue.splitBytes))
-	m.queue.incompleteMergeBytes.Sub(float64(m.queue.mergeBytes))
-	m.queue.incompletePlanJobs.Sub(float64(m.queue.planJobCount))
-	m.queue.pendingJobs.clear()
-	m.queue.activeJobs.clear()
-	m.queue.splitBytes = 0
-	m.queue.mergeBytes = 0
-	m.queue.planJobCount = 0
-	m.queue.clear()
-}
-
-// perJobTypeGauges holds references to a pair of shared {plan,compaction} gauges together with
-// this tenant's per-type contribution, so Clear() can subtract exactly the right amount.
-type perJobTypeGauges struct {
-	plan            prometheus.Gauge
-	compaction      prometheus.Gauge
-	planCount       int
-	compactionCount int
-}
-
-func (g *perJobTypeGauges) inc(isPlan bool) {
-	if isPlan {
-		g.plan.Inc()
-		g.planCount++
-	} else {
-		g.compaction.Inc()
-		g.compactionCount++
-	}
-}
-
-func (g *perJobTypeGauges) dec(isPlan bool) {
-	if isPlan {
-		g.plan.Dec()
-		g.planCount--
-	} else {
-		g.compaction.Dec()
-		g.compactionCount--
-	}
-}
-
-func (g *perJobTypeGauges) clear() {
-	g.plan.Sub(float64(g.planCount))
-	g.compaction.Sub(float64(g.compactionCount))
-	g.planCount = 0
-	g.compactionCount = 0
+	q := m.queue
+	q.incompleteSplitBytes.Sub(float64(q.splitBytes))
+	q.incompleteMergeBytes.Sub(float64(q.mergeBytes))
+	q.pendingPlanJobs.Sub(float64(q.pendingPlanCount))
+	q.pendingCompactionJobs.Sub(float64(q.pendingCompactionCount))
+	q.activePlanJobs.Sub(float64(q.activePlanCount))
+	q.activeCompactionJobs.Sub(float64(q.activeCompactionCount))
+	q.splitBytes = 0
+	q.mergeBytes = 0
+	q.pendingPlanCount = 0
+	q.pendingCompactionCount = 0
+	q.activePlanCount = 0
+	q.activeCompactionCount = 0
+	q.clear()
 }
 
 // queueMetrics encapsulates queue-level metrics for one tenant, allowing the caller to ignore
@@ -162,61 +121,45 @@ type queueMetrics struct {
 	activeJobsByUser  prometheus.Gauge
 
 	// shared across tenants
-	pendingJobs          perJobTypeGauges
-	activeJobs           perJobTypeGauges
-	incompleteSplitBytes prometheus.Gauge
-	incompleteMergeBytes prometheus.Gauge
-	incompletePlanJobs   prometheus.Gauge
+	pendingPlanJobs       prometheus.Gauge
+	pendingCompactionJobs prometheus.Gauge
+	activePlanJobs        prometheus.Gauge
+	activeCompactionJobs  prometheus.Gauge
+	incompleteSplitBytes  prometheus.Gauge
+	incompleteMergeBytes  prometheus.Gauge
 
-	// splitBytes, mergeBytes, and planJobCount track this tenant's contribution to the shared
-	// incomplete gauges so we can subtract exactly the right amount on tenant removal.
-	splitBytes   uint64
-	mergeBytes   uint64
-	planJobCount int
-	clear        func()
+	// This tenant's contribution to the shared gauges, tracked so Clear() can subtract exactly
+	// the right amount on tenant removal.
+	splitBytes             uint64
+	mergeBytes             uint64
+	pendingPlanCount       int
+	pendingCompactionCount int
+	activePlanCount        int
+	activeCompactionCount  int
+	clear                  func()
 }
 
 func (q *queueMetrics) Pending(j TrackedJob) {
-	isPlan := j.ID() == planJobId
-	q.pendingJobsByUser.Inc()
-	q.pendingJobs.inc(isPlan)
-	if isPlan {
-		q.incompletePlanJobs.Inc()
-		q.planJobCount++
-	} else {
-		q.addBytes(j.(*TrackedCompactionJob))
+	q.incPending(j.ID() == planJobId)
+	if cj, ok := j.(*TrackedCompactionJob); ok {
+		q.addBytes(cj)
 	}
 }
 
 func (q *queueMetrics) Leased(j TrackedJob) {
 	isPlan := j.ID() == planJobId
-	q.pendingJobsByUser.Dec()
-	q.pendingJobs.dec(isPlan)
-	q.activeJobsByUser.Inc()
-	q.activeJobs.inc(isPlan)
+	q.decPending(isPlan)
+	q.incActive(isPlan)
 }
 
 // Recover records jobs restored from persisted state on startup.
 func (q *queueMetrics) Recover(pending, leased []TrackedJob) {
 	for _, j := range pending {
-		isPlan := j.ID() == planJobId
-		q.pendingJobsByUser.Inc()
-		q.pendingJobs.inc(isPlan)
-		if isPlan {
-			q.incompletePlanJobs.Inc()
-			q.planJobCount++
-		} else {
-			q.addBytes(j.(*TrackedCompactionJob))
-		}
+		q.Pending(j)
 	}
 	for _, j := range leased {
-		isPlan := j.ID() == planJobId
-		q.activeJobsByUser.Inc()
-		q.activeJobs.inc(isPlan)
-		if isPlan {
-			q.incompletePlanJobs.Inc()
-			q.planJobCount++
-		} else if cj, ok := j.(*TrackedCompactionJob); ok {
+		q.incActive(j.ID() == planJobId)
+		if cj, ok := j.(*TrackedCompactionJob); ok {
 			q.addBytes(cj)
 		}
 	}
@@ -225,35 +168,67 @@ func (q *queueMetrics) Recover(pending, leased []TrackedJob) {
 // Revive records a job moving from active back to pending (lease expired or cancelled).
 func (q *queueMetrics) Revive(j TrackedJob) {
 	isPlan := j.ID() == planJobId
-	q.activeJobsByUser.Dec()
-	q.activeJobs.dec(isPlan)
-	q.pendingJobsByUser.Inc()
-	q.pendingJobs.inc(isPlan)
+	q.decActive(isPlan)
+	q.incPending(isPlan)
 }
 
 // Complete records a job leaving the system from the active queue (success or failure).
 func (q *queueMetrics) Complete(j TrackedJob) {
-	isPlan := j.ID() == planJobId
-	q.activeJobsByUser.Dec()
-	q.activeJobs.dec(isPlan)
-	if isPlan {
-		q.incompletePlanJobs.Dec()
-		q.planJobCount--
-	} else if cj, ok := j.(*TrackedCompactionJob); ok {
+	q.decActive(j.ID() == planJobId)
+	if cj, ok := j.(*TrackedCompactionJob); ok {
 		q.subBytes(cj)
 	}
 }
 
 // DropPending records a job leaving the system from the pending queue.
 func (q *queueMetrics) DropPending(j TrackedJob) {
-	isPlan := j.ID() == planJobId
-	q.pendingJobsByUser.Dec()
-	q.pendingJobs.dec(isPlan)
+	q.decPending(j.ID() == planJobId)
+	if cj, ok := j.(*TrackedCompactionJob); ok {
+		q.subBytes(cj)
+	}
+}
+
+func (q *queueMetrics) incPending(isPlan bool) {
+	q.pendingJobsByUser.Inc()
 	if isPlan {
-		q.incompletePlanJobs.Dec()
-		q.planJobCount--
+		q.pendingPlanJobs.Inc()
+		q.pendingPlanCount++
 	} else {
-		q.subBytes(j.(*TrackedCompactionJob))
+		q.pendingCompactionJobs.Inc()
+		q.pendingCompactionCount++
+	}
+}
+
+func (q *queueMetrics) decPending(isPlan bool) {
+	q.pendingJobsByUser.Dec()
+	if isPlan {
+		q.pendingPlanJobs.Dec()
+		q.pendingPlanCount--
+	} else {
+		q.pendingCompactionJobs.Dec()
+		q.pendingCompactionCount--
+	}
+}
+
+func (q *queueMetrics) incActive(isPlan bool) {
+	q.activeJobsByUser.Inc()
+	if isPlan {
+		q.activePlanJobs.Inc()
+		q.activePlanCount++
+	} else {
+		q.activeCompactionJobs.Inc()
+		q.activeCompactionCount++
+	}
+}
+
+func (q *queueMetrics) decActive(isPlan bool) {
+	q.activeJobsByUser.Dec()
+	if isPlan {
+		q.activePlanJobs.Dec()
+		q.activePlanCount--
+	} else {
+		q.activeCompactionJobs.Dec()
+		q.activeCompactionCount--
 	}
 }
 

--- a/pkg/compactor/scheduler/metrics.go
+++ b/pkg/compactor/scheduler/metrics.go
@@ -16,31 +16,41 @@ const (
 )
 
 type schedulerMetrics struct {
-	pendingJobs         *prometheus.GaugeVec
+	pendingJobs         prometheus.Gauge
+	pendingJobsByUser   *prometheus.GaugeVec
 	incompleteJobsBytes *prometheus.GaugeVec
 	incompletePlanJobs  prometheus.Gauge
-	activeJobs          *prometheus.GaugeVec
+	activeJobs          prometheus.Gauge
+	activeJobsByUser    *prometheus.GaugeVec
 	jobsCompleted       *prometheus.CounterVec
 	repeatedJobFailures prometheus.Counter
 }
 
 func newSchedulerMetrics(reg prometheus.Registerer) *schedulerMetrics {
 	m := &schedulerMetrics{
-		pendingJobs: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+		pendingJobs: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Name: "cortex_compactor_scheduler_pending_jobs",
 			Help: "The number of queued pending jobs.",
+		}),
+		pendingJobsByUser: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "cortex_compactor_scheduler_pending_jobs_by_user",
+			Help: "The number of queued pending jobs, broken down by user.",
 		}, []string{"user"}),
 		incompleteJobsBytes: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cortex_compactor_scheduler_incomplete_compaction_jobs_bytes",
 			Help: "The total bytes of blocks in compaction jobs that have not yet completed (pending or active).",
 		}, []string{"compaction_type"}),
 		incompletePlanJobs: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
-			Name: "cortex_compactor_incomplete_plan_jobs",
+			Name: "cortex_compactor_scheduler_incomplete_plan_jobs",
 			Help: "The total number of plan jobs that have not yet completed (pending or active).",
 		}),
-		activeJobs: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+		activeJobs: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Name: "cortex_compactor_scheduler_active_jobs",
 			Help: "The number of jobs active in workers.",
+		}),
+		activeJobsByUser: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "cortex_compactor_scheduler_active_jobs_by_user",
+			Help: "The number of jobs active in workers, broken down by user.",
 		}, []string{"user"}),
 		jobsCompleted: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "cortex_compactor_scheduler_jobs_completed_total",
@@ -62,14 +72,16 @@ func newSchedulerMetrics(reg prometheus.Registerer) *schedulerMetrics {
 func (s *schedulerMetrics) newTrackerMetricsForTenant(tenant string) *trackerMetrics {
 	return &trackerMetrics{
 		queue: &queueMetrics{
-			pendingJobs:          s.pendingJobs.WithLabelValues(tenant),
-			activeJobs:           s.activeJobs.WithLabelValues(tenant),
+			pendingJobs:          s.pendingJobs,
+			pendingJobsByUser:    s.pendingJobsByUser.WithLabelValues(tenant),
+			activeJobs:           s.activeJobs,
+			activeJobsByUser:     s.activeJobsByUser.WithLabelValues(tenant),
 			incompleteSplitBytes: s.incompleteJobsBytes.WithLabelValues(compactionTypeSplit),
 			incompleteMergeBytes: s.incompleteJobsBytes.WithLabelValues(compactionTypeMerge),
 			incompletePlanJobs:   s.incompletePlanJobs,
 			clear: func() {
-				s.pendingJobs.DeleteLabelValues(tenant)
-				s.activeJobs.DeleteLabelValues(tenant)
+				s.pendingJobsByUser.DeleteLabelValues(tenant)
+				s.activeJobsByUser.DeleteLabelValues(tenant)
 			},
 		},
 		repeatedJobFailures: s.repeatedJobFailures,
@@ -87,9 +99,13 @@ func (m *trackerMetrics) Clear() {
 	m.queue.incompleteSplitBytes.Sub(float64(m.queue.splitBytes))
 	m.queue.incompleteMergeBytes.Sub(float64(m.queue.mergeBytes))
 	m.queue.incompletePlanJobs.Sub(float64(m.queue.planJobCount))
+	m.queue.pendingJobs.Sub(float64(m.queue.pendingJobsCount))
+	m.queue.activeJobs.Sub(float64(m.queue.activeJobsCount))
 	m.queue.splitBytes = 0
 	m.queue.mergeBytes = 0
 	m.queue.planJobCount = 0
+	m.queue.pendingJobsCount = 0
+	m.queue.activeJobsCount = 0
 	m.queue.clear()
 }
 
@@ -98,24 +114,28 @@ func (m *trackerMetrics) Clear() {
 // Callers are responsible for making valid transitions. Invalid calls (e.g. DropPending on an
 // empty queue) will produce incorrect gauge values. Methods are not thread-safe.
 type queueMetrics struct {
-	pendingJobs prometheus.Gauge
-	activeJobs  prometheus.Gauge
+	pendingJobsByUser prometheus.Gauge
+	activeJobsByUser  prometheus.Gauge
 
 	// shared across tenants
+	pendingJobs          prometheus.Gauge
+	activeJobs           prometheus.Gauge
 	incompleteSplitBytes prometheus.Gauge
 	incompleteMergeBytes prometheus.Gauge
 	incompletePlanJobs   prometheus.Gauge
 
-	// splitBytes, mergeBytes, and planJobCount track this tenant's contribution to the shared
-	// incomplete gauges so we can subtract exactly the right amount on tenant removal.
-	splitBytes   uint64
-	mergeBytes   uint64
-	planJobCount int
-	clear        func()
+	// Per-tenant contribution to the shared gauges, tracked so we can subtract exactly the right
+	// amount on tenant removal.
+	splitBytes       uint64
+	mergeBytes       uint64
+	planJobCount     int
+	pendingJobsCount int
+	activeJobsCount  int
+	clear            func()
 }
 
 func (q *queueMetrics) Pending(j TrackedJob) {
-	q.pendingJobs.Inc()
+	q.incPending()
 	if j.ID() == planJobId {
 		q.incompletePlanJobs.Inc()
 		q.planJobCount++
@@ -125,14 +145,14 @@ func (q *queueMetrics) Pending(j TrackedJob) {
 }
 
 func (q *queueMetrics) Leased(j TrackedJob) {
-	q.pendingJobs.Dec()
-	q.activeJobs.Inc()
+	q.decPending()
+	q.incActive()
 }
 
 // Recover records jobs restored from persisted state on startup.
 func (q *queueMetrics) Recover(pending, leased []TrackedJob) {
 	for _, j := range pending {
-		q.pendingJobs.Inc()
+		q.incPending()
 		if j.ID() == planJobId {
 			q.incompletePlanJobs.Inc()
 			q.planJobCount++
@@ -141,7 +161,7 @@ func (q *queueMetrics) Recover(pending, leased []TrackedJob) {
 		}
 	}
 	for _, j := range leased {
-		q.activeJobs.Inc()
+		q.incActive()
 		if j.ID() == planJobId {
 			q.incompletePlanJobs.Inc()
 			q.planJobCount++
@@ -153,13 +173,13 @@ func (q *queueMetrics) Recover(pending, leased []TrackedJob) {
 
 // Revive records a job moving from active back to pending (lease expired or cancelled).
 func (q *queueMetrics) Revive(j TrackedJob) {
-	q.activeJobs.Dec()
-	q.pendingJobs.Inc()
+	q.decActive()
+	q.incPending()
 }
 
 // Complete records a job leaving the system from the active queue (success or failure).
 func (q *queueMetrics) Complete(j TrackedJob) {
-	q.activeJobs.Dec()
+	q.decActive()
 	if j.ID() == planJobId {
 		q.incompletePlanJobs.Dec()
 		q.planJobCount--
@@ -170,13 +190,37 @@ func (q *queueMetrics) Complete(j TrackedJob) {
 
 // DropPending records a job leaving the system from the pending queue.
 func (q *queueMetrics) DropPending(j TrackedJob) {
-	q.pendingJobs.Dec()
+	q.decPending()
 	if j.ID() == planJobId {
 		q.incompletePlanJobs.Dec()
 		q.planJobCount--
 	} else {
 		q.subBytes(j.(*TrackedCompactionJob))
 	}
+}
+
+func (q *queueMetrics) incPending() {
+	q.pendingJobsByUser.Inc()
+	q.pendingJobs.Inc()
+	q.pendingJobsCount++
+}
+
+func (q *queueMetrics) decPending() {
+	q.pendingJobsByUser.Dec()
+	q.pendingJobs.Dec()
+	q.pendingJobsCount--
+}
+
+func (q *queueMetrics) incActive() {
+	q.activeJobsByUser.Inc()
+	q.activeJobs.Inc()
+	q.activeJobsCount++
+}
+
+func (q *queueMetrics) decActive() {
+	q.activeJobsByUser.Dec()
+	q.activeJobs.Dec()
+	q.activeJobsCount--
 }
 
 func (q *queueMetrics) addBytes(cj *TrackedCompactionJob) {


### PR DESCRIPTION
#### What this PR does

* Reworks `cortex_compactor_scheduler_(pending|active)_jobs` metrics in the following way:
	* Before:
	```
	cortex_compactor_scheduler_pending_jobs{user}
	cortex_compactor_scheduler_active_jobs{user}
	```
	* Now:
	```
	cortex_compactor_scheduler_pending_jobs{job_type}
	cortex_compactor_scheduler_active_jobs{job_type}
	cortex_compactor_scheduler_pending_jobs_by_user{user}
	cortex_compactor_scheduler_active_jobs_jobs_by_user{user}
	```
	
	Main purpose is to have a low cardinality version of the original metrics, for lighter use when the user breakdown is not needed (e.g. autoscaling). Bonus change: add `job_type` label to the low cardinality one,  will be nice for dashboards.

* Drop `cortex_compactor_incomplete_plan_jobs`, it's now redundant, calculable from the new metrics above.

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Prometheus metric names/label sets for scheduler job counts and alters how per-tenant contributions are tracked/cleared, which can break dashboards/alerts and risks gauge mis-accounting if transitions are wrong.
> 
> **Overview**
> Reworks scheduler job-count metrics to provide **low-cardinality** `cortex_compactor_scheduler_(pending|active)_jobs{job_type}` gauges alongside new per-tenant breakdowns `cortex_compactor_scheduler_(pending|active)_jobs_by_user{user}`.
> 
> Removes the redundant `cortex_compactor_incomplete_plan_jobs` gauge and updates queue/tracker metric bookkeeping (including `Clear()` subtraction logic) plus related tests to assert the new pending/active plan vs compaction accounting and tenant cleanup behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f168605348bb73e649c7f8ac47abe8f2a88f959. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->