### PR TITLE
Move query string to end of query stats log line

### DIFF
--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -297,15 +297,19 @@ func (f *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // reportSlowQuery reports slow queries.
 func (f *Handler) reportSlowQuery(r *http.Request, queryString url.Values, queryResponseTime time.Duration, details *querymiddleware.QueryDetails) {
-	logMessage := append([]any{
+	logMessage := []any{
 		"msg", "slow query detected",
 		"method", r.Method,
 		"host", r.Host,
 		"path", r.URL.Path,
 		"time_taken", queryResponseTime.String(),
-	}, formatQueryString(details, queryString)...)
+	}
 
 	logMessage = append(logMessage, formatRequestHeaders(&r.Header, f.headersToLog)...)
+
+	// Append query string params last so that, if the log line is truncated downstream,
+	// the long param_query value is what gets cut rather than other fields.
+	logMessage = append(logMessage, formatQueryString(details, queryString)...)
 
 	level.Info(util_log.WithContext(r.Context(), f.log)).Log(logMessage...)
 }
@@ -352,7 +356,7 @@ func (f *Handler) reportQueryStats(
 	}
 
 	// Log stats.
-	logMessage := append([]any{
+	logMessage := []any{
 		"msg", "query stats",
 		"component", "query-frontend",
 		"method", r.Method,
@@ -378,7 +382,7 @@ func (f *Handler) reportQueryStats(
 		"samples_processed", samplesProcessed,
 		"equivalent_samples_read", equivalentSamplesRead,
 		"physical_samples_read", physicalSamplesRead,
-	}, formatQueryString(details, queryString)...)
+	}
 
 	if details != nil {
 		// Start and End may be zero when the request wasn't a query (e.g. /metadata)
@@ -430,6 +434,10 @@ func (f *Handler) reportQueryStats(
 		logMessage = append(logMessage,
 			"status", "success")
 	}
+
+	// Append query string params last so that, if the log line is truncated downstream,
+	// the long param_query value is what gets cut rather than other fields.
+	logMessage = append(logMessage, formatQueryString(details, queryString)...)
 
 	level.Info(util_log.WithContext(r.Context(), f.log)).Log(logMessage...)
 }

--- a/pkg/frontend/transport/handler_test.go
+++ b/pkg/frontend/transport/handler_test.go
@@ -1100,6 +1100,39 @@ func TestQueryStatsLogFieldsDocumentedInRunbook(t *testing.T) {
 	}
 }
 
+func TestHandler_QueryStringLoggedLast(t *testing.T) {
+	roundTripper := roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		time.Sleep(50 * time.Nanosecond)
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("{}"))}, nil
+	})
+
+	logs := &concurrency.SyncBuffer{}
+	cfg := HandlerConfig{
+		QueryStatsEnabled:    true,
+		LogQueriesLongerThan: time.Nanosecond,
+	}
+	handler := NewHandler(cfg, roundTripper, log.NewLogfmtLogger(logs), prometheus.NewPedanticRegistry())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/query?query=some_metric", nil)
+	req = req.WithContext(user.InjectOrgID(context.Background(), "12345"))
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	var sawSlowQuery, sawQueryStats bool
+	for _, line := range strings.Split(strings.TrimSpace(logs.String()), "\n") {
+		switch {
+		case strings.Contains(line, `msg="slow query detected"`):
+			sawSlowQuery = true
+			assert.True(t, strings.HasSuffix(line, "param_query=some_metric"))
+		case strings.Contains(line, `msg="query stats"`):
+			sawQueryStats = true
+			assert.True(t, strings.HasSuffix(line, "param_query=some_metric"))
+		}
+	}
+	require.True(t, sawSlowQuery)
+	require.True(t, sawQueryStats)
+}
+
 func TestFormatRequestHeaders(t *testing.T) {
 	h := http.Header{}
 	h.Add("X-Header-To-Log", "i should be logged!")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

For query stats and slow queries logging, move the query string to the end of the log line. This is as if the query string is long, the log line may be truncated and drop other useful information that are logged after the query string (e.g. request headers). It is likely more valuable to keep the other fields and let the query string be truncated in this case.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging field order only; no query execution, API, or auth behavior changes.
> 
> **Overview**
> Reorders fields in **query-frontend** `query stats` and **slow query** log lines so PromQL/query parameters (`param_query`, etc.) are appended **after** timing, stats, headers, and status. If a log pipeline truncates long lines, the bulky query text is dropped first instead of hiding useful metadata that used to follow the query string.
> 
> Adds `TestHandler_QueryStringLoggedLast` to assert both log types end with `param_query=...`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c57a047978124a331f49a8d4e13b142beddbc947. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->