### PR TITLE
Expose memberlist hashicorp/go-metrics via -tags=hashicorpmetrics

### DIFF
--- a/.github/workflows/scripts/run-unit-tests-group.sh
+++ b/.github/workflows/scripts/run-unit-tests-group.sh
@@ -37,8 +37,9 @@ if [[ -z "$TOTAL" ]]; then
     exit 1
 fi
 
-# If you change the build tags or CLI flags, update warmup-build-cache-unit-tests in the Makefile too.
-BUILD_TAGS="netgo,stringlabels"
+# Keep in sync with GO_TAGS in the Makefile. If you change the build tags or CLI flags,
+# update warmup-build-cache-unit-tests in the Makefile too.
+BUILD_TAGS="netgo,stringlabels,hashicorpmetrics"
 if [[ -n "$EXTRA_BUILD_TAGS" ]]; then
     BUILD_TAGS="$BUILD_TAGS,$EXTRA_BUILD_TAGS"
 fi

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -263,7 +263,7 @@ jobs:
           key: go-build-cache-unit-${{ needs.prepare.outputs.build_image }}-${{ hashFiles('go.sum') }}
 
   # Same as the other warmup jobs but for image builds and linting, which use
-  # CGO_ENABLED=0 (no race) with -tags netgo,stringlabels.
+  # CGO_ENABLED=0 (no race) with the GO_TAGS build tags from the Makefile.
   warmup-go-build-cache-image-and-lint:
     needs: [prepare]
     runs-on: ubuntu-latest
@@ -583,7 +583,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      # Race-enabled image uses CGO_ENABLED=1 -race -tags=netgo,stringlabels, same as unit tests.
+      # Race-enabled image uses CGO_ENABLED=1 -race with the GO_TAGS build tags, same as unit tests.
       - name: Restore Go build cache
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,9 +8,11 @@ run:
   # NOTE: requires_libpcap is not included here because it is only needed for
   # tools/trafficdump/, which is linted separately in the Makefile (see lint target).
   # The tags here match the image-and-lint Go build cache for faster CI linting.
+  # Keep in sync with GO_TAGS in the Makefile.
   build-tags:
     - netgo
     - stringlabels
+    - hashicorpmetrics
 output:
   formats:
     text:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [ENHANCEMENT] Memberlist: Reduce per-call allocations on the compression and TCP state-sync receive paths via internal buffer pools. #15357
 * [ENHANCEMENT] Memberlist: Add `memberlist.processed-messages-queue-size` flag to set the size of the per-key internal queue for processing messages received from other nodes. Increasing this value may help to avoid dropping per-key updates when the node is processing many updates for the same key. #15536
 * [ENHANCEMENT] MQE: Respect the `Cache-Control: no-store` request header when caching intermediate results for range vector splitting. #15148
+* [ENHANCEMENT] Memberlist: Expose memberlist's hashicorp/go-metrics counters, gauges, and timers as Prometheus metrics (`counter_memberlist_*`, `gauge_memberlist_*`, `timer_memberlist_*`, `sample_memberlist_*`). #15370
 * [BUGFIX] Query-frontend: Fix `cardinality_analysis_max_results` being ignored when set higher than the default of 500. #15581
 * [BUGFIX] Ingest storage: Fix `KafkaProducer.ProduceSync()` returning a single result with a nil record when the context is canceled, instead of one result per input record (with the record set) as the underlying franz-go client does. #15199
 * [BUGFIX] Ingest storage: Fix `cortex_ingest_storage_reader_receive_delay_seconds` inflation by no longer setting the Kafka record `Timestamp` on the distributor side; the Kafka client now sets it at produce time. #15572

--- a/Makefile
+++ b/Makefile
@@ -251,7 +251,11 @@ MIMIR_VERSION := github.com/grafana/mimir/pkg/util/version
 
 REGO_POLICIES_PATH=operations/policies
 
-GO_TAGS := netgo,stringlabels
+# Build tags used for all Go binaries and tests. A few places can't reference this variable
+# and hardcode the same list -- keep them in sync: .golangci.yml (build-tags),
+# .github/workflows/scripts/run-unit-tests-group.sh (BUILD_TAGS), and the go build invocations
+# in development/*/compose-up.sh.
+GO_TAGS := netgo,stringlabels,hashicorpmetrics
 GO_FLAGS := -ldflags "\
 		-X $(MIMIR_VERSION).Branch=$(GIT_BRANCH) \
 		-X $(MIMIR_VERSION).Revision=$(GIT_REVISION) \
@@ -527,12 +531,12 @@ print-go-version: ## Print the go version.
 	@go version | awk '{print $$3}' | sed 's/go//'
 
 test-with-race: ## Run all unit tests with data race detect.
