### PR TITLE
mixin: add native histogram variant of MimirRequestLatency alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [CHANGE] Dashboards: Show maximum queue length, not minimum queue length, on the "Queue length" panel in the "Query-scheduler" row of the "Reads" and "Remote ruler reads" dashboards. #15326
 * [ENHANCEMENT] Alerts: Make `MimirInconsistentRuntimeConfig` alert less flaky when performing multiple configuration changes in a row in a large Kubernetes cluster. #15257
 * [ENHANCEMENT] Alerts: Widen the `MimirBlockBuilderPersistentJobFailure` lookback window to 20m to prevent the alert from flapping. #15332
+* [ENHANCEMENT] Alerts: Add a native histogram variant of the `MimirRequestLatency` alert, distinguished by the `histogram` label (`classic` or `native`). #15413
 * [BUGFIX] Dashboards: Fix the classic/ingest-storage split in the "Tenants", "Top tenants" and "Writes" dashboards so that selecting multiple clusters with a mix of architectures no longer drops the classic clusters' data. The `unless on (job)` filter against `cortex_partition_ring_partitions` now also matches on the cluster aggregation labels. #15400
 
 ### Jsonnet

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -69,6 +69,20 @@ spec:
               2.5
             for: 15m
             labels:
+              histogram: classic
+              severity: warning
+          - alert: MimirRequestLatency
+            annotations:
+              message: |
+                  {{ $labels.job }} {{ $labels.route }} is experiencing {{ printf "%.2f" $value }}s 99th percentile latency.
+              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrequestlatency
+            expr: |
+              histogram_quantile(0.99, cluster_namespace_job_route:cortex_request_duration_seconds:sum_rate{route!~"metrics|/frontend.Frontend/Process|ready|/schedulerpb.SchedulerForFrontend/FrontendLoop|/schedulerpb.SchedulerForQuerier/QuerierLoop|debug_pprof"})
+                >
+              2.5
+            for: 15m
+            labels:
+              histogram: native
               severity: warning
           - alert: MimirInconsistentRuntimeConfig
             annotations:

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -57,6 +57,20 @@ groups:
             2.5
           for: 15m
           labels:
+            histogram: classic
+            severity: warning
+        - alert: MimirRequestLatency
+          annotations:
+            message: |
+                {{ $labels.job }} {{ $labels.route }} is experiencing {{ printf "%.2f" $value }}s 99th percentile latency.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrequestlatency
+          expr: |
+            histogram_quantile(0.99, cluster_namespace_job_route:cortex_request_duration_seconds:sum_rate{route!~"metrics|/frontend.Frontend/Process|ready|/schedulerpb.SchedulerForFrontend/FrontendLoop|/schedulerpb.SchedulerForQuerier/QuerierLoop|debug_pprof"})
+              >
+            2.5
+          for: 15m
+          labels:
+            histogram: native
             severity: warning
         - alert: MimirInconsistentRuntimeConfig
           annotations:

--- a/operations/mimir-mixin-compiled-gem/alerts.yaml
+++ b/operations/mimir-mixin-compiled-gem/alerts.yaml
@@ -57,6 +57,20 @@ groups:
             2.5
           for: 15m
           labels:
+            histogram: classic
+            severity: warning
+        - alert: MimirRequestLatency
+          annotations:
+            message: |
+                {{ $labels.job }} {{ $labels.route }} is experiencing {{ printf "%.2f" $value }}s 99th percentile latency.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrequestlatency
+          expr: |
+            histogram_quantile(0.99, cluster_namespace_job_route:cortex_request_duration_seconds:sum_rate{route!~"metrics|/frontend.Frontend/Process|ready|/schedulerpb.SchedulerForFrontend/FrontendLoop|/schedulerpb.SchedulerForQuerier/QuerierLoop|debug_pprof"})
+              >
+            2.5
+          for: 15m
+          labels:
+            histogram: native
             severity: warning
         - alert: MimirInconsistentRuntimeConfig
           annotations:

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -57,6 +57,20 @@ groups:
             2.5
           for: 15m
           labels:
+            histogram: classic
+            severity: warning
+        - alert: MimirRequestLatency
+          annotations:
+            message: |
+                {{ $labels.job }} {{ $labels.route }} is experiencing {{ printf "%.2f" $value }}s 99th percentile latency.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrequestlatency
+          expr: |
+            histogram_quantile(0.99, cluster_namespace_job_route:cortex_request_duration_seconds:sum_rate{route!~"metrics|/frontend.Frontend/Process|ready|/schedulerpb.SchedulerForFrontend/FrontendLoop|/schedulerpb.SchedulerForQuerier/QuerierLoop|debug_pprof"})
+              >
+            2.5
+          for: 15m
+          labels:
+            histogram: native
             severity: warning
         - alert: MimirInconsistentRuntimeConfig
           annotations:

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -94,6 +94,40 @@ local utils = import 'mixin-utils/utils.libsonnet';
                  + $.dashboardURLAnnotation('mimir-remote-ruler-reads.json'),
   },
 
