### PR TITLE
distributor: return early from relabel middleware if neither drop_label nor relabel config is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 ### Grafana Mimir
 
-* [ENHANCEMENT] Distributor: Improve distributor push middleware cleanup handling. #15245
 * [FEATURE] Mimirtool: Add AWS Signature Version 4 (SigV4) support for shared Mimir API client commands including `mimirtool rules`, `mimirtool alertmanager`, `mimirtool alerts`, `mimirtool backfill`, and `mimirtool analyze ruler`. #14959
 * [FEATURE] MQE: Add experimental support for reporting the number of samples read per query. #15276
+* [ENHANCEMENT] Distributor: Relabel middleware returns early if neither label dropping nor relabeling is configured. #15246
+* [ENHANCEMENT] Distributor: Improve distributor push middleware cleanup handling. #15245
 * [ENHANCEMENT] MQE: Improve experimental support for reporting the number of samples read per query. #15179 #15220 #15223 #15232 #15237 #15255
 * [ENHANCEMENT] Ingest storage: Reject the whole batch of records of a Kafka write call when the configured `-ingest-storage.kafka.producer-max-buffered-bytes` limit is reached, instead of rejecting individual records. #15227
 * [ENHANCEMENT] MQE: Simplify `unless` and `or` operations where one side can be proven to be empty by inspecting the expression. #15198

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1169,6 +1169,10 @@ func (d *Distributor) prePushRelabelMiddleware(next PushFunc) PushFunc {
 		dropLabels := d.limits.DropLabels(userID)
 		relabelConfigs := d.limits.MetricRelabelConfigs(userID)
 
+		if len(dropLabels) == 0 && len(relabelConfigs) == 0 {
+			return next(ctx, pushReq)
+		}
+
 		var removeTsIndexes []int
 		lb := labels.NewBuilder(labels.EmptyLabels())
 		for tsIdx := 0; tsIdx < len(req.Timeseries); tsIdx++ {


### PR DESCRIPTION
#### What this PR does

Simply return early when no relabel actions are taken. Why? Because `labels.NewBuilder` does some allocations, and looping over series takes some time.  

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk performance optimization: the relabel middleware now short-circuits when no label dropping or relabel configs exist, avoiding per-series work while preserving behavior when configs are present.
> 
> **Overview**
> **Reduces write-path overhead in the distributor relabel middleware.** When a tenant has neither `drop_labels` nor `metric_relabel_configs` configured, `prePushRelabelMiddleware` now returns immediately to `next`, skipping label builder allocations and the per-timeseries loop.
> 
> Updates `CHANGELOG.md` to record the new distributor enhancement entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1ee6a6c0fe7cb68a9db39304d87947ed7e909f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->