### PR TITLE
fix: MQE: Remove entire no-op function call or aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,7 +222,7 @@
 * [ENHANCEMENT] Query-frontend: Stream JSON encoding directly to the response body to avoid a full-copy allocation of the serialized payload. #14840
 * [ENHANCEMENT] Activity tracker: Added `activity_tracker_unfinished_activities_loaded` metric to report the number of unfinished activities detected on startup. #14860
 * [ENHANCEMENT] Distributor now uses record validation time as Kafka record timestamp to reduce rejections among consumers. #14921
-* [ENHANCEMENT] MQE: Add optimisation pass to optimise away expressions that can't produce results such as those containing comparisons with `timestamp()` due to the query time range or conflicting matchers. #14989 #15014 #15163 #15117
+* [ENHANCEMENT] MQE: Add optimisation pass to optimise away expressions that can't produce results such as those containing comparisons with `timestamp()` due to the query time range or conflicting matchers. #14989 #15014 #15163 #15117 #15260
 * [ENHANCEMENT] Distributor: OTLP endpoint now returns partial success (HTTP 200) instead of HTTP 429 when the usage tracker rejects some series due to the active series limit but other series are successfully ingested. The `RejectedDataPoints` field reports the count of distributor-side rejections (usage tracker filtering). #14789
 * [ENHANCEMENT] MQE: Account for memory consumption of labels returned by binary operations in query memory consumption estimate earlier. #15033
 * [ENHANCEMENT] Query-frontend: Log the number of series and samples returned for queries in `query stats` log lines. #15044