-	go test -tags netgo,stringlabels -timeout 30m -race -count 1 $$(go list ./... | grep -v "^github.com/grafana/mimir/integration")
+	go test -tags $(GO_TAGS) -timeout 30m -race -count 1 $$(go list ./... | grep -v "^github.com/grafana/mimir/integration")
 
 cover: ## Run all unit tests with code coverage and generates reports.
 	$(eval COVERDIR := $(shell mktemp -d coverage.XXXXXXXXXX))
 	$(eval COVERFILE := $(shell mktemp $(COVERDIR)/unit.XXXXXXXXXX))
-	go test -tags netgo,stringlabels -timeout 30m -race -count 1 -coverprofile=$(COVERFILE) $$(go list ./... | grep -v "^github.com/grafana/mimir/integration")
+	go test -tags $(GO_TAGS) -timeout 30m -race -count 1 -coverprofile=$(COVERFILE) $$(go list ./... | grep -v "^github.com/grafana/mimir/integration")
 	go tool cover -html=$(COVERFILE) -o cover.html
 	go tool cover -func=cover.html | tail -n1
 
@@ -581,7 +585,7 @@ check-protobuf-format:
 	buf format --diff --exit-code $(addprefix --path=,$(PROTO_DEFS)) || (echo "Please format Protobuf files by running 'make format-protobuf'" && false)
 
 %.md : %.template
-	# Speed up check-doc in the lint CI job by aligning doc-generator's Go build flags (CGO_ENABLED=0, -tags netgo,stringlabels) with the rest of the lint pipeline, allowing it to reuse the build cache instead of recompiling the entire dependency tree from scratch.
+	# Speed up check-doc in the lint CI job by aligning doc-generator's Go build flags (CGO_ENABLED=0 and the GO_TAGS build tags) with the rest of the lint pipeline, allowing it to reuse the build cache instead of recompiling the entire dependency tree from scratch.
 	CGO_ENABLED=0 go run -tags $(GO_TAGS) ./tools/doc-generator $< > $@
 
 .PHONY: %.md.embedmd
@@ -897,7 +901,7 @@ warmup-build-cache-image-and-lint: ## Warm the Go build cache for image builds a
 		done; \
 	done
 	# Warm remaining packages for lint tools (golangci-lint, faillint) which type-check
-	# all packages with CGO_ENABLED=0 -tags=netgo,stringlabels on linux/amd64.
+	# all packages with CGO_ENABLED=0 and the GO_TAGS build tags on linux/amd64.
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -tags $(GO_TAGS) ./pkg/... ./cmd/... ./tools/... ./integration/... 2>&1 || true
 
 # Those vars are needed for packages target

--- a/development/mimir-ingest-storage/compose-up.sh
+++ b/development/mimir-ingest-storage/compose-up.sh
@@ -20,7 +20,7 @@ cd "$SCRIPT_DIR" && make
 
 # -gcflags "all=-N -l" disables optimizations that allow for better run with combination with Delve debugger.
 # GOARCH is not changed.
-CGO_ENABLED=0 GOOS=linux go build -mod=vendor -tags=netgo,stringlabels -gcflags "all=-N -l" -o "${SCRIPT_DIR}"/mimir "${SCRIPT_DIR}"/../../cmd/mimir
+CGO_ENABLED=0 GOOS=linux go build -mod=vendor -tags=netgo,stringlabels,hashicorpmetrics -gcflags "all=-N -l" -o "${SCRIPT_DIR}"/mimir "${SCRIPT_DIR}"/../../cmd/mimir
 
 docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml build --build-arg BUILD_IMAGE="${BUILD_IMAGE}" distributor-1
 docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml up "$@"

--- a/development/mimir-microservices-mode/compose-up.sh
+++ b/development/mimir-microservices-mode/compose-up.sh
@@ -22,12 +22,12 @@ cd "$SCRIPT_DIR" && make
 
 # -gcflags "all=-N -l" disables optimizations that allow for better run with combination with Delve debugger.
 # GOARCH is not changed.
-CGO_ENABLED=0 GOOS=linux go build -mod=vendor -tags=netgo,stringlabels -gcflags "all=-N -l" -o "${SCRIPT_DIR}"/mimir "${SCRIPT_DIR}"/../../cmd/mimir
+CGO_ENABLED=0 GOOS=linux go build -mod=vendor -tags=netgo,stringlabels,hashicorpmetrics -gcflags "all=-N -l" -o "${SCRIPT_DIR}"/mimir "${SCRIPT_DIR}"/../../cmd/mimir
 docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml build --build-arg BUILD_IMAGE="${BUILD_IMAGE}" distributor-1
 
 if [ "$(yq '.services."query-tee"' "${SCRIPT_DIR}"/docker-compose.yml)" != "null" ]; then
   # If query-tee is enabled, build its binary and image as well.
