### PR TITLE
mixin: compactor dashboard improvements for scheduler mode

### DIFF
--- a/operations/mimir-mixin/dashboards/compactor.libsonnet
+++ b/operations/mimir-mixin/dashboards/compactor.libsonnet
@@ -301,12 +301,12 @@ local fixTargetsForTransformations(panel, refIds) = panel {
         $.panel('Time since last scheduler contact') +
         $.queryPanel(
           |||
-            max by(%(instance)s) (time() - (max_over_time(cortex_compactor_last_scheduler_contact_timestamp_seconds{%(job)s}[1h]) > 0))
+            min by(%(instance)s) (time() - (max_over_time(cortex_compactor_last_scheduler_contact_timestamp_seconds{%(job)s}[1h]) > 0))
             and on(%(instance)s) up{%(job)s}
             or
-            max by(%(instance)s) (time() - max_over_time(process_start_time_seconds{%(job)s}[1h]))
+            min by(%(instance)s) (time() - max_over_time(process_start_time_seconds{%(job)s}[1h]))
             and on(%(instance)s) up{%(job)s}
-            and max by(%(instance)s) (cortex_compactor_last_scheduler_contact_timestamp_seconds{%(job)s} == 0)
+            and min by(%(instance)s) (cortex_compactor_last_scheduler_contact_timestamp_seconds{%(job)s} == 0)
           ||| % {
             instance: $._config.per_instance_label,
             job: $.jobMatcher($._config.job_names.compactor),

--- a/operations/mimir-mixin/dashboards/compactor.libsonnet
+++ b/operations/mimir-mixin/dashboards/compactor.libsonnet
@@ -257,35 +257,48 @@ local fixTargetsForTransformations(panel, refIds) = panel {
       $._config.compactor_scheduler_enabled,
       ($.row('Summary (scheduler mode)') + { collapse: true })
       .addPanel(
-        $.timeseriesPanel('Scheduler jobs') +
+        $.timeseriesPanel('Pending jobs') +
         $.queryPanel(
-          [
-            'sum(cortex_compactor_scheduler_pending_jobs{%s})' % $.jobMatcher($._config.job_names.compactor_scheduler),
-            'sum(cortex_compactor_scheduler_active_jobs{%s})' % $.jobMatcher($._config.job_names.compactor_scheduler),
-          ],
-          ['pending', 'active'],
-        ) +
-        $.stack,
-      )
-      .addPanel(
-        $.timeseriesPanel('Jobs completed / sec') +
-        $.queryPanel(
-          'sum by(job_type) (rate(cortex_compactor_scheduler_jobs_completed_total{%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.compactor_scheduler),
+          'sum by (job_type) (cortex_compactor_scheduler_pending_jobs{%s})' % $.jobMatcher($._config.job_names.compactor_scheduler),
           '{{job_type}}',
         ) +
-        { fieldConfig+: { defaults+: { unit: 'ops' } } },
+        $.stack +
+        $.panelDescription(
+          'Pending jobs',
+          |||
+            Number of jobs queued waiting for a worker, by type. This is the scheduler's backlog: rising trends indicate
+            workers cannot keep up; falling trends indicate the queue is draining.
+          |||
+        ),
       )
       .addPanel(
-        $.timeseriesPanel('Repeated job failures / sec') +
+        $.timeseriesPanel('Active jobs') +
         $.queryPanel(
-          'sum(rate(cortex_compactor_scheduler_repeated_job_failures_total{%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.compactor_scheduler),
-          'failures',
+          'sum by (job_type) (cortex_compactor_scheduler_active_jobs{%s})' % $.jobMatcher($._config.job_names.compactor_scheduler),
+          '{{job_type}}',
         ) +
-        { fieldConfig+: { defaults+: { unit: 'ops' } } } +
-        $.aliasColors({ failures: $._colors.failed }),
+        $.stack +
+        $.panelDescription(
+          'Active jobs',
+          'Number of jobs currently leased by workers, by type.',
+        ),
       )
       .addPanel(
-        $.panel('Time since last scheduler contact per worker') +
+        $.timeseriesPanel('Incomplete compaction job bytes') +
+        $.queryPanel(
+          'sum by (compaction_type) (cortex_compactor_scheduler_incomplete_compaction_jobs_bytes{%s})' % $.jobMatcher($._config.job_names.compactor_scheduler),
+          '{{compaction_type}}',
+        ) +
+        $.stack +
+        { fieldConfig+: { defaults+: { unit: 'bytes' } } } +
+        $.aliasColors({ split: '#2A66CF', merge: '#FF780A' }) +
+        $.panelDescription(
+          'Incomplete compaction job bytes',
+          'Total bytes of source blocks across compaction jobs that have not yet completed (pending or active), broken down by split vs merge. Job size varies a lot, so this is usually a more accurate gauge of outstanding work than the raw job count.',
+        ),
+      )
+      .addPanel(
+        $.panel('Time since last scheduler contact') +
         $.queryPanel(
           |||
             max by(%(instance)s) (time() - (max_over_time(cortex_compactor_last_scheduler_contact_timestamp_seconds{%(job)s}[1h]) > 0))
@@ -343,6 +356,40 @@ local fixTargetsForTransformations(panel, refIds) = panel {
           },
         },
       )
+      .addPanel(
+        $.timeseriesPanel('Jobs completed / sec') +
+        $.queryPanel(
+          'sum by(job_type) (rate(cortex_compactor_scheduler_jobs_completed_total{%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.compactor_scheduler),
+          '{{job_type}}',
+        ) +
+        { fieldConfig+: { defaults+: { unit: 'ops' } } },
+      )
+      .addPanel(
+        $.timeseriesPanel('Repeated job failures / sec') +
+        $.queryPanel(
+          'sum(rate(cortex_compactor_scheduler_repeated_job_failures_total{%s}[$__rate_interval]))' % $.jobMatcher($._config.job_names.compactor_scheduler),
+          'failures',
+        ) +
+        { fieldConfig+: { defaults+: { unit: 'ops' } } } +
+        $.aliasColors({ failures: $._colors.failed }),
+      )
+      .addPanel(
+        local query = utils.ncHistogramSumBy(
+          utils.ncHistogramCountRate(
+            metric='cortex_request_duration_seconds',
+            selector='%s, route=~"/compactorschedulerpb.CompactorScheduler/.*"' % $.jobMatcher($._config.job_names.compactor_scheduler),
+          ),
+          sum_by=['route'],
+        );
+        local stripPrefix(q) = 'label_replace(%s, "method", "$1", "route", "/compactorschedulerpb.CompactorScheduler/(.*)")' % q;
+        $.timeseriesPanel('Scheduler RPC') +
+        $.queryPanel(
+          [stripPrefix(utils.showNativeHistogramQuery(query)), stripPrefix(utils.showClassicHistogramQuery(query))],
+          ['{{method}}', '{{method}}'],
+        ) +
+        { fieldConfig+: { defaults+: { unit: 'reqps' } } }
+      )
+      .splitIntoLines([4, 3])
     )
     .addRow(
       $.row('Compaction')

--- a/operations/mimir-mixin/dashboards/compactor.libsonnet
+++ b/operations/mimir-mixin/dashboards/compactor.libsonnet
@@ -1,4 +1,3 @@
-local utils = import 'mixin-utils/utils.libsonnet';
 local filename = 'mimir-compactor.json';
 
 // This applies to the "longest time since successful run queries"
@@ -374,18 +373,10 @@ local fixTargetsForTransformations(panel, refIds) = panel {
         $.aliasColors({ failures: $._colors.failed }),
       )
       .addPanel(
-        local query = utils.ncHistogramSumBy(
-          utils.ncHistogramCountRate(
-            metric='cortex_request_duration_seconds',
-            selector='%s, route=~"/compactorschedulerpb.CompactorScheduler/.*"' % $.jobMatcher($._config.job_names.compactor_scheduler),
-          ),
-          sum_by=['route'],
-        );
-        local stripPrefix(q) = 'label_replace(%s, "method", "$1", "route", "/compactorschedulerpb.CompactorScheduler/(.*)")' % q;
         $.timeseriesPanel('Scheduler RPC') +
         $.queryPanel(
-          [stripPrefix(utils.showNativeHistogramQuery(query)), stripPrefix(utils.showClassicHistogramQuery(query))],
-          ['{{method}}', '{{method}}'],
+          'label_replace(sum by (route) (histogram_count(rate(cortex_request_duration_seconds{%s, route=~"/compactorschedulerpb.CompactorScheduler/.*"}[$__rate_interval]))), "method", "$1", "route", "/compactorschedulerpb.CompactorScheduler/(.*)")' % $.jobMatcher($._config.job_names.compactor_scheduler),
+          '{{method}}',
         ) +
         { fieldConfig+: { defaults+: { unit: 'reqps' } } }
       )


### PR DESCRIPTION
#### What this PR does

Reworks the "Summary (scheduler mode)" row on the compactor dashboard:

- Splits the combined "Scheduler jobs" panel into separate "Pending jobs" and "Active jobs" panels, broken down by `job_type` (active was previously hidden behind the much larger pending count on a shared axis).
- Adds two new panels:
	- "Incomplete compaction job bytes" (split / merge)
	- "Scheduler RPC" (by gRPC method). Arguably not very useful, finer "abandon/reassign/success" stats would be more meaningful, but we don't have those metrics right now. For now I think this adds _some_ value, we can rework it later.
- Switches the "Time since last scheduler contact" query from `max by (pod)` to `min by(pod)`. We observed a situation where the pod's series changed (external label added/removed) and made it so the pod was marked as unhealthy for an hour due to the stale series. This fixes that, we always take the "best" result.

**Screenshots**

Before

<img width="2299" height="537" alt="image" src="https://github.com/user-attachments/assets/8f91848c-77fc-4e67-83bf-175a0aefa450" />

After


<img width="2312" height="903" alt="image" src="https://github.com/user-attachments/assets/b9c83f82-b939-426b-b130-da3bb03fd125" />


#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: dashboard-only changes (Grafana/PromQL) with no runtime or data-path impact; main risk is incorrect/missing metrics or label assumptions causing broken panels.
> 
> **Overview**
> Reworks the compactor dashboard’s **“Summary (scheduler mode)”** row to make scheduler backlog and worker activity more visible.
> 
> Splits the combined jobs graph into separate stacked `Pending jobs` and `Active jobs` panels (both grouped by `job_type`), adds new panels for `Incomplete compaction job bytes` (split vs merge) and `Scheduler RPC` request rate by gRPC method, and changes the “time since last scheduler contact” table query from `max by` to `min by` to reduce false unhealthy results from stale series.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb446fa2e8173ae3ea5a20524c8729e8c2373062. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->