--- a/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
+++ b/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
@@ -333,6 +333,7 @@ func isAlwaysEmptyBinaryExpression(node *core.BinaryExpression, params *planning
 
 	switch node.Op {
 	case core.BINARY_ADD,
+		core.BINARY_ATAN2,
 		core.BINARY_DIV,
 		core.BINARY_MOD,
 		core.BINARY_MUL,

--- a/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
+++ b/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
@@ -297,7 +297,8 @@ func IsAlwaysEmptyFunctionCall(node *core.FunctionCall, params *planning.QueryPa
 		functions.FUNCTION_YEAR,
 		functions.FUNCTION_PI,
 		functions.FUNCTION_SCALAR,
-		functions.FUNCTION_TIME:
+		functions.FUNCTION_TIME,
+		functions.FUNCTION_UNKNOWN:
 		// Functions that we know are not valid to replace with a no-op node either
 		// because it would generate incorrect results or because they do not operate
 		// on vectors.

--- a/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
+++ b/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
@@ -299,8 +299,7 @@ func IsAlwaysEmptyFunctionCall(node *core.FunctionCall, params *planning.QueryPa
 		functions.FUNCTION_YEAR,
 		functions.FUNCTION_PI,
 		functions.FUNCTION_SCALAR,
-		functions.FUNCTION_TIME,
-		functions.FUNCTION_UNKNOWN:
+		functions.FUNCTION_TIME:
 		// Functions that we know are not valid to replace with a no-op node either
 		// because it would generate incorrect results or because they do not operate
 		// on vectors.

--- a/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
+++ b/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
@@ -178,6 +178,8 @@ func isAlwaysEmpty(node planning.Node, params *planning.QueryParameters) (bool, 
 		return isAlwaysEmptyBinaryExpression(node, params)
 	case *core.FunctionCall:
 		return IsAlwaysEmptyFunctionCall(node, params)
+	case *core.UnaryExpression:
+		return isAlwaysEmpty(node.Inner, params)
 	default:
 		return false, nil
 	}

--- a/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
+++ b/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
@@ -4,6 +4,7 @@ package plan
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/go-kit/log"
@@ -16,6 +17,11 @@ import (
 	"github.com/grafana/mimir/pkg/streamingpromql/planning"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning/core"
 	"github.com/grafana/mimir/pkg/util/spanlogger"
+)
+
+var (
+	ErrInvalidFunctionArgs = errors.New("invalid function arguments")
+	ErrUnknownFunction     = errors.New("unknown function")
 )
 
 // RemoveStaticallyEmptyExpressionsOptimizationPass replaces subexpressions that can be statically
@@ -171,16 +177,20 @@ func isAlwaysEmpty(node planning.Node, params *planning.QueryParameters) (bool, 
 	case *core.BinaryExpression:
 		return isAlwaysEmptyBinaryExpression(node, params)
 	case *core.FunctionCall:
-		return isAlwaysEmptyFunctionCall(node, params)
+		return IsAlwaysEmptyFunctionCall(node, params)
 	default:
 		return false, nil
 	}
 }
 
-func isAlwaysEmptyFunctionCall(node *core.FunctionCall, params *planning.QueryParameters) (bool, error) {
+func IsAlwaysEmptyFunctionCall(node *core.FunctionCall, params *planning.QueryParameters) (bool, error) {
+	// This function is exported because there's no easy way to test it without calling
+	// it directly and the tests are in a different package to avoid import cycles.
 	switch node.Function {
 	case
 		functions.FUNCTION_ABS,
+		functions.FUNCTION_ADAPTIVE_METRICS_RESERVED_1,
+		functions.FUNCTION_ADAPTIVE_METRICS_RESERVED_2,
 		functions.FUNCTION_ACOS,
 		functions.FUNCTION_ACOSH,
 		functions.FUNCTION_ASIN,
@@ -201,6 +211,7 @@ func isAlwaysEmptyFunctionCall(node *core.FunctionCall, params *planning.QueryPa
 		functions.FUNCTION_DERIV,
 		functions.FUNCTION_DOUBLE_EXPONENTIAL_SMOOTHING,
 		functions.FUNCTION_EXP,
+		functions.FUNCTION_FIRST_OVER_TIME,
 		functions.FUNCTION_FLOOR,
 		functions.FUNCTION_HISTOGRAM_AVG,
 		functions.FUNCTION_HISTOGRAM_COUNT,
@@ -211,6 +222,8 @@ func isAlwaysEmptyFunctionCall(node *core.FunctionCall, params *planning.QueryPa
 		functions.FUNCTION_INCREASE,
 		functions.FUNCTION_INFO,
 		functions.FUNCTION_IRATE,
+		functions.FUNCTION_LABEL_JOIN,
+		functions.FUNCTION_LABEL_REPLACE,
 		functions.FUNCTION_LAST_OVER_TIME,
 		functions.FUNCTION_LN,
 		functions.FUNCTION_LOG10,
@@ -243,38 +256,54 @@ func isAlwaysEmptyFunctionCall(node *core.FunctionCall, params *planning.QueryPa
 		functions.FUNCTION_TS_OF_MAX_OVER_TIME,
 		functions.FUNCTION_TS_OF_MIN_OVER_TIME:
 		if len(node.Args) < 1 {
-			return false, fmt.Errorf("expected at least one argument in call to %s, got %d", node.Function, len(node.Args))
+			return false, fmt.Errorf("%w: expected at least one argument in call to %s, got %d (this is a bug)", ErrInvalidFunctionArgs, node.Function, len(node.Args))
 		}
 
 		return isAlwaysEmpty(node.Args[0], params)
 	case functions.FUNCTION_HISTOGRAM_QUANTILE,
 		functions.FUNCTION_QUANTILE_OVER_TIME:
 		if len(node.Args) < 2 {
-			return false, fmt.Errorf("expected at least two arguments in call to %s, got %d", node.Function, len(node.Args))
+			return false, fmt.Errorf("%w: expected at least two arguments in call to %s, got %d (this is a bug)", ErrInvalidFunctionArgs, node.Function, len(node.Args))
 		}
 
 		return isAlwaysEmpty(node.Args[1], params)
-
 	case functions.FUNCTION_HISTOGRAM_FRACTION:
 		if len(node.Args) < 3 {
-			return false, fmt.Errorf("expected at least three arguments in call to %s, got %d", node.Function, len(node.Args))
+			return false, fmt.Errorf("%w: expected at least three arguments in call to %s, got %d (this is a bug)", ErrInvalidFunctionArgs, node.Function, len(node.Args))
 		}
 
 		return isAlwaysEmpty(node.Args[2], params)
 	case functions.FUNCTION_SHARDING_CONCAT:
-		allChildrenEmpty := true
 		for i := range node.ChildCount() {
 			empty, err := isAlwaysEmpty(node.Child(i), params)
 			if err != nil {
 				return false, err
+			} else if !empty {
+				return false, nil
 			}
-
-			allChildrenEmpty = allChildrenEmpty && empty
 		}
 
-		return allChildrenEmpty, nil
-	default:
+		return true, nil
+	case functions.FUNCTION_ABSENT,
+		functions.FUNCTION_ABSENT_OVER_TIME,
+		functions.FUNCTION_DAYS_IN_MONTH,
+		functions.FUNCTION_DAY_OF_MONTH,
+		functions.FUNCTION_DAY_OF_WEEK,
+		functions.FUNCTION_DAY_OF_YEAR,
+		functions.FUNCTION_HOUR,
+		functions.FUNCTION_MINUTE,
+		functions.FUNCTION_MONTH,
+		functions.FUNCTION_VECTOR,
+		functions.FUNCTION_YEAR,
+		functions.FUNCTION_PI,
+		functions.FUNCTION_SCALAR,
+		functions.FUNCTION_TIME:
+		// Functions that we know are not valid to replace with a no-op node either
+		// because it would generate incorrect results or because they do not operate
+		// on vectors.
 		return false, nil
+	default:
+		return false, fmt.Errorf("%w: function call %s is unexpected (this is a bug)", ErrUnknownFunction, node.Function)
 	}
 }
 
@@ -302,6 +331,29 @@ func isAlwaysEmptyBinaryExpression(node *core.BinaryExpression, params *planning
 	}
 
 	switch node.Op {
+	case core.BINARY_ADD,
+		core.BINARY_DIV,
+		core.BINARY_MOD,
+		core.BINARY_MUL,
+		core.BINARY_POW,
+		core.BINARY_SUB:
+		// Arithmetic operations are always no-ops when one side of the operation is a no-op since
+		// they won't have any matching labels.
+		lhsEmpty, err := isAlwaysEmpty(node.LHS, params)
+		if err != nil {
+			return false, err
+		} else if lhsEmpty {
+			return true, nil
+		}
+
+		rhsEmpty, err := isAlwaysEmpty(node.RHS, params)
+		if err != nil {
+			return false, err
+		} else if rhsEmpty {
+			return true, nil
+		}
+
+		return false, nil
 	case core.BINARY_LAND:
 		lhsEmpty, err := isAlwaysEmpty(node.LHS, params)
 		if err != nil {
@@ -453,23 +505,14 @@ func simplify(node planning.Node) planning.Node {
 		}
 
 	case *core.BinaryExpression:
-		switch node.Op {
-		case core.BINARY_ADD:
-			// If we're adding things and one of them is a no-op, we can get rid of the
-			// entire binary expression and replace it with the other side.
-			if _, lhsNop := node.LHS.(*core.NoOp); lhsNop {
-				return node.RHS
-			}
+		if node.Op != core.BINARY_LUNLESS {
+			return nil
+		}
 
-			if _, rhsNop := node.RHS.(*core.NoOp); rhsNop {
-				return node.LHS
-			}
-		case core.BINARY_LUNLESS:
-			// If the LHS is a no-op this means the whole expression is a no-op, and that is
-			// handled by isAlwaysEmptyBinaryExpression.
-			if _, noOp := node.RHS.(*core.NoOp); noOp {
-				return node.LHS
-			}
+		// If the LHS is a no-op this means the whole expression is a no-op, and that is
+		// handled by isAlwaysEmptyBinaryExpression.
+		if _, noOp := node.RHS.(*core.NoOp); noOp {
+			return node.LHS
 		}
 	}
 

--- a/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
+++ b/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
@@ -341,28 +341,10 @@ func isAlwaysEmptyBinaryExpression(node *core.BinaryExpression, params *planning
 		core.BINARY_SUB:
 		// Arithmetic operations are always no-ops when one side of the operation is a no-op since
 		// they won't have any matching labels.
-		lhsEmpty, err := isAlwaysEmpty(node.LHS, params)
-		if err != nil {
-			return false, err
-		}
-
-		if lhsEmpty {
-			return true, nil
-		}
-
-		return isAlwaysEmpty(node.RHS, params)
+		return isEitherBinaryExpressionSideEmpty(node, params)
 
 	case core.BINARY_LAND:
-		lhsEmpty, err := isAlwaysEmpty(node.LHS, params)
-		if err != nil {
-			return false, err
-		}
-
-		if lhsEmpty {
-			return true, nil
-		}
-
-		return isAlwaysEmpty(node.RHS, params)
+		return isEitherBinaryExpressionSideEmpty(node, params)
 
 	case core.BINARY_LOR:
 		// A or B is empty only when both sides are empty.
@@ -383,22 +365,73 @@ func isAlwaysEmptyBinaryExpression(node *core.BinaryExpression, params *planning
 
 	case core.BINARY_LSS:
 		// Check for timestamp(v) < C.
-		return isAlwaysEmptyTimestampComparison(node.LHS, node.RHS, false, params)
+		empty, err := isAlwaysEmptyTimestampComparison(node.LHS, node.RHS, false, params)
+		if err != nil {
+			return false, err
+		}
+
+		if empty {
+			return true, nil
+		}
+
+		return isEitherBinaryExpressionSideEmpty(node, params)
 
 	case core.BINARY_LTE:
 		// Check for timestamp(v) <= C.
-		return isAlwaysEmptyTimestampComparison(node.LHS, node.RHS, true, params)
+		empty, err := isAlwaysEmptyTimestampComparison(node.LHS, node.RHS, true, params)
+		if err != nil {
+			return false, err
+		}
+
+		if empty {
+			return true, nil
+		}
+
+		return isEitherBinaryExpressionSideEmpty(node, params)
 
 	case core.BINARY_GTR:
 		// Check for C > timestamp(v), equivalent to timestamp(v) < C.
-		return isAlwaysEmptyTimestampComparison(node.RHS, node.LHS, false, params)
+		empty, err := isAlwaysEmptyTimestampComparison(node.RHS, node.LHS, false, params)
+		if err != nil {
+			return false, err
+		}
+
+		if empty {
+			return true, nil
+		}
+
+		return isEitherBinaryExpressionSideEmpty(node, params)
 
 	case core.BINARY_GTE:
 		// Check for C >= timestamp(v), equivalent to timestamp(v) <= C.
-		return isAlwaysEmptyTimestampComparison(node.RHS, node.LHS, true, params)
+		empty, err := isAlwaysEmptyTimestampComparison(node.RHS, node.LHS, true, params)
+		if err != nil {
+			return false, err
+		}
+
+		if empty {
+			return true, nil
+		}
+
+		return isEitherBinaryExpressionSideEmpty(node, params)
 	}
 
 	return false, nil
+}
+
+// isEitherBinaryExpressionSideEmpty returns true if either side of a binary expression is
+// empty by recursively calling isAlwaysEmpty.
+func isEitherBinaryExpressionSideEmpty(node *core.BinaryExpression, params *planning.QueryParameters) (bool, error) {
+	lhsEmpty, err := isAlwaysEmpty(node.LHS, params)
+	if err != nil {
+		return false, err
+	}
+
+	if lhsEmpty {
+		return true, nil
+	}
+
+	return isAlwaysEmpty(node.RHS, params)
 }
 
 // isAlwaysEmptyTimestampComparison returns true if timestampSide and constantSide represent

--- a/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
+++ b/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
@@ -344,18 +344,14 @@ func isAlwaysEmptyBinaryExpression(node *core.BinaryExpression, params *planning
 		lhsEmpty, err := isAlwaysEmpty(node.LHS, params)
 		if err != nil {
 			return false, err
-		} else if lhsEmpty {
+		}
+
+		if lhsEmpty {
 			return true, nil
 		}
 
-		rhsEmpty, err := isAlwaysEmpty(node.RHS, params)
-		if err != nil {
-			return false, err
-		} else if rhsEmpty {
-			return true, nil
-		}
+		return isAlwaysEmpty(node.RHS, params)
 
-		return false, nil
 	case core.BINARY_LAND:
 		lhsEmpty, err := isAlwaysEmpty(node.LHS, params)
 		if err != nil {

--- a/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
+++ b/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
@@ -166,8 +166,113 @@ func isAlwaysEmpty(node planning.Node, params *planning.QueryParameters) (bool, 
 	switch node := node.(type) {
 	case *core.NoOp:
 		return true, nil
+	case *core.AggregateExpression:
+		return isAlwaysEmpty(node.Inner, params)
 	case *core.BinaryExpression:
 		return isAlwaysEmptyBinaryExpression(node, params)
+	case *core.FunctionCall:
+		return isAlwaysEmptyFunctionCall(node, params)
+	default:
+		return false, nil
+	}
+}
+
+func isAlwaysEmptyFunctionCall(node *core.FunctionCall, params *planning.QueryParameters) (bool, error) {
+	switch node.Function {
+	case
+		functions.FUNCTION_ABS,
+		functions.FUNCTION_ACOS,
+		functions.FUNCTION_ACOSH,
+		functions.FUNCTION_ASIN,
+		functions.FUNCTION_ASINH,
+		functions.FUNCTION_ATAN,
+		functions.FUNCTION_ATANH,
+		functions.FUNCTION_AVG_OVER_TIME,
+		functions.FUNCTION_CEIL,
+		functions.FUNCTION_CHANGES,
+		functions.FUNCTION_CLAMP,
+		functions.FUNCTION_CLAMP_MAX,
+		functions.FUNCTION_CLAMP_MIN,
+		functions.FUNCTION_COS,
+		functions.FUNCTION_COSH,
+		functions.FUNCTION_COUNT_OVER_TIME,
+		functions.FUNCTION_DEG,
+		functions.FUNCTION_DELTA,
+		functions.FUNCTION_DERIV,
+		functions.FUNCTION_DOUBLE_EXPONENTIAL_SMOOTHING,
+		functions.FUNCTION_EXP,
+		functions.FUNCTION_FLOOR,
+		functions.FUNCTION_HISTOGRAM_AVG,
+		functions.FUNCTION_HISTOGRAM_COUNT,
+		functions.FUNCTION_HISTOGRAM_STDDEV,
+		functions.FUNCTION_HISTOGRAM_STDVAR,
+		functions.FUNCTION_HISTOGRAM_SUM,
+		functions.FUNCTION_IDELTA,
+		functions.FUNCTION_INCREASE,
+		functions.FUNCTION_INFO,
+		functions.FUNCTION_IRATE,
+		functions.FUNCTION_LAST_OVER_TIME,
+		functions.FUNCTION_LN,
+		functions.FUNCTION_LOG10,
+		functions.FUNCTION_LOG2,
+		functions.FUNCTION_MAD_OVER_TIME,
+		functions.FUNCTION_MAX_OVER_TIME,
+		functions.FUNCTION_MIN_OVER_TIME,
+		functions.FUNCTION_PREDICT_LINEAR,
+		functions.FUNCTION_PRESENT_OVER_TIME,
+		functions.FUNCTION_RAD,
+		functions.FUNCTION_RATE,
+		functions.FUNCTION_RESETS,
+		functions.FUNCTION_ROUND,
+		functions.FUNCTION_SGN,
+		functions.FUNCTION_SIN,
+		functions.FUNCTION_SINH,
+		functions.FUNCTION_SORT,
+		functions.FUNCTION_SORT_BY_LABEL,
+		functions.FUNCTION_SORT_BY_LABEL_DESC,
+		functions.FUNCTION_SORT_DESC,
+		functions.FUNCTION_SQRT,
+		functions.FUNCTION_STDDEV_OVER_TIME,
+		functions.FUNCTION_STDVAR_OVER_TIME,
+		functions.FUNCTION_SUM_OVER_TIME,
+		functions.FUNCTION_TAN,
+		functions.FUNCTION_TANH,
+		functions.FUNCTION_TIMESTAMP,
+		functions.FUNCTION_TS_OF_FIRST_OVER_TIME,
+		functions.FUNCTION_TS_OF_LAST_OVER_TIME,
+		functions.FUNCTION_TS_OF_MAX_OVER_TIME,
+		functions.FUNCTION_TS_OF_MIN_OVER_TIME:
+		if len(node.Args) < 1 {
+			return false, fmt.Errorf("expected at least one argument in call to %s, got %d", node.Function, len(node.Args))
+		}
+
+		return isAlwaysEmpty(node.Args[0], params)
+	case functions.FUNCTION_HISTOGRAM_QUANTILE,
+		functions.FUNCTION_QUANTILE_OVER_TIME:
+		if len(node.Args) < 2 {
+			return false, fmt.Errorf("expected at least two arguments in call to %s, got %d", node.Function, len(node.Args))
+		}
+
+		return isAlwaysEmpty(node.Args[1], params)
+
+	case functions.FUNCTION_HISTOGRAM_FRACTION:
+		if len(node.Args) < 3 {
+			return false, fmt.Errorf("expected at least three arguments in call to %s, got %d", node.Function, len(node.Args))
+		}
+
+		return isAlwaysEmpty(node.Args[2], params)
+	case functions.FUNCTION_SHARDING_CONCAT:
+		allChildrenEmpty := true
+		for i := range node.ChildCount() {
+			empty, err := isAlwaysEmpty(node.Child(i), params)
+			if err != nil {
+				return false, err
+			}
+
+			allChildrenEmpty = allChildrenEmpty && empty
+		}
+
+		return allChildrenEmpty, nil
 	default:
 		return false, nil
 	}
@@ -348,14 +453,23 @@ func simplify(node planning.Node) planning.Node {
 		}
 
 	case *core.BinaryExpression:
-		if node.Op != core.BINARY_LUNLESS {
-			return nil
-		}
+		switch node.Op {
+		case core.BINARY_ADD:
+			// If we're adding things and one of them is a no-op, we can get rid of the
+			// entire binary expression and replace it with the other side.
+			if _, lhsNop := node.LHS.(*core.NoOp); lhsNop {
+				return node.RHS
+			}
 
-		// If the LHS is a no-op this means the whole expression is a no-op, and that is
-		// handled by isAlwaysEmptyBinaryExpression.
-		if _, noOp := node.RHS.(*core.NoOp); noOp {
-			return node.LHS
+			if _, rhsNop := node.RHS.(*core.NoOp); rhsNop {
+				return node.LHS
+			}
+		case core.BINARY_LUNLESS:
+			// If the LHS is a no-op this means the whole expression is a no-op, and that is
+			// handled by isAlwaysEmptyBinaryExpression.
+			if _, noOp := node.RHS.(*core.NoOp); noOp {
+				return node.LHS
+			}
 		}
 	}
 

--- a/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions_test.go
+++ b/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions_test.go
@@ -295,16 +295,30 @@ func TestRemoveStaticallyEmptyExpressionsOptimizationPass(t *testing.T) {
 		"binary add with empty result on right side: should optimize": {
 			expr: `sum(metric_a) + sum(EMPTY_RESULT)`,
 			expectedPlan: `
-				- AggregateExpression: sum
-					- VectorSelector: {__name__="metric_a"}
+				- NoOp
 			`,
 		},
 		"binary add with empty result on left side: should optimize": {
 			expr: `sum(EMPTY_RESULT) + sum(metric_a)`,
 			expectedPlan: `
-				- AggregateExpression: sum
-					- VectorSelector: {__name__="metric_a"}
+				- NoOp
 			`,
+		},
+		"binary modulo with empty result on right side: should optimize": {
+			expr: `sum(metric_a) % sum(EMPTY_RESULT)`,
+			expectedPlan: `
+				- NoOp
+			`,
+		},
+		"binary exponent with empty result on left side: should optimize": {
+			expr: `sum(EMPTY_RESULT) ^ sum(metric_a)`,
+			expectedPlan: `
+				- NoOp
+			`,
+		},
+		"binary add with results on both sides: should not optimize": {
+			expr:            `sum(metric_a) + sum(metric_b)`,
+			expectUnchanged: true,
 		},
 		"absent over empty result: should only optimize selector": {
 			expr: `absent(EMPTY_RESULT)`,
@@ -513,4 +527,25 @@ func TestRemoveStaticallyEmptyExpressions_AdaptiveMetrics(t *testing.T) {
 
 		require.Equal(t, "- NoOp", optimizedPlan.String())
 	}
+}
+
+func TestRemoveStaticallyEmptyExpressions_IsAlwaysEmptyFunctionCall_UnknownFunction(t *testing.T) {
+	var currentFunc functions.Function
+	for i := 0; ; i++ {
+		currentFunc = functions.Function(i)
+		// Once there's no nice string representation of the function we know
+		// that we've found the end of the protobuf defined functions.
+		if !strings.HasPrefix(currentFunc.String(), "FUNCTION_") {
+			break
+		}
+	}
+
+	funcCall := &core.FunctionCall{
+		FunctionCallDetails: &core.FunctionCallDetails{
+			Function: currentFunc,
+		},
+	}
+
+	_, err := plan.IsAlwaysEmptyFunctionCall(funcCall, nil)
+	require.ErrorIs(t, err, plan.ErrUnknownFunction)
 }

--- a/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions_test.go
+++ b/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions_test.go
@@ -262,9 +262,7 @@ func TestRemoveStaticallyEmptyExpressionsOptimizationPass(t *testing.T) {
 			expr:       `avg_over_time(metric{pod="foo", pod="bar"}[5m])`,
 			queryStart: time.UnixMilli(selectorThresholdMs),
 			expectedPlan: `
-				- DeduplicateAndMerge
-					- FunctionCall: avg_over_time(...)
-						- NoOp: matrix
+				- NoOp
 			`,
 		},
 		"conflicting equals matchers on LHS of binary expression: should optimize": {
@@ -281,9 +279,61 @@ func TestRemoveStaticallyEmptyExpressionsOptimizationPass(t *testing.T) {
 				- NoOp
 			`,
 		},
-
-		"empty result ANDed with non-empty result: returns empty result": {
-			expr: `EMPTY_RESULT and metric`,
+		"aggregation over empty result: should optimize": {
+			expr:       `sum(EMPTY_RESULT)`,
+			queryStart: time.UnixMilli(selectorThresholdMs),
+			expectedPlan: `
+				- NoOp
+			`,
+		},
+		"aggregation over function over empty result: should optimize": {
+			expr: `sum(rate(EMPTY_RESULT[5m]))`,
+			expectedPlan: `
+				- NoOp
+			`,
+		},
+		"binary add with empty result on right side: should optimize": {
+			expr: `sum(metric_a) + sum(EMPTY_RESULT)`,
+			expectedPlan: `
+				- AggregateExpression: sum
+					- VectorSelector: {__name__="metric_a"}
+			`,
+		},
+		"binary add with empty result on left side: should optimize": {
+			expr: `sum(EMPTY_RESULT) + sum(metric_a)`,
+			expectedPlan: `
+				- AggregateExpression: sum
+					- VectorSelector: {__name__="metric_a"}
+			`,
+		},
+		"absent over empty result: should only optimize selector": {
+			expr: `absent(EMPTY_RESULT)`,
+			expectedPlan: `
+				- FunctionCall: absent(...)
+					- NoOp
+			`,
+		},
+		"absent_over_time over empty result: should only optimize selector": {
+			expr: `absent_over_time(EMPTY_RESULT[5m])`,
+			expectedPlan: `
+				- FunctionCall: absent_over_time(...)
+					- NoOp: matrix
+			`,
+		},
+		"abs over empty result: should optimize": {
+			expr: `abs(EMPTY_RESULT)`,
+			expectedPlan: `
+				- NoOp
+			`,
+		},
+		"histogram_quantile over empty result: should optimize": {
+			expr: `histogram_quantile(0.99, sum(rate(EMPTY_RESULT[5m])))`,
+			expectedPlan: `
+				- NoOp
+			`,
+		},
+		"histogram_fraction over empty result: should optimize": {
+			expr: `histogram_fraction(0, 0.2, rate(EMPTY_RESULT[5m]))`,
 			expectedPlan: `
 				- NoOp
 			`,

--- a/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions_test.go
+++ b/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions_test.go
@@ -314,6 +314,12 @@ func TestRemoveStaticallyEmptyExpressionsOptimizationPass(t *testing.T) {
 				- NoOp
 			`,
 		},
+		"binary atan2 with empty result on right side: should optimize": {
+			expr: `some_metric atan2 EMPTY_RESULT`,
+			expectedPlan: `
+				- NoOp
+			`,
+		},
 		"binary add with results on both sides: should not optimize": {
 			expr:            `sum(metric_a) + sum(metric_b)`,
 			expectUnchanged: true,

--- a/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions_test.go
+++ b/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions_test.go
@@ -533,25 +533,42 @@ func TestRemoveStaticallyEmptyExpressions_AdaptiveMetrics(t *testing.T) {
 	}
 }
 
-func TestRemoveStaticallyEmptyExpressions_IsAlwaysEmptyFunctionCall_AllFunctionsHandled(t *testing.T) {
+func TestRemoveStaticallyEmptyExpressions_IsAlwaysEmptyFunctionCall_UnknownFunctionsHandled(t *testing.T) {
 	params := &planning.QueryParameters{
 		TimeRange:     types.NewInstantQueryTimeRange(time.Now()),
 		LookbackDelta: 5 * time.Minute,
 	}
 
-	var currentFunc functions.Function
-	for i := 0; ; i++ {
-		currentFunc = functions.Function(i)
-		// Once there's no nice string representation of the function we know
-		// that we've found the end of the protobuf defined functions.
+	maxFuncOrd := getMaxFunctionOrdinal()
+	funcCall := &core.FunctionCall{
+		FunctionCallDetails: &core.FunctionCallDetails{
+			Function: functions.Function(maxFuncOrd + 1),
+		},
+	}
+
+	_, err := plan.IsAlwaysEmptyFunctionCall(funcCall, params)
+	require.ErrorIs(t, err, plan.ErrUnknownFunction)
+}
+
+func TestRemoveStaticallyEmptyExpressions_IsAlwaysEmptyFunctionCall_AllKnownFunctionsHandled(t *testing.T) {
+	params := &planning.QueryParameters{
+		TimeRange:     types.NewInstantQueryTimeRange(time.Now()),
+		LookbackDelta: 5 * time.Minute,
+	}
+
+	for i := getMaxFunctionOrdinal(); i >= 0; i-- {
+		currentFunc := functions.Function(i)
+
+		// There are gaps in the ordinals used for the protobuf function enum
+		// so if this particular function isn't defined, skip it.
 		if !strings.HasPrefix(currentFunc.String(), "FUNCTION_") {
-			break
+			continue
 		}
 
-		// If this is a known function, ensure that we either get no error when
-		// determining if it is always empty or an error because we haven't passed
-		// the expected arguments (because we don't pass any). The idea is to make
-		// sure we have explicitly handled every defined function.
+		// This is a known function, ensure that we either get no error when determining
+		// if it is always empty or an error because we haven't passed the expected arguments
+		// (because we don't pass any). The idea is to make sure we have explicitly handled
+		// every defined function.
 		funcCall := &core.FunctionCall{
 			FunctionCallDetails: &core.FunctionCallDetails{
 				Function: currentFunc,
@@ -563,13 +580,15 @@ func TestRemoveStaticallyEmptyExpressions_IsAlwaysEmptyFunctionCall_AllFunctions
 			require.ErrorIs(t, err, plan.ErrInvalidFunctionArgs, "expected no error or invalid arguments error for %s, got %s", currentFunc, err)
 		}
 	}
+}
 
-	funcCall := &core.FunctionCall{
-		FunctionCallDetails: &core.FunctionCallDetails{
-			Function: currentFunc,
-		},
+func getMaxFunctionOrdinal() int32 {
+	maxFuncOrd := int32(0)
+	for _, i := range functions.Function_value {
+		if i > maxFuncOrd {
+			maxFuncOrd = i
+		}
 	}
 
-	_, err := plan.IsAlwaysEmptyFunctionCall(funcCall, params)
-	require.ErrorIs(t, err, plan.ErrUnknownFunction)
+	return maxFuncOrd
 }

--- a/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions_test.go
+++ b/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions_test.go
@@ -227,6 +227,23 @@ func TestRemoveStaticallyEmptyExpressionsOptimizationPass(t *testing.T) {
 			queryStart:      time.Unix(10000, 0),
 			expectUnchanged: true,
 		},
+		"function over subquery with empty results: should not optimize": {
+			// We short-circuit on subqueries now for simplicity
+			expr:            `max_over_time(EMPTY_RESULT[1d:5m])`,
+			expectUnchanged: true,
+		},
+		"function over subquery binary operation with empty results: should optimize": {
+			expr: `max_over_time(metric_a[1d:5m]) + rate(EMPTY_RESULT[5m])`,
+			expectedPlan: `
+				- NoOp
+			`,
+		},
+		"unary operation on empty results: should optimize": {
+			expr: `-rate(EMPTY_RESULT[5m])`,
+			expectedPlan: `
+				- NoOp
+			`,
+		},
 		"non-conflicting equals matchers: should not optimize": {
 			expr:            `metric{pod="foo", env="bar"}`,
 			queryStart:      time.UnixMilli(selectorThresholdMs),

--- a/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions_test.go
+++ b/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions_test.go
@@ -332,8 +332,36 @@ func TestRemoveStaticallyEmptyExpressionsOptimizationPass(t *testing.T) {
 				- NoOp
 			`,
 		},
+		"binary less-than with empty result on right side: should optimize": {
+			expr: `some_metric_a < EMPTY_RESULT`,
+			expectedPlan: `
+				- NoOp
+			`,
+		},
+		"binary less-than-or-equal with empty result on right side: should optimize": {
+			expr: `some_metric_a <= EMPTY_RESULT`,
+			expectedPlan: `
+				- NoOp
+			`,
+		},
+		"binary greater-than with empty result on right side: should optimize": {
+			expr: `some_metric_a > EMPTY_RESULT`,
+			expectedPlan: `
+				- NoOp
+			`,
+		},
+		"binary greater-than-or-equal with empty result on right side: should optimize": {
+			expr: `some_metric_a >= EMPTY_RESULT`,
+			expectedPlan: `
+				- NoOp
+			`,
+		},
 		"binary add with results on both sides: should not optimize": {
 			expr:            `sum(metric_a) + sum(metric_b)`,
+			expectUnchanged: true,
+		},
+		"binary greater-than with results on both sides: should not optimize": {
+			expr:            `some_metric_a > some_metric_b`,
 			expectUnchanged: true,
 		},
 		"absent over empty result: should only optimize selector": {

--- a/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions_test.go
+++ b/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions_test.go
@@ -241,9 +241,7 @@ func TestRemoveStaticallyEmptyExpressionsOptimizationPass(t *testing.T) {
 			expr:       `info(metric{pod="foo", pod="bar"}, {__name__="other_info"})`,
 			queryStart: time.UnixMilli(selectorThresholdMs),
 			expectedPlan: `
-				- FunctionCall: info(...)
-					- param 0: NoOp
-					- param 1: DataLabelSelector: {__name__="other_info"}
+				- NoOp
 			`,
 		},
 		"conflicting equals matchers in second info() argument: should not optimize": {
@@ -529,7 +527,12 @@ func TestRemoveStaticallyEmptyExpressions_AdaptiveMetrics(t *testing.T) {
 	}
 }
 
-func TestRemoveStaticallyEmptyExpressions_IsAlwaysEmptyFunctionCall_UnknownFunction(t *testing.T) {
+func TestRemoveStaticallyEmptyExpressions_IsAlwaysEmptyFunctionCall_AllFunctionsHandled(t *testing.T) {
+	params := &planning.QueryParameters{
+		TimeRange:     types.NewInstantQueryTimeRange(time.Now()),
+		LookbackDelta: 5 * time.Minute,
+	}
+
 	var currentFunc functions.Function
 	for i := 0; ; i++ {
 		currentFunc = functions.Function(i)
@@ -537,6 +540,21 @@ func TestRemoveStaticallyEmptyExpressions_IsAlwaysEmptyFunctionCall_UnknownFunct
 		// that we've found the end of the protobuf defined functions.
 		if !strings.HasPrefix(currentFunc.String(), "FUNCTION_") {
 			break
+		}
+
+		// If this is a known function, ensure that we either get no error when
+		// determining if it is always empty or an error because we haven't passed
+		// the expected arguments (because we don't pass any). The idea is to make
+		// sure we have explicitly handled every defined function.
+		funcCall := &core.FunctionCall{
+			FunctionCallDetails: &core.FunctionCallDetails{
+				Function: currentFunc,
+			},
+		}
+
+		_, err := plan.IsAlwaysEmptyFunctionCall(funcCall, params)
+		if err != nil {
+			require.ErrorIs(t, err, plan.ErrInvalidFunctionArgs, "expected no error or invalid arguments error for %s, got %s", currentFunc, err)
 		}
 	}
 
@@ -546,6 +564,6 @@ func TestRemoveStaticallyEmptyExpressions_IsAlwaysEmptyFunctionCall_UnknownFunct
 		},
 	}
 
-	_, err := plan.IsAlwaysEmptyFunctionCall(funcCall, nil)
+	_, err := plan.IsAlwaysEmptyFunctionCall(funcCall, params)
 	require.ErrorIs(t, err, plan.ErrUnknownFunction)
 }

--- a/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions_test.go
+++ b/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions_test.go
@@ -613,19 +613,18 @@ func TestRemoveStaticallyEmptyExpressions_IsAlwaysEmptyFunctionCall_AllKnownFunc
 		LookbackDelta: 5 * time.Minute,
 	}
 
-	for i := getMaxFunctionOrdinal(); i >= 0; i-- {
-		currentFunc := functions.Function(i)
+	// For every known function, ensure that we either get no error when determining if
+	// it is always empty or an error because we haven't passed the expected arguments
+	// (because we don't pass any). The idea is to make sure we have explicitly handled
+	// every defined function.
+	for ord := range functions.Function_name {
+		currentFunc := functions.Function(ord)
 
-		// There are gaps in the ordinals used for the protobuf function enum
-		// so if this particular function isn't defined, skip it.
-		if !strings.HasPrefix(currentFunc.String(), "FUNCTION_") {
+		// Not a real function so it isn't handled by the optimization pass.
+		if currentFunc == functions.FUNCTION_UNKNOWN {
 			continue
 		}
 
-		// This is a known function, ensure that we either get no error when determining
-		// if it is always empty or an error because we haven't passed the expected arguments
-		// (because we don't pass any). The idea is to make sure we have explicitly handled
-		// every defined function.
 		funcCall := &core.FunctionCall{
 			FunctionCallDetails: &core.FunctionCallDetails{
 				Function: currentFunc,

--- a/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions_test.go
+++ b/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions_test.go
@@ -290,6 +290,18 @@ func TestRemoveStaticallyEmptyExpressionsOptimizationPass(t *testing.T) {
 				- NoOp
 			`,
 		},
+		"aggregation with grouping over empty result: should optimize": {
+			expr: `count by (namespace) (EMPTY_RESULT)`,
+			expectedPlan: `
+				- NoOp
+			`,
+		},
+		"aggregation without grouping over empty result: should optimize": {
+			expr: `sum without (namespace) (EMPTY_RESULT)`,
+			expectedPlan: `
+				- NoOp
+			`,
+		},
 		"binary add with empty result on right side: should optimize": {
 			expr: `sum(metric_a) + sum(EMPTY_RESULT)`,
 			expectedPlan: `


### PR DESCRIPTION
#### What this PR does

Fix an issue where only _selectors_ that could not return results were replaced with a no-op node, not the surounding aggregation, function call, or binary expression. This caused issues with remote execution where some parts of a remote execution group had selectors and some parts did not (which is invalid).

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/15259

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches query-planner optimization logic and broadens the set of expressions replaced with `NoOp`, which could affect query semantics or remote-execution plan validity if misclassified; changes are guarded by extensive new tests.
> 
> **Overview**
> Fixes the statically-empty expression optimization so it can replace **entire** higher-level nodes (aggregations, unary ops, many function calls, and additional binary ops/comparisons) with `NoOp` when their inputs are provably empty, instead of only no-op’ing selectors.
> 
> Adds `IsAlwaysEmptyFunctionCall` with explicit handling/arg-count validation for all known functions (and errors for unknown ones), refactors binary-expression emptiness checks (including arithmetic and comparison ops), and expands coverage with many new plan-based tests plus a changelog entry update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76f4cfb908d536f8b10a23b930f2a4aa7113743b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->