### PR TITLE
ci(build-image): fix Dockerfile change detection on large PRs

### DIFF
--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -27,14 +27,24 @@ jobs:
       # We only want for this workflow to do anything when mimir-build-image/Dockerfile is modified.
       # However, we want for it to be able to run for all PRs, just so it can be made a required check
       # (i.e. so PRs can't be merged until it's done).
+      #
+      # We list changed files via the paginated PR Files API rather than `gh pr diff --name-only`
+      # because the latter caps at 300 files and returns HTTP 406 on larger PRs, in which case the
+      # script would silently fall into the "not modified" branch even when the Dockerfile was
+      # actually modified.
       - name: Check if mimir-build-image/Dockerfile was modified
         id: check_dockerfile
         run: |
-          if gh pr diff ${{ github.event.pull_request.number }} --name-only | grep -q '^mimir-build-image/Dockerfile$'; then
-            echo "modified=true" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          files=$(gh api --paginate \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[].filename')
+          if echo "$files" | grep -qx 'mimir-build-image/Dockerfile'; then
+            echo "modified=true" >> "$GITHUB_OUTPUT"
             echo "Dockerfile was modified"
           else
-            echo "modified=false" >> $GITHUB_OUTPUT
+            echo "modified=false" >> "$GITHUB_OUTPUT"
             echo "Dockerfile was not modified"
           fi
         env:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

`gh pr diff --name-only` caps at 300 files and returns HTTP 406 for larger PRs. When that happens, the check step silently concluds "Dockerfile was not modified" even when it has been changed, so the `build_and_push` job skips the rebuild and subsequent CI runs keeps using the stale build image (e.g. failing on tools added in the same PR).

Switch to the paginated PR Files API (`gh api --paginate`), which raises the ceiling to 3,000 files, and add `set -euo pipefail` so a future API failure fails the step loudly rather than silently misclassifying the PR.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change: updates how the workflow detects `mimir-build-image/Dockerfile` edits to avoid false negatives on large PRs and to fail loudly on API errors.
> 
> **Overview**
> Updates the `push-mimir-build-image` GitHub Actions workflow to detect changes to `mimir-build-image/Dockerfile` via the paginated PR Files API (`gh api --paginate`) instead of `gh pr diff --name-only`, avoiding the 300-file cap/HTTP 406 behavior on large PRs.
> 
> Adds `set -euo pipefail` and tightens output writing/grepping so failures in file listing don’t silently misclassify a PR as “not modified.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae60d3270525f61bd4f310ce82e516cb05c52159. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->