### PR TITLE
Replace use of `Cache.SetMultiAsync` with `SetAsync` when always only setting one item

### DIFF
--- a/pkg/frontend/querymiddleware/cardinality.go
+++ b/pkg/frontend/querymiddleware/cardinality.go
@@ -150,7 +150,7 @@ func (c *cardinalityEstimation) storeCardinalityForKey(key string, count uint64,
 	}
 	// The store is executed asynchronously, potential errors are logged and not
 	// propagated back up the stack.
-	c.cache.SetMultiAsync(map[string][]byte{key: marshaled}, cardinalityEstimateTTL)
+	c.cache.SetAsync(key, marshaled, cardinalityEstimateTTL)
 }
 
 func isCardinalitySimilar(actualCardinality, estimatedCardinality uint64) bool {

--- a/pkg/frontend/querymiddleware/generic_query_cache.go
+++ b/pkg/frontend/querymiddleware/generic_query_cache.go
@@ -155,9 +155,8 @@ func (c *genericQueryCache) storeCachedResponse(ctx context.Context, cachedRes *
 		level.Warn(c.logger).Log("msg", "failed to encode cached query response", "err", err)
 		return
 	}
-	toStore := map[string][]byte{hashedCacheKey: encoded}
-	c.cache.SetMultiAsync(toStore, cacheTTL)
-	c.recordCacheStoreQueryDetails(ctx, toStore)
+	c.cache.SetAsync(hashedCacheKey, encoded, cacheTTL)
+	c.recordCacheStoreQueryDetails(ctx, encoded)
 }
 
 func (c *genericQueryCache) recordCacheHitQueryDetails(ctx context.Context, hits map[string][]byte) {
@@ -170,14 +169,12 @@ func (c *genericQueryCache) recordCacheHitQueryDetails(ctx context.Context, hits
 	}
 }
 
