### PR TITLE
MQE: fix bugs with negated name matchers for info function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@
 * [BUGFIX] Block-builder-scheduler: Fix a spurious "time went backwards" warning logged at startup when a partition has no records after the scan time. #15855
 * [BUGFIX] Compactor: Fix `GatherBlockHealthStats` postings walk error check to prevent swallowing errors. #15895
 * [BUGFIX] MQE: Don't evaluate unnecessary range vector splitting ranges when a split range vector is part of a spun-off subquery and running time-splitting and caching inside MQE is enabled. #15931
+* [BUGFIX] MQE: Fix `info()` function incorrectly handling negated name matchers. #15168
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -274,6 +274,10 @@
 * [BUGFIX] Alertmanager: Fix deadlock when trying to broadcast after stopping a tenant #14922
 * [BUGFIX] Query-frontend: Fix max total query length limit (`-query-frontend.max-total-query-length`) not being enforced on instant queries with subqueries or range selectors. #14985
 * [BUGFIX] Compactor: Fix potential goroutine leak when compaction iteration exits early due to errors. #13420
+* [BUGFIX] MQE: Fix `info()` function not enriching series when inner series are missing one identifying label (instance/job) but matching info series exist. #14832
+* [BUGFIX] MQE: Fix `info()` function only retaining one matcher when multiple data label matchers target the same label name. #14832
+* [BUGFIX] MQE: Fix `info()` function silently overwriting conflicting labels from different info metrics instead of returning an error. #14832
+* [BUGFIX] MQE: Fix `info()` function incorrectly grouping labels from replaced info series at the same evaluation timestamp due to lookback. #14832
 
 ### Mixin
 

