### PR TITLE
ci: pin writers-toolkit deploy-preview workflow to @main

### DIFF
--- a/.github/workflows/deploy-pr-preview-helm-charts.yml
+++ b/.github/workflows/deploy-pr-preview-helm-charts.yml
@@ -17,7 +17,10 @@ jobs:
       pull-requests: write # Create or update pull request comments.
       statuses: write # Update GitHub status check with deploy preview link.
     if: "!github.event.pull_request.head.repo.fork"
-    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@4dbecae7443c69b3e5fdfeeac7037a339cb82e4c # main
+    # Must reference @main (not a pinned SHA): the OIDC trust policy for the
+    # service account used by deploy-preview.yml only trusts the "main" ref of
+    # grafana/writers-toolkit, so pinning to a commit SHA breaks token exchange.
+    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main
     with:
       branch: ${{ github.head_ref }}
       event_number: ${{ github.event.number }}

--- a/.github/workflows/deploy-pr-preview-mimir.yml
+++ b/.github/workflows/deploy-pr-preview-mimir.yml
@@ -17,7 +17,10 @@ jobs:
       pull-requests: write # Create or update pull request comments.
       statuses: write # Update GitHub status check with deploy preview link.
     if: "!github.event.pull_request.head.repo.fork"
-    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@4dbecae7443c69b3e5fdfeeac7037a339cb82e4c # main
+    # Must reference @main (not a pinned SHA): the OIDC trust policy for the
+    # service account used by deploy-preview.yml only trusts the "main" ref of
+    # grafana/writers-toolkit, so pinning to a commit SHA breaks token exchange.
+    uses: grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main
     with:
       branch: ${{ github.head_ref }}
       event_number: ${{ github.event.number }}

--- a/renovate.json5
+++ b/renovate.json5
@@ -147,6 +147,14 @@
       ],
       rebaseWhen: 'behind-base-branch',
       gitIgnoredAuthors: ['199097951+mimir-github-bot[bot]@users.noreply.github.com'],
+    },
+    {
+      description: 'Keep grafana/writers-toolkit deploy-preview workflow on @main: the OIDC service account only trusts the main ref, so pinning to a SHA breaks the docs deploy preview.',
+      matchManagers: ['github-actions'],
+      matchPackageNames: [
+        'grafana/writers-toolkit',
+      ],
+      enabled: false,
     }
   ],
   branchPrefix: 'deps-update/',


### PR DESCRIPTION
The OIDC service account used by `grafana/writers-toolkit`'s `deploy-preview.yml` only trusts the `main` ref. Renovate pinned the `uses:` reference to a commit SHA, which breaks the token exchange and silently fails the docs deploy preview (see #15302).

Revert both `deploy-pr-preview` workflows to `@main` and disable Renovate updates for `grafana/writers-toolkit` github-actions so they don't get re-pinned.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and Renovate config only; restores docs preview auth without touching runtime Mimir code.
> 
> **Overview**
> Restores docs **PR deploy preview** by pointing both `deploy-pr-preview` workflows at `grafana/writers-toolkit/.github/workflows/deploy-preview.yml@main` instead of a Renovate-pinned commit SHA. Inline comments document that the reusable workflow’s OIDC trust only accepts the **`main`** ref, so SHA pinning breaks Vault/token exchange and the preview fails (per #15302).
> 
> **Renovate** gets a new `github-actions` package rule that disables updates for `grafana/writers-toolkit`, so future dependency PRs won’t re-pin that `uses:` reference. The change also fixes the preceding package-rule block in `renovate.json5` (adds the missing closing brace before the new rule).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bfb47408029abd4b9055193aa69ad037e094e89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->