### PR TITLE
mimir-distributed: guard null spec.clients / basicAuth in meta-monitoring CRs

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -55,6 +55,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [BUGFIX] Upgrade rollout-operator chart to 0.38.1, which fixes an issue with permissions preventing the rollout-operator from starting when webhooks are not enabled. #13754.
 * [BUGFIX] Fix Kafka image reference to include the registry in the StatefulSet template. #14211.
 * [BUGFIX] Helm: Removed helm's empty selector for the smoke-test-job file that is throwing errors in ArgoCD #14684
+* [BUGFIX] Meta-monitoring: Do not emit `spec.clients: null` on `LogsInstance` or `basicAuth: null` on `MetricsInstance.spec.remoteWrite[*]` when the corresponding `metaMonitoring.grafanaAgent.{logs,metrics}.remote.url` / `auth` fields are empty. The resulting manifests failed CRD validation under ArgoCD ServerSideApply. #11200
 
 ## 6.0.6
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -55,7 +55,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [BUGFIX] Upgrade rollout-operator chart to 0.38.1, which fixes an issue with permissions preventing the rollout-operator from starting when webhooks are not enabled. #13754.
 * [BUGFIX] Fix Kafka image reference to include the registry in the StatefulSet template. #14211.
 * [BUGFIX] Helm: Removed helm's empty selector for the smoke-test-job file that is throwing errors in ArgoCD #14684
-* [BUGFIX] Meta-monitoring: Do not emit `spec.clients: null` on `LogsInstance` or `basicAuth: null` on `MetricsInstance.spec.remoteWrite[*]` when the corresponding `metaMonitoring.grafanaAgent.{logs,metrics}.remote.url` / `auth` fields are empty. The resulting manifests failed CRD validation under ArgoCD ServerSideApply. #11200
+* [BUGFIX] Meta-monitoring: Do not emit `spec.clients: null` on `LogsInstance` or `basicAuth: null` on `MetricsInstance.spec.remoteWrite[*]` when the corresponding `metaMonitoring.grafanaAgent.{logs,metrics}.remote.url` / `auth` fields are empty. The resulting manifests failed CRD validation under ArgoCD ServerSideApply. #15135
 
 ## 6.0.6
 

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/_helpers.tpl
@@ -5,7 +5,10 @@
 {{- $url = include "mimir.remoteWriteUrl.inCluster" .ctx }}
 {{- end -}}
 - url: {{ $url }}
-  {{- if .auth }}
+  {{- /* Only emit the basicAuth block if at least one populated field exists; emitting
+        `basicAuth:` with no children produces `basicAuth: null` which fails CRD
+        validation on ServerSideApply (see grafana/mimir#11200). */ -}}
+  {{- if and .auth (or .auth.username (and .auth.passwordSecretKey .auth.passwordSecretName)) }}
   basicAuth:
   {{- if .auth.username }}
     username:
@@ -17,9 +20,10 @@
     password:
       name: {{ .passwordSecretName | quote }}
       key: {{ .passwordSecretKey | quote }}
-  {{- else if or .passwordSecretKey .passwordSecretName }}{{ required "Set either both passwordSecretKey and passwordSecretName or neither" nil }}
   {{- end }}
   {{- end }}
+  {{- else if and .auth (or .auth.passwordSecretKey .auth.passwordSecretName) }}
+  {{- required "Set either both passwordSecretKey and passwordSecretName or neither" nil }}
   {{- end }}
   {{- $headers := .headers -}}
   {{- if $writeBackToMimir -}}{{- $_ := set $headers "X-Scope-OrgID" "metamonitoring" -}}{{- end -}}
@@ -36,10 +40,13 @@
 {{- define "mimir.metaMonitoring.logs.client" -}}
 {{- if .url }}
 - url: {{ .url }}
-  {{- if .auth }}
-  {{- if .auth.tenantId }}
+  {{- if and .auth .auth.tenantId }}
   tenantId: {{ .auth.tenantId | quote }}
   {{- end }}
