### PR TITLE
Fix nil pointer panic in WriteRequest.Unmarshal for empty RW2 requests (#14698)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## unreleased
+
+### Grafana Mimir
+
+* [BUGFIX] Distributor: Fix nil pointer panic in `WriteRequest.Unmarshal` when receiving a Remote Write 2.0 request with zero timeseries. #14698
+
 ## 3.0.6
 
 ### Grafana Mimir

--- a/pkg/mimirpb/compat_rw2_test.go
+++ b/pkg/mimirpb/compat_rw2_test.go
@@ -117,6 +117,24 @@ func TestRW2Unmarshal(t *testing.T) {
 		require.Equal(t, expected, &received)
 	})
 
+	t.Run("zero timeseries does not panic", func(t *testing.T) {
+		syms := test.NewSymbolTableBuilder(nil)
+		syms.GetSymbol("unused_symbol")
+		req := &WriteRequest{
+			SymbolsRW2: syms.GetSymbols(),
+		}
+
+		data, err := req.Marshal()
+		require.NoError(t, err)
+
+		received := PreallocWriteRequest{
+			UnmarshalFromRW2: true,
+		}
+		require.NoError(t, received.Unmarshal(data))
+		require.Empty(t, received.Timeseries)
+		require.Empty(t, received.Metadata)
+	})
+
 	t.Run("metadata for all metric types map to expected values", func(t *testing.T) {
 		tc := []struct {
 			name    string

--- a/pkg/mimirpb/mimir.pb.go
+++ b/pkg/mimirpb/mimir.pb.go
@@ -7653,7 +7653,9 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
 	}
 
 	if m.unmarshalFromRW2 {
-		m.Metadata = metadata.slice()
+		if metadata != nil {
+			m.Metadata = metadata.slice()
+		}
 		m.rw2symbols.releasePages()
 	}
 

--- a/pkg/mimirpb/mimir.pb.go.expdiff
+++ b/pkg/mimirpb/mimir.pb.go.expdiff
@@ -204,13 +204,15 @@ index e7d3c6a439..dda8609298 100644
  				return err
  			}
  			iNdEx = postIndex
-@@ -7651,12 +7593,6 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
+@@ -7651,14 +7593,6 @@ func (m *WriteRequest) Unmarshal(dAtA []byte) error {
  	if iNdEx > l {
  		return io.ErrUnexpectedEOF
  	}
 -
 -	if m.unmarshalFromRW2 {
--		m.Metadata = metadata.slice()
+-		if metadata != nil {
+-			m.Metadata = metadata.slice()
+-		}
 -		m.rw2symbols.releasePages()
 -	}
 -


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main -->

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

When unmarshalling a Remote Write 2.0 request with zero timeseries, the metadata variable (`metadataSet` interface) is never initialized because the case 5 branch that lazily creates it is never entered. The finalization block then unconditionally calls `metadata.slice()`, causing a nil pointer dereference panic.

Add a nil guard before calling `metadata.slice()` so that empty RW2 requests are handled gracefully, matching the behavior of empty RW1 requests.

Test case is included.

(cherry picked from commit b95be8d7826e29528fb7b4a0771306ef936cb212)

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Remote Write 2.0 protobuf unmarshal path used in ingestion; while the change is small (a nil guard), mistakes here could impact write request handling.
> 
> **Overview**
> Prevents a nil-pointer panic in `WriteRequest.Unmarshal` for Remote Write 2.0 payloads with **zero timeseries** by only calling `metadata.slice()` when the metadata set was actually initialized.
> 
> Adds a regression test ensuring unmarshalling an empty RW2 request succeeds and leaves `Timeseries`/`Metadata` empty, and records the bugfix in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a39155d60353ef3fefec4696344475721a8639ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->