### PR TITLE
Change MimirRulerMissedEvaluations alert to monitor the global missed evaluation rate, instead of the per rule groups one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -345,6 +345,7 @@
 * [CHANGE] Alerts: Replaced `MimirCompactorSkippedUnhealthyBlocks` with more generic `MimirCompactorSkippedBlocks`. #13876
 * [CHANGE] Dashboards: replace usage of `container_spec_cpu_quota / container_spec_cpu_period` with `kube_pod_container_resource_limits` for calculation of CPU limits. #14425
 * [CHANGE] Dashboards: The queries used in latency panels no longer convert seconds to milliseconds. The dashboard panels now use "seconds" unit instead of "milliseconds". #14896
+* [CHANGE] Alerts: Changed `MimirRulerMissedEvaluations` alert to monitor the global missed evaluation rate, instead of the per rule groups one. #15290
 * [ENHANCEMENT] Dashboards: Group compactor compaction-related panels into a single collapsible "Compaction" row. #14784
 * [ENHANCEMENT] Dashboards: Merge CPU and memory panels in the "Compactor resources" dashboard into a single collapsible row. #14866
 * [ENHANCEMENT] Alerts: Add more native histogram versions of alerts using classic histograms. #13814

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -345,7 +345,7 @@
 * [CHANGE] Alerts: Replaced `MimirCompactorSkippedUnhealthyBlocks` with more generic `MimirCompactorSkippedBlocks`. #13876
 * [CHANGE] Dashboards: replace usage of `container_spec_cpu_quota / container_spec_cpu_period` with `kube_pod_container_resource_limits` for calculation of CPU limits. #14425
 * [CHANGE] Dashboards: The queries used in latency panels no longer convert seconds to milliseconds. The dashboard panels now use "seconds" unit instead of "milliseconds". #14896
-* [CHANGE] Alerts: Changed `MimirRulerMissedEvaluations` alert to monitor the global missed evaluation rate, instead of the per rule groups one. #15290
+* [CHANGE] Alerts: Changed `MimirRulerMissedEvaluations` alert to monitor the per ruler evaluation rate, instead of the per ruler and rule groups one. Added `MimirRulersMissedEvaluations` alert to monitor the global missed evaluations rate. #15290
 * [ENHANCEMENT] Dashboards: Group compactor compaction-related panels into a single collapsible "Compaction" row. #14784
 * [ENHANCEMENT] Dashboards: Merge CPU and memory panels in the "Compactor resources" dashboard into a single collapsible row. #14866
 * [ENHANCEMENT] Alerts: Add more native histogram versions of alerts using classic histograms. #13814

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -462,11 +462,11 @@ How to **fix** it:
 
 ### MimirRulerMissedEvaluations
 
-This alert fires when there is a rule group that is taking longer to evaluate than its evaluation interval.
+This alert fires when a significant % of rule group evaluations are missed (skipped).
 
 How it **works**:
 
