### PR TITLE
scheduler/queue: decouple RequestQueue from SchedulerRequest, add schedulerQueue wrapper

### DIFF
--- a/pkg/scheduler/DESIGN.md
+++ b/pkg/scheduler/DESIGN.md
@@ -1,11 +1,10 @@
 # Query Request Queue Design: Queue Splitting and Prioritization
 
-The scheduler's query request queue is provided by the generic `RequestQueue` (in
-`pkg/scheduler/queue`), wrapped by a thin scheduler-specific `schedulerQueue`. The wrapper
-adds scheduler-flavored ergonomics — dimension extraction, per-tenant max-queriers lookup,
-and the `QueryComponentUtilization` tracking sidecar — so scheduler call sites don't have to
-thread those values through; the `RequestQueue` underneath is responsible for all decisions
-regarding enqueuing and dequeuing of query requests.
+The scheduler's query request queue is provided by the generic `RequestQueue` (in `pkg/scheduler/queue`),
+wrapped by a thin scheduler-specific `schedulerQueue`.
+The wrapper adds scheduler-flavored ergonomics — dimension extraction, per-tenant max-queriers lookup, and the `QueryComponentUtilization` tracking sidecar —
+so scheduler call sites don't have to thread those values through;
+the `RequestQueue` underneath is responsible for all decisions regarding enqueuing and dequeuing of query requests.
 
 While the `RequestQueue`'s responsibilities are relatively broad, including management of
 querier-worker connection lifecycles and graceful startup/shutdown,

--- a/pkg/scheduler/DESIGN.md
+++ b/pkg/scheduler/DESIGN.md
@@ -2,9 +2,11 @@
 
 The scheduler's query request queue is provided by the generic `RequestQueue` (in `pkg/scheduler/queue`),
 wrapped by a thin scheduler-specific `schedulerQueue`.
-The wrapper adds scheduler-flavored ergonomics — dimension extraction, per-tenant max-queriers lookup, and the `QueryComponentUtilization` tracking sidecar —
-so scheduler call sites don't have to thread those values through;
-the `RequestQueue` underneath is responsible for all decisions regarding enqueuing and dequeuing of query requests.
+The wrapper applies the scheduler's queue logic:
+it derives the first queue dimension (the query component) from the annotation that the query-frontend attaches to the request,
+looks up the per-tenant max-queriers limit from the configured limits,
+and owns the `QueryComponentUtilization` tracker.
+The `RequestQueue` underneath is responsible for all decisions regarding enqueuing and dequeuing of query requests.
 
 While the `RequestQueue`'s responsibilities are relatively broad, including management of
 querier-worker connection lifecycles and graceful startup/shutdown,

--- a/pkg/scheduler/DESIGN.md
+++ b/pkg/scheduler/DESIGN.md
@@ -1,7 +1,12 @@
 # Query Request Queue Design: Queue Splitting and Prioritization
 
-The `RequestQueue` subservice embedded into the scheduler process is responsible for
-all decisions regarding enqueuing and dequeuing of query requests.
+The scheduler's query request queue is provided by the generic `RequestQueue` (in
+`pkg/scheduler/queue`), wrapped by a thin scheduler-specific `schedulerQueue`. The wrapper
+adds scheduler-flavored ergonomics — dimension extraction, per-tenant max-queriers lookup,
+and the `QueryComponentUtilization` tracking sidecar — so scheduler call sites don't have to
+thread those values through; the `RequestQueue` underneath is responsible for all decisions
+regarding enqueuing and dequeuing of query requests.
+
 While the `RequestQueue`'s responsibilities are relatively broad, including management of
 querier-worker connection lifecycles and graceful startup/shutdown,
 the queuing logic is isolated into a "tree queue" structure and its associated queue algorithms.

--- a/pkg/scheduler/queue/multi_queuing_algorithm_tree_queue_benchmark_test.go
+++ b/pkg/scheduler/queue/multi_queuing_algorithm_tree_queue_benchmark_test.go
@@ -60,7 +60,7 @@ func makeWeightedRandAdditionalQueueDimensionFunc(
 const slowConsumerQueueDimension = storeGatewayQueueDimension
 
 func makeQueueConsumeFuncWithSlowQueryComponent(
-	queue *RequestQueue,
+	qcu *QueryComponentUtilization,
 	slowConsumerLatency time.Duration,
 	normalConsumerLatency time.Duration,
 	report *testScenarioQueueDurationObservations,
@@ -77,14 +77,14 @@ func makeQueueConsumeFuncWithSlowQueryComponent(
 		}
 		report.Observe(schedulerRequest.UserID, queryComponent, time.Since(schedulerRequest.EnqueueTime).Seconds())
 
-		queue.QueryComponentUtilization.MarkRequestSent(schedulerRequest)
+		qcu.MarkRequestSent(schedulerRequest)
 		if queryComponent == slowConsumerQueueDimension {
 			time.Sleep(slowConsumerLatency)
 		} else {
 			time.Sleep(normalConsumerLatency)
 		}
 
-		queue.QueryComponentUtilization.MarkRequestCompleted(schedulerRequest)
+		qcu.MarkRequestCompleted(schedulerRequest)
 		return nil
 	}
 }
@@ -424,6 +424,10 @@ func TestMultiDimensionalQueueAlgorithmSlowConsumerEffects(t *testing.T) {
 					promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
 					promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 					promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
+				)
+				require.NoError(t, err)
+
+				qcu, err := NewQueryComponentUtilization(
 					promauto.With(nil).NewSummaryVec(prometheus.SummaryOpts{}, []string{"query_component"}),
 				)
 				require.NoError(t, err)
