### PR TITLE
mixin: fix usage tracker dashboard to include TrackSeriesBatch route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,8 @@
 * [ENHANCEMENT] Dashboards: Add the experimental streaming search API endpoints to the "Overview" per-endpoint query breakdown, and include the ingester `SearchLabelNames`/`SearchLabelValues` gRPC routes in the ingester panels of the "Reads", "Queries", and "Remote ruler reads" dashboards. #15571
 * [ENHANCEMENT] Dashboards: Add "p90 compaction delay by level" and "Store-gateway blocks queried by level" panels to the "Compaction" row of the "Compactor" dashboard. #15619
 * [BUGFIX] Dashboards: Fix the classic/ingest-storage split in the "Tenants", "Top tenants" and "Writes" dashboards so that selecting multiple clusters with a mix of architectures no longer drops the classic clusters' data. The `unless on (job)` filter against `cortex_partition_ring_partitions` now also matches on the cluster aggregation labels. #15400
+* [ENHANCEMENT] Dashboards: Break the "Usage Tracker" row "Requests / sec" panel in the "Mimir / Writes" dashboard out into separate non-batch (Sync) and batch (Async) `TrackSeries` routes. #15579
+* [BUGFIX] Dashboards: Fix usage tracker row in "Mimir / Writes" dashboard to include both `TrackSeries` and `TrackSeriesBatch` routes. #15289
 
 ### Jsonnet
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,6 @@
 * [ENHANCEMENT] Dashboards: Add "p90 compaction delay by level" and "Store-gateway blocks queried by level" panels to the "Compaction" row of the "Compactor" dashboard. #15619
 * [BUGFIX] Dashboards: Fix the classic/ingest-storage split in the "Tenants", "Top tenants" and "Writes" dashboards so that selecting multiple clusters with a mix of architectures no longer drops the classic clusters' data. The `unless on (job)` filter against `cortex_partition_ring_partitions` now also matches on the cluster aggregation labels. #15400
 * [ENHANCEMENT] Dashboards: Restructure the "Usage Tracker" and "Usage Tracker (client)" rows in the "Mimir / Writes" dashboard so each shows request rate and latency (p99, p50, average) split by request type (sync single `TrackSeries` and async batch `TrackSeriesBatch`), plus a combined per-instance p99 latency panel. #15289
-* [BUGFIX] Dashboards: Fix the "Usage Tracker" and "Usage Tracker (client)" rows in the "Mimir / Writes" dashboard to include both the `TrackSeries` and `TrackSeriesBatch` routes, so panels are no longer empty when traffic uses the batch route. #15289
 
 ### Jsonnet
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,8 +80,8 @@
 * [ENHANCEMENT] Dashboards: Add 100th percentile to query expression percentiles graph. #15421
 * [ENHANCEMENT] Dashboards: Add the experimental streaming search API endpoints to the "Overview" per-endpoint query breakdown, and include the ingester `SearchLabelNames`/`SearchLabelValues` gRPC routes in the ingester panels of the "Reads", "Queries", and "Remote ruler reads" dashboards. #15571
 * [ENHANCEMENT] Dashboards: Add "p90 compaction delay by level" and "Store-gateway blocks queried by level" panels to the "Compaction" row of the "Compactor" dashboard. #15619
-* [BUGFIX] Dashboards: Fix the classic/ingest-storage split in the "Tenants", "Top tenants" and "Writes" dashboards so that selecting multiple clusters with a mix of architectures no longer drops the classic clusters' data. The `unless on (job)` filter against `cortex_partition_ring_partitions` now also matches on the cluster aggregation labels. #15400
 * [ENHANCEMENT] Dashboards: Restructure the "Usage Tracker" and "Usage Tracker (client)" rows in the "Mimir / Writes" dashboard so each shows request rate and latency (p99, p50, average) split by request type (sync single `TrackSeries` and async batch `TrackSeriesBatch`), plus a combined per-instance p99 latency panel. #15289
