### PR TITLE
docs: Expand Kafka authentication configuration reference

### DIFF
--- a/docs/sources/mimir/configure/configure-kafka-backend.md
+++ b/docs/sources/mimir/configure/configure-kafka-backend.md
@@ -11,11 +11,11 @@ weight: 130
 
 Grafana Mimir supports using Kafka as the first layer of ingestion in the ingest storage architecture. This configuration allows for scalable, decoupled ingestion that separates write and read paths to improve performance and resilience.
 
-Starting with Grafana Mimir 3.0, ingest storage is the preferred and stable architecture for running Grafana Mimir.
+Starting with Mimir 3.0, ingest storage is the preferred and stable architecture for running Mimir.
 
 ## Configure ingest storage
 
-Set the following configuration flags to enable Grafana Mimir to use ingest storage through a Kafka backend:
+Set the following configuration flags to enable Mimir to use ingest storage through a Kafka backend:
 
 - `-ingest-storage.enabled=true`<br />
   You must explicitly enable the ingest storage architecture in all Mimir components.
@@ -30,13 +30,13 @@ Set the following configuration flags to enable Grafana Mimir to use ingest stor
   If the configured topic doesn't exist in the Kafka backend, the Mimir components, either consumers or producers,
   create the topic on first access. The `<number>` parameter sets the number of partitions to create when the topic is automatically created. The number of partitions must be at least the number of ingesters in one zone.
 
-Additionally, you can use these recommended configuration options when running Grafana Mimir with ingest storage architecture:
+Additionally, you can use these recommended configuration options when running Mimir with ingest storage architecture:
 
 - `-distributor.remote-timeout=5s`<br />
   Use this setting to increase the default remote write timeout. This is recommended for writing to Kafka, because pushing
   to Kafka-compatible backends might be slower than writing directly to ingesters.
 
