### PR TITLE
feat(helm): add gateway.nginx.config.mainSnippet for the main NGINX context

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -30,6 +30,8 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
+* [ENHANCEMENT] Gateway: Add `gateway.nginx.config.mainSnippet` to append custom configuration to the main (top-level) NGINX context, for example to load dynamic modules. #15519
+
 ## 6.1.0
 
 * [CHANGE] Kafka: Removed `kafka.extraEnv`. Use `kafka.env` instead. #14892

--- a/operations/helm/charts/mimir-distributed/ci/offline/gateway-nginx-values.yaml
+++ b/operations/helm/charts/mimir-distributed/ci/offline/gateway-nginx-values.yaml
@@ -3,6 +3,11 @@ kubeVersionOverride: "1.32"
 
 gateway:
   enabledNonEnterprise: true
+  nginx:
+    config:
+      mainSnippet: |-
+        load_module /etc/nginx/modules/ndk_http_module.so;
+        load_module /etc/nginx/modules/ngx_http_lua_module.so;
   resources:
     requests:
       memory: 10Mi

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -3378,6 +3378,8 @@ gateway:
       errorLogLevel: error
       # -- Enables NGINX access logs
       accessLogEnabled: true
+      # -- Allows appending custom configuration to the main block
+      mainSnippet: ""
       # -- Allows appending custom configuration to the server block
       serverSnippet: ""
       # -- Allows appending custom configuration to the http block
@@ -3390,6 +3392,9 @@ gateway:
       enableIPv6: true
       # -- Config file contents for Nginx. Passed through the `tpl` function to allow templating.
       file: |
+        {{- if .Values.gateway.nginx.config.mainSnippet -}}
+        {{ .Values.gateway.nginx.config.mainSnippet }}
+        {{ end -}}
         worker_processes  5;  ## Default: 1
         error_log  /dev/stderr {{ .Values.gateway.nginx.config.errorLogLevel }};
         pid        /tmp/nginx.pid;

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/gateway/nginx-configmap.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/gateway/nginx-configmap.yaml
@@ -12,6 +12,8 @@ metadata:
   namespace: "citestns"
 data:
   nginx.conf: |
+    load_module /etc/nginx/modules/ndk_http_module.so;
+    load_module /etc/nginx/modules/ngx_http_lua_module.so;
     worker_processes  5;  ## Default: 1
     error_log  /dev/stderr error;
     pid        /tmp/nginx.pid;


### PR DESCRIPTION
#### What this PR does

Adds a `gateway.nginx.config.mainSnippet` value to the Helm chart, mirroring the
existing `serverSnippet` / `httpSnippet` options but for the top-level (main)
NGINX context. This lets users inject custom directives — for example
`load_module` to enable dynamic modules — without having to override the entire
`gateway.nginx.config.file`.

The snippet is rendered above `worker_processes` and is gated with whitespace
trimming (`{{- if ... -}} ... {{ end -}}`) so that when it is empty the generated
config is byte-for-byte unchanged (no existing golden records change).

e.g. `operations/helm/charts/mimir-distributed/ci/offline/gateway-nginx-values.yaml`:

```yaml
gateway:
  enabledNonEnterprise: true
  nginx:
    config:
      mainSnippet: |-
        load_module /etc/nginx/modules/ndk_http_module.so;
        load_module /etc/nginx/modules/ngx_http_lua_module.so;
```

yields:

```yaml
data:
  nginx.conf: |
    load_module /etc/nginx/modules/ndk_http_module.so;
    load_module /etc/nginx/modules/ngx_http_lua_module.so;
    worker_processes  5;  ## Default: 1
    error_log  /dev/stderr error;
    pid        /tmp/nginx.pid;
```

#### Which issue(s) this PR fixes or relates to

Fixes #9059

#### Checklist

- [x] Tests updated. (`gateway-nginx-values` golden record exercises a non-empty snippet)
- [x] Documentation added. (the `# --` comment on the value, matching the existing `serverSnippet` / `httpSnippet` convention)
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional Helm value with empty default preserves existing nginx.conf; only affects gateway NGINX config when explicitly set.
> 
> **Overview**
> Adds **`gateway.nginx.config.mainSnippet`** to the mimir-distributed Helm chart so operators can inject directives into the **top-level (main) NGINX context**—for example **`load_module`**—without replacing the entire **`gateway.nginx.config.file`**.
> 
> The snippet is rendered **above `worker_processes`** in the default nginx config template, using the same **whitespace-trimmed `{{- if ... -}}`** pattern as **`serverSnippet`** / **`httpSnippet`**, so the default empty value leaves generated **`nginx.conf`** unchanged. CI values and the **gateway-nginx** golden ConfigMap exercise a non-empty snippet with **`load_module`** lines; **CHANGELOG** documents the enhancement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e788037c674fc91fe51fb6eabe002cde6843cea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->