### PR TITLE
[3.1 backport] Add release notes for 3.1

### DIFF
--- a/docs/sources/mimir/release-notes/v3.1.md
+++ b/docs/sources/mimir/release-notes/v3.1.md
@@ -1,0 +1,112 @@
+---
+title: "Grafana Mimir version 3.1 release notes"
+menuTitle: "V3.1 release notes"
+description: "Release notes for Grafana Mimir version 3.1"
+weight: 1100
+---
+
+# Grafana Mimir version 3.1 release notes
+
+<!-- vale Grafana.GoogleWill = NO -->
+<!-- vale Grafana.Timeless = NO -->
+<!-- Release notes are often future focused -->
+
+Grafana Labs is excited to announce version 3.1 of Grafana Mimir.
+
+The highlights that follow include the top features, enhancements, and bug fixes in this release. For the complete list of changes, refer to the [CHANGELOG](https://github.com/grafana/mimir/blob/main/CHANGELOG.md).
+
+## Features and enhancements
+
+Grafana Mimir version 3.1 includes the following key features and enhancements.
+
+### More Kafka options for Ingest storage
+
+Ingest storage now supports additional ways to authenticate with Kafka through the new `-ingest-storage.kafka.sasl-mechanism` flag, including SCRAM, OAUTHBEARER, and AWS MSK IAM authentication. In addition, new `-ingest-storage.kafka.tls*` flags allow connecting to Kafka clusters over TLS, including mTLS.
+
+You can also configure multiple Kafka seed brokers via comma-separated values in `-ingest-storage.kafka.address` and enable rack-aware consumption with `-ingest-storage.kafka.client-rack`.
+
+### Separate ingestion limits by tenant metadata
+
+Distributors can now track limits separately based on tenant metadata. This allows operators to track limits separately for subsets of write requests belonging to the same tenant, for example to prioritize some sources of metrics over others.
+
+Clients may pass tenant metadata in the `X-Scope-OrgID` header using the format `tenantID:key1=value1:key2=value2`, and operators may define per-metadata overrides in the runtime configuration.
+
+### Mimir Query Engine (MQE) improvements
+
+MQE continues to receive significant optimizations in this release:
+
+- Experimental extended range selector modifiers `smoothed` and `anchored`, enabled with `-query-frontend.enabled-promql-extended-range-selectors`.
+- Optimization passes for common subexpression elimination, subset selector elimination, projection pushdown, and multi-aggregation without buffering.
+- Improved per-query memory consumption limit enforcement in histogram and aggregation operations.
+- Experimental support for splitting and caching intermediate results for functions over range vectors in instant queries.
+- Experimental support for the `info()` PromQL function.
+
+### Zone-aware memberlist routing
+
+A new experimental zone-aware routing feature for memberlist reduces cross-AZ data transfer by routing gossip messages within the local availability zone when possible. Configure it with `-memberlist.zone-aware-routing.*` flags.
+
+### Additional improvements
+
+Grafana Mimir 3.1 also includes:
+
+- Store-gateways now verify CRC32 checksums for 1 out of every 128 chunks read from object storage and the chunks cache to detect corruption.
+- GCS uploads are now optionally retryable, with configurable max retries per storage backend.
+- Disk interaction has been removed when loading ruler rules. Rule evaluation failures now include a `reason` label (`operator` or `user`) in `prometheus_rule_evaluation_failures_total` for better error classification.
+- Query blocking via `blocked_queries` is now stable and no longer experimental, with support for blocking queries exceeding a time range duration (`time_range_longer_than`) or with steps smaller than a threshold (`step_size_shorter_than`).
+- The per-tenant postings-for-matchers cache is now stable.
+- Out-of-order ingestion support is now stable, configured via `-ingester.out-of-order-time-window`.
+- The `-alertmanager.utf8-strict-mode-enabled` flag is now stable.
+- The query-scheduler now drains the queue before exiting during shutdown.
+- Distributors support zone-aware rate limiting via `-distributor.ring.instance-availability-zone`, dividing the global ingestion rate by zones instead of total distributors.
+- Default ingest storage configuration now enables concurrency settings for improved throughput.
+- Optional per-tenant max limits for label name and label value requests via `max_label_names_limit` and `max_label_values_limit`.
+- Runtime configuration can now be loaded from HTTP URLs in addition to local files via `-runtime-config.file`. This may reduce configuration propagation times.
+
+## Important changes
+
+Grafana Mimir 3.1 introduces several updates that change default behavior and configuration. Review these changes before upgrading:
+
+- Experimental support for disabling ring heartbeats and heartbeat timeouts has been removed.
+- The `-target=flusher` mode has been removed; use the `/ingester/flush` HTTP endpoint instead.
+- Uploaded TSDB blocks must now use v2 of the index file format. Store-gateways no longer generate index-headers from v1 index format blocks.
+- Per-step stats are no longer supported when MQE is enabled. The `-query-frontend.cache-samples-processed-stats` flag is deprecated and has no effect.
+- The `-querier.response-streaming-enabled` flag has been removed; active series responses are now always streamed.
+- `cortex_ingest_storage_writer_buffered_produce_bytes` has been renamed to `cortex_ingest_storage_writer_buffered_produce_bytes_distribution`.
+- Metric `cortex_ingester_owned_target_info_series` has been removed.
+- The `cost_attribution_labels` configuration option has been removed; use `cost_attribution_labels_structured` instead.
+- The `minimum_step_size` filter in `blocked_queries` has been renamed to `step_size_shorter_than`. Blocked queries configuration is now validated at load time.
+- `-querier.prefer-availability-zone` has been renamed to `-querier.prefer-availability-zones` and now accepts a comma-separated list.
+- The per-query memory consumption limit now considers buffered messages and spans all time-split sub-queries when MQE is enabled.
+- The following flags have been removed:
+  - `-distributor.metric-relabeling-enabled`
+  - `-compactor.no-blocks-file-cleanup-enabled`
+  - `-compactor.in-memory-tenant-meta-cache-size`
+  - `-blocks-storage.bucket-store.index-header.eager-loading-startup-enabled`
+  - `*.memcached.dns-ignore-startup-failures`
+
+## Experimental features
+
+Grafana Mimir 3.1 includes some features that are experimental. Use these features with caution and report any issues that you encounter:
+
+- New usage-tracker component to enforce series limits before data is ingested.
+- Zone-aware memberlist routing to reduce cross-AZ data transfer.
+- Query planning in query-frontends with distributed execution across queriers.
+- MQE extended range selector modifiers (`smoothed`, `anchored`).
+- MQE `info()` function.
+- MQE optimization passes: projection pushdown, multi-aggregation, subset selector elimination, common subexpression elimination for range vector expressions.
+- Per-zone store-gateway shard size (`-store-gateway.tenant-shard-size-per-zone`).
+- Running ingesters with no tokens in the ring when ingest storage is enabled (`-ingester.ring.num-tokens=0`).
+- Per-sample HA deduplication (`-distributor.ha-tracker.per-sample-dedupe`).
+- Per-tenant early head compaction for ingesters based on owned series count.
+- Store-gateway excluded zones (`-store-gateway.sharding-ring.excluded-zones`).
+- Controlling OTLP metric name suffix addition and translation strategy via request headers, gated by `-api.otlp-translation-headers-enabled`.
+- Memberlist propagation delay tracker (`-memberlist.propagation-delay-tracker.enabled`).
+- Reporting the number of samples read per query in MQE.
+
+## Bug fixes
+
+For a detailed list of bug fixes, refer to the [CHANGELOG](https://github.com/grafana/mimir/blob/main/CHANGELOG.md).
+
+### Helm chart improvements
+
+The Grafana Mimir Helm chart is released independently. Refer to the [Grafana Mimir Helm chart documentation](https://grafana.com/docs/helm-charts/mimir-distributed/latest/).


### PR DESCRIPTION
Backport of #15238 to release-3.1 branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no runtime or configuration behavior changes in the codebase.
> 
> **Overview**
> Adds **`docs/sources/mimir/release-notes/v3.1.md`**, a new Grafana Mimir 3.1 release notes page (backport of #15238) aligned with the existing v3.0 release-notes layout and Hugo front matter (`weight: 1100`).
> 
> The page documents 3.1 highlights for operators: ingest-storage Kafka auth/TLS and multi-broker options, tenant-metadata ingestion limits, MQE improvements, zone-aware memberlist routing, and a long list of stable features and operational tweaks. It also calls out **Important changes** (removed flags/modes, TSDB index v2 requirement, metric and config renames) and a dedicated **Experimental features** section, with bug fixes and Helm chart called out via CHANGELOG/Helm doc links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 263dd126335c15c2ad075d9c45dfba31065478e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->