### PR TITLE
compactor scheduler: add last pending empty metric

### DIFF
--- a/pkg/compactor/scheduler/metrics.go
+++ b/pkg/compactor/scheduler/metrics.go
@@ -16,13 +16,14 @@ const (
 )
 
 type schedulerMetrics struct {
-	pendingJobs         *prometheus.GaugeVec
-	pendingJobsByUser   *prometheus.GaugeVec
-	incompleteJobsBytes *prometheus.GaugeVec
-	activeJobs          *prometheus.GaugeVec
-	activeJobsByUser    *prometheus.GaugeVec
-	jobsCompleted       *prometheus.CounterVec
-	repeatedJobFailures prometheus.Counter
+	pendingJobs          *prometheus.GaugeVec
+	pendingJobsByUser    *prometheus.GaugeVec
+	pendingJobsLastEmpty prometheus.Gauge
+	incompleteJobsBytes  *prometheus.GaugeVec
+	activeJobs           *prometheus.GaugeVec
+	activeJobsByUser     *prometheus.GaugeVec
+	jobsCompleted        *prometheus.CounterVec
+	repeatedJobFailures  prometheus.Counter
 }
 
 func newSchedulerMetrics(reg prometheus.Registerer) *schedulerMetrics {
@@ -35,6 +36,10 @@ func newSchedulerMetrics(reg prometheus.Registerer) *schedulerMetrics {
 			Name: "cortex_compactor_scheduler_pending_jobs_by_user",
 			Help: "The number of queued pending jobs, broken down by user.",
 		}, []string{"user"}),
+		pendingJobsLastEmpty: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Name: "cortex_compactor_scheduler_pending_jobs_last_empty_timestamp_seconds",
+			Help: "Unix timestamp of the last time there were no pending jobs remaining.",
+		}),
 		incompleteJobsBytes: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cortex_compactor_scheduler_incomplete_compaction_jobs_bytes",
 			Help: "The total bytes of blocks in compaction jobs that have not yet completed (pending or active).",

--- a/pkg/compactor/scheduler/rotator.go
+++ b/pkg/compactor/scheduler/rotator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/services"
+	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/atomic"
 
 	"github.com/grafana/mimir/pkg/compactor/scheduler/compactorschedulerpb"
