### PR TITLE
integration: Add 3.1.0 to backward compatibility test

### DIFF
--- a/integration/backward_compatibility.go
+++ b/integration/backward_compatibility.go
@@ -7,15 +7,15 @@ import "github.com/grafana/mimir/integration/e2emimir"
 // DefaultPreviousVersionImages is used by `tools/pre-pull-images` so it needs
 // to be in a non `_test.go` file.
 var DefaultPreviousVersionImages = map[string]e2emimir.FlagMapper{
-	"grafana/mimir:2.16.2": e2emimir.ChainFlagMappers(
-		removePartitionRingFlags,
-		removeQuerierRingFlags,
-	),
 	"grafana/mimir:2.17.11": e2emimir.ChainFlagMappers(
 		removePartitionRingFlags,
 		removeQuerierRingFlags,
 	),
 	"grafana/mimir:3.0.6": e2emimir.ChainFlagMappers(
+		removePartitionRingFlags,
+		removeQuerierRingFlags,
+	),
+	"grafana/mimir:3.1.0": e2emimir.ChainFlagMappers(
 		removePartitionRingFlags,
 		removeQuerierRingFlags,
 	),


### PR DESCRIPTION
#### What this PR does

As a post-step of the 3.1.0 release, add it to the backward compatibility test.

Since we keep the last 3 minor releases, we drop 2.16.2.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/issues/14392

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only version pin rotation with no production code or runtime behavior changes.
> 
> **Overview**
> Updates **`DefaultPreviousVersionImages`** so backward-compatibility integration tests (and **`tools/pre-pull-images`**) exercise the **last three minor releases**: **2.17.11**, **3.0.6**, and **3.1.0**.
> 
> **2.16.2** is removed from the map; **3.1.0** is added with the same **`ChainFlagMappers`** (`removePartitionRingFlags`, `removeQuerierRingFlags`) as the other entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28379e2fbe18f4c712f5ba46df209b732a317e55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->