### PR TITLE
Fix ingest reader readiness on Kafka errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [BUGFIX] Compactor, Store-gateway: Fix the store-gateway always logging `num_series=0` in its `loaded new block` message. #16276
 * [BUGFIX] Ingest storage: Account for protobuf framing when splitting Remote Write 1.0 requests so generated Kafka record data stays within `-ingest-storage.kafka.producer-max-record-size-bytes` when individual series and metadata entries fit. #16160
 * [BUGFIX] Memcached: Don't close connections to caches on well-formed server errors. #16303
+* [BUGFIX] Ingester: Report the ingester as not ready when the ingest storage reader is unable to fetch Kafka offsets or commit consumed offsets. #15222
 
 ### Mixin
 

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -977,6 +977,11 @@ func (i *Ingester) CheckReady(ctx context.Context) error {
 	if err := i.checkAvailableForRead(); err != nil {
 		return fmt.Errorf("ingester not ready for reads: %v", err)
 	}
+	if i.ingestReader != nil {
+		if err := i.ingestReader.CheckReady(); err != nil {
+			return fmt.Errorf("ingester not ready for ingest storage reads: %w", err)
+		}
+	}
 	return i.lifecycler.CheckReady(ctx)
 }
 

--- a/pkg/ingester/ingester_ingest_storage_test.go
+++ b/pkg/ingester/ingester_ingest_storage_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kfake"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
@@ -500,6 +501,70 @@ func TestIngester_QueryStream_IngestStorageReadConsistency(t *testing.T) {
 			assert.Len(t, queryRes, testData.expectedQueriedSeries)
 		})
 	}
+}
+
+func TestIngester_CheckReadyFailsWhenIngestStorageReaderCannotFetchKafkaOffsets(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	cfg := defaultIngesterTestConfig(t)
+	overrides := validation.NewOverrides(defaultLimitsTestConfig(), nil)
+	ingester, kafkaCluster, _ := createTestIngesterWithIngestStorage(t, &cfg, overrides, nil, prometheus.NewPedanticRegistry(), util_test.NewTestingLogger(t))
+
+	require.NoError(t, services.StartAndAwaitRunning(ctx, ingester))
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, ingester))
+	})
+
+	test.Poll(t, 5*time.Second, nil, func() interface{} {
+		return ingester.CheckReady(ctx)
+	})
+
+	failListOffsets := atomic.NewBool(true)
+	kafkaCluster.ControlKey(int16(kmsg.ListOffsets), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+		kafkaCluster.KeepControl()
+
+		req := kreq.(*kmsg.ListOffsetsRequest)
+		for _, topic := range req.Topics {
+			for _, partition := range topic.Partitions {
+				if partition.Timestamp != -1 {
+					return nil, nil, false
+				}
+			}
+		}
+
+		if !failListOffsets.Load() {
+			return nil, nil, false
+		}
+
+		res := req.ResponseKind().(*kmsg.ListOffsetsResponse)
+		for _, topic := range req.Topics {
+			resTopic := kmsg.NewListOffsetsResponseTopic()
+			resTopic.Topic = topic.Topic
+
+			for _, partition := range topic.Partitions {
+				resPartition := kmsg.NewListOffsetsResponseTopicPartition()
+				resPartition.Partition = partition.Partition
+				resPartition.ErrorCode = kerr.UnknownTopicOrPartition.Code
+				resTopic.Partitions = append(resTopic.Partitions, resPartition)
+			}
+
+			res.Topics = append(res.Topics, resTopic)
+		}
+
+		return res, nil, true
+	})
+
+	test.Poll(t, 5*time.Second, true, func() interface{} {
+		err := ingester.CheckReady(ctx)
+		return err != nil && errors.Is(err, kerr.UnknownTopicOrPartition)
+	})
+
+	failListOffsets.Store(false)
+	test.Poll(t, 5*time.Second, nil, func() interface{} {
+		return ingester.CheckReady(ctx)
+	})
 }
 
 // encodeSingleClusterReadConsistencyOffsets encodes single-cluster read consistency offsets (one offset