+* [BUGFIX] Dashboards: Fix the classic/ingest-storage split in the "Tenants", "Top tenants" and "Writes" dashboards so that selecting multiple clusters with a mix of architectures no longer drops the classic clusters' data. The `unless on (job)` filter against `cortex_partition_ring_partitions` now also matches on the cluster aggregation labels. #15400
 
 ### Jsonnet
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,8 +81,8 @@
 * [ENHANCEMENT] Dashboards: Add the experimental streaming search API endpoints to the "Overview" per-endpoint query breakdown, and include the ingester `SearchLabelNames`/`SearchLabelValues` gRPC routes in the ingester panels of the "Reads", "Queries", and "Remote ruler reads" dashboards. #15571
 * [ENHANCEMENT] Dashboards: Add "p90 compaction delay by level" and "Store-gateway blocks queried by level" panels to the "Compaction" row of the "Compactor" dashboard. #15619
 * [BUGFIX] Dashboards: Fix the classic/ingest-storage split in the "Tenants", "Top tenants" and "Writes" dashboards so that selecting multiple clusters with a mix of architectures no longer drops the classic clusters' data. The `unless on (job)` filter against `cortex_partition_ring_partitions` now also matches on the cluster aggregation labels. #15400
-* [ENHANCEMENT] Dashboards: Break the "Usage Tracker" row "Requests / sec" panel in the "Mimir / Writes" dashboard out into separate non-batch (Sync) and batch (Async) `TrackSeries` routes. #15579
-* [BUGFIX] Dashboards: Fix usage tracker row in "Mimir / Writes" dashboard to include both `TrackSeries` and `TrackSeriesBatch` routes. #15289
+* [ENHANCEMENT] Dashboards: Restructure the "Usage Tracker" and "Usage Tracker (client)" rows in the "Mimir / Writes" dashboard so each shows request rate and latency (p99, p50, average) split by request type (sync single `TrackSeries` and async batch `TrackSeriesBatch`), plus a combined per-instance p99 latency panel. #15289
+* [BUGFIX] Dashboards: Fix the "Usage Tracker" and "Usage Tracker (client)" rows in the "Mimir / Writes" dashboard to include both the `TrackSeries` and `TrackSeriesBatch` routes, so panels are no longer empty when traffic uses the batch route. #15289
 
 ### Jsonnet
 

--- a/operations/mimir-mixin/dashboards/dashboard-queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-queries.libsonnet
@@ -123,8 +123,6 @@ local utils = import 'mixin-utils/utils.libsonnet';
       readGRPCStoreGatewayRoute: $.queries.read_grpc_store_gateway_route,
       rulerQueryFrontendRoutesRegex: $.queries.ruler_query_frontend_routes_regex,
       usageTrackerTrackSeriesRoutesRegex: $.queries.usage_tracker_track_series_routes_regex,
-      usageTrackerTrackSeriesSyncRouteRegex: $.queries.usage_tracker_track_series_sync_route_regex,
-      usageTrackerTrackSeriesBatchRouteRegex: $.queries.usage_tracker_track_series_batch_route_regex,
       usageTrackerGetUsersCloseToLimitRoutesRegex: $.queries.usage_tracker_get_users_close_to_limit_routes_regex,
       perClusterLabel: $._config.per_cluster_label,
       recordingRulePrefix: $.recordingRulePrefix($.jobSelector('any')),  // The job name does not matter here.
