### PR TITLE
build-image: Pass `--ignore-scripts` to npm install call.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr15423-69b540b902@sha256:bc16c2a44533279227d105e2cd75b4849b1b3767dd2685a1b6781f37b9788b0f
+LATEST_BUILD_IMAGE_TAG ?= pr15457-cfd05df713@sha256:598a70a7446ff123ab6a79930406fcbcc8d530895a1422f41c62d514a30b4b2f
 
 # TTY is parameterized to allow CI and scripts to run builds,
 # as it currently disallows TTY devices.

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -42,7 +42,11 @@ RUN apt-get update && \
     && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN npm install -g prettier@2.3.2
+RUN npm install -g \
+    # Avoid arbitrary code execution in build hook scripts. Prettier 2.3.2 doesn't
+    # happen to have any, but future packages could.
+    --ignore-scripts \
+    prettier@2.3.2
 
 # renovate: depName=github.com/mvdan/sh
 ENV SHFMT_VERSION=3.13.1

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -43,8 +43,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN npm install -g \
-    # Avoid arbitrary code execution in build hook scripts. Prettier 2.3.2 doesn't
-    # happen to have any, but future packages could.
+    # Avoid arbitrary code execution in build hook scripts. (Prettier 2.3.2 doesn't happen to have any.)
     --ignore-scripts \
     prettier@2.3.2
 


### PR DESCRIPTION
#### What this PR does

This makes the build image's `npm install` call slightly safer against malicious code execution by ignoring any bundled install-hook scripts that may run with downloaded packages.

see also: https://www.nodejs-security.com/blog/npm-ignore-scripts-best-practices-as-security-mitigation-for-malicious-packages

#### Checklist

- (n/a) Tests updated.
- (n/a) Documentation added.
- (n/a) `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- (n/a) [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time supply-chain hardening only; no runtime Mimir behavior changes.
> 
> **Overview**
> Hardens the **mimir-build-image** by installing global **Prettier** with `npm install --ignore-scripts`, so lifecycle scripts from downloaded packages cannot run during the image build. The **Makefile** default `LATEST_BUILD_IMAGE_TAG` is bumped so `fetch-build-image` and in-container targets pull the rebuilt image that includes this change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57fa652fe716bf1057cbb9561ad84a907706c4e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->