### PR TITLE
MQE: Don't buffer samples from overlapping ranges in CSE

### DIFF
--- a/pkg/streamingpromql/benchmarks/comparison_test.go
+++ b/pkg/streamingpromql/benchmarks/comparison_test.go
@@ -93,8 +93,6 @@ func BenchmarkQuery(b *testing.B) {
 }
 
 func TestBothEnginesReturnSameResultsForBenchmarkQueries(t *testing.T) {
-	t.Skip("range queries with range selectors that overlap the query step are a pathological case for the CSE pass which causes this test to consume an excessive amount of memory")
-
 	metricSizes := []int{1, 100} // Don't bother with 2000 series test here: these test cases take a while and they're most interesting as benchmarks, not correctness tests.
 	q := createBenchmarkQueryable(t, metricSizes)
 	cases := TestCases(metricSizes)

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator.go
@@ -145,10 +145,7 @@ func (b *RangeVectorDuplicationBuffer) NextSeries(consumer *RangeVectorDuplicati
 }
 
 func (b *RangeVectorDuplicationBuffer) bufferUpToAndIncluding(ctx context.Context, desiredSeriesIndex int, desiredStepIndex int) (bufferedRangeVectorStepData, error) {
-	var (
-		lastStepData bufferedRangeVectorStepData
-		tainted      viewTaint
-	)
+	var lastStepData bufferedRangeVectorStepData
 
 	for b.lastNextSeriesCallIndex < desiredSeriesIndex || (b.lastNextSeriesCallIndex == desiredSeriesIndex && b.lastNextStepSamplesCallIndex < desiredStepIndex) {
 		if b.lastNextStepSamplesCallIndex == b.timeRange.StepCount-1 || b.lastNextSeriesCallIndex == -1 {
@@ -156,12 +153,6 @@ func (b *RangeVectorDuplicationBuffer) bufferUpToAndIncluding(ctx context.Contex
 			if err := b.Inner.NextSeries(ctx); err != nil {
 				return bufferedRangeVectorStepData{}, err
 			}
-
-			// After advancing to next series we need to recreate the views of all the previous series
-			// steps if we updated the underlying buffers used by float points or histogram points and
-			// caused them to be resized.
-			b.updateViewsForSeries(b.lastNextSeriesCallIndex, tainted)
-			tainted = viewTaint{}
 
 			b.lastNextStepSamplesCallIndex = -1
 			b.lastNextSeriesCallIndex++
@@ -177,51 +168,22 @@ func (b *RangeVectorDuplicationBuffer) bufferUpToAndIncluding(ctx context.Contex
 			return bufferedRangeVectorStepData{}, err
 		}
 
-		combinedStepData, combinedTaint, err := b.combineStepData(stepData, b.lastNextSeriesCallIndex)
+		combinedStepData, err := b.combineStepData(stepData, b.lastNextSeriesCallIndex)
 		if err != nil {
 			return bufferedRangeVectorStepData{}, err
 		}
-
-		tainted = tainted.merge(combinedTaint)
 
 		b.lastNextStepSamplesCallIndex++
 		b.buffer.Append(combinedStepData, b.lastNextSeriesCallIndex, b.lastNextStepSamplesCallIndex)
 		lastStepData = combinedStepData
 	}
 
-	// Update the views for the current series one last time if we've added anything to the
-	// underlying float point or histogram point buffers and had to resize since reading step data.
-	b.updateViewsForSeries(b.lastNextSeriesCallIndex, tainted)
-
 	return lastStepData, nil
 }
 
-func (b *RangeVectorDuplicationBuffer) updateViewsForSeries(seriesIndex int, taint viewTaint) {
-	if !taint.needsUpdate() {
-		return
-	}
-
-	floats := b.buffer.GetOrCreateFloatBuffer(seriesIndex)
-	histograms := b.buffer.GetOrCreateHistogramBuffer(seriesIndex)
-
-	for stepIdx := range b.timeRange.StepCount {
-		if d, present := b.buffer.GetIfPresent(seriesIndex, stepIdx); present {
-			// Only update the views for this step if the underlying buffers have been changed
-			// and this step isn't using dedicated buffers (which we do for anchored/smoothed).
-			if taint.floats && d.floatData == nil {
-				d.stepData.Floats = floats.ViewBetweenSearchingBackwards(d.stepData.RangeStart, d.stepData.RangeEnd, d.stepData.Floats)
-			}
-			if taint.histograms && d.histogramData == nil {
-				d.stepData.Histograms = histograms.ViewBetweenSearchingBackwards(d.stepData.RangeStart, d.stepData.RangeEnd, d.stepData.Histograms)
-			}
-		}
-	}
-}
-
 // combineStepData copies stepData into buffers owned by this struct (either shared per series or unique
-// to each step) and returns a "taint" to indicate if the shared buffers were modified, requiring existing
-// views of them to be updated.
-func (b *RangeVectorDuplicationBuffer) combineStepData(stepData *types.RangeVectorStepData, seriesIndex int) (bufferedRangeVectorStepData, viewTaint, error) {
+// to each step).
+func (b *RangeVectorDuplicationBuffer) combineStepData(stepData *types.RangeVectorStepData, seriesIndex int) (bufferedRangeVectorStepData, error) {
 	// anchored/smoothed modifiers cause extra data to be included in the view for a particular
 	// step beyond the range start/end and may include synthetic points. For simplicity in this
 	// case, we don't bother trying to use a shared buffer for all steps and instead fall back
@@ -229,10 +191,10 @@ func (b *RangeVectorDuplicationBuffer) combineStepData(stepData *types.RangeVect
 	if stepData.Anchored || stepData.Smoothed {
 		cloned, err := cloneStepData(stepData)
 		if err != nil {
-			return bufferedRangeVectorStepData{}, viewTaint{}, err
+			return bufferedRangeVectorStepData{}, err
 		}
 
-		return cloned, viewTaint{}, nil
+		return cloned, nil
 	}
 
 	// When not using anchored/smoothed modifiers, we can use a single buffer for all points in a
@@ -630,9 +592,9 @@ func cloneStepData(stepData *types.RangeVectorStepData) (bufferedRangeVectorStep
 
 // mergeStepData adds all unique points from stepData to the shared floats and histograms buffers.
 // The dedicated buffers bufferedRangeVectorStepData will be nil since the shared buffers are used.
-func mergeStepData(stepData *types.RangeVectorStepData, floats *types.FPointRingBuffer, histograms *types.HPointRingBuffer) (bufferedRangeVectorStepData, viewTaint, error) {
+func mergeStepData(stepData *types.RangeVectorStepData, floats *types.FPointRingBuffer, histograms *types.HPointRingBuffer) (bufferedRangeVectorStepData, error) {
 	if stepData.Anchored || stepData.Smoothed {
-		return bufferedRangeVectorStepData{}, viewTaint{}, fmt.Errorf("cannot use shared FPoint and HPoint buffers with anchored/smoothed modifiers (this is a bug)")
+		return bufferedRangeVectorStepData{}, fmt.Errorf("cannot use shared FPoint and HPoint buffers with anchored/smoothed modifiers (this is a bug)")
 	}
 
 	var lastF promql.FPoint
@@ -645,18 +607,14 @@ func mergeStepData(stepData *types.RangeVectorStepData, floats *types.FPointRing
 		lastH = histograms.Last()
 	}
 
-	var taint viewTaint
-
 	headF, tailF := stepData.Floats.UnsafePoints()
 	for _, section := range [][]promql.FPoint{headF, tailF} {
 		for _, p := range section {
 			if floats.Count() == 0 || p.T > lastF.T {
-				resized, err := floats.Append(promql.FPoint{T: p.T, F: p.F})
+				_, err := floats.Append(promql.FPoint{T: p.T, F: p.F})
 				if err != nil {
-					return bufferedRangeVectorStepData{}, taint, err
+					return bufferedRangeVectorStepData{}, err
 				}
-
-				taint.floats = taint.floats || resized
 			}
 		}
 	}
@@ -665,12 +623,10 @@ func mergeStepData(stepData *types.RangeVectorStepData, floats *types.FPointRing
 	for _, section := range [][]promql.HPoint{headH, tailH} {
 		for _, p := range section {
 			if histograms.Count() == 0 || p.T > lastH.T {
-				resized, err := histograms.Append(promql.HPoint{T: p.T, H: p.H.Copy()})
+				_, err := histograms.Append(promql.HPoint{T: p.T, H: p.H.Copy()})
 				if err != nil {
-					return bufferedRangeVectorStepData{}, taint, err
+					return bufferedRangeVectorStepData{}, err
 				}
-
-				taint.histograms = taint.histograms || resized
 			}
 		}
 	}
@@ -685,7 +641,7 @@ func mergeStepData(stepData *types.RangeVectorStepData, floats *types.FPointRing
 	merged.Floats = floats.ViewBetweenSearchingBackwards(stepData.RangeStart, stepData.RangeEnd, nil)
 	merged.Histograms = histograms.ViewBetweenSearchingBackwards(stepData.RangeStart, stepData.RangeEnd, nil)
 
-	return bufferedRangeVectorStepData{stepData: &merged}, taint, nil
+	return bufferedRangeVectorStepData{stepData: &merged}, nil
 }
 
 type bufferedRangeVectorStepData struct {
@@ -887,22 +843,4 @@ func (b *rangeVectorSeriesDataRingBuffer) Clear() {
 		d := b.seriesHistogramData.RemoveFirst()
 		d.Close()
 	}
-}
-
-// viewTaint keeps track of if float or histogram point views for a particular
-// series need to be updated because the underlying buffer has been changed in a
-// way that invalidates the view.
-type viewTaint struct {
-	floats     bool
-	histograms bool
-}
-
-func (v viewTaint) needsUpdate() bool {
-	return v.floats || v.histograms
-}
-
-func (v viewTaint) merge(other viewTaint) viewTaint {
-	v.floats = v.floats || other.floats
-	v.histograms = v.histograms || other.histograms
-	return v
 }

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator.go
@@ -589,7 +589,7 @@ func cloneStepData(stepData *types.RangeVectorStepData) (bufferedRangeVectorStep
 }
 
 // mergeStepData adds all unique points from stepData to the shared floats and histograms buffers.
-// The dedicated buffers bufferedRangeVectorStepData will be nil since the shared buffers are used.
+// The dedicated buffers in bufferedRangeVectorStepData will be nil since the shared buffers are used.
 func (b *RangeVectorDuplicationBuffer) mergeStepData(stepData *types.RangeVectorStepData, seriesIndex int) (bufferedRangeVectorStepData, error) {
 	if stepData.Anchored || stepData.Smoothed {
 		return bufferedRangeVectorStepData{}, fmt.Errorf("cannot use shared FPoint and HPoint buffers with anchored/smoothed modifiers (this is a bug)")

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator.go
@@ -200,9 +200,7 @@ func (b *RangeVectorDuplicationBuffer) combineStepData(stepData *types.RangeVect
 	// When not using anchored/smoothed modifiers, we can use a single buffer for all points in a
 	// particular series. This minimizes duplicated points when the range selector for each step
 	// overlaps with the range selector of the previous step.
-	floats := b.buffer.GetOrCreateFloatBuffer(seriesIndex)
-	histograms := b.buffer.GetOrCreateHistogramBuffer(seriesIndex)
-	return mergeStepData(stepData, floats, histograms)
+	return b.mergeStepData(stepData, seriesIndex)
 }
 
 func (b *RangeVectorDuplicationBuffer) anyConsumerWillReadSeries(unfilteredSeriesIndex int, ignore *RangeVectorDuplicationConsumer) bool {
@@ -592,25 +590,36 @@ func cloneStepData(stepData *types.RangeVectorStepData) (bufferedRangeVectorStep
 
 // mergeStepData adds all unique points from stepData to the shared floats and histograms buffers.
 // The dedicated buffers bufferedRangeVectorStepData will be nil since the shared buffers are used.
-func mergeStepData(stepData *types.RangeVectorStepData, floats *types.FPointRingBuffer, histograms *types.HPointRingBuffer) (bufferedRangeVectorStepData, error) {
+func (b *RangeVectorDuplicationBuffer) mergeStepData(stepData *types.RangeVectorStepData, seriesIndex int) (bufferedRangeVectorStepData, error) {
 	if stepData.Anchored || stepData.Smoothed {
 		return bufferedRangeVectorStepData{}, fmt.Errorf("cannot use shared FPoint and HPoint buffers with anchored/smoothed modifiers (this is a bug)")
 	}
 
-	var lastF promql.FPoint
-	if floats.Count() > 0 {
-		lastF = floats.Last()
+	var (
+		lastF      promql.FPoint
+		lastH      promql.HPoint
+		floats     *types.FPointRingBuffer
+		histograms *types.HPointRingBuffer
+	)
+
+	if stepData.Floats.Any() {
+		floats = b.buffer.GetOrCreateFloatBuffer(seriesIndex)
+		if floats.Count() > 0 {
+			lastF = floats.Last()
+		}
 	}
 
-	var lastH promql.HPoint
-	if histograms.Count() > 0 {
-		lastH = histograms.Last()
+	if stepData.Histograms.Any() {
+		histograms = b.buffer.GetOrCreateHistogramBuffer(seriesIndex)
+		if histograms.Count() > 0 {
+			lastH = histograms.Last()
+		}
 	}
 
 	headF, tailF := stepData.Floats.UnsafePoints()
 	for _, section := range [][]promql.FPoint{headF, tailF} {
 		for _, p := range section {
-			if floats.Count() == 0 || p.T > lastF.T {
+			if floats != nil && (floats.Count() == 0 || p.T > lastF.T) {
 				_, err := floats.Append(promql.FPoint{T: p.T, F: p.F})
 				if err != nil {
 					return bufferedRangeVectorStepData{}, err
@@ -622,7 +631,7 @@ func mergeStepData(stepData *types.RangeVectorStepData, floats *types.FPointRing
 	headH, tailH := stepData.Histograms.UnsafePoints()
 	for _, section := range [][]promql.HPoint{headH, tailH} {
 		for _, p := range section {
-			if histograms.Count() == 0 || p.T > lastH.T {
+			if histograms != nil && (histograms.Count() == 0 || p.T > lastH.T) {
 				_, err := histograms.Append(promql.HPoint{T: p.T, H: p.H.Copy()})
 				if err != nil {
 					return bufferedRangeVectorStepData{}, err
@@ -638,8 +647,17 @@ func mergeStepData(stepData *types.RangeVectorStepData, floats *types.FPointRing
 	merged.RangeEnd = stepData.RangeEnd
 	merged.StepT = stepData.StepT
 
-	merged.Floats = floats.ViewBetweenSearchingBackwards(stepData.RangeStart, stepData.RangeEnd, nil)
-	merged.Histograms = histograms.ViewBetweenSearchingBackwards(stepData.RangeStart, stepData.RangeEnd, nil)
+	if floats != nil {
+		merged.Floats = floats.ViewBetweenSearchingBackwards(stepData.RangeStart, stepData.RangeEnd, nil)
+	} else {
+		merged.Floats = &types.FPointRingBufferView{}
+	}
+
+	if histograms != nil {
+		merged.Histograms = histograms.ViewBetweenSearchingBackwards(stepData.RangeStart, stepData.RangeEnd, nil)
+	} else {
+		merged.Histograms = &types.HPointRingBufferView{}
+	}
 
 	return bufferedRangeVectorStepData{stepData: &merged}, nil
 }

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser/posrange"
 	"github.com/prometheus/prometheus/util/annotations"
 
@@ -61,7 +62,7 @@ func NewRangeVectorDuplicationBuffer(inner types.RangeVectorOperator, memoryCons
 		lastReturnedStepSamplesIndex: -1,
 		lastNextSeriesCallIndex:      -1,
 		lastNextStepSamplesCallIndex: -1,
-		buffer:                       newRangeVectorSeriesDataRingBuffer(timeRange.StepCount),
+		buffer:                       newRangeVectorSeriesDataRingBuffer(timeRange.StepCount, memoryConsumptionTracker),
 	}
 }
 
@@ -144,7 +145,10 @@ func (b *RangeVectorDuplicationBuffer) NextSeries(consumer *RangeVectorDuplicati
 }
 
 func (b *RangeVectorDuplicationBuffer) bufferUpToAndIncluding(ctx context.Context, desiredSeriesIndex int, desiredStepIndex int) (bufferedRangeVectorStepData, error) {
-	var lastStepData bufferedRangeVectorStepData
+	var (
+		lastStepData bufferedRangeVectorStepData
+		tainted      viewTaint
+	)
 
 	for b.lastNextSeriesCallIndex < desiredSeriesIndex || (b.lastNextSeriesCallIndex == desiredSeriesIndex && b.lastNextStepSamplesCallIndex < desiredStepIndex) {
 		if b.lastNextStepSamplesCallIndex == b.timeRange.StepCount-1 || b.lastNextSeriesCallIndex == -1 {
@@ -152,6 +156,12 @@ func (b *RangeVectorDuplicationBuffer) bufferUpToAndIncluding(ctx context.Contex
 			if err := b.Inner.NextSeries(ctx); err != nil {
 				return bufferedRangeVectorStepData{}, err
 			}
+
+			// After advancing to next series we need to recreate the views of all the previous series
+			// steps if we updated the underlying buffers used by float points or histogram points and
+			// caused them to be resized.
+			b.updateViewsForSeries(b.lastNextSeriesCallIndex, tainted)
+			tainted = viewTaint{}
 
 			b.lastNextStepSamplesCallIndex = -1
 			b.lastNextSeriesCallIndex++
@@ -167,17 +177,70 @@ func (b *RangeVectorDuplicationBuffer) bufferUpToAndIncluding(ctx context.Contex
 			return bufferedRangeVectorStepData{}, err
 		}
 
-		b.lastNextStepSamplesCallIndex++
-		clonedData, err := cloneStepData(stepData)
+		combinedStepData, combinedTaint, err := b.combineStepData(stepData, b.lastNextSeriesCallIndex)
 		if err != nil {
 			return bufferedRangeVectorStepData{}, err
 		}
 
-		b.buffer.Append(clonedData, b.lastNextSeriesCallIndex, b.lastNextStepSamplesCallIndex)
-		lastStepData = clonedData
+		tainted = tainted.merge(combinedTaint)
+
+		b.lastNextStepSamplesCallIndex++
+		b.buffer.Append(combinedStepData, b.lastNextSeriesCallIndex, b.lastNextStepSamplesCallIndex)
+		lastStepData = combinedStepData
 	}
 
+	// Update the views for the current series one last time if we've added anything to the
+	// underlying float point or histogram point buffers and had to resize since reading step data.
+	b.updateViewsForSeries(b.lastNextSeriesCallIndex, tainted)
+
 	return lastStepData, nil
+}
+
+func (b *RangeVectorDuplicationBuffer) updateViewsForSeries(seriesIndex int, taint viewTaint) {
+	if !taint.needsUpdate() {
+		return
+	}
+
+	floats := b.buffer.GetOrCreateFloatBuffer(seriesIndex)
+	histograms := b.buffer.GetOrCreateHistogramBuffer(seriesIndex)
+
+	for stepIdx := range b.timeRange.StepCount {
+		if d, present := b.buffer.GetIfPresent(seriesIndex, stepIdx); present {
+			// Only update the views for this step if the underlying buffers have been changed
+			// and this step isn't using dedicated buffers (which we do for anchored/smoothed).
+			if taint.floats && d.floatData == nil {
+				d.stepData.Floats = floats.ViewBetweenSearchingBackwards(d.stepData.RangeStart, d.stepData.RangeEnd, d.stepData.Floats)
+			}
+			if taint.histograms && d.histogramData == nil {
+				d.stepData.Histograms = histograms.ViewBetweenSearchingBackwards(d.stepData.RangeStart, d.stepData.RangeEnd, d.stepData.Histograms)
+			}
+		}
+	}
+}
+
+// combineStepData copies stepData into buffers owned by this struct (either shared per series or unique
+// to each step) and returns a "taint" to indicate if the shared buffers were modified, requiring existing
+// views of them to be updated.
+func (b *RangeVectorDuplicationBuffer) combineStepData(stepData *types.RangeVectorStepData, seriesIndex int) (bufferedRangeVectorStepData, viewTaint, error) {
+	// anchored/smoothed modifiers cause extra data to be included in the view for a particular
+	// step beyond the range start/end and may include synthetic points. For simplicity in this
+	// case, we don't bother trying to use a shared buffer for all steps and instead fall back
+	// to duplicating the data for each step.
+	if stepData.Anchored || stepData.Smoothed {
+		cloned, err := cloneStepData(stepData)
+		if err != nil {
+			return bufferedRangeVectorStepData{}, viewTaint{}, err
+		}
+
+		return cloned, viewTaint{}, nil
+	}
+
+	// When not using anchored/smoothed modifiers, we can use a single buffer for all points in a
+	// particular series. This minimizes duplicated points when the range selector for each step
+	// overlaps with the range selector of the previous step.
+	floats := b.buffer.GetOrCreateFloatBuffer(seriesIndex)
+	histograms := b.buffer.GetOrCreateHistogramBuffer(seriesIndex)
+	return mergeStepData(stepData, floats, histograms)
 }
 
 func (b *RangeVectorDuplicationBuffer) anyConsumerWillReadSeries(unfilteredSeriesIndex int, ignore *RangeVectorDuplicationConsumer) bool {
@@ -383,11 +446,7 @@ func (b *RangeVectorDuplicationBuffer) releaseBufferedData(consumer *RangeVector
 
 func (b *RangeVectorDuplicationBuffer) releaseAllBufferedData() {
 	types.SeriesMetadataSlicePool.Put(&b.seriesMetadata, b.MemoryConsumptionTracker)
-
-	for b.buffer.Size() > 0 {
-		d := b.buffer.RemoveFirst()
-		d.Close()
-	}
+	b.buffer.Clear()
 }
 
 func (b *RangeVectorDuplicationBuffer) earliestSeriesIndexStillToReturn() int {
@@ -543,14 +602,9 @@ func (b *RangeVectorDuplicationBuffer) allConsumersFinalized() bool {
 	return true
 }
 
-type bufferedRangeVectorStepData struct {
-	stepData        *types.RangeVectorStepData
-	floatBuffer     *types.FPointRingBuffer
-	histogramBuffer *types.HPointRingBuffer
-}
-
+// cloneStepData creates a copy of stepData including dedicated underlying buffers.
 func cloneStepData(stepData *types.RangeVectorStepData) (bufferedRangeVectorStepData, error) {
-	buffered := bufferedRangeVectorStepData{
+	cloned := bufferedRangeVectorStepData{
 		stepData: &types.RangeVectorStepData{
 			StepT:      stepData.StepT,
 			RangeStart: stepData.RangeStart,
@@ -561,27 +615,99 @@ func cloneStepData(stepData *types.RangeVectorStepData) (bufferedRangeVectorStep
 	}
 
 	var err error
-
-	buffered.stepData.Floats, buffered.floatBuffer, err = stepData.Floats.Clone()
+	cloned.stepData.Floats, cloned.floatData, err = stepData.Floats.Clone()
 	if err != nil {
 		return bufferedRangeVectorStepData{}, err
 	}
 
-	buffered.stepData.Histograms, buffered.histogramBuffer, err = stepData.Histograms.Clone()
+	cloned.stepData.Histograms, cloned.histogramData, err = stepData.Histograms.Clone()
 	if err != nil {
 		return bufferedRangeVectorStepData{}, err
 	}
 
-	return buffered, nil
+	return cloned, nil
 }
 
-func (d bufferedRangeVectorStepData) Close() {
-	if d.floatBuffer != nil {
-		d.floatBuffer.Close()
+// mergeStepData adds all unique points from stepData to the shared floats and histograms buffers.
+// The dedicated buffers bufferedRangeVectorStepData will be nil since the shared buffers are used.
+func mergeStepData(stepData *types.RangeVectorStepData, floats *types.FPointRingBuffer, histograms *types.HPointRingBuffer) (bufferedRangeVectorStepData, viewTaint, error) {
+	if stepData.Anchored || stepData.Smoothed {
+		return bufferedRangeVectorStepData{}, viewTaint{}, fmt.Errorf("cannot use shared FPoint and HPoint buffers with anchored/smoothed modifiers (this is a bug)")
 	}
 
-	if d.histogramBuffer != nil {
-		d.histogramBuffer.Close()
+	var lastF promql.FPoint
+	if floats.Count() > 0 {
+		lastF = floats.Last()
+	}
+
+	var lastH promql.HPoint
+	if histograms.Count() > 0 {
+		lastH = histograms.Last()
+	}
+
+	var taint viewTaint
+
+	headF, tailF := stepData.Floats.UnsafePoints()
+	for _, section := range [][]promql.FPoint{headF, tailF} {
+		for _, p := range section {
+			if floats.Count() == 0 || p.T > lastF.T {
+				resized, err := floats.Append(promql.FPoint{T: p.T, F: p.F})
+				if err != nil {
+					return bufferedRangeVectorStepData{}, taint, err
+				}
+
+				taint.floats = taint.floats || resized
+			}
+		}
+	}
+
+	headH, tailH := stepData.Histograms.UnsafePoints()
+	for _, section := range [][]promql.HPoint{headH, tailH} {
+		for _, p := range section {
+			if histograms.Count() == 0 || p.T > lastH.T {
+				resized, err := histograms.Append(promql.HPoint{T: p.T, H: p.H.Copy()})
+				if err != nil {
+					return bufferedRangeVectorStepData{}, taint, err
+				}
+
+				taint.histograms = taint.histograms || resized
+			}
+		}
+	}
+
+	var merged types.RangeVectorStepData
+	merged.Smoothed = stepData.Smoothed
+	merged.Anchored = stepData.Anchored
+	merged.RangeStart = stepData.RangeStart
+	merged.RangeEnd = stepData.RangeEnd
+	merged.StepT = stepData.StepT
+
+	merged.Floats = floats.ViewBetweenSearchingBackwards(stepData.RangeStart, stepData.RangeEnd, nil)
+	merged.Histograms = histograms.ViewBetweenSearchingBackwards(stepData.RangeStart, stepData.RangeEnd, nil)
+
+	return bufferedRangeVectorStepData{stepData: &merged}, taint, nil
+}
+
+type bufferedRangeVectorStepData struct {
+	// stepData float and histogram views for this step along with its associated time range.
+	stepData *types.RangeVectorStepData
+
+	// floatData is an optional buffer for float data specific to only this step. Only used
+	// with anchored/smoothed modifiers, otherwise a shared per-series buffer is used.
+	floatData *types.FPointRingBuffer
+
+	// histogramData is an optional buffer for histogram data specific to only this step. Only
+	// used with anchored/smoothed modifiers, otherwise a shared per-series buffer is used.
+	histogramData *types.HPointRingBuffer
+}
+
+func (r bufferedRangeVectorStepData) Close() {
+	if r.floatData != nil {
+		r.floatData.Close()
+	}
+
+	if r.histogramData != nil {
+		r.histogramData.Close()
 	}
 }
 
@@ -668,14 +794,21 @@ func (d *RangeVectorDuplicationConsumer) Close() {
 }
 
 type rangeVectorSeriesDataRingBuffer struct {
-	buffer    *SeriesDataRingBuffer[bufferedRangeVectorStepData]
-	stepCount int
+	seriesStepData      *SeriesDataRingBuffer[bufferedRangeVectorStepData]
+	seriesFloatData     *SeriesDataRingBuffer[*types.FPointRingBuffer]
+	seriesHistogramData *SeriesDataRingBuffer[*types.HPointRingBuffer]
+	stepCount           int
+
+	memoryConsumptionTracker *limiter.MemoryConsumptionTracker
 }
 
-func newRangeVectorSeriesDataRingBuffer(stepCount int) *rangeVectorSeriesDataRingBuffer {
+func newRangeVectorSeriesDataRingBuffer(stepCount int, memory *limiter.MemoryConsumptionTracker) *rangeVectorSeriesDataRingBuffer {
 	return &rangeVectorSeriesDataRingBuffer{
-		buffer:    &SeriesDataRingBuffer[bufferedRangeVectorStepData]{},
-		stepCount: stepCount,
+		seriesStepData:           &SeriesDataRingBuffer[bufferedRangeVectorStepData]{},
+		seriesFloatData:          &SeriesDataRingBuffer[*types.FPointRingBuffer]{},
+		seriesHistogramData:      &SeriesDataRingBuffer[*types.HPointRingBuffer]{},
+		stepCount:                stepCount,
+		memoryConsumptionTracker: memory,
 	}
 }
 
@@ -684,29 +817,92 @@ func (b *rangeVectorSeriesDataRingBuffer) elementIndexFor(seriesIndex int, stepI
 }
 
 func (b *rangeVectorSeriesDataRingBuffer) Append(data bufferedRangeVectorStepData, seriesIndex int, stepIndex int) {
-	b.buffer.Append(data, b.elementIndexFor(seriesIndex, stepIndex))
+	b.seriesStepData.Append(data, b.elementIndexFor(seriesIndex, stepIndex))
+}
+
+func (b *rangeVectorSeriesDataRingBuffer) GetOrCreateFloatBuffer(seriesIndex int) *types.FPointRingBuffer {
+	fpoints, present := b.seriesFloatData.GetIfPresent(seriesIndex)
+	if !present {
+		fpoints = types.NewFPointRingBuffer(b.memoryConsumptionTracker)
+		b.seriesFloatData.Append(fpoints, seriesIndex)
+	}
+
+	return fpoints
+}
+
+func (b *rangeVectorSeriesDataRingBuffer) GetOrCreateHistogramBuffer(seriesIndex int) *types.HPointRingBuffer {
+	hpoints, present := b.seriesHistogramData.GetIfPresent(seriesIndex)
+	if !present {
+		hpoints = types.NewHPointRingBuffer(b.memoryConsumptionTracker)
+		b.seriesHistogramData.Append(hpoints, seriesIndex)
+	}
+
+	return hpoints
 }
 
 func (b *rangeVectorSeriesDataRingBuffer) GetIfPresent(seriesIndex int, stepIndex int) (bufferedRangeVectorStepData, bool) {
-	return b.buffer.GetIfPresent(b.elementIndexFor(seriesIndex, stepIndex))
+	return b.seriesStepData.GetIfPresent(b.elementIndexFor(seriesIndex, stepIndex))
 }
 
 func (b *rangeVectorSeriesDataRingBuffer) RemoveAllStepsForSeriesIfPresent(seriesIndex int) {
 	for stepIdx := range b.stepCount {
-		if d, ok := b.RemoveIfPresent(seriesIndex, stepIdx); ok {
+		if d, present := b.RemoveIfPresent(seriesIndex, stepIdx); present {
 			d.Close()
 		}
+	}
+
+	if d, present := b.seriesFloatData.RemoveIfPresent(seriesIndex); present {
+		d.Close()
+	}
+
+	if d, present := b.seriesHistogramData.RemoveIfPresent(seriesIndex); present {
+		d.Close()
 	}
 }
 
 func (b *rangeVectorSeriesDataRingBuffer) RemoveIfPresent(seriesIndex int, stepIndex int) (bufferedRangeVectorStepData, bool) {
-	return b.buffer.RemoveIfPresent(b.elementIndexFor(seriesIndex, stepIndex))
+	return b.seriesStepData.RemoveIfPresent(b.elementIndexFor(seriesIndex, stepIndex))
 }
 
 func (b *rangeVectorSeriesDataRingBuffer) RemoveFirst() bufferedRangeVectorStepData {
-	return b.buffer.RemoveFirst()
+	return b.seriesStepData.RemoveFirst()
 }
 
 func (b *rangeVectorSeriesDataRingBuffer) Size() int {
-	return b.buffer.Size()
+	return b.seriesStepData.Size()
+}
+
+func (b *rangeVectorSeriesDataRingBuffer) Clear() {
+	for b.seriesStepData.Size() > 0 {
+		d := b.seriesStepData.RemoveFirst()
+		d.Close()
+	}
+
+	for b.seriesFloatData.Size() > 0 {
+		d := b.seriesFloatData.RemoveFirst()
+		d.Close()
+	}
+
+	for b.seriesHistogramData.Size() > 0 {
+		d := b.seriesHistogramData.RemoveFirst()
+		d.Close()
+	}
+}
+
+// viewTaint keeps track of if float or histogram point views for a particular
+// series need to be updated because the underlying buffer has been changed in a
+// way that invalidates the view.
+type viewTaint struct {
+	floats     bool
+	histograms bool
+}
+
+func (v viewTaint) needsUpdate() bool {
+	return v.floats || v.histograms
+}
+
+func (v viewTaint) merge(other viewTaint) viewTaint {
+	v.floats = v.floats || other.floats
+	v.histograms = v.histograms || other.histograms
+	return v
 }

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator_test.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator_test.go
@@ -254,7 +254,7 @@ func testReadConsumerToEnd(t *testing.T, numSeries int, consumer *RangeVectorDup
 	var out []*types.RangeVectorStepData
 	for range numSeries {
 		err := consumer.NextSeries(context.Background())
-		if err == types.EOS {
+		if errors.Is(err, types.EOS) {
 			break
 		}
 
@@ -262,7 +262,7 @@ func testReadConsumerToEnd(t *testing.T, numSeries int, consumer *RangeVectorDup
 
 		for {
 			d, err := consumer.NextStepSamples(context.Background())
-			if err == types.EOS {
+			if errors.Is(err, types.EOS) {
 				break
 			}
 

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator_test.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator_test.go
@@ -151,6 +151,128 @@ func TestRangeVectorOperator_Buffering_NoFiltering(t *testing.T) {
 	requireNoMemoryConsumption(t, memoryConsumptionTracker)
 }
 
+func TestRangeVectorOperator_Buffering_NoFiltering_OverlappingRanges(t *testing.T) {
+	// Test a range query where each step has a range selector that overlaps data
+	// from several previous steps.
+	const (
+		queryLength        = 45 * time.Minute
+		queryRangeSelector = 5 * time.Minute
+		queryStep          = time.Minute
+
+		expectedSeries         = 5
+		expectedStepsPerSeries = int(queryLength/queryStep) + 1
+	)
+
+	storage := promqltest.LoadedStorage(t, `
+		load 1m
+		  float_metric{idx="1"} 1+1x60
+		  float_metric{idx="2"} 2+2x60
+		  float_metric{idx="3"} 3+3x60
+		  float_metric{idx="4"} 4+4x60
+		  float_metric{idx="5"} 5+5x60
+		  histogram_metric{idx="1"} {{count:1}}+{{count:1}}x60
+		  histogram_metric{idx="2"} {{count:2}}+{{count:2}}x60
+		  histogram_metric{idx="3"} {{count:3}}+{{count:3}}x60
+		  histogram_metric{idx="4"} {{count:4}}+{{count:4}}x60
+		  histogram_metric{idx="5"} {{count:5}}+{{count:5}}x60
+	`)
+
+	t.Cleanup(func() { require.NoError(t, storage.Close()) })
+
+	for _, metricName := range []string{"float_metric", "histogram_metric"} {
+		t.Run(metricName, func(t *testing.T) {
+			ctx := context.Background()
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
+			now := time.Unix(0, 0).UTC().Add(queryLength).Add(5 * time.Minute)
+
+			inner := selectors.NewRangeVectorSelector(
+				&selectors.Selector{
+					EagerLoad: true,
+					Queryable: storage,
+					TimeRange: types.NewRangeQueryTimeRange(now.Add(-queryLength), now, queryStep),
+					Range:     queryRangeSelector,
+					Matchers: []types.Matcher{{
+						Type:  labels.MatchEqual,
+						Name:  model.MetricNameLabel,
+						Value: metricName,
+					}},
+					MemoryConsumptionTracker: memoryConsumptionTracker,
+				},
+				memoryConsumptionTracker,
+			)
+
+			buffer := NewRangeVectorDuplicationBuffer(inner, memoryConsumptionTracker, inner.Selector.TimeRange, log.NewNopLogger())
+			consumer1 := buffer.AddConsumer()
+			consumer2 := buffer.AddConsumer()
+
+			require.NoError(t, consumer1.Prepare(ctx, nil))
+			require.NoError(t, consumer2.Prepare(ctx, nil))
+			require.NoError(t, consumer1.AfterPrepare(ctx))
+			require.NoError(t, consumer2.AfterPrepare(ctx))
+
+			metadata1, err := consumer1.SeriesMetadata(ctx, nil)
+			require.NoError(t, err)
+			metadata2, err := consumer2.SeriesMetadata(ctx, nil)
+			require.NoError(t, err)
+
+			require.Len(t, metadata1, expectedSeries)
+			require.Len(t, metadata2, expectedSeries)
+			require.Equal(t, metadata1, metadata2)
+
+			types.SeriesMetadataSlicePool.Put(&metadata1, memoryConsumptionTracker)
+			types.SeriesMetadataSlicePool.Put(&metadata2, memoryConsumptionTracker)
+
+			consumer1Data := testReadConsumerToEnd(t, expectedSeries, consumer1)
+			consumer2Data := testReadConsumerToEnd(t, expectedSeries, consumer2)
+
+			require.Len(t, consumer1Data, expectedStepsPerSeries*expectedSeries)
+			require.Len(t, consumer2Data, expectedStepsPerSeries*expectedSeries)
+			require.Equal(t, consumer1Data, consumer2Data)
+
+			require.NoError(t, consumer1.FinishedReading(ctx))
+			require.NoError(t, consumer2.FinishedReading(ctx))
+
+			stats1, _, err := consumer1.Finalize(ctx)
+			require.NoError(t, err)
+			stats1.Close()
+
+			stats2, _, err := consumer2.Finalize(ctx)
+			require.NoError(t, err)
+			stats2.Close()
+
+			consumer1.Close()
+			consumer2.Close()
+
+			requireNoMemoryConsumption(t, memoryConsumptionTracker)
+		})
+	}
+}
+
+func testReadConsumerToEnd(t *testing.T, numSeries int, consumer *RangeVectorDuplicationConsumer) []*types.RangeVectorStepData {
+	t.Helper()
+
+	var out []*types.RangeVectorStepData
+	for range numSeries {
+		err := consumer.NextSeries(context.Background())
+		if err == types.EOS {
+			break
+		}
+
+		require.NoError(t, err)
+
+		for {
+			d, err := consumer.NextStepSamples(context.Background())
+			if err == types.EOS {
+				break
+			}
+
+			require.NoError(t, err)
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
 func TestRangeVectorOperator_Buffering_Filtering_AllConsumersOpen(t *testing.T) {
 	ctx := context.Background()
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
@@ -177,7 +299,7 @@ func TestRangeVectorOperator_Buffering_Filtering_AllConsumersOpen(t *testing.T) 
 	require.NoError(t, err)
 	requireEqualDataAndReturnToPool(t, expectedData[0], d, memoryConsumptionTracker)
 	require.Equal(t, 0, buffer.buffer.Size())
-	require.Equal(t, 0, cap(buffer.buffer.buffer.elements), "should not temporarily buffer data that won't be read by another consumer")
+	require.Equal(t, 0, cap(buffer.buffer.seriesStepData.elements), "should not temporarily buffer data that won't be read by another consumer")
 
 	err = consumer1.NextSeries(ctx)
 	require.NoError(t, err)
@@ -265,7 +387,7 @@ func TestRangeVectorOperator_Buffering_Filtering_IteratingBeforeCallingSeriesMet
 	require.NoError(t, err)
 	requireEqualDataAndReturnToPool(t, expectedData[0], d, memoryConsumptionTracker)
 	require.Equal(t, 0, buffer.buffer.Size())
-	require.Equal(t, 0, cap(buffer.buffer.buffer.elements), "should not temporarily buffer data that won't be read by another consumer")
+	require.Equal(t, 0, cap(buffer.buffer.seriesStepData.elements), "should not temporarily buffer data that won't be read by another consumer")
 
 	err = consumer1.NextSeries(ctx)
 	require.NoError(t, err)
@@ -708,7 +830,7 @@ func TestRangeVectorOperator_FinishedReadingCalledWithBufferedData_Filtering(t *
 // This test uses reflection to populate values into all fields, clones the record and asserts that the values match.
 // The test will fail if the cloned record does not match, or there are fields found which this test does not consider.
 // Should this test fail, add the necessary field handling to this test and update range_vector_operator.go cloneStepData().
-func TestRangeVectorOperator_StepDataStructure(t *testing.T) {
+func TestRangeVectorOperator_CloneStepDataStructure(t *testing.T) {
 	ctx := context.Background()
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
@@ -747,7 +869,6 @@ func TestRangeVectorOperator_StepDataStructure(t *testing.T) {
 	}
 
 	clonedStepData, err := cloneStepData(data)
-
 	require.NoError(t, err)
 	require.Equal(t, data, clonedStepData.stepData)
 }
@@ -777,12 +898,12 @@ func TestRangeVectorOperator_Cloning_SmoothedAnchored(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			ctx := context.Background()
+
 			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 			tc.stepData.Floats = types.NewFPointRingBuffer(memoryConsumptionTracker).ViewAll(nil)
 			tc.stepData.Histograms = types.NewHPointRingBuffer(memoryConsumptionTracker).ViewUntilSearchingBackwards(0, nil)
 			clonedStepData, err := cloneStepData(&tc.stepData)
 			require.NoError(t, err)
-
 			require.Equal(t, tc.stepData.Smoothed, clonedStepData.stepData.Smoothed)
 			require.Equal(t, tc.stepData.Anchored, clonedStepData.stepData.Anchored)
 		})
@@ -941,15 +1062,15 @@ func TestRangeVectorOperator_ClosingAfterSubsequentReadFails(t *testing.T) {
 	require.NoError(t, err)
 	data, err := consumer1.NextStepSamples(ctx)
 	require.NoError(t, err)
-	require.Equal(t, data.Floats.First(), promql.FPoint{T: 0, F: 1234})
-	require.Equal(t, data.Histograms.First(), promql.HPoint{T: 500, H: &histogram.FloatHistogram{Count: 100, Sum: 2}})
+	require.Equal(t, data.Floats.First(), promql.FPoint{T: 1000, F: 1234})
+	require.Equal(t, data.Histograms.First(), promql.HPoint{T: 1000, H: &histogram.FloatHistogram{Count: 100, Sum: 2}})
 
 	err = consumer2.NextSeries(ctx)
 	require.NoError(t, err)
 	data, err = consumer2.NextStepSamples(ctx)
 	require.NoError(t, err)
-	require.Equal(t, data.Floats.First(), promql.FPoint{T: 0, F: 1234})
-	require.Equal(t, data.Histograms.First(), promql.HPoint{T: 500, H: &histogram.FloatHistogram{Count: 100, Sum: 2}})
+	require.Equal(t, data.Floats.First(), promql.FPoint{T: 1000, F: 1234})
+	require.Equal(t, data.Histograms.First(), promql.HPoint{T: 1000, H: &histogram.FloatHistogram{Count: 100, Sum: 2}})
 
 	// Try reading the next series, which should fail.
 	err = consumer1.NextSeries(ctx)
@@ -1005,19 +1126,23 @@ func (o *failingRangeVectorOperator) NextStepSamples(_ context.Context) (*types.
 
 	if o.floats == nil {
 		o.floats = types.NewFPointRingBuffer(o.memoryConsumptionTracker)
-		if _, err := o.floats.Append(promql.FPoint{T: 0, F: 1234}); err != nil {
+
+		if _, err := o.floats.Append(promql.FPoint{T: 1000, F: 1234}); err != nil {
 			return nil, err
 		}
 
+		o.floats.DiscardPointsAtOrBefore(0)
 		o.floatsView = o.floats.ViewUntilSearchingBackwards(1000, o.floatsView)
 	}
 
 	if o.histograms == nil {
 		o.histograms = types.NewHPointRingBuffer(o.memoryConsumptionTracker)
-		if _, err := o.histograms.Append(promql.HPoint{T: 500, H: &histogram.FloatHistogram{Count: 100, Sum: 2}}); err != nil {
+
+		if _, err := o.histograms.Append(promql.HPoint{T: 1000, H: &histogram.FloatHistogram{Count: 100, Sum: 2}}); err != nil {
 			return nil, err
 		}
 
+		o.histograms.DiscardPointsAtOrBefore(0)
 		o.histogramsView = o.histograms.ViewUntilSearchingBackwards(1000, o.histogramsView)
 	}
 

--- a/pkg/streamingpromql/testdata/ours/anchored.test
+++ b/pkg/streamingpromql/testdata/ours/anchored.test
@@ -431,6 +431,10 @@ eval range from 0 to 10m step 1m increase(metric[1m] anchored)
 eval range from 0 to 10m step 1m increase(metric[1m2s] anchored)
   {} 0 1 2 2 2 2 2 2 2 2 2
 
+# Different function applying to the same range selector to exercise common subexpression elimination.
+eval range from 0 to 10m step 1m increase(metric[5m] anchored) + delta(metric[5m] anchored)
+  {} 0 2 4 6 8 10 10 10 10 10 10
+
 clear
 load 1m
   metric{id="1"} 11 -1 100 0

--- a/pkg/streamingpromql/testdata/ours/at_modifier.test
+++ b/pkg/streamingpromql/testdata/ours/at_modifier.test
@@ -48,6 +48,10 @@ eval range from 0 to 10m step 1m sum_over_time(metric[2m] @ 300)
 eval range from 0 to 10m step 1m increase(metric[2m] @ 300)
   {} 2 2 2 2 2 2 2 2 2 2 2
 
+# Different function applying to the same range selector to exercise common subexpression elimination.
+eval range from 0 to 10m step 1m increase(metric[2m] @ 300) + delta(metric[2m] @ 300)
+  {} 4 4 4 4 4 4 4 4 4 4 4
+
 eval range from 0 to 5m step 1m timestamp(increase(metric[2m] @ 300))
   {} 0 60 120 180 240 300
 

--- a/pkg/streamingpromql/types/fpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/fpoint_ring_buffer.go
@@ -254,6 +254,45 @@ func (b *FPointRingBuffer) ViewUntilSearchingBackwards(maxT int64, existing *FPo
 	return existing
 }
 
+// ViewBetweenSearchingBackwards returns a view into this buffer including only points with timestamps
+// greater than minT and less than or equal to maxT. The method panics if minT is greater than maxT.
+func (b *FPointRingBuffer) ViewBetweenSearchingBackwards(minT, maxT int64, existing *FPointRingBufferView) *FPointRingBufferView {
+	if existing == nil {
+		existing = &FPointRingBufferView{buffer: b}
+	}
+
+	if minT > maxT {
+		panic(fmt.Sprintf("attempted to create an FPointRingBufferView with minT(%d) > maxT(%d) (this is a bug)", minT, maxT))
+	}
+
+	// If the buffer is empty or min time is beyond the last point in this buffer,
+	// return a zero-sized view since there are no points or no matching points.
+	if b.size == 0 || b.Last().T < minT {
+		existing.offset = 0
+		existing.size = 0
+		return existing
+	}
+
+	var start int
+	for start = b.size - 1; start >= 0; start-- {
+		if b.PointAt(start).T <= minT {
+			break
+		}
+	}
+
+	var end int
+	for end = b.size - 1; end >= 0; end-- {
+		if b.PointAt(end).T <= maxT {
+			break
+		}
+	}
+
+	existing.offset = start + 1
+	existing.size = end - start
+
+	return existing
+}
+
 // PointAt returns the point at index 'position'.
 // Note that it is the caller's responsibility to have checked that the buffer size is greater than the given position.
 func (b *FPointRingBuffer) PointAt(position int) promql.FPoint {

--- a/pkg/streamingpromql/types/hpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/hpoint_ring_buffer.go
@@ -47,14 +47,6 @@ func (b *HPointRingBuffer) DiscardPointsAtOrBefore(t int64) {
 	}
 }
 
-// RemoveLast will remove the last point from the buffer.
-// It is safe to call this function on an empty buffer.
-func (b *HPointRingBuffer) RemoveLast() {
-	if b.size > 0 {
-		b.size--
-	}
-}
-
 func (b *HPointRingBuffer) RemoveFirst() {
 	if b.size > 0 {
 		b.firstIndex++

--- a/pkg/streamingpromql/types/hpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/hpoint_ring_buffer.go
@@ -47,6 +47,25 @@ func (b *HPointRingBuffer) DiscardPointsAtOrBefore(t int64) {
 	}
 }
 
+// RemoveLast will remove the last point from the buffer.
+// It is safe to call this function on an empty buffer.
+func (b *HPointRingBuffer) RemoveLast() {
+	if b.size > 0 {
+		b.size--
+	}
+}
+
+func (b *HPointRingBuffer) RemoveFirst() {
+	if b.size > 0 {
+		b.firstIndex++
+		b.size--
+
+		if b.firstIndex >= len(b.points) {
+			b.firstIndex = 0
+		}
+	}
+}
+
 // Append adds p to this buffer, expanding it if required.
 // A boolean is returned indicating if the underlying buffer had to be resized.
 // If this buffer is non-empty, p.T must be greater than or equal to the
@@ -74,7 +93,7 @@ func (b *HPointRingBuffer) ViewUntilSearchingForwards(maxT int64, existing *HPoi
 
 	size := 0
 
-	for size < b.size && b.pointAt(size).T <= maxT {
+	for size < b.size && b.PointAt(size).T <= maxT {
 		size++
 	}
 
@@ -92,7 +111,7 @@ func (b *HPointRingBuffer) ViewUntilSearchingBackwards(maxT int64, existing *HPo
 
 	nextPositionToCheck := b.size - 1
 
-	for nextPositionToCheck >= 0 && b.pointAt(nextPositionToCheck).T > maxT {
+	for nextPositionToCheck >= 0 && b.PointAt(nextPositionToCheck).T > maxT {
 		nextPositionToCheck--
 	}
 
@@ -101,9 +120,59 @@ func (b *HPointRingBuffer) ViewUntilSearchingBackwards(maxT int64, existing *HPo
 	return existing
 }
 
-// pointAt returns the point at index 'position'.
-func (b *HPointRingBuffer) pointAt(position int) promql.HPoint {
+// ViewBetweenSearchingBackwards returns a view into this buffer including only points with timestamps
+// greater than minT and less than or equal to maxT. The method panics if minT is greater than maxT.
+func (b *HPointRingBuffer) ViewBetweenSearchingBackwards(minT, maxT int64, existing *HPointRingBufferView) *HPointRingBufferView {
+	if existing == nil {
+		existing = &HPointRingBufferView{buffer: b}
+	}
+
+	if minT > maxT {
+		panic(fmt.Sprintf("attempted to create an HPointRingBufferView with minT(%d) > maxT(%d) (this is a bug)", minT, maxT))
+	}
+
+	// If the buffer is empty or min time is beyond the last point in this buffer,
+	// return a zero-sized view since there are no points or no matching points.
+	if b.size == 0 || b.Last().T < minT {
+		existing.offset = 0
+		existing.size = 0
+		return existing
+	}
+
+	var start int
+	for start = b.size - 1; start >= 0; start-- {
+		if b.PointAt(start).T <= minT {
+			break
+		}
+	}
+
+	var end int
+	for end = b.size - 1; end >= 0; end-- {
+		if b.PointAt(end).T <= maxT {
+			break
+		}
+	}
+
+	existing.offset = start + 1
+	existing.size = end - start
+
+	return existing
+}
+
+// PointAt returns the point at index 'position'.
+func (b *HPointRingBuffer) PointAt(position int) promql.HPoint {
 	return b.points[(b.firstIndex+position)&b.pointsIndexMask]
+}
+
+// Last returns the last point in the buffer.
+// Note that it is the caller's responsibility to have checked that the buffer size is not empty.
+func (b *HPointRingBuffer) Last() promql.HPoint {
+	return b.PointAt(b.size - 1)
+}
+
+// Count returns the current number of points in the buffer.
+func (b *HPointRingBuffer) Count() int {
+	return b.size
 }
 
 // NextPoint gets the next point in this buffer, expanding it if required.
@@ -340,7 +409,7 @@ func (b *HPointRingBuffer) EquivalentFloatSampleCountUntil(maxT int64) int64 {
 	count := int64(0)
 
 	for i := range b.size {
-		p := b.pointAt(i)
+		p := b.PointAt(i)
 
 		if p.T > maxT {
 			// We've reached the end of the range we need to search.
@@ -358,7 +427,7 @@ func (b *HPointRingBuffer) EquivalentFloatSampleCountBetween(minT, maxT int64) i
 	count := int64(0)
 
 	for i := range b.size {
-		p := b.pointAt(i)
+		p := b.PointAt(i)
 
 		if p.T > maxT {
 			// We've reached the end of the range we need to search.
@@ -385,7 +454,7 @@ func (v HPointRingBufferView) PointAt(i int) promql.HPoint {
 		panic(fmt.Sprintf("PointAt(): out of range, requested index %v but have length %v", i, v.size))
 	}
 
-	return v.buffer.pointAt(v.offset + i)
+	return v.buffer.PointAt(v.offset + i)
 }
 
 // Clone returns a clone of this view and its underlying ring buffer.

--- a/pkg/streamingpromql/types/ring_buffer_test.go
+++ b/pkg/streamingpromql/types/ring_buffer_test.go
@@ -342,6 +342,102 @@ func TestRingBuffer_ViewUntilWithExistingView(t *testing.T) {
 	})
 }
 
+func TestRingBuffer_ViewBetweenSearchingBackwards(t *testing.T) {
+	t.Run("FPoint ring buffer", func(t *testing.T) {
+		buf := &fPointRingBufferWrapper{NewFPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))}
+		mustAppend(t, buf, promql.FPoint{T: 1, F: 100})
+		mustAppend(t, buf, promql.FPoint{T: 2, F: 200})
+		mustAppend(t, buf, promql.FPoint{T: 3, F: 300})
+		mustAppend(t, buf, promql.FPoint{T: 4, F: 400})
+		mustAppend(t, buf, promql.FPoint{T: 5, F: 500})
+		mustAppend(t, buf, promql.FPoint{T: 6, F: 600})
+		mustAppend(t, buf, promql.FPoint{T: 7, F: 700})
+		buf.RemoveFirst()                               // remove T=1
+		buf.RemoveFirst()                               // remove T=2
+		mustAppend(t, buf, promql.FPoint{T: 8, F: 800}) // Takes index 7 in the initial cap(8) slice.
+		mustAppend(t, buf, promql.FPoint{T: 9, F: 900}) // Takes index 0 in the initial cap(8) slice.
+
+		view := buf.ViewBetweenSearchingBackwards(2, 3, nil)
+		viewShouldHavePoints(t, view, promql.FPoint{T: 3, F: 300})
+
+		newView := buf.ViewBetweenSearchingBackwards(1, 5, view)
+		require.Same(t, newView, view)
+		viewShouldHavePoints(t, view, promql.FPoint{T: 3, F: 300}, promql.FPoint{T: 4, F: 400}, promql.FPoint{T: 5, F: 500})
+
+		newView = buf.ViewBetweenSearchingBackwards(2, 4, view)
+		require.Same(t, newView, view)
+		viewShouldHavePoints(t, view, promql.FPoint{T: 3, F: 300}, promql.FPoint{T: 4, F: 400})
+
+		newView = buf.ViewBetweenSearchingBackwards(3, 3, view)
+		require.Same(t, newView, view)
+		viewShouldHavePoints(t, view, []promql.FPoint{}...)
+
+		newView = buf.ViewBetweenSearchingBackwards(10, 15, view)
+		require.Same(t, newView, view)
+		viewShouldHavePoints(t, view, []promql.FPoint{}...)
+
+		newView = buf.ViewBetweenSearchingBackwards(7, 9, view)
+		require.Same(t, newView, view)
+		viewShouldHavePoints(t, view, promql.FPoint{T: 8, F: 800}, promql.FPoint{T: 9, F: 900})
+
+		require.Panics(t, func() {
+			buf.ViewBetweenSearchingBackwards(4, 3, view)
+		})
+	})
+
+	t.Run("HPoint ring buffer", func(t *testing.T) {
+		h1 := &histogram.FloatHistogram{Count: 100}
+		h2 := &histogram.FloatHistogram{Count: 200}
+		h3 := &histogram.FloatHistogram{Count: 300}
+		h4 := &histogram.FloatHistogram{Count: 400}
+		h5 := &histogram.FloatHistogram{Count: 500}
+		h6 := &histogram.FloatHistogram{Count: 600}
+		h7 := &histogram.FloatHistogram{Count: 700}
+		h8 := &histogram.FloatHistogram{Count: 800}
+		h9 := &histogram.FloatHistogram{Count: 900}
+
+		buf := &hPointRingBufferWrapper{NewHPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))}
+		mustAppend(t, buf, promql.HPoint{T: 1, H: h1})
+		mustAppend(t, buf, promql.HPoint{T: 2, H: h2})
+		mustAppend(t, buf, promql.HPoint{T: 3, H: h3})
+		mustAppend(t, buf, promql.HPoint{T: 4, H: h4})
+		mustAppend(t, buf, promql.HPoint{T: 5, H: h5})
+		mustAppend(t, buf, promql.HPoint{T: 6, H: h6})
+		mustAppend(t, buf, promql.HPoint{T: 7, H: h7})
+		buf.RemoveFirst()                              // remove T=1
+		buf.RemoveFirst()                              // remove T=2
+		mustAppend(t, buf, promql.HPoint{T: 8, H: h8}) // Takes index 7 in the initial cap(8) slice.
+		mustAppend(t, buf, promql.HPoint{T: 9, H: h9}) // Takes index 0 in the initial cap(8) slice.
+
+		view := buf.ViewBetweenSearchingBackwards(2, 3, nil)
+		viewShouldHavePoints(t, view, promql.HPoint{T: 3, H: h3})
+
+		newView := buf.ViewBetweenSearchingBackwards(1, 5, view)
+		require.Same(t, newView, view)
+		viewShouldHavePoints(t, view, promql.HPoint{T: 3, H: h3}, promql.HPoint{T: 4, H: h4}, promql.HPoint{T: 5, H: h5})
+
+		newView = buf.ViewBetweenSearchingBackwards(2, 4, view)
+		require.Same(t, newView, view)
+		viewShouldHavePoints(t, view, promql.HPoint{T: 3, H: h3}, promql.HPoint{T: 4, H: h4})
+
+		newView = buf.ViewBetweenSearchingBackwards(3, 3, view)
+		require.Same(t, newView, view)
+		viewShouldHavePoints(t, view, []promql.HPoint{}...)
+
+		newView = buf.ViewBetweenSearchingBackwards(10, 15, view)
+		require.Same(t, newView, view)
+		viewShouldHavePoints(t, view, []promql.HPoint{}...)
+
+		newView = buf.ViewBetweenSearchingBackwards(7, 9, view)
+		require.Same(t, newView, view)
+		viewShouldHavePoints(t, view, promql.HPoint{T: 8, H: h8}, promql.HPoint{T: 9, H: h9})
+
+		require.Panics(t, func() {
+			buf.ViewBetweenSearchingBackwards(4, 3, view)
+		})
+	})
+}
+
 func mustAppend[T any](t *testing.T, buf ringBuffer[T], point T) {
 	_, err := buf.Append(point)
 	require.NoError(t, err)


### PR DESCRIPTION
#### What this PR does

Use a shared per-series buffer for float and histogram points in the CSE `RangeVectorDuplicationBuffer` to minimize duplicated points for range vectors that overlap at each step (e.g. `[5m]` with a 1m step).

The buffer falls back to the previous behavior of duplicating the points for each step when the `anchored` or `smoothed` modifiers are used since they expect to be able to modify their underlying buffers.

#### Which issue(s) this PR fixes or relates to

Follow up to #15127

Depends on #15456

#### Note to reviewers

I've marked this as not needing a changelog entry since it's an implementation change and doesn't add or remove any features.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core streaming PromQL CSE buffering and range-step views; correctness depends on merge/dedup and view slicing, though benchmark parity and new overlapping-range tests mitigate risk.
> 
> **Overview**
> **Reduces memory** in common subexpression elimination (CSE) when multiple consumers reuse the same range vector and each query step’s range window overlaps the previous step (typical range queries with a wide `[Nm]` selector and a small step).
> 
> Instead of **cloning float/histogram points for every step**, `RangeVectorDuplicationBuffer` now **merges** new samples into **shared per-series ring buffers** and exposes each step via **`ViewBetweenSearchingBackwards`** on `(RangeStart, RangeEnd]`. **Anchored** and **smoothed** modifiers still **full-clone** per step because those paths may mutate underlying buffers or include synthetic points.
> 
> Supporting changes: the CSE ring buffer tracks step metadata separately from per-series float/histogram buffers (with proper cleanup on series removal), **`TestBothEnginesReturnSameResultsForBenchmarkQueries`** is **re-enabled** (skip removed), and promql testdata adds CSE cases (e.g. `increase(...) + delta(...)` on the same selector with `@` or `anchored`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea79238226ee4f96cbb06ab93f1dc532e0508fcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->