### PR TITLE
mimirpb: Fix Windows build

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -40,8 +40,14 @@ jobs:
       - name: Get build image from Makefile
         id: build_image_step
         run: echo "build_image=$(make print-build-image)" >> "$GITHUB_OUTPUT"
+      - name: Get supported OS/arch for dist builds
+        id: dist_matrix_step
+        run: |
+          matrix=$(make print-supported-os-arch | jq -Rc 'split("\t") | {os: .[0], arch: .[1]}' | jq -sc '{include: .}')
+          echo "dist_matrix=$matrix" >> "$GITHUB_OUTPUT"
     outputs:
       build_image: ${{ steps.build_image_step.outputs.build_image }}
+      dist_matrix: ${{ steps.dist_matrix_step.outputs.dist_matrix }}
       # Determine if we will deploy (aka push) the image to the registry.
       is_deploy: ${{ (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/r')) && github.event_name == 'push' && github.repository == 'grafana/mimir' }}
 
@@ -482,6 +488,33 @@ jobs:
           artifact_name: docker-image-copyblocks
           target: "./tools/copyblocks/.uptodate"
 
+  build-dist:
+    runs-on: ubuntu-latest
+    name: build-dist (${{ matrix.os }}, ${{ matrix.arch }})
+    needs:
+      - prepare
+      - warmup-go-build-cache-image-and-lint
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prepare.outputs.dist_matrix) }}
+    container:
+      image: ${{ needs.prepare.outputs.build_image }} # zizmor: ignore[unpinned-images] The image output produced by the prepare step is pinned
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Restore Go build cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: /go/cache
+          key: go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-${{ hashFiles('go.sum') }}
+          restore-keys: go-build-cache-image-and-lint-${{ needs.prepare.outputs.build_image }}-
+      - name: Run Git Config
+        run: git config --global --add safe.directory '*'
+      - name: Build
+        run: make BUILD_IN_CONTAINER=false dist GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }}
+
   # This job does not do anything - it exists to simplify the "needs" condition of the "deploy" job,
   # and to make it easier to configure the required passing checks in branch protection rules in GitHub,
   # as we have to specify each required passing job there. This job won't be considered successful unless
@@ -494,6 +527,7 @@ jobs:
       - build-query-tee-image
       - build-mimirtool-image
       - build-copyblocks-image
+      - build-dist
     steps:
       - run: echo "All dependencies succeeded!"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [BUGFIX] Ingest storage: Fix `KafkaProducer.ProduceSync()` returning a single result with a nil record when the context is canceled, instead of one result per input record (with the record set) as the underlying franz-go client does. #15199
 * [BUGFIX] Distributor: Return HTTP 200 with OTLP partial-success when only some samples in an OTLP request are rejected by distributor-level validation (e.g. `too_far_in_past`). #15253
 * [BUGFIX] Querier: Fix querier ScaledObjects native histogram querying and triggering `MimirAutoscalerKedaFailing` when queriers have no traffic because `cortex_querier_request_duration_seconds_sum` is not published until the first request is received. #15106
+* [BUGFIX] Fix build failure on Windows and FreeBSD due to reference leaks instrumentation code. Enabling reference leaks instrumentation in those platforms now causes a configuration validation error instead. #15291
 
 ### Mixin
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ help:
 # WARNING: do not commit to a repository!
 -include Makefile.local
 
-.PHONY: all test test-with-race integration-tests cover clean images protos exes dist doc clean-doc check-doc check-reference-help push-multiarch-build-image license check-license format check-mixin check-mixin-jb check-mixin-mixtool check-mixin-runbooks check-mixin-mimirtool-rules build-mixin format-mixin check-jsonnet-manifests format-jsonnet-manifests push-multiarch-mimir list-image-targets check-jsonnet-getting-started mixin-screenshots warmup-build-cache-integration-tests warmup-build-cache-unit-tests warmup-build-cache-image-and-lint
+.PHONY: all test test-with-race integration-tests cover clean images protos exes dist doc clean-doc check-doc check-reference-help push-multiarch-build-image license check-license format check-mixin check-mixin-jb check-mixin-mixtool check-mixin-runbooks check-mixin-mimirtool-rules build-mixin format-mixin check-jsonnet-manifests format-jsonnet-manifests push-multiarch-mimir list-image-targets check-jsonnet-getting-started mixin-screenshots warmup-build-cache-integration-tests warmup-build-cache-unit-tests warmup-build-cache-image-and-lint print-supported-os-arch
 .DEFAULT_GOAL := all
 
 # Version number
