### PR TITLE
Mixin: replace base_alerts_range_interval_minutes with scrape_interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -280,6 +280,7 @@
 
 ### Mixin
 
+* [CHANGE] Alerts and rules: Replaced `_config.base_alerts_range_interval_minutes` with `_config.scrape_interval` (default `15s`). Instead of configuring a pre-multiplied number of minutes, configure your actual Prometheus scrape interval and the mixin will compute safe rate-function windows automatically (at least 4× the scrape interval). #15174
 * [CHANGE] Dashboards: Add configuration option `dashboards_default_latency_mode` to control the default value of the native/classic latency variable (uses 'classic' if unset). #14424
 * [CHANGE] Alerts: Renamed the following alerts to fit within 40 characters: #13363
   * `MimirAlertmanagerPartialStateMergeFailing` → `MimirAlertmanagerStateMergeFailing`

--- a/operations/mimir-mixin-tests/test-scrape-interval-asserts.sh
+++ b/operations/mimir-mixin-tests/test-scrape-interval-asserts.sh
@@ -41,10 +41,9 @@ check_expressions() {
     # Each line is a single expression (newlines replaced with spaces by yq).
     # Extract all [duration] and [duration:step] brackets.
     # For subquery notation [range:step], we only check the range (first part before the colon).
-    # Note: (:[^]]*) uses * (zero-or-more) to also match the bare-subquery form [10m:].
     local remaining="$line"
-    while [[ $remaining =~ \[([0-9]+[smh])(:[^]]*)\]|\[([0-9]+[smh])\] ]]; do
-      duration="${BASH_REMATCH[1]}${BASH_REMATCH[3]}"
+    while [[ $remaining =~ \[([0-9]+[smh])[^]]*\] ]]; do
+      duration="${BASH_REMATCH[1]}"
       seconds=$(parse_duration_to_seconds "$duration")
 
       if [[ $seconds -lt $MIN_RATE_INTERVAL_SECONDS ]]; then

--- a/operations/mimir-mixin-tests/test-scrape-interval-asserts.sh
+++ b/operations/mimir-mixin-tests/test-scrape-interval-asserts.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+ALERTS_FILE="${SCRIPT_DIR}"/test-scrape-interval/alerts.yaml
+RULES_FILE="${SCRIPT_DIR}"/test-scrape-interval/rules.yaml
+
+SCRAPE_INTERVAL_SECONDS=300  # matches scrape_interval: '5m' in test-scrape-interval.libsonnet
+MIN_RATE_INTERVAL_SECONDS=$((4 * SCRAPE_INTERVAL_SECONDS))
+FAILED=0
+
+assert_failed() {
+  local msg=$1
+  echo ""
+  echo -e "$msg"
+  echo ""
+  FAILED=1
+}
+
+parse_duration_to_seconds() {
+  local duration=$1
+  if [[ $duration =~ ^([0-9]+)h$ ]]; then
+    echo $(( ${BASH_REMATCH[1]} * 3600 ))
+  elif [[ $duration =~ ^([0-9]+)m$ ]]; then
+    echo $(( ${BASH_REMATCH[1]} * 60 ))
+  elif [[ $duration =~ ^([0-9]+)s$ ]]; then
+    echo "${BASH_REMATCH[1]}"
+  else
+    echo "ERROR: cannot parse duration '${duration}'" >&2
+    exit 1
+  fi
+}
+
+check_expressions() {
+  local file=$1
+  local yq_filter=$2
+
+  while IFS= read -r line; do
+    # Each line is a single expression (newlines replaced with spaces by yq).
+    # Extract all [duration] and [duration:step] brackets.
+    # For subquery notation [range:step], we only check the range (first part before the colon).
+    # Note: (:[^]]*) uses * (zero-or-more) to also match the bare-subquery form [10m:].
+    local remaining="$line"
+    while [[ $remaining =~ \[([0-9]+[smh])(:[^]]*)\]|\[([0-9]+[smh])\] ]]; do
+      duration="${BASH_REMATCH[1]}${BASH_REMATCH[3]}"
+      seconds=$(parse_duration_to_seconds "$duration")
+
+      if [[ $seconds -lt $MIN_RATE_INTERVAL_SECONDS ]]; then
+        assert_failed "Expression contains [${duration}...] which is less than 4x the scrape interval (${MIN_RATE_INTERVAL_SECONDS}s):\n  ${line}"
+      fi
+
+      # Advance past the matched bracket to continue scanning the rest of the line.
+      local matched="${BASH_REMATCH[0]}"
+      remaining="${remaining#*"${matched}"}"
+    done
+  done < <(yq eval "$yq_filter" "$file")
+}
+
+echo "Checking ${ALERTS_FILE}"
+# Exclude alerts from vendor mixins (e.g. rollout-operator) which we don't control.
+check_expressions "${ALERTS_FILE}" \
+  '.groups[] | select(.name | test("^rollout_operator") | not) | .rules[].expr | sub("\n", " ")'
+
+echo "Checking ${RULES_FILE}"
+# Exclude recording rules whose names encode a fixed rate interval (e.g. :rate5m, :rate1m),
+# since their interval is intentional and baked into the name consumed by dashboards.
+check_expressions "${RULES_FILE}" \
+  '.groups[].rules[] | select(has("expr")) | select((has("record") | not) or (.record | test(":[a-z]+[0-9]+[smhd]$") | not)) | .expr | sub("\n", " ")'
+
+if [[ $FAILED -ne 0 ]]; then
+  exit 1
+fi

--- a/operations/mimir-mixin-tests/test-scrape-interval.libsonnet
+++ b/operations/mimir-mixin-tests/test-scrape-interval.libsonnet
@@ -1,0 +1,5 @@
+(import 'mixin-compiled.libsonnet') + {
+  _config+:: {
+    scrape_interval: '5m',
+  },
+}

--- a/operations/mimir-mixin/alerts/alertmanager.libsonnet
+++ b/operations/mimir-mixin/alerts/alertmanager.libsonnet
@@ -7,7 +7,7 @@
           alert: $.alertName('AlertmanagerSyncConfigsFailing'),
           expr: |||
             rate(cortex_alertmanager_sync_configs_failed_total[%s]) > 0