-  CGO_ENABLED=0 GOOS=linux go build -mod=vendor -tags=netgo,stringlabels -gcflags "all=-N -l" -o "${SCRIPT_DIR}"/../../cmd/query-tee "${SCRIPT_DIR}"/../../cmd/query-tee
+  CGO_ENABLED=0 GOOS=linux go build -mod=vendor -tags=netgo,stringlabels,hashicorpmetrics -gcflags "all=-N -l" -o "${SCRIPT_DIR}"/../../cmd/query-tee "${SCRIPT_DIR}"/../../cmd/query-tee
   docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml build --build-arg BUILD_IMAGE="${BUILD_IMAGE}" query-tee
 fi
 

--- a/development/mimir-monolithic-mode-with-swift-storage/compose-up.sh
+++ b/development/mimir-monolithic-mode-with-swift-storage/compose-up.sh
@@ -17,6 +17,6 @@ docker_compose() {
 
 SCRIPT_DIR=$(cd "$(dirname -- "$0")" && pwd)
 
-CGO_ENABLED=0 GOOS=linux go build -o "${SCRIPT_DIR}"/mimir "${SCRIPT_DIR}"/../../cmd/mimir && \
+CGO_ENABLED=0 GOOS=linux go build -tags=netgo,stringlabels,hashicorpmetrics -o "${SCRIPT_DIR}"/mimir "${SCRIPT_DIR}"/../../cmd/mimir && \
 docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml build mimir-1 && \
 docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml up "$@"

--- a/development/mimir-monolithic-mode/compose-up.sh
+++ b/development/mimir-monolithic-mode/compose-up.sh
@@ -42,7 +42,7 @@ fi
 
 # -gcflags "all=-N -l" disables optimizations that allow for better run with combination with Delve debugger.
 # GOARCH is not changed.
-CGO_ENABLED=0 GOOS=linux go build -mod=vendor -tags=netgo,stringlabels -gcflags "all=-N -l" -o "${SCRIPT_DIR}"/mimir "${SCRIPT_DIR}"/../../cmd/mimir
+CGO_ENABLED=0 GOOS=linux go build -mod=vendor -tags=netgo,stringlabels,hashicorpmetrics -gcflags "all=-N -l" -o "${SCRIPT_DIR}"/mimir "${SCRIPT_DIR}"/../../cmd/mimir
 
 docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml build mimir-1 && \
 docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml "${PROFILES[@]}" up "${ARGS[@]}"

--- a/integration/integration_memberlist_single_binary_test.go
+++ b/integration/integration_memberlist_single_binary_test.go
@@ -120,6 +120,13 @@ func testSingleBinaryEnvPerNodeFlags(
 	require.NoError(t, mimir2.WaitSumMetrics(e2e.Equals(3), "memberlist_client_cluster_members_count"))
 	require.NoError(t, mimir3.WaitSumMetrics(e2e.Equals(3), "memberlist_client_cluster_members_count"))
 
+	// Memberlist's internal hashicorp/go-metrics instrumentation only reaches the Prometheus
+	// registry when Mimir is built with the hashicorpmetrics tag. The sink creates these
+	// families lazily on first emission, hence WaitMissingMetrics.
+	require.NoError(t, mimir1.WaitSumMetricsWithOptions(e2e.Greater(0), []string{"counter_memberlist_udp_sent"}, e2e.WaitMissingMetrics))
+	require.NoError(t, mimir2.WaitSumMetricsWithOptions(e2e.Greater(0), []string{"counter_memberlist_udp_sent"}, e2e.WaitMissingMetrics))
+	require.NoError(t, mimir3.WaitSumMetricsWithOptions(e2e.Greater(0), []string{"counter_memberlist_udp_sent"}, e2e.WaitMissingMetrics))
+
 	if postConverge != nil {
 		postConverge(mimir1, mimir2, mimir3)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

memberlist (and other hashicorp libraries) emit metrics via hashicorp/go-metrics/compat, a build-tag-dispatched shim that selects between armon/go-metrics (default) and hashicorp/go-metrics (with the `hashicorpmetrics` build tag).

dskit's kv/memberlist/metrics.go configures the global Prometheus sink on hashicorp/go-metrics. Without the build tag, memberlist's metric calls land in armon/go-metrics's unconfigured global and are silently dropped — the two globals never meet. Add the build tag so memberlist's counters, gauges, and timers reach Mimir's `/metrics` endpoint.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
