### PR TITLE
storegateway: track cortex_bucket_store_bucket_index_version_diff_seconds

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1239,15 +1239,8 @@ func (s *BucketStore) recordBucketIndexDiscoveryDiff(ctx context.Context) {
 		level.Warn(spanlogger.FromContext(ctx, s.logger)).Log("msg", "can't get bucket index versions (updated_at) from request", "err", err)
 		return
 	}
-
-	meta := s.bucketIndexMeta.Metadata()
-	diff := meta.UpdatedAt - reqUpdatedAt
-
-	logger := log.With(spanlogger.FromContext(ctx, s.logger), "ours", meta.UpdatedAt, "requested", reqUpdatedAt, "diff", diff)
-	if diff < 0 {
-		level.Warn(logger).Log("msg", "bucket index version (updated_at) is older than requested")
-	} else {
-		level.Debug(logger).Log("msg", "bucket index versions (updated_at)")
+	if reqUpdatedAt > 0 {
+		s.metrics.bucketIndexVersionDiffSeconds.Observe(float64(s.bucketIndexMeta.Metadata().UpdatedAt - reqUpdatedAt))
 	}
 }
 

--- a/pkg/storegateway/bucket_store_metrics.go
+++ b/pkg/storegateway/bucket_store_metrics.go
@@ -38,6 +38,8 @@ type BucketStoreMetrics struct {
 	queriesDropped        *prometheus.CounterVec
 	seriesRefetches       prometheus.Counter
 
+	bucketIndexVersionDiffSeconds prometheus.Histogram
+
 	// Metrics tracked when streaming store-gateway is enabled.
 	streamingSeriesRequestDurationByStage      *prometheus.HistogramVec
 	streamingSeriesBatchPreloadingLoadDuration prometheus.Histogram
@@ -81,6 +83,14 @@ func NewBucketStoreMetrics(reg prometheus.Registerer) *BucketStoreMetrics {
 	m.blockDiscoveryLatency = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 		Name: "cortex_bucket_store_block_discovery_latency_seconds",
 		Help: "Time elapsed from when a block was created, based on its ULID timestamp, to when it was discovered.",
+
+		NativeHistogramBucketFactor:     1.1,
+		NativeHistogramMaxBucketNumber:  100,
+		NativeHistogramMinResetDuration: 1 * time.Hour,
+	})
+	m.bucketIndexVersionDiffSeconds = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+		Name: "cortex_bucket_store_bucket_index_version_diff_seconds",
+		Help: "Difference in seconds between the store-gateway's and the querier's bucket index version (updated_at). Negative values mean the store-gateway has an older version.",
 
 		NativeHistogramBucketFactor:     1.1,
 		NativeHistogramMaxBucketNumber:  100,


### PR DESCRIPTION
#### What this PR does

This is the follow-up to #14046

The original warning logs add noise and they aren't any actionable. We still want to keep track of the bucket-index discovery diff, so this PR replaces the warning with a metric.