### PR TITLE
mimir: move InstrumentRefLeaks out of CommonConfig

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -21684,49 +21684,6 @@
           ],
           "fieldValue": null,
           "fieldDefaultValue": null
-        },
-        {
-          "kind": "block",
-          "name": "instrument_ref_leaks",
-          "required": false,
-          "desc": "",
-          "blockEntries": [
-            {
-              "kind": "field",
-              "name": "percentage",
-              "required": false,
-              "desc": "Percentage [0-100] of request or message buffers to instrument for reference leaks. Set to 0 to disable.",
-              "fieldValue": null,
-              "fieldDefaultValue": 0,
-              "fieldFlag": "common.instrument-reference-leaks.percentage",
-              "fieldType": "float",
-              "fieldCategory": "experimental"
-            },
-            {
-              "kind": "field",
-              "name": "before_reuse_period",
-              "required": false,
-              "desc": "Period after a buffer instrumented for referenced leaks is nominally freed until the buffer is uninstrumented and effectively freed to be reused. After this period, any lingering references to the buffer may potentially be dereferenced again with no detection.",
-              "fieldValue": null,
-              "fieldDefaultValue": 120000000000,
-              "fieldFlag": "common.instrument-reference-leaks.before-reuse-period",
-              "fieldType": "duration",
-              "fieldCategory": "experimental"
-            },
-            {
-              "kind": "field",
-              "name": "max_inflight_instrumented_bytes",
-              "required": false,
-              "desc": "Maximum sum of length of buffers instrumented at any given time, in bytes. When surpassed, incoming buffers will not be instrumented, regardless of the configured percentage. Zero means no limit.",
-              "fieldValue": null,
-              "fieldDefaultValue": 0,
-              "fieldFlag": "common.instrument-reference-leaks.max-inflight-instrumented-bytes",
-              "fieldType": "int",
-              "fieldCategory": "experimental"
-            }
-          ],
-          "fieldValue": null,
-          "fieldDefaultValue": null
         }
       ],
       "fieldValue": null,
@@ -21775,6 +21732,49 @@
       "fieldFlag": "cost-attribution.cleanup-interval",
       "fieldType": "duration",
       "fieldCategory": "experimental"
+    },
+    {
+      "kind": "block",
+      "name": "instrument_ref_leaks",
+      "required": false,
+      "desc": "",
+      "blockEntries": [
+        {
+          "kind": "field",
+          "name": "percentage",
+          "required": false,
+          "desc": "Percentage [0-100] of request or message buffers to instrument for reference leaks. Set to 0 to disable.",
+          "fieldValue": null,
+          "fieldDefaultValue": 0,
+          "fieldFlag": "instrument-reference-leaks.percentage",
+          "fieldType": "float",
+          "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
+          "name": "before_reuse_period",
+          "required": false,
+          "desc": "Period after a buffer instrumented for referenced leaks is nominally freed until the buffer is uninstrumented and effectively freed to be reused. After this period, any lingering references to the buffer may potentially be dereferenced again with no detection.",
+          "fieldValue": null,
+          "fieldDefaultValue": 120000000000,
+          "fieldFlag": "instrument-reference-leaks.before-reuse-period",
+          "fieldType": "duration",
+          "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
+          "name": "max_inflight_instrumented_bytes",
+          "required": false,
+          "desc": "Maximum sum of length of buffers instrumented at any given time, in bytes. When surpassed, incoming buffers will not be instrumented, regardless of the configured percentage. Zero means no limit.",
+          "fieldValue": null,
+          "fieldDefaultValue": 0,
+          "fieldFlag": "instrument-reference-leaks.max-inflight-instrumented-bytes",
+          "fieldType": "int",
+          "fieldCategory": "experimental"
+        }
+      ],
+      "fieldValue": null,
+      "fieldDefaultValue": null
     }
   ],
   "fieldValue": null,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -853,12 +853,6 @@ Usage of ./cmd/mimir/mimir:
     	TSDB WAL segments files max size (bytes). (default 134217728)
   -common.client-cluster-validation.label string
     	[experimental] Primary cluster validation label.
