### PR TITLE
MQE: rename `Finalize` on `Operator` to `FinishedReading`

### DIFF
--- a/pkg/frontend/v2/remoteexec.go
+++ b/pkg/frontend/v2/remoteexec.go
@@ -312,15 +312,15 @@ func (g *RemoteExecutionGroupEvaluator) readNextMessage(ctx context.Context) (*f
 	return msg, nil
 }
 
-func (g *RemoteExecutionGroupEvaluator) finalizeStream(ctx context.Context, nodeStreamIndex remoteExecutionNodeStreamIndex) (*annotations.Annotations, stats.Stats, error) {
+func (g *RemoteExecutionGroupEvaluator) finishedReadingStream(ctx context.Context, nodeStreamIndex remoteExecutionNodeStreamIndex) (*annotations.Annotations, stats.Stats, error) {
 	nodeState := g.nodeStreams.streams[nodeStreamIndex]
 	if nodeState.finished {
-		return nil, stats.Stats{}, fmt.Errorf("can't finalize node stream index %v, as it is already finished", nodeState.nodeIndex)
+		return nil, stats.Stats{}, fmt.Errorf("can't call FinishedReading for node stream index %v, as it is already finished", nodeState.nodeIndex)
 	}
 
 	g.markStreamAsFinished(nodeStreamIndex)
 	if !g.nodeStreams.allFinished() {
-		// We'll return the actual evaluation information when the last node calls Finalize().
+		// We'll return the actual evaluation information when the last node calls FinishedReading().
 		return nil, stats.Stats{}, nil
 	}
 
@@ -530,8 +530,8 @@ func (r *scalarExecutionResponse) GetValues(ctx context.Context) (types.ScalarDa
 	return v, nil
 }
 
-func (r *scalarExecutionResponse) Finalize(ctx context.Context) (*annotations.Annotations, stats.Stats, error) {
-	return r.group.finalizeStream(ctx, r.nodeStreamIndex)
+func (r *scalarExecutionResponse) FinishedReading(ctx context.Context) (*annotations.Annotations, stats.Stats, error) {
+	return r.group.finishedReadingStream(ctx, r.nodeStreamIndex)
 }
 
 func (r *scalarExecutionResponse) Stats(ctx context.Context) (*types.OperatorEvaluationStats, error) {
@@ -621,8 +621,8 @@ func (r *instantVectorExecutionResponse) GetNextSeries(ctx context.Context) (typ
 	return mqeData, nil
 }
 
-func (r *instantVectorExecutionResponse) Finalize(ctx context.Context) (*annotations.Annotations, stats.Stats, error) {
-	return r.group.finalizeStream(ctx, r.nodeStreamIndex)
+func (r *instantVectorExecutionResponse) FinishedReading(ctx context.Context) (*annotations.Annotations, stats.Stats, error) {
+	return r.group.finishedReadingStream(ctx, r.nodeStreamIndex)
 }
 
 func (r *instantVectorExecutionResponse) Stats(ctx context.Context) (*types.OperatorEvaluationStats, error) {
@@ -731,8 +731,8 @@ func (r *rangeVectorExecutionResponse) GetNextStepSamples(ctx context.Context) (
 	return r.stepData, nil
 }
 
-func (r *rangeVectorExecutionResponse) Finalize(ctx context.Context) (*annotations.Annotations, stats.Stats, error) {
-	return r.group.finalizeStream(ctx, r.nodeStreamIndex)
+func (r *rangeVectorExecutionResponse) FinishedReading(ctx context.Context) (*annotations.Annotations, stats.Stats, error) {
+	return r.group.finishedReadingStream(ctx, r.nodeStreamIndex)
 }
 
 func (r *rangeVectorExecutionResponse) Stats(ctx context.Context) (*types.OperatorEvaluationStats, error) {

--- a/pkg/frontend/v2/remoteexec_test.go
+++ b/pkg/frontend/v2/remoteexec_test.go
@@ -845,7 +845,7 @@ func TestEnsureHPointSliceCapacityIsPowerOfTwo(t *testing.T) {
 	}
 }
 
-func TestExecutionResponses_FinalizeAndStats(t *testing.T) {
+func TestExecutionResponses_FinishedReadingAndStats(t *testing.T) {
 	timeRange := types.NewInstantQueryTimeRange(time.Now())
 
 	responseCreators := map[string]func(t *testing.T, ctx context.Context, stream ResponseStream, memoryConsumptionTracker *limiter.MemoryConsumptionTracker) remoteexec.RemoteExecutionResponse{
@@ -904,7 +904,7 @@ func TestExecutionResponses_FinalizeAndStats(t *testing.T) {
 				memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 				response := responseCreator(t, ctx, stream, memoryConsumptionTracker)
 
-				annos, overallStats, err := response.Finalize(ctx)
+				annos, overallStats, err := response.FinishedReading(ctx)
 				if !expectSuccess {
 					require.Equal(t, expectedError, err)
 					return
@@ -1263,10 +1263,10 @@ func TestRemoteExecutionGroupEvaluator_ReadingMessagesInReturnedOrder(t *testing
 	require.Equal(t, expectedData, data)
 	requireNoBufferedDataForAllNodes(t, evaluator)
 
-	annos, returnedStats, err := resp1.Finalize(ctx)
+	annos, returnedStats, err := resp1.FinishedReading(ctx)
 	require.NoError(t, err)
-	require.Empty(t, annos, "should not return annotations for first node, these should be returned when the second node calls Finalize")
-	require.Equal(t, stats.Stats{}, returnedStats, "should not return statistics for first node, these should be returned when the second node calls Finalize")
+	require.Empty(t, annos, "should not return annotations for first node, these should be returned when the second node calls FinishedReading")
+	require.Equal(t, stats.Stats{}, returnedStats, "should not return statistics for first node, these should be returned when the second node calls FinishedReading")
 	requireNoBufferedDataForAllNodes(t, evaluator)
 
 	_, err = resp1.GetNextSeries(ctx)
@@ -1283,7 +1283,7 @@ func TestRemoteExecutionGroupEvaluator_ReadingMessagesInReturnedOrder(t *testing
 	require.Equal(t, expectedData, data)
 	requireNoBufferedDataForAllNodes(t, evaluator)
 
-	annos, returnedStats, err = resp2.Finalize(ctx)
+	annos, returnedStats, err = resp2.FinishedReading(ctx)
 	require.NoError(t, err)
 	expectedAnnos := annotations.New()
 	expectedAnnos.Add(querierpb.NewInfoAnnotation("an info annotation"))
@@ -1296,7 +1296,7 @@ func TestRemoteExecutionGroupEvaluator_ReadingMessagesInReturnedOrder(t *testing
 	_, err = resp2.GetNextSeries(ctx)
 	require.EqualError(t, err, "can't read next message for node stream at index 1, as it is already finished")
 
-	require.True(t, stream.closed.Load(), "stream should be closed after finalizing last node")
+	require.True(t, stream.closed.Load(), "stream should be closed after calling FinishedReading on last node")
 }
 
 func TestRemoteExecutionGroupEvaluator_ReadingMessagesOutOfOrder(t *testing.T) {
@@ -1396,13 +1396,13 @@ func TestRemoteExecutionGroupEvaluator_ReadingMessagesOutOfOrder(t *testing.T) {
 
 	// Read the evaluation completed message for the first node, which should cause no buffering as we'll
 	// read the results when we are done with the second node.
-	annos, returnedStats, err := resp1.Finalize(ctx)
+	annos, returnedStats, err := resp1.FinishedReading(ctx)
 	require.NoError(t, err)
-	require.Empty(t, annos, "should not return annotations for first node, these should be returned when the second node calls Finalize")
-	require.Equal(t, stats.Stats{}, returnedStats, "should not return statistics for first node, these should be returned when the second node calls Finalize")
+	require.Empty(t, annos, "should not return annotations for first node, these should be returned when the second node calls FinishedReading")
+	require.Equal(t, stats.Stats{}, returnedStats, "should not return statistics for first node, these should be returned when the second node calls FinishedReading")
 	requireNoBufferedDataForAllNodes(t, evaluator)
 
-	annos, returnedStats, err = resp2.Finalize(ctx)
+	annos, returnedStats, err = resp2.FinishedReading(ctx)
 	require.NoError(t, err)
 	expectedAnnos := annotations.New()
 	expectedAnnos.Add(querierpb.NewInfoAnnotation("an info annotation"))
@@ -1412,7 +1412,7 @@ func TestRemoteExecutionGroupEvaluator_ReadingMessagesOutOfOrder(t *testing.T) {
 	require.Equal(t, expectedStats, returnedStats)
 	requireNoBufferedDataForAllNodes(t, evaluator) // The messages we skipped over should not be buffered.
 
-	require.True(t, stream.closed.Load(), "stream should be closed after finalizing last node")
+	require.True(t, stream.closed.Load(), "stream should be closed after calling FinishedReading on last node")
 }
 
 func requireNoBufferedDataForAllNodes(t *testing.T, evaluator *RemoteExecutionGroupEvaluator) {
@@ -1506,7 +1506,7 @@ func TestRemoteExecutionGroupEvaluator_ReceiveUnexpectedMessageWithoutNodeIndex(
 	require.Empty(t, series)
 }
 
-func TestRemoteExecutionGroupEvaluator_BufferingBehaviourWithFinalize(t *testing.T) {
+func TestRemoteExecutionGroupEvaluator_BufferingBehaviourWithFinishedReading(t *testing.T) {
 	ctx := context.Background()
 
 	stream := &mockResponseStream{
@@ -1574,11 +1574,11 @@ func TestRemoteExecutionGroupEvaluator_BufferingBehaviourWithFinalize(t *testing
 	requireBufferedDataForNode(t, evaluator, node1, 1)
 	requireNoBufferedDataForNode(t, evaluator, node2)
 
-	// Finalize the first node, confirm the buffered message is dropped.
-	annos, returnedStats, err := resp1.Finalize(ctx)
+	// Call FinishedReading on the first node, confirm the buffered message is dropped.
+	annos, returnedStats, err := resp1.FinishedReading(ctx)
 	require.NoError(t, err)
-	require.Empty(t, annos, "should not return annotations for first node, these should be returned when the second node calls Finalize")
-	require.Equal(t, stats.Stats{}, returnedStats, "should not return statistics for first node, these should be returned when the second node calls Finalize")
+	require.Empty(t, annos, "should not return annotations for first node, these should be returned when the second node calls FinishedReading")
+	require.Equal(t, stats.Stats{}, returnedStats, "should not return statistics for first node, these should be returned when the second node calls FinishedReading")
 	requireNoBufferedDataForAllNodes(t, evaluator)
 
 	// Read the second message from the second node, confirm nothing is buffered for the first node.
@@ -1588,8 +1588,8 @@ func TestRemoteExecutionGroupEvaluator_BufferingBehaviourWithFinalize(t *testing
 	require.Equal(t, expectedData, data)
 	requireNoBufferedDataForAllNodes(t, evaluator)
 
-	// Finalize the second node, skipping over the remaining message, confirm the remaining message is not buffered and the underlying stream is closed.
-	annos, returnedStats, err = resp2.Finalize(ctx)
+	// Call FinishedReading on the second node, skipping over the remaining message, confirm the remaining message is not buffered and the underlying stream is closed.
+	annos, returnedStats, err = resp2.FinishedReading(ctx)
 	require.NoError(t, err)
 	expectedAnnos := annotations.New()
 	expectedAnnos.Add(querierpb.NewInfoAnnotation("an info annotation"))
@@ -1599,7 +1599,7 @@ func TestRemoteExecutionGroupEvaluator_BufferingBehaviourWithFinalize(t *testing
 	require.Equal(t, expectedStats, returnedStats)
 	requireNoBufferedDataForAllNodes(t, evaluator) // The messages we skipped over should not be buffered.
 
-	require.True(t, stream.closed.Load(), "stream should be closed after finalizing last node")
+	require.True(t, stream.closed.Load(), "stream should be closed after calling FinishedReading on last node")
 }
 
 func TestRemoteExecutionGroupEvaluator_BufferingBehaviourWithEarlyCloseOfOneNode(t *testing.T) {
@@ -1681,8 +1681,8 @@ func TestRemoteExecutionGroupEvaluator_BufferingBehaviourWithEarlyCloseOfOneNode
 	require.Equal(t, expectedData, data)
 	requireNoBufferedDataForAllNodes(t, evaluator)
 
-	// Finalize the second node, skipping over the remaining message, confirm the remaining message is not buffered and the underlying stream is closed.
-	annos, returnedStats, err := resp2.Finalize(ctx)
+	// Call FinishedReading on the second node, skipping over the remaining message, confirm the remaining message is not buffered and the underlying stream is closed.
+	annos, returnedStats, err := resp2.FinishedReading(ctx)
 	require.NoError(t, err)
 	expectedAnnos := annotations.New()
 	expectedAnnos.Add(querierpb.NewInfoAnnotation("an info annotation"))
@@ -1692,7 +1692,7 @@ func TestRemoteExecutionGroupEvaluator_BufferingBehaviourWithEarlyCloseOfOneNode
 	require.Equal(t, expectedStats, returnedStats)
 	requireNoBufferedDataForAllNodes(t, evaluator) // The messages we skipped over should not be buffered.
 
-	require.True(t, stream.closed.Load(), "stream should be closed after finalizing last node")
+	require.True(t, stream.closed.Load(), "stream should be closed after calling FinishedReading on last node")
 }
 
 func TestRemoteExecutionGroupEvaluator_BufferingBehaviourWithCloseCalls(t *testing.T) {

--- a/pkg/streamingpromql/evaluator.go
+++ b/pkg/streamingpromql/evaluator.go
@@ -168,7 +168,7 @@ func (e *Evaluator) Evaluate(ctx context.Context, observer EvaluationObserver) (
 			}
 
 			if !haveMoreWork {
-				if err := evaluator.finalize(ctx); err != nil {
+				if err := evaluator.finishedReading(ctx); err != nil {
 					return err
 				}
 
@@ -179,10 +179,10 @@ func (e *Evaluator) Evaluate(ctx context.Context, observer EvaluationObserver) (
 	}
 
 	if e.engine.pedantic {
-		// Finalize the all operators a second time to ensure all operators behave correctly if Finalize is called multiple times.
+		// Call FinishedReading on all operators a second time to ensure all operators behave correctly if FinishedReading is called multiple times.
 		for _, req := range e.nodeRequests {
-			if err := req.operator.Finalize(ctx); err != nil {
-				return fmt.Errorf("pedantic mode: failed to finalize operator a second time after successfully finalizing the first time: %w", err)
+			if err := req.operator.FinishedReading(ctx); err != nil {
+				return fmt.Errorf("pedantic mode: failed to call FinishedReading on the operator a second time after successfully finishedReading the first time: %w", err)
 			}
 		}
 	}
@@ -217,7 +217,7 @@ type operatorEvaluator interface {
 	// performWork returns true if there is more work remaining for this operator, or false otherwise.
 	performWork(ctx context.Context, evaluator *Evaluator, observer EvaluationObserver) (bool, error)
 
-	finalize(ctx context.Context) error
+	finishedReading(ctx context.Context) error
 }
 
 type instantVectorEvaluator struct {
@@ -267,8 +267,8 @@ func (e *instantVectorEvaluator) performWork(ctx context.Context, evaluator *Eva
 	return haveMoreSeries, nil
 }
 
-func (e *instantVectorEvaluator) finalize(ctx context.Context) error {
-	return e.operator.Finalize(ctx)
+func (e *instantVectorEvaluator) finishedReading(ctx context.Context) error {
+	return e.operator.FinishedReading(ctx)
 }
 
 type rangeVectorEvaluator struct {
@@ -334,8 +334,8 @@ func (e *rangeVectorEvaluator) performWork(ctx context.Context, evaluator *Evalu
 	return haveMoreSeries, nil
 }
 
-func (e *rangeVectorEvaluator) finalize(ctx context.Context) error {
-	return e.operator.Finalize(ctx)
+func (e *rangeVectorEvaluator) finishedReading(ctx context.Context) error {
+	return e.operator.FinishedReading(ctx)
 }
 
 type scalarEvaluator struct {
@@ -352,8 +352,8 @@ func (e *scalarEvaluator) performWork(ctx context.Context, evaluator *Evaluator,
 	return false, observer.ScalarEvaluated(ctx, evaluator, e.node, d)
 }
 
-func (e *scalarEvaluator) finalize(ctx context.Context) error {
-	return e.operator.Finalize(ctx)
+func (e *scalarEvaluator) finishedReading(ctx context.Context) error {
+	return e.operator.FinishedReading(ctx)
 }
 
 type stringEvaluator struct {
@@ -367,8 +367,8 @@ func (e *stringEvaluator) performWork(ctx context.Context, evaluator *Evaluator,
 	return false, observer.StringEvaluated(ctx, evaluator, e.node, v)
 }
 
-func (e *stringEvaluator) finalize(ctx context.Context) error {
-	return e.operator.Finalize(ctx)
+func (e *stringEvaluator) finishedReading(ctx context.Context) error {
+	return e.operator.FinishedReading(ctx)
 }
 
 func (e *Evaluator) Cancel() {

--- a/pkg/streamingpromql/operators/aggregations/aggregation.go
+++ b/pkg/streamingpromql/operators/aggregations/aggregation.go
@@ -168,14 +168,14 @@ func (a *Aggregation) AfterPrepare(ctx context.Context) error {
 	return a.Inner.AfterPrepare(ctx)
 }
 
-func (a *Aggregation) Finalize(ctx context.Context) error {
-	// The wrapping operator (if any) is responsible for calling Finalize() on whatever provides a.ParamData, so we don't need to do it here.
+func (a *Aggregation) FinishedReading(ctx context.Context) error {
+	// The wrapping operator (if any) is responsible for calling FinishedReading() on whatever provides a.ParamData, so we don't need to do it here.
 	if a.aggregator != nil {
-		a.aggregator.Finalize()
+		a.aggregator.FinishedReading()
 		a.aggregator = nil
 	}
 
-	return a.Inner.Finalize(ctx)
+	return a.Inner.FinishedReading(ctx)
 }
 
 func (a *Aggregation) SetParamData(data types.ScalarData) {
@@ -464,7 +464,7 @@ func (a *Aggregator) emitAnnotation(generator types.AnnotationGenerator) {
 	a.Annotations.Add(generator(metricName, a.innerExpressionPosition))
 }
 
-func (a *Aggregator) Finalize() {
+func (a *Aggregator) FinishedReading() {
 	if a.ParamData.Samples != nil {
 		types.FPointSlicePool.Put(&a.ParamData.Samples, a.MemoryConsumptionTracker)
 	}

--- a/pkg/streamingpromql/operators/aggregations/aggregation_test.go
+++ b/pkg/streamingpromql/operators/aggregations/aggregation_test.go
@@ -387,8 +387,8 @@ func TestAggregations_ReturnIncompleteGroupsOnEarlyClose(t *testing.T) {
 
 			types.PutInstantVectorSeriesData(seriesData, memoryConsumptionTracker)
 
-			// Finalize the operator and confirm all memory has been released.
-			require.NoError(t, o.Finalize(ctx))
+			// Call FinishedReading on the operator and confirm all memory has been released.
+			require.NoError(t, o.FinishedReading(ctx))
 			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
 			o.Close()
 		})

--- a/pkg/streamingpromql/operators/aggregations/count_values.go
+++ b/pkg/streamingpromql/operators/aggregations/count_values.go
@@ -262,18 +262,18 @@ func (c *CountValues) AfterPrepare(ctx context.Context) error {
 	return c.LabelName.AfterPrepare(ctx)
 }
 
-func (c *CountValues) Finalize(ctx context.Context) error {
+func (c *CountValues) FinishedReading(ctx context.Context) error {
 	for _, d := range c.series {
 		types.FPointSlicePool.Put(&d, c.MemoryConsumptionTracker)
 	}
 
 	c.series = nil
 
-	if err := c.Inner.Finalize(ctx); err != nil {
+	if err := c.Inner.FinishedReading(ctx); err != nil {
 		return err
 	}
 
-	return c.LabelName.Finalize(ctx)
+	return c.LabelName.FinishedReading(ctx)
 }
 
 func (c *CountValues) Stats(ctx context.Context) (*types.OperatorEvaluationStats, error) {

--- a/pkg/streamingpromql/operators/aggregations/limitklimitratio/operator.go
+++ b/pkg/streamingpromql/operators/aggregations/limitklimitratio/operator.go
@@ -186,7 +186,7 @@ func (o *Operator) AfterPrepare(ctx context.Context) error {
 	return o.Param.AfterPrepare(ctx)
 }
 
-func (o *Operator) Finalize(ctx context.Context) error {
+func (o *Operator) FinishedReading(ctx context.Context) error {
 	if o.stepArg != nil {
 		o.stepArg.close()
 	}
@@ -199,11 +199,11 @@ func (o *Operator) Finalize(ctx context.Context) error {
 	}
 	o.seriesToGroups = nil
 
-	if err := o.Inner.Finalize(ctx); err != nil {
+	if err := o.Inner.FinishedReading(ctx); err != nil {
 		return err
 	}
 
-	return o.Param.Finalize(ctx)
+	return o.Param.FinishedReading(ctx)
 }
 
 func (o *Operator) Stats(ctx context.Context) (*types.OperatorEvaluationStats, error) {

--- a/pkg/streamingpromql/operators/aggregations/quantile.go
+++ b/pkg/streamingpromql/operators/aggregations/quantile.go
@@ -102,12 +102,12 @@ func (q *QuantileAggregation) AfterPrepare(ctx context.Context) error {
 	return q.Param.AfterPrepare(ctx)
 }
 
-func (q *QuantileAggregation) Finalize(ctx context.Context) error {
-	if err := q.Aggregation.Finalize(ctx); err != nil {
+func (q *QuantileAggregation) FinishedReading(ctx context.Context) error {
+	if err := q.Aggregation.FinishedReading(ctx); err != nil {
 		return err
 	}
 
-	return q.Param.Finalize(ctx)
+	return q.Param.FinishedReading(ctx)
 }
 
 func (q *QuantileAggregation) Stats(ctx context.Context) (*types.OperatorEvaluationStats, error) {

--- a/pkg/streamingpromql/operators/aggregations/topkbottomk/instant_query.go
+++ b/pkg/streamingpromql/operators/aggregations/topkbottomk/instant_query.go
@@ -308,14 +308,14 @@ func (t *InstantQuery) AfterPrepare(ctx context.Context) error {
 	return t.Param.AfterPrepare(ctx)
 }
 
-func (t *InstantQuery) Finalize(ctx context.Context) error {
+func (t *InstantQuery) FinishedReading(ctx context.Context) error {
 	types.Float64SlicePool.Put(&t.values, t.MemoryConsumptionTracker)
 
-	if err := t.Inner.Finalize(ctx); err != nil {
+	if err := t.Inner.FinishedReading(ctx); err != nil {
 		return err
 	}
 
-	return t.Param.Finalize(ctx)
+	return t.Param.FinishedReading(ctx)
 }
 
 func (t *InstantQuery) Stats(ctx context.Context) (*types.OperatorEvaluationStats, error) {

--- a/pkg/streamingpromql/operators/aggregations/topkbottomk/range_query.go
+++ b/pkg/streamingpromql/operators/aggregations/topkbottomk/range_query.go
@@ -430,7 +430,7 @@ func (t *RangeQuery) AfterPrepare(ctx context.Context) error {
 	return t.Param.AfterPrepare(ctx)
 }
 
-func (t *RangeQuery) Finalize(ctx context.Context) error {
+func (t *RangeQuery) FinishedReading(ctx context.Context) error {
 	types.Int64SlicePool.Put(&t.k, t.MemoryConsumptionTracker)
 
 	if t.currentGroup != nil {
@@ -444,11 +444,11 @@ func (t *RangeQuery) Finalize(ctx context.Context) error {
 
 	t.remainingGroups = nil
 
-	if err := t.Inner.Finalize(ctx); err != nil {
+	if err := t.Inner.FinishedReading(ctx); err != nil {
 		return err
 	}
 
-	return t.Param.Finalize(ctx)
+	return t.Param.FinishedReading(ctx)
 }
 
 func (t *RangeQuery) Stats(ctx context.Context) (*types.OperatorEvaluationStats, error) {

--- a/pkg/streamingpromql/operators/aggregations/topkbottomk/topk_bottomk_test.go
+++ b/pkg/streamingpromql/operators/aggregations/topkbottomk/topk_bottomk_test.go
@@ -87,13 +87,13 @@ func TestAggregations_ReturnIncompleteGroupsOnEarlyClose(t *testing.T) {
 								types.PutInstantVectorSeriesData(seriesData, memoryConsumptionTracker)
 							}
 
-							// TestOperator does not release any unread data on Finalize(), so do that now.
+							// TestOperator does not release any unread data on FinishedReading(), so do that now.
 							for _, d := range inner.Data {
 								types.PutInstantVectorSeriesData(d, memoryConsumptionTracker)
 							}
 
-							// Finalize the operator and confirm all memory has been released.
-							require.NoError(t, o.Finalize(ctx))
+							// Call FinishedReading on the operator and confirm all memory has been released.
+							require.NoError(t, o.FinishedReading(ctx))
 							require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
 							o.Close()
 						})

--- a/pkg/streamingpromql/operators/binops/and_unless_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/and_unless_binary_operation.go
@@ -69,15 +69,15 @@ func (a *AndUnlessBinaryOperation) SeriesMetadata(ctx context.Context, matchers 
 	}
 
 	if a.lastLeftSeriesIndexToRead == -1 {
-		// We're not going to read anything from the left side, finalize it now.
-		if err := a.Left.Finalize(ctx); err != nil {
+		// We're not going to read anything from the left side, call FinishedReading on it now.
+		if err := a.Left.FinishedReading(ctx); err != nil {
 			return nil, err
 		}
 	}
 
 	if a.lastRightSeriesIndexToRead == -1 {
-		// We're not going to read anything from the right side, finalize it now.
-		if err := a.Right.Finalize(ctx); err != nil {
+		// We're not going to read anything from the right side, call FinishedReading on it now.
+		if err := a.Right.FinishedReading(ctx); err != nil {
 			return nil, err
 		}
 	}
@@ -196,10 +196,10 @@ func (a *AndUnlessBinaryOperation) NextSeries(ctx context.Context) (types.Instan
 		return types.InstantVectorSeriesData{}, err
 	}
 
-	// If we're done reading the left side, finalize it so it can do any outstanding work as early as possible.
+	// If we're done reading the left side, call FinishedReading on it so it can do any outstanding work as early as possible.
 	// We do the same thing for the right side in readRightSideUntilGroupComplete.
 	if a.nextLeftSeriesIndex > a.lastLeftSeriesIndexToRead {
-		if err := a.Left.Finalize(ctx); err != nil {
+		if err := a.Left.FinishedReading(ctx); err != nil {
 			return types.InstantVectorSeriesData{}, err
 		}
 	}
@@ -256,7 +256,7 @@ func (a *AndUnlessBinaryOperation) computeNextSeries(ctx context.Context) (types
 
 		if thisSeriesGroup.leftSeriesCount == 0 {
 			// This is the last series for this group, return it to the pool.
-			thisSeriesGroup.Finalize(a.MemoryConsumptionTracker)
+			thisSeriesGroup.FinishedReading(a.MemoryConsumptionTracker)
 		}
 
 		return filteredData, nil
@@ -284,9 +284,9 @@ func (a *AndUnlessBinaryOperation) readRightSideUntilGroupComplete(ctx context.C
 		a.nextRightSeriesIndex++
 	}
 
-	// If we're done reading the right side, finalize it so it can release any resources as early as possible.
+	// If we're done reading the right side, call FinishedReading on it so it can release any resources as early as possible.
 	if a.nextRightSeriesIndex > a.lastRightSeriesIndexToRead {
-		if err := a.Right.Finalize(ctx); err != nil {
+		if err := a.Right.FinishedReading(ctx); err != nil {
 			return err
 		}
 	}
@@ -314,13 +314,13 @@ func (a *AndUnlessBinaryOperation) AfterPrepare(ctx context.Context) error {
 	return a.Right.AfterPrepare(ctx)
 }
 
-func (a *AndUnlessBinaryOperation) Finalize(ctx context.Context) error {
+func (a *AndUnlessBinaryOperation) FinishedReading(ctx context.Context) error {
 	for _, group := range a.leftSeriesGroups {
 		if group == nil {
 			continue
 		}
 
-		group.Finalize(a.MemoryConsumptionTracker)
+		group.FinishedReading(a.MemoryConsumptionTracker)
 	}
 
 	a.leftSeriesGroups = nil
@@ -328,11 +328,11 @@ func (a *AndUnlessBinaryOperation) Finalize(ctx context.Context) error {
 	// We don't need to explicitly close any groups in rightSeriesGroups, as they would have been closed above.
 	a.rightSeriesGroups = nil
 
-	if err := a.Left.Finalize(ctx); err != nil {
+	if err := a.Left.FinishedReading(ctx); err != nil {
 		return err
 	}
 
-	return a.Right.Finalize(ctx)
+	return a.Right.FinishedReading(ctx)
 }
 
 func (a *AndUnlessBinaryOperation) Stats(ctx context.Context) (*types.OperatorEvaluationStats, error) {
@@ -380,6 +380,6 @@ func (g *andGroup) FilterLeftSeries(leftData types.InstantVectorSeriesData, memo
 	return filterSeries(leftData, g.rightSamplePresence, !isUnless, memoryConsumptionTracker, timeRange)
 }
 
-func (g *andGroup) Finalize(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
+func (g *andGroup) FinishedReading(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
 	types.BoolSlicePool.Put(&g.rightSamplePresence, memoryConsumptionTracker)
 }

--- a/pkg/streamingpromql/operators/binops/and_unless_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/and_unless_binary_operation_test.go
@@ -125,7 +125,7 @@ func TestAndUnlessBinaryOperation_PassesHintMatchersToRHS(t *testing.T) {
 			require.Equal(t, testutils.LabelsToSeriesMetadata(testCase.expectedOutputSeries), outputSeries)
 
 			types.SeriesMetadataSlicePool.Put(&outputSeries, memoryConsumptionTracker)
-			require.NoError(t, o.Finalize(ctx))
+			require.NoError(t, o.FinishedReading(ctx))
 			o.Close()
 		})
 	}
@@ -272,21 +272,21 @@ func TestAndUnlessBinaryOperation_PassesExcludeHintMatchersToRHS(t *testing.T) {
 			require.Equal(t, testutils.LabelsToSeriesMetadata(testCase.expectedOutputSeries), outputSeries)
 
 			types.SeriesMetadataSlicePool.Put(&outputSeries, memoryConsumptionTracker)
-			require.NoError(t, o.Finalize(ctx))
+			require.NoError(t, o.FinishedReading(ctx))
 			o.Close()
 		})
 	}
 }
 
-func TestAndUnlessBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *testing.T) {
+func TestAndUnlessBinaryOperation_CallsFinishedReadingOnInnerOperatorsAsSoonAsPossible(t *testing.T) {
 	testCases := map[string]struct {
 		isUnless    bool
 		leftSeries  []labels.Labels
 		rightSeries []labels.Labels
 
-		expectedOutputSeries                           []labels.Labels
-		expectLeftSideFinalizedAfterOutputSeriesIndex  int
-		expectRightSideFinalizedAfterOutputSeriesIndex int
+		expectedOutputSeries                                       []labels.Labels
+		expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex  int
+		expectRightSideFinishedReadingCalledAfterOutputSeriesIndex int
 	}{
 		"and: reach end of both sides at the same time": {
 			isUnless: false,
@@ -306,8 +306,8 @@ func TestAndUnlessBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *tes
 				labels.FromStrings("group", "1", "series", "left-2"),
 				labels.FromStrings("group", "2", "series", "left-3"),
 			},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  2,
-			expectRightSideFinalizedAfterOutputSeriesIndex: 2,
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  2,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: 2,
 		},
 		"unless: reach end of both sides at the same time": {
 			isUnless: true,
@@ -327,8 +327,8 @@ func TestAndUnlessBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *tes
 				labels.FromStrings("group", "1", "series", "left-2"),
 				labels.FromStrings("group", "2", "series", "left-3"),
 			},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  2,
-			expectRightSideFinalizedAfterOutputSeriesIndex: 2,
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  2,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: 2,
 		},
 		"and: no more matches with unmatched series still to read on both sides": {
 			isUnless: false,
@@ -347,8 +347,8 @@ func TestAndUnlessBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *tes
 				labels.FromStrings("group", "1", "series", "left-1"),
 				labels.FromStrings("group", "1", "series", "left-2"),
 			},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  1,
-			expectRightSideFinalizedAfterOutputSeriesIndex: 0,
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  1,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: 0,
 		},
 		"unless: no more matches with unmatched series still to read on both sides": {
 			isUnless: true,
@@ -368,8 +368,8 @@ func TestAndUnlessBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *tes
 				labels.FromStrings("group", "1", "series", "left-2"),
 				labels.FromStrings("group", "2", "series", "left-3"),
 			},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  2,
-			expectRightSideFinalizedAfterOutputSeriesIndex: 0,
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  2,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: 0,
 		},
 		"and: no more matches with unmatched series still to read on left side": {
 			isUnless: false,
@@ -387,8 +387,8 @@ func TestAndUnlessBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *tes
 				labels.FromStrings("group", "1", "series", "left-1"),
 				labels.FromStrings("group", "1", "series", "left-2"),
 			},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  1,
-			expectRightSideFinalizedAfterOutputSeriesIndex: 0,
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  1,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: 0,
 		},
 		"unless: no more matches with unmatched series still to read on left side": {
 			isUnless: true,
@@ -407,8 +407,8 @@ func TestAndUnlessBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *tes
 				labels.FromStrings("group", "1", "series", "left-2"),
 				labels.FromStrings("group", "2", "series", "left-3"),
 			},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  2,
-			expectRightSideFinalizedAfterOutputSeriesIndex: 0,
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  2,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: 0,
 		},
 		"and: no more matches with unmatched series still to read on right side": {
 			isUnless: false,
@@ -426,8 +426,8 @@ func TestAndUnlessBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *tes
 				labels.FromStrings("group", "1", "series", "left-1"),
 				labels.FromStrings("group", "1", "series", "left-2"),
 			},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  1,
-			expectRightSideFinalizedAfterOutputSeriesIndex: 0,
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  1,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: 0,
 		},
 		"unless: no more matches with unmatched series still to read on right side": {
 			isUnless: true,
@@ -445,8 +445,8 @@ func TestAndUnlessBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *tes
 				labels.FromStrings("group", "1", "series", "left-1"),
 				labels.FromStrings("group", "1", "series", "left-2"),
 			},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  1,
-			expectRightSideFinalizedAfterOutputSeriesIndex: 0,
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  1,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: 0,
 		},
 		"and: some series do not match anything on the right": {
 			isUnless: false,
@@ -467,8 +467,8 @@ func TestAndUnlessBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *tes
 				labels.FromStrings("group", "1", "series", "left-3"),
 				labels.FromStrings("group", "3", "series", "left-4"),
 			},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  2,
-			expectRightSideFinalizedAfterOutputSeriesIndex: 2,
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  2,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: 2,
 		},
 		"and: no series match": {
 			isUnless: false,
@@ -480,9 +480,9 @@ func TestAndUnlessBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *tes
 				labels.FromStrings("group", "3", "series", "right-1"),
 			},
 
-			expectedOutputSeries:                           []labels.Labels{},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  -1,
-			expectRightSideFinalizedAfterOutputSeriesIndex: -1,
+			expectedOutputSeries: []labels.Labels{},
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  -1,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: -1,
 		},
 		"unless: no series match": {
 			isUnless: true,
@@ -498,8 +498,8 @@ func TestAndUnlessBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *tes
 				labels.FromStrings("group", "1", "series", "left-1"),
 				labels.FromStrings("group", "2", "series", "left-2"),
 			},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  1,
-			expectRightSideFinalizedAfterOutputSeriesIndex: -1,
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  1,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: -1,
 		},
 		"and: no series on left": {
 			isUnless:   false,
@@ -510,9 +510,9 @@ func TestAndUnlessBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *tes
 				labels.FromStrings("group", "3", "series", "right-3"),
 			},
 
-			expectedOutputSeries:                           []labels.Labels{},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  -1,
-			expectRightSideFinalizedAfterOutputSeriesIndex: -1,
+			expectedOutputSeries: []labels.Labels{},
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  -1,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: -1,
 		},
 		"unless: no series on left": {
 			isUnless:   true,
@@ -523,9 +523,9 @@ func TestAndUnlessBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *tes
 				labels.FromStrings("group", "3", "series", "right-3"),
 			},
 
-			expectedOutputSeries:                           []labels.Labels{},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  -1,
-			expectRightSideFinalizedAfterOutputSeriesIndex: -1,
+			expectedOutputSeries: []labels.Labels{},
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  -1,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: -1,
 		},
 		"and: no series on right": {
 			isUnless: false,
@@ -536,9 +536,9 @@ func TestAndUnlessBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *tes
 			},
 			rightSeries: []labels.Labels{},
 
-			expectedOutputSeries:                           []labels.Labels{},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  -1,
-			expectRightSideFinalizedAfterOutputSeriesIndex: -1,
+			expectedOutputSeries: []labels.Labels{},
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  -1,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: -1,
 		},
 		"unless: no series on right": {
 			isUnless: true,
@@ -554,19 +554,19 @@ func TestAndUnlessBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *tes
 				labels.FromStrings("group", "2", "series", "left-2"),
 				labels.FromStrings("group", "3", "series", "left-3"),
 			},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  2,
-			expectRightSideFinalizedAfterOutputSeriesIndex: -1,
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  2,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: -1,
 		},
 	}
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			if testCase.expectLeftSideFinalizedAfterOutputSeriesIndex >= len(testCase.expectedOutputSeries) {
-				require.Failf(t, "invalid test case", "expectLeftSideFinalizedAfterOutputSeriesIndex %v is beyond end of expected output series %v", testCase.expectLeftSideFinalizedAfterOutputSeriesIndex, testCase.expectedOutputSeries)
+			if testCase.expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex >= len(testCase.expectedOutputSeries) {
+				require.Failf(t, "invalid test case", "expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex %v is beyond end of expected output series %v", testCase.expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex, testCase.expectedOutputSeries)
 			}
 
-			if testCase.expectRightSideFinalizedAfterOutputSeriesIndex >= len(testCase.expectedOutputSeries) {
-				require.Failf(t, "invalid test case", "expectRightSideFinalizedAfterOutputSeriesIndex %v is beyond end of expected output series %v", testCase.expectRightSideFinalizedAfterOutputSeriesIndex, testCase.expectedOutputSeries)
+			if testCase.expectRightSideFinishedReadingCalledAfterOutputSeriesIndex >= len(testCase.expectedOutputSeries) {
+				require.Failf(t, "invalid test case", "expectRightSideFinishedReadingCalledAfterOutputSeriesIndex %v is beyond end of expected output series %v", testCase.expectRightSideFinishedReadingCalledAfterOutputSeriesIndex, testCase.expectedOutputSeries)
 			}
 
 			ctx := context.Background()
@@ -586,16 +586,16 @@ func TestAndUnlessBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *tes
 				require.Equal(t, testutils.LabelsToSeriesMetadata(testCase.expectedOutputSeries), outputSeries)
 			}
 
-			if testCase.expectLeftSideFinalizedAfterOutputSeriesIndex == -1 {
-				require.True(t, left.Finalized, "left side should be finalized after SeriesMetadata, but it is not")
+			if testCase.expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex == -1 {
+				require.True(t, left.FinishedReadingCalled, "left side should have FinishedReading called after SeriesMetadata, but it is not")
 			} else {
-				require.False(t, left.Finalized, "left side should not be finalized after SeriesMetadata, but it is")
+				require.False(t, left.FinishedReadingCalled, "left side should not have FinishedReading called after SeriesMetadata, but it is")
 			}
 
-			if testCase.expectRightSideFinalizedAfterOutputSeriesIndex == -1 {
-				require.True(t, right.Finalized, "right side should be finalized after SeriesMetadata, but it is not")
+			if testCase.expectRightSideFinishedReadingCalledAfterOutputSeriesIndex == -1 {
+				require.True(t, right.FinishedReadingCalled, "right side should have FinishedReading called after SeriesMetadata, but it is not")
 			} else {
-				require.False(t, right.Finalized, "right side should not be finalized after SeriesMetadata, but it is")
+				require.False(t, right.FinishedReadingCalled, "right side should not have FinishedReading called after SeriesMetadata, but it is")
 			}
 
 			require.False(t, left.Closed, "left side should not be closed after SeriesMetadata, but it is")
@@ -605,16 +605,16 @@ func TestAndUnlessBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *tes
 				_, err := o.NextSeries(ctx)
 				require.NoErrorf(t, err, "got error while reading series at index %v", outputSeriesIdx)
 
-				if outputSeriesIdx >= testCase.expectLeftSideFinalizedAfterOutputSeriesIndex {
-					require.Truef(t, left.Finalized, "left side should be finalized after output series at index %v, but it is not", outputSeriesIdx)
+				if outputSeriesIdx >= testCase.expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex {
+					require.Truef(t, left.FinishedReadingCalled, "left side should have FinishedReading called after output series at index %v, but it is not", outputSeriesIdx)
 				} else {
-					require.Falsef(t, left.Finalized, "left side should not be finalized after output series at index %v, but it is", outputSeriesIdx)
+					require.Falsef(t, left.FinishedReadingCalled, "left side should not have FinishedReading called after output series at index %v, but it is", outputSeriesIdx)
 				}
 
-				if outputSeriesIdx >= testCase.expectRightSideFinalizedAfterOutputSeriesIndex {
-					require.Truef(t, right.Finalized, "right side should be finalized after output series at index %v, but it is not", outputSeriesIdx)
+				if outputSeriesIdx >= testCase.expectRightSideFinishedReadingCalledAfterOutputSeriesIndex {
+					require.Truef(t, right.FinishedReadingCalled, "right side should have FinishedReading called after output series at index %v, but it is not", outputSeriesIdx)
 				} else {
-					require.Falsef(t, right.Finalized, "right side should not be finalized after output series at index %v, but it is", outputSeriesIdx)
+					require.Falsef(t, right.FinishedReadingCalled, "right side should not have FinishedReading called after output series at index %v, but it is", outputSeriesIdx)
 				}
 			}
 
@@ -626,9 +626,9 @@ func TestAndUnlessBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *tes
 			_, err = o.NextSeries(ctx)
 			require.Equal(t, types.EOS, err)
 
-			require.NoError(t, o.Finalize(ctx))
-			require.True(t, left.Finalized, "left side should be finalized after calling Finalize, but it is not")
-			require.True(t, right.Finalized, "right side should be finalized after calling Finalize, but it is not")
+			require.NoError(t, o.FinishedReading(ctx))
+			require.True(t, left.FinishedReadingCalled, "left side should have FinishedReading called after calling FinishedReading, but it is not")
+			require.True(t, right.FinishedReadingCalled, "right side should have FinishedReading called after calling FinishedReading, but it is not")
 			// Make sure we've returned everything to their pools.
 			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
 
@@ -726,8 +726,8 @@ func TestAndUnlessBinaryOperation_ReleasesIntermediateStateIfClosedEarly(t *test
 					_, err = o.NextSeries(ctx)
 					require.NoError(t, err)
 
-					// Finalize the operator and confirm that we've returned everything to their pools.
-					require.NoError(t, o.Finalize(ctx))
+					// Call FinishedReading on the operator and confirm that we've returned everything to their pools.
+					require.NoError(t, o.FinishedReading(ctx))
 					require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
 					o.Close()
 				})
@@ -799,7 +799,7 @@ func BenchmarkAndUnlessBinaryOperation_ExcludeHintRHSFiltering(b *testing.B) {
 			// so its length reflects how many RHS series were actually fetched.
 			totalRHSSeries += len(right.Series)
 
-			if err := o.Finalize(ctx); err != nil {
+			if err := o.FinishedReading(ctx); err != nil {
 				b.Fatal(err)
 			}
 			o.Close()

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
@@ -65,9 +65,9 @@ type groupedBinaryOperationOutputSeries struct {
 	oneSide  *oneSide
 }
 
-func (g *groupedBinaryOperationOutputSeries) Finalize(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
-	g.manySide.Finalize(memoryConsumptionTracker)
-	g.oneSide.Finalize(memoryConsumptionTracker)
+func (g *groupedBinaryOperationOutputSeries) FinishedReading(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
+	g.manySide.FinishedReading(memoryConsumptionTracker)
+	g.oneSide.FinishedReading(memoryConsumptionTracker)
 }
 
 type groupedBinaryOperationOutputSeriesWithLabels struct {
@@ -91,7 +91,7 @@ func (s *manySide) latestSeriesIndex() int {
 	return s.seriesIndices[len(s.seriesIndices)-1]
 }
 
-func (s *manySide) Finalize(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
+func (s *manySide) FinishedReading(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
 	types.PutInstantVectorSeriesData(s.mergedData, memoryConsumptionTracker)
 	s.mergedData = types.InstantVectorSeriesData{}
 }
@@ -114,7 +114,7 @@ func (s *oneSide) latestSeriesIndex() int {
 	return s.seriesIndices[len(s.seriesIndices)-1]
 }
 
-func (s *oneSide) Finalize(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
+func (s *oneSide) FinishedReading(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
 	types.PutInstantVectorSeriesData(s.mergedData, memoryConsumptionTracker)
 	s.mergedData = types.InstantVectorSeriesData{}
 
@@ -211,7 +211,7 @@ func (g *GroupedVectorVectorBinaryOperation) SeriesMetadata(ctx context.Context,
 	if canProduceAnySeries, err := g.loadSeriesMetadata(ctx, matchers); err != nil {
 		return nil, err
 	} else if !canProduceAnySeries {
-		if err := g.Finalize(ctx); err != nil {
+		if err := g.FinishedReading(ctx); err != nil {
 			return nil, err
 		}
 
@@ -228,7 +228,7 @@ func (g *GroupedVectorVectorBinaryOperation) SeriesMetadata(ctx context.Context,
 		types.BoolSlicePool.Put(&oneSideSeriesUsed, g.MemoryConsumptionTracker)
 		types.BoolSlicePool.Put(&manySideSeriesUsed, g.MemoryConsumptionTracker)
 
-		if err := g.Finalize(ctx); err != nil {
+		if err := g.FinishedReading(ctx); err != nil {
 			return nil, err
 		}
 
@@ -839,32 +839,32 @@ func (g *GroupedVectorVectorBinaryOperation) AfterPrepare(ctx context.Context) e
 	return g.Right.AfterPrepare(ctx)
 }
 
-func (g *GroupedVectorVectorBinaryOperation) Finalize(ctx context.Context) error {
+func (g *GroupedVectorVectorBinaryOperation) FinishedReading(ctx context.Context) error {
 	types.SeriesMetadataSlicePool.Put(&g.oneSideMetadata, g.MemoryConsumptionTracker)
 	types.SeriesMetadataSlicePool.Put(&g.manySideMetadata, g.MemoryConsumptionTracker)
 
 	if g.oneSideBuffer != nil {
-		g.oneSideBuffer.Finalize()
+		g.oneSideBuffer.FinishedReading()
 		g.oneSideBuffer = nil
 	}
 
 	if g.manySideBuffer != nil {
-		g.manySideBuffer.Finalize()
+		g.manySideBuffer.FinishedReading()
 		g.manySideBuffer = nil
 	}
 
 	for _, s := range g.remainingSeries {
-		s.Finalize(g.MemoryConsumptionTracker)
+		s.FinishedReading(g.MemoryConsumptionTracker)
 	}
 
 	g.remainingSeries = nil
 
-	// We don't need to finalize g.oneSide or g.manySide, as these are either g.Left or g.Right and so will be finalized below.
-	if err := g.Left.Finalize(ctx); err != nil {
+	// We don't need to call FinishedReading on g.oneSide or g.manySide, as these are either g.Left or g.Right and so will have FinishedReading called below.
+	if err := g.Left.FinishedReading(ctx); err != nil {
 		return err
 	}
 
-	return g.Right.Finalize(ctx)
+	return g.Right.FinishedReading(ctx)
 }
 
 func (g *GroupedVectorVectorBinaryOperation) Stats(ctx context.Context) (*types.OperatorEvaluationStats, error) {

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
@@ -329,14 +329,14 @@ func TestGroupedVectorVectorBinaryOperation_OutputSeriesSorting(t *testing.T) {
 	}
 }
 
-func TestGroupedVectorVectorBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *testing.T) {
+func TestGroupedVectorVectorBinaryOperation_CallsFinishedReadingOnInnerOperatorsAsSoonAsPossible(t *testing.T) {
 	testCases := map[string]struct {
 		leftSeries  []labels.Labels
 		rightSeries []labels.Labels
 
-		expectedOutputSeries                           []labels.Labels
-		expectLeftSideFinalizedAfterOutputSeriesIndex  int
-		expectRightSideFinalizedAfterOutputSeriesIndex int
+		expectedOutputSeries                                       []labels.Labels
+		expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex  int
+		expectRightSideFinishedReadingCalledAfterOutputSeriesIndex int
 	}{
 		"no series on left": {
 			leftSeries: []labels.Labels{},
@@ -346,9 +346,9 @@ func TestGroupedVectorVectorBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossi
 				labels.FromStrings("group", "3"),
 			},
 
-			expectedOutputSeries:                           []labels.Labels{},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  -1,
-			expectRightSideFinalizedAfterOutputSeriesIndex: -1,
+			expectedOutputSeries: []labels.Labels{},
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  -1,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: -1,
 		},
 		"no series on right": {
 			leftSeries: []labels.Labels{
@@ -358,9 +358,9 @@ func TestGroupedVectorVectorBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossi
 			},
 			rightSeries: []labels.Labels{},
 
-			expectedOutputSeries:                           []labels.Labels{},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  -1,
-			expectRightSideFinalizedAfterOutputSeriesIndex: -1,
+			expectedOutputSeries: []labels.Labels{},
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  -1,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: -1,
 		},
 		"reach end of both sides at the same time": {
 			leftSeries: []labels.Labels{
@@ -376,8 +376,8 @@ func TestGroupedVectorVectorBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossi
 				labels.FromStrings("group", "1"),
 				labels.FromStrings("group", "2"),
 			},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  1,
-			expectRightSideFinalizedAfterOutputSeriesIndex: 1,
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  1,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: 1,
 		},
 		"no more matches with unmatched series still to read on both sides": {
 			leftSeries: []labels.Labels{
@@ -392,8 +392,8 @@ func TestGroupedVectorVectorBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossi
 			expectedOutputSeries: []labels.Labels{
 				labels.FromStrings("group", "1"),
 			},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  0,
-			expectRightSideFinalizedAfterOutputSeriesIndex: 0,
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  0,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: 0,
 		},
 		"no more matches with unmatched series still to read on left side": {
 			leftSeries: []labels.Labels{
@@ -407,8 +407,8 @@ func TestGroupedVectorVectorBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossi
 			expectedOutputSeries: []labels.Labels{
 				labels.FromStrings("group", "1"),
 			},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  0,
-			expectRightSideFinalizedAfterOutputSeriesIndex: 0,
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  0,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: 0,
 		},
 		"no more matches with unmatched series still to read on right side": {
 			leftSeries: []labels.Labels{
@@ -422,8 +422,8 @@ func TestGroupedVectorVectorBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossi
 			expectedOutputSeries: []labels.Labels{
 				labels.FromStrings("group", "1"),
 			},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  0,
-			expectRightSideFinalizedAfterOutputSeriesIndex: 0,
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  0,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: 0,
 		},
 		"no matches": {
 			leftSeries: []labels.Labels{
@@ -436,9 +436,9 @@ func TestGroupedVectorVectorBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossi
 				labels.FromStrings("group", "5"),
 			},
 
-			expectedOutputSeries:                           []labels.Labels{},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  -1,
-			expectRightSideFinalizedAfterOutputSeriesIndex: -1,
+			expectedOutputSeries: []labels.Labels{},
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  -1,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: -1,
 		},
 		"left side exhausted before right": {
 			leftSeries: []labels.Labels{
@@ -457,19 +457,19 @@ func TestGroupedVectorVectorBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossi
 				labels.FromStrings("group", "2"),
 				labels.FromStrings("group", "3"),
 			},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  1,
-			expectRightSideFinalizedAfterOutputSeriesIndex: 2,
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  1,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: 2,
 		},
 	}
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			if testCase.expectLeftSideFinalizedAfterOutputSeriesIndex >= len(testCase.expectedOutputSeries) {
-				require.Failf(t, "invalid test case", "expectLeftSideFinalizedAfterOutputSeriesIndex %v is beyond end of expected output series %v", testCase.expectLeftSideFinalizedAfterOutputSeriesIndex, testCase.expectedOutputSeries)
+			if testCase.expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex >= len(testCase.expectedOutputSeries) {
+				require.Failf(t, "invalid test case", "expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex %v is beyond end of expected output series %v", testCase.expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex, testCase.expectedOutputSeries)
 			}
 
-			if testCase.expectRightSideFinalizedAfterOutputSeriesIndex >= len(testCase.expectedOutputSeries) {
-				require.Failf(t, "invalid test case", "expectRightSideFinalizedAfterOutputSeriesIndex %v is beyond end of expected output series %v", testCase.expectRightSideFinalizedAfterOutputSeriesIndex, testCase.expectedOutputSeries)
+			if testCase.expectRightSideFinishedReadingCalledAfterOutputSeriesIndex >= len(testCase.expectedOutputSeries) {
+				require.Failf(t, "invalid test case", "expectRightSideFinishedReadingCalledAfterOutputSeriesIndex %v is beyond end of expected output series %v", testCase.expectRightSideFinishedReadingCalledAfterOutputSeriesIndex, testCase.expectedOutputSeries)
 			}
 
 			ctx := context.Background()
@@ -490,16 +490,16 @@ func TestGroupedVectorVectorBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossi
 				require.Equal(t, testutils.LabelsToSeriesMetadata(testCase.expectedOutputSeries), outputSeries)
 			}
 
-			if testCase.expectLeftSideFinalizedAfterOutputSeriesIndex == -1 {
-				require.True(t, left.Finalized, "left side should be finalized after SeriesMetadata, but it is not")
+			if testCase.expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex == -1 {
+				require.True(t, left.FinishedReadingCalled, "left side should have FinishedReading called after SeriesMetadata, but it is not")
 			} else {
-				require.False(t, left.Finalized, "left side should not be finalized after SeriesMetadata, but it is")
+				require.False(t, left.FinishedReadingCalled, "left side should not have FinishedReading called after SeriesMetadata, but it is")
 			}
 
-			if testCase.expectRightSideFinalizedAfterOutputSeriesIndex == -1 {
-				require.True(t, right.Finalized, "right side should be finalized after SeriesMetadata, but it is not")
+			if testCase.expectRightSideFinishedReadingCalledAfterOutputSeriesIndex == -1 {
+				require.True(t, right.FinishedReadingCalled, "right side should have FinishedReading called after SeriesMetadata, but it is not")
 			} else {
-				require.False(t, right.Finalized, "right side should not be finalized after SeriesMetadata, but it is")
+				require.False(t, right.FinishedReadingCalled, "right side should not have FinishedReading called after SeriesMetadata, but it is")
 			}
 
 			require.False(t, left.Closed, "left side should not be closed after SeriesMetadata, but it is")
@@ -509,16 +509,16 @@ func TestGroupedVectorVectorBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossi
 				_, err := o.NextSeries(ctx)
 				require.NoErrorf(t, err, "got error while reading series at index %v", outputSeriesIdx)
 
-				if outputSeriesIdx >= testCase.expectLeftSideFinalizedAfterOutputSeriesIndex {
-					require.Truef(t, left.Finalized, "left side should be finalized after output series at index %v, but it is not", outputSeriesIdx)
+				if outputSeriesIdx >= testCase.expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex {
+					require.Truef(t, left.FinishedReadingCalled, "left side should have FinishedReading called after output series at index %v, but it is not", outputSeriesIdx)
 				} else {
-					require.Falsef(t, left.Finalized, "left side should not be finalized after output series at index %v, but it is", outputSeriesIdx)
+					require.Falsef(t, left.FinishedReadingCalled, "left side should not have FinishedReading called after output series at index %v, but it is", outputSeriesIdx)
 				}
 
-				if outputSeriesIdx >= testCase.expectRightSideFinalizedAfterOutputSeriesIndex {
-					require.Truef(t, right.Finalized, "right side should be finalized after output series at index %v, but it is not", outputSeriesIdx)
+				if outputSeriesIdx >= testCase.expectRightSideFinishedReadingCalledAfterOutputSeriesIndex {
+					require.Truef(t, right.FinishedReadingCalled, "right side should have FinishedReading called after output series at index %v, but it is not", outputSeriesIdx)
 				} else {
-					require.Falsef(t, right.Finalized, "right side should not be finalized after output series at index %v, but it is", outputSeriesIdx)
+					require.Falsef(t, right.FinishedReadingCalled, "right side should not have FinishedReading called after output series at index %v, but it is", outputSeriesIdx)
 				}
 			}
 
@@ -530,9 +530,9 @@ func TestGroupedVectorVectorBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossi
 			_, err = o.NextSeries(ctx)
 			require.Equal(t, types.EOS, err)
 
-			require.NoError(t, o.Finalize(ctx))
-			require.True(t, left.Finalized, "left side should be finalized after calling Finalize, but it is not")
-			require.True(t, right.Finalized, "right side should be finalized after calling Finalize, but it is not")
+			require.NoError(t, o.FinishedReading(ctx))
+			require.True(t, left.FinishedReadingCalled, "left side should have FinishedReading called after calling FinishedReading, but it is not")
+			require.True(t, right.FinishedReadingCalled, "right side should have FinishedReading called after calling FinishedReading, but it is not")
 			// Make sure we've returned everything to their pools.
 			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
 
@@ -682,8 +682,8 @@ func TestGroupedVectorVectorBinaryOperation_ReleasesIntermediateStateIfClosedEar
 			left.ReleaseUnreadData(memoryConsumptionTracker)
 			right.ReleaseUnreadData(memoryConsumptionTracker)
 
-			// Finalize the operator and verify that the intermediate state is released.
-			require.NoError(t, o.Finalize(ctx))
+			// Call FinishedReading on the operator and verify that the intermediate state is released.
+			require.NoError(t, o.FinishedReading(ctx))
 			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
 			o.Close()
 		})
@@ -1343,7 +1343,7 @@ func BenchmarkGroupedVectorVectorBinaryOperation_HintsSideFiltering(b *testing.B
 				totalManySeries += len(right.Series)
 			}
 
-			if err = op.Finalize(ctx); err != nil {
+			if err = op.FinishedReading(ctx); err != nil {
 				b.Fatal(err)
 			}
 			op.Close()

--- a/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation.go
@@ -106,11 +106,11 @@ func (g *oneToOneBinaryOperationRightSide) latestRightSeriesIndex() int {
 	return g.rightSeriesIndices[len(g.rightSeriesIndices)-1]
 }
 
-func (g *oneToOneBinaryOperationRightSide) Finalize(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
+func (g *oneToOneBinaryOperationRightSide) FinishedReading(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
 	types.IntSlicePool.Put(&g.leftSidePresence, memoryConsumptionTracker)
 
 	// If this right side was used for all of its corresponding output series, then mergedData will have already been returned to the pool by the evaluator's computeResult.
-	// However, if the operator is being finalized early, then we need to return mergedData to the pool.
+	// However, if the operator is having FinishedReading called early, then we need to return mergedData to the pool.
 	types.PutInstantVectorSeriesData(g.mergedData, memoryConsumptionTracker)
 	g.mergedData = types.InstantVectorSeriesData{}
 }
@@ -183,7 +183,7 @@ func (b *OneToOneVectorVectorBinaryOperation) SeriesMetadata(ctx context.Context
 		return nil, err
 	} else if len(b.leftMetadata) == 0 {
 		// No series on left-hand side, we'll never have any output series.
-		if err = b.Finalize(ctx); err != nil {
+		if err = b.FinishedReading(ctx); err != nil {
 			return nil, err
 		}
 
@@ -207,7 +207,7 @@ func (b *OneToOneVectorVectorBinaryOperation) SeriesMetadata(ctx context.Context
 		return nil, err
 	} else if len(b.rightMetadata) == 0 {
 		// No series on right-hand side, we'll never have any output series.
-		if err = b.Finalize(ctx); err != nil {
+		if err = b.FinishedReading(ctx); err != nil {
 			return nil, err
 		}
 
@@ -224,7 +224,7 @@ func (b *OneToOneVectorVectorBinaryOperation) SeriesMetadata(ctx context.Context
 		types.BoolSlicePool.Put(&leftSeriesUsed, b.MemoryConsumptionTracker)
 		types.BoolSlicePool.Put(&rightSeriesUsed, b.MemoryConsumptionTracker)
 
-		if err := b.Finalize(ctx); err != nil {
+		if err := b.FinishedReading(ctx); err != nil {
 			return nil, err
 		}
 
@@ -511,10 +511,10 @@ func (b *OneToOneVectorVectorBinaryOperation) NextSeries(ctx context.Context) (t
 	}
 
 	if isLastUseOfRightSide {
-		// We've passed ownership of mergedData to the evaluator, so clear it now to avoid returning it to the pool in Finalize().
+		// We've passed ownership of mergedData to the evaluator, so clear it now to avoid returning it to the pool in FinishedReading().
 		rightSide.mergedData = types.InstantVectorSeriesData{}
 
-		rightSide.Finalize(b.MemoryConsumptionTracker)
+		rightSide.FinishedReading(b.MemoryConsumptionTracker)
 	}
 
 	return finalResult, nil
@@ -613,31 +613,31 @@ func (b *OneToOneVectorVectorBinaryOperation) AfterPrepare(ctx context.Context) 
 	return b.Right.AfterPrepare(ctx)
 }
 
-func (b *OneToOneVectorVectorBinaryOperation) Finalize(ctx context.Context) error {
+func (b *OneToOneVectorVectorBinaryOperation) FinishedReading(ctx context.Context) error {
 	types.SeriesMetadataSlicePool.Put(&b.leftMetadata, b.MemoryConsumptionTracker)
 	types.SeriesMetadataSlicePool.Put(&b.rightMetadata, b.MemoryConsumptionTracker)
 
 	if b.leftBuffer != nil {
-		b.leftBuffer.Finalize()
+		b.leftBuffer.FinishedReading()
 		b.leftBuffer = nil
 	}
 
 	if b.rightBuffer != nil {
-		b.rightBuffer.Finalize()
+		b.rightBuffer.FinishedReading()
 		b.rightBuffer = nil
 	}
 
 	for _, s := range b.remainingSeries {
-		s.rightSide.Finalize(b.MemoryConsumptionTracker)
+		s.rightSide.FinishedReading(b.MemoryConsumptionTracker)
 	}
 
 	b.remainingSeries = nil
 
-	if err := b.Left.Finalize(ctx); err != nil {
+	if err := b.Left.FinishedReading(ctx); err != nil {
 		return err
 	}
 
-	return b.Right.Finalize(ctx)
+	return b.Right.FinishedReading(ctx)
 }
 
 func (b *OneToOneVectorVectorBinaryOperation) Stats(ctx context.Context) (*types.OperatorEvaluationStats, error) {

--- a/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation_test.go
@@ -452,14 +452,14 @@ func TestOneToOneVectorVectorBinaryOperation_Sorting(t *testing.T) {
 	}
 }
 
-func TestOneToOneVectorVectorBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *testing.T) {
+func TestOneToOneVectorVectorBinaryOperation_CallsFinishedReadingOnInnerOperatorsAsSoonAsPossible(t *testing.T) {
 	testCases := map[string]struct {
 		leftSeries  []labels.Labels
 		rightSeries []labels.Labels
 
-		expectedOutputSeries                           []labels.Labels
-		expectLeftSideFinalizedAfterOutputSeriesIndex  int
-		expectRightSideFinalizedAfterOutputSeriesIndex int
+		expectedOutputSeries                                       []labels.Labels
+		expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex  int
+		expectRightSideFinishedReadingCalledAfterOutputSeriesIndex int
 	}{
 		"no series on left": {
 			leftSeries: []labels.Labels{},
@@ -469,9 +469,9 @@ func TestOneToOneVectorVectorBinaryOperation_FinalizesInnerOperatorsAsSoonAsPoss
 				labels.FromStrings("group", "3", "series", "right-3"),
 			},
 
-			expectedOutputSeries:                           []labels.Labels{},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  -1,
-			expectRightSideFinalizedAfterOutputSeriesIndex: -1,
+			expectedOutputSeries: []labels.Labels{},
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  -1,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: -1,
 		},
 		"no series on right": {
 			leftSeries: []labels.Labels{
@@ -481,9 +481,9 @@ func TestOneToOneVectorVectorBinaryOperation_FinalizesInnerOperatorsAsSoonAsPoss
 			},
 			rightSeries: []labels.Labels{},
 
-			expectedOutputSeries:                           []labels.Labels{},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  -1,
-			expectRightSideFinalizedAfterOutputSeriesIndex: -1,
+			expectedOutputSeries: []labels.Labels{},
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  -1,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: -1,
 		},
 		"reach end of both sides at the same time": {
 			leftSeries: []labels.Labels{
@@ -501,8 +501,8 @@ func TestOneToOneVectorVectorBinaryOperation_FinalizesInnerOperatorsAsSoonAsPoss
 				labels.FromStrings("group", "1"),
 				labels.FromStrings("group", "2"),
 			},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  1,
-			expectRightSideFinalizedAfterOutputSeriesIndex: 1,
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  1,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: 1,
 		},
 		"no more matches with unmatched series still to read on both sides": {
 			leftSeries: []labels.Labels{
@@ -519,8 +519,8 @@ func TestOneToOneVectorVectorBinaryOperation_FinalizesInnerOperatorsAsSoonAsPoss
 			expectedOutputSeries: []labels.Labels{
 				labels.FromStrings("group", "1"),
 			},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  0,
-			expectRightSideFinalizedAfterOutputSeriesIndex: 0,
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  0,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: 0,
 		},
 		"no more matches with unmatched series still to read on left side": {
 			leftSeries: []labels.Labels{
@@ -536,8 +536,8 @@ func TestOneToOneVectorVectorBinaryOperation_FinalizesInnerOperatorsAsSoonAsPoss
 			expectedOutputSeries: []labels.Labels{
 				labels.FromStrings("group", "1"),
 			},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  0,
-			expectRightSideFinalizedAfterOutputSeriesIndex: 0,
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  0,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: 0,
 		},
 		"no more matches with unmatched series still to read on right side": {
 			leftSeries: []labels.Labels{
@@ -553,8 +553,8 @@ func TestOneToOneVectorVectorBinaryOperation_FinalizesInnerOperatorsAsSoonAsPoss
 			expectedOutputSeries: []labels.Labels{
 				labels.FromStrings("group", "1"),
 			},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  0,
-			expectRightSideFinalizedAfterOutputSeriesIndex: 0,
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  0,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: 0,
 		},
 		"no matches": {
 			leftSeries: []labels.Labels{
@@ -567,9 +567,9 @@ func TestOneToOneVectorVectorBinaryOperation_FinalizesInnerOperatorsAsSoonAsPoss
 				labels.FromStrings("group", "5", "series", "right-3"),
 			},
 
-			expectedOutputSeries:                           []labels.Labels{},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  -1,
-			expectRightSideFinalizedAfterOutputSeriesIndex: -1,
+			expectedOutputSeries: []labels.Labels{},
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  -1,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: -1,
 		},
 		"right side exhausted before left": {
 			leftSeries: []labels.Labels{
@@ -585,8 +585,8 @@ func TestOneToOneVectorVectorBinaryOperation_FinalizesInnerOperatorsAsSoonAsPoss
 				labels.FromStrings("group", "1"),
 				labels.FromStrings("group", "2"),
 			},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  1,
-			expectRightSideFinalizedAfterOutputSeriesIndex: 0,
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  1,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: 0,
 		},
 		"left side exhausted before right": {
 			leftSeries: []labels.Labels{
@@ -606,19 +606,19 @@ func TestOneToOneVectorVectorBinaryOperation_FinalizesInnerOperatorsAsSoonAsPoss
 				labels.FromStrings("group", "2"),
 				labels.FromStrings("group", "3"),
 			},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  1,
-			expectRightSideFinalizedAfterOutputSeriesIndex: 2,
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  1,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: 2,
 		},
 	}
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			if testCase.expectLeftSideFinalizedAfterOutputSeriesIndex >= len(testCase.expectedOutputSeries) {
-				require.Failf(t, "invalid test case", "expectLeftSideFinalizedAfterOutputSeriesIndex %v is beyond end of expected output series %v", testCase.expectLeftSideFinalizedAfterOutputSeriesIndex, testCase.expectedOutputSeries)
+			if testCase.expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex >= len(testCase.expectedOutputSeries) {
+				require.Failf(t, "invalid test case", "expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex %v is beyond end of expected output series %v", testCase.expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex, testCase.expectedOutputSeries)
 			}
 
-			if testCase.expectRightSideFinalizedAfterOutputSeriesIndex >= len(testCase.expectedOutputSeries) {
-				require.Failf(t, "invalid test case", "expectRightSideFinalizedAfterOutputSeriesIndex %v is beyond end of expected output series %v", testCase.expectRightSideFinalizedAfterOutputSeriesIndex, testCase.expectedOutputSeries)
+			if testCase.expectRightSideFinishedReadingCalledAfterOutputSeriesIndex >= len(testCase.expectedOutputSeries) {
+				require.Failf(t, "invalid test case", "expectRightSideFinishedReadingCalledAfterOutputSeriesIndex %v is beyond end of expected output series %v", testCase.expectRightSideFinishedReadingCalledAfterOutputSeriesIndex, testCase.expectedOutputSeries)
 			}
 
 			ctx := context.Background()
@@ -639,16 +639,16 @@ func TestOneToOneVectorVectorBinaryOperation_FinalizesInnerOperatorsAsSoonAsPoss
 				require.Equal(t, testutils.LabelsToSeriesMetadata(testCase.expectedOutputSeries), outputSeries)
 			}
 
-			if testCase.expectLeftSideFinalizedAfterOutputSeriesIndex == -1 {
-				require.True(t, left.Finalized, "left side should be finalized after SeriesMetadata, but it is not")
+			if testCase.expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex == -1 {
+				require.True(t, left.FinishedReadingCalled, "left side should have FinishedReading called after SeriesMetadata, but it is not")
 			} else {
-				require.False(t, left.Finalized, "left side should not be finalized after SeriesMetadata, but it is")
+				require.False(t, left.FinishedReadingCalled, "left side should not have FinishedReading called after SeriesMetadata, but it is")
 			}
 
-			if testCase.expectRightSideFinalizedAfterOutputSeriesIndex == -1 {
-				require.True(t, right.Finalized, "right side should be finalized after SeriesMetadata, but it is not")
+			if testCase.expectRightSideFinishedReadingCalledAfterOutputSeriesIndex == -1 {
+				require.True(t, right.FinishedReadingCalled, "right side should have FinishedReading called after SeriesMetadata, but it is not")
 			} else {
-				require.False(t, right.Finalized, "right side should not be finalized after SeriesMetadata, but it is")
+				require.False(t, right.FinishedReadingCalled, "right side should not have FinishedReading called after SeriesMetadata, but it is")
 			}
 
 			require.False(t, left.Closed, "left side should not be closed after SeriesMetadata, but it is")
@@ -658,16 +658,16 @@ func TestOneToOneVectorVectorBinaryOperation_FinalizesInnerOperatorsAsSoonAsPoss
 				_, err := o.NextSeries(ctx)
 				require.NoErrorf(t, err, "got error while reading series at index %v", outputSeriesIdx)
 
-				if outputSeriesIdx >= testCase.expectLeftSideFinalizedAfterOutputSeriesIndex {
-					require.Truef(t, left.Finalized, "left side should be finalized after output series at index %v, but it is not", outputSeriesIdx)
+				if outputSeriesIdx >= testCase.expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex {
+					require.Truef(t, left.FinishedReadingCalled, "left side should have FinishedReading called after output series at index %v, but it is not", outputSeriesIdx)
 				} else {
-					require.Falsef(t, left.Finalized, "left side should not be finalized after output series at index %v, but it is", outputSeriesIdx)
+					require.Falsef(t, left.FinishedReadingCalled, "left side should not have FinishedReading called after output series at index %v, but it is", outputSeriesIdx)
 				}
 
-				if outputSeriesIdx >= testCase.expectRightSideFinalizedAfterOutputSeriesIndex {
-					require.Truef(t, right.Finalized, "right side should be finalized after output series at index %v, but it is not", outputSeriesIdx)
+				if outputSeriesIdx >= testCase.expectRightSideFinishedReadingCalledAfterOutputSeriesIndex {
+					require.Truef(t, right.FinishedReadingCalled, "right side should have FinishedReading called after output series at index %v, but it is not", outputSeriesIdx)
 				} else {
-					require.Falsef(t, right.Finalized, "right side should not be finalized after output series at index %v, but it is", outputSeriesIdx)
+					require.Falsef(t, right.FinishedReadingCalled, "right side should not have FinishedReading called after output series at index %v, but it is", outputSeriesIdx)
 				}
 			}
 
@@ -679,9 +679,9 @@ func TestOneToOneVectorVectorBinaryOperation_FinalizesInnerOperatorsAsSoonAsPoss
 			_, err = o.NextSeries(ctx)
 			require.Equal(t, types.EOS, err)
 
-			require.NoError(t, o.Finalize(ctx))
-			require.True(t, left.Finalized, "left side should be finalized after calling Finalize, but it is not")
-			require.True(t, right.Finalized, "right side should be finalized after calling Finalize, but it is not")
+			require.NoError(t, o.FinishedReading(ctx))
+			require.True(t, left.FinishedReadingCalled, "left side should have FinishedReading called after calling FinishedReading, but it is not")
+			require.True(t, right.FinishedReadingCalled, "right side should have FinishedReading called after calling FinishedReading, but it is not")
 			// Make sure we've returned everything to their pools.
 			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
 
@@ -851,7 +851,7 @@ func TestOneToOneVectorVectorBinaryOperation_PassesWithoutDerivedMatchersToRHS(t
 			require.ElementsMatch(t, testutils.LabelsToSeriesMetadata(testCase.expectedOutputSeries), outputSeries)
 
 			types.SeriesMetadataSlicePool.Put(&outputSeries, memoryConsumptionTracker)
-			require.NoError(t, o.Finalize(ctx))
+			require.NoError(t, o.FinishedReading(ctx))
 			o.Close()
 		})
 	}
@@ -897,7 +897,7 @@ func TestOneToOneVectorVectorBinaryOperation_DropsParentMatchersWhenHintsProduce
 	require.Nil(t, right.MatchersProvided, "parent matchers should be dropped when hints are set but produce no matchers")
 
 	types.SeriesMetadataSlicePool.Put(&outputSeries, memoryConsumptionTracker)
-	require.NoError(t, o.Finalize(ctx))
+	require.NoError(t, o.FinishedReading(ctx))
 	o.Close()
 }
 
@@ -956,8 +956,8 @@ func TestOneToOneVectorVectorBinaryOperation_ReleasesIntermediateStateIfClosedEa
 				types.PutInstantVectorSeriesData(d, memoryConsumptionTracker)
 			}
 
-			// Finalize the operator and verify that the intermediate state is released.
-			require.NoError(t, o.Finalize(ctx))
+			// Call FinishedReading on the operator and verify that the intermediate state is released.
+			require.NoError(t, o.FinishedReading(ctx))
 			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
 			o.Close()
 		})

--- a/pkg/streamingpromql/operators/binops/or_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/or_binary_operation.go
@@ -73,11 +73,11 @@ func (o *OrBinaryOperation) SeriesMetadata(ctx context.Context, matchers types.M
 		types.SeriesMetadataSlicePool.Put(&leftMetadata, o.MemoryConsumptionTracker)
 		types.SeriesMetadataSlicePool.Put(&rightMetadata, o.MemoryConsumptionTracker)
 
-		if err := o.Left.Finalize(ctx); err != nil {
+		if err := o.Left.FinishedReading(ctx); err != nil {
 			return nil, err
 		}
 
-		if err := o.Right.Finalize(ctx); err != nil {
+		if err := o.Right.FinishedReading(ctx); err != nil {
 			return nil, err
 		}
 
@@ -90,7 +90,7 @@ func (o *OrBinaryOperation) SeriesMetadata(ctx context.Context, matchers types.M
 		o.rightSeriesCount = []int{len(rightMetadata)}
 		types.SeriesMetadataSlicePool.Put(&leftMetadata, o.MemoryConsumptionTracker)
 
-		if err := o.Left.Finalize(ctx); err != nil {
+		if err := o.Left.FinishedReading(ctx); err != nil {
 			return nil, err
 		}
 
@@ -103,7 +103,7 @@ func (o *OrBinaryOperation) SeriesMetadata(ctx context.Context, matchers types.M
 		o.leftSeriesCount = []int{len(leftMetadata)}
 		types.SeriesMetadataSlicePool.Put(&rightMetadata, o.MemoryConsumptionTracker)
 
-		if err := o.Right.Finalize(ctx); err != nil {
+		if err := o.Right.FinishedReading(ctx); err != nil {
 			return nil, err
 		}
 
@@ -264,8 +264,8 @@ func (o *OrBinaryOperation) nextLeftSeries(ctx context.Context) (types.InstantVe
 	}
 
 	if len(o.leftSeriesCount) == 0 {
-		// No more series from left side remaining, finalize it.
-		if err := o.Left.Finalize(ctx); err != nil {
+		// No more series from left side remaining, call FinishedReading on it.
+		if err := o.Left.FinishedReading(ctx); err != nil {
 			return types.InstantVectorSeriesData{}, err
 		}
 	}
@@ -311,8 +311,8 @@ func (o *OrBinaryOperation) nextRightSeries(ctx context.Context) (types.InstantV
 	}
 
 	if len(o.rightSeriesCount) == 0 {
-		// No more series from right side remaining, finalize it.
-		if err := o.Right.Finalize(ctx); err != nil {
+		// No more series from right side remaining, call FinishedReading on it.
+		if err := o.Right.FinishedReading(ctx); err != nil {
 			return types.InstantVectorSeriesData{}, err
 		}
 	}
@@ -347,7 +347,7 @@ func (o *OrBinaryOperation) readNextRightSeries(ctx context.Context) (types.Inst
 	group.rightSeriesCount--
 	if group.rightSeriesCount == 0 {
 		// This is the last right series for the group, return it to the pool.
-		group.Finalize(o.MemoryConsumptionTracker)
+		group.FinishedReading(o.MemoryConsumptionTracker)
 	}
 
 	return data, nil
@@ -373,13 +373,13 @@ func (o *OrBinaryOperation) AfterPrepare(ctx context.Context) error {
 	return o.Right.AfterPrepare(ctx)
 }
 
-func (o *OrBinaryOperation) Finalize(ctx context.Context) error {
+func (o *OrBinaryOperation) FinishedReading(ctx context.Context) error {
 	for _, g := range o.leftSeriesGroups {
 		if g == nil {
 			continue
 		}
 
-		g.Finalize(o.MemoryConsumptionTracker)
+		g.FinishedReading(o.MemoryConsumptionTracker)
 	}
 
 	o.leftSeriesGroups = nil
@@ -389,16 +389,16 @@ func (o *OrBinaryOperation) Finalize(ctx context.Context) error {
 			continue
 		}
 
-		g.Finalize(o.MemoryConsumptionTracker)
+		g.FinishedReading(o.MemoryConsumptionTracker)
 	}
 
 	o.rightSeriesGroups = nil
 
-	if err := o.Left.Finalize(ctx); err != nil {
+	if err := o.Left.FinishedReading(ctx); err != nil {
 		return err
 	}
 
-	return o.Right.Finalize(ctx)
+	return o.Right.FinishedReading(ctx)
 }
 
 func (o *OrBinaryOperation) Stats(ctx context.Context) (*types.OperatorEvaluationStats, error) {
@@ -446,6 +446,6 @@ func (g *orGroup) FilterRightSeries(rightData types.InstantVectorSeriesData, mem
 	return filterSeries(rightData, g.leftSamplePresence, false, memoryConsumptionTracker, timeRange)
 }
 
-func (g *orGroup) Finalize(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
+func (g *orGroup) FinishedReading(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
 	types.BoolSlicePool.Put(&g.leftSamplePresence, memoryConsumptionTracker)
 }

--- a/pkg/streamingpromql/operators/binops/or_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/or_binary_operation_test.go
@@ -316,14 +316,14 @@ func TestOrBinaryOperationSorting(t *testing.T) {
 	}
 }
 
-func TestOrBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *testing.T) {
+func TestOrBinaryOperation_CallsFinishedReadingOnInnerOperatorsAsSoonAsPossible(t *testing.T) {
 	testCases := map[string]struct {
 		leftSeries  []labels.Labels
 		rightSeries []labels.Labels
 
-		expectedOutputSeries                           []labels.Labels
-		expectLeftSideFinalizedAfterOutputSeriesIndex  int
-		expectRightSideFinalizedAfterOutputSeriesIndex int
+		expectedOutputSeries                                       []labels.Labels
+		expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex  int
+		expectRightSideFinishedReadingCalledAfterOutputSeriesIndex int
 	}{
 		"reach end of both sides at the same time": {
 			leftSeries: []labels.Labels{
@@ -345,8 +345,8 @@ func TestOrBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *testing.T)
 				labels.FromStrings("group", "2", "series", "left-3"),
 				labels.FromStrings("group", "2", "series", "right-3"),
 			},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  4,
-			expectRightSideFinalizedAfterOutputSeriesIndex: 5,
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  4,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: 5,
 		},
 		"no more matches with unmatched series still to read on both sides": {
 			leftSeries: []labels.Labels{
@@ -368,8 +368,8 @@ func TestOrBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *testing.T)
 				labels.FromStrings("group", "3", "series", "right-3"),
 				labels.FromStrings("group", "2", "series", "left-3"),
 			},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  5,
-			expectRightSideFinalizedAfterOutputSeriesIndex: 4,
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  5,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: 4,
 		},
 		"no more matches with unmatched series still to read on left side": {
 			leftSeries: []labels.Labels{
@@ -389,8 +389,8 @@ func TestOrBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *testing.T)
 				labels.FromStrings("group", "1", "series", "right-2"),
 				labels.FromStrings("group", "2", "series", "left-3"),
 			},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  4,
-			expectRightSideFinalizedAfterOutputSeriesIndex: 3,
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  4,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: 3,
 		},
 		"no more matches with unmatched series still to read on right side": {
 			leftSeries: []labels.Labels{
@@ -410,8 +410,8 @@ func TestOrBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *testing.T)
 				labels.FromStrings("group", "1", "series", "right-2"),
 				labels.FromStrings("group", "3", "series", "right-3"),
 			},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  1,
-			expectRightSideFinalizedAfterOutputSeriesIndex: 4,
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  1,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: 4,
 		},
 		"some series do not match anything on the right": {
 			leftSeries: []labels.Labels{
@@ -435,8 +435,8 @@ func TestOrBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *testing.T)
 				labels.FromStrings("group", "3", "series", "left-4"),
 				labels.FromStrings("group", "3", "series", "right-3"),
 			},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  5,
-			expectRightSideFinalizedAfterOutputSeriesIndex: 6,
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  5,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: 6,
 		},
 		"some series do not match anything on the left": {
 			leftSeries: []labels.Labels{
@@ -460,8 +460,8 @@ func TestOrBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *testing.T)
 				labels.FromStrings("group", "3", "series", "left-3"),
 				labels.FromStrings("group", "3", "series", "right-4"),
 			},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  5,
-			expectRightSideFinalizedAfterOutputSeriesIndex: 6,
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  5,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: 6,
 		},
 		"no series match": {
 			leftSeries: []labels.Labels{
@@ -477,8 +477,8 @@ func TestOrBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *testing.T)
 				labels.FromStrings("group", "1", "series", "left-1"),
 				labels.FromStrings("group", "2", "series", "left-2"),
 			},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  2,
-			expectRightSideFinalizedAfterOutputSeriesIndex: 0,
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  2,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: 0,
 		},
 		"no series on left": {
 			leftSeries: []labels.Labels{},
@@ -493,8 +493,8 @@ func TestOrBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *testing.T)
 				labels.FromStrings("group", "2", "series", "right-2"),
 				labels.FromStrings("group", "3", "series", "right-3"),
 			},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  -1,
-			expectRightSideFinalizedAfterOutputSeriesIndex: 2,
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  -1,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: 2,
 		},
 		"no series on right": {
 			leftSeries: []labels.Labels{
@@ -509,27 +509,27 @@ func TestOrBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *testing.T)
 				labels.FromStrings("group", "2", "series", "left-2"),
 				labels.FromStrings("group", "3", "series", "left-3"),
 			},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  2,
-			expectRightSideFinalizedAfterOutputSeriesIndex: -1,
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  2,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: -1,
 		},
 		"no series on either side": {
 			leftSeries:  []labels.Labels{},
 			rightSeries: []labels.Labels{},
 
-			expectedOutputSeries:                           []labels.Labels{},
-			expectLeftSideFinalizedAfterOutputSeriesIndex:  -1,
-			expectRightSideFinalizedAfterOutputSeriesIndex: -1,
+			expectedOutputSeries: []labels.Labels{},
+			expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex:  -1,
+			expectRightSideFinishedReadingCalledAfterOutputSeriesIndex: -1,
 		},
 	}
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			if testCase.expectLeftSideFinalizedAfterOutputSeriesIndex >= len(testCase.expectedOutputSeries) {
-				require.Failf(t, "invalid test case", "expectLeftSideFinalizedAfterOutputSeriesIndex %v is beyond end of expected output series %v", testCase.expectLeftSideFinalizedAfterOutputSeriesIndex, testCase.expectedOutputSeries)
+			if testCase.expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex >= len(testCase.expectedOutputSeries) {
+				require.Failf(t, "invalid test case", "expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex %v is beyond end of expected output series %v", testCase.expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex, testCase.expectedOutputSeries)
 			}
 
-			if testCase.expectRightSideFinalizedAfterOutputSeriesIndex >= len(testCase.expectedOutputSeries) {
-				require.Failf(t, "invalid test case", "expectRightSideFinalizedAfterOutputSeriesIndex %v is beyond end of expected output series %v", testCase.expectRightSideFinalizedAfterOutputSeriesIndex, testCase.expectedOutputSeries)
+			if testCase.expectRightSideFinishedReadingCalledAfterOutputSeriesIndex >= len(testCase.expectedOutputSeries) {
+				require.Failf(t, "invalid test case", "expectRightSideFinishedReadingCalledAfterOutputSeriesIndex %v is beyond end of expected output series %v", testCase.expectRightSideFinishedReadingCalledAfterOutputSeriesIndex, testCase.expectedOutputSeries)
 			}
 
 			ctx := context.Background()
@@ -549,16 +549,16 @@ func TestOrBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *testing.T)
 				require.Equal(t, testutils.LabelsToSeriesMetadata(testCase.expectedOutputSeries), outputSeries)
 			}
 
-			if testCase.expectLeftSideFinalizedAfterOutputSeriesIndex == -1 {
-				require.True(t, left.Finalized, "left side should be finalized after SeriesMetadata, but it is not")
+			if testCase.expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex == -1 {
+				require.True(t, left.FinishedReadingCalled, "left side should have FinishedReading called after SeriesMetadata, but it is not")
 			} else {
-				require.False(t, left.Finalized, "left side should not be finalized after SeriesMetadata, but it is")
+				require.False(t, left.FinishedReadingCalled, "left side should not have FinishedReading called after SeriesMetadata, but it is")
 			}
 
-			if testCase.expectRightSideFinalizedAfterOutputSeriesIndex == -1 {
-				require.True(t, right.Finalized, "right side should be finalized after SeriesMetadata, but it is not")
+			if testCase.expectRightSideFinishedReadingCalledAfterOutputSeriesIndex == -1 {
+				require.True(t, right.FinishedReadingCalled, "right side should have FinishedReading called after SeriesMetadata, but it is not")
 			} else {
-				require.False(t, right.Finalized, "right side should not be finalized after SeriesMetadata, but it is")
+				require.False(t, right.FinishedReadingCalled, "right side should not have FinishedReading called after SeriesMetadata, but it is")
 			}
 
 			require.False(t, left.Closed, "left side should not be closed after SeriesMetadata, but it is")
@@ -568,16 +568,16 @@ func TestOrBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *testing.T)
 				_, err := o.NextSeries(ctx)
 				require.NoErrorf(t, err, "got error while reading series at index %v", outputSeriesIdx)
 
-				if outputSeriesIdx >= testCase.expectLeftSideFinalizedAfterOutputSeriesIndex {
-					require.Truef(t, left.Finalized, "left side should be finalized after output series at index %v, but it is not", outputSeriesIdx)
+				if outputSeriesIdx >= testCase.expectLeftSideFinishedReadingCalledAfterOutputSeriesIndex {
+					require.Truef(t, left.FinishedReadingCalled, "left side should have FinishedReading called after output series at index %v, but it is not", outputSeriesIdx)
 				} else {
-					require.Falsef(t, left.Finalized, "left side should not be finalized after output series at index %v, but it is", outputSeriesIdx)
+					require.Falsef(t, left.FinishedReadingCalled, "left side should not have FinishedReading called after output series at index %v, but it is", outputSeriesIdx)
 				}
 
-				if outputSeriesIdx >= testCase.expectRightSideFinalizedAfterOutputSeriesIndex {
-					require.Truef(t, right.Finalized, "right side should be finalized after output series at index %v, but it is not", outputSeriesIdx)
+				if outputSeriesIdx >= testCase.expectRightSideFinishedReadingCalledAfterOutputSeriesIndex {
+					require.Truef(t, right.FinishedReadingCalled, "right side should have FinishedReading called after output series at index %v, but it is not", outputSeriesIdx)
 				} else {
-					require.Falsef(t, right.Finalized, "right side should not be finalized after output series at index %v, but it is", outputSeriesIdx)
+					require.Falsef(t, right.FinishedReadingCalled, "right side should not have FinishedReading called after output series at index %v, but it is", outputSeriesIdx)
 				}
 			}
 
@@ -589,9 +589,9 @@ func TestOrBinaryOperation_FinalizesInnerOperatorsAsSoonAsPossible(t *testing.T)
 			_, err = o.NextSeries(ctx)
 			require.Equal(t, types.EOS, err)
 
-			require.NoError(t, o.Finalize(ctx))
-			require.True(t, left.Finalized, "left side should be finalized after calling Finalize, but it is not")
-			require.True(t, right.Finalized, "right side should be finalized after calling Finalize, but it is not")
+			require.NoError(t, o.FinishedReading(ctx))
+			require.True(t, left.FinishedReadingCalled, "left side should have FinishedReading called after calling FinishedReading, but it is not")
+			require.True(t, right.FinishedReadingCalled, "right side should have FinishedReading called after calling FinishedReading, but it is not")
 			// Make sure we've returned everything to their pools.
 			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
 
@@ -708,8 +708,8 @@ func TestOrBinaryOperation_ReleasesIntermediateStateIfClosedEarly(t *testing.T) 
 				require.NoError(t, err)
 			}
 
-			// Finalize the operator and confirm that we've returned everything to their pools.
-			require.NoError(t, o.Finalize(ctx))
+			// Call FinishedReading on the operator and confirm that we've returned everything to their pools.
+			require.NoError(t, o.FinishedReading(ctx))
 			require.Equal(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes())
 			o.Close()
 		})

--- a/pkg/streamingpromql/operators/binops/scalar_scalar_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/scalar_scalar_binary_operation.go
@@ -130,12 +130,12 @@ func (s *ScalarScalarBinaryOperation) AfterPrepare(ctx context.Context) error {
 	return s.Right.AfterPrepare(ctx)
 }
 
-func (s *ScalarScalarBinaryOperation) Finalize(ctx context.Context) error {
-	if err := s.Left.Finalize(ctx); err != nil {
+func (s *ScalarScalarBinaryOperation) FinishedReading(ctx context.Context) error {
+	if err := s.Left.FinishedReading(ctx); err != nil {
 		return err
 	}
 
-	return s.Right.Finalize(ctx)
+	return s.Right.FinishedReading(ctx)
 }
 
 func (s *ScalarScalarBinaryOperation) Stats(ctx context.Context) (*types.OperatorEvaluationStats, error) {

--- a/pkg/streamingpromql/operators/binops/vector_scalar_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/vector_scalar_binary_operation.go
@@ -267,14 +267,14 @@ func (v *VectorScalarBinaryOperation) AfterPrepare(ctx context.Context) error {
 	return v.Vector.AfterPrepare(ctx)
 }
 
-func (v *VectorScalarBinaryOperation) Finalize(ctx context.Context) error {
+func (v *VectorScalarBinaryOperation) FinishedReading(ctx context.Context) error {
 	types.FPointSlicePool.Put(&v.scalarData.Samples, v.MemoryConsumptionTracker)
 
-	if err := v.Scalar.Finalize(ctx); err != nil {
+	if err := v.Scalar.FinishedReading(ctx); err != nil {
 		return err
 	}
 
-	return v.Vector.Finalize(ctx)
+	return v.Vector.FinishedReading(ctx)
 }
 
 func (v *VectorScalarBinaryOperation) Stats(ctx context.Context) (*types.OperatorEvaluationStats, error) {

--- a/pkg/streamingpromql/operators/deduplicate_and_merge.go
+++ b/pkg/streamingpromql/operators/deduplicate_and_merge.go
@@ -151,13 +151,13 @@ func (d *DeduplicateAndMerge) AfterPrepare(ctx context.Context) error {
 	return d.Inner.AfterPrepare(ctx)
 }
 
-func (d *DeduplicateAndMerge) Finalize(ctx context.Context) error {
+func (d *DeduplicateAndMerge) FinishedReading(ctx context.Context) error {
 	if d.buffer != nil {
-		d.buffer.Finalize()
+		d.buffer.FinishedReading()
 		d.buffer = nil
 	}
 
-	return d.Inner.Finalize(ctx)
+	return d.Inner.FinishedReading(ctx)
 }
 
 func (d *DeduplicateAndMerge) Stats(ctx context.Context) (*types.OperatorEvaluationStats, error) {

--- a/pkg/streamingpromql/operators/drop_name.go
+++ b/pkg/streamingpromql/operators/drop_name.go
@@ -52,8 +52,8 @@ func (n *DropNameInstant) AfterPrepare(ctx context.Context) error {
 	return n.Inner.AfterPrepare(ctx)
 }
 
-func (n *DropNameInstant) Finalize(ctx context.Context) error {
-	return n.Inner.Finalize(ctx)
+func (n *DropNameInstant) FinishedReading(ctx context.Context) error {
+	return n.Inner.FinishedReading(ctx)
 }
 
 func (n *DropNameInstant) Stats(ctx context.Context) (*types.OperatorEvaluationStats, error) {
@@ -108,8 +108,8 @@ func (n *DropNameRange) AfterPrepare(ctx context.Context) error {
 	return n.Inner.AfterPrepare(ctx)
 }
 
-func (n *DropNameRange) Finalize(ctx context.Context) error {
-	return n.Inner.Finalize(ctx)
+func (n *DropNameRange) FinishedReading(ctx context.Context) error {
+	return n.Inner.FinishedReading(ctx)
 }
 
 func (n *DropNameRange) Stats(ctx context.Context) (*types.OperatorEvaluationStats, error) {

--- a/pkg/streamingpromql/operators/functions/absent.go
+++ b/pkg/streamingpromql/operators/functions/absent.go
@@ -122,9 +122,9 @@ func (a *Absent) AfterPrepare(ctx context.Context) error {
 	return a.Inner.AfterPrepare(ctx)
 }
 
-func (a *Absent) Finalize(ctx context.Context) error {
+func (a *Absent) FinishedReading(ctx context.Context) error {
 	types.BoolSlicePool.Put(&a.presence, a.MemoryConsumptionTracker)
-	return a.Inner.Finalize(ctx)
+	return a.Inner.FinishedReading(ctx)
 }
 
 func (a *Absent) Stats(ctx context.Context) (*types.OperatorEvaluationStats, error) {

--- a/pkg/streamingpromql/operators/functions/absent_over_time.go
+++ b/pkg/streamingpromql/operators/functions/absent_over_time.go
@@ -127,9 +127,9 @@ func (a *AbsentOverTime) AfterPrepare(ctx context.Context) error {
 	return a.Inner.AfterPrepare(ctx)
 }
 
-func (a *AbsentOverTime) Finalize(ctx context.Context) error {
+func (a *AbsentOverTime) FinishedReading(ctx context.Context) error {
 	types.BoolSlicePool.Put(&a.presence, a.MemoryConsumptionTracker)
-	return a.Inner.Finalize(ctx)
+	return a.Inner.FinishedReading(ctx)
 }
 
 func (a *AbsentOverTime) Stats(ctx context.Context) (*types.OperatorEvaluationStats, error) {

--- a/pkg/streamingpromql/operators/functions/function_over_instant_vector.go
+++ b/pkg/streamingpromql/operators/functions/function_over_instant_vector.go
@@ -132,19 +132,19 @@ func (m *FunctionOverInstantVector) AfterPrepare(ctx context.Context) error {
 	return nil
 }
 
-func (m *FunctionOverInstantVector) Finalize(ctx context.Context) error {
+func (m *FunctionOverInstantVector) FinishedReading(ctx context.Context) error {
 	for _, sd := range m.scalarArgsData {
 		types.FPointSlicePool.Put(&sd.Samples, m.MemoryConsumptionTracker)
 	}
 
 	m.scalarArgsData = nil
 
-	if err := m.Inner.Finalize(ctx); err != nil {
+	if err := m.Inner.FinishedReading(ctx); err != nil {
 		return err
 	}
 
 	for _, sa := range m.ScalarArgs {
-		if err := sa.Finalize(ctx); err != nil {
+		if err := sa.FinishedReading(ctx); err != nil {
 			return err
 		}
 	}

--- a/pkg/streamingpromql/operators/functions/function_over_instant_vector_test.go
+++ b/pkg/streamingpromql/operators/functions/function_over_instant_vector_test.go
@@ -125,11 +125,11 @@ func TestFunctionOverInstantVectorWithScalarArgs(t *testing.T) {
 	expectedSeriesDataFuncCalledTimes++
 	require.Equal(t, expectedSeriesDataFuncCalledTimes, seriesDataFuncCalledTimes, "Supplied SeriesDataFunc was called once for each Series")
 
-	require.NoError(t, operator.Finalize(ctx))
-	require.True(t, inner.Finalized)
-	require.True(t, scalarOperator1.finalized)
-	require.True(t, scalarOperator2.finalized)
-	require.Equalf(t, uint64(0), tracker.CurrentEstimatedMemoryConsumptionBytes(), "expected 0 memory consumption after Finalize, but have\n%s", tracker.DescribeCurrentMemoryConsumption())
+	require.NoError(t, operator.FinishedReading(ctx))
+	require.True(t, inner.FinishedReadingCalled)
+	require.True(t, scalarOperator1.finishedReadingCalled)
+	require.True(t, scalarOperator2.finishedReadingCalled)
+	require.Equalf(t, uint64(0), tracker.CurrentEstimatedMemoryConsumptionBytes(), "expected 0 memory consumption after FinishedReading, but have\n%s", tracker.DescribeCurrentMemoryConsumption())
 
 	operator.Close()
 	require.True(t, inner.Closed)
@@ -138,9 +138,9 @@ func TestFunctionOverInstantVectorWithScalarArgs(t *testing.T) {
 }
 
 type testScalarOperator struct {
-	value     types.ScalarData
-	finalized bool
-	closed    bool
+	value                 types.ScalarData
+	finishedReadingCalled bool
+	closed                bool
 }
 
 func (t *testScalarOperator) GetValues(_ context.Context) (types.ScalarData, error) {
@@ -159,8 +159,8 @@ func (t *testScalarOperator) AfterPrepare(_ context.Context) error {
 	return nil
 }
 
-func (t *testScalarOperator) Finalize(_ context.Context) error {
-	t.finalized = true
+func (t *testScalarOperator) FinishedReading(_ context.Context) error {
+	t.finishedReadingCalled = true
 	return nil
 }
 

--- a/pkg/streamingpromql/operators/functions/function_over_range_vector.go
+++ b/pkg/streamingpromql/operators/functions/function_over_range_vector.go
@@ -218,20 +218,20 @@ func (m *FunctionOverRangeVector) AfterPrepare(ctx context.Context) error {
 	return nil
 }
 
-func (m *FunctionOverRangeVector) Finalize(ctx context.Context) error {
+func (m *FunctionOverRangeVector) FinishedReading(ctx context.Context) error {
 	for _, d := range m.scalarArgsData {
 		types.FPointSlicePool.Put(&d.Samples, m.MemoryConsumptionTracker)
 	}
 
 	m.scalarArgsData = nil
 
-	err := m.Inner.Finalize(ctx)
+	err := m.Inner.FinishedReading(ctx)
 	if err != nil {
 		return err
 	}
 
 	for _, sa := range m.ScalarArgs {
-		err := sa.Finalize(ctx)
+		err := sa.FinishedReading(ctx)
 		if err != nil {
 			return err
 		}

--- a/pkg/streamingpromql/operators/functions/histogram_function.go
+++ b/pkg/streamingpromql/operators/functions/histogram_function.go
@@ -547,16 +547,16 @@ func (h *HistogramFunction) AfterPrepare(ctx context.Context) error {
 	return h.inner.AfterPrepare(ctx)
 }
 
-func (h *HistogramFunction) Finalize(ctx context.Context) error {
+func (h *HistogramFunction) FinishedReading(ctx context.Context) error {
 	seriesGroupPairPool.Put(&h.seriesGroupPairs, h.memoryConsumptionTracker)
 	bucketGroupPointerSlicePool.Put(&h.remainingGroups, h.memoryConsumptionTracker)
 	h.nextGroupIdx = 0
 
-	if err := h.f.Finalize(ctx); err != nil {
+	if err := h.f.FinishedReading(ctx); err != nil {
 		return err
 	}
 
-	return h.inner.Finalize(ctx)
+	return h.inner.FinishedReading(ctx)
 }
 
 func (h *HistogramFunction) Stats(ctx context.Context) (*types.OperatorEvaluationStats, error) {
@@ -596,7 +596,7 @@ type histogramFunction interface {
 	ComputeNativeHistogramResult(pointIndex int, seriesIndex int, h *histogram.FloatHistogram) (float64, annotations.Annotations)
 	Prepare(ctx context.Context, params *types.PrepareParams) error
 	AfterPrepare(ctx context.Context) error
-	Finalize(ctx context.Context) error
+	FinishedReading(ctx context.Context) error
 	Stats(ctx context.Context) (*types.OperatorEvaluationStats, error)
 	Close()
 }
@@ -672,9 +672,9 @@ func (q *histogramQuantile) AfterPrepare(ctx context.Context) error {
 	return q.phArg.AfterPrepare(ctx)
 }
 
-func (q *histogramQuantile) Finalize(ctx context.Context) error {
+func (q *histogramQuantile) FinishedReading(ctx context.Context) error {
 	types.FPointSlicePool.Put(&q.phValues.Samples, q.memoryConsumptionTracker)
-	return q.phArg.Finalize(ctx)
+	return q.phArg.FinishedReading(ctx)
 }
 
 func (q *histogramQuantile) Stats(ctx context.Context) (*types.OperatorEvaluationStats, error) {
@@ -741,16 +741,16 @@ func (f *histogramFraction) AfterPrepare(ctx context.Context) error {
 	return f.upperArg.AfterPrepare(ctx)
 }
 
-func (f *histogramFraction) Finalize(ctx context.Context) error {
+func (f *histogramFraction) FinishedReading(ctx context.Context) error {
 	types.FPointSlicePool.Put(&f.lowerValues.Samples, f.memoryConsumptionTracker)
 	types.FPointSlicePool.Put(&f.upperValues.Samples, f.memoryConsumptionTracker)
 
-	err := f.lowerArg.Finalize(ctx)
+	err := f.lowerArg.FinishedReading(ctx)
 	if err != nil {
 		return err
 	}
 
-	return f.upperArg.Finalize(ctx)
+	return f.upperArg.FinishedReading(ctx)
 }
 
 func (f *histogramFraction) Stats(ctx context.Context) (*types.OperatorEvaluationStats, error) {

--- a/pkg/streamingpromql/operators/functions/histogram_function_test.go
+++ b/pkg/streamingpromql/operators/functions/histogram_function_test.go
@@ -170,7 +170,7 @@ func TestHistogramFunction_MemoryTracking(t *testing.T) {
 	require.Equal(t, expectedBGP, tracker.CurrentEstimatedMemoryConsumptionBytesBySource(limiter.BucketGroupPointerSlices),
 		"remainingGroups memory should be tracked")
 
-	err = hOp.Finalize(ctx)
+	err = hOp.FinishedReading(ctx)
 	require.NoError(t, err)
 	hOp.Close()
 

--- a/pkg/streamingpromql/operators/functions/info.go
+++ b/pkg/streamingpromql/operators/functions/info.go
@@ -696,12 +696,12 @@ func (f *InfoFunction) AfterPrepare(ctx context.Context) error {
 	return f.Info.AfterPrepare(ctx)
 }
 
-func (f *InfoFunction) Finalize(ctx context.Context) error {
-	if err := f.Inner.Finalize(ctx); err != nil {
+func (f *InfoFunction) FinishedReading(ctx context.Context) error {
+	if err := f.Inner.FinishedReading(ctx); err != nil {
 		return err
 	}
 
-	return f.Info.Finalize(ctx)
+	return f.Info.FinishedReading(ctx)
 }
 
 func (f *InfoFunction) Stats(ctx context.Context) (*types.OperatorEvaluationStats, error) {

--- a/pkg/streamingpromql/operators/functions/sort.go
+++ b/pkg/streamingpromql/operators/functions/sort.go
@@ -166,7 +166,7 @@ func (s *Sort) AfterPrepare(ctx context.Context) error {
 	return s.inner.AfterPrepare(ctx)
 }
 
-func (s *Sort) Finalize(ctx context.Context) error {
+func (s *Sort) FinishedReading(ctx context.Context) error {
 	// Return any remaining data to the pool.
 	// Any data in allData that was previously passed to the calling operator by NextSeries does not need to be returned to the pool,
 	// as the calling operator is responsible for returning it to the pool.
@@ -177,7 +177,7 @@ func (s *Sort) Finalize(ctx context.Context) error {
 
 	s.allData = nil
 
-	return s.inner.Finalize(ctx)
+	return s.inner.FinishedReading(ctx)
 }
 
 func (s *Sort) Stats(ctx context.Context) (*types.OperatorEvaluationStats, error) {

--- a/pkg/streamingpromql/operators/functions/sort_by_label.go
+++ b/pkg/streamingpromql/operators/functions/sort_by_label.go
@@ -153,15 +153,15 @@ func (s *SortByLabel) AfterPrepare(ctx context.Context) error {
 	return s.inner.AfterPrepare(ctx)
 }
 
-func (s *SortByLabel) Finalize(ctx context.Context) error {
+func (s *SortByLabel) FinishedReading(ctx context.Context) error {
 	if s.buffer != nil {
-		s.buffer.Finalize()
+		s.buffer.FinishedReading()
 		s.buffer = nil
 	}
 
 	types.IntSlicePool.Put(&s.originalIndexes, s.memoryConsumptionTracker)
 
-	return s.inner.Finalize(ctx)
+	return s.inner.FinishedReading(ctx)
 }
 
 func (s *SortByLabel) Stats(ctx context.Context) (*types.OperatorEvaluationStats, error) {

--- a/pkg/streamingpromql/operators/no_op.go
+++ b/pkg/streamingpromql/operators/no_op.go
@@ -48,7 +48,7 @@ func (n *NoOpInstant) NextSeries(_ context.Context) (types.InstantVectorSeriesDa
 	return types.InstantVectorSeriesData{}, types.EOS
 }
 
-func (n *NoOpInstant) Finalize(_ context.Context) error {
+func (n *NoOpInstant) FinishedReading(_ context.Context) error {
 	return nil
 }
 
@@ -88,7 +88,7 @@ func (n *NoOpRange) AfterPrepare(_ context.Context) error {
 	return nil
 }
 
-func (n *NoOpRange) Finalize(_ context.Context) error {
+func (n *NoOpRange) FinishedReading(_ context.Context) error {
 	return nil
 }
 

--- a/pkg/streamingpromql/operators/operator_buffer.go
+++ b/pkg/streamingpromql/operators/operator_buffer.go
@@ -66,8 +66,8 @@ func (b *InstantVectorOperatorBuffer) GetSeries(ctx context.Context, seriesIndic
 	}
 
 	if b.nextIndexToRead > b.lastSeriesIndexUsed {
-		// If we're not going to read any more series, finalize the inner operator.
-		if err := b.source.Finalize(ctx); err != nil {
+		// If we're not going to read any more series, call FinishedReading on the inner operator.
+		if err := b.source.FinishedReading(ctx); err != nil {
 			return nil, err
 		}
 	}
@@ -105,10 +105,10 @@ func (b *InstantVectorOperatorBuffer) getSingleSeries(ctx context.Context, serie
 	return d, nil
 }
 
-// Finalize releases buffered series data and pool resources.
-// It is safe to call Finalize multiple times.
-// It is the responsibility of the caller to call Finalize on the inner operator.
-func (b *InstantVectorOperatorBuffer) Finalize() {
+// FinishedReading releases buffered series data and pool resources.
+// It is safe to call FinishedReading multiple times.
+// It is the responsibility of the caller to call FinishedReading on the inner operator.
+func (b *InstantVectorOperatorBuffer) FinishedReading() {
 	for _, d := range b.buffer {
 		types.PutInstantVectorSeriesData(d, b.memoryConsumptionTracker)
 	}

--- a/pkg/streamingpromql/operators/operator_buffer_test.go
+++ b/pkg/streamingpromql/operators/operator_buffer_test.go
@@ -57,7 +57,7 @@ func TestInstantVectorOperatorBuffer_BufferingSubsetOfInputSeries(t *testing.T) 
 	require.NoError(t, err)
 	require.Equal(t, []types.InstantVectorSeriesData{series0Data}, series)
 	require.Empty(t, buffer.buffer) // Should not buffer series that was immediately returned.
-	require.False(t, inner.Finalized)
+	require.False(t, inner.FinishedReadingCalled)
 	require.False(t, inner.Closed)
 	types.PutInstantVectorSeriesData(series[0], memoryConsumptionTracker)
 
@@ -66,7 +66,7 @@ func TestInstantVectorOperatorBuffer_BufferingSubsetOfInputSeries(t *testing.T) 
 	require.NoError(t, err)
 	require.Equal(t, []types.InstantVectorSeriesData{series2Data}, series)
 	require.Empty(t, buffer.buffer) // Should not buffer series at index 1 that won't be used.
-	require.False(t, inner.Finalized)
+	require.False(t, inner.FinishedReadingCalled)
 	require.False(t, inner.Closed)
 	types.PutInstantVectorSeriesData(series[0], memoryConsumptionTracker)
 
@@ -75,7 +75,7 @@ func TestInstantVectorOperatorBuffer_BufferingSubsetOfInputSeries(t *testing.T) 
 	require.NoError(t, err)
 	require.Equal(t, []types.InstantVectorSeriesData{series4Data}, series)
 	require.Len(t, buffer.buffer, 1) // Should only have buffered a single series (index 3).
-	require.True(t, inner.Finalized, "inner operator should be finalized after reading last series that will be used")
+	require.True(t, inner.FinishedReadingCalled, "inner operator should have FinishedReading called after reading last series that will be used")
 	require.False(t, inner.Closed, "inner operator should not be closed after reading last series that will be used")
 	types.PutInstantVectorSeriesData(series[0], memoryConsumptionTracker)
 
@@ -84,7 +84,7 @@ func TestInstantVectorOperatorBuffer_BufferingSubsetOfInputSeries(t *testing.T) 
 	require.NoError(t, err)
 	require.Equal(t, []types.InstantVectorSeriesData{series3Data}, series)
 	require.Empty(t, buffer.buffer) // Series that has been returned should be removed from buffer once it's returned.
-	require.True(t, inner.Finalized)
+	require.True(t, inner.FinishedReadingCalled)
 	require.False(t, inner.Closed)
 	types.PutInstantVectorSeriesData(series[0], memoryConsumptionTracker)
 
@@ -92,13 +92,13 @@ func TestInstantVectorOperatorBuffer_BufferingSubsetOfInputSeries(t *testing.T) 
 	series, err = buffer.GetSeries(ctx, []int{5, 6})
 	require.NoError(t, err)
 	require.Equal(t, []types.InstantVectorSeriesData{series5Data, series6Data}, series)
-	require.True(t, inner.Finalized)
+	require.True(t, inner.FinishedReadingCalled)
 	require.False(t, inner.Closed)
 	types.PutInstantVectorSeriesData(series[0], memoryConsumptionTracker)
 	types.PutInstantVectorSeriesData(series[1], memoryConsumptionTracker)
 
-	buffer.Finalize()
-	require.True(t, inner.Finalized)
+	buffer.FinishedReading()
+	require.True(t, inner.FinishedReadingCalled)
 	require.Equalf(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes(), "expected 0 memory consumption after test, but have\n%s", memoryConsumptionTracker.DescribeCurrentMemoryConsumption())
 }
 
@@ -142,7 +142,7 @@ func TestInstantVectorOperatorBuffer_BufferingAllInputSeries(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []types.InstantVectorSeriesData{series0Data}, series)
 	require.Empty(t, buffer.buffer) // Should not buffer series that was immediately returned.
-	require.False(t, inner.Finalized)
+	require.False(t, inner.FinishedReadingCalled)
 	require.False(t, inner.Closed)
 	types.PutInstantVectorSeriesData(series[0], memoryConsumptionTracker)
 
@@ -151,7 +151,7 @@ func TestInstantVectorOperatorBuffer_BufferingAllInputSeries(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []types.InstantVectorSeriesData{series2Data}, series)
 	require.Len(t, buffer.buffer, 1) // Should only have buffered a single series (index 1).
-	require.False(t, inner.Finalized)
+	require.False(t, inner.FinishedReadingCalled)
 	require.False(t, inner.Closed)
 	types.PutInstantVectorSeriesData(series[0], memoryConsumptionTracker)
 
@@ -160,7 +160,7 @@ func TestInstantVectorOperatorBuffer_BufferingAllInputSeries(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []types.InstantVectorSeriesData{series4Data}, series)
 	require.Len(t, buffer.buffer, 2) // Should only have buffered two series (indices 1 and 3).
-	require.False(t, inner.Finalized)
+	require.False(t, inner.FinishedReadingCalled)
 	require.False(t, inner.Closed)
 	types.PutInstantVectorSeriesData(series[0], memoryConsumptionTracker)
 
@@ -169,7 +169,7 @@ func TestInstantVectorOperatorBuffer_BufferingAllInputSeries(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []types.InstantVectorSeriesData{series3Data}, series)
 	require.Len(t, buffer.buffer, 1) // Series that has been returned should be removed from buffer once it's returned.
-	require.False(t, inner.Finalized)
+	require.False(t, inner.FinishedReadingCalled)
 	require.False(t, inner.Closed)
 	types.PutInstantVectorSeriesData(series[0], memoryConsumptionTracker)
 
@@ -178,7 +178,7 @@ func TestInstantVectorOperatorBuffer_BufferingAllInputSeries(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []types.InstantVectorSeriesData{series1Data}, series)
 	require.Empty(t, buffer.buffer)
-	require.False(t, inner.Finalized)
+	require.False(t, inner.FinishedReadingCalled)
 	require.False(t, inner.Closed)
 	types.PutInstantVectorSeriesData(series[0], memoryConsumptionTracker)
 
@@ -186,17 +186,17 @@ func TestInstantVectorOperatorBuffer_BufferingAllInputSeries(t *testing.T) {
 	series, err = buffer.GetSeries(ctx, []int{5, 6})
 	require.NoError(t, err)
 	require.Equal(t, []types.InstantVectorSeriesData{series5Data, series6Data}, series)
-	require.True(t, inner.Finalized)
+	require.True(t, inner.FinishedReadingCalled)
 	require.False(t, inner.Closed)
 	types.PutInstantVectorSeriesData(series[0], memoryConsumptionTracker)
 	types.PutInstantVectorSeriesData(series[1], memoryConsumptionTracker)
 
-	buffer.Finalize()
-	require.True(t, inner.Finalized)
+	buffer.FinishedReading()
+	require.True(t, inner.FinishedReadingCalled)
 	require.Equalf(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes(), "expected 0 memory consumption after test, but have\n%s", memoryConsumptionTracker.DescribeCurrentMemoryConsumption())
 }
 
-func TestInstantVectorOperatorBuffer_FinalizeReleasesBufferedData(t *testing.T) {
+func TestInstantVectorOperatorBuffer_FinishedReadingReleasesBufferedData(t *testing.T) {
 	ctx := context.Background()
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
@@ -230,7 +230,7 @@ func TestInstantVectorOperatorBuffer_FinalizeReleasesBufferedData(t *testing.T) 
 	types.PutInstantVectorSeriesData(series[0], memoryConsumptionTracker)
 	require.Len(t, buffer.buffer, 1, "should have buffered first series")
 
-	// Finalizing the buffer should release the buffered series.
-	buffer.Finalize()
-	require.Equalf(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes(), "expected 0 memory consumption after Finalize, but have\n%s", memoryConsumptionTracker.DescribeCurrentMemoryConsumption())
+	// Calling FinishedReading on the buffer should release the buffered series.
+	buffer.FinishedReading()
+	require.Equalf(t, uint64(0), memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes(), "expected 0 memory consumption after FinishedReading, but have\n%s", memoryConsumptionTracker.DescribeCurrentMemoryConsumption())
 }

--- a/pkg/streamingpromql/operators/scalars/instant_vector_to_scalar.go
+++ b/pkg/streamingpromql/operators/scalars/instant_vector_to_scalar.go
@@ -115,8 +115,8 @@ func (i *InstantVectorToScalar) AfterPrepare(ctx context.Context) error {
 	return i.Inner.AfterPrepare(ctx)
 }
 
-func (i *InstantVectorToScalar) Finalize(ctx context.Context) error {
-	return i.Inner.Finalize(ctx)
+func (i *InstantVectorToScalar) FinishedReading(ctx context.Context) error {
+	return i.Inner.FinishedReading(ctx)
 }
 
 func (i *InstantVectorToScalar) Stats(ctx context.Context) (*types.OperatorEvaluationStats, error) {

--- a/pkg/streamingpromql/operators/scalars/scalar_constant.go
+++ b/pkg/streamingpromql/operators/scalars/scalar_constant.go
@@ -65,7 +65,7 @@ func (s *ScalarConstant) AfterPrepare(_ context.Context) error {
 	return nil
 }
 
-func (s *ScalarConstant) Finalize(_ context.Context) error {
+func (s *ScalarConstant) FinishedReading(_ context.Context) error {
 	// Nothing to do.
 	return nil
 }

--- a/pkg/streamingpromql/operators/scalars/scalar_to_instant_vector.go
+++ b/pkg/streamingpromql/operators/scalars/scalar_to_instant_vector.go
@@ -74,8 +74,8 @@ func (s *ScalarToInstantVector) AfterPrepare(ctx context.Context) error {
 	return s.Scalar.AfterPrepare(ctx)
 }
 
-func (s *ScalarToInstantVector) Finalize(ctx context.Context) error {
-	return s.Scalar.Finalize(ctx)
+func (s *ScalarToInstantVector) FinishedReading(ctx context.Context) error {
+	return s.Scalar.FinishedReading(ctx)
 }
 
 func (s *ScalarToInstantVector) Stats(ctx context.Context) (*types.OperatorEvaluationStats, error) {

--- a/pkg/streamingpromql/operators/scalars/unary_negation_scalar.go
+++ b/pkg/streamingpromql/operators/scalars/unary_negation_scalar.go
@@ -49,8 +49,8 @@ func (u *UnaryNegationOfScalar) AfterPrepare(ctx context.Context) error {
 	return u.Inner.AfterPrepare(ctx)
 }
 
-func (u *UnaryNegationOfScalar) Finalize(ctx context.Context) error {
-	return u.Inner.Finalize(ctx)
+func (u *UnaryNegationOfScalar) FinishedReading(ctx context.Context) error {
+	return u.Inner.FinishedReading(ctx)
 }
 
 func (u *UnaryNegationOfScalar) Stats(ctx context.Context) (*types.OperatorEvaluationStats, error) {

--- a/pkg/streamingpromql/operators/selectors/instant_vector_selector.go
+++ b/pkg/streamingpromql/operators/selectors/instant_vector_selector.go
@@ -223,7 +223,7 @@ func (v *InstantVectorSelector) AfterPrepare(ctx context.Context) error {
 	return nil
 }
 
-func (v *InstantVectorSelector) Finalize(ctx context.Context) error {
+func (v *InstantVectorSelector) FinishedReading(ctx context.Context) error {
 	v.memoizedIterator = nil
 	v.chunkIterator = nil
 
@@ -238,7 +238,7 @@ func (v *InstantVectorSelector) Stats(_ context.Context) (*types.OperatorEvaluat
 }
 
 func (v *InstantVectorSelector) Close() {
-	// If the query fails, then Finalize above won't be called, so make sure to close the selector.
+	// If the query fails, then FinishedReading above won't be called, so make sure to close the selector.
 	v.Selector.Close()
 
 	if v.evaluationStats != nil {

--- a/pkg/streamingpromql/operators/selectors/range_vector_selector.go
+++ b/pkg/streamingpromql/operators/selectors/range_vector_selector.go
@@ -272,7 +272,7 @@ func (m *RangeVectorSelector) AfterPrepare(ctx context.Context) error {
 	return nil
 }
 
-func (m *RangeVectorSelector) Finalize(ctx context.Context) error {
+func (m *RangeVectorSelector) FinishedReading(ctx context.Context) error {
 	m.floats.Close()
 	m.histograms.Close()
 	m.chunkIterator = nil
@@ -287,7 +287,7 @@ func (m *RangeVectorSelector) Stats(_ context.Context) (*types.OperatorEvaluatio
 }
 
 func (m *RangeVectorSelector) Close() {
-	// If the query fails, then Finalize above won't be called, so make sure to close the selector.
+	// If the query fails, then FinishedReading above won't be called, so make sure to close the selector.
 	m.Selector.Close()
 
 	if m.evaluationStats != nil {

--- a/pkg/streamingpromql/operators/step_invariant_instant_vector_operator.go
+++ b/pkg/streamingpromql/operators/step_invariant_instant_vector_operator.go
@@ -43,8 +43,8 @@ func (s *StepInvariantInstantVectorOperator) AfterPrepare(ctx context.Context) e
 	return s.inner.AfterPrepare(ctx)
 }
 
-func (s *StepInvariantInstantVectorOperator) Finalize(ctx context.Context) error {
-	return s.inner.Finalize(ctx)
+func (s *StepInvariantInstantVectorOperator) FinishedReading(ctx context.Context) error {
+	return s.inner.FinishedReading(ctx)
 }
 
 func (s *StepInvariantInstantVectorOperator) SeriesMetadata(ctx context.Context, matchers types.Matchers) ([]types.SeriesMetadata, error) {

--- a/pkg/streamingpromql/operators/step_invariant_scalar_operator.go
+++ b/pkg/streamingpromql/operators/step_invariant_scalar_operator.go
@@ -43,8 +43,8 @@ func (s *StepInvariantScalarOperator) AfterPrepare(ctx context.Context) error {
 	return s.inner.AfterPrepare(ctx)
 }
 
-func (s *StepInvariantScalarOperator) Finalize(ctx context.Context) error {
-	return s.inner.Finalize(ctx)
+func (s *StepInvariantScalarOperator) FinishedReading(ctx context.Context) error {
+	return s.inner.FinishedReading(ctx)
 }
 
 func (s *StepInvariantScalarOperator) GetValues(ctx context.Context) (types.ScalarData, error) {

--- a/pkg/streamingpromql/operators/string.go
+++ b/pkg/streamingpromql/operators/string.go
@@ -52,7 +52,7 @@ func (s *StringLiteral) AfterPrepare(_ context.Context) error {
 	return nil
 }
 
-func (s *StringLiteral) Finalize(_ context.Context) error {
+func (s *StringLiteral) FinishedReading(_ context.Context) error {
 	// Nothing to do.
 	return nil
 }

--- a/pkg/streamingpromql/operators/subquery.go
+++ b/pkg/streamingpromql/operators/subquery.go
@@ -140,10 +140,10 @@ func (s *Subquery) AfterPrepare(ctx context.Context) error {
 	return s.Inner.AfterPrepare(ctx)
 }
 
-func (s *Subquery) Finalize(ctx context.Context) error {
+func (s *Subquery) FinishedReading(ctx context.Context) error {
 	s.histograms.Close()
 	s.floats.Close()
-	return s.Inner.Finalize(ctx)
+	return s.Inner.FinishedReading(ctx)
 }
 
 func (s *Subquery) Stats(ctx context.Context) (*types.OperatorEvaluationStats, error) {

--- a/pkg/streamingpromql/operators/test_operator.go
+++ b/pkg/streamingpromql/operators/test_operator.go
@@ -19,7 +19,7 @@ type TestOperator struct {
 	DropName                 []bool
 	Data                     []types.InstantVectorSeriesData
 	Prepared                 bool
-	Finalized                bool
+	FinishedReadingCalled    bool
 	Closed                   bool
 	Position                 posrange.PositionRange
 	MemoryConsumptionTracker *limiter.MemoryConsumptionTracker
@@ -118,8 +118,8 @@ func (t *TestOperator) AfterPrepare(_ context.Context) error {
 	return nil
 }
 
-func (t *TestOperator) Finalize(_ context.Context) error {
-	t.Finalized = true
+func (t *TestOperator) FinishedReading(_ context.Context) error {
+	t.FinishedReadingCalled = true
 	return nil
 }
 
@@ -144,9 +144,9 @@ type TestRangeOperator struct {
 	Histograms                 *types.HPointRingBuffer
 	HistogramsView             *types.HPointRingBufferView
 
-	Finalized        bool
-	Closed           bool
-	MatchersProvided types.Matchers
+	FinishedReadingCalled bool
+	Closed                bool
+	MatchersProvided      types.Matchers
 
 	memoryConsumptionTracker *limiter.MemoryConsumptionTracker
 }
@@ -260,8 +260,8 @@ func (t *TestRangeOperator) AfterPrepare(_ context.Context) error {
 	return nil
 }
 
-func (t *TestRangeOperator) Finalize(_ context.Context) error {
-	t.Finalized = true
+func (t *TestRangeOperator) FinishedReading(_ context.Context) error {
+	t.FinishedReadingCalled = true
 
 	if t.Floats != nil {
 		t.Floats.Close()

--- a/pkg/streamingpromql/operators/time.go
+++ b/pkg/streamingpromql/operators/time.go
@@ -62,7 +62,7 @@ func (s *Time) AfterPrepare(_ context.Context) error {
 	return nil
 }
 
-func (s *Time) Finalize(_ context.Context) error {
+func (s *Time) FinishedReading(_ context.Context) error {
 	// Nothing to do.
 	return nil
 }

--- a/pkg/streamingpromql/optimize/ast/sharding/avg.go
+++ b/pkg/streamingpromql/optimize/ast/sharding/avg.go
@@ -78,8 +78,8 @@ func (a *ShardedAvg) NextSeries(ctx context.Context) (types.InstantVectorSeriesD
 	return a.Inner.NextSeries(ctx)
 }
 
-func (a *ShardedAvg) Finalize(ctx context.Context) error {
-	return a.Inner.Finalize(ctx)
+func (a *ShardedAvg) FinishedReading(ctx context.Context) error {
+	return a.Inner.FinishedReading(ctx)
 }
 
 func (a *ShardedAvg) ExpressionPosition() posrange.PositionRange {

--- a/pkg/streamingpromql/optimize/ast/sharding/concat.go
+++ b/pkg/streamingpromql/optimize/ast/sharding/concat.go
@@ -148,9 +148,9 @@ func (c *Concat) NextSeries(ctx context.Context) (types.InstantVectorSeriesData,
 	return d, err
 }
 
-func (c *Concat) Finalize(ctx context.Context) error {
+func (c *Concat) FinishedReading(ctx context.Context) error {
 	for _, o := range c.Inner {
-		if err := o.Finalize(ctx); err != nil {
+		if err := o.FinishedReading(ctx); err != nil {
 			return err
 		}
 	}

--- a/pkg/streamingpromql/optimize/ast/sharding/concat_test.go
+++ b/pkg/streamingpromql/optimize/ast/sharding/concat_test.go
@@ -88,10 +88,10 @@ func TestConcat(t *testing.T) {
 	_, err = o.NextSeries(ctx)
 	require.Equal(t, types.EOS, err)
 
-	err = o.Finalize(ctx)
+	err = o.FinishedReading(ctx)
 	require.NoError(t, err)
-	require.True(t, inner1.Finalized)
-	require.True(t, inner2.Finalized)
+	require.True(t, inner1.FinishedReadingCalled)
+	require.True(t, inner2.FinishedReadingCalled)
 
 	o.Close()
 	require.True(t, inner1.Closed)
@@ -154,12 +154,12 @@ func TestConcat_InnerOperatorsWithNoSeries(t *testing.T) {
 	_, err = o.NextSeries(ctx)
 	require.Equal(t, types.EOS, err)
 
-	err = o.Finalize(ctx)
+	err = o.FinishedReading(ctx)
 	require.NoError(t, err)
-	require.True(t, inner1.Finalized)
-	require.True(t, inner2.Finalized)
-	require.True(t, inner3.Finalized)
-	require.True(t, inner4.Finalized)
+	require.True(t, inner1.FinishedReadingCalled)
+	require.True(t, inner2.FinishedReadingCalled)
+	require.True(t, inner3.FinishedReadingCalled)
+	require.True(t, inner4.FinishedReadingCalled)
 
 	o.Close()
 	require.True(t, inner1.Closed)

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/instant_vector_operator.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/instant_vector_operator.go
@@ -185,11 +185,11 @@ func (b *InstantVectorDuplicationBuffer) CloseConsumer(consumer *InstantVectorDu
 }
 
 func (b *InstantVectorDuplicationBuffer) releaseBufferedData(consumer *InstantVectorDuplicationConsumer) {
-	if consumer.finalized {
+	if consumer.finishedReadingCalled {
 		return
 	}
 
-	consumer.finalized = true
+	consumer.finishedReadingCalled = true
 
 	defer consumer.subset.close(b.MemoryConsumptionTracker)
 
@@ -198,7 +198,7 @@ func (b *InstantVectorDuplicationBuffer) releaseBufferedData(consumer *InstantVe
 	earliestSeriesIndexStillToReturn := b.earliestSeriesIndexStillToReturn()
 
 	if earliestSeriesIndexStillToReturn == math.MaxInt {
-		// All other consumers are already finalized. Clean up everything.
+		// All other consumers have already had FinishedReading called. Clean up everything.
 		b.releaseAllBufferedData()
 		return
 	}
@@ -257,7 +257,7 @@ func (b *InstantVectorDuplicationBuffer) releaseAllBufferedData() {
 func (b *InstantVectorDuplicationBuffer) earliestSeriesIndexStillToReturn() int {
 	idx := math.MaxInt
 	for _, consumer := range b.consumers {
-		if consumer.finalized {
+		if consumer.finishedReadingCalled {
 			continue
 		}
 
@@ -269,7 +269,7 @@ func (b *InstantVectorDuplicationBuffer) earliestSeriesIndexStillToReturn() int 
 
 func (b *InstantVectorDuplicationBuffer) allOpenConsumersHaveNoFilters() bool {
 	for _, consumer := range b.consumers {
-		if consumer.finalized {
+		if consumer.finishedReadingCalled {
 			continue
 		}
 
@@ -299,23 +299,23 @@ func (b *InstantVectorDuplicationBuffer) AfterPrepare(ctx context.Context) error
 	return b.Inner.AfterPrepare(ctx)
 }
 
-func (b *InstantVectorDuplicationBuffer) Finalize(ctx context.Context, consumer *InstantVectorDuplicationConsumer) error {
-	if consumer.finalized {
+func (b *InstantVectorDuplicationBuffer) FinishedReading(ctx context.Context, consumer *InstantVectorDuplicationConsumer) error {
+	if consumer.finishedReadingCalled {
 		return nil
 	}
 
 	b.releaseBufferedData(consumer)
 
-	if !b.allConsumersFinalized() {
+	if !b.allConsumersFinishedReading() {
 		return nil
 	}
 
-	return b.Inner.Finalize(ctx)
+	return b.Inner.FinishedReading(ctx)
 }
 
-func (b *InstantVectorDuplicationBuffer) allConsumersFinalized() bool {
+func (b *InstantVectorDuplicationBuffer) allConsumersFinishedReading() bool {
 	for _, consumer := range b.consumers {
-		if !consumer.finalized {
+		if !consumer.finishedReadingCalled {
 			return false
 		}
 	}
@@ -334,8 +334,8 @@ func (b *InstantVectorDuplicationBuffer) allConsumersClosed() bool {
 }
 
 func (b *InstantVectorDuplicationBuffer) Stats(ctx context.Context, consumer *InstantVectorDuplicationConsumer) (*types.OperatorEvaluationStats, error) {
-	if !b.allConsumersFinalized() {
-		return nil, errors.New("InstantVectorDuplicationBuffer: cannot get stats when one or more consumers are not finalized")
+	if !b.allConsumersFinishedReading() {
+		return nil, errors.New("InstantVectorDuplicationBuffer: cannot get stats when one or more consumers have not had FinishedReading called")
 	}
 
 	if consumer.hasReadStats {
@@ -402,7 +402,7 @@ type InstantVectorDuplicationConsumer struct {
 
 	nextUnfilteredSeriesIndex int
 	closed                    bool
-	finalized                 bool
+	finishedReadingCalled     bool
 	hasReadStats              bool
 }
 
@@ -420,7 +420,7 @@ func (d *InstantVectorDuplicationConsumer) SeriesMetadata(ctx context.Context, m
 }
 
 func (d *InstantVectorDuplicationConsumer) shouldReturnUnfilteredSeries(unfilteredSeriesIndex int) bool {
-	if d.finalized {
+	if d.finishedReadingCalled {
 		return false
 	}
 
@@ -455,8 +455,8 @@ func (d *InstantVectorDuplicationConsumer) AfterPrepare(ctx context.Context) err
 	return d.Buffer.AfterPrepare(ctx)
 }
 
-func (d *InstantVectorDuplicationConsumer) Finalize(ctx context.Context) error {
-	return d.Buffer.Finalize(ctx, d)
+func (d *InstantVectorDuplicationConsumer) FinishedReading(ctx context.Context) error {
+	return d.Buffer.FinishedReading(ctx, d)
 }
 
 func (d *InstantVectorDuplicationConsumer) Stats(ctx context.Context) (*types.OperatorEvaluationStats, error) {

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/instant_vector_operator_test.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/instant_vector_operator_test.go
@@ -107,17 +107,17 @@ func TestInstantVectorOperator_Buffering_NoFiltering(t *testing.T) {
 	require.Equal(t, 0, buffer.buffer.Size())
 	types.PutInstantVectorSeriesData(d, memoryConsumptionTracker)
 
-	// Check that the inner operator hasn't been closed or finalized yet.
-	require.False(t, inner.Finalized)
+	// Check that the inner operator hasn't been closed or had FinishedReading called yet.
+	require.False(t, inner.FinishedReadingCalled)
 	require.False(t, inner.Closed)
 
-	// Finalize each consumer, and check that the inner operator was only finalized after the last consumer is finalized.
-	require.NoError(t, consumer1.Finalize(ctx))
-	require.False(t, inner.Finalized)
-	require.NoError(t, consumer2.Finalize(ctx))
-	require.True(t, inner.Finalized)
-	require.NoError(t, consumer1.Finalize(ctx), "it should be safe to finalize either consumer a second time")
-	require.NoError(t, consumer2.Finalize(ctx), "it should be safe to finalize either consumer a second time")
+	// Call FinishedReading on each consumer, and check that the inner operator had FinishedReading called only after the last consumer had FinishedReading called.
+	require.NoError(t, consumer1.FinishedReading(ctx))
+	require.False(t, inner.FinishedReadingCalled)
+	require.NoError(t, consumer2.FinishedReading(ctx))
+	require.True(t, inner.FinishedReadingCalled)
+	require.NoError(t, consumer1.FinishedReading(ctx), "it should be safe to call FinishedReading on either consumer a second time")
+	require.NoError(t, consumer2.FinishedReading(ctx), "it should be safe to call FinishedReading on either consumer a second time")
 
 	// Close the second consumer, and check that the inner operator was closed.
 	consumer2.Close()
@@ -193,17 +193,17 @@ func TestInstantVectorOperator_Buffering_Filtering_AllConsumersOpen(t *testing.T
 	consumer1.Close()
 	require.Equal(t, 0, buffer.buffer.Size())
 
-	// Check that the inner operator hasn't been closed or finalized yet.
-	require.False(t, inner.Finalized)
+	// Check that the inner operator hasn't been closed or had FinishedReading called yet.
+	require.False(t, inner.FinishedReadingCalled)
 	require.False(t, inner.Closed)
 
-	// Finalize each consumer, and check that the inner operator was only finalized after the last consumer is finalized.
-	require.NoError(t, consumer1.Finalize(ctx))
-	require.False(t, inner.Finalized)
-	require.NoError(t, consumer2.Finalize(ctx))
-	require.True(t, inner.Finalized)
-	require.NoError(t, consumer1.Finalize(ctx), "it should be safe to finalize either consumer a second time")
-	require.NoError(t, consumer2.Finalize(ctx), "it should be safe to finalize either consumer a second time")
+	// Call FinishedReading on each consumer, and check that the inner operator had FinishedReading called only after the last consumer had FinishedReading called.
+	require.NoError(t, consumer1.FinishedReading(ctx))
+	require.False(t, inner.FinishedReadingCalled)
+	require.NoError(t, consumer2.FinishedReading(ctx))
+	require.True(t, inner.FinishedReadingCalled)
+	require.NoError(t, consumer1.FinishedReading(ctx), "it should be safe to call FinishedReading on either consumer a second time")
+	require.NoError(t, consumer2.FinishedReading(ctx), "it should be safe to call FinishedReading on either consumer a second time")
 
 	// Close the second consumer, and check that the inner operator was closed.
 	consumer2.Close()
@@ -273,17 +273,17 @@ func TestInstantVectorOperator_Buffering_Filtering_IteratingBeforeCallingSeriesM
 	consumer1.Close()
 	require.Equal(t, 0, buffer.buffer.Size())
 
-	// Check that the inner operator hasn't been closed or finalized yet.
-	require.False(t, inner.Finalized)
+	// Check that the inner operator hasn't been closed or had FinishedReading called yet.
+	require.False(t, inner.FinishedReadingCalled)
 	require.False(t, inner.Closed)
 
-	// Finalize each consumer, and check that the inner operator was only finalized after the last consumer is finalized.
-	require.NoError(t, consumer1.Finalize(ctx))
-	require.False(t, inner.Finalized)
-	require.NoError(t, consumer2.Finalize(ctx))
-	require.True(t, inner.Finalized)
-	require.NoError(t, consumer1.Finalize(ctx), "it should be safe to finalize either consumer a second time")
-	require.NoError(t, consumer2.Finalize(ctx), "it should be safe to finalize either consumer a second time")
+	// Call FinishedReading on each consumer, and check that the inner operator had FinishedReading called only after the last consumer had FinishedReading called.
+	require.NoError(t, consumer1.FinishedReading(ctx))
+	require.False(t, inner.FinishedReadingCalled)
+	require.NoError(t, consumer2.FinishedReading(ctx))
+	require.True(t, inner.FinishedReadingCalled)
+	require.NoError(t, consumer1.FinishedReading(ctx), "it should be safe to call FinishedReading on either consumer a second time")
+	require.NoError(t, consumer2.FinishedReading(ctx), "it should be safe to call FinishedReading on either consumer a second time")
 
 	// Close the second consumer, and check that the inner operator was closed.
 	consumer2.Close()
@@ -296,7 +296,7 @@ func TestInstantVectorOperator_Buffering_Filtering_IteratingBeforeCallingSeriesM
 	requireNoMemoryConsumption(t, memoryConsumptionTracker)
 }
 
-func TestInstantVectorOperator_Buffering_Filtering_DoesNotBufferForFinalizedConsumer(t *testing.T) {
+func TestInstantVectorOperator_Buffering_Filtering_DoesNotBufferForConsumerFinishedReading(t *testing.T) {
 	ctx := context.Background()
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	inner, expectedData := createTestInstantVectorOperator(t, 6, memoryConsumptionTracker)
@@ -322,13 +322,13 @@ func TestInstantVectorOperator_Buffering_Filtering_DoesNotBufferForFinalizedCons
 	require.Equal(t, 2, buffer.buffer.Size(), "the first and second series should be buffered for the first consumer")
 	types.PutInstantVectorSeriesData(d, memoryConsumptionTracker)
 
-	// The data being buffered for the first consumer should be released when it's finalized.
-	require.NoError(t, consumer1.Finalize(ctx))
+	// The data being buffered for the first consumer should be released when FinishedReading is called.
+	require.NoError(t, consumer1.FinishedReading(ctx))
 	require.Equal(t, 0, buffer.buffer.Size())
 	consumer1.Close()
 
-	// Check that the inner operator hasn't been closed or finalized yet.
-	require.False(t, inner.Finalized)
+	// Check that the inner operator hasn't been closed or had FinishedReading called yet.
+	require.False(t, inner.FinishedReadingCalled)
 	require.False(t, inner.Closed)
 
 	// Keep reading data for the second consumer, confirm that no further data is buffered for the first consumer.
@@ -344,11 +344,11 @@ func TestInstantVectorOperator_Buffering_Filtering_DoesNotBufferForFinalizedCons
 	require.Equal(t, 0, buffer.buffer.Size())
 	types.PutInstantVectorSeriesData(d, memoryConsumptionTracker)
 
-	// Finalize each consumer, and check that the inner operator was only finalized after the last consumer is finalized.
-	require.NoError(t, consumer2.Finalize(ctx))
-	require.True(t, inner.Finalized)
-	require.NoError(t, consumer1.Finalize(ctx), "it should be safe to finalize either consumer a second time")
-	require.NoError(t, consumer2.Finalize(ctx), "it should be safe to finalize either consumer a second time")
+	// Call FinishedReading on each consumer, and check that the inner operator had FinishedReading called only after the last consumer had FinishedReading called.
+	require.NoError(t, consumer2.FinishedReading(ctx))
+	require.True(t, inner.FinishedReadingCalled)
+	require.NoError(t, consumer1.FinishedReading(ctx), "it should be safe to call FinishedReading on either consumer a second time")
+	require.NoError(t, consumer2.FinishedReading(ctx), "it should be safe to call FinishedReading on either consumer a second time")
 
 	// Close the second consumer, and check that the inner operator was closed.
 	consumer2.Close()
@@ -395,18 +395,18 @@ func TestInstantVectorOperator_Buffering_Filtering_DoesNotBufferUnnecessarilyFor
 	require.Equal(t, 1, buffer.buffer.Size(), "only the first series should be buffered for the first consumer")
 	types.PutInstantVectorSeriesData(d, memoryConsumptionTracker)
 
-	// The data being buffered for the first consumer should be released when it's finalized.
-	require.NoError(t, consumer1.Finalize(ctx))
+	// The data being buffered for the first consumer should be released when FinishedReading is called.
+	require.NoError(t, consumer1.FinishedReading(ctx))
 	require.Equal(t, 0, buffer.buffer.Size())
 	consumer1.Close()
 
-	// Check that the inner operator hasn't been closed or finalized yet.
-	require.False(t, inner.Finalized)
+	// Check that the inner operator hasn't been closed or had FinishedReading called yet.
+	require.False(t, inner.FinishedReadingCalled)
 	require.False(t, inner.Closed)
 
 	// And the same for the second consumer.
-	require.NoError(t, consumer2.Finalize(ctx))
-	require.True(t, inner.Finalized)
+	require.NoError(t, consumer2.FinishedReading(ctx))
+	require.True(t, inner.FinishedReadingCalled)
 	consumer2.Close()
 	require.True(t, inner.Closed)
 	requireNoMemoryConsumption(t, memoryConsumptionTracker)
@@ -463,9 +463,9 @@ func TestInstantVectorOperator_Buffering_NonContiguousSeries(t *testing.T) {
 	require.Equal(t, 3, buffer.buffer.Size())
 	types.PutInstantVectorSeriesData(d, memoryConsumptionTracker)
 
-	require.NoError(t, consumer1.Finalize(ctx))
+	require.NoError(t, consumer1.FinishedReading(ctx))
 	consumer1.Close()
-	require.False(t, inner.Finalized)
+	require.False(t, inner.FinishedReadingCalled)
 	require.False(t, inner.Closed)
 
 	// Read all the data from consumer 3.
@@ -481,9 +481,9 @@ func TestInstantVectorOperator_Buffering_NonContiguousSeries(t *testing.T) {
 	require.Equal(t, 1, buffer.buffer.Size(), "should only be buffering series required by consumer 2")
 	types.PutInstantVectorSeriesData(d, memoryConsumptionTracker)
 
-	require.NoError(t, consumer3.Finalize(ctx))
+	require.NoError(t, consumer3.FinishedReading(ctx))
 	consumer3.Close()
-	require.False(t, inner.Finalized)
+	require.False(t, inner.FinishedReadingCalled)
 	require.False(t, inner.Closed)
 
 	// Read all the data from consumer 2
@@ -494,10 +494,10 @@ func TestInstantVectorOperator_Buffering_NonContiguousSeries(t *testing.T) {
 	types.PutInstantVectorSeriesData(d, memoryConsumptionTracker)
 
 	// Make sure everything is cleaned up properly.
-	require.False(t, inner.Finalized)
+	require.False(t, inner.FinishedReadingCalled)
 	require.False(t, inner.Closed)
-	require.NoError(t, consumer2.Finalize(ctx))
-	require.True(t, inner.Finalized)
+	require.NoError(t, consumer2.FinishedReading(ctx))
+	require.True(t, inner.FinishedReadingCalled)
 	consumer2.Close()
 	require.True(t, inner.Closed)
 	requireNoMemoryConsumption(t, memoryConsumptionTracker)
@@ -530,7 +530,7 @@ func TestInstantVectorOperator_Filtering_SingleConsumer(t *testing.T) {
 	}
 }
 
-func TestInstantVectorOperator_FinalizedWithBufferedData_NoFiltering(t *testing.T) {
+func TestInstantVectorOperator_FinishedReadingCalledWithBufferedData_NoFiltering(t *testing.T) {
 	ctx := context.Background()
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	inner, expectedData := createTestInstantVectorOperator(t, 3, memoryConsumptionTracker)
@@ -567,8 +567,8 @@ func TestInstantVectorOperator_FinalizedWithBufferedData_NoFiltering(t *testing.
 	require.Equal(t, 3, buffer.buffer.Size())
 	types.PutInstantVectorSeriesData(d, memoryConsumptionTracker)
 
-	// Finalize the first consumer, and check the data remains buffered for the second consumer.
-	require.NoError(t, consumer1.Finalize(ctx))
+	// Call FinishedReading on the first consumer, and check the data remains buffered for the second consumer.
+	require.NoError(t, consumer1.FinishedReading(ctx))
 	require.Equal(t, 3, buffer.buffer.Size())
 
 	// Read some of the buffered data.
@@ -578,18 +578,18 @@ func TestInstantVectorOperator_FinalizedWithBufferedData_NoFiltering(t *testing.
 	require.Equal(t, 2, buffer.buffer.Size())
 	types.PutInstantVectorSeriesData(d, memoryConsumptionTracker)
 
-	// Finalize the second consumer, and check that the inner operator was finalized and all buffered data was released.
-	require.NoError(t, consumer2.Finalize(ctx))
-	require.True(t, inner.Finalized)
+	// Call FinishedReading on the second consumer, and check that the inner operator had FinishedReading called and all buffered data was released.
+	require.NoError(t, consumer2.FinishedReading(ctx))
+	require.True(t, inner.FinishedReadingCalled)
 	requireNoMemoryConsumption(t, memoryConsumptionTracker)
 
-	// Make sure it's safe to finalize either consumer a second time.
-	require.NoError(t, consumer1.Finalize(ctx))
-	require.NoError(t, consumer2.Finalize(ctx))
+	// Make sure it's safe to call FinishedReading on either consumer a second time.
+	require.NoError(t, consumer1.FinishedReading(ctx))
+	require.NoError(t, consumer2.FinishedReading(ctx))
 	requireNoMemoryConsumption(t, memoryConsumptionTracker)
 }
 
-func TestInstantVectorOperator_FinalizedWithBufferedData_Filtering(t *testing.T) {
+func TestInstantVectorOperator_FinishedReadingCalledWithBufferedData_Filtering(t *testing.T) {
 	ctx := context.Background()
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	inner, expectedData := createTestInstantVectorOperator(t, 3, memoryConsumptionTracker)
@@ -624,7 +624,7 @@ func TestInstantVectorOperator_FinalizedWithBufferedData_Filtering(t *testing.T)
 	}
 
 	require.Equal(t, 3, buffer.buffer.Size(), "buffer should contain all three series for the remaining two consumers")
-	require.NoError(t, consumer2.Finalize(ctx))
+	require.NoError(t, consumer2.FinishedReading(ctx))
 	require.Equal(t, 1, buffer.buffer.Size(), "buffer should only contain remaining series required by remaining consumer")
 
 	d, err := consumer3.NextSeries(ctx)
@@ -633,8 +633,8 @@ func TestInstantVectorOperator_FinalizedWithBufferedData_Filtering(t *testing.T)
 	require.Equal(t, 0, buffer.buffer.Size())
 	types.PutInstantVectorSeriesData(d, memoryConsumptionTracker)
 
-	require.NoError(t, consumer1.Finalize(ctx))
-	require.NoError(t, consumer3.Finalize(ctx))
+	require.NoError(t, consumer1.FinishedReading(ctx))
+	require.NoError(t, consumer3.FinishedReading(ctx))
 	requireNoMemoryConsumption(t, memoryConsumptionTracker)
 }
 
@@ -818,7 +818,7 @@ func (o *failingInstantVectorOperator) AfterPrepare(ctx context.Context) error {
 	return nil
 }
 
-func (o *failingInstantVectorOperator) Finalize(_ context.Context) error {
+func (o *failingInstantVectorOperator) FinishedReading(_ context.Context) error {
 	return nil
 }
 
@@ -900,9 +900,9 @@ func TestInstantVectorOperator_Stats(t *testing.T) {
 	require.Equal(t, types.InstantVectorSeriesData{Floats: []promql.FPoint{{T: 0, F: 3}}}, data)
 	types.PutInstantVectorSeriesData(data, memoryConsumptionTracker)
 
-	// Finalize both operators, and check that the statistics are calculated correctly.
-	require.NoError(t, consumer1.Finalize(ctx))
-	require.NoError(t, consumer2.Finalize(ctx))
+	// Call FinishedReading on both operators, and check that the statistics are calculated correctly.
+	require.NoError(t, consumer1.FinishedReading(ctx))
+	require.NoError(t, consumer2.FinishedReading(ctx))
 
 	requireStats(t, consumer1, ctx, 3, 3)
 	requireStats(t, consumer2, ctx, 1, 1)

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator.go
@@ -125,8 +125,8 @@ func (b *RangeVectorDuplicationBuffer) SeriesMetadata(ctx context.Context, match
 }
 
 func (b *RangeVectorDuplicationBuffer) NextSeries(consumer *RangeVectorDuplicationConsumer) error {
-	if consumer.finalized {
-		return fmt.Errorf("consumer %p is already finalized, can't advance to next series", consumer)
+	if consumer.finishedReadingCalled {
+		return fmt.Errorf("consumer %p has already had FinishedReading called, can't advance to next series", consumer)
 	}
 
 	thisSeriesIndex := consumer.nextUnfilteredSeriesIndex
@@ -320,15 +320,15 @@ func (b *RangeVectorDuplicationBuffer) CloseConsumer(consumer *RangeVectorDuplic
 }
 
 func (b *RangeVectorDuplicationBuffer) releaseBufferedData(consumer *RangeVectorDuplicationConsumer) {
-	if consumer.finalized {
+	if consumer.finishedReadingCalled {
 		return
 	}
 
-	consumer.finalized = true
+	consumer.finishedReadingCalled = true
 
 	defer consumer.subset.close(b.MemoryConsumptionTracker)
 
-	if b.allConsumersFinalized() {
+	if b.allConsumersFinishedReading() {
 		b.releaseAllBufferedData()
 		return
 	}
@@ -392,7 +392,7 @@ func (b *RangeVectorDuplicationBuffer) earliestSeriesIndexStillToReturn() int {
 	idx := math.MaxInt
 
 	for _, consumer := range b.consumers {
-		if consumer.finalized {
+		if consumer.finishedReadingCalled {
 			continue
 		}
 
@@ -410,7 +410,7 @@ func (b *RangeVectorDuplicationBuffer) earliestSeriesIndexStillToReturn() int {
 
 func (b *RangeVectorDuplicationBuffer) allOpenConsumersHaveNoFilters() bool {
 	for _, consumer := range b.consumers {
-		if consumer.finalized {
+		if consumer.finishedReadingCalled {
 			continue
 		}
 
@@ -450,23 +450,23 @@ func (b *RangeVectorDuplicationBuffer) AfterPrepare(ctx context.Context) error {
 	return b.Inner.AfterPrepare(ctx)
 }
 
-func (b *RangeVectorDuplicationBuffer) Finalize(ctx context.Context, consumer *RangeVectorDuplicationConsumer) error {
-	if consumer.finalized {
+func (b *RangeVectorDuplicationBuffer) FinishedReading(ctx context.Context, consumer *RangeVectorDuplicationConsumer) error {
+	if consumer.finishedReadingCalled {
 		return nil
 	}
 
 	b.releaseBufferedData(consumer)
 
-	if !b.allConsumersFinalized() {
+	if !b.allConsumersFinishedReading() {
 		return nil
 	}
 
-	return b.Inner.Finalize(ctx)
+	return b.Inner.FinishedReading(ctx)
 }
 
-func (b *RangeVectorDuplicationBuffer) allConsumersFinalized() bool {
+func (b *RangeVectorDuplicationBuffer) allConsumersFinishedReading() bool {
 	for _, consumer := range b.consumers {
-		if !consumer.finalized {
+		if !consumer.finishedReadingCalled {
 			return false
 		}
 	}
@@ -475,8 +475,8 @@ func (b *RangeVectorDuplicationBuffer) allConsumersFinalized() bool {
 }
 
 func (b *RangeVectorDuplicationBuffer) Stats(ctx context.Context, consumer *RangeVectorDuplicationConsumer) (*types.OperatorEvaluationStats, error) {
-	if !b.allConsumersFinalized() {
-		return nil, errors.New("RangeVectorDuplicationBuffer: cannot get stats when one or more consumers are not finalized")
+	if !b.allConsumersFinishedReading() {
+		return nil, errors.New("RangeVectorDuplicationBuffer: cannot get stats when one or more consumers have not had FinishedReading called")
 	}
 
 	if consumer.hasReadStats {
@@ -586,7 +586,7 @@ type RangeVectorDuplicationConsumer struct {
 	currentUnfilteredSeriesIndex int // -1 means the consumer hasn't advanced to the first series yet.
 	nextUnfilteredSeriesIndex    int
 	currentSeriesStepIndex       int // -1 means the consumer hasn't called NextStepSamples for the current series yet.
-	finalized                    bool
+	finishedReadingCalled        bool
 	closed                       bool
 	hasReadStats                 bool
 }
@@ -605,7 +605,7 @@ func (d *RangeVectorDuplicationConsumer) SeriesMetadata(ctx context.Context, mat
 }
 
 func (d *RangeVectorDuplicationConsumer) shouldReturnUnfilteredSeries(unfilteredSeriesIndex int) bool {
-	if d.finalized {
+	if d.finishedReadingCalled {
 		return false
 	}
 
@@ -625,7 +625,7 @@ func (d *RangeVectorDuplicationConsumer) advanceToNextUnfilteredSeries() {
 }
 
 func (d *RangeVectorDuplicationConsumer) hasReadAllStepsForCurrentSeries() bool {
-	return d.finalized || d.currentSeriesStepIndex >= d.Buffer.timeRange.StepCount-1
+	return d.finishedReadingCalled || d.currentSeriesStepIndex >= d.Buffer.timeRange.StepCount-1
 }
 
 func (d *RangeVectorDuplicationConsumer) NextSeries(_ context.Context) error {
@@ -648,8 +648,8 @@ func (d *RangeVectorDuplicationConsumer) AfterPrepare(ctx context.Context) error
 	return d.Buffer.AfterPrepare(ctx)
 }
 
-func (d *RangeVectorDuplicationConsumer) Finalize(ctx context.Context) error {
-	return d.Buffer.Finalize(ctx, d)
+func (d *RangeVectorDuplicationConsumer) FinishedReading(ctx context.Context) error {
+	return d.Buffer.FinishedReading(ctx, d)
 }
 
 func (d *RangeVectorDuplicationConsumer) Stats(ctx context.Context) (*types.OperatorEvaluationStats, error) {

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator_test.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator_test.go
@@ -68,7 +68,7 @@ func TestRangeVectorOperator_Buffering_NoFiltering(t *testing.T) {
 	d, err = consumer2.NextStepSamples(ctx)
 	require.NoError(t, err)
 	requireEqualDataAndReturnToPool(t, expectedData[0], d, memoryConsumptionTracker)
-	require.Equal(t, 2, buffer.buffer.Size(), "buffered data should remain buffered until the next NextSeries or Finalize call")
+	require.Equal(t, 2, buffer.buffer.Size(), "buffered data should remain buffered until the next NextSeries or FinishedReading call")
 
 	err = consumer2.NextSeries(ctx)
 	require.NoError(t, err)
@@ -98,7 +98,7 @@ func TestRangeVectorOperator_Buffering_NoFiltering(t *testing.T) {
 	d, err = consumer1.NextStepSamples(ctx)
 	require.NoError(t, err)
 	requireEqualDataAndReturnToPool(t, expectedData[2], d, memoryConsumptionTracker)
-	require.Equal(t, 2, buffer.buffer.Size(), "buffered data should remain buffered until the next NextSeries or Finalize call")
+	require.Equal(t, 2, buffer.buffer.Size(), "buffered data should remain buffered until the next NextSeries or FinishedReading call")
 
 	err = consumer2.NextSeries(ctx)
 	require.NoError(t, err)
@@ -114,10 +114,10 @@ func TestRangeVectorOperator_Buffering_NoFiltering(t *testing.T) {
 	d, err = consumer1.NextStepSamples(ctx)
 	require.NoError(t, err)
 	requireEqualDataAndReturnToPool(t, expectedData[3], d, memoryConsumptionTracker)
-	require.Equal(t, 2, buffer.buffer.Size(), "buffered data should remain buffered until the next NextSeries or Finalize call")
+	require.Equal(t, 2, buffer.buffer.Size(), "buffered data should remain buffered until the next NextSeries or FinishedReading call")
 
-	// Finalize the first consumer, check that the data that was being buffered for it is released.
-	require.NoError(t, consumer1.Finalize(ctx))
+	// Call FinishedReading on the first consumer, check that the data that was being buffered for it is released.
+	require.NoError(t, consumer1.FinishedReading(ctx))
 	require.Equal(t, 0, buffer.buffer.Size())
 
 	// Check that the second consumer can still read data and that we don't bother buffering it.
@@ -128,15 +128,15 @@ func TestRangeVectorOperator_Buffering_NoFiltering(t *testing.T) {
 	requireEqualDataAndReturnToPool(t, expectedData[5], d, memoryConsumptionTracker)
 	require.Equal(t, 0, buffer.buffer.Size())
 
-	// Check that the inner operator hasn't been closed or finalized yet.
-	require.False(t, inner.Finalized)
+	// Check that the inner operator hasn't been closed or had FinishedReading called yet.
+	require.False(t, inner.FinishedReadingCalled)
 	require.False(t, inner.Closed)
 
-	// Finalize the second consumer, and check that the inner operator was finalized after the last consumer is finalized.
-	require.NoError(t, consumer2.Finalize(ctx))
-	require.True(t, inner.Finalized)
-	require.NoError(t, consumer1.Finalize(ctx), "it should be safe to finalize either consumer a second time")
-	require.NoError(t, consumer2.Finalize(ctx), "it should be safe to finalize either consumer a second time")
+	// Call FinishedReading on the second consumer, and check that the inner operator had FinishedReading called after the last consumer had FinishedReading called.
+	require.NoError(t, consumer2.FinishedReading(ctx))
+	require.True(t, inner.FinishedReadingCalled)
+	require.NoError(t, consumer1.FinishedReading(ctx), "it should be safe to call FinishedReading on either consumer a second time")
+	require.NoError(t, consumer2.FinishedReading(ctx), "it should be safe to call FinishedReading on either consumer a second time")
 
 	// Close both consumers, and check that the inner operator was closed.
 	consumer1.Close()
@@ -191,7 +191,7 @@ func TestRangeVectorOperator_Buffering_Filtering_AllConsumersOpen(t *testing.T) 
 	d, err = consumer2.NextStepSamples(ctx)
 	require.NoError(t, err)
 	requireEqualDataAndReturnToPool(t, expectedData[1], d, memoryConsumptionTracker)
-	require.Equal(t, 1, buffer.buffer.Size(), "buffered data should remain buffered until the next NextSeries or Finalize call")
+	require.Equal(t, 1, buffer.buffer.Size(), "buffered data should remain buffered until the next NextSeries or FinishedReading call")
 
 	err = consumer2.NextSeries(ctx)
 	require.NoError(t, err)
@@ -214,21 +214,21 @@ func TestRangeVectorOperator_Buffering_Filtering_AllConsumersOpen(t *testing.T) 
 	d, err = consumer1.NextStepSamples(ctx)
 	require.NoError(t, err)
 	requireEqualDataAndReturnToPool(t, expectedData[2], d, memoryConsumptionTracker)
-	require.Equal(t, 4, buffer.buffer.Size(), "buffered data should remain buffered until the next NextSeries or Finalize call")
+	require.Equal(t, 4, buffer.buffer.Size(), "buffered data should remain buffered until the next NextSeries or FinishedReading call")
 
-	// Finalize the first consumer, check that the data that was being buffered for it is released.
-	require.NoError(t, consumer1.Finalize(ctx))
+	// Call FinishedReading on the first consumer, check that the data that was being buffered for it is released.
+	require.NoError(t, consumer1.FinishedReading(ctx))
 	require.Equal(t, 0, buffer.buffer.Size())
 
-	// Check that the inner operator hasn't been closed or finalized yet.
-	require.False(t, inner.Finalized)
+	// Check that the inner operator hasn't been closed or had FinishedReading called yet.
+	require.False(t, inner.FinishedReadingCalled)
 	require.False(t, inner.Closed)
 
-	// Finalize the second consumer, and check that the inner operator was finalized after the last consumer is finalized.
-	require.NoError(t, consumer2.Finalize(ctx))
-	require.True(t, inner.Finalized)
-	require.NoError(t, consumer1.Finalize(ctx), "it should be safe to finalize either consumer a second time")
-	require.NoError(t, consumer2.Finalize(ctx), "it should be safe to finalize either consumer a second time")
+	// Call FinishedReading on the second consumer, and check that the inner operator had FinishedReading called after the last consumer had FinishedReading called.
+	require.NoError(t, consumer2.FinishedReading(ctx))
+	require.True(t, inner.FinishedReadingCalled)
+	require.NoError(t, consumer1.FinishedReading(ctx), "it should be safe to call FinishedReading on either consumer a second time")
+	require.NoError(t, consumer2.FinishedReading(ctx), "it should be safe to call FinishedReading on either consumer a second time")
 
 	// Close both consumers, and check that the inner operator was closed.
 	consumer1.Close()
@@ -284,7 +284,7 @@ func TestRangeVectorOperator_Buffering_Filtering_IteratingBeforeCallingSeriesMet
 	d, err = consumer2.NextStepSamples(ctx)
 	require.NoError(t, err)
 	requireEqualDataAndReturnToPool(t, expectedData[1], d, memoryConsumptionTracker)
-	require.Equal(t, 1, buffer.buffer.Size(), "buffered data should remain buffered until the next NextSeries or Finalize call")
+	require.Equal(t, 1, buffer.buffer.Size(), "buffered data should remain buffered until the next NextSeries or FinishedReading call")
 
 	err = consumer2.NextSeries(ctx)
 	require.NoError(t, err)
@@ -307,21 +307,21 @@ func TestRangeVectorOperator_Buffering_Filtering_IteratingBeforeCallingSeriesMet
 	d, err = consumer1.NextStepSamples(ctx)
 	require.NoError(t, err)
 	requireEqualDataAndReturnToPool(t, expectedData[2], d, memoryConsumptionTracker)
-	require.Equal(t, 4, buffer.buffer.Size(), "buffered data should remain buffered until the next NextSeries or Finalize call")
+	require.Equal(t, 4, buffer.buffer.Size(), "buffered data should remain buffered until the next NextSeries or FinishedReading call")
 
-	// Finalize the first consumer, check that the data that was being buffered for it is released.
-	require.NoError(t, consumer1.Finalize(ctx))
+	// Call FinishedReading on the first consumer, check that the data that was being buffered for it is released.
+	require.NoError(t, consumer1.FinishedReading(ctx))
 	require.Equal(t, 0, buffer.buffer.Size())
 
-	// Check that the inner operator hasn't been closed or finalized yet.
-	require.False(t, inner.Finalized)
+	// Check that the inner operator hasn't been closed or had FinishedReading called yet.
+	require.False(t, inner.FinishedReadingCalled)
 	require.False(t, inner.Closed)
 
-	// Finalize the remaining consumer, and check that the inner operator was finalized after the last consumer is finalized.
-	require.NoError(t, consumer2.Finalize(ctx))
-	require.True(t, inner.Finalized)
-	require.NoError(t, consumer1.Finalize(ctx), "it should be safe to finalize either consumer a second time")
-	require.NoError(t, consumer2.Finalize(ctx), "it should be safe to finalize either consumer a second time")
+	// Call FinishedReading on the remaining consumer, and check that the inner operator had FinishedReading called after the last consumer had FinishedReading called.
+	require.NoError(t, consumer2.FinishedReading(ctx))
+	require.True(t, inner.FinishedReadingCalled)
+	require.NoError(t, consumer1.FinishedReading(ctx), "it should be safe to call FinishedReading on either consumer a second time")
+	require.NoError(t, consumer2.FinishedReading(ctx), "it should be safe to call FinishedReading on either consumer a second time")
 
 	// Close both consumers, and check that the inner operator was closed.
 	consumer1.Close()
@@ -335,7 +335,7 @@ func TestRangeVectorOperator_Buffering_Filtering_IteratingBeforeCallingSeriesMet
 	requireNoMemoryConsumption(t, memoryConsumptionTracker)
 }
 
-func TestRangeVectorOperator_Buffering_Filtering_DoesNotBufferForFinalizedConsumer(t *testing.T) {
+func TestRangeVectorOperator_Buffering_Filtering_DoesNotBufferForConsumerFinishedReading(t *testing.T) {
 	ctx := context.Background()
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	inner, expectedData := createTestRangeVectorOperator(t, 6, memoryConsumptionTracker)
@@ -363,13 +363,13 @@ func TestRangeVectorOperator_Buffering_Filtering_DoesNotBufferForFinalizedConsum
 	requireEqualDataAndReturnToPool(t, expectedData[1], d, memoryConsumptionTracker)
 	require.Equal(t, 2, buffer.buffer.Size(), "the first and second series should be buffered for the first consumer")
 
-	// The data being buffered for the first consumer should be released when it's finalized.
-	require.NoError(t, consumer1.Finalize(ctx))
+	// The data being buffered for the first consumer should be released when FinishedReading is called.
+	require.NoError(t, consumer1.FinishedReading(ctx))
 	require.Equal(t, 0, buffer.buffer.Size())
 	consumer1.Close()
 
-	// Check that the inner operator hasn't been closed or finalized yet.
-	require.False(t, inner.Finalized)
+	// Check that the inner operator hasn't been closed or had FinishedReading called yet.
+	require.False(t, inner.FinishedReadingCalled)
 	require.False(t, inner.Closed)
 
 	// Keep reading data for the second consumer, confirm that no further data is buffered for the first consumer.
@@ -387,11 +387,11 @@ func TestRangeVectorOperator_Buffering_Filtering_DoesNotBufferForFinalizedConsum
 	requireEqualDataAndReturnToPool(t, expectedData[5], d, memoryConsumptionTracker)
 	require.Equal(t, 0, buffer.buffer.Size())
 
-	// Finalize each consumer, and check that the inner operator was only finalized after the last consumer is finalized.
-	require.NoError(t, consumer2.Finalize(ctx))
-	require.True(t, inner.Finalized)
-	require.NoError(t, consumer1.Finalize(ctx), "it should be safe to finalize either consumer a second time")
-	require.NoError(t, consumer2.Finalize(ctx), "it should be safe to finalize either consumer a second time")
+	// Call FinishedReading on each consumer, and check that the inner operator had FinishedReading called only after the last consumer had FinishedReading called.
+	require.NoError(t, consumer2.FinishedReading(ctx))
+	require.True(t, inner.FinishedReadingCalled)
+	require.NoError(t, consumer1.FinishedReading(ctx), "it should be safe to call FinishedReading on either consumer a second time")
+	require.NoError(t, consumer2.FinishedReading(ctx), "it should be safe to call FinishedReading on either consumer a second time")
 
 	// Close the second consumer, and check that the inner operator was closed.
 	consumer2.Close()
@@ -440,18 +440,18 @@ func TestRangeVectorOperator_Buffering_Filtering_DoesNotBufferUnnecessarilyForLa
 	requireEqualDataAndReturnToPool(t, expectedData[2], d, memoryConsumptionTracker)
 	require.Equal(t, 1, buffer.buffer.Size(), "only the first series should be buffered for the first consumer")
 
-	// The data being buffered for the first consumer should be released when it's finalized.
-	require.NoError(t, consumer1.Finalize(ctx))
+	// The data being buffered for the first consumer should be released when FinishedReading is called.
+	require.NoError(t, consumer1.FinishedReading(ctx))
 	require.Equal(t, 0, buffer.buffer.Size())
 	consumer1.Close()
 
-	// Check that the inner operator hasn't been closed or finalized yet.
-	require.False(t, inner.Finalized)
+	// Check that the inner operator hasn't been closed or had FinishedReading called yet.
+	require.False(t, inner.FinishedReadingCalled)
 	require.False(t, inner.Closed)
 
 	// And the same for the second consumer.
-	require.NoError(t, consumer2.Finalize(ctx))
-	require.True(t, inner.Finalized)
+	require.NoError(t, consumer2.FinishedReading(ctx))
+	require.True(t, inner.FinishedReadingCalled)
 	consumer2.Close()
 	require.True(t, inner.Closed)
 	requireNoMemoryConsumption(t, memoryConsumptionTracker)
@@ -512,9 +512,9 @@ func TestRangeVectorOperator_Buffering_NonContiguousSeries(t *testing.T) {
 	requireEqualDataAndReturnToPool(t, expectedData[3], d, memoryConsumptionTracker)
 	require.Equal(t, 3, buffer.buffer.Size())
 
-	require.NoError(t, consumer1.Finalize(ctx))
+	require.NoError(t, consumer1.FinishedReading(ctx))
 	consumer1.Close()
-	require.False(t, inner.Finalized)
+	require.False(t, inner.FinishedReadingCalled)
 	require.False(t, inner.Closed)
 
 	// Read all the data from consumer 3.
@@ -532,10 +532,10 @@ func TestRangeVectorOperator_Buffering_NonContiguousSeries(t *testing.T) {
 	requireEqualDataAndReturnToPool(t, expectedData[3], d, memoryConsumptionTracker)
 	require.Equal(t, 3, buffer.buffer.Size(), "buffer size should be unchanged as series at index 0 is required for consumer 2, index 1 should be tombstoned, index 2 will be released on next interaction")
 
-	require.NoError(t, consumer3.Finalize(ctx))
+	require.NoError(t, consumer3.FinishedReading(ctx))
 	consumer3.Close()
 	require.Equal(t, 1, buffer.buffer.Size(), "should only be buffering series required by consumer 2 (series 0)")
-	require.False(t, inner.Finalized)
+	require.False(t, inner.FinishedReadingCalled)
 	require.False(t, inner.Closed)
 
 	// Read all the data from consumer 2
@@ -544,13 +544,13 @@ func TestRangeVectorOperator_Buffering_NonContiguousSeries(t *testing.T) {
 	d, err = consumer2.NextStepSamples(ctx)
 	require.NoError(t, err)
 	requireEqualDataAndReturnToPool(t, expectedData[0], d, memoryConsumptionTracker)
-	require.Equal(t, 1, buffer.buffer.Size(), "buffered data should remain buffered until the next NextSeries or Finalize call")
+	require.Equal(t, 1, buffer.buffer.Size(), "buffered data should remain buffered until the next NextSeries or FinishedReading call")
 
 	// Make sure everything is cleaned up properly.
-	require.False(t, inner.Finalized)
+	require.False(t, inner.FinishedReadingCalled)
 	require.False(t, inner.Closed)
-	require.NoError(t, consumer2.Finalize(ctx))
-	require.True(t, inner.Finalized)
+	require.NoError(t, consumer2.FinishedReading(ctx))
+	require.True(t, inner.FinishedReadingCalled)
 	consumer2.Close()
 	require.True(t, inner.Closed)
 	requireNoMemoryConsumption(t, memoryConsumptionTracker)
@@ -584,7 +584,7 @@ func TestRangeVectorOperator_Filtering_SingleConsumer(t *testing.T) {
 	}
 }
 
-func TestRangeVectorOperator_FinalizedWithBufferedData_NoFiltering(t *testing.T) {
+func TestRangeVectorOperator_FinishedReadingCalledWithBufferedData_NoFiltering(t *testing.T) {
 	ctx := context.Background()
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	inner, expectedData := createTestRangeVectorOperator(t, 3, memoryConsumptionTracker)
@@ -624,8 +624,8 @@ func TestRangeVectorOperator_FinalizedWithBufferedData_NoFiltering(t *testing.T)
 	requireEqualDataAndReturnToPool(t, expectedData[2], d, memoryConsumptionTracker)
 	require.Equal(t, 3, buffer.buffer.Size())
 
-	// Finalize the first consumer, and check the data remains buffered for the second consumer.
-	require.NoError(t, consumer1.Finalize(ctx))
+	// Call FinishedReading on the first consumer, and check the data remains buffered for the second consumer.
+	require.NoError(t, consumer1.FinishedReading(ctx))
 	require.Equal(t, 3, buffer.buffer.Size())
 
 	// Read some of the buffered data.
@@ -634,11 +634,11 @@ func TestRangeVectorOperator_FinalizedWithBufferedData_NoFiltering(t *testing.T)
 	d, err = consumer2.NextStepSamples(ctx)
 	require.NoError(t, err)
 	requireEqualDataAndReturnToPool(t, expectedData[0], d, memoryConsumptionTracker)
-	require.Equal(t, 3, buffer.buffer.Size(), "buffered data should remain in the buffer until the next NextSeries or Finalize call")
+	require.Equal(t, 3, buffer.buffer.Size(), "buffered data should remain in the buffer until the next NextSeries or FinishedReading call")
 
-	// Finalize the second consumer, and check that the inner operator was finalized and all buffered data was released.
-	require.NoError(t, consumer2.Finalize(ctx))
-	require.True(t, inner.Finalized)
+	// Call FinishedReading on the second consumer, and check that the inner operator had FinishedReading called and all buffered data was released.
+	require.NoError(t, consumer2.FinishedReading(ctx))
+	require.True(t, inner.FinishedReadingCalled)
 
 	consumer1.Close()
 	consumer2.Close()
@@ -650,7 +650,7 @@ func TestRangeVectorOperator_FinalizedWithBufferedData_NoFiltering(t *testing.T)
 	requireNoMemoryConsumption(t, memoryConsumptionTracker)
 }
 
-func TestRangeVectorOperator_FinalizedWithBufferedData_Filtering(t *testing.T) {
+func TestRangeVectorOperator_FinishedReadingCalledWithBufferedData_Filtering(t *testing.T) {
 	ctx := context.Background()
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 	inner, expectedData := createTestRangeVectorOperator(t, 3, memoryConsumptionTracker)
@@ -686,7 +686,7 @@ func TestRangeVectorOperator_FinalizedWithBufferedData_Filtering(t *testing.T) {
 	}
 
 	require.Equal(t, 3, buffer.buffer.Size(), "buffer should contain all three series for the remaining two consumers")
-	require.NoError(t, consumer2.Finalize(ctx))
+	require.NoError(t, consumer2.FinishedReading(ctx))
 	require.Equal(t, 1, buffer.buffer.Size(), "buffer should only contain remaining series required by remaining consumer")
 
 	err = consumer3.NextSeries(ctx)
@@ -694,11 +694,11 @@ func TestRangeVectorOperator_FinalizedWithBufferedData_Filtering(t *testing.T) {
 	d, err := consumer3.NextStepSamples(ctx)
 	require.NoError(t, err)
 	requireEqualDataAndReturnToPool(t, expectedData[1], d, memoryConsumptionTracker)
-	require.Equal(t, 1, buffer.buffer.Size(), "buffered data should remain in the buffer until the next NextSeries or Finalize call")
+	require.Equal(t, 1, buffer.buffer.Size(), "buffered data should remain in the buffer until the next NextSeries or FinishedReading call")
 
-	require.NoError(t, consumer3.Finalize(ctx))
+	require.NoError(t, consumer3.FinishedReading(ctx))
 	require.Equal(t, 0, buffer.buffer.Size())
-	require.NoError(t, consumer1.Finalize(ctx))
+	require.NoError(t, consumer1.FinishedReading(ctx))
 	requireNoMemoryConsumption(t, memoryConsumptionTracker)
 }
 
@@ -1046,7 +1046,7 @@ func (o *failingRangeVectorOperator) Prepare(_ context.Context, _ *types.Prepare
 	return nil
 }
 
-func (o *failingRangeVectorOperator) Finalize(_ context.Context) error {
+func (o *failingRangeVectorOperator) FinishedReading(_ context.Context) error {
 	return nil
 }
 
@@ -1146,9 +1146,9 @@ func TestRangeVectorOperator_Stats(t *testing.T) {
 	require.NoError(t, err)
 	requireEqualDataAndReturnToPool(t, types.InstantVectorSeriesData{Floats: []promql.FPoint{{T: 0, F: float64(3)}}}, data, memoryConsumptionTracker)
 
-	// Finalize both operators, and check that the statistics are calculated correctly.
-	require.NoError(t, consumer1.Finalize(ctx))
-	require.NoError(t, consumer2.Finalize(ctx))
+	// Call FinishedReading on both operators, and check that the statistics are calculated correctly.
+	require.NoError(t, consumer1.FinishedReading(ctx))
+	require.NoError(t, consumer2.FinishedReading(ctx))
 
 	requireStats(t, consumer1, ctx, 3, 3)
 	requireStats(t, consumer2, ctx, 1, 1)
@@ -1293,11 +1293,11 @@ func TestRangeVectorOperator_RangeQuery(t *testing.T) {
 	require.Equal(t, types.EOS, err)
 	require.Nil(t, d)
 
-	// Finalize consumer2 so that consumer1 is the only remaining consumer.
+	// Call FinishedReading on consumer2 so that consumer1 is the only remaining consumer.
 	// consumer1 will then read series 2 without buffering.
-	require.NoError(t, consumer2.Finalize(ctx))
+	require.NoError(t, consumer2.FinishedReading(ctx))
 	consumer2.Close()
-	require.False(t, inner.finalized, "inner should not be finalized until all consumers are finalized")
+	require.False(t, inner.finishedReadingCalled, "inner should not have FinishedReading called until all consumers have FinishedReading called")
 
 	require.NoError(t, consumer1.NextSeries(ctx))
 	require.Equal(t, 0, buffer.buffer.Size())
@@ -1321,8 +1321,8 @@ func TestRangeVectorOperator_RangeQuery(t *testing.T) {
 	require.Equal(t, types.EOS, err)
 	require.Nil(t, d)
 
-	require.NoError(t, consumer1.Finalize(ctx))
-	require.True(t, inner.finalized)
+	require.NoError(t, consumer1.FinishedReading(ctx))
+	require.True(t, inner.finishedReadingCalled)
 
 	consumer1.Close()
 	require.True(t, inner.closed)
@@ -1331,13 +1331,13 @@ func TestRangeVectorOperator_RangeQuery(t *testing.T) {
 
 type rangeVectorOperatorStateTracker struct {
 	types.RangeVectorOperator
-	finalized bool
-	closed    bool
+	finishedReadingCalled bool
+	closed                bool
 }
 
-func (r *rangeVectorOperatorStateTracker) Finalize(ctx context.Context) error {
-	r.finalized = true
-	return r.RangeVectorOperator.Finalize(ctx)
+func (r *rangeVectorOperatorStateTracker) FinishedReading(ctx context.Context) error {
+	r.finishedReadingCalled = true
+	return r.RangeVectorOperator.FinishedReading(ctx)
 }
 
 func (r *rangeVectorOperatorStateTracker) Close() {

--- a/pkg/streamingpromql/optimize/plan/multiaggregation/operator.go
+++ b/pkg/streamingpromql/optimize/plan/multiaggregation/operator.go
@@ -131,20 +131,20 @@ func (m *MultiAggregatorGroupEvaluator) findIndexOfLastInstanceToConsumeSeries(u
 	return -1
 }
 
-func (m *MultiAggregatorGroupEvaluator) Finalize(ctx context.Context) error {
-	// Only finalize the inner operator if all instances have been finalized.
+func (m *MultiAggregatorGroupEvaluator) FinishedReading(ctx context.Context) error {
+	// Only call FinishedReading on the inner operator if all instances have had FinishedReading called.
 	for _, instance := range m.instances {
-		if !instance.finalized {
+		if !instance.finishedReadingCalled {
 			return nil
 		}
 	}
 
-	return m.inner.Finalize(ctx)
+	return m.inner.FinishedReading(ctx)
 }
 
 func (m *MultiAggregatorGroupEvaluator) Stats(ctx context.Context, instance *MultiAggregatorInstanceOperator) (*types.OperatorEvaluationStats, error) {
-	if !m.allInstancesFinalized() {
-		return nil, errors.New("MultiAggregatorGroupEvaluator: cannot get stats when one or more instances are not finalized")
+	if !m.allInstancesFinishedReading() {
+		return nil, errors.New("MultiAggregatorGroupEvaluator: cannot get stats when one or more instances have not had FinishedReading called")
 	}
 
 	if instance.hasReadStats {
@@ -194,9 +194,9 @@ func (m *MultiAggregatorGroupEvaluator) Stats(ctx context.Context, instance *Mul
 	return stats, nil
 }
 
-func (m *MultiAggregatorGroupEvaluator) allInstancesFinalized() bool {
+func (m *MultiAggregatorGroupEvaluator) allInstancesFinishedReading() bool {
 	for _, instance := range m.instances {
-		if !instance.finalized {
+		if !instance.finishedReadingCalled {
 			return false
 		}
 	}
@@ -244,9 +244,9 @@ type MultiAggregatorInstanceOperator struct {
 
 	outputSeriesMetadata []types.SeriesMetadata
 
-	finalized    bool
-	hasReadStats bool
-	closed       bool
+	finishedReadingCalled bool
+	hasReadStats          bool
+	closed                bool
 }
 
 var _ types.InstantVectorOperator = (*MultiAggregatorInstanceOperator)(nil)
@@ -378,21 +378,21 @@ func (m *MultiAggregatorInstanceOperator) needToConsumeSeries(unfilteredSeriesIn
 	return m.unfilteredSeriesBitmap[unfilteredSeriesIndex]
 }
 
-func (m *MultiAggregatorInstanceOperator) Finalize(ctx context.Context) error {
-	if m.finalized {
+func (m *MultiAggregatorInstanceOperator) FinishedReading(ctx context.Context) error {
+	if m.finishedReadingCalled {
 		return nil
 	}
 
 	if m.aggregator != nil {
-		m.aggregator.Finalize()
+		m.aggregator.FinishedReading()
 		m.aggregator = nil
 	}
 
 	types.BoolSlicePool.Put(&m.unfilteredSeriesBitmap, m.group.memoryConsumptionTracker)
 	types.SeriesMetadataSlicePool.Put(&m.outputSeriesMetadata, m.group.memoryConsumptionTracker)
 
-	m.finalized = true
-	return m.group.Finalize(ctx)
+	m.finishedReadingCalled = true
+	return m.group.FinishedReading(ctx)
 }
 
 func (m *MultiAggregatorInstanceOperator) Stats(ctx context.Context) (*types.OperatorEvaluationStats, error) {

--- a/pkg/streamingpromql/optimize/plan/multiaggregation/operator_test.go
+++ b/pkg/streamingpromql/optimize/plan/multiaggregation/operator_test.go
@@ -25,7 +25,7 @@ import (
 
 // Most of the operator logic is exercised by the tests in pkg/streamingpromql/testdata/ours/multi_aggregation.test.
 // The tests below cover behaviour that is difficult or impossible to exercise through PromQL test scripts.
-func TestOperator_FinalizeAndCloseBehaviour(t *testing.T) {
+func TestOperator_FinishedReadingAndCloseBehaviour(t *testing.T) {
 	ctx := context.Background()
 	inner := &operators.TestOperator{}
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
@@ -34,12 +34,12 @@ func TestOperator_FinalizeAndCloseBehaviour(t *testing.T) {
 	instance1 := group.AddInstance()
 	instance2 := group.AddInstance()
 
-	require.NoError(t, instance1.Finalize(ctx))
-	require.False(t, inner.Finalized, "should only finalize inner operator after all instances have been finalized")
-	require.NoError(t, instance1.Finalize(ctx))
-	require.False(t, inner.Finalized, "should ignore second Finalize call from instance already finalized")
-	require.NoError(t, instance2.Finalize(ctx))
-	require.True(t, inner.Finalized, "should finalize inner operator after all instances have been finalized")
+	require.NoError(t, instance1.FinishedReading(ctx))
+	require.False(t, inner.FinishedReadingCalled, "should only call FinishedReading on inner operator after all instances have had FinishedReading called")
+	require.NoError(t, instance1.FinishedReading(ctx))
+	require.False(t, inner.FinishedReadingCalled, "should ignore second FinishedReading call from instance that already had FinishedReading called")
+	require.NoError(t, instance2.FinishedReading(ctx))
+	require.True(t, inner.FinishedReadingCalled, "should call FinishedReading on inner operator after all instances have had FinishedReading called")
 
 	instance1.Close()
 	require.False(t, inner.Closed, "should only close inner operator after all instances have been closed")
@@ -111,9 +111,9 @@ func TestOperator_Stats(t *testing.T) {
 	require.Equal(t, types.InstantVectorSeriesData{Floats: []promql.FPoint{{T: 0, F: float64(3)}}}, data, "second consumer should get expected result")
 	types.PutInstantVectorSeriesData(data, memoryConsumptionTracker)
 
-	// Finalize both operators, and check that the statistics are calculated correctly.
-	require.NoError(t, instance1.Finalize(ctx))
-	require.NoError(t, instance2.Finalize(ctx))
+	// Call FinishedReading on both operators, and check that the statistics are calculated correctly.
+	require.NoError(t, instance1.FinishedReading(ctx))
+	require.NoError(t, instance2.FinishedReading(ctx))
 
 	requireStats(t, instance1, ctx, 3, 3)
 	requireStats(t, instance2, ctx, 1, 1)

--- a/pkg/streamingpromql/optimize/plan/rangevectorsplitting/operator.go
+++ b/pkg/streamingpromql/optimize/plan/rangevectorsplitting/operator.go
@@ -67,9 +67,9 @@ type FunctionOverRangeVectorSplit[T any] struct {
 	seriesToSplits   [][]SplitSeries
 	currentSeriesIdx int
 
-	metadataConsumed bool
-	finalized        bool
-	storedInCache    bool
+	metadataConsumed      bool
+	finishedReadingCalled bool
+	storedInCache         bool
 
 	logger     log.Logger
 	cacheStats *cache.CacheStats
@@ -78,8 +78,8 @@ type FunctionOverRangeVectorSplit[T any] struct {
 	prepareEnd               time.Time
 	seriesMetadataStart      time.Time
 	seriesMetadataEnd        time.Time
-	finalizeStart            time.Time
-	finalizeEnd              time.Time
+	finishedReadingStart     time.Time
+	finishedReadingEnd       time.Time
 	storeResultsInCacheStart time.Time
 	storeResultsInCacheEnd   time.Time
 }
@@ -446,22 +446,22 @@ func (m *FunctionOverRangeVectorSplit[T]) emitAnnotation(generator types.Annotat
 	m.Annotations.Add(generator(metricName, m.innerNodeExpressionPosition))
 }
 
-func (m *FunctionOverRangeVectorSplit[T]) Finalize(ctx context.Context) error {
-	// Don't finalize again if we have finalized already
-	if m.finalized {
+func (m *FunctionOverRangeVectorSplit[T]) FinishedReading(ctx context.Context) error {
+	// Don't call FinishedReading again if we have already done so
+	if m.finishedReadingCalled {
 		return nil
 	}
 
-	m.finalizeStart = time.Now()
+	m.finishedReadingStart = time.Now()
 
 	for _, split := range m.splits {
-		if err := split.Finalize(ctx); err != nil {
+		if err := split.FinishedReading(ctx); err != nil {
 			return err
 		}
 	}
 
-	m.finalizeEnd = time.Now()
-	m.finalized = true
+	m.finishedReadingEnd = time.Now()
+	m.finishedReadingCalled = true
 	return nil
 }
 
@@ -472,8 +472,8 @@ func (m *FunctionOverRangeVectorSplit[T]) storeResultsInCache(ctx context.Contex
 	if m.storedInCache {
 		return errors.New("should not call FunctionOverRangeVectorSplit.storeResultsInCache multiple times")
 	}
-	if !m.finalized {
-		return errors.New("should not call FunctionOverRangeVectorSplit.storeResultsInCache before Finalize")
+	if !m.finishedReadingCalled {
+		return errors.New("should not call FunctionOverRangeVectorSplit.storeResultsInCache before FinishedReading")
 	}
 
 	// Don't cache in cases where not all series have been processed. It's possible for not all series to be processed
@@ -539,8 +539,8 @@ func (m *FunctionOverRangeVectorSplit[T]) storeResultsInCache(ctx context.Contex
 		"total_cache_bytes", m.cacheStats.TotalBytes,
 		"prepare_duration", m.prepareEnd.Sub(m.prepareStart),
 		"series_metadata_duration", m.seriesMetadataEnd.Sub(m.seriesMetadataStart),
-		"metadata_end_to_finalize_start_duration", m.finalizeStart.Sub(m.seriesMetadataEnd),
-		"finalize_duration", m.finalizeEnd.Sub(m.finalizeStart),
+		"metadata_end_to_finished_reading_start_duration", m.finishedReadingStart.Sub(m.seriesMetadataEnd),
+		"finished_reading_duration", m.finishedReadingEnd.Sub(m.finishedReadingStart),
 		"store_results_in_cache_duration", m.storeResultsInCacheEnd.Sub(m.storeResultsInCacheStart),
 		"total_duration", m.storeResultsInCacheEnd.Sub(m.prepareStart),
 	)
@@ -598,7 +598,7 @@ type Split[T any] interface {
 	// This is used to make sure annotations emitted when generating the result for an uncached split reference the
 	// correct metric name.
 	AppendMergedSeriesIndex(splitLocalIdx int, mergedIdx int)
-	Finalize(ctx context.Context) error
+	FinishedReading(ctx context.Context) error
 	// Stats returns the stats for the split, with one OperatorEvaluationStats instance per range.
 	// The caller must not modify the returned slice or the instances within it.
 	// The implementation is responsible for closing the returned stats instances when Close() is called.
@@ -686,7 +686,7 @@ func (c *CachedSplit[T]) GetResultsAt(_ context.Context, idx int) ([]T, error) {
 	return []T{c.results[idx]}, nil
 }
 
-func (c *CachedSplit[T]) Finalize(_ context.Context) error {
+func (c *CachedSplit[T]) FinishedReading(_ context.Context) error {
 	for _, w := range c.annotations.Warnings {
 		c.parent.Annotations.Add(querierpb.NewWarningAnnotation(w))
 	}
@@ -732,8 +732,8 @@ type UncachedSplit[T any] struct {
 	localToMergedIdx      []int
 	currentLocalSeriesIdx int
 
-	finalized    bool
-	resultGetter *ResultGetter[T]
+	finishedReadingCalled bool
+	resultGetter          *ResultGetter[T]
 }
 
 func (p *UncachedSplit[T]) RangeCount() int {
@@ -758,13 +758,13 @@ func NewUncachedSplit[T any](
 	}
 
 	return &UncachedSplit[T]{
-		ranges:              ranges,
-		operator:            operator,
-		parent:              parent,
-		rangeResults:        rangeResults,
-		rangeAnnotations:    rangeAnnotations,
-		rangeSeriesMetadata: rangeSeriesMetadata,
-		finalized:           false,
+		ranges:                ranges,
+		operator:              operator,
+		parent:                parent,
+		rangeResults:          rangeResults,
+		rangeAnnotations:      rangeAnnotations,
+		rangeSeriesMetadata:   rangeSeriesMetadata,
+		finishedReadingCalled: false,
 	}, nil
 }
 
@@ -847,16 +847,16 @@ func (p *UncachedSplit[T]) emitAndCaptureAnnotation(rangeIdx int, localSeriesIdx
 	p.rangeAnnotations[rangeIdx].Add(annotationErr)
 }
 
-func (p *UncachedSplit[T]) Finalize(ctx context.Context) error {
-	if p.finalized {
+func (p *UncachedSplit[T]) FinishedReading(ctx context.Context) error {
+	if p.finishedReadingCalled {
 		return nil
 	}
 
-	if err := p.operator.Finalize(ctx); err != nil {
+	if err := p.operator.FinishedReading(ctx); err != nil {
 		return err
 	}
 
-	p.finalized = true
+	p.finishedReadingCalled = true
 
 	return nil
 }

--- a/pkg/streamingpromql/optimize/plan/rangevectorsplitting/range_vector_splitting_test.go
+++ b/pkg/streamingpromql/optimize/plan/rangevectorsplitting/range_vector_splitting_test.go
@@ -1234,7 +1234,7 @@ func TestQuerySplitting_NoMetadataConsumption_DoesNotCache(t *testing.T) {
 	baseT := timestamp.Time(0)
 
 	// nonexistent_metric returns no series, so the binary op short-circuits.
-	// This means Finalize() is called on the sum_over_time split operator without SeriesMetadata() being called first.
+	// This means FinishedReading() is called on the sum_over_time split operator without SeriesMetadata() being called first.
 	expr := "nonexistent_metric + sum_over_time(test_metric[24h])"
 	ts := baseT.Add(25 * time.Hour)
 
@@ -1262,7 +1262,7 @@ func TestQuerySplitting_PartialConsumption_DoesNotCache(t *testing.T) {
 
 	// `and on(env)` matches only env=1. The split operator (left) returns 2 series from
 	// SeriesMetadata, but `and` only consumes the first (env=1) via NextSeries before
-	// finalizing the left side. The second series (env=2) is never consumed.
+	// finishing reading from the left side. The second series (env=2) is never consumed.
 	expr := `sum_over_time(some_metric[5h]) and on(env) filter_metric`
 
 	result, stats := runInstantQuery(t, mimirEngine, promStorage, expr, ts)

--- a/pkg/streamingpromql/optimize/plan/remoteexec/executor.go
+++ b/pkg/streamingpromql/optimize/plan/remoteexec/executor.go
@@ -64,19 +64,19 @@ type RemoteExecutionResponse interface {
 	// Calling another method before calling Start may lead to unpredictable behaviour.
 	Start(ctx context.Context) error
 
-	// Finalize finishes evaluation of the request.
+	// FinishedReading finishes evaluation of the request.
 	//
 	// If there is any unread data for this request, it is discarded.
 	//
 	// If this is the last request in a group, it returns the annotations and group statistics from the remote evaluation, or otherwise returns an empty set of annotations
 	// and statistics.
 	//
-	// Finalize can only be called before Close is called.
-	Finalize(ctx context.Context) (*annotations.Annotations, stats.Stats, error)
+	// FinishedReading can only be called before Close is called.
+	FinishedReading(ctx context.Context) (*annotations.Annotations, stats.Stats, error)
 
 	// Stats returns the evaluation stats for this request.
 	//
-	// Stats must only be called once. It may only be called after Finalize has been called for all requests in the group and before Close.
+	// Stats must only be called once. It may only be called after FinishedReading has been called for all requests in the group and before Close.
 	Stats(ctx context.Context) (*types.OperatorEvaluationStats, error)
 
 	// Close cleans up any resources associated with this request.

--- a/pkg/streamingpromql/optimize/plan/remoteexec/instant_vector_operator.go
+++ b/pkg/streamingpromql/optimize/plan/remoteexec/instant_vector_operator.go
@@ -19,8 +19,8 @@ type InstantVectorRemoteExec struct {
 	Annotations        *annotations.Annotations
 	expressionPosition posrange.PositionRange
 
-	resp      InstantVectorRemoteExecutionResponse
-	finalized bool
+	resp                  InstantVectorRemoteExecutionResponse
+	finishedReadingCalled bool
 }
 
 var _ types.InstantVectorOperator = &InstantVectorRemoteExec{}
@@ -47,14 +47,14 @@ func (r *InstantVectorRemoteExec) NextSeries(ctx context.Context) (types.Instant
 	return r.resp.GetNextSeries(ctx)
 }
 
-func (r *InstantVectorRemoteExec) Finalize(ctx context.Context) error {
-	if r.finalized {
+func (r *InstantVectorRemoteExec) FinishedReading(ctx context.Context) error {
+	if r.finishedReadingCalled {
 		return nil
 	}
 
-	r.finalized = true
+	r.finishedReadingCalled = true
 
-	return finalize(ctx, r.resp, r.Annotations)
+	return finishedReading(ctx, r.resp, r.Annotations)
 }
 
 func (r *InstantVectorRemoteExec) ExpressionPosition() posrange.PositionRange {
@@ -70,5 +70,5 @@ func (r *InstantVectorRemoteExec) Close() {
 		r.resp.Close()
 	}
 
-	r.finalized = true // Don't try to finalize from a closed stream.
+	r.finishedReadingCalled = true // Don't try to call FinishedReading from a closed stream.
 }

--- a/pkg/streamingpromql/optimize/plan/remoteexec/instant_vector_operator_test.go
+++ b/pkg/streamingpromql/optimize/plan/remoteexec/instant_vector_operator_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestInstantVectorRemoteExec_FinalizeCalledAfterClosed(t *testing.T) {
-	resp := &finalizationTestMockResponse{}
+func TestInstantVectorRemoteExec_FinishedReadingCalledAfterClosed(t *testing.T) {
+	resp := &finishedReadingTestMockResponse{}
 
 	o := &InstantVectorRemoteExec{
 		Annotations: annotations.New(),
@@ -21,6 +21,6 @@ func TestInstantVectorRemoteExec_FinalizeCalledAfterClosed(t *testing.T) {
 	o.Close()
 	require.True(t, resp.Closed, "the response should have been closed")
 
-	require.NoError(t, o.Finalize(context.Background()))
-	require.False(t, resp.Finalized, "calling Finalize after Close should not try to read from the response stream")
+	require.NoError(t, o.FinishedReading(context.Background()))
+	require.False(t, resp.FinishedReadingCalled, "calling FinishedReading after Close should not try to read from the response stream")
 }

--- a/pkg/streamingpromql/optimize/plan/remoteexec/operators.go
+++ b/pkg/streamingpromql/optimize/plan/remoteexec/operators.go
@@ -10,8 +10,8 @@ import (
 	"github.com/grafana/mimir/pkg/querier/stats"
 )
 
-func finalize(ctx context.Context, resp RemoteExecutionResponse, annos *annotations.Annotations) error {
-	newAnnos, remoteStats, err := resp.Finalize(ctx)
+func finishedReading(ctx context.Context, resp RemoteExecutionResponse, annos *annotations.Annotations) error {
+	newAnnos, remoteStats, err := resp.FinishedReading(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/streamingpromql/optimize/plan/remoteexec/operators_test.go
+++ b/pkg/streamingpromql/optimize/plan/remoteexec/operators_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
 )
 
-func TestFinalize(t *testing.T) {
+func TestFinishedReading(t *testing.T) {
 	querierStats, ctx := stats.ContextWithEmptyStats(context.Background())
 	annos := annotations.New()
 
@@ -29,7 +29,7 @@ func TestFinalize(t *testing.T) {
 	resp.annos.Add(annotations.NewMixedFloatsHistogramsWarning("mixed_metric", posrange.PositionRange{Start: 5, End: 6}))
 	resp.annos.Add(annotations.NewHistogramIgnoredInMixedRangeInfo("another_mixed_metric", posrange.PositionRange{Start: 5, End: 6}))
 
-	err := finalize(ctx, resp, annos)
+	err := finishedReading(ctx, resp, annos)
 	require.NoError(t, err)
 	require.Zero(t, querierStats.SamplesProcessed, "should not directly update number of samples processed on querier stats as this will be captured by the frontend when the query is complete")
 	require.Equal(t, uint64(9000), querierStats.FetchedChunkBytes)
@@ -46,7 +46,7 @@ func TestFinalize(t *testing.T) {
 	})
 }
 
-func TestFinalize_EmptyAnnotationsAndStats(t *testing.T) {
+func TestFinishedReading_EmptyAnnotationsAndStats(t *testing.T) {
 	querierStats, ctx := stats.ContextWithEmptyStats(context.Background())
 	annos := annotations.New()
 
@@ -58,7 +58,7 @@ func TestFinalize_EmptyAnnotationsAndStats(t *testing.T) {
 		annos: nil,
 	}
 
-	err := finalize(ctx, resp, annos)
+	err := finishedReading(ctx, resp, annos)
 	require.NoError(t, err)
 	require.Zero(t, querierStats.SamplesProcessed, "should not directly update number of samples processed on querier stats as this will be captured by the frontend when the query is complete")
 
@@ -81,7 +81,7 @@ func (m *mockResponse) Start(ctx context.Context) error {
 	return nil
 }
 
-func (m *mockResponse) Finalize(ctx context.Context) (*annotations.Annotations, stats.Stats, error) {
+func (m *mockResponse) FinishedReading(ctx context.Context) (*annotations.Annotations, stats.Stats, error) {
 	return m.annos, m.stats, nil
 }
 
@@ -93,44 +93,44 @@ func (m *mockResponse) Close() {
 	panic("should not be called")
 }
 
-type finalizationTestMockResponse struct {
-	Closed    bool
-	Finalized bool
+type finishedReadingTestMockResponse struct {
+	Closed                bool
+	FinishedReadingCalled bool
 }
 
-func (m *finalizationTestMockResponse) Start(ctx context.Context) error {
+func (m *finishedReadingTestMockResponse) Start(ctx context.Context) error {
 	return nil
 }
 
-func (m *finalizationTestMockResponse) Finalize(ctx context.Context) (*annotations.Annotations, stats.Stats, error) {
-	m.Finalized = true
+func (m *finishedReadingTestMockResponse) FinishedReading(ctx context.Context) (*annotations.Annotations, stats.Stats, error) {
+	m.FinishedReadingCalled = true
 	return annotations.New(), stats.Stats{}, nil
 }
 
-func (m *finalizationTestMockResponse) Stats(ctx context.Context) (*types.OperatorEvaluationStats, error) {
+func (m *finishedReadingTestMockResponse) Stats(ctx context.Context) (*types.OperatorEvaluationStats, error) {
 	panic("not supported")
 }
 
-func (m *finalizationTestMockResponse) Close() {
+func (m *finishedReadingTestMockResponse) Close() {
 	m.Closed = true
 }
 
-func (m *finalizationTestMockResponse) GetSeriesMetadata(ctx context.Context) ([]types.SeriesMetadata, error) {
+func (m *finishedReadingTestMockResponse) GetSeriesMetadata(ctx context.Context) ([]types.SeriesMetadata, error) {
 	panic("not supported")
 }
 
-func (m *finalizationTestMockResponse) GetNextSeries(ctx context.Context) (types.InstantVectorSeriesData, error) {
+func (m *finishedReadingTestMockResponse) GetNextSeries(ctx context.Context) (types.InstantVectorSeriesData, error) {
 	panic("not supported")
 }
 
-func (m *finalizationTestMockResponse) AdvanceToNextSeries(ctx context.Context) error {
+func (m *finishedReadingTestMockResponse) AdvanceToNextSeries(ctx context.Context) error {
 	panic("not supported")
 }
 
-func (m *finalizationTestMockResponse) GetNextStepSamples(ctx context.Context) (*types.RangeVectorStepData, error) {
+func (m *finishedReadingTestMockResponse) GetNextStepSamples(ctx context.Context) (*types.RangeVectorStepData, error) {
 	panic("not supported")
 }
 
-func (m *finalizationTestMockResponse) GetValues(ctx context.Context) (types.ScalarData, error) {
+func (m *finishedReadingTestMockResponse) GetValues(ctx context.Context) (types.ScalarData, error) {
 	panic("not supported")
 }

--- a/pkg/streamingpromql/optimize/plan/remoteexec/range_vector_operator.go
+++ b/pkg/streamingpromql/optimize/plan/remoteexec/range_vector_operator.go
@@ -20,7 +20,7 @@ type RangeVectorRemoteExec struct {
 	expressionPosition posrange.PositionRange
 
 	resp                      RangeVectorRemoteExecutionResponse
-	finalized                 bool
+	finishedReadingCalled     bool
 	stepsReadForCurrentSeries int
 }
 
@@ -59,14 +59,14 @@ func (r *RangeVectorRemoteExec) NextStepSamples(ctx context.Context) (*types.Ran
 	return r.resp.GetNextStepSamples(ctx)
 }
 
-func (r *RangeVectorRemoteExec) Finalize(ctx context.Context) error {
-	if r.finalized {
+func (r *RangeVectorRemoteExec) FinishedReading(ctx context.Context) error {
+	if r.finishedReadingCalled {
 		return nil
 	}
 
-	r.finalized = true
+	r.finishedReadingCalled = true
 
-	return finalize(ctx, r.resp, r.Annotations)
+	return finishedReading(ctx, r.resp, r.Annotations)
 }
 
 func (r *RangeVectorRemoteExec) ExpressionPosition() posrange.PositionRange {
@@ -82,5 +82,5 @@ func (r *RangeVectorRemoteExec) Close() {
 		r.resp.Close()
 	}
 
-	r.finalized = true // Don't try to finalize from a closed stream.
+	r.finishedReadingCalled = true // Don't try to call FinishedReading from a closed stream.
 }

--- a/pkg/streamingpromql/optimize/plan/remoteexec/range_vector_operator_test.go
+++ b/pkg/streamingpromql/optimize/plan/remoteexec/range_vector_operator_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRangeVectorRemoteExec_FinalizeCalledAfterClosed(t *testing.T) {
-	resp := &finalizationTestMockResponse{}
+func TestRangeVectorRemoteExec_FinishedReadingCalledAfterClosed(t *testing.T) {
+	resp := &finishedReadingTestMockResponse{}
 
 	o := &RangeVectorRemoteExec{
 		Annotations: annotations.New(),
@@ -21,6 +21,6 @@ func TestRangeVectorRemoteExec_FinalizeCalledAfterClosed(t *testing.T) {
 	o.Close()
 	require.True(t, resp.Closed, "the response should have been closed")
 
-	require.NoError(t, o.Finalize(context.Background()))
-	require.False(t, resp.Finalized, "calling Finalize after Close should not try to read from the response stream")
+	require.NoError(t, o.FinishedReading(context.Background()))
+	require.False(t, resp.FinishedReadingCalled, "calling FinishedReading after Close should not try to read from the response stream")
 }

--- a/pkg/streamingpromql/optimize/plan/remoteexec/scalar_operator.go
+++ b/pkg/streamingpromql/optimize/plan/remoteexec/scalar_operator.go
@@ -19,8 +19,8 @@ type ScalarRemoteExec struct {
 	Annotations        *annotations.Annotations
 	expressionPosition posrange.PositionRange
 
-	resp      ScalarRemoteExecutionResponse
-	finalized bool
+	resp                  ScalarRemoteExecutionResponse
+	finishedReadingCalled bool
 }
 
 var _ types.ScalarOperator = &ScalarRemoteExec{}
@@ -48,14 +48,14 @@ func (s *ScalarRemoteExec) GetValues(ctx context.Context) (types.ScalarData, err
 	return v, nil
 }
 
-func (s *ScalarRemoteExec) Finalize(ctx context.Context) error {
-	if s.finalized {
+func (s *ScalarRemoteExec) FinishedReading(ctx context.Context) error {
+	if s.finishedReadingCalled {
 		return nil
 	}
 
-	s.finalized = true
+	s.finishedReadingCalled = true
 
-	return finalize(ctx, s.resp, s.Annotations)
+	return finishedReading(ctx, s.resp, s.Annotations)
 }
 
 func (s *ScalarRemoteExec) ExpressionPosition() posrange.PositionRange {
@@ -71,5 +71,5 @@ func (s *ScalarRemoteExec) Close() {
 		s.resp.Close()
 	}
 
-	s.finalized = true // Don't try to finalize from a closed stream.
+	s.finishedReadingCalled = true // Don't try to call FinishedReading from a closed stream.
 }

--- a/pkg/streamingpromql/optimize/plan/remoteexec/scalar_operator_test.go
+++ b/pkg/streamingpromql/optimize/plan/remoteexec/scalar_operator_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestScalarRemoteExec_FinalizeCalledAfterClosed(t *testing.T) {
-	resp := &finalizationTestMockResponse{}
+func TestScalarRemoteExec_FinishedReadingCalledAfterClosed(t *testing.T) {
+	resp := &finishedReadingTestMockResponse{}
 
 	o := &ScalarRemoteExec{
 		Annotations: annotations.New(),
@@ -21,6 +21,6 @@ func TestScalarRemoteExec_FinalizeCalledAfterClosed(t *testing.T) {
 	o.Close()
 	require.True(t, resp.Closed, "the response should have been closed")
 
-	require.NoError(t, o.Finalize(context.Background()))
-	require.False(t, resp.Finalized, "calling Finalize after Close should not try to read from the response stream")
+	require.NoError(t, o.FinishedReading(context.Background()))
+	require.False(t, resp.FinishedReadingCalled, "calling FinishedReading after Close should not try to read from the response stream")
 }

--- a/pkg/streamingpromql/types/operator.go
+++ b/pkg/streamingpromql/types/operator.go
@@ -27,8 +27,8 @@ type Operator interface {
 	// Close must not modify query results, annotations or statistics.
 	Close()
 
-	// Prepare prepares the operator for execution. It must be called before calling SeriesMetadata, NextSeries, NextStepSamples or Finalize.
-	// Prepare must not call SeriesMetadata, NextSeries, NextStepSamples or Finalize on another operator, and is expected to call Prepare on
+	// Prepare prepares the operator for execution. It must be called before calling SeriesMetadata, NextSeries, NextStepSamples or FinishedReading.
+	// Prepare must not call SeriesMetadata, NextSeries, NextStepSamples or FinishedReading on another operator, and is expected to call Prepare on
 	// any nested operators.
 	//
 	// Prepare must only be called once.
@@ -36,8 +36,8 @@ type Operator interface {
 
 	// AfterPrepare is called after Prepare has returned successfully for all operators in an evaluation.
 	//
-	// It must be called before calling SeriesMetadata, NextSeries, NextStepSamples or Finalize.
-	// AfterPrepare must not call SeriesMetadata, NextSeries, NextStepSamples or Finalize on another operator, and is expected to call AfterPrepare on
+	// It must be called before calling SeriesMetadata, NextSeries, NextStepSamples or FinishedReading.
+	// AfterPrepare must not call SeriesMetadata, NextSeries, NextStepSamples or FinishedReading on another operator, and is expected to call AfterPrepare on
 	// any nested operators.
 	//
 	// AfterPrepare must only be called once.
@@ -46,17 +46,17 @@ type Operator interface {
 	// Prepare having already been called on all operators (eg. operators that collect requests from other operators).
 	AfterPrepare(ctx context.Context) error
 
-	// Finalize signals that no further data will be requested from this operator.
+	// FinishedReading signals that no further data will be read from this operator.
 	// Implementations may use this to clean up any buffered or outstanding data in memory.
-	// It must be safe to call Finalize even if other methods on the operator have not been called or returned an error.
-	// It must be safe to call Finalize multiple times.
-	// Finalize must not call any method other than Finalize on another operator and is expected to call Finalize on
+	// It must be safe to call FinishedReading even if other methods on the operator have not been called or returned an error.
+	// It must be safe to call FinishedReading multiple times.
+	// FinishedReading must not call any method other than FinishedReading on another operator and is expected to call FinishedReading on
 	// any nested operators.
-	// Once Finalize has been called, calling methods other than Stats or Close may result in unpredictable behaviour, corruption or crashes.
-	Finalize(ctx context.Context) error
+	// Once FinishedReading has been called, calling methods other than Stats or Close may result in unpredictable behaviour, corruption or crashes.
+	FinishedReading(ctx context.Context) error
 
 	// Stats returns the statistics for this operator, including any nested operators.
-	// Stats must only be called after Finalize has been called.
+	// Stats must only be called after FinishedReading has been called.
 	// Calling Stats multiple times may result in unpredictable behaviour, corruption or crashes.
 	// The caller may mutate the returned OperatorEvaluationStats instance.
 	// It is the caller's responsibility to call Close on the returned OperatorEvaluationStats instance.


### PR DESCRIPTION
#### What this PR does

This PR renames the `Finalize` method on the `Operator` interface to `FinishedReading`, as this better describes its purpose.

A follow-up PR will rename `Stats`.

I've chosen not to add a changelog entry given this is not a user-visible change.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
