### PR TITLE
Add cortex_querier_inflight_query_max_age_seconds metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [FEATURE] Mimirtool: Add AWS Signature Version 4 (SigV4) support for shared Mimir API client commands including `mimirtool rules`, `mimirtool alertmanager`, `mimirtool alerts`, `mimirtool backfill`, and `mimirtool analyze ruler`. #14959
 * [FEATURE] MQE: Add experimental support for reporting the number of samples read per query. #15276
+* [FEATURE] Querier: Add `cortex_querier_inflight_query_max_age_seconds` metric reporting the age of the oldest in-flight query memory consumption tracker, to help detect stale or stuck queries. #15299
 * [ENHANCEMENT] Distributor: Relabel middleware returns early if neither label dropping nor relabeling is configured. #15246
 * [ENHANCEMENT] Distributor: Improve distributor push middleware cleanup handling. #15245
 * [ENHANCEMENT] MQE: Improve experimental support for reporting the number of samples read per query. #15179 #15220 #15223 #15232 #15237 #15255 #15285

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * [FEATURE] Mimirtool: Add AWS Signature Version 4 (SigV4) support for shared Mimir API client commands including `mimirtool rules`, `mimirtool alertmanager`, `mimirtool alerts`, `mimirtool backfill`, and `mimirtool analyze ruler`. #14959
 * [FEATURE] MQE: Add experimental support for reporting the number of samples read per query. #15276
-* [FEATURE] Querier: Add `cortex_querier_inflight_query_max_age_seconds` metric reporting the age of the oldest in-flight query memory consumption tracker, to help detect stale or stuck queries. #15299
+* [FEATURE] MQE: Add `cortex_querier_inflight_query_max_age_seconds` metric reporting the age of the oldest in-flight query memory consumption tracker. #15300
 * [ENHANCEMENT] Distributor: Relabel middleware returns early if neither label dropping nor relabeling is configured. #15246
 * [ENHANCEMENT] Distributor: Improve distributor push middleware cleanup handling. #15245
 * [ENHANCEMENT] MQE: Improve experimental support for reporting the number of samples read per query. #15179 #15220 #15223 #15232 #15237 #15255 #15285

