### PR TITLE
golangci-lint: enable gosec rules G402 and G501

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -67,6 +67,8 @@ linters:
         - G114
         - G302
         - G401
+        - G402
+        - G501
       excludes:
         # Relies on system umask to restrict directory permissions, preserving operator flexibility
         - G301

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -7,7 +7,7 @@ package alertmanager
 
 import (
 	"context"
-	"crypto/md5"
+	"crypto/md5" //nolint:gosec // md5 is used to derive a non-cryptographic metric value from the alertmanager config.
 	"encoding/binary"
 	"errors"
 	"fmt"

--- a/pkg/util/shard.go
+++ b/pkg/util/shard.go
@@ -6,7 +6,7 @@
 package util
 
 import (
-	"crypto/md5"
+	"crypto/md5" //nolint:gosec // md5 is used for non-cryptographic sharding hashing only.
 	"encoding/binary"
 	"math"
 	"unsafe"

--- a/tools/querytee/proxy_backend.go
+++ b/tools/querytee/proxy_backend.go
@@ -66,7 +66,9 @@ func NewProxyBackend(name string, endpoint *url.URL, timeout time.Duration, pref
 	innerTransport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: skipTLSVerify,
+			// InsecureSkipVerify is controlled by an operator-supplied CLI flag of a load-testing tool,
+			// intended to allow comparison against backends with self-signed certificates in development.
+			InsecureSkipVerify: skipTLSVerify, //nolint:gosec
 		},
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,


### PR DESCRIPTION
#### What this PR does

G402 flags insecure TLS configuration; G501 flags weak crypto imports (md5, sha1, des, rc4). None were used in a vulnerable way. Existing call sites are annotated with `//nolint:gosec` and a reason.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only and comment/nolint changes; no production logic or security behavior is altered.
> 
> **Overview**
> Turns on **gosec** checks **G402** (insecure TLS client settings) and **G501** (weak crypto imports such as MD5) in `.golangci.yml`, so CI will flag new risky TLS or crypto usage.
> 
> Existing call sites that are intentional and non-security-sensitive are annotated with `//nolint:gosec` and short comments: **MD5** in alertmanager config hashing and util sharding, and **`InsecureSkipVerify`** in the query-tee load-testing proxy (operator-controlled, dev/self-signed certs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5495906bd991f00f767f2e5618065d6455a6b84c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->