### PR TITLE
Add regression tests for OTLP partial_success on sample_timestamp_too_old

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -8667,6 +8667,18 @@ func createSoftStatusWithDetails(t *testing.T, code codes.Code, message string, 
 	return statWithDetails
 }
 
+func createSoftStatusWithDetailsAndRejected(t *testing.T, code codes.Code, message string, cause mimirpb.ErrorCause, rejectedSamples int64) *status.Status {
+	stat := status.New(code, message)
+	statWithDetails, err := stat.WithDetails(&mimirpb.ErrorDetails{
+		Cause:           cause,
+		Soft:            true,
+		RejectedSamples: rejectedSamples,
+	})
+
+	require.NoError(t, err)
+	return statWithDetails
+}
+
 func countCalls(ingesters []*mockIngester, name string) int {
 	count := 0
 

--- a/pkg/distributor/otel_test.go
+++ b/pkg/distributor/otel_test.go
@@ -1768,6 +1768,32 @@ func TestHandlerOTLPPush(t *testing.T) {
 			expectedLogs:          []string{`level=warn user=test msg="detected an error while ingesting OTLP metrics request (the request may have been partially ingested)" httpCode=429 err="` + newActiveSeriesLimitedError(10, 10, 100, http.StatusTooManyRequests, 15).Error() + `" insight=true`},
 			expectedRetryHeader:   true,
 		},
+		{
+			// Regression test for OTLP spec compliance: when an ingester rejects some but not
+			// all samples as too-old (outside the OOO window), the OTLP handler must return
+			// HTTP 200 with partial_success per the OTLP spec, not 400. The status produced
+			// here mirrors what newErrorWithStatus produces server-side for a
+			// softErrorWithRejectedSamples wrapping a sampleTimestampTooOld sampleError.
+			name:       "Soft ingesterPushError simulating sample_timestamp_too_old partial rejection",
+			maxMsgSize: 100000,
+			series:     sampleSeries,
+			metadata:   sampleMetadata,
+			verifyFunc: func(t *testing.T, _ context.Context, _ *Request, _ testCase) error {
+				const tooOldMsg = "the sample has been rejected because its timestamp is too old"
+				return newIngesterPushError(
+					createSoftStatusWithDetailsAndRejected(t, codes.InvalidArgument, tooOldMsg, mimirpb.ERROR_CAUSE_BAD_DATA, 2),
+					"ingester-25",
+				)
+			},
+			responseCode:          http.StatusOK,
+			responseContentType:   pbContentType,
+			responseContentLength: 107,
+			expectedRetryHeader:   false,
+			expectedPartialSuccess: &colmetricpb.ExportMetricsPartialSuccess{
+				RejectedDataPoints: 2,
+				ErrorMessage:       "failed pushing to ingester ingester-25: the sample has been rejected because its timestamp is too old",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/ingester/errors_test.go
+++ b/pkg/ingester/errors_test.go
@@ -441,6 +441,20 @@ func TestMapPushErrorToErrorWithStatus(t *testing.T) {
 			expectedMessage: fmt.Sprintf("wrapped: %s", newSampleError("id", "sample error", timestamp, labelAdapters).Error()),
 			expectedDetails: &mimirpb.ErrorDetails{Cause: mimirpb.ERROR_CAUSE_BAD_DATA, Soft: true},
 		},
+		// Regression test for OTLP spec compliance: when the ingester partially rejects
+		// samples as too-old, it wraps the sampleError in softErrorWithRejectedSamples (see
+		// PushWithCleanup). The resulting gRPC status must carry both Soft=true and the
+		// rejected sample count, so the distributor can surface OTLP partial_success per
+		// the OTLP spec.
+		"a sampleTimestampTooOld wrapped in softErrorWithRejectedSamples carries Soft and RejectedSamples": {
+			err: softErrorWithRejectedSamples{
+				err:             newSampleTimestampTooOldError(timestamp, labelAdapters),
+				rejectedSamples: 2,
+			},
+			expectedCode:    codes.InvalidArgument,
+			expectedMessage: newSampleTimestampTooOldError(timestamp, labelAdapters).Error(),
+			expectedDetails: &mimirpb.ErrorDetails{Cause: mimirpb.ERROR_CAUSE_BAD_DATA, Soft: true, RejectedSamples: 2},
+		},
 		"an exemplarError gets translated into an ErrorWithStatus InvalidArgument error with details": {
 			err:             newExemplarError("id", "exemplar error", timestamp, labelAdapters, labelAdapters),
 			expectedCode:    codes.InvalidArgument,


### PR DESCRIPTION
#### What this PR does

Adds two regression tests verifying the OTLP partial_success path for `sample_timestamp_too_old` rejections. PRs #12579 and #14789 already made the distributor compliant with the [OTLP spec partial-success rules](https://opentelemetry.io/docs/specs/otlp/#partial-success-1) when an ingester partially rejects samples — but existing tests only injected synthetic `ingesterPushError` values, leaving the real gRPC-status encoding/decoding path through `mimirpb.ErrorDetails{Soft, RejectedSamples}` uncovered.

These tests close that gap:

- **`pkg/ingester/errors_test.go`** — verifies a `sampleTimestampTooOld` wrapped in `softErrorWithRejectedSamples` (the path `PushWithCleanup` takes for partial too-old rejection) produces a gRPC status with both `Soft=true` and `RejectedSamples=N` in `mimirpb.ErrorDetails`.
- **`pkg/distributor/otel_test.go`** — verifies an `ingesterPushError` decoded from such a gRPC status produces HTTP 200 with `ExportMetricsPartialSuccess.RejectedDataPoints` populated.

Both pass on `main` with no production code changes.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] \`CHANGELOG.md\` updated — \`changelog-not-needed\` (test-only, no behavior change).
- [ ] \`about-versioning.md\` updated with experimental features.

#### Follow-up (not blocking)

- The `"the sample has been rejected because its timestamp is too old"` message in `pkg/ingester/errors.go` is currently a literal argument inside the unexported `newSampleTimestampTooOldError`. Exporting it as a package-level const would let cross-package tests (like the new one in `pkg/distributor/otel_test.go`) reference the source of truth instead of hand-copying the string.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that add coverage for gRPC status details and OTLP HTTP mapping, with no production logic modifications.
> 
> **Overview**
> Adds regression tests to ensure **OTLP partial-success behavior** is preserved when ingesters *partially* reject metrics due to `sample_timestamp_too_old`.
> 
> The ingester-side test asserts `softErrorWithRejectedSamples` encodes `mimirpb.ErrorDetails` with both `Soft=true` and `RejectedSamples=N`, and the distributor OTLP test asserts the corresponding `ingesterPushError` yields HTTP `200` with `partial_success.RejectedDataPoints` (not an HTTP `400`). A small test helper (`createSoftStatusWithDetailsAndRejected`) was added to construct statuses with rejected-sample counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d04d0c7f3c44da7020ae1ac015058318acde45f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->