### PR TITLE
querymiddleware: close MQE queries on every error path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,7 +207,7 @@
 * [ENHANCEMENT] MQE: Use series selected for one side to reduce data selected on the other side in one-to-many and many-to-one binary operations (eg. `group_left` and `group_right`). #15137
 * [ENHANCEMENT] MQE: Simplify `unless` and `or` operations where one side can be proven to be empty by inspecting the expression. #15198
 * [ENHANCEMENT] MQE: Reduced per-query memory overhead by no longer holding a reference to the HTTP request for the lifetime of a query. #15251
-* [BUGFIX] Query-frontend: Fixed a MemoryConsumptionTracker memory leak caused by MQE queries not having `Close()` called in some error paths. #15251
+* [BUGFIX] Query-frontend: Fixed a memory leak caused that could occur on some error paths if MQE was enabled. #15251
 * [BUGFIX] Ingest storage: Fix `KafkaProducer.ProduceSync()` returning a single result with a nil record when the context is canceled, instead of one result per input record (with the record set) as the underlying franz-go client does. #15199
 * [BUGFIX] Alertmanager: Skip empty/zero config. #15184
 * [BUGFIX] Tracing: Respect `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` environment variables in `NewOTelFromEnv()`. Previously, the sampler was always hardcoded to `AlwaysSample()` when no Jaeger remote sampler was configured, making it impossible to control trace volume through standard OpenTelemetry configuration. #15128

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,8 @@
 * [ENHANCEMENT] MQE: Add support for common subexpression elimination and subset selector elimination of range vector selectors in range queries. Enable with `-querier.mimir-query-engine.enable-range-query-range-vector-common-subexpression-elimination=true`. #15127
 * [ENHANCEMENT] MQE: Use series selected for one side to reduce data selected on the other side in one-to-many and many-to-one binary operations (eg. `group_left` and `group_right`). #15137
 * [ENHANCEMENT] MQE: Simplify `unless` and `or` operations where one side can be proven to be empty by inspecting the expression. #15198
+* [ENHANCEMENT] MQE: `MemoryConsumptionTracker` no longer retains the request `context.Context`. #15251
+* [BUGFIX] Query-frontend: Close MQE queries on all error paths to prevent leaking memory tracker registrations and pooled buffers. #15251
 * [BUGFIX] Ingest storage: Fix `KafkaProducer.ProduceSync()` returning a single result with a nil record when the context is canceled, instead of one result per input record (with the record set) as the underlying franz-go client does. #15199
 * [BUGFIX] Alertmanager: Skip empty/zero config. #15184
 * [BUGFIX] Tracing: Respect `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` environment variables in `NewOTelFromEnv()`. Previously, the sampler was always hardcoded to `AlwaysSample()` when no Jaeger remote sampler was configured, making it impossible to control trace volume through standard OpenTelemetry configuration. #15128

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,8 +206,8 @@
 * [ENHANCEMENT] MQE: Add support for common subexpression elimination and subset selector elimination of range vector selectors in range queries. Enable with `-querier.mimir-query-engine.enable-range-query-range-vector-common-subexpression-elimination=true`. #15127
 * [ENHANCEMENT] MQE: Use series selected for one side to reduce data selected on the other side in one-to-many and many-to-one binary operations (eg. `group_left` and `group_right`). #15137
 * [ENHANCEMENT] MQE: Simplify `unless` and `or` operations where one side can be proven to be empty by inspecting the expression. #15198
-* [ENHANCEMENT] MQE: `MemoryConsumptionTracker` no longer retains the request `context.Context`. #15251
-* [BUGFIX] Query-frontend: Close MQE queries on all error paths to prevent leaking memory tracker registrations and pooled buffers. #15251
+* [ENHANCEMENT] MQE: Reduced per-query memory overhead by no longer holding a reference to the HTTP request for the lifetime of a query. #15251
+* [BUGFIX] Query-frontend: Fixed a MemoryConsumptionTracker memory leak caused by MQE queries not having `Close()` called in some error paths. #15251
 * [BUGFIX] Ingest storage: Fix `KafkaProducer.ProduceSync()` returning a single result with a nil record when the context is canceled, instead of one result per input record (with the record set) as the underlying franz-go client does. #15199
 * [BUGFIX] Alertmanager: Skip empty/zero config. #15184
 * [BUGFIX] Tracing: Respect `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` environment variables in `NewOTelFromEnv()`. Previously, the sampler was always hardcoded to `AlwaysSample()` when no Jaeger remote sampler was configured, making it impossible to control trace volume through standard OpenTelemetry configuration. #15128

