### PR TITLE
MQE: refactor range vector splitting operator and introduce `OperatorEvaluationStats` methods in preparation for implementing "samples read" for range vector splitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@
 * [FEATURE] Ingest storage: Add `-ingest-storage.kafka.tls*` flags to connect to Kafka using TLS. #14550
 * [FEATURE] Ingest storage: Add `-ingest-storage.ingestion-partition-tenant-write-shard-size` to limit the number of partitions used for writes independently from reads, allowing safely reducing the shard size without losing query coverage during the migration. #14780
 * [FEATURE] MQE: Add experimental support for splitting and caching intermediate results for functions over range vectors in instant queries. #13472 #14479 #14506 #14499 #14517 #14536 #14614 #14645 #14677 #14788
-* [FEATURE] MQE: Add experimental support for reporting the number of samples read per query. #14828 #14839 #14952 #15035 #15045 #15179 #15220 #15223 #15237
+* [FEATURE] MQE: Add experimental support for reporting the number of samples read per query. #14828 #14839 #14952 #15035 #15045 #15179 #15220 #15223 #15237 #15255
 * [FEATURE] Compactor: Add `-compactor.ooo-split-and-merge-shards` per-tenant limit to allow a separate shard count for blocks with the out-of-order external label. #14704
 * [FEATURE] Distributor: add experimental support for controlling OTLP metric name suffix addition and translation strategy via `X-Mimir-OTLP-AddSuffixes` and `X-Mimir-OTLP-TranslationStrategy` request headers on the OTLP push path, gated by `-api.otlp-translation-headers-enabled` (off by default). #14782
 * [ENHANCEMENT] Ingest storage: Default to the more efficient `-ingest-storage.kafka.producer-record-version=2` based on Remote-Write 2.0, which reduces Kafka record size and improves write throughput. #15185

