### PR TITLE
ci: align helm version across workflows and regenerate snapshots

### DIFF
--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -16,7 +16,7 @@ jobs:
     with:
       ct_configfile: operations/helm/ct.yaml
       ct_check_version_increment: false
-      helm_version: v4.0.4
+      helm_version: v4.1.4
       kind_kubectl_version: v1.32.12
       kind_node_image: kindest/node:v1.32.0
 

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -163,10 +163,6 @@ jobs:
         run: |
           mkdir -p /go/src/github.com/grafana/mimir
           ln -s $GITHUB_WORKSPACE/* /go/src/github.com/grafana/mimir
-      - name: Set up Helm
-        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
-        with:
-          version: v4.0.1
       - name: Check Helm Tests
         run: make BUILD_IN_CONTAINER=false check-helm-tests
 

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -32,7 +32,10 @@ spec:
     spec:
       serviceAccountName: openshift-values-rollout-operator
       securityContext:
+        fsGroup: null
+        runAsGroup: null
         runAsNonRoot: true
+        runAsUser: null
         seccompProfile:
           type: RuntimeDefault
       containers:

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -92,6 +92,7 @@ spec:
             # needs to be higher to avoid connections being closed abruptly.
             - "-server.http-idle-timeout=6m"
             - -flag-bool=false
+            - -flag-empty=
             - -flag-float=1.23
             - -flag-json1={"foo":"bar"}
             - -flag-json2={"foo":"bar"}

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -84,6 +84,7 @@ spec:
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
             - -flag-bool=false
+            - -flag-empty=
             - -flag-float=1.23
             - -flag-json1={"foo":"bar"}
             - -flag-json2={"foo":"bar"}

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -60,6 +60,7 @@ spec:
             - "-server.grpc.keepalive.max-connection-idle=1m"
             - "-shutdown-delay=90s"
             - -flag-bool=false
+            - -flag-empty=
             - -flag-float=1.23
             - -flag-json1={"foo":"bar"}
             - -flag-json2={"foo":"bar"}

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/gateway/gateway-dep.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/gateway/gateway-dep.yaml
@@ -48,6 +48,7 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - -flag-bool=false
+            - -flag-empty=
             - -flag-float=1.23
             - -flag-json1={"foo":"bar"}
             - -flag-json2={"foo":"bar"}

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
@@ -50,6 +50,7 @@ spec:
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
             - -flag-bool=false
+            - -flag-empty=
             - -flag-float=1.23
             - -flag-json1={"foo":"bar"}
             - -flag-json2={"foo":"bar"}

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -54,6 +54,7 @@ spec:
             - "-server.grpc.keepalive.max-connection-age=30s"
             - "-shutdown-delay=90s"
             - -flag-bool=false
+            - -flag-empty=
             - -flag-float=1.23
             - -flag-json1={"foo":"bar"}
             - -flag-json2={"foo":"bar"}

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/query-scheduler/query-scheduler-dep.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/query-scheduler/query-scheduler-dep.yaml
@@ -49,6 +49,7 @@ spec:
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
             - -flag-bool=false
+            - -flag-empty=
             - -flag-float=1.23
             - -flag-json1={"foo":"bar"}
             - -flag-json2={"foo":"bar"}

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -56,6 +56,7 @@ spec:
             - "-mem-ballast-size-bytes=1073741824"
             - "-distributor.remote-timeout=10s"
             - -flag-bool=false
+            - -flag-empty=
             - -flag-float=1.23
             - -flag-json1={"foo":"bar"}
             - -flag-json2={"foo":"bar"}

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/smoke-test/smoke-test-job.yaml
@@ -48,6 +48,7 @@ spec:
             - "-tests.write-read-series-test.max-query-age=48h"
             - "-server.http-listen-port=8080"
             - -flag-bool=false
+            - -flag-empty=
             - -flag-float=1.23
             - -flag-json1={"foo":"bar"}
             - -flag-json2={"foo":"bar"}

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -98,6 +98,7 @@ spec:
             - "-store-gateway.sharding-ring.instance-availability-zone=zone-a"
             - "-server.grpc-max-send-msg-size-bytes=209715200"
             - -flag-bool=false
+            - -flag-empty=
             - -flag-float=1.23
             - -flag-json1={"foo":"bar"}
             - -flag-json2={"foo":"bar"}
@@ -245,6 +246,7 @@ spec:
             - "-store-gateway.sharding-ring.instance-availability-zone=zone-b"
             - "-server.grpc-max-send-msg-size-bytes=209715200"
             - -flag-bool=false
+            - -flag-empty=
             - -flag-float=1.23
             - -flag-json1={"foo":"bar"}
             - -flag-json2={"foo":"bar"}
@@ -392,6 +394,7 @@ spec:
             - "-store-gateway.sharding-ring.instance-availability-zone=zone-c"
             - "-server.grpc-max-send-msg-size-bytes=209715200"
             - -flag-bool=false
+            - -flag-empty=
             - -flag-float=1.23
             - -flag-json1={"foo":"bar"}
             - -flag-json2={"foo":"bar"}

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -122,7 +122,7 @@ spec:
               port: http-metrics
             initialDelaySeconds: 45
           resources:
-            {}
+            limits: null
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -255,7 +255,7 @@ spec:
               port: http-metrics
             initialDelaySeconds: 45
           resources:
-            {}
+            limits: null
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -388,7 +388,7 @@ spec:
               port: http-metrics
             initialDelaySeconds: 45
           resources:
-            {}
+            limits: null
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -101,7 +101,7 @@ spec:
               port: http-metrics
             initialDelaySeconds: 60
           resources:
-            {}
+            limits: null
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -116,7 +116,7 @@ spec:
               port: http-metrics
             initialDelaySeconds: 60
           resources:
-            {}
+            limits: null
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -244,7 +244,7 @@ spec:
               port: http-metrics
             initialDelaySeconds: 60
           resources:
-            {}
+            limits: null
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -372,7 +372,7 @@ spec:
               port: http-metrics
             initialDelaySeconds: 60
           resources:
-            {}
+            limits: null
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -79,7 +79,7 @@ spec:
               port: http-metrics
             initialDelaySeconds: 45
           resources:
-            {}
+            limits: null
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -77,7 +77,7 @@ spec:
               port: http-metrics
             initialDelaySeconds: 45
           resources:
-            {}
+            limits: null
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/query-scheduler/query-scheduler-dep.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/query-scheduler/query-scheduler-dep.yaml
@@ -72,7 +72,7 @@ spec:
               port: http-metrics
             initialDelaySeconds: 45
           resources:
-            {}
+            limits: null
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -116,7 +116,7 @@ spec:
               port: http-metrics
             initialDelaySeconds: 60
           resources:
-            {}
+            limits: null
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -244,7 +244,7 @@ spec:
               port: http-metrics
             initialDelaySeconds: 60
           resources:
-            {}
+            limits: null
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -372,7 +372,7 @@ spec:
               port: http-metrics
             initialDelaySeconds: 60
           resources:
-            {}
+            limits: null
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -105,7 +105,7 @@ spec:
               port: http-metrics
             initialDelaySeconds: 60
           resources:
-            {}
+            limits: null
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/querier/querier-dep.yaml
@@ -80,7 +80,7 @@ spec:
               port: http-metrics
             initialDelaySeconds: 45
           resources:
-            {}
+            limits: null
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -78,7 +78,7 @@ spec:
               port: http-metrics
             initialDelaySeconds: 45
           resources:
-            {}
+            limits: null
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/query-scheduler/query-scheduler-dep.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/query-scheduler/query-scheduler-dep.yaml
@@ -73,7 +73,7 @@ spec:
               port: http-metrics
             initialDelaySeconds: 45
           resources:
-            {}
+            limits: null
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -104,7 +104,7 @@ spec:
               port: http-metrics
             initialDelaySeconds: 60
           resources:
-            {}
+            limits: null
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/renovate.json5
+++ b/renovate.json5
@@ -46,6 +46,18 @@
         '# renovate: depName=github.com/(?<depName>[^\\s]+)\\s+ENV [A-Z_]+=(?<currentValue>[^\\s]+)\\s+',
       ],
       datasourceTemplate: 'github-tags',
+    },
+    {
+      customType: 'regex',
+      description: 'Update helm_version in helm-ci.yml to track the alpine/helm tag in mimir-build-image/Dockerfile',
+      managerFilePatterns: [
+        '.github/workflows/helm-ci.yml',
+      ],
+      matchStrings: [
+        'helm_version:\\s+v(?<currentValue>[\\d.]+)',
+      ],
+      depNameTemplate: 'alpine/helm',
+      datasourceTemplate: 'docker',
     }
   ],
   baseBranchPatterns: [


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

The repo had three helm-version pins; only mimir-build-image/Dockerfile was tracked by Renovate, so the override in test-build-deploy.yml and the helm_version in helm-ci.yml drifted backward as alpine/helm advanced 4.0.1 -> 4.1.4. This broke PR #15327 when local regen (helm 4.1.4 from the build image) and lint-helm (shadowed helm 4.0.1) disagreed on null map key rendering.

Removing the azure/setup-helm override makes the build image's helm canonical for lint-helm. The helm-ci.yml bump and a new renovate.json5 customManager keep that input aligned going forward.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
