### PR TITLE
MQE: disable benchmark comparison test

### DIFF
--- a/pkg/streamingpromql/benchmarks/comparison_test.go
+++ b/pkg/streamingpromql/benchmarks/comparison_test.go
@@ -93,6 +93,8 @@ func BenchmarkQuery(b *testing.B) {
 }
 
 func TestBothEnginesReturnSameResultsForBenchmarkQueries(t *testing.T) {
+	t.Skip("range queries with range selectors that overlap the query step are a pathological case for the CSE pass which causes this test to consume an excessive amount of memory")
+
 	metricSizes := []int{1, 100} // Don't bother with 2000 series test here: these test cases take a while and they're most interesting as benchmarks, not correctness tests.
 	q := createBenchmarkQueryable(t, metricSizes)
 	cases := TestCases(metricSizes)


### PR DESCRIPTION

#### What this PR does

Disable the benchmark test that compared results from Prometheus and MQE. This uses range selectors that overlap with the step of queries with causes the CSE pass to duplicate data and consume a huge amount of memory. There are other tests that compare results between the engines so we're not missing anything.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only disables a correctness test by unconditionally skipping it to avoid excessive memory usage; no production code paths change.
> 
> **Overview**
> Disables `TestBothEnginesReturnSameResultsForBenchmarkQueries` by adding an unconditional `t.Skip(...)`, preventing this benchmark-query comparison test from running due to excessive memory usage in a pathological range-selector/step overlap case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1bb07ef7510563d7ade521a3eb8193419f85468. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->