### PR TITLE
Add backfill support to copyblocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 ### Tools
 
+* [FEATURE] Copyblocks: add support for the block upload API as a copy destination. #15330
 * [ENHANCEMENT] Makefile: `build-mixin` and `mixin-screenshots` can now be configured to use native histograms for latency panels in dashboards. #15269
 
 ### Query-tee

--- a/integration/backfill_test.go
+++ b/integration/backfill_test.go
@@ -241,7 +241,7 @@ func TestBackfillSlowUploadSpeed(t *testing.T) {
 		// client.GetBlockMetaFromBucket will generate correct meta.json file ready for initiating upload of our block.
 		fsBkt, err := filesystem.NewBucket(tmpDir)
 		require.NoError(t, err)
-		meta, err := client.GetBlockMetaFromBucket(context.Background(), fsBkt, block)
+		meta, err := client.GetBlockMeta(context.Background(), fsBkt, block)
 		require.NoError(t, err)
 
 		buf := bytes.NewBuffer(nil)

--- a/integration/backfill_test.go
+++ b/integration/backfill_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
+	"github.com/thanos-io/objstore/providers/filesystem"
 	"golang.org/x/time/rate"
 
 	"github.com/grafana/mimir/integration/e2emimir"
@@ -237,8 +238,10 @@ func TestBackfillSlowUploadSpeed(t *testing.T) {
 
 	// Initiate new block upload.
 	{
-		// client.GetBlockMeta will generate correct meta.json file ready for initiating upload of our block.
-		meta, err := client.GetBlockMeta(fmt.Sprintf("%s/%s", tmpDir, block.String()))
+		// client.GetBlockMetaFromBucket will generate correct meta.json file ready for initiating upload of our block.
+		fsBkt, err := filesystem.NewBucket(tmpDir)
+		require.NoError(t, err)
+		meta, err := client.GetBlockMetaFromBucket(context.Background(), fsBkt, block)
 		require.NoError(t, err)
 
 		buf := bytes.NewBuffer(nil)

--- a/pkg/mimirtool/client/backfill.go
+++ b/pkg/mimirtool/client/backfill.go
@@ -25,6 +25,28 @@ import (
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
 )
 
+var ErrBlockInvalid = errors.New("block is invalid")
+
+func (c *MimirClient) doBackfillRequest(ctx context.Context, path, method string, payload io.Reader, contentLength int64) (*http.Response, error) {
+	req, resp, err := c.executeRequest(ctx, path, method, payload, contentLength)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode == http.StatusRequestEntityTooLarge || resp.StatusCode == http.StatusUnprocessableEntity {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("%w: %s %s: %s", ErrBlockInvalid, req.Method, req.URL.String(), body)
+	}
+
+	if err := c.checkResponse(resp); err != nil {
+		_ = resp.Body.Close()
+		return nil, errors.Wrapf(err, "%s request to %s failed", req.Method, req.URL.String())
+	}
+
+	return resp, nil
+}
+
 func (c *MimirClient) Backfill(ctx context.Context, blocks []string, sleepTime time.Duration) error {
 	// Upload each block
 	var succeeded, failed, alreadyExists int
@@ -113,7 +135,7 @@ func (c *MimirClient) backfillBlock(ctx context.Context, bkt objstore.BucketRead
 	if err := json.NewEncoder(buf).Encode(blockMeta); err != nil {
 		return errors.Wrap(err, "failed to JSON encode payload")
 	}
-	resp, err := c.doRequest(ctx, path.Join(endpointPrefix, url.PathEscape(blockIDStr), startBlockUpload), http.MethodPost, buf, int64(buf.Len()))
+	resp, err := c.doBackfillRequest(ctx, path.Join(endpointPrefix, url.PathEscape(blockIDStr), startBlockUpload), http.MethodPost, buf, int64(buf.Len()))
 	if err != nil {
 		return errors.Wrap(err, "request to start block upload failed")
 	}
@@ -132,7 +154,7 @@ func (c *MimirClient) backfillBlock(ctx context.Context, bkt objstore.BucketRead
 	}
 
 	for {
-		resp, err = c.doRequest(ctx, path.Join(endpointPrefix, url.PathEscape(blockIDStr), finishBlockUpload), http.MethodPost, nil, -1)
+		resp, err = c.doBackfillRequest(ctx, path.Join(endpointPrefix, url.PathEscape(blockIDStr), finishBlockUpload), http.MethodPost, nil, -1)
 		if err == nil {
 			drainAndCloseBody(resp)
 			break
@@ -161,7 +183,7 @@ func (c *MimirClient) backfillBlock(ctx context.Context, bkt objstore.BucketRead
 		}
 
 		if uploadResult.State == "failed" {
-			return errors.Errorf("block validation failed: %s", uploadResult.Error)
+			return fmt.Errorf("%w: block validation failed: %s", ErrBlockInvalid, uploadResult.Error)
 		}
 
 		// Sleep and then try to get the state again.
@@ -179,7 +201,7 @@ type result struct {
 }
 
 func (c *MimirClient) getBlockUpload(ctx context.Context, url string) (result, error) {
-	resp, err := c.doRequest(ctx, url, http.MethodGet, nil, -1)
+	resp, err := c.doBackfillRequest(ctx, url, http.MethodGet, nil, -1)
 	if err != nil {
 		return result{}, err
 	}
@@ -207,7 +229,7 @@ func (c *MimirClient) uploadBlockFileFromBucket(ctx context.Context, bkt objstor
 
 	level.Info(logctx).Log("msg", "uploading block file", "file", tf.RelPath, "size", tf.SizeBytes)
 
-	resp, err := c.doRequest(ctx, fmt.Sprintf("%s?path=%s", fileUploadEndpoint, url.QueryEscape(tf.RelPath)), http.MethodPost, r, tf.SizeBytes)
+	resp, err := c.doBackfillRequest(ctx, fmt.Sprintf("%s?path=%s", fileUploadEndpoint, url.QueryEscape(tf.RelPath)), http.MethodPost, r, tf.SizeBytes)
 	if err != nil {
 		return errors.Wrapf(err, "request to upload file %q failed", objectName)
 	}

--- a/pkg/mimirtool/client/backfill.go
+++ b/pkg/mimirtool/client/backfill.go
@@ -112,7 +112,6 @@ func drainAndCloseBody(resp *http.Response) {
 }
 
 func (c *MimirClient) backfillBlock(ctx context.Context, bkt objstore.BucketReader, blockID ulid.ULID, logctx log.Logger, sleepTime time.Duration) error {
-	// blockMeta returned by getBlockMetaFromBucket will have thanos.files section pre-populated.
 	blockMeta, err := GetBlockMeta(ctx, bkt, blockID)
 	if err != nil {
 		return err
@@ -209,12 +208,9 @@ func (c *MimirClient) getBlockUpload(ctx context.Context, url string) (result, e
 	defer drainAndCloseBody(resp)
 
 	var r result
-
-	dec := json.NewDecoder(resp.Body)
-	if err := dec.Decode(&r); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
 		return result{}, err
 	}
-
 	return r, nil
 }
 
@@ -244,7 +240,8 @@ func (c *MimirClient) uploadBlockFile(ctx context.Context, bkt objstore.BucketRe
 func GetBlockMeta(ctx context.Context, bkt objstore.BucketReader, blockID ulid.ULID) (block.Meta, error) {
 	var blockMeta block.Meta
 
-	metaPath := path.Join(blockID.String(), block.MetaFilename)
+	blockPrefix := blockID.String()
+	metaPath := path.Join(blockPrefix, block.MetaFilename)
 	r, err := bkt.Get(ctx, metaPath)
 	if err != nil {
 		return blockMeta, errors.Wrapf(err, "failed to read %q", metaPath)
@@ -264,37 +261,28 @@ func GetBlockMeta(ctx context.Context, bkt objstore.BucketReader, blockID ulid.U
 			block.MetaFilename, blockMeta.Version)
 	}
 
-	blockMeta.Thanos.Files = []block.File{
-		{
-			RelPath: block.MetaFilename,
-		},
-	}
+	blockMeta.Thanos.Files = []block.File{{RelPath: block.MetaFilename}}
 
-	relPaths := []string{block.IndexFilename}
-
-	// Add segment files to relPaths.
-	blockPrefix := blockID.String()
-	chunksPrefix := path.Join(blockPrefix, block.ChunksDirname)
-	err = bkt.Iter(ctx, chunksPrefix, func(name string) error {
-		rel := strings.TrimPrefix(name, blockPrefix+"/")
-		relPaths = append(relPaths, rel)
-		return nil
-	})
-	if err != nil {
-		return blockMeta, errors.Wrapf(err, "failed to list chunks in %q", chunksPrefix)
-	}
-
-	for _, relPath := range relPaths {
+	appendFile := func(relPath string) error {
 		objPath := path.Join(blockPrefix, relPath)
 		attrs, err := bkt.Attributes(ctx, objPath)
 		if err != nil {
-			return blockMeta, errors.Wrapf(err, "failed to get attributes for %q", objPath)
+			return errors.Wrapf(err, "failed to get attributes for %q", objPath)
 		}
+		blockMeta.Thanos.Files = append(blockMeta.Thanos.Files, block.File{RelPath: relPath, SizeBytes: attrs.Size})
+		return nil
+	}
 
-		blockMeta.Thanos.Files = append(blockMeta.Thanos.Files, block.File{
-			RelPath:   relPath,
-			SizeBytes: attrs.Size,
-		})
+	if err := appendFile(block.IndexFilename); err != nil {
+		return blockMeta, err
+	}
+
+	chunksPrefix := path.Join(blockPrefix, block.ChunksDirname)
+	err = bkt.Iter(ctx, chunksPrefix, func(name string) error {
+		return appendFile(strings.TrimPrefix(name, blockPrefix+"/"))
+	})
+	if err != nil {
+		return blockMeta, errors.Wrapf(err, "failed to list chunks in %q", chunksPrefix)
 	}
 
 	return blockMeta, nil

--- a/pkg/mimirtool/client/backfill.go
+++ b/pkg/mimirtool/client/backfill.go
@@ -54,7 +54,7 @@ func (c *MimirClient) Backfill(ctx context.Context, blocks []string, sleepTime t
 		}
 
 		if err := c.backfillBlock(ctx, fsBkt, blockID, logctx, sleepTime); err != nil {
-			if errors.Is(err, errConflict) {
+			if errors.Is(err, ErrConflict) {
 				level.Warn(logctx).Log("msg", "block already exists on the server")
 				alreadyExists++
 			} else {

--- a/pkg/mimirtool/client/backfill.go
+++ b/pkg/mimirtool/client/backfill.go
@@ -10,14 +10,17 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/oklog/ulid/v2"
 	"github.com/pkg/errors"
+	"github.com/thanos-io/objstore"
+	"github.com/thanos-io/objstore/providers/filesystem"
 
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
 )
@@ -26,9 +29,31 @@ func (c *MimirClient) Backfill(ctx context.Context, blocks []string, sleepTime t
 	// Upload each block
 	var succeeded, failed, alreadyExists int
 
+	buckets := make(map[string]objstore.BucketReader, 1)
 	for _, b := range blocks {
 		logctx := log.With(c.logger, "path", b)
-		if err := c.backfillBlock(ctx, b, logctx, sleepTime); err != nil {
+
+		dir := filepath.Dir(b)
+		fsBkt, ok := buckets[dir]
+		if !ok {
+			var err error
+			fsBkt, err = filesystem.NewBucket(dir)
+			if err != nil {
+				level.Error(logctx).Log("msg", "failed to create filesystem bucket", "err", err)
+				failed++
+				continue
+			}
+			buckets[dir] = fsBkt
+		}
+
+		blockID, err := ulid.Parse(filepath.Base(b))
+		if err != nil {
+			level.Error(logctx).Log("msg", "failed to parse block ID from path", "err", err)
+			failed++
+			continue
+		}
+
+		if err := c.backfillBlock(ctx, fsBkt, blockID, logctx, sleepTime); err != nil {
 			if errors.Is(err, errConflict) {
 				level.Warn(logctx).Log("msg", "block already exists on the server")
 				alreadyExists++
@@ -52,21 +77,27 @@ func (c *MimirClient) Backfill(ctx context.Context, blocks []string, sleepTime t
 	return nil
 }
 
+// BackfillBlock uploads a single TSDB block from a bucket to a Mimir instance
+// via the block upload API.
+func (c *MimirClient) BackfillBlock(ctx context.Context, bkt objstore.BucketReader, blockID ulid.ULID, sleepTime time.Duration) error {
+	return c.backfillBlock(ctx, bkt, blockID, c.logger, sleepTime)
+}
+
 // drainAndCloseBody drains and closes the body to let the transport reuse the connection.
 func drainAndCloseBody(resp *http.Response) {
 	_, _ = io.Copy(io.Discard, resp.Body)
 	_ = resp.Body.Close()
 }
 
-func (c *MimirClient) backfillBlock(ctx context.Context, blockDir string, logctx log.Logger, sleepTime time.Duration) error {
-	// blockMeta returned by getBlockMeta will have thanos.files section pre-populated.
-	blockMeta, err := GetBlockMeta(blockDir)
+func (c *MimirClient) backfillBlock(ctx context.Context, bkt objstore.BucketReader, blockID ulid.ULID, logctx log.Logger, sleepTime time.Duration) error {
+	// blockMeta returned by getBlockMetaFromBucket will have thanos.files section pre-populated.
+	blockMeta, err := GetBlockMetaFromBucket(ctx, bkt, blockID)
 	if err != nil {
 		return err
 	}
 
-	blockID := blockMeta.ULID.String()
-	logctx = log.With(logctx, "block", blockID)
+	blockIDStr := blockMeta.ULID.String()
+	logctx = log.With(logctx, "block", blockIDStr)
 
 	level.Info(logctx).Log("msg", "making request to start block upload", "file", block.MetaFilename)
 
@@ -82,7 +113,7 @@ func (c *MimirClient) backfillBlock(ctx context.Context, blockDir string, logctx
 	if err := json.NewEncoder(buf).Encode(blockMeta); err != nil {
 		return errors.Wrap(err, "failed to JSON encode payload")
 	}
-	resp, err := c.doRequest(ctx, path.Join(endpointPrefix, url.PathEscape(blockID), startBlockUpload), http.MethodPost, buf, int64(buf.Len()))
+	resp, err := c.doRequest(ctx, path.Join(endpointPrefix, url.PathEscape(blockIDStr), startBlockUpload), http.MethodPost, buf, int64(buf.Len()))
 	if err != nil {
 		return errors.Wrap(err, "request to start block upload failed")
 	}
@@ -95,13 +126,13 @@ func (c *MimirClient) backfillBlock(ctx context.Context, blockDir string, logctx
 			continue
 		}
 
-		if err := c.uploadBlockFile(ctx, tf, blockDir, path.Join(endpointPrefix, url.PathEscape(blockID), uploadFile), logctx); err != nil {
+		if err := c.uploadBlockFileFromBucket(ctx, bkt, blockID, tf, path.Join(endpointPrefix, url.PathEscape(blockIDStr), uploadFile), logctx); err != nil {
 			return err
 		}
 	}
 
 	for {
-		resp, err = c.doRequest(ctx, path.Join(endpointPrefix, url.PathEscape(blockID), finishBlockUpload), http.MethodPost, nil, -1)
+		resp, err = c.doRequest(ctx, path.Join(endpointPrefix, url.PathEscape(blockIDStr), finishBlockUpload), http.MethodPost, nil, -1)
 		if err == nil {
 			drainAndCloseBody(resp)
 			break
@@ -110,11 +141,15 @@ func (c *MimirClient) backfillBlock(ctx context.Context, blockDir string, logctx
 			return errors.Wrap(err, "request to finish block upload failed")
 		}
 		level.Warn(logctx).Log("msg", "will sleep and try again", "err", err)
-		time.Sleep(sleepTime)
+		select {
+		case <-time.After(sleepTime):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
 
 	for {
-		uploadResult, err := c.getBlockUpload(ctx, path.Join(endpointPrefix, url.PathEscape(blockID), checkBlockUpload))
+		uploadResult, err := c.getBlockUpload(ctx, path.Join(endpointPrefix, url.PathEscape(blockIDStr), checkBlockUpload))
 		if err != nil {
 			return errors.Wrap(err, "failed to check state of block upload")
 		}
@@ -130,7 +165,11 @@ func (c *MimirClient) backfillBlock(ctx context.Context, blockDir string, logctx
 		}
 
 		// Sleep and then try to get the state again.
-		time.Sleep(sleepTime)
+		select {
+		case <-time.After(sleepTime):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
 }
 
@@ -156,43 +195,45 @@ func (c *MimirClient) getBlockUpload(ctx context.Context, url string) (result, e
 	return r, nil
 }
 
-func (c *MimirClient) uploadBlockFile(ctx context.Context, tf block.File, blockDir, fileUploadEndpoint string, logctx log.Logger) error {
-	pth := filepath.Join(blockDir, filepath.FromSlash(tf.RelPath))
-	f, err := os.Open(pth)
+func (c *MimirClient) uploadBlockFileFromBucket(ctx context.Context, bkt objstore.BucketReader, blockID ulid.ULID, tf block.File, fileUploadEndpoint string, logctx log.Logger) error {
+	objectName := path.Join(blockID.String(), tf.RelPath)
+	r, err := bkt.Get(ctx, objectName)
 	if err != nil {
-		return errors.Wrapf(err, "failed to open %q", pth)
+		return errors.Wrapf(err, "failed to read %q from bucket", objectName)
 	}
 	defer func() {
-		_ = f.Close()
+		_ = r.Close()
 	}()
 
 	level.Info(logctx).Log("msg", "uploading block file", "file", tf.RelPath, "size", tf.SizeBytes)
 
-	resp, err := c.doRequest(ctx, fmt.Sprintf("%s?path=%s", fileUploadEndpoint, url.QueryEscape(tf.RelPath)), http.MethodPost, f, tf.SizeBytes)
+	resp, err := c.doRequest(ctx, fmt.Sprintf("%s?path=%s", fileUploadEndpoint, url.QueryEscape(tf.RelPath)), http.MethodPost, r, tf.SizeBytes)
 	if err != nil {
-		return errors.Wrapf(err, "request to upload file %q failed", pth)
+		return errors.Wrapf(err, "request to upload file %q failed", objectName)
 	}
 	drainAndCloseBody(resp)
 
 	return nil
 }
 
-// GetBlockMeta reads meta.json file, and adds (or replaces) thanos.files section with
-// list of local files from the local block.
-func GetBlockMeta(blockDir string) (block.Meta, error) {
+// GetBlockMetaFromBucket reads meta.json from the bucket and adds (or replaces)
+// the thanos.files section with the list of files from the block in the bucket.
+func GetBlockMetaFromBucket(ctx context.Context, bkt objstore.BucketReader, blockID ulid.ULID) (block.Meta, error) {
 	var blockMeta block.Meta
 
-	metaPath := filepath.Join(blockDir, block.MetaFilename)
-	f, err := os.Open(metaPath)
+	metaPath := path.Join(blockID.String(), block.MetaFilename)
+	r, err := bkt.Get(ctx, metaPath)
 	if err != nil {
-		return blockMeta, errors.Wrapf(err, "failed to open %q", metaPath)
+		return blockMeta, errors.Wrapf(err, "failed to read %q", metaPath)
 	}
-	defer func() {
-		_ = f.Close()
-	}()
 
-	if err := json.NewDecoder(f).Decode(&blockMeta); err != nil {
-		return blockMeta, errors.Wrapf(err, "failed to decode %q", metaPath)
+	decErr := json.NewDecoder(r).Decode(&blockMeta)
+	closeErr := r.Close()
+	if decErr != nil {
+		return blockMeta, errors.Wrapf(decErr, "failed to decode %q", metaPath)
+	}
+	if closeErr != nil {
+		return blockMeta, errors.Wrapf(closeErr, "failed to close %q", metaPath)
 	}
 
 	if blockMeta.Version != 1 {
@@ -209,32 +250,27 @@ func GetBlockMeta(blockDir string) (block.Meta, error) {
 	relPaths := []string{block.IndexFilename}
 
 	// Add segment files to relPaths.
-	{
-		chunksDir := filepath.Join(blockDir, block.ChunksDirname)
-		entries, err := os.ReadDir(chunksDir)
-		if err != nil {
-			return blockMeta, errors.Wrapf(err, "failed to read dir %q", chunksDir)
-		}
-
-		for _, c := range entries {
-			relPaths = append(relPaths, path.Join(block.ChunksDirname, c.Name()))
-		}
+	blockPrefix := blockID.String()
+	chunksPrefix := path.Join(blockPrefix, block.ChunksDirname)
+	err = bkt.Iter(ctx, chunksPrefix, func(name string) error {
+		rel := strings.TrimPrefix(name, blockPrefix+"/")
+		relPaths = append(relPaths, rel)
+		return nil
+	})
+	if err != nil {
+		return blockMeta, errors.Wrapf(err, "failed to list chunks in %q", chunksPrefix)
 	}
 
 	for _, relPath := range relPaths {
-		p := filepath.Join(blockDir, filepath.FromSlash(relPath))
-		st, err := os.Stat(p)
+		objPath := path.Join(blockPrefix, relPath)
+		attrs, err := bkt.Attributes(ctx, objPath)
 		if err != nil {
-			return blockMeta, errors.Wrapf(err, "failed to stat %q", p)
-		}
-
-		if !st.Mode().IsRegular() {
-			return blockMeta, fmt.Errorf("not a file: %q", p)
+			return blockMeta, errors.Wrapf(err, "failed to get attributes for %q", objPath)
 		}
 
 		blockMeta.Thanos.Files = append(blockMeta.Thanos.Files, block.File{
 			RelPath:   relPath,
-			SizeBytes: st.Size(),
+			SizeBytes: attrs.Size,
 		})
 	}
 

--- a/pkg/mimirtool/client/backfill.go
+++ b/pkg/mimirtool/client/backfill.go
@@ -113,15 +113,10 @@ func drainAndCloseBody(resp *http.Response) {
 
 func (c *MimirClient) backfillBlock(ctx context.Context, bkt objstore.BucketReader, blockID ulid.ULID, logctx log.Logger, sleepTime time.Duration) error {
 	// blockMeta returned by getBlockMetaFromBucket will have thanos.files section pre-populated.
-	blockMeta, err := GetBlockMetaFromBucket(ctx, bkt, blockID)
+	blockMeta, err := GetBlockMeta(ctx, bkt, blockID)
 	if err != nil {
 		return err
 	}
-
-	blockIDStr := blockMeta.ULID.String()
-	logctx = log.With(logctx, "block", blockIDStr)
-
-	level.Info(logctx).Log("msg", "making request to start block upload", "file", block.MetaFilename)
 
 	const (
 		endpointPrefix    = "/api/v1/upload/block"
@@ -131,11 +126,17 @@ func (c *MimirClient) backfillBlock(ctx context.Context, bkt objstore.BucketRead
 		checkBlockUpload  = "check"
 	)
 
+	blockIDStr := blockMeta.ULID.String()
+	blockPath := path.Join(endpointPrefix, url.PathEscape(blockIDStr))
+	logctx = log.With(logctx, "block", blockIDStr)
+
+	level.Info(logctx).Log("msg", "making request to start block upload", "file", block.MetaFilename)
+
 	buf := bytes.NewBuffer(nil)
 	if err := json.NewEncoder(buf).Encode(blockMeta); err != nil {
 		return errors.Wrap(err, "failed to JSON encode payload")
 	}
-	resp, err := c.doBackfillRequest(ctx, path.Join(endpointPrefix, url.PathEscape(blockIDStr), startBlockUpload), http.MethodPost, buf, int64(buf.Len()))
+	resp, err := c.doBackfillRequest(ctx, path.Join(blockPath, startBlockUpload), http.MethodPost, buf, int64(buf.Len()))
 	if err != nil {
 		return errors.Wrap(err, "request to start block upload failed")
 	}
@@ -148,13 +149,13 @@ func (c *MimirClient) backfillBlock(ctx context.Context, bkt objstore.BucketRead
 			continue
 		}
 
-		if err := c.uploadBlockFileFromBucket(ctx, bkt, blockID, tf, path.Join(endpointPrefix, url.PathEscape(blockIDStr), uploadFile), logctx); err != nil {
+		if err := c.uploadBlockFile(ctx, bkt, blockID, tf, path.Join(blockPath, uploadFile), logctx); err != nil {
 			return err
 		}
 	}
 
 	for {
-		resp, err = c.doBackfillRequest(ctx, path.Join(endpointPrefix, url.PathEscape(blockIDStr), finishBlockUpload), http.MethodPost, nil, -1)
+		resp, err = c.doBackfillRequest(ctx, path.Join(blockPath, finishBlockUpload), http.MethodPost, nil, -1)
 		if err == nil {
 			drainAndCloseBody(resp)
 			break
@@ -171,7 +172,7 @@ func (c *MimirClient) backfillBlock(ctx context.Context, bkt objstore.BucketRead
 	}
 
 	for {
-		uploadResult, err := c.getBlockUpload(ctx, path.Join(endpointPrefix, url.PathEscape(blockIDStr), checkBlockUpload))
+		uploadResult, err := c.getBlockUpload(ctx, path.Join(blockPath, checkBlockUpload))
 		if err != nil {
 			return errors.Wrap(err, "failed to check state of block upload")
 		}
@@ -217,7 +218,7 @@ func (c *MimirClient) getBlockUpload(ctx context.Context, url string) (result, e
 	return r, nil
 }
 
-func (c *MimirClient) uploadBlockFileFromBucket(ctx context.Context, bkt objstore.BucketReader, blockID ulid.ULID, tf block.File, fileUploadEndpoint string, logctx log.Logger) error {
+func (c *MimirClient) uploadBlockFile(ctx context.Context, bkt objstore.BucketReader, blockID ulid.ULID, tf block.File, fileUploadEndpoint string, logctx log.Logger) error {
 	objectName := path.Join(blockID.String(), tf.RelPath)
 	r, err := bkt.Get(ctx, objectName)
 	if err != nil {
@@ -238,9 +239,9 @@ func (c *MimirClient) uploadBlockFileFromBucket(ctx context.Context, bkt objstor
 	return nil
 }
 
-// GetBlockMetaFromBucket reads meta.json from the bucket and adds (or replaces)
+// GetBlockMeta reads meta.json from the bucket and adds (or replaces)
 // the thanos.files section with the list of files from the block in the bucket.
-func GetBlockMetaFromBucket(ctx context.Context, bkt objstore.BucketReader, blockID ulid.ULID) (block.Meta, error) {
+func GetBlockMeta(ctx context.Context, bkt objstore.BucketReader, blockID ulid.ULID) (block.Meta, error) {
 	var blockMeta block.Meta
 
 	metaPath := path.Join(blockID.String(), block.MetaFilename)

--- a/pkg/mimirtool/client/backfill_test.go
+++ b/pkg/mimirtool/client/backfill_test.go
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/oklog/ulid/v2"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
+
+	"github.com/grafana/mimir/pkg/storage/tsdb/block"
+)
+
+func TestGetBlockMetaFromBucket(t *testing.T) {
+	blockID := ulid.MustNew(1000, nil)
+	bkt := objstore.NewInMemBucket()
+
+	meta := block.Meta{
+		BlockMeta: tsdb.BlockMeta{
+			ULID:    blockID,
+			Version: 1,
+			MinTime: 100,
+			MaxTime: 200,
+		},
+	}
+	metaBytes, err := json.Marshal(meta)
+	require.NoError(t, err)
+
+	require.NoError(t, bkt.Upload(context.Background(), blockID.String()+"/meta.json", bytes.NewReader(metaBytes)))
+	require.NoError(t, bkt.Upload(context.Background(), blockID.String()+"/index", bytes.NewReader([]byte("index-data"))))
+	require.NoError(t, bkt.Upload(context.Background(), blockID.String()+"/chunks/000001", bytes.NewReader([]byte("chunk-1"))))
+	require.NoError(t, bkt.Upload(context.Background(), blockID.String()+"/chunks/000002", bytes.NewReader([]byte("chunk-22"))))
+
+	result, err := GetBlockMetaFromBucket(context.Background(), bkt, blockID)
+	require.NoError(t, err)
+
+	assert.Equal(t, blockID, result.ULID)
+	assert.Equal(t, int64(100), result.MinTime)
+	assert.Equal(t, int64(200), result.MaxTime)
+
+	filesByPath := map[string]int64{}
+	for _, f := range result.Thanos.Files {
+		filesByPath[f.RelPath] = f.SizeBytes
+	}
+
+	assert.Contains(t, filesByPath, "meta.json")
+	assert.Equal(t, int64(len("index-data")), filesByPath["index"])
+	assert.Equal(t, int64(len("chunk-1")), filesByPath["chunks/000001"])
+	assert.Equal(t, int64(len("chunk-22")), filesByPath["chunks/000002"])
+}
+
+func TestGetBlockMetaFromBucket_InvalidVersion(t *testing.T) {
+	blockID := ulid.MustNew(1000, nil)
+	bkt := objstore.NewInMemBucket()
+
+	meta := block.Meta{
+		BlockMeta: tsdb.BlockMeta{
+			ULID:    blockID,
+			Version: 99,
+		},
+	}
+	metaBytes, err := json.Marshal(meta)
+	require.NoError(t, err)
+
+	require.NoError(t, bkt.Upload(context.Background(), blockID.String()+"/meta.json", bytes.NewReader(metaBytes)))
+
+	_, err = GetBlockMetaFromBucket(context.Background(), bkt, blockID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only version 1")
+}
+
+func TestBackfillBlock(t *testing.T) {
+	blockID := ulid.MustNew(1000, nil)
+	blockIDStr := blockID.String()
+
+	bkt := objstore.NewInMemBucket()
+	meta := block.Meta{
+		BlockMeta: tsdb.BlockMeta{
+			ULID:    blockID,
+			Version: 1,
+			MinTime: 100,
+			MaxTime: 200,
+		},
+	}
+	metaBytes, err := json.Marshal(meta)
+	require.NoError(t, err)
+
+	chunkData := []byte("chunk-data-here")
+	indexData := []byte("index-data-here")
+	require.NoError(t, bkt.Upload(context.Background(), blockIDStr+"/meta.json", bytes.NewReader(metaBytes)))
+	require.NoError(t, bkt.Upload(context.Background(), blockIDStr+"/index", bytes.NewReader(indexData)))
+	require.NoError(t, bkt.Upload(context.Background(), blockIDStr+"/chunks/000001", bytes.NewReader(chunkData)))
+
+	var calls []string
+	uploadedFiles := map[string][]byte{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p := r.URL.Path
+		calls = append(calls, r.Method+" "+p)
+
+		switch {
+		case strings.HasSuffix(p, "/start"):
+			w.WriteHeader(http.StatusOK)
+		case strings.Contains(p, "/files"):
+			filePath := r.URL.Query().Get("path")
+			body, _ := io.ReadAll(r.Body)
+			uploadedFiles[filePath] = body
+			w.WriteHeader(http.StatusOK)
+		case strings.HasSuffix(p, "/finish"):
+			w.WriteHeader(http.StatusOK)
+		case strings.HasSuffix(p, "/check"):
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"result":"complete"}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+
+	mimirClient, err := New(Config{
+		Address: srv.URL,
+		ID:      "test-tenant",
+	}, log.NewNopLogger())
+	require.NoError(t, err)
+
+	err = mimirClient.BackfillBlock(context.Background(), bkt, blockID, 0)
+	srv.Close()
+	require.NoError(t, err)
+
+	require.GreaterOrEqual(t, len(calls), 4)
+	assert.Contains(t, calls[0], "/start")
+	assert.Contains(t, calls[len(calls)-2], "/finish")
+	assert.Contains(t, calls[len(calls)-1], "/check")
+
+	assert.Equal(t, indexData, uploadedFiles["index"])
+	assert.Equal(t, chunkData, uploadedFiles["chunks/000001"])
+	assert.NotContains(t, uploadedFiles, "meta.json")
+}
+
+func TestBackfillBlock_AlreadyExists(t *testing.T) {
+	blockID := ulid.MustNew(1000, nil)
+
+	bkt := objstore.NewInMemBucket()
+	meta := block.Meta{
+		BlockMeta: tsdb.BlockMeta{
+			ULID:    blockID,
+			Version: 1,
+		},
+	}
+	metaBytes, err := json.Marshal(meta)
+	require.NoError(t, err)
+
+	require.NoError(t, bkt.Upload(context.Background(), blockID.String()+"/meta.json", bytes.NewReader(metaBytes)))
+	require.NoError(t, bkt.Upload(context.Background(), blockID.String()+"/index", bytes.NewReader([]byte("data"))))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/start") {
+			w.WriteHeader(http.StatusConflict)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	mimirClient, err := New(Config{
+		Address: srv.URL,
+		ID:      "test-tenant",
+	}, log.NewNopLogger())
+	require.NoError(t, err)
+
+	err = mimirClient.BackfillBlock(context.Background(), bkt, blockID, 0)
+	srv.Close()
+	require.ErrorIs(t, err, errConflict)
+}

--- a/pkg/mimirtool/client/backfill_test.go
+++ b/pkg/mimirtool/client/backfill_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
 )
 
-func TestGetBlockMetaFromBucket(t *testing.T) {
+func TestGetBlockMeta(t *testing.T) {
 	blockID := ulid.MustNew(1000, nil)
 	bkt := objstore.NewInMemBucket()
 
@@ -38,39 +38,36 @@ func TestGetBlockMetaFromBucket(t *testing.T) {
 	metaBytes, err := json.Marshal(meta)
 	require.NoError(t, err)
 
-	require.NoError(t, bkt.Upload(context.Background(), blockID.String()+"/meta.json", bytes.NewReader(metaBytes)))
-	require.NoError(t, bkt.Upload(context.Background(), blockID.String()+"/index", bytes.NewReader([]byte("index-data"))))
-	require.NoError(t, bkt.Upload(context.Background(), blockID.String()+"/chunks/000001", bytes.NewReader([]byte("chunk-1"))))
-	require.NoError(t, bkt.Upload(context.Background(), blockID.String()+"/chunks/000002", bytes.NewReader([]byte("chunk-22"))))
+	ctx := context.Background()
+	prefix := blockID.String()
+	require.NoError(t, bkt.Upload(ctx, prefix+"/meta.json", bytes.NewReader(metaBytes)))
+	require.NoError(t, bkt.Upload(ctx, prefix+"/index", bytes.NewReader(make([]byte, 1))))
+	require.NoError(t, bkt.Upload(ctx, prefix+"/chunks/000001", bytes.NewReader(make([]byte, 2))))
+	require.NoError(t, bkt.Upload(ctx, prefix+"/chunks/000002", bytes.NewReader(make([]byte, 3))))
 
-	result, err := GetBlockMeta(context.Background(), bkt, blockID)
+	result, err := GetBlockMeta(ctx, bkt, blockID)
 	require.NoError(t, err)
 
 	assert.Equal(t, blockID, result.ULID)
 	assert.Equal(t, int64(100), result.MinTime)
 	assert.Equal(t, int64(200), result.MaxTime)
 
-	filesByPath := map[string]int64{}
+	fileSizes := map[string]int64{}
 	for _, f := range result.Thanos.Files {
-		filesByPath[f.RelPath] = f.SizeBytes
+		fileSizes[f.RelPath] = f.SizeBytes
 	}
-
-	assert.Contains(t, filesByPath, "meta.json")
-	assert.Equal(t, int64(len("index-data")), filesByPath["index"])
-	assert.Equal(t, int64(len("chunk-1")), filesByPath["chunks/000001"])
-	assert.Equal(t, int64(len("chunk-22")), filesByPath["chunks/000002"])
+	assert.Len(t, fileSizes, 4)
+	assert.Contains(t, fileSizes, "meta.json")
+	assert.Equal(t, int64(1), fileSizes["index"])
+	assert.Equal(t, int64(2), fileSizes["chunks/000001"])
+	assert.Equal(t, int64(3), fileSizes["chunks/000002"])
 }
 
-func TestGetBlockMetaFromBucket_InvalidVersion(t *testing.T) {
+func TestGetBlockMeta_RejectsUnsupportedVersion(t *testing.T) {
 	blockID := ulid.MustNew(1000, nil)
 	bkt := objstore.NewInMemBucket()
 
-	meta := block.Meta{
-		BlockMeta: tsdb.BlockMeta{
-			ULID:    blockID,
-			Version: 99,
-		},
-	}
+	meta := block.Meta{BlockMeta: tsdb.BlockMeta{ULID: blockID, Version: 99}}
 	metaBytes, err := json.Marshal(meta)
 	require.NoError(t, err)
 
@@ -78,12 +75,13 @@ func TestGetBlockMetaFromBucket_InvalidVersion(t *testing.T) {
 
 	_, err = GetBlockMeta(context.Background(), bkt, blockID)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "only version 1")
 }
 
 func TestBackfillBlock(t *testing.T) {
 	blockID := ulid.MustNew(1000, nil)
-	blockIDStr := blockID.String()
+	prefix := blockID.String()
+	indexData := []byte("index-content")
+	chunkData := []byte("chunk-content")
 
 	bkt := objstore.NewInMemBucket()
 	meta := block.Meta{
@@ -97,88 +95,62 @@ func TestBackfillBlock(t *testing.T) {
 	metaBytes, err := json.Marshal(meta)
 	require.NoError(t, err)
 
-	chunkData := []byte("chunk-data-here")
-	indexData := []byte("index-data-here")
-	require.NoError(t, bkt.Upload(context.Background(), blockIDStr+"/meta.json", bytes.NewReader(metaBytes)))
-	require.NoError(t, bkt.Upload(context.Background(), blockIDStr+"/index", bytes.NewReader(indexData)))
-	require.NoError(t, bkt.Upload(context.Background(), blockIDStr+"/chunks/000001", bytes.NewReader(chunkData)))
+	ctx := context.Background()
+	require.NoError(t, bkt.Upload(ctx, prefix+"/meta.json", bytes.NewReader(metaBytes)))
+	require.NoError(t, bkt.Upload(ctx, prefix+"/index", bytes.NewReader(indexData)))
+	require.NoError(t, bkt.Upload(ctx, prefix+"/chunks/000001", bytes.NewReader(chunkData)))
 
-	var calls []string
-	uploadedFiles := map[string][]byte{}
+	type recorded struct {
+		method string
+		path   string
+		file   string // "path" query param for file uploads
+		body   []byte
+	}
+	var reqs []recorded
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		p := r.URL.Path
-		calls = append(calls, r.Method+" "+p)
-
-		switch {
-		case strings.HasSuffix(p, "/start"):
-			w.WriteHeader(http.StatusOK)
-		case strings.Contains(p, "/files"):
-			filePath := r.URL.Query().Get("path")
-			body, _ := io.ReadAll(r.Body)
-			uploadedFiles[filePath] = body
-			w.WriteHeader(http.StatusOK)
-		case strings.HasSuffix(p, "/finish"):
-			w.WriteHeader(http.StatusOK)
-		case strings.HasSuffix(p, "/check"):
+		body, _ := io.ReadAll(r.Body)
+		reqs = append(reqs, recorded{
+			method: r.Method,
+			path:   r.URL.Path,
+			file:   r.URL.Query().Get("path"),
+			body:   body,
+		})
+		if strings.HasSuffix(r.URL.Path, "/check") {
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprintf(w, `{"result":"complete"}`)
-		default:
-			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, `{"result":"complete"}`)
 		}
 	}))
+	defer srv.Close()
 
-	mimirClient, err := New(Config{
-		Address: srv.URL,
-		ID:      "test-tenant",
-	}, log.NewNopLogger())
+	c, err := New(Config{Address: srv.URL, ID: "test"}, log.NewNopLogger())
 	require.NoError(t, err)
 
-	err = mimirClient.BackfillBlock(context.Background(), bkt, blockID, 0)
-	srv.Close()
-	require.NoError(t, err)
+	require.NoError(t, c.BackfillBlock(ctx, bkt, blockID, 0))
 
-	require.GreaterOrEqual(t, len(calls), 4)
-	assert.Contains(t, calls[0], "/start")
-	assert.Contains(t, calls[len(calls)-2], "/finish")
-	assert.Contains(t, calls[len(calls)-1], "/check")
+	blockPath := "/api/v1/upload/block/" + prefix
 
+	// start, upload index, upload chunk, finish, check
+	require.Len(t, reqs, 5)
+
+	assert.Equal(t, http.MethodPost, reqs[0].method)
+	assert.Equal(t, blockPath+"/start", reqs[0].path)
+	var sentMeta block.Meta
+	require.NoError(t, json.Unmarshal(reqs[0].body, &sentMeta))
+	assert.Equal(t, blockID, sentMeta.ULID)
+
+	uploadedFiles := map[string][]byte{}
+	for _, r := range reqs[1:3] {
+		assert.Equal(t, http.MethodPost, r.method)
+		assert.Equal(t, blockPath+"/files", r.path)
+		uploadedFiles[r.file] = r.body
+	}
 	assert.Equal(t, indexData, uploadedFiles["index"])
 	assert.Equal(t, chunkData, uploadedFiles["chunks/000001"])
-	assert.NotContains(t, uploadedFiles, "meta.json")
-}
 
-func TestBackfillBlock_AlreadyExists(t *testing.T) {
-	blockID := ulid.MustNew(1000, nil)
+	assert.Equal(t, http.MethodPost, reqs[3].method)
+	assert.Equal(t, blockPath+"/finish", reqs[3].path)
 
-	bkt := objstore.NewInMemBucket()
-	meta := block.Meta{
-		BlockMeta: tsdb.BlockMeta{
-			ULID:    blockID,
-			Version: 1,
-		},
-	}
-	metaBytes, err := json.Marshal(meta)
-	require.NoError(t, err)
-
-	require.NoError(t, bkt.Upload(context.Background(), blockID.String()+"/meta.json", bytes.NewReader(metaBytes)))
-	require.NoError(t, bkt.Upload(context.Background(), blockID.String()+"/index", bytes.NewReader([]byte("data"))))
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasSuffix(r.URL.Path, "/start") {
-			w.WriteHeader(http.StatusConflict)
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-	}))
-
-	mimirClient, err := New(Config{
-		Address: srv.URL,
-		ID:      "test-tenant",
-	}, log.NewNopLogger())
-	require.NoError(t, err)
-
-	err = mimirClient.BackfillBlock(context.Background(), bkt, blockID, 0)
-	srv.Close()
-	require.ErrorIs(t, err, ErrConflict)
+	assert.Equal(t, http.MethodGet, reqs[4].method)
+	assert.Equal(t, blockPath+"/check", reqs[4].path)
 }

--- a/pkg/mimirtool/client/backfill_test.go
+++ b/pkg/mimirtool/client/backfill_test.go
@@ -43,7 +43,7 @@ func TestGetBlockMetaFromBucket(t *testing.T) {
 	require.NoError(t, bkt.Upload(context.Background(), blockID.String()+"/chunks/000001", bytes.NewReader([]byte("chunk-1"))))
 	require.NoError(t, bkt.Upload(context.Background(), blockID.String()+"/chunks/000002", bytes.NewReader([]byte("chunk-22"))))
 
-	result, err := GetBlockMetaFromBucket(context.Background(), bkt, blockID)
+	result, err := GetBlockMeta(context.Background(), bkt, blockID)
 	require.NoError(t, err)
 
 	assert.Equal(t, blockID, result.ULID)
@@ -76,7 +76,7 @@ func TestGetBlockMetaFromBucket_InvalidVersion(t *testing.T) {
 
 	require.NoError(t, bkt.Upload(context.Background(), blockID.String()+"/meta.json", bytes.NewReader(metaBytes)))
 
-	_, err = GetBlockMetaFromBucket(context.Background(), bkt, blockID)
+	_, err = GetBlockMeta(context.Background(), bkt, blockID)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only version 1")
 }

--- a/pkg/mimirtool/client/backfill_test.go
+++ b/pkg/mimirtool/client/backfill_test.go
@@ -180,5 +180,5 @@ func TestBackfillBlock_AlreadyExists(t *testing.T) {
 
 	err = mimirClient.BackfillBlock(context.Background(), bkt, blockID, 0)
 	srv.Close()
-	require.ErrorIs(t, err, errConflict)
+	require.ErrorIs(t, err, ErrConflict)
 }

--- a/pkg/mimirtool/client/client.go
+++ b/pkg/mimirtool/client/client.go
@@ -31,7 +31,7 @@ const (
 
 var (
 	ErrResourceNotFound = errors.New("requested resource not found")
-	errConflict         = errors.New("conflict with current state of target resource")
+	ErrConflict         = errors.New("conflict with current state of target resource")
 	errTooManyRequests  = errors.New("too many requests")
 )
 
@@ -230,7 +230,7 @@ func (c *MimirClient) checkResponse(r *http.Response) error {
 	}
 	if r.StatusCode == http.StatusConflict {
 		level.Debug(c.logger).Log("msg", msg, "status", r.Status, "body", bodyStr)
-		return errConflict
+		return ErrConflict
 	}
 	if r.StatusCode == http.StatusTooManyRequests {
 		level.Debug(c.logger).Log("msg", msg, "status", r.Status, "body", bodyStr)

--- a/pkg/mimirtool/client/client.go
+++ b/pkg/mimirtool/client/client.go
@@ -153,9 +153,26 @@ func (c *MimirClient) Query(ctx context.Context, query string) (*http.Response, 
 }
 
 func (c *MimirClient) doRequest(ctx context.Context, path, method string, payload io.Reader, contentLength int64) (*http.Response, error) {
-	req, err := buildRequest(ctx, path, method, *c.endpoint, payload, contentLength)
+	req, resp, err := c.executeRequest(ctx, path, method, payload, contentLength)
 	if err != nil {
 		return nil, err
+	}
+
+	if err := c.checkResponse(resp); err != nil {
+		_ = resp.Body.Close()
+		return nil, errors.Wrapf(err, "%s request to %s failed", req.Method, req.URL.String())
+	}
+
+	return resp, nil
+}
+
+// executeRequest sends the HTTP request and returns the raw response without inspecting its status.
+// Callers that need to interpret specific status codes themselves should use this and then either
+// handle the response directly or fall back to checkResponse.
+func (c *MimirClient) executeRequest(ctx context.Context, path, method string, payload io.Reader, contentLength int64) (*http.Request, *http.Response, error) {
+	req, err := buildRequest(ctx, path, method, *c.endpoint, payload, contentLength)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	switch {
@@ -180,15 +197,10 @@ func (c *MimirClient) doRequest(ctx context.Context, path, method string, payloa
 	resp, err := c.Client.Do(req)
 	if err != nil {
 		level.Error(c.logger).Log("msg", "error during request to Grafana Mimir API", "url", req.URL.String(), "method", req.Method, "err", err.Error())
-		return nil, err
+		return nil, nil, err
 	}
 
-	if err := c.checkResponse(resp); err != nil {
-		_ = resp.Body.Close()
-		return nil, errors.Wrapf(err, "%s request to %s failed", req.Method, req.URL.String())
-	}
-
-	return resp, nil
+	return req, resp, nil
 }
 
 func validateAuthConfig(user, key, authToken string, sigV4Configured bool) error {

--- a/pkg/mimirtool/client/client.go
+++ b/pkg/mimirtool/client/client.go
@@ -7,6 +7,7 @@ package client
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"io"
 	"net/http"
@@ -51,6 +52,17 @@ type Config struct {
 	MimirHTTPPrefix string            `yaml:"mimir_http_prefix"`
 	AuthToken       string            `yaml:"auth_token"`
 	ExtraHeaders    map[string]string `yaml:"extra_headers"`
+}
+
+// RegisterConnectionFlagsWithPrefix registers address, key, auth-token, id,
+// and TLS flags under the given prefix.
+func (cfg *Config) RegisterConnectionFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	prefix = strings.TrimRight(prefix, ".") + "."
+	f.StringVar(&cfg.Address, prefix+"address", "", "Address of the Mimir instance.")
+	f.StringVar(&cfg.Key, prefix+"key", "", "Basic auth password. The tenant ID is used as the username.")
+	f.StringVar(&cfg.AuthToken, prefix+"auth-token", "", "Bearer token for authentication.")
+	f.StringVar(&cfg.ID, prefix+"id", "", "Tenant ID (X-Scope-OrgID header).")
+	cfg.TLS.RegisterFlagsWithPrefix(strings.TrimRight(prefix, "."), f)
 }
 
 // MimirClient is a client to the Mimir API.

--- a/pkg/mimirtool/client/client.go
+++ b/pkg/mimirtool/client/client.go
@@ -54,15 +54,13 @@ type Config struct {
 	ExtraHeaders    map[string]string `yaml:"extra_headers"`
 }
 
-// RegisterConnectionFlagsWithPrefix registers address, key, auth-token, id,
-// and TLS flags under the given prefix.
 func (cfg *Config) RegisterConnectionFlagsWithPrefix(prefix string, f *flag.FlagSet) {
-	prefix = strings.TrimRight(prefix, ".") + "."
-	f.StringVar(&cfg.Address, prefix+"address", "", "Address of the Mimir instance.")
-	f.StringVar(&cfg.Key, prefix+"key", "", "Basic auth password. The tenant ID is used as the username.")
-	f.StringVar(&cfg.AuthToken, prefix+"auth-token", "", "Bearer token for authentication.")
-	f.StringVar(&cfg.ID, prefix+"id", "", "Tenant ID (X-Scope-OrgID header).")
-	cfg.TLS.RegisterFlagsWithPrefix(strings.TrimRight(prefix, "."), f)
+	prefix = strings.TrimRight(prefix, ".")
+	f.StringVar(&cfg.Address, prefix+".address", "", "Address of the Mimir instance.")
+	f.StringVar(&cfg.Key, prefix+".key", "", "Basic auth password. The tenant ID is used as the username.")
+	f.StringVar(&cfg.AuthToken, prefix+".auth-token", "", "Bearer token for authentication.")
+	f.StringVar(&cfg.ID, prefix+".id", "", "Tenant ID (X-Scope-OrgID header).")
+	cfg.TLS.RegisterFlagsWithPrefix(prefix, f)
 }
 
 // MimirClient is a client to the Mimir API.

--- a/pkg/util/objtools/abs.go
+++ b/pkg/util/objtools/abs.go
@@ -182,6 +182,21 @@ func checkCopyStatus(ctx context.Context, client *blob.Client) (*blob.CopyStatus
 	return response.CopyStatus, response.CopyStatusDescription, nil
 }
 
+func (bkt *azureBucket) Exists(ctx context.Context, objectName string) (bool, error) {
+	resp, err := bkt.containerClient.NewBlobClient(objectName).GetProperties(ctx, nil)
+	if err == nil {
+		// Don't treat failed or pending copies as existing
+		if resp.CopyStatus != nil && *resp.CopyStatus != blob.CopyStatusTypeSuccess {
+			return false, nil
+		}
+		return true, nil
+	}
+	if bloberror.HasCode(err, bloberror.BlobNotFound) {
+		return false, nil
+	}
+	return false, err
+}
+
 func (bkt *azureBucket) ClientSideCopy(ctx context.Context, objectName string, dstBucket Bucket, options CopyOptions) error {
 	sourceClient := bkt.containerClient.NewBlobClient(objectName)
 	sourceClient, err := sourceClient.WithVersionID(options.SourceVersionID)

--- a/pkg/util/objtools/bucket.go
+++ b/pkg/util/objtools/bucket.go
@@ -10,6 +10,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-kit/log"
+	"github.com/thanos-io/objstore"
+	"github.com/thanos-io/objstore/providers/azure"
+	"github.com/thanos-io/objstore/providers/gcs"
+	"github.com/thanos-io/objstore/providers/s3"
+
 	"github.com/grafana/mimir/pkg/storage/bucket"
 )
 
@@ -109,7 +115,7 @@ type BucketConfig struct {
 }
 
 func (c *BucketConfig) RegisterFlags(f *flag.FlagSet) {
-	c.registerFlags("", f)
+	c.registerFlags("", f, false)
 }
 
 func ifNotEmptySuffix(s, suffix string) string {
@@ -119,9 +125,12 @@ func ifNotEmptySuffix(s, suffix string) string {
 	return s + suffix
 }
 
-func (c *BucketConfig) registerFlags(descriptor string, f *flag.FlagSet) {
+func (c *BucketConfig) registerFlags(descriptor string, f *flag.FlagSet, backfill bool) {
 	descriptorFlagPrefix := ifNotEmptySuffix(descriptor, ".")
 	acceptedBackends := fmt.Sprintf("%s, %s or %s.", bucket.Azure, bucket.GCS, bucket.S3)
+	if backfill {
+		acceptedBackends = fmt.Sprintf("%s, %s, %s or backfill.", bucket.Azure, bucket.GCS, bucket.S3)
+	}
 	f.StringVar(&c.backend, descriptorFlagPrefix+"backend", "",
 		fmt.Sprintf("The %sobject storage backend. Accepted values are: %s", ifNotEmptySuffix(descriptor, " "), acceptedBackends))
 	c.azure.RegisterFlags(bucket.Azure+"."+descriptorFlagPrefix, f)
@@ -163,6 +172,33 @@ func (c *BucketConfig) ToBucket(ctx context.Context) (Bucket, error) {
 	}
 }
 
+// ToObjstoreBucket is an adapter to objstore
+func (c *BucketConfig) ToObjstoreBucket(ctx context.Context, logger log.Logger) (objstore.Bucket, error) {
+	switch c.backend {
+	case bucket.S3:
+		return s3.NewBucketWithConfig(logger, s3.Config{
+			Bucket:    c.s3.BucketName,
+			Endpoint:  c.s3.Endpoint,
+			AccessKey: c.s3.AccessKeyID,
+			SecretKey: c.s3.SecretAccessKey,
+			Insecure:  !c.s3.Secure,
+			PartSize:  c.s3.PartSize,
+		}, "objtools-s3", nil)
+	case bucket.GCS:
+		return gcs.NewBucketWithConfig(ctx, logger, gcs.Config{
+			Bucket: c.gcs.BucketName,
+		}, "objtools-gcs", nil)
+	case bucket.Azure:
+		azCfg := azure.DefaultConfig
+		azCfg.StorageAccountName = c.azure.AccountName
+		azCfg.StorageAccountKey = c.azure.AccountKey
+		azCfg.ContainerName = c.azure.ContainerName
+		return azure.NewBucketWithConfig(logger, azCfg, "objtools-azure", nil)
+	default:
+		return nil, fmt.Errorf("unknown backend: %v", c.backend)
+	}
+}
+
 func (c *BucketConfig) Backend() string {
 	return c.backend
 }
@@ -173,10 +209,10 @@ type CopyBucketConfig struct {
 	destination    BucketConfig
 }
 
-func (c *CopyBucketConfig) RegisterFlags(f *flag.FlagSet) {
+func (c *CopyBucketConfig) RegisterFlags(f *flag.FlagSet, includeBackfill bool) {
 	f.BoolVar(&c.clientSideCopy, "client-side-copy", false, "Use client side copying. This option is only respected if copying between two buckets of the same backend service. Client side copying is always used when copying between different backend services.")
-	c.source.registerFlags("source", f)
-	c.destination.registerFlags("destination", f)
+	c.source.registerFlags("source", f, false)
+	c.destination.registerFlags("destination", f, includeBackfill)
 }
 
 func (c *CopyBucketConfig) Validate() error {
@@ -185,6 +221,21 @@ func (c *CopyBucketConfig) Validate() error {
 		return err
 	}
 	return c.destination.validate("destination")
+}
+
+// SourceBucket creates and returns only the source bucket.
+func (c *CopyBucketConfig) SourceBucket(ctx context.Context) (Bucket, error) {
+	return c.source.ToBucket(ctx)
+}
+
+// SourceObjstoreBucket creates an objstore.Bucket from the source configuration.
+func (c *CopyBucketConfig) SourceObjstoreBucket(ctx context.Context, logger log.Logger) (objstore.Bucket, error) {
+	return c.source.ToObjstoreBucket(ctx, logger)
+}
+
+// ValidateSource validates only the source bucket configuration.
+func (c *CopyBucketConfig) ValidateSource() error {
+	return c.source.validate("source")
 }
 
 func (c *CopyBucketConfig) ToBuckets(ctx context.Context) (source Bucket, destination Bucket, copyFunc CopyFunc, err error) {
@@ -201,6 +252,10 @@ func (c *CopyBucketConfig) ToBuckets(ctx context.Context) (source Bucket, destin
 
 // CopyFunc copies from the source to the destination either client-side or server-side depending on the configuration
 type CopyFunc func(context.Context, string, CopyOptions) error
+
+func (c *CopyBucketConfig) DestinationBackend() string {
+	return c.destination.backend
+}
 
 func (c *CopyBucketConfig) toCopyFunc(source Bucket, destination Bucket) CopyFunc {
 	if c.clientSideCopy || c.source.backend != c.destination.backend {

--- a/pkg/util/objtools/bucket.go
+++ b/pkg/util/objtools/bucket.go
@@ -116,7 +116,7 @@ type BucketConfig struct {
 }
 
 func (c *BucketConfig) RegisterFlags(f *flag.FlagSet) {
-	c.registerFlags("", f, false)
+	c.registerFlags("", f, nil)
 }
 
 func ifNotEmptySuffix(s, suffix string) string {
@@ -126,12 +126,10 @@ func ifNotEmptySuffix(s, suffix string) string {
 	return s + suffix
 }
 
-func (c *BucketConfig) registerFlags(descriptor string, f *flag.FlagSet, backfill bool) {
+func (c *BucketConfig) registerFlags(descriptor string, f *flag.FlagSet, externalBackends []string) {
 	descriptorFlagPrefix := ifNotEmptySuffix(descriptor, ".")
-	acceptedBackends := fmt.Sprintf("%s, %s or %s.", bucket.Azure, bucket.GCS, bucket.S3)
-	if backfill {
-		acceptedBackends = fmt.Sprintf("%s, %s, %s or backfill.", bucket.Azure, bucket.GCS, bucket.S3)
-	}
+	allBackends := append([]string{bucket.Azure, bucket.GCS, bucket.S3}, externalBackends...)
+	acceptedBackends := strings.Join(allBackends[:len(allBackends)-1], ", ") + " or " + allBackends[len(allBackends)-1] + "."
 	f.StringVar(&c.backend, descriptorFlagPrefix+"backend", "",
 		fmt.Sprintf("The %sobject storage backend. Accepted values are: %s", ifNotEmptySuffix(descriptor, " "), acceptedBackends))
 	c.azure.RegisterFlags(bucket.Azure+"."+descriptorFlagPrefix, f)
@@ -210,10 +208,10 @@ type CopyBucketConfig struct {
 	destination    BucketConfig
 }
 
-func (c *CopyBucketConfig) RegisterFlags(f *flag.FlagSet, includeBackfill bool) {
+func (c *CopyBucketConfig) RegisterFlags(f *flag.FlagSet, extraDestBackends []string) {
 	f.BoolVar(&c.clientSideCopy, "client-side-copy", false, "Use client side copying. This option is only respected if copying between two buckets of the same backend service. Client side copying is always used when copying between different backend services.")
-	c.source.registerFlags("source", f, false)
-	c.destination.registerFlags("destination", f, includeBackfill)
+	c.source.registerFlags("source", f, nil)
+	c.destination.registerFlags("destination", f, extraDestBackends)
 }
 
 func (c *CopyBucketConfig) Validate() error {

--- a/pkg/util/objtools/bucket.go
+++ b/pkg/util/objtools/bucket.go
@@ -26,6 +26,7 @@ const (
 // Bucket is an object storage interface intended to be used by tools that require functionality that isn't in objstore
 type Bucket interface {
 	Get(ctx context.Context, objectName string, options GetOptions) (io.ReadCloser, error)
+	Exists(ctx context.Context, objectName string) (bool, error)
 	ServerSideCopy(ctx context.Context, objectName string, dstBucket Bucket, options CopyOptions) error
 	ClientSideCopy(ctx context.Context, objectName string, dstBucket Bucket, options CopyOptions) error
 	List(ctx context.Context, options ListOptions) (*ListResult, error)

--- a/pkg/util/objtools/gcs.go
+++ b/pkg/util/objtools/gcs.go
@@ -56,6 +56,17 @@ func (bkt *gcsBucket) Get(ctx context.Context, objectName string, options GetOpt
 	return obj.NewReader(ctx)
 }
 
+func (bkt *gcsBucket) Exists(ctx context.Context, objectName string) (bool, error) {
+	_, err := bkt.client.Object(objectName).Attrs(ctx)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, storage.ErrObjectNotExist) {
+		return false, nil
+	}
+	return false, err
+}
+
 func (bkt *gcsBucket) ServerSideCopy(ctx context.Context, objectName string, dstBucket Bucket, options CopyOptions) error {
 	d, ok := dstBucket.(*gcsBucket)
 	if !ok {

--- a/pkg/util/objtools/s3.go
+++ b/pkg/util/objtools/s3.go
@@ -25,8 +25,8 @@ type S3ClientConfig struct {
 func (c *S3ClientConfig) RegisterFlags(prefix string, f *flag.FlagSet) {
 	f.StringVar(&c.BucketName, prefix+"bucket-name", "", "The name of the bucket (not prefixed by a scheme).")
 	f.StringVar(&c.Endpoint, prefix+"endpoint", "", "The endpoint to contact when accessing the bucket.")
-	f.StringVar(&c.AccessKeyID, prefix+"access-key-id", "", "The access key ID used in AWS Signature Version 4 authentication. If unset along with "+prefix+"secret-access-key, credentials are resolved from the environment (IAM roles for service accounts, ECS task roles, or EC2 instance metadata).")
-	f.StringVar(&c.SecretAccessKey, prefix+"secret-access-key", "", "The secret access key used in AWS Signature Version 4 authentication. If unset along with "+prefix+"access-key-id, credentials are resolved from the environment (IAM roles for service accounts, ECS task roles, or EC2 instance metadata).")
+	f.StringVar(&c.AccessKeyID, prefix+"access-key-id", "", "The access key ID used in AWS Signature Version 4 authentication. If unset along with "+prefix+"secret-access-key, credentials are resolved from environment variables, a credentials file, or IAM (ECS task roles, EC2 instance metadata, IRSA).")
+	f.StringVar(&c.SecretAccessKey, prefix+"secret-access-key", "", "The secret access key used in AWS Signature Version 4 authentication. If unset along with "+prefix+"access-key-id, credentials are resolved from environment variables, a credentials file, or IAM (ECS task roles, EC2 instance metadata, IRSA).")
 	f.BoolVar(&c.Secure, prefix+"secure", true, "If true (default), use HTTPS when connecting to the bucket. If false, insecure HTTP is used.")
 	f.Uint64Var(&c.PartSize, prefix+"part-size", 0, "If 0, and object's size is known and optimal for multipart upload, the default value is the minimum allowed size 16MiB.")
 }
@@ -49,8 +49,12 @@ func (c *S3ClientConfig) ToBucket() (Bucket, error) {
 	if c.AccessKeyID != "" {
 		creds = credentials.NewStaticV4(c.AccessKeyID, c.SecretAccessKey, "")
 	} else {
-		// Resolves IAM roles for service accounts (IRSA), ECS task roles and EC2 instance metadata from standard AWS environment variables.
-		creds = credentials.NewIAM("")
+		// Match the objstore credential chain: env vars, then file-based credentials, then IAM.
+		creds = credentials.NewChainCredentials([]credentials.Provider{
+			&credentials.EnvAWS{},
+			&credentials.FileAWSCredentials{},
+			&credentials.IAM{},
+		})
 	}
 	client, err := minio.New(c.Endpoint, &minio.Options{
 		Creds:  creds,

--- a/pkg/util/objtools/s3.go
+++ b/pkg/util/objtools/s3.go
@@ -86,6 +86,17 @@ func (bkt *s3Bucket) Get(ctx context.Context, objectName string, options GetOpti
 	return obj, nil
 }
 
+func (bkt *s3Bucket) Exists(ctx context.Context, objectName string) (bool, error) {
+	_, err := bkt.client.StatObject(ctx, bkt.bucketName, objectName, minio.StatObjectOptions{})
+	if err != nil {
+		if minio.ToErrorResponse(err).Code == minio.NoSuchKey {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
 const maxSingleCopySize int64 = 5 * (1024 * 1024 * 1024) // 5 GiB
 
 func (bkt *s3Bucket) ServerSideCopy(ctx context.Context, objectName string, dstBucket Bucket, options CopyOptions) error {

--- a/tools/copyblocks/README.md
+++ b/tools/copyblocks/README.md
@@ -15,6 +15,7 @@ The currently supported object storage services are Amazon Simple Storage Servic
 - Configurable time range (`--min-time` and `--max-time`) to only copy blocks inclusively within a provided range (e.g. `--min-time 2026-01-15T00:00:00Z`)
 - Copy blocks between users with `--user-mapping`. For instance, `--user-mapping="user1:user2,user3:user4"` maps source blocks from `user1` to `user2` and source blocks from `user3` to `user4`. If you don't provide a mapping for a user, it is assumed to be identical to the source user.
 - Log what would be copied without actually copying anything with `--dry-run`
+- Delete copy markers (e.g. `tenant1/markers/01EZED0X3YZMNJ3NHGMJJKMHCR-copied-backfill`) from the source bucket with `--clear-copy-markers` instead of copying blocks, allowing blocks to be re-copied on the next run. Respects `--enabled-users` and `--disabled-users`.
 
 ## Running
 

--- a/tools/copyblocks/README.md
+++ b/tools/copyblocks/README.md
@@ -1,6 +1,6 @@
 # copyblocks
 
-This program can copy Mimir blocks between two buckets or from a bucket to a backfill destination.
+This program can copy Mimir blocks between two buckets or from a bucket to a backfill destination. It tracks what has been copied by uploading copy markers to the source bucket, preventing blocks from being copied multiple times to the same destination.
 
 By default, a copy between two buckets will be attempted server-side if both the source and destination specify the same object storage service. If the buckets are on different object storage services, or if `--client-side-copy` is passed, then the copy will be performed client side.
 
@@ -8,14 +8,13 @@ The currently supported object storage services are Amazon Simple Storage Servic
 
 ## Features
 
-- Prevents copying blocks multiple times to the same destination by uploading block marker files to the source bucket
-- Runs continuously with periodic checks when supplied a time duration with `--copy-period`, otherwise runs one check then exits
+- Delete copy markers (e.g. `tenant1/markers/01EZED0X3YZMNJ3NHGMJJKMHCR-copied-backfill`) instead of copying with `--clear-copy-markers`
+- Run continuously with periodic checks when supplied a time duration with `--copy-period`, otherwise run one check then exit
 - Include or exclude users from having blocks copied (`--enabled-users` and `--disabled-users`)
-- Configurable minimum block duration (`--min-block-duration`) and (`--skip-no-compact-block-duration-check`) to target blocks that are not awaiting compaction
-- Configurable time range (`--min-time` and `--max-time`) to only copy blocks inclusively within a provided range (e.g. `--min-time 2026-01-15T00:00:00Z`)
+- Set a minimum block duration (`--min-block-duration`) and optionally skip that check for blocks marked as no-compact (`--skip-no-compact-block-duration-check`) to target blocks that are not awaiting compaction
+- Set a time range (`--min-time` and `--max-time`) to only copy blocks within a provided range (e.g. `--min-time 2026-01-15T00:00:00Z`)
 - Copy blocks between users with `--user-mapping`. For instance, `--user-mapping="user1:user2,user3:user4"` maps source blocks from `user1` to `user2` and source blocks from `user3` to `user4`. If you don't provide a mapping for a user, it is assumed to be identical to the source user.
 - Log what would be copied without actually copying anything with `--dry-run`
-- Delete copy markers (e.g. `tenant1/markers/01EZED0X3YZMNJ3NHGMJJKMHCR-copied-backfill`) from the source bucket with `--clear-copy-markers` instead of copying blocks, allowing blocks to be re-copied on the next run. Respects `--enabled-users` and `--disabled-users`.
 
 ## Running
 

--- a/tools/copyblocks/README.md
+++ b/tools/copyblocks/README.md
@@ -109,12 +109,12 @@ Copies blocks from object storage to a Mimir instance using the block upload API
   --s3.source.endpoint <source endpoint> \
   --backfill.address <Mimir address> \
   --backfill.id <tenant id> \
-  --backfill.auth-token <bearer token> \
+  --backfill.key <token used in basic auth> \
   --min-time 2026-01-15T00:00:00Z \
   --max-time 2026-02-15T00:00:00Z \
   --dry-run
 ```
 
-`--backfill.id` sets the tenant ID (X-Scope-OrgID header). Use `--backfill.auth-token` for bearer token auth or `--backfill.basic-auth-key` for basic auth (username is the tenant ID). TLS is configurable with `--backfill.tls-*`.
+`--backfill.id` sets the user ID (X-Scope-OrgID header). Use `--backfill.auth-token` for bearer token auth or `--backfill.key` for basic auth. TLS is configurable with `--backfill.tls-*`.
 
 Note that `--user-mapping` cannot be used with the backfill destination.

--- a/tools/copyblocks/README.md
+++ b/tools/copyblocks/README.md
@@ -97,7 +97,7 @@ For instance, to copy from S3 to ABS:
 
 ### Example for backfilling to Mimir
 
-Blocks can be copied to a Mimir instance via the block upload API by setting `--destination.backend backfill`.
+Copies blocks from object storage to a Mimir instance using the block upload API.
 
 ```bash
 ./copyblocks \
@@ -107,7 +107,7 @@ Blocks can be copied to a Mimir instance via the block upload API by setting `--
   --s3.source.access-key-id <source access key id> \
   --s3.source.secret-access-key <source secret access key> \
   --s3.source.endpoint <source endpoint> \
-  --backfill.address <mimir address> \
+  --backfill.address <Mimir address> \
   --backfill.id <tenant id> \
   --backfill.auth-token <bearer token> \
   --min-time 2026-01-15T00:00:00Z \
@@ -115,6 +115,6 @@ Blocks can be copied to a Mimir instance via the block upload API by setting `--
   --dry-run
 ```
 
-The `--backfill.id` flag sets the tenant ID (X-Scope-OrgID header). Authentication is configured with either `--backfill.auth-token` (bearer token) or `--backfill.basic-auth-key` (basic auth, using the tenant ID as the username). TLS can be configured with the `--backfill.tls-*` flags.
+`--backfill.id` sets the tenant ID (X-Scope-OrgID header). Use `--backfill.auth-token` for bearer token auth or `--backfill.basic-auth-key` for basic auth (username is the tenant ID). TLS is configurable with `--backfill.tls-*`.
 
 Note that `--user-mapping` cannot be used with the backfill destination.

--- a/tools/copyblocks/README.md
+++ b/tools/copyblocks/README.md
@@ -1,14 +1,14 @@
 # copyblocks
 
-This program can copy Mimir blocks between two buckets.
+This program can copy Mimir blocks between two buckets or from a bucket to a backfill destination.
 
-By default, the copy will be attempted server-side if both the source and destination specify the same object storage service. If the buckets are on different object storage services, or if `--client-side-copy` is passed, then the copy will be performed client side.
+By default, a copy between two buckets will be attempted server-side if both the source and destination specify the same object storage service. If the buckets are on different object storage services, or if `--client-side-copy` is passed, then the copy will be performed client side.
 
-The currently supported services are Amazon Simple Storage Service (S3 and S3-compatible), Azure Blob Storage (ABS), and Google Cloud Storage (GCS).
+The currently supported object storage services are Amazon Simple Storage Service (S3 and S3-compatible), Azure Blob Storage (ABS), and Google Cloud Storage (GCS).
 
 ## Features
 
-- Prevents copying blocks multiple times to the same destination bucket by uploading block marker files to the source bucket
+- Prevents copying blocks multiple times to the same destination by uploading block marker files to the source bucket
 - Runs continuously with periodic checks when supplied a time duration with `--copy-period`, otherwise runs one check then exits
 - Include or exclude users from having blocks copied (`--enabled-users` and `--disabled-users`)
 - Configurable minimum block duration (`--min-block-duration`) and (`--skip-no-compact-block-duration-check`) to target blocks that are not awaiting compaction
@@ -52,7 +52,7 @@ Run `go build` in this directory to build the program. Then, use an example belo
 
 ### Example for Amazon Simple Storage Service
 
-The destination is called to intiate the server-side copy which may require setting up additional permissions for the copy to have access the source bucket.
+A destination bucket is called to initiate the server-side copy which may require setting up additional permissions for the copy to have access the source bucket.
 Consider passing `--client-side-copy` to avoid having to deal with that.
 
 ```bash
@@ -74,7 +74,7 @@ Consider passing `--client-side-copy` to avoid having to deal with that.
 
 If both `--s3.<source|destination>.access-key-id` and `--s3.<source|destination>.secret-access-key` are omitted, credentials are resolved from the environment. This supports IAM roles for service accounts (IRSA) on EKS, ECS task roles, and EC2 instance metadata, and lets a single role that has access to both buckets authenticate the source and destination clients without passing static credentials.
 
-### Example for copying between different providers
+### Example for copying between different object storage providers
 
 Combine the relevant source and destination configuration options using the above examples as a guide.
 For instance, to copy from S3 to ABS:
@@ -94,3 +94,23 @@ For instance, to copy from S3 to ABS:
   --min-block-duration 13h \
   --dry-run
 ```
+
+### Example for backfilling to Mimir
+
+Blocks can be copied to a Mimir instance via the block upload API by setting `--destination.backend backfill`.
+
+```bash
+./copyblocks \
+  --source.backend gcs \
+  --destination.backend backfill \
+  --gcs.source.bucket-name <source bucket name> \
+  --backfill.address <mimir address> \
+  --backfill.id <tenant id> \
+  --backfill.auth-token <bearer token> \
+  --min-block-duration 13h \
+  --dry-run
+```
+
+The `--backfill.id` flag sets the tenant ID (X-Scope-OrgID header). Authentication is configured with either `--backfill.auth-token` (bearer token) or `--backfill.basic-auth-key` (basic auth, using the tenant ID as the username). TLS can be configured with the `--backfill.tls-*` flags.
+
+Note that `--user-mapping` cannot be used with the backfill destination.

--- a/tools/copyblocks/README.md
+++ b/tools/copyblocks/README.md
@@ -53,7 +53,7 @@ Run `go build` in this directory to build the program. Then, use an example belo
 
 ### Example for Amazon Simple Storage Service
 
-A destination bucket is called to initiate the server-side copy which may require setting up additional permissions for the copy to have access the source bucket.
+The destination bucket is called to initiate the server-side copy which may require setting up additional permissions for the copy to have access the source bucket.
 Consider passing `--client-side-copy` to avoid having to deal with that.
 
 ```bash

--- a/tools/copyblocks/README.md
+++ b/tools/copyblocks/README.md
@@ -12,7 +12,7 @@ The currently supported object storage services are Amazon Simple Storage Servic
 - Runs continuously with periodic checks when supplied a time duration with `--copy-period`, otherwise runs one check then exits
 - Include or exclude users from having blocks copied (`--enabled-users` and `--disabled-users`)
 - Configurable minimum block duration (`--min-block-duration`) and (`--skip-no-compact-block-duration-check`) to target blocks that are not awaiting compaction
-- Configurable time range (`--min-time` and `--max-time`) to only copy blocks inclusively within a provided range
+- Configurable time range (`--min-time` and `--max-time`) to only copy blocks inclusively within a provided range (e.g. `--min-time 2026-01-15T00:00:00Z`)
 - Copy blocks between users with `--user-mapping`. For instance, `--user-mapping="user1:user2,user3:user4"` maps source blocks from `user1` to `user2` and source blocks from `user3` to `user4`. If you don't provide a mapping for a user, it is assumed to be identical to the source user.
 - Log what would be copied without actually copying anything with `--dry-run`
 
@@ -101,13 +101,17 @@ Blocks can be copied to a Mimir instance via the block upload API by setting `--
 
 ```bash
 ./copyblocks \
-  --source.backend gcs \
+  --source.backend s3 \
   --destination.backend backfill \
-  --gcs.source.bucket-name <source bucket name> \
+  --s3.source.bucket-name <source bucket name> \
+  --s3.source.access-key-id <source access key id> \
+  --s3.source.secret-access-key <source secret access key> \
+  --s3.source.endpoint <source endpoint> \
   --backfill.address <mimir address> \
   --backfill.id <tenant id> \
   --backfill.auth-token <bearer token> \
-  --min-block-duration 13h \
+  --min-time 2026-01-15T00:00:00Z \
+  --max-time 2026-02-15T00:00:00Z \
   --dry-run
 ```
 

--- a/tools/copyblocks/main.go
+++ b/tools/copyblocks/main.go
@@ -149,6 +149,9 @@ func (c *backfillConfig) Validate() error {
 	if c.clientConfig.ID == "" {
 		return fmt.Errorf("-backfill.id is required when -destination.backend is set to backfill")
 	}
+	if err := tenant.ValidTenantID(c.clientConfig.ID); err != nil {
+		return fmt.Errorf("-backfill.id is invalid: %w", err)
+	}
 	if c.clientConfig.Key != "" && c.clientConfig.AuthToken != "" {
 		return fmt.Errorf("at most one of -backfill.key and -backfill.auth-token can be set")
 	}
@@ -228,6 +231,7 @@ func main() {
 			level.Error(logger).Log("msg", "failed to clear copy markers", "err", err)
 			os.Exit(1)
 		}
+		level.Info(logger).Log("msg", "finished clearing copy markers")
 		os.Exit(0)
 	}
 
@@ -356,8 +360,12 @@ func copyBlocks(ctx context.Context, cfg config, userMapping map[string]string, 
 			return nil
 		}
 
-		destinationTenantID, ok := userMapping[sourceTenantID]
-		if !ok {
+		var destinationTenantID string
+		if cfg.isBackfill() {
+			destinationTenantID = cfg.backfill.clientConfig.ID
+		} else if id, ok := userMapping[sourceTenantID]; ok {
+			destinationTenantID = id
+		} else {
 			destinationTenantID = sourceTenantID
 		}
 

--- a/tools/copyblocks/main.go
+++ b/tools/copyblocks/main.go
@@ -51,6 +51,7 @@ type config struct {
 	userMapping                     flagext.StringSliceCSV
 	dryRun                          bool
 	skipNoCompactBlockDurationCheck bool
+	clearCopyMarkers                bool
 	httpListen                      string
 }
 
@@ -68,11 +69,16 @@ func (c *config) registerFlags(f *flag.FlagSet) {
 	f.Var(&c.userMapping, "user-mapping", "A comma-separated list of (source user):(destination user). If a user is not mapped then its destination user is assumed to be identical.")
 	f.BoolVar(&c.dryRun, "dry-run", false, "Don't perform any copy; only log what would happen.")
 	f.BoolVar(&c.skipNoCompactBlockDurationCheck, "skip-no-compact-block-duration-check", false, "If set, blocks marked as no-compact are not checked against min-block-duration.")
+	f.BoolVar(&c.clearCopyMarkers, "clear-copy-markers", false, "If set, delete copy markers from the source bucket instead of copying blocks, allowing blocks to be re-copied. Respects -enabled-users and -disabled-users.")
 	f.StringVar(&c.httpListen, "http-listen-address", ":8080", "HTTP listen address.")
 }
 
 func (c *config) validate() error {
-	if c.isBackfill() {
+	if c.clearCopyMarkers {
+		if err := c.copyConfig.ValidateSource(); err != nil {
+			return err
+		}
+	} else if c.isBackfill() {
 		if err := c.copyConfig.ValidateSource(); err != nil {
 			return err
 		}
@@ -154,6 +160,8 @@ type metrics struct {
 	copyCyclesFailed    prometheus.Counter
 	blocksCopied        prometheus.Counter
 	blocksCopyFailed    prometheus.Counter
+	blocksAlreadyExist  prometheus.Counter
+	blocksInvalid       prometheus.Counter
 }
 
 func newMetrics(reg prometheus.Registerer) *metrics {
@@ -173,6 +181,14 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 		blocksCopyFailed: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "cortex_blocks_copy_blocks_failed_total",
 			Help: "Number of blocks that failed to copy.",
+		}),
+		blocksAlreadyExist: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "cortex_blocks_copy_blocks_already_exist_total",
+			Help: "Number of blocks that were not copied because they already exist on the destination.",
+		}),
+		blocksInvalid: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "cortex_blocks_copy_blocks_invalid_total",
+			Help: "Number of blocks that were rejected as permanently invalid by the destination.",
 		}),
 	}
 }
@@ -206,6 +222,14 @@ func main() {
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
+
+	if cfg.clearCopyMarkers {
+		if err := clearCopyMarkers(ctx, cfg, logger); err != nil {
+			level.Error(logger).Log("msg", "failed to clear copy markers", "err", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
 
 	m := newMetrics(prometheus.DefaultRegisterer)
 
@@ -325,14 +349,7 @@ func copyBlocks(ctx context.Context, cfg config, userMapping map[string]string, 
 		return fmt.Errorf("failed to list tenants: %w", err)
 	}
 
-	enabledUsers := map[string]struct{}{}
-	disabledUsers := map[string]struct{}{}
-	for _, u := range cfg.enabledUsers {
-		enabledUsers[u] = struct{}{}
-	}
-	for _, u := range cfg.disabledUsers {
-		disabledUsers[u] = struct{}{}
-	}
+	enabledUsers, disabledUsers := cfg.userFilters()
 
 	return concurrency.ForEachUser(ctx, tenants, cfg.tenantConcurrency, func(ctx context.Context, sourceTenantID string) error {
 		if !isAllowedUser(enabledUsers, disabledUsers, sourceTenantID) {
@@ -430,15 +447,20 @@ func copyBlocks(ctx context.Context, cfg config, userMapping map[string]string, 
 			level.Info(logger).Log("msg", "copying block")
 
 			err = copier.copyBlock(ctx, sourceTenantID, destinationTenantID, blockID, markers[blockID])
-			if errors.Is(err, errBlockAlreadyExists) {
+			switch {
+			case err == nil:
+				m.blocksCopied.Inc()
+				level.Info(logger).Log("msg", "block copied successfully")
+			case errors.Is(err, errBlockAlreadyExists):
+				m.blocksAlreadyExist.Inc()
 				level.Info(logger).Log("msg", "block already exists on destination, writing copy marker")
-			} else if err != nil {
+			case errors.Is(err, client.ErrBlockInvalid):
+				m.blocksInvalid.Inc()
+				level.Warn(logger).Log("msg", "block is permanently invalid and will not be accepted, writing copy marker to skip", "err", err)
+			default:
 				m.blocksCopyFailed.Inc()
 				level.Error(logger).Log("msg", "failed to copy block", "err", err)
 				return err
-			} else {
-				m.blocksCopied.Inc()
-				level.Info(logger).Log("msg", "block copied successfully")
 			}
 
 			// Note that only the blockID and destination name are considered in the copy marker.
@@ -451,6 +473,65 @@ func copyBlocks(ctx context.Context, cfg config, userMapping map[string]string, 
 			return nil
 		})
 	})
+}
+
+func clearCopyMarkers(ctx context.Context, cfg config, logger log.Logger) error {
+	sourceBucket, err := cfg.copyConfig.SourceBucket(ctx)
+	if err != nil {
+		return err
+	}
+
+	tenants, err := listTenants(ctx, sourceBucket)
+	if err != nil {
+		return fmt.Errorf("failed to list tenants: %w", err)
+	}
+
+	enabledUsers, disabledUsers := cfg.userFilters()
+
+	return concurrency.ForEachUser(ctx, tenants, cfg.tenantConcurrency, func(ctx context.Context, tenantID string) error {
+		if !isAllowedUser(enabledUsers, disabledUsers, tenantID) {
+			return nil
+		}
+
+		logger := log.With(logger, "tenantID", tenantID)
+
+		names, err := listMarkerNamesForTenant(ctx, sourceBucket, tenantID)
+		if err != nil {
+			return fmt.Errorf("failed to list markers for tenant %v: %w", tenantID, err)
+		}
+
+		prefix := tenantID + objtools.Delim + block.MarkersPathname
+		for _, name := range names {
+			if ok, _, _ := IsCopiedToBucketMarkFilename(name); !ok {
+				continue
+			}
+			objectName := prefix + objtools.Delim + name
+			logger := log.With(logger, "marker", objectName)
+			if cfg.dryRun {
+				level.Info(logger).Log("msg", "would delete copy marker, but skipping due to dry-run")
+				continue
+			}
+			level.Info(logger).Log("msg", "deleting copy marker")
+			if err := sourceBucket.Delete(ctx, objectName, objtools.DeleteOptions{}); err != nil {
+				level.Error(logger).Log("msg", "failed to delete copy marker", "err", err)
+				return fmt.Errorf("failed to delete copy marker %v: %w", objectName, err)
+			}
+		}
+
+		return nil
+	})
+}
+
+func (c *config) userFilters() (map[string]struct{}, map[string]struct{}) {
+	enabled := make(map[string]struct{}, len(c.enabledUsers))
+	disabled := make(map[string]struct{}, len(c.disabledUsers))
+	for _, u := range c.enabledUsers {
+		enabled[u] = struct{}{}
+	}
+	for _, u := range c.disabledUsers {
+		disabled[u] = struct{}{}
+	}
+	return enabled, disabled
 }
 
 func isAllowedUser(enabled map[string]struct{}, disabled map[string]struct{}, tenantID string) bool {
@@ -587,7 +668,7 @@ type blockMarkers struct {
 	noCompact bool
 }
 
-func listBlockMarkersForTenant(ctx context.Context, bkt objtools.Bucket, tenantID string, destinationBucket string) (map[ulid.ULID]blockMarkers, error) {
+func listMarkerNamesForTenant(ctx context.Context, bkt objtools.Bucket, tenantID string) ([]string, error) {
 	prefix := tenantID + objtools.Delim + block.MarkersPathname
 	listing, err := bkt.List(ctx, objtools.ListOptions{
 		Prefix:    prefix,
@@ -596,7 +677,11 @@ func listBlockMarkersForTenant(ctx context.Context, bkt objtools.Bucket, tenantI
 	if err != nil {
 		return nil, err
 	}
-	markers, err := listing.ToNamesWithoutPrefix(prefix)
+	return listing.ToNamesWithoutPrefix(prefix)
+}
+
+func listBlockMarkersForTenant(ctx context.Context, bkt objtools.Bucket, tenantID string, destinationBucket string) (map[ulid.ULID]blockMarkers, error) {
+	markers, err := listMarkerNamesForTenant(ctx, bkt, tenantID)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/copyblocks/main.go
+++ b/tools/copyblocks/main.go
@@ -30,7 +30,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/thanos-io/objstore"
 
+	"github.com/grafana/mimir/pkg/mimirtool/client"
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
 	"github.com/grafana/mimir/pkg/util/objtools"
 )
@@ -49,10 +51,13 @@ type config struct {
 	dryRun                          bool
 	skipNoCompactBlockDurationCheck bool
 	httpListen                      string
+
+	backfill backfillConfig
 }
 
 func (c *config) registerFlags(f *flag.FlagSet) {
-	c.copyConfig.RegisterFlags(f)
+	c.copyConfig.RegisterFlags(f, true)
+	c.backfill.RegisterFlags(f)
 	f.DurationVar(&c.minBlockDuration, "min-block-duration", 0, "If non-zero, ignore blocks that cover block range smaller than this.")
 	f.Var(&c.minTime, "min-time", fmt.Sprintf("If set, only blocks with MinTime >= this value are copied. The supported time format is %q.", time.RFC3339))
 	f.Var(&c.maxTime, "max-time", fmt.Sprintf("If set, only blocks with MaxTime <= this value are copied. The supported time format is %q.", time.RFC3339))
@@ -68,7 +73,17 @@ func (c *config) registerFlags(f *flag.FlagSet) {
 }
 
 func (c *config) validate() error {
-	if err := c.copyConfig.Validate(); err != nil {
+	if c.isBackfill() {
+		if err := c.copyConfig.ValidateSource(); err != nil {
+			return err
+		}
+		if err := c.backfill.Validate(); err != nil {
+			return err
+		}
+		if len(c.userMapping) > 0 {
+			return fmt.Errorf("-user-mapping cannot be used with -destination.backend=backfill")
+		}
+	} else if err := c.copyConfig.Validate(); err != nil {
 		return err
 	}
 	if c.tenantConcurrency < 1 {
@@ -81,6 +96,10 @@ func (c *config) validate() error {
 		return fmt.Errorf("-copy-period must be non-negative")
 	}
 	return nil
+}
+
+func (c *config) isBackfill() bool {
+	return c.copyConfig.DestinationBackend() == backfillBackend
 }
 
 func (c *config) parseUserMapping() (map[string]string, error) {
@@ -102,6 +121,31 @@ func (c *config) parseUserMapping() (map[string]string, error) {
 		m[source] = splitMapping[1]
 	}
 	return m, nil
+}
+
+const backfillBackend = "backfill"
+
+type backfillConfig struct {
+	clientConfig client.Config
+	sleepTime    time.Duration
+}
+
+func (c *backfillConfig) RegisterFlags(f *flag.FlagSet) {
+	c.clientConfig.RegisterConnectionFlagsWithPrefix(backfillBackend, f)
+	f.DurationVar(&c.sleepTime, backfillBackend+".sleep-time", 20*time.Second, "How long to sleep between checking the state of block upload.")
+}
+
+func (c *backfillConfig) Validate() error {
+	if c.clientConfig.Address == "" {
+		return fmt.Errorf("-backfill.address is required when -destination.backend is set to backfill")
+	}
+	if c.clientConfig.ID == "" {
+		return fmt.Errorf("-backfill.id is required when -destination.backend is set to backfill")
+	}
+	if c.clientConfig.Key != "" && c.clientConfig.AuthToken != "" {
+		return fmt.Errorf("at most one of -backfill.key and -backfill.auth-token can be set")
+	}
+	return nil
 }
 
 type metrics struct {
@@ -211,8 +255,55 @@ func runCopy(ctx context.Context, cfg config, userMapping map[string]string, log
 	return true
 }
 
-func copyBlocks(ctx context.Context, cfg config, userMapping map[string]string, logger log.Logger, m *metrics) error {
+type blockCopier struct {
+	name      string
+	copyBlock func(ctx context.Context, srcTenant, dstTenant string, blockID ulid.ULID, markers blockMarkers) error
+}
+
+func newBucketBlockCopier(ctx context.Context, cfg config) (objtools.Bucket, *blockCopier, error) {
 	sourceBucket, destBucket, copyFunc, err := cfg.copyConfig.ToBuckets(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	return sourceBucket, &blockCopier{
+		name: destBucket.Name(),
+		copyBlock: func(ctx context.Context, srcTenant, dstTenant string, blockID ulid.ULID, markers blockMarkers) error {
+			return copySingleBlock(ctx, srcTenant, dstTenant, blockID, markers, sourceBucket, copyFunc)
+		},
+	}, nil
+}
+
+func newBackfillBlockCopier(ctx context.Context, cfg config, logger log.Logger) (objtools.Bucket, *blockCopier, error) {
+	sourceBucket, err := cfg.copyConfig.SourceBucket(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	objstoreBkt, err := cfg.copyConfig.SourceObjstoreBucket(ctx, logger)
+	if err != nil {
+		return nil, nil, err
+	}
+	mimirClient, err := client.New(cfg.backfill.clientConfig, logger)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to create Mimir client for backfill")
+	}
+	return sourceBucket, &blockCopier{
+		name: "backfill",
+		copyBlock: func(ctx context.Context, srcTenant, _ string, blockID ulid.ULID, _ blockMarkers) error {
+			prefixedBkt := objstore.NewPrefixedBucket(objstoreBkt, srcTenant)
+			return mimirClient.BackfillBlock(ctx, prefixedBkt, blockID, cfg.backfill.sleepTime)
+		},
+	}, nil
+}
+
+func copyBlocks(ctx context.Context, cfg config, userMapping map[string]string, logger log.Logger, m *metrics) error {
+	var sourceBucket objtools.Bucket
+	var copier *blockCopier
+	var err error
+	if cfg.isBackfill() {
+		sourceBucket, copier, err = newBackfillBlockCopier(ctx, cfg, logger)
+	} else {
+		sourceBucket, copier, err = newBucketBlockCopier(ctx, cfg)
+	}
 	if err != nil {
 		return err
 	}
@@ -249,7 +340,7 @@ func copyBlocks(ctx context.Context, cfg config, userMapping map[string]string, 
 			return errors.Wrapf(err, "failed to list blocks for tenant %v", sourceTenantID)
 		}
 
-		markers, err := listBlockMarkersForTenant(ctx, sourceBucket, sourceTenantID, destBucket.Name())
+		markers, err := listBlockMarkersForTenant(ctx, sourceBucket, sourceTenantID, copier.name)
 		if err != nil {
 			level.Error(logger).Log("msg", "failed to list blocks markers for tenant", "err", err)
 			return errors.Wrapf(err, "failed to list block markers for tenant %v", sourceTenantID)
@@ -326,7 +417,7 @@ func copyBlocks(ctx context.Context, cfg config, userMapping map[string]string, 
 
 			level.Info(logger).Log("msg", "copying block")
 
-			err = copySingleBlock(ctx, sourceTenantID, destinationTenantID, blockID, markers[blockID], sourceBucket, copyFunc)
+			err = copier.copyBlock(ctx, sourceTenantID, destinationTenantID, blockID, markers[blockID])
 			if err != nil {
 				m.blocksCopyFailed.Inc()
 				level.Error(logger).Log("msg", "failed to copy block", "err", err)
@@ -338,7 +429,7 @@ func copyBlocks(ctx context.Context, cfg config, userMapping map[string]string, 
 
 			// Note that only the blockID and destination bucket are considered in the copy marker.
 			// If multiple tenants in the same destination bucket are copied to from the same source tenant the markers will currently clash.
-			err = uploadCopiedMarkerFile(ctx, sourceBucket, sourceTenantID, blockID, destBucket.Name())
+			err = uploadCopiedMarkerFile(ctx, sourceBucket, sourceTenantID, blockID, copier.name)
 			if err != nil {
 				level.Error(logger).Log("msg", "failed to upload copied-marker file for block", "block", blockID.String(), "err", err)
 				return err

--- a/tools/copyblocks/main.go
+++ b/tools/copyblocks/main.go
@@ -39,7 +39,7 @@ import (
 
 type config struct {
 	copyConfig                      objtools.CopyBucketConfig
-	backfill backfillConfig
+	backfill                        backfillConfig
 	minBlockDuration                time.Duration
 	minTime                         flagext.Time
 	maxTime                         flagext.Time
@@ -300,7 +300,7 @@ func newBackfillBlockCopier(ctx context.Context, cfg config, logger log.Logger) 
 			prefixedBkt := objstore.NewPrefixedBucket(objstoreBkt, srcTenant)
 			err := mimirClient.BackfillBlock(ctx, prefixedBkt, blockID, cfg.backfill.sleepTime)
 			if errors.Is(err, client.ErrConflict) {
-				return errBlockAlreadyExists 
+				return errBlockAlreadyExists
 			}
 			return err
 		},

--- a/tools/copyblocks/main.go
+++ b/tools/copyblocks/main.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"net/http"
@@ -26,7 +27,6 @@ import (
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/tenant"
 	"github.com/oklog/ulid/v2"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -39,6 +39,7 @@ import (
 
 type config struct {
 	copyConfig                      objtools.CopyBucketConfig
+	backfill backfillConfig
 	minBlockDuration                time.Duration
 	minTime                         flagext.Time
 	maxTime                         flagext.Time
@@ -51,8 +52,6 @@ type config struct {
 	dryRun                          bool
 	skipNoCompactBlockDurationCheck bool
 	httpListen                      string
-
-	backfill backfillConfig
 }
 
 func (c *config) registerFlags(f *flag.FlagSet) {
@@ -124,6 +123,8 @@ func (c *config) parseUserMapping() (map[string]string, error) {
 }
 
 const backfillBackend = "backfill"
+
+var errBlockAlreadyExists = errors.New("block already exists")
 
 type backfillConfig struct {
 	clientConfig client.Config
@@ -268,6 +269,13 @@ func newBucketBlockCopier(ctx context.Context, cfg config) (objtools.Bucket, *bl
 	return sourceBucket, &blockCopier{
 		name: destBucket.Name(),
 		copyBlock: func(ctx context.Context, srcTenant, dstTenant string, blockID ulid.ULID, markers blockMarkers) error {
+			exists, err := destBucket.Exists(ctx, metaObjectName(dstTenant, blockID))
+			if err != nil {
+				return fmt.Errorf("failed to check if block already exists on destination: %w", err)
+			}
+			if exists {
+				return errBlockAlreadyExists
+			}
 			return copySingleBlock(ctx, srcTenant, dstTenant, blockID, markers, sourceBucket, copyFunc)
 		},
 	}, nil
@@ -284,13 +292,17 @@ func newBackfillBlockCopier(ctx context.Context, cfg config, logger log.Logger) 
 	}
 	mimirClient, err := client.New(cfg.backfill.clientConfig, logger)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to create Mimir client for backfill")
+		return nil, nil, fmt.Errorf("failed to create Mimir client for backfill: %w", err)
 	}
 	return sourceBucket, &blockCopier{
 		name: "backfill",
 		copyBlock: func(ctx context.Context, srcTenant, _ string, blockID ulid.ULID, _ blockMarkers) error {
 			prefixedBkt := objstore.NewPrefixedBucket(objstoreBkt, srcTenant)
-			return mimirClient.BackfillBlock(ctx, prefixedBkt, blockID, cfg.backfill.sleepTime)
+			err := mimirClient.BackfillBlock(ctx, prefixedBkt, blockID, cfg.backfill.sleepTime)
+			if errors.Is(err, client.ErrConflict) {
+				return errBlockAlreadyExists 
+			}
+			return err
 		},
 	}, nil
 }
@@ -310,7 +322,7 @@ func copyBlocks(ctx context.Context, cfg config, userMapping map[string]string, 
 
 	tenants, err := listTenants(ctx, sourceBucket)
 	if err != nil {
-		return errors.Wrapf(err, "failed to list tenants")
+		return fmt.Errorf("failed to list tenants: %w", err)
 	}
 
 	enabledUsers := map[string]struct{}{}
@@ -337,13 +349,13 @@ func copyBlocks(ctx context.Context, cfg config, userMapping map[string]string, 
 		blocks, err := listBlocksForTenant(ctx, sourceBucket, sourceTenantID)
 		if err != nil {
 			level.Error(logger).Log("msg", "failed to list blocks for tenant", "err", err)
-			return errors.Wrapf(err, "failed to list blocks for tenant %v", sourceTenantID)
+			return fmt.Errorf("failed to list blocks for tenant %v: %w", sourceTenantID, err)
 		}
 
 		markers, err := listBlockMarkersForTenant(ctx, sourceBucket, sourceTenantID, copier.name)
 		if err != nil {
 			level.Error(logger).Log("msg", "failed to list blocks markers for tenant", "err", err)
-			return errors.Wrapf(err, "failed to list block markers for tenant %v", sourceTenantID)
+			return fmt.Errorf("failed to list block markers for tenant %v: %w", sourceTenantID, err)
 		}
 
 		var blockIDs []string
@@ -418,17 +430,19 @@ func copyBlocks(ctx context.Context, cfg config, userMapping map[string]string, 
 			level.Info(logger).Log("msg", "copying block")
 
 			err = copier.copyBlock(ctx, sourceTenantID, destinationTenantID, blockID, markers[blockID])
-			if err != nil {
+			if errors.Is(err, errBlockAlreadyExists) {
+				level.Info(logger).Log("msg", "block already exists on destination, writing copy marker")
+			} else if err != nil {
 				m.blocksCopyFailed.Inc()
 				level.Error(logger).Log("msg", "failed to copy block", "err", err)
 				return err
+			} else {
+				m.blocksCopied.Inc()
+				level.Info(logger).Log("msg", "block copied successfully")
 			}
 
-			m.blocksCopied.Inc()
-			level.Info(logger).Log("msg", "block copied successfully")
-
-			// Note that only the blockID and destination bucket are considered in the copy marker.
-			// If multiple tenants in the same destination bucket are copied to from the same source tenant the markers will currently clash.
+			// Note that only the blockID and destination name are considered in the copy marker.
+			// If multiple tenants in the same destination are copied to from the same source tenant the markers will currently clash.
 			err = uploadCopiedMarkerFile(ctx, sourceBucket, sourceTenantID, blockID, copier.name)
 			if err != nil {
 				level.Error(logger).Log("msg", "failed to upload copied-marker file for block", "block", blockID.String(), "err", err)
@@ -462,7 +476,7 @@ func copySingleBlock(ctx context.Context, sourceTenantID, destinationTenantID st
 		Recursive: true,
 	})
 	if err != nil {
-		return errors.Wrapf(err, "copySingleBlock: failed to list block files for %v/%v", sourceTenantID, blockID.String())
+		return fmt.Errorf("copySingleBlock: failed to list block files for %v/%v: %w", sourceTenantID, blockID.String(), err)
 	}
 	paths := result.ToNames()
 
@@ -494,7 +508,7 @@ func copySingleBlock(ctx context.Context, sourceTenantID, destinationTenantID st
 		}
 		err := copyFunc(ctx, fullPath, options)
 		if err != nil {
-			return errors.Wrapf(err, "copySingleBlock: failed to copy %v", fullPath)
+			return fmt.Errorf("copySingleBlock: failed to copy %v: %w", fullPath, err)
 		}
 	}
 
@@ -504,14 +518,21 @@ func copySingleBlock(ctx context.Context, sourceTenantID, destinationTenantID st
 func uploadCopiedMarkerFile(ctx context.Context, bkt objtools.Bucket, tenantID string, blockID ulid.ULID, targetBucketName string) error {
 	objectName := tenantID + objtools.Delim + CopiedToBucketMarkFilename(blockID, targetBucketName)
 	err := bkt.Upload(ctx, objectName, bytes.NewReader([]byte{}), 0)
-	return errors.Wrap(err, "uploadCopiedMarkerFile")
+	if err != nil {
+		return fmt.Errorf("uploadCopiedMarkerFile: %w", err)
+	}
+	return nil
+}
+
+func metaObjectName(tenantID string, blockID ulid.ULID) string {
+	return tenantID + objtools.Delim + blockID.String() + objtools.Delim + block.MetaFilename
 }
 
 func loadMetaJSONFile(ctx context.Context, bkt objtools.Bucket, tenantID string, blockID ulid.ULID) (block.Meta, error) {
-	objectName := tenantID + objtools.Delim + blockID.String() + objtools.Delim + block.MetaFilename
+	objectName := metaObjectName(tenantID, blockID)
 	r, err := bkt.Get(ctx, objectName, objtools.GetOptions{})
 	if err != nil {
-		return block.Meta{}, errors.Wrapf(err, "failed to read %v", objectName)
+		return block.Meta{}, fmt.Errorf("failed to read %v: %w", objectName, err)
 	}
 
 	var m block.Meta
@@ -521,10 +542,10 @@ func loadMetaJSONFile(ctx context.Context, bkt objtools.Bucket, tenantID string,
 	closeErr := r.Close() // do this before any return.
 
 	if err != nil {
-		return block.Meta{}, errors.Wrapf(err, "read %v", objectName)
+		return block.Meta{}, fmt.Errorf("read %v: %w", objectName, err)
 	}
 	if closeErr != nil {
-		return block.Meta{}, errors.Wrapf(err, "close reader for %v", objectName)
+		return block.Meta{}, fmt.Errorf("close reader for %v: %w", objectName, closeErr)
 	}
 
 	return m, nil

--- a/tools/copyblocks/main.go
+++ b/tools/copyblocks/main.go
@@ -56,7 +56,7 @@ type config struct {
 }
 
 func (c *config) registerFlags(f *flag.FlagSet) {
-	c.copyConfig.RegisterFlags(f, true)
+	c.copyConfig.RegisterFlags(f, []string{backfillBackend})
 	c.backfill.RegisterFlags(f)
 	f.DurationVar(&c.minBlockDuration, "min-block-duration", 0, "If non-zero, ignore blocks that cover block range smaller than this.")
 	f.Var(&c.minTime, "min-time", fmt.Sprintf("If set, only blocks with MinTime >= this value are copied. The supported time format is %q.", time.RFC3339))

--- a/tools/copyprefix/main.go
+++ b/tools/copyprefix/main.go
@@ -27,7 +27,7 @@ type config struct {
 }
 
 func (c *config) RegisterFlags(f *flag.FlagSet) {
-	c.copyConfig.RegisterFlags(f, false)
+	c.copyConfig.RegisterFlags(f, nil)
 	f.StringVar(&c.sourcePrefix, "source-prefix", "", "The prefix to copy from the source. If the prefix is not empty and does not end in '"+objtools.Delim+"' then it is appended.")
 	f.StringVar(&c.destinationPrefix, "destination-prefix", "", "Replaces the source prefix in the object name of objects copied to the destination. If not provided the object name from the source is used.")
 	f.BoolVar(&c.skipOverwrites, "skip-overwrites", false, "If true a listing will be performed on the destination bucket to skip copying objects already present there. The presence check is best effort.")

--- a/tools/copyprefix/main.go
+++ b/tools/copyprefix/main.go
@@ -27,7 +27,7 @@ type config struct {
 }
 
 func (c *config) RegisterFlags(f *flag.FlagSet) {
-	c.copyConfig.RegisterFlags(f)
+	c.copyConfig.RegisterFlags(f, false)
 	f.StringVar(&c.sourcePrefix, "source-prefix", "", "The prefix to copy from the source. If the prefix is not empty and does not end in '"+objtools.Delim+"' then it is appended.")
 	f.StringVar(&c.destinationPrefix, "destination-prefix", "", "Replaces the source prefix in the object name of objects copied to the destination. If not provided the object name from the source is used.")
 	f.BoolVar(&c.skipOverwrites, "skip-overwrites", false, "If true a listing will be performed on the destination bucket to skip copying objects already present there. The presence check is best effort.")


### PR DESCRIPTION
#### What this PR does

There's a gap with backfill support currently where blocks are expected to be in a local filesystem, but if the goal is to migrate a Mimir instance that won't be the case. These changes solve this by adding support for backfilling to `copyblocks`. To facilitate testing, `--clear-copy-markers` was also added since removing these markers was only done manually previously.

My first approach was to add bucket support to `mimirtool backfill` itself, but that on its own creates more problems because users would then need to specify tenants and may only want to copy a subset of blocks. `copyblocks` handles all of that already and more, so this adapts `mimirtool` to use a bucket interface and then adapts `copyblocks` to call into that implementation when it identifies a block to copy.

For transparency, these changes began by steering AI, then I cleaned it up and verified it.

There are a few design quirks:
- `copyblocks` uses its own bucket clients via `objtools` for server-side copying, but `objstore` is more standard and supports a filesystem bucket. An adapter method `ToObjstoreBucket` is used to go from the `objtools` configuration to an `objstore` bucket. This means two bucket clients get used for the source bucket.
- `kingpin` is used by `mimirtool` and only a subset of a configuration struct is wired for backfill. Rather than duplicate it, `RegisterConnectionFlagsWithPrefix` is used to register the flags used for the backfill connection.

I have run a manual test and `copyblocks` successfully ran a backfill.

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `backfill` execution path that uploads TSDB blocks to Mimir via the block upload API and introduces new bucket existence checks across S3/GCS/Azure, which could affect copy behavior and skipping logic. Risk is mitigated by new unit/integration tests but the change touches multiple tooling clients and storage backends.
> 
> **Overview**
> Adds a new **`backfill` destination** to `tools/copyblocks`, allowing blocks to be read from object storage and uploaded to a Mimir instance via the block upload API (with new `--backfill.*` connection flags and a polling sleep setting). The tool now records additional outcomes (already-exists/invalid) and supports `--clear-copy-markers` to delete previously written copied-marker files instead of copying.
> 
> Refactors `mimirtool` backfill to upload blocks from an `objstore.BucketReader` (including new `BackfillBlock`, bucket-based `GetBlockMeta`, and improved handling for permanently invalid blocks), and updates the integration test to use a filesystem bucket for meta generation. Extends `objtools.Bucket` with `Exists()` and implements it for S3/GCS/Azure, plus adds an adapter (`ToObjstoreBucket`) and minor credential-chain/docs updates to support the new backfill flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37971548c6eacc9f03be1907b5f715baed4afd94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->