### PR TITLE
MQE: fix issue where subqueries may be evaluated for one more step than necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [BUGFIX] Querier: Fix querier ScaledObjects native histogram querying and triggering `MimirAutoscalerKedaFailing` when queriers have no traffic because `cortex_querier_request_duration_seconds_sum` is not published until the first request is received. #15106
 * [BUGFIX] Fix build failure on Windows and FreeBSD due to reference leaks instrumentation code. Enabling reference leaks instrumentation in those platforms now causes a configuration validation error instead. #15291
 * [BUGFIX] Query-frontend: Fixed a memory leak caused that could occur on some error paths if MQE was enabled. #15392
+* [BUGFIX] MQE: Fix issue where subqueries unnecessarily compute and then discard an additional step if the parent query is not aligned to the step. #15438
 
 ### Mixin
 

--- a/pkg/streamingpromql/planning/core/subquery.go
+++ b/pkg/streamingpromql/planning/core/subquery.go
@@ -87,7 +87,12 @@ func (s *Subquery) ChildrenTimeRange(timeRange types.QueryTimeRange) types.Query
 		alignedStart += stepMilliseconds
 	}
 
+	// Note that this timestamp may not be aligned to the subquery's step grid, but this isn't an issue:
+	// the subquery will be evaluated up to the last step within the range, just like the behaviour for top-level queries.
+	// For example, if the start of the range is 09:00 and the subquery step is 1h, it doesn't matter if
+	// the end is 11:00, 11:01 or 11:59, the last evaluated step will be 11:00, as expected.
 	end = end - s.Offset.Milliseconds()
+
 	return types.NewRangeQueryTimeRange(timestamp.Time(alignedStart), timestamp.Time(end), s.Step)
 }
 

--- a/pkg/streamingpromql/planning/core/subquery.go
+++ b/pkg/streamingpromql/planning/core/subquery.go
@@ -70,6 +70,14 @@ func (s *Subquery) ChildrenTimeRange(timeRange types.QueryTimeRange) types.Query
 	if s.Timestamp != nil {
 		start = timestamp.FromTime(*s.Timestamp)
 		end = start
+	} else if !timeRange.IsInstant {
+		// Align the parent end timestamp down to the parent's step grid before applying the
+		// subquery offset.
+		// This ensures the subquery does not evaluate past the parent's last actual step if the
+		// parent's end time isn't aligned to its step.
+		// For example, if the step is 1h, and the parent time range is 09:00 to 11:30, then the last
+		// parent step is 11:00, and the subquery should not evaluate past that.
+		end = start + ((end-start)/timeRange.IntervalMilliseconds)*timeRange.IntervalMilliseconds
 	}
 
 	// Find the first timestamp inside the subquery range that is aligned to the step.

