### PR TITLE
Jsonnet: add multi-set support to validateMimirMultiZoneConfig()

### DIFF
--- a/operations/mimir-tests/test-multi-zone-config-validation.jsonnet
+++ b/operations/mimir-tests/test-multi-zone-config-validation.jsonnet
@@ -50,7 +50,7 @@ local isError(err, needle) = err != null && std.length(std.findSubstr(needle, er
 // test. Built from multi-zone-common alone so the production assertions next to real
 // callers don't fire on the deliberately broken manifests.
 local validate(deployments, deploymentNames) =
-  (multiZoneCommon + { _config+: env._config } + deployments).validateMimirMultiZoneConfig(deploymentNames);
+  (multiZoneCommon { _config+: env._config } + deployments).validateMimirMultiZoneConfig(deploymentNames);
 
 // 1. Single deployment, cross-zone CLI address.
 local err1 = validate(
@@ -58,7 +58,7 @@ local err1 = validate(
   ['distributor'],
 );
 assert isError(err1, 'non-matching zone') :
-  'case 1: expected non-matching zone error, got: %s' % err1;
+       'case 1: expected non-matching zone error, got: %s' % err1;
 
 // 2. Single deployment, name without any zone marker.
 local err2 = validate(
@@ -66,7 +66,7 @@ local err2 = validate(
   ['distributor'],
 );
 assert isError(err2, 'Unable to extract zone letter') :
-  'case 2: expected zone-letter extraction error, got: %s' % err2;
+       'case 2: expected zone-letter extraction error, got: %s' % err2;
 
 // 3. Single deployment, embedded-form name ("distributor-zone-a-set-0"), cross-zone CLI
 //    address.
@@ -75,7 +75,7 @@ local err3 = validate(
   ['distributor'],
 );
 assert isError(err3, 'non-matching zone') :
-  'case 3: expected non-matching zone error from embedded-form name, got: %s' % err3;
+       'case 3: expected non-matching zone error from embedded-form name, got: %s' % err3;
 
 // 4. Deployment set: one good entry, one bad. Validator must walk the map.
 local err4 = validate(
@@ -86,7 +86,7 @@ local err4 = validate(
   ['deployments'],
 );
 assert isError(err4, 'non-matching zone') :
-  'case 4: expected non-matching zone error from deployment set, got: %s' % err4;
+       'case 4: expected non-matching zone error from deployment set, got: %s' % err4;
 
 // 5. Deployment set with only null entries. Dispatcher must tolerate it (parity with
 //    single-deployment behaviour, which returns null when the field resolves to null).
@@ -95,7 +95,7 @@ local err5 = validate(
   ['deployments'],
 );
 assert err5 == null :
-  'case 5: expected null for null-entry deployment set, got: %s' % err5;
+       'case 5: expected null for null-entry deployment set, got: %s' % err5;
 
 // 6. Querier with a wrong-zone "querier.prefer-availability-zones" flag value.
 //    Exercises validateContainerPreferAvailabilityZones(), which only fires for
@@ -105,7 +105,7 @@ local err6 = validate(
   ['querier'],
 );
 assert isError(err6, '-querier.prefer-availability-zones') && isError(err6, 'invalid zones') :
-  'case 6: expected invalid prefer-availability-zones error, got: %s' % err6;
+       'case 6: expected invalid prefer-availability-zones error, got: %s' % err6;
 
 // 7. Querier missing the "querier.prefer-availability-zones" flag entirely.
 local err7 = validate(
@@ -120,6 +120,6 @@ local err7 = validate(
   ['querier'],
 );
 assert isError(err7, 'missing the required CLI flag "-querier.prefer-availability-zones"') :
-  'case 7: expected missing-flag error, got: %s' % err7;
+       'case 7: expected missing-flag error, got: %s' % err7;
 
 {}

--- a/operations/mimir-tests/test-multi-zone-config-validation.jsonnet
+++ b/operations/mimir-tests/test-multi-zone-config-validation.jsonnet
@@ -1,0 +1,125 @@
+// Tests the validateMimirMultiZoneConfig() assertions.
+//
+// Strategy: build one valid multi-zone mimir environment, capture real distributor and
+// querier deployments from it, then mutate the manifest (CLI flag or metadata.name) and
+// run the validator on a synthetic root. Each test asserts a non-null error matching an
+// expected substring; any mismatch fails this jsonnet build.
+
+local mimir = import 'mimir/mimir.libsonnet';
+local multiZoneCommon = import 'mimir/multi-zone-common.libsonnet';
+
+// Multi-zone-enabled mimir environment. Its own top-level asserts (including the
+// production validateMimirMultiZoneConfig assertions) implicitly cover the happy path.
+local env = mimir {
+  _config+:: {
+    namespace: 'default',
+    external_url: 'http://test',
+
+    storage_backend: 'gcs',
+    blocks_storage_bucket_name: 'blocks-bucket',
+
+    multi_zone_availability_zones: ['us-east-1a', 'us-east-1b', 'us-east-1c'],
+    multi_zone_write_path_enabled: true,
+    multi_zone_read_path_enabled: true,
+    query_scheduler_service_discovery_mode: 'ring',
+  },
+};
+
+// Returns the flag name from an arg string like "-foo=bar" -> "-foo".
+local flagName(arg) =
+  local eq = std.findSubstr('=', arg);
+  if std.length(eq) > 0 then std.substr(arg, 0, eq[0]) else arg;
+
+// Overrides container args on every container of the deployment. For each entry in
+// "overrides", any existing arg with the same flag name is removed and the override is
+// appended. Other args are preserved.
+local overrideContainerArgs(deployment, overrides) =
+  local overrideNames = [flagName(o) for o in overrides];
+  deployment {
+    spec+: { template+: { spec+: {
+      containers: [
+        c { args: std.filter(function(arg) !std.member(overrideNames, flagName(arg)), c.args) + overrides }
+        for c in deployment.spec.template.spec.containers
+      ],
+    } } },
+  };
+
+local isError(err, needle) = err != null && std.length(std.findSubstr(needle, err)) > 0;
+
+// Synthetic root carrying validateMimirMultiZoneConfig and the deployment fields under
+// test. Built from multi-zone-common alone so the production assertions next to real
+// callers don't fire on the deliberately broken manifests.
+local validate(deployments, deploymentNames) =
+  (multiZoneCommon + { _config+: env._config } + deployments).validateMimirMultiZoneConfig(deploymentNames);
+
+// 1. Single deployment, cross-zone CLI address.
+local err1 = validate(
+  { distributor: overrideContainerArgs(env.distributor_zone_a_deployment, ['-foo.address=svc.zone-b.cluster.local']) },
+  ['distributor'],
+);
+assert isError(err1, 'non-matching zone') :
+  'case 1: expected non-matching zone error, got: %s' % err1;
+
+// 2. Single deployment, name without any zone marker.
+local err2 = validate(
+  { distributor: env.distributor_zone_a_deployment { metadata+: { name: 'distributor' } } },
+  ['distributor'],
+);
+assert isError(err2, 'Unable to extract zone letter') :
+  'case 2: expected zone-letter extraction error, got: %s' % err2;
+
+// 3. Single deployment, embedded-form name ("distributor-zone-a-set-0"), cross-zone CLI
+//    address.
+local err3 = validate(
+  { distributor: overrideContainerArgs(env.distributor_zone_a_deployment { metadata+: { name: 'distributor-zone-a-set-0' } }, ['-foo.address=svc.zone-b.cluster.local']) },
+  ['distributor'],
+);
+assert isError(err3, 'non-matching zone') :
+  'case 3: expected non-matching zone error from embedded-form name, got: %s' % err3;
+
+// 4. Deployment set: one good entry, one bad. Validator must walk the map.
+local err4 = validate(
+  { deployments: {
+    set_0: env.distributor_zone_a_deployment,
+    set_1: overrideContainerArgs(env.distributor_zone_a_deployment, ['-foo.address=svc.zone-b.cluster.local']),
+  } },
+  ['deployments'],
+);
+assert isError(err4, 'non-matching zone') :
+  'case 4: expected non-matching zone error from deployment set, got: %s' % err4;
+
+// 5. Deployment set with only null entries. Dispatcher must tolerate it (parity with
+//    single-deployment behaviour, which returns null when the field resolves to null).
+local err5 = validate(
+  { deployments: { set_0: null, set_1: null } },
+  ['deployments'],
+);
+assert err5 == null :
+  'case 5: expected null for null-entry deployment set, got: %s' % err5;
+
+// 6. Querier with a wrong-zone "querier.prefer-availability-zones" flag value.
+//    Exercises validateContainerPreferAvailabilityZones(), which only fires for
+//    deployments named querier-* or ruler-querier-*.
+local err6 = validate(
+  { querier: overrideContainerArgs(env.querier_zone_a_deployment, ['-querier.prefer-availability-zones=zone-b']) },
+  ['querier'],
+);
+assert isError(err6, '-querier.prefer-availability-zones') && isError(err6, 'invalid zones') :
+  'case 6: expected invalid prefer-availability-zones error, got: %s' % err6;
+
+// 7. Querier missing the "querier.prefer-availability-zones" flag entirely.
+local err7 = validate(
+  { querier: env.querier_zone_a_deployment {
+    spec+: { template+: { spec+: {
+      containers: [
+        c { args: std.filter(function(arg) !std.startsWith(arg, '-querier.prefer-availability-zones='), c.args) }
+        for c in env.querier_zone_a_deployment.spec.template.spec.containers
+      ],
+    } } },
+  } },
+  ['querier'],
+);
+assert isError(err7, 'missing the required CLI flag "-querier.prefer-availability-zones"') :
+  'case 7: expected missing-flag error, got: %s' % err7;
+
+{}

--- a/operations/mimir/multi-zone-common.libsonnet
+++ b/operations/mimir/multi-zone-common.libsonnet
@@ -98,15 +98,15 @@ local jsonpath = import 'github.com/jsonnet-libs/xtd/jsonpath.libsonnet';
         false
       );
 
-    // Extracts the zone letter (a, b, or c) from a deployment name.
-    // Expected format: "*_zone_[abc]_*"
-    // Returns: the zone letter or null if not found
-    local extractZoneLetter(deploymentName) =
-      if std.length(std.findSubstr('_zone_a_', deploymentName)) > 0 then
+    // Extracts the zone letter (a, b, or c) from a Kubernetes deployment name. Matches both
+    // the embedded "-zone-[abc]-" form (e.g. "ingester-zone-a-set-0") and the suffix
+    // "-zone-[abc]" form (e.g. "ingester-zone-a"). Returns the zone letter or null if not found.
+    local extractZoneLetter(name) =
+      if std.length(std.findSubstr('-zone-a-', name)) > 0 || std.endsWith(name, '-zone-a') then
         'a'
-      else if std.length(std.findSubstr('_zone_b_', deploymentName)) > 0 then
+      else if std.length(std.findSubstr('-zone-b-', name)) > 0 || std.endsWith(name, '-zone-b') then
         'b'
-      else if std.length(std.findSubstr('_zone_c_', deploymentName)) > 0 then
+      else if std.length(std.findSubstr('-zone-c-', name)) > 0 || std.endsWith(name, '-zone-c') then
         'c'
       else
         null;
@@ -144,7 +144,7 @@ local jsonpath = import 'github.com/jsonnet-libs/xtd/jsonpath.libsonnet';
     // This allows backup zones to be included while ensuring each preference targets the correct availability zone.
     local validateContainerPreferAvailabilityZones(deploymentName, expectedZone, container) =
       // Only validate querier and ruler_querier deployments (they use this flag to prefer same-zone ingesters/store-gateways)
-      if std.startsWith(deploymentName, 'querier_') || std.startsWith(deploymentName, 'ruler_querier_') then
+      if std.startsWith(deploymentName, 'querier-') || std.startsWith(deploymentName, 'ruler-querier-') then
         local flagName = '-querier.prefer-availability-zones';
 
         if std.objectHas(container, 'args') then
@@ -241,27 +241,53 @@ local jsonpath = import 'github.com/jsonnet-libs/xtd/jsonpath.libsonnet';
         null
       );
 
-    local validateDeployment(deploymentName, deployment) =
-      local expectedZone = extractZoneLetter(deploymentName);
-      if expectedZone == null then
-        'Unable to extract zone letter from deployment name "%s". Expected format: "*_zone_[abc]_*"' % deploymentName
-      else if deployment == null then
+    local validateDeployment(deployment) =
+      if deployment == null then
         null
       else
-        local containers = jsonpath.getJSONPath(deployment, 'spec.template.spec.containers', []);
+        local name = deployment.metadata.name;
+        local expectedZone = extractZoneLetter(name);
+        if expectedZone == null then
+          'Unable to extract zone letter from deployment name "%s". Expected the name to contain "-zone-[abc]".' % name
+        else
+          local containers = jsonpath.getJSONPath(deployment, 'spec.template.spec.containers', []);
+          std.foldl(
+            function(firstError, container)
+              if firstError != null then firstError
+              else validateContainer(name, expectedZone, container),
+            containers,
+            null
+          );
+
+    // Returns the metadata.name of a Deployment/StatefulSet, or null if value is not a
+    // Deployment/StatefulSet (e.g. null, a primitive, or a map of Deployments/StatefulSets).
+    local getDeploymentName(value) =
+      if std.isObject(value) && std.objectHas(value, 'metadata') && std.objectHas(value.metadata, 'name') then
+        value.metadata.name
+      else
+        null;
+
+    // Accepts either a single Deployment/StatefulSet or a map of Deployments/StatefulSets
+    // and forwards each one to validateDeployment.
+    local validateDeploymentSet(deploymentOrSet) =
+      if getDeploymentName(deploymentOrSet) != null then
+        validateDeployment(deploymentOrSet)
+      else if std.isObject(deploymentOrSet) then
         std.foldl(
-          function(firstError, container)
+          function(firstError, setKey)
             if firstError != null then firstError
-            else validateContainer(deploymentName, expectedZone, container),
-          containers,
+            else validateDeployment(deploymentOrSet[setKey]),
+          std.objectFields(deploymentOrSet),
           null
-        );
+        )
+      else
+        null;
 
     // Validate all input deployments and return the first error found, or null if all valid.
     std.foldl(
       function(firstError, deploymentName)
         if firstError != null then firstError
-        else validateDeployment(deploymentName, root[deploymentName]),
+        else validateDeploymentSet(root[deploymentName]),
       deploymentNames,
       null
     ),


### PR DESCRIPTION
#### What this PR does

In this PR I'm refactoring `validateMimirMultiZoneConfig()` to add multi-set support, that is required at Grafana Labs (it's a deployment mode that will be eventually OSS-ed if successful).

In particular:

- **Read the zone from the rendered Kubernetes name** (`metadata.name`) instead of the jsonnet field name. `extractZoneLetter` now matches both the embedded form `-zone-[abc]-` (e.g. `ingester-zone-a-set-0`) and the suffix form `-zone-[abc]` (e.g. `ingester-zone-a`). The K8s name is canonical and survives any wrapping done at the jsonnet layer.
- **Accept a map of Deployments/StatefulSets**. A new `validateDeploymentSet` dispatcher routes either a single workload or `{ key_0: <STS>, key_1: <STS>, … }` through `validateDeployment`. This unblocks downstream users that store per-set zonal workloads as a map; upstream callers are unaffected because their root fields still resolve to single workloads.

The deployment-set dispatcher is forward-compatible with set-based deployment patterns used downstream.

I also took the opportunity to add some jsonnet tests, covering:

- cross-zone CLI address (single deployment, embedded-form name, deployment-set with one bad entry)
- name without a zone marker
- deployment-set tolerating all-null entries
- querier wrong-zone / missing `-querier.prefer-availability-zones` flag

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
