### PR TITLE
[release-2.17] ci: fix broken push-mimir-build-image

### DIFF
--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -69,7 +69,7 @@ jobs:
             echo "✗ User ${PR_AUTHOR} is not a Grafana organization member (HTTP $status_code)"
           fi
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-token-for-membership.outputs.token }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
 
       # We want to allow running github actions for all contributors, but don't want all contributors to be able to
@@ -180,22 +180,15 @@ jobs:
             echo "isDifferent=true" >> $GITHUB_OUTPUT
           fi
 
-%%%%%%% diff from: nkyponkn 6dba5224 "chore(deps): update otel/opentelemetry-collector-contrib docker tag to v0.152.0 (main) (#15361)" (parents of rebased revision)
-\\\\\\\        to: ymmpqlvv a43a9f8f "[r395] migrate github workflows to GitHub App Token Broker (#15375)" (rebased revision)
-       # Tokens expire after 1h. Since building the image can take a long time, we create a fresh App Token for the last
--      # step of the build. (https://github.com/actions/create-github-app-token/issues/121#issuecomment-2027574184)
-+      # step of the build.
-       - name: Generate GitHub App Token
-         if: steps.check_dockerfile.outputs.modified == 'true'
-         id: app-token-for-commit
--        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
-+        uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
-         with:
--          app-id: ${{ env.APP_ID }}
--          private-key: ${{ env.PRIVATE_KEY }}
--          owner: ${{ github.repository_owner }}
-+          github_app: mimir-github-bot
- 
+      # Tokens expire after 1h. Since building the image can take a long time, we create a fresh App Token for the last
+      # step of the build.
+      - name: Generate GitHub App Token
+        if: steps.check_dockerfile.outputs.modified == 'true'
+        id: app-token-for-commit
+        uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
+        with:
+          github_app: mimir-github-bot
+
       # This step uses "Mimir bot" token (generated at the start of the workflow) instead of
       # "github-actions bot" (secrets.GITHUB_TOKEN) because any events triggered by the latter
       # don't spawn GitHub actions.
@@ -219,7 +212,7 @@ jobs:
             git push origin HEAD
           fi
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-token-for-commit.outputs.token }}
           GITHUB_LOGIN: ${{ github.event.pull_request.user.login }}
           TAG: ${{ steps.compute_hash.outputs.tag }}
           MAIN_TAG: ${{ steps.prepare.outputs.main_image_tag }}


### PR DESCRIPTION
Fixup https://github.com/grafana/mimir/pull/15383

The mentioned PR added conflicting changes, that we missed in the review. This PR fixes it.