### PR TITLE
Validate digests of binaries downloaded for build image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr15447-e58b1e59d0@sha256:4509f33190409f863f1ca5ca16ae90cd28b8d3cc911a74ba0c382992553c535a
+LATEST_BUILD_IMAGE_TAG ?= pr15501-5a04b6b74f@sha256:7f6591c4ba41d29404a06fc28209dc43cd2e1e507412ec6111cd9e5406624eef
 
 # TTY is parameterized to allow CI and scripts to run builds,
 # as it currently disallows TTY devices.

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -45,7 +45,7 @@ RUN apt-get update && \
 # Set --ignore-scripts to avoid arbitrary code execution in build hook scripts. (Prettier 2.3.2 doesn't happen to have any.)
 RUN npm install -g --ignore-scripts prettier@2.3.2
 
-# renovate: depName=github.com/mvdan/sh
+# renovate: datasource=github-release-attachments depName=mvdan/sh
 ENV SHFMT_VERSION=3.13.1
 RUN GOARCH=$(go env GOARCH) && \
     URL=https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_${GOARCH}; \
@@ -53,13 +53,13 @@ RUN GOARCH=$(go env GOARCH) && \
 	chmod +x shfmt && \
 	mv shfmt /usr/bin
 
-# renovate: depName=github.com/grafana/tanka
+# renovate: datasource=github-release-attachments depName=grafana/tanka
 ENV TANKA_VERSION=0.37.0
 RUN GOARCH=$(go env GOARCH) && \
     curl -fSL -o "/usr/bin/tk" "https://github.com/grafana/tanka/releases/download/v${TANKA_VERSION}/tk-linux-${GOARCH}" && \
     chmod a+x /usr/bin/tk
 
-# renovate: depName=github.com/golangci/golangci-lint
+# renovate: datasource=github-release-attachments depName=golangci/golangci-lint
 ENV GOLANGCI_LINT_VERSION=2.12.2
 RUN set -o pipefail && \
     VERSION_SLUG=golangci-lint-${GOLANGCI_LINT_VERSION}-linux-$(go env GOARCH) && \
@@ -70,7 +70,7 @@ RUN set -o pipefail && \
     tar -xzvf "/tmp/$TARBALL" -C /usr/bin --strip-components=1 "$VERSION_SLUG/golangci-lint" && \
     rm /tmp/$TARBALL
 
-# renovate: depName=github.com/containers/skopeo
+# renovate: datasource=github-release-attachments depName=containers/skopeo
 ENV SKOPEO_VERSION=v1.22.2
 RUN git clone --depth 1 --branch ${SKOPEO_VERSION} https://github.com/containers/skopeo /go/src/github.com/containers/skopeo && \
     DISABLE_DOCS=1 make -C /go/src/github.com/containers/skopeo install && \

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -46,12 +46,17 @@ RUN apt-get update && \
 RUN npm install -g --ignore-scripts prettier@2.3.2
 
 # renovate: datasource=github-release-attachments depName=mvdan/sh
-ENV SHFMT_VERSION=3.13.1
-RUN GOARCH=$(go env GOARCH) && \
-    URL=https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_${GOARCH}; \
-    curl -fsSLo shfmt "${URL}" && \
-	chmod +x shfmt && \
-	mv shfmt /usr/bin
+ENV SHFMT_VERSION=v3.13.1
+# renovate: datasource=github-release-attachments depName=mvdan/sh digestVersion=v3.13.1
+ENV SHFMT_AMD64_DIGEST=fb096c5d1ac6beabbdbaa2874d025badb03ee07929f0c9ff67563ce8c75398b1
+# renovate: datasource=github-release-attachments depName=mvdan/sh digestVersion=v3.13.1
+ENV SHFMT_ARM64_DIGEST=32d92acaa5cd8abb29fc49dac123dc412442d5713967819d8af2c29f1b3857c7
+RUN set -o pipefail && \
+    GOARCH=$(go env GOARCH) && \
+    DIGEST=$(case "$GOARCH" in amd64) echo $SHFMT_AMD64_DIGEST;; arm64) echo $SHFMT_ARM64_DIGEST;; *) echo "unknown architecture $GOARCH" >/dev/stderr && exit 1;; esac) && \
+    curl -fsSLo /usr/bin/shfmt "https://github.com/mvdan/sh/releases/download/${SHFMT_VERSION}/shfmt_${SHFMT_VERSION}_linux_${GOARCH}" && \
+    echo "$DIGEST  /usr/bin/shfmt" | sha256sum --check && \
+    chmod a+x /usr/bin/shfmt
 
 # renovate: datasource=github-release-attachments depName=grafana/tanka
 ENV TANKA_VERSION=v0.37.0
