### PR TITLE
Expose `querymiddleware.resultsCacheMetrics`

### DIFF
--- a/pkg/frontend/querymiddleware/cardinality_query_cache.go
+++ b/pkg/frontend/querymiddleware/cardinality_query_cache.go
@@ -28,7 +28,7 @@ func newCardinalityQueryCacheRoundTripper(cache cache.Cache, generator CacheKeyG
 		limits: limits,
 	}
 
-	return newGenericQueryCacheRoundTripper(cache, generator.LabelValuesCardinality, ttl, next, logger, newResultsCacheMetrics(queryTypeCardinality, reg))
+	return newGenericQueryCacheRoundTripper(cache, generator.LabelValuesCardinality, ttl, next, logger, NewResultsCacheMetrics(queryTypeCardinality, reg))
 }
 
 type cardinalityQueryTTL struct {

--- a/pkg/frontend/querymiddleware/generic_query_cache.go
+++ b/pkg/frontend/querymiddleware/generic_query_cache.go
@@ -40,12 +40,12 @@ type genericQueryCache struct {
 	cache     cache.Cache
 	tenantTTL tenantCacheTTL
 	cacheKey  keyingFunc
-	metrics   *resultsCacheMetrics
+	metrics   *ResultsCacheMetrics
 	next      http.RoundTripper
 	logger    log.Logger
 }
 
-func newGenericQueryCacheRoundTripper(cache cache.Cache, cacheKey keyingFunc, tenantTTL tenantCacheTTL, next http.RoundTripper, logger log.Logger, metrics *resultsCacheMetrics) http.RoundTripper {
+func newGenericQueryCacheRoundTripper(cache cache.Cache, cacheKey keyingFunc, tenantTTL tenantCacheTTL, next http.RoundTripper, logger log.Logger, metrics *ResultsCacheMetrics) http.RoundTripper {
 	return &genericQueryCache{
 		cache:     cache,
 		tenantTTL: tenantTTL,
@@ -95,11 +95,11 @@ func (c *genericQueryCache) RoundTrip(req *http.Request) (*http.Response, error)
 	}
 
 	// Lookup the cache.
-	c.metrics.cacheRequests.Inc()
+	c.metrics.CacheRequests.Inc()
 	cacheKey, hashedCacheKey := generateGenericQueryRequestCacheKey(tenantIDs, queryReq)
 	res := c.fetchCachedResponse(ctx, cacheKey, hashedCacheKey)
 	if res != nil {
-		c.metrics.cacheHits.Inc()
+		c.metrics.CacheHits.Inc()
 		spanLog.DebugLog("msg", "response fetched from the cache")
 		return res, nil
 	}

--- a/pkg/frontend/querymiddleware/labels_query_cache.go
+++ b/pkg/frontend/querymiddleware/labels_query_cache.go
@@ -41,7 +41,7 @@ func newLabelsQueryCacheRoundTripper(
 		limits: limits,
 	}
 
-	return newGenericQueryCacheRoundTripper(cache, generator.LabelValues, ttl, next, logger, newResultsCacheMetrics(queryTypeLabels, reg))
+	return newGenericQueryCacheRoundTripper(cache, generator.LabelValues, ttl, next, logger, NewResultsCacheMetrics(queryTypeLabels, reg))
 }
 
 type labelsQueryTTL struct {

--- a/pkg/frontend/querymiddleware/results_cache.go
+++ b/pkg/frontend/querymiddleware/results_cache.go
@@ -86,19 +86,19 @@ func errUnsupportedResultsCacheBackend(backend string) error {
 	return fmt.Errorf("%w: %q, supported values: %v", errUnsupportedBackend, backend, supportedResultsCacheBackends)
 }
 
-type resultsCacheMetrics struct {
-	cacheRequests prometheus.Counter
-	cacheHits     prometheus.Counter
+type ResultsCacheMetrics struct {
+	CacheRequests prometheus.Counter
+	CacheHits     prometheus.Counter
 }
 
-func newResultsCacheMetrics(requestType string, reg prometheus.Registerer) *resultsCacheMetrics {
-	return &resultsCacheMetrics{
-		cacheRequests: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+func NewResultsCacheMetrics(requestType string, reg prometheus.Registerer) *ResultsCacheMetrics {
+	return &ResultsCacheMetrics{
+		CacheRequests: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name:        "cortex_frontend_query_result_cache_requests_total",
 			Help:        "Total number of requests (or partial requests) looked up in the results cache.",
 			ConstLabels: map[string]string{"request_type": requestType},
 		}),
-		cacheHits: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		CacheHits: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name:        "cortex_frontend_query_result_cache_hits_total",
 			Help:        "Total number of requests (or partial requests) fetched from the results cache.",
 			ConstLabels: map[string]string{"request_type": requestType},
@@ -279,12 +279,12 @@ func isRequestCachable(req MetricsQueryRequest, maxCacheTime int64, cacheUnalign
 	// We can run with step alignment disabled because Grafana does it already. Mimir automatically aligning start and end is not
 	// PromQL compatible. But this means we cannot cache queries that do not have their start and end aligned.
 	if !cacheUnalignedRequests && !isRequestStepAligned(req) {
-		return false, notCachableReasonUnalignedTimeRange
+		return false, NotCachableReasonUnalignedTimeRange
 	}
 
 	// Do not cache it at all if the query time range is more recent than the configured max cache freshness.
 	if req.GetStart() > maxCacheTime {
-		return false, notCachableReasonTooNew
+		return false, NotCachableReasonTooNew
 	}
 
 	if cachable, reason := areEvaluationTimeModifiersCachable(req, maxCacheTime, logger); !cachable {
@@ -363,7 +363,7 @@ func areEvaluationTimeModifiersCachable(r MetricsQueryRequest, maxCacheTime int6
 	})
 
 	if !cachable {
-		return false, notCachableReasonModifiersNotCachable
+		return false, NotCachableReasonModifiersNotCachable
 	}
 	return true, ""
 }

--- a/pkg/frontend/querymiddleware/results_cache_test.go
+++ b/pkg/frontend/querymiddleware/results_cache_test.go
@@ -144,19 +144,19 @@ func TestIsRequestCachable(t *testing.T) {
 			name:                      "@ modifier on vector selector, after end, before maxCacheTime",
 			request:                   &PrometheusRangeQueryRequest{queryExpr: parseQuery(t, "metric @ 127"), end: 125000, step: 5},
 			expected:                  false,
-			expectedNotCachableReason: notCachableReasonModifiersNotCachable,
+			expectedNotCachableReason: NotCachableReasonModifiersNotCachable,
 		},
 		{
 			name:                      "@ modifier on vector selector, before end, after maxCacheTime",
 			request:                   &PrometheusRangeQueryRequest{queryExpr: parseQuery(t, "metric @ 151"), end: 200000, step: 5},
 			expected:                  false,
-			expectedNotCachableReason: notCachableReasonModifiersNotCachable,
+			expectedNotCachableReason: NotCachableReasonModifiersNotCachable,
 		},
 		{
 			name:                      "@ modifier on vector selector, after end, after maxCacheTime",
 			request:                   &PrometheusRangeQueryRequest{queryExpr: parseQuery(t, "metric @ 151"), end: 125000, step: 5},
 			expected:                  false,
-			expectedNotCachableReason: notCachableReasonModifiersNotCachable,
+			expectedNotCachableReason: NotCachableReasonModifiersNotCachable,
 		},
 		{
 			name:     "@ modifier on vector selector with start() before maxCacheTime",
@@ -167,7 +167,7 @@ func TestIsRequestCachable(t *testing.T) {
 			name:                      "@ modifier on vector selector with end() after maxCacheTime",
 			request:                   &PrometheusRangeQueryRequest{queryExpr: parseQuery(t, "metric @ end()"), start: 100000, end: 200000, step: 5},
 			expected:                  false,
-			expectedNotCachableReason: notCachableReasonModifiersNotCachable,
+			expectedNotCachableReason: NotCachableReasonModifiersNotCachable,
 		},
 		// @ modifier on matrix selectors.
 		{
@@ -179,19 +179,19 @@ func TestIsRequestCachable(t *testing.T) {
 			name:                      "@ modifier on matrix selector, after end, before maxCacheTime",
 			request:                   &PrometheusRangeQueryRequest{queryExpr: parseQuery(t, "rate(metric[5m] @ 127)"), end: 125000, step: 5},
 			expected:                  false,
-			expectedNotCachableReason: notCachableReasonModifiersNotCachable,
+			expectedNotCachableReason: NotCachableReasonModifiersNotCachable,
 		},
 		{
 			name:                      "@ modifier on matrix selector, before end, after maxCacheTime",
 			request:                   &PrometheusRangeQueryRequest{queryExpr: parseQuery(t, "rate(metric[5m] @ 151)"), end: 200000, step: 5},
 			expected:                  false,
-			expectedNotCachableReason: notCachableReasonModifiersNotCachable,
+			expectedNotCachableReason: NotCachableReasonModifiersNotCachable,
 		},
 		{
 			name:                      "@ modifier on matrix selector, after end, after maxCacheTime",
 			request:                   &PrometheusRangeQueryRequest{queryExpr: parseQuery(t, "rate(metric[5m] @ 151)"), end: 125000, step: 5},
 			expected:                  false,
-			expectedNotCachableReason: notCachableReasonModifiersNotCachable,
+			expectedNotCachableReason: NotCachableReasonModifiersNotCachable,
 		},
 		{
 			name:     "@ modifier on matrix selector with start() before maxCacheTime",
@@ -202,7 +202,7 @@ func TestIsRequestCachable(t *testing.T) {
 			name:                      "@ modifier on matrix selector with end() after maxCacheTime",
 			request:                   &PrometheusRangeQueryRequest{queryExpr: parseQuery(t, "rate(metric[5m] @ end())"), start: 100000, end: 200000, step: 5},
 			expected:                  false,
-			expectedNotCachableReason: notCachableReasonModifiersNotCachable,
+			expectedNotCachableReason: NotCachableReasonModifiersNotCachable,
 		},
 		// @ modifier on subqueries.
 		{
@@ -214,19 +214,19 @@ func TestIsRequestCachable(t *testing.T) {
 			name:                      "@ modifier on subqueries, after end, before maxCacheTime",
 			request:                   &PrometheusRangeQueryRequest{queryExpr: parseQuery(t, "sum_over_time(rate(metric[1m])[10m:1m] @ 127)"), end: 125000, step: 5},
 			expected:                  false,
-			expectedNotCachableReason: notCachableReasonModifiersNotCachable,
+			expectedNotCachableReason: NotCachableReasonModifiersNotCachable,
 		},
 		{
 			name:                      "@ modifier on subqueries, before end, after maxCacheTime",
 			request:                   &PrometheusRangeQueryRequest{queryExpr: parseQuery(t, "sum_over_time(rate(metric[1m])[10m:1m] @ 151)"), end: 200000, step: 5},
 			expected:                  false,
-			expectedNotCachableReason: notCachableReasonModifiersNotCachable,
+			expectedNotCachableReason: NotCachableReasonModifiersNotCachable,
 		},
 		{
 			name:                      "@ modifier on subqueries, after end, after maxCacheTime",
 			request:                   &PrometheusRangeQueryRequest{queryExpr: parseQuery(t, "sum_over_time(rate(metric[1m])[10m:1m] @ 151)"), end: 125000, step: 5},
 			expected:                  false,
-			expectedNotCachableReason: notCachableReasonModifiersNotCachable,
+			expectedNotCachableReason: NotCachableReasonModifiersNotCachable,
 		},
 		{
 			name:     "@ modifier on subqueries with start() before maxCacheTime",
@@ -237,7 +237,7 @@ func TestIsRequestCachable(t *testing.T) {
 			name:                      "@ modifier on subqueries with end() after maxCacheTime",
 			request:                   &PrometheusRangeQueryRequest{queryExpr: parseQuery(t, "sum_over_time(rate(metric[1m])[10m:1m] @ end())"), start: 100000, end: 200000, step: 5},
 			expected:                  false,
-			expectedNotCachableReason: notCachableReasonModifiersNotCachable,
+			expectedNotCachableReason: NotCachableReasonModifiersNotCachable,
 		},
 		// offset modifier on vector selectors.
 		{
@@ -249,7 +249,7 @@ func TestIsRequestCachable(t *testing.T) {
 			name:                      "negative offset on vector selector",
 			request:                   &PrometheusRangeQueryRequest{queryExpr: parseQuery(t, "metric offset -1ms"), end: 125000, step: 5},
 			expected:                  false,
-			expectedNotCachableReason: notCachableReasonModifiersNotCachable,
+			expectedNotCachableReason: NotCachableReasonModifiersNotCachable,
 		},
 		// offset modifier on subqueries.
 		{
@@ -261,7 +261,7 @@ func TestIsRequestCachable(t *testing.T) {
 			name:                      "negative offset on subqueries",
 			request:                   &PrometheusRangeQueryRequest{queryExpr: parseQuery(t, "sum_over_time(rate(metric[1m])[10m:1m] offset -1ms)"), start: 100000, end: 200000, step: 5},
 			expected:                  false,
-			expectedNotCachableReason: notCachableReasonModifiersNotCachable,
+			expectedNotCachableReason: NotCachableReasonModifiersNotCachable,
 		},
 		// On step aligned and non-aligned requests
 		{
@@ -273,7 +273,7 @@ func TestIsRequestCachable(t *testing.T) {
 			name:                      "request that is NOT step aligned, with cacheStepUnaligned=false",
 			request:                   &PrometheusRangeQueryRequest{queryExpr: parseQuery(t, "query"), start: 100000, end: 200000, step: 3},
 			expected:                  false,
-			expectedNotCachableReason: notCachableReasonUnalignedTimeRange,
+			expectedNotCachableReason: NotCachableReasonUnalignedTimeRange,
 			cacheStepUnaligned:        false,
 		},
 		{

--- a/pkg/frontend/querymiddleware/split_and_cache.go
+++ b/pkg/frontend/querymiddleware/split_and_cache.go
@@ -33,9 +33,9 @@ import (
 )
 
 const (
-	notCachableReasonUnalignedTimeRange                   = "unaligned-time-range"
-	notCachableReasonTooNew                               = "too-new"
-	notCachableReasonModifiersNotCachable                 = "has-modifiers"
+	NotCachableReasonUnalignedTimeRange                   = "unaligned-time-range"
+	NotCachableReasonTooNew                               = "too-new"
+	NotCachableReasonModifiersNotCachable                 = "has-modifiers"
 	notCachableReasonModifiersNotCachableFailedParse      = "has-modifiers-failed-parse"
 	notCachableReasonModifiersNotCachableFailedPreprocess = "has-modifiers-failed-preprocess"
 )
@@ -46,35 +46,35 @@ var (
 	defaultMinCacheExtent = (5 * time.Minute).Milliseconds()
 )
 
-type splitAndCacheMiddlewareMetrics struct {
-	*resultsCacheMetrics
+type SplitAndCacheMetrics struct {
+	*ResultsCacheMetrics
 
-	splitQueriesCount              prometheus.Counter
-	queryResultCacheAttemptedCount prometheus.Counter
-	queryResultCacheSkippedCount   *prometheus.CounterVec
+	SplitQueriesCount              prometheus.Counter
+	QueryResultCacheAttemptedCount prometheus.Counter
+	QueryResultCacheSkippedCount   *prometheus.CounterVec
 }
 
-func newSplitAndCacheMiddlewareMetrics(reg prometheus.Registerer) *splitAndCacheMiddlewareMetrics {
-	m := &splitAndCacheMiddlewareMetrics{
-		resultsCacheMetrics: newResultsCacheMetrics("query_range", reg),
-		splitQueriesCount: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+func NewSplitAndCacheMetrics(reg prometheus.Registerer) *SplitAndCacheMetrics {
+	m := &SplitAndCacheMetrics{
+		ResultsCacheMetrics: NewResultsCacheMetrics("query_range", reg),
+		SplitQueriesCount: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "cortex_frontend_split_queries_total",
 			Help: "Total number of underlying query requests after the split by interval is applied.",
 		}),
-		queryResultCacheAttemptedCount: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		QueryResultCacheAttemptedCount: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "cortex_frontend_query_result_cache_attempted_total",
 			Help: "Total number of queries that were attempted to be fetched from cache.",
 		}),
-		queryResultCacheSkippedCount: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		QueryResultCacheSkippedCount: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "cortex_frontend_query_result_cache_skipped_total",
 			Help: "Total number of times a query was not cacheable because of a reason. This metric is tracked for each partial query when time-splitting is enabled.",
 		}, []string{"reason"}),
 	}
 
 	// Initialize known label values.
-	for _, reason := range []string{notCachableReasonUnalignedTimeRange, notCachableReasonTooNew,
-		notCachableReasonModifiersNotCachable} {
-		m.queryResultCacheSkippedCount.WithLabelValues(reason)
+	for _, reason := range []string{NotCachableReasonUnalignedTimeRange, NotCachableReasonTooNew,
+		NotCachableReasonModifiersNotCachable} {
+		m.QueryResultCacheSkippedCount.WithLabelValues(reason)
 	}
 
 	return m
@@ -89,7 +89,7 @@ type splitAndCacheMiddleware struct {
 
 	merger  Merger
 	logger  log.Logger
-	metrics *splitAndCacheMiddlewareMetrics
+	metrics *SplitAndCacheMetrics
 
 	// Split by interval.
 	splitEnabled  bool
@@ -124,7 +124,7 @@ func newSplitAndCacheMiddleware(
 	logger log.Logger,
 	reg prometheus.Registerer,
 	memoryConsumptionTrackerFactory *limiter.InflightMemoryConsumptionTracker) MetricsQueryMiddleware {
-	metrics := newSplitAndCacheMiddlewareMetrics(reg)
+	metrics := NewSplitAndCacheMetrics(reg)
 
 	return MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
 		return &splitAndCacheMiddleware{
@@ -177,7 +177,7 @@ func (s *splitAndCacheMiddleware) Do(ctx context.Context, req MetricsQueryReques
 	}
 	// Lookup the results cache.
 	if isCacheEnabled {
-		s.metrics.queryResultCacheAttemptedCount.Add(float64(len(splitReqs)))
+		s.metrics.QueryResultCacheAttemptedCount.Add(float64(len(splitReqs)))
 
 		// Build the cache keys for all requests to try to fetch from cache.
 		lookupReqs := make([]*splitRequest, 0, len(splitReqs))
@@ -188,7 +188,7 @@ func (s *splitAndCacheMiddleware) Do(ctx context.Context, req MetricsQueryReques
 			if cachable, reason := isRequestCachable(splitReq.orig, maxCacheTime, cacheUnalignedRequests, s.logger); !cachable {
 				level.Debug(spanLog).Log("msg", "skipping response cache as query is not cacheable", "query", splitReq.orig.GetQuery(), "reason", reason, "tenants", tenant.JoinTenantIDs(tenantIDs))
 				splitReq.downstreamRequests = []MetricsQueryRequest{splitReq.orig}
-				s.metrics.queryResultCacheSkippedCount.WithLabelValues(reason).Inc()
+				s.metrics.QueryResultCacheSkippedCount.WithLabelValues(reason).Inc()
 				continue
 			}
 
@@ -352,7 +352,7 @@ func (s *splitAndCacheMiddleware) splitRequestByInterval(req MetricsQueryRequest
 		return nil, err
 	}
 
-	s.metrics.splitQueriesCount.Add(float64(len(splitReqs)))
+	s.metrics.SplitQueriesCount.Add(float64(len(splitReqs)))
 
 	// Wrap the split requests into our internal data structure.
 	out := make(splitRequests, 0, len(splitReqs))
@@ -388,9 +388,9 @@ func (s *splitAndCacheMiddleware) fetchCacheExtents(ctx context.Context, now tim
 	}
 
 	// Lookup the cache.
-	s.metrics.cacheRequests.Add(float64(len(keys)))
+	s.metrics.CacheRequests.Add(float64(len(keys)))
 	founds := s.cache.GetMulti(ctx, hashedKeys)
-	s.metrics.cacheHits.Add(float64(len(founds)))
+	s.metrics.CacheHits.Add(float64(len(founds)))
 
 	// Decode all cached responses.
 	extents := make([][]Extent, len(keys))


### PR DESCRIPTION
#### What this PR does

This PR exposes the `resultsCacheMetrics` struct in `pkg/frontend/querymiddleware` in preparation for using it from MQE's implementation of splitting and caching.

Given this is not a user-visible change I have not added a changelog entry.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
