### PR TITLE
Build image hardening

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr15429-bf224fe1d5
+LATEST_BUILD_IMAGE_TAG ?= pr15425-fc217a751d
 
 # TTY is parameterized to allow CI and scripts to run builds,
 # as it currently disallows TTY devices.

--- a/Makefile
+++ b/Makefile
@@ -513,9 +513,8 @@ lint: check-makefiles check-merge-conflicts
 	# Ensure gRPC buffers aren't released too early
 	$(LINT_GO_ENV) go run ./tools/lint-buffer-holder
 
-format: ## Run gofmt and goimports.
-	find . $(DONT_FIND) -name '*.pb.go' -prune -o -type f -name '*.go' -exec gofmt -w -s {} \;
-	find . $(DONT_FIND) -name '*.pb.go' -prune -o -type f -name '*.go' -exec goimports -w -local github.com/grafana/mimir {} \;
+format: ## Run formatters.
+	$(LINT_GO_ENV) golangci-lint fmt
 
 test: ## Run all unit tests.
 	go test -timeout 30m $$(go list ./... | grep -v "^github.com/grafana/mimir/integration")

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -13,7 +13,7 @@ ENV GOPROXY=${goproxyValue}
 # https://github.com/docker-library/golang/issues/472
 ENV GOTOOLCHAIN=local
 
-ENV NODE_MAJOR_VERSION=20
+ENV NODE_MAJOR_VERSION=26
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 RUN <<EOF cat > /etc/apt/sources.list.d/nodesource.sources
 Types: deb

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -23,7 +23,6 @@ Components: main
 Signed-By: /etc/apt/keyrings/nodesource.gpg
 EOF
 
-ENV SKOPEO_DEPS="libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config"
 RUN apt-get update && \
     apt-get install -y \
       curl \
@@ -38,7 +37,8 @@ RUN apt-get update && \
       shellcheck \
       libpcap-dev \
       nodejs \
-      $SKOPEO_DEPS \
+      # Dependencies required to build Skopeo below.
+      libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config \
     && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -60,7 +60,8 @@ RUN GOARCH=$(go env GOARCH) && \
 
 # renovate: depName=github.com/golangci/golangci-lint
 ENV GOLANGCI_LINT_VERSION=2.12.2
-RUN GOARCH=$(go env GOARCH) && \
+RUN set -o pipefail && \
+    GOARCH=$(go env GOARCH) && \
     VERSION_SLUG=golangci-lint-${GOLANGCI_LINT_VERSION}-linux-$(go env GOARCH) && \
     TARBALL=$VERSION_SLUG.tar.gz && \
     cd /tmp && \

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -15,7 +15,6 @@ ENV SKOPEO_DEPS="libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-co
 ENV GOTOOLCHAIN=local
 RUN apt-get update && apt-get install -y curl python3-requests python3-yaml file jq zip unzip protobuf-compiler libprotobuf-dev shellcheck libpcap-dev $SKOPEO_DEPS && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-RUN go install golang.org/x/tools/cmd/goimports@3fce476f0a782aeb5034d592c189e63be4ba6c9e
 RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
 RUN apt-get install -y nodejs && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -8,11 +8,22 @@ FROM alpine/helm:4.1.4@sha256:4b0bdd2cf18ff6bca12aba0b2c5671384dab5035c19c57f0c5
 FROM golang:1.26.3-trixie@sha256:d08bf3ed2bd263088ca8e23fefaf10f1b71769f6932f0a4017ba28d2a5baf001
 ARG goproxyValue
 ENV GOPROXY=${goproxyValue}
-ENV SKOPEO_DEPS="libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config"
 # Override toolchain directive in go.mod, to ensure the image's Go version is used.
 # Be aware that the official Go Dockerfiles already do this, but let's be explicit.
 # https://github.com/docker-library/golang/issues/472
 ENV GOTOOLCHAIN=local
+
+ENV NODE_MAJOR_VERSION=20
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+RUN <<EOF cat > /etc/apt/sources.list.d/nodesource.sources
+Types: deb
+URIs: https://deb.nodesource.com/node_${NODE_MAJOR_VERSION}.x/
+Suites: nodistro
+Components: main
+Signed-By: /etc/apt/keyrings/nodesource.gpg
+EOF
+
+ENV SKOPEO_DEPS="libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config"
 RUN apt-get update && \
     apt-get install -y \
       curl \
@@ -26,11 +37,10 @@ RUN apt-get update && \
       libprotobuf-dev \
       shellcheck \
       libpcap-dev \