-- The Mimir ruler will evaluate a rule group according to the evaluation interval on the rule group.
+- The Mimir ruler evaluates each rule group according to the configured evaluation interval.
 - If an evaluation is not finished by the time the next evaluation should happen, the next evaluation is missed.
 
 How to **fix** it:

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -460,9 +460,9 @@ How to **fix** it:
   - If the ruler is logging the gRPC error "trying to send message larger than max", consider increasing `-server.grpc-max-send-msg-size-bytes` in the query-frontend (or ruler-query-frontend if you're running a dedicated read path for rule evaluations). If you're using jsonnet, you should just tune `_config.ruler_remote_evaluation_max_query_response_size_bytes`.
 - When using Memberlist as KV store for hash rings, ensure that Memberlist is working correctly. See instructions for the [`MimirGossipMembersTooHigh`](#MimirGossipMembersTooHigh) and [`MimirGossipMembersTooLow`](#MimirGossipMembersTooLow) alerts.
 
-### MimirRulerMissedEvaluations
+### MimirRulersMissedEvaluations
 
-This alert fires when a significant % of rule group evaluations are missed (skipped).
+This alert fires when a significant % of rule group evaluations are missed (skipped) across all rulers.
 
 How it **works**:
 
@@ -473,6 +473,12 @@ How to **fix** it:
 
 - Increase the evaluation interval of the rule group. You can use the rate of missed evaluation to estimate how long the rule group evaluation actually takes.
 - Try splitting up the rule group into multiple rule groups. Rule groups are evaluated in parallel, so the same rules may still fit in the same resolution.
+
+### MimirRulerMissedEvaluations
+
+This alert fires when a significant % of rule group evaluations are missed (skipped) in a specific ruler instance.
+
+Refer to the [MimirRulersMissedEvaluations](#mimirrulersmissedevaluations) runbook for detailed investigation steps.
 
 ### MimirRulerRemoteEvaluationFailing
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -676,13 +676,13 @@ spec:
           - alert: MimirRulerMissedEvaluations
             annotations:
               message: |
-                  Mimir Ruler {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% missed iterations for the rule group {{ $labels.rule_group }}.
+                  Mimir Rulers in {{ $labels.cluster }}/{{ $labels.namespace }} are experiencing {{ printf "%.2f" $value }}% missed iterations.
               runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulermissedevaluations
             expr: |
               100 * (
-              sum by (cluster, namespace, pod, rule_group) (rate(cortex_prometheus_rule_group_iterations_missed_total[1m]))
+              sum by (cluster, namespace) (rate(cortex_prometheus_rule_group_iterations_missed_total[1m]))
                 /
-              sum by (cluster, namespace, pod, rule_group) (rate(cortex_prometheus_rule_group_iterations_total[1m]))
+              sum by (cluster, namespace) (rate(cortex_prometheus_rule_group_iterations_total[1m]))
               ) > 1
             for: 5m
             labels:

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -673,17 +673,31 @@ spec:
             for: 5m
             labels:
               severity: critical
-          - alert: MimirRulerMissedEvaluations
+          - alert: MimirRulersMissedEvaluations
             annotations:
               message: |
                   Mimir Rulers in {{ $labels.cluster }}/{{ $labels.namespace }} are experiencing {{ printf "%.2f" $value }}% missed iterations.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulermissedevaluations
+              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulersmissedevaluations
             expr: |
               100 * (
               sum by (cluster, namespace) (rate(cortex_prometheus_rule_group_iterations_missed_total[1m]))
                 /
               sum by (cluster, namespace) (rate(cortex_prometheus_rule_group_iterations_total[1m]))
               ) > 1
+            for: 5m
+            labels:
+              severity: warning
+          - alert: MimirRulerMissedEvaluations
+            annotations:
+              message: |
+                  Mimir Ruler {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% missed iterations.
+              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulermissedevaluations
+            expr: |
+              100 * (
+              sum by (cluster, namespace, pod) (rate(cortex_prometheus_rule_group_iterations_missed_total[1m]))
+                /
+              sum by (cluster, namespace, pod) (rate(cortex_prometheus_rule_group_iterations_total[1m]))
+              ) > 5
             for: 5m
             labels:
               severity: warning

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -651,17 +651,31 @@ groups:
           for: 5m
           labels:
             severity: critical
-        - alert: MimirRulerMissedEvaluations
+        - alert: MimirRulersMissedEvaluations
           annotations:
             message: |
                 Mimir Rulers in {{ $labels.cluster }}/{{ $labels.namespace }} are experiencing {{ printf "%.2f" $value }}% missed iterations.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulermissedevaluations
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulersmissedevaluations
           expr: |
             100 * (
             sum by (cluster, namespace) (rate(cortex_prometheus_rule_group_iterations_missed_total[1m]))
               /
             sum by (cluster, namespace) (rate(cortex_prometheus_rule_group_iterations_total[1m]))
             ) > 1
+          for: 5m
+          labels:
+            severity: warning
+        - alert: MimirRulerMissedEvaluations
+          annotations:
+            message: |
+                Mimir Ruler {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% missed iterations.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulermissedevaluations
+          expr: |
+            100 * (
+            sum by (cluster, namespace, instance) (rate(cortex_prometheus_rule_group_iterations_missed_total[1m]))
+              /
+            sum by (cluster, namespace, instance) (rate(cortex_prometheus_rule_group_iterations_total[1m]))
+            ) > 5
           for: 5m
           labels:
             severity: warning

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -654,13 +654,13 @@ groups:
         - alert: MimirRulerMissedEvaluations
           annotations:
             message: |
-                Mimir Ruler {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% missed iterations for the rule group {{ $labels.rule_group }}.
+                Mimir Rulers in {{ $labels.cluster }}/{{ $labels.namespace }} are experiencing {{ printf "%.2f" $value }}% missed iterations.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulermissedevaluations
           expr: |
             100 * (
-            sum by (cluster, namespace, instance, rule_group) (rate(cortex_prometheus_rule_group_iterations_missed_total[1m]))
+            sum by (cluster, namespace) (rate(cortex_prometheus_rule_group_iterations_missed_total[1m]))
               /
-            sum by (cluster, namespace, instance, rule_group) (rate(cortex_prometheus_rule_group_iterations_total[1m]))
+            sum by (cluster, namespace) (rate(cortex_prometheus_rule_group_iterations_total[1m]))
             ) > 1
           for: 5m
           labels:

--- a/operations/mimir-mixin-compiled-gem/alerts.yaml
+++ b/operations/mimir-mixin-compiled-gem/alerts.yaml
@@ -661,17 +661,31 @@ groups:
           for: 5m
           labels:
             severity: critical
-        - alert: MimirRulerMissedEvaluations
+        - alert: MimirRulersMissedEvaluations
           annotations:
             message: |
                 GEM Rulers in {{ $labels.cluster }}/{{ $labels.namespace }} are experiencing {{ printf "%.2f" $value }}% missed iterations.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulermissedevaluations
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulersmissedevaluations
           expr: |
             100 * (
             sum by (cluster, namespace) (rate(cortex_prometheus_rule_group_iterations_missed_total[1m]))
               /
             sum by (cluster, namespace) (rate(cortex_prometheus_rule_group_iterations_total[1m]))
             ) > 1
+          for: 5m
+          labels:
+            severity: warning
+        - alert: MimirRulerMissedEvaluations
+          annotations:
+            message: |
+                GEM Ruler {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% missed iterations.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulermissedevaluations
+          expr: |
+            100 * (
+            sum by (cluster, namespace, pod) (rate(cortex_prometheus_rule_group_iterations_missed_total[1m]))
+              /
+            sum by (cluster, namespace, pod) (rate(cortex_prometheus_rule_group_iterations_total[1m]))
+            ) > 5
           for: 5m
           labels:
             severity: warning

--- a/operations/mimir-mixin-compiled-gem/alerts.yaml
+++ b/operations/mimir-mixin-compiled-gem/alerts.yaml
@@ -664,13 +664,13 @@ groups:
         - alert: MimirRulerMissedEvaluations
           annotations:
             message: |
-                GEM Ruler {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% missed iterations for the rule group {{ $labels.rule_group }}.
+                GEM Rulers in {{ $labels.cluster }}/{{ $labels.namespace }} are experiencing {{ printf "%.2f" $value }}% missed iterations.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulermissedevaluations
           expr: |
             100 * (
-            sum by (cluster, namespace, pod, rule_group) (rate(cortex_prometheus_rule_group_iterations_missed_total[1m]))
+            sum by (cluster, namespace) (rate(cortex_prometheus_rule_group_iterations_missed_total[1m]))
               /
-            sum by (cluster, namespace, pod, rule_group) (rate(cortex_prometheus_rule_group_iterations_total[1m]))
+            sum by (cluster, namespace) (rate(cortex_prometheus_rule_group_iterations_total[1m]))
             ) > 1
           for: 5m
           labels:

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -661,17 +661,31 @@ groups:
           for: 5m
           labels:
             severity: critical
-        - alert: MimirRulerMissedEvaluations
+        - alert: MimirRulersMissedEvaluations
           annotations:
             message: |
                 Mimir Rulers in {{ $labels.cluster }}/{{ $labels.namespace }} are experiencing {{ printf "%.2f" $value }}% missed iterations.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulermissedevaluations
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulersmissedevaluations
           expr: |
             100 * (
             sum by (cluster, namespace) (rate(cortex_prometheus_rule_group_iterations_missed_total[1m]))
               /
             sum by (cluster, namespace) (rate(cortex_prometheus_rule_group_iterations_total[1m]))
             ) > 1
+          for: 5m
+          labels:
+            severity: warning
+        - alert: MimirRulerMissedEvaluations
+          annotations:
+            message: |
+                Mimir Ruler {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% missed iterations.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulermissedevaluations
+          expr: |
+            100 * (
+            sum by (cluster, namespace, pod) (rate(cortex_prometheus_rule_group_iterations_missed_total[1m]))
+              /
+            sum by (cluster, namespace, pod) (rate(cortex_prometheus_rule_group_iterations_total[1m]))
+            ) > 5
           for: 5m
           labels:
             severity: warning

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -664,13 +664,13 @@ groups:
         - alert: MimirRulerMissedEvaluations
           annotations:
             message: |
-                Mimir Ruler {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% missed iterations for the rule group {{ $labels.rule_group }}.
+                Mimir Rulers in {{ $labels.cluster }}/{{ $labels.namespace }} are experiencing {{ printf "%.2f" $value }}% missed iterations.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulermissedevaluations
           expr: |
             100 * (
-            sum by (cluster, namespace, pod, rule_group) (rate(cortex_prometheus_rule_group_iterations_missed_total[1m]))
+            sum by (cluster, namespace) (rate(cortex_prometheus_rule_group_iterations_missed_total[1m]))
               /
-            sum by (cluster, namespace, pod, rule_group) (rate(cortex_prometheus_rule_group_iterations_total[1m]))
+            sum by (cluster, namespace) (rate(cortex_prometheus_rule_group_iterations_total[1m]))
             ) > 1
           for: 5m
           labels:

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -941,7 +941,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
                        + $.dashboardURLAnnotation('mimir-remote-ruler-reads.json'),
         },
         {
-          alert: $.alertName('RulerMissedEvaluations'),
+          // Alert firing if the rate of missed rule evaluations across all rulers is > 1%.
+          alert: $.alertName('RulersMissedEvaluations'),
           expr: |||
             100 * (
             sum by (%(alert_aggregation_labels)s) (rate(cortex_prometheus_rule_group_iterations_missed_total[%(rate_interval)s]))
@@ -958,6 +959,28 @@ local utils = import 'mixin-utils/utils.libsonnet';
           annotations: {
             message: |||
               %(product)s Rulers in %(alert_aggregation_variables)s are experiencing {{ printf "%%.2f" $value }}%% missed iterations.
+            ||| % $._config,
+          },
+        },
+        {
+          // Alert firing if the rate of missed rule evaluations per-ruler is > 5%.
+          alert: $.alertName('RulerMissedEvaluations'),
+          expr: |||
+            100 * (
+            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_prometheus_rule_group_iterations_missed_total[%(rate_interval)s]))
+              /
+            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s) (rate(cortex_prometheus_rule_group_iterations_total[%(rate_interval)s]))
+            ) > 5
+          ||| % $._config {
+            rate_interval: $.rateInterval('1m'),
+          },
+          'for': '5m',
+          labels: {
+            severity: 'warning',
+          },
+          annotations: {
+            message: |||
+              %(product)s Ruler %(alert_instance_variable)s in %(alert_aggregation_variables)s is experiencing {{ printf "%%.2f" $value }}%% missed iterations.
             ||| % $._config,
           },
         },

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -944,9 +944,9 @@ local utils = import 'mixin-utils/utils.libsonnet';
           alert: $.alertName('RulerMissedEvaluations'),
           expr: |||
             100 * (
-            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s, rule_group) (rate(cortex_prometheus_rule_group_iterations_missed_total[%(rate_interval)s]))
+            sum by (%(alert_aggregation_labels)s) (rate(cortex_prometheus_rule_group_iterations_missed_total[%(rate_interval)s]))
               /
-            sum by (%(alert_aggregation_labels)s, %(per_instance_label)s, rule_group) (rate(cortex_prometheus_rule_group_iterations_total[%(rate_interval)s]))
+            sum by (%(alert_aggregation_labels)s) (rate(cortex_prometheus_rule_group_iterations_total[%(rate_interval)s]))
             ) > 1
           ||| % $._config {
             rate_interval: $.rateInterval('1m'),
@@ -957,7 +957,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           },
           annotations: {
             message: |||
-              %(product)s Ruler %(alert_instance_variable)s in %(alert_aggregation_variables)s is experiencing {{ printf "%%.2f" $value }}%% missed iterations for the rule group {{ $labels.rule_group }}.
+              %(product)s Rulers in %(alert_aggregation_variables)s are experiencing {{ printf "%%.2f" $value }}%% missed iterations.
             ||| % $._config,
           },
         },


### PR DESCRIPTION
#### What this PR does

I think `MimirRulerMissedEvaluations` is too noisy and not much actionable. I think from a cluster-level perspective what we care the most is when there's an underlying issue causing a significant number of rule group evaluations to be missed.

In this PR I propose to:
1. Change `MimirRulerMissedEvaluations` alert to monitor the per-ruler missed evaluation rate, instead of the per ruler and rule groups one, with a threshold of 5% (was 1% before).
2. Introduce `MimirRulersMissedEvaluations` alert to monitor the global missed evaluation rate with 1% threshold

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
