### PR TITLE
Optimize LabelValuesOffsets fetching in blockLabelValues

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1602,20 +1602,43 @@ func blockLabelValues(ctx context.Context, b *bucketBlock, postingsStrategy post
 		return values, nil
 	}
 
-	// TODO: if matchers contains labelName, we could use it to filter out label values here.
-	allValuesPostingOffsets, err := b.indexHeaderReader.LabelValuesOffsets(ctx, labelName, "", nil)
-	if err != nil {
-		return nil, errors.Wrap(err, "index header label values")
-	}
-
+	// There are no matchers, we have to fetch offsets for all label values
 	if len(matchers) == 0 {
+		allValuesPostingOffsets, err := b.indexHeaderReader.LabelValuesOffsets(ctx, labelName, "", nil)
+		if err != nil {
+			return nil, errors.Wrap(err, "index header label values")
+		}
+
 		values = extractLabelValues(allValuesPostingOffsets)
 		storeCachedLabelValues(ctx, b.indexCache, b.userID, b.meta.ULID, labelName, matchers, values, logger)
 		return values, nil
 	}
+
+	// There are some matchers, check to see if any apply to this label name as a prefix or exact match to minimize our postings strategy surface area.
+	matchStr, isExactMatch := exactMatchOrPrefixForLabelName(labelName, matchers)
+
+	var allApplicableValuesPostingsOffsets []streamindex.PostingListOffset
+	var err error
+
+	if isExactMatch {
+		// Our matchStr is an exact match for a label value, just fetch that one.
+		postingsOffset, err := b.indexHeaderReader.PostingsOffset(ctx, labelName, matchStr)
+		if err != nil {
+			return nil, errors.Wrap(err, "index header postings offset")
+		}
+		allApplicableValuesPostingsOffsets = []streamindex.PostingListOffset{{matchStr, postingsOffset}}
+	} else {
+		// At this point, we may or may not have an applicable prefix to check. If we do, matchStr will not be empty. If we don't,
+		// we'll fetch all label values offsets. We don't bother trying to determine a filter func, because it wouldn't really save us work here.
+		allApplicableValuesPostingsOffsets, err = b.indexHeaderReader.LabelValuesOffsets(ctx, labelName, matchStr, nil)
+		if err != nil {
+			return nil, errors.Wrap(err, "index header label values")
+		}
+	}
+
 	strategy := &labelValuesPostingsStrategy{
 		matchersStrategy: postingsStrategy,
-		allLabelValues:   allValuesPostingOffsets,
+		allLabelValues:   allApplicableValuesPostingsOffsets,
 	}
 	postingsAndSeriesReader := b.indexReader(strategy)
 	defer runutil.CloseWithLogOnErr(b.logger, postingsAndSeriesReader, "close block index reader")
