### PR TITLE
Fix inflated cortex_ingest_storage_reader_receive_delay_seconds metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [ENHANCEMENT] Memberlist: TCP push-pull and other TCP stream messages now skip compression when the compressed output is no smaller than the input, falling back to a plaintext frame. Mirrors existing UDP behaviour; receivers continue to decode both compressed and plaintext frames so the change is wire-compatible. #15357
 * [ENHANCEMENT] Memberlist: Reduce per-call allocations on the compression and TCP state-sync receive paths via internal buffer pools. #15357
 * [BUGFIX] Ingest storage: Fix `KafkaProducer.ProduceSync()` returning a single result with a nil record when the context is canceled, instead of one result per input record (with the record set) as the underlying franz-go client does. #15199
+* [BUGFIX] Ingest storage: Fix `cortex_ingest_storage_reader_receive_delay_seconds` inflation by no longer setting the Kafka record `Timestamp` on the distributor side; the Kafka client now sets it at produce time. #15572
 * [BUGFIX] Distributor: Return HTTP 200 with OTLP partial-success when only some samples in an OTLP request are rejected by distributor-level validation (e.g. `too_far_in_past`). #15253
 * [BUGFIX] MQE: Bugfixes for experimental range vector splitting. #15147 #15270 #14878
 * [BUGFIX] Querier: Fix querier ScaledObjects native histogram querying and triggering `MimirAutoscalerKedaFailing` when queriers have no traffic because `cortex_querier_request_duration_seconds_sum` is not published until the first request is received. #15106

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -1463,7 +1463,6 @@ func (d *Distributor) prePushValidationMiddleware(next PushFunc) PushFunc {
 		// totalN included samples, exemplars and metadata. Ingester follows this pattern when computing its ingestion rate.
 		d.ingestionRate.Add(int64(totalN))
 
-		ctx = ingest.ContextWithRecordTimestamp(ctx, now)
 		err = next(ctx, pushReq)
 		if err != nil {
 			// Errors resulting from the pushing to the ingesters have priority over

--- a/pkg/storage/ingest/pusher.go
+++ b/pkg/storage/ingest/pusher.go
@@ -25,19 +25,6 @@ import (
 	"github.com/grafana/mimir/pkg/util/spanlogger"
 )
 
-type recordTimestampKeyType struct{}
-
-var recordTimestampKey = recordTimestampKeyType{}
-
-func ContextWithRecordTimestamp(ctx context.Context, ts time.Time) context.Context {
-	return context.WithValue(ctx, recordTimestampKey, ts)
-}
-
-func RecordTimestampFromContext(ctx context.Context) (time.Time, bool) {
-	ts, ok := ctx.Value(recordTimestampKey).(time.Time)
-	return ts, ok
-}
-
 type Pusher interface {
 	PushToStorageAndReleaseRequest(context.Context, *mimirpb.WriteRequest) error
 	PreCommitNotifier

--- a/pkg/storage/ingest/writer.go
+++ b/pkg/storage/ingest/writer.go
@@ -208,15 +208,6 @@ func (w *Writer) MultiWriteSync(ctx context.Context, topic string, userID string
 		return nil
 	}
 
-	// If the caller provided an explicit record timestamp (e.g. the distributor's validation
-	// reference time), set it on every record so that consumers see the same timestamp that
-	// was used for grace-period checks.
-	if ts, ok := RecordTimestampFromContext(ctx); ok {
-		for _, r := range allRecords {
-			r.Timestamp = ts
-		}
-	}
-
 	// Write to backend. The topic and partition fields are already set on each record by ToRecords,
 	// so the Kafka client routes records to the correct topic and partition.
 	res := client.ProduceSync(ctx, allRecords)

--- a/pkg/storage/ingest/writer_client.go
+++ b/pkg/storage/ingest/writer_client.go
@@ -268,6 +268,20 @@ func (c *KafkaProducer) ProduceSync(ctx context.Context, records []*kgo.Record) 
 		return newFailedProduceResultsFromRecords(records, errors.Wrap(context.Cause(ctx), "skipped producing Kafka records because context is already done"))
 	}
 
+	// Record.Timestamp must be left unset by callers. We rely on the franz-go client setting
+	// it as late as possible (right before the record is sent on the wire) so that it accurately
+	// represents the produce time. That timestamp is used to compute end-to-end latency
+	// (cortex_ingest_storage_reader_receive_delay_seconds) and the strong-read-consistency wait
+	// in the partition reader. Stamping it earlier inflates both. If a caller needs to attach
+	// another timestamp with a different meaning (e.g. distributor validation time), it must
+	// use a Kafka record header instead.
+	for _, record := range records {
+		if !record.Timestamp.IsZero() {
+			c.produceRecordsFailedTotal.WithLabelValues("record-timestamp-set").Add(float64(len(records)))
+			return newFailedProduceResultsFromRecords(records, errors.New("Kafka record Timestamp must not be set by the caller; it is reserved for the Kafka client to track produce time"))
+		}
+	}
+
 	c.produceRecordsEnqueuedTotal.Add(float64(len(records)))
 
 	// Reserve buffer space for the whole batch up front. If the reservation would exceed the configured

--- a/pkg/storage/ingest/writer_client_test.go
+++ b/pkg/storage/ingest/writer_client_test.go
@@ -205,90 +205,93 @@ func TestKafkaProducer_ProduceSync_ShouldCircuitBreakIfContextIsDone(t *testing.
 		topicName     = "test"
 	)
 
-	t.Run("context is done", func(t *testing.T) {
-		_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
+	_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
 
-		ctx := context.Background()
-		cfg := createTestKafkaConfig(clusterAddr, topicName)
-		reg := prometheus.NewPedanticRegistry()
-		prefixedReg := prometheus.WrapRegistererWithPrefix(writerMetricsPrefix, reg)
+	ctx := context.Background()
+	cfg := createTestKafkaConfig(clusterAddr, topicName)
+	reg := prometheus.NewPedanticRegistry()
+	prefixedReg := prometheus.WrapRegistererWithPrefix(writerMetricsPrefix, reg)
 
-		client, err := NewKafkaWriterClient(cfg, defaultMaxInflightProduceRequests, log.NewNopLogger(), prefixedReg)
-		require.NoError(t, err)
+	client, err := NewKafkaWriterClient(cfg, defaultMaxInflightProduceRequests, log.NewNopLogger(), prefixedReg)
+	require.NoError(t, err)
 
-		producer := NewKafkaProducer(client, cfg.ProducerMaxBufferedBytes, prefixedReg)
-		t.Cleanup(producer.Close)
+	producer := NewKafkaProducer(client, cfg.ProducerMaxBufferedBytes, prefixedReg)
+	t.Cleanup(producer.Close)
 
-		// Create a context with an expired deadline.
-		expiredCtx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
-		t.Cleanup(cancel)
+	// Create a context with an expired deadline.
+	expiredCtx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
+	t.Cleanup(cancel)
 
-		res := producer.ProduceSync(expiredCtx, []*kgo.Record{{Key: []byte("test"), Value: []byte("message 1")}})
-		require.ErrorIs(t, res.FirstErr(), context.DeadlineExceeded)
+	res := producer.ProduceSync(expiredCtx, []*kgo.Record{{Key: []byte("test"), Value: []byte("message 1")}})
+	require.ErrorIs(t, res.FirstErr(), context.DeadlineExceeded)
 
-		// We expect no records buffered in the Kafka client, because of the circuit breaker.
-		require.Equal(t, int64(0), producer.BufferedProduceRecords())
+	// We expect no records buffered in the Kafka client, because of the circuit breaker.
+	require.Equal(t, int64(0), producer.BufferedProduceRecords())
 
-		// Even if no record was actually enqueued, we expect the metric was tracked anyway to keep it consistent
-		// (we don't want to lose track of such records that, if context wasn't already done, they would have been produced).
-		assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
-			# HELP cortex_ingest_storage_writer_produce_records_enqueued_total Total number of Kafka records enqueued to be sent to the Kafka backend (includes records that fail to be successfully sent to the Kafka backend).
-			# TYPE cortex_ingest_storage_writer_produce_records_enqueued_total counter
-			cortex_ingest_storage_writer_produce_records_enqueued_total{} 1
+	// Even if no record was actually enqueued, we expect the metric was tracked anyway to keep it consistent
+	// (we don't want to lose track of such records that, if context wasn't already done, they would have been produced).
+	assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
+		# HELP cortex_ingest_storage_writer_produce_records_enqueued_total Total number of Kafka records enqueued to be sent to the Kafka backend (includes records that fail to be successfully sent to the Kafka backend).
+		# TYPE cortex_ingest_storage_writer_produce_records_enqueued_total counter
+		cortex_ingest_storage_writer_produce_records_enqueued_total{} 1
 
-			# HELP cortex_ingest_storage_writer_produce_records_failed_total Total number of Kafka records that failed to be sent to the Kafka backend.
-			# TYPE cortex_ingest_storage_writer_produce_records_failed_total counter
-			cortex_ingest_storage_writer_produce_records_failed_total{reason="cancelled-before-producing"} 1
-		`),
-			"cortex_ingest_storage_writer_produce_records_enqueued_total",
-			"cortex_ingest_storage_writer_produce_records_failed_total"))
+		# HELP cortex_ingest_storage_writer_produce_records_failed_total Total number of Kafka records that failed to be sent to the Kafka backend.
+		# TYPE cortex_ingest_storage_writer_produce_records_failed_total counter
+		cortex_ingest_storage_writer_produce_records_failed_total{reason="cancelled-before-producing"} 1
+	`),
+		"cortex_ingest_storage_writer_produce_records_enqueued_total",
+		"cortex_ingest_storage_writer_produce_records_failed_total"))
 
-		// We expect the circuit breaker triggers after we track the remaining context deadline (that in this case is 0).
-		metrics, err := dskit_metrics.NewMetricFamilyMapFromGatherer(reg)
-		require.NoError(t, err)
-		histogram, err := dskit_metrics.FindHistogramWithNameAndLabels(metrics, "cortex_ingest_storage_writer_produce_remaining_deadline_seconds")
-		require.NoError(t, err)
-		require.Equal(t, uint64(1), *histogram.SampleCount)
-		require.Equal(t, float64(0), *histogram.SampleSum)
-	})
+	// We expect the circuit breaker triggers after we track the remaining context deadline (that in this case is 0).
+	metrics, err := dskit_metrics.NewMetricFamilyMapFromGatherer(reg)
+	require.NoError(t, err)
+	histogram, err := dskit_metrics.FindHistogramWithNameAndLabels(metrics, "cortex_ingest_storage_writer_produce_remaining_deadline_seconds")
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), *histogram.SampleCount)
+	require.Equal(t, float64(0), *histogram.SampleSum)
+}
 
