### PR TITLE
[mimir-distributed-release-6.0] ci: update helm-release workflow to use GATB

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -20,7 +20,4 @@ jobs:
       charts_dir: operations/helm/charts
       cr_configfile: operations/helm/cr.yaml
       ct_configfile: operations/helm/ct.yaml
-    secrets:
-      # "mimir-helm-release" is a GitHub app, that has permissions to push to grafana/helm-charts.
-      # The app's credentials seat in the mimir repo's vault (ref https://github.com/grafana/shared-workflows/tree/main/actions/get-vault-secrets).
-      vault_repo_secret_name: mimir-helm-release
+      github_app: mimir-helm-release


### PR DESCRIPTION
Backport of https://github.com/grafana/mimir/pull/15406 to mimir-distributed-release-6.0