### PR TITLE
mixin: Only alert on failed object storage percentage > 1%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -356,6 +356,7 @@
 * [BUGFIX] Dashboards: Fix issue where the MQE-related dashboard panels on the Queries dashboard would show data from both queriers and query-frontends, instead of just queriers. #14029
 * [BUGFIX] Alerts: Fix alert definitions with short range vector selectors that did not respect the configured `base_alerts_range_interval_minutes`. #15083
 * [BUGFIX] Dashboards: Fix mixin build failure when `singleBinary` is `true`. #15108
+* [BUGFIX] Alerts: Fix alert for store-gateway object storage operation failures to alert based on percentage of failed operations, not raw number of them. #15196
 
 ### Jsonnet
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -274,7 +274,11 @@ spec:
               message: Mimir store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ $value | humanizePercentage }} errors while doing {{ $labels.operation }} on the object storage.
               runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstoregatewaytoomanyfailedoperations
             expr: |
-              sum by(cluster, namespace, operation) (rate(thanos_objstore_bucket_operation_failures_total{component="store-gateway"}[1m])) > 0
+              (
+                  sum by(cluster, namespace, operation) (rate(thanos_objstore_bucket_operation_failures_total{component="store-gateway"}[1m]))
+                  /
+                  sum by(cluster, namespace, operation) (rate(thanos_objstore_bucket_operations_total{component="store-gateway"}[1m]))
+              ) >= 0.01
             for: 5m
             labels:
               severity: warning

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -262,7 +262,11 @@ groups:
             message: Mimir store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ $value | humanizePercentage }} errors while doing {{ $labels.operation }} on the object storage.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstoregatewaytoomanyfailedoperations
           expr: |
-            sum by(cluster, namespace, operation) (rate(thanos_objstore_bucket_operation_failures_total{component="store-gateway"}[1m])) > 0
+            (
+                sum by(cluster, namespace, operation) (rate(thanos_objstore_bucket_operation_failures_total{component="store-gateway"}[1m]))
+                /
+                sum by(cluster, namespace, operation) (rate(thanos_objstore_bucket_operations_total{component="store-gateway"}[1m]))
+            ) >= 0.01
           for: 5m
           labels:
             severity: warning

--- a/operations/mimir-mixin-compiled-gem/alerts.yaml
+++ b/operations/mimir-mixin-compiled-gem/alerts.yaml
@@ -262,7 +262,11 @@ groups:
             message: GEM store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ $value | humanizePercentage }} errors while doing {{ $labels.operation }} on the object storage.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstoregatewaytoomanyfailedoperations
           expr: |
-            sum by(cluster, namespace, operation) (rate(thanos_objstore_bucket_operation_failures_total{component="store-gateway"}[1m])) > 0
+            (
+                sum by(cluster, namespace, operation) (rate(thanos_objstore_bucket_operation_failures_total{component="store-gateway"}[1m]))
+                /
+                sum by(cluster, namespace, operation) (rate(thanos_objstore_bucket_operations_total{component="store-gateway"}[1m]))
+            ) >= 0.01
           for: 5m
           labels:
             severity: warning

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -262,7 +262,11 @@ groups:
             message: Mimir store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ $value | humanizePercentage }} errors while doing {{ $labels.operation }} on the object storage.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstoregatewaytoomanyfailedoperations
           expr: |
-            sum by(cluster, namespace, operation) (rate(thanos_objstore_bucket_operation_failures_total{component="store-gateway"}[1m])) > 0
+            (
+                sum by(cluster, namespace, operation) (rate(thanos_objstore_bucket_operation_failures_total{component="store-gateway"}[1m]))
+                /
+                sum by(cluster, namespace, operation) (rate(thanos_objstore_bucket_operations_total{component="store-gateway"}[1m]))
+            ) >= 0.01
           for: 5m
           labels:
             severity: warning

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -420,7 +420,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
           alert: $.alertName('StoreGatewayTooManyFailedOperations'),
           'for': '5m',
           expr: |||
-            sum by(%(alert_aggregation_labels)s, operation) (rate(thanos_objstore_bucket_operation_failures_total{component="store-gateway"}[%(rate_interval)s])) > 0
+            (
+                sum by(%(alert_aggregation_labels)s, operation) (rate(thanos_objstore_bucket_operation_failures_total{component="store-gateway"}[%(rate_interval)s]))
+                /
+                sum by(%(alert_aggregation_labels)s, operation) (rate(thanos_objstore_bucket_operations_total{component="store-gateway"}[%(rate_interval)s]))
+            ) >= 0.01
           ||| % {
             alert_aggregation_labels: $._config.alert_aggregation_labels,
             rate_interval: $.rateInterval('1m'),


### PR DESCRIPTION
#### What this PR does

The existing warning for object storage operations failing for the store-gateway fired any time there were any failures at all, regardless of the _percent_ of operations failing. It also presented the number of failing operations as if it was a percent which was very deceptive.

This change uses the total number of object storage operations to actually compute a percent and only fires the warning when it is over 1%. Running the new query internally, it only would have warned a single time over the last 7 days.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production alerting behavior for store-gateway object storage operations, which could reduce or increase paging depending on traffic volume and introduces a division-by-zero/NaN edge case if total operations are absent.
> 
> **Overview**
> **Fixes `MimirStoreGatewayTooManyFailedOperations` to alert on error *rate* rather than raw failure count.** The alert expression now computes `failures / total operations` (using `thanos_objstore_bucket_operations_total`) and triggers only when the failure ratio is >= `1%`, making the alert value consistent with the `humanizePercentage` annotation.
> 
> Updates the Jsonnet source (`alerts.libsonnet`), regenerated compiled mixin outputs (including Helm metamonitoring test fixtures), and adds a `CHANGELOG.md` bugfix entry documenting the new alert semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94f9686074867560e75590853da8fc1355ac41d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->