+  local requestLatencyAlert(histogram_type) = {
+    local excluded_routes = std.join('|', [
+      'metrics',
+      '/frontend.Frontend/Process',
+      'ready',
+      '/schedulerpb.SchedulerForFrontend/FrontendLoop',
+      '/schedulerpb.SchedulerForQuerier/QuerierLoop',
+    ] + $._config.alert_excluded_routes),
+    local query = {
+      classic: '%(group_prefix_jobs)s_route:cortex_request_duration_seconds:99quantile{route!~"%(excluded_routes)s"}' % ($._config { excluded_routes: excluded_routes }),
+      native: 'histogram_quantile(0.99, %(group_prefix_jobs)s_route:cortex_request_duration_seconds:sum_rate{route!~"%(excluded_routes)s"})' % ($._config { excluded_routes: excluded_routes }),
+    },
+    alert: $.alertName('RequestLatency'),
+    expr: |||
+      %(query)s
+        >
+      %(cortex_p99_latency_threshold_seconds)s
+    ||| % ($._config { query: query[histogram_type] }),
+    'for': '15m',
+    labels: $.histogramLabels({ severity: 'warning' }, histogram_type, nhcb=false),
+    annotations: {
+                   message: |||
+                     {{ $labels.%(per_job_label)s }} {{ $labels.route }} is experiencing {{ printf "%%.2f" $value }}s 99th percentile latency.
+                   ||| % $._config,
+                 }
+                 // Alternative dashboards for investigation:
+                 //   - Mimir / Scaling (mimir-scaling.json) - for scaling decisions
+                 //   - Mimir / Reads (mimir-reads.json) - for read path latency
+                 //   - Mimir / Slow Queries (mimir-slow-queries.json) - to identify slow queries
+                 //   - Mimir / Queries (mimir-queries.json) - for queue length analysis
+                 //   - Mimir / Alertmanager (mimir-alertmanager.json) - for alertmanager path
+                 + $.dashboardURLAnnotation('mimir-writes.json'),
+  },
+
   local kvStoreFailure(histogram_type) = {
     alert: $.alertName('KVStoreFailure'),
     local sum_by = [$._config.alert_aggregation_labels, $._config.per_instance_label, 'status_code', 'kv_name'],
@@ -140,38 +174,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
         },
         requestErrorsAlert('classic'),
         requestErrorsAlert('native'),
-        {
-          alert: $.alertName('RequestLatency'),
-          expr: |||
-            %(group_prefix_jobs)s_route:cortex_request_duration_seconds:99quantile{route!~"%(excluded_routes)s"}
-              >
-            %(cortex_p99_latency_threshold_seconds)s
-          ||| % $._config {
-            excluded_routes: std.join('|', [
-              'metrics',
-              '/frontend.Frontend/Process',
-              'ready',
-              '/schedulerpb.SchedulerForFrontend/FrontendLoop',
-              '/schedulerpb.SchedulerForQuerier/QuerierLoop',
-            ] + $._config.alert_excluded_routes),
-          },
-          'for': '15m',
-          labels: {
-            severity: 'warning',
-          },
-          annotations: {
-                         message: |||
-                           {{ $labels.%(per_job_label)s }} {{ $labels.route }} is experiencing {{ printf "%%.2f" $value }}s 99th percentile latency.
-                         ||| % $._config,
-                       }
-                       // Alternative dashboards for investigation:
-                       //   - Mimir / Scaling (mimir-scaling.json) - for scaling decisions
-                       //   - Mimir / Reads (mimir-reads.json) - for read path latency
-                       //   - Mimir / Slow Queries (mimir-slow-queries.json) - to identify slow queries
-                       //   - Mimir / Queries (mimir-queries.json) - for queue length analysis
-                       //   - Mimir / Alertmanager (mimir-alertmanager.json) - for alertmanager path
-                       + $.dashboardURLAnnotation('mimir-writes.json'),
-        },
+        requestLatencyAlert('classic'),
+        requestLatencyAlert('native'),
         {
           alert: $.alertName('InconsistentRuntimeConfig'),
           expr: |||


### PR DESCRIPTION
## Summary

- Duplicates `MimirRequestLatency` to add a native histogram counterpart. The classic variant keeps its current expression (`<cluster_labels>_route:cortex_request_duration_seconds:99quantile{...}`); the new native variant evaluates `histogram_quantile(0.99, <cluster_labels>_route:cortex_request_duration_seconds:sum_rate{...})`.
- Both variants share the same alert name and are distinguished by the `histogram` label (`classic` / `native`), matching the dual-emission pattern introduced in #13814 for `MimirRequestErrors`, `MimirRulerRemoteEvaluationFailing`, and `MimirKVStoreFailure`.
- The `:sum_rate` recording rule already exists in the `mimir_api_3` group (defined via `utils.histogramRules(..., record_native=true)`), so no recording-rule changes are needed.
- Regenerated `operations/mimir-mixin-compiled*/alerts.yaml` and the helm test golden file via `make build-mixin` + `make build-helm-tests`.

## Test plan

- [x] `make format-mixin`
- [x] `make build-mixin` — compiled outputs updated in-tree
- [x] `make build-helm-tests` — helm golden alerts file updated
- [x] `make check-mixin-tests` passes

Coded with Claude Opus 4.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Prometheus alerting rules by introducing a second `MimirRequestLatency` rule and adding a new `histogram` label, which could impact alert routing/deduplication if consumers aren’t prepared for dual variants.
> 
> **Overview**
> Adds a *native-histogram* variant of the `MimirRequestLatency` alert, keeping the existing classic expression and introducing a `histogram_quantile()`-based expression over `...:sum_rate`, with both rules sharing the same alert name and distinguished via the `histogram` label (`classic`/`native`).
> 
> Updates the mixin source (`alerts.libsonnet`), regenerates compiled alert YAML outputs, updates the Helm metamonitoring golden file, and records the change in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46bb40a4d897afae5c5cbe5b399f7a066ba67e04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->