### PR TITLE
MQE: refactor `commonsubexpressionelimination.SeriesDataRingBuffer` to work with "elements" rather than "series"

### DIFF
--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/series_data_ring_buffer.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/series_data_ring_buffer.go
@@ -24,6 +24,10 @@ import (
 //     reads and writes are always only at the start and end of the buffer.
 //   - In the case where there are many consumers, then the buffer is still not expected to be large and only some reads will
 //     pay the cost of searching for the desired element, so this is an acceptable trade-off.
+//
+// Note that there are two terms used here:
+// - "element position" refers to the index into the elements slice
+// - "element index" refers to the index of the element as makes sense to the caller (eg. series index in an overall stream of series)
 type SeriesDataRingBuffer[T any] struct {
 	elements []seriesDataRingBufferElement[T]
 
@@ -32,14 +36,14 @@ type SeriesDataRingBuffer[T any] struct {
 }
 
 type seriesDataRingBufferElement[T any] struct {
-	data        T
-	seriesIndex int
-	present     bool // If false, this element is a tombstone.
+	data         T
+	elementIndex int
+	present      bool // If false, this element is a tombstone.
 }
 
-func (b *SeriesDataRingBuffer[T]) Append(d T, seriesIndex int) {
-	if b.elementCount > 0 && seriesIndex <= b.LastElementSeriesIndex() {
-		panic(fmt.Sprintf("attempted to append series with index %v, but last series index in buffer is %v", seriesIndex, b.LastElementSeriesIndex()))
+func (b *SeriesDataRingBuffer[T]) Append(d T, elementIndex int) {
+	if b.elementCount > 0 && elementIndex <= b.LastElementIndex() {
+		panic(fmt.Sprintf("attempted to append element with index %v, but last element index in buffer is %v", elementIndex, b.LastElementIndex()))
 	}
 
 	if len(b.elements) == b.elementCount {
@@ -53,20 +57,20 @@ func (b *SeriesDataRingBuffer[T]) Append(d T, seriesIndex int) {
 	}
 
 	b.elements[(b.startIndex+b.elementCount)%len(b.elements)] = seriesDataRingBufferElement[T]{
-		seriesIndex: seriesIndex,
-		data:        d,
-		present:     true,
+		elementIndex: elementIndex,
+		data:         d,
+		present:      true,
 	}
 
 	b.elementCount++
 }
 
-func (b *SeriesDataRingBuffer[T]) FirstElementSeriesIndex() int {
-	return b.getElementAtPosition(0).seriesIndex
+func (b *SeriesDataRingBuffer[T]) FirstElementIndex() int {
+	return b.getElementAtPosition(0).elementIndex
 }
 
-func (b *SeriesDataRingBuffer[T]) LastElementSeriesIndex() int {
-	return b.getElementAtPosition(b.elementCount - 1).seriesIndex
+func (b *SeriesDataRingBuffer[T]) LastElementIndex() int {
+	return b.getElementAtPosition(b.elementCount - 1).elementIndex
 }
 
 func (b *SeriesDataRingBuffer[T]) getElementAtPosition(position int) seriesDataRingBufferElement[T] {
@@ -74,19 +78,19 @@ func (b *SeriesDataRingBuffer[T]) getElementAtPosition(position int) seriesDataR
 }
 
 // Remove removes and returns the first series in the buffer, and panics if that is not the series with index seriesIndex.
-func (b *SeriesDataRingBuffer[T]) Remove(seriesIndex int) T {
+func (b *SeriesDataRingBuffer[T]) Remove(elementIndex int) T {
 	if b.elementCount == 0 {
-		panic(fmt.Sprintf("attempted to remove series at index %v, but buffer is empty", seriesIndex))
+		panic(fmt.Sprintf("attempted to remove element at index %v, but buffer is empty", elementIndex))
 	}
 
-	firstElementSeriesIndex := b.FirstElementSeriesIndex()
-	lastElementSeriesIndex := b.LastElementSeriesIndex()
+	firstElementIndex := b.FirstElementIndex()
+	lastElementIndex := b.LastElementIndex()
 
-	if seriesIndex < firstElementSeriesIndex || seriesIndex > lastElementSeriesIndex {
-		panic(fmt.Sprintf("attempted to remove series at index %v, but have series from index %v to %v", seriesIndex, firstElementSeriesIndex, lastElementSeriesIndex))
+	if elementIndex < firstElementIndex || elementIndex > lastElementIndex {
+		panic(fmt.Sprintf("attempted to remove element at index %v, but have elements from index %v to %v", elementIndex, firstElementIndex, lastElementIndex))
 	}
 
-	position := b.findElementPositionForSeriesIndex(seriesIndex)
+	position := b.findElementPositionForElementIndex(elementIndex)
 	return b.removeAtPosition(position)
 }
 
@@ -119,19 +123,19 @@ func (b *SeriesDataRingBuffer[T]) removeAtPosition(position int) T {
 	return d
 }
 
-// RemoveFirst removes and returns the first series in the buffer.
+// RemoveFirst removes and returns the first element in the buffer.
 // Calling RemoveFirst on an empty buffer panics.
 func (b *SeriesDataRingBuffer[T]) RemoveFirst() T {
 	if b.elementCount == 0 {
-		panic("attempted to remove first series of empty buffer")
+		panic("attempted to remove first element of empty buffer")
 	}
 
-	return b.Remove(b.FirstElementSeriesIndex())
+	return b.Remove(b.FirstElementIndex())
 }
 
-// RemoveIfPresent removes and returns the series with the given series index, if it is present in the buffer.
-func (b *SeriesDataRingBuffer[T]) RemoveIfPresent(seriesIndex int) (T, bool) {
-	pos, found := b.tryToFindElementPositionForSeriesIndex(seriesIndex)
+// RemoveIfPresent removes and returns the element with the given element index, if it is present in the buffer.
+func (b *SeriesDataRingBuffer[T]) RemoveIfPresent(elementIndex int) (T, bool) {
+	pos, found := b.tryToFindElementPositionForElementIndex(elementIndex)
 	if !found || !b.getElementAtPosition(pos).present {
 		var empty T
 
@@ -141,24 +145,24 @@ func (b *SeriesDataRingBuffer[T]) RemoveIfPresent(seriesIndex int) (T, bool) {
 	return b.removeAtPosition(pos), true
 }
 
-func (b *SeriesDataRingBuffer[T]) Get(seriesIndex int) T {
+func (b *SeriesDataRingBuffer[T]) Get(elementIndex int) T {
 	if b.elementCount == 0 {
-		panic(fmt.Sprintf("attempted to get series at index %v, but buffer is empty", seriesIndex))
+		panic(fmt.Sprintf("attempted to get element at index %v, but buffer is empty", elementIndex))
 	}
 
-	firstElementSeriesIndex := b.FirstElementSeriesIndex()
-	lastElementSeriesIndex := b.LastElementSeriesIndex()
+	firstElementIndex := b.FirstElementIndex()
+	lastElementIndex := b.LastElementIndex()
 
-	if seriesIndex < firstElementSeriesIndex || seriesIndex > lastElementSeriesIndex {
-		panic(fmt.Sprintf("attempted to get series at index %v, but have series from index %v to %v", seriesIndex, firstElementSeriesIndex, lastElementSeriesIndex))
+	if elementIndex < firstElementIndex || elementIndex > lastElementIndex {
+		panic(fmt.Sprintf("attempted to get element at index %v, but have element from index %v to %v", elementIndex, firstElementIndex, lastElementIndex))
 	}
 
-	position := b.findElementPositionForSeriesIndex(seriesIndex)
+	position := b.findElementPositionForElementIndex(elementIndex)
 	return b.elements[(b.startIndex+position)%len(b.elements)].data
 }
 
-func (b *SeriesDataRingBuffer[T]) GetIfPresent(seriesIndex int) (T, bool) {
-	pos, found := b.tryToFindElementPositionForSeriesIndex(seriesIndex)
+func (b *SeriesDataRingBuffer[T]) GetIfPresent(elementIndex int) (T, bool) {
+	pos, found := b.tryToFindElementPositionForElementIndex(elementIndex)
 	if !found || !b.getElementAtPosition(pos).present {
 		var empty T
 		return empty, false
@@ -167,57 +171,57 @@ func (b *SeriesDataRingBuffer[T]) GetIfPresent(seriesIndex int) (T, bool) {
 	return b.elements[(b.startIndex+pos)%len(b.elements)].data, true
 }
 
-func (b *SeriesDataRingBuffer[T]) findElementPositionForSeriesIndex(seriesIndex int) int {
-	pos, found := b.tryToFindElementPositionForSeriesIndex(seriesIndex)
+func (b *SeriesDataRingBuffer[T]) findElementPositionForElementIndex(elementIndex int) int {
+	pos, found := b.tryToFindElementPositionForElementIndex(elementIndex)
 	if !found {
-		panic(fmt.Sprintf("attempted to find element position for series index %d, but it is not present in this buffer (first series index is %d, last series index is %d)", seriesIndex, b.FirstElementSeriesIndex(), b.LastElementSeriesIndex()))
+		panic(fmt.Sprintf("attempted to find element position for element index %d, but it is not present in this buffer (first element index is %d, last element index is %d)", elementIndex, b.FirstElementIndex(), b.LastElementIndex()))
 	}
 
 	if !b.getElementAtPosition(pos).present {
-		panic(fmt.Sprintf("attempted to find element position for series index %d, but this element has been removed", seriesIndex))
+		panic(fmt.Sprintf("attempted to find element position for element index %d, but this element has been removed", elementIndex))
 	}
 
 	return pos
 }
 
-func (b *SeriesDataRingBuffer[T]) tryToFindElementPositionForSeriesIndex(seriesIndex int) (int, bool) {
-	// FIXME: we could possibly make this slightly more efficient by guessing where the series should be assuming the
-	// series are evenly distributed and doing linear interpolation to find the expected position of the series.
+func (b *SeriesDataRingBuffer[T]) tryToFindElementPositionForElementIndex(elementIndex int) (int, bool) {
+	// FIXME: we could possibly make this slightly more efficient by guessing where the element should be assuming the
+	// elements are evenly distributed and doing linear interpolation to find the expected position of the element.
 
 	if b.elementCount == 0 {
 		return -1, false
 	}
 
 	// Fast path: first or last element.
-	if b.getElementAtPosition(0).seriesIndex == seriesIndex {
+	if b.getElementAtPosition(0).elementIndex == elementIndex {
 		return 0, true
 	}
 
-	if b.getElementAtPosition(b.elementCount-1).seriesIndex == seriesIndex {
+	if b.getElementAtPosition(b.elementCount-1).elementIndex == elementIndex {
 		return b.elementCount - 1, true
 	}
 
-	if b.getElementAtPosition(0).seriesIndex > seriesIndex || b.getElementAtPosition(b.elementCount-1).seriesIndex < seriesIndex {
+	if b.getElementAtPosition(0).elementIndex > elementIndex || b.getElementAtPosition(b.elementCount-1).elementIndex < elementIndex {
 		return -1, false
 	}
 
 	cmp := func(e seriesDataRingBufferElement[T], target int) int {
-		return e.seriesIndex - target
+		return e.elementIndex - target
 	}
 	haveWrappedAround := b.startIndex+b.elementCount > len(b.elements)
-	seriesIndexAppearsInTail := seriesIndex > b.elements[len(b.elements)-1].seriesIndex
+	elementIndexAppearsInTail := elementIndex > b.elements[len(b.elements)-1].elementIndex
 
-	if haveWrappedAround && seriesIndexAppearsInTail {
+	if haveWrappedAround && elementIndexAppearsInTail {
 		tailSize := b.startIndex + b.elementCount - len(b.elements)
 		headSize := b.elementCount - tailSize
-		posInTail, found := slices.BinarySearchFunc(b.elements[0:tailSize], seriesIndex, cmp)
+		posInTail, found := slices.BinarySearchFunc(b.elements[0:tailSize], elementIndex, cmp)
 
 		return posInTail + headSize, found
 	}
 
-	// Using a binary search here only works because the elements in the buffer are ordered by series index.
+	// Using a binary search here only works because the elements in the buffer are ordered by element index.
 	// This is an invariant enforced by Append().
-	return slices.BinarySearchFunc(b.elements[b.startIndex:min(b.startIndex+b.elementCount, len(b.elements))], seriesIndex, cmp)
+	return slices.BinarySearchFunc(b.elements[b.startIndex:min(b.startIndex+b.elementCount, len(b.elements))], elementIndex, cmp)
 }
 
 // Size returns the number of elements in the buffer, including any empty elements due to

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/series_data_ring_buffer_test.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/series_data_ring_buffer_test.go
@@ -198,7 +198,7 @@ func TestSeriesDataRingBuffer_NonContiguousSeries(t *testing.T) {
 	require.Equal(t, s4, buffer.Get(124))
 }
 
-func TestSeriesDataRingBuffer_FindElementPositionForSeriesIndex(t *testing.T) {
+func TestSeriesDataRingBuffer_FindElementPositionForElementIndex(t *testing.T) {
 	t.Run("odd number of elements", func(t *testing.T) {
 		buffer := &SeriesDataRingBuffer[types.InstantVectorSeriesData]{}
 
@@ -213,34 +213,34 @@ func TestSeriesDataRingBuffer_FindElementPositionForSeriesIndex(t *testing.T) {
 		buffer.Append(s5, 125)
 		buffer.Append(s6, 126)
 
-		require.Equal(t, 0, buffer.findElementPositionForSeriesIndex(121))
-		require.Equal(t, 1, buffer.findElementPositionForSeriesIndex(123))
-		require.Equal(t, 2, buffer.findElementPositionForSeriesIndex(124))
-		require.Equal(t, 3, buffer.findElementPositionForSeriesIndex(125))
-		require.Equal(t, 4, buffer.findElementPositionForSeriesIndex(126))
+		require.Equal(t, 0, buffer.findElementPositionForElementIndex(121))
+		require.Equal(t, 1, buffer.findElementPositionForElementIndex(123))
+		require.Equal(t, 2, buffer.findElementPositionForElementIndex(124))
+		require.Equal(t, 3, buffer.findElementPositionForElementIndex(125))
+		require.Equal(t, 4, buffer.findElementPositionForElementIndex(126))
 
-		require.PanicsWithValue(t, "attempted to find element position for series index 120, but it is not present in this buffer (first series index is 121, last series index is 126)", func() {
-			buffer.findElementPositionForSeriesIndex(120)
+		require.PanicsWithValue(t, "attempted to find element position for element index 120, but it is not present in this buffer (first element index is 121, last element index is 126)", func() {
+			buffer.findElementPositionForElementIndex(120)
 		})
 
-		require.PanicsWithValue(t, "attempted to find element position for series index 122, but it is not present in this buffer (first series index is 121, last series index is 126)", func() {
-			buffer.findElementPositionForSeriesIndex(122)
+		require.PanicsWithValue(t, "attempted to find element position for element index 122, but it is not present in this buffer (first element index is 121, last element index is 126)", func() {
+			buffer.findElementPositionForElementIndex(122)
 		})
 
-		require.PanicsWithValue(t, "attempted to find element position for series index 127, but it is not present in this buffer (first series index is 121, last series index is 126)", func() {
-			buffer.findElementPositionForSeriesIndex(127)
+		require.PanicsWithValue(t, "attempted to find element position for element index 127, but it is not present in this buffer (first element index is 121, last element index is 126)", func() {
+			buffer.findElementPositionForElementIndex(127)
 		})
 
 		// Remove an element in the middle, and confirm we correctly handle tombstones.
 		buffer.Remove(123)
 
-		require.Equal(t, 0, buffer.findElementPositionForSeriesIndex(121))
-		require.Equal(t, 2, buffer.findElementPositionForSeriesIndex(124))
-		require.Equal(t, 3, buffer.findElementPositionForSeriesIndex(125))
-		require.Equal(t, 4, buffer.findElementPositionForSeriesIndex(126))
+		require.Equal(t, 0, buffer.findElementPositionForElementIndex(121))
+		require.Equal(t, 2, buffer.findElementPositionForElementIndex(124))
+		require.Equal(t, 3, buffer.findElementPositionForElementIndex(125))
+		require.Equal(t, 4, buffer.findElementPositionForElementIndex(126))
 
-		require.PanicsWithValue(t, "attempted to find element position for series index 123, but this element has been removed", func() {
-			buffer.findElementPositionForSeriesIndex(123)
+		require.PanicsWithValue(t, "attempted to find element position for element index 123, but this element has been removed", func() {
+			buffer.findElementPositionForElementIndex(123)
 		})
 	})
 
@@ -256,10 +256,10 @@ func TestSeriesDataRingBuffer_FindElementPositionForSeriesIndex(t *testing.T) {
 		buffer.Append(s4, 124)
 		buffer.Append(s5, 125)
 
-		require.Equal(t, 0, buffer.findElementPositionForSeriesIndex(121))
-		require.Equal(t, 1, buffer.findElementPositionForSeriesIndex(123))
-		require.Equal(t, 2, buffer.findElementPositionForSeriesIndex(124))
-		require.Equal(t, 3, buffer.findElementPositionForSeriesIndex(125))
+		require.Equal(t, 0, buffer.findElementPositionForElementIndex(121))
+		require.Equal(t, 1, buffer.findElementPositionForElementIndex(123))
+		require.Equal(t, 2, buffer.findElementPositionForElementIndex(124))
+		require.Equal(t, 3, buffer.findElementPositionForElementIndex(125))
 	})
 
 	t.Run("buffer wrapped around", func(t *testing.T) {
@@ -281,21 +281,21 @@ func TestSeriesDataRingBuffer_FindElementPositionForSeriesIndex(t *testing.T) {
 		buffer.Append(s7, 130)
 		require.Equal(t, 4, buffer.Size())
 
-		require.Equal(t, 0, buffer.findElementPositionForSeriesIndex(124))
-		require.Equal(t, 1, buffer.findElementPositionForSeriesIndex(125))
-		require.Equal(t, 2, buffer.findElementPositionForSeriesIndex(126))
-		require.Equal(t, 3, buffer.findElementPositionForSeriesIndex(130))
+		require.Equal(t, 0, buffer.findElementPositionForElementIndex(124))
+		require.Equal(t, 1, buffer.findElementPositionForElementIndex(125))
+		require.Equal(t, 2, buffer.findElementPositionForElementIndex(126))
+		require.Equal(t, 3, buffer.findElementPositionForElementIndex(130))
 
-		require.PanicsWithValue(t, "attempted to find element position for series index 123, but it is not present in this buffer (first series index is 124, last series index is 130)", func() {
-			buffer.findElementPositionForSeriesIndex(123)
+		require.PanicsWithValue(t, "attempted to find element position for element index 123, but it is not present in this buffer (first element index is 124, last element index is 130)", func() {
+			buffer.findElementPositionForElementIndex(123)
 		})
 
-		require.PanicsWithValue(t, "attempted to find element position for series index 127, but it is not present in this buffer (first series index is 124, last series index is 130)", func() {
-			buffer.findElementPositionForSeriesIndex(127)
+		require.PanicsWithValue(t, "attempted to find element position for element index 127, but it is not present in this buffer (first element index is 124, last element index is 130)", func() {
+			buffer.findElementPositionForElementIndex(127)
 		})
 
-		require.PanicsWithValue(t, "attempted to find element position for series index 131, but it is not present in this buffer (first series index is 124, last series index is 130)", func() {
-			buffer.findElementPositionForSeriesIndex(131)
+		require.PanicsWithValue(t, "attempted to find element position for element index 131, but it is not present in this buffer (first element index is 124, last element index is 130)", func() {
+			buffer.findElementPositionForElementIndex(131)
 		})
 	})
 
@@ -334,20 +334,20 @@ func TestSeriesDataRingBuffer_FindElementPositionForSeriesIndex(t *testing.T) {
 		require.Len(t, buffer.elements, 8)
 		require.Equal(t, 7, buffer.Size())
 
-		require.Equal(t, 0, buffer.findElementPositionForSeriesIndex(124))
-		require.Equal(t, 1, buffer.findElementPositionForSeriesIndex(125))
-		require.Equal(t, 2, buffer.findElementPositionForSeriesIndex(126))
-		require.Equal(t, 3, buffer.findElementPositionForSeriesIndex(127))
-		require.Equal(t, 4, buffer.findElementPositionForSeriesIndex(128))
-		require.Equal(t, 5, buffer.findElementPositionForSeriesIndex(129))
-		require.Equal(t, 6, buffer.findElementPositionForSeriesIndex(130))
+		require.Equal(t, 0, buffer.findElementPositionForElementIndex(124))
+		require.Equal(t, 1, buffer.findElementPositionForElementIndex(125))
+		require.Equal(t, 2, buffer.findElementPositionForElementIndex(126))
+		require.Equal(t, 3, buffer.findElementPositionForElementIndex(127))
+		require.Equal(t, 4, buffer.findElementPositionForElementIndex(128))
+		require.Equal(t, 5, buffer.findElementPositionForElementIndex(129))
+		require.Equal(t, 6, buffer.findElementPositionForElementIndex(130))
 
-		require.PanicsWithValue(t, "attempted to find element position for series index 123, but it is not present in this buffer (first series index is 124, last series index is 130)", func() {
-			buffer.findElementPositionForSeriesIndex(123)
+		require.PanicsWithValue(t, "attempted to find element position for element index 123, but it is not present in this buffer (first element index is 124, last element index is 130)", func() {
+			buffer.findElementPositionForElementIndex(123)
 		})
 
-		require.PanicsWithValue(t, "attempted to find element position for series index 131, but it is not present in this buffer (first series index is 124, last series index is 130)", func() {
-			buffer.findElementPositionForSeriesIndex(131)
+		require.PanicsWithValue(t, "attempted to find element position for element index 131, but it is not present in this buffer (first element index is 124, last element index is 130)", func() {
+			buffer.findElementPositionForElementIndex(131)
 		})
 	})
 }
@@ -415,14 +415,14 @@ func TestSeriesDataRingBuffer_GetIfPresent(t *testing.T) {
 	requireNotPresent(t, buffer, 128)
 }
 
-func requirePresent(t *testing.T, buffer *SeriesDataRingBuffer[types.InstantVectorSeriesData], seriesIndex int, expected types.InstantVectorSeriesData) {
-	returnedSeries, found := buffer.GetIfPresent(seriesIndex)
-	require.True(t, found, "should find series in buffer")
+func requirePresent(t *testing.T, buffer *SeriesDataRingBuffer[types.InstantVectorSeriesData], elementIndex int, expected types.InstantVectorSeriesData) {
+	returnedSeries, found := buffer.GetIfPresent(elementIndex)
+	require.True(t, found, "should find element in buffer")
 	require.Equal(t, expected, returnedSeries)
 }
 
-func requireNotPresent(t *testing.T, buffer *SeriesDataRingBuffer[types.InstantVectorSeriesData], seriesIndex int) {
-	_, found := buffer.GetIfPresent(seriesIndex)
+func requireNotPresent(t *testing.T, buffer *SeriesDataRingBuffer[types.InstantVectorSeriesData], elementIndex int) {
+	_, found := buffer.GetIfPresent(elementIndex)
 	require.False(t, found, "should not find series in buffer")
 }
 


### PR DESCRIPTION
#### What this PR does

This PR contains purely name changes, changing the terminology used by `SeriesDataRingBuffer` to refer to "elements" rather than "series". 

This is in preparation for supporting CSE over range vector expressions in range queries, where the `SeriesDataRingBuffer` will store steps, rather than entire series.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/pull/15127

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to naming/terminology changes and updated tests; runtime behavior should remain unchanged but callers relying on panic message text could be affected.
> 
> **Overview**
> Refactors `commonsubexpressionelimination.SeriesDataRingBuffer` to use *element*-centric terminology (eg. `elementIndex`/`element position`) instead of *series*-centric naming, updating method/field names and all panic/error messages accordingly.
> 
> Updates the corresponding unit tests to match the renamed APIs and expected panic strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42ed66c4e084f1cf1100b79519c4ffa1fefe1c88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->