### PR TITLE
MQE: in-flight memory consumption tracking can leak memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,7 +187,7 @@
 * [ENHANCEMENT] Usage-tracker: Improve performance by using a special shard grouping algorithm. #14715
 * [ENHANCEMENT] MQE: Support subset selector elimination for expressions where the subset is given by regex selectors. #14732
 * [ENHANCEMENT] API: activity tracker (if enabled) covers the full request lifecycle and used on all routes. #14777
-* [ENHANCEMENT] MQE: Add metrics for tracking in-flight memory consumption tracking. `cortex_querier_inflight_query_max_estimated_memory_consumption_limit_bytes`, `cortex_querier_inflight_query_current_estimated_memory_consumption_bytes`, `cortex_querier_inflight_query_peak_estimated_memory_consumption_bytes` and `cortex_querier_inflight_query_sampled_count`. #14807
+* [ENHANCEMENT] MQE: Add metrics for tracking in-flight memory consumption tracking. `cortex_querier_inflight_query_max_estimated_memory_consumption_limit_bytes`, `cortex_querier_inflight_query_current_estimated_memory_consumption_bytes`, `cortex_querier_inflight_query_peak_estimated_memory_consumption_bytes` and `cortex_querier_inflight_query_sampled_count`. #14807 #15242
 * [ENHANCEMENT] Query-frontend: Stream JSON encoding directly to the response body to avoid a full-copy allocation of the serialized payload. #14840
 * [ENHANCEMENT] Activity tracker: Added `activity_tracker_unfinished_activities_loaded` metric to report the number of unfinished activities detected on startup. #14860
 * [ENHANCEMENT] Distributor now uses record validation time as Kafka record timestamp to reduce rejections among consumers. #14921

--- a/pkg/streamingpromql/engine.go
+++ b/pkg/streamingpromql/engine.go
@@ -286,7 +286,7 @@ func (e *Engine) NewEvaluator(ctx context.Context, queryable storage.Queryable, 
 	return e.materializeAndCreateEvaluator(ctx, queryable, params, nodeRequests)
 }
 