-	t.Run("any input record has Timestamp set", func(t *testing.T) {
-		_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
+func TestKafkaProducer_ProduceSync_ShouldRejectRecordsWithTimestampSet(t *testing.T) {
+	const (
+		numPartitions = 1
+		topicName     = "test"
+	)
 
-		cfg := createTestKafkaConfig(clusterAddr, topicName)
-		reg := prometheus.NewPedanticRegistry()
-		prefixedReg := prometheus.WrapRegistererWithPrefix(writerMetricsPrefix, reg)
+	_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
 
-		client, err := NewKafkaWriterClient(cfg, defaultMaxInflightProduceRequests, log.NewNopLogger(), prefixedReg)
-		require.NoError(t, err)
+	cfg := createTestKafkaConfig(clusterAddr, topicName)
+	reg := prometheus.NewPedanticRegistry()
+	prefixedReg := prometheus.WrapRegistererWithPrefix(writerMetricsPrefix, reg)
 
-		producer := NewKafkaProducer(client, cfg.ProducerMaxBufferedBytes, prefixedReg)
-		t.Cleanup(producer.Close)
+	client, err := NewKafkaWriterClient(cfg, defaultMaxInflightProduceRequests, log.NewNopLogger(), prefixedReg)
+	require.NoError(t, err)
 
-		records := []*kgo.Record{
-			{Key: []byte("test"), Value: []byte("message 1")},
-			{Key: []byte("test"), Value: []byte("message 2"), Timestamp: time.Now()},
-		}
+	producer := NewKafkaProducer(client, cfg.ProducerMaxBufferedBytes, prefixedReg)
+	t.Cleanup(producer.Close)
 
-		res := producer.ProduceSync(context.Background(), records)
-		require.Len(t, res, len(records))
-		for i, r := range res {
-			require.Errorf(t, r.Err, "result[%d] should fail", i)
-			require.Containsf(t, r.Err.Error(), "Kafka record Timestamp must not be set", "result[%d] should report the timestamp error", i)
-			require.Samef(t, records[i], r.Record, "result[%d] should reference the original record", i)
-		}
+	records := []*kgo.Record{
+		{Key: []byte("test"), Value: []byte("message 1")},
+		{Key: []byte("test"), Value: []byte("message 2"), Timestamp: time.Now()},
+	}
 
-		// No record should be buffered in the Kafka client (none was produced).
-		require.Equal(t, int64(0), producer.BufferedProduceRecords())
-		require.Equal(t, int64(0), producer.bufferedBytes.Load())
+	res := producer.ProduceSync(context.Background(), records)
+	require.Len(t, res, len(records))
+	for i, r := range res {
+		require.Errorf(t, r.Err, "result[%d] should fail", i)
+		require.Containsf(t, r.Err.Error(), "Kafka record Timestamp must not be set", "result[%d] should report the timestamp error", i)
+		require.Samef(t, records[i], r.Record, "result[%d] should reference the original record", i)
+	}
 
-		assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
-			# HELP cortex_ingest_storage_writer_produce_records_failed_total Total number of Kafka records that failed to be sent to the Kafka backend.
-			# TYPE cortex_ingest_storage_writer_produce_records_failed_total counter
-			cortex_ingest_storage_writer_produce_records_failed_total{reason="record-timestamp-set"} 2
-		`),
-			"cortex_ingest_storage_writer_produce_records_failed_total"))
-	})
+	// No record should be buffered in the Kafka client (none was produced).
+	require.Equal(t, int64(0), producer.BufferedProduceRecords())
+	require.Equal(t, int64(0), producer.bufferedBytes.Load())
+
+	assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
+		# HELP cortex_ingest_storage_writer_produce_records_failed_total Total number of Kafka records that failed to be sent to the Kafka backend.
+		# TYPE cortex_ingest_storage_writer_produce_records_failed_total counter
+		cortex_ingest_storage_writer_produce_records_failed_total{reason="record-timestamp-set"} 2
+	`),
+		"cortex_ingest_storage_writer_produce_records_failed_total"))
 }
 
 func TestKafkaProducer_ProduceSync_ShouldRejectWholeBatchIfBufferIsFull(t *testing.T) {

--- a/pkg/storage/ingest/writer_client_test.go
+++ b/pkg/storage/ingest/writer_client_test.go
@@ -205,50 +205,90 @@ func TestKafkaProducer_ProduceSync_ShouldCircuitBreakIfContextIsDone(t *testing.
 		topicName     = "test"
 	)
 
-	_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
+	t.Run("context is done", func(t *testing.T) {
+		_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
 
-	ctx := context.Background()
-	cfg := createTestKafkaConfig(clusterAddr, topicName)
-	reg := prometheus.NewPedanticRegistry()
-	prefixedReg := prometheus.WrapRegistererWithPrefix(writerMetricsPrefix, reg)
+		ctx := context.Background()
+		cfg := createTestKafkaConfig(clusterAddr, topicName)
+		reg := prometheus.NewPedanticRegistry()
+		prefixedReg := prometheus.WrapRegistererWithPrefix(writerMetricsPrefix, reg)
 
-	client, err := NewKafkaWriterClient(cfg, defaultMaxInflightProduceRequests, log.NewNopLogger(), prefixedReg)
-	require.NoError(t, err)
+		client, err := NewKafkaWriterClient(cfg, defaultMaxInflightProduceRequests, log.NewNopLogger(), prefixedReg)
+		require.NoError(t, err)
 
-	producer := NewKafkaProducer(client, cfg.ProducerMaxBufferedBytes, prefixedReg)
-	t.Cleanup(producer.Close)
+		producer := NewKafkaProducer(client, cfg.ProducerMaxBufferedBytes, prefixedReg)
+		t.Cleanup(producer.Close)
 
-	// Create a context with an expired deadline.
-	expiredCtx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
-	t.Cleanup(cancel)
+		// Create a context with an expired deadline.
+		expiredCtx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
+		t.Cleanup(cancel)
 
-	res := producer.ProduceSync(expiredCtx, []*kgo.Record{{Key: []byte("test"), Value: []byte("message 1")}})
-	require.ErrorIs(t, res.FirstErr(), context.DeadlineExceeded)
+		res := producer.ProduceSync(expiredCtx, []*kgo.Record{{Key: []byte("test"), Value: []byte("message 1")}})
+		require.ErrorIs(t, res.FirstErr(), context.DeadlineExceeded)
 
-	// We expect no records buffered in the Kafka client, because of the circuit breaker.
-	require.Equal(t, int64(0), producer.BufferedProduceRecords())
+		// We expect no records buffered in the Kafka client, because of the circuit breaker.
+		require.Equal(t, int64(0), producer.BufferedProduceRecords())
 
-	// Even if no record was actually enqueued, we expect the metric was tracked anyway to keep it consistent
-	// (we don't want to lose track of such records that, if context wasn't already done, they would have been produced).
-	assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
-		# HELP cortex_ingest_storage_writer_produce_records_enqueued_total Total number of Kafka records enqueued to be sent to the Kafka backend (includes records that fail to be successfully sent to the Kafka backend).
-		# TYPE cortex_ingest_storage_writer_produce_records_enqueued_total counter
-		cortex_ingest_storage_writer_produce_records_enqueued_total{} 1
+		// Even if no record was actually enqueued, we expect the metric was tracked anyway to keep it consistent
+		// (we don't want to lose track of such records that, if context wasn't already done, they would have been produced).
+		assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
+			# HELP cortex_ingest_storage_writer_produce_records_enqueued_total Total number of Kafka records enqueued to be sent to the Kafka backend (includes records that fail to be successfully sent to the Kafka backend).
+			# TYPE cortex_ingest_storage_writer_produce_records_enqueued_total counter
+			cortex_ingest_storage_writer_produce_records_enqueued_total{} 1
 
-		# HELP cortex_ingest_storage_writer_produce_records_failed_total Total number of Kafka records that failed to be sent to the Kafka backend.
-		# TYPE cortex_ingest_storage_writer_produce_records_failed_total counter
-		cortex_ingest_storage_writer_produce_records_failed_total{reason="cancelled-before-producing"} 1
-	`),
-		"cortex_ingest_storage_writer_produce_records_enqueued_total",
-		"cortex_ingest_storage_writer_produce_records_failed_total"))
+			# HELP cortex_ingest_storage_writer_produce_records_failed_total Total number of Kafka records that failed to be sent to the Kafka backend.
+			# TYPE cortex_ingest_storage_writer_produce_records_failed_total counter
+			cortex_ingest_storage_writer_produce_records_failed_total{reason="cancelled-before-producing"} 1
+		`),
+			"cortex_ingest_storage_writer_produce_records_enqueued_total",
+			"cortex_ingest_storage_writer_produce_records_failed_total"))
 
