### PR TITLE
compactor scheduler: prioritize planning

### DIFF
--- a/pkg/compactor/scheduler/job.go
+++ b/pkg/compactor/scheduler/job.go
@@ -4,7 +4,6 @@ package scheduler
 
 import (
 	"errors"
-	"math"
 	"math/rand"
 	"time"
 
@@ -219,7 +218,7 @@ func (j *TrackedPlanJob) ToLeaseResponse(tenant string) *compactorschedulerpb.Le
 }
 
 func (j *TrackedPlanJob) Order() uint32 {
-	return math.MaxUint32
+	return 0
 }
 
 func deserializePlanJob(content []byte) (*TrackedPlanJob, error) {

--- a/pkg/compactor/scheduler/job_tracker.go
+++ b/pkg/compactor/scheduler/job_tracker.go
@@ -265,7 +265,8 @@ func (jt *JobTracker) Maintenance(leaseDuration time.Duration, enforceLeaseExpir
 	}
 
 	if planJob != nil {
-		jt.incompleteJobs[planJobId] = jt.pending.PushBack(planJob)
+		// Prefer the plan job at the front of the queue to achieve a new view of pending jobs
+		jt.incompleteJobs[planJobId] = jt.pending.PushFront(planJob)
 		jt.metrics.queue.Pending(planJob)
 		// Drop the previous completion time since there is now a pending job that overwrote it
 		jt.completePlanTime = time.Time{}

--- a/pkg/compactor/scheduler/job_tracker.go
+++ b/pkg/compactor/scheduler/job_tracker.go
@@ -265,7 +265,7 @@ func (jt *JobTracker) Maintenance(leaseDuration time.Duration, enforceLeaseExpir
 	}
 
 	if planJob != nil {
-		// Prefer the plan job at the front of the queue to achieve a new view of pending jobs
+		// Prefer the plan job at the front of the queue to refresh the view of pending jobs
 		jt.incompleteJobs[planJobId] = jt.pending.PushFront(planJob)
 		jt.metrics.queue.Pending(planJob)
 		// Drop the previous completion time since there is now a pending job that overwrote it

--- a/pkg/compactor/scheduler/job_tracker_test.go
+++ b/pkg/compactor/scheduler/job_tracker_test.go
@@ -128,6 +128,22 @@ func TestJobTracker_Maintenance_Planning(t *testing.T) {
 		require.False(t, transition)
 		require.NotContains(t, jt.incompleteJobs, planJobId)
 	})
+
+	t.Run("new plan job is leased ahead of existing pending compactions", func(t *testing.T) {
+		clk := clock.NewMock()
+		clk.Set(at(3, 0))
+		jt, _ := newTestJobTracker(clk)
+		jt.recoverFrom([]*TrackedCompactionJob{
+			NewTrackedCompactionJob("compactionId", &CompactionJob{}, 1, 0, at(1, 0)),
+		}, nil)
+
+		_, err := jt.Maintenance(leaseDuration, false, true, planningInterval, compactionWaitPeriod)
+		require.NoError(t, err)
+
+		leaseResp, _, err := jt.Lease()
+		require.NoError(t, err)
+		require.Equal(t, planJobId, leaseResp.Key.Id)
+	})
 }
 
 func TestJobTracker_recoverFrom(t *testing.T) {
@@ -199,6 +215,14 @@ func TestJobTracker_recoverFrom(t *testing.T) {
 				newAvailableCompaction("bb", 2),
 			},
 			expectedPending: []string{"aa", "bb", "cc"},
+		},
+		"pending plan job sorts ahead of pending compactions": {
+			compactionJobs: []*TrackedCompactionJob{
+				newAvailableCompaction("aa", 1),
+				newAvailableCompaction("bb", 2),
+			},
+			planJob:         NewTrackedPlanJob(at(1, 0)),
+			expectedPending: []string{planJobId, "aa", "bb"},
 		},
 		"active jobs sorted by status time": {
 			compactionJobs: []*TrackedCompactionJob{

--- a/pkg/compactor/scheduler/scheduler.go
+++ b/pkg/compactor/scheduler/scheduler.go
@@ -278,7 +278,9 @@ func (s *Scheduler) PlannedJobs(ctx context.Context, req *compactorschedulerpb.P
 				blocks:  job.Job.BlockIds,
 				isSplit: job.Job.Split,
 			},
-			uint32(i), // technically this casting could truncate, but that's an unrealistic case
+			// Technically this casting could truncate, but that's an unrealistic case.
+			// The +1 is a minor detail that ensures plan jobs (order of 0) can deterministically sort first in ordering upon recovery if they exist.
+			uint32(i+1),
 			job.Job.TotalBlocksBytes,
 			now,
 		))


### PR DESCRIPTION
#### What this PR does

Plan jobs were previously pushed to the back of a tenant's pending queue in the compactor scheduler. This pushes them to the front instead and ensures that during recovery they are ordered to the front as well. The idea is to prioritize getting a fresh view even when behind.

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes scheduling priority by moving plan jobs ahead of pending compactions and adjusting recovered ordering, which can affect compaction throughput and fairness if ordering assumptions were relied upon.
> 
> **Overview**
> **Plan jobs are now prioritized over compaction work** in the compactor scheduler so tenants refresh their pending-work view sooner when backlogged.
> 
> This makes `TrackedPlanJob.Order()` sort first (0), inserts newly created plan jobs at the *front* of the pending queue during `JobTracker.Maintenance`, and offsets planned compaction job ordering (`i+1`) so recovery ordering deterministically keeps any pending plan job ahead of compactions. Tests are updated/added to assert plan-job-first leasing and recovery sorting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d01919fb1f0266c37d418eedb9f6c569e4f01af3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->