### PR TITLE
feat:(store-gateway): Remove outdated workaround with LabelValues cache encode limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [ENHANCEMENT] MQE: Improve experimental support for reporting the number of samples read per query. #15179 #15220 #15223 #15232 #15237 #15255
 * [ENHANCEMENT] Ingest storage: Reject the whole batch of records of a Kafka write call when the configured `-ingest-storage.kafka.producer-max-buffered-bytes` limit is reached, instead of rejecting individual records. #15227
 * [ENHANCEMENT] MQE: Simplify `unless` and `or` operations where one side can be proven to be empty by inspecting the expression. #15198
+* [ENHANCEMENT] Store-gateway: Remove outdated limit on caching LabelValues responses that contain more than 655360 values. The gob library panic which required workaround was fixed. #5021 #15271
 * [BUGFIX] Ingest storage: Fix `KafkaProducer.ProduceSync()` returning a single result with a nil record when the context is canceled, instead of one result per input record (with the record set) as the underlying franz-go client does. #15199
 * [BUGFIX] Distributor: Return HTTP 200 with OTLP partial-success when only some samples in an OTLP request are rejected by distributor-level validation (e.g. `too_far_in_past`). #15253
 

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1740,12 +1740,6 @@ func fetchCachedLabelValues(ctx context.Context, indexCache indexcache.IndexCach
 }
 
 func storeCachedLabelValues(ctx context.Context, indexCache indexcache.IndexCache, userID string, blockID ulid.ULID, labelName string, matchers []*labels.Matcher, values []string, logger log.Logger) {
-	// This limit is a workaround for panics in decoding large responses. See https://github.com/golang/go/issues/59172
-	const valuesLimit = 655360
-	if len(values) > valuesLimit {
-		spanlogger.FromContext(ctx, logger).DebugLog("msg", "skipping storing label values response to cache because it exceeds number of values limit", "limit", valuesLimit, "values_count", len(values))
-		return
-	}
 	entry := labelValuesCacheEntry{
 		Values:      values,
 		LabelName:   labelName,

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -613,6 +613,39 @@ func TestBlockLabelValues(t *testing.T) {
 	})
 }
 
+func TestStoreCachedLabelValues_GobDecodeLimit(t *testing.T) {
+	// Limit was a workaround for panics in decoding large responses.
+	// See https://github.com/golang/go/issues/59172
+	const valuesLimit = 655360
+	vals := make([]string, valuesLimit+1)
+	for i := range valuesLimit + 1 {
+		vals[i] = "a"
+	}
+
+	ctx, logger := context.Background(), log.NewNopLogger()
+	indexCache := &cacheRecordingStoreLabelValues{}
+	tenant, id, l := "tenant-a", ulid.Make(), "label_a"
+
+	// Values exceed the limit; the cache should not be called
+	storeCachedLabelValues(ctx, indexCache, tenant, id, l, nil, vals, logger)
+	require.False(t, indexCache.called)
+
+	vals = vals[:len(vals)-1]
+
+	// Values truncated below limit; cache should be called.
+	storeCachedLabelValues(ctx, indexCache, tenant, id, l, nil, vals, logger)
+	require.True(t, indexCache.called)
+}
+
+type cacheRecordingStoreLabelValues struct {
+	noopCache
+	called bool
+}
+
+func (c *cacheRecordingStoreLabelValues) StoreLabelValues(string, ulid.ULID, string, indexcache.LabelMatchersKey, []byte) {
+	c.called = true
+}
+
 type cacheNotExpectingToStoreLabelValues struct {
 	noopCache
 	t *testing.T

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -613,37 +613,45 @@ func TestBlockLabelValues(t *testing.T) {
 	})
 }
 
