### PR TITLE
ci: declare permissions on changelog-check workflow

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, labeled, unlabeled]
 
+permissions:
+  contents: read         # actions/checkout
+  pull-requests: read    # `gh pr view --json labels` in the check-label step
+
 jobs:
   check-changelog:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`changelog-check.yml` runs on every PR, checks out the PR, then uses `gh pr view --json labels` to decide whether the changelog reference check is needed.

Scope:
- `contents: read` for `actions/checkout`
- `pull-requests: read` for the `gh pr view` call that reads `labels`

The other 19 workflows in `.github/workflows/` already declare `permissions:` (top-level or per-job); this brings `changelog-check.yml` in line.

YAML validates locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts GitHub Actions workflow permissions, narrowing/clarifying access without changing application code or data handling.
> 
> **Overview**
> Adds an explicit top-level `permissions` block to `.github/workflows/changelog-check.yml`, granting `contents: read` for `actions/checkout` and `pull-requests: read` for the `gh pr view --json labels` step.
> 
> This aligns the changelog-check workflow with the repo’s other workflows that already declare permissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14b3c7745d33c281a611be10e9d7319da89c4af2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->