-func (e *Engine) materializeAndCreateEvaluator(ctx context.Context, queryable storage.Queryable, params *planning.QueryParameters, nodeRequests []NodeEvaluationRequest) (*Evaluator, error) {
+func (e *Engine) materializeAndCreateEvaluator(ctx context.Context, queryable storage.Queryable, params *planning.QueryParameters, nodeRequests []NodeEvaluationRequest) (_ *Evaluator, retErr error) {
 	span, ctx := tracing.StartSpanFromContext(ctx, "Engine.materializeAndCreateEvaluator")
 	defer span.Finish()
 
@@ -319,13 +319,24 @@ func (e *Engine) materializeAndCreateEvaluator(ctx context.Context, queryable st
 			return nil, fmt.Errorf("could not get memory consumption limit for query: %w", err)
 		}
 		operatorParams.MemoryConsumptionTracker = e.memoryConsumptionTrackerFactory.NewMemoryConsumptionTracker(ctx, maxEstimatedMemoryConsumptionPerQuery, params.OriginalExpression)
+
+		// Schedule deregistration of the memory tracker after the context was cancelled.
+		// This is the last-resort protection from leaking the tracking, if the upstream code didn't close the returned evaluator.
+		stopAfterFunc := context.AfterFunc(ctx, func() {
+			e.memoryConsumptionTrackerFactory.Deregister(operatorParams.MemoryConsumptionTracker)
+		})
+		defer func() {
+			if retErr != nil {
+				stopAfterFunc()
+				e.memoryConsumptionTrackerFactory.Deregister(operatorParams.MemoryConsumptionTracker)
+			}
+		}()
 	}
 
 	materializer := planning.NewMaterializer(operatorParams, e.nodeMaterializers)
 	for idx, req := range nodeRequests {
 		op, err := materializer.ConvertNodeToOperator(req.Node, req.TimeRange)
 		if err != nil {
-			e.memoryConsumptionTrackerFactory.Deregister(operatorParams.MemoryConsumptionTracker)
 			return nil, err
 		}
 
@@ -334,7 +345,6 @@ func (e *Engine) materializeAndCreateEvaluator(ctx context.Context, queryable st
 
 	evaluator, err := NewEvaluator(nodeRequests, operatorParams, e, params.OriginalExpression)
 	if err != nil {
-		e.memoryConsumptionTrackerFactory.Deregister(operatorParams.MemoryConsumptionTracker)
 		return nil, err
 	}
 	return evaluator, nil

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -1837,7 +1837,7 @@ func TestEvaluator_ReportsMemoryConsumptionLimit(t *testing.T) {
 	engine, err := NewEngine(opts, stats.NewQueryMetrics(reg), planner)
 	require.NoError(t, err)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	expr := "some_metric"
 	plan, err := planner.NewQueryPlan(ctx, expr, types.NewInstantQueryTimeRange(timestamp.Time(0)), DefaultLookbackDelta, false, NoopPlanningObserver{})
 	require.NoError(t, err)

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 	"unsafe"
 
@@ -1917,6 +1918,48 @@ func TestQuery_ExecDeregistersTrackerOnFailure(t *testing.T) {
 	// The tracker must be deregistered even though we never called q.Close().
 	require.False(t, inflightTracker.IsTracking(q.(*Query).memoryConsumptionTracker))
 	require.NoError(t, testutil.CollectAndCompare(inflightTracker, strings.NewReader(sampledHelp+"cortex_querier_inflight_query_sampled_count 0\n"), sampledMetric))
+}
+
+func TestQuery_ContextCancellationDeregistersTracker(t *testing.T) {
+	// Verify that when the query context is cancelled and Query.Close() isn't called, the tracker is deregistered
+	// from the InflightMemoryConsumptionTracker.
+
+	storage := promqltest.LoadedStorage(t, `
+		load 1m
+			some_metric{idx="1"} 0+1x5
+	`)
+	t.Cleanup(func() { require.NoError(t, storage.Close()) })
+
+	reg := prometheus.NewPedanticRegistry()
+	queryMetrics := stats.NewQueryMetrics(reg)
+	inflightTracker := limiter.NewInflightMemoryConsumptionTracker(reg, queryMetrics.QueriesRejectedTotal.WithLabelValues(stats.RejectReasonMaxEstimatedQueryMemoryConsumption))
+
+	opts := NewTestEngineOpts()
+	opts.CommonOpts.Reg = reg
+	opts.Pedantic = false // We intentionally don't call Close(), so disable pedantic mode.
+	opts.MemoryConsumptionTrackerFactory = inflightTracker
+
+	planner, err := NewQueryPlanner(opts, NewMaximumSupportedVersionQueryPlanVersionProvider())
+	require.NoError(t, err)
+	engine, err := NewEngine(opts, queryMetrics, planner)
+	require.NoError(t, err)
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		q, err := engine.NewInstantQuery(ctx, storage, nil, "some_metric", timestamp.Time(0))
+		require.NoError(t, err)
+
+		// The tracker should be registered before Exec.
+		require.True(t, inflightTracker.IsTracking(q.(*Query).memoryConsumptionTracker))
+
+		// Cancel the context and wait for all async callbacks to finish.
+		cancel()
+		synctest.Wait()
+
+		// The tracker must be deregistered after context cancelled even though we never call q.Close().
+		require.False(t, inflightTracker.IsTracking(q.(*Query).memoryConsumptionTracker))
+	})
 }
 
 func TestQuery_CloseDeregistersTrackerOnSuccess(t *testing.T) {

--- a/pkg/util/limiter/memory_consumption.go
+++ b/pkg/util/limiter/memory_consumption.go
@@ -303,7 +303,7 @@ type MemoryConsumptionTracker struct {
 	haveRecordedRejection bool
 	queryDescription      string
 
-	ctx context.Context // Used to retrieve trace ID to include in panic messages.
+	traceID string // Used to include in panic messages. Can be empty if query didn't carry tracing ID.
 
 	// mtx protects all mutable state of the memory consumption tracker. We use a mutex
 	// rather than atomics because we only want to adjust the memory used after checking
@@ -323,12 +323,14 @@ func NewUnlimitedMemoryConsumptionTracker(ctx context.Context) *MemoryConsumptio
 }
 
 func NewMemoryConsumptionTracker(ctx context.Context, maxEstimatedMemoryConsumptionBytes uint64, rejectionCount prometheus.Counter, queryDescription string) *MemoryConsumptionTracker {
+	traceID, _ := tracing.ExtractTraceID(ctx)
 	return &MemoryConsumptionTracker{
 		maxEstimatedMemoryConsumptionBytes: maxEstimatedMemoryConsumptionBytes,
 
 		rejectionCount:   rejectionCount,
 		queryDescription: queryDescription,
-		ctx:              ctx,
+
+		traceID: traceID,
 	}
 }
 
@@ -371,11 +373,9 @@ func (l *MemoryConsumptionTracker) DecreaseMemoryConsumption(b uint64, source Me
 	defer l.mtx.Unlock()
 
 	if b > l.currentEstimatedMemoryConsumptionBySource[source] {
-		traceID, ok := tracing.ExtractTraceID(l.ctx)
 		traceDescription := ""
-
-		if ok {
-			traceDescription = fmt.Sprintf(" (trace ID: %v)", traceID)
+		if l.traceID != "" {
+			traceDescription = fmt.Sprintf(" (trace ID: %v)", l.traceID)
 		}
 
 		panic(fmt.Sprintf(


### PR DESCRIPTION
#### What this PR does

This is the follow-up to https://github.com/grafana/mimir/pull/14807

The PR updates how MQE's in-flight memory consumption is set up to help with a resource leakage in some scenarios. That is, we observed cases where query-frontend can skip releasing the resources, when a request failed. In order to mitigate that, the PR bounds the lifetime of the request's context with the `MemoryConsumptionTracker`. This guaranties that, when, eventually, the context gets cancelled, the `MemoryConsumptionTracker` will be deregistered.