### PR TITLE
distributor: Cancel ring.DoUntilQuorum in cardinality analysis API when active_series_results_max_size_bytes is breached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -277,6 +277,7 @@
 * [BUGFIX] Query-frontend: Fix max total query length limit (`-query-frontend.max-total-query-length`) not being enforced on instant queries with subqueries or range selectors. #14985
 * [BUGFIX] Compactor: Fix potential goroutine leak when compaction iteration exits early due to errors. #13420
 * [BUGFIX] Query-frontend: Fix bugs with matcher propagation for binary operations where it was not being properly applied within nested expressions and also wrongly propagating internal label matchers. #15110
+* [BUGFIX] Distributor: Cancel DoUntilQuorum in cardinality analysis API when active_series_results_max_size_bytes is breached. #15177
 
 ### Mixin
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -2346,6 +2346,14 @@ func (d *Distributor) updateReceivedMetrics(ctx context.Context, pushReq *Reques
 // forReplicationSets runs f, in parallel, for all ingesters in the input replicationSets.
 // Return an error if any f fails for any of the input replicationSets.
 func forReplicationSets[R any](ctx context.Context, d *Distributor, replicationSets []ring.ReplicationSet, f func(context.Context, ingester_client.IngesterClient) (R, error)) ([]R, error) {
+	quorumConfig := d.queryQuorumConfigForReplicationSets(ctx, replicationSets)
+	return forReplicationSetsWithQuorumConfig(ctx, d, replicationSets, quorumConfig, f)
+}
+
+// forReplicationSetsWithQuorumConfig runs f, in parallel, for all ingesters in the input replicationSets, using the provided quorum config.
+// It is expected that the provided quorumConfig matches the given replicationSets.
+// If you do not need to customize the quorum config, use forReplicationSets instead.
+func forReplicationSetsWithQuorumConfig[R any](ctx context.Context, d *Distributor, replicationSets []ring.ReplicationSet, quorumConfig ring.DoUntilQuorumConfig, f func(context.Context, ingester_client.IngesterClient) (R, error)) ([]R, error) {
 	wrappedF := func(ctx context.Context, ingester *ring.InstanceDesc) (R, error) {
 		client, err := d.ingesterPool.GetClientForInstance(*ingester)
 		if err != nil {
@@ -2359,8 +2367,6 @@ func forReplicationSets[R any](ctx context.Context, d *Distributor, replicationS
 	cleanup := func(_ R) {
 		// Nothing to do.
 	}
-
-	quorumConfig := d.queryQuorumConfigForReplicationSets(ctx, replicationSets)
 
 	return concurrency.ForEachJobMergeResults[ring.ReplicationSet, R](ctx, replicationSets, 0, func(ctx context.Context, set ring.ReplicationSet) ([]R, error) {
 		return ring.DoUntilQuorum(ctx, set, quorumConfig, wrappedF, cleanup)
@@ -2946,7 +2952,9 @@ func (d *Distributor) deduplicateActiveSeries(ctx context.Context, matchers []*l
 		return ignored{}, nil
 	}
 
-	_, err = forReplicationSets(ctx, d, replicationSets, ingesterQuery)
+	quorumConfig := d.queryQuorumConfigForReplicationSets(ctx, replicationSets)
+	quorumConfig.IsTerminalError = validation.IsLimitError
+	_, err = forReplicationSetsWithQuorumConfig(ctx, d, replicationSets, quorumConfig, ingesterQuery)
 	if err != nil {
 		return nil, err
 	}
@@ -2988,7 +2996,9 @@ func newActiveSeriesResponse(hashCollisionCount prometheus.Counter, maxSize int,
 	}
 }
 
-var ErrResponseTooLarge = errors.New("response too large")
+// var ErrResponseTooLarge = errors.New("response too large")
+
+var ErrResponseTooLarge = validation.NewLimitError("response too large")
 
 func (r *activeSeriesResponse) add(series []*mimirpb.Metric, bucketCounts []uint64) error {
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -2996,8 +2996,6 @@ func newActiveSeriesResponse(hashCollisionCount prometheus.Counter, maxSize int,
 	}
 }
 
-// var ErrResponseTooLarge = errors.New("response too large")
-
 var ErrResponseTooLarge = validation.NewLimitError("response too large")
 
 func (r *activeSeriesResponse) add(series []*mimirpb.Metric, bucketCounts []uint64) error {

--- a/pkg/distributor/distributor_ingest_storage_test.go
+++ b/pkg/distributor/distributor_ingest_storage_test.go
@@ -1629,6 +1629,49 @@ func TestDistributor_ActiveSeries_AvailabilityAndConsistencyWithIngestStorage(t 
 	}
 }
 
+func TestDistributor_ActiveSeries_TerminalErrorsWithIngestStorage(t *testing.T) {
+	reqMatchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, model.MetricNameLabel, ".+")}
+
+	ingesterStateByZone := map[string]ingesterZoneState{
+		"zone-a": {numIngesters: 1, happyIngesters: 1},
+		"zone-b": {numIngesters: 1, happyIngesters: 1},
+	}
+	ingesterDataByZone := map[string][]*mimirpb.WriteRequest{
+		"zone-a": {
+			makeWriteRequest(0, 1, 0, false, false, "series_1", "series_2", "series_3"),
+		},
+		"zone-b": {
+			makeWriteRequest(0, 1, 0, false, false, "series_1", "series_2", "series_3"),
+		},
+	}
+
+	limits := prepareDefaultLimits()
+	limits.ActiveSeriesResultsMaxSizeBytes = 1
+
+	distributors, ingesters, _, _ := prepare(t, prepConfig{
+		ingesterStateByZone:  ingesterStateByZone,
+		ingesterDataByZone:   ingesterDataByZone,
+		numDistributors:      1,
+		ingestStorageEnabled: true,
+		limits:               limits,
+		configure: func(config *Config) {
+			config.MinimizeIngesterRequests = true
+			config.PreferAvailabilityZones = []string{"zone-a"}
+		},
+	})
+
+	ctx := user.InjectOrgID(context.Background(), "test")
+
+	_, err := distributors[0].ActiveSeries(ctx, reqMatchers)
+	require.ErrorIs(t, err, ErrResponseTooLarge)
+
+	// With MinimizeRequests enabled and RF=2 (2 zones, MaxUnavailableZones=1),
+	// only 1 zone is queried initially. When that zone returns
+	// ErrResponseTooLarge and the error is treated as terminal, the operation
+	// should abort immediately without starting a request to the 2nd zone.
+	assert.Equal(t, 1, countMockIngestersCalled(ingesters, "ActiveSeries"))
+}
+
 func readAllRecordsFromKafka(t testing.TB, kafkaAddresses []string, numPartitions int32, timeout time.Duration) []*kgo.Record {
 	// Read all partitions from the beginning.
 	offsets := make(map[int32]kgo.Offset, numPartitions)

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -3242,6 +3242,7 @@ func TestDistributor_ActiveSeries_AvailabilityAndConsistency(t *testing.T) {
 		ingesterStateByZone map[string]ingesterZoneState
 		ingesterDataByZone  map[string][]*mimirpb.WriteRequest
 		shardSize           int
+		limits              *validation.Limits
 		expectedSeriesCount int
 		expectedErr         error
 	}{
@@ -3564,6 +3565,30 @@ func TestDistributor_ActiveSeries_AvailabilityAndConsistency(t *testing.T) {
 			shardSize:           1, // Tenant's shard made of: ingester-zone-a-0, ingester-zone-b-0 and ingester-zone-c-0.
 			expectedSeriesCount: 5,
 		},
+		"multi zone, 3 ingesters, limits errors are propagated": {
+			ingesterStateByZone: map[string]ingesterZoneState{
+				"zone-a": {numIngesters: 1, happyIngesters: 1},
+				"zone-b": {numIngesters: 1, happyIngesters: 1},
+				"zone-c": {numIngesters: 1, happyIngesters: 1},
+			},
+			ingesterDataByZone: map[string][]*mimirpb.WriteRequest{
+				"zone-a": {
+					makeWriteRequest(0, 1, 0, false, false, "series_1", "series_2", "series_3"),
+				},
+				"zone-b": {
+					makeWriteRequest(0, 1, 0, false, false, "series_1", "series_2", "series_3"),
+				},
+				"zone-c": {
+					makeWriteRequest(0, 1, 0, false, false, "series_1", "series_2", "series_3"),
+				},
+			},
+			limits: func() *validation.Limits {
+				limits := prepareDefaultLimits()
+				limits.ActiveSeriesResultsMaxSizeBytes = 1
+				return limits
+			}(),
+			expectedErr: ErrResponseTooLarge,
+		},
 	}
 
 	for testName, testData := range tests {
@@ -3574,8 +3599,7 @@ func TestDistributor_ActiveSeries_AvailabilityAndConsistency(t *testing.T) {
 				t.Run(fmt.Sprintf("minimize ingester requests: %t", minimizeIngesterRequests), func(t *testing.T) {
 					t.Parallel()
 
-					// Create distributor.
-					distributors, _, _, _ := prepare(t, prepConfig{
+					cfg := prepConfig{
 						ingesterStateByZone: testData.ingesterStateByZone,
 						ingesterDataByZone:  testData.ingesterDataByZone,
 						numDistributors:     1,
@@ -3583,7 +3607,13 @@ func TestDistributor_ActiveSeries_AvailabilityAndConsistency(t *testing.T) {
 						configure: func(config *Config) {
 							config.MinimizeIngesterRequests = minimizeIngesterRequests
 						},
-					})
+					}
+					if testData.limits != nil {
+						cfg.limits = testData.limits
+					}
+
+					// Create distributor.
+					distributors, _, _, _ := prepare(t, cfg)
 
 					ctx := user.InjectOrgID(context.Background(), "test")
 					qStats, ctx := stats.ContextWithEmptyStats(ctx)
@@ -3604,6 +3634,51 @@ func TestDistributor_ActiveSeries_AvailabilityAndConsistency(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDistributor_ActiveSeries_TerminalErrors(t *testing.T) {
+	reqMatchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchRegexp, model.MetricNameLabel, ".+")}
+
+	ingesterStateByZone := map[string]ingesterZoneState{
+		"zone-a": {numIngesters: 1, happyIngesters: 1},
+		"zone-b": {numIngesters: 1, happyIngesters: 1},
+		"zone-c": {numIngesters: 1, happyIngesters: 1},
+	}
+	ingesterDataByZone := map[string][]*mimirpb.WriteRequest{
+		"zone-a": {
+			makeWriteRequest(0, 1, 0, false, false, "series_1", "series_2", "series_3"),
+		},
+		"zone-b": {
+			makeWriteRequest(0, 1, 0, false, false, "series_1", "series_2", "series_3"),
+		},
+		"zone-c": {
+			makeWriteRequest(0, 1, 0, false, false, "series_1", "series_2", "series_3"),
+		},
+	}
+
+	limits := prepareDefaultLimits()
+	limits.ActiveSeriesResultsMaxSizeBytes = 1
+
+	distributors, ingesters, _, _ := prepare(t, prepConfig{
+		ingesterStateByZone: ingesterStateByZone,
+		ingesterDataByZone:  ingesterDataByZone,
+		numDistributors:     1,
+		limits:              limits,
+		configure: func(config *Config) {
+			config.MinimizeIngesterRequests = true
+		},
+	})
+
+	ctx := user.InjectOrgID(context.Background(), "test")
+
+	_, err := distributors[0].ActiveSeries(ctx, reqMatchers)
+	require.ErrorIs(t, err, ErrResponseTooLarge)
+
+	// With MinimizeRequests enabled and 3 zones (MaxUnavailableZones=1), only 2
+	// zones are queried initially. When the first zone returns
+	// ErrResponseTooLarge and that error is treated as terminal, the operation
+	// should abort immediately without starting a request to the 3rd zone.
+	assert.Equal(t, 2, countMockIngestersCalled(ingesters, "ActiveSeries"))
 }
 
 func BenchmarkDistributor_ActiveSeries(b *testing.B) {

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -3678,7 +3678,12 @@ func TestDistributor_ActiveSeries_TerminalErrors(t *testing.T) {
 	// zones are queried initially. When the first zone returns
 	// ErrResponseTooLarge and that error is treated as terminal, the operation
 	// should abort immediately without starting a request to the 3rd zone.
-	assert.Equal(t, 2, countMockIngestersCalled(ingesters, "ActiveSeries"))
+	//
+	// Sometimes, if the first ingester is very fast, the error is processed by the distributor
+	// while the query is still in-flight to the second ingester.
+	// In that case, the query to the second ingester is cancelled.
+	// Hence, we expect 1 or 2 ingesters to be queried here, but never 3.
+	assert.LessOrEqual(t, 2, countMockIngestersCalled(ingesters, "ActiveSeries"))
 }
 
 func BenchmarkDistributor_ActiveSeries(b *testing.B) {

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -3683,7 +3683,7 @@ func TestDistributor_ActiveSeries_TerminalErrors(t *testing.T) {
 	// while the query is still in-flight to the second ingester.
 	// In that case, the query to the second ingester is cancelled.
 	// Hence, we expect 1 or 2 ingesters to be queried here, but never 3.
-	assert.LessOrEqual(t, 2, countMockIngestersCalled(ingesters, "ActiveSeries"))
+	assert.LessOrEqual(t, countMockIngestersCalled(ingesters, "ActiveSeries"), 2)
 }
 
 func BenchmarkDistributor_ActiveSeries(b *testing.B) {

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -2921,7 +2921,7 @@ func TestDistributor_ActiveSeries(t *testing.T) {
 	tests := map[string]struct {
 		shuffleShardSize            int
 		requestMatchers             []*labels.Matcher
-		expectError                 error
+		expectLimitError            error
 		expectedSeries              [][]mimirpb.LabelAdapter
 		expectedNumQueriedIngesters int
 	}{
@@ -2947,8 +2947,8 @@ func TestDistributor_ActiveSeries(t *testing.T) {
 			expectedNumQueriedIngesters: numIngesters,
 		},
 		"aborts if response is too large": {
-			requestMatchers: []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "large_metric")},
-			expectError:     ErrResponseTooLarge,
+			requestMatchers:  []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "large_metric")},
+			expectLimitError: ErrResponseTooLarge,
 		},
 	}
 
@@ -3019,8 +3019,9 @@ func TestDistributor_ActiveSeries(t *testing.T) {
 
 					// Query active series.
 					series, err := d.ActiveSeries(ctx, testData.requestMatchers)
-					if testData.expectError != nil {
-						require.ErrorIs(t, err, testData.expectError)
+					if testData.expectLimitError != nil {
+						require.ErrorIs(t, err, testData.expectLimitError)
+						require.True(t, validation.IsLimitError(err), "expected error to be a LimitError")
 						return
 					}
 

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -6511,6 +6511,8 @@ func prepare(t testing.TB, cfg prepConfig) ([]*Distributor, []*mockIngester, []*
 		distributorCfg.IngestersLookbackPeriod = time.Hour
 		distributorCfg.StreamingChunksPerIngesterSeriesBufferSize = 128
 		distributorCfg.IngestStorageConfig = ingestCfg
+		// Disable request hedging to other zones to avoid flaky tests when timing is unlucky.
+		distributorCfg.MinimiseIngesterRequestsHedgingDelay = 0
 
 		if cfg.configure != nil {
 			cfg.configure(&distributorCfg)


### PR DESCRIPTION
#### What this PR does

The cardinality analysis API performs a fairly standard replicated read operation against ingesters and merges the results together. The limit `active_series_results_max_size_bytes` is evaluated per ingester call, inside the ring operation, each time data is merged.

The result is that when a customer request legitimately breaches this limit, the distributor treats it as any other failed ingester operation (such as a failure to contact the ingester). The distributor then fails over to other zones in the normal fashion, expecting other zones to work. It then repeats the read operation on other zones for the exact same data, only to fail for each zone until quorum loss.

A side effect is that this event also produces an extremely misleading error log:
```
msg="request to instance has failed, zone cannot contribute to quorum" zone=zone-a failingInstanceAddr=<redacted> failingInstanceID=ingester-zone-a-67 err="response too large"
```

Usually, this causes engineers debugging legitimate quorum issues to go down a red herring path, and they consider such events to indicate that an ingester or zone is legitimately unavailable. In reality, it's just a tenant breaching their request-specific limits, and the ingester is usually perfectly healthy.

This PR fixes this in two stages:
1. Breaches of `active_series_results_max_size_bytes` are now classified as limits errors.
2. The cardinality analysis API considers limits errors to be terminal errors when reading ingesters under quorum.

Note: Label values endpoints and friends are also affected by a similar bug. Due to the maturity of this logic, I opted to fix it in this endpoint only, as it's the worst offender. Once this change is stabilized for a while, we can add the fix to other routes.

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes quorum/cancellation behavior on distributor query paths; incorrect terminal-error classification could reduce availability by aborting reads earlier than before.
> 
> **Overview**
> Prevents the distributor cardinality analysis/`ActiveSeries` query from failing over across zones when the per-request `active_series_results_max_size_bytes` limit is exceeded by treating the error as a **terminal limit error** and cancelling `ring.DoUntilQuorum` early.
> 
> This introduces `forReplicationSetsWithQuorumConfig()` so callers can override quorum behavior (used to set `IsTerminalError = validation.IsLimitError` for `ActiveSeries`), and changes `ErrResponseTooLarge` to be a `validation.LimitError`. Tests are updated/added to assert limit-error classification and that minimized-zone queries stop without querying additional zones; test setup also disables request-hedging to reduce flakiness. Changelog entry added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 722ec4839cfaa72d633092a0ffebbdec46937e83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->