### PR TITLE
Replace CLAUDE.md symlink with one-line redirect

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md


### PR DESCRIPTION
## Summary

- Replace `CLAUDE.md → AGENTS.md → docs/internal/contributing/README.md` symlink chain with a regular file containing `@AGENTS.md`.
- AI coding tools resolved both symlinks independently, injecting the 209-line contributing guide twice into every conversation (~2.9k wasted tokens).