### PR TITLE
Mixin: replace recording_rules_range_interval with scrape_interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -280,7 +280,7 @@
 
 ### Mixin
 
-* [CHANGE] Alerts and rules: Replaced `_config.base_alerts_range_interval_minutes` with `_config.scrape_interval` (default `15s`). Instead of configuring a pre-multiplied number of minutes, configure your actual Prometheus scrape interval and the mixin will compute safe rate-function windows automatically (at least 4× the scrape interval). #15174
+* [CHANGE] Alerts and rules: Replaced `_config.base_alerts_range_interval_minutes` and `_config.recording_rules_range_interval` with `_config.scrape_interval` (default `15s`). Instead of configuring a pre-multiplied number of minutes, configure your actual Prometheus scrape interval and the mixin will compute safe rate-function windows automatically (at least 4× the scrape interval). #15174 #15176
 * [CHANGE] Dashboards: Add configuration option `dashboards_default_latency_mode` to control the default value of the native/classic latency variable (uses 'classic' if unset). #14424
 * [CHANGE] Alerts: Renamed the following alerts to fit within 40 characters: #13363
   * `MimirAlertmanagerPartialStateMergeFailing` → `MimirAlertmanagerStateMergeFailing`

--- a/operations/mimir-mixin/alerts/blocks.libsonnet
+++ b/operations/mimir-mixin/alerts/blocks.libsonnet
@@ -14,13 +14,13 @@
             (max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_ingester_shipper_last_successful_upload_timestamp_seconds) > 0)
             and
             # Only if the ingester has ingested samples over the last 4h.
-            (max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (max_over_time(%(alert_aggregation_rule_prefix)s_%(per_instance_label)s:cortex_ingester_ingested_samples_total:rate%(recording_rules_range_interval)s[4h])) > 0)
+            (max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (max_over_time(%(alert_aggregation_rule_prefix)s_%(per_instance_label)s:cortex_ingester_ingested_samples_total:rate%(rate_interval)s[4h])) > 0)
             and
             # Only if the ingester was ingesting samples 4h ago. This protects against the case where the ingester replica
             # had ingested samples in the past, then no traffic was received for a long period and then it starts
             # receiving samples again. Without this check, the alert would fire as soon as it gets back receiving
             # samples, while the a block shipping is expected within the next 4h.
-            (max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (max_over_time(%(alert_aggregation_rule_prefix)s_%(per_instance_label)s:cortex_ingester_ingested_samples_total:rate%(recording_rules_range_interval)s[1h] offset 4h)) > 0)
+            (max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (max_over_time(%(alert_aggregation_rule_prefix)s_%(per_instance_label)s:cortex_ingester_ingested_samples_total:rate%(rate_interval)s[1h] offset 4h)) > 0)
             # And only if blocks aren't shipped by the block-builder.
             unless on (%(alert_aggregation_labels)s)
             (max by (%(alert_aggregation_labels)s) (max_over_time(cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds[30m])) > 0)
@@ -28,7 +28,7 @@
             alert_aggregation_labels: $._config.alert_aggregation_labels,
             per_instance_label: $._config.per_instance_label,
             alert_aggregation_rule_prefix: $._config.alert_aggregation_rule_prefix,
-            recording_rules_range_interval: $._config.recording_rules_range_interval,
+            rate_interval: $.rateInterval('1m'),
           },
           labels: {
             severity: 'critical',
@@ -45,7 +45,7 @@
           expr: |||
             (max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_ingester_shipper_last_successful_upload_timestamp_seconds) == 0)
             and
-            (max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (max_over_time(%(alert_aggregation_rule_prefix)s_%(per_instance_label)s:cortex_ingester_ingested_samples_total:rate%(recording_rules_range_interval)s[4h])) > 0)
+            (max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (max_over_time(%(alert_aggregation_rule_prefix)s_%(per_instance_label)s:cortex_ingester_ingested_samples_total:rate%(rate_interval)s[4h])) > 0)
             # Only if blocks aren't shipped by the block-builder.
             unless on (%(alert_aggregation_labels)s)
             (max by (%(alert_aggregation_labels)s) (max_over_time(cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds[30m])) > 0)
@@ -53,7 +53,7 @@
             alert_aggregation_labels: $._config.alert_aggregation_labels,
             per_instance_label: $._config.per_instance_label,
             alert_aggregation_rule_prefix: $._config.alert_aggregation_rule_prefix,
