### PR TITLE
ci: migrate update-vendored-mimir-prometheus slack call to send-slack-message v3

### DIFF
--- a/.github/workflows/update-vendored-mimir-prometheus.yml
+++ b/.github/workflows/update-vendored-mimir-prometheus.yml
@@ -180,10 +180,11 @@ jobs:
 
       - name: Send Slack notification on failure
         if: failure()
-        uses: grafana/shared-workflows/actions/send-slack-message@7b628e7352c2dea057c565cc4fcd5564d5f396c0 # v1.0.0
+        uses: grafana/shared-workflows/actions/send-slack-message@952ec381447a2002ff76103395d37bf8b4c7c3f5 # send-slack-message/v3.0.1
         with:
-          channel-id: C04AF91LPFX #mimir-ci-notifications
+          method: chat.postMessage
           payload: |
             {
+              "channel": "C04AF91LPFX",
               "text": ":sadcomputer: *Automated vendoring of mimir-prometheus into Mimir has failed.*\n<!subteam^S03C2P8659U> please check the <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow logs> and coordinate fixes for any issues."
             }


### PR DESCRIPTION
v1.0.0 of grafana/shared-workflows/actions/send-slack-message is broken since grafana/shared-workflows#1957 (merged 2026-06-04) — get-vault-secrets stopped exporting env vars, v1.0.0 reads env.SLACK_BOT_TOKEN. v3.0.1 pins get-vault-secrets transitively via a checkout-and-relative-path dance. channel-id moved into the JSON payload.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change for failure Slack alerts; no application or runtime behavior is affected.
> 
> **Overview**
> Fixes the **Send Slack notification on failure** step in `update-vendored-mimir-prometheus.yml` by upgrading `grafana/shared-workflows/actions/send-slack-message` from **v1.0.0** to **v3.0.1**, which restores Slack auth after upstream `get-vault-secrets` stopped exporting env vars that v1 relied on.
> 
> The step now sets **`method: chat.postMessage`** and passes the target room as **`"channel": "C04AF91LPFX"`** inside the JSON **payload** instead of the separate **`channel-id`** input. The failure message text and `#mimir-ci-notifications` destination are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7535b02270b590c65c7436a5dab529276df8e4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->