--- a/pkg/streamingpromql/operators/functions/info.go
+++ b/pkg/streamingpromql/operators/functions/info.go
@@ -129,7 +129,10 @@ func (f *InfoFunction) generateInfoMatchers(innerMetadata []types.SeriesMetadata
 		values := identifyingLabelValues[labelName]
 		switch len(values) {
 		case 0:
-			return nil, true
+			// No inner series have this identifying label; skip generating a matcher
+			// for it but continue processing other labels. Only skip querying info
+			// entirely if no identifying labels have any values at all.
+			continue
 		case 1:
 			for value := range values {
 				matchers = append(matchers, types.Matcher{
@@ -151,6 +154,10 @@ func (f *InfoFunction) generateInfoMatchers(innerMetadata []types.SeriesMetadata
 				Value: regexPattern,
 			})
 		}
+	}
+
+	if len(matchers) == 0 {
+		return nil, true
 	}
 
 	return matchers, false
@@ -201,12 +208,12 @@ func (f *InfoFunction) processSamplesFromInfoSeries(ctx context.Context, infoMet
 			// Check for duplicate series for the same timestamp and signature.
 			// If a duplicate is found, only error out if the original timestamp is the same.
 			// Otherwise, keep the one with the latest original timestamp.
-			sigTimestamps, exists := sigTimestampsByMetric[metricName]
+			metricSigTimestamps, exists := sigTimestampsByMetric[metricName]
 			if !exists {
-				sigTimestamps = make(map[int64]map[string]labelsTime)
-				sigTimestampsByMetric[metricName] = sigTimestamps
+				metricSigTimestamps = make(map[int64]map[string]labelsTime)
+				sigTimestampsByMetric[metricName] = metricSigTimestamps
 			}
-			sigsAtTimestamp, exists := sigTimestamps[sample.T]
+			sigsAtTimestamp, exists := metricSigTimestamps[sample.T]
 			if !exists {
 				sigsAtTimestamp = make(map[string]labelsTime)
 			}
@@ -222,21 +229,28 @@ func (f *InfoFunction) processSamplesFromInfoSeries(ctx context.Context, infoMet
 				labels: metadata.Labels,
 				time:   origTs,
 			}
-			sigTimestamps[sample.T] = sigsAtTimestamp
-
-			// We summarise the info series by recording per timestamp and labels-only signature
-			// the series labels we've seen.
-			sigAtTimestamp, exists := f.sigTimestamps[sample.T]
-			if !exists {
-				sigAtTimestamp = make(map[string][]labels.Labels)
-			}
-			sigAtTimestamp[string(sig)] = append(sigAtTimestamp[string(sig)], metadata.Labels)
-			f.sigTimestamps[sample.T] = sigAtTimestamp
+			metricSigTimestamps[sample.T] = sigsAtTimestamp
 		}
 
 		// Return the info series data to the pool as we no longer need the raw samples
 		// now that we've saved the processed summary.
 		types.PutInstantVectorSeriesData(d, f.MemoryConsumptionTracker)
+	}
+
+	// Build f.sigTimestamps from sigTimestampsByMetric. This ensures that when
+	// duplicate resolution picks a winner (newer original timestamp), only the
+	// winner's labels appear in f.sigTimestamps — not both old and new.
+	for _, metricSigTimestamps := range sigTimestampsByMetric {
+		for t, sigsAtTimestamp := range metricSigTimestamps {
+			sigAtTimestamp, exists := f.sigTimestamps[t]
+			if !exists {
+				sigAtTimestamp = make(map[string][]labels.Labels)
+			}
+			for sig, lt := range sigsAtTimestamp {
+				sigAtTimestamp[sig] = append(sigAtTimestamp[sig], lt.labels)
+			}
+			f.sigTimestamps[t] = sigAtTimestamp
+		}
 	}
 
 	// Now that we've seen all info series, summarise them overall across all timestamps.
@@ -321,7 +335,9 @@ func matchersMatch(matchers []*labels.Matcher, value string) bool {
 // combineSeriesMetadata combines inner series metadata with info series labels.
 func (f *InfoFunction) combineSeriesMetadata(innerMetadata []types.SeriesMetadata, ignoreSeries map[int]struct{}, dataLabelMatchers types.Matchers) ([]types.SeriesMetadata, error) {
 	// Store user-specified label matchers in a map for easy retrieval.
-	dataLabelMatchersMap := make(map[string]*labels.Matcher)
+	// Multiple matchers may target the same label name (e.g. {data=~".+", data=~".*"}),
+	// so we store all of them per name to match upstream Prometheus behaviour.
+	dataLabelMatchersMap := make(map[string][]*labels.Matcher)
 	for _, m := range dataLabelMatchers {
 		if m.Name == model.MetricNameLabel {
 			continue
@@ -330,15 +346,20 @@ func (f *InfoFunction) combineSeriesMetadata(innerMetadata []types.SeriesMetadat
 		if err != nil {
 			return nil, err
 		}
-		dataLabelMatchersMap[m.Name] = matcher
+		dataLabelMatchersMap[m.Name] = append(dataLabelMatchersMap[m.Name], matcher)
 	}
 
 	// Check if any data label matcher doesn't match the empty string (e.g. {cluster=~".+"}).
 	// If so, inner series without a matching info series should be suppressed.
 	hasNonEmptyDataLabelMatcher := false
-	for _, m := range dataLabelMatchersMap {
-		if !m.Matches("") {
-			hasNonEmptyDataLabelMatcher = true
+	for _, ms := range dataLabelMatchersMap {
+		for _, m := range ms {
+			if !m.Matches("") {
+				hasNonEmptyDataLabelMatcher = true
+				break
+			}
+		}
+		if hasNonEmptyDataLabelMatcher {
 			break
 		}
 	}
@@ -377,7 +398,10 @@ func (f *InfoFunction) combineSeriesMetadata(innerMetadata []types.SeriesMetadat
 
 		// Get all possible combinations of info series labels with this inner series,
 		// and track them properly so we know exactly how many to pull from the pool later.
-		newLabelSets, labelSetsOrder := combineLabels(lb, innerSeries, labelSetsMap, dataLabelMatchersMap)
+		newLabelSets, labelSetsOrder, err := combineLabels(lb, innerSeries, labelSetsMap, dataLabelMatchersMap)
+		if err != nil {
+			return nil, err
+		}
 
 		// If user specified label matchers but no labels from info series matched, skip this series.
 		if len(dataLabelMatchersMap) > 0 && len(newLabelSets) == 0 {
@@ -444,7 +468,7 @@ func (f *InfoFunction) combineSeriesMetadata(innerMetadata []types.SeriesMetadat
 }
 
 // combineLabels combines inner series labels with info series label sets.
-func combineLabels(lb *labels.Builder, innerSeries types.SeriesMetadata, labelSetsMap map[string][]labels.Labels, dataLabelMatchersMap map[string]*labels.Matcher) ([]labels.Labels, []string) {
+func combineLabels(lb *labels.Builder, innerSeries types.SeriesMetadata, labelSetsMap map[string][]labels.Labels, dataLabelMatchersMap map[string][]*labels.Matcher) ([]labels.Labels, []string, error) {
 	newLabelSets := make([]labels.Labels, 0, len(labelSetsMap))
 	labelSetsOrder := make([]string, 0, len(labelSetsMap))
 	savedLabels := make(map[string]struct{})
@@ -453,9 +477,14 @@ func combineLabels(lb *labels.Builder, innerSeries types.SeriesMetadata, labelSe
 		lb.Reset(innerSeries.Labels)
 		clear(savedLabels)
 
+		var conflictErr error
 		for _, infoLabels := range labelSets {
 			// Add requested labels to inner series.
 			infoLabels.Range(func(l labels.Label) {
+				if conflictErr != nil {
+					return
+				}
+
 				// Ignore metric name.
 				if l.Name == model.MetricNameLabel {
 					return
@@ -467,23 +496,40 @@ func combineLabels(lb *labels.Builder, innerSeries types.SeriesMetadata, labelSe
 					return
 				}
 
-				// If user specified certain label matchers, ignore labels that don't match.
+				// If user specified certain label matchers, only include labels
+				// whose name is among the specified data label matchers.
+				// Value filtering is not needed here as info series were already
+				// pre-filtered by the selector during fetching.
 				if len(dataLabelMatchersMap) > 0 {
-					if matcher, ok := dataLabelMatchersMap[l.Name]; !ok || !matcher.Matches(l.Value) {
+					if _, ok := dataLabelMatchersMap[l.Name]; !ok {
 						return
 					}
+				}
+
+				// Detect conflicting labels from different info metrics.
+				if v := lb.Get(l.Name); v != "" && v != l.Value {
+					conflictErr = fmt.Errorf("conflicting label: %s", l.Name)
+					return
 				}
 
 				lb.Set(l.Name, l.Value)
 				savedLabels[l.Name] = struct{}{}
 			})
+			if conflictErr != nil {
+				return nil, nil, conflictErr
+			}
 		}
 
 		shouldSkip := false
 		// If user specified certain label matchers but no labels matched, skip this series.
-		for _, m := range dataLabelMatchersMap {
-			if _, saved := savedLabels[m.Name]; !saved && !m.Matches("") {
-				shouldSkip = true
+		for _, ms := range dataLabelMatchersMap {
+			for _, m := range ms {
+				if _, saved := savedLabels[m.Name]; !saved && !m.Matches("") {
+					shouldSkip = true
+					break
+				}
+			}
+			if shouldSkip {
 				break
 			}
 		}
@@ -495,7 +541,7 @@ func combineLabels(lb *labels.Builder, innerSeries types.SeriesMetadata, labelSe
 		labelSetsOrder = append(labelSetsOrder, makeLabelSetsHash(labelSets))
 	}
 
-	return newLabelSets, labelSetsOrder
+	return newLabelSets, labelSetsOrder, nil
 }
 
 func (f *InfoFunction) NextSeries(ctx context.Context) (types.InstantVectorSeriesData, error) {

--- a/pkg/streamingpromql/operators/functions/info.go
+++ b/pkg/streamingpromql/operators/functions/info.go
@@ -87,6 +87,14 @@ func (f *InfoFunction) SeriesMetadata(ctx context.Context, matchers types.Matche
 	defer types.SeriesMetadataSlicePool.Put(&innerMetadata, f.MemoryConsumptionTracker)
 
 	infoMatchers, skipQueryingInfo := f.generateInfoMatchers(innerMetadata)
+	if !skipQueryingInfo {
+		// If the info selector contains only negative __name__ matchers, add a synthetic
+		// positive __name__=~".+_info" matcher to prevent non-info metrics from being fetched.
+		// This mirrors upstream Prometheus' effectiveInfoNameMatchers logic applied at query time.
+		if syntheticMatcher := syntheticInfoNameMatcher(f.Info.Selector.Matchers); syntheticMatcher != nil {
+			infoMatchers = append(infoMatchers, *syntheticMatcher)
+		}
+	}
 	var infoMetadata []types.SeriesMetadata
 	if skipQueryingInfo {
 		infoMetadata = []types.SeriesMetadata{}
@@ -318,9 +326,10 @@ func (f *InfoFunction) identifyIgnoreSeries(innerMetadata []types.SeriesMetadata
 		return nil, nil
 	}
 
+	effectiveMatchers := effectiveInfoNameMatchers(infoNameMatchers)
 	for i, s := range innerMetadata {
 		name := s.Labels.Get(model.MetricNameLabel)
-		if matchersMatch(infoNameMatchers, name) {
+		if matchersMatch(effectiveMatchers, name) {
 			ignoreSeries[i] = struct{}{}
 		}
 	}
@@ -335,6 +344,48 @@ func matchersMatch(matchers []*labels.Matcher, value string) bool {
 		}
 	}
 	return true
+}
+
+// effectiveInfoNameMatchers mirrors upstream Prometheus logic for determining
+// which __name__ matchers to use when identifying info series to ignore.
+// When only negative matchers exist, a synthetic .+_info positive matcher is
+// prepended, ensuring non-info metrics are never treated as info metrics.
+// InsertOmittedTargetInfoSelector takes care of the case where the original
+// has no __name__ matchers at all.
+func effectiveInfoNameMatchers(matchers []*labels.Matcher) []*labels.Matcher {
+	for _, m := range matchers {
+		if m.Type == labels.MatchEqual || m.Type == labels.MatchRegexp {
+			return matchers
+		}
+	}
+	// Only negative matchers: prepend .+_info to create a contradiction for non-info names.
+	return append([]*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, model.MetricNameLabel, ".+_info")}, matchers...)
+}
+
+// syntheticInfoNameMatcher returns a synthetic __name__=~".+_info" matcher if selectorMatchers
+// contains only negative __name__ matchers, or nil otherwise.
+// This is used to augment the info fetch query so that non-info metrics are not selected,
+// mirroring upstream Prometheus' effectiveInfoNameMatchers logic applied at fetch time.
+func syntheticInfoNameMatcher(selectorMatchers types.Matchers) *types.Matcher {
+	var hasPositive, hasNegative bool
+	for _, m := range selectorMatchers {
+		if m.Name != model.MetricNameLabel {
+			continue
+		}
+		if m.Type == labels.MatchEqual || m.Type == labels.MatchRegexp {
+			hasPositive = true
+			break
+		}
+		hasNegative = true
+	}
+	if !hasPositive && hasNegative {
+		return &types.Matcher{
+			Type:  labels.MatchRegexp,
+			Name:  model.MetricNameLabel,
+			Value: ".+_info",
+		}
+	}
+	return nil
 }
 
 // combineSeriesMetadata combines inner series metadata with info series labels.

--- a/pkg/streamingpromql/operators/functions/info.go
+++ b/pkg/streamingpromql/operators/functions/info.go
@@ -82,6 +82,14 @@ func (f *InfoFunction) SeriesMetadata(ctx context.Context, matchers types.Matche
 	defer types.SeriesMetadataSlicePool.Put(&innerMetadata, f.MemoryConsumptionTracker)
 
 	infoMatchers, skipQueryingInfo := f.generateInfoMatchers(innerMetadata)
+	if !skipQueryingInfo {
+		// If the info selector contains only negative __name__ matchers, add a synthetic
+		// positive __name__=~".+_info" matcher to prevent non-info metrics from being fetched.
+		// This mirrors upstream Prometheus' effectiveInfoNameMatchers logic applied at query time.
+		if syntheticMatcher := syntheticInfoNameMatcher(f.Info.Selector.Matchers); syntheticMatcher != nil {
+			infoMatchers = append(infoMatchers, *syntheticMatcher)
+		}
+	}
 	var infoMetadata []types.SeriesMetadata
 	if skipQueryingInfo {
 		infoMetadata = []types.SeriesMetadata{}
@@ -313,9 +321,10 @@ func (f *InfoFunction) identifyIgnoreSeries(innerMetadata []types.SeriesMetadata
 		return nil, nil
 	}
 
+	effectiveMatchers := effectiveInfoNameMatchers(infoNameMatchers)
 	for i, s := range innerMetadata {
 		name := s.Labels.Get(model.MetricNameLabel)
-		if matchersMatch(infoNameMatchers, name) {
+		if matchersMatch(effectiveMatchers, name) {
 			ignoreSeries[i] = struct{}{}
 		}
 	}
@@ -330,6 +339,48 @@ func matchersMatch(matchers []*labels.Matcher, value string) bool {
 		}
 	}
 	return true
+}
+
+// effectiveInfoNameMatchers mirrors upstream Prometheus logic for determining
+// which __name__ matchers to use when identifying info series to ignore.
+// When only negative matchers exist, a synthetic .+_info positive matcher is
+// prepended, ensuring non-info metrics are never treated as info metrics.
+// InsertOmittedTargetInfoSelector takes care of the case where the original
+// has no __name__ matchers at all.
+func effectiveInfoNameMatchers(matchers []*labels.Matcher) []*labels.Matcher {
+	for _, m := range matchers {
+		if m.Type == labels.MatchEqual || m.Type == labels.MatchRegexp {
+			return matchers
+		}
+	}
+	// Only negative matchers: prepend .+_info to create a contradiction for non-info names.
+	return append([]*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, model.MetricNameLabel, ".+_info")}, matchers...)
+}
+
+// syntheticInfoNameMatcher returns a synthetic __name__=~".+_info" matcher if selectorMatchers
+// contains only negative __name__ matchers, or nil otherwise.
+// This is used to augment the info fetch query so that non-info metrics are not selected,
+// mirroring upstream Prometheus' effectiveInfoNameMatchers logic applied at fetch time.
+func syntheticInfoNameMatcher(selectorMatchers types.Matchers) *types.Matcher {
+	var hasPositive, hasNegative bool
+	for _, m := range selectorMatchers {
+		if m.Name != model.MetricNameLabel {
+			continue
+		}
+		if m.Type == labels.MatchEqual || m.Type == labels.MatchRegexp {
+			hasPositive = true
+			break
+		}
+		hasNegative = true
+	}
+	if !hasPositive && hasNegative {
+		return &types.Matcher{
+			Type:  labels.MatchRegexp,
+			Name:  model.MetricNameLabel,
+			Value: ".+_info",
+		}
+	}
+	return nil
 }
 
 // combineSeriesMetadata combines inner series metadata with info series labels.

--- a/pkg/streamingpromql/testdata/ours/info.test
+++ b/pkg/streamingpromql/testdata/ours/info.test
@@ -199,3 +199,18 @@ eval range from 0m to 2m step 1m info(test_metric, {priority=~"high|medium", pri
 eval range from 0m to 2m step 1m info(test_metric, {__name__=~".*info", __name__=~"target.*", category=~"web|api"})
   test_metric{instance="a", job="1", env="prod", category="web"} 1 2 3
   test_metric{instance="b", job="2", env="dev", category="api"} 4 5 6
+
+clear
+
+# When the second argument has no __name__ matcher, target_info is used by default.
+# build_info is excluded even though its env label also matches env=~".+".
+# The result has env="prod" (from target_info), not env="staging" (from build_info),
+# proving only target_info contributed. If build_info were also used, there would be
+# a conflict on the env label and the query would fail.
+load 5m
+  metric{instance="a", job="1"} 1
+  target_info{instance="a", job="1", env="prod"} 1
+  build_info{instance="a", job="1", env="staging"} 1
+
+eval range from 0m to 0m step 5m info(metric, {env=~".+"})
+  metric{instance="a", job="1", env="prod"} 1

--- a/pkg/streamingpromql/testdata/ours/info.test
+++ b/pkg/streamingpromql/testdata/ours/info.test
@@ -199,3 +199,25 @@ eval range from 0m to 2m step 1m info(test_metric, {priority=~"high|medium", pri
 eval range from 0m to 2m step 1m info(test_metric, {__name__=~".*info", __name__=~"target.*", category=~"web|api"})
   test_metric{instance="a", job="1", env="prod", category="web"} 1 2 3
   test_metric{instance="b", job="2", env="dev", category="api"} 4 5 6
+
+clear
+
+# When inner series are missing one identifying label (e.g. job) but info series
+# match on the present identifying label, enrichment should still happen.
+load 1m
+  metric{instance="a"} 1 2 3
+  custom_info{instance="a", enriched="yes"} 1 1 1
+
+eval range from 0m to 2m step 1m info(metric, {__name__="custom_info"})
+  metric{instance="a", enriched="yes"} 1 2 3
+
+clear
+
+# Conflicting labels across different info metrics should error.
+load 1m
+  metric{instance="a", job="1"} 1 2 3
+  target_info{instance="a", job="1", x="from_target"} 1 1 1
+  build_info{instance="a", job="1", x="from_build"} 1 1 1
+
+eval_fail range from 0m to 2m step 1m info(metric, {__name__=~".+_info"})
+  expected_fail_regexp conflicting label

--- a/pkg/streamingpromql/testdata/ours/info.test
+++ b/pkg/streamingpromql/testdata/ours/info.test
@@ -221,3 +221,18 @@ load 1m
 
 eval_fail range from 0m to 2m step 1m info(metric, {__name__=~".+_info"})
   expected_fail_regexp conflicting label
+
+clear
+
+# When the second argument has no __name__ matcher, target_info is used by default.
+# build_info is excluded even though its env label also matches env=~".+".
+# The result has env="prod" (from target_info), not env="staging" (from build_info),
+# proving only target_info contributed. If build_info were also used, there would be
+# a conflict on the env label and the query would fail.
+load 5m
+    metric{instance="a", job="1"} 1
+    target_info{instance="a", job="1", env="prod"} 1
+    build_info{instance="a", job="1", env="staging"} 1
+
+eval range from 0m to 0m step 5m info(metric, {env=~".+"})
+    metric{instance="a", job="1", env="prod"} 1

--- a/pkg/streamingpromql/testdata/ours/info.test
+++ b/pkg/streamingpromql/testdata/ours/info.test
@@ -230,9 +230,9 @@ clear
 # proving only target_info contributed. If build_info were also used, there would be
 # a conflict on the env label and the query would fail.
 load 5m
-    metric{instance="a", job="1"} 1
-    target_info{instance="a", job="1", env="prod"} 1
-    build_info{instance="a", job="1", env="staging"} 1
+  metric{instance="a", job="1"} 1
+  target_info{instance="a", job="1", env="prod"} 1
+  build_info{instance="a", job="1", env="staging"} 1
 
 eval range from 0m to 0m step 5m info(metric, {env=~".+"})
-    metric{instance="a", job="1", env="prod"} 1
+  metric{instance="a", job="1", env="prod"} 1

--- a/pkg/streamingpromql/testdata/upstream/info.test
+++ b/pkg/streamingpromql/testdata/upstream/info.test
@@ -91,8 +91,7 @@ eval range from 0m to 10m step 5m info(build_info, {__name__=~".+_info"})
 # Negated __name__ matcher: exclude all *_info metrics.
 # Since no info metrics match, and data=~".+" doesn't match empty string, no results.
 # Regression test for https://github.com/prometheus/prometheus/issues/17931.
-# Unsupported by streaming engine.
-# eval range from 0m to 10m step 5m info(metric, {__name__!~".+_info", data=~".+"})
+eval range from 0m to 10m step 5m info(metric, {__name__!~".+_info", data=~".+"})
 
 # Negated __name__ matcher with matcher that accepts empty labels.
 # Since data=~".*" matches empty labels, the base metric is returned unchanged.
@@ -101,9 +100,8 @@ eval range from 0m to 10m step 5m info(metric, {__name__!~".+_info", data=~".*"}
 
 # Negated exact __name__ matcher.
 # Excludes target_info, but build_info still matches.
-# Unsupported by streaming engine.
-# eval range from 0m to 10m step 5m info(metric, {__name__!="target_info"})
-#     metric{instance="a", job="1", label="value", build_data="build"} 0 1 2
+eval range from 0m to 10m step 5m info(metric, {__name__!="target_info"})
+    metric{instance="a", job="1", label="value", build_data="build"} 0 1 2
 
 # When a base series matches one positive __name__ matcher but not another,
 # it should NOT be ignored (AND semantics). build_info matches .+_info but


### PR DESCRIPTION
#### What this PR does

Fix MQE's info function bugs when handling negated name matchers to match upstream behaviour.

#### Which issue(s) this PR fixes or relates to

Follows up on https://github.com/grafana/mimir/pull/14832

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
