### PR TITLE
tests: Migrate some ingest-storage tests to test under record version 2

### DIFF
--- a/pkg/distributor/distributor_ingest_storage_test.go
+++ b/pkg/distributor/distributor_ingest_storage_test.go
@@ -1740,7 +1740,7 @@ func readAllRequestsByPartitionFromKafka(t testing.TB, kafkaAddresses []string, 
 		version := ingest.ParseRecordVersion(record)
 		var prealloc mimirpb.PreallocWriteRequest
 		require.NoError(t, ingest.DeserializeRecordContent(record.Value, &prealloc, version))
-		prealloc.WriteRequest.ClearTimeseriesUnmarshalData()
+		prealloc.ClearTimeseriesUnmarshalData()
 
 		requestsByPartition[record.Partition] = append(requestsByPartition[record.Partition], &prealloc.WriteRequest)
 	}

--- a/pkg/distributor/distributor_ingest_storage_test.go
+++ b/pkg/distributor/distributor_ingest_storage_test.go
@@ -66,6 +66,13 @@ func TestDistributor_Push_ShouldSupportIngestStorage(t *testing.T) {
 				makeTimeseries([]string{model.MetricNameLabel, "series_five"}, makeSamples(now.UnixMilli(), 5), nil, nil),
 			},
 			Metadata: []*mimirpb.MetricMetadata{
+				// Ingest-storage shards metadata separately from series.
+				// There is no guarantee that the metadata will be sharded to the same partition as the series.
+				// The below cases are careful to exercise two paths:
+				// 1. series_one metadata and series_one series shard to different partitions
+				// 2. series_two metadata and series_two series shard to the same partition
+				// The result is that after splitting the request among partitions, we may see an extra "carrier" series for series_one metadata
+				// but since both series_two objects land on the same shard, they are opportunistically combined.
 				{MetricFamilyName: "series_one", Type: mimirpb.COUNTER, Help: "Series one description"},
 				{MetricFamilyName: "series_two", Type: mimirpb.COUNTER, Help: "Series two description"},
 			},
@@ -87,14 +94,16 @@ func TestDistributor_Push_ShouldSupportIngestStorage(t *testing.T) {
 			expectedSeriesByPartition: map[int32][]string{
 				0: {"series_four", "series_one", "series_three"},
 				1: {"series_two"},
-				2: {"series_five"},
+				// Series one metadata is sharded to partition 2. Metadata is sharded separately from series.
+				2: {"series_five", "series_one"},
 			},
 		},
 		"should shard series across the number of configured partitions when shuffle sharding is enabled": {
 			shardSize: 2,
 			expectedSeriesByPartition: map[int32][]string{
 				1: {"series_one", "series_three", "series_two"},
-				2: {"series_five", "series_four"},
+				// Series one metadata is sharded to partition 2. Metadata is sharded separately from series.
+				2: {"series_five", "series_four", "series_one"},
 			},
 		},
 		"should shard writes to fewer partitions when write shard size is smaller than read shard size": {
@@ -115,7 +124,8 @@ func TestDistributor_Push_ShouldSupportIngestStorage(t *testing.T) {
 			expectedSeriesByPartition: map[int32][]string{
 				// Partition 1 is missing because it failed.
 				0: {"series_four", "series_one", "series_three"},
-				2: {"series_five"},
+				// Series one metadata is sharded to partition 2. Metadata is sharded separately from series.
+				2: {"series_five", "series_one"},
 			},
 		},
 
@@ -132,7 +142,8 @@ func TestDistributor_Push_ShouldSupportIngestStorage(t *testing.T) {
 			expectedSeriesByPartition: map[int32][]string{
 				// Partition 1 is missing because it failed.
 				0: {"series_four", "series_one", "series_three"},
-				2: {"series_five"},
+				// Series one metadata is sharded to partition 2. Metadata is sharded separately from series.
+				2: {"series_five", "series_one"},
 			},
 		},
 	}
@@ -158,9 +169,6 @@ func TestDistributor_Push_ShouldSupportIngestStorage(t *testing.T) {
 				ingestStoragePartitions: numPartitions,
 				ingestStorageKafka:      kafkaCluster,
 				limits:                  limits,
-				configure: func(cfg *Config) {
-					cfg.IngestStorageConfig.KafkaConfig.ProducerRecordVersion = 1
-				},
 			}
 
 			distributors, _, regs, _ := prepare(t, testConfig)
@@ -441,7 +449,6 @@ func TestDistributor_Push_ShouldSupportWriteBothToIngestersAndPartitions(t *test
 				limits:                  limits,
 				configure: func(cfg *Config) {
 					cfg.IngestStorageConfig.Migration.DistributorSendToIngestersEnabled = true
-					cfg.IngestStorageConfig.KafkaConfig.ProducerRecordVersion = 1
 				},
 			}
 
