### PR TITLE
MQE: Fix TestRangeOperator behavior for RangeStart

### DIFF
--- a/pkg/streamingpromql/operators/drop_name_test.go
+++ b/pkg/streamingpromql/operators/drop_name_test.go
@@ -24,9 +24,9 @@ func TestDropName(t *testing.T) {
 		labels.FromStrings(model.MetricNameLabel, "metric", "foo", "3"),
 	}
 	inputData := []types.InstantVectorSeriesData{
-		{Floats: []promql.FPoint{{T: 0, F: 0}, {T: 1, F: 1}}},
-		{Floats: []promql.FPoint{{T: 0, F: 10}, {T: 1, F: 11}}},
-		{Floats: []promql.FPoint{{T: 0, F: 20}, {T: 1, F: 21}}},
+		{Floats: []promql.FPoint{{T: 1, F: 1}}},
+		{Floats: []promql.FPoint{{T: 1, F: 11}}},
+		{Floats: []promql.FPoint{{T: 1, F: 21}}},
 	}
 	inputDropName := []bool{
 		true,
@@ -39,9 +39,9 @@ func TestDropName(t *testing.T) {
 		labels.FromStrings("foo", "3"),
 	}
 	expectedOutputData := []types.InstantVectorSeriesData{
-		{Floats: []promql.FPoint{{T: 0, F: 0}, {T: 1, F: 1}}},
-		{Floats: []promql.FPoint{{T: 0, F: 10}, {T: 1, F: 11}}},
-		{Floats: []promql.FPoint{{T: 0, F: 20}, {T: 1, F: 21}}},
+		{Floats: []promql.FPoint{{T: 1, F: 1}}},
+		{Floats: []promql.FPoint{{T: 1, F: 11}}},
+		{Floats: []promql.FPoint{{T: 1, F: 21}}},
 	}
 	expectedOutputDropName := []bool{
 		false,

--- a/pkg/streamingpromql/operators/test_operator.go
+++ b/pkg/streamingpromql/operators/test_operator.go
@@ -233,6 +233,11 @@ func (t *TestRangeOperator) NextStepSamples(_ context.Context) (*types.RangeVect
 			return nil, err
 		}
 	}
+
+	// We use `0` for RangeStart of the only step we emit for each series which is
+	// exclusive, so we need to drop anything at or before that timestamp. This logic
+	// matches the logic used by the RangeVectorSelector.
+	t.Floats.DiscardPointsAtOrBefore(0)
 	t.FloatsView = t.Floats.ViewUntilSearchingBackwards(endT, t.FloatsView)
 
 	t.Histograms.Reset()
@@ -241,6 +246,8 @@ func (t *TestRangeOperator) NextStepSamples(_ context.Context) (*types.RangeVect
 			return nil, err
 		}
 	}
+
+	t.Histograms.DiscardPointsAtOrBefore(0)
 	t.HistogramsView = t.Histograms.ViewUntilSearchingBackwards(endT, t.HistogramsView)
 
 	return &types.RangeVectorStepData{

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator_test.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator_test.go
@@ -793,12 +793,12 @@ func TestRangeVectorOperator_Cloning_SmoothedAnchored(t *testing.T) {
 func TestRangeVectorOperator_Cloning(t *testing.T) {
 	series := types.InstantVectorSeriesData{
 		Floats: []promql.FPoint{
-			{T: 0, F: 0},
 			{T: 1, F: 1},
+			{T: 2, F: 2},
 		},
 		Histograms: []promql.HPoint{
-			{T: 2, H: &histogram.FloatHistogram{Count: 2}},
 			{T: 3, H: &histogram.FloatHistogram{Count: 3}},
+			{T: 4, H: &histogram.FloatHistogram{Count: 4}},
 		},
 	}
 
@@ -871,7 +871,7 @@ func createTestRangeVectorOperator(t *testing.T, seriesCount int, memoryConsumpt
 
 		data = append(data, types.InstantVectorSeriesData{
 			Floats: []promql.FPoint{
-				{T: 0, F: float64(i)},
+				{T: 60_000, F: float64(i)},
 			},
 		})
 	}


### PR DESCRIPTION
#### What this PR does

Fix an issue where step data emitted by `TestRangeOperator` was included even if its timestamp fell on RangeStart which is meant to be exclusive. This brings `TestRangeOperator` behavior inline with `RangeVectorSelector`, the production implementation.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to test-only operators and adjust test fixtures/expectations to match production range selector semantics.
> 
> **Overview**
> Aligns the test-only `TestRangeOperator` with production `RangeVectorSelector` behavior by discarding float and histogram points with timestamps `<= RangeStart` (hardcoded `0` for its single emitted step).
> 
> Updates unit tests (`drop_name_test` and range-vector buffer/clone tests) to avoid using samples at `T=0` and to reflect the new exclusive `RangeStart` semantics (eg. shifting sample timestamps to `T=1`/`60_000`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2af50122194536fda9e3ac67868baa1751d49e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->