### PR TITLE
vendor v0.37.0 rollout-operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 ### Jsonnet
 
 * [CHANGE] Query-frontend: Increase default query-frontend cache size limit to 25MB. #14857
+* [ENHANCEMENT] Updated rollout-operator jsonnet library to v0.37.0. #15328
 
 ### Documentation
 

--- a/operations/mimir-tests/test-automated-downscale-v2-generated.yaml
+++ b/operations/mimir-tests/test-automated-downscale-v2-generated.yaml
@@ -268,6 +268,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -1140,7 +1141,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-autoscaling-store-gateway-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-store-gateway-generated.yaml
@@ -217,6 +217,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -1081,7 +1082,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-compactor-concurrent-rollout-generated.yaml
+++ b/operations/mimir-tests/test-compactor-concurrent-rollout-generated.yaml
@@ -189,6 +189,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -848,7 +849,8 @@ spec:
         - -kubernetes.namespace=default
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-compactor-concurrent-rollout-max-unavailable-percent-generated.yaml
+++ b/operations/mimir-tests/test-compactor-concurrent-rollout-max-unavailable-percent-generated.yaml
@@ -189,6 +189,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -848,7 +849,8 @@ spec:
         - -kubernetes.namespace=default
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -467,6 +467,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -1452,7 +1453,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-auto-client-rack-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-auto-client-rack-generated.yaml
@@ -233,6 +233,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -325,6 +332,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -1307,7 +1315,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-custom-stabilization-window-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-custom-stabilization-window-generated.yaml
@@ -284,6 +284,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -376,6 +383,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -1373,7 +1381,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-multiple-triggers-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-multiple-triggers-generated.yaml
@@ -307,6 +307,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -1304,7 +1305,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-one-trigger-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-one-trigger-generated.yaml
@@ -307,6 +307,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -1304,7 +1305,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-0-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-0-generated.yaml
@@ -233,6 +233,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -325,6 +332,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -1290,7 +1298,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-1-generated.yaml
@@ -233,6 +233,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -325,6 +332,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -1361,7 +1369,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
@@ -284,6 +284,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -376,6 +383,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -1350,7 +1358,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
@@ -284,6 +284,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -376,6 +383,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -1350,7 +1358,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-12-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-12-generated.yaml
@@ -284,6 +284,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -376,6 +383,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -1350,7 +1358,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
@@ -233,6 +233,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -325,6 +332,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -1369,7 +1377,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
@@ -233,6 +233,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -325,6 +332,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -1380,7 +1388,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
@@ -233,6 +233,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -325,6 +332,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -1379,7 +1387,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-5a-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-5a-generated.yaml
@@ -233,6 +233,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -325,6 +332,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -1379,7 +1387,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-5b-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-5b-generated.yaml
@@ -233,6 +233,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -325,6 +332,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -1379,7 +1387,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
@@ -233,6 +233,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -325,6 +332,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -1310,7 +1318,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
@@ -233,6 +233,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -325,6 +332,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -1314,7 +1322,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
@@ -233,6 +233,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -325,6 +332,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -1314,7 +1322,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
@@ -233,6 +233,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -325,6 +332,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -1291,7 +1299,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
@@ -284,6 +284,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -376,6 +383,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -1373,7 +1381,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-generated.yaml
@@ -402,6 +402,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -494,6 +501,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -2318,7 +2326,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-0-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-0-generated.yaml
@@ -272,6 +272,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -364,6 +371,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -1768,7 +1776,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-1-generated.yaml
@@ -532,6 +532,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -624,6 +631,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -3141,7 +3149,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2-generated.yaml
@@ -532,6 +532,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -624,6 +631,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -3190,7 +3198,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2a-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2a-generated.yaml
@@ -532,6 +532,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -624,6 +631,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -3190,7 +3198,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2b-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2b-generated.yaml
@@ -532,6 +532,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -624,6 +631,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -3190,7 +3198,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2c-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2c-generated.yaml
@@ -532,6 +532,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -624,6 +631,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -3190,7 +3198,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2d-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2d-generated.yaml
@@ -532,6 +532,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -624,6 +631,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -3190,7 +3198,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2e-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2e-generated.yaml
@@ -532,6 +532,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -624,6 +631,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -3167,7 +3175,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2f-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2f-generated.yaml
@@ -532,6 +532,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -624,6 +631,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -3167,7 +3175,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-3-generated.yaml
@@ -532,6 +532,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -624,6 +631,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -3167,7 +3175,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-4-generated.yaml
@@ -532,6 +532,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -624,6 +631,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -3167,7 +3175,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-5-generated.yaml
@@ -558,6 +558,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -650,6 +657,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -3229,7 +3237,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-6-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-6-generated.yaml
@@ -558,6 +558,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -650,6 +657,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -3229,7 +3237,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-7-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-7-generated.yaml
@@ -545,6 +545,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -637,6 +644,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -3198,7 +3206,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-8-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-8-generated.yaml
@@ -415,6 +415,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -507,6 +514,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -2518,7 +2526,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-final-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-final-generated.yaml
@@ -415,6 +415,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -507,6 +514,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -2518,7 +2526,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-write-path-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-write-path-generated.yaml
@@ -207,6 +207,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -299,6 +306,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -1306,7 +1314,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-write-path-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-write-path-migration-generated.yaml
@@ -220,6 +220,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -312,6 +319,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -1435,7 +1443,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -194,6 +194,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -286,6 +293,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -1150,7 +1158,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -220,6 +220,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -312,6 +319,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -1218,7 +1226,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
@@ -194,6 +194,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -286,6 +293,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -1150,7 +1158,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-pvc-auto-deletion-generated.yaml
+++ b/operations/mimir-tests/test-pvc-auto-deletion-generated.yaml
@@ -168,6 +168,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -260,6 +267,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -1084,7 +1092,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-range-vector-splitting-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-range-vector-splitting-multi-zone-generated.yaml
@@ -428,6 +428,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -520,6 +527,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -2402,7 +2410,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-replica-template-generated.yaml
+++ b/operations/mimir-tests/test-replica-template-generated.yaml
@@ -93,6 +93,13 @@ spec:
         properties:
           spec:
             properties:
