### PR TITLE
screenshots: Make DASHBOARDS_HISTOGRAM_MODE=native the default

### DIFF
--- a/operations/mimir-mixin-tools/screenshots/run.sh
+++ b/operations/mimir-mixin-tools/screenshots/run.sh
@@ -18,13 +18,16 @@ if [ ! -e "${SCRIPT_DIR}/.config" ]; then
   echo "MIMIR_NAMESPACE=\"<namespace-where-mimir-is-running>\""
   echo "ALERTMANAGER_NAMESPACE=\"<namespace-where-alertmanager-is-running>\""
   echo "MIMIR_USER=\"<mimir-tenant-id>\""
-  echo "DASHBOARDS_HISTOGRAM_MODE=\"native\" # Optional. Leave empty to provision the dashboards as already built."
+  echo "DASHBOARDS_HISTOGRAM_MODE=\"native\" # Optional. Defaults to 'native'. Set to 'inherit' to provision the dashboards as already built."
   echo ""
   exit 1
 fi
 
 # Load config.
 source "${SCRIPT_DIR}/.config"
+
+# Default to native histogram mode if not set in .config.
+DASHBOARDS_HISTOGRAM_MODE="${DASHBOARDS_HISTOGRAM_MODE:-native}"
 
 function cleanup() {
   echo "Cleaning up Docker setup"
@@ -46,8 +49,8 @@ trap cleanup EXIT
 
 DASHBOARDS_DIR="${SCRIPT_DIR}/../../mimir-mixin-compiled/dashboards"
 
-# If DASHBOARDS_HISTOGRAM_MODE is set, recompile the mixin with the desired mode.
-if [ -n "${DASHBOARDS_HISTOGRAM_MODE}" ]; then
+# If DASHBOARDS_HISTOGRAM_MODE is set to a real mode (not "inherit"), recompile the mixin with the desired mode.
+if [ "${DASHBOARDS_HISTOGRAM_MODE}" != "inherit" ]; then
   echo "Compiling mixin with dashboards_default_latency_mode='${DASHBOARDS_HISTOGRAM_MODE}'"
 
   TEMP_MIXIN_OUT=$(mktemp -d)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Make `DASHBOARDS_HISTOGRAM_MODE=native` the default for the screenshots tool.

The previous default behavior (screenshotting the dashboards as already compiled) is now explicit as `inherit`.

#### Which issue(s) this PR fixes or relates to

Follow-up of #15269

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change to a local screenshots helper script that only affects how dashboards are compiled for screenshot generation.
> 
> **Overview**
> The screenshots `run.sh` now defaults `DASHBOARDS_HISTOGRAM_MODE` to `native` when unset, and treats the previous behavior as an explicit `inherit` mode.
> 
> When the mode is not `inherit`, the script recompiles the mixin with the selected histogram mode; the config-file guidance text was updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9012295fe5a7f71acaa442b5fead5d1705b6d852. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->