### PR TITLE
Fixing 'Incorrect conversion between integer types' CodeQL findings

### DIFF
--- a/pkg/storegateway/gateway_blocks_http.go
+++ b/pkg/storegateway/gateway_blocks_http.go
@@ -82,8 +82,8 @@ func (g *StoreGateway) BlocksHandler(w http.ResponseWriter, req *http.Request) {
 		if splitCount < 0 {
 			splitCount = 0
 		}
-		if splitCount > math.MaxUint32 {
-			splitCount = math.MaxUint32
+		if splitCount > math.MaxInt32 {
+			splitCount = math.MaxInt32
 		}
 	}
 

--- a/pkg/storegateway/gateway_blocks_http.go
+++ b/pkg/storegateway/gateway_blocks_http.go
@@ -6,6 +6,7 @@ import (
 	_ "embed" // Used to embed html template
 	"fmt"
 	"html/template"
+	"math"
 	"net/http"
 	"strconv"
 	"time"
@@ -80,6 +81,9 @@ func (g *StoreGateway) BlocksHandler(w http.ResponseWriter, req *http.Request) {
 		splitCount, _ = strconv.Atoi(sc)
 		if splitCount < 0 {
 			splitCount = 0
+		}
+		if splitCount > math.MaxUint32 {
+			splitCount = math.MaxUint32
 		}
 	}
 

--- a/pkg/usagetracker/tracker.go
+++ b/pkg/usagetracker/tracker.go
@@ -994,7 +994,7 @@ func parseInstanceID(instanceID string) (int32, error) {
 		return 0, fmt.Errorf("no sequence number in instance ID %s", instanceID)
 	}
 
-	return int32(seq), nil //nolint:gosec
+	return int32(seq), nil
 }
 
 func snapshotFilename(ts time.Time, instanceID string, partitionID int32) string {

--- a/pkg/usagetracker/tracker.go
+++ b/pkg/usagetracker/tracker.go
@@ -989,7 +989,7 @@ func parseInstanceID(instanceID string) (int32, error) {
 	}
 
 	// Parse the instance sequence number.
-	seq, err := strconv.Atoi(match[1])
+	seq, err := strconv.ParseInt(match[1], 10, 32)
 	if err != nil {
 		return 0, fmt.Errorf("no sequence number in instance ID %s", instanceID)
 	}


### PR DESCRIPTION
#### What this PR does
Addresses two `Incorrect conversion between integer types` (CWE-681) findings reported by CodeQL.

- **`pkg/storegateway/gateway_blocks_http.go`** — `BlocksHandler` parses `split_count` from the request form into `int` and later converts it to `uint32` (`tsdb.HashBlockID(m.ULID) % uint32(splitCount)`). On 64-bit platforms an `int` value above `math.MaxUint32` would silently wrap on the conversion. Bound-check `splitCount` against `math.MaxUint32` (in addition to the existing negative-value guard) so the downstream `uint32(splitCount)` cast is provably safe.
- **`pkg/usagetracker/tracker.go`** — `parseInstanceID` parsed the sequence number with `strconv.Atoi` (returns platform-width `int`) and then narrowed to `int32` with a `//nolint:gosec` annotation. Switch to `strconv.ParseInt(match[1], 10, 32)`, which validates the value fits in `int32` and returns an error otherwise. The downstream `int32(seq)` cast is now guaranteed within range.


Neither change alters externally observable behavior for valid inputs: rejected/clamped values were already unreachable through normal use. The fixes close the static-analysis findings and remove the dependency on linter-suppression comments.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow defensive parsing/bounds checks with no intended behavior change for normal configuration values.
> 
> **Overview**
> Addresses CodeQL **CWE-681** (incorrect integer conversions) in two small, defensive changes.
> 
> In **`BlocksHandler`**, the `split_count` query parameter is now capped at **`math.MaxInt32`** after parsing, so the later **`uint32(splitCount)`** used in block split hashing cannot wrap on 64-bit builds when someone passes an oversized value.
> 
> In **`parseInstanceID`**, the trailing sequence number is parsed with **`strconv.ParseInt(..., 32)`** instead of **`strconv.Atoi`** plus an **`int32`** cast, so out-of-range values fail parsing instead of truncating; the **`//nolint:gosec`** suppression is removed.
> 
> Valid operational inputs should behave the same; the changes mainly satisfy static analysis and remove linter suppressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f427d3f1ee2d4e07707d4597efcec920557b5ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->