### PR TITLE
Simplify build image build workflow and build each architecture in parallel

### DIFF
--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -129,6 +129,7 @@ jobs:
       gar-environment: dev
       gar-repository: docker-mimir-build-image
       gar-image: mimir-build-image
+      generate-summary: true
 
   commit:
     name: Push commit with new build image tag
@@ -173,7 +174,7 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
         env:
-          NEW_IMAGE_TAG: ${{ needs.prepare.outputs.new_image_tag }}@${{ needs.build-push-multiarch.outputs.digest }}
+          NEW_IMAGE_TAG: ${{ needs.build-push-multiarch.outputs.image-digests }}
           MAIN_IMAGE_TAG: ${{ needs.prepare.outputs.main_image_tag }}
 
       # Generate the app token here (rather than earlier in the job) so we only mint one

--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -170,8 +170,9 @@ jobs:
         if: needs.prepare.outputs.need_to_build == 'true'
         run: |
           set -euo pipefail
+          NEW_IMAGE_TAG=$(echo $NEW_IMAGE | cut -d ':' -f 2-)
           echo "Current build image tag is $MAIN_IMAGE_TAG"
-          echo "Built image tag is $NEW_IMAGE_TAG"
+          echo "Built image is $NEW_IMAGE, new tag is $NEW_IMAGE_TAG"
           if [ "$MAIN_IMAGE_TAG" = "$NEW_IMAGE_TAG" ]; then
             echo "Build image tag is already up to date."
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -180,7 +181,7 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
         env:
-          NEW_IMAGE_TAG: ${{ needs.build-push-multiarch.outputs.image-digests }}
+          NEW_IMAGE: ${{ needs.build-push-multiarch.outputs.image-digests }}
           MAIN_IMAGE_TAG: ${{ needs.prepare.outputs.main_image_tag }}
 
       # Generate the app token here (rather than earlier in the job) so we only mint one

--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -16,15 +16,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build_and_push:
+  prepare:
+    name: Prepare
     runs-on: ubuntu-latest
-    permissions:
-      # Allow pushing to the GitHub repo for collaborators, forks should remain read-only
-      contents: write
-      # Allow PR modification for collaborators, forks should remain read-only
-      pull-requests: write
-      # Required by docker-build-push-image for Workload Identity Federation authentication to Google Artifact Registry.
-      id-token: write
     steps:
       # We only want for this workflow to do anything when anything inside mimir-build-image/ is modified,
       # as well as when this workflow is modified.
@@ -36,8 +30,8 @@ jobs:
       # because the latter caps at 300 files and returns HTTP 406 on larger PRs, in which case the
       # script would silently fall into the "not modified" branch even when the Dockerfile was
       # actually modified.