@@ -45,6 +46,7 @@ type Rotator struct {
 	intervalsBeforeColdStartPlanning int
 	clock                            clock.Clock
 	rotationIndexCounter             *atomic.Int32 // only increments, overflow is okay
+	lastPendingEmptyTime             prometheus.Gauge
 	logger                           log.Logger
 
 	mtx            sync.RWMutex
@@ -57,7 +59,7 @@ type TenantRotationState struct {
 	rotationIndex int
 }
 
-func NewRotator(leaseDuration, planningInterval, compactionWaitPeriod, maintenanceInterval time.Duration, intervalsBeforeLeaseExpiration, intervalsBeforeColdStartPlanning int, logger log.Logger) *Rotator {
+func NewRotator(leaseDuration, planningInterval, compactionWaitPeriod, maintenanceInterval time.Duration, intervalsBeforeLeaseExpiration, intervalsBeforeColdStartPlanning int, lastPendingEmptyTime prometheus.Gauge, logger log.Logger) *Rotator {
 	r := &Rotator{
 		leaseDuration:                    leaseDuration,
 		planningInterval:                 planningInterval,
@@ -67,6 +69,7 @@ func NewRotator(leaseDuration, planningInterval, compactionWaitPeriod, maintenan
 		intervalsBeforeColdStartPlanning: intervalsBeforeColdStartPlanning,
 		clock:                            clock.New(),
 		rotationIndexCounter:             atomic.NewInt32(0),
+		lastPendingEmptyTime:             lastPendingEmptyTime,
 		mtx:                              sync.RWMutex{},
 		tenantStateMap:                   make(map[string]*TenantRotationState),
 		rotation:                         make([]string, 0, 10), // initial size doesn't really matter
@@ -143,6 +146,10 @@ func (r *Rotator) RecoverFrom(jobTrackers map[string]*JobTracker, creationTime t
 		if !jobTracker.isPendingEmpty() {
 			r.addToRotation(tenant, rotationState)
 		}
+	}
+
+	if len(r.rotation) == 0 {
+		r.lastPendingEmptyTime.Set(float64(r.clock.Now().Unix()))
 	}
 }
 
@@ -350,10 +357,16 @@ func (r *Rotator) Maintenance(ctx context.Context, enforceLeaseExpiration, plan 
 			addRotationFor = append(addRotationFor, tenant)
 		}
 	}
+	stayingEmpty := len(addRotationFor) == 0 && len(r.rotation) == 0
 	r.mtx.RUnlock()
 
 	if len(addRotationFor) == 0 || ctx.Err() != nil {
 		// No tenant needs to be moved into the rotation or we're shutting down and don't care
+		if stayingEmpty && ctx.Err() == nil {
+			// Ensures periodic updates for the time we last saw an empty queue rather than only on transition.
+			// The context check is to ensure we don't update this when mid-shutdown.
+			r.lastPendingEmptyTime.Set(float64(r.clock.Now().Unix()))
+		}
 		return
 	}
 
@@ -397,4 +410,8 @@ func (r *Rotator) removeFromRotation(tenantState *TenantRotationState) {
 	// Remove the tenant from the rotation
 	r.rotation = r.rotation[:length-1]
 	tenantState.rotationIndex = outsideRotation
+
+	if len(r.rotation) == 0 {
+		r.lastPendingEmptyTime.Set(float64(r.clock.Now().Unix()))
+	}
 }

--- a/pkg/compactor/scheduler/rotator.go
+++ b/pkg/compactor/scheduler/rotator.go
@@ -46,7 +46,7 @@ type Rotator struct {
 	intervalsBeforeColdStartPlanning int
 	clock                            clock.Clock
 	rotationIndexCounter             *atomic.Int32 // only increments, overflow is okay
-	lastPendingEmptyTime             prometheus.Gauge
+	pendingJobsLastEmpty             prometheus.Gauge
 	logger                           log.Logger
 
 	mtx            sync.RWMutex
@@ -59,7 +59,7 @@ type TenantRotationState struct {
 	rotationIndex int
 }
 
-func NewRotator(leaseDuration, planningInterval, compactionWaitPeriod, maintenanceInterval time.Duration, intervalsBeforeLeaseExpiration, intervalsBeforeColdStartPlanning int, lastPendingEmptyTime prometheus.Gauge, logger log.Logger) *Rotator {
+func NewRotator(leaseDuration, planningInterval, compactionWaitPeriod, maintenanceInterval time.Duration, intervalsBeforeLeaseExpiration, intervalsBeforeColdStartPlanning int, pendingJobsLastEmpty prometheus.Gauge, logger log.Logger) *Rotator {
 	r := &Rotator{
 		leaseDuration:                    leaseDuration,
 		planningInterval:                 planningInterval,
@@ -69,7 +69,7 @@ func NewRotator(leaseDuration, planningInterval, compactionWaitPeriod, maintenan
 		intervalsBeforeColdStartPlanning: intervalsBeforeColdStartPlanning,
 		clock:                            clock.New(),
 		rotationIndexCounter:             atomic.NewInt32(0),
-		lastPendingEmptyTime:             lastPendingEmptyTime,
+		pendingJobsLastEmpty:             pendingJobsLastEmpty,
 		mtx:                              sync.RWMutex{},
 		tenantStateMap:                   make(map[string]*TenantRotationState),
 		rotation:                         make([]string, 0, 10), // initial size doesn't really matter
@@ -149,7 +149,7 @@ func (r *Rotator) RecoverFrom(jobTrackers map[string]*JobTracker, creationTime t
 	}
 
 	if len(r.rotation) == 0 {
-		r.lastPendingEmptyTime.Set(float64(r.clock.Now().Unix()))
+		r.pendingJobsLastEmpty.Set(float64(r.clock.Now().Unix()))
 	}
 }
 
@@ -365,7 +365,7 @@ func (r *Rotator) Maintenance(ctx context.Context, enforceLeaseExpiration, plan 
 		if stayingEmpty && ctx.Err() == nil {
 			// Ensures periodic updates for the time we last saw an empty queue rather than only on transition.
 			// The context check is to ensure we don't update this when mid-shutdown.
-			r.lastPendingEmptyTime.Set(float64(r.clock.Now().Unix()))
+			r.pendingJobsLastEmpty.Set(float64(r.clock.Now().Unix()))
 		}
 		return
 	}
@@ -412,6 +412,6 @@ func (r *Rotator) removeFromRotation(tenantState *TenantRotationState) {
 	tenantState.rotationIndex = outsideRotation
 
 	if len(r.rotation) == 0 {
-		r.lastPendingEmptyTime.Set(float64(r.clock.Now().Unix()))
+		r.pendingJobsLastEmpty.Set(float64(r.clock.Now().Unix()))
 	}
 }

--- a/pkg/compactor/scheduler/rotator_test.go
+++ b/pkg/compactor/scheduler/rotator_test.go
@@ -3,11 +3,16 @@
 package scheduler
 
 import (
+	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/benbjohnson/clock"
 	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	prom_testutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -63,11 +68,70 @@ func TestRotator_RecoverFrom_ColdStartDelay(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			r := NewRotator(0, 0, 0, maintenanceInterval, 0, intervalsBeforeColdStartPlanning, log.NewNopLogger())
+			reg := prometheus.NewPedanticRegistry()
+			metrics := newSchedulerMetrics(reg)
+			r := NewRotator(0, 0, 0, maintenanceInterval, 0, intervalsBeforeColdStartPlanning, metrics.pendingJobsLastEmpty, log.NewNopLogger())
 			r.clock = clock
 
 			r.RecoverFrom(tc.jobTrackers, tc.creationTime)
 			require.Equal(t, tc.expectedIntervals, r.intervalsBeforeColdStartPlanning)
+		})
+	}
+}
+
+func TestRotator_LastEmptyQueueMetric(t *testing.T) {
+	now := time.Now()
+
+	pendingTracker := func(clk clock.Clock) *JobTracker {
+		jt, _ := newTestJobTracker(clk)
+		jt.incompleteJobs[planJobId] = jt.pending.PushBack(NewTrackedPlanJob(clk.Now()))
+		return jt
+	}
+
+	tests := map[string]struct {
+		action   func(r *Rotator, clk *clock.Mock)
+		expected int64
+	}{
+		"recovery with no pending jobs": {
+			action:   func(r *Rotator, _ *clock.Mock) { r.RecoverFrom(nil, now) },
+			expected: now.Unix(),
+		},
+		"recovery with pending jobs leaves metric at 0": {
+			action: func(r *Rotator, clk *clock.Mock) {
+				r.RecoverFrom(map[string]*JobTracker{"t1": pendingTracker(clk)}, now)
+			},
+			expected: 0,
+		},
+		"maintenance over empty rotation": {
+			action:   func(r *Rotator, _ *clock.Mock) { r.Maintenance(context.Background(), false, false) },
+			expected: now.Unix(),
+		},
+		"removing the last tenant in rotation": {
+			action: func(r *Rotator, clk *clock.Mock) {
+				r.AddTenant("t1", pendingTracker(clk))
+				_, _ = r.RemoveTenant("t1")
+			},
+			expected: now.Unix(),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			clk := clock.NewMock()
+			clk.Set(now)
+			reg := prometheus.NewPedanticRegistry()
+			metrics := newSchedulerMetrics(reg)
+			r := NewRotator(0, 0, 0, 0, 0, 0, metrics.pendingJobsLastEmpty, log.NewNopLogger())
+			r.clock = clk
+
+			tc.action(r, clk)
+
+			metricName := "cortex_compactor_scheduler_pending_jobs_last_empty_timestamp_seconds"
+			require.NoError(t, prom_testutil.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
+				# HELP %s Unix timestamp of the last time there were no pending jobs remaining.
+				# TYPE %s gauge
+				%s %d
+			`, metricName, metricName, metricName, tc.expected)), metricName))
 		})
 	}
 }

--- a/pkg/compactor/scheduler/rotator_test.go
+++ b/pkg/compactor/scheduler/rotator_test.go
@@ -79,7 +79,7 @@ func TestRotator_RecoverFrom_ColdStartDelay(t *testing.T) {
 	}
 }
 
-func TestRotator_LastEmptyQueueMetric(t *testing.T) {
+func TestRotator_PendingJobsLastEmpty(t *testing.T) {
 	now := time.Now()
 
 	pendingTracker := func(clk clock.Clock) *JobTracker {

--- a/pkg/compactor/scheduler/scheduler.go
+++ b/pkg/compactor/scheduler/scheduler.go
@@ -147,6 +147,7 @@ func newCompactorScheduler(
 		cfg.MaintenanceInterval,
 		cfg.MaintenanceIntervalsBeforeLeaseExpiration,
 		cfg.MaintenanceIntervalsBeforeColdStartPlanning,
+		metrics.pendingJobsLastEmpty,
 		logger,
 	)
 


### PR DESCRIPTION
#### What this PR does

Adds a metric in the compactor scheduler to track times when there were no pending jobs. It is left as zero (unknown) if there are existing pending jobs upon recovery.

The intended use would be to help with autoscaling if we have not cleared the queue in a long time.

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new Prometheus gauge and threads it through the scheduler/rotator with small, well-tested updates to when it’s set, without changing job leasing semantics.
> 
> **Overview**
> Adds a new Prometheus gauge, `cortex_compactor_scheduler_pending_jobs_last_empty_timestamp_seconds`, to record the **last time the scheduler’s pending-job rotation became (or remained) empty**.
> 
> Threads this metric into `Rotator` via `NewRotator(...)` and updates it on startup recovery when no pending work exists, when the last tenant is removed from rotation, and periodically during maintenance while the rotation stays empty; tests are expanded to assert the gauge behavior (including staying `0` when recovery finds pending jobs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f0f408c545c7f3ae8534961c496645399b504cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->