-          ||| % $.alertRangeInterval(5),
+          ||| % $.rateInterval('5m'),
           'for': '30m',
           labels: {
             severity: 'critical',
@@ -22,7 +22,7 @@
           alert: $.alertName('AlertmanagerRingCheckFailing'),
           expr: |||
             rate(cortex_alertmanager_ring_check_errors_total[%s]) > 0
-          ||| % $.alertRangeInterval(2),
+          ||| % $.rateInterval('2m'),
           'for': '10m',
           labels: {
             severity: 'critical',
@@ -37,7 +37,7 @@
           alert: $.alertName('AlertmanagerStateMergeFailing'),
           expr: |||
             rate(cortex_alertmanager_partial_state_merges_failed_total[%s]) > 0
-          ||| % $.alertRangeInterval(2),
+          ||| % $.rateInterval('2m'),
           'for': '10m',
           labels: {
             severity: 'critical',
@@ -52,7 +52,7 @@
           alert: $.alertName('AlertmanagerReplicationFailing'),
           expr: |||
             rate(cortex_alertmanager_state_replication_failed_total[%s]) > 0
-          ||| % $.alertRangeInterval(2),
+          ||| % $.rateInterval('2m'),
           'for': '10m',
           labels: {
             severity: 'critical',
@@ -67,7 +67,7 @@
           alert: $.alertName('AlertmanagerPersistStateFailing'),
           expr: |||
             rate(cortex_alertmanager_state_persist_failed_total[%s]) > 0
-          ||| % $.alertRangeInterval(15),
+          ||| % $.rateInterval('15m'),
           'for': '1h',
           labels: {
             severity: 'critical',
@@ -82,7 +82,7 @@
           alert: $.alertName('AlertmanagerInitialSyncFailed'),
           expr: |||
             increase(cortex_alertmanager_state_initial_sync_completed_total{outcome="failed"}[%s]) > 0
-          ||| % $.alertRangeInterval(1),
+          ||| % $.rateInterval('1m'),
           labels: {
             severity: 'warning',
           },

--- a/operations/mimir-mixin/alerts/alerts-utils.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts-utils.libsonnet
@@ -1,4 +1,4 @@
-{
+(import '../utils.libsonnet') {
   // The alert name is prefixed with the product name (eg. AlertName -> MimirAlertName).
   alertName(name)::
     $._config.alert_product + name,
@@ -50,11 +50,6 @@
       }
       for group in groups
     ],
-
-  alertRangeInterval(multiple)::
-    local minutes = $._config.base_alerts_range_interval_minutes * multiple;
-    if minutes >= 1 && minutes == std.floor(minutes) then minutes + 'm'
-    else std.ceil(minutes * 60) + 's',
 
   histogramLabels(labels, histogram_type, nhcb=false)::
     assert histogram_type == 'native' || histogram_type == 'classic';

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -49,7 +49,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       // Note if alert_aggregation_labels is "job", this will repeat the label. But
       // prometheus seems to tolerate that.
       error_selector='status_code=~"5..", status_code!~"529|598"',
-      rate_interval=$.alertRangeInterval(1),
+      rate_interval=$.rateInterval('1m'),
       sum_by=[$._config.alert_aggregation_labels, $._config.per_job_label, 'route'],
       comment=|||
         # The following 5xx errors considered as non-error:
@@ -77,7 +77,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     local query = requestErrorsQuery(
       selector='route="/httpgrpc.HTTP/Handle", %s' % $.jobMatcher($._config.job_names.ruler_query_frontend),
       error_selector='status_code=~"5.."',
-      rate_interval=$.alertRangeInterval(5),
+      rate_interval=$.rateInterval('5m'),
       sum_by=[$._config.alert_aggregation_labels],
     ),
     alert: $.alertName('RulerRemoteEvaluationFailing'),
@@ -97,9 +97,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
   local kvStoreFailure(histogram_type) = {
     alert: $.alertName('KVStoreFailure'),
     local sum_by = [$._config.alert_aggregation_labels, $._config.per_instance_label, 'status_code', 'kv_name'],
-    local range_interval = $.alertRangeInterval(1),
-    local numerator = utils.ncHistogramSumBy(utils.ncHistogramCountRate('cortex_kv_request_duration_seconds', 'status_code!~"2.+"', rate_interval=range_interval, from_recording=false), sum_by),
-    local denominator = utils.ncHistogramSumBy(utils.ncHistogramCountRate('cortex_kv_request_duration_seconds', '', rate_interval=range_interval, from_recording=false), sum_by),
+    local rate_interval = $.rateInterval('1m'),
+    local numerator = utils.ncHistogramSumBy(utils.ncHistogramCountRate('cortex_kv_request_duration_seconds', 'status_code!~"2.+"', rate_interval=rate_interval, from_recording=false), sum_by),
+    local denominator = utils.ncHistogramSumBy(utils.ncHistogramCountRate('cortex_kv_request_duration_seconds', '', rate_interval=rate_interval, from_recording=false), sum_by),
     expr: |||
       (
         %(numerator)s
@@ -181,14 +181,16 @@ local utils = import 'mixin-utils/utils.libsonnet';
                 # Don't include config hashes that are still being rolled out.
                 # Kubernetes configmap propagation can be slow,
                 # and in large cells we may deploy a new configmap when the previous one isn't still propagated everywhere.
-                (changes((count by (%(alert_aggregation_labels)s, sha256) (cortex_runtime_config_hash))[10m:]) > 0)
+                (changes((count by (%(alert_aggregation_labels)s, sha256) (cortex_runtime_config_hash))[%(rate_interval)s:]) > 0)
                 # Don't include configs that didn't exist one minute ago.
                 # changes() == 0 for metrics appearing for the first time,
                 # but this is still a "we're rolling out a new config" scenario.
                 and on (%(alert_aggregation_labels)s, sha256)
                 group by (%(alert_aggregation_labels)s, sha256) (cortex_runtime_config_hash offset 1m)
             )  > 1
-          ||| % $._config,
+          ||| % $._config {
+            rate_interval: $.rateInterval('10m'),
+          },
           'for': '1h',
           labels: {
             severity: 'critical',
@@ -228,16 +230,16 @@ local utils = import 'mixin-utils/utils.libsonnet';
               min_over_time(
                 delta(
                   sum by (%(group_by)s, %(job_label)s) (cortex_query_scheduler_queue_length)
-                  [%(range_interval)s:%(range_subinterval)s]
+                  [%(rate_interval)s:%(step_interval)s]
                 )
-                [%(range_interval)s:%(range_subinterval)s]
+                [%(rate_interval)s:%(step_interval)s]
               ) >= 0
             )
           ||| % {
             group_by: $._config.alert_aggregation_labels,
             job_label: $._config.per_job_label,
-            range_interval: $.alertRangeInterval(1),
-            range_subinterval: $.alertRangeInterval(0.25),
+            rate_interval: $.rateInterval('1m'),
+            step_interval: $.stepInterval('15s'),
           },
           'for': '7m',  // We don't want to block for longer.
           labels: {
@@ -266,16 +268,16 @@ local utils = import 'mixin-utils/utils.libsonnet';
           expr: |||
             (
               sum by(%(group_by)s, name, operation) (
-                rate(thanos_cache_operation_failures_total{operation!~"add|delete"}[%(range_interval)s])
+                rate(thanos_cache_operation_failures_total{operation!~"add|delete"}[%(rate_interval)s])
               )
               /
               sum by(%(group_by)s, name, operation) (
-                rate(thanos_cache_operations_total{operation!~"add|delete"}[%(range_interval)s])
+                rate(thanos_cache_operations_total{operation!~"add|delete"}[%(rate_interval)s])
               ) > 10
             ) * 100 > 5
           ||| % {
             group_by: $._config.alert_aggregation_labels,
-            range_interval: $.alertRangeInterval(1),
+            rate_interval: $.rateInterval('1m'),
           },
           'for': '5m',
           labels: {
@@ -416,10 +418,10 @@ local utils = import 'mixin-utils/utils.libsonnet';
           alert: $.alertName('StoreGatewayTooManyFailedOperations'),
           'for': '5m',
           expr: |||
-            sum by(%(alert_aggregation_labels)s, operation) (rate(thanos_objstore_bucket_operation_failures_total{component="store-gateway"}[%(range_interval)s])) > 0
+            sum by(%(alert_aggregation_labels)s, operation) (rate(thanos_objstore_bucket_operation_failures_total{component="store-gateway"}[%(rate_interval)s])) > 0
           ||| % {
             alert_aggregation_labels: $._config.alert_aggregation_labels,
-            range_interval: $.alertRangeInterval(1),
+            rate_interval: $.rateInterval('1m'),
           },
           labels: {
             severity: 'warning',
@@ -437,11 +439,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
           // Alert if servers are receiving requests with invalid cluster validation labels (i.e. meant for other clusters).
           alert: $.alertName('ServerInvalidClusterLabelRequests'),
           expr: |||
-            (sum by (%(alert_aggregation_labels)s, protocol) (rate(cortex_server_invalid_cluster_validation_label_requests_total{}[%(range_interval)s]))) > 0
+            (sum by (%(alert_aggregation_labels)s, protocol) (rate(cortex_server_invalid_cluster_validation_label_requests_total{}[%(rate_interval)s]))) > 0
             # Alert only for namespaces with Mimir clusters.
             and on (%(alert_aggregation_labels)s) (mimir_build_info > 0)
           ||| % $._config {
-            range_interval: $.alertRangeInterval(5),
+            rate_interval: $.rateInterval('5m'),
           },
           labels: {
             severity: 'warning',
@@ -454,11 +456,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
           // Alert if clients' requests are rejected due to invalid cluster validation labels (i.e. there's a mismatch between clients' and servers' cluster validation labels).
           alert: $.alertName('ClientInvalidClusterLabelRequests'),
           expr: |||
-            (sum by (%(alert_aggregation_labels)s, protocol) (rate(cortex_client_invalid_cluster_validation_label_requests_total{}[%(range_interval)s]))) > 0
+            (sum by (%(alert_aggregation_labels)s, protocol) (rate(cortex_client_invalid_cluster_validation_label_requests_total{}[%(rate_interval)s]))) > 0
             # Alert only for namespaces with Mimir clusters.
             and on (%(alert_aggregation_labels)s) (mimir_build_info > 0)
           ||| % $._config {
-            range_interval: $.alertRangeInterval(5),
+            rate_interval: $.rateInterval('5m'),
           },
           labels: {
             severity: 'warning',
@@ -511,11 +513,12 @@ local utils = import 'mixin-utils/utils.libsonnet';
         {
           alert: $.alertName('HighGRPCStreamsPerConnection'),
           expr: |||
-            max(avg_over_time(grpc_concurrent_streams_by_conn_max[10m])) by (%(alert_aggregation_labels)s, container)
+            max(avg_over_time(grpc_concurrent_streams_by_conn_max[%(rate_interval)s])) by (%(alert_aggregation_labels)s, container)
             /
             min(cortex_grpc_concurrent_streams_limit) by (%(alert_aggregation_labels)s, container) > 0.9
           ||| % {
             alert_aggregation_labels: $._config.alert_aggregation_labels,
+            rate_interval: $.rateInterval('10m'),
           },
           labels: {
             severity: 'warning',
@@ -751,7 +754,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
             )
           ) and (
             # Pick only those which are unchanging for the interval.
-            changes(%(kube_statefulset_status_replicas_updated)s[%(range_interval)s])
+            changes(%(kube_statefulset_status_replicas_updated)s[%(rate_interval)s:%(step_interval)s])
               ==
             0
           )
@@ -765,7 +768,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
           kube_statefulset_status_update_revision: groupStatefulSetByRolloutGroupAndRevision('kube_statefulset_status_update_revision', $._config.rollout_stuck_alert_ignore_statefulsets),
           kube_statefulset_replicas: groupStatefulSetByRolloutGroup('kube_statefulset_replicas', $._config.rollout_stuck_alert_ignore_statefulsets),
           kube_statefulset_status_replicas_updated: groupStatefulSetByRolloutGroup('kube_statefulset_status_replicas_updated', $._config.rollout_stuck_alert_ignore_statefulsets),
-          range_interval: '15m:' + $.alertRangeInterval(1),
+          rate_interval: $.rateInterval('15m'),
+          step_interval: $.stepInterval('1m'),
         },
         'for': for_duration,
         labels: {
@@ -787,7 +791,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
               !=
             %(kube_deployment_status_replicas_updated)s
           ) and (
-            changes(%(kube_deployment_status_replicas_updated)s[%(range_interval)s])
+            changes(%(kube_deployment_status_replicas_updated)s[%(rate_interval)s:%(step_interval)s])
               ==
             0
           )
@@ -796,7 +800,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
           aggregation_labels: $._config.alert_aggregation_labels,
           kube_deployment_spec_replicas: groupDeploymentByRolloutGroup('kube_deployment_spec_replicas', $._config.rollout_stuck_alert_ignore_deployments),
           kube_deployment_status_replicas_updated: groupDeploymentByRolloutGroup('kube_deployment_status_replicas_updated', $._config.rollout_stuck_alert_ignore_deployments),
-          range_interval: '15m:' + $.alertRangeInterval(1),
+          rate_interval: $.rateInterval('15m'),
+          step_interval: $.stepInterval('1m'),
         },
         'for': for_duration,
         labels: {
@@ -886,12 +891,12 @@ local utils = import 'mixin-utils/utils.libsonnet';
           expr: |||
             100 * (
             # Here it matches on empty "reason" for backwards compatibility, with when the metric didn't have this label.
-            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_ruler_write_requests_failed_total{reason=~"(error|^$)"}[%(range_interval)s]))
+            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_ruler_write_requests_failed_total{reason=~"(error|^$)"}[%(rate_interval)s]))
               /
-            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_ruler_write_requests_total[%(range_interval)s]))
+            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_ruler_write_requests_total[%(rate_interval)s]))
             ) > 1
           ||| % $._config {
-            range_interval: $.alertRangeInterval(1),
+            rate_interval: $.rateInterval('1m'),
           },
           'for': '5m',
           labels: {
@@ -908,12 +913,12 @@ local utils = import 'mixin-utils/utils.libsonnet';
           expr: |||
             100 * (
             # Here it matches on empty "reason" for backwards compatibility, with when the metric didn't have this label.
-            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_ruler_queries_failed_total{reason=~"(error|^$)"}[%(range_interval)s]))
+            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_ruler_queries_failed_total{reason=~"(error|^$)"}[%(rate_interval)s]))
               /