@@ -184,11 +182,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
 
     usage_tracker: {
       local p = self,
-      clientRequestsPerSecondMetric: 'cortex_usage_tracker_client_track_series_duration_seconds',
+      clientRequestDurationMetric: 'cortex_usage_tracker_client_request_duration_seconds',
       requestsPerSecondMetric: $.queries.requests_per_second_metric,
       trackSeriesRequestsPerSecondRouteRegex: '%(usageTrackerTrackSeriesRoutesRegex)s' % variables,
-      trackSeriesSyncRequestsPerSecondSelector: '%(usageTrackerMatcher)s, route=~"%(usageTrackerTrackSeriesSyncRouteRegex)s"' % variables,
-      trackSeriesBatchRequestsPerSecondSelector: '%(usageTrackerMatcher)s, route=~"%(usageTrackerTrackSeriesBatchRouteRegex)s"' % variables,
       getUsersCloseToLimitRequestsPerSecondRouteRegex: '%(usageTrackerGetUsersCloseToLimitRoutesRegex)s' % variables,
       getUsersCloseToLimitRequestsPerSecondSelector: '%(usageTrackerMatcher)s, route=~"%(usageTrackerGetUsersCloseToLimitRoutesRegex)s"' % variables,
 

--- a/operations/mimir-mixin/dashboards/dashboard-queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-queries.libsonnet
@@ -123,6 +123,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
       readGRPCStoreGatewayRoute: $.queries.read_grpc_store_gateway_route,
       rulerQueryFrontendRoutesRegex: $.queries.ruler_query_frontend_routes_regex,
       usageTrackerTrackSeriesRoutesRegex: $.queries.usage_tracker_track_series_routes_regex,
+      usageTrackerTrackSeriesSyncRouteRegex: $.queries.usage_tracker_track_series_sync_route_regex,
+      usageTrackerTrackSeriesBatchRouteRegex: $.queries.usage_tracker_track_series_batch_route_regex,
       usageTrackerGetUsersCloseToLimitRoutesRegex: $.queries.usage_tracker_get_users_close_to_limit_routes_regex,
       perClusterLabel: $._config.per_cluster_label,
       recordingRulePrefix: $.recordingRulePrefix($.jobSelector('any')),  // The job name does not matter here.
@@ -147,7 +149,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
     alertmanager_grpc_routes_regex: '/alertmanagerpb.Alertmanager/HandleRequest',
     // Both support gRPC and HTTP requests. HTTP request is used when rule evaluation query requests go through the query-tee.
     ruler_query_frontend_routes_regex: '/httpgrpc.HTTP/Handle|.*api_v1_query',
-    usage_tracker_track_series_routes_regex: '/usagetrackerpb.UsageTracker/TrackSeries',
+    usage_tracker_track_series_routes_regex: '/usagetrackerpb.UsageTracker/TrackSeries(Batch)?',
+    usage_tracker_track_series_sync_route_regex: '/usagetrackerpb.UsageTracker/TrackSeries',
+    usage_tracker_track_series_batch_route_regex: '/usagetrackerpb.UsageTracker/TrackSeriesBatch',
     usage_tracker_get_users_close_to_limit_routes_regex: '/usagetrackerpb.UsageTracker/GetUsersCloseToLimit',
 
     gateway: {
@@ -183,7 +187,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
       clientRequestsPerSecondMetric: 'cortex_usage_tracker_client_track_series_duration_seconds',
       requestsPerSecondMetric: $.queries.requests_per_second_metric,
       trackSeriesRequestsPerSecondRouteRegex: '%(usageTrackerTrackSeriesRoutesRegex)s' % variables,
-      trackSeriesRequestsPerSecondSelector: '%(usageTrackerMatcher)s, route=~"%(usageTrackerTrackSeriesRoutesRegex)s"' % variables,
+      trackSeriesSyncRequestsPerSecondSelector: '%(usageTrackerMatcher)s, route=~"%(usageTrackerTrackSeriesSyncRouteRegex)s"' % variables,
+      trackSeriesBatchRequestsPerSecondSelector: '%(usageTrackerMatcher)s, route=~"%(usageTrackerTrackSeriesBatchRouteRegex)s"' % variables,
       getUsersCloseToLimitRequestsPerSecondRouteRegex: '%(usageTrackerGetUsersCloseToLimitRoutesRegex)s' % variables,
       getUsersCloseToLimitRequestsPerSecondSelector: '%(usageTrackerMatcher)s, route=~"%(usageTrackerGetUsersCloseToLimitRoutesRegex)s"' % variables,
 

--- a/operations/mimir-mixin/dashboards/writes.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes.libsonnet
@@ -4,6 +4,56 @@ local filename = 'mimir-writes.json';
 (import 'dashboard-utils.libsonnet') +
 (import 'dashboard-queries.libsonnet') {
 
+  // Builds a "requests / sec" panel for the usage-tracker rows, split by request type:
+  // sync single requests (TrackSeries) and async batch requests (TrackSeriesBatch).
+  // typeLabel is the label holding the gRPC route ("route" for the service, "operation" for the client).
+  usageTrackerRequestsPerTypePanel(title, metric, typeLabel, jobSelector)::
+    local syncSelector = utils.toPrometheusSelectorNaked(jobSelector + [utils.selector.re(typeLabel, $.queries.usage_tracker_track_series_sync_route_regex)]);
+    local batchSelector = utils.toPrometheusSelectorNaked(jobSelector + [utils.selector.re(typeLabel, $.queries.usage_tracker_track_series_batch_route_regex)]);
+    local syncQuery = utils.ncHistogramSumBy(utils.ncHistogramCountRate(metric, syncSelector));
+    local batchQuery = utils.ncHistogramSumBy(utils.ncHistogramCountRate(metric, batchSelector));
+    $.timeseriesPanel(title) +
+    $.queryPanel(
+      [
+        utils.showClassicHistogramQuery(syncQuery),
+        utils.showNativeHistogramQuery(syncQuery),
+        utils.showClassicHistogramQuery(batchQuery),
+        utils.showNativeHistogramQuery(batchQuery),
+      ],
+      ['Sync (single)', 'Sync (single)', 'Async (batch)', 'Async (batch)'],
+    ) +
+    $.stack +
+    { fieldConfig+: { defaults+: { unit: 'reqps' } } } +
+    $.aliasColors({
+      'Sync (single)': '#2A66CF',
+      'Async (batch)': '#FFA500',
+    }),
+
+  // Builds a latency panel for the usage-tracker rows showing p99, p50 and average per request type.
+  // This results in up to 6 lines: {Sync (single), Async (batch)} x {p99, p50, average}.
+  usageTrackerLatencyPerTypePanel(title, metric, typeLabel, jobSelector)::
+    local syncSelector = utils.toPrometheusSelectorNaked(jobSelector + [utils.selector.re(typeLabel, $.queries.usage_tracker_track_series_sync_route_regex)]);
+    local batchSelector = utils.toPrometheusSelectorNaked(jobSelector + [utils.selector.re(typeLabel, $.queries.usage_tracker_track_series_batch_route_regex)]);
+    local syncLatency = $.ncLatencyPanel(metric, syncSelector);
+    local batchLatency = $.ncLatencyPanel(metric, batchSelector);
+    $.timeseriesPanel(title) +
+    syncLatency +
+    {
+      targets: [
+        t { legendFormat: 'Sync (single) ' + t.legendFormat }
+        for t in syncLatency.targets
+      ] + [
+        t { legendFormat: 'Async (batch) ' + t.legendFormat, refId: t.refId + '_batch' }
+        for t in batchLatency.targets
+      ],
+    },
+
+  // Builds a per-instance p99 latency panel for the usage-tracker rows, covering both request
+  // types (TrackSeries and TrackSeriesBatch) without distinguishing between them.
+  usageTrackerPerInstanceLatencyPanel(title, metric, typeLabel, jobSelector)::
+    $.timeseriesPanel(title) +
+    $.perInstanceLatencyPanelNativeHistogram('0.99', metric, jobSelector + [utils.selector.re(typeLabel, $.queries.usage_tracker.trackSeriesRequestsPerSecondRouteRegex)]),
+
   [filename]:
     assert std.md5(filename) == '8280707b8f16e7b87b840fc1cc92d4c5' : 'UID of the dashboard has changed, please update references to dashboard.';
     ($.dashboard('Writes') + { uid: std.md5(filename) })
@@ -264,68 +314,43 @@ local filename = 'mimir-writes.json';
       $.row('Usage Tracker (client)')
       .addPanel(
         local title = 'Client req / sec';
-        local asyncJobMatcher = $.jobMatcher(std.set($._config.job_names.distributor + $._config.job_names.ruler));
-        $.timeseriesPanel(title) +
-        $.qpsPanelNativeHistogram($.queries.usage_tracker.clientRequestsPerSecondMetric, $.namespaceMatcher()) +
-        {
-          // Prefix sync target legends with "Sync " and append async targets.
-          targets: [
-            t { legendFormat: 'Sync ' + t.legendFormat }
-            for t in super.targets
-          ] + [
-            {
-              expr: |||
-                sum(rate(cortex_distributor_async_usage_tracker_calls_total{%s}[$__rate_interval]))
-                -
-                (
-                  sum(rate(cortex_distributor_async_usage_tracker_calls_with_rejected_series_total{%s}[$__rate_interval]))
-                  or vector(0)
-                )
-              ||| % [asyncJobMatcher, asyncJobMatcher],
-              format: 'time_series',
-              legendFormat: 'Async',
-              refId: 'async',
-            },
-            {
-              expr: |||
-                sum(rate(cortex_distributor_async_usage_tracker_calls_with_rejected_series_total{%s}[$__rate_interval]))
-              ||| % [asyncJobMatcher],
-              format: 'time_series',
-              legendFormat: 'Async (rejected but ingested)',
-              refId: 'async_rejected',
-            },
-          ],
-        } +
-        $.aliasColors({
-          ['Sync ' + name]: $.qpsPanelColors[name]
-          for name in std.objectFields($.qpsPanelColors)
-        } + {
-          Async: '#2A66CF',
-          'Async (rejected but ingested)': '#9E44C1',
-        }) +
+        $.usageTrackerRequestsPerTypePanel(
+          title,
+          $.queries.usage_tracker.clientRequestDurationMetric,
+          'operation',
+          $.jobSelector(std.set($._config.job_names.distributor + $._config.job_names.ruler)),
+        ) +
         $.panelDescription(
           title,
           |||
-            The number of tracking requests sent through the Usage Tracker client, which are later multiplexed into individual requests to the Usage Tracker service instances.
-            Async requests proceed with the write request without waiting for tracking to complete.
-            Some async requests may have rejected the series that were actually ingested.
-          |||
-        ),
-      )
-      .addPanel(
-        local title = 'Client sync requests latency';
-        $.timeseriesPanel(title) +
-        $.latencyRecordingRulePanelNativeHistogram($.queries.usage_tracker.clientRequestsPerSecondMetric, $.jobSelector(std.set($._config.job_names.distributor + $._config.job_names.ruler))) +
-        $.panelDescription(
-          title,
-          |||
-            Time taken to track all series in remote write request, eventually sharding the tracking among multiple usage-tracker instances.
+            The rate of gRPC requests sent from the Usage Tracker client to the usage-tracker service instances, broken down by request type.
+            Sync (single) requests (TrackSeries) are sent synchronously, one per partition, blocking the write request until tracking completes.
+            Async (batch) requests (TrackSeriesBatch) accumulate series into batches and are sent without blocking the write request.
           |||
         )
       )
       .addPanel(
-        $.timeseriesPanel('Client per %s p99 sync requests latency' % $._config.per_instance_label) +
-        $.perInstanceLatencyPanelNativeHistogram('0.99', $.queries.usage_tracker.clientRequestsPerSecondMetric, $.jobSelector(std.set($._config.job_names.distributor + $._config.job_names.ruler)))
+        local title = 'Client latency';
+        $.usageTrackerLatencyPerTypePanel(
+          title,
+          $.queries.usage_tracker.clientRequestDurationMetric,
+          'operation',
+          $.jobSelector(std.set($._config.job_names.distributor + $._config.job_names.ruler)),
+        ) +
+        $.panelDescription(
+          title,
+          |||
+            Latency of the individual gRPC requests sent from the Usage Tracker client to each usage-tracker instance, split into p99, p50 and average per request type.
+          |||
+        )
+      )
+      .addPanel(
+        $.usageTrackerPerInstanceLatencyPanel(
+          'Client per %s p99 latency' % $._config.per_instance_label,
+          $.queries.usage_tracker.clientRequestDurationMetric,
+          'operation',
+          $.jobSelector(std.set($._config.job_names.distributor + $._config.job_names.ruler)),
+        )
       )
     )
     .addRowIf(
@@ -333,42 +358,42 @@ local filename = 'mimir-writes.json';
       $.row('Usage Tracker')
       .addPanel(
         local title = 'Requests / sec';
-        local syncPanel = $.qpsPanelNativeHistogram($.queries.usage_tracker.requestsPerSecondMetric, $.queries.usage_tracker.trackSeriesSyncRequestsPerSecondSelector);
-        local batchPanel = $.qpsPanelNativeHistogram($.queries.usage_tracker.requestsPerSecondMetric, $.queries.usage_tracker.trackSeriesBatchRequestsPerSecondSelector);
-        $.timeseriesPanel(title) +
-        syncPanel +
-        {
-          // Prefix the non-batch (Sync) target legends and append the batch (Async) targets.
-          targets: [
-            t { legendFormat: 'Sync ' + t.legendFormat }
-            for t in syncPanel.targets
-          ] + [
-            t { legendFormat: 'Async ' + t.legendFormat, refId: t.refId + '_batch' }
-            for t in batchPanel.targets
-          ],
-        } +
-        $.aliasColors({
-          ['Sync ' + name]: $.qpsPanelColors[name]
-          for name in std.objectFields($.qpsPanelColors)
-        } + {
-          ['Async ' + name]: $.qpsPanelColors[name]
-          for name in std.objectFields($.qpsPanelColors)
-        }) +
+        $.usageTrackerRequestsPerTypePanel(
+          title,
+          $.queries.usage_tracker.requestsPerSecondMetric,
+          'route',
+          $.jobSelector($._config.job_names.usage_tracker),
+        ) +
         $.panelDescription(
           title,
           |||
-            The number of TrackSeries requests received by the Usage Tracker service, broken down into the non-batch (Sync) and batch (Async) routes.
-            Non-batch requests are significantly more CPU intensive than batch ones.
+            The rate of requests received by the Usage Tracker service, broken down by request type.
+            Sync (single) requests (TrackSeries) are significantly more CPU intensive than Async (batch) requests (TrackSeriesBatch).
           |||
         )
       )
       .addPanel(
-        $.timeseriesPanel('Latency') +
-        $.latencyRecordingRulePanelNativeHistogram($.queries.usage_tracker.requestsPerSecondMetric, $.jobSelector($._config.job_names.usage_tracker) + [utils.selector.re('route', $.queries.usage_tracker.trackSeriesRequestsPerSecondRouteRegex)])
+        local title = 'Latency';
+        $.usageTrackerLatencyPerTypePanel(
+          title,
+          $.queries.usage_tracker.requestsPerSecondMetric,
+          'route',
+          $.jobSelector($._config.job_names.usage_tracker),
+        ) +
+        $.panelDescription(
+          title,
+          |||
+            Latency of the requests received by the Usage Tracker service, split into p99, p50 and average per request type.
+          |||
+        )
       )
       .addPanel(
-        $.timeseriesPanel('Per %s p99 latency' % $._config.per_instance_label) +
-        $.perInstanceLatencyPanelNativeHistogram('0.99', $.queries.usage_tracker.requestsPerSecondMetric, $.jobSelector($._config.job_names.usage_tracker) + [utils.selector.re('route', $.queries.usage_tracker.trackSeriesRequestsPerSecondRouteRegex)])
+        $.usageTrackerPerInstanceLatencyPanel(
+          'Per %s p99 latency' % $._config.per_instance_label,
+          $.queries.usage_tracker.requestsPerSecondMetric,
+          'route',
+          $.jobSelector($._config.job_names.usage_tracker),
+        )
       )
     )
     .addRowIf(

--- a/operations/mimir-mixin/dashboards/writes.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes.libsonnet
@@ -25,8 +25,8 @@ local filename = 'mimir-writes.json';
     $.stack +
     { fieldConfig+: { defaults+: { unit: 'reqps' } } } +
     $.aliasColors({
-      'Sync (single)': '#2A66CF',
-      'Async (batch)': '#FFA500',
+      'Sync (single)': '#73BF69',
+      'Async (batch)': '#37872D',
     }),
 
   // Builds a latency panel for the usage-tracker rows showing p99, p50 and average per request type.

--- a/operations/mimir-mixin/dashboards/writes.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes.libsonnet
@@ -332,8 +332,35 @@ local filename = 'mimir-writes.json';
       $._config.usage_tracker_enabled,
       $.row('Usage Tracker')
       .addPanel(
-        $.timeseriesPanel('Requests / sec') +
-        $.qpsPanelNativeHistogram($.queries.usage_tracker.requestsPerSecondMetric, $.queries.usage_tracker.trackSeriesRequestsPerSecondSelector)
+        local title = 'Requests / sec';
+        local syncPanel = $.qpsPanelNativeHistogram($.queries.usage_tracker.requestsPerSecondMetric, $.queries.usage_tracker.trackSeriesSyncRequestsPerSecondSelector);
+        local batchPanel = $.qpsPanelNativeHistogram($.queries.usage_tracker.requestsPerSecondMetric, $.queries.usage_tracker.trackSeriesBatchRequestsPerSecondSelector);
+        $.timeseriesPanel(title) +
+        syncPanel +
+        {
+          // Prefix the non-batch (Sync) target legends and append the batch (Async) targets.
+          targets: [
+            t { legendFormat: 'Sync ' + t.legendFormat }
+            for t in syncPanel.targets
+          ] + [
+            t { legendFormat: 'Async ' + t.legendFormat, refId: t.refId + '_batch' }
+            for t in batchPanel.targets
+          ],
+        } +
+        $.aliasColors({
+          ['Sync ' + name]: $.qpsPanelColors[name]
+          for name in std.objectFields($.qpsPanelColors)
+        } + {
+          ['Async ' + name]: $.qpsPanelColors[name]
+          for name in std.objectFields($.qpsPanelColors)
+        }) +
+        $.panelDescription(
+          title,
+          |||
+            The number of TrackSeries requests received by the Usage Tracker service, broken down into the non-batch (Sync) and batch (Async) routes.
+            Non-batch requests are significantly more CPU intensive than batch ones.
+          |||
+        )
       )
       .addPanel(
         $.timeseriesPanel('Latency') +


### PR DESCRIPTION
#### What this PR does

Fixes and reworks the **Usage Tracker** panels in the **Mimir / Writes** dashboard.

**The bug:** the "Usage Tracker" row only queried the `/usagetrackerpb.UsageTracker/TrackSeries` gRPC route. The usage-tracker also serves a `TrackSeriesBatch` (async/batched) route, so when traffic used the batch path the row's panels showed empty or incomplete data. The "Usage Tracker (client)" row right above it had the equivalent gap — its latency panels only reflected the synchronous code path.

**The fix / rework:** both the "Usage Tracker" and "Usage Tracker (client)" rows are now restructured into a consistent 3-panel layout, each broken down by request type — **Sync (single)** (`TrackSeries`) and **Async (batch)** (`TrackSeriesBatch`):

1. **Requests / sec** — request rate split by type (2 series).
2. **Latency** — p99, p50 and average per type (up to 6 series).
3. **Per `<pod>` p99 latency** — combined across both types (`TrackSeries(Batch)?`), no type distinction because the purpose of this panel is to compare pods to each other.

Details:
- The service row queries `cortex_request_duration_seconds` (filtered on the `route` label); the client row queries `cortex_usage_tracker_client_request_duration_seconds` (filtered on the `operation` label), so both rows are now structurally identical and the client row covers both the sync and batch paths.
- Both rows are driven by three shared helper methods (`usageTrackerRequestsPerTypePanel`, `usageTrackerLatencyPerTypePanel`, `usageTrackerPerInstanceLatencyPanel`) to keep them in sync.
- The "Requests / sec" panels use two shades of green (`#73BF69` / `#37872D`) since both series represent successful request rates.
- Removed the now-unused query fields/selectors that the earlier single-route approach relied on.

These panels are gated behind `usage_tracker_enabled` (default `false`), so the compiled mixin output is unchanged.


## Screenshot of dashboard with this change

<img width="1705" height="491" alt="image" src="https://github.com/user-attachments/assets/d1b64ba6-e8d7-4ddf-bf84-909c537a605b" />
