### PR TITLE
mixin: Add DASHBOARDS_HISTOGRAM_MODE option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 ### Tools
 
+* [ENHANCEMENT] Makefile: `build-mixin` and `mixin-screenshots` can now be configured to use native histograms for latency panels in dashboards. #15269
+
 ### Query-tee
 
 ## 3.1.0-rc0

--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,7 @@ SSHVOLUME=  -v ~/.ssh/:/root/.ssh:$(CONTAINER_MOUNT_OPTIONS)
 
 exes $(EXES) $(EXES_RACE) protos $(PROTO_GOS) lint lint-gh-action lint-packaging-scripts test test-with-race cover shell mod-check check-protos doc format dist build-mixin format-mixin check-mixin-tests license check-license conftest-fmt check-conftest-fmt helm-conftest-test helm-conftest-quick-test conftest-verify check-helm-tests build-helm-tests print-go-version format-promql-tests check-promql-tests format-protobuf check-protobuf-format: fetch-build-image
 	@echo ">>>> Entering build container: $@"
-	$(SUDO) time docker run --rm $(TTY) -i $(SSHVOLUME) $(GOVOLUMES) $(BUILD_IMAGE) GOOS=$(GOOS) GOARCH=$(GOARCH) BINARY_SUFFIX=$(BINARY_SUFFIX) $@;
+	$(SUDO) time docker run --rm $(TTY) -i $(SSHVOLUME) $(GOVOLUMES) $(BUILD_IMAGE) GOOS=$(GOOS) GOARCH=$(GOARCH) BINARY_SUFFIX=$(BINARY_SUFFIX) DASHBOARDS_HISTOGRAM_MODE=$(DASHBOARDS_HISTOGRAM_MODE) $@;
 
 else
 
@@ -584,7 +584,14 @@ build-mixin: check-mixin-jb
 	@for suffix in $(MIXIN_OUT_PATH_SUFFIXES); do \
 		mkdir -p "$(MIXIN_OUT_PATH)$$suffix"; \
 		find "$(MIXIN_OUT_PATH)$$suffix" -type f -delete; \
-		mixtool generate all --output-alerts "$(MIXIN_OUT_PATH)$$suffix/alerts.yaml" --output-rules "$(MIXIN_OUT_PATH)$$suffix/rules.yaml" --directory "$(MIXIN_OUT_PATH)$$suffix/dashboards" "${MIXIN_PATH}/mixin-compiled$$suffix.libsonnet"; \
+		input_file="${MIXIN_PATH}/mixin-compiled$$suffix.libsonnet"; \
+		if [ -n "$(DASHBOARDS_HISTOGRAM_MODE)" ]; then \
+			tmp_file="${MIXIN_PATH}/mixin-compiled$$suffix-tmp-latency.libsonnet"; \
+			echo "(import 'mixin-compiled$$suffix.libsonnet') + { _config+:: { dashboards_default_latency_mode: '$(DASHBOARDS_HISTOGRAM_MODE)' } }" > "$$tmp_file"; \
+			input_file="$$tmp_file"; \
+		fi; \
+		mixtool generate all --output-alerts "$(MIXIN_OUT_PATH)$$suffix/alerts.yaml" --output-rules "$(MIXIN_OUT_PATH)$$suffix/rules.yaml" --directory "$(MIXIN_OUT_PATH)$$suffix/dashboards" "$$input_file"; \
+		if [ -n "$(DASHBOARDS_HISTOGRAM_MODE)" ]; then rm -f "$$tmp_file"; fi; \
 		./tools/check-rules.sh "$(MIXIN_OUT_PATH)$$suffix/rules.yaml" 20 ; \
 		cd "$(MIXIN_OUT_PATH)$$suffix/.." && zip -q -r "mimir-mixin$$suffix.zip" $$(basename "$(MIXIN_OUT_PATH)$$suffix"); \
 		cd -; \

--- a/operations/mimir-mixin-tools/screenshots/run.sh
+++ b/operations/mimir-mixin-tools/screenshots/run.sh
@@ -8,6 +8,7 @@ DOCKET_NETWORK="mixin-serve"
 DOCKER_APP_IMAGE="mixin-screenshots-taker"
 DOCKER_APP_NAME="mixin-screenshots-taker"
 GRAFANA_PID=""
