### PR TITLE
ci(backport): bump grafana-github-actions-go pin

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -42,7 +42,7 @@ jobs:
           persist-credentials: false
 
       - name: Run backport
-        uses: grafana/grafana-github-actions-go/backport@73932b01c802dd17e7a6218ba625365a4741d814
+        uses: grafana/grafana-github-actions-go/backport@6782bcaa01680648bdbba76cce1847e1862dbb22
         with:
           token: ${{ steps.app-token.outputs.token }}
           # If triggered by being labelled, only backport that label.


### PR DESCRIPTION
Bumps \`grafana/grafana-github-actions-go/backport\` from \`73932b01…\` to \`6782bcaa…\`. The newer SHA includes the fix landed in [grafana-github-actions-go#208](https://github.com/grafana/grafana-github-actions-go/pull/208), which inlines the \`build-go-binary\` composite back into each action so external consumers don't hit \`Can't find 'action.yml' under '.../build-go-binary'\`. Mimir didn't hit that bug today because the old pin pre-dates the extraction, but bumping keeps us aligned with grafana-github-actions-go main and with the other consumer repos.

No behavioral change for the backport flow itself.