-  -common.instrument-reference-leaks.before-reuse-period duration
-    	[experimental] Period after a buffer instrumented for referenced leaks is nominally freed until the buffer is uninstrumented and effectively freed to be reused. After this period, any lingering references to the buffer may potentially be dereferenced again with no detection. (default 2m0s)
-  -common.instrument-reference-leaks.max-inflight-instrumented-bytes uint
-    	[experimental] Maximum sum of length of buffers instrumented at any given time, in bytes. When surpassed, incoming buffers will not be instrumented, regardless of the configured percentage. Zero means no limit.
-  -common.instrument-reference-leaks.percentage float
-    	[experimental] Percentage [0-100] of request or message buffers to instrument for reference leaks. Set to 0 to disable.
   -common.storage.azure.account-key string
     	Azure storage account key. If unset, Azure managed identities will be used for authentication instead.
   -common.storage.azure.account-name string
@@ -1925,6 +1919,12 @@ Usage of ./cmd/mimir/mimir:
     	[experimental] Period with which to update the per-tenant TSDB configuration. (default 15s)
   -ingester.use-ingester-owned-series-for-limits
     	[experimental] When enabled, only series currently owned by ingester according to the ring are used when checking user per-tenant series limit.
+  -instrument-reference-leaks.before-reuse-period duration
+    	[experimental] Period after a buffer instrumented for referenced leaks is nominally freed until the buffer is uninstrumented and effectively freed to be reused. After this period, any lingering references to the buffer may potentially be dereferenced again with no detection. (default 2m0s)
+  -instrument-reference-leaks.max-inflight-instrumented-bytes uint
+    	[experimental] Maximum sum of length of buffers instrumented at any given time, in bytes. When surpassed, incoming buffers will not be instrumented, regardless of the configured percentage. Zero means no limit.
+  -instrument-reference-leaks.percentage float
+    	[experimental] Percentage [0-100] of request or message buffers to instrument for reference leaks. Set to 0 to disable.
   -log.format string
     	Output log messages in the given format. Valid formats: [logfmt, json] (default "logfmt")
   -log.level value

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -265,13 +265,12 @@ The following features are currently experimental:
     - Assuming that a gRPC client configuration can be reached via `-<grpc-client-config-path>`, cluster validation label is configured via: `-<grpc-client-config-path>.cluster-validation.label`.
     - The cluster validation label of all gRPC clients can be configured via `-common.client-cluster-validation.label`.
     - Requests with invalid cluster validation labels are tracked via the `cortex_client_invalid_cluster_validation_label_requests_total` metric.
-- Common
-  - Instrument a fraction of pooled objects for references that outlive their lifetime.
-    - Only implemented for objects embedding `mimirpb.BufferHolder`.
-    - Flags:
-      - `-common.instrument-reference-leaks.percentage`
-      - `-common.instrument-reference-leaks.before-reuse-period`
-      - `-common.instrument-reference-leaks.max-inflight-instrumented-bytes`
+- Instrument a fraction of pooled objects for references that outlive their lifetime.
+  - Only implemented for objects embedding `mimirpb.BufferHolder`.
+  - Flags:
+    - `-instrument-reference-leaks.percentage`
+    - `-instrument-reference-leaks.before-reuse-period`
+    - `-instrument-reference-leaks.max-inflight-instrumented-bytes`
 - Preferred available zones for querying ingesters and store-gateways
   - `-querier.prefer-availability-zones`
 - Memberlist zone-aware routing

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -495,6 +495,25 @@ overrides_exporter:
 # runs, ensuring inactive cost attribution entries are purged.
 # CLI flag: -cost-attribution.cleanup-interval
 [cost_attribution_cleanup_interval: <duration> | default = 3m]
