### PR TITLE
Alertmanager: fix dispatcher goroutine/memory leak

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/opentracing-contrib/go-stdlib v1.1.2-0.20260528155411-f102363ff79b // indirect
 	github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b
 	github.com/pkg/errors v0.9.1
-	github.com/prometheus/alertmanager v0.32.1
+	github.com/prometheus/alertmanager v0.32.2
 	github.com/prometheus/client_golang v1.23.3-0.20260305100053-48a6770e980b
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.67.5

--- a/go.sum
+++ b/go.sum
@@ -890,8 +890,8 @@ github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSg
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 h1:o4JXh1EVt9k/+g42oCprj/FisM4qX9L3sZB3upGN2ZU=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7/go.mod h1:YARuvh7BUWHNhzDq2OM5tzR2RiCcN2D7sapiKyCel/M=
-github.com/prometheus/alertmanager v0.32.1 h1:BQ3jHXNq2A7VSD9Kh0Qx+kXbifNbHSDuKVbMmdRHHJ0=
-github.com/prometheus/alertmanager v0.32.1/go.mod h1:0Dy9faTtMgpVYxJVxV0o65elTxHnSRCF/7gy5BKGZiE=
+github.com/prometheus/alertmanager v0.32.2 h1:R09NCbM6mN+gh7bz2kABop6cW9JSaikMcotaINmyvec=
+github.com/prometheus/alertmanager v0.32.2/go.mod h1:0Dy9faTtMgpVYxJVxV0o65elTxHnSRCF/7gy5BKGZiE=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.4.0/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3OK1iX/F2sw+iXX5zU=

--- a/vendor/github.com/prometheus/alertmanager/dispatch/dispatch.go
+++ b/vendor/github.com/prometheus/alertmanager/dispatch/dispatch.go
@@ -317,9 +317,14 @@ func (d *Dispatcher) doMaintenance() {
 			ag := el.(*aggrGroup)
 			if ag.destroyed() {
 				ag.stop()
-				d.marker.DeleteByGroupKey(ag.routeID, ag.GroupKey())
 				deleted := d.routeGroupsSlice[i].groups.CompareAndDelete(ag.fingerprint(), ag)
 				if deleted {
+					// TODO(ultrotter, siavash):
+					// Deletion from the marker should only happen if we really deleted the group.
+					// Fully fixing the case where a new group with the same fingerprint is created between
+					// CompareAndDelete and DeleteByGroupKey would require changes to the marker interface,
+					// so we leave it as a fix for after landing the pending marker changes.
+					d.marker.DeleteByGroupKey(ag.routeID, ag.GroupKey())
 					d.routeGroupsSlice[i].groupsLen.Add(-1)
 					d.aggrGroupsNum.Add(-1)
 					d.metrics.aggrGroups.Set(float64(d.aggrGroupsNum.Load()))
@@ -516,6 +521,9 @@ func (d *Dispatcher) groupAlert(ctx context.Context, alert *types.Alert, route *
 			// Try to store the new group in the map. If another goroutine has already created the same group, use the existing one.
 			swapped := d.routeGroupsSlice[route.Idx].groups.CompareAndSwap(fp, el, ag)
 			if swapped {
+				// Since we swapped the new group in, we need to cancel the old one,
+				// as doMaintenance will not be able to find it in the map anymore.
+				el.(*aggrGroup).cancel()
 				// We swapped the new group in, we can break and start it.
 				break
 			}
@@ -734,6 +742,11 @@ func (ag *aggrGroup) run(nf notifyFunc) {
 			})
 
 			cancel()
+
+			// If destroyed, exit: this particular alert group won't be used anymore.
+			if ag.destroyed() {
+				return
+			}
 
 		case <-ag.ctx.Done():
 			return

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1044,7 +1044,7 @@ github.com/pmezard/go-difflib/difflib
 # github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55
 ## explicit; go 1.14
 github.com/power-devops/perfstat
-# github.com/prometheus/alertmanager v0.32.1
+# github.com/prometheus/alertmanager v0.32.2
 ## explicit; go 1.25.0
 github.com/prometheus/alertmanager/alert
 github.com/prometheus/alertmanager/api


### PR DESCRIPTION
Update prometheus/alertmanager from [0.32.1->0.32.2](https://github.com/prometheus/alertmanager/compare/v0.32.1...v0.32.2)

Contains a single relevant commit that fixes a goroutine/memory leak: [dispatcher: fix goroutines leak on swap](https://github.com/prometheus/alertmanager/commit/54b1aecdad9e65615b25999e6187d99155bce7dd)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency patch with targeted lifecycle fixes in alert routing; no Mimir application code changes beyond vendoring and changelog.
> 
> **Overview**
> Bumps the embedded **`prometheus/alertmanager`** dependency from **v0.32.1** to **v0.32.2** (vendor + `go.mod`/`go.sum`) and documents the fix in **CHANGELOG**.
> 
> The upstream change addresses a **dispatcher goroutine/memory leak** when aggregation groups are replaced or torn down: on a successful group **CompareAndSwap**, the replaced group is **cancelled** so its `run()` loop stops; **maintenance** only removes marker entries after the group is actually deleted from the map; and the group **run** loop bails out if the group is already **destroyed** after a notification attempt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e94d869550553cb760cf0ad6ddb49878bb319fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->