### PR TITLE
ci: Invalidate Go cache on different build image version

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -79,8 +79,8 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /go/cache
-          key: go-build-cache-image-and-lint-${{ hashFiles('go.sum') }}-${{ needs.prepare.outputs.build_image }}
-          restore-keys: go-build-cache-image-and-lint-
+          key: go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-${{ hashFiles('go.sum') }}
+          restore-keys: go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
         # Commands in the Makefile are hardcoded with an assumed file structure of the CI container
@@ -195,7 +195,7 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /home/runner/.cache/go-build
-          key: go-build-cache-integration-${{ hashFiles('go.sum') }}-${{ needs.prepare.outputs.build_image }}
+          key: go-build-cache-integration-${{ needs.prepare.outputs.build_image }}-${{ hashFiles('go.sum') }}
           lookup-only: true
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         if: steps.check-cache.outputs.cache-hit != 'true' && (github.ref == 'refs/heads/main' || env.FORCE_BUILD_CACHE_WARMUP == 'true')
@@ -216,7 +216,7 @@ jobs:
         if: steps.check-cache.outputs.cache-hit != 'true' && (github.ref == 'refs/heads/main' || env.FORCE_BUILD_CACHE_WARMUP == 'true')
         with:
           path: /home/runner/.cache/go-build
-          key: go-build-cache-integration-${{ hashFiles('go.sum') }}-${{ needs.prepare.outputs.build_image }}
+          key: go-build-cache-integration-${{ needs.prepare.outputs.build_image }}-${{ hashFiles('go.sum') }}
 
   # Same as above but for unit tests, which compile with -race (producing different cache
   # entries) and run inside a container.
@@ -237,7 +237,7 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /go/cache
-          key: go-build-cache-unit-${{ hashFiles('go.sum') }}-${{ needs.prepare.outputs.build_image }}
+          key: go-build-cache-unit-${{ needs.prepare.outputs.build_image }}-${{ hashFiles('go.sum') }}
           lookup-only: true
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         if: steps.check-cache.outputs.cache-hit != 'true' && (github.ref == 'refs/heads/main' || env.FORCE_BUILD_CACHE_WARMUP == 'true')
@@ -256,7 +256,7 @@ jobs:
         if: steps.check-cache.outputs.cache-hit != 'true' && (github.ref == 'refs/heads/main' || env.FORCE_BUILD_CACHE_WARMUP == 'true')
         with:
           path: /go/cache
-          key: go-build-cache-unit-${{ hashFiles('go.sum') }}-${{ needs.prepare.outputs.build_image }}
+          key: go-build-cache-unit-${{ needs.prepare.outputs.build_image }}-${{ hashFiles('go.sum') }}
 
   # Same as the other warmup jobs but for image builds and linting, which use
   # CGO_ENABLED=0 (no race) with -tags netgo,stringlabels.
@@ -277,7 +277,7 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /go/cache
-          key: go-build-cache-image-and-lint-${{ hashFiles('go.sum') }}-${{ needs.prepare.outputs.build_image }}
+          key: go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-${{ hashFiles('go.sum') }}
           lookup-only: true
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         if: steps.check-cache.outputs.cache-hit != 'true' && (github.ref == 'refs/heads/main' || env.FORCE_BUILD_CACHE_WARMUP == 'true')
@@ -296,7 +296,7 @@ jobs:
         if: steps.check-cache.outputs.cache-hit != 'true' && (github.ref == 'refs/heads/main' || env.FORCE_BUILD_CACHE_WARMUP == 'true')
         with:
           path: /go/cache
-          key: go-build-cache-image-and-lint-${{ hashFiles('go.sum') }}-${{ needs.prepare.outputs.build_image }}
+          key: go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-${{ hashFiles('go.sum') }}
 
   test:
     runs-on: ubuntu-latest
@@ -326,8 +326,8 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /go/cache
-          key: go-build-cache-unit-${{ hashFiles('go.sum') }}-${{ needs.prepare.outputs.build_image }}
-          restore-keys: go-build-cache-unit-
+          key: go-build-cache-unit-${{ needs.prepare.outputs.build_image }}-${{ hashFiles('go.sum') }}
+          restore-keys: go-build-cache-unit-${{ needs.prepare.outputs.build_image }}-
       - name: Install GitHub CLI
         run: ./.github/workflows/scripts/install-gh.sh
       - name: Run Git Config
@@ -378,8 +378,8 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /go/cache
-          key: go-build-cache-image-and-lint-${{ hashFiles('go.sum') }}-${{ needs.prepare.outputs.build_image }}
-          restore-keys: go-build-cache-image-and-lint-
+          key: go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-${{ hashFiles('go.sum') }}
+          restore-keys: go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-
       - name: Build
         uses: ./.github/actions/build-image
         with:
@@ -402,8 +402,8 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /go/cache
-          key: go-build-cache-image-and-lint-${{ hashFiles('go.sum') }}-${{ needs.prepare.outputs.build_image }}
-          restore-keys: go-build-cache-image-and-lint-
+          key: go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-${{ hashFiles('go.sum') }}
+          restore-keys: go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-
       - name: Build
         uses: ./.github/actions/build-image
         with:
@@ -426,8 +426,8 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /go/cache
-          key: go-build-cache-image-and-lint-${{ hashFiles('go.sum') }}-${{ needs.prepare.outputs.build_image }}
-          restore-keys: go-build-cache-image-and-lint-
+          key: go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-${{ hashFiles('go.sum') }}
+          restore-keys: go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-
       - name: Build
         uses: ./.github/actions/build-image
         with:
@@ -450,8 +450,8 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /go/cache
-          key: go-build-cache-image-and-lint-${{ hashFiles('go.sum') }}-${{ needs.prepare.outputs.build_image }}
-          restore-keys: go-build-cache-image-and-lint-
+          key: go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-${{ hashFiles('go.sum') }}
+          restore-keys: go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-
       - name: Build
         uses: ./.github/actions/build-image
         with:
@@ -474,8 +474,8 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /go/cache
-          key: go-build-cache-image-and-lint-${{ hashFiles('go.sum') }}-${{ needs.prepare.outputs.build_image }}
-          restore-keys: go-build-cache-image-and-lint-
+          key: go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-${{ hashFiles('go.sum') }}
+          restore-keys: go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-
       - name: Build
         uses: ./.github/actions/build-image
         with:
@@ -514,8 +514,8 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /go/cache
-          key: go-build-cache-unit-${{ hashFiles('go.sum') }}-${{ needs.prepare.outputs.build_image }}
-          restore-keys: go-build-cache-unit-
+          key: go-build-cache-unit-${{ needs.prepare.outputs.build_image }}-${{ hashFiles('go.sum') }}
+          restore-keys: go-build-cache-unit-${{ needs.prepare.outputs.build_image }}-
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
       - name: Install Docker Client

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -567,8 +567,8 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /home/runner/.cache/go-build
-          key: go-build-cache-integration-${{ hashFiles('go.sum') }}-${{ needs.prepare.outputs.build_imag>>>>>>> e0471b17d
-          restore-keys: go-build-cache-integration-
+          key: go-build-cache-integration-${{ needs.prepare.outputs.build_image }}-${{ hashFiles('go.sum') }}
+          restore-keys: go-build-cache-integration-${{ needs.prepare.outputs.build_image }}-
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
       - name: Symlink Expected Path to Workspace

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -79,7 +79,7 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /go/cache
-          key: go-build-cache-image-and-lint-${{ hashFiles('go.sum') }}
+          key: go-build-cache-image-and-lint-${{ hashFiles('go.sum') }}-${{ needs.prepare.outputs.build_image }}
           restore-keys: go-build-cache-image-and-lint-
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
@@ -195,7 +195,7 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /home/runner/.cache/go-build
-          key: go-build-cache-integration-${{ hashFiles('go.sum') }}
+          key: go-build-cache-integration-${{ hashFiles('go.sum') }}-${{ needs.prepare.outputs.build_image }}
           lookup-only: true
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         if: steps.check-cache.outputs.cache-hit != 'true' && (github.ref == 'refs/heads/main' || env.FORCE_BUILD_CACHE_WARMUP == 'true')
@@ -216,7 +216,7 @@ jobs:
         if: steps.check-cache.outputs.cache-hit != 'true' && (github.ref == 'refs/heads/main' || env.FORCE_BUILD_CACHE_WARMUP == 'true')
         with:
           path: /home/runner/.cache/go-build
-          key: go-build-cache-integration-${{ hashFiles('go.sum') }}
+          key: go-build-cache-integration-${{ hashFiles('go.sum') }}-${{ needs.prepare.outputs.build_image }}
 
   # Same as above but for unit tests, which compile with -race (producing different cache
   # entries) and run inside a container.
@@ -237,7 +237,7 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /go/cache
-          key: go-build-cache-unit-${{ hashFiles('go.sum') }}
+          key: go-build-cache-unit-${{ hashFiles('go.sum') }}-${{ needs.prepare.outputs.build_image }}
           lookup-only: true
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         if: steps.check-cache.outputs.cache-hit != 'true' && (github.ref == 'refs/heads/main' || env.FORCE_BUILD_CACHE_WARMUP == 'true')
@@ -256,7 +256,7 @@ jobs:
         if: steps.check-cache.outputs.cache-hit != 'true' && (github.ref == 'refs/heads/main' || env.FORCE_BUILD_CACHE_WARMUP == 'true')
         with:
           path: /go/cache
-          key: go-build-cache-unit-${{ hashFiles('go.sum') }}
+          key: go-build-cache-unit-${{ hashFiles('go.sum') }}-${{ needs.prepare.outputs.build_image }}
 
   # Same as the other warmup jobs but for image builds and linting, which use
   # CGO_ENABLED=0 (no race) with -tags netgo,stringlabels.
@@ -277,7 +277,7 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /go/cache
-          key: go-build-cache-image-and-lint-${{ hashFiles('go.sum') }}
+          key: go-build-cache-image-and-lint-${{ hashFiles('go.sum') }}-${{ needs.prepare.outputs.build_image }}
           lookup-only: true
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         if: steps.check-cache.outputs.cache-hit != 'true' && (github.ref == 'refs/heads/main' || env.FORCE_BUILD_CACHE_WARMUP == 'true')
@@ -296,7 +296,7 @@ jobs:
         if: steps.check-cache.outputs.cache-hit != 'true' && (github.ref == 'refs/heads/main' || env.FORCE_BUILD_CACHE_WARMUP == 'true')
         with:
           path: /go/cache
-          key: go-build-cache-image-and-lint-${{ hashFiles('go.sum') }}
+          key: go-build-cache-image-and-lint-${{ hashFiles('go.sum') }}-${{ needs.prepare.outputs.build_image }}
 
   test:
     runs-on: ubuntu-latest
@@ -326,7 +326,7 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /go/cache
-          key: go-build-cache-unit-${{ hashFiles('go.sum') }}
+          key: go-build-cache-unit-${{ hashFiles('go.sum') }}-${{ needs.prepare.outputs.build_image }}
           restore-keys: go-build-cache-unit-
       - name: Install GitHub CLI
         run: ./.github/workflows/scripts/install-gh.sh
@@ -378,7 +378,7 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /go/cache
-          key: go-build-cache-image-and-lint-${{ hashFiles('go.sum') }}
+          key: go-build-cache-image-and-lint-${{ hashFiles('go.sum') }}-${{ needs.prepare.outputs.build_image }}
           restore-keys: go-build-cache-image-and-lint-
       - name: Build
         uses: ./.github/actions/build-image
@@ -402,7 +402,7 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /go/cache
-          key: go-build-cache-image-and-lint-${{ hashFiles('go.sum') }}
+          key: go-build-cache-image-and-lint-${{ hashFiles('go.sum') }}-${{ needs.prepare.outputs.build_image }}
           restore-keys: go-build-cache-image-and-lint-
       - name: Build
         uses: ./.github/actions/build-image
@@ -426,7 +426,7 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /go/cache
-          key: go-build-cache-image-and-lint-${{ hashFiles('go.sum') }}
+          key: go-build-cache-image-and-lint-${{ hashFiles('go.sum') }}-${{ needs.prepare.outputs.build_image }}
           restore-keys: go-build-cache-image-and-lint-
       - name: Build
         uses: ./.github/actions/build-image
@@ -450,7 +450,7 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /go/cache
-          key: go-build-cache-image-and-lint-${{ hashFiles('go.sum') }}
+          key: go-build-cache-image-and-lint-${{ hashFiles('go.sum') }}-${{ needs.prepare.outputs.build_image }}
           restore-keys: go-build-cache-image-and-lint-
       - name: Build
         uses: ./.github/actions/build-image
@@ -474,7 +474,7 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /go/cache
-          key: go-build-cache-image-and-lint-${{ hashFiles('go.sum') }}
+          key: go-build-cache-image-and-lint-${{ hashFiles('go.sum') }}-${{ needs.prepare.outputs.build_image }}
           restore-keys: go-build-cache-image-and-lint-
       - name: Build
         uses: ./.github/actions/build-image
@@ -514,7 +514,7 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /go/cache
-          key: go-build-cache-unit-${{ hashFiles('go.sum') }}
+          key: go-build-cache-unit-${{ hashFiles('go.sum') }}-${{ needs.prepare.outputs.build_image }}
           restore-keys: go-build-cache-unit-
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
@@ -567,7 +567,7 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /home/runner/.cache/go-build
-          key: go-build-cache-integration-${{ hashFiles('go.sum') }}
+          key: go-build-cache-integration-${{ hashFiles('go.sum') }}-${{ needs.prepare.outputs.build_imag>>>>>>> e0471b17d
           restore-keys: go-build-cache-integration-
       - name: Run Git Config
         run: git config --global --add safe.directory '*'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

While working on #15263, I noticed that after attributing some CI errors to an invalid cache, and deleting the cache, CI would just pick a different cache key.

It seems to be due to `restore-keys:`:

> restore-keys: Optional A string containing alternative restore keys, with each restore key placed on a new line. If no cache hit occurs for key, these restore keys are used sequentially in the order provided to find and restore a cache. 

~I don't think we want that; we don't want to just load the cache for any other go.sum.~ After discussion with @pracucci we actually do want that. `go mod download` will then only use those parts of the cache that haven't changed. So we only add the constraint that the cache must be built with the same build image.

On top of that, I added the build-image version to the cache key. We also don't want to restore the cache if we're using a different build-image version in the PR, as the artifacts may change (e. g. after a Go version bump) even though go.sum stays the same.

#### Which issue(s) this PR fixes or relates to

—

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only changes that affect cache hit/miss behavior and build times, not production code.
> 
> **Overview**
> Ensures CI Go build caches are **invalidated when the build container image changes** by adding `${{ needs.prepare.outputs.build_image }}` to all Go build cache `key`s.
> 
> Updates `restore-keys` to only fall back to caches created with the same build image (for `lint`, `test`, `integration`, image builds, and all warmup jobs), avoiding restoring caches from different build-image versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d200eb769032c676ecce5600f41042eab9cec746. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->