### PR TITLE
drop opentracing/go-stdlib fork and use upstream version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/minio/minio-go/v7 v7.1.0
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/opentracing-contrib/go-grpc v0.1.3
-	github.com/opentracing-contrib/go-stdlib v1.1.1 // indirect
+	github.com/opentracing-contrib/go-stdlib v1.1.2-0.20260528155411-f102363ff79b // indirect
 	github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/alertmanager v0.32.1
@@ -359,9 +359,6 @@ replace github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-2025090510
 
 // Replace goautoneg with a fork until https://github.com/munnerz/goautoneg/pull/6 is merged
 replace github.com/munnerz/goautoneg => github.com/grafana/goautoneg v0.0.0-20240607115440-f335c04c58ce
-
-// Replace opentracing-contrib/go-stdlib with a fork until https://github.com/opentracing-contrib/go-stdlib/pull/68 is merged.
-replace github.com/opentracing-contrib/go-stdlib => github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956
 
 // Replace opentracing-contrib/go-grpc with a fork until https://github.com/opentracing-contrib/go-grpc/pull/16 is merged.
 replace github.com/opentracing-contrib/go-grpc => github.com/charleskorn/go-grpc v0.0.0-20231024023642-e9298576254f

--- a/go.sum
+++ b/go.sum
@@ -587,8 +587,6 @@ github.com/grafana/mimir-otlptranslator v0.0.0-20251017074411-ea1e8f863e1d h1:k4
 github.com/grafana/mimir-otlptranslator v0.0.0-20251017074411-ea1e8f863e1d/go.mod h1:vRYWnXvI6aWGpsdY/mOT/cbeVRBlPWtBNDb7kGR3uKM=
 github.com/grafana/mimir-prometheus v1.8.2-0.20260528024839-fde2ae6d4999 h1:hrVQOV6G0IMRGQLeyIOU+eG4qiCUBrVYLr9LMOEZl4Y=
 github.com/grafana/mimir-prometheus v1.8.2-0.20260528024839-fde2ae6d4999/go.mod h1:0uqQhgbbJ9C2S3XzfbDXOK0zX8a1ttRm6tU7jijlK1E=
-github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956 h1:em1oddjXL8c1tL0iFdtVtPloq2hRPen2MJQKoAWpxu0=
-github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
 github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF3YH66t4qL8=
 github.com/grafana/otel-profiling-go v0.5.1/go.mod h1:ftN/t5A/4gQI19/8MoWurBEtC6gFw8Dns1sJZ9W4Tls=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.9 h1:c1Us8i6eSmkW+Ez05d3co8kasnuOY813tbMN8i/a3Og=
@@ -846,7 +844,10 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
+github.com/opentracing-contrib/go-stdlib v1.1.2-0.20260528155411-f102363ff79b h1:/Mcr2xSTmQ6FSTiWEEkH9Hbc0BIbonGM5aiZeA8h9D4=
+github.com/opentracing-contrib/go-stdlib v1.1.2-0.20260528155411-f102363ff79b/go.mod h1:S0p+X9p6dcBkoMTL+Qq2VOvxKs9ys5PpYWXWqlCS0bQ=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
+github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b h1:FfH+VrHHk6Lxt9HdVS0PXzSXFyS2NbZKXv33FYPol0A=
 github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b/go.mod h1:AC62GU6hc0BrNm+9RK9VSiwa/EUe1bkIeFORAMcHvJU=
 github.com/oracle/oci-go-sdk/v65 v65.41.1 h1:+lbosOyNiib3TGJDvLq1HwEAuFqkOjPJDIkyxM15WdQ=

--- a/vendor/github.com/opentracing-contrib/go-stdlib/nethttp/server.go
+++ b/vendor/github.com/opentracing-contrib/go-stdlib/nethttp/server.go
@@ -1,3 +1,4 @@
+//go:build go1.7
 // +build go1.7
 
 package nethttp
