### PR TITLE
Address recommendations from supply chain GHA audit

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Check if changelog should be skipped
         id: check-label

--- a/.github/workflows/flaky-tests.yml
+++ b/.github/workflows/flaky-tests.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: '0' # we need all commits so that the git history check returns valid commits
+          persist-credentials: false
 
       - name: Retrieve Secrets from Vault
         id: get-secrets

--- a/.github/workflows/generate-docs-helm-tests-renovate-pr.yml
+++ b/.github/workflows/generate-docs-helm-tests-renovate-pr.yml
@@ -68,7 +68,7 @@ jobs:
           git config --global user.name "${GITHUB_LOGIN}"
 
       - name: Install the gh cli
-        uses: ksivamuthu/actions-setup-gh-cli@c78dbed4be2f8d6133a14a9a597ee12fd4ed5c93 # v3
+        run: ./.github/workflows/scripts/install-gh.sh
 
       - name: Checkout Pull Request Branch
         run: gh pr checkout ${{ github.event.pull_request.number }}

--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -205,25 +205,29 @@ jobs:
       # Refer to https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
       - name: Add commit to PR in order to update Build Image version
         if: steps.check_dockerfile.outputs.modified == 'true' && steps.authorize.outputs.authorized == 'true' && steps.compare_tag.outputs.isDifferent == 'true'
-        run: |
-          echo "Get current Build Image Version"
-          echo "Current Build Image Version is $MAIN_TAG"
-          echo "Built Image Version is $TAG"
-          if [ "$MAIN_TAG" = "$TAG" ]; then
-            echo "Build Image Version is already up to date"
-          else
-            echo "Build Image Version is not up to date"
-            sed -i "s/$MAIN_TAG/${{ steps.compute_hash.outputs.tag }}/g" Makefile
-            git config --global user.email "${GITHUB_EMAIL}"
-            git config --global user.name "${GITHUB_LOGIN}"
-            git config --global url.https://x-access-token:${GITHUB_TOKEN}@github.com/.insteadOf https://github.com/
-            git add Makefile
-            git commit -m "Update build image version to ${{ steps.compute_hash.outputs.tag }}"
-            git push origin HEAD
-          fi
         env:
           GITHUB_TOKEN: ${{ steps.app-token-for-commit.outputs.token }}
           GITHUB_LOGIN: mimir-github-bot[bot]
           GITHUB_EMAIL: 199097951+mimir-github-bot[bot]@users.noreply.github.com
           TAG: ${{ steps.compute_hash.outputs.tag }}
           MAIN_TAG: ${{ steps.prepare.outputs.main_image_tag }}