@@ -1624,10 +1647,11 @@ func blockLabelValues(ctx context.Context, b *bucketBlock, postingsStrategy post
 	if err != nil {
 		return nil, errors.Wrap(err, "expanded postings")
 	}
+
 	if len(pendingMatchers) > 0 || strategy.preferSeriesToPostings(matchersPostings) {
 		values, err = labelValuesFromSeries(ctx, labelName, maxSeriesPerBatch, pendingMatchers, postingsAndSeriesReader, b, matchersPostings, stats)
 	} else {
-		values, err = labelValuesFromPostings(ctx, labelName, postingsAndSeriesReader, allValuesPostingOffsets, matchersPostings, stats)
+		values, err = labelValuesFromPostings(ctx, labelName, postingsAndSeriesReader, allApplicableValuesPostingsOffsets, matchersPostings, stats)
 	}
 	if err != nil {
 		return nil, err
@@ -1635,6 +1659,24 @@ func blockLabelValues(ctx context.Context, b *bucketBlock, postingsStrategy post
 
 	storeCachedLabelValues(ctx, b.indexCache, b.userID, b.meta.ULID, labelName, matchers, values, logger)
 	return values, nil
+}
+
+func exactMatchOrPrefixForLabelName(labelName string, matchers []*labels.Matcher) (matchString string, isExactMatch bool) {
+	for _, m := range matchers {
+		if m.Name == labelName {
+			switch m.Type {
+			case labels.MatchEqual:
+				return m.Value, true
+			case labels.MatchRegexp:
+				if len(m.Prefix()) > len(matchString) {
+					matchString = m.Prefix()
+				}
+			default:
+				continue
+			}
+		}
+	}
+	return
 }
 
 func labelValuesFromSeries(ctx context.Context, labelName string, seriesPerBatch int, pendingMatchers []*labels.Matcher, indexr *bucketIndexReader, b *bucketBlock, matchersPostings []storage.SeriesRef, stats *safeQueryStats) ([]string, error) {

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1631,7 +1631,7 @@ func blockLabelValues(ctx context.Context, b *bucketBlock, postingsStrategy post
 			}
 			return nil, errors.Wrap(err, "index header postings offset")
 		}
-		allApplicableValuesPostingsOffsets = []streamindex.PostingListOffset{{matchStr, postingsOffset}}
+		allApplicableValuesPostingsOffsets = []streamindex.PostingListOffset{{LabelValue: matchStr, Off: postingsOffset}}
 	} else {
 		var err error
 		// At this point, we may or may not have an applicable prefix to check. If we do, matchStr will not be empty. If we don't,

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1586,8 +1586,11 @@ func (s *BucketStore) LabelValues(ctx context.Context, req *storepb.LabelValuesR
 
 // blockLabelValues returns sorted values of the label with requested name,
 // optionally restricting the search to the series that match the matchers provided.
-// - First we fetch all possible values for this label from the index.
-//   - If no matchers were provided, we just return those values.
+// - If no matchers are provided, we fetch all values for this label from the index, and return them.
+// - Otherwise, we check for exact matchers or prefix matchers for the labelName (e.g. foo="bar" or foo="b.*").
+//   - If an exact match is found, we only fetch that label value.
+//   - If a prefix matcher is found, we only fetch the values that match the longest prefix.
+//   - If neither is found, we fetch all values.
 //
 // - Next we load the postings (references to series) for supplied matchers.
 // - Then we load the postings for each label-value fetched in the first step.
@@ -1634,8 +1637,11 @@ func blockLabelValues(ctx context.Context, b *bucketBlock, postingsStrategy post
 		allApplicableValuesPostingsOffsets = []streamindex.PostingListOffset{{LabelValue: matchStr, Off: postingsOffset}}
 	} else {
 		var err error
-		// At this point, we may or may not have an applicable prefix to check. If we do, matchStr will not be empty. If we don't,
-		// we'll fetch all label values offsets. We don't bother trying to determine a filter func, because it wouldn't really save us work here.
+		// At this point, we may or may not have an applicable prefix to check. If we do, matchStr will not be empty.
+		// If we don't, we'll fetch all label values offsets.
+		// We don't bother trying to determine a filter func yet, because without a prefix,
+		// we still need to read all label values and check against the filter,
+		// work that may be made redundant if we end up preferring getting label values from series.
 		allApplicableValuesPostingsOffsets, err = b.indexHeaderReader.LabelValuesOffsets(ctx, labelName, matchStr, nil)
 		if err != nil {
 			return nil, errors.Wrap(err, "index header label values")

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1618,16 +1618,22 @@ func blockLabelValues(ctx context.Context, b *bucketBlock, postingsStrategy post
 	matchStr, isExactMatch := exactMatchOrPrefixForLabelName(labelName, matchers)
 
 	var allApplicableValuesPostingsOffsets []streamindex.PostingListOffset
-	var err error
 
 	if isExactMatch {
 		// Our matchStr is an exact match for a label value, just fetch that one.
 		postingsOffset, err := b.indexHeaderReader.PostingsOffset(ctx, labelName, matchStr)
 		if err != nil {
+			if errors.Is(err, indexheader.NotFoundRangeErr) {
+				// If the label value isn't found in this block, we know the result will be empty,
+				// so we can just cache it now and return early.
+				storeCachedLabelValues(ctx, b.indexCache, b.userID, b.meta.ULID, labelName, matchers, nil, logger)
+				return nil, nil
+			}
 			return nil, errors.Wrap(err, "index header postings offset")
 		}
 		allApplicableValuesPostingsOffsets = []streamindex.PostingListOffset{{matchStr, postingsOffset}}
 	} else {
+		var err error
 		// At this point, we may or may not have an applicable prefix to check. If we do, matchStr will not be empty. If we don't,
 		// we'll fetch all label values offsets. We don't bother trying to determine a filter func, because it wouldn't really save us work here.
 		allApplicableValuesPostingsOffsets, err = b.indexHeaderReader.LabelValuesOffsets(ctx, labelName, matchStr, nil)
@@ -1666,7 +1672,9 @@ func exactMatchOrPrefixForLabelName(labelName string, matchers []*labels.Matcher
 		if m.Name == labelName {
 			switch m.Type {
 			case labels.MatchEqual:
-				return m.Value, true
+				if m.Value != "" {
+					return m.Value, true
+				}
 			case labels.MatchRegexp:
 				if len(m.Prefix()) > len(matchString) {
 					matchString = m.Prefix()

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/encoding"
 	"github.com/prometheus/prometheus/tsdb/hashcache"
+	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/prometheus/prometheus/tsdb/wlog"
 	"github.com/prometheus/prometheus/util/compression"
 	"github.com/prometheus/prometheus/util/testutil"
@@ -60,7 +61,7 @@ import (
 	"github.com/grafana/mimir/pkg/storage/bucket"
 	"github.com/grafana/mimir/pkg/storage/fixtures"
 	"github.com/grafana/mimir/pkg/storage/indexheader"
-	"github.com/grafana/mimir/pkg/storage/indexheader/index"
+	streamindex "github.com/grafana/mimir/pkg/storage/indexheader/index"
 	"github.com/grafana/mimir/pkg/storage/sharding"
 	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
@@ -527,7 +528,15 @@ func TestBlockLabelValues(t *testing.T) {
 	})
 
 	t.Run("happy case cached with no matchers", func(t *testing.T) {
-		expectedCalls := 1
+		testLabels := []struct {
+			name           string
+			expectedValues []string
+		}{
+			{"j", []string{"bar", "foo"}},
+			{"nonexistent_label", []string(nil)},
+		}
+
+		expectedCalls := len(testLabels)
 		b := newTestBucketBlock()
 		b.indexHeaderReader = &interceptedIndexReader{
 			Reader: b.indexHeaderReader,
@@ -541,14 +550,18 @@ func TestBlockLabelValues(t *testing.T) {
 		}
 		b.indexCache = newInMemoryIndexCache(t)
 
-		names, err := blockLabelValues(context.Background(), b, selectAllStrategy{}, 5000, "j", nil, log.NewNopLogger(), newSafeQueryStats())
-		require.NoError(t, err)
-		require.Equal(t, []string{"bar", "foo"}, names)
+		for _, label := range testLabels {
+			for i := 0; i < 2; i++ {
+				values, err := blockLabelValues(context.Background(), b, selectAllStrategy{}, 5000, label.name, nil, log.NewNopLogger(), newSafeQueryStats())
+				require.NoError(t, err)
+				if label.expectedValues == nil {
+					require.Empty(t, values)
+				} else {
+					require.Equal(t, label.expectedValues, values)
+				}
+			}
+		}
 
-		// hit the cache now
-		names, err = blockLabelValues(context.Background(), b, selectAllStrategy{}, 5000, "j", nil, log.NewNopLogger(), newSafeQueryStats())
-		require.NoError(t, err)
-		require.Equal(t, []string{"bar", "foo"}, names)
 	})
 
 	t.Run("error with matchers", func(t *testing.T) {
@@ -566,29 +579,75 @@ func TestBlockLabelValues(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("happy case cached with matchers", func(t *testing.T) {
+	t.Run("empty value equal matcher is not treated as an exact match", func(t *testing.T) {
 		b := newTestBucketBlock()
+		// We should never call PostingsOffset on j=""
+		forbiddenPostingsOffsetCall := labels.Label{Name: "j", Value: ""}
+		b.indexHeaderReader = &interceptedIndexReader{
+			Reader: b.indexHeaderReader,
+			onPostingsOffsetCalled: func(name, value string) error {
+				if name == forbiddenPostingsOffsetCall.Name && value == forbiddenPostingsOffsetCall.Value {
+					return fmt.Errorf("should not execute index.Reader.PostingsOffset() call for empty string value")
+				}
+				return nil
+			},
+		}
 		b.indexCache = newInMemoryIndexCache(t)
 
-		pFooMatchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "p", "foo")}
-		values, err := blockLabelValues(context.Background(), b, selectAllStrategy{}, 5000, "j", pFooMatchers, log.NewNopLogger(), newSafeQueryStats())
+		// All series in the testBlock have j set, so none should match j="".
+		matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "j", "")}
+		values, err := blockLabelValues(context.Background(), b, selectAllStrategy{}, 5000, "j", matchers, log.NewNopLogger(), newSafeQueryStats())
 		require.NoError(t, err)
-		require.Equal(t, []string{"foo"}, values)
+		require.Empty(t, values)
+	})
 
-		qFooMatchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "q", "foo")}
-		values, err = blockLabelValues(context.Background(), b, selectAllStrategy{}, 5000, "j", qFooMatchers, log.NewNopLogger(), newSafeQueryStats())
-		require.NoError(t, err)
-		require.Equal(t, []string{"bar"}, values)
+	t.Run("happy case cached with matchers", func(t *testing.T) {
+		b := newTestBucketBlock()
+		postingsOffsetCallsCount := make(map[labels.Label]int)
+		b.indexHeaderReader = &interceptedIndexReader{
+			Reader: b.indexHeaderReader,
+			onPostingsOffsetCalled: func(name, value string) error {
+				postingsOffsetCallsCount[labels.Label{Name: name, Value: value}]++
+				return nil
+			},
+		}
+
+		b.indexCache = newInMemoryIndexCache(t)
+
+		testLabelsWithMatchers := []struct {
+			name           string
+			matchers       []*labels.Matcher
+			expectedValues []string
+		}{
+			{"j", []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "p", "foo")}, []string{"foo"}},
+			{"j", []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "q", "foo")}, []string{"bar"}},
+			{"j", []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "j", "foo")}, []string{"foo"}},
+			{"j", []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "j", "nonexistent_value")}, nil},
+		}
+
+		for _, testLabel := range testLabelsWithMatchers {
+			values, err := blockLabelValues(context.Background(), b, selectAllStrategy{}, 5000, testLabel.name, testLabel.matchers, log.NewNopLogger(), newSafeQueryStats())
+			require.NoError(t, err)
+			if testLabel.expectedValues == nil {
+				require.Empty(t, values)
+			} else {
+				require.Equal(t, testLabel.expectedValues, values, fmt.Sprintf("unexpected values for label %s and matchers %+v", testLabel.name, testLabel.matchers))
+			}
+		}
 
 		// we break the indexHeaderReader to ensure that results come from a cache
 		b.indexHeaderReader = deadlineExceededIndexHeader()
 
-		values, err = blockLabelValues(context.Background(), b, selectAllStrategy{}, 5000, "j", pFooMatchers, log.NewNopLogger(), newSafeQueryStats())
-		require.NoError(t, err)
-		require.Equal(t, []string{"foo"}, values)
-		values, err = blockLabelValues(context.Background(), b, selectAllStrategy{}, 5000, "j", qFooMatchers, log.NewNopLogger(), newSafeQueryStats())
-		require.NoError(t, err)
-		require.Equal(t, []string{"bar"}, values)
+		for _, testLabel := range testLabelsWithMatchers {
+			values, err := blockLabelValues(context.Background(), b, selectAllStrategy{}, 5000, testLabel.name, testLabel.matchers, log.NewNopLogger(), newSafeQueryStats())
+			require.NoError(t, err)
+			if testLabel.expectedValues == nil {
+				require.Empty(t, values)
+			} else {
+				require.Equal(t, testLabel.expectedValues, values, fmt.Sprintf("unexpected values for label %s and matchers %+v", testLabel.name, testLabel.matchers))
+			}
+		}
+
 	})
 
 	t.Run("happy case cached with weak matchers", func(t *testing.T) {
@@ -598,6 +657,7 @@ func TestBlockLabelValues(t *testing.T) {
 		matchers := []*labels.Matcher{
 			labels.MustNewMatcher(labels.MatchEqual, "p", "foo"),
 			labels.MustNewMatcher(labels.MatchRegexp, "i", "1234.+"),
+			labels.MustNewMatcher(labels.MatchRegexp, "j", "f.*"),
 			labels.MustNewMatcher(labels.MatchRegexp, "j", ".+"), // this is too weak and doesn't bring much value, it should be shortcut
 		}
 		values, err := blockLabelValues(context.Background(), b, worstCaseFetchedDataStrategy{1.0}, 5000, "j", matchers, log.NewNopLogger(), newSafeQueryStats())
@@ -1058,6 +1118,7 @@ type interceptedIndexReader struct {
 	onLabelValuesCalled        func(name string) error
 	onLabelValuesOffsetsCalled func(name string) error
 	onIndexVersionCalled       func() error
+	onPostingsOffsetCalled     func(name, value string) error
 }
 
 func (iir *interceptedIndexReader) LabelNames(ctx context.Context) ([]string, error) {
@@ -1069,7 +1130,7 @@ func (iir *interceptedIndexReader) LabelNames(ctx context.Context) ([]string, er
 	return iir.Reader.LabelNames(ctx)
 }
 
-func (iir *interceptedIndexReader) LabelValuesOffsets(ctx context.Context, name string, prefix string, filter func(string) bool) ([]index.PostingListOffset, error) {
+func (iir *interceptedIndexReader) LabelValuesOffsets(ctx context.Context, name string, prefix string, filter func(string) bool) ([]streamindex.PostingListOffset, error) {
 	if iir.onLabelValuesOffsetsCalled != nil {
 		if err := iir.onLabelValuesOffsetsCalled(name); err != nil {
 			return nil, err
@@ -1085,6 +1146,15 @@ func (iir *interceptedIndexReader) IndexVersion(ctx context.Context) (int, error
 		}
 	}
 	return iir.Reader.IndexVersion(ctx)
+}
+
+func (iir *interceptedIndexReader) PostingsOffset(ctx context.Context, name string, value string) (index.Range, error) {
+	if iir.onPostingsOffsetCalled != nil {
+		if err := iir.onPostingsOffsetCalled(name, value); err != nil {
+			return index.Range{}, err
+		}
+	}
+	return iir.Reader.PostingsOffset(ctx, name, value)
 }
 
 func deadlineExceededIndexHeader() *interceptedIndexReader {

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -626,7 +626,7 @@ func TestBlockLabelValues(t *testing.T) {
 				if testLabel.expectedValues == nil {
 					require.Empty(t, values)
 				} else {
-					require.Equal(t, testLabel.expectedValues, values, fmt.Sprintf("unexpected values for label %s and matchers %+v", testLabel.name, testLabel.matcher))
+					require.Equal(t, testLabel.expectedValues, values)
 				}
 
 				// we break the indexHeaderReader to ensure that results come from a cache on a second call
@@ -636,7 +636,7 @@ func TestBlockLabelValues(t *testing.T) {
 				if testLabel.expectedValues == nil {
 					require.Empty(t, values)
 				} else {
-					require.Equal(t, testLabel.expectedValues, values, fmt.Sprintf("unexpected values for label %s and matchers %+v", testLabel.name, testLabel.matcher))
+					require.Equal(t, testLabel.expectedValues, values)
 				}
 			})
 		}

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -601,53 +601,45 @@ func TestBlockLabelValues(t *testing.T) {
 		require.Empty(t, values)
 	})
 
-	t.Run("happy case cached with matchers", func(t *testing.T) {
+	t.Run("happy case cached with exact matchers", func(t *testing.T) {
 		b := newTestBucketBlock()
-		postingsOffsetCallsCount := make(map[labels.Label]int)
-		b.indexHeaderReader = &interceptedIndexReader{
-			Reader: b.indexHeaderReader,
-			onPostingsOffsetCalled: func(name, value string) error {
-				postingsOffsetCallsCount[labels.Label{Name: name, Value: value}]++
-				return nil
-			},
-		}
-
 		b.indexCache = newInMemoryIndexCache(t)
+		originalIndexHeaderReader := b.indexHeaderReader
 
 		testLabelsWithMatchers := []struct {
 			name           string
-			matchers       []*labels.Matcher
+			matcher        *labels.Matcher
 			expectedValues []string
 		}{
-			{"j", []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "p", "foo")}, []string{"foo"}},
-			{"j", []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "q", "foo")}, []string{"bar"}},
-			{"j", []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "j", "foo")}, []string{"foo"}},
-			{"j", []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "j", "nonexistent_value")}, nil},
+			{"j", labels.MustNewMatcher(labels.MatchEqual, "p", "foo"), []string{"foo"}},
+			{"j", labels.MustNewMatcher(labels.MatchEqual, "q", "foo"), []string{"bar"}},
+			{"j", labels.MustNewMatcher(labels.MatchEqual, "j", "foo"), []string{"foo"}},
+			{"j", labels.MustNewMatcher(labels.MatchEqual, "j", "nonexistent_value"), nil},
 		}
 
 		for _, testLabel := range testLabelsWithMatchers {
-			values, err := blockLabelValues(context.Background(), b, selectAllStrategy{}, 5000, testLabel.name, testLabel.matchers, log.NewNopLogger(), newSafeQueryStats())
-			require.NoError(t, err)
-			if testLabel.expectedValues == nil {
-				require.Empty(t, values)
-			} else {
-				require.Equal(t, testLabel.expectedValues, values, fmt.Sprintf("unexpected values for label %s and matchers %+v", testLabel.name, testLabel.matchers))
-			}
+			t.Run(fmt.Sprintf("%+v", testLabel.matcher), func(t *testing.T) {
+				// Make sure we start with an unbroken index header reader on every subtest
+				b.indexHeaderReader = originalIndexHeaderReader
+				values, err := blockLabelValues(context.Background(), b, selectAllStrategy{}, 5000, testLabel.name, []*labels.Matcher{testLabel.matcher}, log.NewNopLogger(), newSafeQueryStats())
+				require.NoError(t, err)
+				if testLabel.expectedValues == nil {
+					require.Empty(t, values)
+				} else {
+					require.Equal(t, testLabel.expectedValues, values, fmt.Sprintf("unexpected values for label %s and matchers %+v", testLabel.name, testLabel.matcher))
+				}
+
+				// we break the indexHeaderReader to ensure that results come from a cache on a second call
+				b.indexHeaderReader = deadlineExceededIndexHeader()
+				values, err = blockLabelValues(context.Background(), b, selectAllStrategy{}, 5000, testLabel.name, []*labels.Matcher{testLabel.matcher}, log.NewNopLogger(), newSafeQueryStats())
+				require.NoError(t, err)
+				if testLabel.expectedValues == nil {
+					require.Empty(t, values)
+				} else {
+					require.Equal(t, testLabel.expectedValues, values, fmt.Sprintf("unexpected values for label %s and matchers %+v", testLabel.name, testLabel.matcher))
+				}
+			})
 		}
-
-		// we break the indexHeaderReader to ensure that results come from a cache
-		b.indexHeaderReader = deadlineExceededIndexHeader()
-
-		for _, testLabel := range testLabelsWithMatchers {
-			values, err := blockLabelValues(context.Background(), b, selectAllStrategy{}, 5000, testLabel.name, testLabel.matchers, log.NewNopLogger(), newSafeQueryStats())
-			require.NoError(t, err)
-			if testLabel.expectedValues == nil {
-				require.Empty(t, values)
-			} else {
-				require.Equal(t, testLabel.expectedValues, values, fmt.Sprintf("unexpected values for label %s and matchers %+v", testLabel.name, testLabel.matchers))
-			}
-		}
-
 	})
 
 	t.Run("happy case cached with weak matchers", func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
`blockLabelValues` currently fetches all label values offsets by default before making any strategy decisions for preferring getting label values from series or from postings. This is cheap because the posting offsets table is currently stored on disk in the store-gateway, but as we introduce bucket readers for posting offset table reads, these full scans for all a label's values can get quite expensive by way of bucket operations.

This change checks for cases where we can reduce the space scanned (and therefore reduce bucket operations in the case of a bucket reader) by using a prefix or even an exact label value if applicable.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot-path LabelValues logic in the store-gateway; behavior should match prior results but relies on matcher/prefix heuristics, with solid unit test coverage.
> 
> **Overview**
> **`blockLabelValues`** no longer always loads every value’s posting offsets when matchers are present. It uses a new **`exactMatchOrPrefixForLabelName`** helper: for the label being queried, **`=`** with a non-empty value triggers a single **`PostingsOffset`** (empty result cached and returned early on **`NotFoundRangeErr`**); **`=~`** contributes the longest **`Prefix()`** so **`LabelValuesOffsets`** can scan a prefix instead of the full table. The no-matcher path is unchanged (still loads all offsets up front).
> 
> Tests cover exact matchers (including missing values), **`j=""`** not using the exact path, prefix regex in weak-matcher cases, and **`PostingsOffset`** interception on the test index reader.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0ad7f0d7baf7f93fca0757c7607cbf8a6c83b1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->