--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -418,6 +418,17 @@ func (rth *engineQueryRequestRoundTripperHandler) Do(ctx context.Context, r Metr
 		return nil, err
 	}
 
+	// Ownership of q is transferred to the response finalizer on success. On any
+	// failure path before that hand-off we must Close q ourselves, otherwise the
+	// query's resources (memory consumption tracker, pooled buffers, evaluator
+	// context) leak.
+	handedOff := false
+	defer func() {
+		if !handedOff {
+			q.Close()
+		}
+	}()
+
 	res := q.Exec(ctx)
 	if res.Err != nil {
 		err := convertToAPIError(res.Err, apierror.TypeExec)
@@ -451,6 +462,7 @@ func (rth *engineQueryRequestRoundTripperHandler) Do(ctx context.Context, r Metr
 		finalizer: q.Close,
 	}
 
+	handedOff = true
 	return resp, nil
 }
 

--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -422,9 +422,9 @@ func (rth *engineQueryRequestRoundTripperHandler) Do(ctx context.Context, r Metr
 	// failure path before that hand-off we must Close q ourselves, otherwise the
 	// query's resources (memory consumption tracker, pooled buffers, evaluator
 	// context) leak.
-	handedOff := false
+	shouldCloseQuery := true
 	defer func() {
-		if !handedOff {
+		if shouldCloseQuery {
 			q.Close()
 		}
 	}()
@@ -462,7 +462,7 @@ func (rth *engineQueryRequestRoundTripperHandler) Do(ctx context.Context, r Metr
 		finalizer: q.Close,
 	}
 
-	handedOff = true
+	shouldCloseQuery = false
 	return resp, nil
 }
 

--- a/pkg/frontend/querymiddleware/limits_test.go
+++ b/pkg/frontend/querymiddleware/limits_test.go
@@ -33,6 +33,7 @@ import (
 	"go.uber.org/atomic"
 
 	apierror "github.com/grafana/mimir/pkg/api/error"
+	"github.com/grafana/mimir/pkg/frontend/querymiddleware/testdatagen"
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/querier/api"
 	"github.com/grafana/mimir/pkg/querier/stats"
@@ -1489,30 +1490,28 @@ func TestEngineQueryRequestRoundTripperHandler_ClosesQueryOnError(t *testing.T) 
 # TYPE cortex_querier_inflight_query_sampled_count gauge
 `
 
-	parseExpr := func(t *testing.T, s string) parser.Expr {
-		t.Helper()
-		expr, err := promqlext.NewPromQLParser().ParseExpr(s)
-		require.NoError(t, err)
-		return expr
-	}
+	failingQueryable := storage.QueryableFunc(func(int64, int64) (storage.Querier, error) {
+		return nil, apierror.New(apierror.TypeInternal, "boom")
+	})
 
-	const lookbackDelta = 5 * time.Minute
+	successfulQueryable := testdatagen.StorageSeriesQueryable([]storage.Series{
+		testdatagen.NewSeries(labels.FromStrings("__name__", "bar1"), start.Add(-lookbackDelta), end, step, testdatagen.Factor(5)),
+	})
 
 	testCases := map[string]struct {
-		req           MetricsQueryRequest
+		queryable     storage.Queryable
 		expectSuccess bool
 	}{
 		"execution error leaves no tracker registered": {
-			// `some_metric * on(foo) some_other_metric` triggers a duplicate-match
-			// error from Exec — the failure path between Exec and the finalizer
-			// hand-off.
-			req: NewPrometheusInstantQueryRequest("/", nil, 3000, lookbackDelta, parseExpr(t, `some_metric * on(foo) some_other_metric`), Options{}, nil, ""),
+			queryable: failingQueryable,
 		},
 		"successful query drains via finalizer": {
-			req:           NewPrometheusInstantQueryRequest("/", nil, 3000, lookbackDelta, parseExpr(t, `some_metric`), Options{}, nil, ""),
+			queryable:     successfulQueryable,
 			expectSuccess: true,
 		},
 	}
+
+	req := NewPrometheusInstantQueryRequest("/", nil, util.TimeToMillis(end), lookbackDelta, parseQuery(t, "bar1"), Options{}, nil, "")
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
@@ -1529,18 +1528,10 @@ func TestEngineQueryRequestRoundTripperHandler_ClosesQueryOnError(t *testing.T) 
 			engine, err := streamingpromql.NewEngine(opts, queryMetrics, planner)
 			require.NoError(t, err)
 
-			testStorage := promqltest.LoadedStorage(t, `
-				load 1s
-					some_metric{foo="bar"} 0+1x50
-					some_other_metric{foo="bar", idx="0"} 0+1x50
-					some_other_metric{foo="bar", idx="1"} 0+1x50
-			`)
-			t.Cleanup(func() { testStorage.Close() })
-
 			handler := NewEngineQueryRequestRoundTripperHandler(engine, newTestCodec(), log.NewNopLogger())
-			handler.(*engineQueryRequestRoundTripperHandler).storage = testStorage
+			handler.(*engineQueryRequestRoundTripperHandler).storage = tc.queryable
 
-			resp, err := handler.Do(context.Background(), tc.req)
+			resp, err := handler.Do(context.Background(), req)
 
 			if tc.expectSuccess {
 				require.NoError(t, err)

--- a/pkg/frontend/querymiddleware/limits_test.go
+++ b/pkg/frontend/querymiddleware/limits_test.go
@@ -1485,7 +1485,9 @@ func TestEngineQueryRequestRoundTripperHandler(t *testing.T) {
 // inflight tracker count rather than wrapping the engine.
 func TestEngineQueryRequestRoundTripperHandler_ClosesQueryOnError(t *testing.T) {
 	const sampledMetric = "cortex_querier_inflight_query_sampled_count"
-	const sampledHelp = "# HELP cortex_querier_inflight_query_sampled_count Number of in-flight memory consumption trackers accumulated during the last metrics collection.\n# TYPE cortex_querier_inflight_query_sampled_count gauge\n"
+	const sampledHelp = `# HELP cortex_querier_inflight_query_sampled_count Number of in-flight memory consumption trackers accumulated during the last metrics collection.
+# TYPE cortex_querier_inflight_query_sampled_count gauge
+`
 
 	parseExpr := func(t *testing.T, s string) parser.Expr {
 		t.Helper()

--- a/pkg/frontend/querymiddleware/limits_test.go
+++ b/pkg/frontend/querymiddleware/limits_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/tenant"
 	"github.com/grafana/dskit/user"
+	"github.com/prometheus/client_golang/prometheus"
+	promtest "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/prompb"
@@ -38,6 +40,7 @@ import (
 	"github.com/grafana/mimir/pkg/streamingpromql/compat"
 	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/chunkinfologger"
+	"github.com/grafana/mimir/pkg/util/limiter"
 	"github.com/grafana/mimir/pkg/util/promqlext"
 	"github.com/grafana/mimir/pkg/util/validation"
 )
@@ -1470,6 +1473,86 @@ func TestEngineQueryRequestRoundTripperHandler(t *testing.T) {
 
 			options := RequestOptionsFromContext(contextCapturingStorage.ctx)
 			require.Equal(t, testCase.req.GetOptions(), options)
+		})
+	}
+}
+
+// TestEngineQueryRequestRoundTripperHandler_ClosesQueryOnError verifies that
+// engineQueryRequestRoundTripperHandler.Do leaves no in-flight memory
+// consumption tracker behind, regardless of which return path Do takes.
+// `engineQueryRequestRoundTripperHandler` is wired to a concrete
+// *streamingpromql.Engine, so this test asserts the post-condition via the
+// inflight tracker count rather than wrapping the engine.
+func TestEngineQueryRequestRoundTripperHandler_ClosesQueryOnError(t *testing.T) {
+	const sampledMetric = "cortex_querier_inflight_query_sampled_count"
+	const sampledHelp = "# HELP cortex_querier_inflight_query_sampled_count Number of in-flight memory consumption trackers accumulated during the last metrics collection.\n# TYPE cortex_querier_inflight_query_sampled_count gauge\n"
+
+	parseExpr := func(t *testing.T, s string) parser.Expr {
+		t.Helper()
+		expr, err := promqlext.NewPromQLParser().ParseExpr(s)
+		require.NoError(t, err)
+		return expr
+	}
+
+	const lookbackDelta = 5 * time.Minute
+
+	testCases := map[string]struct {
+		req           MetricsQueryRequest
+		expectSuccess bool
+	}{
+		"execution error leaves no tracker registered": {
+			// `some_metric * on(foo) some_other_metric` triggers a duplicate-match
+			// error from Exec — the failure path between Exec and the finalizer
+			// hand-off.
+			req: NewPrometheusInstantQueryRequest("/", nil, 3000, lookbackDelta, parseExpr(t, `some_metric * on(foo) some_other_metric`), Options{}, nil, ""),
+		},
+		"successful query drains via finalizer": {
+			req:           NewPrometheusInstantQueryRequest("/", nil, 3000, lookbackDelta, parseExpr(t, `some_metric`), Options{}, nil, ""),
+			expectSuccess: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			reg := prometheus.NewPedanticRegistry()
+			queryMetrics := stats.NewQueryMetrics(reg)
+			inflightTracker := limiter.NewInflightMemoryConsumptionTracker(reg, queryMetrics.QueriesRejectedTotal.WithLabelValues(stats.RejectReasonMaxEstimatedQueryMemoryConsumption))
+
+			opts := streamingpromql.NewTestEngineOpts()
+			opts.CommonOpts.Reg = reg
+			opts.MemoryConsumptionTrackerFactory = inflightTracker
+
+			planner, err := streamingpromql.NewQueryPlanner(opts, streamingpromql.NewMaximumSupportedVersionQueryPlanVersionProvider())
+			require.NoError(t, err)
+			engine, err := streamingpromql.NewEngine(opts, queryMetrics, planner)
+			require.NoError(t, err)
+
+			testStorage := promqltest.LoadedStorage(t, `
+				load 1s
+					some_metric{foo="bar"} 0+1x50
+					some_other_metric{foo="bar", idx="0"} 0+1x50
+					some_other_metric{foo="bar", idx="1"} 0+1x50
+			`)
+			t.Cleanup(func() { testStorage.Close() })
+
+			handler := NewEngineQueryRequestRoundTripperHandler(engine, newTestCodec(), log.NewNopLogger())
+			handler.(*engineQueryRequestRoundTripperHandler).storage = testStorage
+
+			resp, err := handler.Do(context.Background(), tc.req)
+
+			if tc.expectSuccess {
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				// On success the query is held alive by the finalizer; the
+				// tracker should still be registered until we close the response.
+				require.NoError(t, promtest.CollectAndCompare(inflightTracker, strings.NewReader(sampledHelp+sampledMetric+" 1\n"), sampledMetric))
+				resp.(*PrometheusResponseWithFinalizer).Close()
+			} else {
+				require.Error(t, err)
+				require.Nil(t, resp)
+			}
+
+			require.NoError(t, promtest.CollectAndCompare(inflightTracker, strings.NewReader(sampledHelp+sampledMetric+" 0\n"), sampledMetric))
 		})
 	}
 }

--- a/pkg/frontend/querymiddleware/querysharding.go
+++ b/pkg/frontend/querymiddleware/querysharding.go
@@ -149,6 +149,17 @@ func ExecuteQueryOnQueryable(ctx context.Context, r MetricsQueryRequest, engine 
 		return nil, apierror.New(apierror.TypeBadData, err.Error())
 	}
 
+	// Ownership of qry is transferred to the response finalizer on success. On
+	// any failure path before that hand-off we must Close qry ourselves, otherwise
+	// the query's resources (memory consumption tracker, pooled buffers, evaluator
+	// context) leak.
+	handedOff := false
+	defer func() {
+		if !handedOff {
+			qry.Close()
+		}
+	}()
+
 	res := qry.Exec(ctx)
 	extracted, err := promqlResultToSamples(res)
 	if err != nil {
@@ -176,7 +187,7 @@ func ExecuteQueryOnQueryable(ctx context.Context, r MetricsQueryRequest, engine 
 		headers = shardedQueryable.getResponseHeaders()
 	}
 
-	return &PrometheusResponseWithFinalizer{
+	resp := &PrometheusResponseWithFinalizer{
 		PrometheusResponse: &PrometheusResponse{
 			Status: statusSuccess,
 			Data: &PrometheusData{
@@ -188,7 +199,10 @@ func ExecuteQueryOnQueryable(ctx context.Context, r MetricsQueryRequest, engine 
 			Infos:    info,
 		},
 		finalizer: qry.Close,
-	}, nil
+	}
+
+	handedOff = true
+	return resp, nil
 }
 
 func newQuery(ctx context.Context, r MetricsQueryRequest, engine promql.QueryEngine, queryable storage.Queryable) (promql.Query, error) {

--- a/pkg/frontend/querymiddleware/querysharding.go
+++ b/pkg/frontend/querymiddleware/querysharding.go
@@ -153,9 +153,9 @@ func ExecuteQueryOnQueryable(ctx context.Context, r MetricsQueryRequest, engine 
 	// any failure path before that hand-off we must Close qry ourselves, otherwise
 	// the query's resources (memory consumption tracker, pooled buffers, evaluator
 	// context) leak.
-	handedOff := false
+	shouldCloseQuery := true
 	defer func() {
-		if !handedOff {
+		if shouldCloseQuery {
 			qry.Close()
 		}
 	}()
@@ -201,7 +201,7 @@ func ExecuteQueryOnQueryable(ctx context.Context, r MetricsQueryRequest, engine 
 		finalizer: qry.Close,
 	}
 
-	handedOff = true
+	shouldCloseQuery = false
 	return resp, nil
 }
 

--- a/pkg/frontend/querymiddleware/querysharding_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test.go
@@ -2010,3 +2010,66 @@ func TestQuerySharding_ShouldNotPanicOnNilQueryExpression(t *testing.T) {
 		require.Nil(t, resp)
 	})
 }
+
+// TestExecuteQueryOnQueryable_ClosesQueryOnError verifies that
+// ExecuteQueryOnQueryable calls Close on the underlying promql.Query for every
+// error path between query creation and the response finalizer hand-off. We
+// assert this directly by wrapping the engine and counting Close() calls on
+// every Query it produces.
+func TestExecuteQueryOnQueryable_ClosesQueryOnError(t *testing.T) {
+	failingQueryable := storage.QueryableFunc(func(int64, int64) (storage.Querier, error) {
+		return nil, apierror.New(apierror.TypeInternal, "boom")
+	})
+
+	successfulQueryable := testdatagen.StorageSeriesQueryable([]storage.Series{
+		testdatagen.NewSeries(labels.FromStrings("__name__", "bar1"), start.Add(-lookbackDelta), end, step, testdatagen.Factor(5)),
+	})
+
+	for _, tc := range []struct {
+		name          string
+		queryable     storage.Queryable
+		expectSuccess bool
+	}{
+		{
+			name:      "execution error closes the query",
+			queryable: failingQueryable,
+		},
+		{
+			name:          "successful query is closed via finalizer",
+			queryable:     successfulQueryable,
+			expectSuccess: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, innerEngine := newEngineForTesting(t, querier.MimirEngine)
+			engine := newCloseCountingEngine(innerEngine)
+
+			req := &PrometheusRangeQueryRequest{
+				path:      "/query_range",
+				start:     util.TimeToMillis(start),
+				end:       util.TimeToMillis(end),
+				step:      step.Milliseconds(),
+				queryExpr: parseQuery(t, "sum(bar1)"),
+			}
+
+			ctx := user.InjectOrgID(context.Background(), "test")
+			resp, err := ExecuteQueryOnQueryable(ctx, req, engine, tc.queryable, NewAnnotationAccumulator())
+
+			require.Equal(t, 1, engine.queriesCreated(), "expected exactly one promql.Query to be created")
+
+			if tc.expectSuccess {
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				// Ownership is transferred to the response finalizer; Close
+				// must not have been called yet.
+				require.Zero(t, engine.totalCloseCalls(), "expected Close to not have been called before the response finalizer fires")
+				resp.(*PrometheusResponseWithFinalizer).Close()
+			} else {
+				require.Error(t, err)
+				require.Nil(t, resp)
+			}
+
+			require.GreaterOrEqual(t, engine.totalCloseCalls(), 1, "expected Close to be called at least once on the underlying query")
+		})
+	}
+}

--- a/pkg/frontend/querymiddleware/querysharding_test_utils_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test_utils_test.go
@@ -358,6 +358,65 @@ func newEngineForTesting(t *testing.T, engine string, opts ...engineOpt) (promql
 	panic("unreachable")
 }
 
+// closeCountingEngine wraps a promql.QueryEngine and counts how many queries
+// it has produced and how many of those have had Close() called. It is used
+// by tests that need to verify the close-on-error contract — that callers of
+// NewInstantQuery / NewRangeQuery release the returned promql.Query on every
+// return path, not just the success path that hands ownership to a finalizer.
+type closeCountingEngine struct {
+	inner   promql.QueryEngine
+	queries []*closeCountingQuery
+}
+
+func newCloseCountingEngine(inner promql.QueryEngine) *closeCountingEngine {
+	return &closeCountingEngine{inner: inner}
+}
+
+func (e *closeCountingEngine) NewInstantQuery(ctx context.Context, q storage.Queryable, opts promql.QueryOpts, qs string, ts time.Time) (promql.Query, error) {
+	qry, err := e.inner.NewInstantQuery(ctx, q, opts, qs, ts)
+	if err != nil {
+		return nil, err
+	}
+	wrapped := &closeCountingQuery{Query: qry}
+	e.queries = append(e.queries, wrapped)
+	return wrapped, nil
+}
+
+func (e *closeCountingEngine) NewRangeQuery(ctx context.Context, q storage.Queryable, opts promql.QueryOpts, qs string, start, end time.Time, interval time.Duration) (promql.Query, error) {
+	qry, err := e.inner.NewRangeQuery(ctx, q, opts, qs, start, end, interval)
+	if err != nil {
+		return nil, err
+	}
+	wrapped := &closeCountingQuery{Query: qry}
+	e.queries = append(e.queries, wrapped)
+	return wrapped, nil
+}
+
+// queriesCreated returns the number of queries this engine has produced.
+func (e *closeCountingEngine) queriesCreated() int {
+	return len(e.queries)
+}
+
+// totalCloseCalls returns the sum of Close() invocations across every query
+// this engine has produced.
+func (e *closeCountingEngine) totalCloseCalls() int {
+	total := 0
+	for _, q := range e.queries {
+		total += q.closeCalls
+	}
+	return total
+}
+
+type closeCountingQuery struct {
+	promql.Query
+	closeCalls int
+}
+
+func (q *closeCountingQuery) Close() {
+	q.closeCalls++
+	q.Query.Close()
+}
+
 // runForEngines runs the provided test closure with the Prometheus Engine and Mimir Query Engine.
 func runForEngines(t *testing.T, run func(t *testing.T, opts promql.EngineOpts, eng promql.QueryEngine)) {
 	t.Helper()

--- a/pkg/frontend/querymiddleware/spin_off_subqueries.go
+++ b/pkg/frontend/querymiddleware/spin_off_subqueries.go
@@ -204,9 +204,9 @@ func (s *spinOffSubqueriesMiddleware) Do(ctx context.Context, req MetricsQueryRe
 	// any failure path before that hand-off we must Close qry ourselves, otherwise
 	// the query's resources (memory consumption tracker, pooled buffers, evaluator
 	// context) leak.
-	handedOff := false
+	shouldCloseQuery := true
 	defer func() {
-		if !handedOff {
+		if shouldCloseQuery {
 			qry.Close()
 		}
 	}()
@@ -246,6 +246,6 @@ func (s *spinOffSubqueriesMiddleware) Do(ctx context.Context, req MetricsQueryRe
 		finalizer: qry.Close,
 	}
 
-	handedOff = true
+	shouldCloseQuery = false
 	return resp, nil
 }

--- a/pkg/frontend/querymiddleware/spin_off_subqueries.go
+++ b/pkg/frontend/querymiddleware/spin_off_subqueries.go
@@ -200,6 +200,17 @@ func (s *spinOffSubqueriesMiddleware) Do(ctx context.Context, req MetricsQueryRe
 		return nil, apierror.New(apierror.TypeBadData, err.Error())
 	}
 
+	// Ownership of qry is transferred to the response finalizer on success. On
+	// any failure path before that hand-off we must Close qry ourselves, otherwise
+	// the query's resources (memory consumption tracker, pooled buffers, evaluator
+	// context) leak.
+	handedOff := false
+	defer func() {
+		if !handedOff {
+			qry.Close()
+		}
+	}()
+
 	res := qry.Exec(ctx)
 	extracted, err := promqlResultToSamples(res)
 	if err != nil {
@@ -221,7 +232,7 @@ func (s *spinOffSubqueriesMiddleware) Do(ctx context.Context, req MetricsQueryRe
 	warn = removeDuplicates(warn)
 	info = removeDuplicates(info)
 
-	return &PrometheusResponseWithFinalizer{
+	resp := &PrometheusResponseWithFinalizer{
 		PrometheusResponse: &PrometheusResponse{
 			Status: statusSuccess,
 			Data: &PrometheusData{
@@ -233,5 +244,8 @@ func (s *spinOffSubqueriesMiddleware) Do(ctx context.Context, req MetricsQueryRe
 			Infos:    info,
 		},
 		finalizer: qry.Close,
-	}, nil
+	}
+
+	handedOff = true
+	return resp, nil
 }

--- a/pkg/util/limiter/memory_consumption.go
+++ b/pkg/util/limiter/memory_consumption.go
@@ -303,7 +303,7 @@ type MemoryConsumptionTracker struct {
 	haveRecordedRejection bool
 	queryDescription      string
 
-	ctx context.Context // Used to retrieve trace ID to include in panic messages.
+	traceID string // Used to include in panic messages. Empty if the query didn't carry a tracing ID.
 
 	// mtx protects all mutable state of the memory consumption tracker. We use a mutex
 	// rather than atomics because we only want to adjust the memory used after checking
@@ -323,12 +323,14 @@ func NewUnlimitedMemoryConsumptionTracker(ctx context.Context) *MemoryConsumptio
 }
 
 func NewMemoryConsumptionTracker(ctx context.Context, maxEstimatedMemoryConsumptionBytes uint64, rejectionCount prometheus.Counter, queryDescription string) *MemoryConsumptionTracker {
+	traceID, _ := tracing.ExtractTraceID(ctx)
 	return &MemoryConsumptionTracker{
 		maxEstimatedMemoryConsumptionBytes: maxEstimatedMemoryConsumptionBytes,
 
 		rejectionCount:   rejectionCount,
 		queryDescription: queryDescription,
-		ctx:              ctx,
+
+		traceID: traceID,
 	}
 }
 
@@ -371,11 +373,9 @@ func (l *MemoryConsumptionTracker) DecreaseMemoryConsumption(b uint64, source Me
 	defer l.mtx.Unlock()
 
 	if b > l.currentEstimatedMemoryConsumptionBySource[source] {
-		traceID, ok := tracing.ExtractTraceID(l.ctx)
 		traceDescription := ""
-
-		if ok {
-			traceDescription = fmt.Sprintf(" (trace ID: %v)", traceID)
+		if l.traceID != "" {
+			traceDescription = fmt.Sprintf(" (trace ID: %v)", l.traceID)
 		}
 
 		panic(fmt.Sprintf(


### PR DESCRIPTION
#### What this PR does

This is an alternative fix to https://github.com/grafana/mimir/pull/15242.

The recently added https://github.com/grafana/mimir/pull/14807 can cause a leak of MemoryConsumptionTracker where a query is not closed. This can occur on various error paths.

The query-frontend middlewares that build a promql.Query — the engine round-tripper, query-sharding, and subquery spin-off — transferred ownership of the query to a response finalizer. The finalizer closes the query, and releases the in-flight memory consumption tracker registration, returns pooled result buffers, and cancels the evaluator context.

If there are errors in the Exec or promqlResultToSamples reported an error, the query Close is not called.

Each call site now uses a "transfer-on-success" defer so Close runs on every return path between query creation and the finalizer hand-off. Tests assert the post-condition for the engine handler and a direct Close-counting test for ExecuteQueryOnQueryable that fails without the fix.

Independent: stop holding the request context inside MemoryConsumptionTracker just to extract a trace ID for panic messages; capture the trace ID once at construction.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches query execution lifecycle in multiple query-frontend middlewares; incorrect ownership transfer/closing could cause premature Close() or continued leaks under error conditions.
> 
> **Overview**
> Prevents MQE/promql query resource leaks in query-frontend by ensuring `promql.Query.Close()` is called on **all** error return paths (engine round-tripper, query sharding, and subquery spin-off), while still transferring ownership to the response finalizer on success.
> 
> Reduces per-query memory overhead in `MemoryConsumptionTracker` by capturing the trace ID at construction time instead of retaining the full request `context.Context`, and adds focused tests that assert in-flight tracker/Close behavior on success vs failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2a076241abfb02dc95a4e7775a8051983e4498e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->