+TEMP_MIXIN_OUT=""
 
 # Check if the config file exists.
 if [ ! -e "${SCRIPT_DIR}/.config" ]; then
@@ -17,6 +18,7 @@ if [ ! -e "${SCRIPT_DIR}/.config" ]; then
   echo "MIMIR_NAMESPACE=\"<namespace-where-mimir-is-running>\""
   echo "ALERTMANAGER_NAMESPACE=\"<namespace-where-alertmanager-is-running>\""
   echo "MIMIR_USER=\"<mimir-tenant-id>\""
+  echo "DASHBOARDS_HISTOGRAM_MODE=\"native\" # Optional. Leave empty to provision the dashboards as already built."
   echo ""
   exit 1
 fi
@@ -31,12 +33,35 @@ function cleanup() {
   fi
   docker rm --force "${DOCKER_APP_NAME}" 2>/dev/null || echo "Container ${DOCKER_APP_NAME} not found or already removed"
   docker network rm "${DOCKET_NETWORK}" 2>/dev/null || echo "Network ${DOCKET_NETWORK} not found or has active endpoints"
+  if [[ -n "${TEMP_MIXIN_OUT}" ]]; then
+    rm -rf "${TEMP_MIXIN_OUT}"
+    echo "Removed temporary mixin output ${TEMP_MIXIN_OUT}"
+  fi
   echo "Cleaned up Docker setup"
 }
 
 # Start from a clean setup and also trigger a cleanup on exit.
 cleanup
 trap cleanup EXIT
+
+DASHBOARDS_DIR="${SCRIPT_DIR}/../../mimir-mixin-compiled/dashboards"
+
+# If DASHBOARDS_HISTOGRAM_MODE is set, recompile the mixin with the desired mode.
+if [ -n "${DASHBOARDS_HISTOGRAM_MODE}" ]; then
+  echo "Compiling mixin with dashboards_default_latency_mode='${DASHBOARDS_HISTOGRAM_MODE}'"
+
+  TEMP_MIXIN_OUT=$(mktemp -d)
+  REPO_ROOT="${SCRIPT_DIR}/../../.."
+
+  make -C "${REPO_ROOT}" build-mixin \
+      BUILD_IN_CONTAINER=false \
+      MIXIN_OUT_PATH="${TEMP_MIXIN_OUT}" \
+      MIXIN_OUT_PATH_SUFFIXES='""' \
+      DASHBOARDS_HISTOGRAM_MODE="${DASHBOARDS_HISTOGRAM_MODE}"
+
+  DASHBOARDS_DIR="${TEMP_MIXIN_OUT}/dashboards"
+  echo "Mixin compiled to ${TEMP_MIXIN_OUT}"
+fi
 
 # Build the Docker image.
 echo "Building Docker image ${DOCKER_APP_IMAGE}"
@@ -52,7 +77,7 @@ echo "Pulling latest Grafana image"
 docker pull grafana/grafana:latest
 
 # Start Grafana in background.
-"${SCRIPT_DIR}/../serve/run.sh" --docker-network "${DOCKET_NETWORK}" &
+"${SCRIPT_DIR}/../serve/run.sh" --docker-network "${DOCKET_NETWORK}" --dashboards-dir "${DASHBOARDS_DIR}" &
 GRAFANA_PID="$!"
 
 # Give Grafana some time to startup. It's an hack, but an easy one.
@@ -68,6 +93,6 @@ docker run \
   --env "MIMIR_NAMESPACE=${MIMIR_NAMESPACE}" \
   --env "ALERTMANAGER_NAMESPACE=${ALERTMANAGER_NAMESPACE}" \
   --env "MIMIR_USER=${MIMIR_USER}" \
-  -v "${SCRIPT_DIR}/../../mimir-mixin-compiled/dashboards:/input" \
+  -v "${DASHBOARDS_DIR}:/input" \
   -v "${SCRIPT_DIR}/../../../docs/sources/mimir/manage/monitor-grafana-mimir/dashboards:/output" \
   "${DOCKER_APP_IMAGE}"

--- a/operations/mimir-mixin-tools/serve/run.sh
+++ b/operations/mimir-mixin-tools/serve/run.sh
@@ -9,13 +9,15 @@ GRAFANA_VERSION=11.1.3
 DOCKER_CONTAINER_NAME="mixin-serve-grafana"
 DOCKER_OPTS=""
 MIXIN_PATH="../../mimir-mixin-compiled"  # default path