@@ -69,24 +70,26 @@ func MWURLTagFunc(f func(u *url.URL) string) MWOption {
 // Additionally, it adds the span to the request's context.
 //
 // By default, the operation name of the spans is set to "HTTP {method}".
-// This can be overriden with options.
+// This can be overridden with options.
 //
 // Example:
-// 	 http.ListenAndServe("localhost:80", nethttp.Middleware(tracer, http.DefaultServeMux))
+//
+//	http.ListenAndServe("localhost:80", nethttp.Middleware(tracer, http.DefaultServeMux))
 //
 // The options allow fine tuning the behavior of the middleware.
 //
 // Example:
-//   mw := nethttp.Middleware(
-//      tracer,
-//      http.DefaultServeMux,
-//      nethttp.OperationNameFunc(func(r *http.Request) string {
-//	        return "HTTP " + r.Method + ":/api/customers"
-//      }),
-//      nethttp.MWSpanObserver(func(sp opentracing.Span, r *http.Request) {
-//			sp.SetTag("http.uri", r.URL.EscapedPath())
-//		}),
-//   )
+//
+//	  mw := nethttp.Middleware(
+//	     tracer,
+//	     http.DefaultServeMux,
+//	     nethttp.OperationNameFunc(func(r *http.Request) string {
+//		        return "HTTP " + r.Method + ":/api/customers"
+//	     }),
+//	     nethttp.MWSpanObserver(func(sp opentracing.Span, r *http.Request) {
+//				sp.SetTag("http.uri", r.URL.EscapedPath())
+//			}),
+//	  )
 func Middleware(tr opentracing.Tracer, h http.Handler, options ...MWOption) http.Handler {
 	return MiddlewareFunc(tr, h.ServeHTTP, options...)
 }
@@ -95,7 +98,8 @@ func Middleware(tr opentracing.Tracer, h http.Handler, options ...MWOption) http
 // It behaves identically to the Middleware function above.
 //
 // Example:
-//   http.ListenAndServe("localhost:80", nethttp.MiddlewareFunc(tracer, MyHandler))
+//
+//	http.ListenAndServe("localhost:80", nethttp.MiddlewareFunc(tracer, MyHandler))
 func MiddlewareFunc(tr opentracing.Tracer, h http.HandlerFunc, options ...MWOption) http.HandlerFunc {
 	opts := mwOptions{
 		opNameFunc: func(r *http.Request) string {
@@ -141,7 +145,7 @@ func MiddlewareFunc(tr opentracing.Tracer, h http.HandlerFunc, options ...MWOpti
 				mt.status = 200
 			}
 			if mt.status > 0 {
-				ext.HTTPStatusCode.Set(sp, uint16(mt.status))
+				ext.HTTPStatusCode.Set(sp, uint16(mt.status)) //nolint:gosec // can't have integer overflow with status code
 			}
 			if mt.size > 0 {
 				sp.SetTag(responseSizeKey, mt.size)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -988,7 +988,7 @@ github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumul
 # github.com/opentracing-contrib/go-grpc v0.1.3 => github.com/charleskorn/go-grpc v0.0.0-20231024023642-e9298576254f
 ## explicit; go 1.11
 github.com/opentracing-contrib/go-grpc
-# github.com/opentracing-contrib/go-stdlib v1.1.1 => github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956
+# github.com/opentracing-contrib/go-stdlib v1.1.2-0.20260528155411-f102363ff79b
 ## explicit; go 1.14
 github.com/opentracing-contrib/go-stdlib/nethttp
 # github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b
@@ -2168,6 +2168,5 @@ sigs.k8s.io/yaml
 # go.yaml.in/yaml/v3 => github.com/grafana/go-yaml/v3 v3.0.0-20260130164322-e3c24e8f4c87
 # github.com/grafana/regexp => github.com/grafana/regexp v0.0.0-20250905101755-5eb4f3acbf71
 # github.com/munnerz/goautoneg => github.com/grafana/goautoneg v0.0.0-20240607115440-f335c04c58ce
-# github.com/opentracing-contrib/go-stdlib => github.com/grafana/opentracing-contrib-go-stdlib v0.0.0-20230509071955-f410e79da956
 # github.com/opentracing-contrib/go-grpc => github.com/charleskorn/go-grpc v0.0.0-20231024023642-e9298576254f
 # github.com/prometheus/otlptranslator => github.com/grafana/mimir-otlptranslator v0.0.0-20251017074411-ea1e8f863e1d


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

With https://github.com/opentracing-contrib/go-stdlib/pull/99 merged, we can now drop the replace directive and use the upstream version directly.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency/vendor-only change to HTTP OpenTracing middleware; behavior should match the previously forked fixes now merged upstream.
> 
> **Overview**
> Removes the **`replace`** for `github.com/opentracing-contrib/go-stdlib` that pointed at Grafana’s fork and pins **upstream** `github.com/opentracing-contrib/go-stdlib` at pseudo-version `v1.1.2-0.20260528155411-f102363ff79b` (after upstream PR #99). **`go.sum`**, **`vendor/modules.txt`**, and vendored **`nethttp`** sources are refreshed accordingly.
> 
> The vendored HTTP tracing helpers pick up small upstream tweaks (e.g. `http.MethodHead`, status-code `gosec`/`errcheck` nolint comments, doc formatting)—no Mimir application code changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c225c507983dc0268137f2427b7b7fae235f3b91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->