### PR TITLE
ci: use grafana-actions-go for backports

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,4 +1,5 @@
 name: Backport PR Creator
+run-name: "Backport for ${{ github.event.pull_request.title }} (#${{ github.event.pull_request.number }})"
 
 on:
   pull_request:
@@ -9,7 +10,6 @@ on:
 permissions:
   contents: read
   id-token: write
-  pull-requests: write
 
 jobs:
   main:
@@ -18,31 +18,36 @@ jobs:
     # We don't run the backporting for PRs from forks because those can't access "mimir-github-bot" secrets in vault.
     # We don't use GitHub actions app (secrets.GITHUB_TOKEN) because PRs created by the bot don't trigger CI.
     # Also only run if the PR is merged, as an extra safe-guard.
-    if: ${{ ! github.event.pull_request.head.repo.fork && github.event.pull_request.merged == true }}
+    # On 'labeled' events, require that the label just added is itself a backport label, otherwise
+    # adding an unrelated label to an already-backported PR would re-trigger the job with the wrong label.
+    if: |
+      !github.event.pull_request.head.repo.fork &&
+      github.event.pull_request.merged == true &&
+      (
+        (github.event.action == 'labeled' && startsWith(github.event.label.name, 'backport ')) ||
+        (github.event.action == 'closed' && contains(join(github.event.pull_request.labels.*.name, ','), 'backport '))
+      )
 
     steps:
-      - name: Checkout Actions
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          repository: "grafana/grafana-github-actions"
-          path: ./actions
-          # pin the version to before https://github.com/grafana/grafana-github-actions/pull/113 because
-          # we don't want to have the same strict rules for PR labels
-          ref: d284afd314ca3625c23595e9f62b52d215ead7ce
-          persist-credentials: false
-
-      - name: Install Actions
-        run: npm install --production --prefix ./actions
-
       - name: Generate GitHub App Token
         id: app-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
+        uses: grafana/shared-workflows/actions/create-github-app-token@e5b7989c92b55fe3ac6dd006d6de49082ba8c507 # create-github-app-token (github-script/v9)
         with:
           github_app: mimir-github-bot
 
+      - name: Checkout Mimir
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 2
+          persist-credentials: false
+
       - name: Run backport
-        uses: ./actions/backport
+        uses: grafana/grafana-github-actions-go/backport@407e4b86a206583e2a27912e364a32959e11760a
         with:
           token: ${{ steps.app-token.outputs.token }}
-          labelsToAdd: "backport"
-          title: "[{{base}}] {{originalTitle}}"
+          # If triggered by being labelled, only backport that label.
+          # Otherwise, the action will backport all labels.
+          pr_label: ${{ github.event.action == 'labeled' && github.event.label.name || '' }}
+          pr_number: ${{ github.event.pull_request.number }}
+          repo_owner: ${{ github.repository_owner }}
+          repo_name: ${{ github.event.repository.name }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Uses https://github.com/grafana/grafana-github-actions-go instead of https://github.com/grafana/grafana-github-actions for backport jobs.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release automation and when backports fire; misconfigured `if` or action inputs could skip or mis-target backports, though scope is limited to CI.
> 
> **Overview**
> The **Backport PR Creator** workflow now uses **`grafana/grafana-github-actions-go/backport`** instead of vendoring and running the older **`grafana/grafana-github-actions`** Node action, so the npm install and separate actions checkout steps are removed.
> 
> Job **gating** is tighter: on `labeled` events it only runs when the new label starts with `backport `, and on `closed` it still requires a backport label—avoiding accidental reruns when unrelated labels are added after a backport. A **`run-name`** was added for clearer workflow runs in the UI.
> 
> **`create-github-app-token`** is bumped to a newer shared-workflows pin, **`pull-requests: write`** was dropped from permissions, and the backport step now checks out **Mimir** (shallow) and passes **`pr_label`**, **`pr_number`**, **`repo_owner`**, and **`repo_name`** to the Go action (single-label backport on label events, all backport labels on close).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be0d2639615a541c0dcd759db9b93ca89a68fb3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->