+        run: |
+          set -euo pipefail
+          echo "Get current Build Image Version"
+          echo "Current Build Image Version is $MAIN_TAG"
+          echo "Built Image Version is $TAG"
+          if [ "$MAIN_TAG" = "$TAG" ]; then
+            echo "Build Image Version is already up to date"
+            exit 0
+          fi
+          echo "Build Image Version is not up to date"
+          sed -i "s/${MAIN_TAG}/${TAG}/g" Makefile
+          git config --global user.email "${GITHUB_EMAIL}"
+          git config --global user.name "${GITHUB_LOGIN}"
+          git add Makefile
+          git commit -m "Update build image version to ${TAG}"
+          # Send the App token only on this push via an Authorization header, rather than
+          # persisting `x-access-token:$TOKEN` into the global git config. Avoids leaving the
+          # token recoverable from ~/.gitconfig by any later step in the runner.
+          AUTH_HEADER=$(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=Authorization: Basic ${AUTH_HEADER}" push origin HEAD

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -314,9 +314,11 @@ jobs:
     needs:
       - prepare
       - warmup-go-build-cache-unit-tests
+    # The test job runs untrusted PR code (`go test`) and must NOT have write permissions.
+    # PR comments for streamingpromql failures are handled by the downstream
+    # notify-streamingpromql-failures job, which doesn't run any PR-author code.
     permissions:
       contents: read
-      pull-requests: write
     container:
       image: ${{ needs.prepare.outputs.build_image }} # zizmor: ignore[unpinned-images] The image output produced by the prepare step is pinned
     steps:
@@ -330,8 +332,6 @@ jobs:
           path: /go/cache
           key: go-build-cache-unit-${{ needs.prepare.outputs.build_image }}-${{ hashFiles('go.sum') }}
           restore-keys: go-build-cache-unit-${{ needs.prepare.outputs.build_image }}-
-      - name: Install GitHub CLI
-        run: ./.github/workflows/scripts/install-gh.sh
       - name: Run Git Config
         run: git config --global --add safe.directory '*'
       - name: Symlink Expected Path to Workspace
@@ -342,24 +342,62 @@ jobs:
         run: |
           echo "Running unit tests (group ${{ matrix.test_group_id }} of ${{ matrix.test_group_total }})${{ matrix.extra_build_tags != '' && format(' with build tags: {0}', matrix.extra_build_tags) || '' }} with Go version: $(go version)"
           EXTRA_BUILD_TAGS="${{ matrix.extra_build_tags }}" ./.github/workflows/scripts/run-unit-tests-group.sh --index ${{ matrix.test_group_id }} --total ${{ matrix.test_group_total }}
-      - name: Notify on streamingpromql failures
-        if: failure() && env.FAILED_PACKAGES != '' && contains(github.event.pull_request.labels.*.name, 'vendored-mimir-prometheus-update')
+      - name: Record failed packages for notification
+        if: failure() && env.FAILED_PACKAGES != ''
         run: |
-          if echo "${{ env.FAILED_PACKAGES }}" | grep -q "pkg/streamingpromql"; then
-            gh pr comment ${{ github.event.pull_request.number }} --body \
-              "⚠️ Test failures detected in \`pkg/streamingpromql\` (test group ${{ matrix.test_group_id }}/${{ matrix.test_group_total }})
-              
-          Failed packages in this test group:
-          \`\`\`
-          ${{ env.FAILED_PACKAGES }}
-          \`\`\`
-              
-          cc @charleskorn @56quarters @lamida @zenador @tcp13equals2
-              
-          Please review the [test logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) and push fixes to this PR."
-          fi
+          mkdir -p failed-packages
+          printf '%s\n' "${FAILED_PACKAGES}" > "failed-packages/group-${MATRIX_TAGS:-default}-${MATRIX_GROUP_ID}.txt"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FAILED_PACKAGES: ${{ env.FAILED_PACKAGES }}
+          MATRIX_TAGS: ${{ matrix.extra_build_tags }}
+          MATRIX_GROUP_ID: ${{ matrix.test_group_id }}
+      - name: Upload failed packages artifact
+        if: failure() && env.FAILED_PACKAGES != ''
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: failed-packages-${{ matrix.extra_build_tags || 'default' }}-${{ matrix.test_group_id }}
+          path: failed-packages/
+          retention-days: 1
+
+  notify-streamingpromql-failures:
+    needs: test
+    runs-on: ubuntu-latest
+    # Only runs on PRs labeled for the vendored mimir-prometheus update flow, and only when test failed.
+    if: failure() && github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'vendored-mimir-prometheus-update')
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Download failed packages artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: failed-packages-*
+          merge-multiple: true
+          path: failed-packages
+      - name: Comment on PR if streamingpromql failed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          if [ ! -d failed-packages ] || [ -z "$(ls -A failed-packages 2>/dev/null)" ]; then
+            echo "No failed-packages artifacts produced; nothing to comment."
+            exit 0
+          fi
+          ALL_FAILED=$(cat failed-packages/*.txt 2>/dev/null | tr ' ' '\n' | grep -v '^$' | sort -u)
+          if ! echo "$ALL_FAILED" | grep -q '^github.com/grafana/mimir/pkg/streamingpromql'; then
+            echo "No streamingpromql failures detected."
+            exit 0
+          fi
+          {
+            printf ':warning: Test failures detected in `pkg/streamingpromql`\n\n'
+            printf 'Failed packages across all test groups:\n```\n%s\n```\n\n' "$ALL_FAILED"
+            printf 'cc @charleskorn @56quarters @lamida @zenador @tcp13equals2\n\n'
+            printf 'Please review the [test logs](%s) and push fixes to this PR.\n' "$RUN_URL"
+          } > comment.md
+          gh pr comment "$PR_NUMBER" --body-file comment.md
 
   test-docs:
     uses: ./.github/workflows/test-docs.yml

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -386,7 +386,10 @@ jobs:
             echo "No failed-packages artifacts produced; nothing to comment."
             exit 0
           fi
-          ALL_FAILED=$(cat failed-packages/*.txt 2>/dev/null | tr ' ' '\n' | grep -v '^$' | sort -u)
+          # `grep -v` exits 1 when nothing matches; under `pipefail` that would kill the
+          # script before the streamingpromql check below. Wrap it so the pipeline stays
+          # at exit 0 even if every input line happens to be empty.
+          ALL_FAILED=$(cat failed-packages/*.txt 2>/dev/null | tr ' ' '\n' | { grep -v '^$' || true; } | sort -u)
           if ! echo "$ALL_FAILED" | grep -q '^github.com/grafana/mimir/pkg/streamingpromql'; then
             echo "No streamingpromql failures detected."
             exit 0

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -370,6 +370,7 @@ jobs:
     steps:
       - name: Download failed packages artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        continue-on-error: true
         with:
           pattern: failed-packages-*
           merge-multiple: true

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -20,7 +20,7 @@ jobs:
           -v "${PWD}/docs/sources/mimir:/hugo/content/docs/mimir/latest" \
           -e HUGO_REFLINKSERRORLEVEL=ERROR \
           --rm \
-          grafana/docs-base:latest \
+          grafana/docs-base@sha256:b4d886449a18b7b7532214b58ed08332cc76b9469924cb08bc0c71fe161dc950 \
           /bin/bash -c 'make hugo'
     - name: Determine Mimir version targeted by Helm chart documentation
       id: mimir_version
@@ -55,5 +55,5 @@ jobs:
           -v "${PWD}/docs/sources/helm-charts/mimir-distributed:/hugo/content/docs/helm-charts/mimir-distributed/latest" \
           -e HUGO_REFLINKSERRORLEVEL=ERROR \
           --rm \
-          grafana/docs-base:latest \
+          grafana/docs-base@sha256:b4d886449a18b7b7532214b58ed08332cc76b9469924cb08bc0c71fe161dc950 \
           /bin/bash -c 'make hugo'

--- a/.github/workflows/update-vendored-mimir-prometheus.yml
+++ b/.github/workflows/update-vendored-mimir-prometheus.yml
@@ -56,9 +56,14 @@ jobs:
 
       - name: Determine branch names (combined)
         id: branch-names
+        env:
+          DISPATCH_MIMIR_BRANCH: ${{ steps.branch-names-dispatch.outputs.mimir_branch }}
+          MANUAL_MIMIR_BRANCH: ${{ steps.branch-names-manual.outputs.mimir_branch }}
+          DISPATCH_MIMIR_PROMETHEUS_BRANCH: ${{ steps.branch-names-dispatch.outputs.mimir_prometheus_branch }}
+          MANUAL_MIMIR_PROMETHEUS_BRANCH: ${{ steps.branch-names-manual.outputs.mimir_prometheus_branch }}
         run: |
-          echo "mimir_branch=${{ steps.branch-names-dispatch.outputs.mimir_branch || steps.branch-names-manual.outputs.mimir_branch }}" >> $GITHUB_OUTPUT
-          echo "mimir_prometheus_branch=${{ steps.branch-names-dispatch.outputs.mimir_prometheus_branch || steps.branch-names-manual.outputs.mimir_prometheus_branch }}" >> $GITHUB_OUTPUT
+          echo "mimir_branch=${DISPATCH_MIMIR_BRANCH:-$MANUAL_MIMIR_BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "mimir_prometheus_branch=${DISPATCH_MIMIR_PROMETHEUS_BRANCH:-$MANUAL_MIMIR_PROMETHEUS_BRANCH}" >> "$GITHUB_OUTPUT"
 
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -67,6 +72,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
           set-safe-directory: '*'
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,11 +2,11 @@
 * @grafana/mimir-maintainers
 
 # Documentation.
-/.github/workflows/deploy-pr-preview.yml                                    @grafana/docs-tooling @grafana/mimir-maintainers
+/.github/workflows/deploy-pr-preview-mimir.yml                              @grafana/docs-tooling @grafana/mimir-maintainers
+/.github/workflows/deploy-pr-preview-helm-charts.yml                        @grafana/docs-tooling @grafana/mimir-maintainers
 /.github/workflows/publish-technical-documentation-next.yml                 @grafana/docs-tooling @grafana/mimir-maintainers
 /.github/workflows/publish-technical-documentation-release-helm-charts.yml  @grafana/docs-tooling @grafana/mimir-maintainers
 /.github/workflows/publish-technical-documentation-release-mimir.yml        @grafana/docs-tooling @grafana/mimir-maintainers
-/.github/workflows/update-make-docs.yml                                     @grafana/docs-tooling @grafana/mimir-maintainers
 
 /docs/                                                                      @grafana/docs-metrics @grafana/mimir-maintainers
 /docs/docs.mk                                                               @grafana/docs-tooling @grafana/mimir-maintainers

--- a/renovate.json5
+++ b/renovate.json5
@@ -25,6 +25,20 @@
       datasourceTemplate: 'docker',
     },
     {
+      // grafana/docs-base is referenced inside `docker run` shell commands in
+      // workflow files, which Renovate's github-actions manager does not scan.
+      // This custom manager tracks the digest against the :latest tag so it
+      // can be auto-bumped via a PR rather than baked in at commit time.
+      customType: 'regex',
+      description: 'Update grafana/docs-base digest in workflow files',
+      managerFilePatterns: ['.github/workflows/**'],
+      matchStrings: [
+        '(?<depName>grafana/docs-base)@(?<currentDigest>sha256:[a-f0-9]+)',
+      ],
+      currentValueTemplate: 'latest',
+      datasourceTemplate: 'docker',
+    },
+    {
       customType: 'regex',
       description: 'Update "go install" commands in development Dockerfiles',
       managerFilePatterns: [

--- a/renovate.json5
+++ b/renovate.json5
@@ -147,6 +147,21 @@
       ],
       rebaseWhen: 'behind-base-branch',
       gitIgnoredAuthors: ['199097951+mimir-github-bot[bot]@users.noreply.github.com'],
+    },
+    {
+      // grafana/shared-workflows is a monorepo whose actions are tagged as
+      // `<action-name>/v<semver>` (e.g. `create-github-app-token/v0.2.2`).
+      // Renovate cannot compare those tags with its default versioning, so
+      // references to those actions are never auto-bumped without this rule.
+      // Canonical config from https://github.com/grafana/shared-workflows#custom-renovate-config
+      description: 'Auto-bump grafana/shared-workflows actions (per-action semver tags).',
+      matchPackageNames: ['grafana/shared-workflows'],
+      versioning: 'regex:^(?<compatibility>.*)[-/]v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)?$',
+      additionalBranchPrefix: '{{ lookup (split newVersion "/") 0 }}-',
+      commitMessagePrefix: 'chore(deps):',
+      commitMessageAction: 'update',
+      commitMessageTopic: '{{depName}}/{{ lookup (split newVersion "/") 0 }} action',
+      commitMessageExtra: 'to {{ lookup (split newVersion "/") 1 }}',
     }
   ],
   branchPrefix: 'deps-update/',

--- a/renovate.json5
+++ b/renovate.json5
@@ -176,7 +176,7 @@
       // Renovate cannot compare those tags with its default versioning, so
       // references to those actions are never auto-bumped without this rule.
       // Canonical config from https://github.com/grafana/shared-workflows#custom-renovate-config
-      description: 'Auto-bump grafana/shared-workflows actions (per-action semver tags).',
+      description: 'Auto-bump grafana/shared-workflows actions (per-action semver tags)',
       matchPackageNames: ['grafana/shared-workflows'],
       versioning: 'regex:^(?<compatibility>.*)[-/]v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)?$',
       additionalBranchPrefix: '{{ lookup (split newVersion "/") 0 }}-',


### PR DESCRIPTION
This PR addresses recommendations raised from a GitHub actions supply chain audit. 

Changes by file

**.github/workflows/test-build-deploy.yml** — addresses the test job holding pull-requests: write while running untrusted PR code (go test), which would let a malicious PR test tamper with PR thread state via $GITHUB_TOKEN.
- Dropped pull-requests: write from the test matrix job; permissions are now contents: read only.
- Removed the Install GitHub CLI step (no longer needed in the test job).
- Each shard that fails now writes FAILED_PACKAGES to a small file and uploads it as a failed-packages-<tags>-<id> artifact.
- New downstream job notify-streamingpromql-failures (needs: test, permissions: pull-requests: write) downloads those artifacts, de-duplicates the failed-package list across shards, and posts a single PR comment if pkg/streamingpromql failed. Uses GH_TOKEN/GH_REPO env so gh pr comment works on a runner with no checkout.

**.github/workflows/test-docs.yml** — addresses the mutable grafana/docs-base:latest tag in a PR-triggered workflow.
- Pinned to grafana/docs-base@sha256:b4d886449a18b7b7532214b58ed08332cc76b9469924cb08bc0c71fe161dc950 (current latest digest, fetched from Docker Hub). Renovate's docker manager will keep it updated.

**.github/workflows/update-vendored-mimir-prometheus.yml** — addresses template injection via direct ${{ steps.*.outputs.* }} interpolation into a shell run: block, plus a missing persist-credentials: false.
- Replaced the direct ${{ … }} interpolation in the branch-names (combined) step with env: indirection (DISPATCH_MIMIR_BRANCH, MANUAL_MIMIR_BRANCH, etc.).
- Added persist-credentials: false to the checkout.

**.github/workflows/push-mimir-build-image.yml** — addresses persisting the App token globally via git config --global url.https://x-access-token:$TOKEN@github.com/.insteadOf, which leaves the token recoverable from ~/.gitconfig by any later step in the same runner.
- Replaced the global config rewrite with a one-shot git -c http.https://github.com/.extraheader=Authorization: Basic <base64> flag on the push invocation only.
- Tidied surrounding script: set -euo pipefail, early exit 0 instead of nested else, and lifted ${{ steps.compute_hash.outputs.tag }} into the existing $TAG env var.

**.github/workflows/generate-docs-helm-tests-renovate-pr.yml** — addresses third-party (personal-account) action ksivamuthu/actions-setup-gh-cli in a privileged job that holds the mimir-github-bot App token.
- Swapped for the in-repo ./.github/workflows/scripts/install-gh.sh (build image is Debian-based, so apt install works).

**.github/workflows/changelog-check.yml** — addresses missing persist-credentials: false on a PR-triggered checkout.
- Added persist-credentials: false.

**.github/workflows/flaky-tests.yml** — same as above, on a scheduled workflow that holds Vault secrets.
- Added persist-credentials: false.

**CODEOWNERS** — addresses stale entries referencing workflow files that don't exist (deploy-pr-preview.yml, update-make-docs.yml).
- Removed the two dead entries.
- Added the two real preview workflow files (deploy-pr-preview-mimir.yml, deploy-pr-preview-helm-charts.yml) under the same docs-tooling ownership.

Behaviour changes worth calling out in the PR description

- Streamingpromql-failure comments are now aggregated into one PR comment per workflow run, rather than one per matrix shard.
- gh CLI is no longer installed in the unit-test container (the deleted notify step was the only consumer).

Validation done

- All 7 changed YAML files parse cleanly (ruby -ryaml).
- The two non-trivial new shell blocks pass shellcheck (the two SC2016 hits on markdown backticks are intentional).
- A second-pass Codex review reported no findings.

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI permissions and notification behavior (aggregated streamingpromql comments); misconfiguration could break PR comments or docs/build workflows, but production Mimir is unaffected.
> 
> **Overview**
> This PR hardens **GitHub Actions** workflows after a supply-chain audit, without changing application runtime behavior.
> 
> The **unit test** matrix job no longer has `pull-requests: write` while running untrusted `go test` code; it only uploads failed-package artifacts. A new **`notify-streamingpromql-failures`** job (read-only checkout, `pull-requests: write`) aggregates those artifacts and posts **one** PR comment when `pkg/streamingpromql` fails on vendored-prometheus update PRs.
> 
> Several workflows add **`persist-credentials: false`** on checkout, pin **`grafana/docs-base`** to a digest in docs CI (with Renovate to bump it), replace a third-party **gh** install action with an in-repo script, avoid persisting the **App token** in global git config on build-image pushes (one-shot `extraheader` instead), and use **env indirection** for branch names in the vendoring workflow. **CODEOWNERS** is updated for real docs preview workflows; **Renovate** gains rules for `docs-base` digests and `grafana/shared-workflows` action tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c85c0a939873af4d8cd003fdf1ad2ea9da1ae5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->