--- a/pkg/streamingpromql/planning/core/subquery_test.go
+++ b/pkg/streamingpromql/planning/core/subquery_test.go
@@ -6,9 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/planning"
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
 )
 
 func TestSubquery_Describe(t *testing.T) {
@@ -249,6 +251,102 @@ func TestSubquery_Equivalence(t *testing.T) {
 
 			require.True(t, testCase.a.EquivalentToIgnoringHintsAndChildren(testCase.a), "a should be equivalent to itself")
 			require.True(t, testCase.b.EquivalentToIgnoringHintsAndChildren(testCase.b), "b should be equivalent to itself")
+		})
+	}
+}
+
+func TestSubquery_ChildrenTimeRange(t *testing.T) {
+	// Subquery: [60s:5s], no offset, no @ timestamp.
+	subquery := func() *Subquery {
+		return &Subquery{
+			SubqueryDetails: &SubqueryDetails{
+				Range: time.Minute,
+				Step:  5 * time.Second,
+			},
+		}
+	}
+
+	testCases := map[string]struct {
+		node     *Subquery
+		input    types.QueryTimeRange
+		expected types.QueryTimeRange
+	}{
+		"range query, end aligned to step": {
+			node: subquery(),
+			// Parent step grid: 200, 205, 210, 215, 220.
+			input:    types.NewRangeQueryTimeRange(timestamp.Time(200_000), timestamp.Time(220_000), 5*time.Second),
+			expected: types.NewRangeQueryTimeRange(timestamp.Time(145_000), timestamp.Time(220_000), 5*time.Second),
+		},
+		"range query, end not aligned to step": {
+			// Regression test for https://github.com/prometheus/prometheus/pull/18598.
+			// Parent step grid: 201, 206, 211, 216 (last actual step); 220 is 4s past the last
+			// aligned step. The subquery's end should not extend past the parent's last actual step,
+			// because those samples will never be used.
+			node:     subquery(),
+			input:    types.NewRangeQueryTimeRange(timestamp.Time(201_000), timestamp.Time(220_000), 5*time.Second),
+			expected: types.NewRangeQueryTimeRange(timestamp.Time(145_000), timestamp.Time(216_000), 5*time.Second),
+		},
+		"range query with subquery offset, end aligned to step": {
+			node: &Subquery{
+				SubqueryDetails: &SubqueryDetails{
+					Range:  time.Minute,
+					Step:   5 * time.Second,
+					Offset: time.Minute,
+				},
+			},
+			input:    types.NewRangeQueryTimeRange(timestamp.Time(200_000), timestamp.Time(220_000), 5*time.Second),
+			expected: types.NewRangeQueryTimeRange(timestamp.Time(85_000), timestamp.Time(160_000), 5*time.Second),
+		},
+		"range query with subquery offset, end not aligned to step": {
+			node: &Subquery{
+				SubqueryDetails: &SubqueryDetails{
+					Range:  time.Minute,
+					Step:   5 * time.Second,
+					Offset: time.Minute,
+				},
+			},
+			// Parent's last aligned step is 216s; with subquery offset 60s, the inner end is 156s.
+			input:    types.NewRangeQueryTimeRange(timestamp.Time(201_000), timestamp.Time(220_000), 5*time.Second),
+			expected: types.NewRangeQueryTimeRange(timestamp.Time(85_000), timestamp.Time(156_000), 5*time.Second),
+		},
+		"range query with subquery @ timestamp, ignores parent end": {
+			node: &Subquery{
+				SubqueryDetails: &SubqueryDetails{
+					Range:     time.Minute,
+					Step:      5 * time.Second,
+					Timestamp: timestampOf(123_456),
+				},
+			},
+			// The @ modifier pins the subquery to a fixed instant, so the parent's (unaligned) end
+			// is irrelevant. start = end = 123_456ms; first step-aligned sample is at 65_000ms.
+			input:    types.NewRangeQueryTimeRange(timestamp.Time(201_000), timestamp.Time(220_000), 5*time.Second),
+			expected: types.NewRangeQueryTimeRange(timestamp.Time(65_000), timestamp.Time(123_456), 5*time.Second),
+		},
+		"range query with subquery @ timestamp and offset": {
+			node: &Subquery{
+				SubqueryDetails: &SubqueryDetails{
+					Range:     time.Minute,
+					Step:      5 * time.Second,
+					Offset:    time.Minute,
+					Timestamp: timestampOf(123_456),
+				},
+			},
+			// Similar to above, the @ modifier pins the subquery to a fixed instance, so the parent's unaligned end
+			// is not relevant.
+			input:    types.NewRangeQueryTimeRange(timestamp.Time(201_000), timestamp.Time(220_000), 5*time.Second),
+			expected: types.NewRangeQueryTimeRange(timestamp.Time(5_000), timestamp.Time(63_456), 5*time.Second),
+		},
+		"instant query": {
+			node:     subquery(),
+			input:    types.NewInstantQueryTimeRange(timestamp.Time(200_000)),
+			expected: types.NewRangeQueryTimeRange(timestamp.Time(145_000), timestamp.Time(200_000), 5*time.Second),
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			actual := testCase.node.ChildrenTimeRange(testCase.input)
+			require.Equal(t, testCase.expected, actual)
 		})
 	}
 }


### PR DESCRIPTION
#### What this PR does

This PR is inspired by the similar bugfix upstream (https://github.com/prometheus/prometheus/pull/18598), where subqueries can be evaluated for one more step than necessary if the parent time range is not aligned to the parent's step.

This doesn't cause incorrect query results, but is wasteful, as the unnecessary step is ignored when computing the result of the subquery.

#### Which issue(s) this PR fixes or relates to

https://github.com/prometheus/prometheus/pull/18598

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Planning-only change in subquery time ranges; query results were already correct and behavior matches an upstream Prometheus fix, with new unit tests.
> 
> **Overview**
> **MQE** now caps the inner subquery time range at the parent range query’s **last real step** when the parent `end` is not on the parent step grid, instead of using the raw `end` and running one extra inner step whose samples are discarded.
> 
> `ChildrenTimeRange` aligns the parent end **down** to the parent step before offset/`@` handling (instant queries and subqueries with `@` are unchanged). Comments document that the inner end need not sit on the subquery step grid. New table-driven tests cover aligned vs unaligned parent ends, offset, `@`, and instant parents, mirroring the upstream Prometheus fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a93711f516df2b20b7ca7b7d721a5dd801c82cf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->