-            recording_rules_range_interval: $._config.recording_rules_range_interval,
+            rate_interval: $.rateInterval('1m'),
           },
           labels: {
             severity: 'critical',

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -354,7 +354,7 @@
             sum by (%(alert_aggregation_labels)s, deployment) (
               label_replace(
                 label_replace(
-                  sum by (%(alert_aggregation_labels)s, %(per_instance_label)s)(rate(container_cpu_usage_seconds_total[%(recording_rules_range_interval)s])),
+                  sum by (%(alert_aggregation_labels)s, %(per_instance_label)s)(rate(container_cpu_usage_seconds_total[%(rate_interval)s])),
                   "deployment", "$1", "%(per_instance_label)s", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
                 ),
                 # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
@@ -767,11 +767,6 @@
     // stepInterval() to compute safe windows automatically.
     // See https://www.robustperception.io/what-range-should-i-use-with-rate/
     scrape_interval: '15s',
-
-    // Tunes histogram recording rules to aggregate over this interval.
-    // Set to at least twice the scrape interval; otherwise, recording rules will output no data.
-    // Set to four times the scrape interval to account for edge cases: https://www.robustperception.io/what-range-should-i-use-with-rate/
-    recording_rules_range_interval: '1m',
 
     // Used to inject rows into dashboards at specific places that support it.
     injectRows: {},

--- a/operations/mimir-mixin/recording_rules.libsonnet
+++ b/operations/mimir-mixin/recording_rules.libsonnet
@@ -12,42 +12,42 @@ local utils = import 'mixin-utils/utils.libsonnet';
       {
         name: 'mimir_api_1',
         rules:
-          utils.histogramRules('cortex_request_duration_seconds', [$._config.per_cluster_label, 'job'], $.rateInterval($._config.recording_rules_range_interval), record_native=true),
+          utils.histogramRules('cortex_request_duration_seconds', [$._config.per_cluster_label, 'job'], $.rateInterval('1m'), record_native=true),
       },
       {
         name: 'mimir_api_2',
         rules:
-          utils.histogramRules('cortex_request_duration_seconds', [$._config.per_cluster_label, 'job', 'route'], $.rateInterval($._config.recording_rules_range_interval), record_native=true),
+          utils.histogramRules('cortex_request_duration_seconds', [$._config.per_cluster_label, 'job', 'route'], $.rateInterval('1m'), record_native=true),
       },
       {
         name: 'mimir_api_3',
         rules:
-          utils.histogramRules('cortex_request_duration_seconds', $._config.job_labels + ['route'], $.rateInterval($._config.recording_rules_range_interval), record_native=true),
+          utils.histogramRules('cortex_request_duration_seconds', $._config.job_labels + ['route'], $.rateInterval('1m'), record_native=true),
       },
       {
         name: 'mimir_querier_api',
         rules:
-          utils.histogramRules('cortex_querier_request_duration_seconds', [$._config.per_cluster_label, 'job'], $.rateInterval($._config.recording_rules_range_interval), record_native=true) +
-          utils.histogramRules('cortex_querier_request_duration_seconds', [$._config.per_cluster_label, 'job', 'route'], $.rateInterval($._config.recording_rules_range_interval), record_native=true) +
-          utils.histogramRules('cortex_querier_request_duration_seconds', $._config.job_labels + ['route'], $.rateInterval($._config.recording_rules_range_interval), record_native=true),
+          utils.histogramRules('cortex_querier_request_duration_seconds', [$._config.per_cluster_label, 'job'], $.rateInterval('1m'), record_native=true) +
+          utils.histogramRules('cortex_querier_request_duration_seconds', [$._config.per_cluster_label, 'job', 'route'], $.rateInterval('1m'), record_native=true) +
+          utils.histogramRules('cortex_querier_request_duration_seconds', $._config.job_labels + ['route'], $.rateInterval('1m'), record_native=true),
       },
       {
         name: 'mimir_storage',
         rules:
-          utils.histogramRules('cortex_kv_request_duration_seconds', [$._config.per_cluster_label, 'job'], $.rateInterval($._config.recording_rules_range_interval), record_native=true),
+          utils.histogramRules('cortex_kv_request_duration_seconds', [$._config.per_cluster_label, 'job'], $.rateInterval('1m'), record_native=true),
       },
       {
         name: 'mimir_queries',
         rules:
-          utils.histogramRules('cortex_query_frontend_retries', [$._config.per_cluster_label, 'job'], $.rateInterval($._config.recording_rules_range_interval), record_native=true) +
-          utils.histogramRules('cortex_query_frontend_queue_duration_seconds', [$._config.per_cluster_label, 'job'], $.rateInterval($._config.recording_rules_range_interval), record_native=true),
+          utils.histogramRules('cortex_query_frontend_retries', [$._config.per_cluster_label, 'job'], $.rateInterval('1m'), record_native=true) +
+          utils.histogramRules('cortex_query_frontend_queue_duration_seconds', [$._config.per_cluster_label, 'job'], $.rateInterval('1m'), record_native=true),
       },
       {
         name: 'mimir_ingester_queries',
         rules:
-          utils.histogramRules('cortex_ingester_queried_series', [$._config.per_cluster_label, 'job', 'stage'], $.rateInterval($._config.recording_rules_range_interval), record_native=true) +
-          utils.histogramRules('cortex_ingester_queried_samples', [$._config.per_cluster_label, 'job'], $.rateInterval($._config.recording_rules_range_interval), record_native=true) +
-          utils.histogramRules('cortex_ingester_queried_exemplars', [$._config.per_cluster_label, 'job'], $.rateInterval($._config.recording_rules_range_interval), record_native=true),
+          utils.histogramRules('cortex_ingester_queried_series', [$._config.per_cluster_label, 'job', 'stage'], $.rateInterval('1m'), record_native=true) +
+          utils.histogramRules('cortex_ingester_queried_samples', [$._config.per_cluster_label, 'job'], $.rateInterval('1m'), record_native=true) +
+          utils.histogramRules('cortex_ingester_queried_exemplars', [$._config.per_cluster_label, 'job'], $.rateInterval('1m'), record_native=true),
       },
       {
         name: 'mimir_received_samples',
@@ -232,7 +232,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           },
           {
             record: '%(alert_aggregation_rule_prefix)s_deployment:container_cpu_usage_seconds_total:sum_rate' % _config,
-            expr: _config.mimir_scaling_rules[_config.deployment_type].cpu_usage_seconds_total % (_config { recording_rules_range_interval: $.rateInterval(_config.recording_rules_range_interval) }),
+            expr: _config.mimir_scaling_rules[_config.deployment_type].cpu_usage_seconds_total % (_config { rate_interval: $.rateInterval('1m') }),
           },
           {
             record: '%(alert_aggregation_rule_prefix)s_deployment:kube_pod_container_resource_requests_cpu_cores:sum' % _config,
@@ -333,17 +333,20 @@ local utils = import 'mixin-utils/utils.libsonnet';
         rules: [
           {
             // cortex_ingester_ingested_samples_total is per user, in this rule we want to see the sum per cluster/namespace/instance
-            record: '%s_%s:cortex_ingester_ingested_samples_total:rate%s' % [$._config.alert_aggregation_rule_prefix, $._config.per_instance_label, $._config.recording_rules_range_interval],
+            local rate_interval = $.rateInterval('1m'),
+            record: '%s_%s:cortex_ingester_ingested_samples_total:rate%s' % [$._config.alert_aggregation_rule_prefix, $._config.per_instance_label, rate_interval],
             expr: |||
-              sum by(%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_ingester_ingested_samples_total[%(recording_rules_range_interval)s]))
-            ||| % $._config,
+              sum by(%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_ingester_ingested_samples_total[%(rate_interval)s]))
+            ||| % $._config {
+              rate_interval: rate_interval,
+            },
           },
         ],
       },
       {
         name: 'mimir_usage_tracker_rules',
         rules:
-          utils.histogramRules('cortex_usage_tracker_client_track_series_duration_seconds', [$._config.per_cluster_label, 'job'], $.rateInterval($._config.recording_rules_range_interval), record_native=true) +
+          utils.histogramRules('cortex_usage_tracker_client_track_series_duration_seconds', [$._config.per_cluster_label, 'job'], $.rateInterval('1m'), record_native=true) +
           [
             {
               record: '%(group_prefix_jobs)s:cortex_usage_tracker_active_series:sum' % _config,


### PR DESCRIPTION
#### What this PR does

This PR is a follow up of https://github.com/grafana/mimir/pull/15174.

`recording_rules_range_interval` was a separate config field controlling the window used by histogram recording rules and the ingester rate recording rule. With `scrape_interval` now in config and `rateInterval()` computing the correct floor automatically, this field became redundant — users should not have to configure the same thing twice.

Additionally, `recording_rules_range_interval` was used in the ingester recording rule **name** (e.g. `rate1m`), but the alert queries in `blocks.libsonnet` that reference that rule also constructed the name from the same field. This meant the name and its consumers were always in sync — making it safe to compute the name dynamically from `scrape_interval` instead.

In this PR I've remove `_config.recording_rules_range_interval` from config entirely.

This is a no breaking change at default config. At the default `scrape_interval: '15s'`, `rateInterval('1m')` = max(1m, 4×15s=1m) = `1m`. The ingester recording rule stays named `rate1m`, histogram recording rules keep `[1m]` windows — identical to before. Users who configure a non-default `scrape_interval` will see the recording rule windows (and the ingester rate metric name) adjust accordingly, which is the desired behaviour.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
