### PR TITLE
distributor: fix data race in TestDistributor_ActiveSeries_AvailabilityAndConsistency

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -3242,7 +3242,9 @@ func TestDistributor_ActiveSeries_AvailabilityAndConsistency(t *testing.T) {
 		ingesterStateByZone map[string]ingesterZoneState
 		ingesterDataByZone  map[string][]*mimirpb.WriteRequest
 		shardSize           int
-		limits              *validation.Limits
+		// limitsFn must return a fresh *validation.Limits per call: prepare mutates
+		// fields on it, and parallel sub-tests sharing the same pointer would race.
+		limitsFn            func() *validation.Limits
 		expectedSeriesCount int
 		expectedErr         error
 	}{
@@ -3582,11 +3584,11 @@ func TestDistributor_ActiveSeries_AvailabilityAndConsistency(t *testing.T) {
 					makeWriteRequest(0, 1, 0, false, false, "series_1", "series_2", "series_3"),
 				},
 			},
-			limits: func() *validation.Limits {
+			limitsFn: func() *validation.Limits {
 				limits := prepareDefaultLimits()
 				limits.ActiveSeriesResultsMaxSizeBytes = 1
 				return limits
-			}(),
+			},
 			expectedErr: ErrResponseTooLarge,
 		},
 	}
@@ -3608,8 +3610,8 @@ func TestDistributor_ActiveSeries_AvailabilityAndConsistency(t *testing.T) {
 							config.MinimizeIngesterRequests = minimizeIngesterRequests
 						},
 					}
-					if testData.limits != nil {
-						cfg.limits = testData.limits
+					if testData.limitsFn != nil {
+						cfg.limits = testData.limitsFn()
 					}
 
 					// Create distributor.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

The "limits errors are propagated" case stored a single `*validation.Limits` literal in the test map, then two parallel sub-tests (`minimizeIngesterRequests` `true`/`false`) shared that pointer through prepare, which writes `IngestionTenantShardSize` on it. This would be a cause of test flakiness due to inherent raciness.

Replace the shared `*validation.Limits` field with a factory `func() *Limits` so each parallel sub-test allocates its own instance.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that avoids sharing a mutable `*validation.Limits` across parallel subtests; no production code behavior changes.
> 
> **Overview**
> Fixes a data race in `TestDistributor_ActiveSeries_AvailabilityAndConsistency` by replacing the shared `*validation.Limits` test case field with a `limitsFn` factory so each parallel subtest gets its own limits instance.
> 
> Updates the affected "limits errors are propagated" case and the test setup to call `limitsFn()` when configuring `prepConfig.limits`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6642c796790c4ea7eff7f18e56f4ce9666c86a6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->