### PR TITLE
golangci-lint: enable gosec rules G101 and G117

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,12 +59,14 @@ linters:
         - dupImport
     gosec:
       includes:
+        - G101
         - G103
         - G104
         - G108
         - G109
         - G112
         - G114
+        - G117
         - G302
         - G401
         - G402
@@ -100,6 +102,11 @@ linters:
       - linters:
           - revive
         text: if-return
+      # G101 fires on test fixtures with fake OAuth2/SASL/GCS-service-account values.
+      - linters:
+          - gosec
+        text: "G101"
+        path: _test\.go
 formatters:
   enable:
     - gci

--- a/pkg/mimirtool/commands/env_var.go
+++ b/pkg/mimirtool/commands/env_var.go
@@ -41,7 +41,7 @@ func NewEnvVarsWithPrefix(prefix string) EnvVarNames {
 		mimirHTTPPrefix         = "HTTP_PREFIX"
 		sigV4Region             = "SIGV4_REGION"
 		sigV4AccessKey          = "SIGV4_ACCESS_KEY"
-		sigV4SecretKey          = "SIGV4_SECRET_KEY"
+		sigV4SecretKey          = "SIGV4_SECRET_KEY" //nolint:gosec // these are environment variable names, not credential values.
 		sigV4Profile            = "SIGV4_PROFILE"
 		sigV4AssumeRoleARN      = "SIGV4_ASSUME_ROLE_ARN"
 		sigV4ExternalID         = "SIGV4_EXTERNAL_ID"

--- a/pkg/mimirtool/config/cortex.go
+++ b/pkg/mimirtool/config/cortex.go
@@ -284,6 +284,7 @@ func alertmanagerStorageMapperFunc(source, target Parameters) error {
 // rulerStorageMapperFunc returns a MapperFunc that maps ruler.storage and ruler_storage to ruler_storage.
 // Values from ruler.storage take precedence.
 func rulerStorageMapperFunc(source, target Parameters) error {
+	//nolint:gosec // these are configuration path names, not credential values.
 	pathRenames := map[string]string{
 		"ruler.storage.azure.account_key":                      "ruler_storage.azure.account_key",
 		"ruler.storage.azure.account_name":                     "ruler_storage.azure.account_name",

--- a/pkg/storage/bucket/swift/bucket_client.go
+++ b/pkg/storage/bucket/swift/bucket_client.go
@@ -45,7 +45,7 @@ func NewBucketClient(cfg Config, _ string, logger log.Logger) (objstore.Bucket, 
 
 	// Thanos currently doesn't support passing the config as is, but expects a YAML,
 	// so we're going to serialize it.
-	serialized, err := yaml.Marshal(bucketConfig)
+	serialized, err := yaml.Marshal(bucketConfig) //nolint:gosec // YAML contains credentials by necessity; consumed by Thanos, not logged.
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#### What this PR does

`G101` flags hardcoded credentials (string literals that look like passwords, tokens, or keys assigned to credential-named identifiers). `G117` flags struct fields whose name matches a secret pattern when the struct is marshaled (JSON/YAML). It may surface cases where a credential field could end up in serialized output.                                                                                                                                                                                                   

None were used in a vulnerable way. Test fixtures with fake OAuth2  and service-account values are excluded via a _test.go rule. Existing prod sites are annotated with //nolint:gosec and a reason.                                                                                                                                                                                                     

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only policy change with no runtime behavior; suppressions are limited to env var names, config path strings, and intentional credential YAML for Thanos.
> 
> **Overview**
> Turns on **gosec** rules **G101** (hardcoded credential-like literals) and **G117** (secret-named fields that may be serialized) in `.golangci.yml`, and adds a lint exclusion so **G101** does not run on `*_test.go` (fake OAuth/SASL/GCS fixtures).
> 
> Production false positives are documented with `//nolint:gosec` on the SigV4 env var name constant in `env_var.go`, the ruler storage path-rename map in `cortex.go`, and Swift bucket YAML marshaling in `bucket_client.go`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79e5108d45f2bda8966f9d7ced15e91f10617e30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->