-func TestStoreCachedLabelValues_GobDecodeLimit(t *testing.T) {
-	// Limit was a workaround for panics in decoding large responses.
-	// See https://github.com/golang/go/issues/59172
-	const valuesLimit = 655360
-	vals := make([]string, valuesLimit+1)
-	for i := range valuesLimit + 1 {
+func TestCachedLabelValues_NoGobDecodeLimit(t *testing.T) {
+	// storeCachedLabelValues previously skipped caching above a specific value count
+	// as a workaround for panics in decoding large responses - see https://github.com/golang/go/issues/59172.
+	// This was fixed in https://github.com/golang/go/commit/3d5391ed87d813110e10b954c62bf7ed578b591f.
+	// Test that we no longer impose the limit (and do not panic on decode).
+	const oldValuesLimit = 655360
+	vals := make([]string, oldValuesLimit*2)
+	for i := range oldValuesLimit * 2 {
 		vals[i] = "a"
 	}
 
 	ctx, logger := context.Background(), log.NewNopLogger()
-	indexCache := &cacheRecordingStoreLabelValues{}
+	indexCache := &cacheRecordingStoreLabelValues{
+		IndexCache: newInMemoryIndexCache(t),
+	}
 	tenant, id, l := "tenant-a", ulid.Make(), "label_a"
 
-	// Values exceed the limit; the cache should not be called
-	storeCachedLabelValues(ctx, indexCache, tenant, id, l, nil, vals, logger)
-	require.False(t, indexCache.called)
-
-	vals = vals[:len(vals)-1]
-
-	// Values truncated below limit; cache should be called.
+	// Limit has been removed; the cache should be called.
 	storeCachedLabelValues(ctx, indexCache, tenant, id, l, nil, vals, logger)
 	require.True(t, indexCache.called)
+
+	var hit bool
+	var cachedVals []string
+	testFunc := func() {
+		cachedVals, hit = fetchCachedLabelValues(ctx, indexCache, tenant, id, l, nil, logger)
+	}
+	require.NotPanics(t, testFunc)
+	require.True(t, hit)
+	require.Equal(t, vals, cachedVals)
 }
 
 type cacheRecordingStoreLabelValues struct {
-	noopCache
+	indexcache.IndexCache
 	called bool
 }
 
-func (c *cacheRecordingStoreLabelValues) StoreLabelValues(string, ulid.ULID, string, indexcache.LabelMatchersKey, []byte) {
+func (c *cacheRecordingStoreLabelValues) StoreLabelValues(userID string, blockID ulid.ULID, labelName string, key indexcache.LabelMatchersKey, data []byte) {
 	c.called = true
+	c.IndexCache.StoreLabelValues(userID, blockID, labelName, key, data)
 }
 
 type cacheNotExpectingToStoreLabelValues struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

`storeCachedLabelValues` previously skipped caching above a specific value count as a workaround for panics in `gob` decoding large responses - see https://github.com/golang/go/issues/59172.
That was fixed in https://github.com/golang/go/commit/3d5391ed87d813110e10b954c62bf7ed578b591f - only two months after the initial issue, but we never went back to remove the limit.

Relevant CHANGELOG line from 2023 is
```md
* [BUGFIX] Store-gateway: panics when decoding LabelValues responses that contain more than 655360 values. These responses are no longer cached. #5021
```
* first commit here shows a test for verifying the limit being imposed in the previous code
* second commit removes the limit and changes the test to ensure the limit is not enforced (and there is no panic)

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes store-gateway caching behavior to allow very large `LabelValues` responses to be cached, which could increase cache memory/eviction pressure in high-cardinality tenants despite being a targeted change.
> 
> **Overview**
> Removes the hardcoded workaround in `storeCachedLabelValues` that skipped caching `LabelValues` results above 655,360 values (previously added to avoid `gob` decode panics).
> 
> Adds a regression test (`TestCachedLabelValues_NoGobDecodeLimit`) to ensure large value sets are stored, can be fetched back without panicking, and updates the changelog to note the lifted cache limit now that the upstream `gob` issue is fixed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59e39bdef400cfeab4822c0a0027e63a8737dd60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->