+  {{- /* Only emit the basicAuth block if at least one populated field exists; emitting
+        `basicAuth:` with no children produces `basicAuth: null` which fails CRD
+        validation on ServerSideApply (see grafana/mimir#11200). */ -}}
+  {{- if and .auth (or .auth.username (and .auth.passwordSecretKey .auth.passwordSecretName)) }}
   basicAuth:
   {{- if .auth.username }}
     username:
@@ -51,10 +58,10 @@
     password:
       name: {{ .passwordSecretName | quote }}
       key: {{ .passwordSecretKey | quote }}
-  {{- else if or .passwordSecretKey .passwordSecretName }}
+  {{- end }}
+  {{- end }}
+  {{- else if and .auth (or .auth.passwordSecretKey .auth.passwordSecretName) }}
   {{ required "Set either both passwordSecretKey and passwordSecretName or neither" nil }}
-  {{- end }}
-  {{- end }}
   {{- end }}
   externalLabels:
     cluster: {{ include "mimir.clusterName" $.ctx | quote}}

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/logs-instance.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/logs-instance.yaml
@@ -15,14 +15,22 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- /* Only emit the clients: key when at least one client has a URL. Emitting an
+        empty sequence would produce `clients: null` which fails CRD validation on
+        ServerSideApply (see grafana/mimir#11200). */ -}}
+  {{- $hasClient := false -}}
+  {{- if (.logs).remote -}}{{- if (.logs).remote.url -}}{{- $hasClient = true -}}{{- end -}}{{- end -}}
+  {{- range ((.logs).additionalClientConfigs | default list) -}}
+  {{- if .url -}}{{- $hasClient = true -}}{{- end -}}
+  {{- end -}}
+  {{- if $hasClient }}
   clients:
-    {{- if or (.logs).additionalClientConfigs (.logs).remote }}
     {{- range $i, $cfg := prepend ((.logs).additionalClientConfigs | default list) (.logs).remote }}
     {{- with $cfg }}
     {{- include "mimir.metaMonitoring.logs.client" (dict "ctx" $ "url" .url "auth" .auth "usernameKey" (printf "username-%d" $i)) | nindent 6 -}}
     {{- end }}
     {{- end }}
-    {{- end }}
+  {{- end }}
 
   # Supply an empty namespace selector to look in all namespaces. Remove
   # this to only look in the same namespace as the LogsInstance CR

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/metrics-instance.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/metrics-instance.yaml
@@ -15,14 +15,19 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- /* remoteWrite entries always have a url (either user-supplied or a fallback to
+        Mimir's in-cluster URL via `mimir.remoteWriteUrl.inCluster`), so at least one
+        entry is always produced. Keep the existing outer guard so we don't emit an
+        empty sequence — that would produce `remoteWrite: null` which fails CRD
+        validation on ServerSideApply (see grafana/mimir#11200). */ -}}
+  {{- if or (.metrics).additionalRemoteWriteConfigs (.metrics).remote }}
   remoteWrite:
-    {{- if or (.metrics).additionalRemoteWriteConfigs (.metrics).remote }}
     {{- range $i, $cfg := prepend ((.metrics).additionalRemoteWriteConfigs | default list) (.metrics).remote }}
     {{- with $cfg }}
     {{- include "mimir.metaMonitoring.metrics.remoteWrite" (dict "ctx" $ "url" .url "auth" .auth "usernameKey" (printf "username-%d" $i) "headers" .headers "sigv4" .sigv4 ) | nindent 6 -}}
     {{- end }}
     {{- end }}
-    {{- end }}
+  {{- end }}
 
   # Supply an empty namespace selector to look in all namespaces. Remove
   # this to only look in the same namespace as the MetricsInstance CR

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/metrics-instance.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/metrics-instance.yaml
@@ -13,7 +13,6 @@ metadata:
 spec:
   remoteWrite:
       - url: http://metamonitoring-values-mimir-gateway.citestns.svc:80/api/v1/push
