### PR TITLE
BucketDecbufFactory: use Decbufs which only read a table section

### DIFF
--- a/pkg/storage/indexheader/encoding/bucket_factory.go
+++ b/pkg/storage/indexheader/encoding/bucket_factory.go
@@ -33,19 +33,30 @@ func NewBucketDecbufFactory(ctx context.Context, bkt objstore.BucketReader, obje
 	}
 }
 
-func (bf *BucketDecbufFactory) NewDecbufAtChecked(offset int, table *crc32.Table) Decbuf {
+func (bf *BucketDecbufFactory) getCachedContentLength(offset int) (int, bool) {
+	bf.mu.Lock()
+	defer bf.mu.Unlock()
+	length, ok := bf.sectionLenCache[offset]
+	return length, ok
+}
+
+func (bf *BucketDecbufFactory) getContentLength(offset int) (int, error) {
+	// Check for content length before making a bucket attributes call.
+	if length, ok := bf.getCachedContentLength(offset); ok {
+		return length, nil
+	}
 	attrs, err := bf.bkt.Attributes(bf.ctx, bf.objectPath)
 	if err != nil {
-		return Decbuf{E: fmt.Errorf("get size from %s: %w", bf.objectPath, err)}
+		return 0, fmt.Errorf("get size from %s: %w", bf.objectPath, err)
 	}
 	if offset > int(attrs.Size) {
-		return Decbuf{E: fmt.Errorf("offset greater than object size of %s", bf.objectPath)}
+		return 0, fmt.Errorf("offset greater than object size of %s", bf.objectPath)
 	}
 
 	var contentLength int
 	bf.mu.Lock()
 	if cachedContentLength, ok := bf.sectionLenCache[offset]; ok {
-		// Section length is cached
+		// Section length may have been cached since we last checked
 		contentLength = cachedContentLength
 	} else {
 		// We do not know section length yet;
@@ -58,16 +69,24 @@ func (bf *BucketDecbufFactory) NewDecbufAtChecked(offset int, table *crc32.Table
 		n, err := metaReader.Read(lengthBytes)
 		if err != nil {
 			bf.mu.Unlock()
-			return Decbuf{E: err}
+			return 0, err
 		}
 		if n != numLenBytes {
 			bf.mu.Unlock()
-			return Decbuf{E: fmt.Errorf("insufficient bytes read for size (got %d, wanted %d): %w", n, numLenBytes, ErrInvalidSize)}
+			return 0, fmt.Errorf("insufficient bytes read for size (got %d, wanted %d): %w", n, numLenBytes, ErrInvalidSize)
 		}
 		contentLength = int(binary.BigEndian.Uint32(lengthBytes))
 		bf.sectionLenCache[offset] = contentLength
 	}
 	bf.mu.Unlock()
+	return contentLength, nil
+}
+
+func (bf *BucketDecbufFactory) NewDecbufAtChecked(offset int, table *crc32.Table) Decbuf {
+	contentLength, err := bf.getContentLength(offset)
+	if err != nil {
+		return Decbuf{E: err}
+	}
 
 	bufferLength := numLenBytes + contentLength + crc32.Size
 
@@ -90,6 +109,36 @@ func (bf *BucketDecbufFactory) NewDecbufAtChecked(offset int, table *crc32.Table
 	}
 
 	return d
+}
+
+// NewDecbufInSection creates a Decbuf which can only read a section of a table.
+// sectionStartOffset and sectionEndOffset are relative offsets from tableOffset (an absolute offset).
+// If sectionEndOffset is beyond the end of the table, length is adjusted to only read to the end of the table.
+func (bf *BucketDecbufFactory) NewDecbufInSection(tableOffset, sectionStartOffset, sectionEndOffset int) Decbuf {
+	length, err := bf.getContentLength(tableOffset)
+	if err != nil {
+		return Decbuf{E: err}
+	}
+
+	tableRelativeEndOffset := numLenBytes + length
+
+	// Force the reader to stop at the end of the table first
+	if tableRelativeEndOffset < sectionEndOffset {
+		sectionEndOffset = tableRelativeEndOffset
+	}
+	sectionLength := sectionEndOffset - sectionStartOffset
+	if sectionLength <= 0 {
+		return Decbuf{E: fmt.Errorf("section length must be greater than 0")}
+	}
+	bufReader := NewBucketBufReader(
+		bf.ctx,
+		bf.bkt,
+		bf.objectPath,
+		tableOffset+sectionStartOffset,
+		sectionLength,
+	)
+
+	return Decbuf{r: bufReader}
 }
 
 func (bf *BucketDecbufFactory) NewDecbufAtUnchecked(offset int) Decbuf {

--- a/pkg/storage/indexheader/encoding/factory.go
+++ b/pkg/storage/indexheader/encoding/factory.go
@@ -32,5 +32,11 @@ type DecbufFactory interface {
 	// use NewDecbufAtUnchecked or NewDecbufAtChecked.
 	NewRawDecbuf() Decbuf
 
+	// NewDecbufInSection returns a new binary decoding reader positioned at tableOffset + relativeSectionStartOffset,
+	// spanning to tableOffset+relativeSectionEndOffset or the end of the table, whichever comes first.
+	// It expects the first 4 bytes after tableOffset to hold the big-endian encoded content length.
+	// This method mUST NOT validate or compute the CRC of the content.
+	NewDecbufInSection(tableOffset, relativeSectionStartOffset, relativeSectionEndOffset int) Decbuf
+
 	Close() error
 }

--- a/pkg/storage/indexheader/encoding/factory.go
+++ b/pkg/storage/indexheader/encoding/factory.go
@@ -32,11 +32,13 @@ type DecbufFactory interface {
 	// use NewDecbufAtUnchecked or NewDecbufAtChecked.
 	NewRawDecbuf() Decbuf
 
-	// NewDecbufInSection returns a new binary decoding reader positioned at tableOffset + relativeSectionStartOffset,
-	// spanning to tableOffset+relativeSectionEndOffset or the end of the table, whichever comes first.
+	// NewDecbufInSection returns a new binary decoding reader positioned at tableOffset + sectionStartOffset,
+	// spanning to tableOffset+sectionEndOffset or the end of the table, whichever comes first.
+	// Reading from a section of the table rather than the whole table allows the reader to leverage
+	// shorter read operations, which can improve read latency and cache efficiency (if caching these reads).
 	// It expects the first 4 bytes after tableOffset to hold the big-endian encoded content length.
-	// This method mUST NOT validate or compute the CRC of the content.
-	NewDecbufInSection(tableOffset, relativeSectionStartOffset, relativeSectionEndOffset int) Decbuf
+	// This method MUST NOT validate or compute the CRC of the content.
+	NewDecbufInSection(tableOffset, sectionStartOffset, sectionEndOffset int) Decbuf
 
 	Close() error
 }

--- a/pkg/storage/indexheader/encoding/factory_test.go
+++ b/pkg/storage/indexheader/encoding/factory_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"hash/crc32"
+	"math"
 	"os"
 	"path"
 	"testing"
@@ -57,7 +58,7 @@ func TestDecbufFactory_NewDecbufAtChecked_InvalidCRC(t *testing.T) {
 	enc := createTestEncoder(testContentSize)
 	enc.PutBytes([]byte{0, 0, 0, 0})
 
-	testDecbufFactory(t, testContentSize, enc, true, func(t *testing.T, factory DecbufFactory) {
+	testDecbufFactory(t, testContentSize, enc, true, true, func(t *testing.T, factory DecbufFactory) {
 		d := factory.NewDecbufAtChecked(0, table)
 		t.Cleanup(func() {
 			require.NoError(t, d.Close())
@@ -71,7 +72,7 @@ func TestDecbufFactory_NewDecbufAtChecked_InvalidLength(t *testing.T) {
 	enc := createTestEncoder(testContentSize)
 	enc.PutHash(crc32.New(table))
 
-	testDecbufFactory(t, testContentSize+1000, enc, true, func(t *testing.T, factory DecbufFactory) {
+	testDecbufFactory(t, testContentSize+1000, enc, true, true, func(t *testing.T, factory DecbufFactory) {
 		d := factory.NewDecbufAtChecked(0, table)
 		t.Cleanup(func() {
 			require.NoError(t, d.Close())
@@ -85,7 +86,7 @@ func TestDecbufFactory_NewDecbufAtChecked_HappyPath(t *testing.T) {
 	enc := createTestEncoder(testContentSize)
 	enc.PutHash(crc32.New(table))
 
-	testDecbufFactory(t, testContentSize, enc, true, func(t *testing.T, factory DecbufFactory) {
+	testDecbufFactory(t, testContentSize, enc, true, true, func(t *testing.T, factory DecbufFactory) {
 		d := factory.NewDecbufAtChecked(0, table)
 		t.Cleanup(func() {
 			require.NoError(t, d.Close())
@@ -134,7 +135,7 @@ func TestDecbufFactory_NewDecbufAtChecked_Concurrent(t *testing.T) {
 		concurrency = 10
 	)
 
-	testDecbufFactory(t, testContentSize, enc, true, func(t *testing.T, factory DecbufFactory) {
+	testDecbufFactory(t, testContentSize, enc, true, true, func(t *testing.T, factory DecbufFactory) {
 		g, _ := errgroup.WithContext(context.Background())
 
 		for i := 0; i < concurrency; i++ {
@@ -164,7 +165,7 @@ func TestDecbufFactory_NewDecbufAtUnchecked_HappyPath(t *testing.T) {
 	enc := createTestEncoder(testContentSize)
 	enc.PutHash(crc32.New(table))
 
-	testDecbufFactory(t, testContentSize, enc, true, func(t *testing.T, factory DecbufFactory) {
+	testDecbufFactory(t, testContentSize, enc, true, true, func(t *testing.T, factory DecbufFactory) {
 		d := factory.NewDecbufAtUnchecked(0)
 		t.Cleanup(func() {
 			require.NoError(t, d.Close())
@@ -179,7 +180,7 @@ func TestDecbufFactory_NewDecbufRaw_HappyPath(t *testing.T) {
 	enc := createTestEncoder(testContentSize)
 	enc.PutHash(crc32.New(table))
 
-	testDecbufFactory(t, testContentSize, enc, true, func(t *testing.T, factory DecbufFactory) {
+	testDecbufFactory(t, testContentSize, enc, true, true, func(t *testing.T, factory DecbufFactory) {
 		d := factory.NewRawDecbuf()
 		t.Cleanup(func() {
 			require.NoError(t, d.Close())
@@ -190,12 +191,102 @@ func TestDecbufFactory_NewDecbufRaw_HappyPath(t *testing.T) {
 	})
 }
 
+// TestDecbufFactory_NewDecbufInSection_HappyPath only tests BucketDecbufFactory
+// because NewDecbufInSection is not yet implemented for FilePoolDecbufFactory.
+func TestDecbufFactory_NewDecbufInSection_HappyPath(t *testing.T) {
+	testByte := byte(0x02)
+	startOffset := 10
+	endOffset := 25
+	enc := createTestEncoderWithTestByte(testContentSize, startOffset-numLenBytes, testByte)
+	enc.PutHash(crc32.New(table))
+
+	testDecbufFactory(t, testContentSize, enc, false, true, func(t *testing.T, factory DecbufFactory) {
+		d := factory.NewDecbufInSection(0, startOffset, endOffset)
+		t.Cleanup(func() {
+			require.NoError(t, d.Close())
+		})
+		require.NoError(t, d.Err())
+		require.Equal(t, endOffset-startOffset, d.Len())
+		// Make sure our start offset is placed where we expected by reading the first byte
+		require.Equal(t, testByte, d.Byte())
+	})
+}
+
+// TestDecbufFactory_NewDecbufInSection_SectionEndOffsetBeyondTableLength only tests BucketDecbufFactory
+// because NewDecbufInSection is not yet implemented for FilePoolDecbufFactory.
+func TestDecbufFactory_NewDecbufInSection_SectionEndOffsetBeyondTableLength(t *testing.T) {
+	testByte := byte(0x02)
+	enc := createTestEncoderWithTestByte(testContentSize, 10-numLenBytes, testByte)
+	enc.PutHash(crc32.New(table))
+
+	testDecbufFactory(t, testContentSize, enc, false, true, func(t *testing.T, factory DecbufFactory) {
+		d := factory.NewDecbufInSection(0, 10, testContentSize+1000)
+		t.Cleanup(func() {
+			require.NoError(t, d.Close())
+		})
+		require.NoError(t, d.Err())
+		require.Equal(t, testContentSize+numLenBytes-10, d.Len())
+		require.Equal(t, testByte, d.Byte())
+	})
+}
+
+// TestDecbufFactory_NewDecbufInSection_SectionEndOffsetBeforeStartOffset only tests BucketDecbufFactory
+// because NewDecbufInSection is not yet implemented for FilePoolDecbufFactory.
+func TestDecbufFactory_NewDecbufInSection_SectionEndOffsetBeforeStartOffset(t *testing.T) {
+	enc := createTestEncoder(testContentSize)
+	enc.PutHash(crc32.New(table))
+
+	testDecbufFactory(t, testContentSize, enc, false, true, func(t *testing.T, factory DecbufFactory) {
+		d := factory.NewDecbufInSection(0, 2500, 30)
+		t.Cleanup(func() {
+			require.NoError(t, d.Close())
+		})
+		require.Error(t, d.Err())
+	})
+}
+
+// TestDecbufFactory_NewDecbufInSection_Concurrent only tests BucketDecbufFactory
+// because NewDecbufInSection is not yet implemented for FilePoolDecbufFactory.
+func TestDecbufFactory_NewDecbufInSection_Concurrent(t *testing.T) {
+	enc := createTestEncoder(testContentSize)
+	enc.PutHash(crc32.New(table))
+
+	const (
+		runs        = 100
+		concurrency = 10
+	)
+
+	testDecbufFactory(t, testContentSize, enc, false, true, func(t *testing.T, factory DecbufFactory) {
+		g, _ := errgroup.WithContext(context.Background())
+
+		for i := 0; i < concurrency; i++ {
+			g.Go(func() error {
+				for run := 0; run < runs; run++ {
+					d := factory.NewDecbufInSection(0, numLenBytes, math.MaxInt)
+
+					if err := d.Err(); err != nil {
+						_ = d.Close()
+						return err
+					}
+
+					if err := d.Close(); err != nil {
+						return err
+					}
+				}
+
+				return nil
+			})
+		}
+		require.NoError(t, g.Wait())
+	})
+}
+
 func TestDecbufFactory_Stop(t *testing.T) {
 	enc := createTestEncoder(testContentSize)
 	enc.PutHash(crc32.New(table))
 
 	testBucket := false // bucket-based factory does not do anything on close and will not error
-	testDecbufFactory(t, testContentSize, enc, testBucket, func(t *testing.T, factory DecbufFactory) {
+	testDecbufFactory(t, testContentSize, enc, true, testBucket, func(t *testing.T, factory DecbufFactory) {
 		require.NoError(t, factory.Close())
 
 		d := factory.NewRawDecbuf()
@@ -211,18 +302,21 @@ func testDecbufFactory(
 	t *testing.T,
 	len int,
 	enc promencoding.Encbuf,
+	testDisk bool,
 	testBucket bool,
 	test func(t *testing.T, factory DecbufFactory),
 ) {
-	t.Run("DecbufFactory=Disk-Pooled", func(t *testing.T) {
-		diskFactory, _ := createDecbufFactoriesWithBytes(t, 1, len, enc)
-		test(t, diskFactory)
-	})
+	if testDisk {
+		t.Run("DecbufFactory=Disk-Pooled", func(t *testing.T) {
+			diskFactory, _ := createDecbufFactoriesWithBytes(t, 1, len, enc)
+			test(t, diskFactory)
+		})
 
-	t.Run("DecbufFactory=Disk-NoPool", func(t *testing.T) {
-		diskFactory, _ := createDecbufFactoriesWithBytes(t, 0, len, enc)
-		test(t, diskFactory)
-	})
+		t.Run("DecbufFactory=Disk-NoPool", func(t *testing.T) {
+			diskFactory, _ := createDecbufFactoriesWithBytes(t, 0, len, enc)
+			test(t, diskFactory)
+		})
+	}
 
 	if testBucket {
 		t.Run("DecbufFactory=Bucket", func(t *testing.T) {
@@ -231,6 +325,19 @@ func testDecbufFactory(
 		})
 	}
 
+}
+
+func createTestEncoderWithTestByte(numBytes, testByteOffset int, testByte byte) promencoding.Encbuf {
+	enc := promencoding.Encbuf{}
+
+	for i := 0; i < testByteOffset; i++ {
+		enc.PutByte(0x01)
+	}
+	enc.PutByte(testByte)
+	for i := testByteOffset + 1; i < numBytes; i++ {
+		enc.PutByte(0x01)
+	}
+	return enc
 }
 
 func createTestEncoder(numBytes int) promencoding.Encbuf {

--- a/pkg/storage/indexheader/encoding/factory_test.go
+++ b/pkg/storage/indexheader/encoding/factory_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"hash/crc32"
-	"math"
 	"os"
 	"path"
 	"testing"
@@ -242,42 +241,6 @@ func TestDecbufFactory_NewDecbufInSection_SectionEndOffsetBeforeStartOffset(t *t
 			require.NoError(t, d.Close())
 		})
 		require.Error(t, d.Err())
-	})
-}
-
-// TestDecbufFactory_NewDecbufInSection_Concurrent only tests BucketDecbufFactory
-// because NewDecbufInSection is not yet implemented for FilePoolDecbufFactory.
-func TestDecbufFactory_NewDecbufInSection_Concurrent(t *testing.T) {
-	enc := createTestEncoder(testContentSize)
-	enc.PutHash(crc32.New(table))
-
-	const (
-		runs        = 100
-		concurrency = 10
-	)
-
-	testDecbufFactory(t, testContentSize, enc, false, true, func(t *testing.T, factory DecbufFactory) {
-		g, _ := errgroup.WithContext(context.Background())
-
-		for i := 0; i < concurrency; i++ {
-			g.Go(func() error {
-				for run := 0; run < runs; run++ {
-					d := factory.NewDecbufInSection(0, numLenBytes, math.MaxInt)
-
-					if err := d.Err(); err != nil {
-						_ = d.Close()
-						return err
-					}
-
-					if err := d.Close(); err != nil {
-						return err
-					}
-				}
-
-				return nil
-			})
-		}
-		require.NoError(t, g.Wait())
 	})
 }
 

--- a/pkg/storage/indexheader/encoding/factory_test.go
+++ b/pkg/storage/indexheader/encoding/factory_test.go
@@ -190,8 +190,8 @@ func TestDecbufFactory_NewDecbufRaw_HappyPath(t *testing.T) {
 	})
 }
 
-// TestDecbufFactory_NewDecbufInSection_HappyPath only tests BucketDecbufFactory
-// because NewDecbufInSection is not yet implemented for FilePoolDecbufFactory.
+// TestDecbufFactory_NewDecbufInSection_HappyPath tests that creating a new Decbuf for a table section
+// starts the reader in the correct place by placing a test byte at the expected start offset.
 func TestDecbufFactory_NewDecbufInSection_HappyPath(t *testing.T) {
 	testByte := byte(0x02)
 	startOffset := 10
@@ -199,7 +199,8 @@ func TestDecbufFactory_NewDecbufInSection_HappyPath(t *testing.T) {
 	enc := createTestEncoderWithTestByte(testContentSize, startOffset-numLenBytes, testByte)
 	enc.PutHash(crc32.New(table))
 
-	testDecbufFactory(t, testContentSize, enc, false, true, func(t *testing.T, factory DecbufFactory) {
+	testDisk := false // NewDecbufInSection is currently only implemented for BucketDecbufFactory
+	testDecbufFactory(t, testContentSize, enc, testDisk, true, func(t *testing.T, factory DecbufFactory) {
 		d := factory.NewDecbufInSection(0, startOffset, endOffset)
 		t.Cleanup(func() {
 			require.NoError(t, d.Close())
@@ -211,14 +212,15 @@ func TestDecbufFactory_NewDecbufInSection_HappyPath(t *testing.T) {
 	})
 }
 
-// TestDecbufFactory_NewDecbufInSection_SectionEndOffsetBeyondTableLength only tests BucketDecbufFactory
-// because NewDecbufInSection is not yet implemented for FilePoolDecbufFactory.
+// TestDecbufFactory_NewDecbufInSection_SectionEndOffsetBeyondTableLength tests that calling NewDecbufInSection
+// with an end offset beyond the end of the table produces a Decbuf that ends at the end of the table.
 func TestDecbufFactory_NewDecbufInSection_SectionEndOffsetBeyondTableLength(t *testing.T) {
 	testByte := byte(0x02)
 	enc := createTestEncoderWithTestByte(testContentSize, 10-numLenBytes, testByte)
 	enc.PutHash(crc32.New(table))
 
-	testDecbufFactory(t, testContentSize, enc, false, true, func(t *testing.T, factory DecbufFactory) {
+	testDisk := false // NewDecbufInSection is currently only implemented for BucketDecbufFactory
+	testDecbufFactory(t, testContentSize, enc, testDisk, true, func(t *testing.T, factory DecbufFactory) {
 		d := factory.NewDecbufInSection(0, 10, testContentSize+1000)
 		t.Cleanup(func() {
 			require.NoError(t, d.Close())
@@ -229,13 +231,14 @@ func TestDecbufFactory_NewDecbufInSection_SectionEndOffsetBeyondTableLength(t *t
 	})
 }
 
-// TestDecbufFactory_NewDecbufInSection_SectionEndOffsetBeforeStartOffset only tests BucketDecbufFactory
-// because NewDecbufInSection is not yet implemented for FilePoolDecbufFactory.
+// TestDecbufFactory_NewDecbufInSection_SectionEndOffsetBeforeStartOffset tests that attempting to call NewDecbufInSection
+// with an end offset before the start offset returns an error.
 func TestDecbufFactory_NewDecbufInSection_SectionEndOffsetBeforeStartOffset(t *testing.T) {
 	enc := createTestEncoder(testContentSize)
 	enc.PutHash(crc32.New(table))
 
-	testDecbufFactory(t, testContentSize, enc, false, true, func(t *testing.T, factory DecbufFactory) {
+	testDisk := false // NewDecbufInSection is currently only implemented for BucketDecbufFactory
+	testDecbufFactory(t, testContentSize, enc, testDisk, true, func(t *testing.T, factory DecbufFactory) {
 		d := factory.NewDecbufInSection(0, 2500, 30)
 		t.Cleanup(func() {
 			require.NoError(t, d.Close())

--- a/pkg/storage/indexheader/encoding/file_factory.go
+++ b/pkg/storage/indexheader/encoding/file_factory.go
@@ -4,6 +4,7 @@ package encoding
 
 import (
 	"encoding/binary"
+	"fmt"
 	"hash/crc32"
 
 	"github.com/pkg/errors"
@@ -86,6 +87,10 @@ func (df *FilePoolDecbufFactory) NewDecbufAtChecked(offset int, table *crc32.Tab
 
 func (df *FilePoolDecbufFactory) NewDecbufAtUnchecked(offset int) Decbuf {
 	return df.NewDecbufAtChecked(offset, nil)
+}
+
+func (df *FilePoolDecbufFactory) NewDecbufInSection(_, _, _ int) Decbuf {
+	return Decbuf{E: fmt.Errorf("NewDecbufInSection not implemented for FilePoolDecbufFactory")}
 }
 
 func (df *FilePoolDecbufFactory) NewRawDecbuf() Decbuf {

--- a/pkg/storage/indexheader/index/postings.go
+++ b/pkg/storage/indexheader/index/postings.go
@@ -112,17 +112,20 @@ func (t *PostingsOffsetsTableV2) PostingsOffset(name string, value string) (r in
 
 	var d streamencoding.Decbuf
 	if bf, ok := t.decbufFactory.(*streamencoding.BucketDecbufFactory); ok {
-		var sparseTableOffsetsEnd int
-		if i+1 < len(e.SparseTableOffsets)-1 {
-			// We may need to read one extra entry to get the correct range end offset.
-			sparseTableOffsetsEnd = e.SparseTableOffsets[i+2].Offset
+		var sectionEndOffset int
+
+		// In order to correctly set Range.End, we need to read the next entry beyond the one we are looking for.
+		// In the worst case where the value is found right before the next (i+1'th) sparse table offset,
+		// we need to read the entry that starts at the i+1'th offset. To account for this, we create the reader up to the i+2'th sparse table offset.
+		if i+2 < len(e.SparseTableOffsets) {
+			sectionEndOffset = e.SparseTableOffsets[i+2].Offset
 		} else {
 			// Set this to something that will always be greater than the length of the table
-			sparseTableOffsetsEnd = math.MaxInt
+			sectionEndOffset = math.MaxInt
 		}
 		// At this point we know that our value is somewhere between the i-th offset and the next one;
 		// we shouldn't need to read/cache bucket ops beyond that.
-		d = bf.NewDecbufInSection(t.tableOffset, e.SparseTableOffsets[i].Offset, sparseTableOffsetsEnd)
+		d = bf.NewDecbufInSection(t.tableOffset, e.SparseTableOffsets[i].Offset, sectionEndOffset)
 	} else {
 		d = t.decbufFactory.NewDecbufAtUnchecked(t.tableOffset)
 		d.ResetAt(e.SparseTableOffsets[i].Offset)
@@ -204,17 +207,17 @@ func (t *PostingsOffsetsTableV2) LabelValuesOffsets(ctx context.Context, name, p
 
 	var d streamencoding.Decbuf
 	if bf, ok := t.decbufFactory.(*streamencoding.BucketDecbufFactory); ok {
-		var endOffset int
+		var sectionEndOffset int
 
 		if offsetsEnd+1 < len(e.SparseTableOffsets) {
 			// We buffer the end with the distance to one more sparse offset in case the last matching entry is right at the end of the section.
-			endOffset = e.SparseTableOffsets[offsetsEnd+1].Offset
+			sectionEndOffset = e.SparseTableOffsets[offsetsEnd+1].Offset
 		} else {
-			endOffset = math.MaxInt
+			sectionEndOffset = math.MaxInt
 		}
 		// For the BucketDecbufFactory, we only read the section we care about to optimize
 		// the size of cached GetRange bucket ops.
-		d = bf.NewDecbufInSection(t.tableOffset, e.SparseTableOffsets[offsetsStart].Offset, endOffset)
+		d = bf.NewDecbufInSection(t.tableOffset, e.SparseTableOffsets[offsetsStart].Offset, sectionEndOffset)
 	} else {
 		// Don't Crc32 the entire postings offset table, this is very slow
 		// so hope any issues were caught at startup.

--- a/pkg/storage/indexheader/index/postings.go
+++ b/pkg/storage/indexheader/index/postings.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"hash/crc32"
+	"math"
 	"slices"
 	"sort"
 	"strings"
@@ -97,12 +98,6 @@ func (t *PostingsOffsetsTableV2) PostingsOffset(name string, value string) (r in
 		return index.Range{}, false, nil
 	}
 
-	d := t.decbufFactory.NewDecbufAtUnchecked(t.tableOffset)
-	defer runutil.CloseWithErrCapture(&err, &d, "get sparsePostingsOffsets SparseTableOffsets")
-	if err := d.Err(); err != nil {
-		return index.Range{}, false, err
-	}
-
 	i := sort.Search(len(e.SparseTableOffsets), func(i int) bool { return e.SparseTableOffsets[i].Value >= value })
 
 	if i == len(e.SparseTableOffsets) {
@@ -115,7 +110,28 @@ func (t *PostingsOffsetsTableV2) PostingsOffset(name string, value string) (r in
 		i--
 	}
 
-	d.ResetAt(e.SparseTableOffsets[i].Offset)
+	var d streamencoding.Decbuf
+	if bf, ok := t.decbufFactory.(*streamencoding.BucketDecbufFactory); ok {
+		var sparseTableOffsetsEnd int
+		if i+1 < len(e.SparseTableOffsets)-1 {
+			// We may need to read one extra entry to get the correct range end offset.
+			sparseTableOffsetsEnd = e.SparseTableOffsets[i+2].Offset
+		} else {
+			// Set this to something that will always be greater than the length of the table
+			sparseTableOffsetsEnd = math.MaxInt
+		}
+		// At this point we know that our value is somewhere between the i-th offset and the next one;
+		// we shouldn't need to read/cache bucket ops beyond that.
+		d = bf.NewDecbufInSection(t.tableOffset, e.SparseTableOffsets[i].Offset, sparseTableOffsetsEnd)
+	} else {
+		d = t.decbufFactory.NewDecbufAtUnchecked(t.tableOffset)
+		d.ResetAt(e.SparseTableOffsets[i].Offset)
+	}
+	defer runutil.CloseWithErrCapture(&err, &d, "get sparsePostingsOffsets SparseTableOffsets")
+	if err := d.Err(); err != nil {
+		return index.Range{}, false, err
+	}
+
 	nAndNameSize := 0
 
 	for d.Err() == nil {
@@ -186,12 +202,26 @@ func (t *PostingsOffsetsTableV2) LabelValuesOffsets(ctx context.Context, name, p
 	}
 	offsets := make([]PostingListOffset, 0, (offsetsEnd-offsetsStart)*t.SparseSampleFactor)
 
-	// Don't Crc32 the entire postings offset table, this is very slow
-	// so hope any issues were caught at startup.
-	d := t.decbufFactory.NewDecbufAtUnchecked(t.tableOffset)
-	defer runutil.CloseWithErrCapture(&err, &d, "get label values")
+	var d streamencoding.Decbuf
+	if bf, ok := t.decbufFactory.(*streamencoding.BucketDecbufFactory); ok {
+		var endOffset int
 
-	d.ResetAt(e.SparseTableOffsets[offsetsStart].Offset)
+		if offsetsEnd+1 < len(e.SparseTableOffsets) {
+			// We buffer the end with the distance to one more sparse offset in case the last matching entry is right at the end of the section.
+			endOffset = e.SparseTableOffsets[offsetsEnd+1].Offset
+		} else {
+			endOffset = math.MaxInt
+		}
+		// For the BucketDecbufFactory, we only read the section we care about to optimize
+		// the size of cached GetRange bucket ops.
+		d = bf.NewDecbufInSection(t.tableOffset, e.SparseTableOffsets[offsetsStart].Offset, endOffset)
+	} else {
+		// Don't Crc32 the entire postings offset table, this is very slow
+		// so hope any issues were caught at startup.
+		d = t.decbufFactory.NewDecbufAtUnchecked(t.tableOffset)
+		d.ResetAt(e.SparseTableOffsets[offsetsStart].Offset)
+	}
+	defer runutil.CloseWithErrCapture(&err, &d, "get label values")
 
 	// The last value of a label gets its own offset in e.SparseTableOffsets.
 	// If that value matches, then later we should use e.LastValOffset

--- a/pkg/storage/indexheader/index/postings_test.go
+++ b/pkg/storage/indexheader/index/postings_test.go
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package index
+
+import (
+	"context"
+	"fmt"
+	"hash/crc32"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/grafana/regexp"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/tsdb/encoding"
+	"github.com/prometheus/prometheus/tsdb/index"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
+	"github.com/thanos-io/objstore/providers/filesystem"
+
+	streamencoding "github.com/grafana/mimir/pkg/storage/indexheader/encoding"
+	"github.com/grafana/mimir/pkg/util/filepool"
+)
+
+type postingEntry struct {
+	name   string
+	value  string
+	offset uint64
+}
+
+func TestPostingsOffsetsTableV2_PostingsOffset(t *testing.T) {
+	encBuf, postingsListEnd, tableStart := setupPostingsOffsetsTableEncbuf()
+	factories := setupFactoriesWithPostingsOffsetsTable(t, encBuf)
+
+	// Put every other entry in the sparse offsets table. This way,
+	// any entry we search for which isn't already in the sparse offsets table is also the "worst-case" scenario,
+	// where the found entry is the last one before the next sparse offset.
+	sparseSampleFactor := 2
+
+	for factoryName, factory := range factories {
+		t.Run(fmt.Sprintf("DecbufFactory=%s", factoryName), func(t *testing.T) {
+			sparseOffsets, err := SparseValuesFromPostingsOffsetsTable(factory, tableStart, postingsListEnd, sparseSampleFactor, true)
+			require.NoError(t, err)
+
+			tbl, err := NewPostingsOffsetsTableReader(index.FormatV2, factory, tableStart, sparseOffsets, sparseSampleFactor)
+			require.NoError(t, err)
+
+			tests := []struct {
+				labelName  string
+				labelValue string
+				found      bool
+				expected   index.Range
+			}{
+				// Sparse offset entry exactly
+				{"job", "foo", true, index.Range{Start: 500 + postingLengthFieldSize, End: 600 - crc32.Size}},
+				// Value between sparse offset entries
+				{"__name__", "baz", true, index.Range{Start: 200 + postingLengthFieldSize, End: 300 - crc32.Size}},
+				// Nonexistent values
+				{"__name__", "aaa", false, index.Range{}},
+				{"__name__", "zzz", false, index.Range{}},
+				{"__name__", "bzz", false, index.Range{}},
+				// Nonexistent label
+				{"pod", "foo", false, index.Range{}},
+			}
+
+			for _, tt := range tests {
+				t.Run(fmt.Sprintf("%s=%s", tt.labelName, tt.labelValue), func(t *testing.T) {
+					rng, found, err := tbl.PostingsOffset(tt.labelName, tt.labelValue)
+					require.NoError(t, err)
+					require.Equal(t, tt.found, found)
+					if tt.found {
+						require.Equal(t, tt.expected, rng)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestPostingsOffsetsTableV2_LabelValuesOffsets(t *testing.T) {
+	encBuf, postingsListEnd, tableStart := setupPostingsOffsetsTableEncbuf()
+	factories := setupFactoriesWithPostingsOffsetsTable(t, encBuf)
+	sparseSampleFactor := 2
+
+	for factoryName, factory := range factories {
+		t.Run(fmt.Sprintf("DecbufFactory=%s", factoryName), func(t *testing.T) {
+			sparseOffsets, err := SparseValuesFromPostingsOffsetsTable(factory, tableStart, postingsListEnd, sparseSampleFactor, true)
+			require.NoError(t, err)
+
+			tbl, err := NewPostingsOffsetsTableReader(index.FormatV2, factory, tableStart, sparseOffsets, sparseSampleFactor)
+			require.NoError(t, err)
+
+			tests := []struct {
+				testName    string
+				labelName   string
+				prefix      string
+				filter      func(string) bool
+				expected    []PostingListOffset
+				expectedErr bool
+			}{
+				{
+					testName:  "fetch all values without prefix or filter",
+					labelName: "__name__",
+					expected: []PostingListOffset{
+						{LabelValue: "bar", Off: index.Range{Start: 100 + postingLengthFieldSize, End: 200 - crc32.Size}},
+						{LabelValue: "baz", Off: index.Range{Start: 204, End: 296}},
+						{LabelValue: "foo", Off: index.Range{Start: 304, End: 396}},
+						{LabelValue: "zip", Off: index.Range{Start: 404, End: 496}},
+					},
+				},
+				{
+					testName:  "fetch all values with prefix",
+					labelName: "__name__",
+					prefix:    "b",
+					expected: []PostingListOffset{
+						{LabelValue: "bar", Off: index.Range{Start: 104, End: 196}},
+						{LabelValue: "baz", Off: index.Range{Start: 204, End: 296}},
+					},
+				},
+				{
+					testName:  "prefix matches last value for name",
+					labelName: "__name__",
+					prefix:    "z",
+					expected: []PostingListOffset{
+						{LabelValue: "zip", Off: index.Range{Start: 404, End: 496}},
+					},
+				},
+				{
+					testName:  "filter matches single value",
+					labelName: "__name__",
+					filter: func(v string) bool {
+						r, err := regexp.Compile("fo.*")
+						require.NoError(t, err)
+						return r.MatchString(v)
+					},
+					expected: []PostingListOffset{
+						{LabelValue: "foo", Off: index.Range{Start: 304, End: 396}},
+					},
+				},
+				{
+					testName:  "nonexistent label",
+					labelName: "pod",
+					expected:  nil,
+				},
+			}
+
+			for _, tt := range tests {
+				t.Run(tt.testName, func(t *testing.T) {
+					result, err := tbl.LabelValuesOffsets(context.Background(), tt.labelName, tt.prefix, tt.filter)
+					if tt.expectedErr {
+						require.Error(t, err)
+					}
+
+					require.Equal(t, tt.expected, result)
+				})
+			}
+		})
+	}
+}
+
+func setupFactoriesWithPostingsOffsetsTable(t *testing.T, postingsOffsetsEncbuf encoding.Encbuf) map[string]streamencoding.DecbufFactory {
+	dir := t.TempDir()
+	filePath := path.Join(dir, "index")
+	require.NoError(t, os.WriteFile(filePath, postingsOffsetsEncbuf.Get(), 0700))
+
+	bkt, err := filesystem.NewBucket(dir)
+	require.NoError(t, err)
+	instBkt := objstore.WithNoopInstr(bkt)
+	t.Cleanup(func() {
+		require.NoError(t, bkt.Close())
+	})
+
+	reg := prometheus.WrapRegistererWithPrefix("indexheader_", prometheus.NewPedanticRegistry())
+	diskDecbufFactory := streamencoding.NewFilePoolDecbufFactory(filePath, 0, filepool.NewFilePoolMetrics(reg))
+	bucketDecbufFactory := streamencoding.NewBucketDecbufFactory(context.Background(), instBkt, "index")
+
+	return map[string]streamencoding.DecbufFactory{
+		"disk":   diskDecbufFactory,
+		"bucket": bucketDecbufFactory,
+	}
+}
+
+func setupPostingsOffsetsTableEncbuf() (e encoding.Encbuf, postingsListEnd uint64, tableOffset int) {
+	entries := []postingEntry{
+		{"", "", 0}, // index.AllPostingsKey
+		{"__name__", "bar", 100},
+		{"__name__", "baz", 200},
+		{"__name__", "foo", 300},
+		{"__name__", "zip", 400},
+		{"job", "foo", 500},
+	}
+	var postingsList encoding.Encbuf
+	postingsList.PutBE32int(len(entries))
+	for _, entry := range entries {
+		postingsList.PutUvarint(2)
+		postingsList.PutUvarintStr(entry.name)
+		postingsList.PutUvarintStr(entry.value)
+		postingsList.PutUvarint64(entry.offset)
+	}
+	postingsListEnd = 600
+	e.PutUvarintStr("filler") // simulate table being part of a larger file; we don't want to read these bytes
+	tableStart := e.Len()
+	e.PutBE32int(postingsList.Len())
+	e.PutBytes(postingsList.Get())
+	e.PutBE32(crc32.Checksum(postingsList.Get(), castagnoliTable))
+
+	return e, postingsListEnd, tableStart
+}

--- a/pkg/storage/indexheader/index/postings_test.go
+++ b/pkg/storage/indexheader/index/postings_test.go
@@ -37,43 +37,41 @@ func TestPostingsOffsetsTableV2_PostingsOffset(t *testing.T) {
 	// where the found entry is the last one before the next sparse offset.
 	sparseSampleFactor := 2
 
+	tests := []struct {
+		labelName  string
+		labelValue string
+		found      bool
+		expected   index.Range
+	}{
+		// Sparse offset entry exactly
+		{"job", "foo", true, index.Range{Start: 500 + postingLengthFieldSize, End: 600 - crc32.Size}},
+		// Value between sparse offset entries
+		{"__name__", "baz", true, index.Range{Start: 200 + postingLengthFieldSize, End: 300 - crc32.Size}},
+		// Nonexistent values
+		{"__name__", "aaa", false, index.Range{}},
+		{"__name__", "zzz", false, index.Range{}},
+		{"__name__", "bzz", false, index.Range{}},
+		// Nonexistent label
+		{"pod", "foo", false, index.Range{}},
+	}
+
 	for factoryName, factory := range factories {
-		t.Run(fmt.Sprintf("DecbufFactory=%s", factoryName), func(t *testing.T) {
-			sparseOffsets, err := SparseValuesFromPostingsOffsetsTable(factory, tableStart, postingsListEnd, sparseSampleFactor, true)
-			require.NoError(t, err)
+		sparseOffsets, err := SparseValuesFromPostingsOffsetsTable(factory, tableStart, postingsListEnd, sparseSampleFactor, true)
+		require.NoError(t, err)
 
-			tbl, err := NewPostingsOffsetsTableReader(index.FormatV2, factory, tableStart, sparseOffsets, sparseSampleFactor)
-			require.NoError(t, err)
+		tbl, err := NewPostingsOffsetsTableReader(index.FormatV2, factory, tableStart, sparseOffsets, sparseSampleFactor)
+		require.NoError(t, err)
 
-			tests := []struct {
-				labelName  string
-				labelValue string
-				found      bool
-				expected   index.Range
-			}{
-				// Sparse offset entry exactly
-				{"job", "foo", true, index.Range{Start: 500 + postingLengthFieldSize, End: 600 - crc32.Size}},
-				// Value between sparse offset entries
-				{"__name__", "baz", true, index.Range{Start: 200 + postingLengthFieldSize, End: 300 - crc32.Size}},
-				// Nonexistent values
-				{"__name__", "aaa", false, index.Range{}},
-				{"__name__", "zzz", false, index.Range{}},
-				{"__name__", "bzz", false, index.Range{}},
-				// Nonexistent label
-				{"pod", "foo", false, index.Range{}},
-			}
-
-			for _, tt := range tests {
-				t.Run(fmt.Sprintf("%s=%s", tt.labelName, tt.labelValue), func(t *testing.T) {
-					rng, found, err := tbl.PostingsOffset(tt.labelName, tt.labelValue)
-					require.NoError(t, err)
-					require.Equal(t, tt.found, found)
-					if tt.found {
-						require.Equal(t, tt.expected, rng)
-					}
-				})
-			}
-		})
+		for _, tt := range tests {
+			t.Run(fmt.Sprintf("DecbufFactory=%s/%s=%s", factoryName, tt.labelName, tt.labelValue), func(t *testing.T) {
+				rng, found, err := tbl.PostingsOffset(tt.labelName, tt.labelValue)
+				require.NoError(t, err)
+				require.Equal(t, tt.found, found)
+				if tt.found {
+					require.Equal(t, tt.expected, rng)
+				}
+			})
+		}
 	}
 }
 
@@ -82,79 +80,93 @@ func TestPostingsOffsetsTableV2_LabelValuesOffsets(t *testing.T) {
 	factories := setupFactoriesWithPostingsOffsetsTable(t, encBuf)
 	sparseSampleFactor := 2
 
+	tests := []struct {
+		testName    string
+		labelName   string
+		prefix      string
+		filter      func(string) bool
+		expected    []PostingListOffset
+		expectedErr bool
+	}{
+		{
+			testName:  "fetch all values without prefix or filter",
+			labelName: "__name__",
+			expected: []PostingListOffset{
+				{LabelValue: "bar", Off: index.Range{Start: 100 + postingLengthFieldSize, End: 200 - crc32.Size}},
+				{LabelValue: "baz", Off: index.Range{Start: 204, End: 296}},
+				{LabelValue: "foo", Off: index.Range{Start: 304, End: 396}},
+				{LabelValue: "zip", Off: index.Range{Start: 404, End: 496}},
+			},
+		},
+		{
+			testName:  "fetch all values with prefix",
+			labelName: "__name__",
+			prefix:    "b",
+			expected: []PostingListOffset{
+				{LabelValue: "bar", Off: index.Range{Start: 104, End: 196}},
+				{LabelValue: "baz", Off: index.Range{Start: 204, End: 296}},
+			},
+		},
+		{
+			testName:  "prefix matches last value for name",
+			labelName: "__name__",
+			prefix:    "z",
+			expected: []PostingListOffset{
+				{LabelValue: "zip", Off: index.Range{Start: 404, End: 496}},
+			},
+		},
+		{
+			testName:  "prefix matches no value for name",
+			labelName: "__name__",
+			prefix:    "q",
+			expected:  []PostingListOffset{},
+		},
+		{
+			testName:  "filter matches single value",
+			labelName: "__name__",
+			filter: func(v string) bool {
+				r, err := regexp.Compile("..o")
+				require.NoError(t, err)
+				return r.MatchString(v)
+			},
+			expected: []PostingListOffset{
+				{LabelValue: "foo", Off: index.Range{Start: 304, End: 396}},
+			},
+		},
+		{
+			testName:  "filter matches no value",
+			labelName: "__name__",
+			filter: func(v string) bool {
+				r, err := regexp.Compile(".*q.*")
+				require.NoError(t, err)
+				return r.MatchString(v)
+			},
+			expected: []PostingListOffset{},
+		},
+		{
+			testName:  "nonexistent label",
+			labelName: "pod",
+			expected:  nil,
+		},
+	}
+
 	for factoryName, factory := range factories {
-		t.Run(fmt.Sprintf("DecbufFactory=%s", factoryName), func(t *testing.T) {
-			sparseOffsets, err := SparseValuesFromPostingsOffsetsTable(factory, tableStart, postingsListEnd, sparseSampleFactor, true)
-			require.NoError(t, err)
+		sparseOffsets, err := SparseValuesFromPostingsOffsetsTable(factory, tableStart, postingsListEnd, sparseSampleFactor, true)
+		require.NoError(t, err)
 
-			tbl, err := NewPostingsOffsetsTableReader(index.FormatV2, factory, tableStart, sparseOffsets, sparseSampleFactor)
-			require.NoError(t, err)
+		tbl, err := NewPostingsOffsetsTableReader(index.FormatV2, factory, tableStart, sparseOffsets, sparseSampleFactor)
+		require.NoError(t, err)
 
-			tests := []struct {
-				testName    string
-				labelName   string
-				prefix      string
-				filter      func(string) bool
-				expected    []PostingListOffset
-				expectedErr bool
-			}{
-				{
-					testName:  "fetch all values without prefix or filter",
-					labelName: "__name__",
-					expected: []PostingListOffset{
-						{LabelValue: "bar", Off: index.Range{Start: 100 + postingLengthFieldSize, End: 200 - crc32.Size}},
-						{LabelValue: "baz", Off: index.Range{Start: 204, End: 296}},
-						{LabelValue: "foo", Off: index.Range{Start: 304, End: 396}},
-						{LabelValue: "zip", Off: index.Range{Start: 404, End: 496}},
-					},
-				},
-				{
-					testName:  "fetch all values with prefix",
-					labelName: "__name__",
-					prefix:    "b",
-					expected: []PostingListOffset{
-						{LabelValue: "bar", Off: index.Range{Start: 104, End: 196}},
-						{LabelValue: "baz", Off: index.Range{Start: 204, End: 296}},
-					},
-				},
-				{
-					testName:  "prefix matches last value for name",
-					labelName: "__name__",
-					prefix:    "z",
-					expected: []PostingListOffset{
-						{LabelValue: "zip", Off: index.Range{Start: 404, End: 496}},
-					},
-				},
-				{
-					testName:  "filter matches single value",
-					labelName: "__name__",
-					filter: func(v string) bool {
-						r, err := regexp.Compile("fo.*")
-						require.NoError(t, err)
-						return r.MatchString(v)
-					},
-					expected: []PostingListOffset{
-						{LabelValue: "foo", Off: index.Range{Start: 304, End: 396}},
-					},
-				},
-				{
-					testName:  "nonexistent label",
-					labelName: "pod",
-					expected:  nil,
-				},
-			}
+		for _, tt := range tests {
+			t.Run(fmt.Sprintf("DecbufFactory=%s/%s", factoryName, tt.testName), func(t *testing.T) {
+				result, err := tbl.LabelValuesOffsets(context.Background(), tt.labelName, tt.prefix, tt.filter)
+				if tt.expectedErr {
+					require.Error(t, err)
+				}
 
-			for _, tt := range tests {
-				t.Run(tt.testName, func(t *testing.T) {
-					result, err := tbl.LabelValuesOffsets(context.Background(), tt.labelName, tt.prefix, tt.filter)
-					if tt.expectedErr {
-						require.Error(t, err)
-					}
-
-					require.Equal(t, tt.expected, result)
-				})
-			}
-		})
+				require.Equal(t, tt.expected, result)
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
* Tries to fetch cached content length before making bucket attributes calls
* Introduces `NewDecbufInSection` which only reads a section of a table given relative start/end offsets
  * Reading smaller sections of only content that we care to read (as opposed to buffering in an entire MiB which we may not even read most of) means that when we start caching these reads, we can cache smaller objects and get better utilization.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how postings-offset lookups read from object storage by introducing partial-table reads and new length-caching behavior; incorrect offset math or section sizing could cause subtle lookup failures or out-of-bounds reads in production.
> 
> **Overview**
> **Optimizes object-store index-header reads** by adding `DecbufFactory.NewDecbufInSection()` and implementing it in `BucketDecbufFactory` to create decbufs that only span a requested subsection of a length-prefixed table.
> 
> `BucketDecbufFactory` now checks a cached section length before calling bucket `Attributes`, and centralizes content-length discovery in `getContentLength()`. `PostingsOffsetsTableV2` is updated to use subsection reads when the factory is bucket-backed (falling back to full-table reads for disk), and new unit tests cover subsection behavior and postings-offset/table range correctness across disk vs bucket factories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 785fea856287611d5fda2883daead95f871419ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->