--- a/pkg/frontend/querymiddleware/split_and_cache_test.go
+++ b/pkg/frontend/querymiddleware/split_and_cache_test.go
@@ -237,6 +237,9 @@ func TestSplitAndCacheMiddleware_SplitByInterval(t *testing.T) {
 		# HELP cortex_querier_inflight_query_current_estimated_memory_consumption_bytes Total current estimated memory consumption across all in-flight queries.
 		# TYPE cortex_querier_inflight_query_current_estimated_memory_consumption_bytes gauge
 		cortex_querier_inflight_query_current_estimated_memory_consumption_bytes 0
+		# HELP cortex_querier_inflight_query_max_age_seconds Age in seconds of the oldest in-flight query memory consumption tracker. Zero when there are no in-flight queries.
+		# TYPE cortex_querier_inflight_query_max_age_seconds gauge
+		cortex_querier_inflight_query_max_age_seconds 0
 		# HELP cortex_querier_inflight_query_max_estimated_memory_consumption_limit_bytes Total of the max estimated memory consumption limit across all in-flight queries.
 		# TYPE cortex_querier_inflight_query_max_estimated_memory_consumption_limit_bytes gauge
 		cortex_querier_inflight_query_max_estimated_memory_consumption_limit_bytes 0
@@ -396,6 +399,9 @@ func TestSplitAndCacheMiddleware_ResultsCache(t *testing.T) {
 		# HELP cortex_querier_inflight_query_current_estimated_memory_consumption_bytes Total current estimated memory consumption across all in-flight queries.
 		# TYPE cortex_querier_inflight_query_current_estimated_memory_consumption_bytes gauge
 		cortex_querier_inflight_query_current_estimated_memory_consumption_bytes 0
+		# HELP cortex_querier_inflight_query_max_age_seconds Age in seconds of the oldest in-flight query memory consumption tracker. Zero when there are no in-flight queries.
+		# TYPE cortex_querier_inflight_query_max_age_seconds gauge
+		cortex_querier_inflight_query_max_age_seconds 0
 		# HELP cortex_querier_inflight_query_max_estimated_memory_consumption_limit_bytes Total of the max estimated memory consumption limit across all in-flight queries.
 		# TYPE cortex_querier_inflight_query_max_estimated_memory_consumption_limit_bytes gauge
 		cortex_querier_inflight_query_max_estimated_memory_consumption_limit_bytes 0

--- a/pkg/util/limiter/memory_consumption.go
+++ b/pkg/util/limiter/memory_consumption.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/grafana/dskit/tracing"
 	"github.com/prometheus/client_golang/prometheus"
@@ -148,6 +149,11 @@ type InflightMemoryConsumptionTracker struct {
 	currentDesc *prometheus.Desc
 	peakDesc    *prometheus.Desc
 	sampledDesc *prometheus.Desc
+	maxAgeDesc  *prometheus.Desc
+
+	// now returns the current time. It is overridable so unit tests can deterministically
+	// stamp start times and compute ages. Production code uses time.Now.
+	now func() time.Time
 
 	// This is an optional counter which is passed to each MemoryConsumptionTracker instance.
 	// This metric is not registered by this tracker. MemoryConsumptionTrackers may increment this.
@@ -194,6 +200,12 @@ func NewInflightMemoryConsumptionTracker(reg prometheus.Registerer, queriesRejec
 			"Number of in-flight memory consumption trackers accumulated during the last metrics collection.",
 			nil, nil,
 		),
+		maxAgeDesc: prometheus.NewDesc(
+			"cortex_querier_inflight_query_max_age_seconds",
+			"Age in seconds of the oldest in-flight query memory consumption tracker. Zero when there are no in-flight queries.",
+			nil, nil,
+		),
+		now: time.Now,
 		// Note that we do not register this counter. We just keep a reference to this counter so the memory consumption trackers can update it.
 		queriesRejectedDueToPeakMemoryConsumption: queriesRejectedDueToPeakMemoryConsumption,
 	}
@@ -215,6 +227,7 @@ func (t *InflightMemoryConsumptionTracker) NewMemoryConsumptionTracker(ctx conte
 	}
 	tracker := NewMemoryConsumptionTracker(ctx, maxEstimatedMemoryConsumptionBytes, t.queriesRejectedDueToPeakMemoryConsumption, queryDescription)
 	tracker.producer = t
+	tracker.startTime = t.now()
 	t.inflight.Store(tracker, struct{}{})
 	return tracker
 }
@@ -243,26 +256,37 @@ func (t *InflightMemoryConsumptionTracker) Describe(ch chan<- *prometheus.Desc) 
 	ch <- t.currentDesc
 	ch <- t.peakDesc
 	ch <- t.sampledDesc
+	ch <- t.maxAgeDesc
 }
 
 // Collect implements prometheus.Collector. It aggregates memory consumption across all in-flight
 // queries and emits the gauge values.
 func (t *InflightMemoryConsumptionTracker) Collect(ch chan<- prometheus.Metric) {
 	var maxBytes, currentBytes, peakBytes float64
+	var oldestStart time.Time
 	sampled := 0
 	t.inflight.Range(func(key, _ any) bool {
 		tracker := key.(*MemoryConsumptionTracker)
 		maxBytes += float64(tracker.maxEstimatedMemoryConsumptionBytes)
 		currentBytes += float64(tracker.CurrentEstimatedMemoryConsumptionBytes())
 		peakBytes += float64(tracker.PeakEstimatedMemoryConsumptionBytes())
+		if oldestStart.IsZero() || tracker.startTime.Before(oldestStart) {
+			oldestStart = tracker.startTime
+		}
 		sampled++
 		return true
 	})
+
+	var maxAgeSeconds float64
+	if !oldestStart.IsZero() {
+		maxAgeSeconds = t.now().Sub(oldestStart).Seconds()
+	}
 
 	ch <- prometheus.MustNewConstMetric(t.maxDesc, prometheus.GaugeValue, maxBytes)
 	ch <- prometheus.MustNewConstMetric(t.currentDesc, prometheus.GaugeValue, currentBytes)
 	ch <- prometheus.MustNewConstMetric(t.peakDesc, prometheus.GaugeValue, peakBytes)
 	ch <- prometheus.MustNewConstMetric(t.sampledDesc, prometheus.GaugeValue, float64(sampled))
+	ch <- prometheus.MustNewConstMetric(t.maxAgeDesc, prometheus.GaugeValue, maxAgeSeconds)
 }
 
 // IsTracking returns true if the given tracker is being actively tracked by this InflightMemoryConsumptionTracker.
@@ -314,6 +338,11 @@ type MemoryConsumptionTracker struct {
 	producer *InflightMemoryConsumptionTracker
 
 	parent *MemoryConsumptionTracker
+
+	// startTime is the time at which this tracker became in-flight. It is only set on managed
+	// trackers (those created via InflightMemoryConsumptionTracker.NewMemoryConsumptionTracker)
+	// and is read by InflightMemoryConsumptionTracker.Collect to compute the max in-flight age.
+	startTime time.Time
 }
 
 // NewUnlimitedMemoryConsumptionTracker creates a new MemoryConsumptionTracker that track memory consumption but

