### PR TITLE
scheduler: add metric for oldest query latency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [FEATURE] Mimirtool: Add AWS Signature Version 4 (SigV4) support for shared Mimir API client commands including `mimirtool rules`, `mimirtool alertmanager`, `mimirtool alerts`, `mimirtool backfill`, and `mimirtool analyze ruler`. #14959
 * [FEATURE] MQE: Add `cortex_querier_inflight_query_max_age_seconds` metric reporting the age of the oldest in-flight query memory consumption tracker. #15300
 * [FEATURE] MQE: Add experimental support for splitting and caching `present_over_time` over range vectors in instant queries. #15386
+* [FEATURE] Query-scheduler: Add experimental `cortex_query_scheduler_inflight_max_age_seconds` metric reporting how long the oldest inflight request has been waiting since it was enqueued. Reports 0 when no requests are inflight. Enabled by default; can be disabled with `-query-scheduler.inflight-max-age-metric-enabled=false`. #15419
 * [ENHANCEMENT] Store-gateway, Ingester: Add read support for XOR2 chunk encoding. XOR2 is a new Prometheus TSDB encoding that provides better compression than XOR, particularly for stale markers. #15371
 * [ENHANCEMENT] MQE: Improve experimental support for reporting the number of samples read per query. #14838 #15179 #15191 #15220 #15223 #15232 #15237 #15255 #15276 #15282 #15285
 * [ENHANCEMENT] Distributor: Relabel middleware returns early if neither label dropping nor relabeling is configured. #15246

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -19683,6 +19683,17 @@
           "fieldCategory": "experimental"
         },
         {
+          "kind": "field",
+          "name": "inflight_max_age_metric_enabled",
+          "required": false,
+          "desc": "Enable the cortex_query_scheduler_inflight_max_age_seconds metric, which reports the age of the oldest inflight request. Disabling it skips the per-tick scan over inflight requests.",
+          "fieldValue": null,
+          "fieldDefaultValue": true,
+          "fieldFlag": "query-scheduler.inflight-max-age-metric-enabled",
+          "fieldType": "boolean",
+          "fieldCategory": "experimental"
+        },
+        {
           "kind": "block",
           "name": "grpc_client_config",
           "required": false,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2763,6 +2763,8 @@ Usage of ./cmd/mimir/mimir:
     	Override the default minimum TLS version. Allowed values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13
   -query-scheduler.grpc-client-config.tls-server-name string
     	Override the expected name on the server certificate.
+  -query-scheduler.inflight-max-age-metric-enabled
+    	[experimental] Enable the cortex_query_scheduler_inflight_max_age_seconds metric, which reports the age of the oldest inflight request. Disabling it skips the per-tick scan over inflight requests. (default true)
   -query-scheduler.max-outstanding-requests-per-tenant int
     	Maximum number of outstanding requests per tenant per query-scheduler. In-flight requests above this limit will fail with HTTP response status code 429. (default 100)
   -query-scheduler.max-used-instances int

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -229,6 +229,7 @@ The following features are currently experimental:
   - Experimental PromQL functions and aggregations, including `mad_over_time`, `ts_of_min_over_time`, `ts_of_max_over_time`, `ts_of_first_over_time`, `ts_of_last_over_time`, `sort_by_label`, `sort_by_label_desc`, `limitk` and `limit_ratio` (`-query-frontend.enabled-promql-experimental-functions=...`)
 - Query-scheduler
   - `-query-scheduler.querier-forget-delay`
+  - `-query-scheduler.inflight-max-age-metric-enabled`
 - Store-gateway
   - Eagerly loading some blocks on startup even when lazy loading is enabled `-blocks-storage.bucket-store.index-header.eager-loading-startup-enabled`
   - Allow more than the default of 3 store-gateways to own recent blocks `-store-gateway.dynamic-replication`

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -2331,6 +2331,12 @@ The `query_scheduler` block configures the query-scheduler.
 # CLI flag: -query-scheduler.querier-forget-delay
 [querier_forget_delay: <duration> | default = 0s]
 
+# (experimental) Enable the cortex_query_scheduler_inflight_max_age_seconds
+# metric, which reports the age of the oldest inflight request. Disabling it
+# skips the per-tick scan over inflight requests.
+# CLI flag: -query-scheduler.inflight-max-age-metric-enabled
+[inflight_max_age_metric_enabled: <boolean> | default = true]
+
 # This configures the gRPC client used to report errors back to the
 # query-frontend.
 # The CLI flags prefix for this block configuration is:

--- a/operations/mimir/mimir-flags-defaults.json
+++ b/operations/mimir/mimir-flags-defaults.json
@@ -1402,6 +1402,7 @@
   "memberlist.propagation-delay-tracker.log-beacons-latency-longer-than": 0,
   "query-scheduler.max-outstanding-requests-per-tenant": 100,
   "query-scheduler.querier-forget-delay": 0,
+  "query-scheduler.inflight-max-age-metric-enabled": true,
   "query-scheduler.grpc-client-config.grpc-max-recv-msg-size": 104857600,
   "query-scheduler.grpc-client-config.grpc-max-send-msg-size": 104857600,
   "query-scheduler.grpc-client-config.grpc-compression": "",

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -93,6 +93,7 @@ type Scheduler struct {
 	queueDuration            *prometheus.HistogramVec
 	inflightRequests         prometheus.Summary
 	invalidClusterValidation *prometheus.CounterVec
+	inflightMaxAge           prometheus.Gauge
 }
 
 type connectedFrontend struct {
@@ -105,8 +106,9 @@ type connectedFrontend struct {
 }
 
 type Config struct {
-	MaxOutstandingPerTenant int           `yaml:"max_outstanding_requests_per_tenant"`
-	QuerierForgetDelay      time.Duration `yaml:"querier_forget_delay" category:"experimental"`
+	MaxOutstandingPerTenant     int           `yaml:"max_outstanding_requests_per_tenant"`
+	QuerierForgetDelay          time.Duration `yaml:"querier_forget_delay" category:"experimental"`
+	InflightMaxAgeMetricEnabled bool          `yaml:"inflight_max_age_metric_enabled" category:"experimental"`
 
 	GRPCClientConfig grpcclient.Config         `yaml:"grpc_client_config" doc:"description=This configures the gRPC client used to report errors back to the query-frontend."`
 	ServiceDiscovery schedulerdiscovery.Config `yaml:",inline"`
@@ -115,6 +117,7 @@ type Config struct {
 func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.IntVar(&cfg.MaxOutstandingPerTenant, "query-scheduler.max-outstanding-requests-per-tenant", 100, "Maximum number of outstanding requests per tenant per query-scheduler. In-flight requests above this limit will fail with HTTP response status code 429.")
 	f.DurationVar(&cfg.QuerierForgetDelay, "query-scheduler.querier-forget-delay", 0, "If a querier disconnects without sending notification about graceful shutdown, the query-scheduler will keep the querier in the tenant's shard until the forget delay has passed. This feature is useful to reduce the blast radius when shuffle-sharding is enabled.")
+	f.BoolVar(&cfg.InflightMaxAgeMetricEnabled, "query-scheduler.inflight-max-age-metric-enabled", true, "Enable the cortex_query_scheduler_inflight_max_age_seconds metric, which reports the age of the oldest inflight request. Disabling it skips the per-tick scan over inflight requests.")
 
 	cfg.GRPCClientConfig.CustomCompressors = []string{s2.Name}
 	cfg.GRPCClientConfig.RegisterFlagsWithPrefix("query-scheduler.grpc-client-config", f)
@@ -157,6 +160,12 @@ func NewScheduler(cfg Config, limits Limits, log log.Logger, registerer promethe
 		Name: "cortex_query_scheduler_enqueue_duration_seconds",
 		Help: "Time spent by requests waiting to join the queue or be rejected.",
 	})
+	if cfg.InflightMaxAgeMetricEnabled {
+		s.inflightMaxAge = promauto.With(registerer).NewGauge(prometheus.GaugeOpts{
+			Name: "cortex_query_scheduler_inflight_max_age_seconds",
+			Help: "Time since the oldest inflight request (queued or being processed) was enqueued. 0 if there are no inflight requests.",
+		})
+	}
 	querierInflightRequestsMetric := promauto.With(registerer).NewSummaryVec(
 		prometheus.SummaryOpts{
 			Name:       "cortex_query_scheduler_querier_inflight_requests",
@@ -716,6 +725,9 @@ func (s *Scheduler) running(ctx context.Context) error {
 		select {
 		case <-inflightRequestsTicker.C:
 			s.inflightRequests.Observe(float64(s.schedulerInflightRequestCount.Load()))
+			if s.cfg.InflightMaxAgeMetricEnabled {
+				s.observeInflightMaxAge()
+			}
 		case <-ctx.Done():
 			return nil
 		case err := <-s.subservicesWatcher.Chan():
@@ -749,6 +761,33 @@ func (s *Scheduler) getConnectedFrontendClientsMetric() float64 {
 	}
 
 	return float64(count)
+}
+
+func (s *Scheduler) observeInflightMaxAge() {
+	if s.schedulerInflightRequestCount.Load() == 0 {
+		// no inflight requests
+		s.inflightMaxAge.Set(0)
+		return
+	}
+
+	s.inflightRequestsMu.Lock()
+	defer s.inflightRequestsMu.Unlock()
+
+	var oldest time.Time
+	for _, req := range s.schedulerInflightRequests {
+		if oldest.IsZero() || req.EnqueueTime.Before(oldest) {
+			oldest = req.EnqueueTime
+		}
+	}
+
+	if oldest.IsZero() {
+		// schedulerInflightRequests is empty
+		s.inflightMaxAge.Set(0)
+		return
+	}
+
+	latency := time.Since(oldest).Seconds()
+	s.inflightMaxAge.Set(latency)
 }
 
 func (s *Scheduler) RingHandler(w http.ResponseWriter, req *http.Request) {

--- a/pkg/scheduler/scheduler_bench_test.go
+++ b/pkg/scheduler/scheduler_bench_test.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"go.uber.org/atomic"
+
+	"github.com/grafana/mimir/pkg/scheduler/queue"
+)
+
+// BenchmarkScheduler_ObserveInflightMaxAge measures the cost of a single call to
+// observeInflightMaxAge at varying inflight sizes. Multiply the per-op time by the
+// configured ticker rate (250ms in production) to estimate steady-state overhead.
+func BenchmarkScheduler_ObserveInflightMaxAge(b *testing.B) {
+	for _, n := range []int{100, 1_000, 10_000, 100_000, 1_000_000} {
+		b.Run(fmt.Sprintf("inflight=%d", n), func(b *testing.B) {
+			s := newBenchScheduler(b, true)
+			fillInflight(b, s, n)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				s.observeInflightMaxAge()
+			}
+		})
+	}
+}
+
+// BenchmarkScheduler_InflightChurn measures throughput of the enqueue/dequeue paths
+// (addRequestToPending + cancelRequestAndRemoveFromPending) under concurrency, with
+// and without the inflight-max-age observer running on its production 250ms cadence.
+//
+// Use a long -benchtime (e.g. 5s) so the ticker fires enough times for the
+// observer's impact to land in the measurement window.
+func BenchmarkScheduler_InflightChurn(b *testing.B) {
+	const (
+		frontendAddr     = "frontend-bench"
+		observerInterval = 250 * time.Millisecond
+	)
+
+	for _, inflight := range []int{100, 1_000, 10_000} {
+		for _, observer := range []bool{false, true} {
+			name := fmt.Sprintf("inflight=%d/observer=%v", inflight, observer)
+			b.Run(name, func(b *testing.B) {
+				s := newBenchScheduler(b, observer)
+				fillInflight(b, s, inflight)
+
+				if observer {
+					stop := make(chan struct{})
+					var wg sync.WaitGroup
+					wg.Go(func() {
+						t := time.NewTicker(observerInterval)
+						defer t.Stop()
+						for {
+							select {
+							case <-stop:
+								return
+							case <-t.C:
+								s.observeInflightMaxAge()
+							}
+						}
+					})
+					b.Cleanup(func() {
+						close(stop)
+						wg.Wait()
+					})
+				}
+
+				var nextID atomic.Uint64
+				nextID.Store(uint64(inflight))
+
+				b.ReportAllocs()
+				b.ResetTimer()
+				b.RunParallel(func(pb *testing.PB) {
+					for pb.Next() {
+						req := newBenchRequest(frontendAddr, nextID.Add(1))
+						s.addRequestToPending(req)
+						s.cancelRequestAndRemoveFromPending(req.Key(), "bench")
+					}
+				})
+			})
+		}
+	}
+}
+
+// newBenchScheduler builds a minimal Scheduler with only the state the
+// benchmarked inflight-tracking methods touch. We avoid NewScheduler because
+// it spins up a services.Manager whose listener goroutines would leak unless
+// the service is started and stopped — overhead we don't want in benchmarks.
+func newBenchScheduler(_ *testing.B, observerEnabled bool) *Scheduler {
+	s := &Scheduler{
+		cfg:                           Config{InflightMaxAgeMetricEnabled: observerEnabled},
+		schedulerInflightRequests:     map[queue.RequestKey]*queue.SchedulerRequest{},
+		schedulerInflightRequestCount: atomic.NewInt64(0),
+	}
+	if observerEnabled {
+		r := prometheus.NewRegistry()
+		s.inflightMaxAge = promauto.With(r).NewGauge(prometheus.GaugeOpts{Name: "bench_inflight_max_age_seconds"})
+	}
+	return s
+}
+
+func newBenchRequest(frontendAddr string, queryID uint64) *queue.SchedulerRequest {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	return &queue.SchedulerRequest{
+		FrontendAddr: frontendAddr,
+		QueryID:      queryID,
+		EnqueueTime:  time.Now(),
+		Ctx:          ctx,
+		CancelFunc:   cancel,
+	}
+}
+
+func fillInflight(b *testing.B, s *Scheduler, n int) {
+	b.Helper()
+	for i := range n {
+		s.addRequestToPending(newBenchRequest("frontend-prefill", uint64(i)))
+	}
+}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -781,6 +781,12 @@ func TestSchedulerQuerierMetrics(t *testing.T) {
 		return err == nil
 	}, time.Second, 10*time.Millisecond, "expected cortex_query_scheduler_connected_querier_clients metric to be incremented after querier connected")
 
+	require.Eventually(t, func() bool {
+		// an item is waiting in the queue, inflightMaxAge is reported
+		inflightMaxAge := testutil.ToFloat64(scheduler.inflightMaxAge)
+		return inflightMaxAge > 0
+	}, time.Second, 10*time.Millisecond, "expected cortex_query_scheduler_inflight_max_age_seconds metric to be greater than zero when an item is in the queue")
+
 	cancel()
 	require.NoError(t, util.CloseAndExhaust[*schedulerpb.SchedulerToQuerier](querierLoop))
 
@@ -793,6 +799,12 @@ func TestSchedulerQuerierMetrics(t *testing.T) {
 
 		return err == nil
 	}, time.Second, 10*time.Millisecond, "expected cortex_query_scheduler_connected_querier_clients metric to be decremented after querier disconnected")
+
+	require.Eventually(t, func() bool {
+		// the queue is empty, inflightMaxAge reports 0
+		inflightMaxAge := testutil.ToFloat64(scheduler.inflightMaxAge)
+		return inflightMaxAge == 0
+	}, time.Second, 10*time.Millisecond, "expected cortex_query_scheduler_inflight_max_age_seconds metric to be zero when the queue is empty")
 
 	require.NoError(t, promtest.HasNativeHistogram(reg, "cortex_query_scheduler_queue_duration_seconds"))
 	require.NoError(t, promtest.HasSampleCount(reg, "cortex_query_scheduler_queue_duration_seconds", 1))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

adds a gauge metric `cortex_query_scheduler_inflight_max_age_seconds` reporting how long the oldest inflight request has been waiting since enqueue. 0 when nothing is inflight.

#### Why

queue length tells you *how many* requests are waiting but nothing about *how stuck* they are. a queue with 5 requests waiting 30s each is a much worse signal than 50 requests waiting 100ms each. this metric makes queue-age alertable, which catches slow-drain scenarios that depth-based alerts miss.

#### Notes

- refreshed on the existing 250ms inflight ticker; benchmark added to measure the scan cost
- gated by `-query-scheduler.inflight-max-age-metric-enabled` (default true) so it can be disabled if the scan becomes expensive at scale
- no alert rule in this PR — will follow up once the metric has baked

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change on the scheduler metrics path; disabling the flag avoids the periodic inflight map scan if overhead is a concern.
> 
> **Overview**
> Adds an experimental **`cortex_query_scheduler_inflight_max_age_seconds`** gauge on the query-scheduler. It reports how long the oldest inflight request (queued or in progress) has been waiting since enqueue, and **0** when nothing is inflight.
> 
> The value is refreshed on the existing **250ms** inflight ticker via **`observeInflightMaxAge()`**, which scans **`schedulerInflightRequests`** under the inflight mutex. Operators can turn off the scan with **`-query-scheduler.inflight-max-age-metric-enabled=false`** (default **true**).
> 
> Includes integration checks in **`scheduler_test`**, benchmarks for observer cost and churn, and config/CHANGELOG/docs updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69a8e0c74b41ea25cae1858d2b6dd64881a4eb0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->