@@ -59,18 +64,27 @@ ENV TANKA_VERSION=v0.37.0
 ENV TANKA_AMD64_DIGEST=c75d4b8736724d9adab1cd5e5373eaa70249e5fafbe1f1b1caef617cbd4411a9
 # renovate: datasource=github-release-attachments depName=grafana/tanka digestVersion=v0.37.0
 ENV TANKA_ARM64_DIGEST=3f7af2b241c5a18a0fcef58f49d70314302841f862797b505d5d5a9eac4032f7
-RUN GOARCH=$(go env GOARCH) && \
-    curl -fSL -o "/usr/bin/tk" "https://github.com/grafana/tanka/releases/download/${TANKA_VERSION}/tk-linux-${GOARCH}" && \
+RUN set -o pipefail && \
+    GOARCH=$(go env GOARCH) && \
+    DIGEST=$(case "$GOARCH" in amd64) echo $TANKA_AMD64_DIGEST;; arm64) echo $TANKA_ARM64_DIGEST;; *) echo "unknown architecture $GOARCH" >/dev/stderr && exit 1;; esac) && \
+    curl -fsSLo /usr/bin/tk "https://github.com/grafana/tanka/releases/download/${TANKA_VERSION}/tk-linux-${GOARCH}" && \
+    echo "$DIGEST  /usr/bin/tk" | sha256sum --check && \
     chmod a+x /usr/bin/tk
 
 # renovate: datasource=github-release-attachments depName=golangci/golangci-lint
-ENV GOLANGCI_LINT_VERSION=2.12.2
+ENV GOLANGCI_LINT_VERSION=v2.12.2
+# renovate: datasource=github-release-attachments depName=golangci/golangci-lint digestVersion=v2.12.2
+ENV GOLANGCI_LINT_AMD64_DIGEST=8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553
+# renovate: datasource=github-release-attachments depName=golangci/golangci-lint digestVersion=v2.12.2
+ENV GOLANGCI_LINT_ARM64_DIGEST=44cd40a8c76c86755375adfeea52cfd3533cb43d7bd647771e0ae065e166df3a
 RUN set -o pipefail && \
-    VERSION_SLUG=golangci-lint-${GOLANGCI_LINT_VERSION}-linux-$(go env GOARCH) && \
+    GOARCH=$(go env GOARCH) && \
+    DIGEST=$(case "$GOARCH" in amd64) echo $GOLANGCI_LINT_AMD64_DIGEST;; arm64) echo $GOLANGCI_LINT_ARM64_DIGEST;; *) echo "unknown architecture $GOARCH" >/dev/stderr && exit 1;; esac) && \
+    VERSION_SLUG=golangci-lint-${GOLANGCI_LINT_VERSION#v}-linux-${GOARCH} && \
     TARBALL=$VERSION_SLUG.tar.gz && \
     cd /tmp && \
-    curl -sfL "https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_LINT_VERSION}/$TARBALL" -o "/tmp/$TARBALL" && \
-    curl -sfL "https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_LINT_VERSION}/golangci-lint-${GOLANGCI_LINT_VERSION}-checksums.txt" | grep -E "\s+$TARBALL$" | sha256sum --check - && \
+    curl -fsSLo "/tmp/$TARBALL" "https://github.com/golangci/golangci-lint/releases/download/${GOLANGCI_LINT_VERSION}/$TARBALL" && \
+    echo "$DIGEST  /tmp/$TARBALL" | sha256sum --check && \
     tar -xzvf "/tmp/$TARBALL" -C /usr/bin --strip-components=1 "$VERSION_SLUG/golangci-lint" && \
     rm /tmp/$TARBALL
 

--- a/mimir-build-image/Dockerfile
+++ b/mimir-build-image/Dockerfile
@@ -54,9 +54,13 @@ RUN GOARCH=$(go env GOARCH) && \
 	mv shfmt /usr/bin
 
 # renovate: datasource=github-release-attachments depName=grafana/tanka
-ENV TANKA_VERSION=0.37.0
+ENV TANKA_VERSION=v0.37.0
+# renovate: datasource=github-release-attachments depName=grafana/tanka digestVersion=v0.37.0
+ENV TANKA_AMD64_DIGEST=c75d4b8736724d9adab1cd5e5373eaa70249e5fafbe1f1b1caef617cbd4411a9
+# renovate: datasource=github-release-attachments depName=grafana/tanka digestVersion=v0.37.0
+ENV TANKA_ARM64_DIGEST=3f7af2b241c5a18a0fcef58f49d70314302841f862797b505d5d5a9eac4032f7
 RUN GOARCH=$(go env GOARCH) && \
-    curl -fSL -o "/usr/bin/tk" "https://github.com/grafana/tanka/releases/download/v${TANKA_VERSION}/tk-linux-${GOARCH}" && \
+    curl -fSL -o "/usr/bin/tk" "https://github.com/grafana/tanka/releases/download/${TANKA_VERSION}/tk-linux-${GOARCH}" && \
     chmod a+x /usr/bin/tk
 
 # renovate: datasource=github-release-attachments depName=golangci/golangci-lint

--- a/renovate.json5
+++ b/renovate.json5
@@ -69,9 +69,9 @@
         'mimir-build-image/Dockerfile',
       ],
       matchStrings: [
-        '# renovate: depName=github.com/(?<depName>[^\\s]+)\\s+ENV [A-Z_]+=(?<currentValue>[^\\s]+)\\s+',
+        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)\\s+ENV [A-Z_]+=(\\s|\"|)(?<currentValue>[^\"\\s]*)(\"|)",
+        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+) digestVersion=(?<currentValue>.*)\\s+ENV [A-Z_]+=(\\s|\"|)(?<currentDigest>[^\"\\s]*)(\"|)"
       ],
