### PR TITLE
alertmanager: do not panic on empty/nil config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,6 +202,7 @@
   * `-ingest-storage.kafka.max-buffered-bytes` from `100MB` to `1GB`
 * [ENHANCEMENT] MQE: Enable narrow selectors optimisation and hints passing for `and`/`unless` binary operation. #15096
 * [ENHANCEMENT] MQE: Use series selected for one side to reduce data selected on the other side in one-to-many and many-to-one binary operations (eg. `group_left` and `group_right`). #15137
+* [BUGFIX] Alertmanager: Skip empty/zero config. #15184
 * [BUGFIX] Tracing: Respect `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` environment variables in `NewOTelFromEnv()`. Previously, the sampler was always hardcoded to `AlwaysSample()` when no Jaeger remote sampler was configured, making it impossible to control trace volume through standard OpenTelemetry configuration. #15128
 * [BUGFIX] API: Scope activity tracking middleware to query routes only, preventing it from rejecting write requests that have an unexpected `Content-Type` header with HTTP 500. #15129
 * [BUGFIX] Ingester: enforce a minimum 10s delay between TSDB head compaction iterations when an iteration approaches or exceeds the configured `-blocks-storage.tsdb.head-compaction-interval`, so ingestion is not starved by back-to-back compactions. #15061

--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -324,12 +324,13 @@ func (am *MultitenantAlertmanager) ListAllConfigs(w http.ResponseWriter, r *http
 // first error or nil if validation succeeds.
 func validateAlertmanagerConfig(cfg interface{}) error {
 	v := reflect.ValueOf(cfg)
-	t := v.Type()
 
 	// Skip invalid, the zero value or a nil pointer (checked by zero value).
 	if !v.IsValid() || v.IsZero() {
 		return nil
 	}
+
+	t := v.Type()
 
 	// If the input config is a pointer then we need to get its value.
 	// At this point the pointer value can't be nil.

--- a/pkg/alertmanager/api_test.go
+++ b/pkg/alertmanager/api_test.go
@@ -1091,6 +1091,9 @@ func TestValidateAlertmanagerConfig(t *testing.T) {
 		input    interface{}
 		expected error
 	}{
+		"nil input": {
+			input: nil,
+		},
 		"*HTTPClientConfig": {
 			input: &commoncfg.HTTPClientConfig{
 				BasicAuth: &commoncfg.BasicAuth{
@@ -1245,6 +1248,11 @@ func TestValidateAlertmanagerConfig(t *testing.T) {
 				},
 			},
 			expected: errPasswordFileNotAllowed,
+		},
+		"map containing nil value": {
+			input: map[string]interface{}{
+				"test": nil,
+			},
 		},
 		"map containing TLSConfig as nested child": {
 			input: map[string][]config.EmailConfig{


### PR DESCRIPTION
#### What this PR does

Prevents alertmanager form throwing panics when supplied with a nil/zero config.

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-scoped bugfix in config validation logic with added tests; behavior change is limited to skipping nil/zero values instead of panicking.
> 
> **Overview**
> Fixes a panic in Alertmanager config validation by treating *invalid/zero/nil* values as no-ops before calling reflection type logic in `validateAlertmanagerConfig`.
> 
> Adds regression coverage for `nil` inputs and maps containing `nil` values, and documents the fix in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9f4f0628f65e3d93bf8fdbbc981a343015500f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->