### PR TITLE
Track serialization time in ingest storage writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 * [ENHANCEMENT] Store-gateway: Remove outdated limit on caching LabelValues responses that contain more than 655360 values. The gob library panic which required workaround was fixed. #5021 #15271
 * [ENHANCEMENT] MQE: Reduce memory consumption of range vector splitting when many consecutive intervals are not cached. #15173
 * [ENHANCEMENT] Ingester: Make max concurrency for label values count endpoint configurable with `-ingester.label-values-count-max-concurrency`. #15299
-* [ENHANCEMENT] Ingest storage: Add `cortex_ingest_storage_writer_serialize_duration_seconds` native histogram metric tracking the time spent serializing an incoming request to Kafka records. #15526
+* [ENHANCEMENT] Ingest storage: Add `cortex_ingest_storage_writer_serialize_duration_seconds` native histogram metric tracking the time spent serializing an incoming request to Kafka records. #15527
 * [BUGFIX] Ingest storage: Fix `KafkaProducer.ProduceSync()` returning a single result with a nil record when the context is canceled, instead of one result per input record (with the record set) as the underlying franz-go client does. #15199
 * [BUGFIX] Distributor: Return HTTP 200 with OTLP partial-success when only some samples in an OTLP request are rejected by distributor-level validation (e.g. `too_far_in_past`). #15253
 * [BUGFIX] MQE: Bugfixes for experimental range vector splitting. #15147 #15270 #14878

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [ENHANCEMENT] Store-gateway: Remove outdated limit on caching LabelValues responses that contain more than 655360 values. The gob library panic which required workaround was fixed. #5021 #15271
 * [ENHANCEMENT] MQE: Reduce memory consumption of range vector splitting when many consecutive intervals are not cached. #15173
 * [ENHANCEMENT] Ingester: Make max concurrency for label values count endpoint configurable with `-ingester.label-values-count-max-concurrency`. #15299
+* [ENHANCEMENT] Ingest storage: Add `cortex_ingest_storage_writer_serialize_duration_seconds` native histogram metric tracking the time spent serializing an incoming request to Kafka records. #15526
 * [BUGFIX] Ingest storage: Fix `KafkaProducer.ProduceSync()` returning a single result with a nil record when the context is canceled, instead of one result per input record (with the record set) as the underlying franz-go client does. #15199
 * [BUGFIX] Distributor: Return HTTP 200 with OTLP partial-success when only some samples in an OTLP request are rejected by distributor-level validation (e.g. `too_far_in_past`). #15253
 * [BUGFIX] MQE: Bugfixes for experimental range vector splitting. #15147 #15270 #14878

--- a/pkg/storage/ingest/writer.go
+++ b/pkg/storage/ingest/writer.go
@@ -72,6 +72,7 @@ type Writer struct {
 	writeBytesTotal     prometheus.Counter
 	inputBytesTotal     prometheus.Counter
 	recordsPerRequest   prometheus.Histogram
+	serializeDuration   prometheus.Histogram
 }
 
 func NewWriter(kafkaCfg KafkaConfig, logger log.Logger, reg prometheus.Registerer) *Writer {
@@ -105,6 +106,14 @@ func NewWriter(kafkaCfg KafkaConfig, logger log.Logger, reg prometheus.Registere
 			Name:    "cortex_ingest_storage_writer_records_per_write_request",
 			Help:    "The number of records a single per-partition write request has been split into.",
 			Buckets: prometheus.ExponentialBuckets(1, 2, 8),
+		}),
+		serializeDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Name:                            "cortex_ingest_storage_writer_serialize_duration_seconds",
+			Help:                            "Time spent serializing an incoming request to Kafka records.",
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMinResetDuration: 1 * time.Hour,
+			NativeHistogramMaxBucketNumber:  100,
+			Buckets:                         prometheus.DefBuckets,
 		}),
 	}
 
@@ -173,6 +182,7 @@ func (w *Writer) MultiWriteSync(ctx context.Context, topic string, userID string
 		allRecords       []*kgo.Record
 		requestSizeBytes int
 	)