@@ -459,7 +463,7 @@ func TestMultiDimensionalQueueAlgorithmSlowConsumerEffects(t *testing.T) {
 				// configure queue consumers with respective latencies for processing requests
 				// which were assigned the "normal" or "slow" query component
 				consumeFunc := makeQueueConsumeFuncWithSlowQueryComponent(
-					queue, slowConsumerLatency, normalConsumerLatency, testCaseObservations,
+					qcu, slowConsumerLatency, normalConsumerLatency, testCaseObservations,
 				)
 				queueConsumerErrGroup, startConsumersChan := makeQueueConsumerGroup(
 					context.Background(), queue, totalRequests, numConsumers, numWorkersPerConsumer, consumeFunc,

--- a/pkg/scheduler/queue/query_component_utilization_test.go
+++ b/pkg/scheduler/queue/query_component_utilization_test.go
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package queue
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/grafana/dskit/httpgrpc"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestQCU(t *testing.T) (*QueryComponentUtilization, *prometheus.Registry) {
+	t.Helper()
+	reg := prometheus.NewRegistry()
+	metric := promauto.With(reg).NewSummaryVec(prometheus.SummaryOpts{
+		Name: "cortex_query_scheduler_querier_inflight_requests_test",
+	}, []string{"query_component"})
+	qcu, err := NewQueryComponentUtilization(metric)
+	require.NoError(t, err)
+	return qcu, reg
+}
+
+func newTestSchedulerRequest(queryID uint64, queryComponent string) *SchedulerRequest {
+	var dims []string
+	if queryComponent != "" {
+		dims = []string{queryComponent}
+	}
+	return &SchedulerRequest{
+		FrontendAddr:              "frontend",
+		QueryID:                   queryID,
+		HttpRequest:               &httpgrpc.HTTPRequest{Method: "GET", Url: "/x"},
+		AdditionalQueueDimensions: dims,
+	}
+}
+
+func TestQueryComponentUtilization_MarkRequestSent_ComponentRouting(t *testing.T) {
+	cases := []struct {
+		name           string
+		queryComponent string
+		wantIngester   int
+		wantStoreGW    int
+	}{
+		{"ingester increments only ingester", ingesterQueueDimension, 1, 0},
+		{"store-gateway increments only store-gateway", storeGatewayQueueDimension, 0, 1},
+		{"ingester-and-store-gateway increments both", ingesterAndStoreGatewayQueueDimension, 1, 1},
+		{"empty (unknown) increments both", "", 1, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			qcu, _ := newTestQCU(t)
+			qcu.MarkRequestSent(newTestSchedulerRequest(1, tc.queryComponent))
+			require.Equal(t, tc.wantIngester, qcu.GetForComponent(Ingester))
+			require.Equal(t, tc.wantStoreGW, qcu.GetForComponent(StoreGateway))
+		})
+	}
+}
+
+func TestQueryComponentUtilization_MarkRequestCompleted_Balanced(t *testing.T) {
+	qcu, _ := newTestQCU(t)
+	req := newTestSchedulerRequest(1, ingesterQueueDimension)
+	qcu.MarkRequestSent(req)
+	require.Equal(t, 1, qcu.GetForComponent(Ingester))
+	qcu.MarkRequestCompleted(req)
+	require.Equal(t, 0, qcu.GetForComponent(Ingester))
+}
+
+func TestQueryComponentUtilization_MarkRequestCompleted_UnknownKeyDoesNotDecrement(t *testing.T) {
+	// MarkRequestCompleted for a request the QCU never saw must not decrement
+	// the counters, otherwise a stale or duplicate completion could drive them
+	// negative.
+	qcu, _ := newTestQCU(t)
+	qcu.MarkRequestSent(newTestSchedulerRequest(1, ingesterQueueDimension))
+	qcu.MarkRequestCompleted(newTestSchedulerRequest(99, ingesterQueueDimension))
+	require.Equal(t, 1, qcu.GetForComponent(Ingester))
+}
+
+func TestQueryComponentUtilization_NilRequestIsNoop(t *testing.T) {
+	qcu, _ := newTestQCU(t)
+	qcu.MarkRequestSent(nil)
+	require.Equal(t, 0, qcu.GetForComponent(Ingester))
+	require.Equal(t, 0, qcu.GetForComponent(StoreGateway))
+
+	qcu.MarkRequestSent(newTestSchedulerRequest(1, ingesterQueueDimension))
+	qcu.MarkRequestCompleted(nil)
+	require.Equal(t, 1, qcu.GetForComponent(Ingester))
+}
+
+func TestQueryComponentUtilization_GetForComponent_UnknownComponentReturnsZero(t *testing.T) {
+	qcu, _ := newTestQCU(t)
+	qcu.MarkRequestSent(newTestSchedulerRequest(1, ingesterAndStoreGatewayQueueDimension))
+	require.Equal(t, 0, qcu.GetForComponent(QueryComponent("not-a-real-component")))
+}
+
+func TestQueryComponentUtilization_BalancedUnderConcurrency(t *testing.T) {
+	qcu, _ := newTestQCU(t)
+	const goroutines = 16
+	const reqsPerGoroutine = 100
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < reqsPerGoroutine; i++ {
+				req := newTestSchedulerRequest(uint64(g*reqsPerGoroutine+i), ingesterAndStoreGatewayQueueDimension)
+				qcu.MarkRequestSent(req)
+				qcu.MarkRequestCompleted(req)
+			}
+		}(g)
+	}
+	wg.Wait()
+	require.Equal(t, 0, qcu.GetForComponent(Ingester))
+	require.Equal(t, 0, qcu.GetForComponent(StoreGateway))
+}
+
+func TestQueryComponentUtilization_ObserveInflightRequests(t *testing.T) {
+	qcu, reg := newTestQCU(t)
+	qcu.MarkRequestSent(newTestSchedulerRequest(1, ingesterQueueDimension))
+	qcu.MarkRequestSent(newTestSchedulerRequest(2, ingesterQueueDimension))
+	qcu.MarkRequestSent(newTestSchedulerRequest(3, storeGatewayQueueDimension))
+
+	qcu.ObserveInflightRequests()
+
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	require.Len(t, families, 1)
+
+	// Expect one Summary observation per component (ingester + store-gateway),
+	// keyed on the query_component label.
+	samplesByComponent := map[string]uint64{}
+	for _, m := range families[0].Metric {
+		for _, l := range m.Label {
+			if l.GetName() == "query_component" {
+				samplesByComponent[l.GetValue()] = m.GetSummary().GetSampleCount()
+			}
+		}
+	}
+	require.Equal(t, map[string]uint64{
+		string(Ingester):     1,
+		string(StoreGateway): 1,
+	}, samplesByComponent)
+
+	// A second observation accumulates onto the same per-component summary.
+	qcu.ObserveInflightRequests()
+	families, err = reg.Gather()
+	require.NoError(t, err)
+	for _, m := range families[0].Metric {
+		require.Equal(t, uint64(2), m.GetSummary().GetSampleCount())
+	}
+}
+
+func TestQueryComponentFlags(t *testing.T) {
+	cases := []struct {
+		name         string
+		input        string
+		wantIngester bool
+		wantStoreGW  bool
+	}{
+		{"ingester", ingesterQueueDimension, true, false},
+		{"store-gateway", storeGatewayQueueDimension, false, true},
+		{"ingester-and-store-gateway falls through to default (both)", ingesterAndStoreGatewayQueueDimension, true, true},
+		{"empty falls through to default (both)", "", true, true},
+		{"unrecognised value falls through to default (both)", "garbage", true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			isIng, isSG := queryComponentFlags(tc.input)
+			require.Equal(t, tc.wantIngester, isIng)
+			require.Equal(t, tc.wantStoreGW, isSG)
+		})
+	}
+}