-      - name: Check if build image needs to be built
-        id: check_dockerfile
+      - name: Check if files modified
+        id: check_if_files_modified
         run: |
           set -euo pipefail
           files=$(gh api --paginate \
@@ -54,113 +48,136 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Checkout Repository
-        if: steps.check_dockerfile.outputs.modified == 'true'
+      - name: Checkout repository
+        if: steps.check_if_files_modified.outputs.modified == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-          ref: ${{ github.event.pull_request.head.ref }} # Check out the PR branch itself, not the temporary merge commit
 
-      - name: Prepare Variables
-        if: steps.check_dockerfile.outputs.modified == 'true'
-        id: prepare
+      - name: Compute variables
+        if: steps.check_if_files_modified.outputs.modified == 'true'
+        id: compute_variables
         run: |
           main_build_image=$(make print-build-image)
           main_image_tag=$(echo $main_build_image | cut -d ':' -f 2-) # Get everything after the first : (ie. the image tag and digest, if present)
           image_name=$(echo $main_build_image | cut -d ':' -f 1)
-          echo "image=$image_name" >> $GITHUB_OUTPUT
+          echo "image_name=$image_name" >> $GITHUB_OUTPUT
           echo "main_image_tag=$main_image_tag" >> $GITHUB_OUTPUT
 
-      - name: Compute Image Tag
-        if: steps.check_dockerfile.outputs.modified == 'true'
-        id: compute_hash
-        run: |
           # Compute a hash of the entire build image directory, so that any changes to the Dockerfile or other files trigger a new build.
           # We use tar so that this also captures changes to permissions.
-          current_hash=$(tar -c -f - --exclude .uptodate --mtime='1900-01-01 00:00Z' --sort=name mimir-build-image | md5sum | awk '{print substr($1, 0, 10)}')
-          echo "build tag is $current_hash"
-          tag="pr${{ github.event.pull_request.number }}-$current_hash"
-          echo "tag=$tag" >> $GITHUB_OUTPUT
-
-      - name: Check Should Build Image
-        if: steps.check_dockerfile.outputs.modified == 'true'
-        id: check_build
-        run: |
-          echo "Checking if image should be built"
-          if skopeo inspect --raw "docker://${{ steps.prepare.outputs.image }}:${{ steps.compute_hash.outputs.tag }}"; then
-            echo "build=false" >> $GITHUB_OUTPUT
-            echo "Tag ${{ steps.compute_hash.outputs.tag }} exists"
-          else
-            echo "Tag ${{ steps.compute_hash.outputs.tag }} does not exist"
-            echo "build=true" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Add Comment to the PR
-        if: steps.check_dockerfile.outputs.modified == 'true'
-        id: notification
-        run: |
-          if [ ${{ steps.check_build.outputs.build }} == 'true' ]; then
-           gh pr comment $PR_NUMBER --body "**Building new version of mimir-build-image**. After image is built and pushed to the registry, \
-           a new commit will automatically be added to this PR with new image version \`$IMAGE:$TAG\`. This can take up to 1 hour."
-          else
-            echo "This PR will not trigger a build of mimir-build-image"
-            gh pr comment $PR_NUMBER --body "**Not building new version of mimir-build-image**. This PR modifies the build image or the build image build workflow, but the image \`$IMAGE:$TAG\` already exists."
-          fi
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          TAG: ${{ steps.compute_hash.outputs.tag }}
-          IMAGE: ${{ steps.prepare.outputs.image }}
-
-      - name: Compute build args
-        if: steps.check_build.outputs.build == 'true'
-        id: build_args
-        run: |
+          new_image_hash=$(tar -c -f - --exclude .uptodate --mtime='1900-01-01 00:00Z' --sort=name mimir-build-image | md5sum | awk '{print substr($1, 0, 10)}')
+          echo "New image hash is $new_image_hash"
+          new_image_tag="pr${{ github.event.pull_request.number }}-$new_image_hash"
+          echo "new_image_tag=$new_image_tag" >> $GITHUB_OUTPUT
+          
           {
             echo "build_args<<EOF"
             make print-build-image-build-args
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Build and Push Docker Image
-        if: steps.check_build.outputs.build == 'true'
-        id: build_and_push
-        uses: grafana/shared-workflows/actions/docker-build-push-image@34f27887c37cafe70d34af57dfc86b468a31b8c4 # docker-build-push-image/v0.3.3
+      - name: Check if image is already built
+        if: steps.check_if_files_modified.outputs.modified == 'true'
+        id: check_if_image_is_built
+        run: |
+          echo "Checking if image has already been built"
+          if skopeo inspect --raw "docker://${{ steps.compute_variables.outputs.image_name }}:${{ steps.compute_variables.outputs.new_image_tag }}"; then
+            echo "Tag ${{ steps.compute_variables.outputs.new_image_tag }} exists"
+            echo "need_to_build=false" >> $GITHUB_OUTPUT
+          else
+            echo "Tag ${{ steps.compute_variables.outputs.new_image_tag }} does not exist"
+            echo "need_to_build=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Add comment to the PR
+        if: steps.check_if_files_modified.outputs.modified == 'true'
+        id: notification
+        run: |
+          if [ ${{ steps.check_if_image_is_built.outputs.need_to_build }} == 'true' ]; then
+           gh pr comment $PR_NUMBER --body "**Building new version of mimir-build-image**. After image is built and pushed to the registry, \
+           a new commit will automatically be added to this PR with new image version \`$IMAGE:$NEW_IMAGE_TAG\`. This can take a few minutes."
+          else
+            echo "This PR will not trigger a build of mimir-build-image"
+            gh pr comment $PR_NUMBER --body "**Not building new version of mimir-build-image**. This PR modifies the build image or the build image build workflow, but the image \`$IMAGE:$NEW_IMAGE_TAG\` already exists."
+          fi
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          NEW_IMAGE_TAG: ${{ steps.compute_variables.outputs.new_image_tag }}
+          IMAGE: ${{ steps.compute_variables.outputs.image_name }}
+
+    outputs:
+      need_to_build: ${{ steps.check_if_image_is_built.outputs.need_to_build }}
+      new_image_tag: ${{ steps.compute_variables.outputs.new_image_tag }}
+      main_image_tag: ${{ steps.compute_variables.outputs.main_image_tag }}
+      build_args: ${{ steps.compute_variables.outputs.build_args }}
+
+  build-push-multiarch:
+    name: Build image
+    needs:
+      - prepare
+    if: needs.prepare.outputs.need_to_build == 'true'
+    uses: grafana/shared-workflows/.github/workflows/docker-build-push-multiarch.yml@638f24848a49edb0bd14f771b6dd37b4455f1591 # main
+    with:
+      context: mimir-build-image
+      platforms: linux/arm64,linux/amd64
+      tags: ${{ needs.prepare.outputs.new_image_tag }}
+      build-args: ${{ needs.prepare.outputs.build_args }}
+      push: true
+      registries: gar
+      gar-environment: dev
+      gar-repository: docker-mimir-build-image
+      gar-image: mimir-build-image
+
+  commit:
+    name: Push commit with new build image tag
+    runs-on: ubuntu-latest
+    needs:
+      - prepare
+      - build-push-multiarch
+    if: always() # Even if the build-push-multiarch job is skipped, we still want to run this job and mark it as successful, so that we can make this job a required check.
+    permissions:
+      contents: read
+      id-token: write # Required to generate GitHub app token to push commit.
+    steps:
+      # We always run this job even if the image build is skipped, so that we can make this job a required check.
+      # So if the image build failed, then we want this job to fail too.
+      - name: Fail if image build failed
+        if: needs.prepare.outputs.need_to_build == 'true' && needs.build-push-multiarch.result != 'success'
+        run: |
+          echo "Image build failed, stopping."
+          exit 1
+
+      - name: Checkout repository
+        if: needs.prepare.outputs.need_to_build == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          context: mimir-build-image
-          platforms: linux/amd64,linux/arm64
-          push: "true"
-          registries: gar
-          gar-environment: dev
-          gar-repository: docker-mimir-build-image
-          gar-image: mimir-build-image
-          tags: ${{ steps.compute_hash.outputs.tag }}
-          build-args: ${{ steps.build_args.outputs.build_args }}
+          persist-credentials: false
 
       # Compare the just-built tag against the one currently referenced in the Makefile.
       # If they differ, update the Makefile and signal the next step to commit; otherwise
       # `changed=false` and no commit will be made.
       - name: Check whether Makefile needs updating, and update it
         id: update_makefile
-        if: steps.check_build.outputs.build == 'true'
+        if: needs.prepare.outputs.need_to_build == 'true'
         run: |
           set -euo pipefail
-          echo "Current Build Image Version is $MAIN_TAG"
-          echo "Built Image Version is $TAG"
-          if [ "$MAIN_TAG" = "$TAG" ]; then
-            echo "Build Image Version is already up to date"
+          echo "Current build image tag is $MAIN_IMAGE_TAG"
+          echo "Built image tag is $NEW_IMAGE_TAG"
+          if [ "$MAIN_IMAGE_TAG" = "$NEW_IMAGE_TAG" ]; then
+            echo "Build image tag is already up to date."
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
-            sed -i "s/$MAIN_TAG/$TAG/g" Makefile
+            sed -i "s/$MAIN_IMAGE_TAG/$NEW_IMAGE_TAG/g" Makefile
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
         env:
-          TAG: ${{ steps.compute_hash.outputs.tag }}@${{ steps.build_and_push.outputs.digest }}
-          MAIN_TAG: ${{ steps.prepare.outputs.main_image_tag }}
+          NEW_IMAGE_TAG: ${{ needs.prepare.outputs.new_image_tag }}@${{ needs.build-push-multiarch.outputs.digest }}
+          MAIN_IMAGE_TAG: ${{ needs.prepare.outputs.main_image_tag }}
 
-      # Generate the App Token here (rather than earlier in the job) so we only mint one
-      # when we actually need to commit. Also: building the image can take a long time,
-      # and minting fresh just before use ensures the token hasn't expired (1h TTL).
+      # Generate the app token here (rather than earlier in the job) so we only mint one
+      # when we actually need to commit.
       - name: Generate GitHub App Token
         if: steps.update_makefile.outputs.changed == 'true'
         id: app-token-for-commit
@@ -177,7 +194,7 @@ jobs:
         if: steps.update_makefile.outputs.changed == 'true'
         uses: planetscale/ghcommit-action@25309d8005ac7c3bcd61d3fe19b69e0fe47dbdde # v0.2.20
         with:
-          commit_message: "Update build image version to ${{ steps.compute_hash.outputs.tag }}"
+          commit_message: "Update build image version to ${{ needs.prepare.outputs.new_image_tag }}"
           repo: ${{ github.event.pull_request.head.repo.full_name }}
           branch: ${{ github.head_ref }}
           file_pattern: Makefile

--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -145,7 +145,7 @@ jobs:
       # We always run this job even if the image build is skipped, so that we can make this job a required check.
       # So if the image build failed, then we want this job to fail too.
       - name: Fail if image build failed
-        if: needs.prepare.outputs.need_to_build == 'true' && needs.build-push-multiarch.result != 'success'
+        if: needs.prepare.outputs.need_to_build == 'true' && (needs.prepare.result != 'success' || needs.build-push-multiarch.result != 'success')
         run: |
           echo "Image build failed, stopping."
           exit 1

--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -137,8 +137,10 @@ jobs:
       runner-type-x64: ubuntu-x64
       runner-type-arm64: ubuntu-arm64
 
-  commit:
-    name: Push commit with new build image tag
+  # This name is completely misleading, but a previous version of this workflow used this name and it's used as a required PR check in GitHub.
+  # Renaming it would mean backporting a large number of changes to old release branches, so we're keeping it as-is for now.
+  # Once all active release branches use this workflow, it'll be much easier to rename it and backport just that rename.
+  build_and_push:
     runs-on: ubuntu-latest
     needs:
       - prepare

--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -56,6 +56,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
+          ref: ${{ github.event.pull_request.head.ref }} # Check out the PR branch itself, not the temporary merge commit
 
       - name: Compute variables
         if: steps.check_if_files_modified.outputs.modified == 'true'

--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -133,6 +133,8 @@ jobs:
       gar-repository: docker-mimir-build-image
       gar-image: mimir-build-image
       generate-summary: true
+      runner-type-x64: ubuntu-x64
+      runner-type-arm64: ubuntu-arm64
 
   commit:
     name: Push commit with new build image tag

--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -153,7 +153,7 @@ jobs:
       # We always run this job even if the image build is skipped, so that we can make this job a required check.
       # So if the image build failed, then we want this job to fail too.
       - name: Fail if image build failed
-        if: needs.prepare.outputs.need_to_build == 'true' && (needs.prepare.result != 'success' || needs.build-push-multiarch.result != 'success')
+        if: needs.prepare.result != 'success' || (needs.prepare.outputs.need_to_build == 'true' && needs.build-push-multiarch.result != 'success')
         run: |
           echo "Image build failed, stopping."
           exit 1

--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -155,6 +155,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
+          ref: ${{ github.event.pull_request.head.ref }} # Check out the PR branch itself, not the temporary merge commit
 
       # Compare the just-built tag against the one currently referenced in the Makefile.
       # If they differ, update the Makefile and signal the next step to commit; otherwise

--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -19,6 +19,9 @@ jobs:
   prepare:
     name: Prepare
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write # So we can post comments on the PR.
     steps:
       # We only want for this workflow to do anything when anything inside mimir-build-image/ is modified,
       # as well as when this workflow is modified.

--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -64,9 +64,9 @@ jobs:
           echo "image_name=$image_name" >> $GITHUB_OUTPUT
           echo "main_image_tag=$main_image_tag" >> $GITHUB_OUTPUT
 
-          # Compute a hash of the entire build image directory, so that any changes to the Dockerfile or other files trigger a new build.
+          # Compute a hash of the entire build image directory and this workflow, so that any changes to the Dockerfile or other files trigger a new build.
           # We use tar so that this also captures changes to permissions.
-          new_image_hash=$(tar -c -f - --exclude .uptodate --mtime='1900-01-01 00:00Z' --sort=name mimir-build-image | md5sum | awk '{print substr($1, 0, 10)}')
+          new_image_hash=$(tar -c -f - --exclude .uptodate --mtime='1900-01-01 00:00Z' --sort=name mimir-build-image .github/workflows/push-mimir-build-image.yml | md5sum | awk '{print substr($1, 0, 10)}')
           echo "New image hash is $new_image_hash"
           new_image_tag="pr${{ github.event.pull_request.number }}-$new_image_hash"
           echo "new_image_tag=$new_image_tag" >> $GITHUB_OUTPUT

--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr15457-cfd05df713@sha256:598a70a7446ff123ab6a79930406fcbcc8d530895a1422f41c62d514a30b4b2f
+LATEST_BUILD_IMAGE_TAG ?= pr15439-9fd2d383e2@sha256:588940b00ab4b3c41738eb4fab8ccb63fed0f30ed07a22b96dcad13a23d2a1ac
 
 # TTY is parameterized to allow CI and scripts to run builds,
 # as it currently disallows TTY devices.


### PR DESCRIPTION
#### What this PR does

This PR builds upon the changes in #15423, and makes the following changes:

* the workflow now builds each architecture for the build image on a corresponding runner (ie. build ARM on an ARM runner, x86 on a x86 runner), dramatically improving performance from 40-60 minutes to ~7-8 minutes
* a number of steps that computed various variables have now been consolidated into a single "compute variables" step
* the build image is now rebuilt whenever the build workflow is changed

#### Which issue(s) this PR fixes or relates to

#15423

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI that pushes images and auto-commits Makefile pins; mistakes could break required checks or point developers at wrong build images, but scope is limited to the build-image pipeline.
> 
> **Overview**
> Refactors **`push-mimir-build-image`** from a single job that built and pushed in one place into **`prepare` → `build-push-multiarch` → `build_and_push`**. Image builds now call Grafana’s reusable **`docker-build-push-multiarch`** workflow with **native runners** (`ubuntu-x64` / `ubuntu-arm64`) instead of one job doing multi-arch locally—intended to cut build time sharply.
> 
> **`prepare`** keeps the required-check behavior (runs on all PRs) but only does real work when `mimir-build-image/` or the workflow file changed. It merges tag/hash/build-args into one **Compute variables** step, folds **`.github/workflows/push-mimir-build-image.yml`** into the content hash so workflow edits force a rebuild, and exposes job outputs for downstream jobs. **`build_and_push`** stays the legacy job name for required checks: it fails if prepare or the multiarch build failed, then updates/commits **`Makefile`** `LATEST_BUILD_IMAGE_TAG` from the built digest when needed. PR comments now say builds take **minutes** instead of up to an hour.
> 
> The diff also bumps **`LATEST_BUILD_IMAGE_TAG`** in the **`Makefile`** to a new PR-tagged digest (typical bot follow-up from this workflow).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cb975648226c0ccdec86729efdaab4c93158e95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->