--- a/pkg/storage/ingest/multi_cluster_reader.go
+++ b/pkg/storage/ingest/multi_cluster_reader.go
@@ -235,6 +235,24 @@ func (r *MultiClusterPartitionReader) EnforceReadMaxDelay(maxDelay time.Duration
 	return errs.Err()
 }
 
+// CheckReady returns an error if the multi-cluster reader itself, or any Kafka cluster's reader, is not
+// ready to consume records. The ingester is ready only when all Kafka clusters are. The multi-cluster
+// reader owns state that the per-cluster readers don't (for example the heap merger), so its own service
+// state is checked too: it can fail while the per-cluster readers are still running.
+func (r *MultiClusterPartitionReader) CheckReady() error {
+	if state := r.State(); state != services.Running {
+		return fmt.Errorf("multi-cluster partition reader service is not running (state: %s)", state.String())
+	}
+
+	var errs multierror.MultiError
+	for kafkaClusterID, reader := range r.readers {
+		if err := reader.CheckReady(); err != nil {
+			errs.Add(errors.Wrapf(err, "write compartment %d", kafkaClusterID))
+		}
+	}
+	return errs.Err()
+}
+
 // WaitReadConsistencyUntilOffsets waits, for every Kafka cluster in parallel, until that cluster's reader
 // has consumed up to its own offset. The offsets must cover exactly one offset per Kafka cluster; a
 // mismatch is an invariant violation by the caller. Each per-cluster offset is forwarded to that cluster's

--- a/pkg/storage/ingest/multi_cluster_reader_test.go
+++ b/pkg/storage/ingest/multi_cluster_reader_test.go
@@ -180,6 +180,37 @@ func multiClusterTestOffsetFilePath(t *testing.T) string {
 	return filepath.Join(t.TempDir(), "kafka-offset-wc-"+compartments.WriteCompartmentIDPlaceholder+".json")
 }
 
