### PR TITLE
MQE: and/unless Derive RHS hints from LHS series/data at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,6 +200,7 @@
   * `-ingest-storage.kafka.ingestion-concurrency-target-flushes-per-shard` from `80` to `40`
   * `-ingest-storage.kafka.max-buffered-bytes` from `100MB` to `1GB`
 * [ENHANCEMENT] MQE: Enable narrow selectors optimisation and hints passing for `and`/`unless` binary operation. #15096
+* [ENHANCEMENT] MQE: Derive RHS hints from LHS series for `and`/`unless` operations. #15119
 * [BUGFIX] Ingester: enforce a minimum 10s delay between TSDB head compaction iterations when an iteration approaches or exceeds the configured `-blocks-storage.tsdb.head-compaction-interval`, so ingestion is not starved by back-to-back compactions. #15061
 * [BUGFIX] Update to Go v1.25.9. #15030
 * [BUGFIX] Distributor: OTLP partial success responses now correctly populate `RejectedDataPoints` with the actual count of rejected samples, instead of always reporting 0. In classical architecture, this includes rejected samples propagated from the ingester. #14789

--- a/pkg/streamingpromql/operators/binops/and_unless_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/and_unless_binary_operation.go
@@ -4,8 +4,10 @@ package binops
 
 import (
 	"context"
+	"slices"
 
 	"github.com/go-kit/log"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/promql/parser/posrange"
 
@@ -98,16 +100,20 @@ func (a *AndUnlessBinaryOperation) computeSeriesMetadata(ctx context.Context, ma
 		return nil, nil
 	}
 
-	// Build RHS matchers: when hints are set, build matchers from LHS metadata to narrow
-	// the RHS series fetch. When no hints are available, pass nil (do not apply parent matchers
-	// to the RHS — see SeriesMetadata for why).
+	// Build RHS matchers: first try to derive hints from VectorMatching at runtime (using the
+	// actual LHS label values), then fall back to planner-provided hints. When neither provides
+	// hints, pass nil to RHS (do not apply parent matchers to the RHS — see SeriesMetadata for why).
 	var rhsMatchers types.Matchers
-	if a.hints != nil {
-		rhsMatchers = BuildMatchers(leftMetadata, a.hints)
+	hints := a.hintsFromVectorMatching(leftMetadata)
+	if hints == nil {
+		hints = a.hints
+	}
+	if hints != nil {
+		rhsMatchers = BuildMatchers(leftMetadata, hints)
 		sl := spanlogger.FromContext(ctx, a.logger)
 		sl.DebugLog(
 			"msg", "binary operator passing additional matchers to RHS",
-			"fields", a.hints.Include,
+			"fields", hints.Include,
 			"hint_matchers", len(rhsMatchers),
 		)
 	}
@@ -355,6 +361,69 @@ func (a *AndUnlessBinaryOperation) Stats(ctx context.Context) (*types.OperatorEv
 func (a *AndUnlessBinaryOperation) Close() {
 	a.Left.Close()
 	a.Right.Close()
+}
+
+// hintsFromVectorMatching builds Hints from the VectorMatching at runtime using the actual LHS
+// series metadata.
+//
+// For on(...) matching, it returns the matching labels directly — they are already known at
+// construction time and are safe to use as-is.
+//
+// For ignoring(...) matching, it computes the intersection of label names across all LHS series,
+// excluding the ignored labels and __name__. We use the intersection (not the union) to avoid
+// over-narrowing: if a label is absent from some LHS series, adding a matcher for it would
+// incorrectly filter out RHS series that are valid matches for those LHS series.
+func (a *AndUnlessBinaryOperation) hintsFromVectorMatching(leftMetadata []types.SeriesMetadata) *Hints {
+	if a.VectorMatching.On {
+		if len(a.VectorMatching.MatchingLabels) == 0 {
+			return nil
+		}
+		return &Hints{Include: a.VectorMatching.MatchingLabels}
+	}
+
+	// ignoring(...) case: build the ignored set, then compute the intersection of label names
+	// present in every LHS series.
+	ignoredSet := make(map[string]struct{}, len(a.VectorMatching.MatchingLabels)+1)
+	ignoredSet["__name__"] = struct{}{}
+	for _, l := range a.VectorMatching.MatchingLabels {
+		ignoredSet[l] = struct{}{}
+	}
+
+	var commonLabels map[string]struct{}
+	for i, s := range leftMetadata {
+		seriesLabels := make(map[string]struct{})
+		s.Labels.Range(func(l labels.Label) {
+			if _, ignored := ignoredSet[l.Name]; !ignored {
+				seriesLabels[l.Name] = struct{}{}
+			}
+		})
+
+		if i == 0 {
+			commonLabels = seriesLabels
+		} else {
+			for name := range commonLabels {
+				if _, exists := seriesLabels[name]; !exists {
+					delete(commonLabels, name)
+				}
+			}
+		}
+
+		if len(commonLabels) == 0 {
+			return nil
+		}
+	}
+
+	if len(commonLabels) == 0 {
+		return nil
+	}
+
+	matchingLabels := make([]string, 0, len(commonLabels))
+	for name := range commonLabels {
+		matchingLabels = append(matchingLabels, name)
+	}
+	slices.Sort(matchingLabels)
+
+	return &Hints{Include: matchingLabels}
 }
 
 type andGroup struct {

--- a/pkg/streamingpromql/operators/binops/and_unless_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/and_unless_binary_operation_test.go
@@ -4,6 +4,7 @@ package binops
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -677,4 +678,118 @@ func TestAndUnlessBinaryOperation_ReleasesIntermediateStateIfClosedEarly(t *test
 			}
 		})
 	}
+}
+
+// BenchmarkAndUnlessDerivedHints measures the cost of SeriesMetadata for and/unless operations
+// and validates that the optimisation actually narrows the RHS series fetched.
+//
+// The scenario has LHS series covering 2 out of 10 env values, and a large RHS spread
+// across all 10 env values. The optimised paths (on/ignoring) should derive matchers that
+// filter the RHS to ~20% of total, which is visible in the rhs_series_fetched metric.
+func BenchmarkAndUnlessDerivedHints(b *testing.B) {
+	const totalEnvValues = 10
+	const lhsEnvValues = 2 // LHS only uses env-0 and env-1
+
+	makeLHS := func(count int) []labels.Labels {
+		out := make([]labels.Labels, count)
+		for i := range count {
+			out[i] = labels.FromStrings(
+				"__name__", "http_requests_total",
+				"env", fmt.Sprintf("env-%d", i%lhsEnvValues),
+				"handler", fmt.Sprintf("/api/v%d", i%5),
+				"pod", fmt.Sprintf("pod-%d", i),
+			)
+		}
+		return out
+	}
+
+	makeRHS := func(count int) []labels.Labels {
+		out := make([]labels.Labels, count)
+		for i := range count {
+			out[i] = labels.FromStrings(
+				"__name__", "up",
+				"env", fmt.Sprintf("env-%d", i%totalEnvValues),
+				"handler", fmt.Sprintf("/api/v%d", i%5),
+				"pod", fmt.Sprintf("pod-%d", i),
+			)
+		}
+		return out
+	}
+
+	for _, rhsCount := range []int{1_000, 10_000} {
+		lhsSeries := makeLHS(100)
+		rhsSeries := makeRHS(rhsCount)
+
+		// on(env): matching labels are static — derived directly from VectorMatching.
+		// Narrows RHS to lhsEnvValues/totalEnvValues of total series.
+		b.Run(fmt.Sprintf("on(env)/rhs=%d", rhsCount), func(b *testing.B) {
+			vm := parser.VectorMatching{On: true, MatchingLabels: []string{"env"}}
+			runAndUnlessBench(b, lhsSeries, rhsSeries, vm)
+		})
+
+		// ignoring(handler): matching labels computed at runtime as the intersection of
+		// non-ignored label names across all LHS series.
+		// env and pod are common to all LHS series, so both become RHS matchers.
+		b.Run(fmt.Sprintf("ignoring(handler)/rhs=%d", rhsCount), func(b *testing.B) {
+			vm := parser.VectorMatching{On: false, MatchingLabels: []string{"handler"}}
+			runAndUnlessBench(b, lhsSeries, rhsSeries, vm)
+		})
+
+		// Baseline: on() with no matching labels produces no hints, so the full RHS is fetched.
+		// rhs_series_fetched should equal rhsCount, confirming no narrowing occurs.
+		b.Run(fmt.Sprintf("baseline_no_hints/rhs=%d", rhsCount), func(b *testing.B) {
+			vm := parser.VectorMatching{On: true, MatchingLabels: nil}
+			runAndUnlessBench(b, lhsSeries, rhsSeries, vm)
+		})
+	}
+}
+
+// runAndUnlessBench is a helper that benchmarks a single SeriesMetadata call for the given
+// VectorMatching configuration. It reports rhs_series_fetched — the number of RHS series that
+// survived the derived matcher filter — so callers can confirm the optimisation is active.
+func runAndUnlessBench(b *testing.B, lhsSeries, rhsSeries []labels.Labels, vm parser.VectorMatching) {
+	b.Helper()
+
+	ctx := context.Background()
+	timeRange := types.NewInstantQueryTimeRange(time.Now())
+
+	// Pre-allocate backing arrays to amortise slice allocation cost across iterations.
+	lhsBuf := make([]labels.Labels, len(lhsSeries))
+	rhsBuf := make([]labels.Labels, len(rhsSeries))
+
+	var rhsSeriesFetched int
+	for b.Loop() {
+		// TestOperator.SeriesMetadata filters t.Series in-place, so each iteration needs
+		// a fresh copy of the slice (the underlying labels.Labels values are immutable).
+		copy(lhsBuf, lhsSeries)
+		copy(rhsBuf, rhsSeries)
+
+		memTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
+		left := &operators.TestOperator{
+			Series:                   lhsBuf,
+			Data:                     make([]types.InstantVectorSeriesData, len(lhsBuf)),
+			MemoryConsumptionTracker: memTracker,
+		}
+		right := &operators.TestOperator{
+			Series:                   rhsBuf,
+			Data:                     make([]types.InstantVectorSeriesData, len(rhsBuf)),
+			MemoryConsumptionTracker: memTracker,
+		}
+
+		o := NewAndUnlessBinaryOperation(left, right, vm, memTracker, false, timeRange, posrange.PositionRange{}, nil, log.NewNopLogger())
+		outputSeries, err := o.SeriesMetadata(ctx, nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		rhsSeriesFetched = len(right.Series)
+
+		types.SeriesMetadataSlicePool.Put(&outputSeries, memTracker)
+		if err := o.Finalize(ctx); err != nil {
+			b.Fatal(err)
+		}
+		o.Close()
+	}
+
+	b.ReportMetric(float64(rhsSeriesFetched), "rhs_series_fetched")
 }

--- a/pkg/streamingpromql/operators/binops/and_unless_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/and_unless_binary_operation_test.go
@@ -20,12 +20,16 @@ import (
 )
 
 func TestAndUnlessBinaryOperation_PassesHintMatchersToRHS(t *testing.T) {
-	// Test that when hints are provided, matchers derived from the LHS series' label values are
-	// passed to the RHS SeriesMetadata call to narrow what the RHS fetches. When hints are nil,
-	// the RHS receives nil matchers (which is what happened before).
+	// Test that matchers derived from LHS series label values are passed to the RHS SeriesMetadata
+	// call to narrow what the RHS fetches.
+	//
+	// For on(...) matching, the matching labels are known from VectorMatching and used directly.
+	// For ignoring(...) matching, the effective matching labels are computed as the intersection
+	// of label names present in all LHS series, excluding the ignored labels.
 	testCases := map[string]struct {
-		isUnless bool
-		hints    *Hints
+		isUnless       bool
+		hints          *Hints
+		vectorMatching parser.VectorMatching
 
 		leftSeries  []labels.Labels
 		rightSeries []labels.Labels
@@ -33,16 +37,17 @@ func TestAndUnlessBinaryOperation_PassesHintMatchersToRHS(t *testing.T) {
 		expectedRHSMatchers  types.Matchers
 		expectedOutputSeries []labels.Labels
 	}{
-		"and op with hints: RHS receives matcher derived from LHS label values, filtering non-matching RHS series": {
-			isUnless: false,
-			hints:    &Hints{Include: []string{"env"}},
+		"and op, on(...): RHS receives matcher derived from LHS label values, filtering non-matching RHS series": {
+			isUnless:       false,
+			hints:          nil,
+			vectorMatching: parser.VectorMatching{On: true, MatchingLabels: []string{"env"}},
 			leftSeries: []labels.Labels{
 				labels.FromStrings("env", "prod", "series", "left-1"),
 				labels.FromStrings("env", "prod", "series", "left-2"),
 			},
 			rightSeries: []labels.Labels{
 				labels.FromStrings("env", "prod", "series", "right-1"),
-				labels.FromStrings("env", "staging", "series", "right-2"), // these labels will be filtered out by hint matcher because they're not in RHS
+				labels.FromStrings("env", "staging", "series", "right-2"), // filtered out: "staging" not in LHS env values
 			},
 			expectedRHSMatchers: types.Matchers{
 				{Type: labels.MatchRegexp, Name: "env", Value: "prod"},
@@ -52,29 +57,31 @@ func TestAndUnlessBinaryOperation_PassesHintMatchersToRHS(t *testing.T) {
 				labels.FromStrings("env", "prod", "series", "left-2"),
 			},
 		},
-		"unless op with hints: RHS receives matchers for all LHS env values; RHS series not in LHS env values are filtered out": {
-			isUnless: true,
-			hints:    &Hints{Include: []string{"env"}},
+		"unless op, on(...): RHS receives matchers for all LHS env values; RHS series not in LHS env values are filtered out": {
+			isUnless:       true,
+			hints:          nil,
+			vectorMatching: parser.VectorMatching{On: true, MatchingLabels: []string{"env"}},
 			leftSeries: []labels.Labels{
 				labels.FromStrings("env", "prod", "series", "left-1"),
 				labels.FromStrings("env", "staging", "series", "left-2"),
 			},
 			rightSeries: []labels.Labels{
 				labels.FromStrings("env", "prod", "series", "right-1"),
-				labels.FromStrings("env", "dev", "series", "right-2"), // filtered out by hint matcher like above
+				labels.FromStrings("env", "dev", "series", "right-2"), // filtered out: "dev" not in LHS env values
 			},
 			expectedRHSMatchers: types.Matchers{
 				{Type: labels.MatchRegexp, Name: "env", Value: "prod|staging"},
 			},
-			// the SeriesMetadata for unless should always returns all of the LHS series, filtering happens in a different part of the pipeline
+			// the SeriesMetadata for unless always returns all LHS series; filtering happens later
 			expectedOutputSeries: []labels.Labels{
 				labels.FromStrings("env", "prod", "series", "left-1"),
 				labels.FromStrings("env", "staging", "series", "left-2"),
 			},
 		},
-		"and op with no hints: RHS receives nil matchers": {
-			isUnless: false,
-			hints:    nil,
+		"and op, on() with empty matching labels: RHS receives nil matchers": {
+			isUnless:       false,
+			hints:          nil,
+			vectorMatching: parser.VectorMatching{On: true, MatchingLabels: nil},
 			leftSeries: []labels.Labels{
 				labels.FromStrings("env", "prod", "series", "left-1"),
 			},
@@ -86,21 +93,107 @@ func TestAndUnlessBinaryOperation_PassesHintMatchersToRHS(t *testing.T) {
 				labels.FromStrings("env", "prod", "series", "left-1"),
 			},
 		},
-		"unless op with no hints: RHS receives nil matchers": {
-			isUnless: true,
-			hints:    nil,
+		"and op, ignoring(...): RHS receives matchers for labels common to all LHS series, excluding ignored labels": {
+			isUnless:       false,
+			hints:          nil,
+			vectorMatching: parser.VectorMatching{On: false, MatchingLabels: []string{"series"}},
 			leftSeries: []labels.Labels{
 				labels.FromStrings("env", "prod", "series", "left-1"),
 				labels.FromStrings("env", "staging", "series", "left-2"),
 			},
 			rightSeries: []labels.Labels{
 				labels.FromStrings("env", "prod", "series", "right-1"),
+				labels.FromStrings("env", "staging", "series", "right-2"),
+				labels.FromStrings("env", "dev", "series", "right-3"), // filtered out: "dev" not in LHS env values
 			},
+			// "series" is excluded (it's in the ignoring set), "env" is common to all LHS series
+			expectedRHSMatchers: types.Matchers{
+				{Type: labels.MatchRegexp, Name: "env", Value: "prod|staging"},
+			},
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("env", "prod", "series", "left-1"),
+				labels.FromStrings("env", "staging", "series", "left-2"),
+			},
+		},
+		"and op, ignoring(...): labels not common to all LHS series are excluded from matchers to avoid over-narrowing": {
+			isUnless:       false,
+			hints:          nil,
+			vectorMatching: parser.VectorMatching{On: false, MatchingLabels: []string{"series"}},
+			leftSeries: []labels.Labels{
+				labels.FromStrings("env", "prod", "region", "us-east", "series", "left-1"),
+				labels.FromStrings("env", "staging", "series", "left-2"), // no "region" label
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("env", "prod", "region", "us-east", "series", "right-1"),
+				labels.FromStrings("env", "staging", "series", "right-2"),
+				labels.FromStrings("env", "dev", "series", "right-3"), // filtered out
+			},
+			// "region" is absent from some LHS series, so only "env" (present in all) is used.
+			// Using "region" would incorrectly filter out right-2, a valid match for left-2.
+			expectedRHSMatchers: types.Matchers{
+				{Type: labels.MatchRegexp, Name: "env", Value: "prod|staging"},
+			},
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("env", "prod", "region", "us-east", "series", "left-1"),
+				labels.FromStrings("env", "staging", "series", "left-2"),
+			},
+		},
+		"and op, ignoring() with no labels to ignore: RHS receives matchers for all LHS labels, filtering non-matching RHS series": {
+			isUnless:       false,
+			hints:          nil,
+			vectorMatching: parser.VectorMatching{On: false, MatchingLabels: nil},
+			leftSeries: []labels.Labels{
+				labels.FromStrings("env", "prod", "series", "left-1"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("env", "prod", "series", "left-1"),    // matches all LHS labels → kept
+				labels.FromStrings("env", "prod", "series", "right-1"),   // series differs → filtered out
+				labels.FromStrings("env", "staging", "series", "left-1"), // env differs → filtered out
+			},
+			// All LHS label names (env, series) become hints since ignoring() excludes nothing
+			expectedRHSMatchers: types.Matchers{
+				{Type: labels.MatchRegexp, Name: "env", Value: "prod"},
+				{Type: labels.MatchRegexp, Name: "series", Value: "left-1"},
+			},
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("env", "prod", "series", "left-1"),
+			},
+		},
+		"and op, ignoring(...) with heterogeneous LHS and no common non-ignored labels: RHS receives nil matchers": {
+			isUnless:       false,
+			hints:          nil,
+			vectorMatching: parser.VectorMatching{On: false, MatchingLabels: []string{"series"}},
+			leftSeries: []labels.Labels{
+				labels.FromStrings("env", "prod", "series", "left-1"),
+				labels.FromStrings("region", "us-east", "series", "left-2"), // no "env", different label set
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("env", "prod", "series", "right-1"),
+				labels.FromStrings("region", "us-east", "series", "right-2"),
+			},
+			// no labels common to all LHS series (excluding ignored "series"), so no matchers
 			expectedRHSMatchers: nil,
 			expectedOutputSeries: []labels.Labels{
 				labels.FromStrings("env", "prod", "series", "left-1"),
-				// the SeriesMetadata for unless should always returns all of the LHS series, filtering happens in a different part of the pipeline
-				labels.FromStrings("env", "staging", "series", "left-2"),
+				labels.FromStrings("region", "us-east", "series", "left-2"),
+			},
+		},
+		"planner hints are used as fallback when VectorMatching yields no hints (on() with empty labels)": {
+			isUnless:       false,
+			hints:          &Hints{Include: []string{"env"}},
+			vectorMatching: parser.VectorMatching{On: true, MatchingLabels: nil},
+			leftSeries: []labels.Labels{
+				labels.FromStrings("env", "prod", "series", "left-1"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("env", "prod", "series", "right-1"),
+				labels.FromStrings("env", "staging", "series", "right-2"), // filtered by planner hint
+			},
+			expectedRHSMatchers: types.Matchers{
+				{Type: labels.MatchRegexp, Name: "env", Value: "prod"},
+			},
+			expectedOutputSeries: []labels.Labels{
+				labels.FromStrings("env", "prod", "series", "left-1"),
 			},
 		},
 	}
@@ -112,8 +205,7 @@ func TestAndUnlessBinaryOperation_PassesHintMatchersToRHS(t *testing.T) {
 			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 			left := &operators.TestOperator{Series: testCase.leftSeries, MemoryConsumptionTracker: memoryConsumptionTracker}
 			right := &operators.TestOperator{Series: testCase.rightSeries, Data: make([]types.InstantVectorSeriesData, len(testCase.rightSeries)), MemoryConsumptionTracker: memoryConsumptionTracker}
-			vectorMatching := parser.VectorMatching{On: true, MatchingLabels: []string{"env"}}
-			o := NewAndUnlessBinaryOperation(left, right, vectorMatching, memoryConsumptionTracker, testCase.isUnless, timeRange, posrange.PositionRange{}, testCase.hints, log.NewNopLogger())
+			o := NewAndUnlessBinaryOperation(left, right, testCase.vectorMatching, memoryConsumptionTracker, testCase.isUnless, timeRange, posrange.PositionRange{}, testCase.hints, log.NewNopLogger())
 
 			outputSeries, err := o.SeriesMetadata(ctx, nil)
 			require.NoError(t, err)

--- a/pkg/streamingpromql/testdata/ours/binary_operators.test
+++ b/pkg/streamingpromql/testdata/ours/binary_operators.test
@@ -1895,3 +1895,49 @@ eval range from 0 to 18m step 6m left and on(env) right
 eval range from 0 to 18m step 6m left unless on(env) right
   left{env="prod", pod="a"} _ 2 _ 4
   left{env="prod", pod="b"} _ 6 _ 8
+
+clear
+
+# Test that the ignoring(...) narrowing optimisation for 'and'/'unless' produces correct results.
+# When VectorMatching.On is false, the operator computes the intersection of label names present
+# in all LHS series (excluding the ignored labels) and uses them as RHS hints. Here the common
+# non-ignored label is "env", so a matcher env=~"prod" is built and passed to the RHS, filtering
+# out the env="staging" series which could never match the LHS anyway.
+load 6m
+  left{env="prod",    pod="a"} 1 2 3 4
+  left{env="prod",    pod="b"} 5 6 7 8
+  right{env="prod",   pod="x"} 10 _ 30 _
+  right{env="staging", pod="y"} _  _ _  _
+
+# and ignoring(pod): env="staging" RHS series is narrowed away by hint matcher env=~"prod".
+# The result is identical to what it would be without narrowing.
+eval range from 0 to 18m step 6m left and ignoring(pod) right
+  left{env="prod", pod="a"} 1 _ 3 _
+  left{env="prod", pod="b"} 5 _ 7 _
+
+# unless ignoring(pod): same narrowing applies; env="prod" LHS series are suppressed at steps
+# where env="prod" RHS has data (t=0, t=12), and returned at other steps.
+eval range from 0 to 18m step 6m left unless ignoring(pod) right
+  left{env="prod", pod="a"} _ 2 _ 4
+  left{env="prod", pod="b"} _ 6 _ 8
+
+clear
+
+# Test that when LHS series have heterogeneous label sets, the ignoring(...) narrowing uses only
+# labels common to all LHS series, to avoid over-narrowing the RHS. Here "region" is absent from
+# the second LHS series, so only "env" (common to all) is used as a hint. If "region" were also
+# used, right{env="staging"} would be incorrectly filtered out, breaking the match for left-b.
+load 6m
+  left{env="prod",    region="us", pod="a"} 1 2 3 4
+  left{env="staging", pod="b"}              5 6 7 8
+  right{env="prod",    region="us", pod="x"} 10 _ 30 _
+  right{env="staging", pod="y"}              _  _ 30 _
+  right{env="dev",     pod="z"}              _  _ _  _
+
+eval range from 0 to 18m step 6m left and ignoring(pod) right
+  left{env="prod",    region="us", pod="a"} 1 _ 3 _
+  left{env="staging", pod="b"}              _ _ 7 _
+
+eval range from 0 to 18m step 6m left unless ignoring(pod) right
+  left{env="prod",    region="us", pod="a"} _ 2 _ 4
+  left{env="staging", pod="b"}              5 6 _ 8


### PR DESCRIPTION
#### What this PR does
This PR generates RHS hints from the LHS matchers and data during execution like one-to-one and one-to-many/many-to-one. 

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `and`/`unless` build RHS selector matchers based on runtime LHS metadata, which can affect query correctness/performance if matching-label inference is wrong (especially for `ignoring(...)`). Covered by expanded tests and new benchmark but touches core query execution.
> 
> **Overview**
> **Streaming PromQL `and`/`unless` now derives RHS narrowing hints at runtime** from the actual LHS series metadata, instead of relying only on planner-provided hints.
> 
> For `on(...)`, the operator uses the explicit matching labels; for `ignoring(...)`, it computes the *intersection* of non-ignored label names present across all LHS series (excluding `__name__`) to avoid over-narrowing, and falls back to planner hints when no runtime hints can be derived.
> 
> Adds extensive unit + promqltest coverage for `on`/`ignoring` edge cases and introduces a benchmark that reports how much the RHS fetch is narrowed. Updates `CHANGELOG.md` with the MQE enhancement entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba47c9c0563a95a02105f3263a7ebb4775bce42b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->