### PR TITLE
docs: Add documentation for Kafka authentication

### DIFF
--- a/docs/sources/mimir/configure/configure-kafka-backend.md
+++ b/docs/sources/mimir/configure/configure-kafka-backend.md
@@ -25,6 +25,7 @@ Set the following configuration flags to enable Grafana Mimir to use ingest stor
 
 - `-ingest-storage.kafka.topic=<name>`<br />
   The `<name>` is the name of the Kafka topic that is used for ingesting data.
+
 - `-ingest-storage.kafka.auto-create-topic-default-partitions=<number>`<br />
   If the configured topic doesn't exist in the Kafka backend, the Mimir components, either consumers or producers,
   create the topic on first access. The `<number>` parameter sets the number of partitions to create when the topic is automatically created. The number of partitions must be at least the number of ingesters in one zone.
@@ -90,3 +91,116 @@ Configure the following CLI flags or their YAML equivalent.
 ```
 -ingest-storage.kafka.use-compressed-bytes-as-fetch-max-bytes=false
 ```
+
+## Authentication
+
+Grafana Mimir supports multiple ways of authenticating with a Kafka cluster.
+
+### Username and password (PLAIN, SCRAM)
+
+Set the following configuration flags to authenticate with username and password:
+
+- `-ingest-storage.kafka.sasl-mechanism`<br />
+  Set to `SCRAM-SHA-256`, `SCRAM-SHA-512`, or `PLAIN`.
+
+- `-ingest-storage.kafka.sasl-username`
+
+- `-ingest-storage.kafka.sasl-password`
+
+## OAUTHBEARER or AWS_MSK_IAM
+
+Set the following configuration flags to authenticate with OAuth or MSK IAM:
+
+- `-ingest-storage.kafka.sasl-mechanism`<br />
+  Set to `OAUTHBEARER` or `AWS_MSK_IAM`.
+
+Both mechanisms share common patterns: either statically, with values set at startup and then don't change, or dynamically, through a configuration file or a HTTP callback that are checked anew every time reauthentication is required.
+
+#### With static configuration
+
+You may set authentication configuration directly as configuration flags. See below for the flags each mechanism requires.
+
+An important downside of this approach is that the Grafana Mimir components that connect to Kafka must be restarted whenever reauthentication is required.
+
+#### With path to configuration file
+
+Set the following configuration flag to specify the path to a file that contains a JSON object configuring authentication credentials:
+
+- `-ingest-storage.kafka.sasl-<MECHANISM>-file-path`<br />
+  Replace `<MECHANISM>` with `oauthbearer` or `msk-iam`.
+
+See below for the shape the JSON object in the file must take.
+
+This file is opened and read anew whenever reauthentication is required. Grafana Mimir doesn't signal when this happens; authentication credentials lifetime and file updates must be handled out-of-band. Alternatively, you may configure an HTTP callback, which receives an HTTP request whenever reauthentication is required.
+
+#### With HTTP callback
+
+Set the following configuration flag to specify the path to a Unix domain socket:
+
+- `-ingest-storage.kafka.sasl-<MECHANISM>-http-socket-path`<br />
+  Replace `<MECHANISM>` with `oauthbearer` or `msk-iam`.
+
+A server must be listening for connections on this Unix domain socket. On receiving an HTTP GET request to path `/`, the server must respond with status 200 OK and a JSON object containing the authentication configuration.
+
+See below for the shape the JSON object must take.
+
+Using an HTTP callback has some important benefits compared to the static configuration and the file-based approaches:
+
+- Because Grafana Mimir issues an HTTP request whenever reauthentication is required, you don't need to manage authentication lifetime out-of-band.
+- Authentication credentials don't need to be persisted. They may be obtained on-the-fly and sent back to Grafana Mimir for the lifespan of a single HTTP request.
+
+#### OAUTHBEARER configuration details
+
+For static configuration, set the following configuration flags:
+
+- `-ingest-storage.kafka.sasl-oauthbearer-token`
+- `-ingest-storage.kafka.sasl-oauthbearer-zid`
+- `-ingest-storage.kafka.sasl-oauthbearer-extensions` (optional)
+
+For dynamic configuration (file or HTTP callback), set a JSON object with the following shape:
+
+```json
+{
+  "token": "<token>",
+  "zid": "<authorization ID>",
+  "extensions": {
+    "<key>": "<value>"
+  } // (optional)
+}
+```
+
+Only `token` is required.
+
+#### MSK_IAM configuration details
+
+For static configuration, set the following configuration flags:
+
+- `-ingest-storage.kafka.sasl-msk-iam-access-key`
+- `-ingest-storage.kafka.sasl-msk-iam-secret-key`
+- `-ingest-storage.kafka.sasl-msk-iam-session-token` (optional)
+- `-ingest-storage.kafka.sasl-msk-iam-user-agent` (optional)
+
+For dynamic configuration (file or HTTP callback), set a JSON object with the following shape:
+
+```json
+{
+  "AccessKey": "<access key ID>",
+  "SecretKey": "<secret access key>",
+  "SessionToken": "<session token>", // (optional)
+  "UserAgent": "<user agent>" // (optional)
+}
+```
+
+### TLS / mTLS
+
+Set the following configuration parameter to enable connecting to the Kafka cluster over TLS:
+
+- `-ingest-storage.kafka.tls-enabled=true`
+
+For mutual authentication (mTLS), set the following additional flags:
+
+- `-ingest-storage.kafka.tls-ca-path`
+- `-ingest-storage.kafka.tls-cert-path`
+- `-ingest-storage.kafka.tls-key-path`
+
+Refer to Grafana Mimir [configuration parameters](https://grafana.com/docs/mimir/<MIMIR_VERSION>/configure/configuration-parameters/) for details and additional options.

--- a/docs/sources/mimir/configure/configure-kafka-backend.md
+++ b/docs/sources/mimir/configure/configure-kafka-backend.md
@@ -107,7 +107,7 @@ Set the following configuration flags to authenticate with username and password
 
 - `-ingest-storage.kafka.sasl-password`
 
-## OAUTHBEARER or AWS_MSK_IAM
+### OAUTHBEARER or AWS_MSK_IAM
 
 Set the following configuration flags to authenticate with OAuth or MSK IAM:
 

--- a/docs/sources/mimir/release-notes/v3.1.md
+++ b/docs/sources/mimir/release-notes/v3.1.md
@@ -21,7 +21,7 @@ Grafana Mimir version 3.1 includes the following key features and enhancements.
 
 ### More Kafka options for Ingest storage
 
-Ingest storage now supports additional ways to authenticate with Kafka through the new `-ingest-storage.kafka.sasl-mechanism` flag, including SCRAM, OAUTHBEARER, and AWS MSK IAM authentication. In addition, new `-ingest-storage.kafka.tls*` flags allow connecting to Kafka clusters over TLS, including mTLS.
+Ingest storage now supports additional ways to authenticate with Kafka through the new `-ingest-storage.kafka.sasl-mechanism` flag, including SCRAM, OAUTHBEARER, and AWS MSK IAM authentication. In addition, new `-ingest-storage.kafka.tls*` flags allow connecting to Kafka clusters over TLS, including mTLS. Refer to [Kafka configuration](https://grafana.com/docs/mimir/<MIMIR_VERSION>/configure/configure-kafka-backend/) for details.
 
 You can also configure multiple Kafka seed brokers via comma-separated values in `-ingest-storage.kafka.address` and enable rack-aware consumption with `-ingest-storage.kafka.client-rack`.
 


### PR DESCRIPTION
#### What this PR does

Adds docs for Kafka authentication.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/issues/13366

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or configuration behavior impact.
> 
> **Overview**
> Documents how to authenticate Grafana Mimir ingest storage to Kafka, covering **PLAIN/SCRAM**, **OAUTHBEARER**, and **AWS_MSK_IAM**, plus **TLS/mTLS** via the `-ingest-storage.kafka.tls*` flags.
> 
> The new **Authentication** section in `configure-kafka-backend.md` explains static flags, JSON **file** paths (`sasl-<mechanism>-file-path`), and **Unix socket HTTP callbacks** (`sasl-<mechanism>-http-socket-path`) for credential refresh without restarts, including JSON shapes for OAuth and MSK IAM.
> 
> The v3.1 release notes **More Kafka options for Ingest storage** bullet now points readers to that Kafka configuration page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08ceb5266965dd12628469086bd0d3a03a9e9751. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->