### PR TITLE
docs: Add link to planning

### DIFF
--- a/docs/sources/mimir/set-up/_index.md
+++ b/docs/sources/mimir/set-up/_index.md
@@ -12,4 +12,6 @@ weight: 15
 
 # Set up Mimir
 
+- [Planning capacity](https://grafana.com/docs/mimir/<MIMIR_VERSION>/manage/run-production-environment/planning-capacity/)
+
 {{< section menuTitle="true" >}}


### PR DESCRIPTION
#### What this PR does

While reviewing https://github.com/grafana/mimir/pull/14927, I saw that there is a Planning Capacity topic under Manage.  I thought it would be useful to add a link to that topic to the setup landing page.  I don't want to move the topic, but as a user "planning" is something that I tend to want to think about before installing.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a single navigation link; no code or behavior changes.
> 
> **Overview**
> Adds a prominent link to the *Planning capacity* documentation on the `Set up Mimir` landing page (`docs/sources/mimir/set-up/_index.md`) to help users find sizing guidance earlier in the setup flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39f26aa1d9443bea3cf947422e98c6424e305c95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->