### PR TITLE
ci(backport): restore git user config required by cherry-pick

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -41,6 +41,16 @@ jobs:
           fetch-depth: 2
           persist-credentials: false
 
+      # `git cherry-pick` inside the backport action requires a committer identity to create the
+      # local cherry-pick commit, even though that commit's committer is later overwritten by
+      # GitHub's web-flow key when the commit is published via the createCommitOnBranch API.
+      # The mimir-github-bot identity is what eventually owns the published commit (the App token
+      # above runs the publish), so we set the local cherry-pick committer to match.
+      - name: Configure git user
+        run: |
+          git config --local user.name "mimir-github-bot[bot]"
+          git config --local user.email "199097951+mimir-github-bot[bot]@users.noreply.github.com"
+
       - name: Run backport
         uses: grafana/grafana-github-actions-go/backport@407e4b86a206583e2a27912e364a32959e11760a
         with:


### PR DESCRIPTION
## What

Restores the `Configure git user` step that #15385 dropped from `.github/workflows/backport.yaml`.

## Why

`git cherry-pick` (run locally by the backport action) refuses to create the local commit without a committer identity. The published commit's committer is overwritten by GitHub's web-flow key when it's published via `createCommitOnBranch`, but the local cherry-pick step still needs a name/email to construct the intermediate commit object.

#15385 dropped this step based on PR review feedback (mine — sorry) that claimed it was inert post-grafana/grafana-github-actions-go#187. That was wrong. The failure mode is visible on #15472 — first end-to-end test of the new workflow:

> [The backport to `test-release-1` failed](https://github.com/grafana/mimir/pull/15472#issuecomment-4563020122) with `Committer identity unknown — Please tell me who you are.`

## Identity choice

`mimir-github-bot[bot]` / `199097951+mimir-github-bot[bot]@users.noreply.github.com`, matching the bot identity used elsewhere in Mimir (e.g. `push-mimir-build-image.yml`). The App token in the same job is the one that ultimately publishes the commit via web-flow, so configuring the local cherry-pick committer to the same identity is consistent.

## Test plan

After this lands, I'll re-trigger the backport on #15472 (adding/removing a backport label is enough to fire the `labeled` event) and confirm:

- Workflow completes green.
- A `backport-15472-to-test-release-1` branch is created with the cherry-picked commit signed by web-flow (`verification.verified: true`).
- A backport PR is opened against `test-release-1`.