--- a/pkg/streamingpromql/optimize/plan/rangevectorsplitting/operator.go
+++ b/pkg/streamingpromql/optimize/plan/rangevectorsplitting/operator.go
@@ -463,8 +463,14 @@ func (m *FunctionOverRangeVectorSplit[T]) Finalize(ctx context.Context) error {
 	}
 
 	for _, split := range m.splits {
-		if err := split.Finalize(ctx, shouldCache); err != nil {
+		if err := split.Finalize(ctx); err != nil {
 			return err
+		}
+
+		if shouldCache {
+			if err := split.StoreResultsInCache(ctx); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -527,7 +533,8 @@ type Split[T any] interface {
 	// This is used to make sure annotations emitted when generating the result for an uncached split reference the
 	// correct metric name.
 	AppendMergedSeriesIndex(splitLocalIdx int, mergedIdx int)
-	Finalize(ctx context.Context, storeResultsInCache bool) error
+	Finalize(ctx context.Context) error
+	StoreResultsInCache(ctx context.Context) error
 	Close()
 	IsCached() bool
 	RangeCount() int
@@ -600,13 +607,17 @@ func (c *CachedSplit[T]) GetResultsAt(_ context.Context, idx int) ([]T, error) {
 	return []T{c.results[idx]}, nil
 }
 
-func (c *CachedSplit[T]) Finalize(ctx context.Context, storeResultsInCache bool) error {
+func (c *CachedSplit[T]) Finalize(_ context.Context) error {
 	for _, w := range c.annotations.Warnings {
 		c.parent.Annotations.Add(querierpb.NewWarningAnnotation(w))
 	}
 	for _, i := range c.annotations.Infos {
 		c.parent.Annotations.Add(querierpb.NewInfoAnnotation(i))
 	}
+	return nil
+}
+
+func (c *CachedSplit[T]) StoreResultsInCache(_ context.Context) error {
 	return nil
 }
 
@@ -756,7 +767,7 @@ func (p *UncachedSplit[T]) emitAndCaptureAnnotation(rangeIdx int, localSeriesIdx
 	p.rangeAnnotations[rangeIdx].Add(annotationErr)
 }
 
-func (p *UncachedSplit[T]) Finalize(ctx context.Context, storeResultsInCache bool) error {
+func (p *UncachedSplit[T]) Finalize(ctx context.Context) error {
 	if p.finalized {
 		return nil
 	}
@@ -767,10 +778,10 @@ func (p *UncachedSplit[T]) Finalize(ctx context.Context, storeResultsInCache boo
 
 	p.finalized = true
 
-	if !storeResultsInCache {
-		return nil
-	}
+	return nil
+}
 
+func (p *UncachedSplit[T]) StoreResultsInCache(ctx context.Context) error {
 	for rangeIdx, splitRange := range p.ranges {
 		if !splitRange.Cacheable {
 			continue

--- a/pkg/streamingpromql/types/stats.go
+++ b/pkg/streamingpromql/types/stats.go
@@ -266,6 +266,10 @@ func (s *OperatorEvaluationStats) CloneSingleStep(timeRange QueryTimeRange) (*Op
 		return nil, fmt.Errorf("cannot clone single step of OperatorEvaluationStats because the desired time %v is not aligned with the steps of the source (start time %v, step %v)", timeRange.StartT, s.timeRange.StartT, s.timeRange.IntervalMilliseconds)
 	}
 
+	if stepIdx < 0 || stepIdx >= int64(s.timeRange.StepCount) {
+		return nil, fmt.Errorf("cannot clone single step of OperatorEvaluationStats because the desired time %v is outside the source time range (start time %v, end time %v)", timeRange.StartT, s.timeRange.StartT, s.timeRange.EndT)
+	}
+
 	singleStepStats, err := s.newEmptyInstanceWithSameSubsets(timeRange)
 	if err != nil {
 		return nil, err

--- a/pkg/streamingpromql/types/stats.go
+++ b/pkg/streamingpromql/types/stats.go
@@ -201,6 +201,36 @@ func (s *OperatorEvaluationStats) Add(other *OperatorEvaluationStats) error {
 	return nil
 }
 
+// AddSingleStep adds the statistics from other to this instance.
+//
+// Both instances must have a single step, but may have different time ranges.
+//
+// Both instances must have the same number of subsets.
+//
+// This instance is modified in place.
+func (s *OperatorEvaluationStats) AddSingleStep(other *OperatorEvaluationStats) error {
+	if s.timeRange.StepCount != 1 {
+		return fmt.Errorf("cannot add a single step to a OperatorEvaluationStats instance with %v steps", s.timeRange.StepCount)
+	}
+
+	if other.timeRange.StepCount != 1 {
+		return fmt.Errorf("cannot add a single step to a OperatorEvaluationStats instance from another instance with %v steps", other.timeRange.StepCount)
+	}
+
+	if len(s.subsets) != len(other.subsets) {
+		return fmt.Errorf("cannot add a single step to a OperatorEvaluationStats instance with %v subsets from another instance with %v subsets", len(s.subsets), len(other.subsets))
+	}
+
+	s.allSeries.Add(int64(0), other.allSeries.samplesProcessedPerStep[0], other.allSeries.samplesReadIfSubsequentStep[0], other.allSeries.samplesReadIfFirstStep[0])
+
+	for subsetIdx, subset := range s.subsets {
+		otherSubset := other.subsets[subsetIdx]
+		subset.Add(int64(0), otherSubset.samplesProcessedPerStep[0], otherSubset.samplesReadIfSubsequentStep[0], otherSubset.samplesReadIfFirstStep[0])
+	}
+
+	return nil
+}
+
 func (s *OperatorEvaluationStats) newEmptyInstanceWithSameSubsets(timeRange QueryTimeRange) (*OperatorEvaluationStats, error) {
 	return NewOperatorEvaluationStatsWithQueryStats(timeRange, s.memoryConsumptionTracker, s.queryStats, len(s.subsets))
 }

--- a/pkg/streamingpromql/types/stats.go
+++ b/pkg/streamingpromql/types/stats.go
@@ -221,6 +221,35 @@ func (s *OperatorEvaluationStats) Clone() (*OperatorEvaluationStats, error) {
 	return clone, nil
 }
 
+// CloneSingleStep returns a new OperatorEvaluationStats instance containing the sample counts for the single step
+// in the provided time range.
+//
+// The returned instance will have the same subset definitions as the original.
+func (s *OperatorEvaluationStats) CloneSingleStep(timeRange QueryTimeRange) (*OperatorEvaluationStats, error) {
+	if timeRange.StepCount != 1 {
+		return nil, fmt.Errorf("cannot clone single step of OperatorEvaluationStats for time range with %v steps", timeRange.StepCount)
+	}
+
+	stepIdx := s.timeRange.PointIndex(timeRange.StartT)
+
+	if s.timeRange.IndexTime(stepIdx) != timeRange.StartT {
+		return nil, fmt.Errorf("cannot clone single step of OperatorEvaluationStats because the desired time %v is not aligned with the steps of the source (start time %v, step %v)", timeRange.StartT, s.timeRange.StartT, s.timeRange.IntervalMilliseconds)
+	}
+
+	singleStepStats, err := s.newEmptyInstanceWithSameSubsets(timeRange)
+	if err != nil {
+		return nil, err
+	}
+
+	singleStepStats.allSeries.CopySingleStepFrom(s.allSeries, stepIdx)
+
+	for i, subset := range s.subsets {
+		singleStepStats.subsets[i].CopySingleStepFrom(subset, stepIdx)
+	}
+
+	return singleStepStats, nil
+}
+
 // UseSubset replaces the unfiltered statistics on this instance with those from the given subset,
 // and removes all other subsets.
 func (s *OperatorEvaluationStats) UseSubset(idx int) {
@@ -493,6 +522,12 @@ func (s *subsetStats) CopyFrom(source *subsetStats) {
 	copy(s.samplesProcessedPerStep, source.samplesProcessedPerStep)
 	copy(s.samplesReadIfSubsequentStep, source.samplesReadIfSubsequentStep)
 	copy(s.samplesReadIfFirstStep, source.samplesReadIfFirstStep)
+}
+
+func (s *subsetStats) CopySingleStepFrom(source *subsetStats, stepIdx int64) {
+	s.samplesProcessedPerStep[0] = source.samplesProcessedPerStep[stepIdx]
+	s.samplesReadIfSubsequentStep[0] = source.samplesReadIfSubsequentStep[stepIdx]
+	s.samplesReadIfFirstStep[0] = source.samplesReadIfFirstStep[stepIdx]
 }
 
 func (s *subsetStats) Encode() EncodedSubsetStats {

--- a/pkg/streamingpromql/types/stats_test.go
+++ b/pkg/streamingpromql/types/stats_test.go
@@ -510,6 +510,67 @@ func TestOperatorEvaluationStats_Add_WithSubsets(t *testing.T) {
 	require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
 }
 
+func TestOperatorEvaluationStats_AddSingleStep(t *testing.T) {
+	ctx := context.Background()
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
+
+	source, err := NewOperatorEvaluationStats(ctx, NewInstantQueryTimeRange(timestamp.Time(1234)), memoryConsumptionTracker, 1)
+	require.NoError(t, err)
+
+	source.allSeries.samplesProcessedPerStep[0] = 10
+	source.allSeries.samplesReadIfSubsequentStep[0] = 1
+	source.allSeries.samplesReadIfFirstStep[0] = 100
+	source.subsets[0].samplesProcessedPerStep[0] = 5
+	source.subsets[0].samplesReadIfSubsequentStep[0] = 3
+	source.subsets[0].samplesReadIfFirstStep[0] = 300
+
+	destination, err := NewOperatorEvaluationStats(ctx, NewInstantQueryTimeRange(timestamp.Time(5678)), memoryConsumptionTracker, 1)
+	require.NoError(t, err)
+
+	destination.allSeries.samplesProcessedPerStep[0] = 20
+	destination.allSeries.samplesReadIfSubsequentStep[0] = 4
+	destination.allSeries.samplesReadIfFirstStep[0] = 200
+	destination.subsets[0].samplesProcessedPerStep[0] = 9
+	destination.subsets[0].samplesReadIfSubsequentStep[0] = 7
+	destination.subsets[0].samplesReadIfFirstStep[0] = 700
+
+	require.NoError(t, destination.AddSingleStep(source))
+
+	// The destination should be updated.
+	require.Equal(t, int64(10+20), destination.allSeries.samplesProcessedPerStep[0])
+	require.Equal(t, int64(1+4), destination.allSeries.samplesReadIfSubsequentStep[0])
+	require.Equal(t, int64(100+200), destination.allSeries.samplesReadIfFirstStep[0])
+	require.Equal(t, int64(5+9), destination.subsets[0].samplesProcessedPerStep[0])
+	require.Equal(t, int64(3+7), destination.subsets[0].samplesReadIfSubsequentStep[0])
+	require.Equal(t, int64(300+700), destination.subsets[0].samplesReadIfFirstStep[0])
+
+	// The source should be unchanged.
+	require.Equal(t, int64(10), source.allSeries.samplesProcessedPerStep[0])
+	require.Equal(t, int64(1), source.allSeries.samplesReadIfSubsequentStep[0])
+	require.Equal(t, int64(100), source.allSeries.samplesReadIfFirstStep[0])
+	require.Equal(t, int64(5), source.subsets[0].samplesProcessedPerStep[0])
+	require.Equal(t, int64(3), source.subsets[0].samplesReadIfSubsequentStep[0])
+	require.Equal(t, int64(300), source.subsets[0].samplesReadIfFirstStep[0])
+
+	source.Close()
+	destination.Close()
+	require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
+}
+
+func TestOperatorEvaluationStats_AddSingleStep_MultipleSteps(t *testing.T) {
+	ctx := context.Background()
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
+
+	oneStep, err := NewOperatorEvaluationStats(ctx, NewInstantQueryTimeRange(timestamp.Time(0)), memoryConsumptionTracker, 0)
+	require.NoError(t, err)
+
+	multipleSteps, err := NewOperatorEvaluationStats(ctx, NewRangeQueryTimeRange(timestamp.Time(0), timestamp.Time(0).Add(5*time.Minute), time.Minute), memoryConsumptionTracker, 0)
+	require.NoError(t, err)
+
+	require.EqualError(t, oneStep.AddSingleStep(multipleSteps), "cannot add a single step to a OperatorEvaluationStats instance from another instance with 6 steps")
+	require.EqualError(t, multipleSteps.AddSingleStep(oneStep), "cannot add a single step to a OperatorEvaluationStats instance with 6 steps")
+}
+
 func TestOperatorEvaluationStats_Clone(t *testing.T) {
 	start := timestamp.Time(0)
 	step := time.Minute

--- a/pkg/streamingpromql/types/stats_test.go
+++ b/pkg/streamingpromql/types/stats_test.go
@@ -599,6 +599,104 @@ func TestOperatorEvaluationStats_Clone_WithSubsets(t *testing.T) {
 	require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
 }
 
+func TestOperatorEvaluationStats_CloneSingleStep(t *testing.T) {
+	start := timestamp.Time(0)
+	step := time.Minute
+	end := start.Add(2 * step)
+	timeRange := NewRangeQueryTimeRange(start, end, step)
+
+	ctx := context.Background()
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
+
+	original, err := NewOperatorEvaluationStats(ctx, timeRange, memoryConsumptionTracker, 1)
+	require.NoError(t, err)
+
+	original.allSeries.samplesProcessedPerStep[0] = 10
+	original.allSeries.samplesProcessedPerStep[1] = 20
+	original.allSeries.samplesProcessedPerStep[2] = 30
+	original.allSeries.samplesReadIfSubsequentStep[0] = 1
+	original.allSeries.samplesReadIfSubsequentStep[1] = 2
+	original.allSeries.samplesReadIfSubsequentStep[2] = 3
+	original.allSeries.samplesReadIfFirstStep[0] = 100
+	original.allSeries.samplesReadIfFirstStep[1] = 200
+	original.allSeries.samplesReadIfFirstStep[2] = 300
+
+	original.subsets[0].samplesProcessedPerStep[0] = 7
+	original.subsets[0].samplesProcessedPerStep[1] = 8
+	original.subsets[0].samplesProcessedPerStep[2] = 9
+	original.subsets[0].samplesReadIfSubsequentStep[0] = 4
+	original.subsets[0].samplesReadIfSubsequentStep[1] = 5
+	original.subsets[0].samplesReadIfSubsequentStep[2] = 6
+	original.subsets[0].samplesReadIfFirstStep[0] = 400
+	original.subsets[0].samplesReadIfFirstStep[1] = 500
+	original.subsets[0].samplesReadIfFirstStep[2] = 600
+
+	singleStepTimeRange := NewInstantQueryTimeRange(start.Add(step))
+	clone, err := original.CloneSingleStep(singleStepTimeRange)
+	require.NoError(t, err)
+
+	require.Equal(t, []int64{20}, clone.allSeries.samplesProcessedPerStep)
+	require.Equal(t, []int64{2}, clone.allSeries.samplesReadIfSubsequentStep)
+	require.Equal(t, []int64{200}, clone.allSeries.samplesReadIfFirstStep)
+	require.Len(t, clone.subsets, 1)
+	require.Equal(t, []int64{8}, clone.subsets[0].samplesProcessedPerStep)
+	require.Equal(t, []int64{5}, clone.subsets[0].samplesReadIfSubsequentStep)
+	require.Equal(t, []int64{500}, clone.subsets[0].samplesReadIfFirstStep)
+
+	// Modifying the clone should not affect the original.
+	clone.allSeries.samplesProcessedPerStep[0] = 99
+	clone.allSeries.samplesReadIfSubsequentStep[0] = 99
+	clone.allSeries.samplesReadIfFirstStep[0] = 99
+	clone.subsets[0].samplesProcessedPerStep[0] = 99
+	clone.subsets[0].samplesReadIfSubsequentStep[0] = 99
+	clone.subsets[0].samplesReadIfFirstStep[0] = 99
+	require.Equal(t, int64(20), original.allSeries.samplesProcessedPerStep[1])
+	require.Equal(t, int64(2), original.allSeries.samplesReadIfSubsequentStep[1])
+	require.Equal(t, int64(200), original.allSeries.samplesReadIfFirstStep[1])
+	require.Equal(t, int64(8), original.subsets[0].samplesProcessedPerStep[1])
+	require.Equal(t, int64(5), original.subsets[0].samplesReadIfSubsequentStep[1])
+	require.Equal(t, int64(500), original.subsets[0].samplesReadIfFirstStep[1])
+
+	original.Close()
+	clone.Close()
+	require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
+}
+
+func TestOperatorEvaluationStats_Clone_InvalidTimeRanges(t *testing.T) {
+	start := timestamp.Time(0)
+	step := time.Minute
+	end := start.Add(2 * step)
+	timeRange := NewRangeQueryTimeRange(start, end, step)
+
+	ctx := context.Background()
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
+
+	original, err := NewOperatorEvaluationStats(ctx, timeRange, memoryConsumptionTracker, 0)
+	require.NoError(t, err)
+
+	testCases := map[string]struct {
+		timeRange QueryTimeRange
+		err       string
+	}{
+		"multiple steps": {
+			timeRange: NewRangeQueryTimeRange(start, start.Add(3*step), step),
+			err:       `cannot clone single step of OperatorEvaluationStats for time range with 4 steps`,
+		},
+		"not aligned to source time range": {
+			timeRange: NewInstantQueryTimeRange(start.Add(30 * time.Second)),
+			err:       `cannot clone single step of OperatorEvaluationStats because the desired time 30000 is not aligned with the steps of the source (start time 0, step 60000)`,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			_, err := original.CloneSingleStep(testCase.timeRange)
+			require.EqualError(t, err, testCase.err)
+
+		})
+	}
+}
+
 func TestOperatorEvaluationStats_ComputeForSubquery(t *testing.T) {
 	// Inner time range: steps at 0, 2, 4, 6, 8, 10 minutes (6 steps with 2 minute interval).
 	innerStep := 2 * time.Minute

--- a/pkg/streamingpromql/types/stats_test.go
+++ b/pkg/streamingpromql/types/stats_test.go
@@ -747,6 +747,14 @@ func TestOperatorEvaluationStats_Clone_InvalidTimeRanges(t *testing.T) {
 			timeRange: NewInstantQueryTimeRange(start.Add(30 * time.Second)),
 			err:       `cannot clone single step of OperatorEvaluationStats because the desired time 30000 is not aligned with the steps of the source (start time 0, step 60000)`,
 		},
+		"after source time range": {
+			timeRange: NewInstantQueryTimeRange(start.Add(5 * step)),
+			err:       `cannot clone single step of OperatorEvaluationStats because the desired time 300000 is outside the source time range (start time 0, end time 120000)`,
+		},
+		"before source time range": {
+			timeRange: NewInstantQueryTimeRange(start.Add(-step)),
+			err:       `cannot clone single step of OperatorEvaluationStats because the desired time -60000 is outside the source time range (start time 0, end time 120000)`,
+		},
 	}
 
 	for name, testCase := range testCases {


### PR DESCRIPTION
#### What this PR does

This PR makes a couple of small changes in preparation for implementing "samples read" tracking support to range vector splitting:

* it extracts a method for storing previously uncached range vector splits in the cache
* it introduces the `OperatorEvaluationStats.CloneSingleStep` method, which will be used to extract the stats of a single range vector split before storing it in the cache
* it introduces the `OperatorEvaluationStats.AddSingleStep` method, which will be used to compute the final set of statistics from all range vector splits

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches MQE range-vector splitting finalization/caching and introduces new stats-combining helpers; risk is moderate because subtle caching/finalize ordering issues could affect query correctness or cache consistency.
> 
> **Overview**
> **Range vector splitting refactor:** `FunctionOverRangeVectorSplit` now always calls `split.Finalize(ctx)` and conditionally performs caching via a new `Split.StoreResultsInCache(ctx)` method, moving cache-write logic out of `Finalize`’s signature.
> 
> **Stats prep for samples-read tracking:** adds `OperatorEvaluationStats.CloneSingleStep` (extract one step’s counts into a new stats instance) and `OperatorEvaluationStats.AddSingleStep` (merge single-step stats), plus supporting `subsetStats.CopySingleStepFrom` and new unit tests.
> 
> Also updates the changelog entry for “samples read per query” to include the latest PR reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84848ff16f746c959ba88eb32dcbb23de8077f0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->