### PR TITLE
query-frontend: fix cardinality_analysis_max_results handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [ENHANCEMENT] Memberlist: Reduce per-call allocations on the compression and TCP state-sync receive paths via internal buffer pools. #15357
 * [ENHANCEMENT] Memberlist: Add `memberlist.processed-messages-queue-size` flag to set the size of the per-key internal queue for processing messages received from other nodes. Increasing this value may help to avoid dropping per-key updates when the node is processing many updates for the same key. #15536
 * [ENHANCEMENT] MQE: Respect the `Cache-Control: no-store` request header when caching intermediate results for range vector splitting. #15148
+* [BUGFIX] Query-frontend: Fix `cardinality_analysis_max_results` being ignored when set higher than the default of 500. #15581
 * [BUGFIX] Ingest storage: Fix `KafkaProducer.ProduceSync()` returning a single result with a nil record when the context is canceled, instead of one result per input record (with the record set) as the underlying franz-go client does. #15199
 * [BUGFIX] Ingest storage: Fix `cortex_ingest_storage_reader_receive_delay_seconds` inflation by no longer setting the Kafka record `Timestamp` on the distributor side; the Kafka client now sets it at produce time. #15572
 * [BUGFIX] Distributor: Return HTTP 200 with OTLP partial-success when only some samples in an OTLP request are rejected by distributor-level validation (e.g. `too_far_in_past`). #15253

--- a/pkg/cardinality/request.go
+++ b/pkg/cardinality/request.go
@@ -232,14 +232,11 @@ func extractLimit(values url.Values, tenantMaxLimit int) (limit int, err error) 
 		return 0, fmt.Errorf("'limit' param cannot be less than '%v'", minLimit)
 	}
 
-	// Use the tenant-specific limit from Overrides if available
-	if tenantMaxLimit == 0 {
-		tenantMaxLimit = maxLimit
-	}
-
-	if limit > tenantMaxLimit {
+	// Use the tenant-specific limit from overrides if available.
+	if tenantMaxLimit > 0 && limit > tenantMaxLimit {
 		return 0, fmt.Errorf("'limit' param cannot be greater than '%v'", tenantMaxLimit)
 	}
+
 	return limit, nil
 }
 


### PR DESCRIPTION
#### What this PR does

This PR updates internals of `cardinality` package to only check tenant max limit when one is configured. The net result of the changes is that QFE won't cap the `limit` parameter with default 500. Instead, the request will be propagated to queriers, who already check the mentioned `limit` against the tenant's override ([also default to 500][1]).

#### Which issue(s) this PR fixes or relates to

Fixes #15520 

[1]: https://github.com/grafana/mimir/blob/7e49b242db829ab87d25fe20989992e7a153a7d4/pkg/util/validation/limits.go#L429