### PR TITLE
Fix KafkaProducer.ProduceSync to return one result per record on context cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,7 @@
 * [ENHANCEMENT] MQE: Add support for common subexpression elimination and subset selector elimination of range vector selectors in range queries. Enable with `-querier.mimir-query-engine.enable-range-query-range-vector-common-subexpression-elimination=true`. #15127
 * [ENHANCEMENT] MQE: Use series selected for one side to reduce data selected on the other side in one-to-many and many-to-one binary operations (eg. `group_left` and `group_right`). #15137
 * [ENHANCEMENT] MQE: Simplify `unless` and `or` operations where one side can be proven to be empty by inspecting the expression. #15198
+* [BUGFIX] Ingest storage: Fix `KafkaProducer.ProduceSync()` returning a single result with a nil record when the context is canceled, instead of one result per input record (with the record set) as the underlying franz-go client does. #15199
 * [BUGFIX] Alertmanager: Skip empty/zero config. #15184
 * [BUGFIX] Tracing: Respect `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` environment variables in `NewOTelFromEnv()`. Previously, the sampler was always hardcoded to `AlwaysSample()` when no Jaeger remote sampler was configured, making it impossible to control trace volume through standard OpenTelemetry configuration. #15128
 * [BUGFIX] API: Scope activity tracking middleware to query routes only, preventing it from rejecting write requests that have an unexpected `Content-Type` header with HTTP 500. #15129

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,7 @@
   * `-ingest-storage.kafka.max-buffered-bytes` from `100MB` to `1GB`
 * [ENHANCEMENT] MQE: Enable narrow selectors optimisation and hints passing for `and`/`unless` binary operation. #15096
 * [ENHANCEMENT] MQE: Use series selected for one side to reduce data selected on the other side in one-to-many and many-to-one binary operations (eg. `group_left` and `group_right`). #15137
+* [BUGFIX] Ingest storage: Fix `KafkaProducer.ProduceSync()` returning a single result with a nil record when the context is canceled, instead of one result per input record (with the record set) as the underlying franz-go client does. #15199
 * [BUGFIX] Alertmanager: Skip empty/zero config. #15184
 * [BUGFIX] Tracing: Respect `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` environment variables in `NewOTelFromEnv()`. Previously, the sampler was always hardcoded to `AlwaysSample()` when no Jaeger remote sampler was configured, making it impossible to control trace volume through standard OpenTelemetry configuration. #15128
 * [BUGFIX] API: Scope activity tracking middleware to query routes only, preventing it from rejecting write requests that have an unexpected `Content-Type` header with HTTP 500. #15129

