### PR TITLE
Fix MimirSchedulerQueriesStuck alert false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -345,7 +345,7 @@
 * [ENHANCEMENT] Alerts: Make `MimirInconsistentRuntimeConfig` alert less flaky when performing multiple configuration changes in a row in a large Kubernetes cluster. #14743 #14933 #15051
 * [ENHANCEMENT] Alerts: Suppress `MimirRingMembersMismatch` alert during ingester rollouts. The alert now uses an `unless` clause to avoid false positives when ingester statefulsets are being updated. #14895
 * [ENHANCEMENT] Recording rules: add a low-cardinality recorded version of usage_tracker_active_series. #14901
-* [ENHANCEMENT] Alerts: Fix `MimirSchedulerQueriesStuck` false positives by only looking for cases where the number of enqueued queries doesn't decrease. #14943
+* [ENHANCEMENT] Alerts: Fix `MimirSchedulerQueriesStuck` false positives by only looking for cases where the number of enqueued queries doesn't decrease. #14943 #15193
 * [ENHANCEMENT] Dashboards: Add ephemeral storage panels to "Resources" dashboards. #14999
 * [ENHANCEMENT] Dashboards: Add disk utilization panels to experimental Block-builder dashboard. #15029
 * [BUGFIX] Dashboards: Fix compactor dashboard to exclude instances without the last successful run metric in the "Last successful run per-compactor replica" table. #14784

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -112,15 +112,18 @@ spec:
               # There are some queries in the queue.
               (sum by (cluster, namespace, job) (cortex_query_scheduler_queue_length) > 0)
   
-              # And the queue size doesn't decrease. We compute the delta with an higher frequency (so a lower step
-              # in the subquery) to increase chances of detecting even short-term downward variations.
+              # And the queue size doesn't decrease.
+              # We use a hardcoded 5s subquery step rather than a dynamic step interval. Prometheus aligns subquery
+              # evaluation times to the Unix epoch modulo the step, so a larger step can miss brief decreases in
+              # queue length that fall between evaluation points, causing delta() to appear non-negative even when
+              # the queue is slowly draining. With 5s we get dense sampling to detect any short-term downward trend.
               and (
                 min_over_time(
                   delta(
                     sum by (cluster, namespace, job) (cortex_query_scheduler_queue_length)
-                    [1m:15s]
+                    [1m:5s]
                   )
-                  [1m:15s]
+                  [1m:5s]
                 ) >= 0
               )
             for: 7m

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -100,15 +100,18 @@ groups:
             # There are some queries in the queue.
             (sum by (cluster, namespace, job) (cortex_query_scheduler_queue_length) > 0)
 
-            # And the queue size doesn't decrease. We compute the delta with an higher frequency (so a lower step
-            # in the subquery) to increase chances of detecting even short-term downward variations.
+            # And the queue size doesn't decrease.
+            # We use a hardcoded 5s subquery step rather than a dynamic step interval. Prometheus aligns subquery
+            # evaluation times to the Unix epoch modulo the step, so a larger step can miss brief decreases in
+            # queue length that fall between evaluation points, causing delta() to appear non-negative even when
+            # the queue is slowly draining. With 5s we get dense sampling to detect any short-term downward trend.
             and (
               min_over_time(
                 delta(
                   sum by (cluster, namespace, job) (cortex_query_scheduler_queue_length)
-                  [1m:15s]
+                  [1m:5s]
                 )
-                [1m:15s]
+                [1m:5s]
               ) >= 0
             )
           for: 7m

--- a/operations/mimir-mixin-compiled-gem/alerts.yaml
+++ b/operations/mimir-mixin-compiled-gem/alerts.yaml
@@ -100,15 +100,18 @@ groups:
             # There are some queries in the queue.
             (sum by (cluster, namespace, job) (cortex_query_scheduler_queue_length) > 0)
 
