### PR TITLE
Sign commits created by peter-evans/create-pull-request

### DIFF
--- a/.github/workflows/helm-weekly-release-pr.yaml
+++ b/.github/workflows/helm-weekly-release-pr.yaml
@@ -37,6 +37,7 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ steps.app-token.outputs.token }}
+          sign-commits: true
           title: Release mimir-distributed Helm chart ${{ steps.update.outputs.new_chart_version }}
           body: Automated PR created by [helm-weekly-release-pr.yaml](https://github.com/grafana/mimir/blob/main/.github/workflows/helm-weekly-release-pr.yaml)
           commit-message: Update mimir-distributed chart to ${{ steps.update.outputs.new_chart_version }}

--- a/.github/workflows/update-vendored-mimir-prometheus.yml
+++ b/.github/workflows/update-vendored-mimir-prometheus.yml
@@ -144,6 +144,7 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ steps.app-token.outputs.token }}
+          sign-commits: true
           title: '[${{ steps.branch-names.outputs.mimir_branch }}] Update mimir-prometheus to ${{ steps.get-commit-info.outputs.short_hash }}'
           body: |
             ## Update mimir-prometheus dependency


### PR DESCRIPTION
## Summary

Set `sign-commits: true` on both `peter-evans/create-pull-request` invocations so the commits in the bot-opened PRs are created via the GitHub API and signed by GitHub's web-flow key (shown as **Verified**), instead of plain unsigned `git push`.

Affected workflows:
- `.github/workflows/helm-weekly-release-pr.yaml`
- `.github/workflows/update-vendored-mimir-prometheus.yml`

Continuation of the bot-commit-signing effort started in #15429.

## Test plan

- [ ] Trigger one of the workflows manually (or wait for the next scheduled run) and confirm the bot-opened PR's commits show the green Verified badge.