+              crossZoneEvictionDelay:
+                description: An optional duration that defines the minimum time that
+                  must elapse after a pod returns to a ready state before another
+                  pod for the same partition can be evicted. The value must be a valid
+                  Go duration string (e.g. "20m", "1h"). This field is only applicable
+                  when podNamePartitionRegex is set.
+                type: string
               maxUnavailable:
                 description: The number of pods that can be unavailable within a zone
                   or partition.
@@ -185,6 +192,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -308,7 +316,8 @@ spec:
         - -server-tls.enabled=true
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
-        image: grafana/rollout-operator:v0.36.1
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.37.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir/jsonnetfile.json
+++ b/operations/mimir/jsonnetfile.json
@@ -35,7 +35,7 @@
           "subdir": "operations/rollout-operator"
         }
       },
-      "version": "v0.36.1"
+      "version": "v0.37.0"
     },
     {
       "source": {

--- a/operations/mimir/jsonnetfile.lock.json
+++ b/operations/mimir/jsonnetfile.lock.json
@@ -38,8 +38,19 @@
           "subdir": "operations/rollout-operator"
         }
       },
-      "version": "8da1b220cf28cb0cde805f30aae113ed57459949",
-      "sum": "t3nMMxw7cEOOmpdtKfadQRhvu2XQVvPigDq4CipmPIg="
+      "version": "196524018a531ab373af641cfd98af6d7be6f049",
+      "sum": "oCWkgEn08jQRkBnv6sczQaNJew+IPBp6HQCdiYhnz8U="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/jsonnet-libs/keda-libsonnet.git",
+          "subdir": "2.15"
+        }
+      },
+      "version": "dbc8cf1a9847f123d8325378111155fb135983ab",
+      "sum": "EVCNg9VpU9ghIYHZtbQffHbZs+EqKOD0cw+ZPilWR48=",
+      "name": "keda-libsonnet"
     },
     {
       "source": {

--- a/operations/mimir/jsonnetfile.lock.json
+++ b/operations/mimir/jsonnetfile.lock.json
@@ -44,17 +44,6 @@
     {
       "source": {
         "git": {
-          "remote": "https://github.com/jsonnet-libs/keda-libsonnet.git",
-          "subdir": "2.15"
-        }
-      },
-      "version": "dbc8cf1a9847f123d8325378111155fb135983ab",
-      "sum": "EVCNg9VpU9ghIYHZtbQffHbZs+EqKOD0cw+ZPilWR48=",
-      "name": "keda-libsonnet"
-    },
-    {
-      "source": {
-        "git": {
           "remote": "https://github.com/jsonnet-libs/xtd.git",
           "subdir": ""
         }


### PR DESCRIPTION
#### What this PR does

Vendor v0.37.0 rollout-operator.

Note that this PR has not vendored the update into mimir helm charts. This will be done in a separate PR after further validation of running this release. 

This PR has been prepared according to https://github.com/grafana/rollout-operator/blob/main/RELEASE.md

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bumps a core operational dependency (`rollout-operator`) and updates generated Kubernetes manifests/CRDs and RBAC, which can change rollout/eviction behavior at runtime.
> 
> **Overview**
> Vendors the `rollout-operator` Jsonnet library at `v0.37.0` (updates `jsonnetfile.json` and `jsonnetfile.lock.json`) and records the change in `CHANGELOG.md`.
> 
> Regenerates `operations/mimir-tests/*-generated.yaml` to use `grafana/rollout-operator:v0.37.0`, add `-zpdb.pod-ready-annotation-patch-timeout=5s`, grant `patch` on `pods`, and extend the `ZoneAwarePodDisruptionBudget` CRD schema with `spec.crossZoneEvictionDelay`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 905a4dc2f349818ddb2823458c5550a347ca97f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->