### PR TITLE
Fix typo in Grafana URL in README

### DIFF
--- a/development/README.md
+++ b/development/README.md
@@ -15,7 +15,7 @@ Choose a sub-folder for whichever Mimir deployment mode you want to run. Then, t
 ./compose-up.sh
 ```
 
-This should give you a running Mimir system with Grafana available at [htttp://localhost:3000](http://localhost:3000), and other Mimir service UIs available via different ports (check `docker ps` for exact ports).
+This should give you a running Mimir system with Grafana available at [http://localhost:3000](http://localhost:3000), and other Mimir service UIs available via different ports (check `docker ps` for exact ports).
 
 The Minio console is available in most dev environments at [http://localhost:9001](http://localhost:9001), with the credentials defined in [mimir.yaml][minio-creds].
 


### PR DESCRIPTION

#### What this PR does

Fixes a typo in the development/README.md file (htttp to http). This typo was originally part of https://github.com/grafana/mimir/pull/15201, but the original author hasn't signed the CLA. 

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [X] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link fix with no runtime or security impact.
> 
> **Overview**
> Corrects a typo in the Grafana link in `development/README.md`: the URL text and href used `htttp` instead of `http` for localhost:3000.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9b01a2107bb855eb6011d893200805077f04207. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->