### PR TITLE
MQE: fix issue where step-invariant range vector operators could be created with the wrong time range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -282,6 +282,7 @@
 * [BUGFIX] Compactor: Fix potential goroutine leak when compaction iteration exits early due to errors. #13420
 * [BUGFIX] Query-frontend: Fix bugs with matcher propagation for binary operations where it was not being properly applied within nested expressions and also wrongly propagating internal label matchers. #15110
 * [BUGFIX] Distributor: Cancel DoUntilQuorum in cardinality analysis API when active_series_results_max_size_bytes is breached. #15177
+* [BUGFIX] MQE: Fix issue where queries with step-invariant range vector expressions (eg. `quantile_over_time(scalar(arg), metric[5m] @ 1000)`) could return incorrect results. #15192
 
 ### Mixin
 

--- a/pkg/streamingpromql/planning.go
+++ b/pkg/streamingpromql/planning.go
@@ -772,6 +772,20 @@ func (p *QueryPlanner) nodeFromExpr(expr parser.Expr, timeRange types.QueryTimeR
 			return inner, nil
 		}
 
+		if resultType, err := inner.ResultType(); err != nil {
+			return nil, err
+		} else if resultType != parser.ValueTypeVector && resultType != parser.ValueTypeScalar {
+			// If the query was wrapped in a step-invariant expression and this branch is reached, the inner expression must be a
+			// subquery or range vector selector that returns a range vector at a fixed evaluation timestamp. For example:
+			// metric[3m:1m] @ 100, metric[3m] @ 100, or the range vector selector in
+			// quantile_over_time(scalar(arg), metric[3m] @ 100).
+			//
+			// Both the range vector selector and subquery operators handle this scenario themselves, and we don't need to
+			// wrap them in a step-invariant expression operator, so we don't bother wrapping them in a step-invariant node
+			// either.
+			return inner, nil
+		}
+
 		p.planningMetricsTracker.StepInvariantTracker.OnStepInvariantExpressionAdded(timeRange.StepCount)
 
 		return &core.StepInvariantExpression{

--- a/pkg/streamingpromql/planning/core/step_invariant_expression.go
+++ b/pkg/streamingpromql/planning/core/step_invariant_expression.go
@@ -4,7 +4,6 @@ package core
 
 import (
 	"fmt"
-	"reflect"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -103,26 +102,9 @@ func MaterializeStepInvariantExpression(s *StepInvariantExpression, materializer
 		return planning.NewSingleUseOperatorFactory(operators.NewStepInvariantInstantVectorOperator(op, timeRange, params.MemoryConsumptionTracker)), nil
 	case types.ScalarOperator:
 		return planning.NewSingleUseOperatorFactory(operators.NewStepInvariantScalarOperator(op, timeRange, params.MemoryConsumptionTracker)), nil
-	case types.RangeVectorOperator:
-		// Notes on range vector handling:
-		//
-		// If the query was wrapped in a step-invariant expression and this branch is reached,
-		// the inner expression must be a subquery or range vector selector that returns a range vector at a fixed evaluation
-		// timestamp — for example: metric[3m:1m] @ 100 or metric[3m] @ 100.
-		//
-		// Since range queries cannot directly produce range-vector results for step evaluation,
-		// this must be an instant query; therefore, no special step-invariant operator is required.
-		//
-		// Other step-invariant expressions that wrap range-vector-producing queries are handled
-		// above in the InstantVectorOperator case. For example, a query such as
-		// max_over_time(metric[3m] @ 100) would have the entire function wrapped as a step-invariant,
-		// and its inner operation (the range function call) would be materialized via the
-		// InstantVectorOperator path.
-
-		return planning.NewSingleUseOperatorFactory(op), nil
 	}
 
-	return nil, fmt.Errorf("unable to materialize step invariant expression because of unhandled operator, operator=%v", reflect.TypeOf(op))
+	return nil, fmt.Errorf("unable to materialize step invariant expression with inner node type %T", op)
 }
 
 func (s *StepInvariantExpression) ResultType() (parser.ValueType, error) {

--- a/pkg/streamingpromql/planning/core/step_invariant_expression.go
+++ b/pkg/streamingpromql/planning/core/step_invariant_expression.go
@@ -90,6 +90,24 @@ func (s *StepInvariantExpression) ChildrenLabels() []string {
 }
 
 func MaterializeStepInvariantExpression(s *StepInvariantExpression, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
+	resultType, err := s.Inner.ResultType()
+	if err != nil {
+		return nil, err
+	}
+
+	if resultType == parser.ValueTypeMatrix {
+		// Earlier versions incorrectly wrapped range vector expressions in step-invariant expression nodes.
+		// This has since been fixed, but new queriers might still get incorrect plans from old query-frontends.
+		// If this happens, materialize the inner node as if the step-invariant node does not exist: both the range
+		// vector selector operator and subquery operator behave correctly in this case.
+		op, err := materializer.ConvertNodeToRangeVectorOperator(s.Inner, timeRange)
+		if err != nil {
+			return nil, err
+		}
+
+		return planning.NewSingleUseOperatorFactory(op), nil
+	}
+
 	adjustedTimeRange := s.ChildrenTimeRange(timeRange)
 
 	op, err := materializer.ConvertNodeToOperator(s.Inner, adjustedTimeRange)

--- a/pkg/streamingpromql/planning/materialize.go
+++ b/pkg/streamingpromql/planning/materialize.go
@@ -88,6 +88,20 @@ func (m *Materializer) ConvertNodeToInstantVectorOperator(node Node, timeRange t
 	return ivo, nil
 }
 
+func (m *Materializer) ConvertNodeToRangeVectorOperator(node Node, timeRange types.QueryTimeRange) (types.RangeVectorOperator, error) {
+	o, err := m.ConvertNodeToOperator(node, timeRange)
+	if err != nil {
+		return nil, err
+	}
+
+	rvo, ok := o.(types.RangeVectorOperator)
+	if !ok {
+		return nil, fmt.Errorf("expected RangeVectorOperator, got %T", o)
+	}
+
+	return rvo, nil
+}
+
 func (m *Materializer) ConvertNodeToScalarOperator(node Node, timeRange types.QueryTimeRange) (types.ScalarOperator, error) {
 	o, err := m.ConvertNodeToOperator(node, timeRange)
 	if err != nil {

--- a/pkg/streamingpromql/testdata/ours-only/step_invariant_expression.test
+++ b/pkg/streamingpromql/testdata/ours-only/step_invariant_expression.test
@@ -1,0 +1,37 @@
+# Some of these tests currently fail against Prometheus' engine due to https://github.com/prometheus/prometheus/issues/18610.
+
+load 30s
+  arg 0 0.5 1 0.75
+  metric 1 2 3 4 5
+
+eval range from 0 to 1m30s step 30s scalar(arg)
+  {} 0 0.5 1 0.75
+
+eval instant at 0 metric[2m1s] @ 2m
+  expect range vector from 0 to 2m step 30s
+  metric 1 2 3 4 5
+
+eval instant at 0 metric[2m1s:30s] @ 2m
+  expect range vector from 0 to 2m step 30s
+  metric 1 2 3 4 5
+
+eval range from 0 to 1m30s step 30s quantile_over_time(scalar(arg), metric[2m1s] @ 2m)
+  {} 1 3 5 4
+
+eval instant at 0 quantile_over_time(scalar(arg), metric[2m1s] @ 2m)
+  {} 1
+
+eval range from 0 to 1m30s step 30s quantile_over_time(scalar(arg), metric[2m1s:30s] @ 2m)
+  {} 1 3 5 4
+
+eval instant at 0 quantile_over_time(scalar(arg), metric[2m1s:30s] @ 2m)
+  {} 1
+
+eval range from 0 to 1m30s step 30s quantile_over_time(0.5, metric[2m1s:30s] @ 2m)
+  {} 3 3 3 3
+
+eval instant at 0 quantile_over_time(0.5, metric[2m1s:30s] @ 2m)
+  {} 3
+
+eval range from 0 to 1m30s step 30s quantile_over_time(scalar(arg), metric[2m1s:30s])
+  {} 1 1.5 3 3.25

--- a/pkg/streamingpromql/testdata/ours/step_invariant_expression.test
+++ b/pkg/streamingpromql/testdata/ours/step_invariant_expression.test
@@ -1,9 +1,0 @@
-load 30s
-  arg 0 0.5 1 0.75
-  metric 1 2 3 4 5
-
-eval range from 0 to 1m30s step 30s quantile_over_time(scalar(arg), metric[2m1s] @ 2m)
-  {} 1 3 5 4
-
-eval range from 0 to 1m30s step 30s quantile_over_time(scalar(arg), metric[2m1s:30s] @ 2m)
-  {} 1 3 5 4

--- a/pkg/streamingpromql/testdata/ours/step_invariant_expression.test
+++ b/pkg/streamingpromql/testdata/ours/step_invariant_expression.test
@@ -1,0 +1,9 @@
+load 30s
+  arg 0 0.5 1 0.75
+  metric 1 2 3 4 5
+
+eval range from 0 to 1m30s step 30s quantile_over_time(scalar(arg), metric[2m1s] @ 2m)
+  {} 1 3 5 4
+
+eval range from 0 to 1m30s step 30s quantile_over_time(scalar(arg), metric[2m1s:30s] @ 2m)
+  {} 1 3 5 4


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue where expressions containing a step-invariant range vector operator could be created with the wrong time range.

For example, in the expression `quantile_over_time(scalar(arg), metric[5m] @ 1000)`, `metric[5m] @ 1000` is step-invariant, but `scalar(arg)` is not, so the query plan node for `metric[5m] @ 1000` would have been wrapped in a `StepInvariantExpression` node. 

However, no special handling is required for range vector selectors or subqueries that are step invariant. So the materializer for `StepInvariantExpression` nodes returned the range vector selector operator or subquery operator as-is, without wrapping it in a step-invariant operator as is done for instant vectors or scalars. But the materializer still created the range vector selector operator or subquery operator with a single-step time range as if it was wrapped in a step-invariant expression operator. This could lead to incorrect query results if the query was a range query, as only one step would be evaluated rather than all of them.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches query planning and operator materialization semantics; incorrect handling could affect query results for step-invariant expressions, though changes are targeted and covered by new tests.
> 
> **Overview**
> Fixes MQE planning/materialization so *step-invariant wrapping* is no longer applied to range-vector/subquery expressions (eg. `metric[5m] @ 1000` inside `quantile_over_time(...)`), preventing those nodes from being evaluated with an unintended single-step time range during range queries.
> 
> Adds a compatibility path in `MaterializeStepInvariantExpression` to detect (and safely ignore) legacy step-invariant nodes around matrix/range-vector results, plus a new `ConvertNodeToRangeVectorOperator` helper and updated tests covering these step-invariant/range-vector combinations. Also updates the changelog with the bugfix entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 750f9babefa0035e53faec4afab281113cc29a85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->