+// Asserts that the multi-cluster reader reports its own service state, and not just the per-cluster
+// readers' state. The multi-cluster reader owns state the per-cluster readers don't (for example the heap
+// merger), so it can stop or fail while every per-cluster reader is still running.
+func TestMultiClusterPartitionReader_CheckReady(t *testing.T) {
+	const (
+		readTopic   = "ingest-rc-0"
+		partitionID = int32(0)
+	)
+
+	ctx := context.Background()
+
+	_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, readTopic)
+	clusterConfigs := []KafkaConfig{createTestKafkaConfig(clusterAddr, readTopic), createTestKafkaConfig(clusterAddr, readTopic)}
+
+	reader, err := NewMultiClusterPartitionReader(clusterConfigs, OrderedConsumptionConfig{}, partitionID, "ingester-0", multiClusterTestOffsetFilePath(t), pusherFunc(func(context.Context, *mimirpb.WriteRequest) error { return nil }), log.NewNopLogger(), prometheus.NewPedanticRegistry())
+	require.NoError(t, err)
+
+	// Not started yet, so not ready. No per-cluster reader has failed: the error comes from the
+	// multi-cluster reader's own state.
+	require.ErrorContains(t, reader.CheckReady(), "multi-cluster partition reader service is not running")
+
+	require.NoError(t, services.StartAndAwaitRunning(ctx, reader))
+	t.Cleanup(func() { require.NoError(t, services.StopAndAwaitTerminated(ctx, reader)) })
+
+	require.NoError(t, reader.CheckReady())
+
+	// Once stopped, it's not ready again, even though every per-cluster reader stopped cleanly.
+	require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
+	require.ErrorContains(t, reader.CheckReady(), "multi-cluster partition reader service is not running")
+}
+
 func TestMultiClusterPartitionReader_WaitReadConsistencyUntilOffsets_RejectsKafkaClusterCountMismatch(t *testing.T) {
 	const (
 		readTopic   = "ingest-rc-0"

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -8,6 +8,7 @@ import (
 	"iter"
 	"math"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/go-kit/log"
@@ -85,6 +86,9 @@ type PartitionReader interface {
 	// WaitReadConsistencyUntilLastProducedOffset waits until the reader has caught up with the
 	// last-produced offset of every Kafka cluster.
 	WaitReadConsistencyUntilLastProducedOffset(ctx context.Context) error
+
+	// CheckReady returns an error if the reader is not ready to consume records.
+	CheckReady() error
 }
 
 type SingleClusterPartitionReader struct {
@@ -214,6 +218,31 @@ func (r *SingleClusterPartitionReader) LastSeenOffsets() kmeta.PartitionOffsets 
 
 func (r *SingleClusterPartitionReader) LastCommittedOffset() int64 {
 	return r.committer.LastCommittedOffset()
+}
+
+// CheckReady returns an error if the partition reader is not ready to consume records.
+func (r *SingleClusterPartitionReader) CheckReady() error {
+	if state := r.State(); state != services.Running {
+		return fmt.Errorf("partition reader service is not running (state: %s)", state.String())
+	}
+
+	return r.checkDependenciesReady()
+}
+
+func (r *SingleClusterPartitionReader) checkDependenciesReady() error {
+	if r.offsetReader != nil {
+		if _, err := r.offsetReader.CachedOffset(); err != nil {
+			return fmt.Errorf("partition reader failed to fetch last produced offset: %w", err)
+		}
+	}
+
+	if r.committer != nil {
+		if err := r.committer.LastCommitError(); err != nil {
+			return fmt.Errorf("partition reader failed to commit last consumed offset: %w", err)
+		}
+	}
+
+	return nil
 }
 
 func (r *SingleClusterPartitionReader) start(ctx context.Context) (returnErr error) {
@@ -1139,6 +1168,8 @@ type partitionCommitter struct {
 
 	logger     log.Logger
 	offsetFile *offsetFile
+	errMx      sync.RWMutex
+	lastErr    error
 
 	// Metrics.
 	commitRequestsTotal   prometheus.Counter
@@ -1204,6 +1235,14 @@ func (r *partitionCommitter) LastCommittedOffset() int64 {
 	return r.lastCommittedOffset.Load()
 }
 
+// LastCommitError returns the most recent offset commit error, if any.
+func (r *partitionCommitter) LastCommitError() error {
+	r.errMx.RLock()
+	defer r.errMx.RUnlock()
+
+	return r.lastErr
+}
+
 func (r *partitionCommitter) run(ctx context.Context) error {
 	commitTicker := time.NewTicker(r.kafkaCfg.ConsumerGroupOffsetCommitInterval)
 	defer commitTicker.Stop()
@@ -1236,6 +1275,10 @@ func (r *partitionCommitter) commit(ctx context.Context, offset int64) (returnEr
 	}
 
 	defer func() {
+		r.errMx.Lock()
+		r.lastErr = returnErr
+		r.errMx.Unlock()
+
 		r.commitRequestsLatency.Observe(time.Since(startTime).Seconds())
 		if returnErr != nil {
 			level.Error(r.logger).Log("msg", "failed to commit last consumed offset", "err", returnErr, "offset", offset)

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -143,6 +143,55 @@ func TestSingleClusterPartitionReader_logFetchErrors(t *testing.T) {
 	`), "cortex_ingest_storage_reader_fetch_errors_total"))
 }
 
+func TestSingleClusterPartitionReader_checkDependenciesReady(t *testing.T) {
+	const (
+		topicName   = "test"
+		partitionID = 1
+	)
+
+	t.Run("should return offset reader error", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := defaultReaderTestConfig(t, "", topicName, partitionID, nil)
+		reader, err := newSingleClusterPartitionReader(cfg.kafka, cfg.partitionID, "test-group", cfg.offsetFilePath, cfg.consumer, &NoOpPreCommitNotifier{}, cfg.logger, cfg.registry)
+		require.NoError(t, err)
+
+		offsetReader := &singleClusterPartitionOffsetReader{
+			GenericOffsetReader: NewGenericOffsetReader[int64](func(context.Context) (int64, error) {
+				return 0, kerr.UnknownTopicOrPartition
+			}, time.Hour, log.NewNopLogger()),
+		}
+		offsetReader.getAndNotifyLastProducedOffset(context.Background())
+		reader.offsetReader = offsetReader
+
+		err = reader.checkDependenciesReady()
+		require.Error(t, err)
+		assert.ErrorIs(t, err, kerr.UnknownTopicOrPartition)
+		assert.Contains(t, err.Error(), "failed to fetch last produced offset")
+	})
+
+	t.Run("should return commit error and clear it after successful commit", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := defaultReaderTestConfig(t, "", topicName, partitionID, nil)
+		reader, err := newSingleClusterPartitionReader(cfg.kafka, cfg.partitionID, "test-group", cfg.offsetFilePath, cfg.consumer, &NoOpPreCommitNotifier{}, cfg.logger, cfg.registry)
+		require.NoError(t, err)
+
+		commitErr := fmt.Errorf("wrapped: %w", kerr.UnknownTopicOrPartition)
+		reader.committer = newPartitionCommitter(cfg.kafka, &mockAdminClient{err: commitErr}, partitionID, "test-group", &NoOpPreCommitNotifier{}, reader.offsetFile, log.NewNopLogger(), prometheus.NewPedanticRegistry())
+
+		require.Error(t, reader.committer.commit(context.Background(), 123))
+		err = reader.checkDependenciesReady()
+		require.Error(t, err)
+		assert.ErrorIs(t, err, kerr.UnknownTopicOrPartition)
+		assert.Contains(t, err.Error(), "failed to commit last consumed offset")
+
+		reader.committer.admClient = &mockAdminClient{}
+		require.NoError(t, reader.committer.commit(context.Background(), 123))
+		require.NoError(t, reader.checkDependenciesReady())
+	})
+}
+
 func TestSingleClusterPartitionReader_ConsumerError(t *testing.T) {
 	const (
 		topicName   = "test"
@@ -4031,13 +4080,14 @@ func (t *testPreCommitNotifier) NotifyPreCommit(_ context.Context) error {
 
 type mockAdminClient struct {
 	onCommit func()
+	err      error
 }
 
 func (m *mockAdminClient) CommitOffsets(ctx context.Context, group string, offsets kadm.Offsets) (kadm.OffsetResponses, error) {
 	if m.onCommit != nil {
 		m.onCommit()
 	}
-	return kadm.OffsetResponses{}, nil
+	return kadm.OffsetResponses{}, m.err
 }
 
 func (m *mockAdminClient) Close() {}


### PR DESCRIPTION
#### What this PR does

Updates ingester readiness to include ingest storage reader health. When ingest storage is enabled, `/ready` now fails if the partition reader is not running, if the reader's latest Kafka last-produced-offset poll is failing, or if the latest consumed-offset commit is still failing. Successful offset polls or commits clear the readiness error.

#### Which issue(s) this PR fixes or relates to

Fixes #14516

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

Tests:

- `make BUILD_IN_CONTAINER=false format`
- `go test ./pkg/storage/ingest -run 'TestPartitionReader_checkDependenciesReady|TestPartitionCommitter_commit|TestPartitionCommitter_LastCommittedOffset' -count=1`
- `go test ./pkg/ingester -run 'TestIngester_CheckReadyFailsWhenIngestStorageReaderCannotFetchKafkaOffsets|Test.*CheckReady|Test.*IngestStorage' -count=1`
- `go test ./pkg/storage/ingest`
- `go test ./pkg/ingester`

Not run locally: Docker-backed integration tests, because the local Docker CLI is installed but the daemon is not reachable at `unix:///Users/kcbalusu/.docker/run/docker.sock`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Kubernetes readiness for ingest-storage ingesters during Kafka outages, which can remove pods from service but avoids routing traffic to unhealthy consumers; logic is localized to readiness checks and error tracking on the commit path.
> 
> **Overview**
> **Ingester `/ready` now reflects ingest-storage Kafka health**, not only push/read availability and the lifecycler. When ingest storage is enabled, readiness fails if the partition reader is not running, the cached last-produced offset poll is failing, or the latest consumed-offset commit is still failing; successful polls or commits clear those errors.
> 
> **`PartitionReader`** exposes `CheckReady()` / `checkDependenciesReady()` wired to the offset reader’s `CachedOffset()` and the committer’s new `LastCommitError()`, which stores the most recent commit failure under a mutex. **Integration and unit tests** cover offset-fetch failures (mock Kafka `ListOffsets`) and dependency readiness behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8d298a1d5d1723162cdbd02bf7395b804844adc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->