### PR TITLE
Fix trace message emitted by "remove statically empty expressions" optimization pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,7 +188,7 @@
 * [ENHANCEMENT] Query-frontend: Stream JSON encoding directly to the response body to avoid a full-copy allocation of the serialized payload. #14840
 * [ENHANCEMENT] Activity tracker: Added `activity_tracker_unfinished_activities_loaded` metric to report the number of unfinished activities detected on startup. #14860
 * [ENHANCEMENT] Distributor now uses record validation time as Kafka record timestamp to reduce rejections among consumers. #14921
-* [ENHANCEMENT] MQE: Add optimisation pass to optimise away expressions containing comparisons with `timestamp()` that can't produce results due to the query time range. #14989 #15014
+* [ENHANCEMENT] MQE: Add optimisation pass to optimise away expressions containing comparisons with `timestamp()` that can't produce results due to the query time range. #14989 #15014 #15163
 * [ENHANCEMENT] Distributor: OTLP endpoint now returns partial success (HTTP 200) instead of HTTP 429 when the usage tracker rejects some series due to the active series limit but other series are successfully ingested. The `RejectedDataPoints` field reports the count of distributor-side rejections (usage tracker filtering). #14789
 * [ENHANCEMENT] MQE: Account for memory consumption of labels returned by binary operations in query memory consumption estimate earlier. #15033
 * [ENHANCEMENT] Query-frontend: Log the number of series and samples returned for queries in `query stats` log lines. #15044

--- a/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
+++ b/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
@@ -84,7 +84,7 @@ func (s *RemoveStaticallyEmptyExpressionsOptimizationPass) Apply(ctx context.Con
 	}
 
 	if modified {
-		logger.DebugLog("msg", "replaced statically empty expression(s) with no-op", "count", modified)
+		logger.DebugLog("msg", "replaced statically empty expression(s) with no-op")
 		s.modified.Inc()
 	}
 


### PR DESCRIPTION
#### What this PR does

This PR fixes the trace message emitted by the "remove statically empty expressions" optimization pass, as it currently logs `count: true` when any part of the plan is replaced with a `NoOp` node.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/pull/14989

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only affect a debug log message and a changelog reference, with no impact on query planning behavior.
> 
> **Overview**
> Fixes the `RemoveStaticallyEmptyExpressionsOptimizationPass` debug log to no longer emit a misleading `count: true` field when replacements occur.
> 
> Updates the related `CHANGELOG.md` enhancement entry to include the additional PR reference `#15163`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9439254f541223cc0a30fed305201a070973313c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->