### PR TITLE
distributor: track 'needs cleanup' state in requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Grafana Mimir
 
+* [ENHANCEMENT] Distributor: Improve distributor push middleware cleanup handling. #15245
 * [FEATURE] Mimirtool: Add AWS Signature Version 4 (SigV4) support for shared Mimir API client commands including `mimirtool rules`, `mimirtool alertmanager`, `mimirtool alerts`, `mimirtool backfill`, and `mimirtool analyze ruler`. #14959
 * [ENHANCEMENT] MQE: Improve experimental support for reporting the number of samples read per query. #15179 #15220 #15223 #15232 #15237 #15255
 * [ENHANCEMENT] Ingest storage: Reject the whole batch of records of a Kafka write call when the configured `-ingest-storage.kafka.producer-max-buffered-bytes` limit is reached, instead of rejecting individual records. #15227

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -329,30 +329,20 @@ type PushWrapper func(next PushFunc) PushFunc
 
 // WithCleanup wraps the given pushWrapper function with automatic resource cleanup handling.
 // It ensures Request.CleanUp() is called via defer if the given next PushFunc isn't invoked.
-// See NextOrCleanup for the cleanup detection mechanism.
 func WithCleanup(next PushFunc, pushWrapper func(next PushFunc, ctx context.Context, pushReq *Request) error) PushFunc {
-	return func(ctx context.Context, pushReq *Request) error {
-		next, maybeCleanup := NextOrCleanup(next, pushReq)
-		defer maybeCleanup()
-		return pushWrapper(next, ctx, pushReq)
+	nextWrapper := func(ctx context.Context, req *Request) error {
+		req.needsCleanup = false
+		return next(ctx, req)
 	}
-}
-
-// NextOrCleanup returns a new PushFunc and a cleanup function that should be deferred by the caller.
-// The cleanup function will only call Request.CleanUp() if next() wasn't called previously.
-//
-// This function is used outside of this codebase.
-func NextOrCleanup(next PushFunc, pushReq *Request) (_ PushFunc, maybeCleanup func()) {
-	cleanupInDefer := true
-	return func(ctx context.Context, req *Request) error {
-			cleanupInDefer = false
-			return next(ctx, req)
-		},
-		func() {
-			if cleanupInDefer {
+	return func(ctx context.Context, pushReq *Request) error {
+		pushReq.needsCleanup = true
+		defer func() {
+			if pushReq.needsCleanup {
 				pushReq.CleanUp()
 			}
-		}
+		}()
+		return pushWrapper(nextWrapper, ctx, pushReq)
+	}
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet

--- a/pkg/distributor/request.go
+++ b/pkg/distributor/request.go
@@ -44,6 +44,11 @@ type Request struct {
 	// onInit is called after the supplier function completes in initWriteRequest.
 	onInit func()
 
+	// needsCleanup is set to true by WithCleanup's wrapper and is cleared when the
+	// next PushFunc in the middleware chain is invoked. It allows WithCleanup to
+	// decide whether it has to call CleanUp.
+	needsCleanup bool
+
 	// nameValidationSchemeOverride, when non-nil, overrides the tenant's name validation
 	// scheme for this request. This is used by the OTLP handler to auto-upgrade the
 	// validation scheme to UTF-8 when translation headers produce UTF-8 names.


### PR DESCRIPTION
Idea: track `needsCleanup` in requests instead of allocating a next wrapper per-middleware. 

<details>
<summary>Benchmarks</summary>

```

$ go test -run='^$' -bench='BenchmarkDistributor_Push' -benchmem -benchtime=1000x -count=6 

goos: darwin
goarch: arm64
pkg: github.com/grafana/mimir/pkg/distributor
cpu: Apple M4 Pro
                                                                                                                                   │ /tmp/distr_bench_old.tmp │     /tmp/distr_bench_new.tmp      │
                                                                                                                                   │          sec/op          │   sec/op     vs base              │
Distributor_Push/cost_attribution=disabled/dedupe=per_request/scenario=all_samples_successfully_pushed-14                                        635.1µ ±  3%   613.6µ ± 9%       ~ (p=0.065 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_request/scenario=ingestion_rate_limit_reached-14                                           356.5µ ±  4%   351.4µ ± 5%       ~ (p=0.485 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_request/scenario=too_many_labels_limit_reached-14                                          2.084m ±  0%   1.980m ± 1%  -4.99% (p=0.002 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_request/scenario=max_label_name_length_limit_reached-14                                    1.417m ±  1%   1.338m ± 0%  -5.59% (p=0.002 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_request/scenario=timestamp_too_new-14                                                      577.0µ ±  6%   563.2µ ± 1%  -2.40% (p=0.002 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_request/scenario=HA_dedupe,_4_clusters_each_with_a_single_primary_replica-14               713.4µ ±  2%   691.9µ ± 2%  -3.01% (p=0.009 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_request/scenario=max_label_value_length_limit_reached-14                                   1.551m ±  2%   1.484m ± 4%  -4.32% (p=0.015 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_request/scenario=all_samples_go_to_metric_relabel_configs-14                               1.233m ±  2%   1.153m ± 0%  -6.48% (p=0.002 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_request/scenario=HA_dedupe,_all_series_from_primary_replica-14                             705.8µ ±  2%   685.6µ ± 1%  -2.87% (p=0.026 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_sample/scenario=HA_dedupe,_all_series_from_primary_replica-14                              740.7µ ±  3%   689.3µ ± 1%  -6.93% (p=0.002 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_sample/scenario=all_samples_successfully_pushed-14                                         623.4µ ±  3%   578.8µ ± 2%  -7.16% (p=0.002 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_sample/scenario=ingestion_rate_limit_reached-14                                            359.1µ ±  3%   336.0µ ± 1%  -6.45% (p=0.002 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_sample/scenario=too_many_labels_limit_reached-14                                           2.092m ±  5%   1.960m ± 0%  -6.31% (p=0.002 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_sample/scenario=max_label_name_length_limit_reached-14                                     1.368m ±  0%   1.326m ± 1%  -3.05% (p=0.002 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_sample/scenario=timestamp_too_new-14                                                       574.5µ ±  2%   574.9µ ± 6%       ~ (p=1.000 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_sample/scenario=HA_dedupe,_4_clusters_each_with_a_single_primary_replica-14                741.1µ ±  1%   710.8µ ± 2%  -4.09% (p=0.002 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_sample/scenario=max_label_value_length_limit_reached-14                                    1.492m ±  0%   1.464m ± 0%  -1.87% (p=0.002 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_sample/scenario=all_samples_go_to_metric_relabel_configs-14                                1.163m ±  5%   1.139m ± 1%  -2.07% (p=0.002 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_request/scenario=HA_dedupe,_all_series_from_primary_replica-14                              694.1µ ±  1%   688.2µ ± 1%  -0.85% (p=0.026 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_request/scenario=all_samples_successfully_pushed-14                                         630.3µ ±  2%   620.1µ ± 2%  -1.61% (p=0.026 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_request/scenario=ingestion_rate_limit_reached-14                                            371.3µ ±  2%   356.1µ ± 5%       ~ (p=0.065 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_request/scenario=too_many_labels_limit_reached-14                                           2.033m ±  0%   2.033m ± 1%       ~ (p=1.000 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_request/scenario=max_label_name_length_limit_reached-14                                     1.385m ±  2%   1.380m ± 1%       ~ (p=0.240 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_request/scenario=timestamp_too_new-14                                                       618.9µ ±  1%   615.5µ ± 1%       ~ (p=0.132 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_request/scenario=HA_dedupe,_4_clusters_each_with_a_single_primary_replica-14                691.8µ ±  1%   695.3µ ± 1%  +0.51% (p=0.041 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_request/scenario=max_label_value_length_limit_reached-14                                    1.516m ±  0%   1.524m ± 0%  +0.52% (p=0.009 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_request/scenario=all_samples_go_to_metric_relabel_configs-14                                1.171m ±  1%   1.176m ± 0%       ~ (p=0.132 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_sample/scenario=HA_dedupe,_all_series_from_primary_replica-14                               719.5µ ±  2%   738.3µ ± 0%  +2.61% (p=0.002 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_sample/scenario=all_samples_successfully_pushed-14                                          622.8µ ±  1%   617.2µ ± 2%       ~ (p=0.065 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_sample/scenario=ingestion_rate_limit_reached-14                                             350.7µ ± 10%   368.3µ ± 2%       ~ (p=0.093 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_sample/scenario=too_many_labels_limit_reached-14                                            2.006m ±  0%   2.044m ± 1%  +1.93% (p=0.002 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_sample/scenario=max_label_name_length_limit_reached-14                                      1.370m ±  3%   1.388m ± 0%       ~ (p=0.065 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_sample/scenario=timestamp_too_new-14                                                        612.0µ ±  1%   615.2µ ± 9%  +0.52% (p=0.041 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_sample/scenario=HA_dedupe,_4_clusters_each_with_a_single_primary_replica-14                 747.1µ ±  1%   750.1µ ± 1%       ~ (p=0.310 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_sample/scenario=max_label_value_length_limit_reached-14                                     1.508m ±  1%   1.518m ± 1%       ~ (p=0.180 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_sample/scenario=all_samples_go_to_metric_relabel_configs-14                                 1.164m ±  1%   1.179m ± 1%  +1.22% (p=0.026 n=6)
geomean                                                                                                                                          891.0µ         874.4µ       -1.87%

                                                                                                                                   │ /tmp/distr_bench_old.tmp │      /tmp/distr_bench_new.tmp       │
                                                                                                                                   │           B/op           │     B/op      vs base               │
Distributor_Push/cost_attribution=disabled/dedupe=per_request/scenario=all_samples_successfully_pushed-14                                        157.0Ki ± 0%   156.8Ki ± 0%   -0.11% (p=0.015 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_request/scenario=ingestion_rate_limit_reached-14                                           2.482Ki ± 2%   2.151Ki ± 2%  -13.32% (p=0.002 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_request/scenario=too_many_labels_limit_reached-14                                          1.148Mi ± 0%   1.147Mi ± 0%   -0.07% (p=0.004 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_request/scenario=max_label_name_length_limit_reached-14                                    1.087Mi ± 0%   1.086Mi ± 0%   -0.05% (p=0.002 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_request/scenario=timestamp_too_new-14                                                      318.3Ki ± 0%   317.7Ki ± 0%   -0.18% (p=0.002 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_request/scenario=HA_dedupe,_4_clusters_each_with_a_single_primary_replica-14               157.2Ki ± 0%   157.0Ki ± 0%   -0.15% (p=0.002 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_request/scenario=max_label_value_length_limit_reached-14                                   708.1Ki ± 0%   707.1Ki ± 0%   -0.14% (p=0.002 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_request/scenario=all_samples_go_to_metric_relabel_configs-14                               236.8Ki ± 0%   236.8Ki ± 0%        ~ (p=0.589 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_request/scenario=HA_dedupe,_all_series_from_primary_replica-14                             157.3Ki ± 0%   156.9Ki ± 0%   -0.22% (p=0.002 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_sample/scenario=HA_dedupe,_all_series_from_primary_replica-14                              158.9Ki ± 0%   158.8Ki ± 0%        ~ (p=0.240 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_sample/scenario=all_samples_successfully_pushed-14                                         157.1Ki ± 0%   156.8Ki ± 0%        ~ (p=0.065 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_sample/scenario=ingestion_rate_limit_reached-14                                            2.484Ki ± 1%   2.152Ki ± 2%  -13.37% (p=0.002 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_sample/scenario=too_many_labels_limit_reached-14                                           1.148Mi ± 0%   1.148Mi ± 0%        ~ (p=0.065 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_sample/scenario=max_label_name_length_limit_reached-14                                     1.086Mi ± 0%   1.086Mi ± 0%        ~ (p=0.699 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_sample/scenario=timestamp_too_new-14                                                       318.2Ki ± 0%   318.1Ki ± 0%        ~ (p=0.485 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_sample/scenario=HA_dedupe,_4_clusters_each_with_a_single_primary_replica-14                158.9Ki ± 0%   158.9Ki ± 0%        ~ (p=0.310 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_sample/scenario=max_label_value_length_limit_reached-14                                    707.9Ki ± 0%   708.1Ki ± 0%   +0.03% (p=0.015 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_sample/scenario=all_samples_go_to_metric_relabel_configs-14                                236.9Ki ± 0%   236.9Ki ± 0%        ~ (p=0.258 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_request/scenario=HA_dedupe,_all_series_from_primary_replica-14                              173.1Ki ± 0%   172.7Ki ± 0%   -0.22% (p=0.002 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_request/scenario=all_samples_successfully_pushed-14                                         157.1Ki ± 0%   157.0Ki ± 0%   -0.09% (p=0.041 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_request/scenario=ingestion_rate_limit_reached-14                                            2.453Ki ± 0%   2.114Ki ± 0%  -13.81% (p=0.002 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_request/scenario=too_many_labels_limit_reached-14                                           1.148Mi ± 0%   1.148Mi ± 0%        ~ (p=0.394 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_request/scenario=max_label_name_length_limit_reached-14                                     1.087Mi ± 0%   1.087Mi ± 0%   -0.08% (p=0.002 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_request/scenario=timestamp_too_new-14                                                       318.3Ki ± 0%   318.0Ki ± 0%   -0.08% (p=0.004 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_request/scenario=HA_dedupe,_4_clusters_each_with_a_single_primary_replica-14                173.0Ki ± 0%   172.7Ki ± 0%   -0.15% (p=0.002 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_request/scenario=max_label_value_length_limit_reached-14                                    708.1Ki ± 0%   707.9Ki ± 0%        ~ (p=0.310 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_request/scenario=all_samples_go_to_metric_relabel_configs-14                                236.9Ki ± 0%   236.8Ki ± 0%        ~ (p=0.615 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_sample/scenario=HA_dedupe,_all_series_from_primary_replica-14                               174.6Ki ± 0%   174.3Ki ± 0%   -0.18% (p=0.002 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_sample/scenario=all_samples_successfully_pushed-14                                          157.1Ki ± 0%   156.8Ki ± 0%   -0.15% (p=0.002 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_sample/scenario=ingestion_rate_limit_reached-14                                             2.412Ki ± 3%   2.115Ki ± 3%  -12.31% (p=0.002 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_sample/scenario=too_many_labels_limit_reached-14                                            1.147Mi ± 0%   1.147Mi ± 0%        ~ (p=0.132 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_sample/scenario=max_label_name_length_limit_reached-14                                      1.087Mi ± 0%   1.087Mi ± 0%   +0.06% (p=0.002 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_sample/scenario=timestamp_too_new-14                                                        318.0Ki ± 0%   318.0Ki ± 0%        ~ (p=1.000 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_sample/scenario=HA_dedupe,_4_clusters_each_with_a_single_primary_replica-14                 174.8Ki ± 0%   174.3Ki ± 0%   -0.29% (p=0.004 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_sample/scenario=max_label_value_length_limit_reached-14                                     707.5Ki ± 0%   707.2Ki ± 0%        ~ (p=0.065 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_sample/scenario=all_samples_go_to_metric_relabel_configs-14                                 236.6Ki ± 0%   236.6Ki ± 0%        ~ (p=0.667 n=6)
geomean                                                                                                                                          208.4Ki        205.0Ki        -1.63%

                                                                                                                                   │ /tmp/distr_bench_old.tmp │      /tmp/distr_bench_new.tmp      │
                                                                                                                                   │        allocs/op         │  allocs/op   vs base               │
Distributor_Push/cost_attribution=disabled/dedupe=per_request/scenario=all_samples_successfully_pushed-14                                          78.00 ± 0%    57.00 ± 0%  -26.92% (p=0.002 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_request/scenario=ingestion_rate_limit_reached-14                                             43.00 ± 0%    25.00 ± 0%  -41.86% (p=0.002 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_request/scenario=too_many_labels_limit_reached-14                                           5.061k ± 0%   5.042k ± 0%   -0.37% (p=0.002 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_request/scenario=max_label_name_length_limit_reached-14                                     5.059k ± 0%   5.041k ± 0%   -0.36% (p=0.002 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_request/scenario=timestamp_too_new-14                                                       4.055k ± 0%   4.037k ± 0%   -0.44% (p=0.002 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_request/scenario=HA_dedupe,_4_clusters_each_with_a_single_primary_replica-14                 81.00 ± 0%    60.00 ± 0%  -25.93% (p=0.002 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_request/scenario=max_label_value_length_limit_reached-14                                    4.061k ± 0%   4.042k ± 0%   -0.47% (p=0.002 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_request/scenario=all_samples_go_to_metric_relabel_configs-14                                5.081k ± 0%   5.060k ± 0%   -0.41% (p=0.002 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_request/scenario=HA_dedupe,_all_series_from_primary_replica-14                               81.00 ± 0%    60.00 ± 0%  -25.93% (p=0.002 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_sample/scenario=HA_dedupe,_all_series_from_primary_replica-14                                85.00 ± 0%    64.00 ± 0%  -24.71% (p=0.002 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_sample/scenario=all_samples_successfully_pushed-14                                           78.00 ± 0%    57.00 ± 0%  -26.92% (p=0.002 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_sample/scenario=ingestion_rate_limit_reached-14                                              43.00 ± 0%    25.00 ± 0%  -41.86% (p=0.002 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_sample/scenario=too_many_labels_limit_reached-14                                            5.060k ± 0%   5.042k ± 0%   -0.36% (p=0.002 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_sample/scenario=max_label_name_length_limit_reached-14                                      5.058k ± 0%   5.041k ± 0%   -0.34% (p=0.002 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_sample/scenario=timestamp_too_new-14                                                        4.055k ± 0%   4.037k ± 0%   -0.44% (p=0.002 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_sample/scenario=HA_dedupe,_4_clusters_each_with_a_single_primary_replica-14                  95.00 ± 0%    74.00 ± 0%  -22.11% (p=0.002 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_sample/scenario=max_label_value_length_limit_reached-14                                     4.061k ± 0%   4.043k ± 0%   -0.44% (p=0.002 n=6)
Distributor_Push/cost_attribution=disabled/dedupe=per_sample/scenario=all_samples_go_to_metric_relabel_configs-14                                 5.081k ± 0%   5.060k ± 0%   -0.41% (p=0.002 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_request/scenario=HA_dedupe,_all_series_from_primary_replica-14                               1.081k ± 0%   1.060k ± 0%   -1.94% (p=0.002 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_request/scenario=all_samples_successfully_pushed-14                                           78.00 ± 0%    57.00 ± 0%  -26.92% (p=0.002 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_request/scenario=ingestion_rate_limit_reached-14                                              43.00 ± 0%    25.00 ± 0%  -41.86% (p=0.002 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_request/scenario=too_many_labels_limit_reached-14                                            5.061k ± 0%   5.043k ± 0%   -0.36% (p=0.002 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_request/scenario=max_label_name_length_limit_reached-14                                      5.061k ± 0%   5.042k ± 0%   -0.38% (p=0.002 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_request/scenario=timestamp_too_new-14                                                        4.055k ± 0%   4.037k ± 0%   -0.43% (p=0.002 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_request/scenario=HA_dedupe,_4_clusters_each_with_a_single_primary_replica-14                 1.081k ± 0%   1.060k ± 0%   -1.94% (p=0.002 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_request/scenario=max_label_value_length_limit_reached-14                                     4.062k ± 0%   4.044k ± 0%   -0.44% (p=0.002 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_request/scenario=all_samples_go_to_metric_relabel_configs-14                                 5.081k ± 0%   5.060k ± 0%   -0.41% (p=0.002 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_sample/scenario=HA_dedupe,_all_series_from_primary_replica-14                                1.086k ± 0%   1.064k ± 0%   -2.03% (p=0.002 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_sample/scenario=all_samples_successfully_pushed-14                                            78.00 ± 0%    57.00 ± 0%  -26.92% (p=0.002 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_sample/scenario=ingestion_rate_limit_reached-14                                               43.00 ± 0%    25.00 ± 0%  -41.86% (p=0.002 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_sample/scenario=too_many_labels_limit_reached-14                                             5.060k ± 0%   5.043k ± 0%   -0.34% (p=0.002 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_sample/scenario=max_label_name_length_limit_reached-14                                       5.060k ± 0%   5.044k ± 0%   -0.32% (p=0.002 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_sample/scenario=timestamp_too_new-14                                                         4.055k ± 0%   4.038k ± 0%   -0.42% (p=0.002 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_sample/scenario=HA_dedupe,_4_clusters_each_with_a_single_primary_replica-14                  1.095k ± 0%   1.074k ± 0%   -1.92% (p=0.002 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_sample/scenario=max_label_value_length_limit_reached-14                                      4.061k ± 0%   4.043k ± 0%   -0.44% (p=0.002 n=6)
Distributor_Push/cost_attribution=enabled/dedupe=per_sample/scenario=all_samples_go_to_metric_relabel_configs-14                                  5.081k ± 0%   5.060k ± 0%   -0.41% (p=0.002 n=6)
geomean                                                                                                                                            955.8         838.4       -12.28%

```
</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the distributor push middleware cleanup path; mistakes could cause double-free/leaks or missing cleanup in error/early-return cases, though the change is localized and behavior-preserving by design.
> 
> **Overview**
> **Improves distributor push middleware cleanup handling** by moving the “did we call `next`?” tracking into `Request` via a new `needsCleanup` flag.
> 
> `WithCleanup` is rewritten to set `needsCleanup` and only call `Request.CleanUp()` on exit when the middleware chain short-circuits, removing the exported `NextOrCleanup` helper and avoiding per-middleware closure state/allocations. Changelog updated to note the enhancement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf9490188db818f9a7830fd69f7436f0160886c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->