+
+instrument_ref_leaks:
+  # (experimental) Percentage [0-100] of request or message buffers to
+  # instrument for reference leaks. Set to 0 to disable.
+  # CLI flag: -instrument-reference-leaks.percentage
+  [percentage: <float> | default = 0]
+
+  # (experimental) Period after a buffer instrumented for referenced leaks is
+  # nominally freed until the buffer is uninstrumented and effectively freed to
+  # be reused. After this period, any lingering references to the buffer may
+  # potentially be dereferenced again with no detection.
+  # CLI flag: -instrument-reference-leaks.before-reuse-period
+  [before_reuse_period: <duration> | default = 2m]
+
+  # (experimental) Maximum sum of length of buffers instrumented at any given
+  # time, in bytes. When surpassed, incoming buffers will not be instrumented,
+  # regardless of the configured percentage. Zero means no limit.
+  # CLI flag: -instrument-reference-leaks.max-inflight-instrumented-bytes
+  [max_inflight_instrumented_bytes: <int> | default = 0]
 ```
 
 ### common
@@ -537,25 +556,6 @@ client_cluster_validation:
   # (experimental) Primary cluster validation label.
   # CLI flag: -common.client-cluster-validation.label
   [label: <string> | default = ""]
-
-instrument_ref_leaks:
-  # (experimental) Percentage [0-100] of request or message buffers to
-  # instrument for reference leaks. Set to 0 to disable.
-  # CLI flag: -common.instrument-reference-leaks.percentage
-  [percentage: <float> | default = 0]
-
-  # (experimental) Period after a buffer instrumented for referenced leaks is
-  # nominally freed until the buffer is uninstrumented and effectively freed to
-  # be reused. After this period, any lingering references to the buffer may
-  # potentially be dereferenced again with no detection.
-  # CLI flag: -common.instrument-reference-leaks.before-reuse-period
-  [before_reuse_period: <duration> | default = 2m]
-
-  # (experimental) Maximum sum of length of buffers instrumented at any given
-  # time, in bytes. When surpassed, incoming buffers will not be instrumented,
-  # regardless of the configured percentage. Zero means no limit.
-  # CLI flag: -common.instrument-reference-leaks.max-inflight-instrumented-bytes
-  [max_inflight_instrumented_bytes: <int> | default = 0]
 ```
 
 ### server

--- a/operations/mimir/mimir-flags-defaults.json
+++ b/operations/mimir/mimir-flags-defaults.json
@@ -1545,11 +1545,11 @@
   "common.storage.swift.request-timeout": 5000000000,
   "common.storage.filesystem.dir": "",
   "common.client-cluster-validation.label": "",
-  "common.instrument-reference-leaks.percentage": 0,
-  "common.instrument-reference-leaks.before-reuse-period": 120000000000,
-  "common.instrument-reference-leaks.max-inflight-instrumented-bytes": 0,
   "timeseries-unmarshal-caching-optimization-enabled": true,
   "cost-attribution.eviction-interval": 1200000000000,
   "cost-attribution.registry-path": "",
-  "cost-attribution.cleanup-interval": 180000000000
+  "cost-attribution.cleanup-interval": 180000000000,
+  "instrument-reference-leaks.percentage": 0,
+  "instrument-reference-leaks.before-reuse-period": 120000000000,
+  "instrument-reference-leaks.max-inflight-instrumented-bytes": 0
 }

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -155,6 +155,8 @@ type Config struct {
 	CostAttributionEvictionInterval time.Duration `yaml:"cost_attribution_eviction_interval" category:"experimental"`
 	CostAttributionRegistryPath     string        `yaml:"cost_attribution_registry_path" category:"experimental"`
 	CostAttributionCleanupInterval  time.Duration `yaml:"cost_attribution_cleanup_interval" category:"experimental"`
+
+	InstrumentRefLeaks mimirpb.InstrumentRefLeaksConfig `yaml:"instrument_ref_leaks" category:"experimental"`
 }
 
 // RegisterFlags registers flags.