-            # And the queue size doesn't decrease. We compute the delta with an higher frequency (so a lower step
-            # in the subquery) to increase chances of detecting even short-term downward variations.
+            # And the queue size doesn't decrease.
+            # We use a hardcoded 5s subquery step rather than a dynamic step interval. Prometheus aligns subquery
+            # evaluation times to the Unix epoch modulo the step, so a larger step can miss brief decreases in
+            # queue length that fall between evaluation points, causing delta() to appear non-negative even when
+            # the queue is slowly draining. With 5s we get dense sampling to detect any short-term downward trend.
             and (
               min_over_time(
                 delta(
                   sum by (cluster, namespace, job) (cortex_query_scheduler_queue_length)
-                  [1m:15s]
+                  [1m:5s]
                 )
-                [1m:15s]
+                [1m:5s]
               ) >= 0
             )
           for: 7m

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -100,15 +100,18 @@ groups:
             # There are some queries in the queue.
             (sum by (cluster, namespace, job) (cortex_query_scheduler_queue_length) > 0)
 
-            # And the queue size doesn't decrease. We compute the delta with an higher frequency (so a lower step
-            # in the subquery) to increase chances of detecting even short-term downward variations.
+            # And the queue size doesn't decrease.
+            # We use a hardcoded 5s subquery step rather than a dynamic step interval. Prometheus aligns subquery
+            # evaluation times to the Unix epoch modulo the step, so a larger step can miss brief decreases in
+            # queue length that fall between evaluation points, causing delta() to appear non-negative even when
+            # the queue is slowly draining. With 5s we get dense sampling to detect any short-term downward trend.
             and (
               min_over_time(
                 delta(
                   sum by (cluster, namespace, job) (cortex_query_scheduler_queue_length)
-                  [1m:15s]
+                  [1m:5s]
                 )
-                [1m:15s]
+                [1m:5s]
               ) >= 0
             )
           for: 7m

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -224,22 +224,24 @@ local utils = import 'mixin-utils/utils.libsonnet';
             # There are some queries in the queue.
             (sum by (%(group_by)s, %(job_label)s) (cortex_query_scheduler_queue_length) > 0)
 
-            # And the queue size doesn't decrease. We compute the delta with an higher frequency (so a lower step
-            # in the subquery) to increase chances of detecting even short-term downward variations.
+            # And the queue size doesn't decrease.
+            # We use a hardcoded 5s subquery step rather than a dynamic step interval. Prometheus aligns subquery
+            # evaluation times to the Unix epoch modulo the step, so a larger step can miss brief decreases in
+            # queue length that fall between evaluation points, causing delta() to appear non-negative even when
+            # the queue is slowly draining. With 5s we get dense sampling to detect any short-term downward trend.
             and (
               min_over_time(
                 delta(
                   sum by (%(group_by)s, %(job_label)s) (cortex_query_scheduler_queue_length)
-                  [%(rate_interval)s:%(step_interval)s]
+                  [%(rate_interval)s:5s]
                 )
-                [%(rate_interval)s:%(step_interval)s]
+                [%(rate_interval)s:5s]
               ) >= 0
             )
           ||| % {
             group_by: $._config.alert_aggregation_labels,
             job_label: $._config.per_job_label,
             rate_interval: $.rateInterval('1m'),
-            step_interval: $.stepInterval('15s'),
           },
           'for': '7m',  // We don't want to block for longer.
           labels: {


### PR DESCRIPTION
#### What this PR does

This PR is a follow up of #14943.

What I've missed in #14943 is that Prometheus aligns subquery evaluation times to the Unix epoch modulo the step. With a larger step (e.g. 15s or 30s), the evaluation points can miss brief decreases in queue length that fall between two consecutive evaluation times. Since the alert fires when `min_over_time(delta(...)) >= 0`, missing a short-lived dip means the minimum never goes negative — the alert fires even when the queue is actually processed.

This PR fixes the `MimirSchedulerQueriesStuck` alert by replacing the dynamic `stepInterval('15s')` subquery step with a hardcoded `5s`. With a 5s step:

- Evaluation points are denser, so any short-term downward movement in the queue is captured
- The maximum gap between the actual range boundary and the nearest evaluation point is ≤ 4s

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