+      nodejs \
       $SKOPEO_DEPS \
     && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
-RUN apt-get install -y nodejs && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN npm install -g prettier@2.3.2
 

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -13,7 +13,21 @@ ENV SKOPEO_DEPS="libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-co
 # Be aware that the official Go Dockerfiles already do this, but let's be explicit.
 # https://github.com/docker-library/golang/issues/472
 ENV GOTOOLCHAIN=local
-RUN apt-get update && apt-get install -y curl python3-requests python3-yaml file jq zip unzip protobuf-compiler libprotobuf-dev shellcheck libpcap-dev $SKOPEO_DEPS && \
+RUN apt-get update && \
+    apt-get install -y \
+      curl \
+      python3-requests \
+      python3-yaml \
+      file \
+      jq \
+      zip \
+      unzip \
+      protobuf-compiler \
+      libprotobuf-dev \
+      shellcheck \
+      libpcap-dev \
+      $SKOPEO_DEPS \
+    && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
 RUN apt-get install -y nodejs && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -60,7 +60,14 @@ RUN GOARCH=$(go env GOARCH) && \
 
 # renovate: depName=github.com/golangci/golangci-lint
 ENV GOLANGCI_LINT_VERSION=2.12.2
-RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/v"${GOLANGCI_LINT_VERSION}"/install.sh| sh -s -- -b /usr/bin v"${GOLANGCI_LINT_VERSION}"
+RUN GOARCH=$(go env GOARCH) && \
+    VERSION_SLUG=golangci-lint-${GOLANGCI_LINT_VERSION}-linux-$(go env GOARCH) && \
+    TARBALL=$VERSION_SLUG.tar.gz && \
+    cd /tmp && \
+    curl -sfL "https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_LINT_VERSION}/$TARBALL" -o "/tmp/$TARBALL" && \
+    curl -sfL "https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_LINT_VERSION}/golangci-lint-${GOLANGCI_LINT_VERSION}-checksums.txt" | grep -E "\s+$TARBALL$" | sha256sum --check - && \
+    tar -xzvf "/tmp/$TARBALL" -C /usr/bin --strip-components=1 "$VERSION_SLUG/golangci-lint" && \
+    rm /tmp/$TARBALL
 
 # renovate: depName=github.com/containers/skopeo
 ENV SKOPEO_VERSION=v1.22.2

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -61,7 +61,6 @@ RUN GOARCH=$(go env GOARCH) && \
 # renovate: depName=github.com/golangci/golangci-lint
 ENV GOLANGCI_LINT_VERSION=2.12.2
 RUN set -o pipefail && \
-    GOARCH=$(go env GOARCH) && \
     VERSION_SLUG=golangci-lint-${GOLANGCI_LINT_VERSION}-linux-$(go env GOARCH) && \
     TARBALL=$VERSION_SLUG.tar.gz && \
     cd /tmp && \


### PR DESCRIPTION
#### What this PR does

This PR makes a number of small changes to the build image:

* it updates the Node.js version to v26, as v20 is now EOL
* it removes `goimports`, as import formatting is already covered by `golangci-lint` (`gci` is used through `golangci-lint`, and this is run whenever `golangci-lint fmt` or `golangci-lint run` is run)
* it removes the use of shell scripts downloaded from the internet to install Node.js and `golangci-lint`, preferring explicit steps in the Dockerfile to avoid the risk of malicious changes to these scripts

Given these changes are not user-facing, I have not added a changelog entry.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect only the Docker build image and Makefile formatting targets, not Mimir runtime or user-facing behavior.
> 
> **Overview**
> Hardens the **mimir build image** and aligns local formatting with what CI already uses via **golangci-lint**.
> 
> The Dockerfile bumps **Node.js to v26** using an explicit Nodesource apt source and GPG key instead of piping remote setup scripts into the shell. **`goimports` is removed** from the image; import ordering stays covered by **`gci` through `golangci-lint`**. **`golangci-lint` is installed** by downloading the release tarball and verifying it against the published checksums file, replacing the upstream `install.sh` pattern. Skopeo build dependencies are folded into the main `apt-get install` block.
> 
> The root **`make format` target** now runs **`golangci-lint fmt`** instead of **`gofmt`/`goimports` over all Go files**, and **`LATEST_BUILD_IMAGE_TAG`** is bumped so consumers pull the new image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24be890e6f42ea1386d27e5cde1b0df9a632d746. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->