### PR TITLE
Modify push-mimir-build-image.yml workflow to sign commits and publish image to GAR

### DIFF
--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -35,22 +35,18 @@ jobs:
       - name: Check if mimir-build-image/Dockerfile was modified
         id: check_dockerfile
         run: |
-          # TEMPORARY: force modified=true so CI always builds the image while we test the
-          # GAR publishing path. Restore the real detection (commented out below) before merging.
-          echo "modified=true" >> "$GITHUB_OUTPUT"
-          echo "Dockerfile was modified (forced for testing)"
-          # set -euo pipefail
-          # files=$(gh api --paginate \
-          #   -H "Accept: application/vnd.github+json" \
-          #   "/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
-          #   --jq '.[].filename')
-          # if echo "$files" | grep -qx 'mimir-build-image/Dockerfile'; then
-          #   echo "modified=true" >> "$GITHUB_OUTPUT"
-          #   echo "Dockerfile was modified"
-          # else
-          #   echo "modified=false" >> "$GITHUB_OUTPUT"
-          #   echo "Dockerfile was not modified"
-          # fi
+          set -euo pipefail
+          files=$(gh api --paginate \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[].filename')
+          if echo "$files" | grep -qx 'mimir-build-image/Dockerfile'; then
+            echo "modified=true" >> "$GITHUB_OUTPUT"
+            echo "Dockerfile was modified"
+          else
+            echo "modified=false" >> "$GITHUB_OUTPUT"
+            echo "Dockerfile was not modified"
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -16,7 +16,7 @@ jobs:
       contents: write
       # Allow PR modification for collaborators, forks should remain read-only
       pull-requests: write
-      # Necessary to authenticate with Vault which happens in dockerhub-login
+      # Required for Workload Identity Federation authentication to Google Artifact Registry.
       id-token: write
     steps:
       - name: Checkout Repository
@@ -108,17 +108,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
-      - name: Setup QEMU
+      # The build image is published to a Google Artifact Registry repository
+      # that allows writes from pull_request events. The registry is configured
+      # to allow anonymous pulls so external contributors can still fetch the
+      # build image without authentication.
+      - name: Login to GAR
         if: steps.check_dockerfile.outputs.modified == 'true' && steps.authorize.outputs.authorized == 'true'
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
-
-      - name: Set up Docker Buildx
-        if: steps.check_dockerfile.outputs.modified == 'true' && steps.authorize.outputs.authorized == 'true'
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      - name: Login to Docker Hub
-        if: steps.check_dockerfile.outputs.modified == 'true' && steps.authorize.outputs.authorized == 'true'
-        uses: grafana/shared-workflows/actions/dockerhub-login@13fb504e3bfe323c1188bf244970d94b2d336e86 # v1.0.1
+        uses: grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136 # login-to-gar/v1.0.2
 
       - name: Prepare Variables
         if: steps.check_dockerfile.outputs.modified == 'true' && steps.authorize.outputs.authorized == 'true'
@@ -159,7 +155,7 @@ jobs:
         id: notification
         run: |
           if [ ${{ steps.check_build.outputs.build }} == 'true' ]; then
-           gh pr comment $PR_NUMBER --body "**Building new version of mimir-build-image**. After image is built and pushed to Docker Hub, \
+           gh pr comment $PR_NUMBER --body "**Building new version of mimir-build-image**. After image is built and pushed to the registry, \
            a new commit will automatically be added to this PR with new image version \`$IMAGE:$TAG\`. This can take up to 1 hour."
           else
             echo "This PR will not trigger a build of mimir-build-image"
@@ -171,11 +167,29 @@ jobs:
           TAG: ${{ steps.compute_hash.outputs.tag }}
           IMAGE: ${{ steps.prepare.outputs.image }}
 
+      - name: Compute build args
+        if: steps.check_dockerfile.outputs.modified == 'true' && steps.authorize.outputs.authorized == 'true' && steps.check_build.outputs.build == 'true'
+        id: build_args
+        run: |
+          {
+            echo "build_args<<EOF"
+            make print-build-image-build-args
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build and Push Docker Image
         if: steps.check_dockerfile.outputs.modified == 'true' && steps.authorize.outputs.authorized == 'true' && steps.check_build.outputs.build == 'true'
-        run: |
-          echo "Building and Pushing Docker Image"
-          make push-multiarch-build-image IMAGE_TAG=${{ steps.compute_hash.outputs.tag }}
+        uses: grafana/shared-workflows/actions/docker-build-push-image@34f27887c37cafe70d34af57dfc86b468a31b8c4 # docker-build-push-image/v0.3.3
+        with:
+          context: mimir-build-image
+          platforms: linux/amd64,linux/arm64
+          push: "true"
+          registries: gar
+          gar-environment: dev
+          gar-repository: docker-mimir-build-image
+          gar-image: mimir-build-image
+          tags: ${{ steps.compute_hash.outputs.tag }}
+          build-args: ${{ steps.build_args.outputs.build_args }}
 
       - name: Compare built tag with Makefile
         if: steps.check_dockerfile.outputs.modified == 'true' && steps.authorize.outputs.authorized == 'true'
@@ -199,35 +213,35 @@ jobs:
         with:
           github_app: mimir-github-bot
 
-      # This step uses "Mimir bot" token (generated at the start of the workflow) instead of
-      # "github-actions bot" (secrets.GITHUB_TOKEN) because any events triggered by the latter
-      # don't spawn GitHub actions.
-      # Refer to https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
-      - name: Add commit to PR in order to update Build Image version
+      - name: Update Makefile with new Build Image version
+        id: update_makefile
         if: steps.check_dockerfile.outputs.modified == 'true' && steps.authorize.outputs.authorized == 'true' && steps.compare_tag.outputs.isDifferent == 'true'
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token-for-commit.outputs.token }}
-          GITHUB_LOGIN: mimir-github-bot[bot]
-          GITHUB_EMAIL: 199097951+mimir-github-bot[bot]@users.noreply.github.com
-          TAG: ${{ steps.compute_hash.outputs.tag }}
-          MAIN_TAG: ${{ steps.prepare.outputs.main_image_tag }}
         run: |
-          set -euo pipefail
-          echo "Get current Build Image Version"
           echo "Current Build Image Version is $MAIN_TAG"
           echo "Built Image Version is $TAG"
           if [ "$MAIN_TAG" = "$TAG" ]; then
             echo "Build Image Version is already up to date"
-            exit 0
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            sed -i "s/$MAIN_TAG/$TAG/g" Makefile
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
-          echo "Build Image Version is not up to date"
-          sed -i "s/${MAIN_TAG}/${TAG}/g" Makefile
-          git config --global user.email "${GITHUB_EMAIL}"
-          git config --global user.name "${GITHUB_LOGIN}"
-          git add Makefile
-          git commit -m "Update build image version to ${TAG}"
-          # Send the App token only on this push via an Authorization header, rather than
-          # persisting `x-access-token:$TOKEN` into the global git config. Avoids leaving the
-          # token recoverable from ~/.gitconfig by any later step in the runner.
-          AUTH_HEADER=$(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')
-          git -c "http.https://github.com/.extraheader=Authorization: Basic ${AUTH_HEADER}" push origin HEAD
+        env:
+          TAG: ${{ steps.compute_hash.outputs.tag }}
+          MAIN_TAG: ${{ steps.prepare.outputs.main_image_tag }}
+
+      # Commit via the GraphQL createCommitOnBranch mutation so that the resulting commit
+      # is signed by GitHub's web-flow key (shows as Verified in the PR). We use the
+      # "Mimir bot" App token rather than secrets.GITHUB_TOKEN because events triggered
+      # by the latter don't spawn GitHub Actions runs.
+      # Refer to https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+      - name: Commit Makefile update to PR branch
+        if: steps.update_makefile.outputs.changed == 'true' && steps.authorize.outputs.authorized == 'true' && steps.compare_tag.outputs.isDifferent == 'true'
+        uses: planetscale/ghcommit-action@25309d8005ac7c3bcd61d3fe19b69e0fe47dbdde # v0.2.20
+        with:
+          commit_message: "Update build image version to ${{ steps.compute_hash.outputs.tag }}"
+          repo: ${{ github.event.pull_request.head.repo.full_name }}
+          branch: ${{ github.head_ref }}
+          file_pattern: Makefile
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token-for-commit.outputs.token }}

--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -16,7 +16,7 @@ jobs:
       contents: write
       # Allow PR modification for collaborators, forks should remain read-only
       pull-requests: write
-      # Required for Workload Identity Federation authentication to Google Artifact Registry.
+      # Required by docker-build-push-image for Workload Identity Federation authentication to Google Artifact Registry.
       id-token: write
     steps:
       - name: Checkout Repository
@@ -108,14 +108,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
-      # The build image is published to a Google Artifact Registry repository
-      # that allows writes from pull_request events. The registry is configured
-      # to allow anonymous pulls so external contributors can still fetch the
-      # build image without authentication.
-      - name: Login to GAR
-        if: steps.check_dockerfile.outputs.modified == 'true' && steps.authorize.outputs.authorized == 'true'
-        uses: grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136 # login-to-gar/v1.0.2
-
       - name: Prepare Variables
         if: steps.check_dockerfile.outputs.modified == 'true' && steps.authorize.outputs.authorized == 'true'
         id: prepare
@@ -191,31 +183,12 @@ jobs:
           tags: ${{ steps.compute_hash.outputs.tag }}
           build-args: ${{ steps.build_args.outputs.build_args }}
 
-      - name: Compare built tag with Makefile
-        if: steps.check_dockerfile.outputs.modified == 'true' && steps.authorize.outputs.authorized == 'true'
-        id: compare_tag
-        run: |
-          echo "Comparing built tag with Makefile"
-          if [ ${{ steps.compute_hash.outputs.tag }} == "$(make print-build-image)" ]; then
-            echo "Built tag is the same as the one in Makefile"
-            echo "isDifferent=false" >> $GITHUB_OUTPUT
-          else
-            echo "Built tag is different from the one in Makefile"
-            echo "isDifferent=true" >> $GITHUB_OUTPUT
-          fi
-
-      # Tokens expire after 1h. Since building the image can take a long time, we create a fresh App Token for the last
-      # step of the build.
-      - name: Generate GitHub App Token
-        if: steps.check_dockerfile.outputs.modified == 'true'
-        id: app-token-for-commit
-        uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
-        with:
-          github_app: mimir-github-bot
-
-      - name: Update Makefile with new Build Image version
+      # Compare the just-built tag against the one currently referenced in the Makefile.
+      # If they differ, update the Makefile and signal the next step to commit; otherwise
+      # `changed=false` and no commit will be made.
+      - name: Check whether Makefile needs updating, and update it
         id: update_makefile
-        if: steps.check_dockerfile.outputs.modified == 'true' && steps.authorize.outputs.authorized == 'true' && steps.compare_tag.outputs.isDifferent == 'true'
+        if: steps.check_dockerfile.outputs.modified == 'true' && steps.authorize.outputs.authorized == 'true'
         run: |
           echo "Current Build Image Version is $MAIN_TAG"
           echo "Built Image Version is $TAG"
@@ -230,13 +203,23 @@ jobs:
           TAG: ${{ steps.compute_hash.outputs.tag }}
           MAIN_TAG: ${{ steps.prepare.outputs.main_image_tag }}
 
+      # Generate the App Token here (rather than earlier in the job) so we only mint one
+      # when we actually need to commit. Also: building the image can take a long time,
+      # and minting fresh just before use ensures the token hasn't expired (1h TTL).
+      - name: Generate GitHub App Token
+        if: steps.check_dockerfile.outputs.modified == 'true' && steps.authorize.outputs.authorized == 'true' && steps.update_makefile.outputs.changed == 'true'
+        id: app-token-for-commit
+        uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
+        with:
+          github_app: mimir-github-bot
+
       # Commit via the GraphQL createCommitOnBranch mutation so that the resulting commit
       # is signed by GitHub's web-flow key (shows as Verified in the PR). We use the
       # "Mimir bot" App token rather than secrets.GITHUB_TOKEN because events triggered
       # by the latter don't spawn GitHub Actions runs.
       # Refer to https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
       - name: Commit Makefile update to PR branch
-        if: steps.update_makefile.outputs.changed == 'true' && steps.authorize.outputs.authorized == 'true' && steps.compare_tag.outputs.isDifferent == 'true'
+        if: steps.check_dockerfile.outputs.modified == 'true' && steps.authorize.outputs.authorized == 'true' && steps.update_makefile.outputs.changed == 'true'
         uses: planetscale/ghcommit-action@25309d8005ac7c3bcd61d3fe19b69e0fe47dbdde # v0.2.20
         with:
           commit_message: "Update build image version to ${{ steps.compute_hash.outputs.tag }}"

--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -190,6 +190,7 @@ jobs:
         id: update_makefile
         if: steps.check_dockerfile.outputs.modified == 'true' && steps.authorize.outputs.authorized == 'true'
         run: |
+          set -euo pipefail
           echo "Current Build Image Version is $MAIN_TAG"
           echo "Built Image Version is $TAG"
           if [ "$MAIN_TAG" = "$TAG" ]; then

--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -35,18 +35,22 @@ jobs:
       - name: Check if mimir-build-image/Dockerfile was modified
         id: check_dockerfile
         run: |
-          set -euo pipefail
-          files=$(gh api --paginate \
-            -H "Accept: application/vnd.github+json" \
-            "/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
-            --jq '.[].filename')
-          if echo "$files" | grep -qx 'mimir-build-image/Dockerfile'; then
-            echo "modified=true" >> "$GITHUB_OUTPUT"
-            echo "Dockerfile was modified"
-          else
-            echo "modified=false" >> "$GITHUB_OUTPUT"
-            echo "Dockerfile was not modified"
-          fi
+          # TEMPORARY: force modified=true so CI always builds the image while we test the
+          # GAR publishing path. Restore the real detection (commented out below) before merging.
+          echo "modified=true" >> "$GITHUB_OUTPUT"
+          echo "Dockerfile was modified (forced for testing)"
+          # set -euo pipefail
+          # files=$(gh api --paginate \
+          #   -H "Accept: application/vnd.github+json" \
+          #   "/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+          #   --jq '.[].filename')
+          # if echo "$files" | grep -qx 'mimir-build-image/Dockerfile'; then
+          #   echo "modified=true" >> "$GITHUB_OUTPUT"
+          #   echo "Dockerfile was modified"
+          # else
+          #   echo "modified=false" >> "$GITHUB_OUTPUT"
+          #   echo "Dockerfile was not modified"
+          # fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr15360-bf224fe1d5
+LATEST_BUILD_IMAGE_TAG ?= pr15429-bf224fe1d5
 
 # TTY is parameterized to allow CI and scripts to run builds,
 # as it currently disallows TTY devices.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ help:
 # WARNING: do not commit to a repository!
 -include Makefile.local
 
-.PHONY: all test test-with-race integration-tests cover clean images protos exes dist doc clean-doc check-doc check-reference-help push-multiarch-build-image license check-license format check-mixin check-mixin-jb check-mixin-mixtool check-mixin-runbooks check-mixin-mimirtool-rules build-mixin format-mixin check-jsonnet-manifests format-jsonnet-manifests push-multiarch-mimir list-image-targets check-jsonnet-getting-started mixin-screenshots warmup-build-cache-integration-tests warmup-build-cache-unit-tests warmup-build-cache-image-and-lint print-supported-os-arch
+.PHONY: all test test-with-race integration-tests cover clean images protos exes dist doc clean-doc check-doc check-reference-help license check-license format check-mixin check-mixin-jb check-mixin-mixtool check-mixin-runbooks check-mixin-mimirtool-rules build-mixin format-mixin check-jsonnet-manifests format-jsonnet-manifests push-multiarch-mimir list-image-targets check-jsonnet-getting-started mixin-screenshots warmup-build-cache-integration-tests warmup-build-cache-unit-tests warmup-build-cache-image-and-lint print-supported-os-arch
 .DEFAULT_GOAL := all
 
 # Version number
@@ -106,7 +106,6 @@ SED ?= $(shell which gsed 2>/dev/null || which sed)
 	@echo Image name: $(IMAGE_PREFIX)$(shell basename $(@D))
 	@echo Image name: $(IMAGE_PREFIX)$(shell basename $(@D)):$(IMAGE_TAG)
 	@echo
-	@echo Please use '"make push-multiarch-build-image"' to build and push build image.
 	@echo Please use '"make push-multiarch-mimir"' to build and push Mimir image.
 	@echo
 	@touch $@
@@ -134,8 +133,6 @@ SED ?= $(shell which gsed 2>/dev/null || which sed)
 PUSH_MULTIARCH_TARGET ?= type=registry
 
 # This target compiles mimir for linux/amd64 and linux/arm64 and then builds and pushes a multiarch image to the target repository.
-# We don't do separate building of single-platform and multiplatform images here (as we do for push-multiarch-build-image), as
-# these Dockerfiles are not doing much, and are unlikely to fail.
 push-multiarch-%/$(UPTODATE):
 	$(eval DIR := $(patsubst push-multiarch-%/$(UPTODATE),%,$@))
 
@@ -161,25 +158,13 @@ fetch-build-image: ## Fetch latest the docker build image if it isn't already pr
 	docker tag $(BUILD_IMAGE):$(LATEST_BUILD_IMAGE_TAG) $(BUILD_IMAGE):latest
 	touch mimir-build-image/.uptodate
 
-# Build args passed to docker when building mimir-build-image. Defined as a space-separated
-# list of KEY=VALUE so it can be reused by `push-multiarch-build-image` (via `addprefix`)
-# and emitted one-per-line by `print-build-image-build-args` for consumption from CI.
-BUILD_IMAGE_BUILD_ARGS = revision=$(GIT_REVISION) goproxyValue=$(GOPROXY_VALUE)
-
-# push-multiarch-build-image requires the ability to build images for multiple platforms:
-# https://docs.docker.com/buildx/working-with-buildx/#build-multi-platform-images
-push-multiarch-build-image: ## Push the docker build image.
-	@echo
-	# Build and push mimir build image for linux/amd64 and linux/arm64
-	$(SUDO) docker buildx build -o type=registry --platform linux/amd64,linux/arm64 --progress=plain $(addprefix --build-arg=,$(BUILD_IMAGE_BUILD_ARGS)) -t $(BUILD_IMAGE):$(IMAGE_TAG) mimir-build-image/
-
 .PHONY: print-build-image
 print-build-image:
 	@echo $(BUILD_IMAGE):$(LATEST_BUILD_IMAGE_TAG)
 
 .PHONY: print-build-image-build-args
 print-build-image-build-args:
-	@printf '%s\n' $(BUILD_IMAGE_BUILD_ARGS)
+	@printf '%s\n' revision=$(GIT_REVISION) goproxyValue=$(GOPROXY_VALUE)
 
 # Supported operating systems and architectures for dist builds.
 DIST_OSES ?= linux darwin windows freebsd

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,9 @@ BINARY_SUFFIX ?= ""
 # Boiler plate for building Docker containers.
 # All this must go at top of file I'm afraid.
 IMAGE_PREFIX ?= grafana/
-BUILD_IMAGE ?= $(IMAGE_PREFIX)mimir-build-image
+# The build image is published to Google Artifact Registry and is anonymously pullable.
+# See .github/workflows/push-mimir-build-image.yml for the publishing flow.
+BUILD_IMAGE ?= us-docker.pkg.dev/grafanalabs-dev/docker-mimir-build-image/mimir-build-image
 CONTAINER_MOUNT_OPTIONS ?= delegated,z
 
 # For a tag push, $GITHUB_REF will look like refs/tags/<tag_name>.
@@ -159,16 +161,25 @@ fetch-build-image: ## Fetch latest the docker build image if it isn't already pr
 	docker tag $(BUILD_IMAGE):$(LATEST_BUILD_IMAGE_TAG) $(BUILD_IMAGE):latest
 	touch mimir-build-image/.uptodate
 
+# Build args passed to docker when building mimir-build-image. Defined as a space-separated
+# list of KEY=VALUE so it can be reused by `push-multiarch-build-image` (via `addprefix`)
+# and emitted one-per-line by `print-build-image-build-args` for consumption from CI.
+BUILD_IMAGE_BUILD_ARGS = revision=$(GIT_REVISION) goproxyValue=$(GOPROXY_VALUE)
+
 # push-multiarch-build-image requires the ability to build images for multiple platforms:
 # https://docs.docker.com/buildx/working-with-buildx/#build-multi-platform-images
 push-multiarch-build-image: ## Push the docker build image.
 	@echo
 	# Build and push mimir build image for linux/amd64 and linux/arm64
-	$(SUDO) docker buildx build -o type=registry --platform linux/amd64,linux/arm64 --progress=plain --build-arg=revision=$(GIT_REVISION) --build-arg=goproxyValue=$(GOPROXY_VALUE) -t $(BUILD_IMAGE):$(IMAGE_TAG) mimir-build-image/
+	$(SUDO) docker buildx build -o type=registry --platform linux/amd64,linux/arm64 --progress=plain $(addprefix --build-arg=,$(BUILD_IMAGE_BUILD_ARGS)) -t $(BUILD_IMAGE):$(IMAGE_TAG) mimir-build-image/
 
 .PHONY: print-build-image
 print-build-image:
 	@echo $(BUILD_IMAGE):$(LATEST_BUILD_IMAGE_TAG)
+
+.PHONY: print-build-image-build-args
+print-build-image-build-args:
+	@printf '%s\n' $(BUILD_IMAGE_BUILD_ARGS)
 
 # Supported operating systems and architectures for dist builds.
 DIST_OSES ?= linux darwin windows freebsd

--- a/Makefile.local.example
+++ b/Makefile.local.example
@@ -1,6 +1,6 @@
 # Example of extending Makefile with Makefile.local.
 
-BUILD_IMAGE ?= grafana/mimir-build-image
+BUILD_IMAGE ?= us-docker.pkg.dev/grafanalabs-dev/docker-mimir-build-image/mimir-build-image
 IMAGE_PREFIX ?= custom-prefix/
 
 mimir-push: cmd/mimir/.uptodate

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -3,14 +3,73 @@
 # Provenance-includes-license: Apache-2.0
 # Provenance-includes-copyright: The Cortex Authors.
 
-# TEMPORARY: minimal stub used only to validate the CI publish path to GAR.
-# The full Dockerfile is in git history at the previous commit (`git show HEAD~:mimir-build-image/Dockerfile`)
-# and must be restored before this branch is merged.
-
+FROM registry.k8s.io/kustomize/kustomize:v5.4.3 AS kustomize
+FROM alpine/helm:4.1.4@sha256:4b0bdd2cf18ff6bca12aba0b2c5671384dab5035c19c57f0c58b854a0baf65be AS helm
+FROM golang:1.26.3-trixie@sha256:d08bf3ed2bd263088ca8e23fefaf10f1b71769f6932f0a4017ba28d2a5baf001
 ARG goproxyValue
-ARG revision
+ENV GOPROXY=${goproxyValue}
+ENV SKOPEO_DEPS="libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config"
+# Override toolchain directive in go.mod, to ensure the image's Go version is used.
+# Be aware that the official Go Dockerfiles already do this, but let's be explicit.
+# https://github.com/docker-library/golang/issues/472
+ENV GOTOOLCHAIN=local
+RUN apt-get update && apt-get install -y curl python3-requests python3-yaml file jq zip unzip protobuf-compiler libprotobuf-dev shellcheck libpcap-dev $SKOPEO_DEPS && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN go install golang.org/x/tools/cmd/goimports@3fce476f0a782aeb5034d592c189e63be4ba6c9e
+RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
+RUN apt-get install -y nodejs && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-FROM alpine:3.20
+RUN npm install -g prettier@2.3.2
+
+# renovate: depName=github.com/mvdan/sh
+ENV SHFMT_VERSION=3.13.1
+RUN GOARCH=$(go env GOARCH) && \
+    URL=https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_${GOARCH}; \
+    curl -fsSLo shfmt "${URL}" && \
+	chmod +x shfmt && \
+	mv shfmt /usr/bin
+
+# renovate: depName=github.com/grafana/tanka
+ENV TANKA_VERSION=0.37.0
+RUN GOARCH=$(go env GOARCH) && \
+    curl -fSL -o "/usr/bin/tk" "https://github.com/grafana/tanka/releases/download/v${TANKA_VERSION}/tk-linux-${GOARCH}" && \
+    chmod a+x /usr/bin/tk
+
+# renovate: depName=github.com/golangci/golangci-lint
+ENV GOLANGCI_LINT_VERSION=2.12.2
+RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/v"${GOLANGCI_LINT_VERSION}"/install.sh| sh -s -- -b /usr/bin v"${GOLANGCI_LINT_VERSION}"
+
+# renovate: depName=github.com/containers/skopeo
+ENV SKOPEO_VERSION=v1.22.2
+RUN git clone --depth 1 --branch ${SKOPEO_VERSION} https://github.com/containers/skopeo /go/src/github.com/containers/skopeo && \
+    DISABLE_DOCS=1 make -C /go/src/github.com/containers/skopeo install && \
+    rm -rf /go/pkg /go/src /root/.cache
+
+RUN GO111MODULE=on \
+	go install github.com/client9/misspell/cmd/misspell@v0.3.4 && \
+	go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.11 && \
+	go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.6.2 && \
+	go install github.com/gogo/protobuf/protoc-gen-gogoslick@v1.3.2 && \
+	go install github.com/weaveworks/tools/cover@bdd647e92546027e12cdde3ae0714bb495e43013 && \
+	go install github.com/fatih/faillint@v1.15.0 && \
+	go install github.com/campoy/embedmd/v2@v2.0.0 && \
+	go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.6.0 && \
+	go install github.com/monitoring-mixins/mixtool/cmd/mixtool@b97ae11 && \
+	go install github.com/mikefarah/yq/v4@v4.53.2 && \
+	go install github.com/google/go-jsonnet/cmd/jsonnet@v0.22.0 && \
+	go install github.com/google/go-jsonnet/cmd/jsonnetfmt@v0.22.0 && \
+	go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.14.2 && \
+	go install github.com/open-policy-agent/conftest@v0.68.2 && \
+	go install github.com/uber-go/gopatch@v0.4.0 && \
+	go install github.com/bufbuild/buf/cmd/buf@v1.69.0 && \
+	rm -rf /go/pkg /go/src /root/.cache
+
+COPY --from=helm /usr/bin/helm /usr/bin/helm
+COPY --from=kustomize /app/kustomize /usr/bin/kustomize
+ENV NODE_PATH=/usr/lib/node_modules
+COPY build.sh /
+ENV GOCACHE=/go/cache
+ENTRYPOINT ["/build.sh"]
 
 ARG revision
 LABEL org.opencontainers.image.title="mimir-build-image" \

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -3,73 +3,14 @@
 # Provenance-includes-license: Apache-2.0
 # Provenance-includes-copyright: The Cortex Authors.
 
-FROM registry.k8s.io/kustomize/kustomize:v5.4.3 AS kustomize
-FROM alpine/helm:4.1.4@sha256:4b0bdd2cf18ff6bca12aba0b2c5671384dab5035c19c57f0c58b854a0baf65be AS helm
-FROM golang:1.26.3-trixie@sha256:d08bf3ed2bd263088ca8e23fefaf10f1b71769f6932f0a4017ba28d2a5baf001
+# TEMPORARY: minimal stub used only to validate the CI publish path to GAR.
+# The full Dockerfile is in git history at the previous commit (`git show HEAD~:mimir-build-image/Dockerfile`)
+# and must be restored before this branch is merged.
+
 ARG goproxyValue
-ENV GOPROXY=${goproxyValue}
-ENV SKOPEO_DEPS="libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config"
-# Override toolchain directive in go.mod, to ensure the image's Go version is used.
-# Be aware that the official Go Dockerfiles already do this, but let's be explicit.
-# https://github.com/docker-library/golang/issues/472
-ENV GOTOOLCHAIN=local
-RUN apt-get update && apt-get install -y curl python3-requests python3-yaml file jq zip unzip protobuf-compiler libprotobuf-dev shellcheck libpcap-dev $SKOPEO_DEPS && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-RUN go install golang.org/x/tools/cmd/goimports@3fce476f0a782aeb5034d592c189e63be4ba6c9e
-RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
-RUN apt-get install -y nodejs && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+ARG revision
 
-RUN npm install -g prettier@2.3.2
-
-# renovate: depName=github.com/mvdan/sh
-ENV SHFMT_VERSION=3.13.1
-RUN GOARCH=$(go env GOARCH) && \
-    URL=https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_${GOARCH}; \
-    curl -fsSLo shfmt "${URL}" && \
-	chmod +x shfmt && \
-	mv shfmt /usr/bin
-
-# renovate: depName=github.com/grafana/tanka
-ENV TANKA_VERSION=0.37.0
-RUN GOARCH=$(go env GOARCH) && \
-    curl -fSL -o "/usr/bin/tk" "https://github.com/grafana/tanka/releases/download/v${TANKA_VERSION}/tk-linux-${GOARCH}" && \
-    chmod a+x /usr/bin/tk
-
-# renovate: depName=github.com/golangci/golangci-lint
-ENV GOLANGCI_LINT_VERSION=2.12.2
-RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/v"${GOLANGCI_LINT_VERSION}"/install.sh| sh -s -- -b /usr/bin v"${GOLANGCI_LINT_VERSION}"
-
-# renovate: depName=github.com/containers/skopeo
-ENV SKOPEO_VERSION=v1.22.2
-RUN git clone --depth 1 --branch ${SKOPEO_VERSION} https://github.com/containers/skopeo /go/src/github.com/containers/skopeo && \
-    DISABLE_DOCS=1 make -C /go/src/github.com/containers/skopeo install && \
-    rm -rf /go/pkg /go/src /root/.cache
-
-RUN GO111MODULE=on \
-	go install github.com/client9/misspell/cmd/misspell@v0.3.4 && \
-	go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.11 && \
-	go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.6.2 && \
-	go install github.com/gogo/protobuf/protoc-gen-gogoslick@v1.3.2 && \
-	go install github.com/weaveworks/tools/cover@bdd647e92546027e12cdde3ae0714bb495e43013 && \
-	go install github.com/fatih/faillint@v1.15.0 && \
-	go install github.com/campoy/embedmd/v2@v2.0.0 && \
-	go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.6.0 && \
-	go install github.com/monitoring-mixins/mixtool/cmd/mixtool@b97ae11 && \
-	go install github.com/mikefarah/yq/v4@v4.53.2 && \
-	go install github.com/google/go-jsonnet/cmd/jsonnet@v0.22.0 && \
-	go install github.com/google/go-jsonnet/cmd/jsonnetfmt@v0.22.0 && \
-	go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.14.2 && \
-	go install github.com/open-policy-agent/conftest@v0.68.2 && \
-	go install github.com/uber-go/gopatch@v0.4.0 && \
-	go install github.com/bufbuild/buf/cmd/buf@v1.69.0 && \
-	rm -rf /go/pkg /go/src /root/.cache
-
-COPY --from=helm /usr/bin/helm /usr/bin/helm
-COPY --from=kustomize /app/kustomize /usr/bin/kustomize
-ENV NODE_PATH=/usr/lib/node_modules
-COPY build.sh /
-ENV GOCACHE=/go/cache
-ENTRYPOINT ["/build.sh"]
+FROM alpine:3.20
 
 ARG revision
 LABEL org.opencontainers.image.title="mimir-build-image" \

--- a/operations/mimir-mixin-tools/screenshots/Dockerfile
+++ b/operations/mimir-mixin-tools/screenshots/Dockerfile
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-only
-FROM grafana/mimir-build-image AS builder
+FROM us-docker.pkg.dev/grafanalabs-dev/docker-mimir-build-image/mimir-build-image AS builder
 
 WORKDIR /app
 COPY go.mod go.sum ./


### PR DESCRIPTION
#### What this PR does

Modify push-mimir-build-image.yml workflow to sign commits and publish the mimir-build-image to a GAR dev registry instead of DockerHub. Rationale:

- Signing commits because next step will be requiring signing commits in Mimir repository
- Use GAR dev registry because CI is no more allowed to publish images to Docker Hub (GAR dev registry allows for more fine grained privileges)

Notes:
- To commit I'm using https://github.com/planetscale/ghcommit-action instead of manually crafting GitHub API calls (there's no other way to sign commits from a github action).

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
