### PR TITLE
feat(mimir): add option to set X-Scope-OrgID header

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -30,6 +30,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
+* [FEATURE] Allows setting how the X-Scope-OrgID header should be set
 * [CHANGE] Kafka: Removed `kafka.extraEnv`. Use `kafka.env` instead. #14892
 * [ENHANCEMENT] Kafka: Add `kafka.env` to let users selectively override default Kafka environment variables by name, following the same merge pattern used by other chart components (`ingester.env`, etc.). Individual defaults can be replaced in-place without discarding the rest of the list. #14892
 * [CHANGE] Update minimum supported Kubernetes version to 1.32. This reflects the fact that Grafana does not test with older versions of Kubernetes. #14335

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -30,7 +30,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
-* [FEATURE] Allows setting how the X-Scope-OrgID header should be set
+* [FEATURE] Allows setting how the X-Scope-OrgID header should be set #15182
 * [CHANGE] Kafka: Removed `kafka.extraEnv`. Use `kafka.env` instead. #14892
 * [ENHANCEMENT] Kafka: Add `kafka.env` to let users selectively override default Kafka environment variables by name, following the same merge pattern used by other chart components (`ingester.env`, etc.). Individual defaults can be replaced in-place without discarding the rest of the list. #14892
 * [CHANGE] Update minimum supported Kubernetes version to 1.32. This reflects the fact that Grafana does not test with older versions of Kubernetes. #14335

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -3382,6 +3382,8 @@ gateway:
       serverSnippet: ""
       # -- Allows appending custom configuration to the http block
       httpSnippet: ""
+      # -- Alows to set how the X-Scope-OrgID header should get set (default $ensured_x_scope_orgid, replace it with '$remote_user' if you want to set X-Scope-OrgID to the authenticated user)
+      xScopeOrgIDHeaderValue: $ensured_x_scope_orgid
       # -- Allow to set client_max_body_size in the nginx configuration
       clientMaxBodySize: 540M
       # -- Allows to set a custom resolver
@@ -3474,8 +3476,8 @@ gateway:
               return 200 'OK';
               auth_basic off;
             }
-
-            proxy_set_header X-Scope-OrgID $ensured_x_scope_orgid;
+            
+            proxy_set_header X-Scope-OrgID {{ .Values.gateway.nginx.config. }};
 
             # Distributor endpoints
             location /distributor {

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -3382,7 +3382,7 @@ gateway:
       serverSnippet: ""
       # -- Allows appending custom configuration to the http block
       httpSnippet: ""
-      # -- Alows to set how the X-Scope-OrgID header should get set (default $ensured_x_scope_orgid, replace it with '$remote_user' if you want to set X-Scope-OrgID to the authenticated user)
+      # -- Allows to set how the X-Scope-OrgID header should get set (default $ensured_x_scope_orgid, replace it with '$remote_user' if you want to set X-Scope-OrgID to the authenticated user)
       xScopeOrgIDHeaderValue: $ensured_x_scope_orgid
       # -- Allow to set client_max_body_size in the nginx configuration
       clientMaxBodySize: 540M
@@ -3477,7 +3477,7 @@ gateway:
               auth_basic off;
             }
             
-            proxy_set_header X-Scope-OrgID {{ .Values.gateway.nginx.config. }};
+            proxy_set_header X-Scope-OrgID {{ .Values.gateway.nginx.config.xScopeOrgIDHeaderValue }};
 
             # Distributor endpoints
             location /distributor {

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -3382,7 +3382,8 @@ gateway:
       serverSnippet: ""
       # -- Allows appending custom configuration to the http block
       httpSnippet: ""
-      # -- Allows to set how the X-Scope-OrgID header should get set (default $ensured_x_scope_orgid, replace it with '$remote_user' if you want to set X-Scope-OrgID to the authenticated user)
+      # -- Allows setting how the X-Scope-OrgID header should be set.
+      #    Defaults to "$ensured_x_scope_orgid". Use "$remote_user" to set it to the authenticated user.
       xScopeOrgIDHeaderValue: $ensured_x_scope_orgid
       # -- Allow to set client_max_body_size in the nginx configuration
       clientMaxBodySize: 540M
@@ -3476,7 +3477,7 @@ gateway:
               return 200 'OK';
               auth_basic off;
             }
-            
+
             proxy_set_header X-Scope-OrgID {{ .Values.gateway.nginx.config.xScopeOrgIDHeaderValue }};
 
             # Distributor endpoints


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #15175

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Default behavior is unchanged; risk is limited to deployments that override the new value and could misroute tenant IDs if configured incorrectly.
> 
> **Overview**
> Adds a new Helm value `gateway.nginx.config.xScopeOrgIDHeaderValue` to control the `proxy_set_header X-Scope-OrgID ...` value in the gateway’s embedded NGINX config (defaulting to the prior behavior of `$ensured_x_scope_orgid`, but allowing alternatives like `$remote_user`).
> 
> Updates the chart changelog to document the new feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 982200582ba766533c99a003801fd92d69ba5883. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->