### PR TITLE
MQE: pass the node's time range to `MinimumRequiredPlanVersion`

### DIFF
--- a/pkg/frontend/v2/remoteexec.go
+++ b/pkg/frontend/v2/remoteexec.go
@@ -147,7 +147,7 @@ func (g *RemoteExecutionGroupEvaluator) sendRequest(ctx context.Context) error {
 	version := planning.QueryPlanVersionZero
 	for _, state := range g.nodeStreams.streams {
 		nodes = append(nodes, state.node)
-		version = max(version, planning.MinimumRequiredPlanVersion(state.node))
+		version = max(version, planning.MinimumRequiredPlanVersion(state.node, state.timeRange))
 	}
 
 	subsetPlan := &planning.QueryPlan{

--- a/pkg/frontend/v2/remoteexec.go
+++ b/pkg/frontend/v2/remoteexec.go
@@ -147,7 +147,12 @@ func (g *RemoteExecutionGroupEvaluator) sendRequest(ctx context.Context) error {
 	version := planning.QueryPlanVersionZero
 	for _, state := range g.nodeStreams.streams {
 		nodes = append(nodes, state.node)
-		version = max(version, planning.MinimumRequiredPlanVersion(state.node, state.timeRange))
+		nodeVersion, err := planning.MinimumRequiredPlanVersion(state.node, state.timeRange)
+		if err != nil {
+			return err
+		}
+
+		version = max(version, nodeVersion)
 	}
 
 	subsetPlan := &planning.QueryPlan{

--- a/pkg/frontend/v2/remoteexec_test.go
+++ b/pkg/frontend/v2/remoteexec_test.go
@@ -1955,8 +1955,8 @@ type nodeWithOverriddenVersion struct {
 	child   planning.Node
 }
 
-func (n *nodeWithOverriddenVersion) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
-	return n.version
+func (n *nodeWithOverriddenVersion) MinimumRequiredPlanVersion(types.QueryTimeRange) (planning.QueryPlanVersion, error) {
+	return n.version, nil
 }
 
 func (n *nodeWithOverriddenVersion) Details() proto.Message {

--- a/pkg/frontend/v2/remoteexec_test.go
+++ b/pkg/frontend/v2/remoteexec_test.go
@@ -1955,7 +1955,7 @@ type nodeWithOverriddenVersion struct {
 	child   planning.Node
 }
 
-func (n *nodeWithOverriddenVersion) MinimumRequiredPlanVersion() planning.QueryPlanVersion {
+func (n *nodeWithOverriddenVersion) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
 	return n.version
 }
 

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/node.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/node.go
@@ -107,7 +107,7 @@ func (d *Duplicate) ExpressionPosition() (posrange.PositionRange, error) {
 	return d.Inner.ExpressionPosition()
 }
 
-func (d *Duplicate) MinimumRequiredPlanVersion() planning.QueryPlanVersion {
+func (d *Duplicate) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
 	return planning.QueryPlanVersionZero
 }
 
@@ -239,7 +239,7 @@ func (f *DuplicateFilter) ExpressionPosition() (posrange.PositionRange, error) {
 	return f.Inner.ExpressionPosition()
 }
 
-func (f *DuplicateFilter) MinimumRequiredPlanVersion() planning.QueryPlanVersion {
+func (f *DuplicateFilter) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
 	return planning.QueryPlanV7
 }
 

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/node.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/node.go
@@ -107,8 +107,8 @@ func (d *Duplicate) ExpressionPosition() (posrange.PositionRange, error) {
 	return d.Inner.ExpressionPosition()
 }
 
-func (d *Duplicate) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
-	return planning.QueryPlanVersionZero
+func (d *Duplicate) MinimumRequiredPlanVersion(types.QueryTimeRange) (planning.QueryPlanVersion, error) {
+	return planning.QueryPlanVersionZero, nil
 }
 
 func MaterializeDuplicate(d *Duplicate, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters, overrideTimeParams planning.RangeParams) (planning.OperatorFactory, error) {
@@ -239,8 +239,8 @@ func (f *DuplicateFilter) ExpressionPosition() (posrange.PositionRange, error) {
 	return f.Inner.ExpressionPosition()
 }
 
-func (f *DuplicateFilter) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
-	return planning.QueryPlanV7
+func (f *DuplicateFilter) MinimumRequiredPlanVersion(types.QueryTimeRange) (planning.QueryPlanVersion, error) {
+	return planning.QueryPlanV7, nil
 }
 
 func MaterializeDuplicateFilter(f *DuplicateFilter, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters, overrideTimeParams planning.RangeParams) (planning.OperatorFactory, error) {

--- a/pkg/streamingpromql/optimize/plan/multiaggregation/node.go
+++ b/pkg/streamingpromql/optimize/plan/multiaggregation/node.go
@@ -109,8 +109,8 @@ func (g *MultiAggregationGroup) ExpressionPosition() (posrange.PositionRange, er
 	return g.Inner.ExpressionPosition()
 }
 
-func (g *MultiAggregationGroup) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
-	return planning.QueryPlanV5
+func (g *MultiAggregationGroup) MinimumRequiredPlanVersion(types.QueryTimeRange) (planning.QueryPlanVersion, error) {
+	return planning.QueryPlanV5, nil
 }
 
 type MultiAggregationInstance struct {
@@ -215,12 +215,12 @@ func (a *MultiAggregationInstance) ExpressionPosition() (posrange.PositionRange,
 	return a.Group.ExpressionPosition()
 }
 
-func (a *MultiAggregationInstance) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
+func (a *MultiAggregationInstance) MinimumRequiredPlanVersion(types.QueryTimeRange) (planning.QueryPlanVersion, error) {
 	if len(a.Filters) > 0 {
-		return planning.QueryPlanV8
+		return planning.QueryPlanV8, nil
 	}
 
-	return planning.QueryPlanV5
+	return planning.QueryPlanV5, nil
 }
 
 func MaterializeMultiAggregationGroup(node *MultiAggregationGroup, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {

--- a/pkg/streamingpromql/optimize/plan/multiaggregation/node.go
+++ b/pkg/streamingpromql/optimize/plan/multiaggregation/node.go
@@ -109,7 +109,7 @@ func (g *MultiAggregationGroup) ExpressionPosition() (posrange.PositionRange, er
 	return g.Inner.ExpressionPosition()
 }
 
-func (g *MultiAggregationGroup) MinimumRequiredPlanVersion() planning.QueryPlanVersion {
+func (g *MultiAggregationGroup) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
 	return planning.QueryPlanV5
 }
 
@@ -215,7 +215,7 @@ func (a *MultiAggregationInstance) ExpressionPosition() (posrange.PositionRange,
 	return a.Group.ExpressionPosition()
 }
 
-func (a *MultiAggregationInstance) MinimumRequiredPlanVersion() planning.QueryPlanVersion {
+func (a *MultiAggregationInstance) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
 	if len(a.Filters) > 0 {
 		return planning.QueryPlanV8
 	}

--- a/pkg/streamingpromql/optimize/plan/rangevectorsplitting/node.go
+++ b/pkg/streamingpromql/optimize/plan/rangevectorsplitting/node.go
@@ -139,7 +139,7 @@ func (s *SplitFunctionCall) ExpressionPosition() (posrange.PositionRange, error)
 	return s.Inner.ExpressionPosition()
 }
 
-func (s *SplitFunctionCall) MinimumRequiredPlanVersion() planning.QueryPlanVersion {
+func (s *SplitFunctionCall) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
 	// Query splitting with intermediate result caching requires QueryPlanV6
 	return planning.QueryPlanV6
 }

--- a/pkg/streamingpromql/optimize/plan/rangevectorsplitting/node.go
+++ b/pkg/streamingpromql/optimize/plan/rangevectorsplitting/node.go
@@ -139,9 +139,9 @@ func (s *SplitFunctionCall) ExpressionPosition() (posrange.PositionRange, error)
 	return s.Inner.ExpressionPosition()
 }
 
-func (s *SplitFunctionCall) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
+func (s *SplitFunctionCall) MinimumRequiredPlanVersion(types.QueryTimeRange) (planning.QueryPlanVersion, error) {
 	// Query splitting with intermediate result caching requires QueryPlanV6
-	return planning.QueryPlanV6
+	return planning.QueryPlanV6, nil
 }
 
 type Materializer struct {

--- a/pkg/streamingpromql/optimize/plan/remoteexec/node.go
+++ b/pkg/streamingpromql/optimize/plan/remoteexec/node.go
@@ -124,12 +124,12 @@ func (r *RemoteExecutionGroup) ExpressionPosition() (posrange.PositionRange, err
 	return posrange.PositionRange{}, errors.New("cannot call ExpressionPosition on RemoteExecutionGroup node directly, call ExpressionPosition on consumer node instead")
 }
 
-func (r *RemoteExecutionGroup) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
+func (r *RemoteExecutionGroup) MinimumRequiredPlanVersion(types.QueryTimeRange) (planning.QueryPlanVersion, error) {
 	if len(r.Nodes) > 1 {
-		return planning.QueryPlanV3
+		return planning.QueryPlanV3, nil
 	}
 
-	return planning.QueryPlanVersionZero
+	return planning.QueryPlanVersionZero, nil
 }
 
 type RemoteExecutionConsumer struct {
@@ -251,13 +251,13 @@ func (c *RemoteExecutionConsumer) getEvaluatedNode() (planning.Node, error) {
 	return c.Group.Nodes[c.NodeIndex], nil
 }
 
-func (c *RemoteExecutionConsumer) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
+func (c *RemoteExecutionConsumer) MinimumRequiredPlanVersion(types.QueryTimeRange) (planning.QueryPlanVersion, error) {
 	// Even though this node type was introduced around the time of query plan v3, this node type is only
 	// ever used in query-frontends, and is needed to support remote execution of single nodes against
 	// queriers supporting v2 or earlier.
 	// So we return v0 here and rely on the RemoteExecutionGroup's MinimumRequiredPlanVersion() to
 	// return the correct version required based on whether one or many nodes are being evaluated.
-	return planning.QueryPlanVersionZero
+	return planning.QueryPlanVersionZero, nil
 }
 
 type RemoteExecutionGroupMaterializer struct {

--- a/pkg/streamingpromql/optimize/plan/remoteexec/node.go
+++ b/pkg/streamingpromql/optimize/plan/remoteexec/node.go
@@ -124,7 +124,7 @@ func (r *RemoteExecutionGroup) ExpressionPosition() (posrange.PositionRange, err
 	return posrange.PositionRange{}, errors.New("cannot call ExpressionPosition on RemoteExecutionGroup node directly, call ExpressionPosition on consumer node instead")
 }
 
-func (r *RemoteExecutionGroup) MinimumRequiredPlanVersion() planning.QueryPlanVersion {
+func (r *RemoteExecutionGroup) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
 	if len(r.Nodes) > 1 {
 		return planning.QueryPlanV3
 	}
@@ -251,7 +251,7 @@ func (c *RemoteExecutionConsumer) getEvaluatedNode() (planning.Node, error) {
 	return c.Group.Nodes[c.NodeIndex], nil
 }
 
-func (c *RemoteExecutionConsumer) MinimumRequiredPlanVersion() planning.QueryPlanVersion {
+func (c *RemoteExecutionConsumer) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
 	// Even though this node type was introduced around the time of query plan v3, this node type is only
 	// ever used in query-frontends, and is needed to support remote execution of single nodes against
 	// queriers supporting v2 or earlier.

--- a/pkg/streamingpromql/planning/core/aggregate_expression.go
+++ b/pkg/streamingpromql/planning/core/aggregate_expression.go
@@ -240,7 +240,7 @@ func (a *AggregateExpression) ExpressionPosition() (posrange.PositionRange, erro
 	return a.GetExpressionPosition().ToPrometheusType(), nil
 }
 
-func (a *AggregateExpression) MinimumRequiredPlanVersion() planning.QueryPlanVersion {
+func (a *AggregateExpression) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
 	switch a.Op {
 	case AGGREGATION_LIMITK, AGGREGATION_LIMIT_RATIO:
 		return planning.QueryPlanV2

--- a/pkg/streamingpromql/planning/core/aggregate_expression.go
+++ b/pkg/streamingpromql/planning/core/aggregate_expression.go
@@ -240,10 +240,10 @@ func (a *AggregateExpression) ExpressionPosition() (posrange.PositionRange, erro
 	return a.GetExpressionPosition().ToPrometheusType(), nil
 }
 
-func (a *AggregateExpression) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
+func (a *AggregateExpression) MinimumRequiredPlanVersion(types.QueryTimeRange) (planning.QueryPlanVersion, error) {
 	switch a.Op {
 	case AGGREGATION_LIMITK, AGGREGATION_LIMIT_RATIO:
-		return planning.QueryPlanV2
+		return planning.QueryPlanV2, nil
 	}
-	return planning.QueryPlanVersionZero
+	return planning.QueryPlanVersionZero, nil
 }

--- a/pkg/streamingpromql/planning/core/binary_expression.go
+++ b/pkg/streamingpromql/planning/core/binary_expression.go
@@ -313,7 +313,7 @@ func (b *BinaryExpression) ExpressionPosition() (posrange.PositionRange, error) 
 	return b.GetExpressionPosition().ToPrometheusType(), nil
 }
 
-func (b *BinaryExpression) MinimumRequiredPlanVersion() planning.QueryPlanVersion {
+func (b *BinaryExpression) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
 	return planning.QueryPlanVersionZero
 }
 

--- a/pkg/streamingpromql/planning/core/binary_expression.go
+++ b/pkg/streamingpromql/planning/core/binary_expression.go
@@ -313,8 +313,8 @@ func (b *BinaryExpression) ExpressionPosition() (posrange.PositionRange, error) 
 	return b.GetExpressionPosition().ToPrometheusType(), nil
 }
 
-func (b *BinaryExpression) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
-	return planning.QueryPlanVersionZero
+func (b *BinaryExpression) MinimumRequiredPlanVersion(types.QueryTimeRange) (planning.QueryPlanVersion, error) {
+	return planning.QueryPlanVersionZero, nil
 }
 
 func (v *VectorMatching) Equals(other *VectorMatching) bool {

--- a/pkg/streamingpromql/planning/core/deduplicate_and_merge.go
+++ b/pkg/streamingpromql/planning/core/deduplicate_and_merge.go
@@ -94,8 +94,8 @@ func (d *DeduplicateAndMerge) ExpressionPosition() (posrange.PositionRange, erro
 	return d.Inner.ExpressionPosition()
 }
 
-func (d *DeduplicateAndMerge) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
-	return planning.QueryPlanVersionZero
+func (d *DeduplicateAndMerge) MinimumRequiredPlanVersion(types.QueryTimeRange) (planning.QueryPlanVersion, error) {
+	return planning.QueryPlanVersionZero, nil
 }
 
 func MaterializeDeduplicateAndMerge(d *DeduplicateAndMerge, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {

--- a/pkg/streamingpromql/planning/core/deduplicate_and_merge.go
+++ b/pkg/streamingpromql/planning/core/deduplicate_and_merge.go
@@ -94,7 +94,7 @@ func (d *DeduplicateAndMerge) ExpressionPosition() (posrange.PositionRange, erro
 	return d.Inner.ExpressionPosition()
 }
 
-func (d *DeduplicateAndMerge) MinimumRequiredPlanVersion() planning.QueryPlanVersion {
+func (d *DeduplicateAndMerge) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
 	return planning.QueryPlanVersionZero
 }
 

--- a/pkg/streamingpromql/planning/core/drop_name.go
+++ b/pkg/streamingpromql/planning/core/drop_name.go
@@ -94,8 +94,8 @@ func (n *DropName) ExpressionPosition() (posrange.PositionRange, error) {
 	return n.Inner.ExpressionPosition()
 }
 
-func (n *DropName) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
-	return planning.QueryPlanV1
+func (n *DropName) MinimumRequiredPlanVersion(types.QueryTimeRange) (planning.QueryPlanVersion, error) {
+	return planning.QueryPlanV1, nil
 }
 
 func MaterializeDropName(n *DropName, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {

--- a/pkg/streamingpromql/planning/core/drop_name.go
+++ b/pkg/streamingpromql/planning/core/drop_name.go
@@ -94,7 +94,7 @@ func (n *DropName) ExpressionPosition() (posrange.PositionRange, error) {
 	return n.Inner.ExpressionPosition()
 }
 
-func (n *DropName) MinimumRequiredPlanVersion() planning.QueryPlanVersion {
+func (n *DropName) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
 	return planning.QueryPlanV1
 }
 

--- a/pkg/streamingpromql/planning/core/function_call.go
+++ b/pkg/streamingpromql/planning/core/function_call.go
@@ -160,6 +160,6 @@ func (f *FunctionCall) ExpressionPosition() (posrange.PositionRange, error) {
 	return f.GetExpressionPosition().ToPrometheusType(), nil
 }
 
-func (f *FunctionCall) MinimumRequiredPlanVersion() planning.QueryPlanVersion {
+func (f *FunctionCall) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
 	return planning.QueryPlanVersionZero
 }

--- a/pkg/streamingpromql/planning/core/function_call.go
+++ b/pkg/streamingpromql/planning/core/function_call.go
@@ -160,6 +160,6 @@ func (f *FunctionCall) ExpressionPosition() (posrange.PositionRange, error) {
 	return f.GetExpressionPosition().ToPrometheusType(), nil
 }
 
-func (f *FunctionCall) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
-	return planning.QueryPlanVersionZero
+func (f *FunctionCall) MinimumRequiredPlanVersion(types.QueryTimeRange) (planning.QueryPlanVersion, error) {
+	return planning.QueryPlanVersionZero, nil
 }

--- a/pkg/streamingpromql/planning/core/matrix_selector.go
+++ b/pkg/streamingpromql/planning/core/matrix_selector.go
@@ -185,7 +185,7 @@ func (m *MatrixSelector) ExpressionPosition() (posrange.PositionRange, error) {
 	return m.GetExpressionPosition().ToPrometheusType(), nil
 }
 
-func (m *MatrixSelector) MinimumRequiredPlanVersion() planning.QueryPlanVersion {
+func (m *MatrixSelector) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
 	if m.Anchored || m.Smoothed {
 		return planning.QueryPlanV4
 	}

--- a/pkg/streamingpromql/planning/core/matrix_selector.go
+++ b/pkg/streamingpromql/planning/core/matrix_selector.go
@@ -185,11 +185,11 @@ func (m *MatrixSelector) ExpressionPosition() (posrange.PositionRange, error) {
 	return m.GetExpressionPosition().ToPrometheusType(), nil
 }
 
-func (m *MatrixSelector) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
+func (m *MatrixSelector) MinimumRequiredPlanVersion(types.QueryTimeRange) (planning.QueryPlanVersion, error) {
 	if m.Anchored || m.Smoothed {
-		return planning.QueryPlanV4
+		return planning.QueryPlanV4, nil
 	}
-	return planning.QueryPlanVersionZero
+	return planning.QueryPlanVersionZero, nil
 }
 
 func (m *MatrixSelector) GetRange() time.Duration {

--- a/pkg/streamingpromql/planning/core/no_op.go
+++ b/pkg/streamingpromql/planning/core/no_op.go
@@ -84,7 +84,7 @@ func (n *NoOp) ExpressionPosition() (posrange.PositionRange, error) {
 	return posrange.PositionRange{}, nil
 }
 
-func (n *NoOp) MinimumRequiredPlanVersion() planning.QueryPlanVersion {
+func (n *NoOp) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
 	return planning.QueryPlanV9
 }
 

--- a/pkg/streamingpromql/planning/core/no_op.go
+++ b/pkg/streamingpromql/planning/core/no_op.go
@@ -84,8 +84,8 @@ func (n *NoOp) ExpressionPosition() (posrange.PositionRange, error) {
 	return posrange.PositionRange{}, nil
 }
 
-func (n *NoOp) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
-	return planning.QueryPlanV9
+func (n *NoOp) MinimumRequiredPlanVersion(types.QueryTimeRange) (planning.QueryPlanVersion, error) {
+	return planning.QueryPlanV9, nil
 }
 
 func MaterializeNoOp(_ *NoOp, _ *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {

--- a/pkg/streamingpromql/planning/core/number_literal.go
+++ b/pkg/streamingpromql/planning/core/number_literal.go
@@ -89,6 +89,6 @@ func (n *NumberLiteral) ExpressionPosition() (posrange.PositionRange, error) {
 	return n.GetExpressionPosition().ToPrometheusType(), nil
 }
 
-func (n *NumberLiteral) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
-	return planning.QueryPlanVersionZero
+func (n *NumberLiteral) MinimumRequiredPlanVersion(types.QueryTimeRange) (planning.QueryPlanVersion, error) {
+	return planning.QueryPlanVersionZero, nil
 }

--- a/pkg/streamingpromql/planning/core/number_literal.go
+++ b/pkg/streamingpromql/planning/core/number_literal.go
@@ -89,6 +89,6 @@ func (n *NumberLiteral) ExpressionPosition() (posrange.PositionRange, error) {
 	return n.GetExpressionPosition().ToPrometheusType(), nil
 }
 
-func (n *NumberLiteral) MinimumRequiredPlanVersion() planning.QueryPlanVersion {
+func (n *NumberLiteral) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
 	return planning.QueryPlanVersionZero
 }

--- a/pkg/streamingpromql/planning/core/step_invariant_expression.go
+++ b/pkg/streamingpromql/planning/core/step_invariant_expression.go
@@ -53,8 +53,8 @@ func (s *StepInvariantExpression) ChildCount() int {
 	return 1
 }
 
-func (s *StepInvariantExpression) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
-	return planning.QueryPlanV1
+func (s *StepInvariantExpression) MinimumRequiredPlanVersion(types.QueryTimeRange) (planning.QueryPlanVersion, error) {
+	return planning.QueryPlanV1, nil
 }
 
 func (s *StepInvariantExpression) SetChildren(children []planning.Node) error {

--- a/pkg/streamingpromql/planning/core/step_invariant_expression.go
+++ b/pkg/streamingpromql/planning/core/step_invariant_expression.go
@@ -53,7 +53,7 @@ func (s *StepInvariantExpression) ChildCount() int {
 	return 1
 }
 
-func (s *StepInvariantExpression) MinimumRequiredPlanVersion() planning.QueryPlanVersion {
+func (s *StepInvariantExpression) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
 	return planning.QueryPlanV1
 }
 

--- a/pkg/streamingpromql/planning/core/string_literal.go
+++ b/pkg/streamingpromql/planning/core/string_literal.go
@@ -89,6 +89,6 @@ func (s *StringLiteral) ExpressionPosition() (posrange.PositionRange, error) {
 	return s.GetExpressionPosition().ToPrometheusType(), nil
 }
 
-func (s *StringLiteral) MinimumRequiredPlanVersion() planning.QueryPlanVersion {
+func (s *StringLiteral) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
 	return planning.QueryPlanVersionZero
 }

--- a/pkg/streamingpromql/planning/core/string_literal.go
+++ b/pkg/streamingpromql/planning/core/string_literal.go
@@ -89,6 +89,6 @@ func (s *StringLiteral) ExpressionPosition() (posrange.PositionRange, error) {
 	return s.GetExpressionPosition().ToPrometheusType(), nil
 }
 
-func (s *StringLiteral) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
-	return planning.QueryPlanVersionZero
+func (s *StringLiteral) MinimumRequiredPlanVersion(types.QueryTimeRange) (planning.QueryPlanVersion, error) {
+	return planning.QueryPlanVersionZero, nil
 }

--- a/pkg/streamingpromql/planning/core/subquery.go
+++ b/pkg/streamingpromql/planning/core/subquery.go
@@ -168,6 +168,6 @@ func (s *Subquery) ExpressionPosition() (posrange.PositionRange, error) {
 	return s.GetExpressionPosition().ToPrometheusType(), nil
 }
 
-func (s *Subquery) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
-	return planning.QueryPlanVersionZero
+func (s *Subquery) MinimumRequiredPlanVersion(types.QueryTimeRange) (planning.QueryPlanVersion, error) {
+	return planning.QueryPlanVersionZero, nil
 }

--- a/pkg/streamingpromql/planning/core/subquery.go
+++ b/pkg/streamingpromql/planning/core/subquery.go
@@ -168,6 +168,6 @@ func (s *Subquery) ExpressionPosition() (posrange.PositionRange, error) {
 	return s.GetExpressionPosition().ToPrometheusType(), nil
 }
 
-func (s *Subquery) MinimumRequiredPlanVersion() planning.QueryPlanVersion {
+func (s *Subquery) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
 	return planning.QueryPlanVersionZero
 }

--- a/pkg/streamingpromql/planning/core/unary_expression.go
+++ b/pkg/streamingpromql/planning/core/unary_expression.go
@@ -119,6 +119,6 @@ func (u *UnaryExpression) ExpressionPosition() (posrange.PositionRange, error) {
 	return u.GetExpressionPosition().ToPrometheusType(), nil
 }
 
-func (u *UnaryExpression) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
-	return planning.QueryPlanVersionZero
+func (u *UnaryExpression) MinimumRequiredPlanVersion(types.QueryTimeRange) (planning.QueryPlanVersion, error) {
+	return planning.QueryPlanVersionZero, nil
 }

--- a/pkg/streamingpromql/planning/core/unary_expression.go
+++ b/pkg/streamingpromql/planning/core/unary_expression.go
@@ -119,6 +119,6 @@ func (u *UnaryExpression) ExpressionPosition() (posrange.PositionRange, error) {
 	return u.GetExpressionPosition().ToPrometheusType(), nil
 }
 
-func (u *UnaryExpression) MinimumRequiredPlanVersion() planning.QueryPlanVersion {
+func (u *UnaryExpression) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
 	return planning.QueryPlanVersionZero
 }

--- a/pkg/streamingpromql/planning/core/vector_selector.go
+++ b/pkg/streamingpromql/planning/core/vector_selector.go
@@ -151,9 +151,9 @@ func (v *VectorSelector) ExpressionPosition() (posrange.PositionRange, error) {
 	return v.GetExpressionPosition().ToPrometheusType(), nil
 }
 
-func (v *VectorSelector) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
+func (v *VectorSelector) MinimumRequiredPlanVersion(types.QueryTimeRange) (planning.QueryPlanVersion, error) {
 	if v.Smoothed {
-		return planning.QueryPlanV4
+		return planning.QueryPlanV4, nil
 	}
-	return planning.QueryPlanVersionZero
+	return planning.QueryPlanVersionZero, nil
 }

--- a/pkg/streamingpromql/planning/core/vector_selector.go
+++ b/pkg/streamingpromql/planning/core/vector_selector.go
@@ -151,7 +151,7 @@ func (v *VectorSelector) ExpressionPosition() (posrange.PositionRange, error) {
 	return v.GetExpressionPosition().ToPrometheusType(), nil
 }
 
-func (v *VectorSelector) MinimumRequiredPlanVersion() planning.QueryPlanVersion {
+func (v *VectorSelector) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
 	if v.Smoothed {
 		return planning.QueryPlanV4
 	}

--- a/pkg/streamingpromql/planning/plan.go
+++ b/pkg/streamingpromql/planning/plan.go
@@ -167,7 +167,7 @@ type Node interface {
 
 	// MinimumRequiredPlanVersion returns the minimum query plan version required to execute a plan that includes this node.
 	// It does not consider the query plan version required by any of its children (for that, use planning.MinimumRequiredPlanVersion).
-	MinimumRequiredPlanVersion(timeRange types.QueryTimeRange) QueryPlanVersion
+	MinimumRequiredPlanVersion(timeRange types.QueryTimeRange) (QueryPlanVersion, error)
 
 	// FIXME: implementations for many of the above methods can be generated automatically
 }
@@ -324,18 +324,30 @@ func (p *QueryPlan) DeterminePlanVersion() error {
 	if p.Root == nil {
 		return errors.New("query plan version can not be determined without a root node")
 	}
-	p.Version = MinimumRequiredPlanVersion(p.Root, p.Parameters.TimeRange)
-	return nil
+
+	var err error
+	p.Version, err = MinimumRequiredPlanVersion(p.Root, p.Parameters.TimeRange)
+	return err
 }
 
 // MinimumRequiredPlanVersion returns the minimum required query plan version of node and all its children.
-func MinimumRequiredPlanVersion(node Node, timeRange types.QueryTimeRange) QueryPlanVersion {
-	maxVersion := node.MinimumRequiredPlanVersion(timeRange)
+func MinimumRequiredPlanVersion(node Node, timeRange types.QueryTimeRange) (QueryPlanVersion, error) {
+	maxVersion, err := node.MinimumRequiredPlanVersion(timeRange)
+	if err != nil {
+		return 0, err
+	}
+
 	childTimeRange := node.ChildrenTimeRange(timeRange)
 	for child := range ChildrenIter(node) {
-		maxVersion = max(maxVersion, MinimumRequiredPlanVersion(child, childTimeRange))
+		childVersion, err := MinimumRequiredPlanVersion(child, childTimeRange)
+		if err != nil {
+			return 0, err
+		}
+
+		maxVersion = max(maxVersion, childVersion)
 	}
-	return maxVersion
+
+	return maxVersion, nil
 }
 
 func ToEncodedTimeRange(t types.QueryTimeRange) EncodedQueryTimeRange {

--- a/pkg/streamingpromql/planning/plan.go
+++ b/pkg/streamingpromql/planning/plan.go
@@ -167,7 +167,7 @@ type Node interface {
 
 	// MinimumRequiredPlanVersion returns the minimum query plan version required to execute a plan that includes this node.
 	// It does not consider the query plan version required by any of its children (for that, use planning.MinimumRequiredPlanVersion).
-	MinimumRequiredPlanVersion() QueryPlanVersion
+	MinimumRequiredPlanVersion(timeRange types.QueryTimeRange) QueryPlanVersion
 
 	// FIXME: implementations for many of the above methods can be generated automatically
 }
@@ -324,15 +324,16 @@ func (p *QueryPlan) DeterminePlanVersion() error {
 	if p.Root == nil {
 		return errors.New("query plan version can not be determined without a root node")
 	}
-	p.Version = MinimumRequiredPlanVersion(p.Root)
+	p.Version = MinimumRequiredPlanVersion(p.Root, p.Parameters.TimeRange)
 	return nil
 }
 
 // MinimumRequiredPlanVersion returns the minimum required query plan version of node and all its children.
-func MinimumRequiredPlanVersion(node Node) QueryPlanVersion {
-	maxVersion := node.MinimumRequiredPlanVersion()
+func MinimumRequiredPlanVersion(node Node, timeRange types.QueryTimeRange) QueryPlanVersion {
+	maxVersion := node.MinimumRequiredPlanVersion(timeRange)
+	childTimeRange := node.ChildrenTimeRange(timeRange)
 	for child := range ChildrenIter(node) {
-		maxVersion = max(maxVersion, MinimumRequiredPlanVersion(child))
+		maxVersion = max(maxVersion, MinimumRequiredPlanVersion(child, childTimeRange))
 	}
 	return maxVersion
 }

--- a/pkg/streamingpromql/planning/plan_test.go
+++ b/pkg/streamingpromql/planning/plan_test.go
@@ -122,8 +122,8 @@ func (t *testNode) EquivalentToIgnoringHintsAndChildren(_ Node) bool {
 
 func (t *testNode) MergeHints(_ Node) error { panic("not supported") }
 
-func (t *testNode) ChildrenTimeRange(_ types.QueryTimeRange) types.QueryTimeRange {
-	panic("not supported")
+func (t *testNode) ChildrenTimeRange(timeRange types.QueryTimeRange) types.QueryTimeRange {
+	return timeRange
 }
 
 func (t *testNode) ResultType() (parser.ValueType, error) {
@@ -138,7 +138,7 @@ func (t *testNode) ExpressionPosition() (posrange.PositionRange, error) {
 	panic("not supported")
 }
 
-func (t *testNode) MinimumRequiredPlanVersion() QueryPlanVersion {
+func (t *testNode) MinimumRequiredPlanVersion(types.QueryTimeRange) QueryPlanVersion {
 	return t.minimumRequiredPlanVersion
 }
 
@@ -159,12 +159,18 @@ func TestQueryPlanVersion(t *testing.T) {
 		},
 		"single root node": {
 			plan: QueryPlan{
+				Parameters: &QueryParameters{
+					TimeRange: types.NewInstantQueryTimeRange(time.Now()),
+				},
 				Root: &testNode{minimumRequiredPlanVersion: v1},
 			},
 			expectedVersion: v1,
 		},
 		"node with children": {
 			plan: QueryPlan{
+				Parameters: &QueryParameters{
+					TimeRange: types.NewInstantQueryTimeRange(time.Now()),
+				},
 				Root: &testNode{
 					minimumRequiredPlanVersion: v1,
 					children: []Node{
@@ -181,6 +187,9 @@ func TestQueryPlanVersion(t *testing.T) {
 		},
 		"node with deep children": {
 			plan: QueryPlan{
+				Parameters: &QueryParameters{
+					TimeRange: types.NewInstantQueryTimeRange(time.Now()),
+				},
 				Root: &testNode{
 					minimumRequiredPlanVersion: v0,
 					children: []Node{

--- a/pkg/streamingpromql/planning/plan_test.go
+++ b/pkg/streamingpromql/planning/plan_test.go
@@ -138,8 +138,8 @@ func (t *testNode) ExpressionPosition() (posrange.PositionRange, error) {
 	panic("not supported")
 }
 
-func (t *testNode) MinimumRequiredPlanVersion(types.QueryTimeRange) QueryPlanVersion {
-	return t.minimumRequiredPlanVersion
+func (t *testNode) MinimumRequiredPlanVersion(types.QueryTimeRange) (QueryPlanVersion, error) {
+	return t.minimumRequiredPlanVersion, nil
 }
 
 func TestQueryPlanVersion(t *testing.T) {

--- a/pkg/streamingpromql/planning_test.go
+++ b/pkg/streamingpromql/planning_test.go
@@ -2192,6 +2192,6 @@ func (t *versioningTestNode) ExpressionPosition() (posrange.PositionRange, error
 	return posrange.PositionRange{}, nil
 }
 
-func (t *versioningTestNode) MinimumRequiredPlanVersion() planning.QueryPlanVersion {
+func (t *versioningTestNode) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
 	return planning.QueryPlanVersion(t.Value)
 }

--- a/pkg/streamingpromql/planning_test.go
+++ b/pkg/streamingpromql/planning_test.go
@@ -2192,6 +2192,6 @@ func (t *versioningTestNode) ExpressionPosition() (posrange.PositionRange, error
 	return posrange.PositionRange{}, nil
 }
 
-func (t *versioningTestNode) MinimumRequiredPlanVersion(types.QueryTimeRange) planning.QueryPlanVersion {
-	return planning.QueryPlanVersion(t.Value)
+func (t *versioningTestNode) MinimumRequiredPlanVersion(types.QueryTimeRange) (planning.QueryPlanVersion, error) {
+	return planning.QueryPlanVersion(t.Value), nil
 }


### PR DESCRIPTION
#### What this PR does

This PR changes the signature of `Node.MinimumRequiredPlanVersion` to include the node's time range.

This allows nodes to return different query plan versions based on whether the query is a range or instant query. This is useful in cases like range vector common subexpression elimination, which currently only supports instant queries, but I plan to add support for range queries in a future PR.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core `planning.Node` interface and plan-version determination logic across many node implementations, so any missed implementation or error path could break planning/remote execution. Functional behavior should be unchanged today, but it adds new error propagation and time-range-dependent versioning hooks.
> 
> **Overview**
> Updates query plan versioning to be *time-range aware* by changing `Node.MinimumRequiredPlanVersion` to accept a `types.QueryTimeRange` and return `(version, error)`.
> 
> `planning.MinimumRequiredPlanVersion`/`QueryPlan.DeterminePlanVersion` now propagate the parent/child time ranges (via `ChildrenTimeRange`) and bubble up errors, and remote execution (`frontend/v2/remoteexec.go`) computes the request plan version per node using each node’s own `timeRange`. Tests and various plan node types are updated to the new signature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19c6bb09bd20eb962db7d05f490f47b053868daa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->