### PR TITLE
chore: remove backport workflow test artifacts

### DIFF
--- a/docs/internal/backport-test-scenario-c.md
+++ b/docs/internal/backport-test-scenario-c.md
@@ -1,5 +1,0 @@
-# Backport workflow test artifact
-
-Source PR for verifying the grafana/grafana-github-actions-go-based
-backport flow (post-#15478, picking up upstream PR #201 which fixes
-"Committer identity unknown"). Safe to delete after the test completes.

--- a/docs/internal/backport-test.md
+++ b/docs/internal/backport-test.md
@@ -1,5 +1,0 @@
-# Backport workflow test artifact
-
-Created to verify the `Backport PR Creator` workflow after grafana/mimir#15385.
-
-Safe to delete — this file has no production purpose.


### PR DESCRIPTION
## Summary

Removes the two test artifacts that landed during the end-to-end verification of the migrated backport workflow:

- `docs/internal/backport-test.md` (from #15472)
- `docs/internal/backport-test-scenario-c.md` (from #15480)

See #15385 for context. Neither file has a production purpose.