### PR TITLE
MQE: optimise `unless` and `or` operations where one side is known to be empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,7 @@
   * `-ingest-storage.kafka.max-buffered-bytes` from `100MB` to `1GB`
 * [ENHANCEMENT] MQE: Enable narrow selectors optimisation and hints passing for `and`/`unless` binary operation. #15096
 * [ENHANCEMENT] MQE: Use series selected for one side to reduce data selected on the other side in one-to-many and many-to-one binary operations (eg. `group_left` and `group_right`). #15137
+* [ENHANCEMENT] MQE: Simplify `unless` and `or` operations where one side can be proven to be empty by inspecting the expression. #15198
 * [BUGFIX] Alertmanager: Skip empty/zero config. #15184
 * [BUGFIX] Tracing: Respect `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` environment variables in `NewOTelFromEnv()`. Previously, the sampler was always hardcoded to `AlwaysSample()` when no Jaeger remote sampler was configured, making it impossible to control trace volume through standard OpenTelemetry configuration. #15128
 * [BUGFIX] API: Scope activity tracking middleware to query routes only, preventing it from rejecting write requests that have an unexpected `Content-Type` header with HTTP 500. #15129

--- a/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
+++ b/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
@@ -21,24 +21,13 @@ import (
 // RemoveStaticallyEmptyExpressionsOptimizationPass replaces subexpressions that can be statically
 // determined to return no results with a NoOp node, avoiding unnecessary computation.
 //
-// It detects the following pattern in both "and" operands:
+// It detects the following patterns for timestamp() calls:
 //
 //	timestamp(<inner>) < <constant>   (or the symmetric form <constant> > timestamp(<inner>))
 //	timestamp(<inner>) <= <constant>  (or the symmetric form <constant> >= timestamp(<inner>))
 //
-// where <constant> is a NumberLiteral (possibly wrapped in transparent nodes).
-//
-// The check is conservative: the optimization applies only when the query start is far enough
-// after <constant> that even a sample as old as one lookback-delta before the step cannot
-// satisfy the comparison:
-//
-//	timestamp(v) < C  →  always false when StartT (in ms) >= C*1000 + lookback delta (in ms)
-//	timestamp(v) <= C →  always false when StartT (in ms) >  C*1000 + lookback delta (in ms)
-//
-// This allows the optimization pass to work correctly when v is an instant vector selector
-// (which returns the underlying sample timestamp and so could return a value as early as
-// StartT - lookback delta), and when v is any other kind of expression (which will
-// return the output timestamp, and so could return a value as early as StartT).
+// where <constant> is a NumberLiteral (possibly wrapped in transparent nodes) that is before the start of the possible
+// timestamps that could be returned given the query's time range.
 //
 // For simplicity, the optimization pass does not descend into Subquery nodes, because the effective time range for
 // expressions inside a subquery differs from the outer query time range.
@@ -48,6 +37,15 @@ import (
 //	metric{label1="example", label1="another"}
 //
 // This exact match selector is guaranteed to not match any results.
+//
+// It also detects combinations of the above with 'and', 'or' and 'unless' operations:
+//
+//	empty AND anything is empty
+//	anything AND empty is empty
+//	empty OR RHS is RHS
+//	LHS OR empty is LHS
+//	empty UNLESS anything is empty
+//	LHS UNLESS empty is LHS
 type RemoveStaticallyEmptyExpressionsOptimizationPass struct {
 	attempts prometheus.Counter
 	modified prometheus.Counter
@@ -98,9 +96,9 @@ func (s *RemoveStaticallyEmptyExpressionsOptimizationPass) Apply(ctx context.Con
 	return plan, nil
 }
 
-// apply recursively walks the plan tree, replacing statically-empty "and" binary expressions
-// with a NoOp node. It returns the replacement node (non-nil if this node should be replaced),
-// the number of replacements made, and any error.
+// apply recursively walks the plan tree, replacing statically-empty binary expressions
+// with a NoOp node or simplified equivalent. It returns the replacement node (non-nil if this
+// node should be replaced), whether any modification was made, and any error.
 func (s *RemoveStaticallyEmptyExpressionsOptimizationPass) apply(node planning.Node, params *planning.QueryParameters) (planning.Node, bool, error) {
 	// Do not descend into subqueries for simplicity: their children are evaluated over a different time range
 	// (shifted backwards by the subquery range), so params.TimeRange does not apply there.
@@ -129,17 +127,24 @@ func (s *RemoveStaticallyEmptyExpressionsOptimizationPass) apply(node planning.N
 			if err := node.ReplaceChild(idx, replacement); err != nil {
 				return nil, false, err
 			}
+			modified = true
 		}
 	}
 
 	if empty, matrix := isAlwaysEmptySelector(node); empty {
 		noOp := &core.NoOp{NoOpDetails: &core.NoOpDetails{MatrixSelector: matrix}}
 		return noOp, true, nil
-	} else if empty, err := isAlwaysEmpty(node, params); err != nil {
+	}
+
+	if empty, err := isAlwaysEmpty(node, params); err != nil {
 		return nil, false, err
 	} else if empty {
 		noOp := &core.NoOp{NoOpDetails: &core.NoOpDetails{}}
 		return noOp, true, nil
+	}
+
+	if replacement, simplified := simplify(node, params); simplified {
+		return replacement, true, nil
 	}
 
 	return nil, modified, nil
@@ -218,6 +223,23 @@ func isAlwaysEmptyBinaryExpression(node *core.BinaryExpression, params *planning
 		}
 
 		return isAlwaysEmpty(node.RHS, params)
+
+	case core.BINARY_LOR:
+		// A or B is empty only when both sides are empty.
+		lhsEmpty, err := isAlwaysEmpty(node.LHS, params)
+		if err != nil {
+			return false, err
+		}
+
+		if !lhsEmpty {
+			return false, nil
+		}
+
+		return isAlwaysEmpty(node.RHS, params)
+
+	case core.BINARY_LUNLESS:
+		// A unless B is empty whenever A is empty, regardless of B.
+		return isAlwaysEmpty(node.LHS, params)
 
 	case core.BINARY_LSS:
 		// Check for timestamp(v) < C.
@@ -316,6 +338,42 @@ func findConstant(node planning.Node) (*core.NumberLiteral, bool) {
 
 	literal, ok := node.(*core.NumberLiteral)
 	return literal, ok
+}
+
+func simplify(node planning.Node, params *planning.QueryParameters) (planning.Node, bool) {
+	switch node := node.(type) {
+	case *core.DeduplicateAndMerge:
+		// 'or' operations are wrapped in a DeduplicateAndMerge node.
+		// If we can optimize the 'or' away, then there's no need for the DeduplicateAndMerge either.
+
+		inner, isBinOp := node.Inner.(*core.BinaryExpression)
+		if !isBinOp || inner.Op != core.BINARY_LOR {
+			return nil, false
+		}
+
+		// empty OR RHS is equivalent to RHS.
+		if _, noOp := inner.LHS.(*core.NoOp); noOp {
+			return inner.RHS, true
+		}
+
+		// LHS or empty is equivalent to LHS.
+		if _, noOp := inner.RHS.(*core.NoOp); noOp {
+			return inner.LHS, true
+		}
+
+	case *core.BinaryExpression:
+		if node.Op != core.BINARY_LUNLESS {
+			return nil, false
+		}
+
+		// If the LHS is a no-op this means the whole expression is a no-op, and that is
+		// handled by isAlwaysEmptyBinaryExpression.
+		if _, noOp := node.RHS.(*core.NoOp); noOp {
+			return node.LHS, true
+		}
+	}
+
+	return nil, false
 }
 
 // unwrap removes transparent wrapper nodes returning the innermost non-wrapper node.

--- a/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
+++ b/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
@@ -142,7 +142,7 @@ func (s *RemoveStaticallyEmptyExpressionsOptimizationPass) apply(node planning.N
 		return noOp, true, nil
 	}
 
-	if replacement, simplified := simplify(node); simplified {
+	if replacement := simplify(node); replacement != nil {
 		return replacement, true, nil
 	}
 
@@ -339,7 +339,8 @@ func findConstant(node planning.Node) (*core.NumberLiteral, bool) {
 	return literal, ok
 }
 
-func simplify(node planning.Node) (planning.Node, bool) {
+// simplify returns a simpler version of node, or nil if no simplification applies.
+func simplify(node planning.Node) planning.Node {
 	switch node := node.(type) {
 	case *core.DeduplicateAndMerge:
 		// 'or' operations are wrapped in a DeduplicateAndMerge node.
@@ -347,32 +348,32 @@ func simplify(node planning.Node) (planning.Node, bool) {
 
 		inner, isBinOp := node.Inner.(*core.BinaryExpression)
 		if !isBinOp || inner.Op != core.BINARY_LOR {
-			return nil, false
+			return nil
 		}
 
 		// empty OR RHS is equivalent to RHS.
 		if _, noOp := inner.LHS.(*core.NoOp); noOp {
-			return inner.RHS, true
+			return inner.RHS
 		}
 
 		// LHS or empty is equivalent to LHS.
 		if _, noOp := inner.RHS.(*core.NoOp); noOp {
-			return inner.LHS, true
+			return inner.LHS
 		}
 
 	case *core.BinaryExpression:
 		if node.Op != core.BINARY_LUNLESS {
-			return nil, false
+			return nil
 		}
 
 		// If the LHS is a no-op this means the whole expression is a no-op, and that is
 		// handled by isAlwaysEmptyBinaryExpression.
 		if _, noOp := node.RHS.(*core.NoOp); noOp {
-			return node.LHS, true
+			return node.LHS
 		}
 	}
 
-	return nil, false
+	return nil
 }
 
 // unwrap removes transparent wrapper nodes returning the innermost non-wrapper node.

--- a/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
+++ b/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
@@ -127,7 +127,6 @@ func (s *RemoveStaticallyEmptyExpressionsOptimizationPass) apply(node planning.N
 			if err := node.ReplaceChild(idx, replacement); err != nil {
 				return nil, false, err
 			}
-			modified = true
 		}
 	}
 

--- a/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
+++ b/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
@@ -143,7 +143,7 @@ func (s *RemoveStaticallyEmptyExpressionsOptimizationPass) apply(node planning.N
 		return noOp, true, nil
 	}
 
-	if replacement, simplified := simplify(node, params); simplified {
+	if replacement, simplified := simplify(node); simplified {
 		return replacement, true, nil
 	}
 
@@ -340,7 +340,7 @@ func findConstant(node planning.Node) (*core.NumberLiteral, bool) {
 	return literal, ok
 }
 
-func simplify(node planning.Node, params *planning.QueryParameters) (planning.Node, bool) {
+func simplify(node planning.Node) (planning.Node, bool) {
 	switch node := node.(type) {
 	case *core.DeduplicateAndMerge:
 		// 'or' operations are wrapped in a DeduplicateAndMerge node.

--- a/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions_test.go
+++ b/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions_test.go
@@ -273,6 +273,75 @@ func TestRemoveStaticallyEmptyExpressionsOptimizationPass(t *testing.T) {
 				- NoOp
 			`,
 		},
+
+		"empty result ANDed with non-empty result: returns empty result": {
+			expr: `EMPTY_RESULT and metric`,
+			expectedPlan: `
+				- NoOp
+			`,
+		},
+		"non-empty result ANDed with empty result: returns empty result": {
+			expr: `metric and EMPTY_RESULT`,
+			expectedPlan: `
+				- NoOp
+			`,
+		},
+		"non-empty result ANDed with non-empty result: stays as-is": {
+			expr:            `metric and other_metric`,
+			expectUnchanged: true,
+		},
+		"empty result ANDed with empty result: returns empty result": {
+			expr: `EMPTY_RESULT and EMPTY_RESULT`,
+			expectedPlan: `
+				- NoOp
+			`,
+		},
+
+		"empty result ORed with non-empty result: returns non-empty side": {
+			expr: `EMPTY_RESULT or metric`,
+			expectedPlan: `
+				- VectorSelector: {__name__="metric"}
+			`,
+		},
+		"non-empty result ORed with empty result: returns non-empty side": {
+			expr: `metric or EMPTY_RESULT`,
+			expectedPlan: `
+				- VectorSelector: {__name__="metric"}
+			`,
+		},
+		"non-empty result ORed with non-empty result: stays as-is": {
+			expr:            `metric or other_metric`,
+			expectUnchanged: true,
+		},
+		"empty result ORed with empty result: returns empty result": {
+			expr: `EMPTY_RESULT or EMPTY_RESULT`,
+			expectedPlan: `
+				- NoOp
+			`,
+		},
+
+		"empty result UNLESSed with non-empty result: returns empty result": {
+			expr: `EMPTY_RESULT unless metric`,
+			expectedPlan: `
+				- NoOp
+			`,
+		},
+		"non-empty result UNLESSed with empty result: returns non-empty side": {
+			expr: `metric unless EMPTY_RESULT`,
+			expectedPlan: `
+				- VectorSelector: {__name__="metric"}
+			`,
+		},
+		"non-empty result UNLESSed with non-empty result: stays as-is": {
+			expr:            `metric unless other_metric`,
+			expectUnchanged: true,
+		},
+		"empty result UNLESSed with empty result: returns empty result": {
+			expr: `EMPTY_RESULT unless EMPTY_RESULT`,
+			expectedPlan: `
+				- NoOp
+			`,
+		},
 	}
 
 	ctx := context.Background()
@@ -296,6 +365,7 @@ func TestRemoveStaticallyEmptyExpressionsOptimizationPass(t *testing.T) {
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
 			testCase.expr = strings.ReplaceAll(testCase.expr, "CONSTANT", strconv.Itoa(constant))
+			testCase.expr = strings.ReplaceAll(testCase.expr, "EMPTY_RESULT", `some_metric{foo="bar", foo="not-bar"}`)
 
 			timeRange := types.NewRangeQueryTimeRange(testCase.queryStart, testCase.queryStart.Add(24*time.Hour), time.Minute)
 			expectedModified := 1

--- a/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions_test.go
+++ b/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions_test.go
@@ -190,13 +190,12 @@ func TestRemoveStaticallyEmptyExpressionsOptimizationPass(t *testing.T) {
 			expectUnchanged: true,
 		},
 		"nested and expressions: should optimize as far as possible": {
+			// The inner "and" has the timestamp filter → replaced with NoOp.
+			// The outer "or" then has NoOp as its LHS → simplified to just the RHS.
 			expr:       "(metric and timestamp(metric) < CONSTANT) or metric2",
 			queryStart: time.UnixMilli(selectorThresholdMs + 1),
 			expectedPlan: `
-				- DeduplicateAndMerge
-					- BinaryExpression: LHS or RHS
-						- LHS: NoOp
-						- RHS: VectorSelector: {__name__="metric2"}
+				- VectorSelector: {__name__="metric2"}
 			`,
 		},
 


### PR DESCRIPTION
#### What this PR does

This PR extends the "remove statically empty expressions" optimisation pass to simplify `unless` or `or` operations where one side is known to be empty.

It uses the following rules:

| Input | Output |
|--------|--------|
| `empty or RHS` | `RHS` |
| `LHS or empty` | `LHS` |
| `empty unless anything` | `empty` | 
| `LHS unless empty` | `LHS` |

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes query-plan optimization logic for `or`/`unless`, which can affect query results if the emptiness detection or simplification is incorrect, though it’s guarded by conservative checks and covered by tests.
> 
> **Overview**
> Extends the MQE `RemoveStaticallyEmptyExpressions` optimization to detect statically-empty `or` and `unless` binary expressions, not just `and`/timestamp and conflicting-matcher cases.
> 
> When one side is proven empty, the optimizer now simplifies the plan (`empty or X` → `X`, `X or empty` → `X` by dropping the surrounding `DeduplicateAndMerge`; `X unless empty` → `X`; and `A unless B` is considered empty if `A` is empty). Tests are expanded to cover these new simplifications, and the changelog records the enhancement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a15841681747b665f8f7a326b3eb80f945ac312b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->