-func (c *genericQueryCache) recordCacheStoreQueryDetails(ctx context.Context, toStore map[string][]byte) {
+func (c *genericQueryCache) recordCacheStoreQueryDetails(ctx context.Context, value []byte) {
 	details := QueryDetailsFromContext(ctx)
 	if details == nil {
 		return
 	}
-	for _, val := range toStore {
-		details.ResultsCacheMissBytes += len(val)
-	}
+	details.ResultsCacheMissBytes += len(value)
 }
 
 func generateGenericQueryRequestCacheKey(tenantIDs []string, req *GenericQueryCacheKey) (cacheKey, hashedCacheKey string) {

--- a/pkg/frontend/querymiddleware/generic_query_cache_test.go
+++ b/pkg/frontend/querymiddleware/generic_query_cache_test.go
@@ -120,7 +120,7 @@ func testGenericQueryCacheRoundTrip(t *testing.T, newRoundTripper newGenericQuer
 				data, err := res.Marshal()
 				require.NoError(t, err)
 
-				c.SetMultiAsync(map[string][]byte{reqHashedCacheKey: data}, time.Minute)
+				c.SetAsync(reqHashedCacheKey, data, time.Minute)
 			},
 			cacheTTL:                 time.Minute,
 			downstreamRes:            downstreamRes(200, []byte(`{content:"fresh"}`)),
@@ -133,7 +133,7 @@ func testGenericQueryCacheRoundTrip(t *testing.T, newRoundTripper newGenericQuer
 		},
 		"should fetch the response from the downstream and overwrite the cached response if corrupted": {
 			init: func(_ *testing.T, c cache.Cache, _, reqHashedCacheKey string) {
-				c.SetMultiAsync(map[string][]byte{reqHashedCacheKey: []byte("corrupted")}, time.Minute)
+				c.SetAsync(reqHashedCacheKey, []byte("corrupted"), time.Minute)
 			},
 			cacheTTL:                 time.Minute,
 			downstreamRes:            downstreamRes(200, []byte(`{content:"fresh"}`)),
@@ -150,7 +150,7 @@ func testGenericQueryCacheRoundTrip(t *testing.T, newRoundTripper newGenericQuer
 				data, err := res.Marshal()
 				require.NoError(t, err)
 
-				c.SetMultiAsync(map[string][]byte{reqHashedCacheKey: data}, time.Minute)
+				c.SetAsync(reqHashedCacheKey, data, time.Minute)
 			},
 			cacheTTL:                 time.Minute,
 			downstreamRes:            downstreamRes(200, []byte(`{content:"fresh"}`)),

--- a/pkg/frontend/querymiddleware/split_and_cache.go
+++ b/pkg/frontend/querymiddleware/split_and_cache.go
@@ -494,7 +494,7 @@ func (s *splitAndCacheMiddleware) storeCacheExtents(spanLog *spanlogger.SpanLogg
 	}
 
 	level.Debug(spanLog).Log("msg", "asynchronously storing response in cache", "key", key, "size", len(buf), "ttl", usedTTL, "extents", len(extents))
-	s.cache.SetMultiAsync(map[string][]byte{hashCacheKey(key): buf}, usedTTL)
+	s.cache.SetAsync(hashCacheKey(key), buf, usedTTL)
 }
 
 func getTTLForExtent(now time.Time, ttl, ttlInOOOWindow, oooWindow time.Duration, e Extent) time.Duration {

--- a/pkg/frontend/querymiddleware/split_and_cache_test.go
+++ b/pkg/frontend/querymiddleware/split_and_cache_test.go
@@ -1576,7 +1576,7 @@ func TestSplitAndCacheMiddleware_StoreAndFetchCacheExtents(t *testing.T) {
 		// Simulate an hash collision on "key-1".
 		buf, err := proto.Marshal(&CachedResponse{Key: "another", Extents: []Extent{mkExtent(10, 20)}})
 		require.NoError(t, err)
-		cacheBackend.SetMultiAsync(map[string][]byte{hashCacheKey("key-1"): buf}, 0)
+		cacheBackend.SetAsync(hashCacheKey("key-1"), buf, 0)
 
 		mw.storeCacheExtents(spanLog, "key-3", []string{"tenant"}, []Extent{mkExtent(20, 30), mkExtent(40, 50)})
 

--- a/pkg/storage/tsdb/bucketcache/caching_bucket.go
+++ b/pkg/storage/tsdb/bucketcache/caching_bucket.go
@@ -250,7 +250,7 @@ func (cb *CachingBucket) Iter(ctx context.Context, dir string, f func(string) er
 	if err == nil && remainingTTL > 0 {
 		data, encErr := cfg.codec.Encode(list)
 		if encErr == nil {
-			cfg.cache.SetMultiAsync(map[string][]byte{key: data}, remainingTTL)
+			cfg.cache.SetAsync(key, data, remainingTTL)
 			return nil
 		}
 		level.Warn(cb.logger).Log("msg", "failed to encode Iter result", "key", key, "err", encErr)
@@ -303,7 +303,7 @@ func storeExistsCacheEntry(ctx context.Context, cachingKey, lockKey string, exis
 
 	if ttl > 0 {
 		if addErr := cache.Add(ctx, lockKey, []byte{}, invalidationLockTTL); addErr == nil {
-			cache.SetMultiAsync(map[string][]byte{cachingKey: []byte(strconv.FormatBool(exists))}, ttl)
+			cache.SetAsync(cachingKey, []byte(strconv.FormatBool(exists)), ttl)
 		}
 	}
 }
@@ -445,7 +445,7 @@ func (cb *CachingBucket) cachedAttributes(ctx context.Context, name string, keyG
 		// content when we were able to insert the lock key meaning this object isn't being updated
 		// by another request.
 		if addErr := cache.Add(ctx, lockKey, []byte{}, invalidationLockTTL); addErr == nil {
-			cache.SetMultiAsync(map[string][]byte{key: raw}, ttl)
+			cache.SetAsync(key, raw, ttl)
 		}
 	} else {
 		level.Warn(cb.logger).Log("msg", "failed to encode cached Attributes result", "key", key, "err", err)
@@ -611,7 +611,7 @@ func (cb *CachingBucket) fetchMissingSubranges(ctx context.Context, name string,
 
 				if storeToCache {
 					cb.fetchedGetRangeBytes.WithLabelValues(originBucket, cfgName).Add(float64(len(subrangeData)))
-					cfg.cache.SetMultiAsync(map[string][]byte{key: subrangeData}, cfg.subrangeTTL)
+					cfg.cache.SetAsync(key, subrangeData, cfg.subrangeTTL)
 				} else {
 					cb.refetchedGetRangeBytes.WithLabelValues(originCache, cfgName).Add(float64(len(subrangeData)))
 				}
@@ -992,7 +992,7 @@ func (g *getReader) Read(p []byte) (n int, err error) {
 			// content when we were able to insert the lock key meaning this object isn't being updated
 			// by another request.
 			if addErr := g.c.Add(context.Background(), g.lockKey, []byte{}, invalidationLockTTL); addErr == nil {
-				g.c.SetMultiAsync(map[string][]byte{g.cacheKey: g.buf.Bytes()}, remainingTTL)
+				g.c.SetAsync(g.cacheKey, g.buf.Bytes(), remainingTTL)
 			}
 		}
 		// Clear reference, to avoid doing another Store on next read.

--- a/pkg/streamingpromql/optimize/plan/rangevectorsplitting/cache/cache.go
+++ b/pkg/streamingpromql/optimize/plan/rangevectorsplitting/cache/cache.go
@@ -25,7 +25,7 @@ import (
 
 type Backend interface {
 	GetMulti(ctx context.Context, keys []string, opts ...cache.Option) map[string][]byte
-	SetMultiAsync(data map[string][]byte, ttl time.Duration)
+	SetAsync(key string, value []byte, ttl time.Duration)
 }
 
 type TTLProvider interface {
@@ -219,7 +219,7 @@ func (c *Cache[T]) Set(
 	}
 
 	hashedKey := hashCacheKey(cacheKey)
-	c.backend.SetMultiAsync(map[string][]byte{hashedKey: data}, ttl)
+	c.backend.SetAsync(hashedKey, data, ttl)
 
 	seriesCount := len(seriesMetadata)
 	level.Debug(c.logger).Log("msg", "cache entry written", "hashed_cache_key", hashedKey, "series_count", seriesCount, "entry_size", len(data))

--- a/pkg/streamingpromql/optimize/plan/rangevectorsplitting/range_vector_splitting_test.go
+++ b/pkg/streamingpromql/optimize/plan/rangevectorsplitting/range_vector_splitting_test.go
@@ -1544,11 +1544,9 @@ func (c *testCacheBackend) GetMulti(_ context.Context, keys []string, _ ...dskit
 	return result
 }
 
-func (c *testCacheBackend) SetMultiAsync(data map[string][]byte, _ time.Duration) {
+func (c *testCacheBackend) SetAsync(key string, value []byte, _ time.Duration) {
 	c.sets++
-	for key, value := range data {
-		c.items[key] = value
-	}
+	c.items[key] = value
 }
 
 func (c *testCacheBackend) Reset() {


### PR DESCRIPTION
#### What this PR does

This PR addresses an observation from @56quarters in https://github.com/grafana/mimir/pull/14838#discussion_r3242428185: we use `SetMultiAsync` in a variety of places, but always only have one cache entry. In this case, we could use `SetAsync` instead.

Given this is a user-invisible refactoring, I've chosen not to add a changelog entry.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/pull/14838#discussion_r3242428185

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
