### PR TITLE
Streaming labels values PR 3

### DIFF
--- a/pkg/querier/memory_tracking_queryable.go
+++ b/pkg/querier/memory_tracking_queryable.go
@@ -4,6 +4,7 @@ package querier
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/labels"
@@ -11,6 +12,7 @@ import (
 	"github.com/prometheus/prometheus/util/annotations"
 
 	"github.com/grafana/mimir/pkg/storage/series"
+	"github.com/grafana/mimir/pkg/streaminglabelvalues"
 	"github.com/grafana/mimir/pkg/util/limiter"
 )
 
@@ -59,6 +61,28 @@ func (q *memoryTrackingQuerier) LabelValues(ctx context.Context, name string, hi
 
 func (q *memoryTrackingQuerier) LabelNames(ctx context.Context, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
 	return q.inner.LabelNames(ctx, hints, matchers...)
+}
+
+// SearchLabelNames passes through to the inner querier's mimirSearcher
+// implementation. No memory tracking is applied to label search — the
+// streaming SearchResultSet caps memory at the per-tenant Limit via the
+// merge tree, so wrapping each emitted Value in a tracker would be
+// redundant work on the hot path.
+func (q *memoryTrackingQuerier) SearchLabelNames(ctx context.Context, params *streaminglabelvalues.Params, hints *storage.SearchHints, matchers ...*labels.Matcher) storage.SearchResultSet {
+	s, ok := q.inner.(mimirSearcher)
+	if !ok {
+		return storage.ErrSearchResultSet(fmt.Errorf("inner querier %T does not implement search", q.inner))
+	}
+	return s.SearchLabelNames(ctx, params, hints, matchers...)
+}
+
+// SearchLabelValues mirrors SearchLabelNames; see that docstring for rationale.
+func (q *memoryTrackingQuerier) SearchLabelValues(ctx context.Context, name string, params *streaminglabelvalues.Params, hints *storage.SearchHints, matchers ...*labels.Matcher) storage.SearchResultSet {
+	s, ok := q.inner.(mimirSearcher)
+	if !ok {
+		return storage.ErrSearchResultSet(fmt.Errorf("inner querier %T does not implement search", q.inner))
+	}
+	return s.SearchLabelValues(ctx, name, params, hints, matchers...)
 }
 
 func (q *memoryTrackingQuerier) Close() error {

--- a/pkg/querier/memory_tracking_queryable_test.go
+++ b/pkg/querier/memory_tracking_queryable_test.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package querier
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/util/annotations"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/streaminglabelvalues"
+)
+
+// passThroughQuerier satisfies storage.Querier and mimirSearcher. The search
+// methods record which one was called and return a single configured result so
+// the test can verify pass-through happened without re-testing the merge logic.
+type passThroughQuerier struct {
+	searchNamesResults  []storage.SearchResult
+	searchValuesResults []storage.SearchResult
+	searchValuesName    string
+	searchNamesCalls    int
+	searchValuesCalls   int
+}
+
+func (p *passThroughQuerier) Select(_ context.Context, _ bool, _ *storage.SelectHints, _ ...*labels.Matcher) storage.SeriesSet {
+	return storage.EmptySeriesSet()
+}
+func (p *passThroughQuerier) LabelValues(_ context.Context, _ string, _ *storage.LabelHints, _ ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	return nil, nil, nil
+}
+func (p *passThroughQuerier) LabelNames(_ context.Context, _ *storage.LabelHints, _ ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	return nil, nil, nil
+}
+func (p *passThroughQuerier) Close() error { return nil }
+
+func (p *passThroughQuerier) SearchLabelNames(_ context.Context, _ *streaminglabelvalues.Params, _ *storage.SearchHints, _ ...*labels.Matcher) storage.SearchResultSet {
+	p.searchNamesCalls++
+	return storage.NewSearchResultSetFromSlice(p.searchNamesResults, nil)
+}
+
+func (p *passThroughQuerier) SearchLabelValues(_ context.Context, name string, _ *streaminglabelvalues.Params, _ *storage.SearchHints, _ ...*labels.Matcher) storage.SearchResultSet {
+	p.searchValuesCalls++
+	p.searchValuesName = name
+	return storage.NewSearchResultSetFromSlice(p.searchValuesResults, nil)
+}
+
+// nonSearcherQuerier deliberately omits the mimirSearcher methods so we can
+// verify the graceful-degradation path through memoryTrackingQuerier.
+type nonSearcherQuerier struct{}
+
+func (n *nonSearcherQuerier) Select(_ context.Context, _ bool, _ *storage.SelectHints, _ ...*labels.Matcher) storage.SeriesSet {
+	return storage.EmptySeriesSet()
+}
+func (n *nonSearcherQuerier) LabelValues(_ context.Context, _ string, _ *storage.LabelHints, _ ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	return nil, nil, nil
+}
+func (n *nonSearcherQuerier) LabelNames(_ context.Context, _ *storage.LabelHints, _ ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	return nil, nil, nil
+}
+func (n *nonSearcherQuerier) Close() error { return nil }
+
+func TestMemoryTrackingQuerier_SearchLabelNames_PassesThrough(t *testing.T) {
+	inner := &passThroughQuerier{searchNamesResults: []storage.SearchResult{{Value: "foo", Score: 1.0}}}
+	q := &memoryTrackingQuerier{inner: inner}
+
+	rs := q.SearchLabelNames(context.Background(), nil, nil)
+	defer rs.Close()
+	var got []string
+	for rs.Next() {
+		got = append(got, rs.At().Value)
+	}
+	require.NoError(t, rs.Err())
+	assert.Equal(t, []string{"foo"}, got)
+	assert.Equal(t, 1, inner.searchNamesCalls, "inner.SearchLabelNames must be called exactly once")
+}
+
+func TestMemoryTrackingQuerier_SearchLabelValues_PassesThroughLabelName(t *testing.T) {
+	inner := &passThroughQuerier{searchValuesResults: []storage.SearchResult{{Value: "prod", Score: 1.0}}}
+	q := &memoryTrackingQuerier{inner: inner}
+
+	rs := q.SearchLabelValues(context.Background(), "env", nil, nil)
+	defer rs.Close()
+	var got []string
+	for rs.Next() {
+		got = append(got, rs.At().Value)
+	}
+	require.NoError(t, rs.Err())
+	assert.Equal(t, []string{"prod"}, got)
+	assert.Equal(t, "env", inner.searchValuesName, "label name must reach inner querier")
+	assert.Equal(t, 1, inner.searchValuesCalls)
+}
+
+func TestMemoryTrackingQuerier_SearchLabelNames_InnerWithoutSearchReturnsErr(t *testing.T) {
+	q := &memoryTrackingQuerier{inner: &nonSearcherQuerier{}}
+	rs := q.SearchLabelNames(context.Background(), nil, nil)
+	defer rs.Close()
+	assert.False(t, rs.Next())
+	require.Error(t, rs.Err())
+}
+
+func TestMemoryTrackingQuerier_SearchLabelValues_InnerWithoutSearchReturnsErr(t *testing.T) {
+	q := &memoryTrackingQuerier{inner: &nonSearcherQuerier{}}
+	rs := q.SearchLabelValues(context.Background(), "env", nil, nil)
+	defer rs.Close()
+	assert.False(t, rs.Next())
+	require.Error(t, rs.Err())
+}

--- a/pkg/querier/multi_searcher.go
+++ b/pkg/querier/multi_searcher.go
@@ -55,7 +55,7 @@ func (mq *multiQuerier) SearchLabelNames(ctx context.Context, params *streamingl
 	}
 
 	hints, clampWarn := clampSearchHintsLimit(spanLog, hints, mq.limits.MaxLabelNamesLimit(userID), validation.MaxLabelNamesLimitFlag)
-	sets := fanOutSearch(ctx, queriers, clampWarn, func(s mimirSearcher) storage.SearchResultSet {
+	sets := fanOutSearch(queriers, clampWarn, func(s mimirSearcher) storage.SearchResultSet {
 		return s.SearchLabelNames(ctx, params, hints, matchers...)
 	})
 	return storage.MergeSearchResultSets(sets, hints)
@@ -81,7 +81,7 @@ func (mq *multiQuerier) SearchLabelValues(ctx context.Context, name string, para
 	}
 
 	hints, clampWarn := clampSearchHintsLimit(spanLog, hints, mq.limits.MaxLabelValuesLimit(userID), validation.MaxLabelValuesLimitFlag)
-	sets := fanOutSearch(ctx, queriers, clampWarn, func(s mimirSearcher) storage.SearchResultSet {
+	sets := fanOutSearch(queriers, clampWarn, func(s mimirSearcher) storage.SearchResultSet {
 		return s.SearchLabelValues(ctx, name, params, hints, matchers...)
 	})
 	return storage.MergeSearchResultSets(sets, hints)
@@ -117,7 +117,7 @@ func clampSearchHintsLimit(spanLog *spanlogger.SpanLogger, hints *storage.Search
 // merge composes around the error. If clampWarn is non-empty an extra
 // warning-only set is appended; the merge primitive merges its Warnings()
 // into the final set.
-func fanOutSearch(_ context.Context, queriers []storage.Querier, clampWarn annotations.Annotations, call func(mimirSearcher) storage.SearchResultSet) []storage.SearchResultSet {
+func fanOutSearch(queriers []storage.Querier, clampWarn annotations.Annotations, call func(mimirSearcher) storage.SearchResultSet) []storage.SearchResultSet {
 	sets := make([]storage.SearchResultSet, 0, len(queriers)+1)
 	for _, q := range queriers {
 		s, ok := q.(mimirSearcher)

--- a/pkg/querier/multi_searcher.go
+++ b/pkg/querier/multi_searcher.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package querier
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/grafana/dskit/tenant"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/util/annotations"
+
+	"github.com/grafana/mimir/pkg/streaminglabelvalues"
+	"github.com/grafana/mimir/pkg/util/spanlogger"
+	"github.com/grafana/mimir/pkg/util/validation"
+)
+
+// mimirSearcher is the cross-source Searcher interface used at the querier
+// fan-out layer. It differs from Prometheus's storage.Searcher
+// (vendor/github.com/prometheus/prometheus/storage/interface.go) by taking an
+// extra *streaminglabelvalues.Params: each leaf (ingester / store-gateway)
+// builds its own concurrency-unsafe storage.Filter from these params (spec
+// invariant 9), so the params travel separately from the opaque hints.Filter.
+//
+// distributorQuerier and blocksStoreQuerier (added in PR #2) both implement
+// this shape.
+type mimirSearcher interface {
+	SearchLabelNames(ctx context.Context, params *streaminglabelvalues.Params, hints *storage.SearchHints, matchers ...*labels.Matcher) storage.SearchResultSet
+	SearchLabelValues(ctx context.Context, name string, params *streaminglabelvalues.Params, hints *storage.SearchHints, matchers ...*labels.Matcher) storage.SearchResultSet
+}
+
+// SearchLabelNames fans out across the per-source queriers, merging streamed
+// results via storage.MergeSearchResultSets. The merge preserves the requested
+// ordering, deduplicates across sources, and stops after the per-tenant-clamped
+// limit.
+//
+// Children that don't implement mimirSearcher are surfaced as
+// storage.ErrSearchResultSet so the merge still composes cleanly.
+func (mq *multiQuerier) SearchLabelNames(ctx context.Context, params *streaminglabelvalues.Params, hints *storage.SearchHints, matchers ...*labels.Matcher) storage.SearchResultSet {
+	spanLog, ctx := spanlogger.New(ctx, mq.logger, tracer, "multiQuerier.SearchLabelNames")
+	defer spanLog.Finish()
+
+	ctx, queriers, _, _, err := mq.getQueriers(ctx, mq.minT, mq.maxT)
+	if errors.Is(err, errEmptyTimeRange) {
+		return storage.EmptySearchResultSet()
+	}
+	if err != nil {
+		return storage.ErrSearchResultSet(err)
+	}
+
+	userID, err := tenant.TenantID(ctx)
+	if err != nil {
+		return storage.ErrSearchResultSet(err)
+	}
+
+	hints, clampWarn := clampSearchHintsLimit(spanLog, hints, mq.limits.MaxLabelNamesLimit(userID), validation.MaxLabelNamesLimitFlag)
+	sets := fanOutSearch(ctx, queriers, clampWarn, func(s mimirSearcher) storage.SearchResultSet {
+		return s.SearchLabelNames(ctx, params, hints, matchers...)
+	})
+	return storage.MergeSearchResultSets(sets, hints)
+}
+
+// SearchLabelValues mirrors SearchLabelNames; it forwards the label name to
+// the children.
+func (mq *multiQuerier) SearchLabelValues(ctx context.Context, name string, params *streaminglabelvalues.Params, hints *storage.SearchHints, matchers ...*labels.Matcher) storage.SearchResultSet {
+	spanLog, ctx := spanlogger.New(ctx, mq.logger, tracer, "multiQuerier.SearchLabelValues")
+	defer spanLog.Finish()
+
+	ctx, queriers, _, _, err := mq.getQueriers(ctx, mq.minT, mq.maxT)
+	if errors.Is(err, errEmptyTimeRange) {
+		return storage.EmptySearchResultSet()
+	}
+	if err != nil {
+		return storage.ErrSearchResultSet(err)
+	}
+
+	userID, err := tenant.TenantID(ctx)
+	if err != nil {
+		return storage.ErrSearchResultSet(err)
+	}
+
+	hints, clampWarn := clampSearchHintsLimit(spanLog, hints, mq.limits.MaxLabelValuesLimit(userID), validation.MaxLabelValuesLimitFlag)
+	sets := fanOutSearch(ctx, queriers, clampWarn, func(s mimirSearcher) storage.SearchResultSet {
+		return s.SearchLabelValues(ctx, name, params, hints, matchers...)
+	})
+	return storage.MergeSearchResultSets(sets, hints)
+}
+
+// clampSearchHintsLimit returns a defensively-copied hints with Limit clamped
+// to maxLimit per the tenant's per-source ceiling. When the clamp fires it
+// also returns a single-element annotations.Annotations carrying the
+// MaxLimitError for the merge layer to surface via Warnings(). Mirrors the
+// existing LabelNames/LabelValues clamp warning behaviour.
+//
+// A nil hints becomes a zero hints — no implicit limit is invented.
+func clampSearchHintsLimit(spanLog *spanlogger.SpanLogger, hints *storage.SearchHints, maxLimit int, settingName string) (*storage.SearchHints, annotations.Annotations) {
+	if hints == nil {
+		hints = &storage.SearchHints{}
+	} else {
+		hintsCopy := *hints
+		hints = &hintsCopy
+	}
+	originalLimit := hints.Limit
+	hints.Limit = clampToMaxLimit(spanLog, originalLimit, maxLimit, settingName)
+	if hints.Limit > 0 && originalLimit != hints.Limit {
+		var warn annotations.Annotations
+		warn.Add(NewMaxLimitError(originalLimit, hints.Limit, settingName))
+		return hints, warn
+	}
+	return hints, nil
+}
+
+// fanOutSearch collects a SearchResultSet from each child querier by
+// type-asserting to mimirSearcher and invoking the caller-supplied closure.
+// Children that fail the assertion yield storage.ErrSearchResultSet so the
+// merge composes around the error. If clampWarn is non-empty an extra
+// warning-only set is appended; the merge primitive merges its Warnings()
+// into the final set.
+func fanOutSearch(_ context.Context, queriers []storage.Querier, clampWarn annotations.Annotations, call func(mimirSearcher) storage.SearchResultSet) []storage.SearchResultSet {
+	sets := make([]storage.SearchResultSet, 0, len(queriers)+1)
+	for _, q := range queriers {
+		s, ok := q.(mimirSearcher)
+		if !ok {
+			sets = append(sets, storage.ErrSearchResultSet(fmt.Errorf("querier %T does not implement search", q)))
+			continue
+		}
+		sets = append(sets, call(s))
+	}
+	if len(clampWarn) > 0 {
+		sets = append(sets, storage.NewSearchResultSetFromSlice(nil, clampWarn))
+	}
+	return sets
+}

--- a/pkg/querier/multi_searcher.go
+++ b/pkg/querier/multi_searcher.go
@@ -21,11 +21,10 @@ import (
 // fan-out layer. It differs from Prometheus's storage.Searcher
 // (vendor/github.com/prometheus/prometheus/storage/interface.go) by taking an
 // extra *streaminglabelvalues.Params: each leaf (ingester / store-gateway)
-// builds its own concurrency-unsafe storage.Filter from these params (spec
-// invariant 9), so the params travel separately from the opaque hints.Filter.
+// builds its own concurrency-unsafe storage.Filter from these params, so the
+// params travel separately from the opaque hints.Filter.
 //
-// distributorQuerier and blocksStoreQuerier (added in PR #2) both implement
-// this shape.
+// distributorQuerier and blocksStoreQuerier both implement this shape.
 type mimirSearcher interface {
 	SearchLabelNames(ctx context.Context, params *streaminglabelvalues.Params, hints *storage.SearchHints, matchers ...*labels.Matcher) storage.SearchResultSet
 	SearchLabelValues(ctx context.Context, name string, params *streaminglabelvalues.Params, hints *storage.SearchHints, matchers ...*labels.Matcher) storage.SearchResultSet

--- a/pkg/querier/multi_searcher_test.go
+++ b/pkg/querier/multi_searcher_test.go
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package querier
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/flagext"
+	"github.com/grafana/dskit/user"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/util/annotations"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/querier/stats"
+	"github.com/grafana/mimir/pkg/streaminglabelvalues"
+	"github.com/grafana/mimir/pkg/util/validation"
+)
+
+// mockSearchQuerier satisfies storage.Querier and mimirSearcher. The search
+// methods return either an err or the configured slice; non-search methods
+// return zero values (not used in these tests).
+type mockSearchQuerier struct {
+	namesResults  []storage.SearchResult
+	namesErr      error
+	valuesResults []storage.SearchResult
+	valuesErr     error
+}
+
+func (m *mockSearchQuerier) Select(_ context.Context, _ bool, _ *storage.SelectHints, _ ...*labels.Matcher) storage.SeriesSet {
+	return storage.EmptySeriesSet()
+}
+func (m *mockSearchQuerier) LabelValues(_ context.Context, _ string, _ *storage.LabelHints, _ ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	return nil, nil, nil
+}
+func (m *mockSearchQuerier) LabelNames(_ context.Context, _ *storage.LabelHints, _ ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	return nil, nil, nil
+}
+func (m *mockSearchQuerier) Close() error { return nil }
+
+func (m *mockSearchQuerier) SearchLabelNames(_ context.Context, _ *streaminglabelvalues.Params, _ *storage.SearchHints, _ ...*labels.Matcher) storage.SearchResultSet {
+	if m.namesErr != nil {
+		return storage.ErrSearchResultSet(m.namesErr)
+	}
+	return storage.NewSearchResultSetFromSlice(m.namesResults, nil)
+}
+
+func (m *mockSearchQuerier) SearchLabelValues(_ context.Context, _ string, _ *streaminglabelvalues.Params, _ *storage.SearchHints, _ ...*labels.Matcher) storage.SearchResultSet {
+	if m.valuesErr != nil {
+		return storage.ErrSearchResultSet(m.valuesErr)
+	}
+	return storage.NewSearchResultSetFromSlice(m.valuesResults, nil)
+}
+
+// mockSearchQueryable returns its configured mockSearchQuerier for any (mint, maxt).
+type mockSearchQueryable struct {
+	q *mockSearchQuerier
+}
+
+func (qq *mockSearchQueryable) Querier(_, _ int64) (storage.Querier, error) {
+	return qq.q, nil
+}
+
+// buildSearchTestMultiQuerier wires a multiQuerier with two child queryables.
+// Setting either to nil simulates that source not being configured.
+func buildSearchTestMultiQuerier(t *testing.T, distQ, blockQ *mockSearchQuerier, opts ...func(*validation.Limits)) *multiQuerier {
+	t.Helper()
+	limits := defaultLimitsConfig()
+	limits.QueryIngestersWithin = 0
+	for _, opt := range opts {
+		opt(&limits)
+	}
+	overrides := validation.NewOverrides(limits, nil)
+
+	var cfg Config
+	flagext.DefaultValues(&cfg)
+	mq := &multiQuerier{
+		queryMetrics: stats.NewQueryMetrics(prometheus.NewRegistry()),
+		cfg:          cfg,
+		minT:         0,
+		maxT:         1000,
+		limits:       overrides,
+		logger:       log.NewNopLogger(),
+	}
+	if distQ != nil {
+		mq.distributor = &mockSearchQueryable{q: distQ}
+	}
+	if blockQ != nil {
+		mq.blockStore = &mockSearchQueryable{q: blockQ}
+	}
+	return mq
+}
+
+func searchResult(v string, score float64) storage.SearchResult {
+	return storage.SearchResult{Value: v, Score: score}
+}
+
+func drainSearchResultSet(t *testing.T, rs storage.SearchResultSet) (vals []string, scores []float64, warns []string, err error) {
+	t.Helper()
+	defer rs.Close()
+	for rs.Next() {
+		r := rs.At()
+		vals = append(vals, r.Value)
+		scores = append(scores, r.Score)
+	}
+	err = rs.Err()
+	for _, w := range rs.Warnings() {
+		warns = append(warns, w.Error())
+	}
+	return
+}
+
+func TestMultiQuerier_SearchLabelNames_BothChildrenOK(t *testing.T) {
+	distQ := &mockSearchQuerier{namesResults: []storage.SearchResult{searchResult("a", 1.0), searchResult("c", 1.0)}}
+	blockQ := &mockSearchQuerier{namesResults: []storage.SearchResult{searchResult("b", 1.0), searchResult("d", 1.0)}}
+	mq := buildSearchTestMultiQuerier(t, distQ, blockQ)
+
+	ctx := user.InjectOrgID(context.Background(), "user-1")
+	rs := mq.SearchLabelNames(ctx, nil, &storage.SearchHints{OrderBy: storage.OrderByValueAsc})
+	vals, _, _, err := drainSearchResultSet(t, rs)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a", "b", "c", "d"}, vals)
+}
+
+func TestMultiQuerier_SearchLabelNames_DistributorErrorSurfacesViaMerge(t *testing.T) {
+	wantErr := errors.New("boom from distributor")
+	distQ := &mockSearchQuerier{namesErr: wantErr}
+	blockQ := &mockSearchQuerier{namesResults: []storage.SearchResult{searchResult("b", 1.0)}}
+	mq := buildSearchTestMultiQuerier(t, distQ, blockQ)
+
+	ctx := user.InjectOrgID(context.Background(), "user-1")
+	rs := mq.SearchLabelNames(ctx, nil, &storage.SearchHints{OrderBy: storage.OrderByValueAsc})
+	_, _, _, err := drainSearchResultSet(t, rs)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestMultiQuerier_SearchLabelNames_BlockStoreErrorSurfacesViaMerge(t *testing.T) {
+	wantErr := errors.New("boom from blockstore")
+	distQ := &mockSearchQuerier{namesResults: []storage.SearchResult{searchResult("a", 1.0)}}
+	blockQ := &mockSearchQuerier{namesErr: wantErr}
+	mq := buildSearchTestMultiQuerier(t, distQ, blockQ)
+
+	ctx := user.InjectOrgID(context.Background(), "user-1")
+	rs := mq.SearchLabelNames(ctx, nil, &storage.SearchHints{OrderBy: storage.OrderByValueAsc})
+	_, _, _, err := drainSearchResultSet(t, rs)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestMultiQuerier_SearchLabelNames_BothChildrenEmptyReturnsEmpty(t *testing.T) {
+	mq := buildSearchTestMultiQuerier(t, &mockSearchQuerier{}, &mockSearchQuerier{})
+	ctx := user.InjectOrgID(context.Background(), "user-1")
+	rs := mq.SearchLabelNames(ctx, nil, &storage.SearchHints{OrderBy: storage.OrderByValueAsc})
+	vals, _, _, err := drainSearchResultSet(t, rs)
+	require.NoError(t, err)
+	assert.Empty(t, vals)
+}
+
+func TestMultiQuerier_SearchLabelNames_TimeRangeShortCircuit(t *testing.T) {
+	// MaxLabelsQueryLength clamps minT to maxT - duration. With minT > maxT after
+	// the implicit nothing-changes path, we can force errEmptyTimeRange via
+	// minT > maxT directly.
+	distQ := &mockSearchQuerier{namesResults: []storage.SearchResult{searchResult("a", 1.0)}}
+	mq := buildSearchTestMultiQuerier(t, distQ, nil)
+	mq.minT = 1000
+	mq.maxT = 500 // minT > maxT triggers validateQueryTimeRange's empty-range path.
+
+	ctx := user.InjectOrgID(context.Background(), "user-1")
+	rs := mq.SearchLabelNames(ctx, nil, &storage.SearchHints{OrderBy: storage.OrderByValueAsc})
+	vals, _, _, err := drainSearchResultSet(t, rs)
+	require.NoError(t, err)
+	assert.Empty(t, vals)
+}
+
+func TestMultiQuerier_SearchLabelNames_LimitClampTriggersWarning(t *testing.T) {
+	distQ := &mockSearchQuerier{namesResults: []storage.SearchResult{searchResult("a", 1.0), searchResult("b", 1.0), searchResult("c", 1.0)}}
+	mq := buildSearchTestMultiQuerier(t, distQ, nil, func(l *validation.Limits) {
+		l.MaxLabelNamesLimit = 100
+	})
+
+	ctx := user.InjectOrgID(context.Background(), "user-1")
+	rs := mq.SearchLabelNames(ctx, nil, &storage.SearchHints{OrderBy: storage.OrderByValueAsc, Limit: 10_000})
+	_, _, warns, err := drainSearchResultSet(t, rs)
+	require.NoError(t, err)
+	require.Len(t, warns, 1, "expected one clamp warning")
+	assert.Contains(t, warns[0], validation.MaxLabelNamesLimitFlag)
+}
+
+func TestMultiQuerier_SearchLabelNames_LimitClampNotTriggered(t *testing.T) {
+	distQ := &mockSearchQuerier{namesResults: []storage.SearchResult{searchResult("a", 1.0)}}
+	mq := buildSearchTestMultiQuerier(t, distQ, nil, func(l *validation.Limits) {
+		l.MaxLabelNamesLimit = 100
+	})
+
+	ctx := user.InjectOrgID(context.Background(), "user-1")
+	rs := mq.SearchLabelNames(ctx, nil, &storage.SearchHints{OrderBy: storage.OrderByValueAsc, Limit: 50})
+	_, _, warns, err := drainSearchResultSet(t, rs)
+	require.NoError(t, err)
+	assert.Empty(t, warns)
+}
+
+func TestMultiQuerier_SearchLabelNames_DedupAcrossSourcesKeepsHighestScoreUnderValueOrder(t *testing.T) {
+	// Same value "foo" appears in both sources. Under OrderByValueAsc the merge
+	// collapses to one entry, keeping the higher score.
+	distQ := &mockSearchQuerier{namesResults: []storage.SearchResult{searchResult("bar", 1.0), searchResult("foo", 0.7)}}
+	blockQ := &mockSearchQuerier{namesResults: []storage.SearchResult{searchResult("baz", 1.0), searchResult("foo", 0.9)}}
+	mq := buildSearchTestMultiQuerier(t, distQ, blockQ)
+
+	ctx := user.InjectOrgID(context.Background(), "user-1")
+	rs := mq.SearchLabelNames(ctx, nil, &storage.SearchHints{OrderBy: storage.OrderByValueAsc})
+	vals, scores, _, err := drainSearchResultSet(t, rs)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"bar", "baz", "foo"}, vals)
+	require.Len(t, scores, 3)
+	assert.InDelta(t, 0.9, scores[2], 1e-9, "duplicate value collapses to higher score under value ordering")
+}
+
+func TestMultiQuerier_SearchLabelNames_OrderByValueDesc(t *testing.T) {
+	distQ := &mockSearchQuerier{namesResults: []storage.SearchResult{searchResult("c", 1.0), searchResult("a", 1.0)}}
+	blockQ := &mockSearchQuerier{namesResults: []storage.SearchResult{searchResult("d", 1.0), searchResult("b", 1.0)}}
+	mq := buildSearchTestMultiQuerier(t, distQ, blockQ)
+
+	ctx := user.InjectOrgID(context.Background(), "user-1")
+	rs := mq.SearchLabelNames(ctx, nil, &storage.SearchHints{OrderBy: storage.OrderByValueDesc})
+	vals, _, _, err := drainSearchResultSet(t, rs)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"d", "c", "b", "a"}, vals)
+}
+
+func TestMultiQuerier_SearchLabelNames_OrderByScoreDesc(t *testing.T) {
+	// Sources pre-sorted by (Score desc, Value asc).
+	distQ := &mockSearchQuerier{namesResults: []storage.SearchResult{searchResult("alpha", 0.95), searchResult("delta", 0.5)}}
+	blockQ := &mockSearchQuerier{namesResults: []storage.SearchResult{searchResult("beta", 0.9), searchResult("gamma", 0.6)}}
+	mq := buildSearchTestMultiQuerier(t, distQ, blockQ)
+
+	ctx := user.InjectOrgID(context.Background(), "user-1")
+	rs := mq.SearchLabelNames(ctx, nil, &storage.SearchHints{OrderBy: storage.OrderByScoreDesc})
+	vals, _, _, err := drainSearchResultSet(t, rs)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"alpha", "beta", "gamma", "delta"}, vals)
+}
+
+func TestMultiQuerier_SearchLabelValues_ForwardsLabelName(t *testing.T) {
+	distQ := &mockSearchQuerier{valuesResults: []storage.SearchResult{searchResult("prod", 1.0), searchResult("staging", 1.0)}}
+	blockQ := &mockSearchQuerier{valuesResults: []storage.SearchResult{searchResult("dev", 1.0), searchResult("prod", 1.0)}}
+	mq := buildSearchTestMultiQuerier(t, distQ, blockQ)
+
+	ctx := user.InjectOrgID(context.Background(), "user-1")
+	rs := mq.SearchLabelValues(ctx, "env", nil, &storage.SearchHints{OrderBy: storage.OrderByValueAsc})
+	vals, _, _, err := drainSearchResultSet(t, rs)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"dev", "prod", "staging"}, vals)
+}
+
+func TestMultiQuerier_SearchLabelValues_LimitClampUsesValuesLimit(t *testing.T) {
+	distQ := &mockSearchQuerier{valuesResults: []storage.SearchResult{searchResult("a", 1.0), searchResult("b", 1.0), searchResult("c", 1.0)}}
+	mq := buildSearchTestMultiQuerier(t, distQ, nil, func(l *validation.Limits) {
+		l.MaxLabelValuesLimit = 100
+		l.MaxLabelNamesLimit = 50 // distinct value so we can assert which one fired.
+	})
+
+	ctx := user.InjectOrgID(context.Background(), "user-1")
+	rs := mq.SearchLabelValues(ctx, "env", nil, &storage.SearchHints{OrderBy: storage.OrderByValueAsc, Limit: 10_000})
+	_, _, warns, err := drainSearchResultSet(t, rs)
+	require.NoError(t, err)
+	require.Len(t, warns, 1)
+	assert.Contains(t, warns[0], validation.MaxLabelValuesLimitFlag)
+	assert.NotContains(t, warns[0], validation.MaxLabelNamesLimitFlag)
+}

--- a/pkg/storage/lazyquery/lazyquery.go
+++ b/pkg/storage/lazyquery/lazyquery.go
@@ -7,11 +7,14 @@ package lazyquery
 
 import (
 	"context"
+	"fmt"
 	"slices"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/util/annotations"
+
+	"github.com/grafana/mimir/pkg/streaminglabelvalues"
 )
 
 // LazyQueryable wraps a storage.Queryable
@@ -78,6 +81,35 @@ func (l LazyQuerier) LabelValues(ctx context.Context, name string, hints *storag
 // LabelNames implements Storage.Querier
 func (l LazyQuerier) LabelNames(ctx context.Context, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
 	return l.next.LabelNames(ctx, hints, matchers...)
+}
+
+// searcher is the Mimir-side cross-source Searcher interface that
+// LazyQuerier defers to when the wrapped querier supports label/value
+// search. Defined locally to avoid an import cycle on pkg/querier.
+type searcher interface {
+	SearchLabelNames(ctx context.Context, params *streaminglabelvalues.Params, hints *storage.SearchHints, matchers ...*labels.Matcher) storage.SearchResultSet
+	SearchLabelValues(ctx context.Context, name string, params *streaminglabelvalues.Params, hints *storage.SearchHints, matchers ...*labels.Matcher) storage.SearchResultSet
+}
+
+// SearchLabelNames passes through to the wrapped querier when it implements
+// search; otherwise surfaces a clear error. Prometheus's lazySearchResultSet
+// already covers deferred init at the merge layer, so no extra wrapping is
+// needed here — this is a straight pass-through.
+func (l LazyQuerier) SearchLabelNames(ctx context.Context, params *streaminglabelvalues.Params, hints *storage.SearchHints, matchers ...*labels.Matcher) storage.SearchResultSet {
+	s, ok := l.next.(searcher)
+	if !ok {
+		return storage.ErrSearchResultSet(fmt.Errorf("wrapped querier %T does not implement search", l.next))
+	}
+	return s.SearchLabelNames(ctx, params, hints, matchers...)
+}
+
+// SearchLabelValues mirrors SearchLabelNames.
+func (l LazyQuerier) SearchLabelValues(ctx context.Context, name string, params *streaminglabelvalues.Params, hints *storage.SearchHints, matchers ...*labels.Matcher) storage.SearchResultSet {
+	s, ok := l.next.(searcher)
+	if !ok {
+		return storage.ErrSearchResultSet(fmt.Errorf("wrapped querier %T does not implement search", l.next))
+	}
+	return s.SearchLabelValues(ctx, name, params, hints, matchers...)
 }
 
 // Close implements Storage.Querier

--- a/pkg/storage/lazyquery/lazyquery.go
+++ b/pkg/storage/lazyquery/lazyquery.go
@@ -86,6 +86,12 @@ func (l LazyQuerier) LabelNames(ctx context.Context, hints *storage.LabelHints, 
 // searcher is the Mimir-side cross-source Searcher interface that
 // LazyQuerier defers to when the wrapped querier supports label/value
 // search. Defined locally to avoid an import cycle on pkg/querier.
+//
+// MUST stay in lock-step with pkg/querier.mimirSearcher: this declaration
+// is consumed only via a runtime type assertion (l.next.(searcher)), so any
+// drift between the two definitions silently turns into "search not
+// supported" at runtime rather than a compile error. If the mimirSearcher
+// signature changes, update this one too.
 type searcher interface {
 	SearchLabelNames(ctx context.Context, params *streaminglabelvalues.Params, hints *storage.SearchHints, matchers ...*labels.Matcher) storage.SearchResultSet
 	SearchLabelValues(ctx context.Context, name string, params *streaminglabelvalues.Params, hints *storage.SearchHints, matchers ...*labels.Matcher) storage.SearchResultSet

--- a/pkg/storage/lazyquery/lazyquery_test.go
+++ b/pkg/storage/lazyquery/lazyquery_test.go
@@ -3,11 +3,17 @@
 package lazyquery
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/util/annotations"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/streaminglabelvalues"
 )
 
 func TestCopyParamsDeepCopy(t *testing.T) {
@@ -46,4 +52,106 @@ func TestCopyParamsDeepCopy(t *testing.T) {
 			// Any other types are copied by value, so the assert.Equal above is enough.
 		}
 	}
+}
+
+// passThroughSearchQuerier satisfies storage.Querier and the local searcher
+// interface declared in lazyquery.go. It records call counts so the test can
+// assert pass-through behaviour.
+type passThroughSearchQuerier struct {
+	searchNamesResults  []storage.SearchResult
+	searchValuesResults []storage.SearchResult
+	searchValuesName    string
+	searchNamesCalls    int
+	searchValuesCalls   int
+}
+
+func (p *passThroughSearchQuerier) Select(_ context.Context, _ bool, _ *storage.SelectHints, _ ...*labels.Matcher) storage.SeriesSet {
+	return storage.EmptySeriesSet()
+}
+func (p *passThroughSearchQuerier) LabelValues(_ context.Context, _ string, _ *storage.LabelHints, _ ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	return nil, nil, nil
+}
+func (p *passThroughSearchQuerier) LabelNames(_ context.Context, _ *storage.LabelHints, _ ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	return nil, nil, nil
+}
+func (p *passThroughSearchQuerier) Close() error { return nil }
+
+func (p *passThroughSearchQuerier) SearchLabelNames(_ context.Context, _ *streaminglabelvalues.Params, _ *storage.SearchHints, _ ...*labels.Matcher) storage.SearchResultSet {
+	p.searchNamesCalls++
+	return storage.NewSearchResultSetFromSlice(p.searchNamesResults, nil)
+}
+
+func (p *passThroughSearchQuerier) SearchLabelValues(_ context.Context, name string, _ *streaminglabelvalues.Params, _ *storage.SearchHints, _ ...*labels.Matcher) storage.SearchResultSet {
+	p.searchValuesCalls++
+	p.searchValuesName = name
+	return storage.NewSearchResultSetFromSlice(p.searchValuesResults, nil)
+}
+
+// nonSearcherQuerier omits the search methods so we exercise the
+// graceful-degradation path in LazyQuerier.SearchLabel*.
+type nonSearcherQuerier struct{}
+
+func (n *nonSearcherQuerier) Select(_ context.Context, _ bool, _ *storage.SelectHints, _ ...*labels.Matcher) storage.SeriesSet {
+	return storage.EmptySeriesSet()
+}
+func (n *nonSearcherQuerier) LabelValues(_ context.Context, _ string, _ *storage.LabelHints, _ ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	return nil, nil, nil
+}
+func (n *nonSearcherQuerier) LabelNames(_ context.Context, _ *storage.LabelHints, _ ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	return nil, nil, nil
+}
+func (n *nonSearcherQuerier) Close() error { return nil }
+
+func TestLazyQuerier_SearchLabelNames_PassesThrough(t *testing.T) {
+	inner := &passThroughSearchQuerier{searchNamesResults: []storage.SearchResult{{Value: "foo", Score: 1.0}}}
+	lq := NewLazyQuerier(inner)
+
+	rs := lq.(LazyQuerier).SearchLabelNames(context.Background(), nil, nil)
+	defer rs.Close()
+	var got []string
+	for rs.Next() {
+		got = append(got, rs.At().Value)
+	}
+	require.NoError(t, rs.Err())
+	assert.Equal(t, []string{"foo"}, got)
+	assert.Equal(t, 1, inner.searchNamesCalls)
+}
+
+func TestLazyQuerier_SearchLabelValues_PassesThroughLabelName(t *testing.T) {
+	inner := &passThroughSearchQuerier{searchValuesResults: []storage.SearchResult{{Value: "prod", Score: 1.0}}}
+	lq := NewLazyQuerier(inner)
+
+	rs := lq.(LazyQuerier).SearchLabelValues(context.Background(), "env", nil, nil)
+	defer rs.Close()
+	var got []string
+	for rs.Next() {
+		got = append(got, rs.At().Value)
+	}
+	require.NoError(t, rs.Err())
+	assert.Equal(t, []string{"prod"}, got)
+	assert.Equal(t, "env", inner.searchValuesName)
+	assert.Equal(t, 1, inner.searchValuesCalls)
+}
+
+func TestLazyQuerier_SearchLabelNames_WrappedWithoutSearchReturnsErr(t *testing.T) {
+	lq := NewLazyQuerier(&nonSearcherQuerier{})
+	rs := lq.(LazyQuerier).SearchLabelNames(context.Background(), nil, nil)
+	defer rs.Close()
+	assert.False(t, rs.Next())
+	require.Error(t, rs.Err())
+}
+
+func TestLazyQuerier_SearchLabelValues_WrappedWithoutSearchReturnsErr(t *testing.T) {
+	lq := NewLazyQuerier(&nonSearcherQuerier{})
+	rs := lq.(LazyQuerier).SearchLabelValues(context.Background(), "env", nil, nil)
+	defer rs.Close()
+	assert.False(t, rs.Next())
+	require.Error(t, rs.Err())
+}
+
+func TestLazyQuerier_SearchLabelNames_CloseBeforeNextIsSafe(t *testing.T) {
+	inner := &passThroughSearchQuerier{searchNamesResults: []storage.SearchResult{{Value: "foo", Score: 1.0}}}
+	lq := NewLazyQuerier(inner)
+	rs := lq.(LazyQuerier).SearchLabelNames(context.Background(), nil, nil)
+	require.NoError(t, rs.Close())
 }


### PR DESCRIPTION
#### What this PR does

This is the third PR in the streaming labels/values search API stack. 

See https://github.com/prometheus/proposals/pull/74.

This PR builds upon https://github.com/grafana/mimir/pull/15233 and https://github.com/grafana/mimir/pull/15301

This PR wires the querier-side multi-source fan-out that consumes the work from the above PRs.

Reachable but unused - there is no Mimir-internal caller from the HTTP layer — the new methods are exercised only by unit tests in this PR. The user-visible HTTP endpoints will come in a subsequent PR.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new querier-level `SearchLabelNames`/`SearchLabelValues` fan-out and limit-clamping logic plus wrapper passthroughs; while covered by unit tests, it touches core query orchestration and could affect search correctness, ordering, and per-tenant limits.
> 
> **Overview**
> Adds `multiQuerier.SearchLabelNames`/`SearchLabelValues` to **fan out streaming label/values search across distributor and block-store**, then merge/deduplicate ordered `storage.SearchResultSet`s while enforcing per-tenant `Limit` via `MaxLabelNamesLimit`/`MaxLabelValuesLimit` (including clamp warnings).
> 
> Extends `memoryTrackingQuerier` and `lazyquery.LazyQuerier` with **search pass-through methods** that type-assert for search support and otherwise return `ErrSearchResultSet`, intentionally skipping additional memory tracking on the streaming search path. Comprehensive unit tests cover pass-through behavior, error propagation, ordering/dedup, empty-range short-circuit, and limit-clamp warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fabc59992b4083405368af611c3f690fa64a9c33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->