-      datasourceTemplate: 'github-tags',
     },
     {
       customType: 'regex',

--- a/renovate.json5
+++ b/renovate.json5
@@ -69,8 +69,8 @@
         'mimir-build-image/Dockerfile',
       ],
       matchStrings: [
-        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)\\s+ENV [A-Z_]+=(\\s|\"|)(?<currentValue>[^\"\\s]*)(\"|)",
-        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+) digestVersion=(?<currentValue>.*)\\s+ENV [A-Z_]+=(\\s|\"|)(?<currentDigest>[^\"\\s]*)(\"|)"
+        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)\\s+ENV [A-Z0-9_]+=(\\s|\"|)(?<currentValue>[^\"\\s]*)(\"|)",
+        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+) digestVersion=(?<currentValue>.*)\\s+ENV [A-Z0-9_]+=(\\s|\"|)(?<currentDigest>[^\"\\s]*)(\"|)"
       ],
     },
     {

--- a/renovate.json5
+++ b/renovate.json5
@@ -58,7 +58,7 @@
         'development/**/dev.dockerfile',
       ],
       matchStrings: [
-        'npm install.*\\s+(?<depName>[^@]+)@(?<currentValue>[^\\s]+)',
+        'npm install\\s+(?:-[^\\s]+\\s+)*(?<depName>[^@\\s]+)@(?<currentValue>[^\\s]+)',
       ],
       datasourceTemplate: 'npm',
     },


### PR DESCRIPTION
#### What this PR does

This PR hardens the build image by validating the checksum of each binary downloaded from GitHub.

These checksums will be updated automatically by Renovate.

This PR also fixes the Renovate configuration for the `npm install` rule added in https://github.com/grafana/mimir/pull/15463.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect the CI/build Docker image and dependency automation, not Mimir runtime or customer-facing behavior.
> 
> **Overview**
> Hardens **`mimir-build-image`** by pinning **per-arch SHA256 digests** for GitHub release binaries (`shfmt`, `tanka`, `golangci-lint`) and running **`sha256sum --check`** after download instead of trusting URLs alone. **golangci-lint** no longer relies on the release checksums file; it uses the same digest-in-`ENV` pattern as the other tools.
> 
> Renovate comments on those installs switch to **`github-release-attachments`** with separate rules for version and digest `ENV` lines, and **`renovate.json5`** regex managers are updated so Renovate can bump versions and digests (and so **`npm install`** lines with flags like `--ignore-scripts` are matched correctly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7d2c92151f4510dca85fcc9e5ab5a8a1996f8ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->