### PR TITLE
MQE: indicate if buffers are resized on append

### DIFF
--- a/pkg/streamingpromql/operators/selectors/extend_range_vector.go
+++ b/pkg/streamingpromql/operators/selectors/extend_range_vector.go
@@ -164,7 +164,7 @@ func (m *RevertibleExtendedPointsState) ApplyBoundaryMutations(rangeStart, range
 
 	// Add synthetic or clamp start boundary
 	if m.first.T > rangeStart {
-		if err := m.buff.AppendAtStart(promql.FPoint{T: rangeStart, F: m.first.F}); err != nil {
+		if _, err := m.buff.AppendAtStart(promql.FPoint{T: rangeStart, F: m.first.F}); err != nil {
 			return err
 		}
 		m.undoHeadModifications = removed
@@ -183,7 +183,7 @@ func (m *RevertibleExtendedPointsState) ApplyBoundaryMutations(rangeStart, range
 
 	// Add synthetic or clamp end boundary
 	if m.last.T < rangeEnd {
-		if err := m.buff.Append(promql.FPoint{T: rangeEnd, F: m.last.F}); err != nil {
+		if _, err := m.buff.Append(promql.FPoint{T: rangeEnd, F: m.last.F}); err != nil {
 			return err
 		}
 		m.undoTailModifications = removed
@@ -229,13 +229,13 @@ func (m *RevertibleExtendedPointsState) UndoChanges() error {
 	}
 
 	if m.restoreExcludedLast {
-		if err := m.buff.Append(m.excludedLast); err != nil {
+		if _, err := m.buff.Append(m.excludedLast); err != nil {
 			return err
 		}
 	}
 
 	if m.restoreExcludedFirst {
-		if err := m.buff.AppendAtStart(m.excludedFirst); err != nil {
+		if _, err := m.buff.AppendAtStart(m.excludedFirst); err != nil {
 			return err
 		}
 	}

--- a/pkg/streamingpromql/operators/selectors/range_vector_selector.go
+++ b/pkg/streamingpromql/operators/selectors/range_vector_selector.go
@@ -222,7 +222,7 @@ func (m *RangeVectorSelector) fillBuffer(floats *types.FPointRingBuffer, histogr
 			// We might append a sample beyond the range end, but this is OK:
 			// - callers of NextStepSamples are expected to pass the same RingBuffer to subsequent calls, so the point is not lost
 			// - callers of NextStepSamples are expected to handle the case where the buffer contains points beyond the end of the range
-			if err := floats.Append(promql.FPoint{T: t, F: f}); err != nil {
+			if _, err := floats.Append(promql.FPoint{T: t, F: f}); err != nil {
 				return false, err
 			}
 
@@ -236,7 +236,7 @@ func (m *RangeVectorSelector) fillBuffer(floats *types.FPointRingBuffer, histogr
 				continue
 			}
 
-			hPoint, err := histograms.NextPoint()
+			hPoint, _, err := histograms.NextPoint()
 			if err != nil {
 				return false, err
 			}

--- a/pkg/streamingpromql/operators/test_operator.go
+++ b/pkg/streamingpromql/operators/test_operator.go
@@ -229,7 +229,7 @@ func (t *TestRangeOperator) NextStepSamples(_ context.Context) (*types.RangeVect
 
 	t.Floats.Reset()
 	for _, p := range d.Floats {
-		if err := t.Floats.Append(p); err != nil {
+		if _, err := t.Floats.Append(p); err != nil {
 			return nil, err
 		}
 	}
@@ -242,7 +242,7 @@ func (t *TestRangeOperator) NextStepSamples(_ context.Context) (*types.RangeVect
 
 	t.Histograms.Reset()
 	for _, p := range d.Histograms {
-		if err := t.Histograms.Append(p); err != nil {
+		if _, err := t.Histograms.Append(p); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator_test.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator_test.go
@@ -1005,7 +1005,7 @@ func (o *failingRangeVectorOperator) NextStepSamples(_ context.Context) (*types.
 
 	if o.floats == nil {
 		o.floats = types.NewFPointRingBuffer(o.memoryConsumptionTracker)
-		if err := o.floats.Append(promql.FPoint{T: 0, F: 1234}); err != nil {
+		if _, err := o.floats.Append(promql.FPoint{T: 0, F: 1234}); err != nil {
 			return nil, err
 		}
 
@@ -1014,7 +1014,7 @@ func (o *failingRangeVectorOperator) NextStepSamples(_ context.Context) (*types.
 
 	if o.histograms == nil {
 		o.histograms = types.NewHPointRingBuffer(o.memoryConsumptionTracker)
-		if err := o.histograms.Append(promql.HPoint{T: 500, H: &histogram.FloatHistogram{Count: 100, Sum: 2}}); err != nil {
+		if _, err := o.histograms.Append(promql.HPoint{T: 500, H: &histogram.FloatHistogram{Count: 100, Sum: 2}}); err != nil {
 			return nil, err
 		}
 

--- a/pkg/streamingpromql/types/fpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/fpoint_ring_buffer.go
@@ -32,11 +32,14 @@ func NewFPointRingBuffer(memoryConsumptionTracker *limiter.MemoryConsumptionTrac
 	return &FPointRingBuffer{memoryConsumptionTracker: memoryConsumptionTracker}
 }
 
-func (b *FPointRingBuffer) resizeIfRequired(additionalPoints int, appendingAtStart bool) error {
+// resizeIfRequired resizes the underlying buffer if required to hold additionalPoints and returns
+// a boolean indicating if the underlying buffer was resized or an error if the buffer could not be
+// resized.
+func (b *FPointRingBuffer) resizeIfRequired(additionalPoints int, appendingAtStart bool) (bool, error) {
 	newRequestedSize := b.size + additionalPoints
 
 	if newRequestedSize <= len(b.points) {
-		return nil
+		return false, nil
 	}
 
 	newSize := math.NextPowerTwo(newRequestedSize)
@@ -44,14 +47,14 @@ func (b *FPointRingBuffer) resizeIfRequired(additionalPoints int, appendingAtSta
 	// We create a new slice, and we will copy the elements from the current slice to the new slice
 	newSlice, err := getFPointSliceForRingBuffer(newSize, b.memoryConsumptionTracker)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	if !pool.IsPowerOfTwo(cap(newSlice)) {
 		// We rely on the capacity being a power of two for the pointsIndexMask optimisation below.
 		// If we can guarantee that newSlice has a capacity that is a power of two in the future, then we can drop this check.
 		// Note that the capacity of newSlice is guaranteed to be at least 2 due to the implementation in math.NextPowerTwo()
-		return fmt.Errorf("pool returned slice of capacity %v (requested %v), but wanted a power of two", cap(newSlice), newSize)
+		return false, fmt.Errorf("pool returned slice of capacity %v (requested %v), but wanted a power of two", cap(newSlice), newSize)
 	}
 
 	newSlice = newSlice[:cap(newSlice)]
@@ -76,7 +79,7 @@ func (b *FPointRingBuffer) resizeIfRequired(additionalPoints int, appendingAtSta
 	putFPointSliceForRingBuffer(&b.points, b.memoryConsumptionTracker)
 	b.points = newSlice
 	b.pointsIndexMask = cap(newSlice) - 1
-	return nil
+	return true, nil
 }
 
 // DiscardPointsAtOrBefore discards all points in this buffer with timestamp less than or equal to the given timestamp.
@@ -141,34 +144,39 @@ func (b *FPointRingBuffer) ReplaceFirst(point promql.FPoint) error {
 }
 
 // AppendAtStart will insert the given point into the head of this buffer, expanding if required.
-// Subsequently calling PointAt(0) will return this point.
-// It is the responsibility of the caller to ensure that inserting this point maintains chronological order of the buffer.
-func (b *FPointRingBuffer) AppendAtStart(point promql.FPoint) error {
-	if err := b.resizeIfRequired(1, true); err != nil {
-		return err
+// A boolean is returned indicating if the underlying buffer had to be resized. Subsequently calling
+// PointAt(0) will return this point. It is the responsibility of the caller to ensure that inserting
+// this point maintains chronological order of the buffer.
+func (b *FPointRingBuffer) AppendAtStart(point promql.FPoint) (bool, error) {
+	resized, err := b.resizeIfRequired(1, true)
+	if err != nil {
+		return resized, err
 	}
 
 	b.firstIndex = (b.firstIndex - 1) & b.pointsIndexMask
 	b.points[b.firstIndex] = point
 	b.size++
 
-	return nil
+	return resized, nil
 }
 
 // Append adds p to this buffer, expanding it if required.
+// A boolean is returned indicating if the underlying buffer had to be resized.
 // It is the responsibility of the caller to ensure that inserting this point maintains chronological order of the buffer.
-func (b *FPointRingBuffer) Append(p promql.FPoint) error {
-	if err := b.resizeIfRequired(1, false); err != nil {
-		return err
+func (b *FPointRingBuffer) Append(p promql.FPoint) (bool, error) {
+	resized, err := b.resizeIfRequired(1, false)
+	if err != nil {
+		return resized, err
 	}
 
 	nextIndex := (b.firstIndex + b.size) & b.pointsIndexMask
 	b.points[nextIndex] = p
 	b.size++
-	return nil
+	return resized, nil
 }
 
-// AppendSlice will append all the given points to the buffer.
+// AppendSlice will append all the given points to the buffer returning a boolean if
+// the underlying buffer had to be resized.
 //
 // It is more efficient to call this for a collection of points then to call Append()
 // for each individual point. In this function the underlying buffer will only be grown once based
@@ -176,13 +184,14 @@ func (b *FPointRingBuffer) Append(p promql.FPoint) error {
 //
 // It is the caller's responsibility to ensure that the given points are in chronological order
 // and that the points chronologically follow any existing points in the buffer.
-func (b *FPointRingBuffer) AppendSlice(points []promql.FPoint) error {
+func (b *FPointRingBuffer) AppendSlice(points []promql.FPoint) (bool, error) {
 	if len(points) == 0 {
-		return nil
+		return false, nil
 	}
 
-	if err := b.resizeIfRequired(len(points), false); err != nil {
-		return err
+	resized, err := b.resizeIfRequired(len(points), false)
+	if err != nil {
+		return resized, err
 	}
 
 	for _, pt := range points {
@@ -191,7 +200,7 @@ func (b *FPointRingBuffer) AppendSlice(points []promql.FPoint) error {
 		b.size++
 	}
 
-	return nil
+	return resized, nil
 }
 
 // ViewUntilSearchingForwards returns a view into this buffer, including only points with timestamps less than or equal to maxT.

--- a/pkg/streamingpromql/types/hpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/hpoint_ring_buffer.go
@@ -48,16 +48,17 @@ func (b *HPointRingBuffer) DiscardPointsAtOrBefore(t int64) {
 }
 
 // Append adds p to this buffer, expanding it if required.
+// A boolean is returned indicating if the underlying buffer had to be resized.
 // If this buffer is non-empty, p.T must be greater than or equal to the
 // timestamp of the last point in the buffer.
-func (b *HPointRingBuffer) Append(p promql.HPoint) error {
-	hPoint, err := b.NextPoint()
+func (b *HPointRingBuffer) Append(p promql.HPoint) (bool, error) {
+	hPoint, resized, err := b.NextPoint()
 	if err != nil {
-		return err
+		return resized, err
 	}
 	hPoint.T = p.T
 	hPoint.H = p.H
-	return nil
+	return resized, nil
 }
 
 // ViewUntilSearchingForwards returns a view into this buffer, including only points with timestamps less than or equal to maxT.
@@ -106,13 +107,18 @@ func (b *HPointRingBuffer) pointAt(position int) promql.HPoint {
 }
 
 // NextPoint gets the next point in this buffer, expanding it if required.
+//
+// A boolean is returned indicating if the underlying buffer had to be resized.
+//
 // The returned point's timestamp (HPoint.T) must be set to greater than or equal
 // to the timestamp of the last point in the buffer before further methods
 // are called on this buffer (with the exception of RemoveLastPoint, Reset or Close).
 //
 // This method allows reusing an existing HPoint in this buffer where possible,
 // reducing the number of FloatHistograms allocated.
-func (b *HPointRingBuffer) NextPoint() (*promql.HPoint, error) {
+func (b *HPointRingBuffer) NextPoint() (*promql.HPoint, bool, error) {
+	resized := false
+
 	if b.size == len(b.points) {
 		// Create a new slice, copy the elements from the current slice.
 		newSize := b.size * 2
@@ -122,15 +128,16 @@ func (b *HPointRingBuffer) NextPoint() (*promql.HPoint, error) {
 
 		newSlice, err := getHPointSliceForRingBuffer(newSize, b.memoryConsumptionTracker)
 		if err != nil {
-			return nil, err
+			return nil, resized, err
 		}
 
 		if !pool.IsPowerOfTwo(cap(newSlice)) {
 			// We rely on the capacity being a power of two for the pointsIndexMask optimisation below.
 			// If we can guarantee that newSlice has a capacity that is a power of two in the future, then we can drop this check.
-			return nil, fmt.Errorf("pool returned slice of capacity %v (requested %v), but wanted a power of two", cap(newSlice), newSize)
+			return nil, resized, fmt.Errorf("pool returned slice of capacity %v (requested %v), but wanted a power of two", cap(newSlice), newSize)
 		}
 
+		resized = true
 		newSlice = newSlice[:cap(newSlice)]
 		pointsAtEnd := b.size - b.firstIndex
 		copy(newSlice, b.points[b.firstIndex:])
@@ -149,7 +156,7 @@ func (b *HPointRingBuffer) NextPoint() (*promql.HPoint, error) {
 
 	nextIndex := (b.firstIndex + b.size) & b.pointsIndexMask
 	b.size++
-	return &b.points[nextIndex], nil
+	return &b.points[nextIndex], resized, nil
 }
 
 // RemoveLastPoint removes the last point that was allocated.

--- a/pkg/streamingpromql/types/ring_buffer_test.go
+++ b/pkg/streamingpromql/types/ring_buffer_test.go
@@ -18,7 +18,7 @@ import (
 // and we don't care about performance here so we can use an interface+generics.
 type ringBuffer[T any] interface {
 	DiscardPointsAtOrBefore(t int64)
-	Append(p T) error
+	Append(p T) (bool, error)
 	Reset()
 	Use(s []T) error
 	Release()
@@ -82,10 +82,10 @@ func testRingBuffer[T any](t *testing.T, buf ringBuffer[T], points []T) {
 	buf.DiscardPointsAtOrBefore(0) // Should handle empty buffer.
 	shouldHaveNoPoints(t, buf)
 
-	require.NoError(t, buf.Append(points[0]))
+	mustAppend(t, buf, points[0])
 	shouldHavePoints(t, buf, points[:1]...)
 
-	require.NoError(t, buf.Append(points[1]))
+	mustAppend(t, buf, points[1])
 	shouldHavePoints(t, buf, points[:2]...)
 
 	buf.DiscardPointsAtOrBefore(0)
@@ -94,35 +94,35 @@ func testRingBuffer[T any](t *testing.T, buf ringBuffer[T], points []T) {
 	buf.DiscardPointsAtOrBefore(1)
 	shouldHavePoints(t, buf, points[1:2]...)
 
-	require.NoError(t, buf.Append(points[2]))
+	mustAppend(t, buf, points[2])
 	shouldHavePoints(t, buf, points[1:3]...)
 
 	buf.DiscardPointsAtOrBefore(3)
 	shouldHaveNoPoints(t, buf)
 
-	require.NoError(t, buf.Append(points[3]))
-	require.NoError(t, buf.Append(points[4]))
+	mustAppend(t, buf, points[3])
+	mustAppend(t, buf, points[4])
 	shouldHavePoints(t, buf, points[3:5]...)
 
 	// Trigger expansion of buffer (we resize in powers of two, and the underlying slice comes from a pool that uses a factor of 2 as well).
-	// Ideally we wouldn't reach into the internals here, but this helps ensure the test is testing the correct scenario.
-	require.Len(t, buf.GetPoints(), 2, "expected underlying slice to have length 2, if this assertion fails, the test setup is not as expected")
-	require.Equal(t, 2, cap(buf.GetPoints()), "expected underlying slice to have capacity 2, if this assertion fails, the test setup is not as expected")
-	require.NoError(t, buf.Append(points[5]))
-	require.NoError(t, buf.Append(points[6]))
-	require.Greater(t, cap(buf.GetPoints()), 2, "expected underlying slice to be expanded, if this assertion fails, the test setup is not as expected")
+	resized, err := buf.Append(points[5])
+	require.NoError(t, err)
+	require.True(t, resized, "expected Append() to trigger a resize")
+	resized, err = buf.Append(points[6])
+	require.NoError(t, err)
+	require.False(t, resized, "expected Append() not to trigger a resize")
 
 	shouldHavePoints(t, buf, points[3:7]...)
 
 	buf.Reset()
 	shouldHaveNoPoints(t, buf)
 
-	require.NoError(t, buf.Append(points[8]))
+	mustAppend(t, buf, points[8])
 	shouldHavePoints(t, buf, points[8])
 
 	pointsWithPowerOfTwoCapacity := make([]T, 0, 16) // Use must be passed a slice with a capacity that is equal to a power of 2.
 	pointsWithPowerOfTwoCapacity = append(pointsWithPowerOfTwoCapacity, points...)
-	err := buf.Use(pointsWithPowerOfTwoCapacity)
+	err = buf.Use(pointsWithPowerOfTwoCapacity)
 	require.NoError(t, err)
 	shouldHavePoints(t, buf, points...)
 
@@ -179,15 +179,15 @@ func testDiscardPointsBeforeThroughWrapAround[T any](t *testing.T, buf ringBuffe
 	// We resize in powers of two, and the underlying slice comes from a pool that uses a factor of 2 as well.
 
 	for _, p := range points[:4] {
-		require.NoError(t, buf.Append(p))
+		mustAppend(t, buf, p)
 	}
 
 	// Ideally we wouldn't reach into the internals here, but this helps ensure the test is testing the correct scenario.
 	require.Len(t, buf.GetPoints(), 4, "expected underlying slice to have length 4, if this assertion fails, the test setup is not as expected")
 	require.Equal(t, 4, cap(buf.GetPoints()), "expected underlying slice to have capacity 4, if this assertion fails, the test setup is not as expected")
 	buf.DiscardPointsAtOrBefore(2)
-	require.NoError(t, buf.Append(points[4]))
-	require.NoError(t, buf.Append(points[5]))
+	mustAppend(t, buf, points[4])
+	mustAppend(t, buf, points[5])
 
 	// Should not have expanded slice.
 	require.Len(t, buf.GetPoints(), 4, "expected underlying slice to have length 4")
@@ -221,17 +221,16 @@ func TestRingBuffer_RemoveLastPoint(t *testing.T) {
 	t.Run("test removing points until none exist", func(t *testing.T) {
 		buf.Reset()
 		for _, p := range points[:2] {
-			require.NoError(t, buf.Append(p))
+			mustAppend(t, buf, p)
 		}
 
 		shouldHavePoints(t, buf, points[:2]...)
 		require.Equal(t, 2, len(buf.GetPoints()))
 		require.Equal(t, 2, buf.size)
 
-		nextPoint, err := buf.NextPoint()
+		nextPoint, resized, err := buf.NextPoint()
 		require.NoError(t, err)
-		require.Equal(t, 4, len(buf.GetPoints()), "underlying slice has expanded by a power of 2")
-		require.Equal(t, 3, buf.size, "The size has increase to accommodate the next point")
+		require.True(t, resized, "expected NextPoint() to trigger a resize")
 
 		*nextPoint = points[2]
 		// We assign "NextPoint" points[2], and then check it is in the ring
@@ -264,7 +263,7 @@ func TestRingBuffer_RemoveLastPoint(t *testing.T) {
 		// We resize in powers of two, and the underlying slice comes from a pool that uses a factor of 2 as well.
 
 		for _, p := range points[:4] {
-			require.NoError(t, buf.Append(p))
+			mustAppend(t, buf, p)
 		}
 
 		require.Len(t, buf.GetPoints(), 4, "expected underlying slice to have length 4, if this assertion fails, the test setup is not as expected")
@@ -277,10 +276,9 @@ func TestRingBuffer_RemoveLastPoint(t *testing.T) {
 		// Check we only have the expected points
 		shouldHavePoints(t, buf, points[2:4]...)
 
-		nextPoint, err := buf.NextPoint()
+		nextPoint, resized, err := buf.NextPoint()
 		require.NoError(t, err)
-		require.Equal(t, 4, len(buf.GetPoints()), "underlying slice remains the same")
-		require.Equal(t, 3, buf.size, "The size has increased")
+		require.False(t, resized, "expected NextPoint() not to trigger a resize")
 
 		*nextPoint = points[4]
 		// We assign "NextPoint" points[4], and then check it is in the ring
@@ -297,11 +295,11 @@ func TestRingBuffer_RemoveLastPoint(t *testing.T) {
 
 func TestRingBuffer_ViewUntilWithExistingView(t *testing.T) {
 	t.Run("FPoint ring buffer", func(t *testing.T) {
-		buf := NewFPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))
-		require.NoError(t, buf.Append(promql.FPoint{T: 1, F: 100}))
-		require.NoError(t, buf.Append(promql.FPoint{T: 2, F: 200}))
-		require.NoError(t, buf.Append(promql.FPoint{T: 3, F: 300}))
-		require.NoError(t, buf.Append(promql.FPoint{T: 4, F: 400}))
+		buf := &fPointRingBufferWrapper{NewFPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))}
+		mustAppend(t, buf, promql.FPoint{T: 1, F: 100})
+		mustAppend(t, buf, promql.FPoint{T: 2, F: 200})
+		mustAppend(t, buf, promql.FPoint{T: 3, F: 300})
+		mustAppend(t, buf, promql.FPoint{T: 4, F: 400})
 
 		view := buf.ViewUntilSearchingForwards(2, nil)
 		viewShouldHavePoints(t, view, promql.FPoint{T: 1, F: 100}, promql.FPoint{T: 2, F: 200})
@@ -323,11 +321,11 @@ func TestRingBuffer_ViewUntilWithExistingView(t *testing.T) {
 		h3 := &histogram.FloatHistogram{Count: 300}
 		h4 := &histogram.FloatHistogram{Count: 400}
 
-		buf := NewHPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))
-		require.NoError(t, buf.Append(promql.HPoint{T: 1, H: h1}))
-		require.NoError(t, buf.Append(promql.HPoint{T: 2, H: h2}))
-		require.NoError(t, buf.Append(promql.HPoint{T: 3, H: h3}))
-		require.NoError(t, buf.Append(promql.HPoint{T: 4, H: h4}))
+		buf := &hPointRingBufferWrapper{NewHPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))}
+		mustAppend(t, buf, promql.HPoint{T: 1, H: h1})
+		mustAppend(t, buf, promql.HPoint{T: 2, H: h2})
+		mustAppend(t, buf, promql.HPoint{T: 3, H: h3})
+		mustAppend(t, buf, promql.HPoint{T: 4, H: h4})
 
 		view := buf.ViewUntilSearchingForwards(2, nil)
 		viewShouldHavePoints(t, view, promql.HPoint{T: 1, H: h1}, promql.HPoint{T: 2, H: h2})
@@ -342,6 +340,11 @@ func TestRingBuffer_ViewUntilWithExistingView(t *testing.T) {
 		require.Same(t, newView, view)
 		viewShouldHavePoints(t, view, promql.HPoint{T: 1, H: h1}, promql.HPoint{T: 2, H: h2}, promql.HPoint{T: 3, H: h3})
 	})
+}
+
+func mustAppend[T any](t *testing.T, buf ringBuffer[T], point T) {
+	_, err := buf.Append(point)
+	require.NoError(t, err)
 }
 
 func shouldHaveNoPoints[T any](t *testing.T, buf ringBuffer[T]) {
@@ -484,9 +487,9 @@ func (w *hPointRingBufferWrapper) GetTimestamp(point promql.HPoint) int64 {
 }
 
 func TestRingBuffer_FPointView_Cloning(t *testing.T) {
-	originalBuffer := NewFPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))
-	require.NoError(t, originalBuffer.Append(promql.FPoint{T: 0, F: 10}))
-	require.NoError(t, originalBuffer.Append(promql.FPoint{T: 1, F: 11}))
+	originalBuffer := &fPointRingBufferWrapper{NewFPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))}
+	mustAppend(t, originalBuffer, promql.FPoint{T: 0, F: 10})
+	mustAppend(t, originalBuffer, promql.FPoint{T: 1, F: 11})
 
 	originalView := originalBuffer.ViewUntilSearchingBackwards(2, nil)
 	clonedView, clonedBuffer, err := originalView.Clone()
@@ -505,11 +508,11 @@ func TestRingBuffer_FPointView_Cloning(t *testing.T) {
 }
 
 func TestRingBuffer_HPointView_Cloning(t *testing.T) {
-	originalBuffer := NewHPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))
+	originalBuffer := &hPointRingBufferWrapper{NewHPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))}
 	h1 := &histogram.FloatHistogram{Count: 100}
 	h2 := &histogram.FloatHistogram{Count: 200}
-	require.NoError(t, originalBuffer.Append(promql.HPoint{T: 0, H: h1}))
-	require.NoError(t, originalBuffer.Append(promql.HPoint{T: 1, H: h2}))
+	mustAppend(t, originalBuffer, promql.HPoint{T: 0, H: h1})
+	mustAppend(t, originalBuffer, promql.HPoint{T: 1, H: h2})
 
 	originalView := originalBuffer.ViewUntilSearchingBackwards(2, nil)
 	clonedView, clonedBuffer, err := originalView.Clone()
@@ -546,7 +549,7 @@ func TestRingBufferView_SubView(t *testing.T) {
 				wraparound: false,
 				setupBuffer: func(t *testing.T) *FPointRingBufferView {
 					memoryTracker := limiter.NewUnlimitedMemoryConsumptionTracker(context.Background())
-					buf := NewFPointRingBuffer(memoryTracker)
+					buf := &fPointRingBufferWrapper{NewFPointRingBuffer(memoryTracker)}
 					points := []promql.FPoint{
 						{T: 10, F: 100},
 						{T: 20, F: 200},
@@ -554,7 +557,7 @@ func TestRingBufferView_SubView(t *testing.T) {
 						{T: 40, F: 400},
 					}
 					for _, p := range points {
-						require.NoError(t, buf.Append(p))
+						mustAppend(t, buf, p)
 					}
 					return buf.ViewUntilSearchingBackwards(40, nil)
 				},
@@ -564,21 +567,21 @@ func TestRingBufferView_SubView(t *testing.T) {
 				wraparound: true,
 				setupBuffer: func(t *testing.T) *FPointRingBufferView {
 					memoryTracker := limiter.NewUnlimitedMemoryConsumptionTracker(context.Background())
-					buf := NewFPointRingBuffer(memoryTracker)
+					buf := &fPointRingBufferWrapper{NewFPointRingBuffer(memoryTracker)}
 					// Strategy: Create a buffer with wraparound where newer samples wrap to the beginning.
 					// Final buffer: [T=40, T=10, T=20, T=30] with firstIndex=1, size=4
 
 					// Step 1: Fill buffer to capacity 4 with T=1 (to discard), T=10, T=20, T=30
-					require.NoError(t, buf.Append(promql.FPoint{T: 1, F: 10}))
-					require.NoError(t, buf.Append(promql.FPoint{T: 10, F: 100}))
-					require.NoError(t, buf.Append(promql.FPoint{T: 20, F: 200}))
-					require.NoError(t, buf.Append(promql.FPoint{T: 30, F: 300}))
+					mustAppend(t, buf, promql.FPoint{T: 1, F: 10})
+					mustAppend(t, buf, promql.FPoint{T: 10, F: 100})
+					mustAppend(t, buf, promql.FPoint{T: 20, F: 200})
+					mustAppend(t, buf, promql.FPoint{T: 30, F: 300})
 
 					// Step 2: Discard first point (T=1)
 					buf.DiscardPointsAtOrBefore(1)
 
 					// Step 3: Add T=40, which wraps to position 0 (overwrites discarded T=1)
-					require.NoError(t, buf.Append(promql.FPoint{T: 40, F: 400}))
+					mustAppend(t, buf, promql.FPoint{T: 40, F: 400})
 
 					// Verify wraparound occurred
 					view := buf.ViewUntilSearchingBackwards(40, nil)
@@ -691,7 +694,7 @@ func TestRingBufferView_SubView(t *testing.T) {
 				wraparound: false,
 				setupBuffer: func(t *testing.T) *HPointRingBufferView {
 					memoryTracker := limiter.NewUnlimitedMemoryConsumptionTracker(context.Background())
-					buf := NewHPointRingBuffer(memoryTracker)
+					buf := &hPointRingBufferWrapper{NewHPointRingBuffer(memoryTracker)}
 					points := []promql.HPoint{
 						{T: 10, H: &histogram.FloatHistogram{Count: 100}},
 						{T: 20, H: &histogram.FloatHistogram{Count: 200}},
@@ -699,7 +702,7 @@ func TestRingBufferView_SubView(t *testing.T) {
 						{T: 40, H: &histogram.FloatHistogram{Count: 400}},
 					}
 					for _, p := range points {
-						require.NoError(t, buf.Append(p))
+						mustAppend(t, buf, p)
 					}
 					return buf.ViewUntilSearchingBackwards(40, nil)
 				},
@@ -709,16 +712,15 @@ func TestRingBufferView_SubView(t *testing.T) {
 				wraparound: true,
 				setupBuffer: func(t *testing.T) *HPointRingBufferView {
 					memoryTracker := limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, "")
-					buf := NewHPointRingBuffer(memoryTracker)
+					buf := &hPointRingBufferWrapper{NewHPointRingBuffer(memoryTracker)}
 
-					require.NoError(t, buf.Append(promql.HPoint{T: 1, H: &histogram.FloatHistogram{Count: 10}}))
-					require.NoError(t, buf.Append(promql.HPoint{T: 10, H: &histogram.FloatHistogram{Count: 100}}))
-					require.NoError(t, buf.Append(promql.HPoint{T: 20, H: &histogram.FloatHistogram{Count: 200}}))
-					require.NoError(t, buf.Append(promql.HPoint{T: 30, H: &histogram.FloatHistogram{Count: 300}}))
-
+					mustAppend(t, buf, promql.HPoint{T: 1, H: &histogram.FloatHistogram{Count: 10}})
+					mustAppend(t, buf, promql.HPoint{T: 10, H: &histogram.FloatHistogram{Count: 100}})
+					mustAppend(t, buf, promql.HPoint{T: 20, H: &histogram.FloatHistogram{Count: 200}})
+					mustAppend(t, buf, promql.HPoint{T: 30, H: &histogram.FloatHistogram{Count: 300}})
 					buf.DiscardPointsAtOrBefore(1)
 
-					require.NoError(t, buf.Append(promql.HPoint{T: 40, H: &histogram.FloatHistogram{Count: 400}}))
+					mustAppend(t, buf, promql.HPoint{T: 40, H: &histogram.FloatHistogram{Count: 400}})
 
 					view := buf.ViewUntilSearchingBackwards(40, nil)
 					head, tail := view.UnsafePoints()
@@ -833,12 +835,11 @@ func TestRingBufferView_SubView(t *testing.T) {
 
 func TestRingBufferView_SubView_ConsecutiveRanges(t *testing.T) {
 	t.Run("FPoint ring buffer", func(t *testing.T) {
-		buffer := NewFPointRingBuffer(limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, ""))
+		buffer := &fPointRingBufferWrapper{NewFPointRingBuffer(limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, ""))}
 
 		// Add points at T=10, 20, 30, 40, 50, 60, 70, 80, 90, 100
 		for i := int64(1); i <= 10; i++ {
-			err := buffer.Append(promql.FPoint{T: i * 10, F: float64(i)})
-			require.NoError(t, err)
+			mustAppend(t, buffer, promql.FPoint{T: i * 10, F: float64(i)})
 		}
 
 		fullView := buffer.ViewUntilSearchingForwards(101, nil)
@@ -868,12 +869,11 @@ func TestRingBufferView_SubView_ConsecutiveRanges(t *testing.T) {
 	})
 
 	t.Run("HPoint ring buffer", func(t *testing.T) {
-		buffer := NewHPointRingBuffer(limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, ""))
+		buffer := &hPointRingBufferWrapper{NewHPointRingBuffer(limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, ""))}
 
 		// Add points at T=10, 20, 30, 40, 50, 60, 70, 80, 90, 100
 		for i := int64(1); i <= 10; i++ {
-			err := buffer.Append(promql.HPoint{T: i * 10, H: &histogram.FloatHistogram{Count: float64(i)}})
-			require.NoError(t, err)
+			mustAppend(t, buffer, promql.HPoint{T: i * 10, H: &histogram.FloatHistogram{Count: float64(i)}})
 		}
 
 		fullView := buffer.ViewUntilSearchingForwards(101, nil)
@@ -913,10 +913,10 @@ func TestRingBufferView_SubView_OnSubView(t *testing.T) {
 				name: "without wraparound",
 				setupBuffer: func(t *testing.T) *FPointRingBufferView {
 					memoryTracker := limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, "")
-					buf := NewFPointRingBuffer(memoryTracker)
+					buf := &fPointRingBufferWrapper{NewFPointRingBuffer(memoryTracker)}
 					// Add points T=10, 20, 30, 40, 50, 60, 70, 80, 90, 100
 					for i := int64(1); i <= 10; i++ {
-						require.NoError(t, buf.Append(promql.FPoint{T: i * 10, F: float64(i * 100)}))
+						mustAppend(t, buf, promql.FPoint{T: i * 10, F: float64(i * 100)})
 					}
 					return buf.ViewUntilSearchingForwards(100, nil)
 				},
@@ -925,18 +925,19 @@ func TestRingBufferView_SubView_OnSubView(t *testing.T) {
 				name: "with wraparound",
 				setupBuffer: func(t *testing.T) *FPointRingBufferView {
 					memoryTracker := limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, "")
-					buf := NewFPointRingBuffer(memoryTracker)
+					buf := &fPointRingBufferWrapper{NewFPointRingBuffer(memoryTracker)}
 					// Add initial points to fill capacity
-					require.NoError(t, buf.Append(promql.FPoint{T: 1, F: 10}))
-					require.NoError(t, buf.Append(promql.FPoint{T: 2, F: 10}))
-					require.NoError(t, buf.Append(promql.FPoint{T: 10, F: 100}))
-					require.NoError(t, buf.Append(promql.FPoint{T: 20, F: 200}))
-					require.NoError(t, buf.Append(promql.FPoint{T: 30, F: 300}))
+					mustAppend(t, buf, promql.FPoint{T: 1, F: 10})
+					mustAppend(t, buf, promql.FPoint{T: 2, F: 10})
+					mustAppend(t, buf, promql.FPoint{T: 10, F: 100})
+					mustAppend(t, buf, promql.FPoint{T: 20, F: 200})
+					mustAppend(t, buf, promql.FPoint{T: 30, F: 300})
+
 					// Discard T=1 to make room
 					buf.DiscardPointsAtOrBefore(2)
 					// Add remaining points to cause wraparound
 					for i := int64(4); i <= 10; i++ {
-						require.NoError(t, buf.Append(promql.FPoint{T: i * 10, F: float64(i * 100)}))
+						mustAppend(t, buf, promql.FPoint{T: i * 10, F: float64(i * 100)})
 					}
 					// Now buffer has [T=10,20,30,40,50,60,70,80,90,100] with wraparound
 					return buf.ViewUntilSearchingForwards(100, nil)
@@ -982,10 +983,10 @@ func TestRingBufferView_SubView_OnSubView(t *testing.T) {
 				name: "without wraparound",
 				setupBuffer: func(t *testing.T) *HPointRingBufferView {
 					memoryTracker := limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, "")
-					buf := NewHPointRingBuffer(memoryTracker)
+					buf := &hPointRingBufferWrapper{NewHPointRingBuffer(memoryTracker)}
 					// Add points T=10, 20, 30, 40, 50, 60, 70, 80, 90, 100
 					for i := int64(1); i <= 10; i++ {
-						require.NoError(t, buf.Append(promql.HPoint{T: i * 10, H: &histogram.FloatHistogram{Count: float64(i * 100)}}))
+						mustAppend(t, buf, promql.HPoint{T: i * 10, H: &histogram.FloatHistogram{Count: float64(i * 100)}})
 					}
 					return buf.ViewUntilSearchingForwards(100, nil)
 				},
@@ -994,18 +995,19 @@ func TestRingBufferView_SubView_OnSubView(t *testing.T) {
 				name: "with wraparound",
 				setupBuffer: func(t *testing.T) *HPointRingBufferView {
 					memoryTracker := limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, "")
-					buf := NewHPointRingBuffer(memoryTracker)
+					buf := &hPointRingBufferWrapper{NewHPointRingBuffer(memoryTracker)}
 					// Add initial points to fill capacity
-					require.NoError(t, buf.Append(promql.HPoint{T: 1, H: &histogram.FloatHistogram{Count: 10}}))
-					require.NoError(t, buf.Append(promql.HPoint{T: 2, H: &histogram.FloatHistogram{Count: 10}}))
-					require.NoError(t, buf.Append(promql.HPoint{T: 10, H: &histogram.FloatHistogram{Count: 100}}))
-					require.NoError(t, buf.Append(promql.HPoint{T: 20, H: &histogram.FloatHistogram{Count: 200}}))
-					require.NoError(t, buf.Append(promql.HPoint{T: 30, H: &histogram.FloatHistogram{Count: 300}}))
+					mustAppend(t, buf, promql.HPoint{T: 1, H: &histogram.FloatHistogram{Count: 10}})
+					mustAppend(t, buf, promql.HPoint{T: 2, H: &histogram.FloatHistogram{Count: 10}})
+					mustAppend(t, buf, promql.HPoint{T: 10, H: &histogram.FloatHistogram{Count: 100}})
+					mustAppend(t, buf, promql.HPoint{T: 20, H: &histogram.FloatHistogram{Count: 200}})
+					mustAppend(t, buf, promql.HPoint{T: 30, H: &histogram.FloatHistogram{Count: 300}})
+
 					// Discard T=1 to make room
 					buf.DiscardPointsAtOrBefore(2)
 					// Add remaining points to cause wraparound
 					for i := int64(4); i <= 10; i++ {
-						require.NoError(t, buf.Append(promql.HPoint{T: i * 10, H: &histogram.FloatHistogram{Count: float64(i * 100)}}))
+						mustAppend(t, buf, promql.HPoint{T: i * 10, H: &histogram.FloatHistogram{Count: float64(i * 100)}})
 					}
 					// Now buffer has [T=10,20,30,40,50,60,70,80,90,100] with wraparound
 					return buf.ViewUntilSearchingForwards(100, nil)
@@ -1046,11 +1048,11 @@ func TestRingBufferView_SubView_OnSubView(t *testing.T) {
 func TestRingBufferView_ReuseWithNonZeroOffset(t *testing.T) {
 	t.Run("FPoint ViewUntilSearchingForwards resets offset", func(t *testing.T) {
 		memoryTracker := limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, "")
-		buf := NewFPointRingBuffer(memoryTracker)
+		buf := &fPointRingBufferWrapper{NewFPointRingBuffer(memoryTracker)}
 
 		// Add points T=10, 20, 30, 40, 50
 		for i := int64(1); i <= 5; i++ {
-			require.NoError(t, buf.Append(promql.FPoint{T: i * 10, F: float64(i * 100)}))
+			mustAppend(t, buf, promql.FPoint{T: i * 10, F: float64(i * 100)})
 		}
 
 		fullView := buf.ViewUntilSearchingForwards(50, nil)
@@ -1065,10 +1067,10 @@ func TestRingBufferView_ReuseWithNonZeroOffset(t *testing.T) {
 
 	t.Run("FPoint ViewUntilSearchingBackwards resets offset", func(t *testing.T) {
 		memoryTracker := limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, "")
-		buf := NewFPointRingBuffer(memoryTracker)
+		buf := &fPointRingBufferWrapper{NewFPointRingBuffer(memoryTracker)}
 
 		for i := int64(1); i <= 5; i++ {
-			require.NoError(t, buf.Append(promql.FPoint{T: i * 10, F: float64(i * 100)}))
+			mustAppend(t, buf, promql.FPoint{T: i * 10, F: float64(i * 100)})
 		}
 
 		fullView := buf.ViewUntilSearchingBackwards(50, nil)
@@ -1082,10 +1084,10 @@ func TestRingBufferView_ReuseWithNonZeroOffset(t *testing.T) {
 
 	t.Run("FPoint ViewAll resets offset", func(t *testing.T) {
 		memoryTracker := limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, "")
-		buf := NewFPointRingBuffer(memoryTracker)
+		buf := &fPointRingBufferWrapper{NewFPointRingBuffer(memoryTracker)}
 
 		for i := int64(1); i <= 5; i++ {
-			require.NoError(t, buf.Append(promql.FPoint{T: i * 10, F: float64(i * 100)}))
+			mustAppend(t, buf, promql.FPoint{T: i * 10, F: float64(i * 100)})
 		}
 
 		fullView := buf.ViewAll(nil)
@@ -1099,10 +1101,10 @@ func TestRingBufferView_ReuseWithNonZeroOffset(t *testing.T) {
 
 	t.Run("HPoint ViewUntilSearchingForwards resets offset", func(t *testing.T) {
 		memoryTracker := limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, "")
-		buf := NewHPointRingBuffer(memoryTracker)
+		buf := &hPointRingBufferWrapper{NewHPointRingBuffer(memoryTracker)}
 
 		for i := int64(1); i <= 5; i++ {
-			require.NoError(t, buf.Append(promql.HPoint{T: i * 10, H: &histogram.FloatHistogram{Count: float64(i * 100)}}))
+			mustAppend(t, buf, promql.HPoint{T: i * 10, H: &histogram.FloatHistogram{Count: float64(i * 100)}})
 		}
 
 		fullView := buf.ViewUntilSearchingForwards(50, nil)
@@ -1117,10 +1119,10 @@ func TestRingBufferView_ReuseWithNonZeroOffset(t *testing.T) {
 
 	t.Run("HPoint ViewUntilSearchingBackwards resets offset", func(t *testing.T) {
 		memoryTracker := limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, "")
-		buf := NewHPointRingBuffer(memoryTracker)
+		buf := &hPointRingBufferWrapper{NewHPointRingBuffer(memoryTracker)}
 
 		for i := int64(1); i <= 5; i++ {
-			require.NoError(t, buf.Append(promql.HPoint{T: i * 10, H: &histogram.FloatHistogram{Count: float64(i * 100)}}))
+			mustAppend(t, buf, promql.HPoint{T: i * 10, H: &histogram.FloatHistogram{Count: float64(i * 100)}})
 		}
 
 		fullView := buf.ViewUntilSearchingBackwards(50, nil)
@@ -1368,7 +1370,7 @@ func TestFPointRingBuffer_AppendSlice(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			buff := NewFPointRingBuffer(limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, ""))
 			require.NoError(t, buff.Use(tc.buff))
-			err := buff.AppendSlice(tc.append)
+			_, err := buff.AppendSlice(tc.append)
 			require.NoError(t, err)
 			shouldHavePoints(t, &fPointRingBufferWrapper{FPointRingBuffer: buff}, tc.expected...)
 		})
@@ -1376,35 +1378,43 @@ func TestFPointRingBuffer_AppendSlice(t *testing.T) {
 }
 
 func TestFPointRingBuffer_AppendAtStart(t *testing.T) {
-	buff := NewFPointRingBuffer(limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, ""))
-	require.NoError(t, buff.Append(promql.FPoint{T: 10, F: 20}))
+	buff := &fPointRingBufferWrapper{NewFPointRingBuffer(limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, ""))}
+	mustAppend(t, buff, promql.FPoint{T: 10, F: 20})
 	require.Equal(t, 1, buff.size)
 	require.Equal(t, 0, buff.firstIndex)
 	require.Len(t, buff.points, 2)
 
 	// inserting another point will not grow the underlying buffer, so the new point is stored in the upper end of the existing 2 slot buffer
-	require.NoError(t, buff.AppendAtStart(promql.FPoint{T: 9, F: 20}))
+	resized, err := buff.AppendAtStart(promql.FPoint{T: 9, F: 20})
+	require.NoError(t, err)
+	require.False(t, resized, "expected AppendAtStart() not to trigger a buffer resize")
 	require.Equal(t, 2, buff.size)
 	require.Equal(t, 1, buff.firstIndex)
 	require.Len(t, buff.points, 2)
 	require.Equal(t, promql.FPoint{T: 9, F: 20}, buff.PointAt(0))
 
 	// inserting another point will grow the underlying buffer - since we are growing the buffer we can re-align so that the firstIndex is 0 for the new head
-	require.NoError(t, buff.AppendAtStart(promql.FPoint{T: 8, F: 20}))
+	resized, err = buff.AppendAtStart(promql.FPoint{T: 8, F: 20})
+	require.NoError(t, err)
+	require.True(t, resized, "expected AppendAtStart() to trigger a buffer resize")
 	require.Equal(t, 3, buff.size)
 	require.Equal(t, 0, buff.firstIndex)
 	require.Len(t, buff.points, 4)
 	require.Equal(t, promql.FPoint{T: 8, F: 20}, buff.PointAt(0))
 
 	// inserting another point will not grow the underlying buffer, so the new point is stored at the end of the existing buffer
-	require.NoError(t, buff.AppendAtStart(promql.FPoint{T: 7, F: 20}))
+	resized, err = buff.AppendAtStart(promql.FPoint{T: 7, F: 20})
+	require.NoError(t, err)
+	require.False(t, resized, "expected AppendAtStart() not to trigger a buffer resize")
 	require.Equal(t, 4, buff.size)
 	require.Equal(t, 3, buff.firstIndex)
 	require.Len(t, buff.points, 4)
 	require.Equal(t, promql.FPoint{T: 7, F: 20}, buff.PointAt(0))
 
 	// inserting another point will grow the underlying buffer - since we are growing the buffer we can re-align so that the firstIndex is 0 for the new head
-	require.NoError(t, buff.AppendAtStart(promql.FPoint{T: 6, F: 20}))
+	resized, err = buff.AppendAtStart(promql.FPoint{T: 6, F: 20})
+	require.NoError(t, err)
+	require.True(t, resized, "expected AppendAtStart() to trigger a buffer resize")
 	require.Equal(t, 5, buff.size)
 	require.Equal(t, 0, buff.firstIndex)
 	require.Len(t, buff.points, 8)
@@ -1414,15 +1424,19 @@ func TestFPointRingBuffer_AppendAtStart(t *testing.T) {
 func TestFPointRingBuffer_AppendSlice_Alignment(t *testing.T) {
 	buff := NewFPointRingBuffer(limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, ""))
 	// insert 2 samples - the first point will be at the tail of the ring
-	require.NoError(t, buff.AppendAtStart(promql.FPoint{T: 10, F: 20}))
-	require.NoError(t, buff.AppendAtStart(promql.FPoint{T: 5, F: 20}))
+	_, err := buff.AppendAtStart(promql.FPoint{T: 10, F: 20})
+	require.NoError(t, err)
+	_, err = buff.AppendAtStart(promql.FPoint{T: 5, F: 20})
+	require.NoError(t, err)
 
 	require.Equal(t, 2, buff.size)
 	require.Equal(t, 1, buff.firstIndex)
 	require.Len(t, buff.points, 2)
 
 	// append a slice and validate that the buffer has been re-aligned to start at firstIndex=0
-	require.NoError(t, buff.AppendSlice([]promql.FPoint{{T: 20, F: 20}, {T: 30, F: 20}, {T: 40, F: 20}}))
+	resized, err := buff.AppendSlice([]promql.FPoint{{T: 20, F: 20}, {T: 30, F: 20}, {T: 40, F: 20}})
+	require.NoError(t, err)
+	require.True(t, resized, "expected AppendSlice() to trigger a buffer resize")
 	shouldHavePoints(t, &fPointRingBufferWrapper{FPointRingBuffer: buff}, []promql.FPoint{{T: 5, F: 20}, {T: 10, F: 20}, {T: 20, F: 20}, {T: 30, F: 20}, {T: 40, F: 20}}...)
 
 	require.Equal(t, 0, buff.firstIndex)
@@ -1431,17 +1445,18 @@ func TestFPointRingBuffer_AppendSlice_Alignment(t *testing.T) {
 
 // TestSizeLessThanFirstIndex creates a scenario where the buffer size is 1, the underlying point slice is 4 and the firstIndex is 3
 func TestFPointRingBuffer_AppendSlice_SizeLessThanFirstIndex(t *testing.T) {
-	buff := NewFPointRingBuffer(limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, ""))
-	require.NoError(t, buff.Append(promql.FPoint{T: 10}))
-	require.NoError(t, buff.Append(promql.FPoint{T: 20}))
-	require.NoError(t, buff.Append(promql.FPoint{T: 30}))
-	require.NoError(t, buff.Append(promql.FPoint{T: 40}))
+	buff := &fPointRingBufferWrapper{NewFPointRingBuffer(limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, ""))}
+	mustAppend(t, buff, promql.FPoint{T: 10})
+	mustAppend(t, buff, promql.FPoint{T: 20})
+	mustAppend(t, buff, promql.FPoint{T: 30})
+	mustAppend(t, buff, promql.FPoint{T: 40})
 	require.Equal(t, 4, buff.size)
 	require.Len(t, buff.points, 4)
 	require.Equal(t, 0, buff.firstIndex)
 
 	buff.RemoveLast()
-	require.NoError(t, buff.AppendAtStart(promql.FPoint{T: 5}))
+	_, err := buff.AppendAtStart(promql.FPoint{T: 5})
+	require.NoError(t, err)
 	require.Equal(t, 4, buff.size)
 	require.Len(t, buff.points, 4)
 	require.Equal(t, 3, buff.firstIndex)
@@ -1453,20 +1468,21 @@ func TestFPointRingBuffer_AppendSlice_SizeLessThanFirstIndex(t *testing.T) {
 	require.Len(t, buff.points, 4)
 	require.Equal(t, 3, buff.firstIndex)
 
-	require.NoError(t, buff.AppendSlice([]promql.FPoint{{T: 50}, {T: 60}, {T: 70}, {T: 80}}))
+	_, err = buff.AppendSlice([]promql.FPoint{{T: 50}, {T: 60}, {T: 70}, {T: 80}})
+	require.NoError(t, err)
 }
 
 func TestFPointRingBuffer_CountUntil(t *testing.T) {
-	buff := NewFPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))
+	buff := &fPointRingBufferWrapper{NewFPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))}
 
 	// Should work with empty buffer.
 	require.Zero(t, buff.CountUntil(0))
 	require.Zero(t, buff.CountUntil(100))
 
-	require.NoError(t, buff.Append(promql.FPoint{T: 10}))
-	require.NoError(t, buff.Append(promql.FPoint{T: 20}))
-	require.NoError(t, buff.Append(promql.FPoint{T: 30}))
-	require.NoError(t, buff.Append(promql.FPoint{T: 40}))
+	mustAppend(t, buff, promql.FPoint{T: 10})
+	mustAppend(t, buff, promql.FPoint{T: 20})
+	mustAppend(t, buff, promql.FPoint{T: 30})
+	mustAppend(t, buff, promql.FPoint{T: 40})
 
 	require.Equal(t, 0, buff.CountUntil(0))
 	require.Equal(t, 0, buff.CountUntil(5))
@@ -1481,16 +1497,16 @@ func TestFPointRingBuffer_CountUntil(t *testing.T) {
 }
 
 func TestFPointRingBuffer_CountBetween(t *testing.T) {
-	buff := NewFPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))
+	buff := &fPointRingBufferWrapper{NewFPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))}
 
 	// Should work with empty buffer.
 	require.Zero(t, buff.CountBetween(0, 0))
 	require.Zero(t, buff.CountBetween(0, 100))
 
-	require.NoError(t, buff.Append(promql.FPoint{T: 10}))
-	require.NoError(t, buff.Append(promql.FPoint{T: 20}))
-	require.NoError(t, buff.Append(promql.FPoint{T: 30}))
-	require.NoError(t, buff.Append(promql.FPoint{T: 40}))
+	mustAppend(t, buff, promql.FPoint{T: 10})
+	mustAppend(t, buff, promql.FPoint{T: 20})
+	mustAppend(t, buff, promql.FPoint{T: 30})
+	mustAppend(t, buff, promql.FPoint{T: 40})
 
 	require.Equal(t, 0, buff.CountBetween(0, 0))
 	require.Equal(t, 4, buff.CountBetween(0, 100))
@@ -1506,17 +1522,17 @@ func TestFPointRingBuffer_CountBetween(t *testing.T) {
 }
 
 func TestHPointRingBuffer_EquivalentFloatSampleCountUntil(t *testing.T) {
-	buff := NewHPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))
+	buff := &hPointRingBufferWrapper{NewHPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))}
 
 	// Should work with empty buffer.
 	require.Zero(t, buff.EquivalentFloatSampleCountUntil(0))
 	require.Zero(t, buff.EquivalentFloatSampleCountUntil(100))
 
 	h := &histogram.FloatHistogram{}
-	require.NoError(t, buff.Append(promql.HPoint{T: 10, H: h}))
-	require.NoError(t, buff.Append(promql.HPoint{T: 20, H: h}))
-	require.NoError(t, buff.Append(promql.HPoint{T: 30, H: h}))
-	require.NoError(t, buff.Append(promql.HPoint{T: 40, H: h}))
+	mustAppend(t, buff, promql.HPoint{T: 10, H: h})
+	mustAppend(t, buff, promql.HPoint{T: 20, H: h})
+	mustAppend(t, buff, promql.HPoint{T: 30, H: h})
+	mustAppend(t, buff, promql.HPoint{T: 40, H: h})
 
 	equivalentSampleCount := EquivalentFloatSampleCount(h)
 
@@ -1533,17 +1549,17 @@ func TestHPointRingBuffer_EquivalentFloatSampleCountUntil(t *testing.T) {
 }
 
 func TestHPointRingBuffer_EquivalentFloatSampleCountBetween(t *testing.T) {
-	buff := NewHPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))
+	buff := &hPointRingBufferWrapper{NewHPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))}
 
 	// Should work with empty buffer.
 	require.Zero(t, buff.EquivalentFloatSampleCountBetween(0, 0))
 	require.Zero(t, buff.EquivalentFloatSampleCountBetween(0, 100))
 
 	h := &histogram.FloatHistogram{}
-	require.NoError(t, buff.Append(promql.HPoint{T: 10, H: h}))
-	require.NoError(t, buff.Append(promql.HPoint{T: 20, H: h}))
-	require.NoError(t, buff.Append(promql.HPoint{T: 30, H: h}))
-	require.NoError(t, buff.Append(promql.HPoint{T: 40, H: h}))
+	mustAppend(t, buff, promql.HPoint{T: 10, H: h})
+	mustAppend(t, buff, promql.HPoint{T: 20, H: h})
+	mustAppend(t, buff, promql.HPoint{T: 30, H: h})
+	mustAppend(t, buff, promql.HPoint{T: 40, H: h})
 
 	equivalentSampleCount := EquivalentFloatSampleCount(h)
 

--- a/pkg/streamingpromql/types/stats_test.go
+++ b/pkg/streamingpromql/types/stats_test.go
@@ -68,13 +68,15 @@ func TestOperatorEvaluationStats_TrackSamplesForRangeVectorSelector(t *testing.T
 	}{
 		"floats": {
 			append: func(ts int64, floats *FPointRingBuffer, histograms *HPointRingBuffer) error {
-				return floats.Append(promql.FPoint{T: ts})
+				_, err := floats.Append(promql.FPoint{T: ts})
+				return err
 			},
 			samplesPerPoint: 1,
 		},
 		"histograms": {
 			append: func(ts int64, floatsf *FPointRingBuffer, histograms *HPointRingBuffer) error {
-				return histograms.Append(promql.HPoint{T: ts, H: &histogram.FloatHistogram{}})
+				_, err := histograms.Append(promql.HPoint{T: ts, H: &histogram.FloatHistogram{}})
+				return err
 			},
 			samplesPerPoint: EquivalentFloatSampleCount(&histogram.FloatHistogram{}),
 		},
@@ -184,9 +186,12 @@ func TestOperatorEvaluationStats_TrackSamplesForRangeVectorSelector_FloatsAndHis
 	histograms := NewHPointRingBuffer(memoryConsumptionTracker)
 
 	h := &histogram.FloatHistogram{}
-	require.NoError(t, floats.Append(promql.FPoint{T: timestamp.FromTime(start.Add(-3 * time.Second))}))
-	require.NoError(t, histograms.Append(promql.HPoint{T: timestamp.FromTime(start.Add(-2 * time.Second)), H: h}))
-	require.NoError(t, floats.Append(promql.FPoint{T: timestamp.FromTime(start.Add(-time.Second))}))
+	_, err = floats.Append(promql.FPoint{T: timestamp.FromTime(start.Add(-3 * time.Second))})
+	require.NoError(t, err)
+	_, err = histograms.Append(promql.HPoint{T: timestamp.FromTime(start.Add(-2 * time.Second)), H: h})
+	require.NoError(t, err)
+	_, err = floats.Append(promql.FPoint{T: timestamp.FromTime(start.Add(-time.Second))})
+	require.NoError(t, err)
 
 	stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start), floats, histograms, timestamp.FromTime(start.Add(-4*time.Second)), timestamp.FromTime(start), false, nil)
 	samplesProcessedPerStep.requireChange(t, stats.allSeries.samplesProcessedPerStep, 2+EquivalentFloatSampleCount(h), 0, 0)
@@ -220,8 +225,10 @@ func TestOperatorEvaluationStats_TrackSamplesForRangeVectorSelector_FixedTimesta
 	floats := NewFPointRingBuffer(memoryConsumptionTracker)
 	histograms := NewHPointRingBuffer(memoryConsumptionTracker)
 
-	require.NoError(t, floats.Append(promql.FPoint{T: timestamp.FromTime(start.Add(-2 * time.Second))}))
-	require.NoError(t, floats.Append(promql.FPoint{T: timestamp.FromTime(start.Add(-time.Second))}))
+	_, err = floats.Append(promql.FPoint{T: timestamp.FromTime(start.Add(-2 * time.Second))})
+	require.NoError(t, err)
+	_, err = floats.Append(promql.FPoint{T: timestamp.FromTime(start.Add(-time.Second))})
+	require.NoError(t, err)
 
 	haveTimestamp := true
 	stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start), floats, histograms, timestamp.FromTime(start.Add(-4*time.Second)), timestamp.FromTime(start), haveTimestamp, nil)
@@ -324,10 +331,14 @@ func TestOperatorEvaluationStats_Subsets_TrackSamplesForRangeVectorSelector(t *t
 
 	floats := NewFPointRingBuffer(memoryConsumptionTracker)
 	histograms := NewHPointRingBuffer(memoryConsumptionTracker)
-	require.NoError(t, floats.Append(promql.FPoint{T: timestamp.FromTime(start.Add(-3 * time.Second))}))
-	require.NoError(t, floats.Append(promql.FPoint{T: timestamp.FromTime(start.Add(-2 * time.Second))}))
-	require.NoError(t, floats.Append(promql.FPoint{T: timestamp.FromTime(start.Add(-time.Second))}))
-	require.NoError(t, floats.Append(promql.FPoint{T: timestamp.FromTime(start)}))
+	_, err = floats.Append(promql.FPoint{T: timestamp.FromTime(start.Add(-3 * time.Second))})
+	require.NoError(t, err)
+	_, err = floats.Append(promql.FPoint{T: timestamp.FromTime(start.Add(-2 * time.Second))})
+	require.NoError(t, err)
+	_, err = floats.Append(promql.FPoint{T: timestamp.FromTime(start.Add(-time.Second))})
+	require.NoError(t, err)
+	_, err = floats.Append(promql.FPoint{T: timestamp.FromTime(start)})
+	require.NoError(t, err)
 
 	overallProcessed := newPerStepTracker("overall samples processed", timeRange.StepCount)
 	overallReadIfSubsequentStep := newPerStepTracker("overall samples read if subsequent step", timeRange.StepCount)


### PR DESCRIPTION
#### What this PR does

Return an indication if the underlying point buffer was resized when appending to the buffer. This is useful for determining when any views based on the buffer become invalid.

#### Which issue(s) this PR fixes or relates to

Required for #15412

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> API signature changes are localized to MQE ring buffers and callers; behavior is unchanged aside from the new return value, with tests covering resize semantics.
> 
> **Overview**
> MQE float and histogram **ring buffers** now report whether the backing storage grew on insert: `Append`, `AppendAtStart`, `AppendSlice`, `resizeIfRequired`, and `HPointRingBuffer.NextPoint` return `(bool, error)` (or `(point, bool, error)` for `NextPoint`). Call sites in range-vector selectors, extended-range undo logic, test operators, and stats tests ignore the flag with `_` for now.
> 
> **Tests** were updated to use shared `mustAppend` helpers and to assert resize vs no-resize on growth paths (including `AppendAtStart` / `AppendSlice` alignment cases).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa54dd30528b4b806bf2590ff7e8d5e476cb4e8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->