### PR TITLE
Add backport workflow test artifact

### DIFF
--- a/docs/internal/backport-test.md
+++ b/docs/internal/backport-test.md
@@ -1,0 +1,5 @@
+# Backport workflow test artifact
+
+Created to verify the `Backport PR Creator` workflow after grafana/mimir#15385.
+
+Safe to delete — this file has no production purpose.


### PR DESCRIPTION
Test PR for verifying the new backport workflow introduced in #15385. Adds a single doc file under `docs/internal/` with no production purpose. Will be backported to throwaway `test-release-1` and `test-release-2` branches as part of the workflow verification, then cleaned up.