@@ -217,6 +219,8 @@ func (c *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	c.OverridesExporter.RegisterFlags(f, logger)
 
 	c.Common.RegisterFlags(f)
+
+	c.InstrumentRefLeaks.RegisterFlagsWithPrefix("instrument-reference-leaks.", f)
 }
 
 func (c *Config) CommonConfigInheritance() CommonConfigInheritance {
@@ -358,7 +362,7 @@ func (c *Config) Validate(log log.Logger) error {
 	if err := c.OverridesExporter.Validate(); err != nil {
 		return errors.Wrap(err, "invalid overrides-exporter config")
 	}
-	if err := c.Common.InstrumentRefLeaks.Validate(); err != nil {
+	if err := c.InstrumentRefLeaks.Validate(); err != nil {
 		return errors.Wrap(err, "invalid instrument-ref-leaks config")
 	}
 	if err := c.API.Validate(); err != nil {
@@ -734,16 +738,11 @@ func UnmarshalCommonYAML(value *yaml.Node, inheriters ...CommonConfigInheriter) 
 		for name, loc := range inheritance.ClientClusterValidation {
 			specificClusterValidationLocations[name] = loc
 		}
-		specificInstrumentRefLeaksLocations := specificLocationsUnmarshaler{}
-		for name, loc := range inheritance.InstrumentRefLeaksConfig {
-			specificInstrumentRefLeaksLocations[name] = loc
-		}
 
 		common := configWithCustomCommonUnmarshaler{
 			Common: &commonConfigUnmarshaler{
 				Storage:                 &specificStorageLocations,
 				ClientClusterValidation: &specificClusterValidationLocations,
-				InstrumentRefLeaks:      &specificInstrumentRefLeaksLocations,
 			},
 		}
 
@@ -813,20 +812,17 @@ func inheritFlags(log log.Logger, orig flagext.RegisteredFlagsTracker, dest flag
 type CommonConfig struct {
 	Storage                 bucket.StorageBackendConfig         `yaml:"storage"`
 	ClientClusterValidation clusterutil.ClusterValidationConfig `yaml:"client_cluster_validation" category:"experimental"`
-	InstrumentRefLeaks      mimirpb.InstrumentRefLeaksConfig    `yaml:"instrument_ref_leaks" category:"experimental"`
 }
 
 type CommonConfigInheritance struct {
-	Storage                  map[string]*bucket.StorageBackendConfig
-	ClientClusterValidation  map[string]*clusterutil.ClusterValidationConfig
-	InstrumentRefLeaksConfig map[string]*mimirpb.InstrumentRefLeaksConfig
+	Storage                 map[string]*bucket.StorageBackendConfig
+	ClientClusterValidation map[string]*clusterutil.ClusterValidationConfig
 }
 
 // RegisterFlags registers flag.
 func (c *CommonConfig) RegisterFlags(f *flag.FlagSet) {
 	c.Storage.RegisterFlagsWithPrefix("common.storage.", f)
 	c.ClientClusterValidation.RegisterFlagsWithPrefix("common.client-cluster-validation.", f)
-	c.InstrumentRefLeaks.RegisterFlagsWithPrefix("common.instrument-reference-leaks.", f)
 }
 
 // configWithCustomCommonUnmarshaler unmarshals config with custom unmarshaler for the `common` field.
@@ -843,7 +839,6 @@ type configWithCustomCommonUnmarshaler struct {
 type commonConfigUnmarshaler struct {
 	Storage                 *specificLocationsUnmarshaler `yaml:"storage"`
 	ClientClusterValidation *specificLocationsUnmarshaler `yaml:"client_cluster_validation"`
-	InstrumentRefLeaks      *specificLocationsUnmarshaler `yaml:"instrument_ref_leaks"`
 }
 
 // specificLocationsUnmarshaler will unmarshal yaml into specific locations.
@@ -945,11 +940,7 @@ func New(cfg Config, reg prometheus.Registerer) (*Mimir, error) {
 	setUpGoRuntimeMetrics(cfg, reg)
 
 	mimirpb.CustomCodecConfig{
-		InstrumentRefLeaksConfig: mimirpb.InstrumentRefLeaksConfig{
-			Percentage:                   cfg.Common.InstrumentRefLeaks.Percentage,
-			BeforeReusePeriod:            cfg.Common.InstrumentRefLeaks.BeforeReusePeriod,
-			MaxInflightInstrumentedBytes: cfg.Common.InstrumentRefLeaks.MaxInflightInstrumentedBytes,
-		},
+		InstrumentRefLeaksConfig: cfg.InstrumentRefLeaks,
 	}.RegisterGlobally(reg)
 
 	if cfg.TenantFederation.Enabled && cfg.Ruler.TenantFederation.Enabled {

--- a/pkg/mimir/mimir_config_test.go
+++ b/pkg/mimir/mimir_config_test.go
@@ -25,9 +25,9 @@ func TestCommonConfigCanBeExtended(t *testing.T) {
 		args := []string{
 			"-common.storage.backend", "s3",
 			"-common.client-cluster-validation.label", "client-cluster",
-			"-common.instrument-reference-leaks.percentage", "13.37",
-			"-common.instrument-reference-leaks.before-reuse-period", "20h",
-			"-common.instrument-reference-leaks.max-inflight-instrumented-bytes", "1048576",
+			"-instrument-reference-leaks.percentage", "13.37",
+			"-instrument-reference-leaks.before-reuse-period", "20h",
+			"-instrument-reference-leaks.max-inflight-instrumented-bytes", "1048576",
 		}
 		require.NoError(t, fs.Parse(args))
 
@@ -40,10 +40,10 @@ func TestCommonConfigCanBeExtended(t *testing.T) {
 		// Mimir's inheritance should still work.
 		checkAllClusterValidationLabels(t, cfg, "client-cluster")
 
-		// Non-inherited flags still work.
-		require.Equal(t, 13.37, cfg.MimirConfig.Common.InstrumentRefLeaks.Percentage)
-		require.Equal(t, 20*time.Hour, cfg.MimirConfig.Common.InstrumentRefLeaks.BeforeReusePeriod)
-		require.Equal(t, uint64(1048576), cfg.MimirConfig.Common.InstrumentRefLeaks.MaxInflightInstrumentedBytes)
+		// Top-level flags still work.
+		require.Equal(t, 13.37, cfg.MimirConfig.InstrumentRefLeaks.Percentage)
+		require.Equal(t, 20*time.Hour, cfg.MimirConfig.InstrumentRefLeaks.BeforeReusePeriod)
+		require.Equal(t, uint64(1048576), cfg.MimirConfig.InstrumentRefLeaks.MaxInflightInstrumentedBytes)
 	})
 
 	t.Run("yaml inheritance", func(t *testing.T) {
@@ -53,10 +53,10 @@ common:
     backend: s3
   client_cluster_validation:
     label: client-cluster
-  instrument_ref_leaks:
-    percentage: 13.37
-    before_reuse_period: 20h
-    max_inflight_instrumented_bytes: 2097152
+instrument_ref_leaks:
+  percentage: 13.37
+  before_reuse_period: 20h
+  max_inflight_instrumented_bytes: 2097152
 `
 
 		var cfg customExtendedConfig
@@ -73,10 +73,10 @@ common:
 		// Mimir's inheritance should still work.
 		checkAllClusterValidationLabels(t, cfg, "client-cluster")
 
-		// Non-inherited flags should still work.
-		require.Equal(t, 13.37, cfg.MimirConfig.Common.InstrumentRefLeaks.Percentage)
-		require.Equal(t, 20*time.Hour, cfg.MimirConfig.Common.InstrumentRefLeaks.BeforeReusePeriod)
-		require.Equal(t, uint64(2097152), cfg.MimirConfig.Common.InstrumentRefLeaks.MaxInflightInstrumentedBytes)
+		// Top-level flags should still work.
+		require.Equal(t, 13.37, cfg.MimirConfig.InstrumentRefLeaks.Percentage)
+		require.Equal(t, 20*time.Hour, cfg.MimirConfig.InstrumentRefLeaks.BeforeReusePeriod)
+		require.Equal(t, uint64(2097152), cfg.MimirConfig.InstrumentRefLeaks.MaxInflightInstrumentedBytes)
 	})
 }
 


### PR DESCRIPTION
#### What this PR does

`CommonConfig` is for settings inherited across multiple sub-configs. `InstrumentRefLeaks` was never inherited — it was used once globally in `New()`. Keeping it in `CommonConfig` added unnecessary inheritance machinery (`specificLocationsUnmarshaler`, `CommonConfigInheritance` entry, YAML unmarshaling complexity) with no benefit.

This moves it to the top-level `Config`. Flag prefix changes from `-common.instrument-reference-leaks.*` to `-instrument-reference-leaks.*` and the YAML key moves from `common.instrument_ref_leaks` to top-level `instrument_ref_leaks`.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Config surface changes (YAML key and CLI flag prefixes) can break existing deployments if not updated, though runtime behavior is otherwise unchanged.
> 
> **Overview**
> Moves `instrument_ref_leaks` out of `CommonConfig` into the top-level `Config`, removing the unused common-config inheritance/unmarshal wiring for this setting.
> 
> Renames the CLI flags from `-common.instrument-reference-leaks.*` to `-instrument-reference-leaks.*` and relocates YAML from `common.instrument_ref_leaks` to top-level `instrument_ref_leaks`, updating generated help/config docs, defaults JSON, config descriptor, and tests accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a6b129b8e4295d37c231092c8e0d926d049acae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->