### PR TITLE
Remove unused usage tracker query selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Mixin
 
 * [ENHANCEMENT] Alerts: Make `MimirInconsistentRuntimeConfig` alert less flaky when performing multiple configuration changes in a row in a large Kubernetes cluster. #15257
+* [ENHANCEMENT] Dashboards: Break the "Usage Tracker" row "Requests / sec" panel in the "Mimir / Writes" dashboard out into separate non-batch (Sync) and batch (Async) `TrackSeries` routes. #15579
 * [BUGFIX] Dashboards: Fix usage tracker row in "Mimir / Writes" dashboard to include both `TrackSeries` and `TrackSeriesBatch` routes. #15289
 
 ### Jsonnet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Mixin
 
 * [ENHANCEMENT] Alerts: Make `MimirInconsistentRuntimeConfig` alert less flaky when performing multiple configuration changes in a row in a large Kubernetes cluster. #15257
+* [BUGFIX] Dashboards: Fix usage tracker row in "Mimir / Writes" dashboard to include both `TrackSeries` and `TrackSeriesBatch` routes. #15289
 
 ### Jsonnet
 

--- a/operations/mimir-mixin/dashboards/dashboard-queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-queries.libsonnet
@@ -123,6 +123,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
       readGRPCStoreGatewayRoute: $.queries.read_grpc_store_gateway_route,
       rulerQueryFrontendRoutesRegex: $.queries.ruler_query_frontend_routes_regex,
       usageTrackerTrackSeriesRoutesRegex: $.queries.usage_tracker_track_series_routes_regex,
+      usageTrackerTrackSeriesSyncRouteRegex: $.queries.usage_tracker_track_series_sync_route_regex,
+      usageTrackerTrackSeriesBatchRouteRegex: $.queries.usage_tracker_track_series_batch_route_regex,
       usageTrackerGetUsersCloseToLimitRoutesRegex: $.queries.usage_tracker_get_users_close_to_limit_routes_regex,
       perClusterLabel: $._config.per_cluster_label,
       recordingRulePrefix: $.recordingRulePrefix($.jobSelector('any')),  // The job name does not matter here.
@@ -148,6 +150,10 @@ local utils = import 'mixin-utils/utils.libsonnet';
     // Both support gRPC and HTTP requests. HTTP request is used when rule evaluation query requests go through the query-tee.
     ruler_query_frontend_routes_regex: '/httpgrpc.HTTP/Handle|.*api_v1_query',
     usage_tracker_track_series_routes_regex: '/usagetrackerpb.UsageTracker/TrackSeries(Batch)?',