@@ -527,7 +534,6 @@ func TestDistributor_Push_ShouldCleanupWriteRequestAfterWritingBothToIngestersAn
 		limits:                  prepareDefaultLimits(),
 		configure: func(cfg *Config) {
 			cfg.IngestStorageConfig.Migration.DistributorSendToIngestersEnabled = true
-			cfg.IngestStorageConfig.KafkaConfig.ProducerRecordVersion = 1
 		},
 	}
 
@@ -1731,10 +1737,12 @@ func readAllRequestsByPartitionFromKafka(t testing.TB, kafkaAddresses []string, 
 	records := readAllRecordsFromKafka(t, kafkaAddresses, numPartitions, timeout)
 
 	for _, record := range records {
-		req := &mimirpb.WriteRequest{}
-		require.NoError(t, req.Unmarshal(record.Value))
+		version := ingest.ParseRecordVersion(record)
+		var prealloc mimirpb.PreallocWriteRequest
+		require.NoError(t, ingest.DeserializeRecordContent(record.Value, &prealloc, version))
+		prealloc.WriteRequest.ClearTimeseriesUnmarshalData()
 
-		requestsByPartition[record.Partition] = append(requestsByPartition[record.Partition], req)
+		requestsByPartition[record.Partition] = append(requestsByPartition[record.Partition], &prealloc.WriteRequest)
 	}
 
 	return requestsByPartition

--- a/pkg/distributor/distributor_max_series_limit_test.go
+++ b/pkg/distributor/distributor_max_series_limit_test.go
@@ -167,9 +167,6 @@ func TestDistributor_Push_ShouldEnforceMaxSeriesLimits(t *testing.T) {
 				ingestStorageEnabled:    true,
 				ingestStoragePartitions: 1,
 				limits:                  limits,
-				configure: func(cfg *Config) {
-					cfg.IngestStorageConfig.KafkaConfig.ProducerRecordVersion = 1
-				},
 			}
 
 			distributors, _, regs, kafkaCluster := prepare(t, testConfig)

--- a/pkg/storage/ingest/writer_test.go
+++ b/pkg/storage/ingest/writer_test.go
@@ -59,7 +59,6 @@ func TestWriter_WriteSync(t *testing.T) {
 
 		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
 		cfg := createTestKafkaConfig(clusterAddr, topicName)
-		cfg.ProducerRecordVersion = 1
 		writer, reg := createTestWriter(t, cfg)
 
 		produceRequestProcessed := atomic.NewBool(false)
@@ -93,8 +92,7 @@ func TestWriter_WriteSync(t *testing.T) {
 		require.Len(t, fetches.Records(), 1)
 		assert.Equal(t, []byte(tenantID), fetches.Records()[0].Key)
 
-		received := mimirpb.WriteRequest{}
-		require.NoError(t, received.Unmarshal(fetches.Records()[0].Value))
+		received := deserializeRecord(t, fetches.Records()[0])
 		require.Len(t, received.Timeseries, len(multiSeries))
 
 		for idx, expected := range multiSeries {
@@ -144,7 +142,6 @@ func TestWriter_WriteSync(t *testing.T) {
 		// Customize the max record size to force splitting the WriteRequest into two records.
 		expectedReq := &mimirpb.WriteRequest{Timeseries: multiSeries, Metadata: nil, Source: mimirpb.API}
 		cfg := createTestKafkaConfig(clusterAddr, topicName)
-		cfg.ProducerRecordVersion = 1
 		cfg.ProducerMaxRecordSizeBytes = int(float64(expectedReq.Size()) * 0.8)
 
 		writer, reg := createTestWriter(t, cfg)
@@ -186,15 +183,12 @@ func TestWriter_WriteSync(t *testing.T) {
 		assert.Equal(t, []byte(tenantID), records[0].Key)
 		assert.Equal(t, []byte(tenantID), records[1].Key)
 
-		actualReq1 := &mimirpb.WriteRequest{}
-		actualReq2 := &mimirpb.WriteRequest{}
-		require.NoError(t, actualReq1.Unmarshal(records[0].Value))
-		require.NoError(t, actualReq2.Unmarshal(records[1].Value))
+		actualReq1 := deserializeRecord(t, records[0])
+		actualReq2 := deserializeRecord(t, records[1])
 
-		actualMergedReq := *actualReq1
-		actualMergedReq.Timeseries = append(actualMergedReq.Timeseries, actualReq2.Timeseries...)
-		actualMergedReq.ClearTimeseriesUnmarshalData()
-		assert.Equal(t, expectedReq, &actualMergedReq)
+		mergedTimeseries := append(actualReq1.Timeseries, actualReq2.Timeseries...)
+		assert.Equal(t, expectedReq.Timeseries, mergedTimeseries)
+		assert.Equal(t, expectedReq.Source, actualReq1.Source)
 
 		// Check metrics.
 		expectedSentBytes := len(records[0].Value) + len(records[1].Value)
@@ -242,7 +236,6 @@ func TestWriter_WriteSync(t *testing.T) {
 
 		_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
 		config := createTestKafkaConfig(clusterAddr, topicName)
-		config.ProducerRecordVersion = 1
 		writer, reg := createTestWriter(t, config)
 
 		// Write to partitions.
@@ -265,8 +258,7 @@ func TestWriter_WriteSync(t *testing.T) {
 			require.Len(t, fetches.Records(), 1)
 			assert.Equal(t, []byte(tenantID), fetches.Records()[0].Key)
 
-			received := mimirpb.WriteRequest{}
-			require.NoError(t, received.Unmarshal(fetches.Records()[0].Value))
+			received := deserializeRecord(t, fetches.Records()[0])
 			require.Len(t, received.Timeseries, len(expectedSeries))
 
 			for idx, expected := range expectedSeries {
@@ -295,9 +287,7 @@ func TestWriter_WriteSync(t *testing.T) {
 		)
 
 		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
-		cfg := createTestKafkaConfig(clusterAddr, topicName)
-		cfg.ProducerRecordVersion = 1
-		writer, _ := createTestWriter(t, cfg)
+		writer, _ := createTestWriter(t, createTestKafkaConfig(clusterAddr, topicName))
 
 		// Get the underlying Kafka client used by the writer.
 		cluster.ControlKey(int16(kmsg.Produce), func(request kmsg.Request) (kmsg.Response, error, bool) {
@@ -371,7 +361,6 @@ func TestWriter_WriteSync(t *testing.T) {
 
 		// Allow only 1 in-flight Produce request in this test, to easily reproduce the scenario.
 		cfg := createTestKafkaConfig(clusterAddr, topicName)
-		cfg.ProducerRecordVersion = 1
 		cfg.MaxInflightProduceRequests = 1
 		writer, _ := createTestWriter(t, cfg)
 
@@ -424,9 +413,7 @@ func TestWriter_WriteSync(t *testing.T) {
 		t.Parallel()
 
 		_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
-		cfg := createTestKafkaConfig(clusterAddr, topicName)
-		cfg.ProducerRecordVersion = 1
-		writer, reg := createTestWriter(t, cfg)
+		writer, reg := createTestWriter(t, createTestKafkaConfig(clusterAddr, topicName))
 
 		// Write to a non-existing partition.
 		err := writer.WriteSync(ctx, topicName, 100, tenantID, &mimirpb.WriteRequest{Timeseries: multiSeries, Metadata: nil, Source: mimirpb.API})
@@ -451,7 +438,6 @@ func TestWriter_WriteSync(t *testing.T) {
 
 		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
 		kafkaCfg := createTestKafkaConfig(clusterAddr, topicName)
-		kafkaCfg.ProducerRecordVersion = 1
 		writer, reg := createTestWriter(t, kafkaCfg)
 
 		cluster.ControlKey(int16(kmsg.Produce), func(kmsg.Request) (kmsg.Response, error, bool) {
@@ -487,7 +473,6 @@ func TestWriter_WriteSync(t *testing.T) {
 
 		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
 		kafkaCfg := createTestKafkaConfig(clusterAddr, topicName)
-		kafkaCfg.ProducerRecordVersion = 1
 		writer, _ := createTestWriter(t, kafkaCfg)
 
 		var (
@@ -561,9 +546,7 @@ func TestWriter_WriteSync(t *testing.T) {
 		}
 
 		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
-		cfg := createTestKafkaConfig(clusterAddr, topicName)
-		cfg.ProducerRecordVersion = 1
-		writer, reg := createTestWriter(t, cfg)
+		writer, reg := createTestWriter(t, createTestKafkaConfig(clusterAddr, topicName))
 
 		produceRequestProcessed := atomic.NewBool(false)
 
@@ -594,9 +577,7 @@ func TestWriter_WriteSync(t *testing.T) {
 		require.Len(t, fetches.Records(), 1)
 		assert.Equal(t, []byte(tenantID), fetches.Records()[0].Key)
 
-		received := mimirpb.WriteRequest{}
-		require.NoError(t, received.Unmarshal(fetches.Records()[0].Value))
-		received.ClearTimeseriesUnmarshalData()
+		received := deserializeRecord(t, fetches.Records()[0])
 
 		// We expect that the small time series has been ingested, while the huge one has been discarded.
 		require.Len(t, received.Timeseries, 1)
@@ -652,7 +633,8 @@ func TestWriter_WriteSync(t *testing.T) {
 
 		// Estimate the size of each record written in this test.
 		writeReq := createWriteRequest()
-		writeReqRecords, err := marshalWriteRequestToRecords(topicName, partitionID, tenantID, writeReq, writeReq.Size(), maxProducerRecordDataBytesLimit, mimirpb.SplitWriteRequestByMaxMarshalSize)
+		serializer := RecordSerializerFromVersion(2)
+		writeReqRecords, _, err := serializer.ToRecords(topicName, partitionID, tenantID, writeReq, maxProducerRecordDataBytesLimit)
 		require.NoError(t, err)
 		require.Len(t, writeReqRecords, 1)
 		estimatedRecordSize := len(writeReqRecords[0].Value)
@@ -671,7 +653,6 @@ func TestWriter_WriteSync(t *testing.T) {
 		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
 
 		cfg := createTestKafkaConfig(clusterAddr, topicName)
-		cfg.ProducerRecordVersion = 1
 		cfg.ProducerMaxBufferedBytes = int64((estimatedRecordSize * 4) - 1) // Configure the test so that we expect 3 produced records.
 		cfg.WriteTimeout = time.Second
 
@@ -796,9 +777,7 @@ func TestWriter_WriteSync(t *testing.T) {
 		t.Parallel()
 
 		_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
-		cfg := createTestKafkaConfig(clusterAddr, topicName)
-		cfg.ProducerRecordVersion = 1
-		writer, _ := createTestWriter(t, cfg)
+		writer, _ := createTestWriter(t, createTestKafkaConfig(clusterAddr, topicName))
 
 		err := writer.WriteSync(ctx, topicName, partitionID, tenantID, &mimirpb.WriteRequest{Timeseries: multiSeries, Metadata: nil, Source: mimirpb.API})
 		require.NoError(t, err)
@@ -1749,6 +1728,16 @@ func TestWriter_WriteSync_SetsRecordTimestampFromContext(t *testing.T) {
 	records := fetches.Records()
 	require.Len(t, records, 1)
 	assert.Equal(t, ts, records[0].Timestamp)
+}
+
+func deserializeRecord(t *testing.T, rec *kgo.Record) mimirpb.WriteRequest {
+	t.Helper()
+
+	version := ParseRecordVersion(rec)
+	var prealloc mimirpb.PreallocWriteRequest
+	require.NoError(t, DeserializeRecordContent(rec.Value, &prealloc, version))
+	prealloc.WriteRequest.ClearTimeseriesUnmarshalData()
+	return prealloc.WriteRequest
 }
 
 func createTestKafkaClient(t *testing.T, cfg KafkaConfig) *kgo.Client {

--- a/pkg/storage/ingest/writer_test.go
+++ b/pkg/storage/ingest/writer_test.go
@@ -1736,7 +1736,7 @@ func deserializeRecord(t *testing.T, rec *kgo.Record) mimirpb.WriteRequest {
 	version := ParseRecordVersion(rec)
 	var prealloc mimirpb.PreallocWriteRequest
 	require.NoError(t, DeserializeRecordContent(rec.Value, &prealloc, version))
-	prealloc.WriteRequest.ClearTimeseriesUnmarshalData()
+	prealloc.ClearTimeseriesUnmarshalData()
 	return prealloc.WriteRequest
 }
 


### PR DESCRIPTION
#### What this PR does

This is a follow-up to https://github.com/grafana/mimir/pull/15185 that only touches tests.

V2 itself is well-tested, but a few stray ingest-storage tests have internal ties to a specific record version.
For example, a test may intercept a record and deserialize it in-line, and the deserialization logic is tied to a specific record format.

This PR migrates tests that use inline deserialization to use the version-aware deserializer.
In general, ingest-storage tests operate in V2 unless otherwise specified.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that update ingest-storage fixtures and assertions; risk is limited to potential false positives/negatives in Kafka record decoding and partition expectations.
> 
> **Overview**
> Updates ingest-storage tests to run against **record version 2 by default** instead of pinning `ProducerRecordVersion = 1`, removing several test-only config overrides.
> 
> Reworks test Kafka record decoding to be **version-aware** (using `ParseRecordVersion` + `DeserializeRecordContent` and a shared `deserializeRecord()` helper) and adjusts sharding expectations/fixtures where **metadata can shard to different partitions than series** (including asserting the extra “carrier” series case).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44aff3a56ffe1304c4d502e55f9372764a602b41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->