### PR TITLE
backport r389 - close MQE queries on every error path (#15251)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,8 @@
 * [ENHANCEMENT] API: activity tracker (if enabled) covers the full request lifecycle and used on all routes. #14777
 * [ENHANCEMENT] MQE: Add metrics for tracking in-flight memory consumption tracking. `cortex_querier_inflight_query_max_estimated_memory_consumption_limit_bytes`, `cortex_querier_inflight_query_current_estimated_memory_consumption_bytes`, `cortex_querier_inflight_query_peak_estimated_memory_consumption_bytes` and `cortex_querier_inflight_query_sampled_count`. #14807
 * [ENHANCEMENT] Activity tracker: Added `activity_tracker_unfinished_activities_loaded` metric to report the number of unfinished activities detected on startup. #14860
+* [ENHANCEMENT] MQE: Reduced per-query memory overhead by no longer holding a reference to the HTTP request for the lifetime of a query. #15251
+* [BUGFIX] Query-frontend: Fixed a memory leak caused that could occur on some error paths if MQE was enabled. #15251
 * [BUGFIX] Distributor: Fix race condition where usage-tracker partition ring may not be initialized before the distributor service starts, causing `usage-tracker partition ring is required` error on startup. #14675
 * [BUGFIX] Store-gateway: Fix `cortex_bucket_store_series_data_touched{data_type="series", stage="returned"}` metric observing negative values when series-for-postings cache is hit and pending matchers filter out some series. #14655
 * [BUGFIX] Mimir: Fix false positive in filesystem path overlap detection when one path is a string prefix of another but not an ancestor directory. #14426

--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -407,6 +407,17 @@ func (rth *engineQueryRequestRoundTripperHandler) Do(ctx context.Context, r Metr
 		return nil, err
 	}
 
+	// Ownership of q is transferred to the response finalizer on success. On any
+	// failure path before that hand-off we must Close q ourselves, otherwise the
+	// query's resources (memory consumption tracker, pooled buffers, evaluator
+	// context) leak.
+	shouldCloseQuery := true
+	defer func() {
+		if shouldCloseQuery {
+			q.Close()
+		}
+	}()
+
 	res := q.Exec(ctx)
 	if res.Err != nil {
 		err := convertToAPIError(res.Err, apierror.TypeExec)
@@ -449,6 +460,7 @@ func (rth *engineQueryRequestRoundTripperHandler) Do(ctx context.Context, r Metr
 		finalizer: q.Close,
 	}
 
+	shouldCloseQuery = false
 	return resp, nil
 }
 

--- a/pkg/frontend/querymiddleware/querysharding.go
+++ b/pkg/frontend/querymiddleware/querysharding.go
@@ -149,6 +149,17 @@ func ExecuteQueryOnQueryable(ctx context.Context, r MetricsQueryRequest, engine 
 		return nil, apierror.New(apierror.TypeBadData, err.Error())
 	}
 
+	// Ownership of qry is transferred to the response finalizer on success. On
+	// any failure path before that hand-off we must Close qry ourselves, otherwise
+	// the query's resources (memory consumption tracker, pooled buffers, evaluator
+	// context) leak.
+	shouldCloseQuery := true
+	defer func() {
+		if shouldCloseQuery {
+			qry.Close()
+		}
+	}()
+
 	res := qry.Exec(ctx)
 	extracted, err := promqlResultToSamples(res)
 	if err != nil {
@@ -176,7 +187,7 @@ func ExecuteQueryOnQueryable(ctx context.Context, r MetricsQueryRequest, engine 
 		headers = shardedQueryable.getResponseHeaders()
 	}
 
-	return &PrometheusResponseWithFinalizer{
+	resp := &PrometheusResponseWithFinalizer{
 		PrometheusResponse: &PrometheusResponse{
 			Status: statusSuccess,
 			Data: &PrometheusData{
@@ -188,7 +199,10 @@ func ExecuteQueryOnQueryable(ctx context.Context, r MetricsQueryRequest, engine 
 			Infos:    info,
 		},
 		finalizer: qry.Close,
-	}, nil
+	}
+
+	shouldCloseQuery = false
+	return resp, nil
 }
 
 func newQuery(ctx context.Context, r MetricsQueryRequest, engine promql.QueryEngine, queryable storage.Queryable) (promql.Query, error) {

--- a/pkg/frontend/querymiddleware/querysharding_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test.go
@@ -1999,3 +1999,66 @@ func TestQuerySharding_ShouldNotPanicOnNilQueryExpression(t *testing.T) {
 		require.Nil(t, resp)
 	})
 }
+
+// TestExecuteQueryOnQueryable_ClosesQueryOnError verifies that
+// ExecuteQueryOnQueryable calls Close on the underlying promql.Query for every
+// error path between query creation and the response finalizer hand-off. We
+// assert this directly by wrapping the engine and counting Close() calls on
+// every Query it produces.
+func TestExecuteQueryOnQueryable_ClosesQueryOnError(t *testing.T) {
+	failingQueryable := storage.QueryableFunc(func(int64, int64) (storage.Querier, error) {
+		return nil, apierror.New(apierror.TypeInternal, "boom")
+	})
+
+	successfulQueryable := testdatagen.StorageSeriesQueryable([]storage.Series{
+		testdatagen.NewSeries(labels.FromStrings("__name__", "bar1"), start.Add(-lookbackDelta), end, step, testdatagen.Factor(5)),
+	})
+
+	for _, tc := range []struct {
+		name          string
+		queryable     storage.Queryable
+		expectSuccess bool
+	}{
+		{
+			name:      "execution error closes the query",
+			queryable: failingQueryable,
+		},
+		{
+			name:          "successful query is closed via finalizer",
+			queryable:     successfulQueryable,
+			expectSuccess: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, innerEngine := newEngineForTesting(t, querier.MimirEngine)
+			engine := newCloseCountingEngine(innerEngine)
+
+			req := &PrometheusRangeQueryRequest{
+				path:      "/query_range",
+				start:     util.TimeToMillis(start),
+				end:       util.TimeToMillis(end),
+				step:      step.Milliseconds(),
+				queryExpr: parseQuery(t, "sum(bar1)"),
+			}
+
+			ctx := user.InjectOrgID(context.Background(), "test")
+			resp, err := ExecuteQueryOnQueryable(ctx, req, engine, tc.queryable, NewAnnotationAccumulator())
+
+			require.Equal(t, 1, engine.queriesCreated(), "expected exactly one promql.Query to be created")
+
+			if tc.expectSuccess {
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				// Ownership is transferred to the response finalizer; Close
+				// must not have been called yet.
+				require.Zero(t, engine.totalCloseCalls(), "expected Close to not have been called before the response finalizer fires")
+				resp.(*PrometheusResponseWithFinalizer).Close()
+			} else {
+				require.Error(t, err)
+				require.Nil(t, resp)
+			}
+
+			require.GreaterOrEqual(t, engine.totalCloseCalls(), 1, "expected Close to be called at least once on the underlying query")
+		})
+	}
+}

--- a/pkg/frontend/querymiddleware/querysharding_test_utils_test.go
+++ b/pkg/frontend/querymiddleware/querysharding_test_utils_test.go
@@ -351,6 +351,65 @@ func newEngineForTesting(t *testing.T, engine string, opts ...engineOpt) (promql
 	panic("unreachable")
 }
 
+// closeCountingEngine wraps a promql.QueryEngine and counts how many queries
+// it has produced and how many of those have had Close() called. It is used
+// by tests that need to verify the close-on-error contract — that callers of
+// NewInstantQuery / NewRangeQuery release the returned promql.Query on every
+// return path, not just the success path that hands ownership to a finalizer.
+type closeCountingEngine struct {
+	inner   promql.QueryEngine
+	queries []*closeCountingQuery
+}
+
+func newCloseCountingEngine(inner promql.QueryEngine) *closeCountingEngine {
+	return &closeCountingEngine{inner: inner}
+}
+
+func (e *closeCountingEngine) NewInstantQuery(ctx context.Context, q storage.Queryable, opts promql.QueryOpts, qs string, ts time.Time) (promql.Query, error) {
+	qry, err := e.inner.NewInstantQuery(ctx, q, opts, qs, ts)
+	if err != nil {
+		return nil, err
+	}
+	wrapped := &closeCountingQuery{Query: qry}
+	e.queries = append(e.queries, wrapped)
+	return wrapped, nil
+}
+
+func (e *closeCountingEngine) NewRangeQuery(ctx context.Context, q storage.Queryable, opts promql.QueryOpts, qs string, start, end time.Time, interval time.Duration) (promql.Query, error) {
+	qry, err := e.inner.NewRangeQuery(ctx, q, opts, qs, start, end, interval)
+	if err != nil {
+		return nil, err
+	}
+	wrapped := &closeCountingQuery{Query: qry}
+	e.queries = append(e.queries, wrapped)
+	return wrapped, nil
+}
+
+// queriesCreated returns the number of queries this engine has produced.
+func (e *closeCountingEngine) queriesCreated() int {
+	return len(e.queries)
+}
+
+// totalCloseCalls returns the sum of Close() invocations across every query
+// this engine has produced.
+func (e *closeCountingEngine) totalCloseCalls() int {
+	total := 0
+	for _, q := range e.queries {
+		total += q.closeCalls
+	}
+	return total
+}
+
+type closeCountingQuery struct {
+	promql.Query
+	closeCalls int
+}
+
+func (q *closeCountingQuery) Close() {
+	q.closeCalls++
+	q.Query.Close()
+}
+
 // runForEngines runs the provided test closure with the Prometheus Engine and Mimir Query Engine.
 func runForEngines(t *testing.T, run func(t *testing.T, opts promql.EngineOpts, eng promql.QueryEngine)) {
 	t.Helper()

--- a/pkg/frontend/querymiddleware/spin_off_subqueries.go
+++ b/pkg/frontend/querymiddleware/spin_off_subqueries.go
@@ -200,6 +200,17 @@ func (s *spinOffSubqueriesMiddleware) Do(ctx context.Context, req MetricsQueryRe
 		return nil, apierror.New(apierror.TypeBadData, err.Error())
 	}
 
+	// Ownership of qry is transferred to the response finalizer on success. On
+	// any failure path before that hand-off we must Close qry ourselves, otherwise
+	// the query's resources (memory consumption tracker, pooled buffers, evaluator
+	// context) leak.
+	shouldCloseQuery := true
+	defer func() {
+		if shouldCloseQuery {
+			qry.Close()
+		}
+	}()
+
 	res := qry.Exec(ctx)
 	extracted, err := promqlResultToSamples(res)
 	if err != nil {
@@ -221,7 +232,7 @@ func (s *spinOffSubqueriesMiddleware) Do(ctx context.Context, req MetricsQueryRe
 	warn = removeDuplicates(warn)
 	info = removeDuplicates(info)
 
-	return &PrometheusResponseWithFinalizer{
+	resp := &PrometheusResponseWithFinalizer{
 		PrometheusResponse: &PrometheusResponse{
 			Status: statusSuccess,
 			Data: &PrometheusData{
@@ -233,5 +244,8 @@ func (s *spinOffSubqueriesMiddleware) Do(ctx context.Context, req MetricsQueryRe
 			Infos:    info,
 		},
 		finalizer: qry.Close,
-	}, nil
+	}
+
+	shouldCloseQuery = false
+	return resp, nil
 }

--- a/pkg/util/limiter/memory_consumption.go
+++ b/pkg/util/limiter/memory_consumption.go
@@ -237,7 +237,7 @@ type MemoryConsumptionTracker struct {
 	haveRecordedRejection bool
 	queryDescription      string
 
-	ctx context.Context // Used to retrieve trace ID to include in panic messages.
+	traceID string // Used to include in panic messages. Empty if the query didn't carry a tracing ID.
 
 	// mtx protects all mutable state of the memory consumption tracker. We use a mutex
 	// rather than atomics because we only want to adjust the memory used after checking
@@ -254,12 +254,14 @@ func NewUnlimitedMemoryConsumptionTracker(ctx context.Context) *MemoryConsumptio
 }
 
 func NewMemoryConsumptionTracker(ctx context.Context, maxEstimatedMemoryConsumptionBytes uint64, rejectionCount prometheus.Counter, queryDescription string) *MemoryConsumptionTracker {
+	traceID, _ := tracing.ExtractTraceID(ctx)
 	return &MemoryConsumptionTracker{
 		maxEstimatedMemoryConsumptionBytes: maxEstimatedMemoryConsumptionBytes,
 
 		rejectionCount:   rejectionCount,
 		queryDescription: queryDescription,
-		ctx:              ctx,
+
+		traceID: traceID,
 	}
 }
 
@@ -292,11 +294,9 @@ func (l *MemoryConsumptionTracker) DecreaseMemoryConsumption(b uint64, source Me
 	defer l.mtx.Unlock()
 
 	if b > l.currentEstimatedMemoryConsumptionBySource[source] {
-		traceID, ok := tracing.ExtractTraceID(l.ctx)
 		traceDescription := ""
-
-		if ok {
-			traceDescription = fmt.Sprintf(" (trace ID: %v)", traceID)
+		if l.traceID != "" {
+			traceDescription = fmt.Sprintf(" (trace ID: %v)", l.traceID)
 		}
 
 		panic(fmt.Sprintf(


### PR DESCRIPTION
#### What this PR does

This is a backport to ensure that MQE queries are closed on error.

This is equivalent to the backport to r393 - https://github.com/grafana/mimir/pull/15252.

Note that one test update has been excluded since the structure of the code has changed making the test back port more complex.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches query execution/cleanup paths in the query-frontend and MQE, where mistakes could cause double-closes or missed closes under rare error conditions. Changes are well-scoped and covered by new close-counting tests, but affect memory/resource lifetime behavior.
> 
> **Overview**
> Prevents **MQE/query-frontend memory leaks** by making `engineQueryRequestRoundTripperHandler.Do`, `ExecuteQueryOnQueryable`, and subquery spin-off execution always `Close()` the created `promql.Query` on *every* early-return/error path, while still handing ownership to the response finalizer on success.
> 
> Reduces per-query memory overhead by updating `MemoryConsumptionTracker` to store only an extracted `traceID` string (instead of retaining the full `context.Context`/request chain) and adds a regression test harness (`closeCountingEngine`) plus a focused test to assert the close-on-error contract.
> 
> Updates `CHANGELOG.md` with the MQE overhead reduction and the query-frontend leak fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db5e7d3e797a5446b3d20e4755ff2bb3068add41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->