### PR TITLE
Reject the whole batch of records of a Kafka write call when the max buffered bytes limit is reached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@
 * [FEATURE] Compactor: Add `-compactor.ooo-split-and-merge-shards` per-tenant limit to allow a separate shard count for blocks with the out-of-order external label. #14704
 * [FEATURE] Distributor: add experimental support for controlling OTLP metric name suffix addition and translation strategy via `X-Mimir-OTLP-AddSuffixes` and `X-Mimir-OTLP-TranslationStrategy` request headers on the OTLP push path, gated by `-api.otlp-translation-headers-enabled` (off by default). #14782
 * [ENHANCEMENT] Ingest storage: Default to the more efficient `-ingest-storage.kafka.producer-record-version=2` based on Remote-Write 2.0, which reduces Kafka record size and improves write throughput. #15185
-* [ENHANCEMENT] Ingest storage: Reject the whole batch of records of a Kafka write call when the configured `-ingest-storage.kafka.producer-max-buffered-bytes` limit is reached, instead of rejecting individual records. #15226
+* [ENHANCEMENT] Ingest storage: Reject the whole batch of records of a Kafka write call when the configured `-ingest-storage.kafka.producer-max-buffered-bytes` limit is reached, instead of rejecting individual records. #15227
 * [ENHANCEMENT] Distributor: Add per-tenant `-distributor.active-series-limit-response-code` override to configure the HTTP response code returned when rejecting series due to the active series limit. Defaults to 429 (Too Many Requests). Set to 400 (Bad Request) to prevent clients from retrying rejected requests. #14981
 * [ENHANCEMENT] Query-frontend: Add `minimum_step_size` filter to blocked queries config to reject range queries with a step smaller than the configured threshold. #14885
 * [ENHANCEMENT] Query-frontend: Add support for blocking queries exceeding a time range duration with `time_range_longer_than`. #14609

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 * [FEATURE] Compactor: Add `-compactor.ooo-split-and-merge-shards` per-tenant limit to allow a separate shard count for blocks with the out-of-order external label. #14704
 * [FEATURE] Distributor: add experimental support for controlling OTLP metric name suffix addition and translation strategy via `X-Mimir-OTLP-AddSuffixes` and `X-Mimir-OTLP-TranslationStrategy` request headers on the OTLP push path, gated by `-api.otlp-translation-headers-enabled` (off by default). #14782
 * [ENHANCEMENT] Ingest storage: Default to the more efficient `-ingest-storage.kafka.producer-record-version=2` based on Remote-Write 2.0, which reduces Kafka record size and improves write throughput. #15185
+* [ENHANCEMENT] Ingest storage: Reject the whole batch of records of a Kafka write call when the configured `-ingest-storage.kafka.producer-max-buffered-bytes` limit is reached, instead of rejecting individual records. #15226
 * [ENHANCEMENT] Distributor: Add per-tenant `-distributor.active-series-limit-response-code` override to configure the HTTP response code returned when rejecting series due to the active series limit. Defaults to 429 (Too Many Requests). Set to 400 (Bad Request) to prevent clients from retrying rejected requests. #14981
 * [ENHANCEMENT] Query-frontend: Add `minimum_step_size` filter to blocked queries config to reject range queries with a step smaller than the configured threshold. #14885
 * [ENHANCEMENT] Query-frontend: Add support for blocking queries exceeding a time range duration with `time_range_longer_than`. #14609

