### PR TITLE
Add label-based access control (LBAC) for queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [CHANGE] Querier: Remove experimental MQE Projection Pushdown optimization pass and associated CLI flag `querier.mimir-query-engine.enable-projection-pushdown`. #15618
 * [CHANGE] Continuous-test: Change default values for `tests.write-read-series-test.num-series` and `tests.write-read-series-test.max-query-age` to match the values being set in jsonnet. #15705
 * [CHANGE] Update Docker image bases from Debian 12 to Debian 13 (`gcr.io/distroless/static-debian13`; race images use `base-nossl-debian13`). #15629
+* [FEATURE] Querier: Add experimental label-based access control (LBAC) for metric read queries. When enabled via `-auth.label-access-control-enabled`, Mimir enforces label selectors from the `X-Prom-Label-Policy` HTTP header at query time, filtering series and exemplars per tenant policy. Cache key isolation is applied automatically in the query-frontend. #15554
 * [FEATURE] API: Add alertmanager limits (alertmanager_notification_rate_limit, alertmanager_max_dispatcher_aggregation_groups, alertmanager_max_templates_count) to the user limits API response. #15308
 * [FEATURE] Mimirtool: Add AWS Signature Version 4 (SigV4) support for shared Mimir API client commands including `mimirtool rules`, `mimirtool alertmanager`, `mimirtool alerts`, `mimirtool backfill`, and `mimirtool analyze ruler`. #14959
 * [FEATURE] Cost attribution: Support multiple named cost attribution trackers per tenant via new `additional_cost_attribution_trackers` config field. #15302

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -22429,6 +22429,17 @@
       ],
       "fieldValue": null,
       "fieldDefaultValue": null
+    },
+    {
+      "kind": "field",
+      "name": "label_access_control_enabled",
+      "required": false,
+      "desc": "If enabled, Mimir enforces label-based access control on metric read queries using the X-Prom-Label-Policy HTTP header.",
+      "fieldValue": null,
+      "fieldDefaultValue": false,
+      "fieldFlag": "auth.label-access-control-enabled",
+      "fieldType": "boolean",
+      "fieldCategory": "experimental"
     }
   ],
   "fieldValue": null,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -373,6 +373,8 @@ Usage of ./cmd/mimir/mimir:
     	Allows to disable enforcement of the label count limit "max_label_names_per_series" via X-Mimir-SkipLabelCountValidation header on the http write path. Allowing this for external clients allows any client to send invalid label counts. After enabling it, requests with a specific HTTP header set to true will not have label counts validated.
   -api.skip-label-name-validation-header-enabled
     	Allows to skip label name validation via X-Mimir-SkipLabelNameValidation header on the http write path. Use with caution as it breaks PromQL. Allowing this for external clients allows any client to send invalid label names. After enabling it, requests with a specific HTTP header set to true will not have label names validated.
+  -auth.label-access-control-enabled
+    	[experimental] If enabled, Mimir enforces label-based access control on metric read queries using the X-Prom-Label-Policy HTTP header.
   -auth.multitenancy-enabled
     	When set to true, incoming HTTP requests must specify tenant ID in HTTP X-Scope-OrgId header. When set to false, tenant ID from -auth.no-auth-tenant is used instead. (default true)
   -auth.no-auth-tenant string

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -46,6 +46,9 @@ Experimental configuration and flags are subject to change.
 
 The following features are currently experimental:
 
+- Auth
+  - Label-Based Access Control (LBAC) for metric read queries
+    - `-auth.label-access-control-enabled`
 - Cost attribution
   - Configure labels for cost attribution
     - `-validation.cost-attribution-labels-structured`

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -522,6 +522,11 @@ instrument_ref_leaks:
   # regardless of the configured percentage. Zero means no limit.
   # CLI flag: -instrument-reference-leaks.max-inflight-instrumented-bytes
   [max_inflight_instrumented_bytes: <int> | default = 0]
