### PR TITLE
Bump grafana/helm-charts reusable workflow pins

### DIFF
--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -7,12 +7,12 @@ permissions:
 
 jobs:
   call-lint:
-    uses: grafana/helm-charts/.github/workflows/linter.yml@77e5ea2de369fa1ff3441b08765c164be209eaa2 # main
+    uses: grafana/helm-charts/.github/workflows/linter.yml@0cb44b98b41df1bc345376ac40897453fa88df93 # main
     with:
       filter_regex_include: .*operations/helm/.*
 
   call-lint-test:
-    uses: grafana/helm-charts/.github/workflows/lint-test.yaml@77e5ea2de369fa1ff3441b08765c164be209eaa2 # main
+    uses: grafana/helm-charts/.github/workflows/lint-test.yaml@0cb44b98b41df1bc345376ac40897453fa88df93 # main
     with:
       ct_configfile: operations/helm/ct.yaml
       ct_check_version_increment: false

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -11,7 +11,7 @@ permissions: {}
 
 jobs:
   call-update-helm-repo:
-    uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@77e5ea2de369fa1ff3441b08765c164be209eaa2 # main
+    uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@0cb44b98b41df1bc345376ac40897453fa88df93 # main
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
## Summary

Bump the three `grafana/helm-charts` reusable-workflow pins in this repo from `77e5ea2de369fa1ff3441b08765c164be209eaa2` to `0cb44b98b41df1bc345376ac40897453fa88df93` (current `main` tip of grafana/helm-charts):

- `.github/workflows/helm-release.yaml` → `update-helm-repo.yaml`
- `.github/workflows/helm-ci.yml` → `linter.yml`
- `.github/workflows/helm-ci.yml` → `lint-test.yaml`

The release flow now picks up grafana/helm-charts#4169, which makes the bot commit pushed to `grafana/helm-charts@gh-pages` (`index.yaml` update) signed by GitHub's web-flow key (shown as **Verified**) instead of an unsigned `git push` from chart-releaser. The linter and lint-test reusable workflows didn't change in the intervening commits; bumping them together keeps the pin consistent.

Continuation of the bot-commit-signing effort started in #15429.