-        basicAuth:
         headers:
           X-Scope-OrgID: metamonitoring
       - url: https://mimir.example.com


### PR DESCRIPTION
#### What this PR does

ArgoCD ServerSideApply rejects the meta-monitoring `LogsInstance` and `MetricsInstance` manifests when the chart is rendered with an empty or partially-filled `auth` block, or without a `remote.url`:

```
LogsInstance "mimir-meta-monitoring" is invalid:
  spec.clients: Invalid value: "null"

MetricsInstance "mimir-meta-monitoring" is invalid:
  spec.remoteWrite[0].basicAuth: Invalid value: "null"
```

(As `@rishabhkhemka` pointed out on the issue: *"don't provide the auth section, empty auth values are causing that null in the generated value"*.)

Two root causes:

1. **`basicAuth: null`** — `mimir.metaMonitoring.metrics.remoteWrite` and `mimir.metaMonitoring.logs.client` emitted the `basicAuth:` key whenever `.auth` was non-nil, even when every field under it (`username`, `passwordSecretName`, `passwordSecretKey`) was the empty string. The children all got skipped by their own guards so `basicAuth:` ended up with no body → `null`. Tightened the guard so the block is only emitted when at least one populated field exists.
2. **`spec.clients: null` / `spec.remoteWrite: null`** — `logs-instance.yaml` always emitted `spec.clients:` and `metrics-instance.yaml` always emitted `spec.remoteWrite:`, even when the range produced no entries. Moved the `clients:` / `remoteWrite:` keys inside the conditional so they are omitted entirely when nothing is to be rendered, and skipped `LogsInstance` clients whose `.url` is empty.

#### Verification

Rendered `ci/offline/metamonitoring-values.yaml` — output is byte-identical to `operations/helm/tests/metamonitoring-values-generated/` (no golden record change).

With the minimal reproducer:

```yaml
metaMonitoring:
  serviceMonitor: { enabled: true }
  grafanaAgent: { enabled: true, installOperator: true }
```

**Before:** `spec.clients: null` (fails CRD validation).
**After:** `clients:` key omitted entirely — passes validation.

With the "empty auth" reproducer from the issue:

```yaml
metaMonitoring:
  serviceMonitor: { enabled: true }
  grafanaAgent:
    enabled: true
    installOperator: true
    logs:
      remote:
        url: http://test.com
        auth: { username: "", passwordSecretName: "", passwordSecretKey: "" }
    metrics:
      remote:
        url: http://test.com
        auth: { username: "", passwordSecretName: "", passwordSecretKey: "" }
```

**Before:** `basicAuth: null` under each entry.
**After:** `basicAuth:` key omitted — passes validation.

#### Which issue(s) this PR fixes or relates to

Fixes #11200

#### Checklist

- [x] Tests updated — the existing golden records under `operations/helm/tests/*-generated/` are unchanged for all existing test values; CI `check-helm-tests` will re-verify.
- [x] Documentation added — chart CHANGELOG entry added.
- [x] `CHANGELOG.md` updated (`operations/helm/charts/mimir-distributed/CHANGELOG.md`, under `main / unreleased`)
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features — N/A, bugfix only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Helm templating change limited to meta-monitoring CR rendering; main risk is unintentionally omitting `clients`/`basicAuth` blocks when users relied on empty/partial configs.
> 
> **Overview**
> Fixes Helm rendering of meta-monitoring `LogsInstance`/`MetricsInstance` CRs to **avoid emitting invalid `null` fields** under ArgoCD ServerSideApply.
> 
> The templates now only render `basicAuth` when at least one auth field is populated (and still enforce password secret key/name pairing), and only render `spec.clients`/`spec.remoteWrite` when entries with a URL are actually produced, preventing `clients: null` / `basicAuth: null` CRD validation failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3231bfbc0e8c2ca23250ca816ecd4c5149f44ec9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->