@@ -169,6 +169,17 @@ push-multiarch-build-image: ## Push the docker build image.
 .PHONY: print-build-image
 print-build-image:
 	@echo $(BUILD_IMAGE):$(LATEST_BUILD_IMAGE_TAG)
+
+# Supported operating systems and architectures for dist builds.
+DIST_OSES ?= linux darwin windows freebsd
+DIST_ARCHES ?= amd64 arm64
+
+print-supported-os-arch: ## Print supported OS/arch combinations for dist.
+	@for os in $(DIST_OSES); do \
+		for arch in $(DIST_ARCHES); do \
+			printf '%s\t%s\n' "$$os" "$$arch"; \
+		done; \
+	done
 
 # We don't want find to scan inside a bunch of directories, to accelerate the
 # 'make: Entering directory '/go/src/github.com/grafana/mimir' phase.
@@ -548,8 +559,17 @@ dist: ## Generates binaries for a Mimir release.
 	@mkdir -p ./dist
 	@# Build binaries for various architectures and operating systems. Only
 	@# mimirtool supports Windows for now.
-	@for os in linux darwin windows freebsd; do \
-		for arch in amd64 arm64; do \
+	@# When GOOS and/or GOARCH are passed on the command line, only matching
+	@# targets are built.
+	@set -e; \
+	for os in $(DIST_OSES); do \
+		if [ -n "$(filter command line,$(origin GOOS))" ] && [ "$$os" != "$(GOOS)" ]; then \
+			continue; \
+		fi; \
+		for arch in $(DIST_ARCHES); do \
+			if [ -n "$(filter command line,$(origin GOARCH))" ] && [ "$$arch" != "$(GOARCH)" ]; then \
+				continue; \
+			fi; \
 			suffix="" ; \
 			if [ "$$os" = "windows" ]; then \
 				suffix=".exe" ; \

--- a/pkg/mimirpb/ref_leaks.go
+++ b/pkg/mimirpb/ref_leaks.go
@@ -3,11 +3,12 @@
 package mimirpb
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"math"
+	"runtime"
 	"sync"
-	"syscall"
 	"time"
 	"unsafe"
 
@@ -29,7 +30,12 @@ func (c *InstrumentRefLeaksConfig) RegisterFlagsWithPrefix(prefix string, f *fla
 	f.Uint64Var(&c.MaxInflightInstrumentedBytes, prefix+"max-inflight-instrumented-bytes", 0, `Maximum sum of length of buffers instrumented at any given time, in bytes. When surpassed, incoming buffers will not be instrumented, regardless of the configured percentage. Zero means no limit.`)
 }
 