-Refer to Grafana Mimir [configuration parameters](https://grafana.com/docs/mimir/<MIMIR_VERSION>/configure/configuration-parameters/) for detailed descriptions of all available configuration options.
+Refer to Mimir [configuration parameters](https://grafana.com/docs/mimir/<MIMIR_VERSION>/configure/configuration-parameters/) for detailed descriptions of all available configuration options.
 
 ## Different Kafka backend implementations
 
@@ -94,18 +94,30 @@ Configure the following CLI flags or their YAML equivalent.
 
 ## Authentication
 
-Grafana Mimir supports multiple ways of authenticating with a Kafka cluster.
+Mimir supports multiple ways of authenticating with a Kafka cluster.
+Most methods use the Simple Authentication and Security Layer (SASL) framework, which supports the following mechanisms:
+
+- `PLAIN`: Authenticate with a username and password.
+- `SCRAM-SHA-256` and `SCRAM-SHA-512`: Authenticate with a username and password using Salted Challenge Response Authentication Mechanism (SCRAM).
+- `OAUTHBEARER`: Authenticate with an OAuth 2.0 bearer token.
+- `AWS_MSK_IAM`: Authenticate to Amazon Managed Streaming for Apache Kafka (Amazon MSK) using AWS Identity and Access Management (IAM).
+
+You can also connect to Kafka over Transport Layer Security (TLS), including mutual TLS (mTLS) for certificate-based authentication.
 
 ### Username and password (PLAIN, SCRAM)
 
-Set the following configuration flags to authenticate with username and password:
+Set the following configuration flags to authenticate with a username and password:
 
 - `-ingest-storage.kafka.sasl-mechanism`<br />
-  Set to `SCRAM-SHA-256`, `SCRAM-SHA-512`, or `PLAIN`.
+  The SASL mechanism used to authenticate to Kafka. Set to `SCRAM-SHA-256`, `SCRAM-SHA-512`, or `PLAIN`. The default value is `PLAIN`.
 
-- `-ingest-storage.kafka.sasl-username`
+- `-ingest-storage.kafka.sasl-username`<br />
+  The username used to authenticate to Kafka.
 
-- `-ingest-storage.kafka.sasl-password`
+- `-ingest-storage.kafka.sasl-password`<br />
+  The password used to authenticate to Kafka.
+
+To enable SASL, configure both the username and the password. For backwards compatibility, the `PLAIN` mechanism with no username and no password disables SASL.
 
 ### OAUTHBEARER or AWS_MSK_IAM
 
@@ -114,13 +126,16 @@ Set the following configuration flags to authenticate with OAuth or MSK IAM:
 - `-ingest-storage.kafka.sasl-mechanism`<br />
   Set to `OAUTHBEARER` or `AWS_MSK_IAM`.
 
-Both mechanisms share common patterns: either statically, with values set at startup and then don't change, or dynamically, through a configuration file or a HTTP callback that are checked anew every time reauthentication is required.
+Both mechanisms share common patterns: either statically, with values set at startup and then don't change, or dynamically, through a configuration file or an HTTP callback that are checked anew every time reauthentication is required.
 
 #### With static configuration
 
-You may set authentication configuration directly as configuration flags. See below for the flags each mechanism requires.
+You can set authentication configuration directly as configuration flags. The flags that each mechanism requires are listed in the following sections.
 
-An important downside of this approach is that the Grafana Mimir components that connect to Kafka must be restarted whenever reauthentication is required.
+{{< admonition type="note" >}}
+Mimir components that connect to Kafka must be restarted whenever reauthentication is required.
+{{< /admonition >}}
+
 
 #### With path to configuration file
 
@@ -129,9 +144,11 @@ Set the following configuration flag to specify the path to a file that contains
 - `-ingest-storage.kafka.sasl-<MECHANISM>-file-path`<br />
   Replace `<MECHANISM>` with `oauthbearer` or `msk-iam`.
 
-See below for the shape the JSON object in the file must take.
+Refer to the following sections for the shape that the JSON object in the file must take.
 
-This file is opened and read anew whenever reauthentication is required. Grafana Mimir doesn't signal when this happens; authentication credentials lifetime and file updates must be handled out-of-band. Alternatively, you may configure an HTTP callback, which receives an HTTP request whenever reauthentication is required.
+This file is opened and read anew whenever reauthentication is required.
+Mimir doesn't signal when this happens, so you must handle the authentication credentials lifetime and file updates out-of-band.
+Alternatively, you can configure an HTTP callback, which receives an HTTP request whenever reauthentication is required.
 
 #### With HTTP callback
 
@@ -140,14 +157,19 @@ Set the following configuration flag to specify the path to a Unix domain socket
 - `-ingest-storage.kafka.sasl-<MECHANISM>-http-socket-path`<br />
   Replace `<MECHANISM>` with `oauthbearer` or `msk-iam`.
 
+You can also configure the timeout for the HTTP request:
+
+- `-ingest-storage.kafka.sasl-<MECHANISM>-http-socket-timeout`<br />
+  The timeout for requesting credentials from the HTTP socket. Replace `<MECHANISM>` with `oauthbearer` or `msk-iam`. The default value is `10s`.
+
 A server must be listening for connections on this Unix domain socket. On receiving an HTTP GET request to path `/`, the server must respond with status 200 OK and a JSON object containing the authentication configuration.
 
-See below for the shape the JSON object must take.
+Refer to the following sections for the shape that the JSON object must take.
 
 Using an HTTP callback has some important benefits compared to the static configuration and the file-based approaches:
 
-- Because Grafana Mimir issues an HTTP request whenever reauthentication is required, you don't need to manage authentication lifetime out-of-band.
-- Authentication credentials don't need to be persisted. They may be obtained on-the-fly and sent back to Grafana Mimir for the lifespan of a single HTTP request.
+- Because Mimir issues an HTTP request whenever reauthentication is required, you don't need to manage authentication lifetime out-of-band.
+- Authentication credentials don't need to be persisted. They can be obtained on-the-fly and sent back to Mimir for the lifespan of a single HTTP request.
 
 #### OAUTHBEARER configuration details
 
@@ -199,8 +221,21 @@ Set the following configuration parameter to enable connecting to the Kafka clus
 
 For mutual authentication (mTLS), set the following additional flags:
 
-- `-ingest-storage.kafka.tls-ca-path`
-- `-ingest-storage.kafka.tls-cert-path`
-- `-ingest-storage.kafka.tls-key-path`
+- `-ingest-storage.kafka.tls-ca-path`<br />
+  Path to the CA certificates used to validate the server certificate. If you don't set this flag, Mimir uses the host's root CA certificates.
 
-Refer to Grafana Mimir [configuration parameters](https://grafana.com/docs/mimir/<MIMIR_VERSION>/configure/configuration-parameters/) for details and additional options.
+- `-ingest-storage.kafka.tls-cert-path`<br />
+  Path to the client certificate used to authenticate with the server. Requires the key path to also be configured.
+
+- `-ingest-storage.kafka.tls-key-path`<br />
+  Path to the key for the client certificate. Requires the client certificate to also be configured.
+
+You can also set the following optional flags to customize the TLS connection:
+
+- `-ingest-storage.kafka.tls-server-name`<br />
+  Override the expected name on the server certificate.
+
+- `-ingest-storage.kafka.tls-insecure-skip-verify`<br />
+  Skip validating the server certificate. This option is insecure and is intended only for testing.
+
+Refer to Mimir [configuration parameters](https://grafana.com/docs/mimir/<MIMIR_VERSION>/configure/configuration-parameters/) for details and additional options, such as `-ingest-storage.kafka.tls-cipher-suites` and `-ingest-storage.kafka.tls-min-version`.

--- a/docs/sources/mimir/configure/configure-kafka-backend.md
+++ b/docs/sources/mimir/configure/configure-kafka-backend.md
@@ -136,7 +136,6 @@ You can set authentication configuration directly as configuration flags. The fl
 Mimir components that connect to Kafka must be restarted whenever reauthentication is required.
 {{< /admonition >}}
 
-
 #### With path to configuration file
 
 Set the following configuration flag to specify the path to a file that contains a JSON object configuring authentication credentials:


### PR DESCRIPTION
#### What this PR does

Updated the Authentication of the Kafka backend configuration page. Most of these changes add missing descriptions for listed flags/options and correct stylistic issues (for example, the first occurrence of a product name uses long form (Grafana Mimir), subsequent use short form (Mimir)) to align with the Grafana style guide in the Writers' Toolkit. 

Details:

- Add an overview under the **Authentication** heading that lists the supported methods: SASL, SCRAM, OAUTHBEARER, AWS_MSK_IAM, and TLS/mTLS.
- Add `-ingest-storage.kafka.sasl-<MECHANISM>-http-socket-timeout` flag in the HTTP callback subsection.
- Add descriptions for `tls-ca-path`, `tls-cert-path`, `tls-key-path`, and the previously undocumented `tls-server-name` and `tls-insecure-skip-verify`, and point to `tls-cipher-suites`/`tls-min-version` in the configuration parameters reference.

All flag names and defaults were verified against `cmd/mimir/help-all.txt.tmpl` and `cmd/mimir/config-descriptor.json`.

#### Which issue(s) this PR fixes or relates to

Relates to #13366 and #15534

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes to configure-kafka-backend.md; no code or configuration behavior changes.
> 
> **Overview**
> Expands **Authentication** on the Kafka backend configure page with a SASL/TLS overview and fuller flag descriptions, plus Writers' Toolkit naming (Grafana Mimir once, then **Mimir**).
> 
> Under **Authentication**, the page now summarizes supported methods (PLAIN, SCRAM, OAUTHBEARER, AWS_MSK_IAM, TLS/mTLS). PLAIN/SCRAM flags get explicit descriptions and a note that SASL needs both username and password. The OAuth/MSK HTTP callback section documents `-ingest-storage.kafka.sasl-<MECHANISM>-http-socket-timeout` (default `10s`). **TLS / mTLS** documents `tls-ca-path`, `tls-cert-path`, `tls-key-path`, `tls-server-name`, and `tls-insecure-skip-verify`, and links to `tls-cipher-suites` and `tls-min-version` in the configuration parameters reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c657d6616b1f96ee04169d633caddf14075687c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->