### PR TITLE
Unify secret_access_key and access_key_id  order

### DIFF
--- a/docs/sources/mimir/configure/configure-object-storage-backend.md
+++ b/docs/sources/mimir/configure/configure-object-storage-backend.md
@@ -65,8 +65,8 @@ common:
     s3:
       endpoint: s3.us-east-2.amazonaws.com
       region: us-east-2
-      secret_access_key: "${AWS_SECRET_ACCESS_KEY}" # This is a secret injected via an environment variable
       access_key_id: "${AWS_ACCESS_KEY_ID}" # This is a secret injected via an environment variable
+      secret_access_key: "${AWS_SECRET_ACCESS_KEY}" # This is a secret injected via an environment variable
 
 blocks_storage:
   s3:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that reorders S3 credential keys in an example; no runtime behavior changes.
> 
> **Overview**
> Updates the S3 YAML example in `configure-object-storage-backend.md` to consistently list `access_key_id` before `secret_access_key`, aligning the credential key order across docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dee9306b4c827016482fcab92480d71871baf5a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->