--- a/pkg/util/limiter/memory_consumption_test.go
+++ b/pkg/util/limiter/memory_consumption_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -505,5 +506,90 @@ func TestMemoryTrackerNestedTrackers(t *testing.T) {
 		childTracker := tracker.NewNestedMemoryConsumptionTracker(context.Background(), "child")
 
 		require.PanicsWithValue(t, "cannot nest a tracker not created via a InflightMemoryConsumptionTracker", func() { childTracker.NewNestedMemoryConsumptionTracker(context.Background(), "child") })
+	})
+}
+
+func TestInflightMemoryConsumptionTracker_MaxAge(t *testing.T) {
+	const maxAgeMetric = "cortex_querier_inflight_query_max_age_seconds"
+
+	// fakeClock returns a controllable time source. Reading it never advances it; tests
+	// mutate the underlying time directly to simulate the passage of time.
+	type fakeClock struct {
+		t time.Time
+	}
+
+	newTracker := func(c *fakeClock) *InflightMemoryConsumptionTracker {
+		reg := prometheus.NewPedanticRegistry()
+		tt := NewInflightMemoryConsumptionTracker(reg, nil)
+		tt.now = func() time.Time { return c.t }
+		return tt
+	}
+
+	t.Run("no in-flight queries emits zero", func(t *testing.T) {
+		clock := &fakeClock{t: time.Unix(1_000_000, 0)}
+		tt := newTracker(clock)
+
+		reg := prometheus.NewPedanticRegistry()
+		reg.MustRegister(tt)
+
+		expected := `
+			# HELP cortex_querier_inflight_query_max_age_seconds Age in seconds of the oldest in-flight query memory consumption tracker. Zero when there are no in-flight queries.
+			# TYPE cortex_querier_inflight_query_max_age_seconds gauge
+			cortex_querier_inflight_query_max_age_seconds 0
+		`
+		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expected), maxAgeMetric))
+	})
+
+	t.Run("single in-flight query reports its age", func(t *testing.T) {
+		clock := &fakeClock{t: time.Unix(1_000_000, 0)}
+		tt := newTracker(clock)
+
+		reg := prometheus.NewPedanticRegistry()
+		reg.MustRegister(tt)
+
+		// Tracker is stamped with the clock's current time at registration.
+		_ = tt.NewMemoryConsumptionTracker(context.Background(), 0, "query1")
+		// Advance the clock by 30 seconds before collecting.
+		clock.t = clock.t.Add(30 * time.Second)
+
+		expected := `
+			# HELP cortex_querier_inflight_query_max_age_seconds Age in seconds of the oldest in-flight query memory consumption tracker. Zero when there are no in-flight queries.
+			# TYPE cortex_querier_inflight_query_max_age_seconds gauge
+			cortex_querier_inflight_query_max_age_seconds 30
+		`
+		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expected), maxAgeMetric))
+	})
+
+	t.Run("multiple in-flight queries report the oldest age", func(t *testing.T) {
+		clock := &fakeClock{t: time.Unix(1_000_000, 0)}
+		tt := newTracker(clock)
+
+		reg := prometheus.NewPedanticRegistry()
+		reg.MustRegister(tt)
+
+		// Register three trackers at different points in time so the oldest is 90s old at collection.
+		oldest := tt.NewMemoryConsumptionTracker(context.Background(), 0, "oldest")
+		clock.t = clock.t.Add(30 * time.Second)
+		_ = tt.NewMemoryConsumptionTracker(context.Background(), 0, "middle")
+		clock.t = clock.t.Add(30 * time.Second)
+		_ = tt.NewMemoryConsumptionTracker(context.Background(), 0, "newest")
+		// Advance to the collection time: oldest is now 90s old, newest is 30s old.
+		clock.t = clock.t.Add(30 * time.Second)
+
+		expected := `
+			# HELP cortex_querier_inflight_query_max_age_seconds Age in seconds of the oldest in-flight query memory consumption tracker. Zero when there are no in-flight queries.
+			# TYPE cortex_querier_inflight_query_max_age_seconds gauge
+			cortex_querier_inflight_query_max_age_seconds 90
+		`
+		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expected), maxAgeMetric))
+
+		// After deregistering the oldest, the next oldest (middle, 60s) should take over.
+		tt.Deregister(oldest)
+		expected = `
+			# HELP cortex_querier_inflight_query_max_age_seconds Age in seconds of the oldest in-flight query memory consumption tracker. Zero when there are no in-flight queries.
+			# TYPE cortex_querier_inflight_query_max_age_seconds gauge
+			cortex_querier_inflight_query_max_age_seconds 60
+		`
+		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expected), maxAgeMetric))
 	})
 }


### PR DESCRIPTION
#### What this PR does

This PR adds a new metric to the in-flight query memory consumption tracker to report on the maximum age of the inflight trackers. This can then be used to help detect stale or stuck trackers.  

The metric is emitted by the existing InflightMemoryConsumptionTracker.Collect path: each managed MemoryConsumptionTracker is stamped with a start time on registration, and Collect reports the maximum age across all in-flight trackers (0 when none are in flight).

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new Prometheus gauge and lightweight timestamp tracking in the in-flight memory tracker, with unit tests updated to cover the new behavior.
> 
> **Overview**
> Adds a new Prometheus gauge, `cortex_querier_inflight_query_max_age_seconds`, reporting the age of the oldest in-flight query memory-consumption tracker (or `0` when none are in flight).
> 
> `InflightMemoryConsumptionTracker` now timestamps managed trackers at creation (via a test-overridable `now` clock) and computes the max age during `Collect`; tests and metric expectation snapshots are updated accordingly, and the change is recorded in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cb7b7945a39efa993c2d0c1c2f9453d2e2e73ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->