### PR TITLE
mixin: widen `BlockBuilderPersistentJobFailure` alert lookback to prevent flapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 * [CHANGE] Dashboards: Show maximum queue length, not minimum queue length, on the "Queue length" panel in the "Query-scheduler" row of the "Reads" and "Remote ruler reads" dashboards. #15326
 * [ENHANCEMENT] Alerts: Make `MimirInconsistentRuntimeConfig` alert less flaky when performing multiple configuration changes in a row in a large Kubernetes cluster. #15257
+* [ENHANCEMENT] Alerts: Widen the `MimirBlockBuilderPersistentJobFailure` lookback window to 20m to prevent the alert from flapping. #15332
 
 ### Jsonnet
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -1641,7 +1641,7 @@ spec:
               message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has detected a persistently failing job.
               runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderpersistentjobfailure
             expr: |
-              increase(cortex_blockbuilder_scheduler_persistent_job_failures_total[1m]) > 0
+              increase(cortex_blockbuilder_scheduler_persistent_job_failures_total[20m]) > 0
             labels:
               severity: critical
           - alert: MimirFewerIngestersConsumingThanActivePartitions

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -1615,7 +1615,7 @@ groups:
             message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has detected a persistently failing job.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderpersistentjobfailure
           expr: |
-            increase(cortex_blockbuilder_scheduler_persistent_job_failures_total[1m]) > 0
+            increase(cortex_blockbuilder_scheduler_persistent_job_failures_total[20m]) > 0
           labels:
             severity: critical
         - alert: MimirFewerIngestersConsumingThanActivePartitions

--- a/operations/mimir-mixin-compiled-gem/alerts.yaml
+++ b/operations/mimir-mixin-compiled-gem/alerts.yaml
@@ -1629,7 +1629,7 @@ groups:
             message: GEM {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has detected a persistently failing job.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderpersistentjobfailure
           expr: |
-            increase(cortex_blockbuilder_scheduler_persistent_job_failures_total[1m]) > 0
+            increase(cortex_blockbuilder_scheduler_persistent_job_failures_total[20m]) > 0
           labels:
             severity: critical
         - alert: MimirFewerIngestersConsumingThanActivePartitions

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -1629,7 +1629,7 @@ groups:
             message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has detected a persistently failing job.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderpersistentjobfailure
           expr: |
-            increase(cortex_blockbuilder_scheduler_persistent_job_failures_total[1m]) > 0
+            increase(cortex_blockbuilder_scheduler_persistent_job_failures_total[20m]) > 0
           labels:
             severity: critical
         - alert: MimirFewerIngestersConsumingThanActivePartitions

--- a/operations/mimir-mixin/alerts/ingest-storage.libsonnet
+++ b/operations/mimir-mixin/alerts/ingest-storage.libsonnet
@@ -364,14 +364,11 @@ local utils = import 'mixin-utils/utils.libsonnet';
           },
         },
 
-        // Alert immediately if block-builder-scheduler detects a persistently failing job.
         {
           alert: $.alertName('BlockBuilderPersistentJobFailure'),
           expr: |||
-            increase(cortex_blockbuilder_scheduler_persistent_job_failures_total[%(range)s]) > 0
-          ||| % {
-            range: $.rateInterval('1m'),
-          },
+            increase(cortex_blockbuilder_scheduler_persistent_job_failures_total[20m]) > 0
+          |||,
           labels: {
             severity: 'critical',
           },

--- a/operations/mimir-mixin/alerts/ingest-storage.libsonnet
+++ b/operations/mimir-mixin/alerts/ingest-storage.libsonnet
@@ -364,6 +364,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
           },
         },
 
+        // Alert immediately if block-builder-scheduler detects a persistently failing job.
         {
           alert: $.alertName('BlockBuilderPersistentJobFailure'),
           expr: |||


### PR DESCRIPTION
#### What this PR does

Widen `BlockBuilderPersistentJobFailure` alert lookback to 20m to prevent/minimze flapping. We had an occasion where a job has consistently failing and being retried every ~5mins. A lookback shorter than that was causing the alert to constantly fire and resolve.

This makes the lookback larger to minimize the chances of that happening. It could still happen that the job is retried in cycles >20min, but hopefully that's much less likely. 

The flip side of this is the alert will take 20mins to resolve itself if the errors actually stopped. But to me it's a fair trade off, and without additional complexity. 

#### Which issue(s) this PR fixes or relates to


N/A

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk monitoring-only change, but it will delay alert resolution and could change paging behavior due to the longer lookback window.
> 
> **Overview**
> Widen the `MimirBlockBuilderPersistentJobFailure` alert’s PromQL lookback from `1m` to `20m` to reduce flapping when failures occur on multi-minute retry cycles.
> 
> Propagates the new lookback through the source mixin (`ingest-storage.libsonnet`), regenerated compiled alert bundles, and helm metamonitoring test outputs, and records the change in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b93e4f7f90c1b2f4fa4c3d428c3c143feb337a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->