### PR TITLE
MQE: fix issue where inner operators of `sort_by_label` function and `DeduplicateAndMerge` operators are finalized later than necessary

### DIFF
--- a/pkg/streamingpromql/operators/deduplicate_and_merge.go
+++ b/pkg/streamingpromql/operators/deduplicate_and_merge.go
@@ -56,7 +56,7 @@ func (d *DeduplicateAndMerge) SeriesMetadata(ctx context.Context, matchers types
 	}
 
 	d.groups = groups
-	d.buffer = NewInstantVectorOperatorBuffer(d.Inner, nil, len(innerMetadata), d.MemoryConsumptionTracker)
+	d.buffer = NewInstantVectorOperatorBuffer(d.Inner, nil, len(innerMetadata)-1, d.MemoryConsumptionTracker)
 	types.SeriesMetadataSlicePool.Put(&innerMetadata, d.MemoryConsumptionTracker)
 
 	return outputMetadata, nil

--- a/pkg/streamingpromql/operators/functions/sort_by_label.go
+++ b/pkg/streamingpromql/operators/functions/sort_by_label.go
@@ -72,7 +72,7 @@ func (s *SortByLabel) SeriesMetadata(ctx context.Context, matchers types.Matcher
 	})
 
 	s.originalIndexes = indexes
-	s.buffer = operators.NewInstantVectorOperatorBuffer(s.inner, nil, len(innerMetadata), s.memoryConsumptionTracker)
+	s.buffer = operators.NewInstantVectorOperatorBuffer(s.inner, nil, len(innerMetadata)-1, s.memoryConsumptionTracker)
 
 	return innerMetadata, nil
 }


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue where operators that use `InstantVectorOperatorBuffer`s finalize their inner operator later than necessary.

The impact of this is mild: the inner operators would be finalized shortly afterwards when the outer operator is finalized.

I've chosen not to add a changelog entry given this is not likely to have any user-visible impact.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