+
+# (experimental) If enabled, Mimir enforces label-based access control on metric
+# read queries using the X-Prom-Label-Policy HTTP header.
+# CLI flag: -auth.label-access-control-enabled
+[label_access_control_enabled: <boolean> | default = false]
 ```
 
 ### common

--- a/pkg/frontend/labelaccess/tripperware.go
+++ b/pkg/frontend/labelaccess/tripperware.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package labelaccess
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/grafana/mimir/pkg/frontend/querymiddleware"
+	shared "github.com/grafana/mimir/pkg/labelaccess"
+	"github.com/grafana/mimir/pkg/util/propagation"
+)
+
+type contextKey int
+
+const (
+	contextKeyLabelPolicyHash contextKey = iota
+
+	// Used by GEM and not supported by upstream Mimir
+	labelPolicySeparator string = "!"
+)
+
+type tripperwareWrapper struct {
+	next http.RoundTripper
+}
+
+// WrapTripperware takes the provided tripperware and injects the label policy hash in the context
+// before passing the request to the wrapped tripperware.
+func WrapTripperware(qrTrw querymiddleware.Tripperware) querymiddleware.Tripperware {
+	return func(next http.RoundTripper) http.RoundTripper {
+		// Call chain for RoundTrip() is:
+		// tripperwareWrapper.RoundTrip -> querymiddleware -> next
+		lbacTrw := &tripperwareWrapper{
+			next: qrTrw(next),
+		}
+		return lbacTrw
+	}
+}
+
+func (t *tripperwareWrapper) RoundTrip(r *http.Request) (*http.Response, error) {
+	ctx := r.Context()
+	labelPolicySet, err := shared.ExtractLabelMatchersContext(ctx)
+	// This should never happen anyways because we have auth middleware before this.
+	if err != nil {
+		return nil, err
+	}
+
+	// If the instance policies are set on the query, then inject the hash of the policy set,
+	// so that CacheKeyGenerator can use it to cache results for the tenant differently with and without the policy.
+	if len(labelPolicySet) != 0 {
+		ctx = context.WithValue(ctx, contextKeyLabelPolicyHash, labelPolicySet.Hash())
+		r = r.Clone(ctx)
+	}
+
+	return t.next.RoundTrip(r)
+}
+
+func NewInjector() propagation.Injector {
+	return &injector{}
+}
+
+type injector struct{}
+
+func (i *injector) InjectToCarrier(ctx context.Context, carrier propagation.Carrier) error {
+	labelPolicySet, err := shared.ExtractLabelMatchersContext(ctx)
+	// This should never happen anyways because we have auth middleware before this.
+	if err != nil {
+		return err
+	}
+
+	// If the instance policies are set on the query, ensure the LBAC configs are reinjected into the HTTP request
+	// as headers. This is necessary that this is done after the querymiddleware has done its job,
+	// because the RoundTrippers in querymiddleware throw away any HTTP headers they don't care about.
+	if len(labelPolicySet) != 0 {
+		matchers, err := shared.InjectLabelMatchersSlice(labelPolicySet)
+		if err != nil {
+			return err
+		}
+
+		carrier.SetAll(shared.HTTPHeaderKey, matchers)
+	}
+
+	return nil
+}
+
+// CacheKeyGenerator changes the userID for a cache key if the current request is using LBAC.
+// It then delegates the actual key generation to another querymiddleware.CacheKeyGenerator.
+type CacheKeyGenerator struct {
+	delegate querymiddleware.CacheKeyGenerator
+}
+
+func NewCacheSplitter(delegate querymiddleware.CacheKeyGenerator) CacheKeyGenerator {
+	return CacheKeyGenerator{
+		delegate: delegate,
+	}
+}
+
+// QueryRequest implements querymiddleware.CacheKeyGenerator
+func (c CacheKeyGenerator) QueryRequest(ctx context.Context, tenantID string, r querymiddleware.MetricsQueryRequest) string {
+	if labelPolicyHash, _ := ctx.Value(contextKeyLabelPolicyHash).(string); len(labelPolicyHash) > 0 {
+		tenantID = tenantID + labelPolicySeparator + labelPolicyHash
+	}
+	return c.delegate.QueryRequest(ctx, tenantID, r)
+}
+
+// QueryRequestLimiter implements querymiddleware.CacheKeyGenerator
+func (c CacheKeyGenerator) QueryRequestLimiter(ctx context.Context, tenantID string, r querymiddleware.MetricsQueryRequest) string {
+	if labelPolicyHash, _ := ctx.Value(contextKeyLabelPolicyHash).(string); len(labelPolicyHash) > 0 {
+		tenantID = tenantID + labelPolicySeparator + labelPolicyHash
+	}
+	return c.delegate.QueryRequestLimiter(ctx, tenantID, r)
+}
+
+// QueryRequestError implements querymiddleware.CacheKeyGenerator
+func (c CacheKeyGenerator) QueryRequestError(ctx context.Context, tenantID string, r querymiddleware.MetricsQueryRequest) string {
+	if labelPolicyHash, _ := ctx.Value(contextKeyLabelPolicyHash).(string); len(labelPolicyHash) > 0 {
+		tenantID = tenantID + labelPolicySeparator + labelPolicyHash
+	}
+	return c.delegate.QueryRequestError(ctx, tenantID, r)
+}
+
+func (c CacheKeyGenerator) LabelValues(r *http.Request) (*querymiddleware.GenericQueryCacheKey, error) {
+	cacheKey, err := c.delegate.LabelValues(r)
+	if err != nil {
+		return nil, err
+	}
+	if labelPolicyHash, _ := r.Context().Value(contextKeyLabelPolicyHash).(string); len(labelPolicyHash) > 0 {
+		cacheKey.CacheKeyPrefix += labelPolicySeparator + labelPolicyHash
+	}
+	return cacheKey, nil
+}
+
+func (c CacheKeyGenerator) LabelValuesCardinality(r *http.Request) (*querymiddleware.GenericQueryCacheKey, error) {
+	if labelPolicyHash, _ := r.Context().Value(contextKeyLabelPolicyHash).(string); len(labelPolicyHash) > 0 {
+		return nil, fmt.Errorf("label values cardinality caching is not supported with LBAC: %w", querymiddleware.ErrUnsupportedRequest)
+	}
+	return c.delegate.LabelValuesCardinality(r)
+}

--- a/pkg/labelaccess/propagation.go
+++ b/pkg/labelaccess/propagation.go
@@ -52,7 +52,7 @@ func (l LabelPolicySet) Hash() string {
 	for t := range l {
 		tenants = append(tenants, t)
 	}
-	h := sha1.New()
+	h := sha1.New() //nolint:gosec SHA1 is used for non-cryptographic hashing
 	sort.Strings(tenants)
 	for _, t := range tenants {
 		_, _ = h.Write([]byte(t))

--- a/pkg/labelaccess/propagation.go
+++ b/pkg/labelaccess/propagation.go
@@ -52,7 +52,7 @@ func (l LabelPolicySet) Hash() string {
 	for t := range l {
 		tenants = append(tenants, t)
 	}
-	h := sha1.New() //nolint:gosec SHA1 is used for non-cryptographic hashing
+	h := sha1.New() //nolint:gosec // SHA1 is used for non-cryptographic hashing
 	sort.Strings(tenants)
 	for _, t := range tenants {
 		_, _ = h.Write([]byte(t))

--- a/pkg/labelaccess/propagation.go
+++ b/pkg/labelaccess/propagation.go
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package labelaccess
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/base32"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/grafana/mimir/pkg/util/promqlext"
+)
+
+type key int
+
+const (
+	// HTTPHeaderKey is used as the header to store label matcher values
+	HTTPHeaderKey = "X-Prom-Label-Policy"
+
+	contextKey key = 0
+)
+
+var (
+	errNoMatcherSource     = errors.New("no label matcher source")
+	errInvalidHeaderParse  = errors.New("invalid label policy header value, unable to parse tenant and selector")
+	errInvalidHeaderEscape = errors.New("invalid label policy header value unable to url escape selector string")
+	errInvalidSelector     = errors.New("invalid label policy header value unable to parse selector string")
+)
+
+type LabelPolicy struct {
+	Selector []*labels.Matcher
+}
+
+// LabelPolicySet is used
+type LabelPolicySet map[string][]*LabelPolicy
+
+func (l LabelPolicySet) GetLabelPolicySet() (LabelPolicySet, error) {
+	return l, nil
+}
+
+// Hash iterates through the tenant map in ascending order and returns a base32 string of
+// and sha1 hash of all of the tenants
+func (l LabelPolicySet) Hash() string {
+	tenants := make([]string, 0, len(l))
+	for t := range l {
+		tenants = append(tenants, t)
+	}
+	h := sha1.New()
+	sort.Strings(tenants)
+	for _, t := range tenants {
+		_, _ = h.Write([]byte(t))
+		for _, p := range l[t] {
+			for i := range p.Selector {
+				_, _ = h.Write([]byte(p.Selector[i].String()))
+			}
+		}
+	}
+	return base32.StdEncoding.EncodeToString(h.Sum(nil))
+}
+
+func policyToHeaderValue(instanceName string, policy *LabelPolicy) (string, error) {
+	matchers := make([]string, len(policy.Selector))
+
+	for i := range policy.Selector {
+		matchers[i] = policy.Selector[i].String()
+	}
+
+	return instanceName + ":" + url.PathEscape("{"+strings.Join(matchers, ", ")+"}"), nil
+}
+
+func policyFromHeaderValue(headerString string) (string, *LabelPolicy, error) {
+	components := strings.SplitN(headerString, ":", 2)
+	if len(components) != 2 {
+		return "", nil, errInvalidHeaderParse
+	}
+	selectorString, err := url.PathUnescape(components[1])
+	if err != nil {
+		return "", nil, fmt.Errorf("%w, '%v'", errInvalidHeaderEscape, err)
+	}
+	matchers, err := promqlext.NewPromQLParser().ParseMetricSelector(selectorString)
+	if err != nil {
+		return "", nil, fmt.Errorf("%w '%s', error: '%v'", errInvalidSelector, selectorString, err)
+	}
+
+	for _, m := range matchers {
+		if m.Name == "" {
+			return "", nil, fmt.Errorf("%w '%s', error: 'a label name was empty'", errInvalidSelector, selectorString)
+		}
+	}
+
+	policy := &LabelPolicy{
+		Selector: matchers,
+	}
+
+	return components[0], policy, nil
+}
+
+// InjectLabelMatchersHTTP takes the provided matcher protobufs and stores them as HTTP headers
+func InjectLabelMatchersHTTP(r *http.Request, instancePolicyMap LabelPolicySet) error {
+	// Ensure any existing policy sets are erased
+	r.Header.Del(HTTPHeaderKey)
+
+	values, err := InjectLabelMatchersSlice(instancePolicyMap)
+	if err != nil {
+		return err
+	}
+
+	r.Header[HTTPHeaderKey] = values
+
+	return nil
+}
+
+// InjectLabelMatchersSlice takes the provided label policy set and encodes them as a slice of strings, suitable for use as header values.
+func InjectLabelMatchersSlice(instancePolicyMap LabelPolicySet) ([]string, error) {
+	var values []string
+
+	for instanceName, policies := range instancePolicyMap {
+		for _, policy := range policies {
+			encodedPolicy, err := policyToHeaderValue(instanceName, policy)
+			if err != nil {
+				return nil, err
+			}
+
+			values = append(values, encodedPolicy)
+		}
+	}
+
+	return values, nil
+}
+
+// ExtractLabelMatchersHTTP takes the provided HTTP request and parses out label matcher protobufs
+func ExtractLabelMatchersHTTP(r *http.Request) (LabelPolicySet, error) {
+	headerValues := r.Header.Values(HTTPHeaderKey)
+
+	return ExtractLabelMatchersSlice(headerValues)
+}
+
+// ExtractLabelMatchersSlice takes a slice of label matcher header values and parses a label policy set from them.
+func ExtractLabelMatchersSlice(values []string) (LabelPolicySet, error) {
+	instancePolicyMap := LabelPolicySet{}
+
+	// Iterate through each set header value
+	for _, headerValue := range values {
+		// Split the header value on a comma and iterate through each policy.
+		for _, v := range strings.Split(headerValue, ",") {
+			instanceName, policy, err := policyFromHeaderValue(v)
+			if err != nil {
+				return nil, err
+			}
+
+			currentPolicies, exists := instancePolicyMap[instanceName]
+			if exists {
+				instancePolicyMap[instanceName] = append(currentPolicies, policy)
+			} else {
+				instancePolicyMap[instanceName] = []*LabelPolicy{policy}
+			}
+		}
+	}
+
+	return instancePolicyMap, nil
+}
+
+type matcherSource interface {
+	GetMatchers() LabelPolicySet
+}
+
+type labelMatcherCarrier struct {
+	matcher LabelPolicySet
+}
+
+func (l *labelMatcherCarrier) GetMatchers() LabelPolicySet {
+	return l.matcher
+}
+
+// ExtractLabelMatchersContext gets the embedded label matchers from the context
+func ExtractLabelMatchersContext(ctx context.Context) (LabelPolicySet, error) {
+	source, ok := ctx.Value(contextKey).(matcherSource)
+
+	if !ok {
+		return nil, errNoMatcherSource
+	}
+
+	return source.GetMatchers(), nil
+}
+
+// InjectLabelMatchersContext returns a derived context containing the provided label matchers
+func InjectLabelMatchersContext(ctx context.Context, matchers LabelPolicySet) context.Context {
+	return context.WithValue(ctx, interface{}(contextKey), &labelMatcherCarrier{matchers})
+}

--- a/pkg/labelaccess/propagation.go
+++ b/pkg/labelaccess/propagation.go
@@ -52,7 +52,7 @@ func (l LabelPolicySet) Hash() string {
 	for t := range l {
 		tenants = append(tenants, t)
 	}
-	h := sha1.New() //nolint:gosec // SHA1 is used for non-cryptographic hashing
+	h := sha1.New() // #nosec G401 -- nosemgrep: use-of-sha1 SHA1 is used for non-cryptographic hashing
 	sort.Strings(tenants)
 	for _, t := range tenants {
 		_, _ = h.Write([]byte(t))

--- a/pkg/labelaccess/propagation_test.go
+++ b/pkg/labelaccess/propagation_test.go
@@ -1,0 +1,401 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package labelaccess
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPolicyHTTPHeaderValue(t *testing.T) {
+	tests := []struct {
+		name         string
+		wantErr      bool
+		instanceName string
+		policy       *LabelPolicy
+	}{
+		{
+			name:         "default",
+			wantErr:      false,
+			instanceName: "test-instance",
+			policy: &LabelPolicy{
+				Selector: []*labels.Matcher{
+					{
+						Type:  labels.MatchEqual,
+						Value: "test_value",
+						Name:  "test_name",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			headerVal, err := policyToHeaderValue(tt.instanceName, tt.policy)
+			require.NoError(t, err)
+
+			instanceName, policy, err := policyFromHeaderValue(headerVal)
+			require.NoError(t, err)
+			require.Equal(t, tt.instanceName, instanceName)
+			require.Equal(t, len(tt.policy.Selector), len(policy.Selector))
+		})
+	}
+
+	t.Run("invalid label policies results in error", func(t *testing.T) {
+		// Pass an invalid policy.
+		_, _, err := policyFromHeaderValue("test-instance:xxx/yyy")
+		require.Error(t, err)
+	})
+
+	t.Run("empty label name in policies results in error", func(t *testing.T) {
+		policy := &LabelPolicy{
+			Selector: []*labels.Matcher{
+				{
+					Type:  labels.MatchNotRegexp,
+					Value: "test_value",
+					// Empty string is not a valid label name
+					Name: "",
+				},
+			},
+		}
+
+		headerVal, err := policyToHeaderValue("test-instance", policy)
+		require.NoError(t, err)
+
+		_, _, err = policyFromHeaderValue(headerVal)
+		require.Error(t, err)
+	})
+}
+
+func TestPropagation(t *testing.T) {
+	tests := []struct {
+		name              string
+		instancePolicyMap LabelPolicySet
+	}{
+		{
+			name: "simple",
+			instancePolicyMap: LabelPolicySet{
+				"test-instance": {
+					{
+						Selector: []*labels.Matcher{
+							{
+								Type:  labels.MatchEqual,
+								Value: "test_value",
+								Name:  "test_name",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple",
+			instancePolicyMap: LabelPolicySet{
+				"test-instance": {
+					{
+						Selector: []*labels.Matcher{
+							{
+								Type:  labels.MatchEqual,
+								Name:  "test_name",
+								Value: "test_value",
+							},
+							{
+								Type:  labels.MatchNotEqual,
+								Name:  "test_name_alt",
+								Value: "test_value",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requirePolicyIsExpected := func(t *testing.T, instancePolicyMap LabelPolicySet) {
+				require.Equal(t, len(tt.instancePolicyMap), len(instancePolicyMap))
+
+				for instanceName, policies := range instancePolicyMap {
+					expectedPolicies, instanceExpected := tt.instancePolicyMap[instanceName]
+					require.True(t, instanceExpected)
+					require.Equal(t, len(expectedPolicies), len(policies))
+					for i, policy := range policies {
+						require.Equal(t, len(expectedPolicies[i].Selector), len(policy.Selector))
+						for n, matcher := range policy.Selector {
+							require.Equal(t, expectedPolicies[i].Selector[n].Type, matcher.Type)
+							require.Equal(t, expectedPolicies[i].Selector[n].Name, matcher.Name)
+							require.Equal(t, expectedPolicies[i].Selector[n].Value, matcher.Value)
+						}
+					}
+				}
+			}
+
+			t.Run("HTTP", func(t *testing.T) {
+				r := &http.Request{
+					Header: http.Header{},
+				}
+				err := InjectLabelMatchersHTTP(r, tt.instancePolicyMap)
+				require.NoError(t, err)
+
+				instancePolicyMap, err := ExtractLabelMatchersHTTP(r)
+				require.NoError(t, err)
+				requirePolicyIsExpected(t, instancePolicyMap)
+			})
+
+			t.Run("slice", func(t *testing.T) {
+				v, err := InjectLabelMatchersSlice(tt.instancePolicyMap)
+				require.NoError(t, err)
+
+				instancePolicyMap, err := ExtractLabelMatchersSlice(v)
+				require.NoError(t, err)
+				requirePolicyIsExpected(t, instancePolicyMap)
+			})
+		})
+	}
+}
+
+func TestPropagationContext(t *testing.T) {
+	tests := []struct {
+		name              string
+		instancePolicyMap LabelPolicySet
+	}{
+		{
+			name: "simple",
+			instancePolicyMap: LabelPolicySet{
+				"test-instance": {
+					{
+						Selector: []*labels.Matcher{
+							{
+								Type:  labels.MatchEqual,
+								Value: "test_value",
+								Name:  "test_name",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple",
+			instancePolicyMap: LabelPolicySet{
+				"test-instance": {
+					{
+						Selector: []*labels.Matcher{
+							{
+								Type:  labels.MatchEqual,
+								Name:  "test_name",
+								Value: "test_value",
+							},
+							{
+								Type:  labels.MatchNotEqual,
+								Name:  "test_name_alt",
+								Value: "test_value",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			ctx = InjectLabelMatchersContext(ctx, tt.instancePolicyMap)
+			instancePolicyMap, err := ExtractLabelMatchersContext(ctx)
+			require.NoError(t, err)
+			require.Equal(t, len(tt.instancePolicyMap), len(instancePolicyMap))
+
+			for instanceName, policies := range instancePolicyMap {
+				expectedPolicies, instanceExpected := tt.instancePolicyMap[instanceName]
+				require.True(t, instanceExpected)
+				require.Equal(t, len(expectedPolicies), len(policies))
+				for i, policy := range policies {
+					require.Equal(t, len(expectedPolicies[i].Selector), len(policy.Selector))
+					for n, matcher := range policy.Selector {
+						require.Equal(t, expectedPolicies[i].Selector[n].Type, matcher.Type)
+						require.Equal(t, expectedPolicies[i].Selector[n].Name, matcher.Name)
+						require.Equal(t, expectedPolicies[i].Selector[n].Value, matcher.Value)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestExtractLabelMatchers(t *testing.T) {
+	fooBarPolicy := &LabelPolicy{
+		Selector: []*labels.Matcher{
+			{
+				Type:  labels.MatchEqual,
+				Name:  "foo",
+				Value: "bar",
+			},
+		},
+	}
+	fooCarPolicy := &LabelPolicy{
+		Selector: []*labels.Matcher{
+			{
+				Type:  labels.MatchEqual,
+				Name:  "foo",
+				Value: "car",
+			},
+		},
+	}
+
+	tests := []struct {
+		name         string
+		headerValues []string
+		want         LabelPolicySet
+		wantErr      error
+	}{
+		{
+			name: "passthrough",
+			want: LabelPolicySet{},
+		},
+		{
+			name:         "single-header/single-policy",
+			headerValues: []string{"user-1:%7Bfoo=%22bar%22%7D"},
+			want: LabelPolicySet{
+				"user-1": {
+					fooBarPolicy,
+				},
+			},
+		},
+		{
+			name:         "single-header/empty-selector",
+			headerValues: []string{"user-1:%7B%7D"},
+			want: LabelPolicySet{
+				"user-1": {
+					{
+						Selector: []*labels.Matcher{},
+					},
+				},
+			},
+		},
+		{
+			name:         "single-header/multiple-policies",
+			headerValues: []string{"user-1:%7Bfoo=%22bar%22%7D,user-2:%7Bfoo=%22bar%22%7D,user-1:%7Bfoo=%22car%22%7D"},
+			want: LabelPolicySet{
+				"user-1": {
+					fooBarPolicy,
+					fooCarPolicy,
+				},
+				"user-2": {
+					fooBarPolicy,
+				},
+			},
+		},
+		{
+			name: "multiple-header/multiple-policies",
+			headerValues: []string{
+				"user-1:%7Bfoo=%22bar%22%7D,user-2:%7Bfoo=%22bar%22%7D,user-1:%7Bfoo=%22car%22%7D",
+				"user-2:%7Bfoo=%22car%22%7D",
+			},
+			want: LabelPolicySet{
+				"user-1": {
+					fooBarPolicy,
+					fooCarPolicy,
+				},
+				"user-2": {
+					fooBarPolicy,
+					fooCarPolicy,
+				},
+			},
+		},
+		{
+			name: "invalid-header/extra-comma",
+			headerValues: []string{
+				"user-1:%7Bfoo=%22bar%22%7D,user-2:%7Bfoo=%22bar%22%7D,user-1:%7Bfoo=%22car%22%7D,",
+			},
+			wantErr: errInvalidHeaderParse,
+		},
+		{
+			name: "invalid-header/empty",
+			headerValues: []string{
+				"user-1:%7Bfoo=%22bar%22%7D,user-2:%7Bfoo=%22bar%22%7D,user-1:%7Bfoo=%22car%22%7D,",
+				"",
+			},
+			wantErr: errInvalidHeaderParse,
+		},
+		{
+			name: "invalid-header/no-tenant",
+			headerValues: []string{
+				"%7Bfoo=%22bar%22%7D",
+			},
+			wantErr: errInvalidHeaderParse,
+		},
+		{
+			name: "invalid-header/bad-escape",
+			headerValues: []string{
+				"user-1:%%7Bfoo=%22bar%22%7D",
+			},
+			wantErr: errInvalidHeaderEscape,
+		},
+		{
+			name: "invalid-header/bad-selector",
+			headerValues: []string{
+				`user-1:{foo=="bar"}`,
+			},
+			wantErr: errInvalidSelector,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Run("from HTTP headers", func(t *testing.T) {
+				r, err := http.NewRequest("GET", "test", nil)
+				require.NoError(t, err)
+				for _, headerValue := range tt.headerValues {
+					r.Header.Add(HTTPHeaderKey, headerValue)
+				}
+				got, err := ExtractLabelMatchersHTTP(r)
+				if tt.wantErr == nil {
+					require.NoError(t, err)
+				} else {
+					require.ErrorIs(t, err, tt.wantErr)
+					require.Equal(t, tt.want, got)
+				}
+			})
+
+			t.Run("from slice", func(t *testing.T) {
+				got, err := ExtractLabelMatchersSlice(tt.headerValues)
+				if tt.wantErr == nil {
+					require.NoError(t, err)
+				} else {
+					require.ErrorIs(t, err, tt.wantErr)
+					require.Equal(t, tt.want, got)
+				}
+			})
+		})
+	}
+}
+
+func TestHashCollisionResistance(t *testing.T) {
+	const instanceCount = 50000
+	var lps LabelPolicySet
+	fooBarPolicy := &LabelPolicy{
+		Selector: []*labels.Matcher{
+			{
+				Type:  labels.MatchEqual,
+				Name:  "foo",
+				Value: "bar",
+			},
+		},
+	}
+	hashes := make(map[string]struct{})
+
+	for i := 0; i < instanceCount; i++ {
+		lps = LabelPolicySet{
+			fmt.Sprintf("billing%d", i): {
+				fooBarPolicy,
+			},
+		}
+		hashes[lps.Hash()] = struct{}{}
+	}
+
+	require.Equal(t, len(hashes), instanceCount)
+}

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -159,6 +159,8 @@ type Config struct {
 	CostAttributionCleanupInterval  time.Duration `yaml:"cost_attribution_cleanup_interval" category:"experimental"`
 
 	InstrumentRefLeaks mimirpb.InstrumentRefLeaksConfig `yaml:"instrument_ref_leaks" category:"experimental"`
+
+	LabelAccessControlEnabled bool `yaml:"label_access_control_enabled" category:"experimental"`
 }
 
 // RegisterFlags registers flags.
@@ -179,6 +181,7 @@ func (c *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 
 	f.BoolVar(&c.MultitenancyEnabled, "auth.multitenancy-enabled", true, "When set to true, incoming HTTP requests must specify tenant ID in HTTP X-Scope-OrgId header. When set to false, tenant ID from -auth.no-auth-tenant is used instead.")
 	f.StringVar(&c.NoAuthTenant, "auth.no-auth-tenant", "anonymous", "Tenant ID to use when multitenancy is disabled.")
+	f.BoolVar(&c.LabelAccessControlEnabled, "auth.label-access-control-enabled", false, "If enabled, Mimir enforces label-based access control on metric read queries using the X-Prom-Label-Policy HTTP header.")
 	f.BoolVar(&c.PrintConfig, "print.config", false, "Print the config and exit.")
 	f.DurationVar(&c.ShutdownDelay, "shutdown-delay", 0, "How long to wait between SIGTERM and shutdown. After receiving SIGTERM, Mimir will report not-ready status via /ready endpoint.")
 	f.IntVar(&c.MaxSeparateMetricsGroupsPerUser, "max-separate-metrics-groups-per-user", 1000, "Maximum number of groups allowed per user by which specified distributor and ingester metrics can be further separated.")

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -47,6 +47,7 @@ import (
 	"github.com/grafana/mimir/pkg/costattribution"
 	"github.com/grafana/mimir/pkg/distributor"
 	"github.com/grafana/mimir/pkg/frontend"
+	frontend_labelaccess "github.com/grafana/mimir/pkg/frontend/labelaccess"
 	"github.com/grafana/mimir/pkg/frontend/querymiddleware"
 	"github.com/grafana/mimir/pkg/frontend/transport"
 	v2 "github.com/grafana/mimir/pkg/frontend/v2"
@@ -54,6 +55,7 @@ import (
 	"github.com/grafana/mimir/pkg/querier"
 	querierapi "github.com/grafana/mimir/pkg/querier/api"
 	"github.com/grafana/mimir/pkg/querier/engine"
+	querier_labelaccess "github.com/grafana/mimir/pkg/querier/labelaccess"
 	"github.com/grafana/mimir/pkg/querier/stats"
 	"github.com/grafana/mimir/pkg/querier/tenantfederation"
 	querier_worker "github.com/grafana/mimir/pkg/querier/worker"
@@ -670,6 +672,11 @@ func (t *Mimir) initQuerier() (serv services.Service, err error) {
 	t.Cfg.Worker.MaxConcurrentRequests = t.Cfg.Querier.EngineConfig.MaxConcurrent
 	t.Cfg.Worker.QuerySchedulerDiscovery = t.Cfg.QueryScheduler.ServiceDiscovery
 
+	if t.Cfg.LabelAccessControlEnabled {
+		t.QuerierQueryable = querier_labelaccess.WrapQueryable(t.QuerierQueryable, util_log.Logger)
+		t.ExemplarQueryable = querier_labelaccess.WrapExemplarQueryable(t.ExemplarQueryable, util_log.Logger)
+	}
+
 	// Add the default propagators.
 	t.Extractors = append(
 		t.Extractors,
@@ -679,6 +686,10 @@ func (t *Mimir) initQuerier() (serv services.Service, err error) {
 		// Since we don't use the regular RegisterQueryAPI, we need to register the consistency extractor here too.
 		&querierapi.ConsistencyExtractor{},
 	)
+
+	if t.Cfg.LabelAccessControlEnabled {
+		t.Extractors = append(t.Extractors, querier_labelaccess.NewExtractor())
+	}
 
 	extractor := &propagation.MultiExtractor{Extractors: t.Extractors}
 	metrics := querier.NewRequestMetrics(t.Registerer)
@@ -704,6 +715,10 @@ func (t *Mimir) initQuerier() (serv services.Service, err error) {
 		t.Overrides,
 		extractor,
 	)
+
+	if t.Cfg.LabelAccessControlEnabled {
+		internalQuerierRouter = querier_labelaccess.NewLabelAccessMiddleware(util_log.Logger).Wrap(internalQuerierRouter)
+	}
 
 	// If the querier is running standalone without the query-frontend or query-scheduler, we must register it's internal
 	// HTTP handler externally and provide the external Mimir Server HTTP handler to the frontend worker
@@ -825,6 +840,10 @@ func (t *Mimir) initQueryFrontendCodec() (services.Service, error) {
 	// Add our default injectors.
 	t.Injectors = append(t.Injectors, &querierapi.ConsistencyInjector{})
 
+	if t.Cfg.LabelAccessControlEnabled {
+		t.Injectors = append(t.Injectors, frontend_labelaccess.NewInjector())
+	}
+
 	t.QueryFrontendCodec = querymiddleware.NewCodec(
 		t.Registerer,
 		t.Cfg.Querier.EngineConfig.LookbackDelta,
@@ -914,6 +933,14 @@ func (t *Mimir) initQueryFrontendTripperware() (serv services.Service, err error
 		panic(fmt.Sprintf("invalid config not caught by validation: unknown PromQL engine '%s'", t.Cfg.Frontend.QueryEngine))
 	}
 
+	if t.Cfg.LabelAccessControlEnabled {
+		cacheKeyGenerator := t.Cfg.Frontend.QueryMiddleware.CacheKeyGenerator
+		if cacheKeyGenerator == nil {
+			cacheKeyGenerator = querymiddleware.NewDefaultCacheKeyGenerator(t.QueryFrontendCodec, t.Cfg.Frontend.QueryMiddleware.SplitQueriesByInterval)
+		}
+		t.Cfg.Frontend.QueryMiddleware.CacheKeyGenerator = frontend_labelaccess.NewCacheSplitter(cacheKeyGenerator)
+	}
+
 	tripperware, err := querymiddleware.NewTripperware(
 		t.Cfg.Frontend.QueryMiddleware,
 		util_log.Logger,
@@ -936,6 +963,10 @@ func (t *Mimir) initQueryFrontendTripperware() (serv services.Service, err error
 	)
 	if err != nil {
 		return nil, err
+	}
+
+	if t.Cfg.LabelAccessControlEnabled {
+		tripperware = frontend_labelaccess.WrapTripperware(tripperware)
 	}
 
 	t.QueryFrontendTripperware = tripperware
@@ -984,7 +1015,14 @@ func (t *Mimir) initQueryFrontend() (serv services.Service, err error) {
 	handler := transport.NewHandler(t.Cfg.Frontend.Handler, roundTripper, util_log.Logger, t.Registerer)
 	// Allow the Prometheus engine to be explicitly selected if MQE is in use and a fallback is configured.
 	fallbackInjector := propagation.Middleware(&streamingpromqlcompat.EngineFallbackExtractor{})
-	t.API.RegisterQueryFrontendHandler(fallbackInjector.Wrap(handler), t.BuildInfoHandler, t.Cfg.Frontend.Handler.MaxBodySize)
+	wrappedHandler := fallbackInjector.Wrap(handler)
+	if t.Cfg.LabelAccessControlEnabled {
+		// Wrap the handler so LBAC policies from the X-Prom-Label-Policy header are
+		// extracted into the request context before the round tripper runs. This is
+		// required for WrapTripperware to see the policy set when computing the cache key.
+		wrappedHandler = querier_labelaccess.NewLabelAccessMiddleware(util_log.Logger).Wrap(wrappedHandler)
+	}
+	t.API.RegisterQueryFrontendHandler(wrappedHandler, t.BuildInfoHandler, t.Cfg.Frontend.Handler.MaxBodySize)
 
 	w := services.NewFailureWatcher()
 	return services.NewBasicService(func(_ context.Context) error {

--- a/pkg/querier/labelaccess/middleware.go
+++ b/pkg/querier/labelaccess/middleware.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package labelaccess
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/middleware"
+
+	shared "github.com/grafana/mimir/pkg/labelaccess"
+	"github.com/grafana/mimir/pkg/util/propagation"
+)
+
+type labelAccessMiddleware struct {
+	logger log.Logger
+}
+
+// NewLabelAccessMiddleware returns a HTTP middleware that parses the X-Prom-Label-Policy header
+// and injects the parsed label selectors into the request context.
+func NewLabelAccessMiddleware(logger log.Logger) middleware.Interface {
+	return &labelAccessMiddleware{
+		logger: logger,
+	}
+}
+
+// Wrap implements the middleware interface
+func (l *labelAccessMiddleware) Wrap(next http.Handler) http.Handler {
+	unsupportedEndpoints := []string{"/cardinality/label_values", "/cardinality/label_names", "/cardinality/active_series"}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		matchers, err := shared.ExtractLabelMatchersHTTP(r)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		if len(matchers) > 0 {
+			level.Debug(l.logger).Log("msg", "extracted label selector policies from HTTP request", "num_matchers", len(matchers))
+			for _, unsupportedEndpoint := range unsupportedEndpoints {
+				if strings.HasSuffix(r.URL.Path, unsupportedEndpoint) {
+					http.Error(w, fmt.Sprintf("%v endpoint doesn't support access policies with label-based access control", r.URL.Path), http.StatusBadRequest)
+					return
+				}
+			}
+		}
+		r = r.Clone(shared.InjectLabelMatchersContext(r.Context(), matchers))
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+type labelAccessExtractor struct{}
+
+func NewExtractor() propagation.Extractor {
+	return &labelAccessExtractor{}
+}
+
+func (l *labelAccessExtractor) ExtractFromCarrier(ctx context.Context, carrier propagation.Carrier) (context.Context, error) {
+	matchers, err := shared.ExtractLabelMatchersSlice(carrier.GetAll(shared.HTTPHeaderKey))
+	if err != nil {
+		return nil, err
+	}
+
+	// Unlike labelAccessMiddleware above, this extractor does not need to check for unsupported endpoints as it's only used for
+	// range queries and instant queries at the time of writing.
+
+	return shared.InjectLabelMatchersContext(ctx, matchers), nil
+}

--- a/pkg/querier/labelaccess/middleware_test.go
+++ b/pkg/querier/labelaccess/middleware_test.go
@@ -10,11 +10,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/go-kit/log"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
 	shared "github.com/grafana/mimir/pkg/labelaccess"
-	util_log "github.com/grafana/mimir/pkg/util/log"
 	"github.com/grafana/mimir/pkg/util/propagation"
 )
 
@@ -65,7 +65,7 @@ func Test_labelAccessMiddleware_Wrap(t *testing.T) {
 	for name, data := range tests {
 		t.Run(name, func(t *testing.T) {
 			l := &labelAccessMiddleware{
-				logger: util_log.Logger,
+				logger: log.NewNopLogger(),
 			}
 			handler := l.Wrap(mockHandler{})
 			request, err := http.NewRequestWithContext(context.Background(), "GET", data.url, http.NoBody)

--- a/pkg/querier/labelaccess/middleware_test.go
+++ b/pkg/querier/labelaccess/middleware_test.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package labelaccess
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+
+	shared "github.com/grafana/mimir/pkg/labelaccess"
+	util_log "github.com/grafana/mimir/pkg/util/log"
+	"github.com/grafana/mimir/pkg/util/propagation"
+)
+
+func Test_labelAccessMiddleware_Wrap(t *testing.T) {
+	tests := map[string]struct {
+		url           string
+		expectedError string
+		useLBAC       bool
+	}{
+		"expected error if request with LBAC and url ends with /cardinality/label_values": {
+			url:           "/cardinality/label_values",
+			expectedError: "/cardinality/label_values endpoint doesn't support access policies with label-based access control",
+			useLBAC:       true,
+		},
+		"expected error if request with LBAC and url ends with /cardinality/label_names": {
+			url:           "/cardinality/label_names",
+			expectedError: "/cardinality/label_names endpoint doesn't support access policies with label-based access control",
+			useLBAC:       true,
+		},
+		"expected error if request with LBAC and url ends with /cardinality/label_names ignoring request params": {
+			url:           "/cardinality/label_names?limit=500",
+			expectedError: "/cardinality/label_names endpoint doesn't support access policies with label-based access control",
+			useLBAC:       true,
+		},
+		"expect error on active_series request with LBAC enabled": {
+			url:           "/cardinality/active_series",
+			expectedError: "/cardinality/active_series endpoint doesn't support access policies with label-based access control",
+			useLBAC:       true,
+		},
+		"expect error on active_series request with parameters and LBAC enabled": {
+			url:           "/cardinality/active_series?selector=foo",
+			expectedError: "/cardinality/active_series endpoint doesn't support access policies with label-based access control",
+			useLBAC:       true,
+		},
+		"expected no errors if request with LBAC but url is not related to cardinality analysis": {
+			url: "/any-url",
+		},
+		"expected no errors if request without LBAC and url ends with /cardinality/label_values": {
+			url: "/cardinality/label_values",
+		},
+		"expected no errors if request without LBAC and url ends with /cardinality/label_names": {
+			url: "/cardinality/label_names",
+		},
+		"expect no errors for active_series request without LBAC": {
+			url: "/cardinality/active_series",
+		},
+	}
+	for name, data := range tests {
+		t.Run(name, func(t *testing.T) {
+			l := &labelAccessMiddleware{
+				logger: util_log.Logger,
+			}
+			handler := l.Wrap(mockHandler{})
+			request, err := http.NewRequestWithContext(context.Background(), "GET", data.url, http.NoBody)
+			require.NoError(t, err)
+			if data.useLBAC {
+				headerValue := "user-2:%7Bfoo=%22car%22%7D"
+				request.Header.Add(shared.HTTPHeaderKey, headerValue)
+			}
+			recorder := httptest.NewRecorder()
+
+			handler.ServeHTTP(recorder, request)
+
+			body := recorder.Result().Body
+			bodyContent, err := io.ReadAll(body)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				_ = body.Close()
+			})
+			if len(data.expectedError) > 0 {
+				require.Equal(t, http.StatusBadRequest, recorder.Result().StatusCode)
+				require.Contains(t, string(bodyContent), data.expectedError)
+				return
+			}
+			require.Equal(t, http.StatusOK, recorder.Result().StatusCode)
+			require.Equal(t, "mock ok response", string(bodyContent))
+		})
+	}
+}
+
+type mockHandler struct {
+}
+
+func (m mockHandler) ServeHTTP(writer http.ResponseWriter, _ *http.Request) {
+	writer.WriteHeader(http.StatusOK)
+	fmt.Fprint(writer, "mock ok response")
+}
+
+func TestLabelAccessExtractor(t *testing.T) {
+	testCases := map[string]struct {
+		metadata          map[string][]string
+		expectedPolicySet shared.LabelPolicySet
+	}{
+		"no matching metadata value": {
+			metadata:          map[string][]string{},
+			expectedPolicySet: shared.LabelPolicySet{},
+		},
+		"single policy": {
+			metadata: map[string][]string{shared.HTTPHeaderKey: {"user-1:%7Bfoo=%22bar-1%22%7D"}},
+			expectedPolicySet: shared.LabelPolicySet{
+				"user-1": []*shared.LabelPolicy{
+					{Selector: []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "foo", "bar-1")}},
+				},
+			},
+		},
+		"multiple policies": {
+			metadata: map[string][]string{shared.HTTPHeaderKey: {"user-1:%7Bfoo=%22bar-1%22%7D", "user-2:%7Bfoo=%22bar-2%22%7D"}},
+			expectedPolicySet: shared.LabelPolicySet{
+				"user-1": []*shared.LabelPolicy{
+					{Selector: []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "foo", "bar-1")}},
+				},
+				"user-2": []*shared.LabelPolicy{
+					{Selector: []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "foo", "bar-2")}},
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			extractor := NewExtractor()
+			ctx, err := extractor.ExtractFromCarrier(context.Background(), propagation.MapCarrier(testCase.metadata))
+			require.NoError(t, err)
+
+			policySet, err := shared.ExtractLabelMatchersContext(ctx)
+			require.NoError(t, err)
+			require.Equal(t, testCase.expectedPolicySet, policySet)
+		})
+	}
+}

--- a/pkg/querier/labelaccess/mock_queryable_test.go
+++ b/pkg/querier/labelaccess/mock_queryable_test.go
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package labelaccess
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/util/annotations"
+)
+
+// MockQueryable can be used as a querier or queryable in test cases, it is
+// only intended for unit tests and not for any production use.
+// It takes a series of expected querier calls and select calls on the querier,
+// it validates whether all the expected calls have been received and none more.
+// For each expected call the return value can also be defined.
+type MockQueryable struct {
+	sync.Mutex
+	TB testing.TB
+
+	// List of expected calls to the Queryable's .Querier() method,
+	// order is not enforced to allow for multi-threaded use.
+	ExpectedQuerierCalls []QuerierCall
+
+	// List of expected calls to the Queryable's .ChunkQuerier() method,
+	// order is not enforced to allow for multi-threaded use.
+	ExpectedChunkQuerierCalls []QuerierCall
+
+	// List of expected calls to the Querier's .Select() method,
+	// order is not enforced to allow for multi-threaded use.
+	ExpectedSelectCalls []SelectCall
+
+	// List of expected calls to the ChunkQuerier's .Select() method,
+	// order is not enforced to allow for multi-threaded use.
+	ExpectedChunkSelectCalls []ChunkSelectCall
+
+	// List of expected calls to the Querier's .LabelValues() method,
+	// order is not enforced to allow for multi-threaded use.
+	ExpectedLabelValuesCalls []LabelValuesCall
+
+	UnlimitedCalls bool
+}
+
+func (m *MockQueryable) Close() error {
+	return nil
+}
+
+func (m *MockQueryable) LabelNames(context.Context, *storage.LabelHints, ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	return nil, nil, nil
+}
+
+type QuerierCall struct {
+	ExpectedMinT int64
+	ExpectedMaxT int64
+}
+
+type SelectCall struct {
+	ArgSortSeries bool
+	ArgHints      *storage.SelectHints
+	ArgMatchers   []*labels.Matcher
+	ReturnValue   func() storage.SeriesSet
+}
+
+type ChunkSelectCall struct {
+	ArgSortSeries bool
+	ArgHints      *storage.SelectHints
+	ArgMatchers   []*labels.Matcher
+	ReturnValue   func() storage.ChunkSeriesSet
+}
+
+type LabelValuesCall struct {
+	Label        string
+	Matchers     []*labels.Matcher
+	ReturnValues []string
+}
+
+func (m *MockQueryable) Querier(mint, maxt int64) (storage.Querier, error) {
+	m.Lock()
+	defer m.Unlock()
+
+	for callIdx := range m.ExpectedQuerierCalls {
+		if m.ExpectedQuerierCalls[callIdx].ExpectedMinT != mint || m.ExpectedQuerierCalls[callIdx].ExpectedMaxT != maxt {
+			continue
+		}
+
+		if !m.UnlimitedCalls {
+			m.ExpectedQuerierCalls = append(m.ExpectedQuerierCalls[:callIdx], m.ExpectedQuerierCalls[callIdx+1:]...)
+		}
+
+		// mockQueryable satisfies both interfaces
+		// storage.Queryable and storage.Querier.
+		return m, nil
+	}
+
+	m.TB.Fatalf("MockQueryable: Unexpected call to .Querier(ctx, %d, %d)", mint, maxt)
+	return nil, errors.New("no querier")
+}
+
+func (m *MockQueryable) ChunkQuerier(mint, maxt int64) (storage.ChunkQuerier, error) {
+	m.Lock()
+	defer m.Unlock()
+
+	for callIdx, expCall := range m.ExpectedChunkQuerierCalls {
+		if expCall.ExpectedMinT != mint || expCall.ExpectedMaxT != maxt {
+			continue
+		}
+
+		if !m.UnlimitedCalls {
+			m.ExpectedChunkQuerierCalls = append(m.ExpectedChunkQuerierCalls[:callIdx], m.ExpectedChunkQuerierCalls[callIdx+1:]...)
+		}
+
+		return &mockChunkQuerier{
+			TB:                  m.TB,
+			ExpectedSelectCalls: m.ExpectedChunkSelectCalls,
+			UnlimitedCalls:      m.UnlimitedCalls,
+		}, nil
+	}
+
+	m.TB.Fatalf("MockQueryable: Unexpected call to .ChunkQuerier(ctx, %d, %d)", mint, maxt)
+	return nil, errors.New("no querier")
+}
+
+type mockChunkQuerier struct {
+	sync.Mutex
+	TB testing.TB
+
+	ExpectedSelectCalls []ChunkSelectCall
+
+	UnlimitedCalls bool
+}
+
+func (q *mockChunkQuerier) Select(_ context.Context,
+	sortSeries bool,
+	hints *storage.SelectHints,
+	matchers ...*labels.Matcher) storage.ChunkSeriesSet {
+	q.Lock()
+	defer q.Unlock()
+
+CALLS:
+	for callIdx, expectedCall := range q.ExpectedSelectCalls {
+		// Compare all relevant properties of the expected calls to the given
+		// arguments to decide whether this call matches an expected call.
+
+		if expectedCall.ArgSortSeries != sortSeries {
+			continue
+		}
+		if (expectedCall.ArgHints == nil) != (hints == nil) {
+			continue
+		}
+		if expectedCall.ArgHints != nil &&
+			(expectedCall.ArgHints.Start != hints.Start || expectedCall.ArgHints.End != hints.End) {
+			continue
+		}
+		if len(expectedCall.ArgMatchers) != len(matchers) {
+			continue
+		}
+
+		for i := range expectedCall.ArgMatchers {
+			if expectedCall.ArgMatchers[i].Type != matchers[i].Type {
+				continue CALLS
+			}
+			if expectedCall.ArgMatchers[i].Name != matchers[i].Name {
+				continue CALLS
+			}
+			if expectedCall.ArgMatchers[i].Value != matchers[i].Value {
+				continue CALLS
+			}
+		}
+
+		res := expectedCall.ReturnValue()
+
+		if !q.UnlimitedCalls {
+			q.ExpectedSelectCalls = append(q.ExpectedSelectCalls[:callIdx], q.ExpectedSelectCalls[callIdx+1:]...)
+		}
+
+		return res
+	}
+
+	q.TB.Fatalf("mockChunkQuerier: Unexpected call to .Select(%t, %+v, %+v)", sortSeries, hints, matchers)
+	return nil
+}
+
+func (q *mockChunkQuerier) LabelValues(context.Context, string, *storage.LabelHints, ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	return nil, nil, nil
+}
+
+func (q *mockChunkQuerier) LabelNames(context.Context, *storage.LabelHints, ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	return nil, nil, nil
+}
+
+func (q *mockChunkQuerier) Close() error {
+	return nil
+}
+
+func (m *MockQueryable) Select(_ context.Context, sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
+	m.Lock()
+	defer m.Unlock()
+
+CALLS:
+	for callIdx, expectedCall := range m.ExpectedSelectCalls {
+		// Compare all relevant properties of the expected calls to the given
+		// arguments to decide whether this call matches an expected call.
+
+		if expectedCall.ArgSortSeries != sortSeries {
+			continue
+		}
+		if (expectedCall.ArgHints == nil) != (hints == nil) {
+			continue
+		}
+		if expectedCall.ArgHints != nil &&
+			(expectedCall.ArgHints.Start != hints.Start || expectedCall.ArgHints.End != hints.End) {
+			continue
+		}
+		if len(expectedCall.ArgMatchers) != len(matchers) {
+			continue
+		}
+
+		for i := range expectedCall.ArgMatchers {
+			if expectedCall.ArgMatchers[i].Type != matchers[i].Type {
+				continue CALLS
+			}
+			if expectedCall.ArgMatchers[i].Name != matchers[i].Name {
+				continue CALLS
+			}
+			if expectedCall.ArgMatchers[i].Value != matchers[i].Value {
+				continue CALLS
+			}
+		}
+
+		res := expectedCall.ReturnValue()
+
+		if !m.UnlimitedCalls {
+			m.ExpectedSelectCalls = append(m.ExpectedSelectCalls[:callIdx], m.ExpectedSelectCalls[callIdx+1:]...)
+		}
+
+		return res
+	}
+
+	m.TB.Fatalf("MockQuerier: Unexpected call to .Select(%t, %+v, %+v)", sortSeries, hints, matchers)
+	return nil
+}
+
+func (m *MockQueryable) LabelValues(_ context.Context, labelName string, _ *storage.LabelHints, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	m.Lock()
+	defer m.Unlock()
+
+	for callIdx, expectedCall := range m.ExpectedLabelValuesCalls {
+		if expectedCall.Label != labelName {
+			continue
+		}
+
+		if !reflect.DeepEqual(expectedCall.Matchers, matchers) {
+			continue
+		}
+
+		res := expectedCall.ReturnValues
+
+		if !m.UnlimitedCalls {
+			m.ExpectedLabelValuesCalls = append(m.ExpectedLabelValuesCalls[:callIdx],
+				m.ExpectedLabelValuesCalls[callIdx+1:]...)
+		}
+
+		return res, nil, nil
+	}
+
+	m.TB.Fatalf("MockQuerier: Unexpected call to .Labelvalues(%s)", labelName)
+	return nil, nil, nil
+}
+
+// ValidateAllCalls checks if all the expected calls have been made, if not it
+// raises a fatal error.
+func (m *MockQueryable) ValidateAllCalls() {
+	m.TB.Helper()
+
+	// Checking whether the mock querier was expecting more calls
+	// to its .Querier() method.
+	if len(m.ExpectedQuerierCalls) > 0 {
+		m.TB.Fatalf("Expected querier calls have not been made: %+v", m.ExpectedQuerierCalls)
+	}
+
+	// Checking whether the mock querier was expecting more calls
+	// to its .Select() method.
+	if len(m.ExpectedSelectCalls) > 0 {
+		m.TB.Fatalf("Expected select calls: %+v", m.ExpectedSelectCalls)
+	}
+
+	// Checking whether the mock querier was expecting more calls
+	// to its .LabelValues() method.
+	if len(m.ExpectedLabelValuesCalls) > 0 {
+		m.TB.Fatalf("Expected label values calls: %+v", m.ExpectedLabelValuesCalls)
+	}
+}

--- a/pkg/querier/labelaccess/queryable.go
+++ b/pkg/querier/labelaccess/queryable.go
@@ -1,0 +1,485 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package labelaccess
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/user"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/util/annotations"
+	"go.opentelemetry.io/otel"
+
+	shared "github.com/grafana/mimir/pkg/labelaccess"
+	"github.com/grafana/mimir/pkg/util/spanlogger"
+)
+
+var tracer = otel.Tracer("pkg/querier/labelaccess")
+
+// WrapQueryable wraps the provided queryable with a labelAccessQueryable
+func WrapQueryable(next storage.SampleAndChunkQueryable, logger log.Logger) storage.SampleAndChunkQueryable {
+	return &labelAccessQueryable{next, logger}
+}
+
+// promSelector encompasses multiple Prometheus label Matchers, translated from shared label policy types
+//
+// Uses of promSelector are usually slices of them, each slice representing an LBAC policy. The slices
+// are unioned together while the matchers within each selector are an intersection. The effect of this
+// is that results (samples, exemplars) must match all matchers in a promSelector but may match any
+// promSelector instance.
+type promSelector []*labels.Matcher
+
+// matches returns whether the labels satisfy all matchers.
+func (s promSelector) matches(labels labels.Labels) bool {
+	for _, m := range s {
+		if v := labels.Get(m.Name); !m.Matches(v) {
+			return false
+		}
+	}
+	return true
+}
+
+func (s promSelector) String() string {
+	matcherStrings := make([]string, len(s))
+	for i, m := range s {
+		matcherStrings[i] = m.String()
+	}
+
+	return "{" + strings.Join(matcherStrings, ", ") + "}"
+}
+
+// labelPoliciesToPromSelectors converts shared labelaccess types to groups of Prometheus matchers
+func labelPoliciesToPromSelectors(policies []*shared.LabelPolicy) []promSelector {
+	var selectors []promSelector
+	for _, p := range policies {
+		var selector []*labels.Matcher
+		selector = append(selector, p.Selector...)
+		selectors = append(selectors, selector)
+	}
+
+	return selectors
+}
+
+type labelAccessQueryable struct {
+	next   storage.SampleAndChunkQueryable
+	logger log.Logger
+}
+
+// Querier returns a new Querier on the storage. Fulfils the storage.Queryable interface.
+func (l *labelAccessQueryable) Querier(mint int64, maxt int64) (storage.Querier, error) {
+	nextQuerier, err := l.next.Querier(mint, maxt)
+	if err != nil {
+		return nil, err
+	}
+
+	return &labelAccessQuerier{
+		labelQuerier: nextQuerier,
+		querier:      nextQuerier,
+		logger:       l.logger,
+	}, nil
+}
+
+// ChunkQuerier provides querying access over time series data of a fixed time range with labels matching the
+// specified selectors. Fulfills the storage.ChunkQueryable interface.
+func (l *labelAccessQueryable) ChunkQuerier(mint, maxt int64) (storage.ChunkQuerier, error) {
+	nextQuerier, err := l.next.ChunkQuerier(mint, maxt)
+	if err != nil {
+		return nil, err
+	}
+
+	return &labelAccessChunkQuerier{
+		labelAccessQuerier: labelAccessQuerier{
+			labelQuerier: nextQuerier,
+			logger:       l.logger,
+		},
+		next: nextQuerier,
+	}, nil
+}
+
+type labelAccessQuerier struct {
+	querier      storage.Querier
+	labelQuerier storage.LabelQuerier // Separate field to allow reuse in labelAccessChunkQuerier
+	logger       log.Logger
+}
+
+// LabelValues returns all potential values for a label name.
+// It is not safe to use the strings beyond the lifetime of the querier.
+func (l *labelAccessQuerier) LabelValues(ctx context.Context, name string, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	spanlog, _ := spanlogger.New(ctx, l.logger, tracer, "labelAccessQuerier.LabelValues")
+	defer spanlog.Finish()
+
+	selectors, err := l.selectors(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// There are no LBAC selectors that we have to enforce, just delegate to upstream.
+	if len(selectors) == 0 {
+		spanlog.DebugLog("msg", "no LBAC selectors, delegating to upstream")
+		return l.labelQuerier.LabelValues(ctx, name, hints, matchers...)
+	}
+
+	// If there's only a single selector we don't need to call the upstream LabelValues method
+	// multiple times and union the results together, we can just append our LBAC matchers
+	// directly to the matchers already being passed upstream and return.
+	if len(selectors) == 1 {
+		spanlog.DebugLog("msg", "label values filtered by single LBAC selector as upstream matchers", "selector", selectors[0])
+		matchers = l.mergeMatchers(matchers, selectors[0])
+		return l.labelQuerier.LabelValues(ctx, name, hints, matchers...)
+	}
+
+	unique := make(map[string]struct{})
+	// LBAC policies can be applied to any labels associated with a series. Because of this we
+	// need to include the matchers from each distinct LBAC selector in the call to the upstream
+	// querier because we don't have any other way to make sure they are applied to the various
+	// labels they might reference. I.e. we can't just select all label values and filter them
+	// afterwards like we do for series or exemplars.
+	for _, selector := range selectors {
+		// We repeat the call to the upstream label querier for each LBAC selector we have since
+		// LBAC selectors are unioned together but the results of an individual call must be the
+		// intersection of all matchers. The only way to achieve this is to merge each of our
+		// selectors with the matchers provided to the upstream querier.
+		ourMatchers := make([]*labels.Matcher, 0, len(matchers)+len(selector))
+		ourMatchers = append(ourMatchers, matchers...)
+		ourMatchers = l.mergeMatchers(ourMatchers, selector)
+		lbls, _, err := l.labelQuerier.LabelValues(ctx, name, hints, ourMatchers...)
+
+		// Return an error here immediately even if there are some partial values we could return
+		// to callers. We'd rather return an error so that callers could retry instead of partial
+		// (incorrect) results.
+		if err != nil {
+			return nil, nil, fmt.Errorf("unable to get label values for %s with selector %s: %w", name, selector, err)
+		}
+
+		spanlog.DebugLog("msg", "label values filtered by LBAC selector", "name", name, "selector", selector, "results", len(lbls))
+		for _, lbl := range lbls {
+			unique[lbl] = struct{}{}
+		}
+	}
+
+	values := make([]string, 0, len(unique))
+	for k := range unique {
+		values = append(values, k)
+	}
+
+	return values, nil, nil
+}
+
+// LabelNames returns all the unique label names present in the block in sorted order.
+func (l *labelAccessQuerier) LabelNames(ctx context.Context, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	spanlog, _ := spanlogger.New(ctx, l.logger, tracer, "labelAccessQuerier.LabelNames")
+	defer spanlog.Finish()
+
+	selectors, err := l.selectors(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// There are no LBAC selectors that we have to enforce, just delegate to upstream.
+	if len(selectors) == 0 {
+		spanlog.DebugLog("msg", "no LBAC selectors, delegating to upstream")
+		return l.labelQuerier.LabelNames(ctx, hints, matchers...)
+	}
+
+	// If there's only a single selector we don't need to call the upstream LabelNames method
+	// multiple times and union the results together, we can just append our LBAC matchers
+	// directly to the matchers already being passed upstream and return.
+	if len(selectors) == 1 {
+		spanlog.DebugLog("msg", "label names filtered by single LBAC selector as upstream matchers", "selector", selectors[0])
+		matchers = l.mergeMatchers(matchers, selectors[0])
+		return l.labelQuerier.LabelNames(ctx, hints, matchers...)
+	}
+
+	unique := make(map[string]struct{})
+	// LBAC policies can be applied to any labels associated with a series. Because of this we
+	// need to include the matchers from each distinct LBAC selector in the call to the upstream
+	// querier because we don't have any other way to make sure they are applied to the various
+	// labels they might reference. I.e. we can't just select all label names and filter them
+	// afterwards like we do for series or exemplars.
+	for _, selector := range selectors {
+		// We repeat the call to the upstream label querier for each LBAC selector we have since
+		// LBAC selectors are unioned together but the results of an individual call must be the
+		// intersection of all matchers. The only way to achieve this is to merge each of our
+		// selectors with the matchers provided to the upstream querier.
+		ourMatchers := make([]*labels.Matcher, 0, len(matchers)+len(selector))
+		ourMatchers = append(ourMatchers, matchers...)
+		ourMatchers = l.mergeMatchers(ourMatchers, selector)
+		lbls, _, err := l.labelQuerier.LabelNames(ctx, hints, ourMatchers...)
+
+		// Return an error here immediately even if there are some partial values we could return
+		// to callers. We'd rather return an error so that callers could retry instead of partial
+		// (incorrect) results.
+		if err != nil {
+			return nil, nil, fmt.Errorf("unable to get label names with selector %s: %w", selector, err)
+		}
+
+		spanlog.DebugLog("msg", "label names filtered by LBAC selector", "selector", selector, "results", len(lbls))
+		for _, lbl := range lbls {
+			unique[lbl] = struct{}{}
+		}
+	}
+
+	names := make([]string, 0, len(unique))
+	for k := range unique {
+		names = append(names, k)
+	}
+	// Label names are defined to be sorted in the Querier interface.
+	// Note: we could potentially avoid this sort by taking advantage of the fact that the
+	// upstream querier is required to return sorted label names if performance becomes a concern.
+	sort.Strings(names)
+
+	return names, nil, nil
+}
+
+// Close releases the resources of the Querier.
+func (l *labelAccessQuerier) Close() error {
+	return l.querier.Close()
+}
+
+// Select returns a set of series that matches the given label matchers and match one of the policy selectors.
+func (l *labelAccessQuerier) Select(
+	ctx context.Context,
+	sortSeries bool,
+	hints *storage.SelectHints,
+	matchers ...*labels.Matcher,
+) storage.SeriesSet {
+	spanlog, _ := spanlogger.New(ctx, l.logger, tracer, "labelAccessQuerier.Select")
+	defer spanlog.Finish()
+
+	selectors, err := l.selectors(ctx)
+	if err != nil {
+		return storage.ErrSeriesSet(err)
+	}
+
+	if len(selectors) == 0 {
+		spanlog.DebugLog("msg", "no LBAC selectors, delegating to upstream")
+		return l.querier.Select(ctx, sortSeries, hints, matchers...)
+	}
+
+	// If there is only one LBAC policy attached, then we can skip selecting everything and then filtering.
+	// We can just add the LBAC selectors to matchers and select only what is required.
+	if len(selectors) == 1 {
+		spanlog.DebugLog("msg", "series filtered by single LBAC selector as upstream matchers", "selector", selectors[0])
+		matchers = l.mergeMatchers(matchers, selectors[0])
+		return l.querier.Select(ctx, sortSeries, hints, matchers...)
+	}
+
+	return &labelAccessSeriesSet{
+		selectors: selectors,
+		upstream:  l.querier.Select(ctx, sortSeries, hints, matchers...),
+		logger:    l.logger,
+	}
+}
+
+type hashableMatcher struct {
+	Type  labels.MatchType
+	Name  string
+	Value string
+}
+
+// mergeMatchers appends non-duplicate LBAC matchers to the input matchers and returns the input slice
+func (l *labelAccessQuerier) mergeMatchers(matchers []*labels.Matcher, lbacMatchers []*labels.Matcher) []*labels.Matcher {
+	unique := make(map[hashableMatcher]struct{})
+	for _, m := range matchers {
+		unique[hashableMatcher{
+			Type:  m.Type,
+			Name:  m.Name,
+			Value: m.Value,
+		}] = struct{}{}
+	}
+
+	for _, lbac := range lbacMatchers {
+		if _, ok := unique[hashableMatcher{
+			Type:  lbac.Type,
+			Name:  lbac.Name,
+			Value: lbac.Value,
+		}]; !ok {
+			matchers = append(matchers, lbac)
+		}
+	}
+
+	return matchers
+}
+
+// selectors attempts to construct promSelectors based on the tenant name in the context.
+func (l *labelAccessQuerier) selectors(ctx context.Context) ([]promSelector, error) {
+	instancePolicyMap, err := shared.ExtractLabelMatchersContext(ctx)
+	if err != nil {
+		level.Error(l.logger).Log("msg", "unable to find instance policy map", "err", err)
+		return nil, err
+	}
+
+	instanceName, err := user.ExtractOrgID(ctx)
+	if err != nil {
+		level.Error(l.logger).Log("msg", "unable to find instance name", "err", err)
+		return nil, err
+	}
+
+	policies, exists := instancePolicyMap[instanceName]
+	if !exists {
+		return nil, nil
+	}
+
+	level.Debug(l.logger).Log("msg", "enforcing label policy on query", "instance_name", instanceName)
+	return labelPoliciesToPromSelectors(policies), nil
+}
+
+type labelAccessSeriesSet struct {
+	selectors []promSelector
+	upstream  storage.SeriesSet
+	logger    log.Logger
+	curSeries storage.Series
+}
+
+// Next iterates through the upstream series set and returns true for the next series that is found that matches the
+// specified set of selectors
+// TODO: Logging to debug this feature
+// TODO: Add metrics for this feature
+// TODO: Low hanging fruit to optimize this feature to pre-process/buffer upcoming series that match a series selector
+func (l *labelAccessSeriesSet) Next() bool {
+	var seriesToSkip []storage.Series
+
+	for l.upstream.Next() {
+		l.curSeries = l.upstream.At()
+		lbls := l.curSeries.Labels()
+		for _, s := range l.selectors {
+			if s.matches(lbls) {
+				level.Debug(l.logger).Log("msg", "label match found on query", "selector", s, "series", lbls)
+
+				if len(seriesToSkip) > 0 {
+					// When ingester to querier or store-gateway to querier chunks streaming is enabled with LBAC enabled,
+					// if we want to omit a series from a result because it does not match the access policy, we still need
+					// to create the iterator for the forbidden series. This is because creating the iterator triggers reading
+					// the chunks for the forbidden series, and if we don't read the chunks for the forbidden series, we'll get out
+					// of sync with the stream of chunks and get errors like:
+					//   execution: attempted to read series at index 1 from ingester chunks stream, but the stream has series with index 0
+					l.curSeries = &skipPreviousSeries{
+						seriesToSkip: seriesToSkip,
+						inner:        l.curSeries,
+					}
+				}
+
+				return true
+			}
+
+			level.Debug(l.logger).Log("msg", "label match not found on query", "selector", s, "series", lbls)
+		}
+
+		seriesToSkip = append(seriesToSkip, l.curSeries)
+	}
+	l.curSeries = nil
+	return false
+}
+
+// At returns the current upstream series
+func (l *labelAccessSeriesSet) At() storage.Series {
+	return l.curSeries
+}
+
+// Err returns the upstream series set error
+func (l *labelAccessSeriesSet) Err() error {
+	return l.upstream.Err()
+}
+
+// Warnings returns any warning from the upstream series set
+func (l *labelAccessSeriesSet) Warnings() annotations.Annotations {
+	return l.upstream.Warnings()
+}
+
+type skipPreviousSeries struct {
+	seriesToSkip []storage.Series
+	inner        storage.Series
+}
+
+func (s *skipPreviousSeries) Labels() labels.Labels {
+	return s.inner.Labels()
+}
+
+func (s *skipPreviousSeries) Iterator(iterator chunkenc.Iterator) chunkenc.Iterator {
+	for _, series := range s.seriesToSkip {
+		iterator = series.Iterator(iterator)
+	}
+
+	return s.inner.Iterator(iterator)
+}
+
+type labelAccessChunkQuerier struct {
+	labelAccessQuerier
+	next storage.ChunkQuerier
+}
+
+// Close releases the resources of the Querier.
+func (l *labelAccessChunkQuerier) Close() error {
+	return l.next.Close()
+}
+
+// Select returns a set of series that matches the given label matchers.
+func (l *labelAccessChunkQuerier) Select(
+	ctx context.Context,
+	sortSeries bool,
+	hints *storage.SelectHints,
+	matchers ...*labels.Matcher,
+) storage.ChunkSeriesSet {
+	selectors, err := l.selectors(ctx)
+	if err != nil {
+		return storage.ErrChunkSeriesSet(err)
+	}
+
+	if len(selectors) == 0 {
+		return l.next.Select(ctx, sortSeries, hints, matchers...)
+	}
+
+	return &labelAccessChunkSeriesSet{
+		selectors: selectors,
+		upstream:  l.next.Select(ctx, sortSeries, hints, matchers...),
+		logger:    l.logger,
+	}
+}
+
+type labelAccessChunkSeriesSet struct {
+	selectors []promSelector
+	upstream  storage.ChunkSeriesSet
+	curSeries storage.ChunkSeries
+	logger    log.Logger
+}
+
+// Next iterates through the upstream series set and returns true for the next series that is found that matches the
+// specified set of selectors
+// TODO: Logging to debug this feature
+// TODO: Add metrics for this feature
+// TODO: Low hanging fruit to optimize this feature to pre-process/buffer upcoming series that match a series selector
+func (l *labelAccessChunkSeriesSet) Next() bool {
+	for l.upstream.Next() {
+
+		l.curSeries = l.upstream.At()
+		for _, s := range l.selectors {
+			if s.matches(l.curSeries.Labels()) {
+				return true
+			}
+		}
+	}
+	l.curSeries = nil
+	return false
+}
+
+// At returns the current upstream series
+func (l *labelAccessChunkSeriesSet) At() storage.ChunkSeries {
+	return l.curSeries
+}
+
+// Err returns the upstream series set error
+func (l *labelAccessChunkSeriesSet) Err() error {
+	return l.upstream.Err()
+}
+
+// Warnings returns any warning from the upstream series set
+func (l *labelAccessChunkSeriesSet) Warnings() annotations.Annotations {
+	return l.upstream.Warnings()
+}

--- a/pkg/querier/labelaccess/queryable_exemplar.go
+++ b/pkg/querier/labelaccess/queryable_exemplar.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package labelaccess
+
+import (
+	"context"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/user"
+	"github.com/prometheus/prometheus/model/exemplar"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+
+	shared "github.com/grafana/mimir/pkg/labelaccess"
+	"github.com/grafana/mimir/pkg/util"
+	"github.com/grafana/mimir/pkg/util/spanlogger"
+)
+
+// WrapExemplarQueryable wraps the provided queryable with a labelAccessExemplarQueryable. This
+// queryable implementation allows access to exemplars to be restricted based on label matching
+// policies set as part of an admin API access policy.
+func WrapExemplarQueryable(next storage.ExemplarQueryable, logger log.Logger) storage.ExemplarQueryable {
+	return &labelAccessExemplarQueryable{next, logger}
+}
+
+type labelAccessExemplarQueryable struct {
+	next   storage.ExemplarQueryable
+	logger log.Logger
+}
+
+// ExemplarQuerier returns a new storage.ExemplarQuerier on the storage.
+func (l *labelAccessExemplarQueryable) ExemplarQuerier(ctx context.Context) (storage.ExemplarQuerier, error) {
+	instancePolicyMap, err := shared.ExtractLabelMatchersContext(ctx)
+	if err != nil {
+		level.Error(l.logger).Log("msg", "unable to find instance policy map", "err", err)
+		return nil, err
+	}
+
+	instanceName, err := user.ExtractOrgID(ctx)
+	if err != nil {
+		level.Error(l.logger).Log("msg", "unable to find instance name", "err", err)
+		return nil, err
+	}
+
+	nextQuerier, err := l.next.ExemplarQuerier(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	policies, exist := instancePolicyMap[instanceName]
+	if !exist {
+		return nextQuerier, nil
+	}
+	level.Debug(l.logger).Log("msg", "enforcing label policy on query", "instance_name", instanceName)
+
+	selectors := labelPoliciesToPromSelectors(policies)
+
+	return newLabelAccessExemplarQuerier(ctx, selectors, nextQuerier, l.logger), nil
+}
+
+type labelAccessExemplarQuerier struct {
+	selectors   []promSelector
+	stringers   util.MultiMatchersStringer
+	nextQuerier storage.ExemplarQuerier
+	logger      log.Logger
+	ctx         context.Context
+}
+
+func newLabelAccessExemplarQuerier(ctx context.Context, selectors []promSelector, upstream storage.ExemplarQuerier, logger log.Logger) *labelAccessExemplarQuerier {
+	var stringers util.MultiMatchersStringer
+	for _, s := range selectors {
+		stringers = append(stringers, s)
+	}
+
+	return &labelAccessExemplarQuerier{
+		selectors:   selectors,
+		stringers:   stringers,
+		nextQuerier: upstream,
+		logger:      logger,
+		ctx:         ctx,
+	}
+}
+
+func (l *labelAccessExemplarQuerier) Select(start, end int64, matchers ...[]*labels.Matcher) ([]exemplar.QueryResult, error) {
+	spanlog, _ := spanlogger.New(l.ctx, l.logger, tracer, "labelAccessExemplarQuerier.Select")
+	defer spanlog.Finish()
+
+	// There are no LBAC selectors that we have to enforce, just delegate to upstream. This
+	// shouldn't actually happen since the Queryable responsible for creating this querier
+	// would have just returned the upstream querier to the caller instead, but it doesn't
+	// hurt to spend a little extra effort to prevent misuse.
+	if len(l.selectors) == 0 {
+		level.Debug(spanlog).Log("msg", "no LBAC selectors, delegating to upstream")
+		return l.nextQuerier.Select(start, end, matchers...)
+	}
+
+	// The Select method gets multiple slices of matchers. Each slice is unioned together while all
+	// matchers within a slice are treated as an intersection. If we only have a single LBAC selector
+	// we can add our matchers to each slice of matchers passed to the upstream querier to enforce
+	// that anything returned also satisfies our matchers (intersection). This allows us to avoid
+	// querying all exemplars and then filtering them in memory here.
+	if len(l.selectors) == 1 {
+		for i, m := range matchers {
+			m = append(m, l.selectors[0]...)
+			matchers[i] = m
+		}
+
+		level.Debug(spanlog).Log("msg", "exemplars filtered by single LBAC selector as upstream matchers", "selector", l.stringers)
+		return l.nextQuerier.Select(start, end, matchers...)
+	}
+
+	exemplars, err := l.nextQuerier.Select(start, end, matchers...)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		numUnfiltered int
+		numFiltered   int
+		filtered      []exemplar.QueryResult
+	)
+
+	for _, e := range exemplars {
+		numUnfiltered += len(e.Exemplars)
+
+		for _, s := range l.selectors {
+			// Each LBAC policy is OR'd together so stop evaluating them as soon as we find
+			// one that this exemplar matches.
+			if s.matches(e.SeriesLabels) {
+				numFiltered += len(e.Exemplars)
+				filtered = append(filtered, e)
+				break
+			}
+		}
+	}
+
+	level.Debug(spanlog).Log("msg", "exemplars filtered by LBAC selectors", "unfiltered", numUnfiltered, "filtered", numFiltered, "selectors", l.stringers)
+	return filtered, nil
+}

--- a/pkg/querier/labelaccess/queryable_exemplar_test.go
+++ b/pkg/querier/labelaccess/queryable_exemplar_test.go
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package labelaccess
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/user"
+	"github.com/prometheus/prometheus/model/exemplar"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	shared "github.com/grafana/mimir/pkg/labelaccess"
+)
+
+type mockExemplarQuerier struct {
+	matchers []promSelector
+	results  []exemplar.QueryResult
+	err      error
+}
+
+func (e *mockExemplarQuerier) Select(_, _ int64, matchers ...[]*labels.Matcher) ([]exemplar.QueryResult, error) {
+	for _, m := range matchers {
+		e.matchers = append(e.matchers, m)
+	}
+
+	if e.err != nil {
+		return nil, e.err
+	}
+
+	return e.results, nil
+}
+
+type mockExemplarQueryable struct {
+	querier storage.ExemplarQuerier
+	err     error
+}
+
+func (e *mockExemplarQueryable) ExemplarQuerier(_ context.Context) (storage.ExemplarQuerier, error) {
+	if e.err != nil {
+		return nil, e.err
+	}
+
+	return e.querier, nil
+}
+
+func newTestExemplarQueryable(next storage.ExemplarQueryable) *labelAccessExemplarQueryable {
+	var logger log.Logger
+	if testing.Verbose() {
+		logger = log.NewLogfmtLogger(os.Stdout)
+	} else {
+		logger = log.NewNopLogger()
+	}
+
+	return &labelAccessExemplarQueryable{
+		next:   next,
+		logger: logger,
+	}
+}
+
+func TestLabelAccessExemplarQueryable_ExemplarQuerier(t *testing.T) {
+	t.Run("no instance policy map in context results in error", func(t *testing.T) {
+		ctx := context.Background()
+		ctx = user.InjectOrgID(ctx, "team-a")
+
+		next := &mockExemplarQueryable{}
+		next.querier = &mockExemplarQuerier{}
+		queryable := newTestExemplarQueryable(next)
+		_, err := queryable.ExemplarQuerier(ctx)
+
+		assert.Error(t, err)
+	})
+
+	t.Run("no instance ID in context results in error", func(t *testing.T) {
+		ctx := context.Background()
+		ctx = shared.InjectLabelMatchersContext(ctx, shared.LabelPolicySet{
+			"team-a": []*shared.LabelPolicy{newSingleLabelPolicy(labels.MatchEqual, "secret", "false")},
+		})
+
+		next := &mockExemplarQueryable{}
+		next.querier = &mockExemplarQuerier{}
+		queryable := newTestExemplarQueryable(next)
+		_, err := queryable.ExemplarQuerier(ctx)
+
+		assert.Error(t, err)
+	})
+
+	t.Run("no matching policy results in using fallback queryable", func(t *testing.T) {
+		ctx := context.Background()
+		ctx = user.InjectOrgID(ctx, "team-b")
+		ctx = shared.InjectLabelMatchersContext(ctx, shared.LabelPolicySet{
+			"team-a": []*shared.LabelPolicy{newSingleLabelPolicy(labels.MatchEqual, "secret", "false")},
+		})
+
+		next := &mockExemplarQueryable{}
+		next.querier = &mockExemplarQuerier{}
+		queryable := newTestExemplarQueryable(next)
+		q, err := queryable.ExemplarQuerier(ctx)
+
+		// The tenant ID in the context doesn't match any of the injected LBAC matchers so the
+		// label access queryable should delegate to the upstream queryable. We test that the
+		// returned querier is the same type as our mock one that we've set as upstream.
+		require.NoError(t, err)
+		assert.IsType(t, &mockExemplarQuerier{}, q)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		ctx := context.Background()
+		ctx = user.InjectOrgID(ctx, "team-a")
+		ctx = shared.InjectLabelMatchersContext(ctx, shared.LabelPolicySet{
+			"team-a": []*shared.LabelPolicy{newSingleLabelPolicy(labels.MatchEqual, "secret", "false")},
+		})
+
+		next := &mockExemplarQueryable{}
+		next.querier = &mockExemplarQuerier{}
+		queryable := newTestExemplarQueryable(next)
+		q, err := queryable.ExemplarQuerier(ctx)
+
+		require.NoError(t, err)
+		assert.IsType(t, &labelAccessExemplarQuerier{}, q)
+	})
+}
+
+func TestLabelAccessExemplarQuerier_Select(t *testing.T) {
+	now := time.Now()
+	startMs := now.Add(-1 * time.Hour).UnixMilli()
+	endMs := now.Add(1 * time.Minute).UnixMilli()
+
+	seriesMatcher1 := labels.MustNewMatcher(labels.MatchEqual, "__name__", "series_1")
+	seriesMatcher2 := labels.MustNewMatcher(labels.MatchEqual, "__name__", "series_2")
+	clusterMatcher := labels.MustNewMatcher(labels.MatchEqual, "cluster", "prod")
+
+	result1 := exemplar.QueryResult{
+		SeriesLabels: labels.FromStrings(
+			"__name__", "series_1",
+			"method", "GET",
+			"status_code", "500",
+			"path", "/details/",
+		),
+		Exemplars: []exemplar.Exemplar{
+			{
+				Labels: labels.FromStrings("trace_id", "1234"),
+				Value:  1234.5,
+				Ts:     now.UnixMilli(),
+			},
+		},
+	}
+
+	result2 := exemplar.QueryResult{
+		SeriesLabels: labels.FromStrings(
+			"__name__", "series_1",
+			"method", "POST",
+			"status_code", "201",
+			"path", "/login/",
+		),
+		Exemplars: []exemplar.Exemplar{
+			{
+				Labels: labels.FromStrings("trace_id", "1234"),
+				Value:  1234.5,
+				Ts:     now.UnixMilli(),
+			},
+		},
+	}
+	result3 := exemplar.QueryResult{
+		SeriesLabels: labels.FromStrings(
+			"__name__", "series_1",
+			"method", "POST",
+			"status_code", "200",
+			"path", "/login/",
+		),
+		Exemplars: []exemplar.Exemplar{
+			{
+				Labels: labels.FromStrings("trace_id", "1234"),
+				Value:  1234.5,
+				Ts:     now.UnixMilli(),
+			},
+		},
+	}
+
+	t.Run("no selectors", func(t *testing.T) {
+		upstream := &mockExemplarQuerier{results: []exemplar.QueryResult{result1, result2, result3}}
+		querier := newLabelAccessExemplarQuerier(context.Background(), []promSelector{}, upstream, log.NewNopLogger())
+
+		res, err := querier.Select(startMs, endMs, []*labels.Matcher{seriesMatcher1})
+		require.NoError(t, err)
+		require.Len(t, res, 3)
+
+		assert.Equal(t, "series_1", res[0].SeriesLabels.Get("__name__"))
+		assert.Equal(t, "GET", res[0].SeriesLabels.Get("method"))
+		assert.Equal(t, "500", res[0].SeriesLabels.Get("status_code"))
+
+		assert.Equal(t, "series_1", res[1].SeriesLabels.Get("__name__"))
+		assert.Equal(t, "POST", res[1].SeriesLabels.Get("method"))
+		assert.Equal(t, "201", res[1].SeriesLabels.Get("status_code"))
+
+		assert.Equal(t, "series_1", res[2].SeriesLabels.Get("__name__"))
+		assert.Equal(t, "POST", res[2].SeriesLabels.Get("method"))
+		assert.Equal(t, "200", res[2].SeriesLabels.Get("status_code"))
+	})
+
+	t.Run("single selector multiple matcher passed directly to upstream", func(t *testing.T) {
+		selectors := labelPoliciesToPromSelectors([]*shared.LabelPolicy{
+			newDoubleLabelPolicy(labels.MatchEqual, "method", "GET", "status_code", "200"),
+		})
+
+		upstream := &mockExemplarQuerier{}
+		querier := newLabelAccessExemplarQuerier(context.Background(), selectors, upstream, log.NewNopLogger())
+
+		_, err := querier.Select(startMs, endMs, []*labels.Matcher{seriesMatcher1, clusterMatcher}, []*labels.Matcher{seriesMatcher2, clusterMatcher})
+		require.NoError(t, err)
+		// The Select method gets multiple slices of matchers. Each slice is unioned together while all
+		// matchers within a slice are treated as an intersection. If we only have a single LBAC selector
+		// we can add our matchers to each slice of matchers passed to the upstream querier to enforce
+		// that anything returned also satisfies our matchers (intersection). Test that our matchers
+		// were appended to each slice of matchers
+		assert.Contains(t, upstream.matchers[0], seriesMatcher1)
+		assert.Contains(t, upstream.matchers[0], clusterMatcher)
+		assert.Contains(t, upstream.matchers[0], selectors[0][0])
+		assert.Contains(t, upstream.matchers[0], selectors[0][1])
+		assert.Contains(t, upstream.matchers[1], seriesMatcher2)
+		assert.Contains(t, upstream.matchers[1], clusterMatcher)
+		assert.Contains(t, upstream.matchers[1], selectors[0][0])
+		assert.Contains(t, upstream.matchers[1], selectors[0][1])
+	})
+
+	t.Run("upstream error results in error", func(t *testing.T) {
+		// Multiple selectors so we don't short-circuit and just pass the LBAC selector
+		// to the Select method of the upstream querier.
+		selectors := labelPoliciesToPromSelectors([]*shared.LabelPolicy{
+			newSingleLabelPolicy(labels.MatchEqual, "method", "GET"),
+			newSingleLabelPolicy(labels.MatchEqual, "status_code", "200"),
+		})
+
+		expectedError := errors.New("things are crashing")
+		upstream := &mockExemplarQuerier{err: expectedError}
+		querier := newLabelAccessExemplarQuerier(context.Background(), selectors, upstream, log.NewNopLogger())
+
+		_, err := querier.Select(startMs, endMs, []*labels.Matcher{seriesMatcher1})
+		assert.ErrorIs(t, err, expectedError)
+	})
+
+	t.Run("matches", func(t *testing.T) {
+		// Multiple selectors so we don't short-circuit and just pass the LBAC selector
+		// to the Select method of the upstream querier.
+		selectors := labelPoliciesToPromSelectors([]*shared.LabelPolicy{
+			newSingleLabelPolicy(labels.MatchEqual, "method", "GET"),
+			newSingleLabelPolicy(labels.MatchEqual, "status_code", "200"),
+		})
+
+		upstream := &mockExemplarQuerier{
+			// Multiple results to verify that LBAC rules are applied and they are "OR'd" together.
+			// The first one should match the "method=GET" LBAC rule. The second one will not match
+			// either LBAC rule. The third one should match the "status_code=200" LBAC rule.
+			results: []exemplar.QueryResult{result1, result2, result3},
+		}
+		querier := newLabelAccessExemplarQuerier(context.Background(), selectors, upstream, log.NewNopLogger())
+
+		res, err := querier.Select(startMs, endMs, []*labels.Matcher{seriesMatcher1})
+		require.NoError(t, err)
+		require.Len(t, res, 2)
+
+		assert.Equal(t, "series_1", res[0].SeriesLabels.Get("__name__"))
+		assert.Equal(t, "GET", res[0].SeriesLabels.Get("method"))
+		assert.Equal(t, "500", res[0].SeriesLabels.Get("status_code"))
+
+		assert.Equal(t, "series_1", res[1].SeriesLabels.Get("__name__"))
+		assert.Equal(t, "POST", res[1].SeriesLabels.Get("method"))
+		assert.Equal(t, "200", res[1].SeriesLabels.Get("status_code"))
+	})
+
+	t.Run("no matches", func(t *testing.T) {
+		// Multiple selectors so we don't short-circuit and just pass the LBAC selector
+		// to the Select method of the upstream querier.
+		selectors := labelPoliciesToPromSelectors([]*shared.LabelPolicy{
+			newSingleLabelPolicy(labels.MatchEqual, "method", "GET"),
+			newSingleLabelPolicy(labels.MatchEqual, "status_code", "200"),
+		})
+
+		upstream := &mockExemplarQuerier{
+			// Single result that should match neither LBAC selector (POST, HTTP 201)
+			results: []exemplar.QueryResult{result2},
+		}
+		querier := newLabelAccessExemplarQuerier(context.Background(), selectors, upstream, log.NewNopLogger())
+
+		res, err := querier.Select(startMs, endMs, []*labels.Matcher{seriesMatcher1})
+		require.NoError(t, err)
+		assert.Empty(t, res)
+	})
+}

--- a/pkg/querier/labelaccess/queryable_test.go
+++ b/pkg/querier/labelaccess/queryable_test.go
@@ -1,0 +1,803 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package labelaccess
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"sort"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/user"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/util/annotations"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	shared "github.com/grafana/mimir/pkg/labelaccess"
+	"github.com/grafana/mimir/pkg/querier"
+)
+
+func newSingleLabelPolicy(t labels.MatchType, n string, v string) *shared.LabelPolicy {
+	return &shared.LabelPolicy{
+		Selector: []*labels.Matcher{labels.MustNewMatcher(t, n, v)},
+	}
+}
+
+func newDoubleLabelPolicy(t labels.MatchType, n1 string, v1 string, n2 string, v2 string) *shared.LabelPolicy {
+	return &shared.LabelPolicy{
+		Selector: []*labels.Matcher{
+			labels.MustNewMatcher(t, n1, v1),
+			labels.MustNewMatcher(t, n2, v2),
+		},
+	}
+}
+
+func TestLabelAccessQuerier_Select(t *testing.T) {
+	t.Run("label matchers not in context", func(t *testing.T) {
+		ctx := user.InjectOrgID(shared.InjectLabelMatchersContext(context.Background(), nil), "test")
+		next := &MockQueryable{
+			TB: t,
+			ExpectedQuerierCalls: []QuerierCall{
+				{
+					ExpectedMinT: 0,
+					ExpectedMaxT: 1,
+				},
+			},
+			ExpectedSelectCalls: []SelectCall{
+				{
+					ArgSortSeries: false,
+					ReturnValue: func() storage.SeriesSet {
+						return nil
+					},
+				},
+			},
+		}
+		queryable := &labelAccessQueryable{
+			logger: log.NewNopLogger(),
+			next:   querier.NewSampleAndChunkQueryable(next),
+		}
+		q, err := queryable.Querier(0, 1)
+		require.NoError(t, err)
+		ss := q.Select(ctx, false, nil)
+		require.Nil(t, ss, "the Select call should be delegated to the upstream querier")
+	})
+
+	t.Run("empty label matchers set in context", func(t *testing.T) {
+		const tenantID = "test"
+		policySet := shared.LabelPolicySet{
+			tenantID: {},
+		}
+		ctx := user.InjectOrgID(shared.InjectLabelMatchersContext(context.Background(), policySet), tenantID)
+		next := &MockQueryable{
+			TB: t,
+			ExpectedQuerierCalls: []QuerierCall{
+				{
+					ExpectedMinT: 0,
+					ExpectedMaxT: 1,
+				},
+			},
+			ExpectedSelectCalls: []SelectCall{
+				{
+					ArgSortSeries: false,
+					ReturnValue: func() storage.SeriesSet {
+						return nil
+					},
+				},
+			},
+		}
+		queryable := &labelAccessQueryable{
+			logger: log.NewNopLogger(),
+			next:   querier.NewSampleAndChunkQueryable(next),
+		}
+		q, err := queryable.Querier(0, 1)
+		require.NoError(t, err)
+		ss := q.Select(ctx, false, nil)
+		require.Nil(t, ss, "the Select call should be delegated to the upstream querier")
+	})
+
+	t.Run("single label selectors use upstream matchers and dedupe", func(t *testing.T) {
+		const tenantID = "test"
+
+		// One LBAC matcher is a duplicate of the matchers passed to the Select() call. Make
+		// sure that only a single instance of the matcher is passed to the upstream querier.
+		selectMatcher1 := labels.MustNewMatcher(labels.MatchEqual, "env", "prd")
+		selectMatcher2 := labels.MustNewMatcher(labels.MatchEqual, "user", tenantID)
+		lbacMatcher1 := labels.MustNewMatcher(labels.MatchNotEqual, "class", "secret")
+		lbacMatcher2 := labels.MustNewMatcher(labels.MatchEqual, "user", tenantID)
+
+		policySet := shared.LabelPolicySet{
+			tenantID: {
+				{
+					Selector: []*labels.Matcher{lbacMatcher1, lbacMatcher2},
+				},
+			},
+		}
+		ctx := user.InjectOrgID(shared.InjectLabelMatchersContext(context.Background(), policySet), tenantID)
+		next := &MockQueryable{
+			TB: t,
+			ExpectedQuerierCalls: []QuerierCall{
+				{
+					ExpectedMinT: 0,
+					ExpectedMaxT: 1,
+				},
+			},
+			ExpectedSelectCalls: []SelectCall{
+				{
+					ArgSortSeries: false,
+					ArgMatchers:   []*labels.Matcher{selectMatcher1, selectMatcher2, lbacMatcher1},
+					ReturnValue: func() storage.SeriesSet {
+						return nil
+					},
+				},
+			},
+		}
+		queryable := &labelAccessQueryable{
+			logger: log.NewNopLogger(),
+			next:   querier.NewSampleAndChunkQueryable(next),
+		}
+		q, err := queryable.Querier(0, 1)
+		require.NoError(t, err)
+		ss := q.Select(ctx, false, nil, selectMatcher1, selectMatcher2)
+		require.Nil(t, ss, "the Select call should be delegated to the upstream querier")
+	})
+}
+
+func TestLabelAccessChunkQuerier_Select(t *testing.T) {
+	t.Run("label matchers not in context", func(t *testing.T) {
+		ctx := user.InjectOrgID(shared.InjectLabelMatchersContext(context.Background(), nil), "test")
+		next := &MockQueryable{
+			TB: t,
+			ExpectedChunkQuerierCalls: []QuerierCall{
+				{
+					ExpectedMinT: 0,
+					ExpectedMaxT: 1,
+				},
+			},
+			ExpectedChunkSelectCalls: []ChunkSelectCall{
+				{
+					ArgSortSeries: false,
+					ReturnValue: func() storage.ChunkSeriesSet {
+						return nil
+					},
+				},
+			},
+		}
+		queryable := &labelAccessQueryable{
+			logger: log.NewNopLogger(),
+			next:   next,
+		}
+		q, err := queryable.ChunkQuerier(0, 1)
+		require.NoError(t, err)
+		ss := q.Select(ctx, false, nil)
+		require.Nil(t, ss, "the Select call should be delegated to the upstream querier")
+	})
+
+	t.Run("empty label matchers set in context", func(t *testing.T) {
+		const tenantID = "test"
+		policySet := shared.LabelPolicySet{
+			tenantID: {},
+		}
+		ctx := user.InjectOrgID(shared.InjectLabelMatchersContext(context.Background(), policySet), tenantID)
+		next := &MockQueryable{
+			TB: t,
+			ExpectedChunkQuerierCalls: []QuerierCall{
+				{
+					ExpectedMinT: 0,
+					ExpectedMaxT: 1,
+				},
+			},
+			ExpectedChunkSelectCalls: []ChunkSelectCall{
+				{
+					ArgSortSeries: false,
+					ReturnValue: func() storage.ChunkSeriesSet {
+						return nil
+					},
+				},
+			},
+		}
+		queryable := &labelAccessQueryable{
+			logger: log.NewNopLogger(),
+			next:   next,
+		}
+		q, err := queryable.ChunkQuerier(0, 1)
+		require.NoError(t, err)
+		ss := q.Select(ctx, false, nil)
+		require.Nil(t, ss, "the Select call should be delegated to the upstream querier")
+	})
+}
+
+func TestPromSelector_Matches(t *testing.T) {
+	t.Run("does not match", func(t *testing.T) {
+		matcher1, err := labels.NewMatcher(labels.MatchEqual, "method", "GET")
+		require.NoError(t, err)
+		matcher2, err := labels.NewMatcher(labels.MatchEqual, "path", "/")
+		require.NoError(t, err)
+
+		selector := promSelector{matcher1, matcher2}
+		assert.False(t, selector.matches(labels.FromStrings(
+			"method", "GET",
+			"path", "/login",
+		)))
+	})
+
+	t.Run("matches", func(t *testing.T) {
+		matcher1 := labels.MustNewMatcher(labels.MatchEqual, "method", "GET")
+		matcher2 := labels.MustNewMatcher(labels.MatchEqual, "path", "/")
+
+		selector := promSelector{matcher1, matcher2}
+		assert.True(t, selector.matches(labels.FromStrings(
+			"method", "GET",
+			"path", "/",
+		)))
+	})
+}
+
+func TestLabelPoliciesToPromSelectors(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		policies := []*shared.LabelPolicy{
+			newSingleLabelPolicy(labels.MatchEqual, "status_code", "200"),
+			newSingleLabelPolicy(labels.MatchEqual, "method", "GET"),
+		}
+
+		matcher1 := labels.MustNewMatcher(labels.MatchEqual, "status_code", "200")
+		matcher2 := labels.MustNewMatcher(labels.MatchEqual, "method", "GET")
+		selectors := labelPoliciesToPromSelectors(policies)
+
+		assert.Equal(t, []promSelector{{matcher1}, {matcher2}}, selectors)
+	})
+}
+
+type mockQuerier struct {
+	series []labels.Labels
+	err    error
+}
+
+func (q *mockQuerier) LabelValues(_ context.Context, name string, _ *storage.LabelHints, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	if q.err != nil {
+		return nil, nil, q.err
+	}
+
+	// Verify that matchers passed to this querier do not have any duplicates.
+	unique := make(map[string]struct{})
+	for _, m := range matchers {
+		s := m.String()
+		if _, ok := unique[s]; ok {
+			panic(fmt.Sprintf("unexpected duplicate matcher %s. existing %+v", s, unique))
+		}
+
+		unique[s] = struct{}{}
+	}
+
+	var values []string
+	for _, s := range q.series {
+		// Value of the label we're looking for. We can only return this as part of
+		// the label values if all the matchers match this series.
+		target := s.Get(name)
+		if target == "" {
+			continue
+		}
+
+		matched := true
+		for _, m := range matchers {
+			if v := s.Get(m.Name); !m.Matches(v) {
+				matched = false
+				break
+			}
+		}
+
+		if matched {
+			values = append(values, target)
+		}
+	}
+
+	return values, nil, nil
+}
+
+func (q *mockQuerier) LabelNames(_ context.Context, _ *storage.LabelHints, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	if q.err != nil {
+		return nil, nil, q.err
+	}
+
+	// Verify that matchers passed to this querier do not have any duplicates.
+	unique := make(map[string]struct{})
+	for _, m := range matchers {
+		s := m.String()
+		if _, ok := unique[s]; ok {
+			panic(fmt.Sprintf("unexpected duplicate matcher %s. existing %+v", s, unique))
+		}
+
+		unique[s] = struct{}{}
+	}
+
+	var values []string
+	for _, s := range q.series {
+		matched := true
+		for _, m := range matchers {
+			if v := s.Get(m.Name); !m.Matches(v) {
+				matched = false
+				break
+			}
+		}
+
+		if !matched {
+			continue
+		}
+
+		s.Range(func(l labels.Label) {
+			if !slices.Contains(values, l.Name) {
+				values = append(values, l.Name)
+			}
+		})
+	}
+
+	sort.Strings(values)
+
+	return values, nil, nil
+}
+
+func (q *mockQuerier) Close() error {
+	panic("unimplemented")
+}
+
+func (q *mockQuerier) Select(context.Context, bool, *storage.SelectHints, ...*labels.Matcher) storage.SeriesSet {
+	panic("unimplemented")
+}
+
+func TestMockQuerier_LabelValues(t *testing.T) {
+	q := mockQuerier{
+		series: []labels.Labels{
+			labels.FromStrings(
+				"env", "dev",
+				"class", "open",
+				"foo", "bar",
+			),
+			labels.FromStrings(
+				"env", "prd",
+				"class", "secret",
+				"foo", "bar",
+			),
+		},
+	}
+
+	ctx := context.Background()
+
+	matcher1 := labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")
+	matcher2 := labels.MustNewMatcher(labels.MatchEqual, "class", "open")
+
+	t.Run("single matcher", func(t *testing.T) {
+		lbls, _, err := q.LabelValues(ctx, "env", &storage.LabelHints{}, matcher1)
+		require.NoError(t, err)
+		require.Len(t, lbls, 2)
+
+		sort.Strings(lbls)
+		assert.Equal(t, []string{"dev", "prd"}, lbls)
+	})
+
+	t.Run("multiple matchers", func(t *testing.T) {
+		lbls, _, err := q.LabelValues(ctx, "env", &storage.LabelHints{}, matcher1, matcher2)
+		require.NoError(t, err)
+		require.Len(t, lbls, 1)
+		assert.Equal(t, "dev", lbls[0])
+	})
+}
+
+func TestMockQuerier_LabelNames(t *testing.T) {
+	q := mockQuerier{
+		series: []labels.Labels{
+			labels.FromStrings(
+				"env", "dev",
+				"class", "open",
+				"foo", "bar",
+				"series1", "value1",
+			),
+			labels.FromStrings(
+				"env", "prd",
+				"class", "secret",
+				"foo", "bar",
+				"series2", "value2",
+			),
+		},
+	}
+
+	ctx := context.Background()
+
+	matcher1 := labels.MustNewMatcher(labels.MatchEqual, "foo", "bar")
+	matcher2 := labels.MustNewMatcher(labels.MatchEqual, "class", "open")
+
+	t.Run("single matcher", func(t *testing.T) {
+		names, _, err := q.LabelNames(ctx, &storage.LabelHints{}, matcher1)
+		require.NoError(t, err)
+		require.Len(t, names, 5)
+
+		sort.Strings(names)
+		assert.Equal(t, []string{"class", "env", "foo", "series1", "series2"}, names)
+	})
+
+	t.Run("multiple matchers", func(t *testing.T) {
+		names, _, err := q.LabelNames(ctx, &storage.LabelHints{}, matcher1, matcher2)
+		require.NoError(t, err)
+		require.Len(t, names, 4)
+
+		sort.Strings(names)
+		assert.Equal(t, []string{"class", "env", "foo", "series1"}, names)
+	})
+}
+
+func TestLabelAccessQuerier_LabelValues(t *testing.T) {
+	upstream := mockQuerier{
+		series: []labels.Labels{
+			labels.FromStrings(
+				"env", "dev",
+				"class", "open",
+				"foo", "bar",
+			),
+			labels.FromStrings(
+				"env", "prd",
+				"class", "secret",
+				"foo", "bar",
+			),
+		},
+	}
+	const tenantID = "test-instance"
+	ctx := user.InjectOrgID(context.Background(), tenantID)
+
+	t.Run("no selectors", func(t *testing.T) {
+		q := labelAccessQuerier{
+			querier:      &upstream,
+			labelQuerier: &upstream,
+			logger:       log.NewNopLogger(),
+		}
+		ctx = shared.InjectLabelMatchersContext(ctx, shared.LabelPolicySet{})
+
+		lbls, _, err := q.LabelValues(ctx, "class", &storage.LabelHints{})
+		require.NoError(t, err)
+		sort.Strings(lbls)
+		assert.Equal(t, []string{"open", "secret"}, lbls)
+	})
+
+	t.Run("single selector", func(t *testing.T) {
+		q := labelAccessQuerier{
+			querier:      &upstream,
+			labelQuerier: &upstream,
+			logger:       log.NewNopLogger(),
+		}
+		ctx = shared.InjectLabelMatchersContext(ctx, shared.LabelPolicySet{
+			tenantID: {
+				{
+					Selector: []*labels.Matcher{labels.MustNewMatcher(labels.MatchNotEqual, "class", "secret")},
+				},
+			},
+		})
+
+		lbls, _, err := q.LabelValues(ctx, "env", &storage.LabelHints{})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"dev"}, lbls)
+	})
+
+	t.Run("multiple selectors", func(t *testing.T) {
+		q := labelAccessQuerier{
+			querier:      &upstream,
+			labelQuerier: &upstream,
+			logger:       log.NewNopLogger(),
+		}
+		ctx = shared.InjectLabelMatchersContext(ctx, shared.LabelPolicySet{
+			tenantID: {
+				{
+					Selector: []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "env", "prd")},
+				},
+				{
+					Selector: []*labels.Matcher{labels.MustNewMatcher(labels.MatchNotEqual, "class", "secret")},
+				},
+			},
+		})
+
+		lbls, _, err := q.LabelValues(ctx, "env", &storage.LabelHints{})
+		require.NoError(t, err)
+		sort.Strings(lbls)
+		assert.Equal(t, []string{"dev", "prd"}, lbls)
+	})
+
+	t.Run("single selector and matcher", func(t *testing.T) {
+		q := labelAccessQuerier{
+			querier:      &upstream,
+			labelQuerier: &upstream,
+			logger:       log.NewNopLogger(),
+		}
+		ctx = shared.InjectLabelMatchersContext(ctx, shared.LabelPolicySet{
+			tenantID: {
+				{
+					Selector: []*labels.Matcher{labels.MustNewMatcher(labels.MatchNotEqual, "class", "secret")},
+				},
+			},
+		})
+
+		matcher := labels.MustNewMatcher(labels.MatchEqual, "env", "dev")
+		lbls, _, err := q.LabelValues(ctx, "class", &storage.LabelHints{}, matcher)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"open"}, lbls)
+	})
+
+	t.Run("single selector and matcher no values", func(t *testing.T) {
+		q := labelAccessQuerier{
+			querier:      &upstream,
+			labelQuerier: &upstream,
+			logger:       log.NewNopLogger(),
+		}
+		ctx = shared.InjectLabelMatchersContext(ctx, shared.LabelPolicySet{
+			tenantID: {
+				{
+					Selector: []*labels.Matcher{labels.MustNewMatcher(labels.MatchNotEqual, "class", "secret")},
+				},
+			},
+		})
+
+		matcher := labels.MustNewMatcher(labels.MatchEqual, "env", "prd")
+		lbls, _, err := q.LabelValues(ctx, "foo", &storage.LabelHints{}, matcher)
+		require.NoError(t, err)
+		assert.Empty(t, lbls)
+	})
+
+	t.Run("single selector and duplicate matcher", func(t *testing.T) {
+		q := labelAccessQuerier{
+			querier:      &upstream,
+			labelQuerier: &upstream,
+			logger:       log.NewNopLogger(),
+		}
+		ctx = shared.InjectLabelMatchersContext(ctx, shared.LabelPolicySet{
+			tenantID: {
+				{
+					Selector: []*labels.Matcher{labels.MustNewMatcher(labels.MatchNotEqual, "class", "secret")},
+				},
+			},
+		})
+
+		matcher1 := labels.MustNewMatcher(labels.MatchEqual, "env", "dev")
+		matcher2 := labels.MustNewMatcher(labels.MatchNotEqual, "class", "secret")
+
+		lbls, _, err := q.LabelValues(ctx, "class", &storage.LabelHints{}, matcher1, matcher2)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"open"}, lbls)
+	})
+
+	t.Run("multiple selectors and duplicate matcher", func(t *testing.T) {
+		q := labelAccessQuerier{
+			querier:      &upstream,
+			labelQuerier: &upstream,
+			logger:       log.NewNopLogger(),
+		}
+		ctx = shared.InjectLabelMatchersContext(ctx, shared.LabelPolicySet{
+			tenantID: {
+				{
+					Selector: []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "env", "dev")},
+				},
+				{
+					Selector: []*labels.Matcher{labels.MustNewMatcher(labels.MatchNotEqual, "class", "secret")},
+				},
+			},
+		})
+
+		matcher1 := labels.MustNewMatcher(labels.MatchEqual, "env", "dev")
+		matcher2 := labels.MustNewMatcher(labels.MatchNotEqual, "class", "secret")
+
+		lbls, _, err := q.LabelValues(ctx, "class", &storage.LabelHints{}, matcher1, matcher2)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"open"}, lbls)
+	})
+
+	t.Run("upstream error", func(t *testing.T) {
+		upstreamErr := mockQuerier{err: errors.New("something bad")}
+		q := labelAccessQuerier{
+			querier:      &upstreamErr,
+			labelQuerier: &upstreamErr,
+			logger:       log.NewNopLogger(),
+		}
+		ctx = shared.InjectLabelMatchersContext(ctx, shared.LabelPolicySet{
+			tenantID: {
+				{
+					Selector: []*labels.Matcher{labels.MustNewMatcher(labels.MatchNotEqual, "env", "")},
+				},
+				{
+					Selector: []*labels.Matcher{labels.MustNewMatcher(labels.MatchNotEqual, "class", "secret")},
+				},
+			},
+		})
+
+		lbls, _, err := q.LabelValues(ctx, "env", &storage.LabelHints{})
+		assert.Empty(t, lbls)
+		assert.Error(t, err)
+	})
+}
+
+func TestLabelAccessQuerier_LabelNames(t *testing.T) {
+	upstream := mockQuerier{
+		series: []labels.Labels{
+			labels.FromStrings(
+				"env", "dev",
+				"class", "open",
+				"foo", "bar",
+				"series1", "value1",
+			),
+			labels.FromStrings(
+				"env", "prd",
+				"class", "secret",
+				"foo", "bar",
+				"series2", "value2",
+			),
+			labels.FromStrings(
+				"env", "stg",
+				"class", "secret",
+				"foo", "bar",
+				"series3", "value2",
+			),
+		},
+	}
+	const tenantID = "test-instance"
+	ctx := user.InjectOrgID(context.Background(), tenantID)
+
+	t.Run("no selectors", func(t *testing.T) {
+		q := labelAccessQuerier{
+			querier:      &upstream,
+			labelQuerier: &upstream,
+			logger:       log.NewNopLogger(),
+		}
+		ctx = shared.InjectLabelMatchersContext(ctx, shared.LabelPolicySet{})
+
+		names, _, err := q.LabelNames(ctx, &storage.LabelHints{})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"class", "env", "foo", "series1", "series2", "series3"}, names)
+	})
+
+	t.Run("single selector", func(t *testing.T) {
+		q := labelAccessQuerier{
+			querier:      &upstream,
+			labelQuerier: &upstream,
+			logger:       log.NewNopLogger(),
+		}
+		ctx = shared.InjectLabelMatchersContext(ctx, shared.LabelPolicySet{
+			tenantID: {
+				{
+					Selector: []*labels.Matcher{labels.MustNewMatcher(labels.MatchNotEqual, "class", "secret")},
+				},
+			},
+		})
+
+		names, _, err := q.LabelNames(ctx, &storage.LabelHints{})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"class", "env", "foo", "series1"}, names)
+	})
+
+	t.Run("multiple selectors", func(t *testing.T) {
+		q := labelAccessQuerier{
+			querier:      &upstream,
+			labelQuerier: &upstream,
+			logger:       log.NewNopLogger(),
+		}
+		ctx = shared.InjectLabelMatchersContext(ctx, shared.LabelPolicySet{
+			tenantID: {
+				{
+					Selector: []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "env", "prd")},
+				},
+				{
+					Selector: []*labels.Matcher{labels.MustNewMatcher(labels.MatchNotEqual, "class", "secret")},
+				},
+			},
+		})
+
+		names, _, err := q.LabelNames(ctx, &storage.LabelHints{})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"class", "env", "foo", "series1", "series2"}, names)
+	})
+
+	t.Run("single selector and matcher", func(t *testing.T) {
+		q := labelAccessQuerier{
+			querier:      &upstream,
+			labelQuerier: &upstream,
+			logger:       log.NewNopLogger(),
+		}
+		ctx = shared.InjectLabelMatchersContext(ctx, shared.LabelPolicySet{
+			tenantID: {
+				{
+					Selector: []*labels.Matcher{labels.MustNewMatcher(labels.MatchNotEqual, "class", "secret")},
+				},
+			},
+		})
+
+		matcher := labels.MustNewMatcher(labels.MatchEqual, "env", "dev")
+		names, _, err := q.LabelNames(ctx, &storage.LabelHints{}, matcher)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"class", "env", "foo", "series1"}, names)
+	})
+
+	t.Run("single selector and matcher no values", func(t *testing.T) {
+		q := labelAccessQuerier{
+			querier:      &upstream,
+			labelQuerier: &upstream,
+			logger:       log.NewNopLogger(),
+		}
+		ctx = shared.InjectLabelMatchersContext(ctx, shared.LabelPolicySet{
+			tenantID: {
+				{
+					Selector: []*labels.Matcher{labels.MustNewMatcher(labels.MatchNotEqual, "class", "secret")},
+				},
+			},
+		})
+
+		matcher := labels.MustNewMatcher(labels.MatchEqual, "env", "prd")
+		names, _, err := q.LabelNames(ctx, &storage.LabelHints{}, matcher)
+		require.NoError(t, err)
+		assert.Empty(t, names)
+	})
+
+	t.Run("single selector and duplicate matcher", func(t *testing.T) {
+		q := labelAccessQuerier{
+			querier:      &upstream,
+			labelQuerier: &upstream,
+			logger:       log.NewNopLogger(),
+		}
+		ctx = shared.InjectLabelMatchersContext(ctx, shared.LabelPolicySet{
+			tenantID: {
+				{
+					Selector: []*labels.Matcher{labels.MustNewMatcher(labels.MatchNotEqual, "class", "secret")},
+				},
+			},
+		})
+
+		matcher1 := labels.MustNewMatcher(labels.MatchEqual, "env", "dev")
+		matcher2 := labels.MustNewMatcher(labels.MatchNotEqual, "class", "secret")
+		names, _, err := q.LabelNames(ctx, &storage.LabelHints{}, matcher1, matcher2)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"class", "env", "foo", "series1"}, names)
+	})
+
+	t.Run("multiple selectors and duplicate matcher", func(t *testing.T) {
+		q := labelAccessQuerier{
+			querier:      &upstream,
+			labelQuerier: &upstream,
+			logger:       log.NewNopLogger(),
+		}
+		ctx = shared.InjectLabelMatchersContext(ctx, shared.LabelPolicySet{
+			tenantID: {
+				{
+					Selector: []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "env", "dev")},
+				},
+				{
+					Selector: []*labels.Matcher{labels.MustNewMatcher(labels.MatchNotEqual, "class", "secret")},
+				},
+			},
+		})
+
+		matcher1 := labels.MustNewMatcher(labels.MatchEqual, "env", "dev")
+		matcher2 := labels.MustNewMatcher(labels.MatchNotEqual, "class", "secret")
+		names, _, err := q.LabelNames(ctx, &storage.LabelHints{}, matcher1, matcher2)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"class", "env", "foo", "series1"}, names)
+	})
+
+	t.Run("upstream error", func(t *testing.T) {
+		upstreamErr := mockQuerier{err: errors.New("something bad")}
+		q := labelAccessQuerier{
+			querier:      &upstreamErr,
+			labelQuerier: &upstreamErr,
+			logger:       log.NewNopLogger(),
+		}
+		ctx = shared.InjectLabelMatchersContext(ctx, shared.LabelPolicySet{
+			tenantID: {
+				{
+					Selector: []*labels.Matcher{labels.MustNewMatcher(labels.MatchNotEqual, "env", "")},
+				},
+				{
+					Selector: []*labels.Matcher{labels.MustNewMatcher(labels.MatchNotEqual, "class", "secret")},
+				},
+			},
+		})
+
+		names, _, err := q.LabelNames(ctx, &storage.LabelHints{})
+		assert.Empty(t, names)
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
## What this PR does

Adds experimental label-based access control (LBAC) for metric read queries, ported from Grafana Enterprise Metrics. When enabled via `-auth.label-access-control-enabled` (default off), Mimir enforces the label selectors carried in the `X-Prom-Label-Policy` HTTP header at query time, per tenant.

Enforcement covers:

- **Series** (`Select`) and **label names/values** in the querier, by unioning each policy selector and merging matchers into the upstream call.
- **Exemplars**, filtered by the same policy selectors.
- **Cache-key isolation** in the query-frontend, so a query carrying a policy can never read a cached result produced without it. The policy header is re-injected onto the outbound carrier after querymiddleware strips unknown headers.
- Cardinality endpoints reject requests that carry a policy header (unsupported).

### Packages

- `pkg/labelaccess` - header serialisation, parsing, context propagation, policy-set hashing.
- `pkg/querier/labelaccess` - HTTP middleware, remote-execution extractor, sample and exemplar queryable wrappers.
- `pkg/frontend/labelaccess` - cache-key generator and header injector.
- Wired into `pkg/mimir` behind the config flag.

Note originally the PR was in #14608 but I reopened here because the old PR has been behind main for too long.

## Which issue(s) this PR fixes

https://github.com/grafana/mimir-squad/issues/3482

## Notes

Feature is experimental and disabled by default.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authorization on the metric read path and cache key generation; mis-enforcement or cache bleed between policy and non-policy queries would be a serious data exposure. Default-off and experimental, but the scope spans querier, frontend, and remote execution propagation.
> 
> **Overview**
> Adds **experimental label-based access control (LBAC)** for metric read queries, gated by `-auth.label-access-control-enabled` (default off). Policies arrive in the **`X-Prom-Label-Policy`** HTTP header as per-tenant PromQL label selectors; Mimir parses them into request context and enforces them on the read path.
> 
> On the **querier**, HTTP middleware extracts the header (and rejects cardinality analysis routes when a policy is present). Sample/chunk **Select**, **LabelNames/LabelValues**, and **exemplars** are filtered by unioning policy selectors for the active tenant; multi-policy queries may merge matchers into upstream calls or post-filter series sets, including chunk-stream sync when series are skipped.
> 
> On the **query-frontend**, tripperware injects a policy hash into context for **cache key isolation** (tenant ID + hash), re-injects the header after querymiddleware strips unknown headers, and disables label-values cardinality caching when LBAC is active.
> 
> New packages: `pkg/labelaccess` (header encode/decode, context, hashing), `pkg/querier/labelaccess`, and `pkg/frontend/labelaccess`, wired from `pkg/mimir/modules.go` when the flag is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc1d136d319d87b94ef99d74248d5befcb5d1f32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->