### PR TITLE
ci: Push images to GAR for Dockerhub mirroring

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -728,11 +728,15 @@ jobs:
           for f in built-images/**/images.tar; do
             tar xvf $f -C /tmp/images
           done
-      - name: Login to DockerHub
-        uses: grafana/shared-workflows/actions/dockerhub-login@13fb504e3bfe323c1188bf244970d94b2d336e86 # v1.0.1
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+      - name: Log into GAR
+        uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1
+        with:
+          registry: us-docker.pkg.dev
       - name: Push Docker Images
         run: |
-          ./.github/workflows/scripts/push-images.sh /tmp/images grafana/ $(make image-tag)
+          ./.github/workflows/scripts/push-images.sh /tmp/images us-docker.pkg.dev/grafanalabs-global/dockerhub-mimir-prod-mirror/ $(make image-tag)
 
   send-slack-notification-on-automated-vendoring:
     needs:


### PR DESCRIPTION
#### What this PR does

We (Grafana Labs) are no longer pushing to Dockerhub directly from CI. Instead, we push to GAR, and then mirror from there to Dockerhub.

#### Which issue(s) this PR fixes or relates to

https://grafana.com/blog/grafana-labs-security-update-latest-on-tanstack-npm-supply-chain-ransomware-incident/

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the production image publish path; a misconfigured registry or mirror could delay or break public image availability until fixed.
> 
> **Overview**
> The **deploy** job no longer authenticates to Docker Hub or pushes images to `grafana/*`. It now uses **Google Cloud SDK** and Grafana’s **login-to-gar** action, then runs `push-images.sh` against `us-docker.pkg.dev/grafanalabs-global/dockerhub-mimir-prod-mirror/` with the same `make image-tag` tags.
> 
> This matches Grafana Labs’ move to publish release images to **GAR** first and rely on mirroring for Docker Hub, instead of pushing directly from CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2845699e3c0b949fbbbc90adf8e4c8f51652035. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->