### PR TITLE
ci(backport): bump grafana/grafana-github-actions-go/backport pin

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -42,7 +42,7 @@ jobs:
           persist-credentials: false
 
       - name: Run backport
-        uses: grafana/grafana-github-actions-go/backport@407e4b86a206583e2a27912e364a32959e11760a
+        uses: grafana/grafana-github-actions-go/backport@73932b01c802dd17e7a6218ba625365a4741d814
         with:
           token: ${{ steps.app-token.outputs.token }}
           # If triggered by being labelled, only backport that label.


### PR DESCRIPTION
## What

Bumps `grafana/grafana-github-actions-go/backport@…` from `407e4b86` to `73932b01` to pick up [grafana/grafana-github-actions-go#201](https://github.com/grafana/grafana-github-actions-go/pull/201).

## Why

#201 sets a default committer identity (`grafanabot` / `bot@grafana.com`) for the local `git cherry-pick` inside the backport action, scoped via `-c` so `.git/config` isn't touched. Without that fix, `git cherry-pick` refuses to create the local commit on runners that don't have a git user pre-configured, and the backport fails with `Committer identity unknown` — which is what bit us during the first end-to-end test of the migrated workflow:

> https://github.com/grafana/mimir/pull/15472#issuecomment-4563020122

The local cherry-pick's committer is overwritten by GitHub's web-flow key when the commit is published via `createCommitOnBranch`, so the configured identity is purely a placeholder.

## Test plan

After this lands, I'll re-trigger the backport workflow on the still-open test PR #15472 by removing and re-adding the `backport test-release-1` label (fires the `labeled` event with the merged-PR gate satisfied), and confirm end-to-end:

- Workflow completes green.
- A `backport-15472-to-test-release-1` branch is created with the cherry-picked commit signed by web-flow (`verification.verified: true`).
- A backport PR is opened against `test-release-1`.

Then repeat with `backport test-release-2` to exercise the second target. Both test branches, labels, and the merged source PR are still in place from the original test plan.