-	// We expect the circuit breaker triggers after we track the remaining context deadline (that in this case is 0).
-	metrics, err := dskit_metrics.NewMetricFamilyMapFromGatherer(reg)
-	require.NoError(t, err)
-	histogram, err := dskit_metrics.FindHistogramWithNameAndLabels(metrics, "cortex_ingest_storage_writer_produce_remaining_deadline_seconds")
-	require.NoError(t, err)
-	require.Equal(t, uint64(1), *histogram.SampleCount)
-	require.Equal(t, float64(0), *histogram.SampleSum)
+		// We expect the circuit breaker triggers after we track the remaining context deadline (that in this case is 0).
+		metrics, err := dskit_metrics.NewMetricFamilyMapFromGatherer(reg)
+		require.NoError(t, err)
+		histogram, err := dskit_metrics.FindHistogramWithNameAndLabels(metrics, "cortex_ingest_storage_writer_produce_remaining_deadline_seconds")
+		require.NoError(t, err)
+		require.Equal(t, uint64(1), *histogram.SampleCount)
+		require.Equal(t, float64(0), *histogram.SampleSum)
+	})
+
+	t.Run("any input record has Timestamp set", func(t *testing.T) {
+		_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
+
+		cfg := createTestKafkaConfig(clusterAddr, topicName)
+		reg := prometheus.NewPedanticRegistry()
+		prefixedReg := prometheus.WrapRegistererWithPrefix(writerMetricsPrefix, reg)
+
+		client, err := NewKafkaWriterClient(cfg, defaultMaxInflightProduceRequests, log.NewNopLogger(), prefixedReg)
+		require.NoError(t, err)
+
+		producer := NewKafkaProducer(client, cfg.ProducerMaxBufferedBytes, prefixedReg)
+		t.Cleanup(producer.Close)
+
+		records := []*kgo.Record{
+			{Key: []byte("test"), Value: []byte("message 1")},
+			{Key: []byte("test"), Value: []byte("message 2"), Timestamp: time.Now()},
+		}
+
+		res := producer.ProduceSync(context.Background(), records)
+		require.Len(t, res, len(records))
+		for i, r := range res {
+			require.Errorf(t, r.Err, "result[%d] should fail", i)
+			require.Containsf(t, r.Err.Error(), "Kafka record Timestamp must not be set", "result[%d] should report the timestamp error", i)
+			require.Samef(t, records[i], r.Record, "result[%d] should reference the original record", i)
+		}
+
+		// No record should be buffered in the Kafka client (none was produced).
+		require.Equal(t, int64(0), producer.BufferedProduceRecords())
+		require.Equal(t, int64(0), producer.bufferedBytes.Load())
+
+		assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
+			# HELP cortex_ingest_storage_writer_produce_records_failed_total Total number of Kafka records that failed to be sent to the Kafka backend.
+			# TYPE cortex_ingest_storage_writer_produce_records_failed_total counter
+			cortex_ingest_storage_writer_produce_records_failed_total{reason="record-timestamp-set"} 2
+		`),
+			"cortex_ingest_storage_writer_produce_records_failed_total"))
+	})
 }
 
 func TestKafkaProducer_ProduceSync_ShouldRejectWholeBatchIfBufferIsFull(t *testing.T) {

--- a/pkg/storage/ingest/writer_test.go
+++ b/pkg/storage/ingest/writer_test.go
@@ -1712,45 +1712,6 @@ func createTestWriter(t *testing.T, cfg KafkaConfig) (*Writer, prometheus.Gather
 	return writer, reg
 }
 
-func TestWriter_WriteSync_SetsRecordTimestampFromContext(t *testing.T) {
-	t.Parallel()
-
-	const (
-		topicName     = "test"
-		numPartitions = 1
-		partitionID   = 0
-		tenantID      = "user-1"
-	)
-
-	_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
-	writer, _ := createTestWriter(t, createTestKafkaConfig(clusterAddr, topicName))
-
-	// Use a timestamp close to now so it doesn't trip franz-go's RecordDeliveryTimeout.
-	ts := time.Now().Add(-time.Second).Truncate(time.Millisecond)
-	ctx := ContextWithRecordTimestamp(context.Background(), ts)
-
-	err := writer.WriteSync(ctx, topicName, partitionID, tenantID, &mimirpb.WriteRequest{
-		Timeseries: []mimirpb.PreallocTimeseries{mockPreallocTimeseries("series_1")},
-		Source:     mimirpb.API,
-	})
-	require.NoError(t, err)
-
-	consumer, err := kgo.NewClient(kgo.SeedBrokers(clusterAddr), kgo.ConsumePartitions(map[string]map[int32]kgo.Offset{
-		topicName: {partitionID: kgo.NewOffset().AtStart()},
-	}))
-	require.NoError(t, err)
-	t.Cleanup(consumer.Close)
-
-	fetchCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	t.Cleanup(cancel)
-
-	fetches := consumer.PollFetches(fetchCtx)
-	require.NoError(t, fetches.Err())
-	records := fetches.Records()
-	require.Len(t, records, 1)
-	assert.Equal(t, ts, records[0].Timestamp)
-}
-
 func deserializeRecord(t *testing.T, rec *kgo.Record) mimirpb.WriteRequest {
 	t.Helper()
 


### PR DESCRIPTION
#### What this PR does

The `cortex_ingest_storage_reader_receive_delay_seconds` metric and the delay measured in ingesters to enforce the max consumption delay at query time are inflated since #14921. After #14921, the record timestamp is no more set at last minute, but it's set while the request is still processing in the ingesters. In particular, we observed an edge case caused by long record serialization times (a few seconds) in rulers, due to large recording rule outputs.

This PR fixes it by reverting #14921, in particular.

- Stops setting `Record.Timestamp` in the writer and removes the now-unused `ContextWithRecordTimestamp` / `RecordTimestampFromContext` helpers and the distributor call site.
- Adds a guard in `KafkaProducer.ProduceSync` that rejects the whole batch if any input record has `Timestamp` already set, with a comment explaining why. If a caller needs to attach another timestamp with a different meaning, it must use a Kafka record header.

It's important to note that **this PR doesn't introduce any regression**. The reason we were stamping it ourselves is historical. In `Writer.MultiWriteSync` we used to set every Kafka record's `Timestamp` to the distributor's validation reference time (PR #14921), so that ingesters could use the same wall clock for out-of-order grace-period checks (PRs #14611, #14744). PRs #14611 and #14744 were later reverted in PR #15036 because using Kafka record timestamps for active-series and grace-period logic stalled TSDB early compaction and active-series purging when timestamps stopped advancing. The producer-side stamping from PR #14921 was not reverted alongside, even though there is no longer anything on the consumer side that needs `Record.Timestamp` to equal the distributor's validation time.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.