### PR TITLE
compactor scheduler: account for delayed planning

### DIFF
--- a/pkg/compactor/scheduler/job_tracker.go
+++ b/pkg/compactor/scheduler/job_tracker.go
@@ -324,7 +324,7 @@ func (jt *JobTracker) computePlan(planningInterval, compactionWaitPeriod time.Du
 
 	// L1 blocks are expected on even UTC hours and the planning for them is affected by the compaction wait period.
 	// Instead of only accounting for that wait period on even hours, account for it all the time for a better spread.
-	nextPlanningWindow := jt.completePlanTime.Add(planningInterval).UTC().Truncate(planningInterval).Add(compactionWaitPeriod)
+	nextPlanningWindow := jt.completePlanTime.UTC().Add(-compactionWaitPeriod).Truncate(planningInterval).Add(planningInterval).Add(compactionWaitPeriod)
 
 	if now.Before(nextPlanningWindow) {
 		// This window has already been planned

--- a/pkg/compactor/scheduler/job_tracker_test.go
+++ b/pkg/compactor/scheduler/job_tracker_test.go
@@ -65,7 +65,7 @@ func TestJobTracker_Maintenance_Planning(t *testing.T) {
 		},
 		"skips within compaction wait period": {
 			setup: func(jt *JobTracker) {
-				// 3:30 + 1h = 4:30, truncate to 1h = 4:00, so 4:00 + compactionWaitPeriod
+				// (3:30 - 15m = 3:15).Truncate(1h) = 3:00, so 3:00 + 1h = 4:00 + compactionWaitPeriod
 				jt.completePlanTime = at(3, 30)
 			},
 			now: at(4, 0).Add(compactionWaitPeriod - time.Minute),
@@ -127,6 +127,23 @@ func TestJobTracker_Maintenance_Planning(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, transition)
 		require.NotContains(t, jt.incompleteJobs, planJobId)
+	})
+
+	t.Run("plans for next window when plan completion bleeds past interval boundary", func(t *testing.T) {
+		// Previous plan: 1:30 + 25m = 1:55 start time.
+		// If a plan completes at 2:03 (past the 2:00 boundary), the 2:00 + 25m = 2:25 should still be planned, not skipped.
+		const planInterval = 30 * time.Minute
+		const waitPeriod = 25 * time.Minute
+
+		clk := clock.NewMock()
+		clk.Set(at(2, 25))
+		jt, _ := newTestJobTracker(clk)
+		jt.completePlanTime = at(2, 3)
+
+		transition, err := jt.Maintenance(time.Minute, false, true, planInterval, waitPeriod)
+		require.NoError(t, err)
+		require.True(t, transition)
+		require.Contains(t, jt.incompleteJobs, planJobId)
 	})
 
 	t.Run("new plan job is leased ahead of existing pending compactions", func(t *testing.T) {

--- a/pkg/compactor/scheduler/job_tracker_test.go
+++ b/pkg/compactor/scheduler/job_tracker_test.go
@@ -140,7 +140,7 @@ func TestJobTracker_Maintenance_Planning(t *testing.T) {
 		jt, _ := newTestJobTracker(clk)
 		jt.completePlanTime = at(2, 3)
 
-		transition, err := jt.Maintenance(time.Minute, false, true, planInterval, waitPeriod)
+		transition, err := jt.Maintenance(leaseDuration, false, true, planInterval, waitPeriod)
 		require.NoError(t, err)
 		require.True(t, transition)
 		require.Contains(t, jt.incompleteJobs, planJobId)


### PR DESCRIPTION
#### What this PR does

When testing a `30m` planning interval and a `25m` compaction wait interval an issue arose when some plans took a bit longer to complete, causing them to be skipped for the next window.

<img width="250" height="200" alt="image" src="https://github.com/user-attachments/assets/d6b6f90c-ae5b-44d1-8a4e-2c470854b252" />

This fixes this by accounting for the compaction wait period and truncating first to calculate the previous window.

For a concrete example:
30m planning interval, 25m compaction wait interval, 13:35 previous plan completion time.

Now:
13:35 - 25m = 13:05, truncated to 13:00, next window is 13:00+30m+25m = 13:55.

Previously:
13:35 + 30m = 14:05, truncated to 14:00, 14:00+25m = 14:25.

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts time-window computation for plan-job scheduling; incorrect math could cause extra or missed planning runs, impacting compaction throughput/timing. Covered by updated and new unit tests, but it changes core scheduling behavior.
> 
> **Overview**
> Fixes plan-job scheduling so the next planning window is computed by *truncating the previous window first* (accounting for `compactionWaitPeriod`) rather than truncating after adding the interval, preventing windows from being skipped when a plan completes just after an interval boundary.
> 
> Updates planning tests to reflect the new window math and adds a regression test for the “completion bleeds past boundary” case with a `30m` planning interval and `25m` wait period.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92e2e3b59f617ee4cd5cf71957b2396466e287c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->