### PR TITLE
Make max concurrency for label values count endpoint configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [ENHANCEMENT] MQE: Simplify `unless` and `or` operations where one side can be proven to be empty by inspecting the expression. #15198
 * [ENHANCEMENT] Store-gateway: Remove outdated limit on caching LabelValues responses that contain more than 655360 values. The gob library panic which required workaround was fixed. #5021 #15271
 * [ENHANCEMENT] MQE: Reduce memory consumption of range vector splitting when many consecutive intervals are not cached. #15173
+* [ENHANCEMENT] Ingester: Make max concurrency for label values count endpoint configurable with `-ingester.label-values-count-max-concurrency`. #15299
 * [BUGFIX] Ingest storage: Fix `KafkaProducer.ProduceSync()` returning a single result with a nil record when the context is canceled, instead of one result per input record (with the record set) as the underlying franz-go client does. #15199
 * [BUGFIX] Distributor: Return HTTP 200 with OTLP partial-success when only some samples in an OTLP request are rejected by distributor-level validation (e.g. `too_far_in_past`). #15253
 * [BUGFIX] Querier: Fix querier ScaledObjects native histogram querying and triggering `MimirAutoscalerKedaFailing` when queriers have no traffic because `cortex_querier_request_duration_seconds_sum` is not published until the first request is received. #15106

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -5333,6 +5333,17 @@
           ],
           "fieldValue": null,
           "fieldDefaultValue": null
+        },
+        {
+          "kind": "field",
+          "name": "label_values_count_request_max_concurrency",
+          "required": false,
+          "desc": "Maximum concurrency used to compute a single label values count request.",
+          "fieldValue": null,
+          "fieldDefaultValue": 16,
+          "fieldFlag": "ingester.label-values-count-max-concurrency",
+          "fieldType": "int",
+          "fieldCategory": "experimental"
         }
       ],
       "fieldValue": null,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1693,6 +1693,8 @@ Usage of ./cmd/mimir/mimir:
     	Max series that this ingester can hold (across all tenants). Requests to create additional series will be rejected. 0 = unlimited.
   -ingester.instance-limits.max-tenants int
     	Max tenants that this ingester can hold. Requests from additional tenants will be rejected. 0 = unlimited.
+  -ingester.label-values-count-max-concurrency int
+    	[experimental] Maximum concurrency used to compute a single label values count request. (default 16)
   -ingester.max-global-exemplars-per-user int
     	[experimental] The maximum number of exemplars in memory, across the cluster. 0 to disable exemplars ingestion.
   -ingester.max-global-metadata-per-metric int

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -1699,6 +1699,11 @@ read_reactive_limiter:
   # current inflight requests, after which all requests are rejected
   # CLI flag: -ingester.read-reactive-limiter.max-rejection-factor
   [max_rejection_factor: <float> | default = 3]