+DASHBOARDS_DIR=""
 
 function usage() {
-    echo "Usage: $0 [--docker-network <name>] [-p|--path <mixin-path>]"
+    echo "Usage: $0 [--docker-network <name>] [-p|--path <mixin-path>] [--dashboards-dir <path>]"
     echo ""
     echo "Options:"
     echo "  --docker-network <name>   Joins the Docker network <name>"
-    echo "  -p, --path <path>         Path to mixin dashboards directory"
+    echo "  -p, --path <path>         Path to mixin compiled directory (relative to repo root)"
+    echo "  --dashboards-dir <path>   Path to the dashboards directory (overrides --path)"
 }
 
 while [[ $# -gt 0 ]]; do
@@ -30,6 +32,11 @@ while [[ $# -gt 0 ]]; do
     shift
     shift
     ;;
+  --dashboards-dir)
+    DASHBOARDS_DIR="$2"
+    shift
+    shift
+    ;;
   *)  break
     ;;
   esac
@@ -38,6 +45,11 @@ done
 if [[ $# -gt 0 ]]; then
   usage
   exit 1
+fi
+
+# Default DASHBOARDS_DIR if not explicitly set via --dashboards-dir.
+if [[ -z "${DASHBOARDS_DIR}" ]]; then
+  DASHBOARDS_DIR="${SCRIPT_DIR}/${MIXIN_PATH}/dashboards"
 fi
 
 # Check if the config file exists.
@@ -86,7 +98,7 @@ docker run \
   --env "LOKI_DATASOURCE_URL=${LOKI_DATASOURCE_URL}" \
   --env "LOKI_DATASOURCE_USERNAME=${LOKI_DATASOURCE_USERNAME}" \
   --env "LOKI_DATASOURCE_PASSWORD=${LOKI_DATASOURCE_PASSWORD}" \
-  -v "${SCRIPT_DIR}/${MIXIN_PATH}/dashboards:/var/lib/grafana/dashboards" \
+  -v "${DASHBOARDS_DIR}:/var/lib/grafana/dashboards" \
   -v "${SCRIPT_DIR}/provisioning-dashboards.yaml:/etc/grafana/provisioning/dashboards/provisioning-dashboards.yaml" \
   -v "${SCRIPT_DIR}/provisioning-datasources.yaml:/etc/grafana/provisioning/datasources/provisioning-datasources.yaml" \
   --expose 3000 \


### PR DESCRIPTION
#### What this PR does

Since we've switched cortex-dev-01 to native histograms, but we're still keeping classic histograms as default in the mixin's dashboards, `make mixin-screenshots` is now generating empty graphs.

With this change:

* `make build-mixin` takes a DASHBOARDS_HISTOGRAM_MODE parameter. When set, it generates a Jsonnet one-liner entry point which sets the corresponding config and builds the mixin from it.
* `make mixin-screenshots` config can also take DASHBOARDS_HISTOGRAM_MODE. When set, instead of screenshotting the compiled dashboards, it recompiles them into a temp dir passing through the DASHBOARDS_HISTOGRAM_MODE option, and screenshots that instead.

[Already tested in release-3.1](https://github.com/grafana/mimir/commit/bacf1b7e89d18bb3008392c2be0d573fc3cc53c1).

#### Which issue(s) this PR fixes or relates to

—

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to build/tooling scripts for mixin/dashboard generation and screenshot automation, with no impact on runtime binaries or production code paths.
> 
> **Overview**
> Adds an opt-in `DASHBOARDS_HISTOGRAM_MODE` knob to regenerate mixin dashboards with a different default latency histogram mode (eg. native histograms).
> 
> `make build-mixin` now conditionally wraps the compiled mixin entrypoint with a one-liner Jsonnet overlay to set `dashboards_default_latency_mode`, and passes the env var through containerized builds. `mixin-screenshots` can optionally recompile dashboards into a temp dir using the same setting and the Grafana `serve` script now supports `--dashboards-dir` to provision dashboards from an arbitrary directory.
> 
> Updates `CHANGELOG.md` with the new tooling enhancement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97276ea672197c63e87420b5f3a4f07a4b486070. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->