### PR TITLE
feat(helm): allow injecting additional labels into mixin alerts and r…

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -30,6 +30,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
+* [ENHANCEMENT] Helm: Allow injecting additional labels into mixin alerts and rules via `additionalRuleLabels`.
 * [CHANGE] Kafka: Removed `kafka.extraEnv`. Use `kafka.env` instead. #14892
 * [ENHANCEMENT] Kafka: Add `kafka.env` to let users selectively override default Kafka environment variables by name, following the same merge pattern used by other chart components (`ingester.env`, etc.). Individual defaults can be replaced in-place without discarding the rest of the list. #14892
 * [CHANGE] Update minimum supported Kubernetes version to 1.32. This reflects the fact that Grafana does not test with older versions of Kubernetes. #14335

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -30,7 +30,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
-* [ENHANCEMENT] Helm: Allow injecting additional labels into mixin alerts and rules via `additionalRuleLabels`.
+* [ENHANCEMENT] Helm: Allow injecting additional labels into mixin alerts and rules via `additionalRuleLabels`. #15303
 * [CHANGE] Kafka: Removed `kafka.extraEnv`. Use `kafka.env` instead. #14892
 * [ENHANCEMENT] Kafka: Add `kafka.env` to let users selectively override default Kafka environment variables by name, following the same merge pattern used by other chart components (`ingester.env`, etc.). Individual defaults can be replaced in-place without discarding the rest of the list. #14892
 * [CHANGE] Update minimum supported Kubernetes version to 1.32. This reflects the fact that Grafana does not test with older versions of Kubernetes. #14335

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -15,6 +15,20 @@ metadata:
     {{- end }}
   namespace: {{ .namespace | default $.Release.Namespace | quote }}
 spec:
+  {{- if .additionalRuleLabels }}
+  {{- $alertsDict := $.Files.Get "mixins/alerts.yaml" | fromYaml }}
+  {{- $extraLabels := .additionalRuleLabels }}
+  {{- range $group := $alertsDict.groups }}
+    {{- range $rule := $group.rules }}
+      {{- if $rule.alert }}
+        {{- $currentLabels := default (dict) $rule.labels }}
+        {{- $_ := set $rule "labels" (merge (dict) $extraLabels $currentLabels) }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+    {{- toYaml $alertsDict | nindent 2 }}
+  {{- else }}
     {{- $.Files.Get "mixins/alerts.yaml" | nindent 2 }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/metamonitoring/recording-rules.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/metamonitoring/recording-rules.yaml
@@ -15,6 +15,20 @@ metadata:
     {{- end }}
   namespace: {{ .namespace | default $.Release.Namespace | quote }}
 spec:
+  {{- if .additionalRuleLabels }}
+  {{- $rulesDict := $.Files.Get "mixins/rules.yaml" | fromYaml }}
+  {{- $extraLabels := .additionalRuleLabels }}
+  {{- range $group := $rulesDict.groups }}
+    {{- range $rule := $group.rules }}
+      {{- if $rule.record }}
+        {{- $currentLabels := default (dict) $rule.labels }}
+        {{- $_ := set $rule "labels" (merge (dict) $extraLabels $currentLabels) }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+    {{- toYaml $rulesDict | nindent 2 }}
+  {{- else }}
     {{- $.Files.Get "mixins/rules.yaml" | nindent 2 }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -3606,6 +3606,8 @@ metaMonitoring:
     # -- Create standard Mimir alerts in Prometheus Operator via a PrometheusRule CRD
     mimirAlerts: false
     # -- Create standard Mimir recording rules in Prometheus Operator via a PrometheusRule CRD
+    additionalRuleLabels: {}
+    # -- Additional labels to inject into each individual alerting and recording rule within the PrometheusRule CRD
     mimirRules: false
     # -- PrometheusRule annotations
     annotations: {}


### PR DESCRIPTION
#### What this PR does
Currently, the Helm chart for Mimir includes static alerting rules from mixins. While the `PrometheusRule` object itself can have labels, these labels are only applied at the metadata level. They are NOT propagated into the individual alerting or recording rules.

This PR updates the `mixin-alerts.yaml` and `mixin-rules.yaml` Helm templates. It processes the static files, parses them via `fromYaml`, and injects `additionalRuleLabels` (defined in `values.yaml`) into the actual rules. This allows users to rely on specific labels (like `service` or `team`) for seamless routing via `AlertmanagerConfig` CRDs.

#### Which issue(s) this PR fixes or relates to
Fixes [#8153](https://github.com/grafana/mimir/issues/8153)

#### Checklist
- [ ] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] `about-versioning.md` updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the rendered `PrometheusRule` spec by parsing and mutating mixin rule files to merge in user-provided labels, which could affect alert/rule selection and routing if misconfigured.
> 
> **Overview**
> Adds support for injecting user-defined `additionalRuleLabels` into each individual alerting and recording rule generated from the mixin files (not just the `PrometheusRule` metadata labels).
> 
> Updates the Helm templates for `mixin-alerts.yaml` and `recording-rules.yaml` to `fromYaml` the mixin content, merge in extra labels per rule, and re-emit the modified YAML; documents the new value in `values.yaml` and records the enhancement in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b8c64957bda5356e1f1af31c980483182629e96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->