### PR TITLE
Automatically update NPM dependencies in build image with Renovate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr15439-9fd2d383e2@sha256:588940b00ab4b3c41738eb4fab8ccb63fed0f30ed07a22b96dcad13a23d2a1ac
+LATEST_BUILD_IMAGE_TAG ?= pr15463-d1ed6accb7@sha256:658922a91e00e285ae21114ae69d7a3b5fa845cc90e9c07e95e3810f4be350b4
 
 # TTY is parameterized to allow CI and scripts to run builds,
 # as it currently disallows TTY devices.

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -42,10 +42,8 @@ RUN apt-get update && \
     && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN npm install -g \
-    # Avoid arbitrary code execution in build hook scripts. (Prettier 2.3.2 doesn't happen to have any.)
-    --ignore-scripts \
-    prettier@2.3.2
+# Set --ignore-scripts to avoid arbitrary code execution in build hook scripts. (Prettier 2.3.2 doesn't happen to have any.)
+RUN npm install -g --ignore-scripts prettier@2.3.2
 
 # renovate: depName=github.com/mvdan/sh
 ENV SHFMT_VERSION=3.13.1

--- a/renovate.json5
+++ b/renovate.json5
@@ -52,6 +52,18 @@
     },
     {
       customType: 'regex',
+      description: 'Update "npm install" commands in development Dockerfiles',
+      managerFilePatterns: [
+        'mimir-build-image/Dockerfile',
+        'development/**/dev.dockerfile',
+      ],
+      matchStrings: [
+        'npm install.*\\s+(?<depName>[^@]+)@(?<currentValue>[^\\s]+)',
+      ],
+      datasourceTemplate: 'npm',
+    },
+    {
+      customType: 'regex',
       description: 'Update tools in build image installed from Git tags',
       managerFilePatterns: [
         'mimir-build-image/Dockerfile',


### PR DESCRIPTION
#### What this PR does

This PR configures Renovate to automatically update NPM dependencies in the build image.

At the time of writing, this only affects Prettier.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-image tooling and Renovate config only; no runtime Mimir behavior changes.
> 
> **Overview**
> Adds a **Renovate** custom regex manager so global **`npm install …@version`** lines in `mimir-build-image/Dockerfile` and `development/**/dev.dockerfile` get automated npm updates (today that’s **Prettier** in the build image).
> 
> The **Dockerfile** change only puts the existing Prettier install on one line and keeps **`--ignore-scripts`** with a short comment so the new matcher can read `prettier@2.3.2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 939e21e6fdd3488997d4cacd4435687a4007f48f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->