### PR TITLE
perf(store-gateway): Index-header bucket reader: Add in-memory LRU wrapper for object attributes calls

### DIFF
--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -11042,6 +11042,17 @@
                 },
                 {
                   "kind": "field",
+                  "name": "attributes_in_memory_max_items",
+                  "required": false,
+                  "desc": "Maximum number of individual attributes items to keep in a first level in-memory LRU cache. Attributes will be stored and fetched in-memory before hitting the cache backend. 0 to disable the in-memory cache.",
+                  "fieldValue": null,
+                  "fieldDefaultValue": 10000,
+                  "fieldFlag": "blocks-storage.bucket-store.index-header-cache.attributes-in-memory-max-items",
+                  "fieldType": "int",
+                  "fieldCategory": "experimental"
+                },
+                {
+                  "kind": "field",
                   "name": "subrange_ttl",
                   "required": false,
                   "desc": "TTL for caching individual index-header subranges.",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -519,6 +519,8 @@ Usage of ./cmd/mimir/mimir:
     	Override the default minimum TLS version. Allowed values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13
   -blocks-storage.bucket-store.index-cache.memcached.tls-server-name string
     	Override the expected name on the server certificate.
+  -blocks-storage.bucket-store.index-header-cache.attributes-in-memory-max-items int
+    	[experimental] Maximum number of individual attributes items to keep in a first level in-memory LRU cache. Attributes will be stored and fetched in-memory before hitting the cache backend. 0 to disable the in-memory cache. (default 10000)
   -blocks-storage.bucket-store.index-header-cache.attributes-ttl duration
     	[experimental] TTL for caching object attributes of the block index for the index-header reader.  If the metadata cache is configured, attributes will be stored in the metadata cache backend, otherwise attributes are stored in the index-header cache backend. (default 168h0m0s)
   -blocks-storage.bucket-store.index-header-cache.backend string

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -5688,6 +5688,13 @@ bucket_store:
     # CLI flag: -blocks-storage.bucket-store.index-header-cache.attributes-ttl
     [attributes_ttl: <duration> | default = 168h]
 
+    # (experimental) Maximum number of individual attributes items to keep in a
+    # first level in-memory LRU cache. Attributes will be stored and fetched
+    # in-memory before hitting the cache backend. 0 to disable the in-memory
+    # cache.
+    # CLI flag: -blocks-storage.bucket-store.index-header-cache.attributes-in-memory-max-items
+    [attributes_in_memory_max_items: <int> | default = 10000]
+
     # (experimental) TTL for caching individual index-header subranges.
     # CLI flag: -blocks-storage.bucket-store.index-header-cache.subrange-ttl
     [subrange_ttl: <duration> | default = 24h]

--- a/operations/mimir/mimir-flags-defaults.json
+++ b/operations/mimir/mimir-flags-defaults.json
@@ -778,6 +778,7 @@
   "blocks-storage.bucket-store.index-header-cache.memcached.tls-cipher-suites": "",
   "blocks-storage.bucket-store.index-header-cache.memcached.tls-min-version": "",
   "blocks-storage.bucket-store.index-header-cache.attributes-ttl": 604800000000000,
+  "blocks-storage.bucket-store.index-header-cache.attributes-in-memory-max-items": 10000,
   "blocks-storage.bucket-store.index-header-cache.subrange-ttl": 86400000000000,
   "blocks-storage.bucket-store.index-header-cache.subrange-in-memory-max-items": 100000,
   "blocks-storage.bucket-store.index-header-cache.max-get-range-requests": 3,

--- a/pkg/storage/tsdb/caching_config.go
+++ b/pkg/storage/tsdb/caching_config.go
@@ -67,10 +67,11 @@ func (cfg *MetadataCacheConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix 
 type IndexHeaderCacheConfig struct {
 	cache.BackendConfig `yaml:",inline"  category:"experimental"`
 
-	AttributesTTL            time.Duration `yaml:"attributes_ttl" category:"experimental"`
-	SubrangeTTL              time.Duration `yaml:"subrange_ttl" category:"experimental"`
-	SubRangeInMemoryMaxItems int           `yaml:"subrange_in_memory_max_items" category:"experimental"`
-	MaxGetRangeRequests      int           `yaml:"max_get_range_requests" category:"experimental"`
+	AttributesTTL              time.Duration `yaml:"attributes_ttl" category:"experimental"`
+	AttributesInMemoryMaxItems int           `yaml:"attributes_in_memory_max_items" category:"experimental"`
+	SubrangeTTL                time.Duration `yaml:"subrange_ttl" category:"experimental"`
+	SubRangeInMemoryMaxItems   int           `yaml:"subrange_in_memory_max_items" category:"experimental"`
+	MaxGetRangeRequests        int           `yaml:"max_get_range_requests" category:"experimental"`
 }
 
 func (cfg *IndexHeaderCacheConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
@@ -78,6 +79,7 @@ func (cfg *IndexHeaderCacheConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, pref
 	cfg.Memcached.RegisterFlagsWithPrefix(prefix+"memcached.", f)
 
 	f.DurationVar(&cfg.AttributesTTL, prefix+"attributes-ttl", 168*time.Hour, "TTL for caching object attributes of the block index for the index-header reader.  If the metadata cache is configured, attributes will be stored in the metadata cache backend, otherwise attributes are stored in the index-header cache backend.")
+	f.IntVar(&cfg.AttributesInMemoryMaxItems, prefix+"attributes-in-memory-max-items", 10000, "Maximum number of individual attributes items to keep in a first level in-memory LRU cache. Attributes will be stored and fetched in-memory before hitting the cache backend. 0 to disable the in-memory cache.")
 	f.DurationVar(&cfg.SubrangeTTL, prefix+"subrange-ttl", 24*time.Hour, "TTL for caching individual index-header subranges.")
 	f.IntVar(&cfg.SubRangeInMemoryMaxItems, prefix+"subrange-in-memory-max-items", 100000, "Maximum number of individual subrange items to keep in a first level in-memory LRU cache. Subranges will be stored and fetched in-memory before hitting the cache backend. 0 to disable the in-memory cache.")
 	f.IntVar(&cfg.MaxGetRangeRequests, prefix+"max-get-range-requests", 3, "Maximum number of sub-GetRange requests that a single GetRange request can be split into when fetching index-header ranges. Zero or negative value = unlimited number of sub-requests.")
@@ -259,6 +261,20 @@ func newStoreCachingBucket(
 		if metadataCache != nil {
 			attributesCache = metadataCache
 		}
+		if cfg.BucketStore.IndexHeaderCache.AttributesInMemoryMaxItems > 0 {
+			attributesCache, err = cache.WrapWithLRUCache(
+				attributesCache,
+				"block-index-header-attributes-cache",
+				prometheus.WrapRegistererWithPrefix("cortex_", reg),
+				cfg.BucketStore.IndexHeaderCache.AttributesInMemoryMaxItems,
+				cfg.BucketStore.IndexHeaderCache.AttributesTTL,
+				logger,
+			)
+			if err != nil {
+				return nil, errors.Wrapf(err, "wrap index-header attributes cache with in-memory cache")
+			}
+		}
+
 		if cfg.BucketStore.IndexHeaderCache.SubRangeInMemoryMaxItems > 0 {
 			indexHeaderCache, err = cache.WrapWithLRUCache(
 				indexHeaderCache,

--- a/pkg/storegateway/bucket_e2e_test.go
+++ b/pkg/storegateway/bucket_e2e_test.go
@@ -130,6 +130,9 @@ type prepareStoreConfig struct {
 	nonOverlappingBlocks bool
 	numBlocks            int
 	bucketStoreConfig    mimir_tsdb.BucketStoreConfig
+
+	// Optionally wrap objstore.Bucket for caching (e.g. NewStoreCachingBucket) or to inject test instrumentation.
+	wrapBucket func(tb testing.TB, bkt objstore.Bucket, logger log.Logger, reg prometheus.Registerer) (objstore.Bucket, error)
 }
 
 func (c *prepareStoreConfig) apply(opts ...prepareStoreConfigOption) *prepareStoreConfig {
@@ -204,10 +207,16 @@ func prepareStoreWithTestBlocks(t testing.TB, bkt objstore.Bucket, cfg *prepareS
 
 	const userID = "tenant"
 
+	storeBkt := bkt
+	if cfg.wrapBucket != nil {
+		storeBkt, err = cfg.wrapBucket(t, bkt, s.logger, s.metricsRegistry)
+		require.NoError(t, err)
+	}
+
 	const maxGapBytes = mimir_tsdb.DefaultPartitionerMaxGapSize
 	store, err := NewBucketStore(
 		userID,
-		objstore.WithNoopInstr(bkt),
+		objstore.WithNoopInstr(storeBkt),
 		newTestBucketIndexMetadataReader(t, bkt, userID),
 		metaFetcher,
 		cfg.tempDir,

--- a/pkg/storegateway/bucket_stores_test.go
+++ b/pkg/storegateway/bucket_stores_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/dskit/cache"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/services"
 	"github.com/oklog/ulid/v2"
@@ -44,6 +45,7 @@ import (
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/storage/bucket"
 	"github.com/grafana/mimir/pkg/storage/bucket/filesystem"
+	"github.com/grafana/mimir/pkg/storage/indexheader"
 	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
 	"github.com/grafana/mimir/pkg/storage/tsdb/indexcache"
@@ -662,8 +664,8 @@ func promLabels(m *storeTestSeries) labels.Labels {
 	return mimirpb.FromLabelAdaptersToLabels(m.Labels)
 }
 
-func prepareStorageConfig(t *testing.T) mimir_tsdb.BlocksStorageConfig {
-	tmpDir := t.TempDir()
+func prepareStorageConfig(tb testing.TB) mimir_tsdb.BlocksStorageConfig {
+	tmpDir := tb.TempDir()
 
 	cfg := mimir_tsdb.BlocksStorageConfig{}
 	flagext.DefaultValues(&cfg)
@@ -878,6 +880,19 @@ func (f *failFirstGetBucket) Get(ctx context.Context, name string) (io.ReadClose
 	return f.Bucket.Get(ctx, name)
 }
 
+func indexHeaderCachingBucket(
+	tb testing.TB, bkt objstore.Bucket, logger log.Logger, reg prometheus.Registerer,
+) (objstore.Bucket, error) {
+
+	// With a non-nil index-header cache, the default cache config will enable index-header caching.
+	indexHeaderCache := cache.NewMockCache()
+	blocksStorageCfg := prepareStorageConfig(tb)
+
+	return mimir_tsdb.NewStoreCachingBucket(
+		blocksStorageCfg, nil, indexHeaderCache, nil, bkt, logger, reg,
+	)
+}
+
 func BenchmarkBucketStoreLabelValues(tb *testing.B) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -893,136 +908,173 @@ func BenchmarkBucketStoreLabelValues(tb *testing.B) {
 	series = append(series, highCardinalitySeries...)
 	tb.Logf("Total %d series generated", len(series))
 
-	prepareCfg := defaultPrepareStoreConfig(tb)
-	prepareCfg.tempDir = dir
-	prepareCfg.series = series
-	prepareCfg.postingsStrategy = worstCaseFetchedDataStrategy{1.0}
-
-	s := prepareStoreWithTestBlocks(tb, bkt, prepareCfg)
-	mint, maxt := s.store.TimeRange()
-	assert.Equal(tb, s.minTime, mint)
-	assert.Equal(tb, s.maxTime, maxt)
-
-	indexCache, err := indexcache.NewInMemoryIndexCacheWithConfig(indexcache.InMemoryIndexCacheConfig{
-		MaxItemSizeBytes:  1e5,
-		MaxCacheSizeBytes: 2e5,
-	}, nil, s.logger)
-	assert.NoError(tb, err)
-
-	benchmarks := func(tb *testing.B) {
-		tb.Run("10-series-matched-with-10-label-values", func(tb *testing.B) {
-			ms, err := storepb.PromMatchersToMatchers(
-				labels.MustNewMatcher(labels.MatchEqual, "label_2", "0"),
-				labels.MustNewMatcher(labels.MatchEqual, "label_3", "0"),
-			)
-			require.NoError(tb, err)
-
-			req := &storepb.LabelValuesRequest{
-				Label:    "label_1",
-				Start:    timestamp.FromTime(minTime),
-				End:      timestamp.FromTime(maxTime),
-				Matchers: ms,
-			}
-			// warmup cache if any
-			resp, err := s.store.LabelValues(ctx, req)
-			require.NoError(tb, err)
-			assert.Equal(tb, 10, len(resp.Values))
-
-			tb.ResetTimer()
-			for i := 0; i < tb.N; i++ {
-				resp, err := s.store.LabelValues(ctx, req)
-				require.NoError(tb, err)
-				assert.Equal(tb, 10, len(resp.Values))
-			}
-		})
-
-		tb.Run("1000-series-matched-with-1000-label-values", func(tb *testing.B) {
-			ms, err := storepb.PromMatchersToMatchers(
-				labels.MustNewMatcher(labels.MatchEqual, "label_1", "0"),
-				labels.MustNewMatcher(labels.MatchEqual, "label_2", "0"),
-			)
-			require.NoError(tb, err)
-
-			req := &storepb.LabelValuesRequest{
-				Label:    "label_3",
-				Start:    timestamp.FromTime(minTime),
-				End:      timestamp.FromTime(maxTime),
-				Matchers: ms,
-			}
-
-			// warmup cache if any
-			resp, err := s.store.LabelValues(ctx, req)
-			require.NoError(tb, err)
-			assert.Equal(tb, 1000, len(resp.Values))
-
-			tb.ResetTimer()
-			for i := 0; i < tb.N; i++ {
-				resp, err := s.store.LabelValues(ctx, req)
-				require.NoError(tb, err)
-				assert.Equal(tb, 1000, len(resp.Values))
-			}
-		})
-
-		tb.Run("1_000_000-series-matched-with-10-label-values", func(tb *testing.B) {
-			ms, err := storepb.PromMatchersToMatchers(
-				labels.MustNewMatcher(labels.MatchEqual, "label_0", "0"), // matches all series
-			)
-			require.NoError(tb, err)
-
-			req := &storepb.LabelValuesRequest{
-				Label:    "label_1",
-				Start:    timestamp.FromTime(minTime),
-				End:      timestamp.FromTime(maxTime),
-				Matchers: ms,
-			}
-			// warmup cache if any
-			resp, err := s.store.LabelValues(ctx, req)
-			require.NoError(tb, err)
-			assert.Equal(tb, 10, len(resp.Values))
-
-			tb.ResetTimer()
-			for i := 0; i < tb.N; i++ {
-				resp, err := s.store.LabelValues(ctx, req)
-				require.NoError(tb, err)
-				assert.Equal(tb, 10, len(resp.Values))
-			}
-		})
-
-		tb.Run("1_000_000-series-matched-with-1-label-values", func(tb *testing.B) {
-			ms, err := storepb.PromMatchersToMatchers(
-				labels.MustNewMatcher(labels.MatchEqual, "high_cardinality_label_1", "0"),   // matches a single series
-				labels.MustNewMatcher(labels.MatchNotEqual, "high_cardinality_label_0", ""), // matches 1M series
-			)
-			require.NoError(tb, err)
-
-			req := &storepb.LabelValuesRequest{
-				Label:    "high_cardinality_label_0", // there is only 1 value for this label
-				Start:    timestamp.FromTime(minTime),
-				End:      timestamp.FromTime(maxTime),
-				Matchers: ms,
-			}
-			// warmup cache if any
-			resp, err := s.store.LabelValues(ctx, req)
-			require.NoError(tb, err)
-			assert.Equal(tb, 1, len(resp.Values))
-
-			tb.ResetTimer()
-			for i := 0; i < tb.N; i++ {
-				resp, err := s.store.LabelValues(ctx, req)
-				require.NoError(tb, err)
-				assert.Equal(tb, 1, len(resp.Values))
-			}
-		})
+	bucketPostingsOffsets := indexheader.BucketReaderConfig{
+		Enabled:             true,
+		BucketIndexSections: indexheader.SectionPostingsOffsetsTable,
 	}
 
-	tb.Run("no cache", func(tb *testing.B) {
-		s.cache.SwapIndexCacheWith(noopCache{})
-		benchmarks(tb)
+	storeConfigs := []struct {
+		name            string
+		bucketReaderCfg indexheader.BucketReaderConfig
+		wrapBucket      func(tb testing.TB, bkt objstore.Bucket, logger log.Logger, reg prometheus.Registerer) (objstore.Bucket, error)
+	}{
+		{
+			name:            "Reader=disk",
+			bucketReaderCfg: indexheader.BucketReaderConfig{},
+		},
+		{
+			name:            "Reader=bucket/BucketCache=off",
+			bucketReaderCfg: bucketPostingsOffsets,
+		},
+		{
+			name:            "Reader=bucket/BucketCache=index-header",
+			bucketReaderCfg: bucketPostingsOffsets,
+			wrapBucket:      indexHeaderCachingBucket,
+		},
+	}
+
+	for _, storeCfg := range storeConfigs {
+		tb.Run(storeCfg.name, func(tb *testing.B) {
+			dir := tb.TempDir()
+
+			bkt, err := filesystemstore.NewBucket(filepath.Join(dir, "bkt"))
+			assert.NoError(tb, err)
+			defer func() { assert.NoError(tb, bkt.Close()) }()
+
+			prepareCfg := defaultPrepareStoreConfig(tb)
+			prepareCfg.tempDir = dir
+			prepareCfg.series = series
+			prepareCfg.postingsStrategy = worstCaseFetchedDataStrategy{1.0}
+			prepareCfg.bucketStoreConfig.IndexHeader.BucketReader = storeCfg.bucketReaderCfg
+			prepareCfg.wrapBucket = storeCfg.wrapBucket
+
+			s := prepareStoreWithTestBlocks(tb, bkt, prepareCfg)
+			mint, maxt := s.store.TimeRange()
+			assert.Equal(tb, s.minTime, mint)
+			assert.Equal(tb, s.maxTime, maxt)
+
+			indexCache, err := indexcache.NewInMemoryIndexCacheWithConfig(indexcache.InMemoryIndexCacheConfig{
+				MaxItemSizeBytes:  1e5,
+				MaxCacheSizeBytes: 2e5,
+			}, nil, s.logger)
+			assert.NoError(tb, err)
+
+			tb.Run("no cache", func(tb *testing.B) {
+				s.cache.SwapIndexCacheWith(noopCache{})
+				benchmarkBucketStoreLabelValues(ctx, tb, s.store)
+			})
+
+			tb.Run("inmemory cache (without label values cache)", func(tb *testing.B) {
+				s.cache.SwapIndexCacheWith(indexCacheMissingLabelValues{indexCache})
+				benchmarkBucketStoreLabelValues(ctx, tb, s.store)
+			})
+		})
+	}
+}
+
+func benchmarkBucketStoreLabelValues(ctx context.Context, tb *testing.B, store *BucketStore) {
+	tb.Run("10-series-matched-with-10-label-values", func(tb *testing.B) {
+		ms, err := storepb.PromMatchersToMatchers(
+			labels.MustNewMatcher(labels.MatchEqual, "label_2", "0"),
+			labels.MustNewMatcher(labels.MatchEqual, "label_3", "0"),
+		)
+		require.NoError(tb, err)
+
+		req := &storepb.LabelValuesRequest{
+			Label:    "label_1",
+			Start:    timestamp.FromTime(minTime),
+			End:      timestamp.FromTime(maxTime),
+			Matchers: ms,
+		}
+		// warmup cache if any
+		resp, err := store.LabelValues(ctx, req)
+		require.NoError(tb, err)
+		assert.Equal(tb, 10, len(resp.Values))
+
+		tb.ResetTimer()
+		for i := 0; i < tb.N; i++ {
+			resp, err := store.LabelValues(ctx, req)
+			require.NoError(tb, err)
+			assert.Equal(tb, 10, len(resp.Values))
+		}
 	})
 
-	tb.Run("inmemory cache (without label values cache)", func(tb *testing.B) {
-		s.cache.SwapIndexCacheWith(indexCacheMissingLabelValues{indexCache})
-		benchmarks(tb)
+	tb.Run("1000-series-matched-with-1000-label-values", func(tb *testing.B) {
+		ms, err := storepb.PromMatchersToMatchers(
+			labels.MustNewMatcher(labels.MatchEqual, "label_1", "0"),
+			labels.MustNewMatcher(labels.MatchEqual, "label_2", "0"),
+		)
+		require.NoError(tb, err)
+
+		req := &storepb.LabelValuesRequest{
+			Label:    "label_3",
+			Start:    timestamp.FromTime(minTime),
+			End:      timestamp.FromTime(maxTime),
+			Matchers: ms,
+		}
+
+		// warmup cache if any
+		resp, err := store.LabelValues(ctx, req)
+		require.NoError(tb, err)
+		assert.Equal(tb, 1000, len(resp.Values))
+
+		tb.ResetTimer()
+		for i := 0; i < tb.N; i++ {
+			resp, err := store.LabelValues(ctx, req)
+			require.NoError(tb, err)
+			assert.Equal(tb, 1000, len(resp.Values))
+		}
+	})
+
+	tb.Run("1_000_000-series-matched-with-10-label-values", func(tb *testing.B) {
+		ms, err := storepb.PromMatchersToMatchers(
+			labels.MustNewMatcher(labels.MatchEqual, "label_0", "0"), // matches all series
+		)
+		require.NoError(tb, err)
+
+		req := &storepb.LabelValuesRequest{
+			Label:    "label_1",
+			Start:    timestamp.FromTime(minTime),
+			End:      timestamp.FromTime(maxTime),
+			Matchers: ms,
+		}
+		// warmup cache if any
+		resp, err := store.LabelValues(ctx, req)
+		require.NoError(tb, err)
+		assert.Equal(tb, 10, len(resp.Values))
+
+		tb.ResetTimer()
+		for i := 0; i < tb.N; i++ {
+			resp, err := store.LabelValues(ctx, req)
+			require.NoError(tb, err)
+			assert.Equal(tb, 10, len(resp.Values))
+		}
+	})
+
+	tb.Run("1_000_000-series-matched-with-1-label-values", func(tb *testing.B) {
+		ms, err := storepb.PromMatchersToMatchers(
+			labels.MustNewMatcher(labels.MatchEqual, "high_cardinality_label_1", "0"),   // matches a single series
+			labels.MustNewMatcher(labels.MatchNotEqual, "high_cardinality_label_0", ""), // matches 1M series
+		)
+		require.NoError(tb, err)
+
+		req := &storepb.LabelValuesRequest{
+			Label:    "high_cardinality_label_0", // there is only 1 value for this label
+			Start:    timestamp.FromTime(minTime),
+			End:      timestamp.FromTime(maxTime),
+			Matchers: ms,
+		}
+		// warmup cache if any
+		resp, err := store.LabelValues(ctx, req)
+		require.NoError(tb, err)
+		assert.Equal(tb, 1, len(resp.Values))
+
+		tb.ResetTimer()
+		for i := 0; i < tb.N; i++ {
+			resp, err := store.LabelValues(ctx, req)
+			require.NoError(tb, err)
+			assert.Equal(tb, 1, len(resp.Values))
+		}
 	})
 }
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

During performance testing of the index-header bucket reader, we found that a significant source of LabelValues latency was in `cachedGetAttributes`, with the caching bucket doing a lot of Memcached i/o.
The adds the in-memory LRU wrapper to that attributes caching which saves significant latency at the cost of very little memory.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Experimental store-gateway caching only; behavior mirrors an existing chunks-cache pattern with tunable defaults and no auth or data-path semantics changes.
> 
> **Overview**
> Adds an **experimental** first-level in-memory LRU in front of the index-header **object attributes** cache path used by the bucket index-header reader (same idea as the existing subrange in-memory wrapper and chunks attributes cache).
> 
> When index-header caching is enabled, attribute lookups now hit an in-process LRU (default **10,000** items, TTL from `attributes-ttl`) before the metadata or index-header backend. Setting **`attributes-in-memory-max-items` to 0** disables that layer. Config is wired through `IndexHeaderCacheConfig`, CLI/YAML, and regenerated docs/defaults.
> 
> Store-gateway tests gain optional **`wrapBucket`** for `NewStoreCachingBucket` in e2e setup, and **`BenchmarkBucketStoreLabelValues`** is split to compare disk reader, bucket reader without cache, and bucket reader with index-header caching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7502067d671dcd354272d5657e3c1d0294b7a33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->