### PR TITLE
fix: release-2.17 update to go 1.26.3 for CVE fixes - manual backport

### DIFF
--- a/.github/workflows/update-vendored-mimir-prometheus.yml
+++ b/.github/workflows/update-vendored-mimir-prometheus.yml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           # We only use this to run `go mod` commands, so it doesn't need to follow the version used in the Dockerfile.
-          go-version: "1.25.9"
+          go-version: "1.26.3"
 
       # This job uses "mimir-vendoring bot" instead of "github-actions bot" (secrets.GITHUB_TOKEN)
       # because any events triggered by the later don't spawn GitHub actions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## unreleased
+
+### Grafana Mimir
+
+* [BUGFIX] Update to Go v1.26.3 to address high-severity CVEs [CVE-2026-42501](https://pkg.go.dev/vuln/GO-2026-4984), [CVE-2026-39836](https://pkg.go.dev/vuln/GO-2026-4971), [CVE-2026-33811](https://pkg.go.dev/vuln/GO-2026-4981), [CVE-2026-33814](https://pkg.go.dev/vuln/GO-2026-4918), [CVE-2026-42499](https://pkg.go.dev/vuln/GO-2026-4977), [CVE-2026-39820](https://pkg.go.dev/vuln/GO-2026-4986) and other lower-severity CVEs. #15401
+
 ## 2.17.11
 
 ### Grafana Mimir

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [BUGFIX] Update go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp to v0.19.0 to address [CVE-2026-39882](https://nvd.nist.gov/vuln/detail/CVE-2026-39882). #15329
 * [BUGFIX] Update go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp to v1.43.0 to address [CVE-2026-39882](https://nvd.nist.gov/vuln/detail/CVE-2026-39882). #15329
 * [BUGFIX] Update go.opentelemetry.io/otel/exporters/stdout/stdoutlog to v0.19.0 for compatibility with updated OTLP exporters. #15329
+* [BUGFIX] Update to Go v1.25.10. #15388
 
 ## 2.17.10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@
 * [BUGFIX] Update go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp to v0.19.0 to address [CVE-2026-39882](https://nvd.nist.gov/vuln/detail/CVE-2026-39882). #15329
 * [BUGFIX] Update go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp to v1.43.0 to address [CVE-2026-39882](https://nvd.nist.gov/vuln/detail/CVE-2026-39882). #15329
 * [BUGFIX] Update go.opentelemetry.io/otel/exporters/stdout/stdoutlog to v0.19.0 for compatibility with updated OTLP exporters. #15329
-* [BUGFIX] Update to Go v1.25.10. #15388
 
 ## 2.17.10
 

--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr15042-5dd0b1424a
+LATEST_BUILD_IMAGE_TAG ?= pr15263-b90faf9665
 
 # TTY is parameterized to allow CI and scripts to run builds,
 # as it currently disallows TTY devices.

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -16461,12 +16461,12 @@
             "User": null,
             "Host": "localhost:8080",
             "Path": "/alertmanager",
-            "RawPath": "",
-            "OmitHost": false,
-            "ForceQuery": false,
-            "RawQuery": "",
             "Fragment": "",
-            "RawFragment": ""
+            "RawQuery": "",
+            "RawPath": "",
+            "RawFragment": "",
+            "ForceQuery": false,
+            "OmitHost": false
           },
           "fieldFlag": "alertmanager.web.external-url",
           "fieldType": "url"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/mimir
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/mimir
 
-go 1.25.10
+go 1.26.3
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.1

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -5,7 +5,7 @@
 
 FROM registry.k8s.io/kustomize/kustomize:v5.4.3 AS kustomize
 FROM alpine/helm:3.17.2 AS helm
-FROM golang:1.25.9-trixie@sha256:091e6099f4a58e9393b8cc5615622a59c1cef64481b0ffcf349ec1574449059e
+FROM golang:1.26.3-trixie@sha256:d08bf3ed2bd263088ca8e23fefaf10f1b71769f6932f0a4017ba28d2a5baf001
 ARG goproxyValue
 ENV GOPROXY=${goproxyValue}
 ENV SKOPEO_DEPS="libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config"
@@ -39,7 +39,9 @@ RUN GOARCH=$(go env GOARCH) && \
     curl -fSL -o "/usr/bin/tk" "https://github.com/grafana/tanka/releases/download/v${TANKA_VERSION}/tk-linux-${GOARCH}" && \
     chmod a+x /usr/bin/tk
 
-RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b /usr/bin v2.4.0
+# renovate: depName=github.com/golangci/golangci-lint
+ENV GOLANGCI_LINT_VERSION=2.12.2
+RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/v"${GOLANGCI_LINT_VERSION}"/install.sh| sh -s -- -b /usr/bin v"${GOLANGCI_LINT_VERSION}"
 
 ENV SKOPEO_VERSION=v1.15.1
 RUN git clone --depth 1 --branch ${SKOPEO_VERSION} https://github.com/containers/skopeo /go/src/github.com/containers/skopeo && \

--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -333,7 +333,7 @@ func validateAlertmanagerConfig(cfg interface{}) error {
 
 	// If the input config is a pointer then we need to get its value.
 	// At this point the pointer value can't be nil.
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
 		t = v.Type()
 	}

--- a/pkg/blockbuilder/scheduler/scheduler_test.go
+++ b/pkg/blockbuilder/scheduler/scheduler_test.go
@@ -250,16 +250,17 @@ func requireGaps(t *testing.T, reg *prometheus.Registry, partition int32, planne
 	t.Helper()
 
 	var b strings.Builder
-
-	if planned != 0 || committed != 0 {
-		b.WriteString(`# HELP cortex_blockbuilder_scheduler_job_gap_detected The number of times an unexpected gap was detected between jobs.
+	b.WriteString(`# HELP cortex_blockbuilder_scheduler_job_gap_detected The number of times an unexpected gap was detected between jobs.
 		# TYPE cortex_blockbuilder_scheduler_job_gap_detected counter
 		`)
 
+	if planned != 0 {
 		fmt.Fprintf(&b,
-			"cortex_blockbuilder_scheduler_job_gap_detected{offset_type=\"planned\"} %d\n", planned)
+			"cortex_blockbuilder_scheduler_job_gap_detected{offset_type=\"planned\",partition=\"%d\"} %d\n", partition, planned)
+	}
+	if committed != 0 {
 		fmt.Fprintf(&b,
-			"cortex_blockbuilder_scheduler_job_gap_detected{offset_type=\"committed\"} %d\n", committed)
+			"cortex_blockbuilder_scheduler_job_gap_detected{offset_type=\"committed\",partition=\"%d\"} %d\n", partition, committed)
 	}
 
 	require.NoError(t,

--- a/pkg/blockbuilder/scheduler/scheduler_test.go
+++ b/pkg/blockbuilder/scheduler/scheduler_test.go
@@ -256,14 +256,10 @@ func requireGaps(t *testing.T, reg *prometheus.Registry, partition int32, planne
 		# TYPE cortex_blockbuilder_scheduler_job_gap_detected counter
 		`)
 
-		if planned != 0 {
-			b.WriteString(fmt.Sprintf(
-				"cortex_blockbuilder_scheduler_job_gap_detected{offset_type=\"planned\",partition=\"%d\"} %d\n", partition, planned))
-		}
-		if committed != 0 {
-			b.WriteString(fmt.Sprintf(
-				"cortex_blockbuilder_scheduler_job_gap_detected{offset_type=\"committed\",partition=\"%d\"} %d\n", partition, committed))
-		}
+		fmt.Fprintf(&b,
+			"cortex_blockbuilder_scheduler_job_gap_detected{offset_type=\"planned\"} %d\n", planned)
+		fmt.Fprintf(&b,
+			"cortex_blockbuilder_scheduler_job_gap_detected{offset_type=\"committed\"} %d\n", committed)
 	}
 
 	require.NoError(t,

--- a/pkg/frontend/querymiddleware/labels_query_cache.go
+++ b/pkg/frontend/querymiddleware/labels_query_cache.go
@@ -109,9 +109,9 @@ func generateLabelsQueryRequestCacheKey(startTime, endTime int64, labelName stri
 	}
 
 	// Add start and end time.
-	b.WriteString(fmt.Sprintf("%d", startTime))
+	fmt.Fprintf(&b, "%d", startTime)
 	b.WriteRune(stringParamSeparator)
-	b.WriteString(fmt.Sprintf("%d", endTime))
+	fmt.Fprintf(&b, "%d", endTime)
 
 	// Add label name (if any).
 	if labelName != "" {

--- a/pkg/frontend/querymiddleware/response_parsing_edge_cases_test.go
+++ b/pkg/frontend/querymiddleware/response_parsing_edge_cases_test.go
@@ -222,7 +222,7 @@ func TestCodec_ResponseParsingEdgeCases(t *testing.T) {
 						buf.WriteString(",")
 					}
 					buf.WriteString(`{"index":`)
-					buf.WriteString(fmt.Sprintf("%d", i))
+					fmt.Fprintf(&buf, "%d", i)
 					buf.WriteString(`,"data":"`)
 					buf.WriteString(strings.Repeat("1234567890", 10)) // 100 chars per item
 					buf.WriteString(`"}`)

--- a/pkg/frontend/querymiddleware/roundtrip_test.go
+++ b/pkg/frontend/querymiddleware/roundtrip_test.go
@@ -632,7 +632,7 @@ func TestMiddlewaresConsistency(t *testing.T) {
 	// Utility to get the name of the struct.
 	getName := func(i interface{}) string {
 		t := reflect.TypeOf(i)
-		if t.Kind() == reflect.Ptr {
+		if t.Kind() == reflect.Pointer {
 			t = t.Elem()
 		}
 		return t.Name()

--- a/pkg/ingester/activeseries/model/custom_trackers_config_test.go
+++ b/pkg/ingester/activeseries/model/custom_trackers_config_test.go
@@ -133,7 +133,7 @@ func TestMaximumNumberOfTrackers(t *testing.T) {
 		var flagToSet bytes.Buffer
 		numberOfTrackers := maxNumberOfTrackers + 1
 		for i := 0; i < numberOfTrackers; i++ {
-			flagToSet.WriteString(fmt.Sprintf("name%d:{__name__=%d}", i, i))
+			fmt.Fprintf(&flagToSet, "name%d:{__name__=%d}", i, i)
 			if i < numberOfTrackers-1 {
 				flagToSet.WriteString(";")
 			}

--- a/pkg/mimirpb/split_test.go
+++ b/pkg/mimirpb/split_test.go
@@ -155,7 +155,7 @@ func TestSplitWriteRequestByMaxMarshalSize_WriteRequestHasChanged(t *testing.T) 
 	val := reflect.ValueOf(&WriteRequest{})
 	typ := val.Type()
 
-	if typ.Kind() == reflect.Ptr {
+	if typ.Kind() == reflect.Pointer {
 		typ = typ.Elem()
 	}
 

--- a/pkg/mimirtool/commands/config.go
+++ b/pkg/mimirtool/commands/config.go
@@ -153,21 +153,21 @@ func (c *ConfigCommand) writeNotices(notices config.ConversionNotices, w io.Writ
 	}
 	noticesOut := bytes.Buffer{}
 	for _, p := range notices.RemovedParameters {
-		_, _ = noticesOut.WriteString(fmt.Sprintf("field is no longer supported: %s\n", p))
+		_, _ = fmt.Fprintf(&noticesOut, "field is no longer supported: %s\n", p)
 	}
 	for _, f := range notices.RemovedCLIFlags {
-		_, _ = noticesOut.WriteString(fmt.Sprintf("flag is no longer supported: -%s \n", f))
+		_, _ = fmt.Fprintf(&noticesOut, "flag is no longer supported: -%s \n", f)
 	}
 	for _, d := range notices.ChangedDefaults {
 		oldDefault, newDefault := placeholderIfEmpty(d.OldDefault), placeholderIfEmpty(d.NewDefault)
-		_, _ = noticesOut.WriteString(fmt.Sprintf("using a new default for %s: %s (used to be %s)\n", d.Path, newDefault, oldDefault))
+		_, _ = fmt.Fprintf(&noticesOut, "using a new default for %s: %s (used to be %s)\n", d.Path, newDefault, oldDefault)
 	}
 	for _, d := range notices.SkippedChangedDefaults {
 		oldDefault, newDefault := placeholderIfEmpty(d.OldDefault), placeholderIfEmpty(d.NewDefault)
-		_, _ = noticesOut.WriteString(fmt.Sprintf("default value for %s changed: %s (used to be %s); not updating\n", d.Path, newDefault, oldDefault))
+		_, _ = fmt.Fprintf(&noticesOut, "default value for %s changed: %s (used to be %s); not updating\n", d.Path, newDefault, oldDefault)
 	}
 	for _, d := range notices.PrunedDefaults {
-		_, _ = noticesOut.WriteString(fmt.Sprintf("removed default value %s: %s\n", d.Path, placeholderIfEmpty(d.Value)))
+		_, _ = fmt.Fprintf(&noticesOut, "removed default value %s: %s\n", d.Path, placeholderIfEmpty(d.Value))
 	}
 
 	_, err := noticesOut.WriteTo(w)

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -2203,7 +2203,7 @@ func TestPartitionReader_ShouldNotMissRecordsIfKafkaReturnsAFetchBothWithAnError
 	const (
 		topicName            = "test"
 		partitionID          = 1
-		totalProducedRecords = 10000
+		totalProducedRecords = 1000
 		recordSizeBytes      = initialBytesPerRecord
 		maxBufferedBytes     = (totalProducedRecords * initialBytesPerRecord) / 100
 	)
@@ -2225,7 +2225,7 @@ func TestPartitionReader_ShouldNotMissRecordsIfKafkaReturnsAFetchBothWithAnError
 				reg                  = prometheus.NewPedanticRegistry()
 			)
 
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 			t.Cleanup(cancel)
 
 			// Produce records.
@@ -2273,8 +2273,8 @@ func TestPartitionReader_ShouldNotMissRecordsIfKafkaReturnsAFetchBothWithAnError
 					return nil, fmt.Errorf("expected 1 partition in the response, got %d", len(res.Topics[0].Partitions)), true
 				}
 
-				// Simulate a 10% error rate in the Kafka responses, mixed with records.
-				if rand.Int()%10 == 0 {
+				// Simulate a 25% error rate in the Kafka responses, mixed with records.
+				if rand.Int()%4 == 0 {
 					// Make a copy so we don't overwrite the cached version, which will be later requested again.
 					resCopy := &kmsg.FetchResponse{Version: req.Version}
 					if err := resCopy.ReadFrom(res.AppendTo(nil)); err != nil {

--- a/pkg/storage/lazyquery/lazyquery_test.go
+++ b/pkg/storage/lazyquery/lazyquery_test.go
@@ -38,7 +38,7 @@ func TestCopyParamsDeepCopy(t *testing.T) {
 
 		switch originalField.Kind() {
 		// For reference types, ensure they point to different memory
-		case reflect.Slice, reflect.Map, reflect.Ptr:
+		case reflect.Slice, reflect.Map, reflect.Pointer:
 			if !originalField.IsNil() {
 				assert.NotEqual(t, originalField.UnsafePointer(), copiedField.UnsafePointer(), "Field %s shares memory between original and copy", typ.Field(i).Name)
 			}

--- a/pkg/util/limiter/utilization.go
+++ b/pkg/util/limiter/utilization.go
@@ -276,7 +276,7 @@ func (b *cpuSampleBuffer) String() string {
 	var sb strings.Builder
 	for i := range b.samples {
 		s := b.samples[(b.head+i)%len(b.samples)]
-		sb.WriteString(fmt.Sprintf("%.2f", s))
+		fmt.Fprintf(&sb, "%.2f", s)
 		if i < len(b.samples)-1 {
 			sb.WriteByte(',')
 		}

--- a/pkg/util/usage/usage.go
+++ b/pkg/util/usage/usage.go
@@ -151,6 +151,12 @@ func parseStructure(structure interface{}, fields map[uintptr]reflect.StructFiel
 		// Take address of field value and map it to field
 		fields[fieldValue.Addr().Pointer()] = field
 
+		// For pointer fields (e.g. *bool), the flag is registered with the
+		// pointed-to address, not the address of the pointer field itself.
+		if fieldValue.Kind() == reflect.Pointer && !fieldValue.IsNil() {
+			fields[fieldValue.Pointer()] = field
+		}
+
 		// Recurse if a struct
 		if field.Type.Kind() != reflect.Struct || isFieldHidden(field, "") || ignoreStructType(field.Type) || !field.IsExported() {
 			continue

--- a/pkg/util/usage/usage.go
+++ b/pkg/util/usage/usage.go
@@ -38,7 +38,7 @@ func Usage(printAll bool, configs ...interface{}) error {
 		if fl.Value.String() == "deprecated" {
 			return
 		}
-		if v.Kind() == reflect.Ptr {
+		if v.Kind() == reflect.Pointer {
 			ptr := v.Pointer()
 			field, hasField = fields[ptr]
 			if hasField && isFieldHidden(field, fl.Name) {
@@ -90,7 +90,7 @@ func Usage(printAll bool, configs ...interface{}) error {
 
 		if defValue := getFlagDefault(fl, field); !isZeroValue(fl, defValue) {
 			v := reflect.ValueOf(fl.Value)
-			if v.Kind() == reflect.Ptr {
+			if v.Kind() == reflect.Pointer {
 				v = v.Elem()
 			}
 			if v.Kind() == reflect.String {
@@ -118,7 +118,7 @@ func isZeroValue(fl *flag.Flag, value string) bool {
 	// This works unless the Value type is itself an interface type.
 	typ := reflect.TypeOf(fl.Value)
 	var z reflect.Value
-	if typ.Kind() == reflect.Ptr {
+	if typ.Kind() == reflect.Pointer {
 		z = reflect.New(typ.Elem())
 	} else {
 		z = reflect.Zero(typ)
@@ -129,9 +129,9 @@ func isZeroValue(fl *flag.Flag, value string) bool {
 // parseStructure parses a struct and populates fields.
 func parseStructure(structure interface{}, fields map[uintptr]reflect.StructField) error {
 	// structure is expected to be a pointer to a struct
-	if reflect.TypeOf(structure).Kind() != reflect.Ptr {
+	if reflect.TypeOf(structure).Kind() != reflect.Pointer {
 		t := reflect.TypeOf(structure)
-		return fmt.Errorf("%s is a %s while a %s is expected", t, t.Kind(), reflect.Ptr)
+		return fmt.Errorf("%s is a %s while a %s is expected", t, t.Kind(), reflect.Pointer)
 	}
 	v := reflect.ValueOf(structure).Elem()
 	if v.Kind() != reflect.Struct {

--- a/tools/add-license/main.go
+++ b/tools/add-license/main.go
@@ -88,7 +88,7 @@ func addLicense(dir string) error {
 		// Add the default license directory if none exists.
 		if !strings.Contains(string(b), commentStyle+" "+licenseDirective+":") {
 			log.Printf("adding the license directive to %s\n", path)
-			_, _ = bb.WriteString(fmt.Sprintf("%s %s: %s\n", commentStyle, licenseDirective, defaultLicense))
+			_, _ = fmt.Fprintf(&bb, "%s %s: %s\n", commentStyle, licenseDirective, defaultLicense)
 		}
 
 		// Add the provenance from Cortex for forked files. This has been run just once

--- a/tools/doc-generator/parse/parser.go
+++ b/tools/doc-generator/parse/parser.go
@@ -186,8 +186,9 @@ func config(block *ConfigBlock, cfg interface{}, flags map[uintptr]*flag.Flag, r
 			continue
 		}
 
-		// Recursively re-iterate if it's a struct and it's not a custom type.
-		if _, custom := getCustomFieldType(field.Type); (field.Type.Kind() == reflect.Struct || field.Type.Kind() == reflect.Pointer) && !custom {
+		// Recursively re-iterate if it's a struct (or pointer to struct) and it's not a custom type.
+		if _, custom := getFieldCustomType(field.Type); !custom &&
+			(field.Type.Kind() == reflect.Struct || (field.Type.Kind() == reflect.Pointer && field.Type.Elem().Kind() == reflect.Struct)) {
 			// Check whether the sub-block is a root config block
 			rootName, rootDesc, isRoot := isRootBlock(field.Type, rootBlocks)
 
@@ -449,32 +450,6 @@ func getFieldType(t reflect.Type) (string, error) {
 	}
 }
 
-func getCustomFieldType(t reflect.Type) (string, bool) {
-	// Handle custom data types used in the config
-	switch t.String() {
-	case reflect.TypeOf(flagext.LimitsMap[float64]{}).String():
-		return "map of string to float64", true
-	case reflect.TypeOf(flagext.LimitsMap[int]{}).String():
-		return "map of string to int", true
-	case reflect.TypeOf(flagext.LimitsMap[string]{}).String():
-		return "map of string to string", true
-	case reflect.TypeOf(&url.URL{}).String():
-		return "url", true
-	case reflect.TypeOf(time.Duration(0)).String():
-		return "duration", true
-	case reflect.TypeOf(flagext.StringSliceCSV{}).String():
-		return "string", true
-	case reflect.TypeOf(flagext.CIDRSliceCSV{}).String():
-		return "string", true
-	case reflect.TypeOf([]*relabel.Config{}).String():
-		return "relabel_config...", true
-	case reflect.TypeOf(asmodel.CustomTrackersConfig{}).String():
-		return "map of tracker name (string) to matcher (string)", true
-	default:
-		return "", false
-	}
-}
-
 func ReflectType(typ string) reflect.Type {
 	switch typ {
 	case "string":
@@ -516,7 +491,12 @@ func getFieldFlag(field reflect.StructField, fieldValue reflect.Value, flags map
 	if isAbsentInCLI(field) {
 		return nil, nil
 	}
-	fieldPtr := fieldValue.Addr().Pointer()
+	var fieldPtr uintptr
+	if fieldValue.Kind() == reflect.Pointer && !fieldValue.IsNil() {
+		fieldPtr = fieldValue.Pointer()
+	} else {
+		fieldPtr = fieldValue.Addr().Pointer()
+	}
 	fieldFlag, ok := flags[fieldPtr]
 	if !ok {
 		return nil, nil

--- a/tools/doc-generator/parse/parser.go
+++ b/tools/doc-generator/parse/parser.go
@@ -137,9 +137,9 @@ func config(block *ConfigBlock, cfg interface{}, flags map[uintptr]*flag.Flag, r
 	}
 
 	// The input config is expected to be addressable.
-	if reflect.TypeOf(cfg).Kind() != reflect.Ptr {
+	if reflect.TypeOf(cfg).Kind() != reflect.Pointer {
 		t := reflect.TypeOf(cfg)
-		return nil, fmt.Errorf("%s is a %s while a %s is expected", t, t.Kind(), reflect.Ptr)
+		return nil, fmt.Errorf("%s is a %s while a %s is expected", t, t.Kind(), reflect.Pointer)
 	}
 
 	// The input config is expected to be a pointer to struct.
@@ -187,7 +187,7 @@ func config(block *ConfigBlock, cfg interface{}, flags map[uintptr]*flag.Flag, r
 		}
 
 		// Recursively re-iterate if it's a struct and it's not a custom type.
-		if _, custom := getCustomFieldType(field.Type); (field.Type.Kind() == reflect.Struct || field.Type.Kind() == reflect.Ptr) && !custom {
+		if _, custom := getCustomFieldType(field.Type); (field.Type.Kind() == reflect.Struct || field.Type.Kind() == reflect.Pointer) && !custom {
 			// Check whether the sub-block is a root config block
 			rootName, rootDesc, isRoot := isRootBlock(field.Type, rootBlocks)
 
@@ -230,7 +230,7 @@ func config(block *ConfigBlock, cfg interface{}, flags map[uintptr]*flag.Flag, r
 				subBlock = block
 			}
 
-			if field.Type.Kind() == reflect.Ptr {
+			if field.Type.Kind() == reflect.Pointer {
 				// If this is a pointer, it's probably nil, so we initialize it.
 				fieldValue = reflect.New(field.Type.Elem())
 			} else if field.Type.Kind() == reflect.Struct {
@@ -260,7 +260,7 @@ func config(block *ConfigBlock, cfg interface{}, flags map[uintptr]*flag.Flag, r
 			// Add ConfigBlock for slices only if the field isn't a custom type,
 			// which shouldn't be inspected because doesn't have YAML tags, flag registrations, etc.
 			_, isCustomType := getFieldCustomType(field.Type)
-			isSliceOfStructs := field.Type.Kind() == reflect.Slice && (field.Type.Elem().Kind() == reflect.Struct || field.Type.Elem().Kind() == reflect.Ptr)
+			isSliceOfStructs := field.Type.Kind() == reflect.Slice && (field.Type.Elem().Kind() == reflect.Struct || field.Type.Elem().Kind() == reflect.Pointer)
 			if !isCustomType && isSliceOfStructs {
 				element = &ConfigBlock{
 					Name: fieldName,
@@ -273,7 +273,7 @@ func config(block *ConfigBlock, cfg interface{}, flags map[uintptr]*flag.Flag, r
 					return nil, errors.Wrapf(err, "couldn't inspect slice, element_type=%s", field.Type.Elem())
 				}
 			}
-			isMapOfStructs := field.Type.Kind() == reflect.Map && (field.Type.Elem().Kind() == reflect.Struct || field.Type.Elem().Kind() == reflect.Ptr)
+			isMapOfStructs := field.Type.Kind() == reflect.Map && (field.Type.Elem().Kind() == reflect.Struct || field.Type.Elem().Kind() == reflect.Pointer)
 			if !isCustomType && isMapOfStructs {
 				element = &ConfigBlock{
 					Name: fieldName,
@@ -441,7 +441,7 @@ func getFieldType(t reflect.Type) (string, error) {
 
 	case reflect.Struct:
 		return t.Name(), nil
-	case reflect.Ptr:
+	case reflect.Pointer:
 		return getFieldType(t.Elem())
 
 	default:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Fixes Go-related CVEs for branch `release-2.17` by upgrading Go 1.25.9 to 1.26.3.
We went right to 1.26.3 because it fixes all the same CVEs a 1.25.10, but the build image for main already got updated to 1.26.3 so we would be maintaining separate build images if we tried to keep this pinned down to 1.25.x

**High**
* [CVE-2026-42501](https://nvd.nist.gov/vuln/detail/CVE-2026-42501)
* [CVE-2026-42499](https://nvd.nist.gov/vuln/detail/CVE-2026-42499)
* [CVE-2026-39836](https://nvd.nist.gov/vuln/detail/CVE-2026-39836)
* [CVE-2026-39820](https://nvd.nist.gov/vuln/detail/CVE-2026-39820)
* [CVE-2026-33814](https://nvd.nist.gov/vuln/detail/CVE-2026-33814)
* [CVE-2026-33811](https://nvd.nist.gov/vuln/detail/CVE-2026-33811)

**Medium**
* [CVE-2026-39826](https://nvd.nist.gov/vuln/detail/CVE-2026-39826)
* [CVE-2026-39823](https://nvd.nist.gov/vuln/detail/CVE-2026-39823)
* [CVE-2026-39817](https://nvd.nist.gov/vuln/detail/CVE-2026-39817)
* [CVE-2026-39825](https://nvd.nist.gov/vuln/detail/CVE-2026-39825)
* [CVE-2026-39819](https://nvd.nist.gov/vuln/detail/CVE-2026-39819)

All code changes are lint fixes due to the change in Go version, backported from https://github.com/grafana/mimir/commit/b567e1932068646497a76ccbb9f9834067a7f5e6

For reference, the same was done for `release-3.0` at https://github.com/grafana/mimir/pull/15402

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades the Go toolchain and build image, which can subtly change compilation, reflection behavior, and test/runtime characteristics across the project. Remaining changes are largely mechanical/lint and test-stability adjustments, but they touch config doc/usage reflection paths.
> 
> **Overview**
> Updates the project toolchain from **Go 1.25.9 to 1.26.3** (including workflow setup-go, `go.mod`, and the `mimir-build-image` base image) to address multiple Go CVEs, and records the change in `CHANGELOG.md`.
> 
> Adjusts reflection-based code to use `reflect.Pointer` and improves pointer-field handling when mapping flags / generating config docs (notably in `pkg/util/usage` and `tools/doc-generator`). Includes mechanical string-building cleanups (`fmt.Fprintf`), bumps `golangci-lint` in the build image, updates the build image tag, and tweaks a Kafka reader test to reduce load/increase timeout and error rate for stability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 899cf0c1cc8fc3c4eba49431a1f6b5f063954e1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->