### PR TITLE
Sanitize HTTP header values before logging them

### DIFF
--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -574,6 +574,9 @@ func safeHeadersToLog(headersToLog []string) (safeHeaders []safeHeader) {
 func sanitizeHeaderValue(header *http.Header, headerName safeHeader, acceptEmpty bool) (string, bool) {
 	value := header.Get(headerName.String())
 	value = strings.TrimSpace(value)
+	if value != "" {
+		value = dskitlog.DropUnsafeChars(value).String()
+	}
 
 	return value, acceptEmpty || value != ""
 }


### PR DESCRIPTION
#### What this PR does
This is a follow-up of https://github.com/grafana/mimir/pull/15536.
This PR strips control/formatting characters from HTTP request header values before they are emitted via the query-frontend's request-header logger.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change with no request handling or auth impact; header values in logs may differ slightly when they contained control characters.
> 
> **Overview**
> Extends query-frontend logging hygiene by running **allow-listed request header values** through `dskitlog.DropUnsafeChars` inside `sanitizeHeaderValue`, after trim and only when the value is non-empty.
> 
> That path feeds **Cache-Control** and operator-configured headers in **query stats** and **slow query** logs via `formatRequestHeaders`, matching how method, path, user-agent, and query params are already sanitized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e8b0845b0fbdfaa3983fb654bd9cd9be1910ba9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->