### PR TITLE
r391: Expose per-tenant tsdb_head_samples_appended_total

### DIFF
--- a/pkg/storage/tsdb/tsdb_metrics.go
+++ b/pkg/storage/tsdb/tsdb_metrics.go
@@ -54,6 +54,7 @@ type TSDBMetrics struct {
 	tsdbBlocksBytes        *prometheus.Desc
 
 	tsdbOOOAppendedSamples *prometheus.Desc
+	tsdbAppendedSamples    *prometheus.Desc
 
 	checkpointDeleteFail    *prometheus.Desc
 	checkpointDeleteTotal   *prometheus.Desc
@@ -234,6 +235,10 @@ func NewTSDBMetrics(r prometheus.Registerer, logger log.Logger) *TSDBMetrics {
 			"tsdb_out_of_order_samples_appended_total",
 			"Total number of out-of-order samples appended.",
 			[]string{"user"}, nil),
+		tsdbAppendedSamples: prometheus.NewDesc(
+			"tsdb_head_samples_appended_total",
+			"Total number of appended samples.",
+			[]string{"user", "type"}, nil),
 
 		memSeries: prometheus.NewDesc(
 			"memory_series",
@@ -316,6 +321,7 @@ func (sm *TSDBMetrics) Describe(out chan<- *prometheus.Desc) {
 	out <- sm.tsdbExemplarsOutOfOrder
 
 	out <- sm.tsdbOOOAppendedSamples
+	out <- sm.tsdbAppendedSamples
 
 	out <- sm.memSeries
 	out <- sm.memSeriesCreatedTotal
@@ -369,6 +375,7 @@ func (sm *TSDBMetrics) Collect(out chan<- prometheus.Metric) {
 	data.SendSumOfGaugesPerTenant(out, sm.tsdbExemplarLastTs, "prometheus_tsdb_exemplar_last_exemplars_timestamp_seconds")
 	data.SendSumOfCounters(out, sm.tsdbExemplarsOutOfOrder, "prometheus_tsdb_exemplar_out_of_order_exemplars_total")
 	data.SendSumOfCountersPerTenant(out, sm.tsdbOOOAppendedSamples, "prometheus_tsdb_head_out_of_order_samples_appended_total")
+	data.SendSumOfCountersPerTenant(out, sm.tsdbAppendedSamples, "prometheus_tsdb_head_samples_appended_total", dskit_metrics.WithLabels("type"))
 	data.SendSumOfGauges(out, sm.memSeries, "prometheus_tsdb_head_series")
 	data.SendSumOfCountersPerTenant(out, sm.memSeriesCreatedTotal, "prometheus_tsdb_head_series_created_total")
 	data.SendSumOfCountersPerTenant(out, sm.memSeriesRemovedTotal, "prometheus_tsdb_head_series_removed_total")

--- a/pkg/storage/tsdb/tsdb_metrics_test.go
+++ b/pkg/storage/tsdb/tsdb_metrics_test.go
@@ -232,6 +232,15 @@ func TestTSDBMetrics(t *testing.T) {
 			cortex_ingester_tsdb_exemplar_exemplars_appended_total{user="user2"} 100
 			cortex_ingester_tsdb_exemplar_exemplars_appended_total{user="user3"} 100
 
+			# HELP cortex_ingester_tsdb_head_samples_appended_total Total number of appended samples.
+			# TYPE cortex_ingester_tsdb_head_samples_appended_total counter
+			cortex_ingester_tsdb_head_samples_appended_total{type="float", user="user1"} 123450
+			cortex_ingester_tsdb_head_samples_appended_total{type="float", user="user2"} 857870
+			cortex_ingester_tsdb_head_samples_appended_total{type="float", user="user3"} 9990
+			cortex_ingester_tsdb_head_samples_appended_total{type="histogram", user="user1"} 24690
+			cortex_ingester_tsdb_head_samples_appended_total{type="histogram", user="user2"} 171574
+			cortex_ingester_tsdb_head_samples_appended_total{type="histogram", user="user3"} 1998
+
 			# HELP cortex_ingester_tsdb_out_of_order_samples_appended_total Total number of out-of-order samples appended.
 			# TYPE cortex_ingester_tsdb_out_of_order_samples_appended_total counter
 			cortex_ingester_tsdb_out_of_order_samples_appended_total{user="user1"} 3
@@ -469,6 +478,13 @@ func TestTSDBMetricsWithRemoval(t *testing.T) {
 			# HELP cortex_ingester_tsdb_exemplar_exemplars_in_storage Number of TSDB exemplars currently in storage.
 			# TYPE cortex_ingester_tsdb_exemplar_exemplars_in_storage gauge
 			cortex_ingester_tsdb_exemplar_exemplars_in_storage 20
+
+			# HELP cortex_ingester_tsdb_head_samples_appended_total Total number of appended samples.
+			# TYPE cortex_ingester_tsdb_head_samples_appended_total counter
+			cortex_ingester_tsdb_head_samples_appended_total{type="float", user="user1"} 123450
+			cortex_ingester_tsdb_head_samples_appended_total{type="float", user="user2"} 857870
+			cortex_ingester_tsdb_head_samples_appended_total{type="histogram", user="user1"} 24690
+			cortex_ingester_tsdb_head_samples_appended_total{type="histogram", user="user2"} 171574
 
 			# HELP cortex_ingester_tsdb_out_of_order_samples_appended_total Total number of out-of-order samples appended.
 			# TYPE cortex_ingester_tsdb_out_of_order_samples_appended_total counter
@@ -737,6 +753,13 @@ func populateTSDBMetrics(base float64) *prometheus.Registry {
 		Help: "Total number of appended out-of-order samples.",
 	})
 	outOfOrderSamplesAppendedTotal.Add(3)
+
+	samplesAppendedTotal := promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+		Name: "prometheus_tsdb_head_samples_appended_total",
+		Help: "Total number of appended samples.",
+	}, []string{"type"})
+	samplesAppendedTotal.WithLabelValues("float").Add(float64(base * 10))
+	samplesAppendedTotal.WithLabelValues("histogram").Add(float64(base * 2))
 
 	chunksMmappedTotal := promauto.With(r).NewCounter(prometheus.CounterOpts{
 		Name: "prometheus_tsdb_mmap_chunks_total",


### PR DESCRIPTION
## Why

`cortex_ingester_ingested_samples_total` is incremented per `Append()` call, **before** the TSDB commit step. At commit time, TSDB silently drops exact duplicates (same timestamp + same value arriving in separate requests) — `acc.floatsAppended--` in `head_append.go` — with no corresponding `cortex_discarded_samples_total` increment and no per-tenant visibility.

`prometheus_tsdb_head_samples_appended_total` reflects the post-commit truth, but the per-tenant TSDB collector did not re-expose it with a `user` label, leaving a gap: there is no way today to compare "samples Append()-called" vs "samples actually stored" per tenant.

## What

Adds `cortex_ingester_tsdb_head_samples_appended_total{user, type}` to the `TSDBMetrics` collector, following the same pattern as `tsdb_out_of_order_samples_appended_total` (with an extra `type` label to preserve float/histogram breakdown).

## Temporary

This metric is added for investigation purposes. Once the investigation is complete it should be removed to avoid long-term cardinality overhead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metrics-only change with added user×type cardinality; no ingestion or storage logic is modified.
> 
> **Overview**
> Adds **`cortex_ingester_tsdb_head_samples_appended_total{user, type}`** to the per-tenant `TSDBMetrics` collector by re-aggregating Prometheus’s **`prometheus_tsdb_head_samples_appended_total`** (with a **`type`** label for float vs histogram), mirroring the existing out-of-order appended-samples pattern.
> 
> This closes a visibility gap versus **`cortex_ingester_ingested_samples_total`**, which counts samples at `Append()` time while TSDB can drop exact duplicates at commit without a matching discard metric. Tests and **`populateTSDBMetrics`** were updated to assert the new series.
> 
> The PR description marks this as **temporary** for investigation and intended removal afterward to limit ongoing cardinality.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c2ce7c030dedde8a4358f1b9eb239ed6f8e2d57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->