### PR TITLE
Fix htttp:// typo in development README

### DIFF
--- a/development/README.md
+++ b/development/README.md
@@ -15,7 +15,7 @@ Choose a sub-folder for whichever Mimir deployment mode you want to run. Then, t
 ./compose-up.sh
 ```
 
-This should give you a running Mimir system with Grafana available at [htttp://localhost:3000](http://localhost:3000), and other Mimir service UIs available via different ports (check `docker ps` for exact ports).
+This should give you a running Mimir system with Grafana available at [http://localhost:3000](http://localhost:3000), and other Mimir service UIs available via different ports (check `docker ps` for exact ports).
 
 The Minio console is available in most dev environments at [http://localhost:9001](http://localhost:9001), with the credentials defined in [mimir.yaml][minio-creds].
 


### PR DESCRIPTION
Line 18 of `development/README.md` has `htttp://localhost:3000` (extra t) as the displayed link text. The link target itself was correct (`http://localhost:3000`), so the link worked, but the visible text shown to developers reading the dev docs was wrong. The next paragraph already uses the correct `http://localhost:9001` form for the Minio console.

Per CLAUDE.md: this is a developer-facing dev README only, not user-visible, so no CHANGELOG entry needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; corrects displayed URL text without affecting any runtime behavior.
> 
> **Overview**
> Fixes a typo in `development/README.md` where the Grafana link text was shown as `htttp://localhost:3000`, updating it to the correct `http://localhost:3000`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a685512ac3582d561633fc395ce78930be10a1e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->