+    // Non-batch (synchronous) and batch (asynchronous) variants of the TrackSeries route, matched separately
+    // because non-batch requests are significantly more CPU intensive than batch ones.
+    usage_tracker_track_series_sync_route_regex: '/usagetrackerpb.UsageTracker/TrackSeries',
+    usage_tracker_track_series_batch_route_regex: '/usagetrackerpb.UsageTracker/TrackSeriesBatch',
     usage_tracker_get_users_close_to_limit_routes_regex: '/usagetrackerpb.UsageTracker/GetUsersCloseToLimit',
 
     gateway: {
@@ -184,6 +190,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
       requestsPerSecondMetric: $.queries.requests_per_second_metric,
       trackSeriesRequestsPerSecondRouteRegex: '%(usageTrackerTrackSeriesRoutesRegex)s' % variables,
       trackSeriesRequestsPerSecondSelector: '%(usageTrackerMatcher)s, route=~"%(usageTrackerTrackSeriesRoutesRegex)s"' % variables,
+      trackSeriesSyncRequestsPerSecondSelector: '%(usageTrackerMatcher)s, route=~"%(usageTrackerTrackSeriesSyncRouteRegex)s"' % variables,
+      trackSeriesBatchRequestsPerSecondSelector: '%(usageTrackerMatcher)s, route=~"%(usageTrackerTrackSeriesBatchRouteRegex)s"' % variables,
       getUsersCloseToLimitRequestsPerSecondRouteRegex: '%(usageTrackerGetUsersCloseToLimitRoutesRegex)s' % variables,
       getUsersCloseToLimitRequestsPerSecondSelector: '%(usageTrackerMatcher)s, route=~"%(usageTrackerGetUsersCloseToLimitRoutesRegex)s"' % variables,
 

--- a/operations/mimir-mixin/dashboards/dashboard-queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-queries.libsonnet
@@ -147,7 +147,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     alertmanager_grpc_routes_regex: '/alertmanagerpb.Alertmanager/HandleRequest',
     // Both support gRPC and HTTP requests. HTTP request is used when rule evaluation query requests go through the query-tee.
     ruler_query_frontend_routes_regex: '/httpgrpc.HTTP/Handle|.*api_v1_query',
-    usage_tracker_track_series_routes_regex: '/usagetrackerpb.UsageTracker/TrackSeries',
+    usage_tracker_track_series_routes_regex: '/usagetrackerpb.UsageTracker/TrackSeries(Batch)?',
     usage_tracker_get_users_close_to_limit_routes_regex: '/usagetrackerpb.UsageTracker/GetUsersCloseToLimit',
 
     gateway: {

--- a/operations/mimir-mixin/dashboards/dashboard-queries.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-queries.libsonnet
@@ -189,7 +189,6 @@ local utils = import 'mixin-utils/utils.libsonnet';
       clientRequestsPerSecondMetric: 'cortex_usage_tracker_client_track_series_duration_seconds',
       requestsPerSecondMetric: $.queries.requests_per_second_metric,
       trackSeriesRequestsPerSecondRouteRegex: '%(usageTrackerTrackSeriesRoutesRegex)s' % variables,
-      trackSeriesRequestsPerSecondSelector: '%(usageTrackerMatcher)s, route=~"%(usageTrackerTrackSeriesRoutesRegex)s"' % variables,
       trackSeriesSyncRequestsPerSecondSelector: '%(usageTrackerMatcher)s, route=~"%(usageTrackerTrackSeriesSyncRouteRegex)s"' % variables,
       trackSeriesBatchRequestsPerSecondSelector: '%(usageTrackerMatcher)s, route=~"%(usageTrackerTrackSeriesBatchRouteRegex)s"' % variables,
       getUsersCloseToLimitRequestsPerSecondRouteRegex: '%(usageTrackerGetUsersCloseToLimitRoutesRegex)s' % variables,

--- a/operations/mimir-mixin/dashboards/writes.libsonnet
+++ b/operations/mimir-mixin/dashboards/writes.libsonnet
@@ -332,8 +332,38 @@ local filename = 'mimir-writes.json';
       $._config.usage_tracker_enabled,
       $.row('Usage Tracker')
       .addPanel(
-        $.timeseriesPanel('Requests / sec') +
-        $.qpsPanelNativeHistogram($.queries.usage_tracker.requestsPerSecondMetric, $.queries.usage_tracker.trackSeriesRequestsPerSecondSelector)
+        local title = 'Requests / sec';
+        // Break the non-batch (Sync) and batch (Async) TrackSeries routes out into separate series,
+        // mirroring the Sync/Async split in the "Client req / sec" panel above. Non-batch requests
+        // are significantly more CPU intensive than batch ones, so keeping them separate is useful.
+        local syncPanel = $.qpsPanelNativeHistogram($.queries.usage_tracker.requestsPerSecondMetric, $.queries.usage_tracker.trackSeriesSyncRequestsPerSecondSelector);
+        local batchPanel = $.qpsPanelNativeHistogram($.queries.usage_tracker.requestsPerSecondMetric, $.queries.usage_tracker.trackSeriesBatchRequestsPerSecondSelector);
+        $.timeseriesPanel(title) +
+        syncPanel +
+        {
+          // Prefix the non-batch (Sync) target legends and append the batch (Async) targets.
+          targets: [
+            t { legendFormat: 'Sync ' + t.legendFormat }
+            for t in syncPanel.targets
+          ] + [
+            t { legendFormat: 'Async ' + t.legendFormat, refId: t.refId + '_batch' }
+            for t in batchPanel.targets
+          ],
+        } +
+        $.aliasColors({
+          ['Sync ' + name]: $.qpsPanelColors[name]
+          for name in std.objectFields($.qpsPanelColors)
+        } + {
+          ['Async ' + name]: $.qpsPanelColors[name]
+          for name in std.objectFields($.qpsPanelColors)
+        }) +
+        $.panelDescription(
+          title,
+          |||
+            The number of TrackSeries requests received by the Usage Tracker service, broken down into the non-batch (Sync) and batch (Async) routes.
+            Non-batch requests are significantly more CPU intensive than batch ones.
+          |||
+        )
       )
       .addPanel(
         $.timeseriesPanel('Latency') +


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### What this PR does

Removes the now-unused `trackSeriesRequestsPerSecondSelector` query property from the usage tracker dashboard query definitions.

#### Which issue(s) this PR fixes or relates to

Relates to cleanup feedback on commit `2e78dfee9d2927d47f25ed41c469cce1cddf15ee`.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e73a7c19-1575-4d8a-952b-945b903bd378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e73a7c19-1575-4d8a-952b-945b903bd378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