+
+# (experimental) Maximum concurrency used to compute a single label values count
+# request.
+# CLI flag: -ingester.label-values-count-max-concurrency
+[label_values_count_request_max_concurrency: <int> | default = 16]
 ```
 
 ### querier

--- a/operations/mimir/mimir-flags-defaults.json
+++ b/operations/mimir/mimir-flags-defaults.json
@@ -365,6 +365,7 @@
   "ingester.read-reactive-limiter.correlation-window": 50,
   "ingester.read-reactive-limiter.initial-rejection-factor": 2,
   "ingester.read-reactive-limiter.max-rejection-factor": 3,
+  "ingester.label-values-count-max-concurrency": 16,
   "distributor.request-rate-limit": 0,
   "distributor.request-burst-size": 0,
   "distributor.ingestion-rate-limit": 10000,

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -186,6 +186,8 @@ type Config struct {
 	PushReactiveLimiter  reactivelimiter.Config            `yaml:"push_reactive_limiter"`
 	ReadReactiveLimiter  reactivelimiter.Config            `yaml:"read_reactive_limiter"`
 
+	LabelValuesCountRequestMaxConcurrency int `yaml:"label_values_count_request_max_concurrency" category:"experimental"`
+
 	PushGrpcMethodEnabled bool `yaml:"push_grpc_method_enabled" category:"experimental" doc:"hidden"`
 
 	// This config is dynamically injected because defined outside the ingester config.
@@ -217,6 +219,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.BoolVar(&cfg.UseIngesterOwnedSeriesForLimits, "ingester.use-ingester-owned-series-for-limits", false, "When enabled, only series currently owned by ingester according to the ring are used when checking user per-tenant series limit.")
 	f.BoolVar(&cfg.UpdateIngesterOwnedSeries, "ingester.track-ingester-owned-series", false, "This option enables tracking of ingester-owned series based on ring state, even if -ingester.use-ingester-owned-series-for-limits is disabled.")
 	f.DurationVar(&cfg.OwnedSeriesUpdateInterval, "ingester.owned-series-update-interval", 15*time.Second, "How often to check for ring changes and possibly recompute owned series as a result of detected change.")
+	f.IntVar(&cfg.LabelValuesCountRequestMaxConcurrency, "ingester.label-values-count-max-concurrency", 16, "Maximum concurrency used to compute a single label values count request.")
 	f.BoolVar(&cfg.PushGrpcMethodEnabled, "ingester.push-grpc-method-enabled", true, "Enables Push gRPC method on ingester. Can be only disabled when using ingest-storage to make sure ingesters only receive data from Kafka.")
 
 	// Hardcoded config (can only be overridden in tests).
@@ -231,6 +234,10 @@ func (cfg *Config) Validate(log.Logger) error {
 	// Tokenless mode requires gRPC push to be disabled.
 	if cfg.IngesterRing.NumTokens == 0 && cfg.PushGrpcMethodEnabled {
 		return fmt.Errorf("ring tokens can only be disabled when gRPC push is disabled")
+	}
+
+	if cfg.LabelValuesCountRequestMaxConcurrency < 1 {
+		return errors.New("label values count request max concurrency must be greater than 0")
 	}
 
 	if err := cfg.PushReactiveLimiter.Validate(); err != nil {

--- a/pkg/ingester/ingester_query.go
+++ b/pkg/ingester/ingester_query.go
@@ -497,6 +497,7 @@ func (i *Ingester) LabelValuesCardinality(req *client.LabelValuesCardinalityRequ
 		idx,
 		postingsForMatchersFn,
 		labelValuesCardinalityTargetSizeBytes,
+		i.cfg.LabelValuesCountRequestMaxConcurrency,
 		srv,
 	)
 }

--- a/pkg/ingester/label_names_and_values.go
+++ b/pkg/ingester/label_names_and_values.go
@@ -119,6 +119,7 @@ func labelValuesCardinality(
 	idxReader tsdb.IndexReader,
 	postingsForMatchersFn func(context.Context, tsdb.IndexPostingsReader, ...*labels.Matcher) (index.Postings, error),
 	msgSizeThreshold int,
+	concurrency int,
 	srv client.Ingester_LabelValuesCardinalityServer,
 ) error {
 	ctx := srv.Context()
@@ -139,7 +140,7 @@ func labelValuesCardinality(
 		// For each value count total number of series storing the result into cardinality response item.
 		var respItem *client.LabelValueSeriesCount
 
-		resultCh := computeLabelValuesSeriesCount(ctx, lblName, lblValues, matchers, idxReader, postingsForMatchersFn)
+		resultCh := computeLabelValuesSeriesCount(ctx, lblName, lblValues, matchers, idxReader, postingsForMatchersFn, concurrency)
 
 		for countRes := range resultCh {
 			if countRes.err != nil {
@@ -185,8 +186,8 @@ func computeLabelValuesSeriesCount(
 	matchers []*labels.Matcher,
 	idxReader tsdb.IndexReader,
 	postingsForMatchersFn func(context.Context, tsdb.IndexPostingsReader, ...*labels.Matcher) (index.Postings, error),
+	maxConcurrency int,
 ) <-chan labelValueCountResult {
-	maxConcurrency := 16
 	if len(lblValues) < maxConcurrency {
 		maxConcurrency = len(lblValues)
 	}


### PR DESCRIPTION
#### What this PR does

This PR introduces a CLI flag to make the maximum concurrency used by the label values count endpoint configurable.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to plumbing a new ingester config/flag into the label values count endpoint and validating it, with no data model or protocol changes.
> 
> **Overview**
> Adds an *experimental* ingester setting/CLI flag, `-ingester.label-values-count-max-concurrency` (default `16`), to control the parallelism used when computing `LabelValuesCardinality` (label values series-count) results.
> 
> Wires the new config through the ingester query path into `computeLabelValuesSeriesCount`, removes the previously hardcoded concurrency constant, and adds config validation to reject values `< 1`. Documentation/flag descriptors/defaults and the changelog are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0910e19ddda1c43b56a5af6bd0ad42b0c1fa940f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->