--- a/pkg/storage/ingest/writer_client.go
+++ b/pkg/storage/ingest/writer_client.go
@@ -227,8 +227,11 @@ func (c *KafkaProducer) updateMetricsLoop() {
 // ProduceSync produces records to Kafka and returns once all records have been successfully committed,
 // or an error occurred.
 //
-// This function honors the configure max buffered bytes and refuse to produce a record, returnin kgo.ErrMaxBuffered,
-// if the configured limit is reached.
+// This function honors the configured max buffered bytes: if the whole batch would not fit in the
+// remaining buffer space, none of the records are produced and every result is set to kgo.ErrMaxBuffered.
+// The admission is all-or-nothing per call (rather than per record) so that a partial in-buffer
+// acceptance does not turn into a wasted full retry from the caller, which fails the whole batch on
+// any error.
 func (c *KafkaProducer) ProduceSync(ctx context.Context, records []*kgo.Record) kgo.ProduceResults {
 	var (
 		remaining = atomic.NewInt64(int64(len(records)))
@@ -258,6 +261,29 @@ func (c *KafkaProducer) ProduceSync(ctx context.Context, records []*kgo.Record) 
 		return kgo.ProduceResults{{Err: errors.Wrap(context.Cause(ctx), "skipped producing Kafka records because context is already done")}}
 	}
 
+	c.produceRecordsEnqueuedTotal.Add(float64(len(records)))
+
+	// Reserve buffer space for the whole batch up front. If the reservation would exceed the configured
+	// limit, refund it and reject every record with kgo.ErrMaxBuffered. This makes admission all-or-nothing
+	// per call: callers retry the whole request on failure, so a partial in-buffer acceptance is wasted work.
+	if c.maxBufferedBytes > 0 {
+		var batchBytes int64
+		for _, record := range records {
+			batchBytes += int64(len(record.Value))
+		}
+
+		if c.bufferedBytes.Add(batchBytes) > c.maxBufferedBytes {
+			c.bufferedBytes.Add(-batchBytes)
+			c.produceRecordsFailedTotal.WithLabelValues(produceErrReason(kgo.ErrMaxBuffered)).Add(float64(len(records)))
+
+			rejected := make(kgo.ProduceResults, len(records))
+			for i, record := range records {
+				rejected[i] = kgo.ProduceResult{Record: record, Err: kgo.ErrMaxBuffered}
+			}
+			return rejected
+		}
+	}
+
 	onProduceDone := func(r *kgo.Record, err error) {
 		if c.maxBufferedBytes > 0 {
 			c.bufferedBytes.Add(-int64(len(r.Value)))
@@ -284,15 +310,8 @@ func (c *KafkaProducer) ProduceSync(ctx context.Context, records []*kgo.Record) 
 	// data point when we troubleshoot high production latencies.
 	{
 		enqueueStartTime := time.Now()
-		c.produceRecordsEnqueuedTotal.Add(float64(len(records)))
 
 		for _, record := range records {
-			// Fast fail if the Kafka client buffer is full. Buffered bytes counter is decreased onProducerDone().
-			if c.maxBufferedBytes > 0 && c.bufferedBytes.Add(int64(len(record.Value))) > c.maxBufferedBytes {
-				onProduceDone(record, kgo.ErrMaxBuffered)
-				continue
-			}
-
 			// We use a new context to avoid that other Produce() may be cancelled when this call's context is
 			// canceled. It's important to note that cancelling the context passed to Produce() doesn't actually
 			// prevent the data to be sent over the wire (because it's never removed from the buffer) but in some

--- a/pkg/storage/ingest/writer_client_test.go
+++ b/pkg/storage/ingest/writer_client_test.go
@@ -250,6 +250,63 @@ func TestKafkaProducer_ProduceSync_ShouldCircuitBreakIfContextIsDone(t *testing.
 	require.Equal(t, float64(0), *histogram.SampleSum)
 }
 
+func TestKafkaProducer_ProduceSync_ShouldRejectWholeBatchIfBufferIsFull(t *testing.T) {
+	const (
+		numPartitions = 1
+		topicName     = "test"
+		recordValue   = "1234567890"
+	)
+
+	_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
+
+	cfg := createTestKafkaConfig(clusterAddr, topicName)
+	// Set the limit lower than the size of a 3-record batch so the batch must be rejected as a whole.
+	cfg.ProducerMaxBufferedBytes = int64(2 * len(recordValue))
+
+	reg := prometheus.NewPedanticRegistry()
+	prefixedReg := prometheus.WrapRegistererWithPrefix(writerMetricsPrefix, reg)
+
+	client, err := NewKafkaWriterClient(cfg, 1, log.NewNopLogger(), prefixedReg)
+	require.NoError(t, err)
+
+	producer := NewKafkaProducer(client, cfg.ProducerMaxBufferedBytes, prefixedReg)
+	t.Cleanup(producer.Close)
+
+	batch := []*kgo.Record{
+		{Key: []byte("test"), Value: []byte(recordValue)},
+		{Key: []byte("test"), Value: []byte(recordValue)},
+		{Key: []byte("test"), Value: []byte(recordValue)},
+	}
+
+	res := producer.ProduceSync(context.Background(), batch)
+	require.Len(t, res, len(batch))
+	for i, r := range res {
+		require.ErrorIsf(t, r.Err, kgo.ErrMaxBuffered, "result[%d] should be ErrMaxBuffered", i)
+		require.Same(t, batch[i], r.Record, "result[%d] should reference the original record", i)
+	}
+
+	// No record should be buffered in the Kafka client (none was produced).
+	require.Equal(t, int64(0), producer.BufferedProduceRecords())
+	require.Equal(t, int64(0), producer.bufferedBytes.Load())
+
+	// Every record in the rejected batch should be counted as enqueued and as failed with reason "buffer-full".
+	assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
+		# HELP cortex_ingest_storage_writer_produce_records_enqueued_total Total number of Kafka records enqueued to be sent to the Kafka backend (includes records that fail to be successfully sent to the Kafka backend).
+		# TYPE cortex_ingest_storage_writer_produce_records_enqueued_total counter
+		cortex_ingest_storage_writer_produce_records_enqueued_total 3
+
+		# HELP cortex_ingest_storage_writer_produce_records_failed_total Total number of Kafka records that failed to be sent to the Kafka backend.
+		# TYPE cortex_ingest_storage_writer_produce_records_failed_total counter
+		cortex_ingest_storage_writer_produce_records_failed_total{reason="buffer-full"} 3
+	`),
+		"cortex_ingest_storage_writer_produce_records_enqueued_total",
+		"cortex_ingest_storage_writer_produce_records_failed_total"))
+
+	// A subsequent batch that fits in the buffer should succeed.
+	res = producer.ProduceSync(context.Background(), []*kgo.Record{{Key: []byte("test"), Value: []byte(recordValue)}})
+	require.NoError(t, res.FirstErr())
+}
+
 func TestKafkaProducer_ProduceSync_LatencyShouldBeDrivenByKafkaProduceLatency(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
#### What this PR does

Make the `-ingest-storage.kafka.producer-max-buffered-bytes` admission control all-or-nothing per `ProduceSync` call instead of per-record.

Before this change, `KafkaProducer.ProduceSync` admitted records to the kgo client one-by-one, charging the shared `bufferedBytes` counter as it went. When the limit was crossed mid-batch, only the offending record was rejected with `kgo.ErrMaxBuffered`; earlier records were already buffered and produced to Kafka, and later (smaller) records could still squeeze in.

The caller (`writer.MultiWriteSync` → `produceResultsErr`) treats *any* per-record failure as a whole-batch failure and surfaces a non-2xx error to the distributor's client, which then retries the entire request. So, records that did get through the buffer gate were wasted work — Kafka produced them, but the client retransmits them on retry anyway.

Credits to @grobinson-grafana for having found it.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
