### PR TITLE
Add 100th percentile to query expression percentile graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * [ENHANCEMENT] Alerts: Make `MimirInconsistentRuntimeConfig` alert less flaky when performing multiple configuration changes in a row in a large Kubernetes cluster. #15257
 * [ENHANCEMENT] Alerts: Widen the `MimirBlockBuilderPersistentJobFailure` lookback window to 20m to prevent the alert from flapping. #15332
 * [ENHANCEMENT] Alerts: Add a native histogram variant of the `MimirRequestLatency` alert, distinguished by the `histogram` label (`classic` or `native`). #15413
+* [ENHANCEMENT] Dashboards: Add 100th percentile to query expression percentiles graph. #15421
 * [BUGFIX] Dashboards: Fix the classic/ingest-storage split in the "Tenants", "Top tenants" and "Writes" dashboards so that selecting multiple clusters with a mix of architectures no longer drops the classic clusters' data. The `unless on (job)` filter against `cortex_partition_ring_partitions` now also matches on the cluster aggregation labels. #15400
 
 ### Jsonnet

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -12710,6 +12710,10 @@ data:
                                "fillOpacity": 1,
                                "lineWidth": 1,
                                "pointSize": 5,
+                               "scaleDistribution": {
+                                  "log": 2,
+                                  "type": "log"
+                               },
                                "showPoints": "never",
                                "spanNulls": false,
                                "stacking": {
@@ -12739,6 +12743,12 @@ data:
                       },
                       "span": 6,
                       "targets": [
+                         {
+                            "expr": "histogram_quantile(1.00, sum(rate(cortex_query_frontend_queries_expression_bytes{namespace=\"$namespace\"}[$__rate_interval])))",
+                            "format": "time_series",
+                            "legendFormat": "100th Percentile",
+                            "legendLink": null
+                         },
                          {
                             "expr": "histogram_quantile(0.99, sum(rate(cortex_query_frontend_queries_expression_bytes{namespace=\"$namespace\"}[$__rate_interval])))",
                             "format": "time_series",

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-queries.json
@@ -907,6 +907,10 @@
                            "fillOpacity": 1,
                            "lineWidth": 1,
                            "pointSize": 5,
+                           "scaleDistribution": {
+                              "log": 2,
+                              "type": "log"
+                           },
                            "showPoints": "never",
                            "spanNulls": false,
                            "stacking": {
@@ -936,6 +940,12 @@
                   },
                   "span": 6,
                   "targets": [
+                     {
+                        "expr": "histogram_quantile(1.00, sum(rate(cortex_query_frontend_queries_expression_bytes{namespace=\"$namespace\"}[$__rate_interval])))",
+                        "format": "time_series",
+                        "legendFormat": "100th Percentile",
+                        "legendLink": null
+                     },
                      {
                         "expr": "histogram_quantile(0.99, sum(rate(cortex_query_frontend_queries_expression_bytes{namespace=\"$namespace\"}[$__rate_interval])))",
                         "format": "time_series",

--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-queries.json
@@ -975,6 +975,10 @@
                            "fillOpacity": 1,
                            "lineWidth": 1,
                            "pointSize": 5,
+                           "scaleDistribution": {
+                              "log": 2,
+                              "type": "log"
+                           },
                            "showPoints": "never",
                            "spanNulls": false,
                            "stacking": {
@@ -1004,6 +1008,12 @@
                   },
                   "span": 6,
                   "targets": [
+                     {
+                        "expr": "histogram_quantile(1.00, sum(rate(cortex_query_frontend_queries_expression_bytes{namespace=\"$namespace\"}[$__rate_interval])))",
+                        "format": "time_series",
+                        "legendFormat": "100th Percentile",
+                        "legendLink": null
+                     },
                      {
                         "expr": "histogram_quantile(0.99, sum(rate(cortex_query_frontend_queries_expression_bytes{namespace=\"$namespace\"}[$__rate_interval])))",
                         "format": "time_series",

--- a/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-queries.json
@@ -907,6 +907,10 @@
                            "fillOpacity": 1,
                            "lineWidth": 1,
                            "pointSize": 5,
+                           "scaleDistribution": {
+                              "log": 2,
+                              "type": "log"
+                           },
                            "showPoints": "never",
                            "spanNulls": false,
                            "stacking": {
@@ -936,6 +940,12 @@
                   },
                   "span": 6,
                   "targets": [
+                     {
+                        "expr": "histogram_quantile(1.00, sum(rate(cortex_query_frontend_queries_expression_bytes{namespace=\"$namespace\"}[$__rate_interval])))",
+                        "format": "time_series",
+                        "legendFormat": "100th Percentile",
+                        "legendLink": null
+                     },
                      {
                         "expr": "histogram_quantile(0.99, sum(rate(cortex_query_frontend_queries_expression_bytes{namespace=\"$namespace\"}[$__rate_interval])))",
                         "format": "time_series",

--- a/operations/mimir-mixin/dashboards/queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/queries.libsonnet
@@ -261,6 +261,10 @@ local filename = 'mimir-queries.json';
       .addPanel(
         $.timeseriesPanel('Query Expression Percentiles') +
         $.queryPanel(
+          'histogram_quantile(1.00, sum(rate(cortex_query_frontend_queries_expression_bytes{namespace="$namespace"}[$__rate_interval])))',
+          '100th Percentile'
+        ) +
+        $.queryPanel(
           'histogram_quantile(0.99, sum(rate(cortex_query_frontend_queries_expression_bytes{namespace="$namespace"}[$__rate_interval])))',
           '99th Percentile'
         ) +
@@ -272,7 +276,19 @@ local filename = 'mimir-queries.json';
           'histogram_avg(sum(rate(cortex_query_frontend_queries_expression_bytes{namespace="$namespace"}[$__rate_interval])))',
           'Average'
         ) +
-        { fieldConfig+: { defaults+: { unit: 'bytes' } } }
+        {
+          fieldConfig+: {
+            defaults+: {
+              unit: 'bytes',
+              custom+: {
+                scaleDistribution: {
+                  type: 'log',
+                  log: 2,
+                },
+              },
+            },
+          },
+        }
       )
     )
     .addRowIf(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Adds 100th percentile to query expression percentile graph to help see when extreme outlier cases happen.

Also set the scale to logarithmic so that changes in lower percentiles are still visible.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only changes: adds a new percentile series and switches the panel to log scaling; no runtime or data-path behavior is modified.
> 
> **Overview**
> Adds a `100th Percentile` (`histogram_quantile(1.00, ...)`) series to the *Query Expression Percentiles* panel and switches the panel’s y-scale to logarithmic (`scaleDistribution` log base 2) to better visualize both outliers and lower percentiles.
> 
> Regenerates the compiled dashboard artifacts (compiled mixins and metamonitoring Helm test output) and records the enhancement in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49ab1d89bacf52264d89d11be945a6591a62de35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->