### PR TITLE
fix: release-3.0 update to go 1.26.3 for CVE fixes - manual backport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Grafana Mimir
 
 * [BUGFIX] Distributor: Fix nil pointer panic in `WriteRequest.Unmarshal` when receiving a Remote Write 2.0 request with zero timeseries. #14698
+* [BUGFIX] Update to Go v1.26.3 to address high-severity CVEs [CVE-2026-42501](https://pkg.go.dev/vuln/GO-2026-4984), [CVE-2026-39836](https://pkg.go.dev/vuln/GO-2026-4971), [CVE-2026-33811](https://pkg.go.dev/vuln/GO-2026-4981), [CVE-2026-33814](https://pkg.go.dev/vuln/GO-2026-4918), [CVE-2026-42499](https://pkg.go.dev/vuln/GO-2026-4977), [CVE-2026-39820](https://pkg.go.dev/vuln/GO-2026-4986) and other lower-severity CVEs. #15402
 
 ## 3.0.6
 

--- a/Makefile
+++ b/Makefile
@@ -225,7 +225,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr15043-5dd0b1424a
+LATEST_BUILD_IMAGE_TAG ?= pr15263-b90faf9665
 
 # TTY is parameterized to allow CI and scripts to run builds,
 # as it currently disallows TTY devices.

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -15377,12 +15377,12 @@
             "User": null,
             "Host": "localhost:8080",
             "Path": "/alertmanager",
-            "RawPath": "",
-            "OmitHost": false,
-            "ForceQuery": false,
-            "RawQuery": "",
             "Fragment": "",
-            "RawFragment": ""
+            "RawQuery": "",
+            "RawPath": "",
+            "RawFragment": "",
+            "ForceQuery": false,
+            "OmitHost": false
           },
           "fieldFlag": "alertmanager.web.external-url",
           "fieldType": "url"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/mimir
 
-go 1.25.9
+go 1.26.3
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.2
@@ -334,7 +334,7 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
-	golang.org/x/exp v0.0.0-20251009144603-d2f985daa21b
+	golang.org/x/exp v0.0.0-20251009144603-d2f985daa21b // indirect
 	golang.org/x/mod v0.34.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -5,7 +5,7 @@
 
 FROM registry.k8s.io/kustomize/kustomize:v5.4.3 AS kustomize
 FROM alpine/helm:3.17.2 AS helm
-FROM golang:1.25.9-trixie@sha256:091e6099f4a58e9393b8cc5615622a59c1cef64481b0ffcf349ec1574449059e
+FROM golang:1.26.3-trixie@sha256:d08bf3ed2bd263088ca8e23fefaf10f1b71769f6932f0a4017ba28d2a5baf001
 ARG goproxyValue
 ENV GOPROXY=${goproxyValue}
 ENV SKOPEO_DEPS="libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config"

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -39,7 +39,9 @@ RUN GOARCH=$(go env GOARCH) && \
     curl -fSL -o "/usr/bin/tk" "https://github.com/grafana/tanka/releases/download/v${TANKA_VERSION}/tk-linux-${GOARCH}" && \
     chmod a+x /usr/bin/tk
 
-RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b /usr/bin v2.4.0
+# renovate: depName=github.com/golangci/golangci-lint
+ENV GOLANGCI_LINT_VERSION=2.12.2
+RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/v"${GOLANGCI_LINT_VERSION}"/install.sh| sh -s -- -b /usr/bin v"${GOLANGCI_LINT_VERSION}"
 
 ENV SKOPEO_VERSION=v1.15.1
 RUN git clone --depth 1 --branch ${SKOPEO_VERSION} https://github.com/containers/skopeo /go/src/github.com/containers/skopeo && \

--- a/operations/mimir/mimir-flags-defaults.json
+++ b/operations/mimir/mimir-flags-defaults.json
@@ -1078,12 +1078,12 @@
     "User": null,
     "Host": "localhost:8080",
     "Path": "/alertmanager",