--- a/pkg/storage/ingest/writer_client.go
+++ b/pkg/storage/ingest/writer_client.go
@@ -227,8 +227,11 @@ func (c *KafkaProducer) updateMetricsLoop() {
 // ProduceSync produces records to Kafka and returns once all records have been successfully committed,
 // or an error occurred.
 //
-// This function honors the configure max buffered bytes and refuse to produce a record, returning kgo.ErrMaxBuffered,
-// if the configured limit is reached.
+// This function honors the configured max buffered bytes: if the whole batch would not fit in the
+// remaining buffer space, none of the records are produced and every result is set to kgo.ErrMaxBuffered.
+// The admission is all-or-nothing per call (rather than per record) so that a partial in-buffer
+// acceptance does not turn into a wasted full retry from the caller, which fails the whole batch on
+// any error.
 //
 // On context cancellation/timeout after records have been handed to the Kafka client, the returned
 // results carry per-record errors but the Record on each result is a synthetic value with only the

--- a/pkg/storage/ingest/writer_client.go
+++ b/pkg/storage/ingest/writer_client.go
@@ -227,11 +227,13 @@ func (c *KafkaProducer) updateMetricsLoop() {
 // ProduceSync produces records to Kafka and returns once all records have been successfully committed,
 // or an error occurred.
 //
-// This function honors the configured max buffered bytes: if the whole batch would not fit in the
-// remaining buffer space, none of the records are produced and every result is set to kgo.ErrMaxBuffered.
-// The admission is all-or-nothing per call (rather than per record) so that a partial in-buffer
-// acceptance does not turn into a wasted full retry from the caller, which fails the whole batch on
-// any error.
+// This function honors the configure max buffered bytes and refuse to produce a record, returnin kgo.ErrMaxBuffered,
+// if the configured limit is reached.
+//
+// On context cancellation/timeout after records have been handed to the Kafka client, the returned
+// results carry per-record errors but the Record on each result is a synthetic value with only the
+// input partition set. Callers must not assume Record points back to the original input record or
+// that any field other than Partition is populated in that case.
 func (c *KafkaProducer) ProduceSync(ctx context.Context, records []*kgo.Record) kgo.ProduceResults {
 	var (
 		remaining = atomic.NewInt64(int64(len(records)))
@@ -258,30 +260,19 @@ func (c *KafkaProducer) ProduceSync(ctx context.Context, records []*kgo.Record) 
 		c.produceRecordsFailedTotal.WithLabelValues("cancelled-before-producing").Add(recordsCount)
 
 		// We wrap the error to make it cristal clear where the context canceled/timeout comes from.
-		return kgo.ProduceResults{{Err: errors.Wrap(context.Cause(ctx), "skipped producing Kafka records because context is already done")}}
+		// Records haven't been handed to the Kafka client yet, so the input record pointers are
+		// still safe to expose on the results.
+		return newFailedProduceResultsFromRecords(records, errors.Wrap(context.Cause(ctx), "skipped producing Kafka records because context is already done"))
 	}
 
-	c.produceRecordsEnqueuedTotal.Add(float64(len(records)))
-
-	// Reserve buffer space for the whole batch up front. If the reservation would exceed the configured
-	// limit, refund it and reject every record with kgo.ErrMaxBuffered. This makes admission all-or-nothing
-	// per call: callers retry the whole request on failure, so a partial in-buffer acceptance is wasted work.
-	if c.maxBufferedBytes > 0 {
-		var batchBytes int64
-		for _, record := range records {
-			batchBytes += int64(len(record.Value))
-		}
-
-		if c.bufferedBytes.Add(batchBytes) > c.maxBufferedBytes {
-			c.bufferedBytes.Add(-batchBytes)
-			c.produceRecordsFailedTotal.WithLabelValues(produceErrReason(kgo.ErrMaxBuffered)).Add(float64(len(records)))
-
-			rejected := make(kgo.ProduceResults, len(records))
-			for i, record := range records {
-				rejected[i] = kgo.ProduceResult{Record: record, Err: kgo.ErrMaxBuffered}
-			}
-			return rejected
-		}
+	// Snapshot each record's partition before handing the records off to the Kafka client.
+	// After Produce() is called, the client may concurrently mutate record fields (e.g. franz-go
+	// writes Record.Partition from its metadata-update goroutine), so we can no longer safely
+	// read from the input records. The snapshot is used to build per-record results on the
+	// post-Produce cancellation path, which is exactly where we abandon the in-flight callbacks.
+	recordPartitions := make([]int32, len(records))
+	for i, r := range records {
+		recordPartitions[i] = r.Partition
 	}
 
 	onProduceDone := func(r *kgo.Record, err error) {
@@ -310,8 +301,15 @@ func (c *KafkaProducer) ProduceSync(ctx context.Context, records []*kgo.Record) 
 	// data point when we troubleshoot high production latencies.
 	{
 		enqueueStartTime := time.Now()
+		c.produceRecordsEnqueuedTotal.Add(float64(len(records)))
 
 		for _, record := range records {
+			// Fast fail if the Kafka client buffer is full. Buffered bytes counter is decreased onProducerDone().
+			if c.maxBufferedBytes > 0 && c.bufferedBytes.Add(int64(len(record.Value))) > c.maxBufferedBytes {
+				onProduceDone(record, kgo.ErrMaxBuffered)
+				continue
+			}
+
 			// We use a new context to avoid that other Produce() may be cancelled when this call's context is
 			// canceled. It's important to note that cancelling the context passed to Produce() doesn't actually
 			// prevent the data to be sent over the wire (because it's never removed from the buffer) but in some
@@ -330,11 +328,36 @@ func (c *KafkaProducer) ProduceSync(ctx context.Context, records []*kgo.Record) 
 	select {
 	case <-ctx.Done():
 		// We wrap the error to make it cristal clear where the context canceled/timeout comes from.
-		return kgo.ProduceResults{{Err: errors.Wrap(context.Cause(ctx), "waiting for Kafka records to be produced and acknowledged")}}
+		// Records have already been handed to the Kafka client, so we can't expose the original
+		// record pointers on the results; build fresh records from the partition snapshot taken above.
+		return newFailedProduceResultsFromPartitions(recordPartitions, errors.Wrap(context.Cause(ctx), "waiting for Kafka records to be produced and acknowledged"))
 	case <-done:
 		// Once we're done, it's guaranteed that no more results will be appended, so we can safely return it.
 		return res
 	}
+}
+
+// newFailedProduceResultsFromRecords builds a kgo.ProduceResults that reports the given error
+// for each input record, exposing the input record pointer on each result. Only safe to call
+// while the caller still owns the records (i.e. before handing them to the Kafka client);
+// otherwise use newFailedProduceResultsFromPartitions to avoid racing with the client.
+func newFailedProduceResultsFromRecords(records []*kgo.Record, err error) kgo.ProduceResults {
+	results := make(kgo.ProduceResults, 0, len(records))
+	for _, record := range records {
+		results = append(results, kgo.ProduceResult{Record: record, Err: err})
+	}
+	return results
+}
+
+// newFailedProduceResultsFromPartitions is like newFailedProduceResultsFromRecords but allocates
+// fresh kgo.Record values carrying just the given partition, so it's safe to use when the
+// original records have been handed to the Kafka client and may still be mutated by it.
+func newFailedProduceResultsFromPartitions(partitions []int32, err error) kgo.ProduceResults {
+	results := make(kgo.ProduceResults, 0, len(partitions))
+	for _, partition := range partitions {
+		results = append(results, kgo.ProduceResult{Record: &kgo.Record{Partition: partition}, Err: err})
+	}
+	return results
 }
 
 func produceErrReason(err error) string {

--- a/pkg/storage/ingest/writer_client.go
+++ b/pkg/storage/ingest/writer_client.go
@@ -227,7 +227,7 @@ func (c *KafkaProducer) updateMetricsLoop() {
 // ProduceSync produces records to Kafka and returns once all records have been successfully committed,
 // or an error occurred.
 //
-// This function honors the configure max buffered bytes and refuse to produce a record, returnin kgo.ErrMaxBuffered,
+// This function honors the configure max buffered bytes and refuse to produce a record, returning kgo.ErrMaxBuffered,
 // if the configured limit is reached.
 //
 // On context cancellation/timeout after records have been handed to the Kafka client, the returned
@@ -263,6 +263,29 @@ func (c *KafkaProducer) ProduceSync(ctx context.Context, records []*kgo.Record) 
 		// Records haven't been handed to the Kafka client yet, so the input record pointers are
 		// still safe to expose on the results.
 		return newFailedProduceResultsFromRecords(records, errors.Wrap(context.Cause(ctx), "skipped producing Kafka records because context is already done"))
+	}
+
+	c.produceRecordsEnqueuedTotal.Add(float64(len(records)))
+
+	// Reserve buffer space for the whole batch up front. If the reservation would exceed the configured
+	// limit, refund it and reject every record with kgo.ErrMaxBuffered. This makes admission all-or-nothing
+	// per call: callers retry the whole request on failure, so a partial in-buffer acceptance is wasted work.
+	if c.maxBufferedBytes > 0 {
+		var batchBytes int64
+		for _, record := range records {
+			batchBytes += int64(len(record.Value))
+		}
+
+		if c.bufferedBytes.Add(batchBytes) > c.maxBufferedBytes {
+			c.bufferedBytes.Add(-batchBytes)
+			c.produceRecordsFailedTotal.WithLabelValues(produceErrReason(kgo.ErrMaxBuffered)).Add(float64(len(records)))
+
+			rejected := make(kgo.ProduceResults, len(records))
+			for i, record := range records {
+				rejected[i] = kgo.ProduceResult{Record: record, Err: kgo.ErrMaxBuffered}
+			}
+			return rejected
+		}
 	}
 
 	// Snapshot each record's partition before handing the records off to the Kafka client.
@@ -301,15 +324,8 @@ func (c *KafkaProducer) ProduceSync(ctx context.Context, records []*kgo.Record) 
 	// data point when we troubleshoot high production latencies.
 	{
 		enqueueStartTime := time.Now()
-		c.produceRecordsEnqueuedTotal.Add(float64(len(records)))
 
 		for _, record := range records {
-			// Fast fail if the Kafka client buffer is full. Buffered bytes counter is decreased onProducerDone().
-			if c.maxBufferedBytes > 0 && c.bufferedBytes.Add(int64(len(record.Value))) > c.maxBufferedBytes {
-				onProduceDone(record, kgo.ErrMaxBuffered)
-				continue
-			}
-
 			// We use a new context to avoid that other Produce() may be cancelled when this call's context is
 			// canceled. It's important to note that cancelling the context passed to Produce() doesn't actually
 			// prevent the data to be sent over the wire (because it's never removed from the buffer) but in some

--- a/pkg/storage/ingest/writer_client.go
+++ b/pkg/storage/ingest/writer_client.go
@@ -255,7 +255,7 @@ func (c *KafkaProducer) ProduceSync(ctx context.Context, records []*kgo.Record) 
 		c.produceRecordsFailedTotal.WithLabelValues("cancelled-before-producing").Add(recordsCount)
 
 		// We wrap the error to make it cristal clear where the context canceled/timeout comes from.
-		return kgo.ProduceResults{{Err: errors.Wrap(context.Cause(ctx), "skipped producing Kafka records because context is already done")}}
+		return produceResultsForErr(records, errors.Wrap(context.Cause(ctx), "skipped producing Kafka records because context is already done"))
 	}
 
 	onProduceDone := func(r *kgo.Record, err error) {
@@ -311,11 +311,22 @@ func (c *KafkaProducer) ProduceSync(ctx context.Context, records []*kgo.Record) 
 	select {
 	case <-ctx.Done():
 		// We wrap the error to make it cristal clear where the context canceled/timeout comes from.
-		return kgo.ProduceResults{{Err: errors.Wrap(context.Cause(ctx), "waiting for Kafka records to be produced and acknowledged")}}
+		return produceResultsForErr(records, errors.Wrap(context.Cause(ctx), "waiting for Kafka records to be produced and acknowledged"))
 	case <-done:
 		// Once we're done, it's guaranteed that no more results will be appended, so we can safely return it.
 		return res
 	}
+}
+
+// produceResultsForErr returns a kgo.ProduceResults with one entry per input record,
+// each with its Record set and the given error. This matches the behaviour of
+// kgo.Client.ProduceSync, which always returns one result per input record.
+func produceResultsForErr(records []*kgo.Record, err error) kgo.ProduceResults {
+	results := make(kgo.ProduceResults, 0, len(records))
+	for _, record := range records {
+		results = append(results, kgo.ProduceResult{Record: record, Err: err})
+	}
+	return results
 }
 
 func produceErrReason(err error) string {

--- a/pkg/storage/ingest/writer_client_test.go
+++ b/pkg/storage/ingest/writer_client_test.go
@@ -5,6 +5,7 @@ package ingest
 import (
 	"context"
 	"crypto/rand"
+	"errors"
 	"strings"
 	"sync"
 	"testing"
@@ -250,61 +251,149 @@ func TestKafkaProducer_ProduceSync_ShouldCircuitBreakIfContextIsDone(t *testing.
 	require.Equal(t, float64(0), *histogram.SampleSum)
 }
 
-func TestKafkaProducer_ProduceSync_ShouldRejectWholeBatchIfBufferIsFull(t *testing.T) {
+func TestKafkaProducer_ProduceSync_ShouldReturnOneResultPerRecordOnContextCancellation(t *testing.T) {
 	const (
 		numPartitions = 1
 		topicName     = "test"
-		recordValue   = "1234567890"
 	)
 
-	_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
+	t.Run("context is already done before producing", func(t *testing.T) {
+		_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
 
-	cfg := createTestKafkaConfig(clusterAddr, topicName)
-	// Set the limit lower than the size of a 3-record batch so the batch must be rejected as a whole.
-	cfg.ProducerMaxBufferedBytes = int64(2 * len(recordValue))
+		cfg := createTestKafkaConfig(clusterAddr, topicName)
+		reg := prometheus.NewPedanticRegistry()
+		prefixedReg := prometheus.WrapRegistererWithPrefix(writerMetricsPrefix, reg)
 
-	reg := prometheus.NewPedanticRegistry()
-	prefixedReg := prometheus.WrapRegistererWithPrefix(writerMetricsPrefix, reg)
+		client, err := NewKafkaWriterClient(cfg, defaultMaxInflightProduceRequests, log.NewNopLogger(), prefixedReg)
+		require.NoError(t, err)
 
-	client, err := NewKafkaWriterClient(cfg, 1, log.NewNopLogger(), prefixedReg)
-	require.NoError(t, err)
+		producer := NewKafkaProducer(client, cfg.ProducerMaxBufferedBytes, prefixedReg)
+		t.Cleanup(producer.Close)
 
-	producer := NewKafkaProducer(client, cfg.ProducerMaxBufferedBytes, prefixedReg)
-	t.Cleanup(producer.Close)
+		// Cancel the context before producing.
+		cancelCtx, cancel := context.WithCancel(context.Background())
+		cancel()
 
-	batch := []*kgo.Record{
-		{Key: []byte("test"), Value: []byte(recordValue)},
-		{Key: []byte("test"), Value: []byte(recordValue)},
-		{Key: []byte("test"), Value: []byte(recordValue)},
-	}
+		records := []*kgo.Record{
+			{Key: []byte("key-1"), Value: []byte("message 1")},
+			{Key: []byte("key-2"), Value: []byte("message 2")},
+		}
+		res := producer.ProduceSync(cancelCtx, records)
 
-	res := producer.ProduceSync(context.Background(), batch)
-	require.Len(t, res, len(batch))
-	for i, r := range res {
-		require.ErrorIsf(t, r.Err, kgo.ErrMaxBuffered, "result[%d] should be ErrMaxBuffered", i)
-		require.Same(t, batch[i], r.Record, "result[%d] should reference the original record", i)
-	}
+		// We expect one result per input record, each with its Record set and the cancellation error.
+		require.Len(t, res, len(records))
+		for i, r := range res {
+			assert.Same(t, records[i], r.Record)
+			assert.ErrorIs(t, r.Err, context.Canceled)
+		}
+	})
 
-	// No record should be buffered in the Kafka client (none was produced).
-	require.Equal(t, int64(0), producer.BufferedProduceRecords())
-	require.Equal(t, int64(0), producer.bufferedBytes.Load())
+	t.Run("context is already done before producing with a non-Canceled cause", func(t *testing.T) {
+		_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
 
-	// Every record in the rejected batch should be counted as enqueued and as failed with reason "buffer-full".
-	assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
-		# HELP cortex_ingest_storage_writer_produce_records_enqueued_total Total number of Kafka records enqueued to be sent to the Kafka backend (includes records that fail to be successfully sent to the Kafka backend).
-		# TYPE cortex_ingest_storage_writer_produce_records_enqueued_total counter
-		cortex_ingest_storage_writer_produce_records_enqueued_total 3
+		cfg := createTestKafkaConfig(clusterAddr, topicName)
+		reg := prometheus.NewPedanticRegistry()
+		prefixedReg := prometheus.WrapRegistererWithPrefix(writerMetricsPrefix, reg)
 
-		# HELP cortex_ingest_storage_writer_produce_records_failed_total Total number of Kafka records that failed to be sent to the Kafka backend.
-		# TYPE cortex_ingest_storage_writer_produce_records_failed_total counter
-		cortex_ingest_storage_writer_produce_records_failed_total{reason="buffer-full"} 3
-	`),
-		"cortex_ingest_storage_writer_produce_records_enqueued_total",
-		"cortex_ingest_storage_writer_produce_records_failed_total"))
+		client, err := NewKafkaWriterClient(cfg, defaultMaxInflightProduceRequests, log.NewNopLogger(), prefixedReg)
+		require.NoError(t, err)
 
-	// A subsequent batch that fits in the buffer should succeed.
-	res = producer.ProduceSync(context.Background(), []*kgo.Record{{Key: []byte("test"), Value: []byte(recordValue)}})
-	require.NoError(t, res.FirstErr())
+		producer := NewKafkaProducer(client, cfg.ProducerMaxBufferedBytes, prefixedReg)
+		t.Cleanup(producer.Close)
+
+		// Cancel the context before producing, with a custom cause that wraps something other than context.Canceled.
+		customCause := errors.New("custom cancellation cause")
+		cancelCtx, cancel := context.WithCancelCause(context.Background())
+		cancel(customCause)
+
+		records := []*kgo.Record{
+			{Key: []byte("key-1"), Value: []byte("message 1")},
+			{Key: []byte("key-2"), Value: []byte("message 2")},
+		}
+		res := producer.ProduceSync(cancelCtx, records)
+
+		// We expect one result per input record, each with its Record set and the custom cause as the underlying error.
+		require.Len(t, res, len(records))
+		for i, r := range res {
+			assert.Same(t, records[i], r.Record)
+			assert.ErrorIs(t, r.Err, customCause)
+		}
+	})
+
+	t.Run("context is canceled while waiting for produce results", func(t *testing.T) {
+		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
+
+		// Block Produce requests until the test unblocks them, so we have time to cancel the context
+		// after records have been buffered.
+		unblockProduceRequests := make(chan struct{})
+		t.Cleanup(func() {
+			// Make sure goroutines blocked on the Kafka cluster are released even if the test fails early.
+			select {
+			case <-unblockProduceRequests:
+			default:
+				close(unblockProduceRequests)
+			}
+		})
+		cluster.ControlKey(int16(kmsg.Produce), func(_ kmsg.Request) (kmsg.Response, error, bool) {
+			<-unblockProduceRequests
+			return nil, nil, false
+		})
+
+		cfg := createTestKafkaConfig(clusterAddr, topicName)
+		reg := prometheus.NewPedanticRegistry()
+		prefixedReg := prometheus.WrapRegistererWithPrefix(writerMetricsPrefix, reg)
+
+		client, err := NewKafkaWriterClient(cfg, defaultMaxInflightProduceRequests, log.NewNopLogger(), prefixedReg)
+		require.NoError(t, err)
+
+		producer := NewKafkaProducer(client, cfg.ProducerMaxBufferedBytes, prefixedReg)
+		t.Cleanup(producer.Close)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		records := []*kgo.Record{
+			{Key: []byte("key-1"), Value: []byte("message 1")},
+			{Key: []byte("key-2"), Value: []byte("message 2")},
+		}
+
+		// Snapshot the input partitions so the assertions below don't read the live records,
+		// which the Kafka client may concurrently mutate after Produce() has been called.
+		expectedPartitions := make([]int32, len(records))
+		for i, r := range records {
+			expectedPartitions[i] = r.Partition
+		}
+
+		// Run ProduceSync in a goroutine and cancel the context once records are buffered in the Kafka client.
+		resCh := make(chan kgo.ProduceResults, 1)
+		go func() {
+			resCh <- producer.ProduceSync(ctx, records)
+		}()
+
+		require.Eventually(t, func() bool {
+			return producer.BufferedProduceRecords() == int64(len(records))
+		}, 5*time.Second, 10*time.Millisecond)
+
+		cancel()
+
+		var res kgo.ProduceResults
+		select {
+		case res = <-resCh:
+		case <-time.After(5 * time.Second):
+			t.Fatal("ProduceSync did not return after context cancellation")
+		}
+
+		// We expect one result per input record, each with a non-nil Record carrying the input
+		// partition and the cancellation error. We don't assert pointer equality here: once
+		// records have been handed to the Kafka client, it may concurrently mutate them, so
+		// ProduceSync exposes synthetic records to avoid racing with the client.
+		require.Len(t, res, len(records))
+		for i, r := range res {
+			require.NotNil(t, r.Record)
+			assert.Equal(t, expectedPartitions[i], r.Record.Partition)
+			assert.ErrorIs(t, r.Err, context.Canceled)
+		}
+	})
 }
 
 func TestKafkaProducer_ProduceSync_LatencyShouldBeDrivenByKafkaProduceLatency(t *testing.T) {

--- a/pkg/storage/ingest/writer_client_test.go
+++ b/pkg/storage/ingest/writer_client_test.go
@@ -251,6 +251,63 @@ func TestKafkaProducer_ProduceSync_ShouldCircuitBreakIfContextIsDone(t *testing.
 	require.Equal(t, float64(0), *histogram.SampleSum)
 }
 
+func TestKafkaProducer_ProduceSync_ShouldRejectWholeBatchIfBufferIsFull(t *testing.T) {
+	const (
+		numPartitions = 1
+		topicName     = "test"
+		recordValue   = "1234567890"
+	)
+
+	_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
+
+	cfg := createTestKafkaConfig(clusterAddr, topicName)
+	// Set the limit lower than the size of a 3-record batch so the batch must be rejected as a whole.
+	cfg.ProducerMaxBufferedBytes = int64(2 * len(recordValue))
+
+	reg := prometheus.NewPedanticRegistry()
+	prefixedReg := prometheus.WrapRegistererWithPrefix(writerMetricsPrefix, reg)
+
+	client, err := NewKafkaWriterClient(cfg, 1, log.NewNopLogger(), prefixedReg)
+	require.NoError(t, err)
+
+	producer := NewKafkaProducer(client, cfg.ProducerMaxBufferedBytes, prefixedReg)
+	t.Cleanup(producer.Close)
+
+	batch := []*kgo.Record{
+		{Key: []byte("test"), Value: []byte(recordValue)},
+		{Key: []byte("test"), Value: []byte(recordValue)},
+		{Key: []byte("test"), Value: []byte(recordValue)},
+	}
+
+	res := producer.ProduceSync(context.Background(), batch)
+	require.Len(t, res, len(batch))
+	for i, r := range res {
+		require.ErrorIsf(t, r.Err, kgo.ErrMaxBuffered, "result[%d] should be ErrMaxBuffered", i)
+		require.Same(t, batch[i], r.Record, "result[%d] should reference the original record", i)
+	}
+
+	// No record should be buffered in the Kafka client (none was produced).
+	require.Equal(t, int64(0), producer.BufferedProduceRecords())
+	require.Equal(t, int64(0), producer.bufferedBytes.Load())
+
+	// Every record in the rejected batch should be counted as enqueued and as failed with reason "buffer-full".
+	assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
+		# HELP cortex_ingest_storage_writer_produce_records_enqueued_total Total number of Kafka records enqueued to be sent to the Kafka backend (includes records that fail to be successfully sent to the Kafka backend).
+		# TYPE cortex_ingest_storage_writer_produce_records_enqueued_total counter
+		cortex_ingest_storage_writer_produce_records_enqueued_total 3
+
+		# HELP cortex_ingest_storage_writer_produce_records_failed_total Total number of Kafka records that failed to be sent to the Kafka backend.
+		# TYPE cortex_ingest_storage_writer_produce_records_failed_total counter
+		cortex_ingest_storage_writer_produce_records_failed_total{reason="buffer-full"} 3
+	`),
+		"cortex_ingest_storage_writer_produce_records_enqueued_total",
+		"cortex_ingest_storage_writer_produce_records_failed_total"))
+
+	// A subsequent batch that fits in the buffer should succeed.
+	res = producer.ProduceSync(context.Background(), []*kgo.Record{{Key: []byte("test"), Value: []byte(recordValue)}})
+	require.NoError(t, res.FirstErr())
+}
+
 func TestKafkaProducer_ProduceSync_ShouldReturnOneResultPerRecordOnContextCancellation(t *testing.T) {
 	const (
 		numPartitions = 1

--- a/pkg/storage/ingest/writer_client_test.go
+++ b/pkg/storage/ingest/writer_client_test.go
@@ -250,6 +250,108 @@ func TestKafkaProducer_ProduceSync_ShouldCircuitBreakIfContextIsDone(t *testing.
 	require.Equal(t, float64(0), *histogram.SampleSum)
 }
 
+func TestKafkaProducer_ProduceSync_ShouldReturnOneResultPerRecordOnContextCancellation(t *testing.T) {
+	const (
+		numPartitions = 1
+		topicName     = "test"
+	)
+
+	t.Run("context is already done before producing", func(t *testing.T) {
+		_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
+
+		cfg := createTestKafkaConfig(clusterAddr, topicName)
+		reg := prometheus.NewPedanticRegistry()
+		prefixedReg := prometheus.WrapRegistererWithPrefix(writerMetricsPrefix, reg)
+
+		client, err := NewKafkaWriterClient(cfg, defaultMaxInflightProduceRequests, log.NewNopLogger(), prefixedReg)
+		require.NoError(t, err)
+
+		producer := NewKafkaProducer(client, cfg.ProducerMaxBufferedBytes, prefixedReg)
+		t.Cleanup(producer.Close)
+
+		// Cancel the context before producing.
+		cancelCtx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		records := []*kgo.Record{
+			{Key: []byte("key-1"), Value: []byte("message 1")},
+			{Key: []byte("key-2"), Value: []byte("message 2")},
+		}
+		res := producer.ProduceSync(cancelCtx, records)
+
+		// We expect one result per input record, each with its Record set and the cancellation error.
+		require.Len(t, res, len(records))
+		for i, r := range res {
+			assert.Same(t, records[i], r.Record)
+			assert.ErrorIs(t, r.Err, context.Canceled)
+		}
+	})
+
+	t.Run("context is canceled while waiting for produce results", func(t *testing.T) {
+		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
+
+		// Block Produce requests until the test unblocks them, so we have time to cancel the context
+		// after records have been buffered.
+		unblockProduceRequests := make(chan struct{})
+		t.Cleanup(func() {
+			// Make sure goroutines blocked on the Kafka cluster are released even if the test fails early.
+			select {
+			case <-unblockProduceRequests:
+			default:
+				close(unblockProduceRequests)
+			}
+		})
+		cluster.ControlKey(int16(kmsg.Produce), func(_ kmsg.Request) (kmsg.Response, error, bool) {
+			<-unblockProduceRequests
+			return nil, nil, false
+		})
+
+		cfg := createTestKafkaConfig(clusterAddr, topicName)
+		reg := prometheus.NewPedanticRegistry()
+		prefixedReg := prometheus.WrapRegistererWithPrefix(writerMetricsPrefix, reg)
+
+		client, err := NewKafkaWriterClient(cfg, defaultMaxInflightProduceRequests, log.NewNopLogger(), prefixedReg)
+		require.NoError(t, err)
+
+		producer := NewKafkaProducer(client, cfg.ProducerMaxBufferedBytes, prefixedReg)
+		t.Cleanup(producer.Close)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		records := []*kgo.Record{
+			{Key: []byte("key-1"), Value: []byte("message 1")},
+			{Key: []byte("key-2"), Value: []byte("message 2")},
+		}
+
+		// Run ProduceSync in a goroutine and cancel the context once records are buffered in the Kafka client.
+		resCh := make(chan kgo.ProduceResults, 1)
+		go func() {
+			resCh <- producer.ProduceSync(ctx, records)
+		}()
+
+		require.Eventually(t, func() bool {
+			return producer.BufferedProduceRecords() == int64(len(records))
+		}, 5*time.Second, 10*time.Millisecond)
+
+		cancel()
+
+		var res kgo.ProduceResults
+		select {
+		case res = <-resCh:
+		case <-time.After(5 * time.Second):
+			t.Fatal("ProduceSync did not return after context cancellation")
+		}
+
+		// We expect one result per input record, each with its Record set and the cancellation error.
+		require.Len(t, res, len(records))
+		for i, r := range res {
+			assert.Same(t, records[i], r.Record)
+			assert.ErrorIs(t, r.Err, context.Canceled)
+		}
+	})
+}
+
 func TestKafkaProducer_ProduceSync_LatencyShouldBeDrivenByKafkaProduceLatency(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What this PR does

Fixes `KafkaProducer.ProduceSync` (in `pkg/storage/ingest`) so it returns one `kgo.ProduceResult` per input record (each with its `Record` field populated) when the context is canceled, matching the contract of franz-go's `kgo.Client.ProduceSync`.

Previously, on both early-cancel paths — context already done before producing, and context canceled while waiting for results — `ProduceSync` returned a single result with a nil `Record`, regardless of how many records were passed in.

The same divergence was recently fixed in Loki: grafana/loki#21702. Credit to @grobinson-grafana for spotting it.

**Real impact**:

The bug is mostly latent today, but it does cause one user-visible regression:

- **Error messages on Kafka write timeouts lose the failing partitions list.** `Writer.MultiWriteSync` calls `produceResultsErr`, which builds the failed-partitions list from `res.Record.Partition`. Because `Record` is nil on the buggy paths, the error returned to the distributor reads `failed to write to partitions []: waiting for Kafka records to be produced and acknowledged: context canceled` — instead of listing the partitions actually affected. This makes troubleshooting ingest-storage write failures harder when the context is canceled mid-flight (e.g. client disconnect, request timeout).

It is also a foot-gun for any future caller that — reasonably — assumes franz-go semantics and inspects results per record.

What is **not** affected:

- Metrics: `produceRecordsFailedTotal` is incremented from `onProduceDone` (per-record path) and from the `cancelled-before-producing` branch with the full record count, both unaffected by the result shape.
- Other `ProduceSync` callers in `pkg/usagetracker` and the read-consistency test use `*kgo.Client.ProduceSync` directly (not the Mimir wrapper), so they were never affected.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
