### PR TITLE
[release-3.1] ci: pin remaining github workflows

### DIFF
--- a/.github/workflows/deploy-pr-preview-helm-charts.yml
+++ b/.github/workflows/deploy-pr-preview-helm-charts.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write # Create or update pull request comments.
       statuses: write # Update GitHub status check with deploy preview link.
     if: "!github.event.pull_request.head.repo.fork"
-    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main
+    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@4dbecae7443c69b3e5fdfeeac7037a339cb82e4c # main
     with:
       branch: ${{ github.head_ref }}
       event_number: ${{ github.event.number }}

--- a/.github/workflows/deploy-pr-preview-mimir.yml
+++ b/.github/workflows/deploy-pr-preview-mimir.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write # Create or update pull request comments.
       statuses: write # Update GitHub status check with deploy preview link.
     if: "!github.event.pull_request.head.repo.fork"
-    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main
+    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@4dbecae7443c69b3e5fdfeeac7037a339cb82e4c # main
     with:
       branch: ${{ github.head_ref }}
       event_number: ${{ github.event.number }}

--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -7,12 +7,12 @@ permissions:
 
 jobs:
   call-lint:
-    uses: grafana/helm-charts/.github/workflows/linter.yml@main
+    uses: grafana/helm-charts/.github/workflows/linter.yml@77e5ea2de369fa1ff3441b08765c164be209eaa2 # main
     with:
       filter_regex_include: .*operations/helm/.*
 
   call-lint-test:
-    uses: grafana/helm-charts/.github/workflows/lint-test.yaml@main
+    uses: grafana/helm-charts/.github/workflows/lint-test.yaml@77e5ea2de369fa1ff3441b08765c164be209eaa2 # main
     with:
       ct_configfile: operations/helm/ct.yaml
       ct_check_version_increment: false

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -11,7 +11,7 @@ permissions: {}
 
 jobs:
   call-update-helm-repo:
-    uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@main
+    uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@77e5ea2de369fa1ff3441b08765c164be209eaa2 # main
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
Backport of #15414 to release-3.1.