### PR TITLE
dashboards: config option to disable histogram mode toggle for alertmanager dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 * [FEATURE] MQE: Add experimental support for reporting the number of samples read per query. #14828 #14839 #14952 #15035 #15045 #15179 #15220 #15223 #15237
 * [FEATURE] Compactor: Add `-compactor.ooo-split-and-merge-shards` per-tenant limit to allow a separate shard count for blocks with the out-of-order external label. #14704
 * [FEATURE] Distributor: add experimental support for controlling OTLP metric name suffix addition and translation strategy via `X-Mimir-OTLP-AddSuffixes` and `X-Mimir-OTLP-TranslationStrategy` request headers on the OTLP push path, gated by `-api.otlp-translation-headers-enabled` (off by default). #14782
+* [ENHANCEMENT] Dashboards: Add config option `dashboards_latency_mode_native_only` that when enabled, removes classic latency queries from alertmanager dashboard. #15241
 * [ENHANCEMENT] Ingest storage: Default to the more efficient `-ingest-storage.kafka.producer-record-version=2` based on Remote-Write 2.0, which reduces Kafka record size and improves write throughput. #15185
 * [ENHANCEMENT] Ingest storage: Reject the whole batch of records of a Kafka write call when the configured `-ingest-storage.kafka.producer-max-buffered-bytes` limit is reached, instead of rejecting individual records. #15227
 * [ENHANCEMENT] Distributor: Add per-tenant `-distributor.active-series-limit-response-code` override to configure the HTTP response code returned when rejecting series due to the active series limit. Defaults to 429 (Too Many Requests). Set to 400 (Bad Request) to prevent clients from retrying rejected requests. #14981

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -220,6 +220,8 @@
 
     // Controls whether dashboards show classic or native latency histograms. Allowed values: 'classic' (default), 'native'.
     dashboards_default_latency_mode: 'classic',
+    // If enabled, only renders native version of queries in dashboards.
+    dashboards_latency_mode_native_only: false,
 
     // Used to add extra labels to all alerts. Careful: takes precedence over default labels.
     alert_extra_labels: {},