--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -121,8 +121,6 @@ type RequestQueue struct {
 	stopCompleted chan struct{} // Closed by dispatcherLoop() after a stop is requested and the dispatcher has stopped.
 
 	requestsToEnqueue                     chan requestToEnqueue
-	requestsSent                          chan *SchedulerRequest
-	requestsCompleted                     chan *SchedulerRequest
 	querierWorkerOperations               chan *querierWorkerOperation
 	waitingDequeueRequests                chan *QuerierWorkerDequeueRequest
 	waitingDequeueRequestsToDispatch      *list.List
@@ -205,11 +203,12 @@ func (qwo *querierWorkerOperation) AwaitQuerierWorkerConnUpdate() error {
 }
 
 type requestToEnqueue struct {
-	tenantID    string
-	req         QueryRequest
-	maxQueriers int
-	successFn   func()
-	errChan     chan error
+	tenantID       string
+	queueDimension string
+	req            QueryRequest
+	maxQueriers    int
+	successFn      func()
+	errChan        chan error
 }
 
 func NewRequestQueue(
@@ -243,8 +242,6 @@ func NewRequestQueue(
 		stopCompleted: make(chan struct{}),
 
 		requestsToEnqueue:                     make(chan requestToEnqueue),
-		requestsSent:                          make(chan *SchedulerRequest),
-		requestsCompleted:                     make(chan *SchedulerRequest),
 		querierWorkerOperations:               make(chan *querierWorkerOperation),
 		waitingDequeueRequests:                make(chan *QuerierWorkerDequeueRequest),
 		waitingDequeueRequestsToDispatch:      list.New(),
@@ -389,8 +386,9 @@ func (q *RequestQueue) dispatcherLoop() {
 // If request is enqueued successFn is called before the request can be dispatched to a querier.
 func (q *RequestQueue) enqueueRequestInternal(r requestToEnqueue) error {
 	tr := tenantRequest{
-		tenantID: r.tenantID,
-		req:      r.req,
+		tenantID:       r.tenantID,
+		queueDimension: r.queueDimension,
+		req:            r.req,
 	}
 	err := q.queueBroker.enqueueRequestBack(&tr, r.maxQueriers)
 	if err != nil {
@@ -459,20 +457,24 @@ func (q *RequestQueue) trySendNextRequestForQuerier(dequeueReq *QuerierWorkerDeq
 // If request is successfully enqueued, successFn is called before any querier can receive the request.
 // Returns error if any occurred during enqueuing, or if the RequestQueue service stopped before enqueuing the request.
 //
+// queueDimension is the first-layer queue dimension to file the request under (e.g. a query component name).
+// An empty string is treated as the "unknown" dimension.
+//
 // maxQueriers is tenant-specific value to compute which queriers should handle requests for this tenant.
 // It is passed to SubmitRequestToEnqueue because the value can change between calls.
-func (q *RequestQueue) SubmitRequestToEnqueue(tenantID string, req QueryRequest, maxQueriers int, successFn func()) error {
+func (q *RequestQueue) SubmitRequestToEnqueue(tenantID string, req QueryRequest, queueDimension string, maxQueriers int, successFn func()) error {
 	start := time.Now()
 	defer func() {
 		q.enqueueDuration.Observe(time.Since(start).Seconds())
 	}()
 
 	r := requestToEnqueue{
-		tenantID:    tenantID,
-		req:         req,
-		maxQueriers: maxQueriers,
-		successFn:   successFn,
-		errChan:     make(chan error),
+		tenantID:       tenantID,
+		queueDimension: queueDimension,
+		req:            req,
+		maxQueriers:    maxQueriers,
+		successFn:      successFn,
+		errChan:        make(chan error),
 	}
 
 	select {

--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -126,11 +126,6 @@ type RequestQueue struct {
 	waitingDequeueRequestsToDispatch      *list.List
 	waitingDequeueRequestsToDispatchCount *atomic.Int64
 
-	// QueryComponentUtilization encapsulates tracking requests from the time they are forwarded to a querier
-	// to the time are completed by the querier or failed due to cancel, timeout, or disconnect.
-	// Unlike schedulerInflightRequests, tracking begins only when the request is sent to a querier.
-	QueryComponentUtilization *QueryComponentUtilization
-
 	queueBroker *queueBroker
 }
 
@@ -218,13 +213,7 @@ func NewRequestQueue(
 	queueLength *prometheus.GaugeVec,
 	discardedRequests *prometheus.CounterVec,
 	enqueueDuration prometheus.Histogram,
-	querierInflightRequestsMetric *prometheus.SummaryVec,
 ) (*RequestQueue, error) {
-	queryComponentCapacity, err := NewQueryComponentUtilization(querierInflightRequestsMetric)
-	if err != nil {
-		return nil, err
-	}
-
 	q := &RequestQueue{
 		// settings
 		log:                     log,
@@ -247,8 +236,7 @@ func NewRequestQueue(
 		waitingDequeueRequestsToDispatch:      list.New(),
 		waitingDequeueRequestsToDispatchCount: atomic.NewInt64(0),
 
-		QueryComponentUtilization: queryComponentCapacity,
-		queueBroker:               newQueueBroker(maxOutstandingPerTenant, forgetDelay),
+		queueBroker: newQueueBroker(maxOutstandingPerTenant, forgetDelay),
 	}
 
 	q.Service = services.NewBasicService(q.starting, q.running, q.stop).WithName("request queue")
@@ -268,18 +256,10 @@ func (q *RequestQueue) running(ctx context.Context) error {
 	forgetDisconnectedQueriersTicker := time.NewTicker(forgetCheckPeriod)
 	defer forgetDisconnectedQueriersTicker.Stop()
 
-	// periodically submit a message to dispatcherLoop to observe inflight requests;
-	// same as scheduler, we observe inflight requests frequently and at regular intervals
-	// to have a good approximation of max inflight requests over percentiles of time.
-	inflightRequestsTicker := time.NewTicker(250 * time.Millisecond)
-	defer inflightRequestsTicker.Stop()
-
 	for {
 		select {
 		case <-forgetDisconnectedQueriersTicker.C:
 			q.submitForgetDisconnectedQueriers(ctx)
-		case <-inflightRequestsTicker.C:
-			q.QueryComponentUtilization.ObserveInflightRequests()
 		case <-ctx.Done():
 			// context done case serves as a default case to bail out
 			// if the waiting querier-worker connection's context times out or is canceled,

--- a/pkg/scheduler/queue/queue_broker.go
+++ b/pkg/scheduler/queue/queue_broker.go
@@ -19,9 +19,14 @@ const storeGatewayQueueDimension = "store-gateway"
 const ingesterAndStoreGatewayQueueDimension = "ingester-and-store-gateway"
 const unknownQueueDimension = "unknown" // utilized when AdditionalQueueDimensions is not assigned by the frontend
 
+// tenantRequest is the queue's internal wrapper for an enqueued QueryRequest.
+// queueDimension is the first-layer queue dimension to enqueue under (e.g. a
+// query component name); the tenantID is appended internally to form the full
+// queue path.
 type tenantRequest struct {
-	tenantID string
-	req      QueryRequest
+	tenantID       string
+	queueDimension string
+	req            QueryRequest
 }
 
 // queueBroker encapsulates access to the Tree queue for pending requests, and brokers logic dependencies between
@@ -81,18 +86,12 @@ func (qb *queueBroker) enqueueRequestBack(request *tenantRequest, tenantMaxQueri
 		return err
 	}
 
-	queuePath, err := qb.makeQueuePath(request)
-	if err != nil {
-		return err
-	}
-
 	tenantQueueSize := qb.tenantQuerierAssignments.queuingAlgorithm.TotalQueueSizeForTenant(request.tenantID)
 	if tenantQueueSize+1 > qb.maxTenantQueueSize {
 		return ErrTooManyRequests
 	}
 
-	err = qb.tree.EnqueueBackByPath(queuePath, request)
-	return err
+	return qb.tree.EnqueueBackByPath(qb.queuePath(request), request)
 }
 
 // enqueueRequestFront should only be used for re-enqueueing previously dequeued requests
@@ -105,22 +104,18 @@ func (qb *queueBroker) enqueueRequestFront(request *tenantRequest, tenantMaxQuer
 	if err != nil {
 		return err
 	}
-
-	queuePath, err := qb.makeQueuePath(request)
-	if err != nil {
-		return err
-	}
-	return qb.tree.EnqueueFrontByPath(queuePath, request)
+	return qb.tree.EnqueueFrontByPath(qb.queuePath(request), request)
 }
 
-func (qb *queueBroker) makeQueuePath(request *tenantRequest) (tree.QueuePath, error) {
-	// some requests may not be type asserted to a schedulerRequest; in this case,
-	// they should also be queued as "unknown" query components
-	queryComponent := unknownQueueDimension
-	if schedulerRequest, ok := request.req.(*SchedulerRequest); ok {
-		queryComponent = schedulerRequest.ExpectedQueryComponentName()
+// queuePath returns the two-level queue path for an enqueued tenantRequest:
+// the first-layer queue dimension (typically a query component name)
+// supplied by the caller, followed by the tenantID.
+func (qb *queueBroker) queuePath(request *tenantRequest) tree.QueuePath {
+	dim := request.queueDimension
+	if dim == "" {
+		dim = unknownQueueDimension
 	}
-	return []string{queryComponent, request.tenantID}, nil
+	return tree.QueuePath{dim, request.tenantID}
 }
 
 func (qb *queueBroker) dequeueRequestForQuerier(

--- a/pkg/scheduler/queue/queue_broker_test.go
+++ b/pkg/scheduler/queue/queue_broker_test.go
@@ -26,20 +26,8 @@ func (qb *queueBroker) enqueueObjectsForTests(tenantID string, numObjects int) e
 			tenantID: tenantID,
 			req:      fmt.Sprintf("%v: object-%v", tenantID, i),
 		}
-		var path tree.QueuePath
-		var err error
-		if _, ok := qb.tree.(*tree.MultiAlgorithmTreeQueue); ok {
-			path = tree.QueuePath{unknownQueueDimension, tenantID}
-
-		} else {
-			path, err = qb.makeQueuePath(req)
-			if err != nil {
-				return err
-			}
-		}
-
-		err = qb.tree.EnqueueBackByPath(path, req)
-		if err != nil {
+		path := qb.queuePath(req)
+		if err := qb.tree.EnqueueBackByPath(path, req); err != nil {
 			return err
 		}
 	}
@@ -237,7 +225,11 @@ func TestQueuesRespectMaxTenantQueueSizeWithSubQueues(t *testing.T) {
 	for i := 0; i < len(additionalQueueDimensions); i++ {
 		for j := 0; j < maxTenantQueueSize/len(additionalQueueDimensions); j++ {
 			req.AdditionalQueueDimensions = additionalQueueDimensions[i]
-			tenantReq := &tenantRequest{tenantID: "tenant-1", req: req}
+			tenantReq := &tenantRequest{
+				tenantID:       "tenant-1",
+				queueDimension: req.ExpectedQueryComponentName(),
+				req:            req,
+			}
 			err := qb.enqueueRequestBack(tenantReq, 0)
 			assert.NoError(t, err)
 		}
@@ -274,7 +266,11 @@ func TestQueuesRespectMaxTenantQueueSizeWithSubQueues(t *testing.T) {
 		// error should be received no matter if the enqueue attempt
 		// is for the tenant queue or any of its subqueues
 		req.AdditionalQueueDimensions = additionalQueueDimension
-		tenantReq := &tenantRequest{tenantID: "tenant-1", req: req}
+		tenantReq := &tenantRequest{
+			tenantID:       "tenant-1",
+			queueDimension: req.ExpectedQueryComponentName(),
+			req:            req,
+		}
 		err := qb.enqueueRequestBack(tenantReq, 0)
 		assert.ErrorIs(t, err, ErrTooManyRequests)
 	}

--- a/pkg/scheduler/queue/queue_broker_test.go
+++ b/pkg/scheduler/queue/queue_broker_test.go
@@ -284,7 +284,11 @@ func TestQueuesRespectMaxTenantQueueSizeWithSubQueues(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, dequeuedTenantReq)
 
-	tenantReq := &tenantRequest{tenantID: "tenant-1", req: req}
+	tenantReq := &tenantRequest{
+		tenantID:       "tenant-1",
+		queueDimension: req.ExpectedQueryComponentName(),
+		req:            req,
+	}
 	// assert not hitting an error when enqueueing after dequeuing to below the limit
 	err = qb.enqueueRequestBack(tenantReq, 0)
 	assert.NoError(t, err)

--- a/pkg/scheduler/queue/queue_test.go
+++ b/pkg/scheduler/queue/queue_test.go
@@ -223,7 +223,7 @@ func queueProduce(
 	}
 	req := makeSchedulerRequest(tenantID, additionalQueueDimensions)
 	for {
-		err := queue.SubmitRequestToEnqueue(tenantID, req, maxQueriersPerTenant, func() {})
+		err := queue.SubmitRequestToEnqueue(tenantID, req, req.ExpectedQueryComponentName(), maxQueriersPerTenant, func() {})
 		if err == nil {
 			break
 		}
@@ -421,13 +421,13 @@ func TestDispatchToWaitingDequeueRequestForUnregisteredQuerierWorker(t *testing.
 		HttpRequest:               &httpgrpc.HTTPRequest{Method: "GET", Url: "/hello"},
 		AdditionalQueueDimensions: []string{"ingester"},
 	}
-	assert.NoError(t, queue.SubmitRequestToEnqueue("user-2", reqNotShardedToQuerier1, 1, nil))
+	assert.NoError(t, queue.SubmitRequestToEnqueue("user-2", reqNotShardedToQuerier1, reqNotShardedToQuerier1.ExpectedQueryComponentName(), 1, nil))
 	reqNotShardedToQuerier1 = &SchedulerRequest{
 		Ctx:                       context.Background(),
 		HttpRequest:               &httpgrpc.HTTPRequest{Method: "GET", Url: "/hello"},
 		AdditionalQueueDimensions: []string{"store-gateway"},
 	}
-	assert.NoError(t, queue.SubmitRequestToEnqueue("user-2", reqNotShardedToQuerier1, 1, nil))
+	assert.NoError(t, queue.SubmitRequestToEnqueue("user-2", reqNotShardedToQuerier1, reqNotShardedToQuerier1.ExpectedQueryComponentName(), 1, nil))
 
 	// Querier-1 submits a request to dequeue;
 	// it will not receive anything as the only requests in the queue are not sharded to querier-1.
@@ -616,7 +616,7 @@ func TestRequestQueue_GetNextRequestForQuerier_ShouldGetRequestAfterReshardingBe
 		HttpRequest:               &httpgrpc.HTTPRequest{Method: "GET", Url: "/hello"},
 		AdditionalQueueDimensions: randAdditionalQueueDimension(""),
 	}
-	require.NoError(t, queue.SubmitRequestToEnqueue("user-1", req, 1, nil))
+	require.NoError(t, queue.SubmitRequestToEnqueue("user-1", req, req.ExpectedQueryComponentName(), 1, nil))
 
 	startTime := time.Now()
 	done := make(chan struct{})
@@ -705,7 +705,7 @@ func TestRequestQueue_GetNextRequestForQuerier_ReshardNotifiedCorrectlyForMultip
 		HttpRequest:               &httpgrpc.HTTPRequest{Method: "GET", Url: "/hello"},
 		AdditionalQueueDimensions: randAdditionalQueueDimension(""),
 	}
-	require.NoError(t, queue.SubmitRequestToEnqueue("user-1", req, 2, nil))
+	require.NoError(t, queue.SubmitRequestToEnqueue("user-1", req, req.ExpectedQueryComponentName(), 2, nil))
 
 	startTime := time.Now()
 	done := make(chan struct{})
@@ -839,8 +839,9 @@ func TestRequestQueue_tryDispatchRequestToQuerier_ShouldReEnqueueAfterFailedSend
 		AdditionalQueueDimensions: queueDim,
 	}
 	tr := tenantRequest{
-		tenantID: "tenant-1",
-		req:      req,
+		tenantID:       "tenant-1",
+		queueDimension: req.ExpectedQueryComponentName(),
+		req:            req,
 	}
 
 	var multiAlgorithmTreeQueuePath tree.QueuePath
@@ -899,7 +900,7 @@ func TestRequestQueue_ShutdownWithPendingRequests_ShouldDrainRequests(t *testing
 	// And push a request to the queue
 	req := makeSchedulerRequest(tenantID, []string{})
 	require.NotNil(t, req)
-	err = queue.SubmitRequestToEnqueue(tenantID, req, 1, func() {})
+	err = queue.SubmitRequestToEnqueue(tenantID, req, req.ExpectedQueryComponentName(), 1, func() {})
 	require.NoError(t, err)
 
 	// And make sure it got to the queue

--- a/pkg/scheduler/queue/queue_test.go
+++ b/pkg/scheduler/queue/queue_test.go
@@ -100,7 +100,6 @@ func BenchmarkConcurrentQueueOperations(b *testing.B) {
 								promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
 								promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 								promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
-								promauto.With(nil).NewSummaryVec(prometheus.SummaryOpts{}, []string{"query_component"}),
 							)
 							require.NoError(b, err)
 
@@ -370,7 +369,6 @@ func TestDispatchToWaitingDequeueRequestForUnregisteredQuerierWorker(t *testing.
 		promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
 		promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 		promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
-		promauto.With(nil).NewSummaryVec(prometheus.SummaryOpts{}, []string{"query_component"}),
 	)
 	require.NoError(t, err)
 
@@ -487,7 +485,6 @@ func TestRequestQueue_RegisterAndUnregisterQuerierWorkerConnections(t *testing.T
 		promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
 		promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 		promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
-		promauto.With(nil).NewSummaryVec(prometheus.SummaryOpts{}, []string{"query_component"}),
 	)
 	require.NoError(t, err)
 
@@ -573,7 +570,6 @@ func TestRequestQueue_GetNextRequestForQuerier_ShouldGetRequestAfterReshardingBe
 		promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
 		promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 		promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
-		promauto.With(nil).NewSummaryVec(prometheus.SummaryOpts{}, []string{"query_component"}),
 	)
 	require.NoError(t, err)
 
@@ -646,7 +642,6 @@ func TestRequestQueue_GetNextRequestForQuerier_ReshardNotifiedCorrectlyForMultip
 		promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
 		promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 		promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
-		promauto.With(nil).NewSummaryVec(prometheus.SummaryOpts{}, []string{"query_component"}),
 	)
 	require.NoError(t, err)
 
@@ -735,7 +730,6 @@ func TestRequestQueue_GetNextRequestForQuerier_ShouldReturnAfterContextCancelled
 		promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
 		promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 		promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
-		promauto.With(nil).NewSummaryVec(prometheus.SummaryOpts{}, []string{"query_component"}),
 	)
 	require.NoError(t, err)
 
@@ -791,7 +785,6 @@ func TestRequestQueue_GetNextRequestForQuerier_ShouldReturnImmediatelyIfQuerierI
 		promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
 		promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 		promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
-		promauto.With(nil).NewSummaryVec(prometheus.SummaryOpts{}, []string{"query_component"}),
 	)
 	require.NoError(t, err)
 
@@ -822,7 +815,6 @@ func TestRequestQueue_tryDispatchRequestToQuerier_ShouldReEnqueueAfterFailedSend
 		promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
 		promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 		promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
-		promauto.With(nil).NewSummaryVec(prometheus.SummaryOpts{}, []string{"query_component"}),
 	)
 	require.NoError(t, err)
 
@@ -888,7 +880,6 @@ func TestRequestQueue_ShutdownWithPendingRequests_ShouldDrainRequests(t *testing
 		promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
 		promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 		promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
-		promauto.With(nil).NewSummaryVec(prometheus.SummaryOpts{}, []string{"query_component"}),
 	)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(ctx, queue))

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -25,7 +25,6 @@ import (
 	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/services"
-	"github.com/grafana/dskit/tenant"
 	"github.com/grafana/dskit/user"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -47,7 +46,6 @@ import (
 	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/grpcencoding/s2"
 	"github.com/grafana/mimir/pkg/util/httpgrpcutil"
-	"github.com/grafana/mimir/pkg/util/validation"
 )
 
 var errEnqueuingRequestFailed = cancellation.NewErrorf("enqueuing request failed")
@@ -67,8 +65,8 @@ type Scheduler struct {
 	connectedFrontendsMu sync.Mutex
 	connectedFrontends   map[string]*connectedFrontend
 
-	requestQueue *queue.RequestQueue
-	activeUsers  *util.ActiveUsersCleanupService
+	queue       *schedulerQueue
+	activeUsers *util.ActiveUsersCleanupService
 
 	inflightRequestsMu sync.Mutex
 	// schedulerInflightRequests tracks requests from the time they are received to be enqueued by the scheduler
@@ -169,10 +167,10 @@ func NewScheduler(cfg Config, limits Limits, log log.Logger, registerer promethe
 	)
 	s.invalidClusterValidation = util.NewRequestInvalidClusterValidationLabelsTotalCounter(registerer, "query-scheduler", util.GRPCProtocol)
 
-	s.requestQueue, err = queue.NewRequestQueue(
+	s.queue, err = newSchedulerQueue(
+		cfg,
+		limits,
 		s.log,
-		cfg.MaxOutstandingPerTenant,
-		cfg.QuerierForgetDelay,
 		s.queueLength,
 		s.discardedRequests,
 		enqueueDuration,
@@ -193,7 +191,7 @@ func NewScheduler(cfg Config, limits Limits, log log.Logger, registerer promethe
 	s.connectedQuerierClients = promauto.With(registerer).NewGaugeFunc(prometheus.GaugeOpts{
 		Name: "cortex_query_scheduler_connected_querier_clients",
 		Help: "Number of querier worker clients currently connected to the query-scheduler.",
-	}, s.requestQueue.GetConnectedQuerierWorkersMetric)
+	}, s.queue.GetConnectedQuerierWorkersMetric)
 	s.connectedFrontendClients = promauto.With(registerer).NewGaugeFunc(prometheus.GaugeOpts{
 		Name: "cortex_query_scheduler_connected_frontend_clients",
 		Help: "Number of query-frontend worker clients currently connected to the query-scheduler.",
@@ -208,7 +206,7 @@ func NewScheduler(cfg Config, limits Limits, log log.Logger, registerer promethe
 	})
 
 	s.activeUsers = util.NewActiveUsersCleanupWithDefaultValues(s.cleanupMetricsForInactiveUser)
-	subservices := []services.Service{s.requestQueue, s.activeUsers}
+	subservices := []services.Service{s.queue, s.activeUsers}
 
 	// Init the ring only if the ring-based service discovery mode is used.
 	if cfg.ServiceDiscovery.Mode == schedulerdiscovery.ModeRing {
@@ -307,7 +305,7 @@ func (s *Scheduler) FrontendLoop(frontend schedulerpb.SchedulerForFrontend_Front
 			schedulerReq := s.cancelRequestAndRemoveFromPending(requestKey, "frontend cancelled query")
 			// we may not have reached MarkRequestSent for this query before receiving the cancel,
 			// but RequestQueue will just no-op if the request was not yet tracked in the inflightRequests map.
-			s.requestQueue.QueryComponentUtilization.MarkRequestCompleted(schedulerReq)
+			s.queue.MarkRequestCompleted(schedulerReq)
 			resp = &schedulerpb.SchedulerToFrontend{Status: schedulerpb.OK}
 
 		default:
@@ -399,15 +397,8 @@ func (s *Scheduler) enqueueRequest(requestContext context.Context, frontendAddr 
 	req.EnqueueTime = now
 	req.CancelFunc = cancel
 
-	// aggregate the max queriers limit in the case of a multi tenant query
-	tenantIDs, err := tenant.TenantIDsFromOrgID(userID)
-	if err != nil {
-		return err
-	}
-	maxQueriers := validation.SmallestPositiveNonZeroIntPerTenant(tenantIDs, s.limits.MaxQueriersPerUser)
-
 	s.activeUsers.UpdateUserTimestamp(userID, now)
-	return s.requestQueue.SubmitRequestToEnqueue(userID, req, req.ExpectedQueryComponentName(), maxQueriers, func() {
+	return s.queue.Enqueue(req, func() {
 		shouldCancel = false
 		s.addRequestToPending(req)
 	})
@@ -458,18 +449,18 @@ func (s *Scheduler) QuerierLoop(querier schedulerpb.SchedulerForQuerier_QuerierL
 
 	querierID := resp.GetQuerierID()
 	querierWorkerConn := queue.NewUnregisteredQuerierWorkerConn(querier.Context(), querierID)
-	err = s.requestQueue.AwaitRegisterQuerierWorkerConn(querierWorkerConn)
+	err = s.queue.AwaitRegisterQuerierWorkerConn(querierWorkerConn)
 	if err != nil {
 		return s.transformRequestQueueError(err)
 	}
-	defer s.requestQueue.SubmitUnregisterQuerierWorkerConn(querierWorkerConn)
+	defer s.queue.SubmitUnregisterQuerierWorkerConn(querierWorkerConn)
 
 	lastTenantIdx := queue.FirstTenant()
 
 	// In stopping state scheduler is not accepting new queries, but still dispatching queries in the queues.
 	for s.isRunningOrStopping() {
 		dequeueReq := queue.NewQuerierWorkerDequeueRequest(querierWorkerConn, lastTenantIdx)
-		queryReq, idx, err := s.requestQueue.AwaitRequestForQuerier(dequeueReq)
+		queryReq, idx, err := s.queue.AwaitRequestForQuerier(dequeueReq)
 		if err != nil {
 			// The error returned can either be ErrQuerierShuttingDown or ErrQuerierWorkerDisconnected.
 			// ErrQuerierShuttingDown is a control-flow message between services to exit this loop.
@@ -504,7 +495,7 @@ func (s *Scheduler) QuerierLoop(querier schedulerpb.SchedulerForQuerier_QuerierL
 		if schedulerReq.Ctx.Err() != nil {
 			// remove from pending requests
 			s.cancelRequestAndRemoveFromPending(schedulerReq.Key(), "request cancelled")
-			s.requestQueue.QueryComponentUtilization.MarkRequestCompleted(schedulerReq)
+			s.queue.MarkRequestCompleted(schedulerReq)
 			lastTenantIdx = lastTenantIdx.ReuseLastTenant()
 			continue
 		}
@@ -522,14 +513,14 @@ func (s *Scheduler) QuerierLoop(querier schedulerpb.SchedulerForQuerier_QuerierL
 func (s *Scheduler) NotifyQuerierShutdown(ctx context.Context, req *schedulerpb.NotifyQuerierShutdownRequest) (*schedulerpb.NotifyQuerierShutdownResponse, error) {
 	level.Info(s.log).Log("msg", "received shutdown notification from querier", "querier", req.GetQuerierID())
 
-	s.requestQueue.SubmitNotifyQuerierShutdown(ctx, req.GetQuerierID())
+	s.queue.SubmitNotifyQuerierShutdown(ctx, req.GetQuerierID())
 
 	return &schedulerpb.NotifyQuerierShutdownResponse{}, nil
 }
 
 func (s *Scheduler) forwardRequestToQuerier(querier schedulerpb.SchedulerForQuerier_QuerierLoopServer, querierID string, req *queue.SchedulerRequest, queueTime time.Duration) error {
-	s.requestQueue.QueryComponentUtilization.MarkRequestSent(req)
-	defer s.requestQueue.QueryComponentUtilization.MarkRequestCompleted(req)
+	s.queue.MarkRequestSent(req)
+	defer s.queue.MarkRequestCompleted(req)
 	defer s.cancelRequestAndRemoveFromPending(req.Key(), "request complete")
 
 	// Handle the stream sending & receiving on a goroutine so we can

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -397,9 +397,9 @@ func (s *Scheduler) enqueueRequest(requestContext context.Context, frontendAddr 
 	req.EnqueueTime = now
 	req.CancelFunc = cancel
 
-	s.activeUsers.UpdateUserTimestamp(userID, now)
 	return s.queue.Enqueue(req, func() {
 		shouldCancel = false
+		s.activeUsers.UpdateUserTimestamp(userID, now)
 		s.addRequestToPending(req)
 	})
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -407,7 +407,7 @@ func (s *Scheduler) enqueueRequest(requestContext context.Context, frontendAddr 
 	maxQueriers := validation.SmallestPositiveNonZeroIntPerTenant(tenantIDs, s.limits.MaxQueriersPerUser)
 
 	s.activeUsers.UpdateUserTimestamp(userID, now)
-	return s.requestQueue.SubmitRequestToEnqueue(userID, req, maxQueriers, func() {
+	return s.requestQueue.SubmitRequestToEnqueue(userID, req, req.ExpectedQueryComponentName(), maxQueriers, func() {
 		shouldCancel = false
 		s.addRequestToPending(req)
 	})

--- a/pkg/scheduler/scheduler_queue.go
+++ b/pkg/scheduler/scheduler_queue.go
@@ -4,6 +4,7 @@ package scheduler
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/go-kit/log"
@@ -25,6 +26,8 @@ type schedulerQueue struct {
 	queue                     *queue.RequestQueue
 	queryComponentUtilization *queue.QueryComponentUtilization
 	limits                    Limits
+
+	subservicesWatcher *services.FailureWatcher
 }
 
 func newSchedulerQueue(
@@ -57,6 +60,7 @@ func newSchedulerQueue(
 		queue:                     q,
 		queryComponentUtilization: qcu,
 		limits:                    limits,
+		subservicesWatcher:        services.NewFailureWatcher(),
 	}
 	sq.Service = services.NewBasicService(sq.starting, sq.running, sq.stopping).WithName("scheduler queue")
 	return sq, nil
@@ -70,6 +74,7 @@ func (sq *schedulerQueue) starting(ctx context.Context) error {
 		_ = services.StopAndAwaitTerminated(context.Background(), sq.queue)
 		return err
 	}
+	sq.subservicesWatcher.WatchService(sq.queue)
 	return nil
 }
 
@@ -84,6 +89,8 @@ func (sq *schedulerQueue) running(ctx context.Context) error {
 		select {
 		case <-inflightRequestsTicker.C:
 			sq.queryComponentUtilization.ObserveInflightRequests()
+		case err := <-sq.subservicesWatcher.Chan():
+			return fmt.Errorf("scheduler queue subservice failed: %w", err)
 		case <-ctx.Done():
 			return nil
 		}

--- a/pkg/scheduler/scheduler_queue.go
+++ b/pkg/scheduler/scheduler_queue.go
@@ -16,10 +16,12 @@ import (
 	"github.com/grafana/mimir/pkg/util/validation"
 )
 
-// schedulerQueue wraps the generic queue.RequestQueue with scheduler-flavored
-// ergonomics: it owns dimension extraction and per-tenant max-queriers lookup
-// so call sites in the scheduler don't have to thread either value through,
-// and bundles in the QueryComponentUtilization tracking sidecar.
+// schedulerQueue wraps the generic queue.RequestQueue with scheduler-specific queue logic:
+//   - the first queue dimension is the query component,
+//     determined from the annotation that the query-frontend attaches to the request.
+//   - the per-tenant max-queriers limit is looked up from the configured Limits.
+//   - the QueryComponentUtilization tracker, and its periodic inflight observation,
+//     live here rather than in the generic queue.
 type schedulerQueue struct {
 	services.Service
 

--- a/pkg/scheduler/scheduler_queue.go
+++ b/pkg/scheduler/scheduler_queue.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package scheduler
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/services"
+	"github.com/grafana/dskit/tenant"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/grafana/mimir/pkg/scheduler/queue"
+	"github.com/grafana/mimir/pkg/util/validation"
+)
+
+// schedulerQueue wraps the generic queue.RequestQueue with scheduler-flavored
+// ergonomics: it owns dimension extraction and per-tenant max-queriers lookup
+// so call sites in the scheduler don't have to thread either value through,
+// and bundles in the QueryComponentUtilization tracking sidecar.
+type schedulerQueue struct {
+	services.Service
+
+	queue                     *queue.RequestQueue
+	queryComponentUtilization *queue.QueryComponentUtilization
+	limits                    Limits
+}
+
+func newSchedulerQueue(
+	cfg Config,
+	limits Limits,
+	logger log.Logger,
+	queueLength *prometheus.GaugeVec,
+	discardedRequests *prometheus.CounterVec,
+	enqueueDuration prometheus.Histogram,
+	querierInflightRequestsMetric *prometheus.SummaryVec,
+) (*schedulerQueue, error) {
+	q, err := queue.NewRequestQueue(
+		logger,
+		cfg.MaxOutstandingPerTenant,
+		cfg.QuerierForgetDelay,
+		queueLength,
+		discardedRequests,
+		enqueueDuration,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	qcu, err := queue.NewQueryComponentUtilization(querierInflightRequestsMetric)
+	if err != nil {
+		return nil, err
+	}
+
+	sq := &schedulerQueue{
+		queue:                     q,
+		queryComponentUtilization: qcu,
+		limits:                    limits,
+	}
+	sq.Service = services.NewBasicService(sq.starting, sq.running, sq.stopping).WithName("scheduler queue")
+	return sq, nil
+}
+
+func (sq *schedulerQueue) starting(ctx context.Context) error {
+	return services.StartAndAwaitRunning(ctx, sq.queue)
+}
+
+func (sq *schedulerQueue) running(ctx context.Context) error {
+	// Observe inflight requests on a regular tick to approximate max-inflight
+	// percentiles even when no new queries are arriving. Matches the cadence
+	// used by the scheduler's own inflight observation.
+	inflightRequestsTicker := time.NewTicker(250 * time.Millisecond)
+	defer inflightRequestsTicker.Stop()
+
+	for {
+		select {
+		case <-inflightRequestsTicker.C:
+			sq.queryComponentUtilization.ObserveInflightRequests()
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+func (sq *schedulerQueue) stopping(_ error) error {
+	return services.StopAndAwaitTerminated(context.Background(), sq.queue)
+}
+
+// Enqueue submits a SchedulerRequest, deriving the queue dimension from the
+// request itself and the per-tenant max-queriers from the configured Limits.
+func (sq *schedulerQueue) Enqueue(req *queue.SchedulerRequest, successFn func()) error {
+	tenantIDs, err := tenant.TenantIDsFromOrgID(req.UserID)
+	if err != nil {
+		return err
+	}
+	maxQueriers := validation.SmallestPositiveNonZeroIntPerTenant(tenantIDs, sq.limits.MaxQueriersPerUser)
+	return sq.queue.SubmitRequestToEnqueue(req.UserID, req, req.ExpectedQueryComponentName(), maxQueriers, successFn)
+}
+
+func (sq *schedulerQueue) AwaitRegisterQuerierWorkerConn(conn *queue.QuerierWorkerConn) error {
+	return sq.queue.AwaitRegisterQuerierWorkerConn(conn)
+}
+
+func (sq *schedulerQueue) SubmitUnregisterQuerierWorkerConn(conn *queue.QuerierWorkerConn) {
+	sq.queue.SubmitUnregisterQuerierWorkerConn(conn)
+}
+
+func (sq *schedulerQueue) AwaitRequestForQuerier(req *queue.QuerierWorkerDequeueRequest) (queue.QueryRequest, queue.TenantIndex, error) {
+	return sq.queue.AwaitRequestForQuerier(req)
+}
+
+func (sq *schedulerQueue) SubmitNotifyQuerierShutdown(ctx context.Context, querierID string) {
+	sq.queue.SubmitNotifyQuerierShutdown(ctx, querierID)
+}
+
+func (sq *schedulerQueue) GetConnectedQuerierWorkersMetric() float64 {
+	return sq.queue.GetConnectedQuerierWorkersMetric()
+}
+
+func (sq *schedulerQueue) IsEmpty() bool {
+	return sq.queue.IsEmpty()
+}
+
+// MarkRequestSent reports the request was forwarded to a querier so the
+// QueryComponentUtilization sidecar starts counting it as inflight.
+func (sq *schedulerQueue) MarkRequestSent(req *queue.SchedulerRequest) {
+	sq.queryComponentUtilization.MarkRequestSent(req)
+}
+
+// MarkRequestCompleted reports the request was completed or cancelled so the
+// QueryComponentUtilization sidecar stops counting it as inflight.
+func (sq *schedulerQueue) MarkRequestCompleted(req *queue.SchedulerRequest) {
+	sq.queryComponentUtilization.MarkRequestCompleted(req)
+}

--- a/pkg/scheduler/scheduler_queue.go
+++ b/pkg/scheduler/scheduler_queue.go
@@ -63,7 +63,14 @@ func newSchedulerQueue(
 }
 
 func (sq *schedulerQueue) starting(ctx context.Context) error {
-	return services.StartAndAwaitRunning(ctx, sq.queue)
+	if err := services.StartAndAwaitRunning(ctx, sq.queue); err != nil {
+		// BasicService will not call our stopping() when starting() returns an error,
+		// so we must clean up the inner queue ourselves if it managed to reach Running
+		// before ctx was cancelled.
+		_ = services.StopAndAwaitTerminated(context.Background(), sq.queue)
+		return err
+	}
+	return nil
 }
 
 func (sq *schedulerQueue) running(ctx context.Context) error {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -142,19 +142,19 @@ func drainScheduler(t *testing.T, s *Scheduler) {
 	querierID := "emptying-consumer"
 
 	querierWorkerConn := queue.NewUnregisteredQuerierWorkerConn(context.Background(), querierID)
-	require.NoError(t, s.requestQueue.AwaitRegisterQuerierWorkerConn(querierWorkerConn))
-	defer s.requestQueue.SubmitUnregisterQuerierWorkerConn(querierWorkerConn)
+	require.NoError(t, s.queue.AwaitRegisterQuerierWorkerConn(querierWorkerConn))
+	defer s.queue.SubmitUnregisterQuerierWorkerConn(querierWorkerConn)
 
 	consumer := func(request queue.QueryRequest) error {
 		return nil
 	}
 
 	for {
-		if s.requestQueue.IsEmpty() {
+		if s.queue.IsEmpty() {
 			return
 		}
 
-		idx, err := queueConsume(s.requestQueue, querierWorkerConn, lastTenantIndex, consumer)
+		idx, err := queueConsume(s.queue, querierWorkerConn, lastTenantIndex, consumer)
 		require.NoError(t, err)
 		lastTenantIndex = idx
 	}
@@ -163,7 +163,7 @@ func drainScheduler(t *testing.T, s *Scheduler) {
 type consumeRequest func(request queue.QueryRequest) error
 
 func queueConsume(
-	q *queue.RequestQueue, querierWorkerConn *queue.QuerierWorkerConn, lastTenantIdx queue.TenantIndex, consumeFunc consumeRequest,
+	q *schedulerQueue, querierWorkerConn *queue.QuerierWorkerConn, lastTenantIdx queue.TenantIndex, consumeFunc consumeRequest,
 ) (queue.TenantIndex, error) {
 	dequeueReq := queue.NewQuerierWorkerDequeueRequest(querierWorkerConn, lastTenantIdx)
 	request, idx, err := q.AwaitRequestForQuerier(dequeueReq)
@@ -546,7 +546,7 @@ func TestSchedulerShutdown_PendingRequests(t *testing.T) {
 	require.Equal(t, uint64(2), req.QueryID)
 
 	// The queue is empty and there's no inflight requests
-	require.Equal(t, true, scheduler.requestQueue.IsEmpty())
+	require.Equal(t, true, scheduler.queue.IsEmpty())
 
 	// This should error because the queue is stopped (we can't check the error exactly because its wrapped by grpc)
 	err = querierLoop.Send(&schedulerpb.QuerierToScheduler{})
@@ -863,8 +863,8 @@ func verifyQueryComponentUtilizationLeft(t *testing.T, scheduler *Scheduler) {
 	test.Poll(t, 2*time.Second, services.Terminated, func() interface{} {
 		return scheduler.State()
 	})
-	require.Zero(t, scheduler.requestQueue.QueryComponentUtilization.GetForComponent(queue.Ingester))
-	require.Zero(t, scheduler.requestQueue.QueryComponentUtilization.GetForComponent(queue.StoreGateway))
+	require.Zero(t, scheduler.queue.queryComponentUtilization.GetForComponent(queue.Ingester))
+	require.Zero(t, scheduler.queue.queryComponentUtilization.GetForComponent(queue.StoreGateway))
 }
 
 type limits struct {


### PR DESCRIPTION
#### What this PR does

This is the **first** of four stacked PRs that together make the scheduler's tenant-fair request queue reusable so it can drive a new worker pool in the ingester (for `label-values-cardinality`). This PR is internal-refactor only — no public-facing flag changes.

The queue's broker used to type-assert dequeued items to `*SchedulerRequest` to compute the first-layer queue dimension (via `ExpectedQueryComponentName`), and it owned a `QueryComponentUtilization` sidecar in its `running()` goroutine. Both kept the queue from being reused outside the scheduler.

#### What changed (high level)

- **Decoupled the queue from `*SchedulerRequest`.** The first-layer queue dimension is now passed explicitly into `SubmitRequestToEnqueue` instead of being derived by type-asserting the enqueued item. The broker builds the queue path purely from the supplied dimension and tenant ID, so it no longer knows anything about the scheduler's request type.
- **Moved scheduler-specific behaviour into a new `schedulerQueue` wrapper** (`pkg/scheduler/scheduler_queue.go`). The generic `RequestQueue` no longer constructs or owns the `QueryComponentUtilization` sidecar or its inflight-observation ticker. The wrapper owns those, derives the queue dimension and per-tenant max-queriers from the request and configured limits, and forwards the mark-sent / mark-completed calls — so scheduler call sites keep the same behaviour without threading those values through.
- **Added dedicated unit tests for `QueryComponentUtilization`**, which previously only had indirect coverage.
- **Two small correctness fixes** found along the way: a tenant is now marked active only *after* a successful enqueue, and the inner queue is stopped if the wrapper's startup errors (avoiding a leaked dispatcher goroutine).

See the individual commits for the detailed, per-change descriptions.

#### Stacked PRs

1. **This PR (#15491)** — decouple queue + wrapper
2. #15492 — move queue to `pkg/queue`, split scheduler-specific types out
3. #15508 — generalize the queue's naming (`RequestQueue`→`Queue`, `QueryRequest`→`Item`, …)
4. #15493 — new `pkg/util/workerpool` + tenant-fair pool in ingester `label-values-cardinality`

#### Which issue(s) this PR fixes or relates to

N/A — internal refactor in preparation for ingester worker-pool work.

#### Checklist

- [x] Tests updated.
- [x] Documentation added. — N/A, no user-visible changes
- [x] `CHANGELOG.md` updated — N/A, please add the `changelog-not-needed` label.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features. — N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors the hot path for query scheduling and enqueue/shutdown lifecycle; behavior is intended to be unchanged but mistakes in wrapper lifecycle or dimension routing could affect fairness or metrics.
> 
> **Overview**
> This PR **separates generic queue mechanics from scheduler-specific behavior** so the tenant-fair `RequestQueue` can be reused later (e.g. ingester worker pool). No user-facing flags.
> 
> The generic **`RequestQueue`** no longer knows about `*SchedulerRequest`. Callers pass an explicit **`queueDimension`** into `SubmitRequestToEnqueue`; the broker builds tree paths from that dimension plus tenant ID (empty dimension → `unknown`). **`QueryComponentUtilization`**, its metrics constructor arg, and the inflight observation ticker are **removed** from the generic queue.
> 
> A new **`schedulerQueue`** wrapper owns scheduler-only logic: derives the queue dimension from the frontend annotation (`ExpectedQueryComponentName()`), resolves **max queriers per tenant** from limits, runs the **250ms inflight** QCU observations, and exposes **`MarkRequestSent` / `MarkRequestCompleted`**. The scheduler uses the wrapper for enqueue, querier loops, and shutdown instead of touching `RequestQueue` directly.
> 
> **Docs/tests:** `DESIGN.md` describes the wrapper; new **unit tests for `QueryComponentUtilization`**; existing queue/scheduler tests updated for the new enqueue API.
> 
> **Small correctness fixes:** mark tenants active only **after** a successful enqueue (`successFn`); if wrapper startup fails, **stop the inner queue** so the dispatcher goroutine is not leaked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdd94e265a0b5a919af2b6559d9050dfa1661687. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


