### PR TITLE
block-builder-scheduler: use iterator in job creation policy

### DIFF
--- a/pkg/blockbuilder/scheduler/jobs.go
+++ b/pkg/blockbuilder/scheduler/jobs.go
@@ -5,6 +5,8 @@ package scheduler
 import (
 	"container/list"
 	"errors"
+	"fmt"
+	"iter"
 	"sync"
 	"time"
 
@@ -126,14 +128,19 @@ func (s *jobQueue[T]) add(id string, spec T) error {
 		return errJobAlreadyExists
 	}
 
-	// See if the creation policy would allow it.
-
-	existingJobs := make([]*T, 0, len(s.jobs))
-	for _, j := range s.jobs {
-		existingJobs = append(existingJobs, &j.spec)
+	// See if the creation policy would allow it. The iterator yields a
+	// reference to each existing job's spec; the policy must not retain those
+	// references beyond the call as the underlying jobs may mutate or be
+	// removed once the queue lock is released.
+	existing := func(yield func(*T) bool) {
+		for _, j := range s.jobs {
+			if !yield(&j.spec) {
+				return
+			}
+		}
 	}
-	if !s.creationPolicy.canCreateJob(jobKey{id: id}, &spec, existingJobs) {
-		return errJobCreationDisallowed
+	if err := s.creationPolicy.canCreateJob(jobKey{id: id}, &spec, existing); err != nil {
+		return fmt.Errorf("%w: %w", errJobCreationDisallowed, err)
 	}
 
 	j := &job[T]{
@@ -314,14 +321,20 @@ type jobKey struct {
 	epoch int64
 }
 
+// jobCreationPolicy decides whether a candidate job is allowed to be added to
+// the queue. existing is a lazy iterator over references to the specs of jobs
+// already in the queue at the time of the call; policies are free to stop
+// iterating early. The references must not be retained after canCreateJob
+// returns. A nil error means the job is allowed; any non-nil error rejects the
+// job and is wrapped in errJobCreationDisallowed.
 type jobCreationPolicy[T any] interface {
-	canCreateJob(jobKey, *T, []*T) bool
+	canCreateJob(key jobKey, spec *T, existing iter.Seq[*T]) error
 }
 
 type noOpJobCreationPolicy[T any] struct{}
 
-func (p noOpJobCreationPolicy[T]) canCreateJob(_ jobKey, _ *T, _ []*T) bool { // nolint:unused
-	return true
+func (p noOpJobCreationPolicy[T]) canCreateJob(_ jobKey, _ *T, _ iter.Seq[*T]) error { // nolint:unused
+	return nil
 }
 
 var _ jobCreationPolicy[any] = (*noOpJobCreationPolicy[any])(nil)

--- a/pkg/blockbuilder/scheduler/jobs_test.go
+++ b/pkg/blockbuilder/scheduler/jobs_test.go
@@ -3,6 +3,8 @@
 package scheduler
 
 import (
+	"errors"
+	"iter"
 	"strings"
 	"testing"
 	"time"
@@ -227,8 +229,8 @@ func TestJobCreationPolicies(t *testing.T) {
 // allowNoneJobCreationPolicy is a job creation policy that never allows job creation.
 type allowNoneJobCreationPolicy[T any] struct{}
 
-func (p allowNoneJobCreationPolicy[T]) canCreateJob(_ jobKey, _ *T, _ []*T) bool { // nolint:unused
-	return false
+func (p allowNoneJobCreationPolicy[T]) canCreateJob(_ jobKey, _ *T, _ iter.Seq[*T]) error { // nolint:unused
+	return errors.New("allowNoneJobCreationPolicy")
 }
 
 var _ jobCreationPolicy[any] = (*allowNoneJobCreationPolicy[any])(nil)

--- a/pkg/blockbuilder/scheduler/scheduler.go
+++ b/pkg/blockbuilder/scheduler/scheduler.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"iter"
 	"slices"
 	"strings"
 	"sync"
@@ -1010,20 +1011,20 @@ type limitPerPartitionJobCreationPolicy struct {
 }
 
 // canCreateJob allows at most $partitionLimit jobs per partition.
-// TODO(davidgrant): add an error return to explain the reason for rejection.
-func (p limitPerPartitionJobCreationPolicy) canCreateJob(_ jobKey, spec *schedulerpb.JobSpec, existingJobs []*schedulerpb.JobSpec) bool {
+func (p limitPerPartitionJobCreationPolicy) canCreateJob(_ jobKey, spec *schedulerpb.JobSpec, existing iter.Seq[*schedulerpb.JobSpec]) error {
 	remaining := p.partitionLimit - 1 // -1: we're about to add one.
 
-	for _, existing := range existingJobs {
-		if existing.Topic == spec.Topic && existing.Partition == spec.Partition {
-			remaining--
-			if remaining < 0 {
-				return false
-			}
+	for existingSpec := range existing {
+		if existingSpec.Topic != spec.Topic || existingSpec.Partition != spec.Partition {
+			continue
+		}
+		if remaining--; remaining < 0 {
+			return fmt.Errorf("partition %d already has %d in-flight jobs (limit %d)",
+				spec.Partition, p.partitionLimit, p.partitionLimit)
 		}
 	}
 
-	return true
+	return nil
 }
 
 var _ jobCreationPolicy[schedulerpb.JobSpec] = (*limitPerPartitionJobCreationPolicy)(nil)

--- a/pkg/blockbuilder/scheduler/scheduler_test.go
+++ b/pkg/blockbuilder/scheduler/scheduler_test.go
@@ -6,7 +6,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"iter"
 	"math/rand"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -971,50 +973,89 @@ func TestPopulateInitialJobs_ProbeTimesReused(t *testing.T) {
 }
 
 func TestLimitNPolicy(t *testing.T) {
+	existing := func(specs ...*schedulerpb.JobSpec) iter.Seq[*schedulerpb.JobSpec] {
+		return slices.Values(specs)
+	}
+
 	allow1 := limitPerPartitionJobCreationPolicy{partitionLimit: 1}
 
-	ok := allow1.canCreateJob(jobKey{id: "job1"}, &schedulerpb.JobSpec{Topic: "topic", Partition: 0}, []*schedulerpb.JobSpec{})
-	require.True(t, ok)
+	require.NoError(t, allow1.canCreateJob(jobKey{id: "job1"},
+		&schedulerpb.JobSpec{Topic: "topic", Partition: 0}, existing()))
 
-	ok = allow1.canCreateJob(jobKey{id: "job4"}, &schedulerpb.JobSpec{Topic: "topic", Partition: 0}, []*schedulerpb.JobSpec{
-		{Topic: "topic", Partition: 1},
-	})
-	require.True(t, ok)
+	require.NoError(t, allow1.canCreateJob(jobKey{id: "job4"},
+		&schedulerpb.JobSpec{Topic: "topic", Partition: 0},
+		existing(&schedulerpb.JobSpec{Topic: "topic", Partition: 1})))
 
-	ok = allow1.canCreateJob(jobKey{id: "job5"}, &schedulerpb.JobSpec{Topic: "topic", Partition: 1}, []*schedulerpb.JobSpec{
-		{Topic: "topic", Partition: 1},
-	})
-	require.False(t, ok)
+	require.Error(t, allow1.canCreateJob(jobKey{id: "job5"},
+		&schedulerpb.JobSpec{Topic: "topic", Partition: 1},
+		existing(&schedulerpb.JobSpec{Topic: "topic", Partition: 1})))
 
-	ok = allow1.canCreateJob(jobKey{id: "job5"}, &schedulerpb.JobSpec{Topic: "topic", Partition: 1}, []*schedulerpb.JobSpec{
-		{Topic: "topic", Partition: 2},
-		{Topic: "topic", Partition: 3},
-		{Topic: "topic", Partition: 3},
-	})
-	require.True(t, ok)
+	require.NoError(t, allow1.canCreateJob(jobKey{id: "job5"},
+		&schedulerpb.JobSpec{Topic: "topic", Partition: 1},
+		existing(
+			&schedulerpb.JobSpec{Topic: "topic", Partition: 2},
+			&schedulerpb.JobSpec{Topic: "topic", Partition: 3},
+			&schedulerpb.JobSpec{Topic: "topic", Partition: 3},
+		)))
 
 	allow2 := limitPerPartitionJobCreationPolicy{partitionLimit: 2}
-	ok = allow2.canCreateJob(jobKey{id: "job6"}, &schedulerpb.JobSpec{Topic: "topic", Partition: 1}, []*schedulerpb.JobSpec{
-		{Topic: "topic", Partition: 2},
-		{Topic: "topic", Partition: 3},
-	})
-	require.True(t, ok)
-	ok = allow2.canCreateJob(jobKey{id: "job6"}, &schedulerpb.JobSpec{Topic: "topic", Partition: 1}, []*schedulerpb.JobSpec{
-		{Topic: "topic", Partition: 1},
-		{Topic: "topic", Partition: 2},
-	})
-	require.True(t, ok)
-	ok = allow2.canCreateJob(jobKey{id: "job6"}, &schedulerpb.JobSpec{Topic: "topic", Partition: 1}, []*schedulerpb.JobSpec{
-		{Topic: "topic", Partition: 1},
-		{Topic: "topic", Partition: 1},
-	})
-	require.False(t, ok)
-	ok = allow2.canCreateJob(jobKey{id: "job6"}, &schedulerpb.JobSpec{Topic: "topic", Partition: 1}, []*schedulerpb.JobSpec{
-		{Topic: "topic", Partition: 1},
-		{Topic: "topic", Partition: 1},
-		{Topic: "topic", Partition: 1},
-	})
-	require.False(t, ok)
+	require.NoError(t, allow2.canCreateJob(jobKey{id: "job6"},
+		&schedulerpb.JobSpec{Topic: "topic", Partition: 1},
+		existing(
+			&schedulerpb.JobSpec{Topic: "topic", Partition: 2},
+			&schedulerpb.JobSpec{Topic: "topic", Partition: 3},
+		)))
+	require.NoError(t, allow2.canCreateJob(jobKey{id: "job6"},
+		&schedulerpb.JobSpec{Topic: "topic", Partition: 1},
+		existing(
+			&schedulerpb.JobSpec{Topic: "topic", Partition: 1},
+			&schedulerpb.JobSpec{Topic: "topic", Partition: 2},
+		)))
+	require.Error(t, allow2.canCreateJob(jobKey{id: "job6"},
+		&schedulerpb.JobSpec{Topic: "topic", Partition: 1},
+		existing(
+			&schedulerpb.JobSpec{Topic: "topic", Partition: 1},
+			&schedulerpb.JobSpec{Topic: "topic", Partition: 1},
+		)))
+	require.Error(t, allow2.canCreateJob(jobKey{id: "job6"},
+		&schedulerpb.JobSpec{Topic: "topic", Partition: 1},
+		existing(
+			&schedulerpb.JobSpec{Topic: "topic", Partition: 1},
+			&schedulerpb.JobSpec{Topic: "topic", Partition: 1},
+			&schedulerpb.JobSpec{Topic: "topic", Partition: 1},
+		)))
+}
+
+func TestLimitNPolicyShortCircuits(t *testing.T) {
+	// Verify that the policy stops iterating as soon as it has counted enough
+	// matches to reject: with partitionLimit=2 we are about to add one, so the
+	// second matching existing job is what trips rejection. The iterator must
+	// not be advanced beyond that point.
+	policy := limitPerPartitionJobCreationPolicy{partitionLimit: 2}
+	spec := &schedulerpb.JobSpec{Topic: "topic", Partition: 0}
+
+	visited := 0
+	existing := func(yield func(*schedulerpb.JobSpec) bool) {
+		matching := []*schedulerpb.JobSpec{
+			{Topic: "topic", Partition: 0},
+			{Topic: "topic", Partition: 0},
+		}
+		for _, s := range matching {
+			visited++
+			if !yield(s) {
+				return
+			}
+		}
+		for i := 0; i < 1000; i++ {
+			visited++
+			if !yield(&schedulerpb.JobSpec{Topic: "topic", Partition: 99}) {
+				return
+			}
+		}
+	}
+
+	require.Error(t, policy.canCreateJob(jobKey{id: "job1"}, spec, existing))
+	require.Equal(t, 2, visited, "policy should stop iterating once it has decided to reject")
 }
 
 func TestPartitionState(t *testing.T) {


### PR DESCRIPTION
#### What this PR does

Refactors the job creation policy code so `canCreateJob` method takes an iterator instead of a slice. This removes some greedy overzealous slice alloc/copying from that code. Also addressed an old TODO which was to return a more meaningful reason when the policy rejects a job.

#### Checklist

- [x] Tests updated.
- (n/a) Documentation added.
- (n/a) `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- (n/a) [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the job admission path in the scheduler by altering the `jobCreationPolicy` API and error-handling semantics; mistakes could cause jobs to be incorrectly accepted/rejected or produce noisier errors, but scope is limited to scheduler job-queueing.
> 
> **Overview**
> Refactors scheduler job admission so `jobCreationPolicy.canCreateJob` takes a lazy `iter.Seq` of existing job specs instead of an eagerly-built slice, avoiding allocation/copy and allowing policies to short-circuit iteration.
> 
> Updates policies to return an `error` explaining rejection (instead of `bool`), with `jobQueue.add` wrapping the underlying reason under `errJobCreationDisallowed`; `limitPerPartitionJobCreationPolicy` now emits a specific “in-flight jobs” error. Tests are updated accordingly and add coverage that the iterator is not advanced once rejection is decided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be3e2e872cc43360cdeb66e851d86f08e5a7e218. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->