+var errRefLeaksNotAvailable = errors.New("reference leaks instrumentation not available in " + runtime.GOOS)
+
 func (c InstrumentRefLeaksConfig) Validate() error {
+	if !refLeaksInstrumentationSupported && c.Percentage != 0 {
+		return errRefLeaksNotAvailable
+	}
 	if c.Percentage < 0 || c.Percentage > 100 {
 		return fmt.Errorf("percentage must be in [0-100], got: %v", c.Percentage)
 	}
@@ -96,7 +102,7 @@ func (t *refLeaksTracker) maybeInstrumentRefLeaks(data mem.BufferSlice) mem.Buff
 	// Allocate separate pages for this buffer. We'll detect ref leaks by
 	// munmaping the pages on Free, after which trying to access them will
 	// segfault.
-	b, err := syscall.Mmap(-1, 0, pageAlignedLen, syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_PRIVATE|syscall.MAP_ANON)
+	b, err := mmapAnon(pageAlignedLen)
 	if err != nil {
 		panic(fmt.Errorf("mmap: %w", err))
 	}
@@ -134,7 +140,7 @@ func (b *instrumentLeaksBuf) Free() {
 		ptr := unsafe.SliceData(buf)
 		allPages := unsafe.Slice(ptr, roundUpToMultiple(len(buf), pageSize))
 		if b.waitBeforeReuse > 0 {
-			err := syscall.Mprotect(allPages, syscall.PROT_NONE)
+			err := mprotectNone(allPages)
 			if err != nil {
 				panic(fmt.Errorf("mprotect: %w", err))
 			}
@@ -179,7 +185,7 @@ func (t *refLeaksTracker) unmap(buf []byte) {
 	newInflight := t.inflightInstrumentedBytes.Sub(uint64(len(buf)))
 	t.inflightInstrumentedBytesMetric.Set(float64(newInflight))
 
-	err := syscall.Munmap(buf)
+	err := munmap(buf)
 	if err != nil {
 		panic(fmt.Errorf("munmap: %w", err))
 	}

--- a/pkg/mimirpb/ref_leaks_supported.go
+++ b/pkg/mimirpb/ref_leaks_supported.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//go:build linux || darwin
+
+package mimirpb
+
+import (
+	"syscall"
+)
+
+const refLeaksInstrumentationSupported = true
+
+func mmapAnon(len int) ([]byte, error) {
+	return syscall.Mmap(-1, 0, len, syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_PRIVATE|syscall.MAP_ANON)
+}
+
+func mprotectNone(b []byte) error {
+	return syscall.Mprotect(b, syscall.PROT_NONE)
+}
+
+func munmap(b []byte) error {
+	return syscall.Munmap(b)
+}

--- a/pkg/mimirpb/ref_leaks_test.go
+++ b/pkg/mimirpb/ref_leaks_test.go
@@ -12,6 +12,10 @@ import (
 )
 
 func TestInstrumentRefLeaks(t *testing.T) {
+	if !refLeaksInstrumentationSupported {
+		t.Skip(errRefLeaksNotAvailable)
+	}
+
 	prev := debug.SetPanicOnFault(true)
 	defer debug.SetPanicOnFault(prev)
 

--- a/pkg/mimirpb/ref_leaks_unsupported.go
+++ b/pkg/mimirpb/ref_leaks_unsupported.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//go:build !linux && !darwin
+
+package mimirpb
+
+const refLeaksInstrumentationSupported = false
+
+func mmapAnon(len int) ([]byte, error) {
+	panic(errRefLeaksNotAvailable)
+}
+
+func mprotectNone(b []byte) error {
+	panic(errRefLeaksNotAvailable)
+}
+
+func munmap(b []byte) error {
+	panic(errRefLeaksNotAvailable)
+}


### PR DESCRIPTION
#### What this PR does

`make dist` on Windows (and FreeBSD) fails because some of the syscalls that we use for ref leaks instrumentation aren't available.

This replaces those with panics on non-Linux, non-Darwin OSes, and adds a check on config validation.

It also adds a CI job matrix to check that `make dist` works.

#### Which issue(s) this PR fixes or relates to

—

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes release build tooling/CI behavior and introduces OS-specific build-tagged code paths for `mimirpb` reference-leak instrumentation, which could affect cross-platform builds and validation.
> 
> **Overview**
> **Fixes cross-platform `make dist` failures** by isolating reference-leak instrumentation syscalls behind build-tagged wrappers (`ref_leaks_supported.go` / `ref_leaks_unsupported.go`) and adding config validation that rejects enabling instrumentation on unsupported OSes.
> 
> **Improves release build coverage** by adding a `Makefile` target (`print-supported-os-arch`) and updating `dist` to support filtering by command-line `GOOS`/`GOARCH`, then wiring a new GitHub Actions `build-dist` matrix job to run `make dist` for each supported OS/arch and making the aggregate `build` job depend on it. A changelog entry documents the Windows/FreeBSD fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52c0adcb433b9a2db11ab8abf907c86e9ec96aa8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->