--- a/operations/mimir-mixin/dashboards/alertmanager.libsonnet
+++ b/operations/mimir-mixin/dashboards/alertmanager.libsonnet
@@ -3,13 +3,14 @@ local filename = 'mimir-alertmanager.json';
 
 (import 'dashboard-utils.libsonnet') {
   [filename]:
+    local nativeOnly = $._config.dashboards_latency_mode_native_only;
     local jobSelector = $.jobSelector($._config.job_names.alertmanager);
     local jobInstanceSelector = jobSelector + [utils.selector.noop($._config.per_instance_label)];
     local jobIntegrationSelector = jobSelector + [utils.selector.noop('integration')];
     assert std.md5(filename) == 'b0d38d318bbddd80476246d4930f9e55' : 'UID of the dashboard has changed, please update references to dashboard.';
     ($.dashboard('Alertmanager') + { uid: std.md5(filename) })
     .addClusterSelectorTemplates()
-    .addShowNativeLatencyVariable($.latencyVariableDefault())
+    .addShowNativeLatencyVariable($.latencyVariableDefault(), nativeOnly=nativeOnly)
     .addRow(
       ($.row('Headlines') + {
          height: '100px',
@@ -33,11 +34,11 @@ local filename = 'mimir-alertmanager.json';
       $.row('Alertmanager Distributor')
       .addPanel(
         $.timeseriesPanel('QPS') +
-        $.qpsPanelNativeHistogram($.queries.alertmanager.requestsPerSecondMetric, utils.toPrometheusSelectorNaked($.jobSelector($._config.job_names.alertmanager) + [alertmanagerGRPCRoutesRegex]))
+        $.qpsPanelNativeHistogram($.queries.alertmanager.requestsPerSecondMetric, utils.toPrometheusSelectorNaked($.jobSelector($._config.job_names.alertmanager) + [alertmanagerGRPCRoutesRegex]), nativeOnly=nativeOnly)
       )
       .addPanel(
         $.timeseriesPanel('Latency') +
-        $.latencyRecordingRulePanelNativeHistogram($.queries.alertmanager.requestsPerSecondMetric, $.jobSelector($._config.job_names.alertmanager) + [alertmanagerGRPCRoutesRegex])
+        $.latencyRecordingRulePanelNativeHistogram($.queries.alertmanager.requestsPerSecondMetric, $.jobSelector($._config.job_names.alertmanager) + [alertmanagerGRPCRoutesRegex], nativeOnly=nativeOnly)
       )
     )
     .addRow(
@@ -105,7 +106,7 @@ local filename = 'mimir-alertmanager.json';
       )
       .addPanel(
         $.timeseriesPanel('Latency') +
-        $.ncLatencyPanel('cortex_alertmanager_notification_latency_seconds', '%s' % $.jobMatcher($._config.job_names.alertmanager))
+        $.ncLatencyPanel('cortex_alertmanager_notification_latency_seconds', '%s' % $.jobMatcher($._config.job_names.alertmanager), nativeOnly=nativeOnly)
       )
     )
     .addRowIf(
@@ -113,15 +114,15 @@ local filename = 'mimir-alertmanager.json';
       $.row('Configuration API (gateway) + Alertmanager UI')
       .addPanel(
         $.timeseriesPanel('QPS') +
-        $.qpsPanelNativeHistogram($.queries.alertmanager.requestsPerSecondMetric, utils.toPrometheusSelectorNaked($.jobSelector($._config.job_names.gateway) + [utils.selector.re('route', '%s' % $.queries.alertmanager_http_routes_regex)]))
+        $.qpsPanelNativeHistogram($.queries.alertmanager.requestsPerSecondMetric, utils.toPrometheusSelectorNaked($.jobSelector($._config.job_names.gateway) + [utils.selector.re('route', '%s' % $.queries.alertmanager_http_routes_regex)]), nativeOnly=nativeOnly)
       )
       .addPanel(
         $.timeseriesPanel('Latency') +
-        $.latencyRecordingRulePanelNativeHistogram($.queries.gateway.requestsPerSecondMetric, $.jobSelector($._config.job_names.gateway) + [utils.selector.re('route', '%s' % $.queries.alertmanager_http_routes_regex)])
+        $.latencyRecordingRulePanelNativeHistogram($.queries.gateway.requestsPerSecondMetric, $.jobSelector($._config.job_names.gateway) + [utils.selector.re('route', '%s' % $.queries.alertmanager_http_routes_regex)], nativeOnly=nativeOnly)
       )
     )
     .addRows(
-      $.getObjectStoreRows('Alertmanager Configuration Object Store (Alertmanager accesses)', 'alertmanager-storage')
+      $.getObjectStoreRows('Alertmanager Configuration Object Store (Alertmanager accesses)', 'alertmanager-storage', nativeOnly=nativeOnly)
     )
     .addRow(
       $.row('Replication')
@@ -196,7 +197,7 @@ local filename = 'mimir-alertmanager.json';
       )
       .addPanel(
         $.timeseriesPanel('Initial sync duration') +
-        $.ncLatencyPanel('cortex_alertmanager_state_initial_sync_duration_seconds', '%s' % $.jobMatcher($._config.job_names.alertmanager)) + {
+        $.ncLatencyPanel('cortex_alertmanager_state_initial_sync_duration_seconds', '%s' % $.jobMatcher($._config.job_names.alertmanager), nativeOnly=nativeOnly) + {
           targets: [
             target {
               interval: '1m',

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -152,6 +152,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
                .addTemplate('cluster', $._config.dashboard_variables.cluster_query, '%s' % $._config.per_cluster_label, allValue='.*', includeAll=true, sort=sortAscending)
                .addTemplate('namespace', $._config.dashboard_variables.namespace_query, '%s' % $._config.per_namespace_label, sort=sortAscending),
 
+      addShowNativeLatencyVariable(default='classic', nativeOnly=false)::
+        if nativeOnly
+        then self
+        else super.addShowNativeLatencyVariable(default),
+
       addActiveUserSelectorTemplates()::
         self.addTemplate('user', 'cortex_ingester_active_series{%s=~"$cluster", %s=~"$namespace"}' % [$._config.per_cluster_label, $._config.per_namespace_label], 'user', sort=sortNaturalAscending),
 
@@ -302,8 +307,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
       },
     },
 
-  ncLatencyPanel(metricName, selector, multiplier='', quantile=[99, 50])::
-    super.latencyPanelNativeHistogram(metricName, selector, multiplier, quantile) + {
+  ncLatencyPanel(metricName, selector, multiplier='', quantile=[99, 50], nativeOnly=false)::
+    super.latencyPanelNativeHistogram(metricName, selector, multiplier, quantile, false, nativeOnly) + {
       fieldConfig+: {
         defaults+: { unit: 's' },
       },
@@ -1277,7 +1282,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     },
   },
 
-  getObjectStoreRows(title, component):: [
+  getObjectStoreRows(title, component, nativeOnly=false):: [
     $.row(title)
     .addPanel(
       $.timeseriesPanel('Operations / sec') +
@@ -1292,27 +1297,27 @@ local utils = import 'mixin-utils/utils.libsonnet';
     )
     .addPanel(
       $.timeseriesPanel('Latency of op: Attributes') +
-      $.ncLatencyPanel('thanos_objstore_bucket_operation_duration_seconds', '%s,component="%s",operation="attributes"' % [$.namespaceMatcher(), component]),
+      $.ncLatencyPanel('thanos_objstore_bucket_operation_duration_seconds', '%s,component="%s",operation="attributes"' % [$.namespaceMatcher(), component], nativeOnly=nativeOnly),
     )
     .addPanel(
       $.timeseriesPanel('Latency of op: Exists') +
-      $.ncLatencyPanel('thanos_objstore_bucket_operation_duration_seconds', '%s,component="%s",operation="exists"' % [$.namespaceMatcher(), component]),
+      $.ncLatencyPanel('thanos_objstore_bucket_operation_duration_seconds', '%s,component="%s",operation="exists"' % [$.namespaceMatcher(), component], nativeOnly=nativeOnly),
     )
     .addPanel(
       $.timeseriesPanel('Latency of op: Get') +
-      $.ncLatencyPanel('thanos_objstore_bucket_operation_duration_seconds', '%s,component="%s",operation="get"' % [$.namespaceMatcher(), component]),
+      $.ncLatencyPanel('thanos_objstore_bucket_operation_duration_seconds', '%s,component="%s",operation="get"' % [$.namespaceMatcher(), component], nativeOnly=nativeOnly),
     )
     .addPanel(
       $.timeseriesPanel('Latency of op: GetRange') +
-      $.ncLatencyPanel('thanos_objstore_bucket_operation_duration_seconds', '%s,component="%s",operation="get_range"' % [$.namespaceMatcher(), component]),
+      $.ncLatencyPanel('thanos_objstore_bucket_operation_duration_seconds', '%s,component="%s",operation="get_range"' % [$.namespaceMatcher(), component], nativeOnly=nativeOnly),
     )
     .addPanel(
       $.timeseriesPanel('Latency of op: Upload') +
-      $.ncLatencyPanel('thanos_objstore_bucket_operation_duration_seconds', '%s,component="%s",operation="upload"' % [$.namespaceMatcher(), component]),
+      $.ncLatencyPanel('thanos_objstore_bucket_operation_duration_seconds', '%s,component="%s",operation="upload"' % [$.namespaceMatcher(), component], nativeOnly=nativeOnly),
     )
     .addPanel(
       $.timeseriesPanel('Latency of op: Delete') +
-      $.ncLatencyPanel('thanos_objstore_bucket_operation_duration_seconds', '%s,component="%s",operation="delete"' % [$.namespaceMatcher(), component]),
+      $.ncLatencyPanel('thanos_objstore_bucket_operation_duration_seconds', '%s,component="%s",operation="delete"' % [$.namespaceMatcher(), component], nativeOnly=nativeOnly),
     )
     .splitIntoLines([4, 4]),
   ],


### PR DESCRIPTION
#### What this PR does

Add config option `` that disables the latency mode toggle (on dashboards that support it) and removes classic queries from its panels.
This PR introduces this option for the `Mimir / Alertmanager` dashboard _only_.

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: mixin-only configuration and dashboard query wiring changes, affecting Grafana rendering but not runtime services or data paths.
> 
> **Overview**
> Adds a new mixin config option, `dashboards_latency_mode_native_only`, to force dashboards to *only* render native-histogram latency queries and optionally remove the latency-mode variable.
> 
> Wires this flag into the `Mimir / Alertmanager` dashboard so QPS/latency and object-store latency panels drop classic query variants when enabled, and updates dashboard helper functions (`addShowNativeLatencyVariable`, `ncLatencyPanel`, `getObjectStoreRows`) to accept and propagate the `nativeOnly` behavior. Includes a `CHANGELOG.md` enhancement entry documenting the new option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2ce85f0c5d991e3bb9320bed9114a499c94143f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->