### PR TITLE
fix(api): apply path-prefix to embedded static assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,6 +215,7 @@
 * [BUGFIX] Distributor: Fix ingestion rate limit error message reporting incorrect burst size when `ingestion_burst_factor` is configured. #14471
 * [BUGFIX] Mimir: Fix nil pointer dereference when `-target` is set to an empty string. #14381
 * [BUGFIX] API: Fixed web UI links not respecting `-server.path-prefix` configuration. #14090
+* [BUGFIX] API: Fixed embedded web UI static assets (CSS, JS, images) returning 404 when `-server.path-prefix` is configured. #15181
 * [BUGFIX] Distributor: Fix issue where distributors didn't send custom values of native histograms. #13849
 * [BUGFIX] Compactor: Fix potential concurrent map writes. #13053
 * [BUGFIX] Query-frontend: Fix issue where queries sometimes fail with `failed to receive query result stream message: rpc error: code = Canceled desc = context canceled` if remote execution is enabled. #13084

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -268,7 +268,12 @@ func (a *API) RegisterAPI(actualCfg interface{}, defaultCfg interface{}, buildIn
 
 	a.RegisterRoute("/config", a.cfg.configHandler(actualCfg, defaultCfg), false, true, "GET")
 	a.RegisterRoute("/", indexHandler(a.indexPage), false, true, "GET")
-	a.RegisterRoutesWithPrefix("/static/", http.FileServer(http.FS(staticFiles)), false, true, 0, "GET")
+	// http.FileServer serves files relative to the embed.FS root, where assets live under "static/".
+	// The dskit server registers all routes on a subrouter rooted at -server.path-prefix, so when a
+	// path prefix is configured, r.URL.Path still includes it (e.g. "/mimir/static/foo.css") and
+	// FileServer would look up "mimir/static/foo.css" in the FS and 404. Stripping the prefix here
+	// ensures FileServer always sees "/static/...". When ServerPrefix is empty, this is a no-op.
+	a.RegisterRoutesWithPrefix("/static/", http.StripPrefix(a.cfg.ServerPrefix, http.FileServer(http.FS(staticFiles))), false, true, 0, "GET")
 	a.RegisterRoute("/debug/fgprof", fgprof.Handler(), false, true, "GET")
 	a.RegisterRoute("/api/v1/status/buildinfo", buildInfoHandler, false, true, "GET")
 	a.RegisterRoute("/api/v1/status/config", a.cfg.statusConfigHandler(), false, true, "GET")

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -246,6 +246,60 @@ func TestApiIngesterShutdown(t *testing.T) {
 	}
 }
 
+// TestStaticAssetsRespectPathPrefix verifies that the embedded static assets are reachable
+// both when -server.path-prefix is unset and when it is configured. Without the StripPrefix
+// wrapper, http.FileServer would receive the path-prefixed URL (e.g. /mimir/static/foo.css),
+// fail to find "mimir/static/foo.css" in the embedded FS, and return 404. See #13476.
+func TestStaticAssetsRespectPathPrefix(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		pathPrefix string
+		requestURL string
+	}{
+		{
+			name:       "no path prefix",
+			pathPrefix: "",
+			requestURL: "/static/mimir-styles.css",
+		},
+		{
+			name:       "with path prefix",
+			pathPrefix: "/mimir",
+			requestURL: "/mimir/static/mimir-styles.css",
+		},
+		{
+			name:       "with nested path prefix",
+			pathPrefix: "/foo/bar",
+			requestURL: "/foo/bar/static/mimir-styles.css",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Config{
+				GzipCompressionLevel: gzip.DefaultCompression,
+				ServerPrefix:         tc.pathPrefix,
+			}
+			serverCfg := getServerConfig(t)
+			serverCfg.PathPrefix = tc.pathPrefix
+			federationCfg := tenantfederation.Config{}
+			srv, err := server.New(serverCfg)
+			require.NoError(t, err)
+			t.Cleanup(srv.Shutdown)
+
+			api, err := New(cfg, federationCfg, serverCfg, srv, log.NewNopLogger(), nil)
+			require.NoError(t, err)
+			api.RegisterAPI(&cfg, &cfg, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+			// srv.HTTP is the (sub)router built by dskit; when cfg.PathPrefix is non-empty
+			// it is the subrouter that matches the full path including the prefix.
+			req := httptest.NewRequest(http.MethodGet, tc.requestURL, nil)
+			w := httptest.NewRecorder()
+			srv.HTTP.ServeHTTP(w, req)
+
+			require.Equal(t, http.StatusOK, w.Code, "static asset should be served at %s", tc.requestURL)
+			require.NotEmpty(t, w.Body.Bytes(), "response body should contain the asset bytes")
+		})
+	}
+}
+
 // Generates server config, with gRPC listening on random port.
 func getServerConfig(t *testing.T) server.Config {
 	grpcHost, grpcPortNum := getHostnameAndRandomPort(t)


### PR DESCRIPTION
#### What this PR does

When `-server.path-prefix=/mimir` is configured, the embedded admin UI's static assets at `/mimir/static/*` returned 404 even though API routes worked.

dskit mounts all routes on a `PathPrefix(prefix).Subrouter()`, so the request reaches the registered handler with the prefix still on `r.URL.Path`. `http.FileServer(http.FS(staticFiles))` reads that path verbatim and tries to open `mimir/static/foo.css` from an embed.FS that only has `static/foo.css`.

Wrapping the FileServer in `http.StripPrefix(a.cfg.ServerPrefix, ...)` makes it always see `/static/...`. When `ServerPrefix` is empty, `http.StripPrefix("", h)` is a no-op so the unprefixed case is unaffected. Complements #14090, which fixed the link templating but left static assets broken (per @narqo's follow-up on #13476).


Fixes #13476

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small routing change limited to the embedded `/static/` file server plus a targeted test; main risk is mis-stripping paths if `ServerPrefix` is misconfigured.
> 
> **Overview**
> Fixes embedded web UI static assets returning 404 when `-server.path-prefix` is set by wrapping the `/static/` handler with `http.StripPrefix(a.cfg.ServerPrefix, ...)` so `http.FileServer` always resolves paths against `static/` in the embedded FS.
> 
> Adds `TestStaticAssetsRespectPathPrefix` to assert `/static/*` and path-prefixed `/.../static/*` requests return 200 (including nested prefixes), and records the bugfix in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e10b6c47b7b495aa5e8a006905439c8aa7175dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->