+	serializeStart := time.Now()
 	for _, pr := range partitionRequests {
 		// Nothing to do if the input data is empty.
 		if pr.WriteRequest.IsEmpty() {
@@ -192,6 +202,7 @@ func (w *Writer) MultiWriteSync(ctx context.Context, topic string, userID string
 		allRecords = append(allRecords, records...)
 		requestSizeBytes += reqSizeBytes
 	}
+	w.serializeDuration.Observe(time.Since(serializeStart).Seconds())
 
 	// Nothing to do if all requests were empty.
 	if len(allRecords) == 0 {

--- a/pkg/storage/ingest/writer.go
+++ b/pkg/storage/ingest/writer.go
@@ -182,7 +182,6 @@ func (w *Writer) MultiWriteSync(ctx context.Context, topic string, userID string
 		allRecords       []*kgo.Record
 		requestSizeBytes int
 	)
-	serializeStart := time.Now()
 	for _, pr := range partitionRequests {
 		// Nothing to do if the input data is empty.
 		if pr.WriteRequest.IsEmpty() {
@@ -202,7 +201,7 @@ func (w *Writer) MultiWriteSync(ctx context.Context, topic string, userID string
 		allRecords = append(allRecords, records...)
 		requestSizeBytes += reqSizeBytes
 	}
-	w.serializeDuration.Observe(time.Since(serializeStart).Seconds())
+	w.serializeDuration.Observe(time.Since(startTime).Seconds())
 
 	// Nothing to do if all requests were empty.
 	if len(allRecords) == 0 {

--- a/pkg/storage/ingest/writer_test.go
+++ b/pkg/storage/ingest/writer_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/grafana/dskit/flagext"
+	dskit_metrics "github.com/grafana/dskit/metrics"
 	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
 	promtest "github.com/prometheus/client_golang/prometheus/testutil"
@@ -132,6 +133,8 @@ func TestWriter_WriteSync(t *testing.T) {
 			"cortex_ingest_storage_writer_sent_bytes_total",
 			"cortex_ingest_storage_writer_records_per_write_request",
 			"cortex_ingest_storage_writer_produce_records_enqueued_total"))
+
+		assertHistogramSampleCount(t, reg, "cortex_ingest_storage_writer_serialize_duration_seconds", 1)
 	})
 
 	t.Run("should block until data has been committed to storage (WriteRequest stored in multiple records)", func(t *testing.T) {
@@ -224,6 +227,8 @@ func TestWriter_WriteSync(t *testing.T) {
 			"cortex_ingest_storage_writer_sent_bytes_total",
 			"cortex_ingest_storage_writer_records_per_write_request",
 			"cortex_ingest_storage_writer_produce_records_enqueued_total"))
+
+		assertHistogramSampleCount(t, reg, "cortex_ingest_storage_writer_serialize_duration_seconds", 1)
 	})
 
 	t.Run("should write to the requested partition", func(t *testing.T) {
@@ -885,6 +890,8 @@ func TestWriter_MultiWriteSync(t *testing.T) {
 			"cortex_ingest_storage_writer_sent_bytes_total",
 			"cortex_ingest_storage_writer_records_per_write_request",
 			"cortex_ingest_storage_writer_produce_records_enqueued_total"))
+
+		assertHistogramSampleCount(t, reg, "cortex_ingest_storage_writer_serialize_duration_seconds", 1)
 	})
 
 	t.Run("should skip empty requests", func(t *testing.T) {
@@ -953,6 +960,8 @@ func TestWriter_MultiWriteSync(t *testing.T) {
 			"cortex_ingest_storage_writer_sent_bytes_total",
 			"cortex_ingest_storage_writer_records_per_write_request",
 			"cortex_ingest_storage_writer_produce_records_enqueued_total"))
+
+		assertHistogramSampleCount(t, reg, "cortex_ingest_storage_writer_serialize_duration_seconds", 1)
 	})
 
 	t.Run("should return nil when all partition requests are empty", func(t *testing.T) {
@@ -1676,6 +1685,18 @@ func createTestKafkaConfig(clusterAddr, topicName string) KafkaConfig {
 	cfg.concurrentFetchersFetchBackoffConfig = fastFetchBackoffConfig
 
 	return cfg
+}
+
+// assertHistogramSampleCount asserts that the histogram metric with the given name
+// has been observed the expected number of times.
+func assertHistogramSampleCount(t *testing.T, reg prometheus.Gatherer, metricName string, expected uint64) {
+	t.Helper()
+
+	mfm, err := dskit_metrics.NewMetricFamilyMapFromGatherer(reg)
+	require.NoError(t, err)
+	hist, err := dskit_metrics.FindHistogramWithNameAndLabels(mfm, metricName)
+	require.NoError(t, err)
+	assert.Equal(t, expected, hist.GetSampleCount())
 }
 
 func createTestWriter(t *testing.T, cfg KafkaConfig) (*Writer, prometheus.Gatherer) {


### PR DESCRIPTION
#### What this PR does

Adds a new native histogram metric `cortex_ingest_storage_writer_serialize_duration_seconds` that measures the time `MultiWriteSync()` spends serializing the input write request(s) into Kafka records.

#### Why

We found edge cases where serializing large rule evaluation results into Kafka records takes a few seconds. The existing `cortex_ingest_storage_writer_latency_seconds` metric covers the whole `MultiWriteSync()` call (including the round-trip to Kafka), so it's not possible today to tell how much of that latency is CPU-bound serialization vs. Kafka. The new metric makes the serialization cost directly observable.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.