### PR TITLE
Alertmanager: refine state initial sync duration buckets

### DIFF
--- a/pkg/alertmanager/state_replication.go
+++ b/pkg/alertmanager/state_replication.go
@@ -116,7 +116,7 @@ func newReplicatedStates(userID string, rf int, re Replicator, st alertstore.Ale
 		initialSyncDuration: promauto.With(r).NewHistogram(prometheus.HistogramOpts{
 			Name:    "alertmanager_state_initial_sync_duration_seconds",
 			Help:    "Time spent syncing initial state from peers or remote storage.",
-			Buckets: prometheus.ExponentialBuckets(0.008, 4, 7),
+			Buckets: []float64{0.1, 0.5, 1, 2, 5, 10, 15, 30, 60, 120, 300},
 		}),
 	}
 	s.initialSyncCompleted.WithLabelValues(syncFromReplica)


### PR DESCRIPTION
Adjusts buckets for `alertmanager_state_initial_sync_duration_seconds`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes Prometheus histogram bucket boundaries for an existing metric, which may affect dashboards/alerts but not runtime behavior.
> 
> **Overview**
> Refines the `alertmanager_state_initial_sync_duration_seconds` Prometheus histogram by replacing exponential buckets with an explicit set of duration buckets (0.1s through 300s) to improve visibility into initial sync timings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ad9f59fcea1d019da74ea85e0fd28efce410f4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->