### PR TITLE
test: verify migrated backport workflow (scenario C)

### DIFF
--- a/docs/internal/backport-test-scenario-c.md
+++ b/docs/internal/backport-test-scenario-c.md
@@ -1,0 +1,5 @@
+# Backport workflow test artifact
+
+Source PR for verifying the grafana/grafana-github-actions-go-based
+backport flow (post-#15478, picking up upstream PR #201 which fixes
+"Committer identity unknown"). Safe to delete after the test completes.


### PR DESCRIPTION
## Summary

Throwaway test PR to verify the migrated backport workflow now that:

- #15385 migrated to `grafana/grafana-github-actions-go/backport`.
- #15478 bumped the pin to include grafana/grafana-github-actions-go#201, which sets a default committer identity for the local `git cherry-pick`.

The previous test PR (#15472) ran an older workflow file from its own branch and never picked up the bump.

## Test plan

- [ ] Merge this PR.
- [ ] Confirm a backport PR is opened against `test-release-3` and the commit on it is signed (Verified badge).
- [ ] Delete this PR's artifact and the throwaway branches after the test.