### PR TITLE
Fix issue where the physical samples read count is incorrect for range vector selectors in range queries where the query step is smaller than the selector range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@
 * [FEATURE] Ingest storage: Add `-ingest-storage.kafka.tls*` flags to connect to Kafka using TLS. #14550
 * [FEATURE] Ingest storage: Add `-ingest-storage.ingestion-partition-tenant-write-shard-size` to limit the number of partitions used for writes independently from reads, allowing safely reducing the shard size without losing query coverage during the migration. #14780
 * [FEATURE] MQE: Add experimental support for splitting and caching intermediate results for functions over range vectors in instant queries. #13472 #14479 #14506 #14499 #14517 #14536 #14614 #14645 #14677 #14788
-* [FEATURE] MQE: Add experimental support for reporting the number of samples read per query. #14828 #14839 #14952 #15035 #15045 #15179 #15220 #15223
+* [FEATURE] MQE: Add experimental support for reporting the number of samples read per query. #14828 #14839 #14952 #15035 #15045 #15179 #15220 #15223 #15237
 * [FEATURE] Compactor: Add `-compactor.ooo-split-and-merge-shards` per-tenant limit to allow a separate shard count for blocks with the out-of-order external label. #14704
 * [FEATURE] Distributor: add experimental support for controlling OTLP metric name suffix addition and translation strategy via `X-Mimir-OTLP-AddSuffixes` and `X-Mimir-OTLP-TranslationStrategy` request headers on the OTLP push path, gated by `-api.otlp-translation-headers-enabled` (off by default). #14782
 * [ENHANCEMENT] Ingest storage: Default to the more efficient `-ingest-storage.kafka.producer-record-version=2` based on Remote-Write 2.0, which reduces Kafka record size and improves write throughput. #15185

--- a/pkg/streamingpromql/types/stats.go
+++ b/pkg/streamingpromql/types/stats.go
@@ -156,7 +156,12 @@ func (s *OperatorEvaluationStats) TrackSamplesForRangeVectorSelector(stepT int64
 	samplesReadIfSubsequentStep := int64(floats.CountBetween(newSampleRangeStart, rangeEnd)) + histograms.EquivalentFloatSampleCountBetween(newSampleRangeStart, rangeEnd)
 
 	s.allSeries.Add(pointIdx, allSamplesInRange, samplesReadIfSubsequentStep, allSamplesInRange)
-	s.queryStats.AddPhysicalSamplesRead(uint64(samplesReadIfSubsequentStep))
+
+	if pointIdx == 0 {
+		s.queryStats.AddPhysicalSamplesRead(uint64(allSamplesInRange))
+	} else {
+		s.queryStats.AddPhysicalSamplesRead(uint64(samplesReadIfSubsequentStep))
+	}
 
 	for subsetIdx, subset := range s.subsets {
 		if matchesSubsets[subsetIdx] {

--- a/pkg/streamingpromql/types/stats_test.go
+++ b/pkg/streamingpromql/types/stats_test.go
@@ -157,7 +157,7 @@ func TestOperatorEvaluationStats_TrackSamplesForRangeVectorSelector(t *testing.T
 			histograms.Close()
 			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
 
-			require.Equal(t, uint64((4+3+4+4+4)*testCase.samplesPerPoint), queryStats.LoadPhysicalSamplesRead())
+			require.Equal(t, uint64((4+3+4+6+4)*testCase.samplesPerPoint), queryStats.LoadPhysicalSamplesRead())
 		})
 	}
 }


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue with the calculation of the physical samples read count for range vector selectors. The value can be lower than expected if the range vector selector is evaluated in a range query, and the query step is smaller than the selector range.

If these conditions were met, the physical sample count would not include any samples read for the first sample that were in the window between the start of the range and the "new samples" threshold.

For example, if the range vector selector was evaluated from T=5m to T=15m with a step of 1m and a range of 3m, then the samples in the window from T=2m to T=4m were not counted.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/pull/15220

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes query statistics accounting for range vector selectors, which could impact any downstream logic or dashboards relying on `physical_samples_read` (including potential query-cost enforcement). Scope is small and covered by updated unit tests.
> 
> **Overview**
> Fixes undercounting of `physical samples read` for range vector selectors in range queries when the query step is smaller than the selector range.
> 
> `TrackSamplesForRangeVectorSelector` now records *all* samples in the window for the first evaluated step (instead of only “new” samples), and tests are updated to assert the corrected totals. The changelog entry is also updated to include the additional PR reference (`#15237`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 829deab9e62734484a4a8d39ea01425bf9b4f733. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->