### PR TITLE
ci(backport): pin checkout to default-branch ref

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -38,6 +38,7 @@ jobs:
       - name: Checkout Mimir
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 2
           persist-credentials: false
 


### PR DESCRIPTION
## Problem

The backport workflow [failed](https://github.com/grafana/mimir/actions/runs/26600638351/job/78383094737) end-to-end on #15489 with:

\`\`\`
git fetch --shallow-since=1779989773
fatal: error processing shallow info: 4
exit status 128
\`\`\`

Re-running the failed job reproduced the same error deterministically. Earlier the same day (PR #15480 → \`test-release-3\`, \`test-release-4\`) the same workflow with the same \`fetch-depth: 2\` worked, so the failure isn't 100% systematic — but it is reproducible for the topology of #15489 (merge commit + recent merge-base).

## Theory

The failing step is the action's \`git fetch --shallow-since=<unix-timestamp>\` deepen, which goes back to the commit-merge-base date to make sure cherry-pick has enough history. This step has been buggy in multiple iterations (originally \`--unshallow\`, then \`--shallow-since="<YYYY-MM-DD>"\`, then \`--shallow-since=<UNIX-EPOCH>\` after a [fix for "today's date"](https://github.com/grafana/grafana-github-actions-go/commit/101ad8827a)). Even the current Unix-timestamp variant trips a known-fragile area of git's shallow protocol — there are recent fixes in git 2.54.0 (\`3ef68ff40e\` "shallow: handling fetch relative-deepen") and 2.55.0 (\`2431f5e0e5\` "shallow: fix relative deepen on non-shallow repositories") that touch exactly this code path.

But \`grafana/grafana\` has been running the same backport action on \`fetch-depth: 2\` for ~a year without this failure. The substantive difference between the two checkout configurations is the refspec:

- **Mimir today** (no \`ref:\`, default for pull_request events): \`actions/checkout\` resolves to the merge-commit SHA and runs \`git fetch ... +<merge-commit-SHA>:refs/remotes/origin/main\`. \`origin/main\` is pinned to a specific SHA, not following \`refs/heads/main\`.
- **Grafana** (\`ref: \${{ github.event.repository.default_branch }}\`): \`actions/checkout\` runs \`git fetch ... +refs/heads/main:refs/remotes/origin/main\`. \`origin/main\` tracks the branch ref.

The shallow-info protocol negotiation is known to be sensitive to local ref state; the branch-name refspec appears to be the form that's been hardened over time, and may be what's letting grafana succeed where mimir trips.

## Fix attempt

Add \`ref: \${{ github.event.repository.default_branch }}\` to mimir's backport checkout to match grafana's working configuration. Minimal one-line change, doesn't touch the upstream action, and aligns mimir with the configuration that's been proven in production for ~a year.

I've added the \`backport test-backport-pr-15489\` label to this PR so the action runs end-to-end on merge and we can observe whether the change resolves the failure. The same test target branch (\`test-backport-pr-15489\`) is reused, preserving the topology that triggered the original failure.