-            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_ruler_queries_total[%(range_interval)s]))
+            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_ruler_queries_total[%(rate_interval)s]))
             ) > 1
           ||| % $._config {
-            range_interval: $.alertRangeInterval(1),
+            rate_interval: $.rateInterval('1m'),
           },
           'for': '5m',
           labels: {
@@ -932,12 +937,12 @@ local utils = import 'mixin-utils/utils.libsonnet';
           alert: $.alertName('RulerMissedEvaluations'),
           expr: |||
             100 * (
-            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s, rule_group) (rate(cortex_prometheus_rule_group_iterations_missed_total[%(range_interval)s]))
+            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s, rule_group) (rate(cortex_prometheus_rule_group_iterations_missed_total[%(rate_interval)s]))
               /
-            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s, rule_group) (rate(cortex_prometheus_rule_group_iterations_total[%(range_interval)s]))
+            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s, rule_group) (rate(cortex_prometheus_rule_group_iterations_total[%(rate_interval)s]))
             ) > 1
           ||| % $._config {
-            range_interval: $.alertRangeInterval(1),
+            rate_interval: $.rateInterval('1m'),
           },
           'for': '5m',
           labels: {
@@ -952,10 +957,10 @@ local utils = import 'mixin-utils/utils.libsonnet';
         {
           alert: $.alertName('RulerFailedRingCheck'),
           expr: |||
-            sum by (%(alert_aggregation_labels)s, %(per_job_label)s) (rate(cortex_ruler_ring_check_errors_total[%(range_interval)s]))
+            sum by (%(alert_aggregation_labels)s, %(per_job_label)s) (rate(cortex_ruler_ring_check_errors_total[%(rate_interval)s]))
                > 0
           ||| % $._config {
-            range_interval: $.alertRangeInterval(1),
+            rate_interval: $.rateInterval('1m'),
           },
           'for': '5m',
           labels: {
@@ -1119,7 +1124,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
             sum by (%(alert_aggregation_labels)s) (rate(memberlist_client_zone_aware_routing_select_nodes_skipped_total[%(range)s])) > 0
           ||| % {
             alert_aggregation_labels: $._config.alert_aggregation_labels,
-            range: $.alertRangeInterval(1),
+            range: $.rateInterval('1m'),
           },
           'for': '10m',
           labels: {

--- a/operations/mimir-mixin/alerts/autoscaling.libsonnet
+++ b/operations/mimir-mixin/alerts/autoscaling.libsonnet
@@ -47,14 +47,14 @@
           expr: |||
             (
                 # Find KEDA scalers reporting errors.
-                label_replace(rate(keda_scaler_errors[%(range_interval)s]), "namespace", "$1", "exported_namespace", "(.*)")
+                label_replace(rate(keda_scaler_errors[%(rate_interval)s]), "namespace", "$1", "exported_namespace", "(.*)")
                 # Match only Mimir namespaces.
                 * on(%(aggregation_labels)s) group_left max by(%(aggregation_labels)s) (cortex_build_info)
             )
             > 0
           ||| % {
             aggregation_labels: $._config.alert_aggregation_labels,
-            range_interval: $.alertRangeInterval(5),
+            rate_interval: $.rateInterval('5m'),
           },
           labels: {
             severity: 'critical',

--- a/operations/mimir-mixin/alerts/blocks.libsonnet
+++ b/operations/mimir-mixin/alerts/blocks.libsonnet
@@ -93,7 +93,7 @@
           'for': '15m',
           expr: |||
             rate(cortex_ingester_tsdb_compactions_failed_total[%s]) > 0
-          ||| % $.alertRangeInterval(5),
+          ||| % $.rateInterval('5m'),
           labels: {
             severity: 'critical',
           },
@@ -105,7 +105,7 @@
           alert: $.alertName('IngesterTSDBHeadTruncationFailed'),
           expr: |||
             rate(cortex_ingester_tsdb_head_truncations_failed_total[%s]) > 0
-          ||| % $.alertRangeInterval(5),
+          ||| % $.rateInterval('5m'),
           labels: {
             severity: 'critical',
           },
@@ -117,7 +117,7 @@
           alert: $.alertName('IngesterTSDBCheckpointCreateFailed'),
           expr: |||
             rate(cortex_ingester_tsdb_checkpoint_creations_failed_total[%s]) > 0
-          ||| % $.alertRangeInterval(5),
+          ||| % $.rateInterval('5m'),
           labels: {
             severity: 'critical',
           },
@@ -129,7 +129,7 @@
           alert: $.alertName('IngesterTSDBCheckpointDeleteFailed'),
           expr: |||
             rate(cortex_ingester_tsdb_checkpoint_deletions_failed_total[%s]) > 0
-          ||| % $.alertRangeInterval(5),
+          ||| % $.rateInterval('5m'),
           labels: {
             severity: 'critical',
           },
@@ -141,7 +141,7 @@
           alert: $.alertName('IngesterTSDBWALTruncationFailed'),
           expr: |||
             rate(cortex_ingester_tsdb_wal_truncations_failed_total[%s]) > 0
-          ||| % $.alertRangeInterval(5),
+          ||| % $.rateInterval('5m'),
           labels: {
             severity: 'warning',
           },
@@ -153,12 +153,12 @@
           alert: $.alertName('IngesterTSDBWALCorrupted'),
           expr: |||
             # alert when there are more than one corruptions
-            count by (%(alert_aggregation_labels)s) (rate(cortex_ingester_tsdb_wal_corruptions_total[%(range_interval)s]) > 0) > 1
+            count by (%(alert_aggregation_labels)s) (rate(cortex_ingester_tsdb_wal_corruptions_total[%(rate_interval)s]) > 0) > 1
             and
             # and there is only one zone
             count by (%(alert_aggregation_labels)s) (group by (%(alert_aggregation_labels)s, %(per_job_label)s) (cortex_ingester_tsdb_wal_corruptions_total)) == 1
           ||| % $._config {
-            range_interval: $.alertRangeInterval(5),
+            rate_interval: $.rateInterval('5m'),
           },
           labels: {
             severity: 'critical',
@@ -172,12 +172,12 @@
           alert: $.alertName('IngesterTSDBWALCorrupted'),
           expr: |||
             # alert when there are more than one corruptions
-            count by (%(alert_aggregation_labels)s) (sum by (%(alert_aggregation_labels)s, %(per_job_label)s) (rate(cortex_ingester_tsdb_wal_corruptions_total[%(range_interval)s]) > 0)) > 1
+            count by (%(alert_aggregation_labels)s) (sum by (%(alert_aggregation_labels)s, %(per_job_label)s) (rate(cortex_ingester_tsdb_wal_corruptions_total[%(rate_interval)s]) > 0)) > 1
             and
             # and there are multiple zones
             count by (%(alert_aggregation_labels)s) (group by (%(alert_aggregation_labels)s, %(per_job_label)s) (cortex_ingester_tsdb_wal_corruptions_total)) > 1
           ||| % $._config {
-            range_interval: $.alertRangeInterval(5),
+            rate_interval: $.rateInterval('5m'),
           },
           labels: {
             severity: 'critical',
@@ -192,7 +192,7 @@
           'for': '3m',
           expr: |||
             rate(cortex_ingester_tsdb_wal_writes_failed_total[%s]) > 0
-          ||| % $.alertRangeInterval(1),
+          ||| % $.rateInterval('1m'),
           labels: {
             severity: 'critical',
           },
@@ -237,8 +237,10 @@
           // by default). Allow a 15m lookback (the default compactor.cleanup-interval) to include compactors that may have recently updated the index and then been terminated.
           alert: $.alertName('BucketIndexNotUpdated'),
           expr: |||
-            min by(%(alert_aggregation_labels)s, user) (time() - (max_over_time(cortex_bucket_index_last_successful_update_timestamp_seconds[15m]))) > 2100
-          ||| % $._config,
+            min by(%(alert_aggregation_labels)s, user) (time() - (max_over_time(cortex_bucket_index_last_successful_update_timestamp_seconds[%(rate_interval)s]))) > 2100
+          ||| % $._config {
+            rate_interval: $.rateInterval('15m'),
+          },
           labels: {
             severity: 'critical',
           },
@@ -253,13 +255,13 @@
           'for': '6h',
           expr: |||
             (
-            sum by(%(alert_aggregation_labels)s) (rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",out_of_order="false",%(job)s}[%(range_interval)s]))
+            sum by(%(alert_aggregation_labels)s) (rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",out_of_order="false",%(job)s}[%(rate_interval)s]))
             /
-            sum by(%(alert_aggregation_labels)s) (rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",out_of_order="false",%(job)s}[%(range_interval)s]))
+            sum by(%(alert_aggregation_labels)s) (rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",out_of_order="false",%(job)s}[%(rate_interval)s]))
             ) > 0.05
           ||| % $._config {
             job: $.jobMatcher($._config.job_names.store_gateway),
-            range_interval: $.alertRangeInterval(10),
+            rate_interval: $.rateInterval('10m'),
           },
           labels: {
             severity: 'warning',

--- a/operations/mimir-mixin/alerts/compactor-scheduler.libsonnet
+++ b/operations/mimir-mixin/alerts/compactor-scheduler.libsonnet
@@ -61,7 +61,7 @@
               increase(cortex_compactor_scheduler_jobs_completed_total[%(rate_interval)s])
             ) == 0
           ||| % $._config {
-            rate_interval: '6h',
+            rate_interval: $.rateInterval('6h'),
           },
           labels: {
             severity: 'critical',

--- a/operations/mimir-mixin/alerts/compactor-scheduler.libsonnet
+++ b/operations/mimir-mixin/alerts/compactor-scheduler.libsonnet
@@ -40,10 +40,10 @@
           alert: $.alertName('CompactorSchedulerRepeatedJobFailure'),
           expr: |||
             sum by(%(alert_aggregation_labels)s) (
-              increase(cortex_compactor_scheduler_repeated_job_failures_total[%(range_interval)s])
+              increase(cortex_compactor_scheduler_repeated_job_failures_total[%(rate_interval)s])
             ) > 0
           ||| % $._config {
-            range_interval: $.alertRangeInterval(5),
+            rate_interval: $.rateInterval('5m'),
           },
           labels: {
             severity: 'warning',
@@ -58,10 +58,10 @@
           'for': '30m',
           expr: |||
             sum by(%(alert_aggregation_labels)s) (
-              increase(cortex_compactor_scheduler_jobs_completed_total[%(range_interval)s])
+              increase(cortex_compactor_scheduler_jobs_completed_total[%(rate_interval)s])
             ) == 0
           ||| % $._config {
-            range_interval: '6h',
+            rate_interval: '6h',
           },
           labels: {
             severity: 'critical',

--- a/operations/mimir-mixin/alerts/compactor.libsonnet
+++ b/operations/mimir-mixin/alerts/compactor.libsonnet
@@ -154,9 +154,9 @@
           alert: $.alertName('CompactorBuildingSparseIndexFailed'),
           'for': '30m',
           expr: |||
-            (sum by(%(alert_aggregation_labels)s, %(per_instance_label)s) (increase(cortex_compactor_build_sparse_headers_failures_total[%(range_interval)s])) > 0)
+            (sum by(%(alert_aggregation_labels)s, %(per_instance_label)s) (increase(cortex_compactor_build_sparse_headers_failures_total[%(rate_interval)s])) > 0)
           ||| % $._config {
-            range_interval: $.alertRangeInterval(5),
+            rate_interval: $.rateInterval('5m'),
           },
           labels: {
             severity: 'warning',

--- a/operations/mimir-mixin/alerts/continuous-test.libsonnet
+++ b/operations/mimir-mixin/alerts/continuous-test.libsonnet
@@ -9,9 +9,9 @@
           alert: $.alertName('ContinuousTestNotRunningOnWrites'),
           'for': '1h',
           expr: |||
-            sum by(%(alert_aggregation_labels)s, test) (rate(mimir_continuous_test_writes_failed_total[%(range_interval)s])) > 0
+            sum by(%(alert_aggregation_labels)s, test) (rate(mimir_continuous_test_writes_failed_total[%(rate_interval)s])) > 0
           ||| % $._config {
-            range_interval: $.alertRangeInterval(5),
+            rate_interval: $.rateInterval('5m'),
           },
           labels: {
             severity: 'warning',
@@ -26,9 +26,9 @@
           alert: $.alertName('ContinuousTestNotRunningOnReads'),
           'for': '1h',
           expr: |||
-            sum by(%(alert_aggregation_labels)s, test) (rate(mimir_continuous_test_queries_failed_total[%(range_interval)s])) > 0
+            sum by(%(alert_aggregation_labels)s, test) (rate(mimir_continuous_test_queries_failed_total[%(rate_interval)s])) > 0
           ||| % $._config {
-            range_interval: $.alertRangeInterval(5),
+            rate_interval: $.rateInterval('5m'),
           },
           labels: {
             severity: 'warning',
@@ -42,8 +42,10 @@
           // should have no "grace period" and alert as soon as the test fails.
           alert: $.alertName('ContinuousTestFailed'),
           expr: |||
-            sum by(%(alert_aggregation_labels)s, test) (rate(mimir_continuous_test_query_result_checks_failed_total[10m])) > 0
-          ||| % $._config,
+            sum by(%(alert_aggregation_labels)s, test) (rate(mimir_continuous_test_query_result_checks_failed_total[%(rate_interval)s])) > 0
+          ||| % $._config {
+            rate_interval: $.rateInterval('10m'),
+          },
           labels: {
             severity: 'warning',
           },

--- a/operations/mimir-mixin/alerts/distributor.libsonnet
+++ b/operations/mimir-mixin/alerts/distributor.libsonnet
@@ -8,19 +8,19 @@
           alert: $.alertName('DistributorGcUsesTooMuchCpu'),
           'for': '10m',
           expr: |||
-            (quantile by (%(alert_aggregation_labels)s) (0.9, sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(go_cpu_classes_gc_total_cpu_seconds_total{container="distributor"}[%(range_interval)s]))
+            (quantile by (%(alert_aggregation_labels)s) (0.9, sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(go_cpu_classes_gc_total_cpu_seconds_total{container="distributor"}[%(rate_interval)s]))
               /
               (
-                sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(go_cpu_classes_total_cpu_seconds_total{container="distributor"}[%(range_interval)s]))
+                sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(go_cpu_classes_total_cpu_seconds_total{container="distributor"}[%(rate_interval)s]))
                 -
-                sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(go_cpu_classes_idle_cpu_seconds_total{container="distributor"}[%(range_interval)s]))
+                sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(go_cpu_classes_idle_cpu_seconds_total{container="distributor"}[%(rate_interval)s]))
               )
             ) * 100) > %(distributor_gc_cpu_threshold)s
 
             # Alert only for namespaces with Mimir clusters.
             and (count by (%(alert_aggregation_labels)s) (mimir_build_info) > 0)
           ||| % $._config {
-            range_interval: $.alertRangeInterval(5),
+            rate_interval: $.rateInterval('5m'),
           },
           labels: {
             severity: 'warning',

--- a/operations/mimir-mixin/alerts/gem.libsonnet
+++ b/operations/mimir-mixin/alerts/gem.libsonnet
@@ -4,9 +4,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
   local GEMFederationFrontendRemoteClusterErrors(histogram_type) = {
     alert: 'GEMFederationFrontendRemoteClusterErrors',  // We do not use the alertName function here because this alert only makes sense in the context of GEM.
     local sum_by = ['remote_cluster'],
-    local range_interval = $.alertRangeInterval(1),
-    local numerator = utils.ncHistogramSumBy(utils.ncHistogramCountRate('cortex_federation_frontend_cluster_remote_latency_seconds', 'status="server_error"', rate_interval=range_interval, from_recording=false), sum_by),
-    local denominator = utils.ncHistogramSumBy(utils.ncHistogramCountRate('cortex_federation_frontend_cluster_remote_latency_seconds', '', rate_interval=range_interval, from_recording=false), sum_by),
+    local rate_interval = $.rateInterval('1m'),
+    local numerator = utils.ncHistogramSumBy(utils.ncHistogramCountRate('cortex_federation_frontend_cluster_remote_latency_seconds', 'status="server_error"', rate_interval=rate_interval, from_recording=false), sum_by),
+    local denominator = utils.ncHistogramSumBy(utils.ncHistogramCountRate('cortex_federation_frontend_cluster_remote_latency_seconds', '', rate_interval=rate_interval, from_recording=false), sum_by),
     expr: |||
       100 * (
         %(numerator)s

--- a/operations/mimir-mixin/alerts/ingest-storage.libsonnet
+++ b/operations/mimir-mixin/alerts/ingest-storage.libsonnet
@@ -5,18 +5,20 @@ local utils = import 'mixin-utils/utils.libsonnet';
     // This is an experiment. We compute derivation (ie. rate of consumption lag change) over 5 minutes. If derivation is above 0, it means consumption lag is increasing, instead of decreasing.
     alert: $.alertName('StartingIngesterKafkaDelayGrowing'),
     local sum_by = [$._config.alert_aggregation_labels, $._config.per_instance_label],
-    local range_interval = $.alertRangeInterval(1),
-    local numerator = utils.ncHistogramSumBy(utils.ncHistogramSumRate('cortex_ingest_storage_reader_receive_delay_seconds', 'phase="starting"', rate_interval=range_interval, from_recording=false), sum_by),
-    local denominator = utils.ncHistogramSumBy(utils.ncHistogramCountRate('cortex_ingest_storage_reader_receive_delay_seconds', 'phase="starting"', rate_interval=range_interval, from_recording=false), sum_by),
+    local rate_interval = $.rateInterval('1m'),
+    local numerator = utils.ncHistogramSumBy(utils.ncHistogramSumRate('cortex_ingest_storage_reader_receive_delay_seconds', 'phase="starting"', rate_interval=rate_interval, from_recording=false), sum_by),
+    local denominator = utils.ncHistogramSumBy(utils.ncHistogramCountRate('cortex_ingest_storage_reader_receive_delay_seconds', 'phase="starting"', rate_interval=rate_interval, from_recording=false), sum_by),
     expr: |||
       deriv((
           %(numerator)s
           /
           %(denominator)s
-      )[5m:1m]) > 0
+      )[%(rate_interval)s:%(step_interval)s]) > 0
     ||| % {
       numerator: numerator[histogram_type],
       denominator: denominator[histogram_type],
+      rate_interval: $.rateInterval('5m'),
+      step_interval: $.stepInterval('1m'),
     },
     'for': '5m',
     labels: $.histogramLabels({ severity: 'warning' }, histogram_type, nhcb=false),
@@ -28,9 +30,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
   local runningIngesterReceiveDelayTooHigh(histogram_type, threshold_value, for_duration, threshold_label) = {
     alert: $.alertName('RunningIngesterReceiveDelayTooHigh'),
     local sum_by = [$._config.alert_aggregation_labels, $._config.per_instance_label],
-    local range_interval = $.alertRangeInterval(1),
-    local numerator = utils.ncHistogramSumBy(utils.ncHistogramSumRate('cortex_ingest_storage_reader_receive_delay_seconds', 'phase="running"', rate_interval=range_interval, from_recording=false), sum_by),
-    local denominator = utils.ncHistogramSumBy(utils.ncHistogramCountRate('cortex_ingest_storage_reader_receive_delay_seconds', 'phase="running"', rate_interval=range_interval, from_recording=false), sum_by),
+    local rate_interval = $.rateInterval('1m'),
+    local numerator = utils.ncHistogramSumBy(utils.ncHistogramSumRate('cortex_ingest_storage_reader_receive_delay_seconds', 'phase="running"', rate_interval=rate_interval, from_recording=false), sum_by),
+    local denominator = utils.ncHistogramSumBy(utils.ncHistogramCountRate('cortex_ingest_storage_reader_receive_delay_seconds', 'phase="running"', rate_interval=rate_interval, from_recording=false), sum_by),
     expr: |||
       (
         %(numerator)s
@@ -68,11 +70,13 @@ local utils = import 'mixin-utils/utils.libsonnet';
           alert: $.alertName('IngesterOffsetCommitFailed'),
           'for': '15m',
           expr: |||
-            sum by(%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_ingest_storage_reader_offset_commit_failures_total[5m]))
+            sum by(%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_ingest_storage_reader_offset_commit_failures_total[%(rate_interval)s]))
             /
-            sum by(%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_ingest_storage_reader_offset_commit_requests_total[5m]))
+            sum by(%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_ingest_storage_reader_offset_commit_requests_total[%(rate_interval)s]))
             > 0.2
-          ||| % $._config,
+          ||| % $._config {
+            rate_interval: $.rateInterval('5m'),
+          },
           labels: {
             severity: 'critical',
           },
@@ -94,7 +98,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           ||| % {
             alert_aggregation_labels: $._config.alert_aggregation_labels,
             per_instance_label: $._config.per_instance_label,
-            range: $.alertRangeInterval(1),
+            range: $.rateInterval('1m'),
           },
           labels: {
             severity: 'critical',
@@ -109,11 +113,13 @@ local utils = import 'mixin-utils/utils.libsonnet';
           'for': '15m',
           // See https://github.com/grafana/mimir/blob/24591ae56cd7d6ef24a7cc1541a41405676773f4/vendor/github.com/twmb/franz-go/pkg/kgo/record_and_fetch.go#L332-L366 for errors that can be reported here.
           expr: |||
-            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate (cortex_ingest_storage_reader_fetch_errors_total[5m]))
+            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate (cortex_ingest_storage_reader_fetch_errors_total[%(rate_interval)s]))
             /
-            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate (cortex_ingest_storage_reader_fetches_total[5m]))
+            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate (cortex_ingest_storage_reader_fetches_total[%(rate_interval)s]))
             > 0.1
-          ||| % $._config,
+          ||| % $._config {
+            rate_interval: $.rateInterval('5m'),
+          },
           labels: {
             severity: 'critical',
           },
@@ -149,7 +155,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           ||| % {
             alert_aggregation_labels: $._config.alert_aggregation_labels,
             per_instance_label: $._config.per_instance_label,
-            range: $.alertRangeInterval(1),
+            range: $.rateInterval('1m'),
           },
           labels: {
             severity: 'critical',
@@ -167,13 +173,15 @@ local utils = import 'mixin-utils/utils.libsonnet';
             # Alert if the reader is not processing any records, but there buffered records to process in the Kafka client.
             (sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (
                 # This is the old metric name. We're keeping support for backward compatibility.
-              rate(cortex_ingest_storage_reader_records_total[5m])
+              rate(cortex_ingest_storage_reader_records_total[%(rate_interval)s])
               or
-              rate(cortex_ingest_storage_reader_requests_total[5m])
+              rate(cortex_ingest_storage_reader_requests_total[%(rate_interval)s])
             ) == 0)
             and
             (sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_ingest_storage_reader_buffered_fetched_records) > 0)
-          ||| % $._config,
+          ||| % $._config {
+            rate_interval: $.rateInterval('5m'),
+          },
           labels: {
             severity: 'critical',
           },
@@ -188,7 +196,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           expr: |||
             # Alert if the ingester missed some records from Kafka.
             increase(cortex_ingest_storage_reader_missed_records_total[%s]) > 0
-          ||| % $.alertRangeInterval(10),
+          ||| % $.rateInterval('10m'),
           labels: {
             severity: 'critical',
           },
@@ -206,7 +214,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           ||| % {
             alert_aggregation_labels: $._config.alert_aggregation_labels,
             per_instance_label: $._config.per_instance_label,
-            range: $.alertRangeInterval(1),
+            range: $.rateInterval('1m'),
           },
           labels: {
             severity: 'critical',
@@ -227,7 +235,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
             * 100 > 5
           ||| % {
             alert_aggregation_labels: $._config.alert_aggregation_labels,
-            range: $.alertRangeInterval(1),
+            range: $.rateInterval('1m'),
           },
           labels: {
             severity: 'warning',
@@ -255,7 +263,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           ||| % {
             alert_aggregation_labels: $._config.alert_aggregation_labels,
             per_instance_label: $._config.per_instance_label,
-            range: $.alertRangeInterval(1),
+            range: $.rateInterval('1m'),
           },
           labels: {
             severity: 'critical',
@@ -289,7 +297,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
             alert_aggregation_labels: $._config.alert_aggregation_labels,
             per_instance_label: $._config.per_instance_label,
-            range: $.alertRangeInterval(1),
+            range: $.rateInterval('1m'),
           },
           labels: {
             severity: 'critical',
@@ -328,8 +336,10 @@ local utils = import 'mixin-utils/utils.libsonnet';
           // if the series was previously present. Thus we do not need to predicate the alert on presence of
           // a block-builder-scheduler.
           expr: |||
-            max by (%(alert_aggregation_labels)s, %(per_instance_label)s) (histogram_count(increase(cortex_blockbuilder_scheduler_schedule_update_seconds[5m])) == 0)
-          ||| % $._config,
+            max by (%(alert_aggregation_labels)s, %(per_instance_label)s) (histogram_count(increase(cortex_blockbuilder_scheduler_schedule_update_seconds[%(rate_interval)s])) == 0)
+          ||| % $._config {
+            rate_interval: $.rateInterval('5m'),
+          },
           labels: {
             severity: 'warning',
           },
@@ -360,7 +370,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           expr: |||
             increase(cortex_blockbuilder_scheduler_persistent_job_failures_total[%(range)s]) > 0
           ||| % {
-            range: $.alertRangeInterval(1),
+            range: $.rateInterval('1m'),
           },
           labels: {
             severity: 'critical',

--- a/operations/mimir-mixin/alerts/usage-tracker.libsonnet
+++ b/operations/mimir-mixin/alerts/usage-tracker.libsonnet
@@ -7,8 +7,10 @@
           alert: $.alertName('UsageTrackerSnapshotUploadFailing'),
           'for': '15m',
           expr: |||
-            sum by(%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_usage_tracker_snapshot_events_publish_failures_total[5m])) > 0
-          ||| % $._config,
+            sum by(%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_usage_tracker_snapshot_events_publish_failures_total[%(rate_interval)s])) > 0
+          ||| % $._config {
+            rate_interval: $.rateInterval('5m'),
+          },
           labels: {
             severity: 'critical',
           },
@@ -20,8 +22,10 @@
           alert: $.alertName('UsageTrackerSnapshotDownloadFailing'),
           'for': '15m',
           expr: |||
-            sum by(%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_usage_tracker_snapshot_events_errors_total{error="download"}[5m])) > 0
-          ||| % $._config,
+            sum by(%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_usage_tracker_snapshot_events_errors_total{error="download"}[%(rate_interval)s])) > 0
+          ||| % $._config {
+            rate_interval: $.rateInterval('5m'),
+          },
           labels: {
             severity: 'critical',
           },

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -763,14 +763,15 @@
     dashboard_datasource: 'default',
     datasource_regex: '',
 
+    // The Prometheus scrape interval configured in your Prometheus. Used by rateInterval() and
+    // stepInterval() to compute safe windows automatically.
+    // See https://www.robustperception.io/what-range-should-i-use-with-rate/
+    scrape_interval: '15s',
+
     // Tunes histogram recording rules to aggregate over this interval.
     // Set to at least twice the scrape interval; otherwise, recording rules will output no data.
     // Set to four times the scrape interval to account for edge cases: https://www.robustperception.io/what-range-should-i-use-with-rate/
     recording_rules_range_interval: '1m',
-
-    // Used to calculate range interval in alerts with default range selector under 10 minutes.
-    // Needed to account for edge cases: https://www.robustperception.io/what-range-should-i-use-with-rate/
-    base_alerts_range_interval_minutes: 1,
 
     // Used to inject rows into dashboards at specific places that support it.
     injectRows: {},

--- a/operations/mimir-mixin/recording_rules.libsonnet
+++ b/operations/mimir-mixin/recording_rules.libsonnet
@@ -1,6 +1,6 @@
 local utils = import 'mixin-utils/utils.libsonnet';
 
-{
+(import 'utils.libsonnet') {
   local _config = {
     max_series_per_ingester: 1.5e6,
     max_samples_per_sec_per_ingester: 80e3,
@@ -12,42 +12,42 @@ local utils = import 'mixin-utils/utils.libsonnet';
       {
         name: 'mimir_api_1',
         rules:
-          utils.histogramRules('cortex_request_duration_seconds', [$._config.per_cluster_label, 'job'], $._config.recording_rules_range_interval, record_native=true),
+          utils.histogramRules('cortex_request_duration_seconds', [$._config.per_cluster_label, 'job'], $.rateInterval($._config.recording_rules_range_interval), record_native=true),
       },
       {
         name: 'mimir_api_2',
         rules:
-          utils.histogramRules('cortex_request_duration_seconds', [$._config.per_cluster_label, 'job', 'route'], $._config.recording_rules_range_interval, record_native=true),
+          utils.histogramRules('cortex_request_duration_seconds', [$._config.per_cluster_label, 'job', 'route'], $.rateInterval($._config.recording_rules_range_interval), record_native=true),
       },
       {
         name: 'mimir_api_3',
         rules:
-          utils.histogramRules('cortex_request_duration_seconds', $._config.job_labels + ['route'], $._config.recording_rules_range_interval, record_native=true),
+          utils.histogramRules('cortex_request_duration_seconds', $._config.job_labels + ['route'], $.rateInterval($._config.recording_rules_range_interval), record_native=true),
       },
       {
         name: 'mimir_querier_api',
         rules:
-          utils.histogramRules('cortex_querier_request_duration_seconds', [$._config.per_cluster_label, 'job'], $._config.recording_rules_range_interval, record_native=true) +
-          utils.histogramRules('cortex_querier_request_duration_seconds', [$._config.per_cluster_label, 'job', 'route'], $._config.recording_rules_range_interval, record_native=true) +
-          utils.histogramRules('cortex_querier_request_duration_seconds', $._config.job_labels + ['route'], $._config.recording_rules_range_interval, record_native=true),
+          utils.histogramRules('cortex_querier_request_duration_seconds', [$._config.per_cluster_label, 'job'], $.rateInterval($._config.recording_rules_range_interval), record_native=true) +
+          utils.histogramRules('cortex_querier_request_duration_seconds', [$._config.per_cluster_label, 'job', 'route'], $.rateInterval($._config.recording_rules_range_interval), record_native=true) +
+          utils.histogramRules('cortex_querier_request_duration_seconds', $._config.job_labels + ['route'], $.rateInterval($._config.recording_rules_range_interval), record_native=true),
       },
       {
         name: 'mimir_storage',
         rules:
-          utils.histogramRules('cortex_kv_request_duration_seconds', [$._config.per_cluster_label, 'job'], $._config.recording_rules_range_interval, record_native=true),
+          utils.histogramRules('cortex_kv_request_duration_seconds', [$._config.per_cluster_label, 'job'], $.rateInterval($._config.recording_rules_range_interval), record_native=true),
       },
       {
         name: 'mimir_queries',
         rules:
-          utils.histogramRules('cortex_query_frontend_retries', [$._config.per_cluster_label, 'job'], $._config.recording_rules_range_interval, record_native=true) +
-          utils.histogramRules('cortex_query_frontend_queue_duration_seconds', [$._config.per_cluster_label, 'job'], $._config.recording_rules_range_interval, record_native=true),
+          utils.histogramRules('cortex_query_frontend_retries', [$._config.per_cluster_label, 'job'], $.rateInterval($._config.recording_rules_range_interval), record_native=true) +
+          utils.histogramRules('cortex_query_frontend_queue_duration_seconds', [$._config.per_cluster_label, 'job'], $.rateInterval($._config.recording_rules_range_interval), record_native=true),
       },
       {
         name: 'mimir_ingester_queries',
         rules:
-          utils.histogramRules('cortex_ingester_queried_series', [$._config.per_cluster_label, 'job', 'stage'], $._config.recording_rules_range_interval, record_native=true) +
-          utils.histogramRules('cortex_ingester_queried_samples', [$._config.per_cluster_label, 'job'], $._config.recording_rules_range_interval, record_native=true) +
-          utils.histogramRules('cortex_ingester_queried_exemplars', [$._config.per_cluster_label, 'job'], $._config.recording_rules_range_interval, record_native=true),
+          utils.histogramRules('cortex_ingester_queried_series', [$._config.per_cluster_label, 'job', 'stage'], $.rateInterval($._config.recording_rules_range_interval), record_native=true) +
+          utils.histogramRules('cortex_ingester_queried_samples', [$._config.per_cluster_label, 'job'], $.rateInterval($._config.recording_rules_range_interval), record_native=true) +
+          utils.histogramRules('cortex_ingester_queried_exemplars', [$._config.per_cluster_label, 'job'], $.rateInterval($._config.recording_rules_range_interval), record_native=true),
       },
       {
         name: 'mimir_received_samples',
@@ -232,7 +232,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           },
           {
             record: '%(alert_aggregation_rule_prefix)s_deployment:container_cpu_usage_seconds_total:sum_rate' % _config,
-            expr: _config.mimir_scaling_rules[_config.deployment_type].cpu_usage_seconds_total % _config,
+            expr: _config.mimir_scaling_rules[_config.deployment_type].cpu_usage_seconds_total % (_config { recording_rules_range_interval: $.rateInterval(_config.recording_rules_range_interval) }),
           },
           {
             record: '%(alert_aggregation_rule_prefix)s_deployment:kube_pod_container_resource_requests_cpu_cores:sum' % _config,
@@ -343,7 +343,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       {
         name: 'mimir_usage_tracker_rules',
         rules:
-          utils.histogramRules('cortex_usage_tracker_client_track_series_duration_seconds', [$._config.per_cluster_label, 'job'], $._config.recording_rules_range_interval, record_native=true) +
+          utils.histogramRules('cortex_usage_tracker_client_track_series_duration_seconds', [$._config.per_cluster_label, 'job'], $.rateInterval($._config.recording_rules_range_interval), record_native=true) +
           [
             {
               record: '%(group_prefix_jobs)s:cortex_usage_tracker_active_series:sum' % _config,

--- a/operations/mimir-mixin/utils.libsonnet
+++ b/operations/mimir-mixin/utils.libsonnet
@@ -1,0 +1,24 @@
+local parseDuration(d) =
+  if std.endsWith(d, 'ms') then std.parseJson(std.substr(d, 0, std.length(d) - 2)) / 1000
+  else if std.endsWith(d, 's') then std.parseJson(std.substr(d, 0, std.length(d) - 1))
+  else if std.endsWith(d, 'm') then std.parseJson(std.substr(d, 0, std.length(d) - 1)) * 60
+  else if std.endsWith(d, 'h') then std.parseJson(std.substr(d, 0, std.length(d) - 1)) * 3600
+  else error 'unable to parse duration: %s' % d;
+
+local formatDuration(seconds) =
+  if seconds % 3600 == 0 then '%dh' % std.floor(seconds / 3600)
+  else if seconds % 60 == 0 then '%dm' % std.floor(seconds / 60)
+  else '%ds' % seconds;
+
+{
+  // Returns a safe window for rate() and similar functions, ensuring it is large enough
+  // relative to the configured scrape interval.
+  // See https://www.robustperception.io/what-range-should-i-use-with-rate/
+  rateInterval(min_duration)::
+    formatDuration(std.max(parseDuration(min_duration), 4 * parseDuration($._config.scrape_interval))),
+
+  // Returns a safe step for subquery notation (e.g. [range:step]), matching the scrape interval
+  // so we don't query at a finer resolution than the data is collected.
+  stepInterval(min_interval)::
+    formatDuration(std.max(parseDuration(min_interval), parseDuration($._config.scrape_interval))),
+}


### PR DESCRIPTION
#### What this PR does

Alerts and recording rules in the mimir-mixin use `rate()` and similar functions that require a duration window. Prometheus recommends that window to be at least 4× the scrape interval to avoid edge cases (see https://www.robustperception.io/what-range-should-i-use-with-rate/).

Previously, the mixin exposed `_config.base_alerts_range_interval_minutes` as the knob to tune this (introduced in https://github.com/grafana/mimir/pull/7591). The problem is that `alertRangeInterval()` applies a multiplier even to large durations. For example, we have some cases where `alertRangeInterval()` is called with a multiplier of 10 (that with the current default config would mean 10 minutes) but if the user sets `base_alerts_range_interval_minutes` to 2, then alertRangeInterval(10) would return 20 minutes that doesn't make any sense because 10 minutes was enough with a 30s scrape interval (30s scrape interval x 4 = 2m base range interval).

In this PR I'm fixing it the following way:

- **Replace `base_alerts_range_interval_minutes` with `scrape_interval`** (default `15s`). Users now configure the scrape interval directly, and the mixin computes safe windows automatically.
- **Introduce `rateInterval(min_duration)`** in a new `utils.libsonnet`: returns `max(min_duration, 4 × scrape_interval)`, used everywhere a rate-function window appears in alerts and recording rules.
- **Introduce `stepInterval(min_interval)`**: returns `max(min_interval, scrape_interval)`, used for subquery step resolution.
- **Migrate all alert files** from `alertRangeInterval()` to `rateInterval()`, and rename local variables `range_interval` → `rate_interval` for clarity (keep consistency with `$__rate_interval` used by Grafana).
- **Fix hardcoded durations** in several alerts and recording rules that were not going through any interval helper.
- **Add a mixin test** (`test-scrape-interval`) that compiles the mixin with `scrape_interval: '5m'` and asserts every duration bracket in compiled alerts and recording rules is ≥ 4× the scrape interval (20m). Recording rules with fixed-interval names (e.g. `:rate5m`) are intentionally excluded since their interval is baked into the name consumed by dashboards.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
