### PR TITLE
Distributor: return OTLP partial-success on partial too_far_in_past rejection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -293,6 +293,7 @@
 * [BUGFIX] MQE: Fix `info()` function only retaining one matcher when multiple data label matchers target the same label name. #14832
 * [BUGFIX] MQE: Fix `info()` function silently overwriting conflicting labels from different info metrics instead of returning an error. #14832
 * [BUGFIX] MQE: Fix `info()` function incorrectly grouping labels from replaced info series at the same evaluation timestamp due to lookback. #14832
+* [BUGFIX] Distributor: Return HTTP 200 with OTLP partial-success when only some samples in an OTLP request are rejected by distributor-level validation (e.g. `too_far_in_past`). #15253
 
 ### Mixin
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1325,6 +1325,12 @@ func (d *Distributor) prePushValidationMiddleware(next PushFunc) PushFunc {
 		var droppedNativeHistograms int
 
 		var firstPartialErr error
+		// firstSampleValidationErr holds the unwrapped sample-validation error (the
+		// underlying fmt.Errorf from validateSample). It is kept separately from
+		// firstPartialErr (which may also hold a metadata-validation error) so we can
+		// build a soft validationError when the request is partially accepted.
+		var firstSampleValidationErr error
+		var rejectedSamplesCount int64
 		var removeIndexes []int
 		totalSamples, totalExemplars := 0, 0
 		const maxMetricsWithDeduplicatedSamplesToTrace = 10
@@ -1359,7 +1365,9 @@ func (d *Distributor) prePushValidationMiddleware(next PushFunc) PushFunc {
 				if firstPartialErr == nil {
 					// The series are never retained by validationErr. This is guaranteed by the way the latter is built.
 					firstPartialErr = newValidationError(validationErr)
+					firstSampleValidationErr = validationErr
 				}
+				rejectedSamplesCount += int64(rawSamples + rawHistograms)
 				removeIndexes = append(removeIndexes, tsIdx)
 				continue
 			}
@@ -1465,8 +1473,35 @@ func (d *Distributor) prePushValidationMiddleware(next PushFunc) PushFunc {
 		ctx = ingest.ContextWithRecordTimestamp(ctx, now)
 		err = next(ctx, pushReq)
 		if err != nil {
-			// Errors resulting from the pushing to the ingesters have priority over validation errors.
+			// Errors resulting from the pushing to the ingesters have priority over
+			// validation errors, but if a downstream middleware returns a soft
+			// partial-success error we fold this middleware's rejection count into
+			// it. Mirrors what's done for active-series rejections.
+			//
+			// Note: when counts are combined, partial_success.error_message reflects
+			// only the downstream cause; per-reason rejection breakdowns are
+			// available via cortex_discarded_samples_total.
+			//
+			// TODO: if a future soft Error type carries a rejectedSamples count
+			// (e.g., a soft variant of partitionPushError for ingest-storage Kafka),
+			// add a parallel branch here so its count is also combined.
+			if rejectedSamplesCount > 0 {
+				var ingErr ingesterPushError
+				if errors.As(err, &ingErr) && ingErr.IsSoft() {
+					ingErr.rejectedSamples += rejectedSamplesCount
+					return ingErr
+				}
+				var asErr activeSeriesLimitedError
+				if errors.As(err, &asErr) && asErr.IsSoft() {
+					asErr.rejectedSamples += rejectedSamplesCount
+					return asErr
+				}
+			}
 			return err
+		}
+
+		if firstSampleValidationErr != nil && validatedSamples > 0 {
+			return newSoftValidationError(firstSampleValidationErr, rejectedSamplesCount)
 		}
 
 		return firstPartialErr

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1325,11 +1325,10 @@ func (d *Distributor) prePushValidationMiddleware(next PushFunc) PushFunc {
 		var droppedNativeHistograms int
 
 		var firstPartialErr error
-		// firstSampleValidationErr holds the unwrapped sample-validation error (the
-		// underlying fmt.Errorf from validateSample). It is kept separately from
-		// firstPartialErr (which may also hold a metadata-validation error) so we can
-		// build a soft validationError when the request is partially accepted.
-		var firstSampleValidationErr error
+		// firstValidationErr holds the first encountered series validation error.
+		// It is kept separately from firstPartialErr (which may also hold a metadata-validation error)
+		// so we can build a soft validationError when the request is partially accepted.
+		var firstValidationErr error
 		var rejectedSamplesCount int64
 		var removeIndexes []int
 		totalSamples, totalExemplars := 0, 0
@@ -1365,7 +1364,7 @@ func (d *Distributor) prePushValidationMiddleware(next PushFunc) PushFunc {
 				if firstPartialErr == nil {
 					// The series are never retained by validationErr. This is guaranteed by the way the latter is built.
 					firstPartialErr = newValidationError(validationErr)
-					firstSampleValidationErr = validationErr
+					firstValidationErr = validationErr
 				}
 				rejectedSamplesCount += int64(rawSamples + rawHistograms)
 				removeIndexes = append(removeIndexes, tsIdx)
@@ -1500,8 +1499,8 @@ func (d *Distributor) prePushValidationMiddleware(next PushFunc) PushFunc {
 			return err
 		}
 
-		if firstSampleValidationErr != nil && validatedSamples > 0 {
-			return newSoftValidationError(firstSampleValidationErr, rejectedSamplesCount)
+		if firstValidationErr != nil && validatedSamples > 0 {
+			return newSoftValidationError(firstValidationErr, rejectedSamplesCount)
 		}
 
 		return firstPartialErr

--- a/pkg/distributor/errors.go
+++ b/pkg/distributor/errors.go
@@ -131,11 +131,20 @@ var _ Error = tooManyClustersError{}
 // validationError is an error, used to represent all validation errors from the validation package.
 type validationError struct {
 	error
+	rejectedSamples int64
+	soft            bool
 }
 
 // newValidationError wraps the given error into a validationError error.
 func newValidationError(err error) validationError {
 	return validationError{error: err}
+}
+
+// newSoftValidationError wraps the given error as a partial rejection: Some samples
+// were rejected by distributor-level validation while the rest of the request was
+// successfully pushed.
+func newSoftValidationError(err error, rejectedSamples int64) validationError {
+	return validationError{error: err, rejectedSamples: rejectedSamples, soft: true}
 }
 
 func (e validationError) Cause() mimirpb.ErrorCause {
@@ -147,7 +156,7 @@ func (e validationError) Unwrap() error {
 }
 
 func (e validationError) IsSoft() bool {
-	return false
+	return e.soft
 }
 
 // Ensure that validationError implements Error.

--- a/pkg/distributor/otel.go
+++ b/pkg/distributor/otel.go
@@ -215,10 +215,13 @@ func handlePartialOTLPPush(pushErr error, w http.ResponseWriter, r *http.Request
 	var rejectedDataPoints int64
 	var ingPushErr ingesterPushError
 	var asErr activeSeriesLimitedError
+	var vErr validationError
 	if errors.As(pushErr, &ingPushErr) {
 		rejectedDataPoints = ingPushErr.rejectedSamples
 	} else if errors.As(pushErr, &asErr) {
 		rejectedDataPoints = asErr.rejectedSamples
+	} else if errors.As(pushErr, &vErr) {
+		rejectedDataPoints = vErr.rejectedSamples
 	}
 
 	expResp := colmetricpb.ExportMetricsServiceResponse{

--- a/pkg/distributor/otel_test.go
+++ b/pkg/distributor/otel_test.go
@@ -1326,6 +1326,8 @@ func TestHandlerOTLPPush(t *testing.T) {
 		},
 	}
 
+	now := time.Now()
+
 	const (
 		jsonContentType = "application/json"
 		pbContentType   = "application/x-protobuf"
@@ -1737,6 +1739,25 @@ func TestHandlerOTLPPush(t *testing.T) {
 			},
 		},
 		{
+			// Locks in the validationError branch in handlePartialOTLPPush in
+			// isolation from the full distributor pipeline.
+			name:       "Soft validationError with rejected samples",
+			maxMsgSize: 100000,
+			series:     sampleSeries,
+			metadata:   sampleMetadata,
+			verifyFunc: func(*testing.T, context.Context, *Request, testCase) error {
+				return newSoftValidationError(fmt.Errorf("some samples rejected"), 3)
+			},
+			responseCode:          http.StatusOK,
+			responseContentType:   pbContentType,
+			responseContentLength: 27,
+			expectedRetryHeader:   false,
+			expectedPartialSuccess: &colmetricpb.ExportMetricsPartialSuccess{
+				RejectedDataPoints: 3,
+				ErrorMessage:       "some samples rejected",
+			},
+		},
+		{
 			name:       "Soft activeSeriesLimitedError with rejected samples",
 			maxMsgSize: 100000,
 			series:     sampleSeries,
@@ -1767,6 +1788,83 @@ func TestHandlerOTLPPush(t *testing.T) {
 			errMessage:            newActiveSeriesLimitedError(10, 10, 100, http.StatusTooManyRequests, 15).Error(),
 			expectedLogs:          []string{`level=warn user=test msg="detected an error while ingesting OTLP metrics request (the request may have been partially ingested)" httpCode=429 err="` + newActiveSeriesLimitedError(10, 10, 100, http.StatusTooManyRequests, 15).Error() + `" insight=true`},
 			expectedRetryHeader:   true,
+		},
+		{
+			// Drives prePushValidationMiddleware end-to-end with one too-old sample
+			// (rejected by validation) and one valid sample. The stub `next` returns
+			// a soft ingesterPushError for an unrelated partial ingester rejection.
+			// The middleware must fold its own rejection count into the ingester
+			// error so the OTLP partial_success body reports the combined total.
+			name:       "Combine validation rejection with soft ingesterPushError",
+			maxMsgSize: 100000,
+			series: []prompb.TimeSeries{
+				{
+					Labels:  []prompb.Label{{Name: "__name__", Value: "too_old"}},
+					Samples: []prompb.Sample{{Value: 1, Timestamp: now.Add(-2 * time.Hour).UnixMilli()}},
+				},
+				{
+					Labels:  []prompb.Label{{Name: "__name__", Value: "valid"}},
+					Samples: []prompb.Sample{{Value: 2, Timestamp: now.UnixMilli()}},
+				},
+			},
+			metadata: []mimirpb.MetricMetadata{{MetricFamilyName: "too_old"}, {MetricFamilyName: "valid"}},
+			verifyFunc: func(_ *testing.T, ctx context.Context, pushReq *Request, _ testCase) error {
+				var limitsCfg validation.Limits
+				flagext.DefaultValues(&limitsCfg)
+				limitsCfg.PastGracePeriod = model.Duration(time.Hour)
+				distributors, _, _, _ := prepare(t, prepConfig{numDistributors: 1, limits: &limitsCfg})
+				stubNext := func(context.Context, *Request) error {
+					return ingesterPushError{message: "some samples rejected", cause: mimirpb.ERROR_CAUSE_BAD_DATA, soft: true, rejectedSamples: 5}
+				}
+				return distributors[0].prePushValidationMiddleware(stubNext)(ctx, pushReq)
+			},
+			responseCode:          http.StatusOK,
+			responseContentType:   pbContentType,
+			responseContentLength: 27,
+			expectedRetryHeader:   false,
+			expectedPartialSuccess: &colmetricpb.ExportMetricsPartialSuccess{
+				RejectedDataPoints: 6, // 5 from ingester + 1 from validation
+				ErrorMessage:       "some samples rejected",
+			},
+		},
+		{
+			// Drives prePushValidationMiddleware end-to-end with one too-old sample
+			// (rejected by validation) and one valid sample. The stub `next` mimics
+			// prePushMaxSeriesLimitMiddleware returning a soft activeSeriesLimitedError
+			// for an unrelated partial active-series rejection. The middleware must
+			// fold its own rejection count into the active-series error so the OTLP
+			// partial_success body reports the combined total.
+			name:       "Combine validation rejection with soft activeSeriesLimitedError",
+			maxMsgSize: 100000,
+			series: []prompb.TimeSeries{
+				{
+					Labels:  []prompb.Label{{Name: "__name__", Value: "too_old"}},
+					Samples: []prompb.Sample{{Value: 1, Timestamp: now.Add(-2 * time.Hour).UnixMilli()}},
+				},
+				{
+					Labels:  []prompb.Label{{Name: "__name__", Value: "valid"}},
+					Samples: []prompb.Sample{{Value: 2, Timestamp: now.UnixMilli()}},
+				},
+			},
+			metadata: []mimirpb.MetricMetadata{{MetricFamilyName: "too_old"}, {MetricFamilyName: "valid"}},
+			verifyFunc: func(_ *testing.T, ctx context.Context, pushReq *Request, _ testCase) error {
+				var limitsCfg validation.Limits
+				flagext.DefaultValues(&limitsCfg)
+				limitsCfg.PastGracePeriod = model.Duration(time.Hour)
+				distributors, _, _, _ := prepare(t, prepConfig{numDistributors: 1, limits: &limitsCfg})
+				stubNext := func(context.Context, *Request) error {
+					return newActiveSeriesLimitedError(10, 3, 100, http.StatusTooManyRequests, 5)
+				}
+				return distributors[0].prePushValidationMiddleware(stubNext)(ctx, pushReq)
+			},
+			responseCode:          http.StatusOK,
+			responseContentType:   pbContentType,
+			responseContentLength: 321,
+			expectedRetryHeader:   false,
+			expectedPartialSuccess: &colmetricpb.ExportMetricsPartialSuccess{
+				RejectedDataPoints: 6, // 5 from active-series + 1 from validation
+				ErrorMessage:       newActiveSeriesLimitedError(10, 3, 100, http.StatusTooManyRequests, 5).Error(),
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -1857,6 +1955,102 @@ func TestHandlerOTLPPush(t *testing.T) {
 			assert.Equal(t, tt.expectedRetryHeader, retryAfter != "")
 		})
 	}
+}
+
+// TestOTLPHandler_TooFarInPast covers the OTLP partial-success behavior for
+// distributor-level too_far_in_past validation rejections.
+//
+// Per the OTLP spec (https://opentelemetry.io/docs/specs/otlp/#partial-success-1), a
+// partially-accepted request must respond with HTTP 200 and a partial_success body
+// listing the rejected count; a fully-rejected request keeps HTTP 400.
+func TestOTLPHandler_TooFarInPast(t *testing.T) {
+	var limits validation.Limits
+	flagext.DefaultValues(&limits)
+	limits.PastGracePeriod = model.Duration(time.Hour)
+
+	ds, _, _, _ := prepare(t, prepConfig{
+		numIngesters:    3,
+		happyIngesters:  3,
+		numDistributors: 1,
+		limits:          &limits,
+	})
+
+	handler := OTLPHandler(
+		100000, nil, nil, false, ds[0].limits,
+		nil, nil, RetryConfig{}, nil,
+		ds[0].PushWithMiddlewares,
+		nil, nil, log.NewNopLogger(),
+	)
+
+	sendOTLP := func(t *testing.T, series []prompb.TimeSeries, metadata []mimirpb.MetricMetadata) *httptest.ResponseRecorder {
+		t.Helper()
+		exportReq := TimeseriesToOTLPRequest(series, metadata)
+		body, err := exportReq.MarshalProto()
+		require.NoError(t, err)
+		httpReq := createOTLPRequest(t, body, "", "application/x-protobuf")
+		resp := httptest.NewRecorder()
+		handler.ServeHTTP(resp, httpReq)
+		return resp
+	}
+
+	t.Run("partial rejection returns HTTP 200 with partial_success", func(t *testing.T) {
+		now := time.Now()
+		// One sample 2 hours old → triggers too_far_in_past at the distributor
+		// (past_grace_period=1h, ooo_window=0). One sample at "now" → passes
+		// validation and is pushed to the (mock) ingesters.
+		series := []prompb.TimeSeries{
+			{
+				Labels:  []prompb.Label{{Name: "__name__", Value: "too_old_metric"}},
+				Samples: []prompb.Sample{{Value: 1, Timestamp: now.Add(-2 * time.Hour).UnixMilli()}},
+			},
+			{
+				Labels:  []prompb.Label{{Name: "__name__", Value: "valid_metric"}},
+				Samples: []prompb.Sample{{Value: 2, Timestamp: now.UnixMilli()}},
+			},
+		}
+		metadata := []mimirpb.MetricMetadata{
+			{MetricFamilyName: "too_old_metric"},
+			{MetricFamilyName: "valid_metric"},
+		}
+
+		resp := sendOTLP(t, series, metadata)
+		require.Equal(t, http.StatusOK, resp.Code, "body: %s", resp.Body.String())
+
+		var exportResp colmetricpb.ExportMetricsServiceResponse
+		require.NoError(t, proto.Unmarshal(resp.Body.Bytes(), &exportResp))
+		require.NotNil(t, exportResp.PartialSuccess, "expected partial_success in response, got: %+v", &exportResp)
+		assert.Equal(t, int64(1), exportResp.PartialSuccess.RejectedDataPoints)
+		assert.Contains(t, exportResp.PartialSuccess.ErrorMessage, "too far in the past")
+	})
+
+	t.Run("all samples rejected returns HTTP 400", func(t *testing.T) {
+		// When every sample in an OTLP request is rejected by distributor-level
+		// validation, the response is a hard HTTP 400 (not partial-success).
+		// Guards against regressions where the soft-promotion logic accidentally
+		// treats the all-rejected case as partial.
+		now := time.Now()
+		series := []prompb.TimeSeries{
+			{
+				Labels:  []prompb.Label{{Name: "__name__", Value: "too_old_metric_a"}},
+				Samples: []prompb.Sample{{Value: 1, Timestamp: now.Add(-2 * time.Hour).UnixMilli()}},
+			},
+			{
+				Labels:  []prompb.Label{{Name: "__name__", Value: "too_old_metric_b"}},
+				Samples: []prompb.Sample{{Value: 2, Timestamp: now.Add(-2 * time.Hour).UnixMilli()}},
+			},
+		}
+		metadata := []mimirpb.MetricMetadata{
+			{MetricFamilyName: "too_old_metric_a"},
+			{MetricFamilyName: "too_old_metric_b"},
+		}
+
+		resp := sendOTLP(t, series, metadata)
+		require.Equal(t, http.StatusBadRequest, resp.Code, "body: %s", resp.Body.String())
+
+		respStatus := &status.Status{}
+		require.NoError(t, proto.Unmarshal(resp.Body.Bytes(), respStatus))
+		assert.Contains(t, respStatus.GetMessage(), "too far in the past")
+	})
 }
 
 // TestOTLPHandler_TranslationHeaders tests OTLPHandler with HTTP handlers controlling


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

The distributor's pre-push validation produces a `validationError` which `IsSoft()` is hard-coded `false`. The OTLP handler treats that as a hard error and responds with HTTP 400, even though `prePushValidationMiddleware` removes the offending series and successfully pushes the surviving valid samples. Per the OTLP spec the response in that case must be HTTP 200 with `partial_success.RejectedDataPoints` set.

Track the unwrapped first sample-validation error and a running rejected sample count alongside the existing `firstPartialErr`. After the push to backends succeeds, if any sample-validation error occurred and other samples were accepted, surface a soft `validationError` carrying the count. The OTLP handler reads the count alongside the existing `ingesterPushError`/`activeSeriesLimitedError` branches. When all samples are rejected the function still returns the hard error, so the response remains HTTP 400.

If a downstream middleware returns a soft `ingesterPushError` or a soft `activeSeriesLimitedError`, fold this middleware's rejection count into that error so the `partial_success` body reports the combined total. The ingester-error branch covers ingest-storage and classic ingester soft rejections; the active-series-error branch covers partial active-series rejections from `prePushMaxSeriesLimitMiddleware`. Mirrors the existing pattern in that middleware for combining its own count with a downstream ingester rejection. Note that `partial_success.error_message` reflects only the downstream cause when counts are combined; per-reason breakdowns are available via `cortex_discarded_samples_total`.

Adding corresponding tests.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OTLP ingestion error semantics by promoting some distributor validation failures to soft partial-success (HTTP 200), which could affect client retry/alerting behavior if miscounted or triggered unexpectedly.
> 
> **Overview**
> Fixes OTLP write handling so **partially-accepted requests** (e.g. some samples rejected by distributor validation like `too_far_in_past`) return **HTTP 200 with `partial_success.rejected_data_points`**, instead of HTTP 400.
> 
> `prePushValidationMiddleware` now tracks the first series-validation error and counts rejected samples/histograms; after a successful downstream push it returns a new *soft* `validationError` carrying the rejected count, and when downstream returns a soft `ingesterPushError`/`activeSeriesLimitedError` it **adds** the validation rejection count into that error’s rejected total.
> 
> Updates OTLP partial-success response construction to read rejected counts from soft `validationError`, adds changelog entry, and extends OTLP tests to cover soft validation partial-success and combined rejection-count cases (including end-to-end `too_far_in_past` partial vs all-rejected behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f87c7186c879be3889de29938b89af0a2ef0a790. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->