### PR TITLE
[r391] alertmanager: do not panic on empty/nil config (#15184)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,7 @@
 * [ENHANCEMENT] Distributor: OTLP endpoint now returns partial success (HTTP 200) instead of HTTP 429 when the usage tracker rejects some series due to the active series limit but other series are successfully ingested. The `RejectedDataPoints` field reports the count of distributor-side rejections (usage tracker filtering). #14789
 * [ENHANCEMENT] MQE: Account for memory consumption of labels returned by binary operations in query memory consumption estimate earlier. #15033
 * [ENHANCEMENT] Query-frontend: Log the number of series and samples returned for queries in `query stats` log lines. #15044
+* [BUGFIX] Alertmanager: Skip empty/zero config. #15184
 * [BUGFIX] Update to Go v1.25.9. #15030
 * [BUGFIX] Distributor: OTLP partial success responses now correctly populate `RejectedDataPoints` with the actual count of rejected samples, instead of always reporting 0. In classical architecture, this includes rejected samples propagated from the ingester. #14789
 * [BUGFIX] Distributor: Fix race condition where usage-tracker partition ring may not be initialized before the distributor service starts, causing `usage-tracker partition ring is required` error on startup. #14675

--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -324,12 +324,13 @@ func (am *MultitenantAlertmanager) ListAllConfigs(w http.ResponseWriter, r *http
 // first error or nil if validation succeeds.
 func validateAlertmanagerConfig(cfg interface{}) error {
 	v := reflect.ValueOf(cfg)
-	t := v.Type()
 
 	// Skip invalid, the zero value or a nil pointer (checked by zero value).
 	if !v.IsValid() || v.IsZero() {
 		return nil
 	}
+
+	t := v.Type()
 
 	// If the input config is a pointer then we need to get its value.
 	// At this point the pointer value can't be nil.

--- a/pkg/alertmanager/api_test.go
+++ b/pkg/alertmanager/api_test.go
@@ -1091,6 +1091,9 @@ func TestValidateAlertmanagerConfig(t *testing.T) {
 		input    interface{}
 		expected error
 	}{
+		"nil input": {
+			input: nil,
+		},
 		"*HTTPClientConfig": {
 			input: &commoncfg.HTTPClientConfig{
 				BasicAuth: &commoncfg.BasicAuth{
@@ -1245,6 +1248,11 @@ func TestValidateAlertmanagerConfig(t *testing.T) {
 				},
 			},
 			expected: errPasswordFileNotAllowed,
+		},
+		"map containing nil value": {
+			input: map[string]interface{}{
+				"test": nil,
+			},
 		},
 		"map containing TLSConfig as nested child": {
 			input: map[string][]config.EmailConfig{


### PR DESCRIPTION
Prevents alertmanager form throwing panics when supplied with a nil/zero config.

Backport of https://github.com/grafana/mimir/pull/15184/.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to reflection-based validation plus tests; behavior only changes for nil/empty inputs and should only prevent crashes.
> 
> **Overview**
> Fixes Alertmanager config validation to **gracefully skip nil/zero inputs** by deferring reflection type access until after validity/zero checks, preventing panics when an empty or nil config is encountered.
> 
> Adds unit coverage for `nil` and map entries with `nil` values, and documents the bugfix in the changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fd99a27e671bf6676fd8b4d743b3fcfc42502f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->