-    "RawPath": "",
-    "OmitHost": false,
-    "ForceQuery": false,
-    "RawQuery": "",
     "Fragment": "",
-    "RawFragment": ""
+    "RawQuery": "",
+    "RawPath": "",
+    "RawFragment": "",
+    "ForceQuery": false,
+    "OmitHost": false
   },
   "alertmanager.configs.poll-interval": 15000000000,
   "alertmanager.max-recv-msg-size": 104857600,

--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -333,7 +333,7 @@ func validateAlertmanagerConfig(cfg interface{}) error {
 
 	// If the input config is a pointer then we need to get its value.
 	// At this point the pointer value can't be nil.
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
 		t = v.Type()
 	}

--- a/pkg/alertmanager/multitenant_test.go
+++ b/pkg/alertmanager/multitenant_test.go
@@ -3739,7 +3739,7 @@ func Test_amConfigFingerprint(t *testing.T) {
 		// Helper function to get field count of a struct
 		getFieldCount := func(v interface{}) int {
 			t := reflect.TypeOf(v)
-			if t.Kind() == reflect.Ptr {
+			if t.Kind() == reflect.Pointer {
 				t = t.Elem()
 			}
 			return t.NumField()

--- a/pkg/blockbuilder/scheduler/scheduler_test.go
+++ b/pkg/blockbuilder/scheduler/scheduler_test.go
@@ -255,10 +255,10 @@ func requireGaps(t *testing.T, reg *prometheus.Registry, planned, committed int,
 		# TYPE cortex_blockbuilder_scheduler_job_gap_detected counter
 		`)
 
-	b.WriteString(fmt.Sprintf(
-		"cortex_blockbuilder_scheduler_job_gap_detected{offset_type=\"planned\"} %d\n", planned))
-	b.WriteString(fmt.Sprintf(
-		"cortex_blockbuilder_scheduler_job_gap_detected{offset_type=\"committed\"} %d\n", committed))
+	fmt.Fprintf(&b,
+		"cortex_blockbuilder_scheduler_job_gap_detected{offset_type=\"planned\"} %d\n", planned)
+	fmt.Fprintf(&b,
+		"cortex_blockbuilder_scheduler_job_gap_detected{offset_type=\"committed\"} %d\n", committed)
 
 	require.NoError(t,
 		promtest.GatherAndCompare(reg, strings.NewReader(b.String()),

--- a/pkg/frontend/querymiddleware/labels_query_cache.go
+++ b/pkg/frontend/querymiddleware/labels_query_cache.go
@@ -109,9 +109,9 @@ func generateLabelsQueryRequestCacheKey(startTime, endTime int64, labelName stri
 	}
 
 	// Add start and end time.
-	b.WriteString(fmt.Sprintf("%d", startTime))
+	fmt.Fprintf(&b, "%d", startTime)
 	b.WriteRune(stringParamSeparator)
-	b.WriteString(fmt.Sprintf("%d", endTime))
+	fmt.Fprintf(&b, "%d", endTime)
 
 	// Add label name (if any).
 	if labelName != "" {

--- a/pkg/frontend/querymiddleware/response_parsing_edge_cases_test.go
+++ b/pkg/frontend/querymiddleware/response_parsing_edge_cases_test.go
@@ -220,7 +220,7 @@ func TestCodec_ResponseParsingEdgeCases(t *testing.T) {
 						buf.WriteString(",")
 					}
 					buf.WriteString(`{"index":`)
-					buf.WriteString(fmt.Sprintf("%d", i))
+					fmt.Fprintf(&buf, "%d", i)
 					buf.WriteString(`,"data":"`)
 					buf.WriteString(strings.Repeat("1234567890", 10)) // 100 chars per item
 					buf.WriteString(`"}`)

--- a/pkg/frontend/querymiddleware/roundtrip_test.go
+++ b/pkg/frontend/querymiddleware/roundtrip_test.go
@@ -641,7 +641,7 @@ func TestMiddlewaresConsistency(t *testing.T) {
 	// Utility to get the name of the struct.
 	getName := func(i interface{}) string {
 		t := reflect.TypeOf(i)
-		if t.Kind() == reflect.Ptr {
+		if t.Kind() == reflect.Pointer {
 			t = t.Elem()
 		}
 		return t.Name()

--- a/pkg/ingester/activeseries/model/custom_trackers_config_test.go
+++ b/pkg/ingester/activeseries/model/custom_trackers_config_test.go
@@ -133,7 +133,7 @@ func TestMaximumNumberOfTrackers(t *testing.T) {
 		var flagToSet bytes.Buffer
 		numberOfTrackers := maxNumberOfTrackers + 1
 		for i := 0; i < numberOfTrackers; i++ {
-			flagToSet.WriteString(fmt.Sprintf("name%d:{__name__=%d}", i, i))
+			fmt.Fprintf(&flagToSet, "name%d:{__name__=%d}", i, i)
 			if i < numberOfTrackers-1 {
 				flagToSet.WriteString(";")
 			}

--- a/pkg/mimirpb/prealloc_rw2_test.go
+++ b/pkg/mimirpb/prealloc_rw2_test.go
@@ -674,7 +674,7 @@ func TestWriteRequestRW2Conversion_WriteRequestHasChanged(t *testing.T) {
 	val := reflect.ValueOf(&WriteRequest{})
 	typ := val.Type()
 
-	if typ.Kind() == reflect.Ptr {
+	if typ.Kind() == reflect.Pointer {
 		typ = typ.Elem()
 	}
 

--- a/pkg/mimirpb/split_test.go
+++ b/pkg/mimirpb/split_test.go
@@ -423,7 +423,7 @@ func TestSplitWriteRequestByMaxMarshalSize_WriteRequestHasChanged(t *testing.T) 
 	val := reflect.ValueOf(&WriteRequest{})
 	typ := val.Type()
 
-	if typ.Kind() == reflect.Ptr {
+	if typ.Kind() == reflect.Pointer {
 		typ = typ.Elem()
 	}
 

--- a/pkg/mimirtool/commands/config.go
+++ b/pkg/mimirtool/commands/config.go
@@ -153,21 +153,21 @@ func (c *ConfigCommand) writeNotices(notices config.ConversionNotices, w io.Writ
 	}
 	noticesOut := bytes.Buffer{}
 	for _, p := range notices.RemovedParameters {
-		_, _ = noticesOut.WriteString(fmt.Sprintf("field is no longer supported: %s\n", p))
+		_, _ = fmt.Fprintf(&noticesOut, "field is no longer supported: %s\n", p)
 	}
 	for _, f := range notices.RemovedCLIFlags {
-		_, _ = noticesOut.WriteString(fmt.Sprintf("flag is no longer supported: -%s \n", f))
+		_, _ = fmt.Fprintf(&noticesOut, "flag is no longer supported: -%s \n", f)
 	}
 	for _, d := range notices.ChangedDefaults {
 		oldDefault, newDefault := placeholderIfEmpty(d.OldDefault), placeholderIfEmpty(d.NewDefault)
-		_, _ = noticesOut.WriteString(fmt.Sprintf("using a new default for %s: %s (used to be %s)\n", d.Path, newDefault, oldDefault))
+		_, _ = fmt.Fprintf(&noticesOut, "using a new default for %s: %s (used to be %s)\n", d.Path, newDefault, oldDefault)
 	}
 	for _, d := range notices.SkippedChangedDefaults {
 		oldDefault, newDefault := placeholderIfEmpty(d.OldDefault), placeholderIfEmpty(d.NewDefault)
-		_, _ = noticesOut.WriteString(fmt.Sprintf("default value for %s changed: %s (used to be %s); not updating\n", d.Path, newDefault, oldDefault))
+		_, _ = fmt.Fprintf(&noticesOut, "default value for %s changed: %s (used to be %s); not updating\n", d.Path, newDefault, oldDefault)
 	}
 	for _, d := range notices.PrunedDefaults {
-		_, _ = noticesOut.WriteString(fmt.Sprintf("removed default value %s: %s\n", d.Path, placeholderIfEmpty(d.Value)))
+		_, _ = fmt.Fprintf(&noticesOut, "removed default value %s: %s\n", d.Path, placeholderIfEmpty(d.Value))
 	}
 
 	_, err := noticesOut.WriteTo(w)

--- a/pkg/storage/lazyquery/lazyquery_test.go
+++ b/pkg/storage/lazyquery/lazyquery_test.go
@@ -38,7 +38,7 @@ func TestCopyParamsDeepCopy(t *testing.T) {
 
 		switch originalField.Kind() {
 		// For reference types, ensure they point to different memory
-		case reflect.Slice, reflect.Map, reflect.Ptr:
+		case reflect.Slice, reflect.Map, reflect.Pointer:
 			if !originalField.IsNil() {
 				assert.NotEqual(t, originalField.UnsafePointer(), copiedField.UnsafePointer(), "Field %s shares memory between original and copy", typ.Field(i).Name)
 			}

--- a/pkg/util/limiter/utilization.go
+++ b/pkg/util/limiter/utilization.go
@@ -276,7 +276,7 @@ func (b *cpuSampleBuffer) String() string {
 	var sb strings.Builder
 	for i := range b.samples {
 		s := b.samples[(b.head+i)%len(b.samples)]
-		sb.WriteString(fmt.Sprintf("%.2f", s))
+		fmt.Fprintf(&sb, "%.2f", s)
 		if i < len(b.samples)-1 {
 			sb.WriteByte(',')
 		}

--- a/pkg/util/usage/usage.go
+++ b/pkg/util/usage/usage.go
@@ -38,7 +38,7 @@ func Usage(printAll bool, configs ...interface{}) error {
 		if fl.Value.String() == "deprecated" {
 			return
 		}
-		if v.Kind() == reflect.Ptr {
+		if v.Kind() == reflect.Pointer {
 			ptr := v.Pointer()
 			field, hasField = fields[ptr]
 			if hasField && isFieldHidden(field, fl.Name) {
@@ -90,7 +90,7 @@ func Usage(printAll bool, configs ...interface{}) error {
 
 		if defValue := getFlagDefault(fl, field); !isZeroValue(fl, defValue) {
 			v := reflect.ValueOf(fl.Value)
-			if v.Kind() == reflect.Ptr {
+			if v.Kind() == reflect.Pointer {
 				v = v.Elem()
 			}
 			if v.Kind() == reflect.String {
@@ -118,7 +118,7 @@ func isZeroValue(fl *flag.Flag, value string) bool {
 	// This works unless the Value type is itself an interface type.
 	typ := reflect.TypeOf(fl.Value)
 	var z reflect.Value
-	if typ.Kind() == reflect.Ptr {
+	if typ.Kind() == reflect.Pointer {
 		z = reflect.New(typ.Elem())
 	} else {
 		z = reflect.Zero(typ)
@@ -129,9 +129,9 @@ func isZeroValue(fl *flag.Flag, value string) bool {
 // parseStructure parses a struct and populates fields.
 func parseStructure(structure interface{}, fields map[uintptr]reflect.StructField) error {
 	// structure is expected to be a pointer to a struct
-	if reflect.TypeOf(structure).Kind() != reflect.Ptr {
+	if reflect.TypeOf(structure).Kind() != reflect.Pointer {
 		t := reflect.TypeOf(structure)
-		return fmt.Errorf("%s is a %s while a %s is expected", t, t.Kind(), reflect.Ptr)
+		return fmt.Errorf("%s is a %s while a %s is expected", t, t.Kind(), reflect.Pointer)
 	}
 	v := reflect.ValueOf(structure).Elem()
 	if v.Kind() != reflect.Struct {
@@ -150,6 +150,12 @@ func parseStructure(structure interface{}, fields map[uintptr]reflect.StructFiel
 
 		// Take address of field value and map it to field
 		fields[fieldValue.Addr().Pointer()] = field
+
+		// For pointer fields (e.g. *bool), the flag is registered with the
+		// pointed-to address, not the address of the pointer field itself.
+		if fieldValue.Kind() == reflect.Pointer && !fieldValue.IsNil() {
+			fields[fieldValue.Pointer()] = field
+		}
 
 		// Recurse if a struct
 		if field.Type.Kind() != reflect.Struct || isFieldHidden(field, "") || ignoreStructType(field.Type) || !field.IsExported() {

--- a/tools/add-license/main.go
+++ b/tools/add-license/main.go
@@ -88,7 +88,7 @@ func addLicense(dir string) error {
 		// Add the default license directory if none exists.
 		if !strings.Contains(string(b), commentStyle+" "+licenseDirective+":") {
 			log.Printf("adding the license directive to %s\n", path)
-			_, _ = bb.WriteString(fmt.Sprintf("%s %s: %s\n", commentStyle, licenseDirective, defaultLicense))
+			_, _ = fmt.Fprintf(&bb, "%s %s: %s\n", commentStyle, licenseDirective, defaultLicense)
 		}
 
 		// Add the provenance from Cortex for forked files. This has been run just once

--- a/tools/doc-generator/parse/parser.go
+++ b/tools/doc-generator/parse/parser.go
@@ -138,9 +138,9 @@ func config(block *ConfigBlock, cfg interface{}, flags map[uintptr]*flag.Flag, r
 	}
 
 	// The input config is expected to be addressable.
-	if reflect.TypeOf(cfg).Kind() != reflect.Ptr {
+	if reflect.TypeOf(cfg).Kind() != reflect.Pointer {
 		t := reflect.TypeOf(cfg)
-		return nil, fmt.Errorf("%s is a %s while a %s is expected", t, t.Kind(), reflect.Ptr)
+		return nil, fmt.Errorf("%s is a %s while a %s is expected", t, t.Kind(), reflect.Pointer)
 	}
 
 	// The input config is expected to be a pointer to struct.
@@ -187,8 +187,9 @@ func config(block *ConfigBlock, cfg interface{}, flags map[uintptr]*flag.Flag, r
 			continue
 		}
 
-		// Recursively re-iterate if it's a struct and it's not a custom type.
-		if _, custom := getFieldCustomType(field.Type); (field.Type.Kind() == reflect.Struct || field.Type.Kind() == reflect.Ptr) && !custom {
+		// Recursively re-iterate if it's a struct (or pointer to struct) and it's not a custom type.
+		if _, custom := getFieldCustomType(field.Type); !custom &&
+			(field.Type.Kind() == reflect.Struct || (field.Type.Kind() == reflect.Pointer && field.Type.Elem().Kind() == reflect.Struct)) {
 			// Check whether the sub-block is a root config block
 			rootName, rootDesc, isRoot := isRootBlock(field.Type, rootBlocks)
 
@@ -231,7 +232,7 @@ func config(block *ConfigBlock, cfg interface{}, flags map[uintptr]*flag.Flag, r
 				subBlock = block
 			}
 
-			if field.Type.Kind() == reflect.Ptr {
+			if field.Type.Kind() == reflect.Pointer {
 				// If this is a pointer, it's probably nil, so we initialize it.
 				fieldValue = reflect.New(field.Type.Elem())
 			} else if field.Type.Kind() == reflect.Struct {
@@ -261,7 +262,7 @@ func config(block *ConfigBlock, cfg interface{}, flags map[uintptr]*flag.Flag, r
 			// Add ConfigBlock for slices only if the field isn't a custom type,
 			// which shouldn't be inspected because doesn't have YAML tags, flag registrations, etc.
 			_, isCustomType := getFieldCustomType(field.Type)
-			isSliceOfStructs := field.Type.Kind() == reflect.Slice && (field.Type.Elem().Kind() == reflect.Struct || field.Type.Elem().Kind() == reflect.Ptr)
+			isSliceOfStructs := field.Type.Kind() == reflect.Slice && (field.Type.Elem().Kind() == reflect.Struct || field.Type.Elem().Kind() == reflect.Pointer)
 			if !isCustomType && isSliceOfStructs {
 				element = &ConfigBlock{
 					Name: fieldName,
@@ -274,7 +275,7 @@ func config(block *ConfigBlock, cfg interface{}, flags map[uintptr]*flag.Flag, r
 					return nil, errors.Wrapf(err, "couldn't inspect slice, element_type=%s", field.Type.Elem())
 				}
 			}
-			isMapOfStructs := field.Type.Kind() == reflect.Map && (field.Type.Elem().Kind() == reflect.Struct || field.Type.Elem().Kind() == reflect.Ptr)
+			isMapOfStructs := field.Type.Kind() == reflect.Map && (field.Type.Elem().Kind() == reflect.Struct || field.Type.Elem().Kind() == reflect.Pointer)
 			if !isCustomType && isMapOfStructs {
 				element = &ConfigBlock{
 					Name: fieldName,
@@ -444,7 +445,7 @@ func getFieldType(t reflect.Type) (string, error) {
 
 	case reflect.Struct:
 		return t.Name(), nil
-	case reflect.Ptr:
+	case reflect.Pointer:
 		return getFieldType(t.Elem())
 
 	default:
@@ -493,7 +494,12 @@ func getFieldFlag(field reflect.StructField, fieldValue reflect.Value, flags map
 	if isAbsentInCLI(field) {
 		return nil, nil
 	}
-	fieldPtr := fieldValue.Addr().Pointer()
+	var fieldPtr uintptr
+	if fieldValue.Kind() == reflect.Pointer && !fieldValue.IsNil() {
+		fieldPtr = fieldValue.Pointer()
+	} else {
+		fieldPtr = fieldValue.Addr().Pointer()
+	}
 	fieldFlag, ok := flags[fieldPtr]
 	if !ok {
 		return nil, nil

--- a/tools/promql-generator/promql-generator.go
+++ b/tools/promql-generator/promql-generator.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -34,7 +35,6 @@ import (
 	"github.com/grafana/dskit/flagext"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
-	"golang.org/x/exp/slices"
 )
 
 var (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Update to Go v1.26.3 to address high-severity CVEs [CVE-2026-42501](https://pkg.go.dev/vuln/GO-2026-4984), [CVE-2026-39836](https://pkg.go.dev/vuln/GO-2026-4971), [CVE-2026-33811](https://pkg.go.dev/vuln/GO-2026-4981), [CVE-2026-33814](https://pkg.go.dev/vuln/GO-2026-4918), [CVE-2026-42499](https://pkg.go.dev/vuln/GO-2026-4977), [CVE-2026-39820](https://pkg.go.dev/vuln/GO-2026-4986) and other lower-severity CVEs.

All code changes are lint fixes due to the change in Go version, backported from https://github.com/grafana/mimir/commit/b567e1932068646497a76ccbb9f9834067a7f5e6

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades the Go toolchain and build image, which can subtly change compilation/runtime behavior and CI tooling outputs. Also adjusts reflection-based flag/doc mapping for pointer fields, which could affect generated docs/usage output if incorrect.
> 
> **Overview**
> Updates the project to **Go 1.26.3** (including the `mimir-build-image` base `golang` image) and records the CVE-driven bump in `CHANGELOG.md`.
> 
> Modernizes code for the newer Go/stdlib by switching reflection checks from `reflect.Ptr` to `reflect.Pointer` and replacing a number of `fmt.Sprintf`+`WriteString` patterns with `fmt.Fprintf` to builders/buffers.
> 
> Fixes/adjusts reflection-based config/flag documentation and usage generation to better handle pointer fields by mapping both the pointer field address and the pointed-to value address when resolving CLI flags; this also results in regenerated default config JSON ordering for URL fields. Additionally, `tools/promql-generator` moves from `golang.org/x/exp/slices` to the stdlib `slices` package, and the build tooling pins `golangci-lint` via an environment variable (v2.12.2).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05b6693120d134c361012576e725ed66983b5931. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->