### PR TITLE
MQE: add node-gen code generator for SetChildren method

### DIFF
--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/node.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/node.go
@@ -42,16 +42,6 @@ func (d *Duplicate) NodeType() planning.NodeType {
 	return planning.NODE_TYPE_DUPLICATE
 }
 
-func (d *Duplicate) SetChildren(children []planning.Node) error {
-	if len(children) != 1 {
-		return fmt.Errorf("node of type Duplicate supports 1 child, but got %d", len(children))
-	}
-
-	d.Inner = children[0]
-
-	return nil
-}
-
 func (d *Duplicate) ReplaceChild(idx int, node planning.Node) error {
 	if idx != 0 {
 		return fmt.Errorf("node of type Duplicate supports 1 child, but attempted to replace child at index %d", idx)
@@ -176,14 +166,6 @@ func (f *DuplicateFilter) Details() proto.Message {
 
 func (f *DuplicateFilter) NodeType() planning.NodeType {
 	return planning.NODE_TYPE_DUPLICATE_FILTER
-}
-
-func (f *DuplicateFilter) SetChildren(children []planning.Node) error {
-	if len(children) != 1 {
-		return fmt.Errorf("node of type DuplicateFilter supports 1 child, but got %d", len(children))
-	}
-
-	return f.ReplaceChild(0, children[0])
 }
 
 func (f *DuplicateFilter) ReplaceChild(idx int, node planning.Node) error {

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/node_gen.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/node_gen.go
@@ -24,7 +24,6 @@ func (d *Duplicate) SetChildren(children []planning.Node) error {
 	if len(children) != 1 {
 		return fmt.Errorf("node of type Duplicate expects one child, but got %d", len(children))
 	}
-
 	d.Inner = children[0]
 	return nil
 }
@@ -44,10 +43,9 @@ func (d *DuplicateFilter) SetChildren(children []planning.Node) error {
 	if len(children) != 1 {
 		return fmt.Errorf("node of type DuplicateFilter expects one child, but got %d", len(children))
 	}
-
 	child0, ok := children[0].(*Duplicate)
 	if !ok {
-		return fmt.Errorf("node of type DuplicateFilter expects child 0 to be of type *Duplicate, but got %T", children[0])
+		return fmt.Errorf("node of type DuplicateFilter expects child Inner to be of type *Duplicate, but got %T", children[0])
 	}
 	d.Inner = child0
 	return nil

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/node_gen.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/node_gen.go
@@ -20,6 +20,15 @@ func (d *Duplicate) ChildCount() int {
 	return 1
 }
 
+func (d *Duplicate) SetChildren(children []planning.Node) error {
+	if len(children) != 1 {
+		return fmt.Errorf("node of type Duplicate expects one child, but got %d", len(children))
+	}
+
+	d.Inner = children[0]
+	return nil
+}
+
 func (d *DuplicateFilter) Child(idx int) planning.Node {
 	if idx != 0 {
 		panic(fmt.Sprintf("node of type DuplicateFilter supports 1 child, but attempted to get child at index %d", idx))
@@ -29,4 +38,17 @@ func (d *DuplicateFilter) Child(idx int) planning.Node {
 
 func (d *DuplicateFilter) ChildCount() int {
 	return 1
+}
+
+func (d *DuplicateFilter) SetChildren(children []planning.Node) error {
+	if len(children) != 1 {
+		return fmt.Errorf("node of type DuplicateFilter expects one child, but got %d", len(children))
+	}
+
+	child0, ok := children[0].(*Duplicate)
+	if !ok {
+		return fmt.Errorf("node of type DuplicateFilter expects child 0 to be of type *Duplicate, but got %T", children[0])
+	}
+	d.Inner = child0
+	return nil
 }

--- a/pkg/streamingpromql/optimize/plan/multiaggregation/node.go
+++ b/pkg/streamingpromql/optimize/plan/multiaggregation/node.go
@@ -41,15 +41,6 @@ func (g *MultiAggregationGroup) NodeType() planning.NodeType {
 	return planning.NODE_TYPE_MULTI_AGGREGATION_GROUP
 }
 
-func (g *MultiAggregationGroup) SetChildren(children []planning.Node) error {
-	if len(children) != 1 {
-		return fmt.Errorf("node of type MultiAggregationGroup supports 1 child, but got %d", len(children))
-	}
-
-	g.Inner = children[0]
-	return nil
-}
-
 func (g *MultiAggregationGroup) ReplaceChild(idx int, node planning.Node) error {
 	if idx != 0 {
 		return fmt.Errorf("node of type MultiAggregationGroup supports 1 child, but attempted to replace child at index %d", idx)
@@ -114,14 +105,6 @@ func (a *MultiAggregationInstance) Details() proto.Message {
 
 func (a *MultiAggregationInstance) NodeType() planning.NodeType {
 	return planning.NODE_TYPE_MULTI_AGGREGATION_INSTANCE
-}
-
-func (a *MultiAggregationInstance) SetChildren(children []planning.Node) error {
-	if len(children) != 1 {
-		return fmt.Errorf("node of type MultiAggregationInstance supports 1 child, but got %d", len(children))
-	}
-
-	return a.ReplaceChild(0, children[0])
 }
 
 func (a *MultiAggregationInstance) ReplaceChild(idx int, node planning.Node) error {

--- a/pkg/streamingpromql/optimize/plan/multiaggregation/node_gen.go
+++ b/pkg/streamingpromql/optimize/plan/multiaggregation/node_gen.go
@@ -20,6 +20,15 @@ func (m *MultiAggregationGroup) ChildCount() int {
 	return 1
 }
 
+func (m *MultiAggregationGroup) SetChildren(children []planning.Node) error {
+	if len(children) != 1 {
+		return fmt.Errorf("node of type MultiAggregationGroup expects one child, but got %d", len(children))
+	}
+
+	m.Inner = children[0]
+	return nil
+}
+
 func (m *MultiAggregationInstance) Child(idx int) planning.Node {
 	if idx != 0 {
 		panic(fmt.Sprintf("node of type MultiAggregationInstance supports 1 child, but attempted to get child at index %d", idx))
@@ -29,4 +38,17 @@ func (m *MultiAggregationInstance) Child(idx int) planning.Node {
 
 func (m *MultiAggregationInstance) ChildCount() int {
 	return 1
+}
+
+func (m *MultiAggregationInstance) SetChildren(children []planning.Node) error {
+	if len(children) != 1 {
+		return fmt.Errorf("node of type MultiAggregationInstance expects one child, but got %d", len(children))
+	}
+
+	child0, ok := children[0].(*MultiAggregationGroup)
+	if !ok {
+		return fmt.Errorf("node of type MultiAggregationInstance expects child 0 to be of type *MultiAggregationGroup, but got %T", children[0])
+	}
+	m.Group = child0
+	return nil
 }

--- a/pkg/streamingpromql/optimize/plan/multiaggregation/node_gen.go
+++ b/pkg/streamingpromql/optimize/plan/multiaggregation/node_gen.go
@@ -24,7 +24,6 @@ func (m *MultiAggregationGroup) SetChildren(children []planning.Node) error {
 	if len(children) != 1 {
 		return fmt.Errorf("node of type MultiAggregationGroup expects one child, but got %d", len(children))
 	}
-
 	m.Inner = children[0]
 	return nil
 }
@@ -44,10 +43,9 @@ func (m *MultiAggregationInstance) SetChildren(children []planning.Node) error {
 	if len(children) != 1 {
 		return fmt.Errorf("node of type MultiAggregationInstance expects one child, but got %d", len(children))
 	}
-
 	child0, ok := children[0].(*MultiAggregationGroup)
 	if !ok {
-		return fmt.Errorf("node of type MultiAggregationInstance expects child 0 to be of type *MultiAggregationGroup, but got %T", children[0])
+		return fmt.Errorf("node of type MultiAggregationInstance expects child Group to be of type *MultiAggregationGroup, but got %T", children[0])
 	}
 	m.Group = child0
 	return nil

--- a/pkg/streamingpromql/optimize/plan/rangevectorsplitting/node.go
+++ b/pkg/streamingpromql/optimize/plan/rangevectorsplitting/node.go
@@ -41,19 +41,6 @@ func (s *SplitFunctionCall) NodeType() planning.NodeType {
 	return planning.NODE_TYPE_SPLIT_FUNCTION_OVER_RANGE_VECTOR
 }
 
-func (s *SplitFunctionCall) SetChildren(children []planning.Node) error {
-	if len(children) != 1 {
-		return fmt.Errorf("node of type SplitFunctionCall supports 1 child, but got %d", len(children))
-	}
-
-	inner, ok := children[0].(*core.FunctionCall)
-	if !ok {
-		return fmt.Errorf("SplitFunctionCall node should only wrap FunctionCall nodes, got %T", children[0])
-	}
-	s.Inner = inner
-	return nil
-}
-
 func (s *SplitFunctionCall) ReplaceChild(idx int, child planning.Node) error {
 	if idx > 0 {
 		return fmt.Errorf("SplitFunctionCall node has 1 child, but attempted to replace child at index %d", idx)

--- a/pkg/streamingpromql/optimize/plan/rangevectorsplitting/node_gen.go
+++ b/pkg/streamingpromql/optimize/plan/rangevectorsplitting/node_gen.go
@@ -25,10 +25,9 @@ func (s *SplitFunctionCall) SetChildren(children []planning.Node) error {
 	if len(children) != 1 {
 		return fmt.Errorf("node of type SplitFunctionCall expects one child, but got %d", len(children))
 	}
-
 	child0, ok := children[0].(*core.FunctionCall)
 	if !ok {
-		return fmt.Errorf("node of type SplitFunctionCall expects child 0 to be of type *core.FunctionCall, but got %T", children[0])
+		return fmt.Errorf("node of type SplitFunctionCall expects child Inner to be of type *core.FunctionCall, but got %T", children[0])
 	}
 	s.Inner = child0
 	return nil

--- a/pkg/streamingpromql/optimize/plan/rangevectorsplitting/node_gen.go
+++ b/pkg/streamingpromql/optimize/plan/rangevectorsplitting/node_gen.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/planning"
+	"github.com/grafana/mimir/pkg/streamingpromql/planning/core"
 )
 
 func (s *SplitFunctionCall) Child(idx int) planning.Node {
@@ -18,4 +19,17 @@ func (s *SplitFunctionCall) Child(idx int) planning.Node {
 
 func (s *SplitFunctionCall) ChildCount() int {
 	return 1
+}
+
+func (s *SplitFunctionCall) SetChildren(children []planning.Node) error {
+	if len(children) != 1 {
+		return fmt.Errorf("node of type SplitFunctionCall expects one child, but got %d", len(children))
+	}
+
+	child0, ok := children[0].(*core.FunctionCall)
+	if !ok {
+		return fmt.Errorf("node of type SplitFunctionCall expects child 0 to be of type *core.FunctionCall, but got %T", children[0])
+	}
+	s.Inner = child0
+	return nil
 }

--- a/pkg/streamingpromql/optimize/plan/remoteexec/node.go
+++ b/pkg/streamingpromql/optimize/plan/remoteexec/node.go
@@ -31,7 +31,7 @@ func init() {
 //node:generate
 type RemoteExecutionGroup struct {
 	*RemoteExecutionGroupDetails
-	Nodes []planning.Node `node:"children"`
+	Nodes []planning.Node `node:"children,min=1"`
 }
 
 func (r *RemoteExecutionGroup) Details() proto.Message {
@@ -40,16 +40,6 @@ func (r *RemoteExecutionGroup) Details() proto.Message {
 
 func (r *RemoteExecutionGroup) NodeType() planning.NodeType {
 	return planning.NODE_TYPE_REMOTE_EXEC_GROUP
-}
-
-func (r *RemoteExecutionGroup) SetChildren(children []planning.Node) error {
-	if len(children) < 1 {
-		return fmt.Errorf("node of type RemoteExecutionGroup requires at least one child, but got %d", len(children))
-	}
-
-	r.Nodes = children
-
-	return nil
 }
 
 func (r *RemoteExecutionGroup) ReplaceChild(idx int, node planning.Node) error {
@@ -134,20 +124,6 @@ func (c *RemoteExecutionConsumer) Details() proto.Message {
 
 func (c *RemoteExecutionConsumer) NodeType() planning.NodeType {
 	return planning.NODE_TYPE_REMOTE_EXEC_CONSUMER
-}
-
-func (c *RemoteExecutionConsumer) SetChildren(children []planning.Node) error {
-	if len(children) != 1 {
-		return fmt.Errorf("node of type RemoteExecutionConsumer requires 1 child, but got %d", len(children))
-	}
-
-	group, ok := children[0].(*RemoteExecutionGroup)
-	if !ok {
-		return fmt.Errorf("node of type RemoteExecutionConsumer requires child of type RemoteExecutionGroup, but got %T", children[0])
-	}
-
-	c.Group = group
-	return nil
 }
 
 func (c *RemoteExecutionConsumer) ReplaceChild(idx int, child planning.Node) error {

--- a/pkg/streamingpromql/optimize/plan/remoteexec/node_gen.go
+++ b/pkg/streamingpromql/optimize/plan/remoteexec/node_gen.go
@@ -20,6 +20,19 @@ func (r *RemoteExecutionConsumer) ChildCount() int {
 	return 1
 }
 
+func (r *RemoteExecutionConsumer) SetChildren(children []planning.Node) error {
+	if len(children) != 1 {
+		return fmt.Errorf("node of type RemoteExecutionConsumer expects one child, but got %d", len(children))
+	}
+
+	child0, ok := children[0].(*RemoteExecutionGroup)
+	if !ok {
+		return fmt.Errorf("node of type RemoteExecutionConsumer expects child 0 to be of type *RemoteExecutionGroup, but got %T", children[0])
+	}
+	r.Group = child0
+	return nil
+}
+
 func (r *RemoteExecutionGroup) Child(idx int) planning.Node {
 	if idx >= len(r.Nodes) {
 		panic(fmt.Sprintf("this RemoteExecutionGroup node has %d children, but attempted to get child at index %d", len(r.Nodes), idx))
@@ -29,4 +42,13 @@ func (r *RemoteExecutionGroup) Child(idx int) planning.Node {
 
 func (r *RemoteExecutionGroup) ChildCount() int {
 	return len(r.Nodes)
+}
+
+func (r *RemoteExecutionGroup) SetChildren(children []planning.Node) error {
+	if len(children) < 1 {
+		return fmt.Errorf("node of type RemoteExecutionGroup expects at least one child, but got %d", len(children))
+	}
+
+	r.Nodes = children
+	return nil
 }

--- a/pkg/streamingpromql/optimize/plan/remoteexec/node_gen.go
+++ b/pkg/streamingpromql/optimize/plan/remoteexec/node_gen.go
@@ -24,10 +24,9 @@ func (r *RemoteExecutionConsumer) SetChildren(children []planning.Node) error {
 	if len(children) != 1 {
 		return fmt.Errorf("node of type RemoteExecutionConsumer expects one child, but got %d", len(children))
 	}
-
 	child0, ok := children[0].(*RemoteExecutionGroup)
 	if !ok {
-		return fmt.Errorf("node of type RemoteExecutionConsumer expects child 0 to be of type *RemoteExecutionGroup, but got %T", children[0])
+		return fmt.Errorf("node of type RemoteExecutionConsumer expects child Group to be of type *RemoteExecutionGroup, but got %T", children[0])
 	}
 	r.Group = child0
 	return nil

--- a/pkg/streamingpromql/planning/core/aggregate_expression.go
+++ b/pkg/streamingpromql/planning/core/aggregate_expression.go
@@ -66,19 +66,6 @@ func (a *AggregateExpression) NodeType() planning.NodeType {
 	return planning.NODE_TYPE_AGGREGATE_EXPRESSION
 }
 
-func (a *AggregateExpression) SetChildren(children []planning.Node) error {
-	switch len(children) {
-	case 1:
-		a.Inner, a.Param = children[0], nil
-	case 2:
-		a.Inner, a.Param = children[0], children[1]
-	default:
-		return fmt.Errorf("node of type AggregateExpression expects 1 or 2 children, but got %d", len(children))
-	}
-
-	return nil
-}
-
 func (a *AggregateExpression) ReplaceChild(idx int, node planning.Node) error {
 	switch idx {
 	case 0:

--- a/pkg/streamingpromql/planning/core/binary_expression.go
+++ b/pkg/streamingpromql/planning/core/binary_expression.go
@@ -117,16 +117,6 @@ func (b *BinaryExpression) NodeType() planning.NodeType {
 	return planning.NODE_TYPE_BINARY_EXPRESSION
 }
 
-func (b *BinaryExpression) SetChildren(children []planning.Node) error {
-	if len(children) != 2 {
-		return fmt.Errorf("node of type BinaryExpression expects 2 children, but got %d", len(children))
-	}
-
-	b.LHS, b.RHS = children[0], children[1]
-
-	return nil
-}
-
 func (b *BinaryExpression) ReplaceChild(idx int, node planning.Node) error {
 	switch idx {
 	case 0:

--- a/pkg/streamingpromql/planning/core/deduplicate_and_merge.go
+++ b/pkg/streamingpromql/planning/core/deduplicate_and_merge.go
@@ -29,16 +29,6 @@ func (d *DeduplicateAndMerge) NodeType() planning.NodeType {
 	return planning.NODE_TYPE_DEDUPLICATE_AND_MERGE
 }
 
-func (d *DeduplicateAndMerge) SetChildren(children []planning.Node) error {
-	if len(children) != 1 {
-		return fmt.Errorf("node of type DeduplicateAndMerge supports 1 child, but got %d", len(children))
-	}
-
-	d.Inner = children[0]
-
-	return nil
-}
-
 func (d *DeduplicateAndMerge) ReplaceChild(idx int, node planning.Node) error {
 	if idx != 0 {
 		return fmt.Errorf("node of type DeduplicateAndMerge supports 1 child, but attempted to replace child at index %d", idx)

--- a/pkg/streamingpromql/planning/core/drop_name.go
+++ b/pkg/streamingpromql/planning/core/drop_name.go
@@ -29,16 +29,6 @@ func (n *DropName) NodeType() planning.NodeType {
 	return planning.NODE_TYPE_DROP_NAME
 }
 
-func (n *DropName) SetChildren(children []planning.Node) error {
-	if len(children) != 1 {
-		return fmt.Errorf("node of type DropName supports 1 child, but got %d", len(children))
-	}
-
-	n.Inner = children[0]
-
-	return nil
-}
-
 func (n *DropName) ReplaceChild(idx int, node planning.Node) error {
 	if idx != 0 {
 		return fmt.Errorf("node of type DropName supports 1 child, but attempted to replace child at index %d", idx)

--- a/pkg/streamingpromql/planning/core/function_call.go
+++ b/pkg/streamingpromql/planning/core/function_call.go
@@ -47,11 +47,6 @@ func (f *FunctionCall) NodeType() planning.NodeType {
 	return planning.NODE_TYPE_FUNCTION_CALL
 }
 
-func (f *FunctionCall) SetChildren(children []planning.Node) error {
-	f.Args = children
-	return nil
-}
-
 func (f *FunctionCall) ReplaceChild(idx int, node planning.Node) error {
 	if idx >= len(f.Args) {
 		return fmt.Errorf("this FunctionCall node has %d children, but attempted to replace child at index %d", len(f.Args), idx)

--- a/pkg/streamingpromql/planning/core/info.go
+++ b/pkg/streamingpromql/planning/core/info.go
@@ -31,14 +31,6 @@ func (t *DataLabelSelector) NodeType() planning.NodeType {
 	return planning.NODE_TYPE_DATA_LABEL_SELECTOR
 }
 
-func (t *DataLabelSelector) SetChildren(children []planning.Node) error {
-	if len(children) != 0 {
-		return fmt.Errorf("node of type DataLabelSelector expects 0 children, but got %d", len(children))
-	}
-
-	return nil
-}
-
 func (t *DataLabelSelector) ReplaceChild(idx int, _ planning.Node) error {
 	return fmt.Errorf("node of type DataLabelSelector supports no children, but attempted to replace child at index %d", idx)
 }

--- a/pkg/streamingpromql/planning/core/matrix_selector.go
+++ b/pkg/streamingpromql/planning/core/matrix_selector.go
@@ -45,14 +45,6 @@ func (m *MatrixSelector) NodeType() planning.NodeType {
 	return planning.NODE_TYPE_MATRIX_SELECTOR
 }
 
-func (m *MatrixSelector) SetChildren(children []planning.Node) error {
-	if len(children) != 0 {
-		return fmt.Errorf("node of type MatrixSelector expects 0 children, but got %d", len(children))
-	}
-
-	return nil
-}
-
 func (m *MatrixSelector) ReplaceChild(idx int, node planning.Node) error {
 	return fmt.Errorf("node of type MatrixSelector supports no children, but attempted to replace child at index %d", idx)
 }

--- a/pkg/streamingpromql/planning/core/no_op.go
+++ b/pkg/streamingpromql/planning/core/no_op.go
@@ -32,14 +32,6 @@ func (n *NoOp) NodeType() planning.NodeType {
 	return planning.NODE_TYPE_NO_OP
 }
 
-func (n *NoOp) SetChildren(children []planning.Node) error {
-	if len(children) != 0 {
-		return fmt.Errorf("node of type NoOp expects 0 children, but got %d", len(children))
-	}
-
-	return nil
-}
-
 func (n *NoOp) ReplaceChild(idx int, _ planning.Node) error {
 	return fmt.Errorf("node of type NoOp supports no children, but attempted to replace child at index %d", idx)
 }

--- a/pkg/streamingpromql/planning/core/node_gen.go
+++ b/pkg/streamingpromql/planning/core/node_gen.go
@@ -30,6 +30,20 @@ func (a *AggregateExpression) ChildCount() int {
 	return 2
 }
 
+func (a *AggregateExpression) SetChildren(children []planning.Node) error {
+	switch len(children) {
+	case 1:
+		a.Inner = children[0]
+		a.Param = nil
+	case 2:
+		a.Inner = children[0]
+		a.Param = children[1]
+	default:
+		return fmt.Errorf("node of type AggregateExpression expects 1 or 2 children, but got %d", len(children))
+	}
+	return nil
+}
+
 func (b *BinaryExpression) Child(idx int) planning.Node {
 	switch idx {
 	case 0:
@@ -45,12 +59,29 @@ func (b *BinaryExpression) ChildCount() int {
 	return 2
 }
 
+func (b *BinaryExpression) SetChildren(children []planning.Node) error {
+	if len(children) != 2 {
+		return fmt.Errorf("node of type BinaryExpression expects 2 children, but got %d", len(children))
+	}
+
+	b.LHS = children[0]
+	b.RHS = children[1]
+	return nil
+}
+
 func (d *DataLabelSelector) Child(idx int) planning.Node {
 	panic(fmt.Sprintf("node of type DataLabelSelector has no children, but attempted to get child at index %d", idx))
 }
 
 func (d *DataLabelSelector) ChildCount() int {
 	return 0
+}
+
+func (d *DataLabelSelector) SetChildren(children []planning.Node) error {
+	if len(children) != 0 {
+		return fmt.Errorf("node of type DataLabelSelector expects 0 children, but got %d", len(children))
+	}
+	return nil
 }
 
 func (d *DeduplicateAndMerge) Child(idx int) planning.Node {
@@ -64,6 +95,15 @@ func (d *DeduplicateAndMerge) ChildCount() int {
 	return 1
 }
 
+func (d *DeduplicateAndMerge) SetChildren(children []planning.Node) error {
+	if len(children) != 1 {
+		return fmt.Errorf("node of type DeduplicateAndMerge expects one child, but got %d", len(children))
+	}
+
+	d.Inner = children[0]
+	return nil
+}
+
 func (d *DropName) Child(idx int) planning.Node {
 	if idx != 0 {
 		panic(fmt.Sprintf("node of type DropName supports 1 child, but attempted to get child at index %d", idx))
@@ -73,6 +113,15 @@ func (d *DropName) Child(idx int) planning.Node {
 
 func (d *DropName) ChildCount() int {
 	return 1
+}
+
+func (d *DropName) SetChildren(children []planning.Node) error {
+	if len(children) != 1 {
+		return fmt.Errorf("node of type DropName expects one child, but got %d", len(children))
+	}
+
+	d.Inner = children[0]
+	return nil
 }
 
 func (f *FunctionCall) Child(idx int) planning.Node {
@@ -86,12 +135,24 @@ func (f *FunctionCall) ChildCount() int {
 	return len(f.Args)
 }
 
+func (f *FunctionCall) SetChildren(children []planning.Node) error {
+	f.Args = children
+	return nil
+}
+
 func (m *MatrixSelector) Child(idx int) planning.Node {
 	panic(fmt.Sprintf("node of type MatrixSelector has no children, but attempted to get child at index %d", idx))
 }
 
 func (m *MatrixSelector) ChildCount() int {
 	return 0
+}
+
+func (m *MatrixSelector) SetChildren(children []planning.Node) error {
+	if len(children) != 0 {
+		return fmt.Errorf("node of type MatrixSelector expects 0 children, but got %d", len(children))
+	}
+	return nil
 }
 
 func (n *NoOp) Child(idx int) planning.Node {
@@ -102,12 +163,26 @@ func (n *NoOp) ChildCount() int {
 	return 0
 }
 
+func (n *NoOp) SetChildren(children []planning.Node) error {
+	if len(children) != 0 {
+		return fmt.Errorf("node of type NoOp expects 0 children, but got %d", len(children))
+	}
+	return nil
+}
+
 func (n *NumberLiteral) Child(idx int) planning.Node {
 	panic(fmt.Sprintf("node of type NumberLiteral has no children, but attempted to get child at index %d", idx))
 }
 
 func (n *NumberLiteral) ChildCount() int {
 	return 0
+}
+
+func (n *NumberLiteral) SetChildren(children []planning.Node) error {
+	if len(children) != 0 {
+		return fmt.Errorf("node of type NumberLiteral expects 0 children, but got %d", len(children))
+	}
+	return nil
 }
 
 func (s *StepInvariantExpression) Child(idx int) planning.Node {
@@ -121,12 +196,28 @@ func (s *StepInvariantExpression) ChildCount() int {
 	return 1
 }
 
+func (s *StepInvariantExpression) SetChildren(children []planning.Node) error {
+	if len(children) != 1 {
+		return fmt.Errorf("node of type StepInvariantExpression expects one child, but got %d", len(children))
+	}
+
+	s.Inner = children[0]
+	return nil
+}
+
 func (s *StringLiteral) Child(idx int) planning.Node {
 	panic(fmt.Sprintf("node of type StringLiteral has no children, but attempted to get child at index %d", idx))
 }
 
 func (s *StringLiteral) ChildCount() int {
 	return 0
+}
+
+func (s *StringLiteral) SetChildren(children []planning.Node) error {
+	if len(children) != 0 {
+		return fmt.Errorf("node of type StringLiteral expects 0 children, but got %d", len(children))
+	}
+	return nil
 }
 
 func (s *Subquery) Child(idx int) planning.Node {
@@ -140,6 +231,15 @@ func (s *Subquery) ChildCount() int {
 	return 1
 }
 
+func (s *Subquery) SetChildren(children []planning.Node) error {
+	if len(children) != 1 {
+		return fmt.Errorf("node of type Subquery expects one child, but got %d", len(children))
+	}
+
+	s.Inner = children[0]
+	return nil
+}
+
 func (u *UnaryExpression) Child(idx int) planning.Node {
 	if idx != 0 {
 		panic(fmt.Sprintf("node of type UnaryExpression supports 1 child, but attempted to get child at index %d", idx))
@@ -151,10 +251,26 @@ func (u *UnaryExpression) ChildCount() int {
 	return 1
 }
 
+func (u *UnaryExpression) SetChildren(children []planning.Node) error {
+	if len(children) != 1 {
+		return fmt.Errorf("node of type UnaryExpression expects one child, but got %d", len(children))
+	}
+
+	u.Inner = children[0]
+	return nil
+}
+
 func (v *VectorSelector) Child(idx int) planning.Node {
 	panic(fmt.Sprintf("node of type VectorSelector has no children, but attempted to get child at index %d", idx))
 }
 
 func (v *VectorSelector) ChildCount() int {
 	return 0
+}
+
+func (v *VectorSelector) SetChildren(children []planning.Node) error {
+	if len(children) != 0 {
+		return fmt.Errorf("node of type VectorSelector expects 0 children, but got %d", len(children))
+	}
+	return nil
 }

--- a/pkg/streamingpromql/planning/core/node_gen.go
+++ b/pkg/streamingpromql/planning/core/node_gen.go
@@ -63,7 +63,6 @@ func (b *BinaryExpression) SetChildren(children []planning.Node) error {
 	if len(children) != 2 {
 		return fmt.Errorf("node of type BinaryExpression expects 2 children, but got %d", len(children))
 	}
-
 	b.LHS = children[0]
 	b.RHS = children[1]
 	return nil
@@ -99,7 +98,6 @@ func (d *DeduplicateAndMerge) SetChildren(children []planning.Node) error {
 	if len(children) != 1 {
 		return fmt.Errorf("node of type DeduplicateAndMerge expects one child, but got %d", len(children))
 	}
-
 	d.Inner = children[0]
 	return nil
 }
@@ -119,7 +117,6 @@ func (d *DropName) SetChildren(children []planning.Node) error {
 	if len(children) != 1 {
 		return fmt.Errorf("node of type DropName expects one child, but got %d", len(children))
 	}
-
 	d.Inner = children[0]
 	return nil
 }
@@ -200,7 +197,6 @@ func (s *StepInvariantExpression) SetChildren(children []planning.Node) error {
 	if len(children) != 1 {
 		return fmt.Errorf("node of type StepInvariantExpression expects one child, but got %d", len(children))
 	}
-
 	s.Inner = children[0]
 	return nil
 }
@@ -235,7 +231,6 @@ func (s *Subquery) SetChildren(children []planning.Node) error {
 	if len(children) != 1 {
 		return fmt.Errorf("node of type Subquery expects one child, but got %d", len(children))
 	}
-
 	s.Inner = children[0]
 	return nil
 }
@@ -255,7 +250,6 @@ func (u *UnaryExpression) SetChildren(children []planning.Node) error {
 	if len(children) != 1 {
 		return fmt.Errorf("node of type UnaryExpression expects one child, but got %d", len(children))
 	}
-
 	u.Inner = children[0]
 	return nil
 }

--- a/pkg/streamingpromql/planning/core/number_literal.go
+++ b/pkg/streamingpromql/planning/core/number_literal.go
@@ -37,14 +37,6 @@ func (n *NumberLiteral) NodeType() planning.NodeType {
 	return planning.NODE_TYPE_NUMBER_LITERAL
 }
 
-func (n *NumberLiteral) SetChildren(children []planning.Node) error {
-	if len(children) != 0 {
-		return fmt.Errorf("node of type NumberLiteral expects 0 children, but got %d", len(children))
-	}
-
-	return nil
-}
-
 func (n *NumberLiteral) ReplaceChild(idx int, node planning.Node) error {
 	return fmt.Errorf("node of type NumberLiteral supports no children, but attempted to replace child at index %d", idx)
 }

--- a/pkg/streamingpromql/planning/core/step_invariant_expression.go
+++ b/pkg/streamingpromql/planning/core/step_invariant_expression.go
@@ -46,16 +46,6 @@ func (s *StepInvariantExpression) MinimumRequiredPlanVersion(types.QueryTimeRang
 	return planning.QueryPlanV1, nil
 }
 
-func (s *StepInvariantExpression) SetChildren(children []planning.Node) error {
-	if len(children) != 1 {
-		return fmt.Errorf("node of type StepInvariantExpression expects 1 child, but got %d", len(children))
-	}
-
-	s.Inner = children[0]
-
-	return nil
-}
-
 func (s *StepInvariantExpression) ReplaceChild(idx int, node planning.Node) error {
 	if idx != 0 {
 		return fmt.Errorf("node of type StepInvariantExpression supports 1 child, but attempted to replace child at index %d", idx)

--- a/pkg/streamingpromql/planning/core/string_literal.go
+++ b/pkg/streamingpromql/planning/core/string_literal.go
@@ -37,14 +37,6 @@ func (s *StringLiteral) NodeType() planning.NodeType {
 	return planning.NODE_TYPE_STRING_LITERAL
 }
 
-func (s *StringLiteral) SetChildren(children []planning.Node) error {
-	if len(children) != 0 {
-		return fmt.Errorf("node of type StringLiteral expects 0 children, but got %d", len(children))
-	}
-
-	return nil
-}
-
 func (s *StringLiteral) ReplaceChild(idx int, node planning.Node) error {
 	return fmt.Errorf("node of type StringLiteral supports no children, but attempted to replace child at index %d", idx)
 }

--- a/pkg/streamingpromql/planning/core/subquery.go
+++ b/pkg/streamingpromql/planning/core/subquery.go
@@ -105,16 +105,6 @@ func (s *Subquery) NodeType() planning.NodeType {
 	return planning.NODE_TYPE_SUBQUERY
 }
 
-func (s *Subquery) SetChildren(children []planning.Node) error {
-	if len(children) != 1 {
-		return fmt.Errorf("node of type Subquery expects 1 child, but got %d", len(children))
-	}
-
-	s.Inner = children[0]
-
-	return nil
-}
-
 func (s *Subquery) ReplaceChild(idx int, node planning.Node) error {
 	if idx != 0 {
 		return fmt.Errorf("node of type Subquery supports 1 child, but attempted to replace child at index %d", idx)

--- a/pkg/streamingpromql/planning/core/unary_expression.go
+++ b/pkg/streamingpromql/planning/core/unary_expression.go
@@ -39,16 +39,6 @@ func (u *UnaryExpression) NodeType() planning.NodeType {
 	return planning.NODE_TYPE_UNARY_EXPRESSION
 }
 
-func (u *UnaryExpression) SetChildren(children []planning.Node) error {
-	if len(children) != 1 {
-		return fmt.Errorf("node of type UnaryExpression expects 1 child, but got %d", len(children))
-	}
-
-	u.Inner = children[0]
-
-	return nil
-}
-
 func (u *UnaryExpression) ReplaceChild(idx int, node planning.Node) error {
 	if idx != 0 {
 		return fmt.Errorf("node of type UnaryExpression supports 1 child, but attempted to replace child at index %d", idx)

--- a/pkg/streamingpromql/planning/core/vector_selector.go
+++ b/pkg/streamingpromql/planning/core/vector_selector.go
@@ -48,14 +48,6 @@ func (v *VectorSelector) NodeType() planning.NodeType {
 	return planning.NODE_TYPE_VECTOR_SELECTOR
 }
 
-func (v *VectorSelector) SetChildren(children []planning.Node) error {
-	if len(children) != 0 {
-		return fmt.Errorf("node of type VectorSelector expects 0 children, but got %d", len(children))
-	}
-
-	return nil
-}
-
 func (v *VectorSelector) ReplaceChild(idx int, node planning.Node) error {
 	return fmt.Errorf("node of type VectorSelector supports no children, but attempted to replace child at index %d", idx)
 }

--- a/tools/node-gen/README.md
+++ b/tools/node-gen/README.md
@@ -8,10 +8,11 @@ top of `planning.Node`.
 
 # Supported generators
 
-| Method                         | Description                           |
-| ------------------------------ | ------------------------------------- |
-| `Child(idx int) planning.Node` | Returns the child at the given index. |
-| `ChildCount() int`             | Returns the number of children.       |
+| Method                                        | Description                                                      |
+| --------------------------------------------- | ---------------------------------------------------------------- |
+| `Child(idx int) planning.Node`                | Returns the child at the given index.                            |
+| `ChildCount() int`                            | Returns the number of children.                                  |
+| `SetChildren(children []planning.Node) error` | Sets all children at once, validating the count and child types. |
 
 # How to opt a struct in
 
@@ -21,6 +22,8 @@ top of `planning.Node`.
    - `node:"child,nilable"` — single child that may be `nil` at
      runtime (rare; e.g. `AggregateExpression.Param`).
    - `node:"children"` — slice of children (`[]planning.Node`).
+   - `node:"children,min=N"` — as `children`, but a node
+     requires at least `N` children.
 
 # How to run
 

--- a/tools/node-gen/generator.go
+++ b/tools/node-gen/generator.go
@@ -25,6 +25,7 @@ func CreateGenerators() []MethodGenerator {
 	return []MethodGenerator{
 		ChildMethod,
 		ChildCountMethod,
+		SetChildrenMethod,
 	}
 }
 

--- a/tools/node-gen/generator_child_method.go
+++ b/tools/node-gen/generator_child_method.go
@@ -15,6 +15,7 @@ type templateStructData struct {
 	Type          string
 	ChildFields   []childField
 	ChildrenField string
+	ChildrenMin   int
 }
 
 func (d *templateStructData) LastField() childField {
@@ -29,8 +30,10 @@ func (d *templateStructData) CountWithoutLast() int {
 
 // childField represents a struct field tagged with child/children.
 type childField struct {
-	Name    string
-	Nilable bool
+	Name       string
+	Nilable    bool
+	Type       string // source type (e.g. *core.FunctionCall)
+	TypeImport string
 }
 
 //go:embed child_method.tmpl
@@ -51,6 +54,15 @@ var childCountTmpl = template.Must(template.New("child_count_method").Parse(chil
 var ChildCountMethod = MethodGenerator{
 	Name:     "ChildCount",
 	Generate: childCountMethodGenerate,
+}
+
+//go:embed set_children_method.tmpl
+var setChildrenTmplContent string
+var setChildrenTmpl = template.Must(template.New("set_children_method").Parse(setChildrenTmplContent))
+
+var SetChildrenMethod = MethodGenerator{
+	Name:     "SetChildren",
+	Generate: setChildrenMethodGenerate,
 }
 
 func childMethodGenerate(s *Struct, imports *ImportsCollector) (string, error) {
@@ -96,8 +108,36 @@ func childCountMethodGenerate(s *Struct, _ *ImportsCollector) (string, error) {
 	return renderTemplate(childCountTmpl, subtmplName, data)
 }
 
+func setChildrenMethodGenerate(s *Struct, imports *ImportsCollector) (string, error) {
+	data, err := buildTemplateStructData(s)
+	if err != nil {
+		return "", err
+	}
+
+	imports.Add("fmt")
+	imports.Add("github.com/grafana/mimir/pkg/streamingpromql/planning")
+	for _, cf := range data.ChildFields {
+		imports.Add(cf.TypeImport)
+	}
+
+	var subtmplName string
+	switch {
+	case data.ChildrenField != "":
+		subtmplName = "children_field"
+	case len(data.ChildFields) == 0:
+		subtmplName = "no_fields"
+	case data.LastField().Nilable:
+		subtmplName = "nilable_last"
+	default:
+		subtmplName = "child_fields"
+	}
+
+	return renderTemplate(setChildrenTmpl, subtmplName, data)
+}
+
 // buildTemplateStructData validates the tagged fields of the given structure and returns the template input for it.
 // Returns an error if the tags violate the supported shape:
+//   - node:"children,min=N" must have a non-negative N,
 //   - node:"child" and node:"children" cannot be mixed,
 //   - at most one node:"children" field,
 //   - at most one node:"child,nilable" field, and it must be the last node:"child" field,
@@ -107,6 +147,7 @@ func buildTemplateStructData(s *Struct) (*templateStructData, error) {
 		childFields       []childField
 		nilableFieldCount int
 		childrenFieldName string
+		childrenMin       int
 	)
 	for _, f := range s.Fields {
 		if f.Tag == nil {
@@ -123,12 +164,21 @@ func buildTemplateStructData(s *Struct) (*templateStructData, error) {
 			if f.Tag.Nilable {
 				nilableFieldCount++
 			}
-			childFields = append(childFields, childField{Name: f.Name, Nilable: f.Tag.Nilable})
+			childFields = append(childFields, childField{
+				Name:       f.Name,
+				Nilable:    f.Tag.Nilable,
+				Type:       f.Type.Name,
+				TypeImport: f.Type.ImportPath,
+			})
 		case f.Tag.IsChildren:
 			if childrenFieldName != "" {
 				return nil, fmt.Errorf(`multiple node:"children" fields are not supported`)
 			}
+			if f.Tag.Min < 0 {
+				return nil, fmt.Errorf(`node:"children" min must be non-negative, got %d`, f.Tag.Min)
+			}
 			childrenFieldName = f.Name
+			childrenMin = f.Tag.Min
 		}
 	}
 	if len(childFields) > 0 && childrenFieldName != "" {
@@ -146,6 +196,7 @@ func buildTemplateStructData(s *Struct) (*templateStructData, error) {
 		Type:          s.Name,
 		ChildFields:   childFields,
 		ChildrenField: childrenFieldName,
+		ChildrenMin:   childrenMin,
 	}, nil
 }
 

--- a/tools/node-gen/generator_set_children_method_test.go
+++ b/tools/node-gen/generator_set_children_method_test.go
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetChildrenMethod(t *testing.T) {
+	cases := []struct {
+		name     string
+		source   string
+		expected string
+	}{
+		{
+			name: "no children",
+			source: `package core
+					 //node:generate
+ 					 type NumberLiteral struct{ Value float64 }`,
+			expected: `func (n *NumberLiteral) SetChildren(children []planning.Node) error {
+						 if len(children) != 0 {
+							 return fmt.Errorf("node of type NumberLiteral expects 0 children, but got %d", len(children))
+						 }
+						 return nil
+					   }`,
+		},
+		{
+			name: "single non-nilable child",
+			source: `package core
+				     import "planning"
+					 //node:generate
+					 type Subquery struct { Inner planning.Node ` + "`" + `node:"child"` + "`" + ` }
+					`,
+			expected: `func (s *Subquery) SetChildren(children []planning.Node) error {
+						 if len(children) != 1 {
+							 return fmt.Errorf("node of type Subquery expects one child, but got %d", len(children))
+						 }
+
+						 s.Inner = children[0]
+						 return nil
+					   }`,
+		},
+		{
+			name: "single non-nilable child from another package",
+			source: `package core
+				     import "planning"
+					 import "github.com/grafana/mimir/pkg/streamingpromql/planning/core"
+					 //node:generate
+					 type Subquery struct { Inner *core.FunctionCall ` + "`" + `node:"child"` + "`" + ` }
+					`,
+			expected: `func (s *Subquery) SetChildren(children []planning.Node) error {
+						 if len(children) != 1 {
+							 return fmt.Errorf("node of type Subquery expects one child, but got %d", len(children))
+						 }
+
+						 child0, ok := children[0].(*core.FunctionCall)
+  						 if !ok {
+							return fmt.Errorf("node of type Subquery expects child 0 to be of type *core.FunctionCall, but got %T", children[0])
+                         }
+	                     s.Inner = child0
+						 return nil
+					   }`,
+		},
+		{
+			name: "single nilable child",
+			source: `package core
+				     import "planning"
+					 //node:generate
+					 type Subquery struct { Inner planning.Node ` + "`" + `node:"child,nilable"` + "`" + ` }
+					`,
+			expected: `func (s *Subquery) SetChildren(children []planning.Node) error {
+						 switch len(children) {
+						 case 0:
+							 s.Inner = nil
+						 case 1:
+							 s.Inner = children[0]
+						 default:
+							 return fmt.Errorf("node of type Subquery expects 0 or 1 children, but got %d", len(children))
+						 }
+						 return nil
+					   }`,
+		},
+		{
+			name: "non-nilable children",
+			source: `package core
+                     import "planning"
+                     //node:generate
+                     type BinaryExpression struct {
+                     	LHS planning.Node ` + "`" + `node:"child"` + "`" + `
+                     	RHS planning.Node ` + "`" + `node:"child"` + "`" + `
+                     }`,
+			expected: `func (b *BinaryExpression) SetChildren(children []planning.Node) error {
+					  	if len(children) != 2 {
+					  		return fmt.Errorf("node of type BinaryExpression expects 2 children, but got %d", len(children))
+					  	}
+
+					  	b.LHS = children[0]
+					  	b.RHS = children[1]
+					  	return nil
+					  }`,
+		},
+		{
+			name: "non-nilable plus nilable child",
+			source: `package core
+                     import "planning"
+                     //node:generate
+                     type AggregateExpression struct {
+                     	Inner planning.Node ` + "`" + `node:"child"` + "`" + `
+                     	Param planning.Node ` + "`" + `node:"child,nilable"` + "`" + `
+                     }`,
+			expected: `func (a *AggregateExpression) SetChildren(children []planning.Node) error {
+					  	switch len(children) {
+					  	case 1:
+					  		a.Inner = children[0]
+					  		a.Param = nil
+					  	case 2:
+					  		a.Inner = children[0]
+					  		a.Param = children[1]
+					  	default:
+					  		return fmt.Errorf("node of type AggregateExpression expects 1 or 2 children, but got %d", len(children))
+					  	}
+					  	return nil
+					  }`,
+		},
+		{
+			name: "children slice",
+			source: `package core
+                     import "planning"
+                     //node:generate
+                     type FunctionCall struct {
+                     	Args []planning.Node ` + "`" + `node:"children"` + "`" + `
+                     }`,
+			expected: `func (f *FunctionCall) SetChildren(children []planning.Node) error {
+					  	  f.Args = children
+					  	  return nil
+			           }`,
+		},
+		{
+			name: "children slice with min=1",
+			source: `package core
+                     import "planning"
+                     //node:generate
+                     type RemoteExecutionGroup struct {
+                     	Nodes []planning.Node ` + "`" + `node:"children,min=1"` + "`" + `
+                     }`,
+			expected: `func (r *RemoteExecutionGroup) SetChildren(children []planning.Node) error {
+					  	  if len(children) < 1 {
+					  		  return fmt.Errorf("node of type RemoteExecutionGroup expects at least one child, but got %d", len(children))
+					  	  }
+
+					  	  r.Nodes = children
+					  	  return nil
+			           }`,
+		},
+		{
+			name: "children slice with min=2",
+			source: `package core
+                     import "planning"
+                     //node:generate
+                     type ManyChildren struct {
+                     	Nodes []planning.Node ` + "`" + `node:"children,min=2"` + "`" + `
+                     }`,
+			expected: `func (m *ManyChildren) SetChildren(children []planning.Node) error {
+					  	  if len(children) < 2 {
+					  		  return fmt.Errorf("node of type ManyChildren expects at least 2 children, but got %d", len(children))
+					  	  }
+
+					  	  m.Nodes = children
+					  	  return nil
+			           }`,
+		},
+		{
+			name: "typed single child",
+			source: `package core
+                     import "planning"
+                     //node:generate
+                     type RemoteExecutionConsumer struct {
+                     	Group *RemoteExecutionGroup ` + "`" + `node:"child"` + "`" + `
+                     }`,
+			expected: `func (r *RemoteExecutionConsumer) SetChildren(children []planning.Node) error {
+					  	if len(children) != 1 {
+					  		return fmt.Errorf("node of type RemoteExecutionConsumer expects one child, but got %d", len(children))
+					  	}
+
+					  	child0, ok := children[0].(*RemoteExecutionGroup)
+					  	if !ok {
+					  		return fmt.Errorf("node of type RemoteExecutionConsumer expects child 0 to be of type *RemoteExecutionGroup, but got %T", children[0])
+					  	}
+					  	r.Group = child0
+					  	return nil
+					  }`,
+		},
+		{
+			name: "typed non-nilable plus typed nilable child",
+			source: `package core
+                     import "planning"
+                     //node:generate
+                     type Wrapper struct {
+                     	Inner planning.Node ` + "`" + `node:"child"` + "`" + `
+                     	Opt   *Foo          ` + "`" + `node:"child,nilable"` + "`" + `
+                     }`,
+			expected: `func (w *Wrapper) SetChildren(children []planning.Node) error {
+					  	switch len(children) {
+					  	case 1:
+					  		w.Inner = children[0]
+					  		w.Opt = nil
+					  	case 2:
+					  		w.Inner = children[0]
+					  		child1, ok := children[1].(*Foo)
+					  		if !ok {
+					  			return fmt.Errorf("node of type Wrapper expects child 1 to be of type *Foo, but got %T", children[1])
+					  		}
+					  		w.Opt = child1
+					  	default:
+					  		return fmt.Errorf("node of type Wrapper expects 1 or 2 children, but got %d", len(children))
+					  	}
+					  	return nil
+					  }`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pkg := parseFixture(t, tc.source)
+			s := resolveAnnotatedStruct(t, pkg)
+			imports := newImportsCollector()
+
+			actual, err := SetChildrenMethod.Generate(s, imports)
+			require.NoError(t, err)
+
+			expected := gofmt(t, tc.expected)
+
+			require.Equal(t, expected, actual)
+		})
+	}
+}
+
+func TestSetChildrenMethod_RegistersChildTypeImport(t *testing.T) {
+	pkg := parseFixture(t, `package rangevectorsplitting
+		import "github.com/grafana/mimir/pkg/streamingpromql/planning"
+		import "github.com/grafana/mimir/pkg/streamingpromql/planning/core"
+		//node:generate
+		type SplitFunctionCall struct {
+			Inner *core.FunctionCall `+"`"+`node:"child"`+"`"+`
+		}`)
+	s := resolveAnnotatedStruct(t, pkg)
+	imports := newImportsCollector()
+
+	_, err := SetChildrenMethod.Generate(s, imports)
+
+	require.NoError(t, err)
+	require.Contains(t, imports.Paths(), "github.com/grafana/mimir/pkg/streamingpromql/planning/core")
+}

--- a/tools/node-gen/generator_set_children_method_test.go
+++ b/tools/node-gen/generator_set_children_method_test.go
@@ -37,7 +37,6 @@ func TestSetChildrenMethod(t *testing.T) {
 						 if len(children) != 1 {
 							 return fmt.Errorf("node of type Subquery expects one child, but got %d", len(children))
 						 }
-
 						 s.Inner = children[0]
 						 return nil
 					   }`,
@@ -54,10 +53,9 @@ func TestSetChildrenMethod(t *testing.T) {
 						 if len(children) != 1 {
 							 return fmt.Errorf("node of type Subquery expects one child, but got %d", len(children))
 						 }
-
 						 child0, ok := children[0].(*core.FunctionCall)
   						 if !ok {
-							return fmt.Errorf("node of type Subquery expects child 0 to be of type *core.FunctionCall, but got %T", children[0])
+							return fmt.Errorf("node of type Subquery expects child Inner to be of type *core.FunctionCall, but got %T", children[0])
                          }
 	                     s.Inner = child0
 						 return nil
@@ -95,7 +93,6 @@ func TestSetChildrenMethod(t *testing.T) {
 					  	if len(children) != 2 {
 					  		return fmt.Errorf("node of type BinaryExpression expects 2 children, but got %d", len(children))
 					  	}
-
 					  	b.LHS = children[0]
 					  	b.RHS = children[1]
 					  	return nil
@@ -183,10 +180,9 @@ func TestSetChildrenMethod(t *testing.T) {
 					  	if len(children) != 1 {
 					  		return fmt.Errorf("node of type RemoteExecutionConsumer expects one child, but got %d", len(children))
 					  	}
-
 					  	child0, ok := children[0].(*RemoteExecutionGroup)
 					  	if !ok {
-					  		return fmt.Errorf("node of type RemoteExecutionConsumer expects child 0 to be of type *RemoteExecutionGroup, but got %T", children[0])
+					  		return fmt.Errorf("node of type RemoteExecutionConsumer expects child Group to be of type *RemoteExecutionGroup, but got %T", children[0])
 					  	}
 					  	r.Group = child0
 					  	return nil
@@ -210,7 +206,7 @@ func TestSetChildrenMethod(t *testing.T) {
 					  		w.Inner = children[0]
 					  		child1, ok := children[1].(*Foo)
 					  		if !ok {
-					  			return fmt.Errorf("node of type Wrapper expects child 1 to be of type *Foo, but got %T", children[1])
+					  			return fmt.Errorf("node of type Wrapper expects child Opt to be of type *Foo, but got %T", children[1])
 					  		}
 					  		w.Opt = child1
 					  	default:

--- a/tools/node-gen/parser.go
+++ b/tools/node-gen/parser.go
@@ -8,6 +8,7 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
+	"path"
 	"path/filepath"
 	"reflect"
 	"slices"
@@ -32,6 +33,13 @@ type Field struct {
 	Name     string
 	Tag      *NodeTag
 	Embedded bool
+	Type     *FieldType
+}
+
+// FieldType is a struct field's declared type, resolved for code generation.
+type FieldType struct {
+	Name       string // Name is the type rendered as source, e.g. "planning.Node", "*core.FunctionCall", "[]planning.Node".
+	ImportPath string // import path of the type's package qualifier, or "" when the type has no qualifier (a local or builtin type).
 }
 
 // NodeTag is the parsed value of a node:"..." struct tag.
@@ -39,6 +47,7 @@ type NodeTag struct {
 	IsChild    bool
 	IsChildren bool
 	Nilable    bool // child only; non-nil by default; set true with the "nilable" tag option for the rare case (e.g. AggregateExpression.Param)
+	Min        int  // children only; minimum required number of children, set with the "min=N" tag option (0 means no lower bound)
 }
 
 // ParsePackage reads all non-test .go files in packagePath (skipping the generated file named genFileName)
@@ -59,10 +68,10 @@ func ParsePackage(packagePath, genFileName string) (*Package, error) {
 		if !strings.HasSuffix(entry.Name(), ".go") || genFileName == entry.Name() || strings.HasSuffix(entry.Name(), "_test.go") {
 			continue
 		}
-		path := filepath.Join(packagePath, entry.Name())
-		f, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		filePath := filepath.Join(packagePath, entry.Name())
+		f, err := parser.ParseFile(fset, filePath, nil, parser.ParseComments)
 		if err != nil {
-			return nil, fmt.Errorf("parsing %q: %w", path, err)
+			return nil, fmt.Errorf("parsing %q: %w", filePath, err)
 		}
 		files = append(files, f)
 	}
@@ -93,6 +102,10 @@ func buildPackage(files []*ast.File) (*Package, error) {
 // collectNodeStructs returns the //node:generate-annotated struct type declarations found in file.
 // Non-annotated declarations are ignored.
 func collectNodeStructs(f *ast.File) ([]*Struct, error) {
+	imports, err := parseFileImports(f)
+	if err != nil {
+		return nil, err
+	}
 	var structs []*Struct
 	for _, decl := range f.Decls {
 		gd, ok := decl.(*ast.GenDecl)
@@ -111,7 +124,7 @@ func collectNodeStructs(f *ast.File) ([]*Struct, error) {
 			if !ok {
 				continue
 			}
-			s, err := parseStruct(ts.Name.Name, st)
+			s, err := parseStruct(ts.Name.Name, st, imports)
 			if err != nil {
 				return nil, fmt.Errorf("struct %s: %w", ts.Name.Name, err)
 			}
@@ -133,10 +146,10 @@ func hasNodeGenerateComment(cg *ast.CommentGroup) bool {
 	return false
 }
 
-func parseStruct(name string, st *ast.StructType) (*Struct, error) {
+func parseStruct(name string, st *ast.StructType, imports map[string]string) (*Struct, error) {
 	s := &Struct{Name: name}
 	for _, field := range st.Fields.List {
-		fields, err := parseField(field)
+		fields, err := parseField(field, imports)
 		if err != nil {
 			return nil, err
 		}
@@ -147,7 +160,7 @@ func parseStruct(name string, st *ast.StructType) (*Struct, error) {
 
 // parseField expands one ast.Field declaration into one or more Field entries:
 // multi-name declarations (e.g. "a, b int") yield one Field per name
-func parseField(field *ast.Field) ([]Field, error) {
+func parseField(field *ast.Field, imports map[string]string) ([]Field, error) {
 	var tag *NodeTag
 	if field.Tag != nil {
 		raw, err := strconv.Unquote(field.Tag.Value)
@@ -162,14 +175,74 @@ func parseField(field *ast.Field) ([]Field, error) {
 			return nil, fmt.Errorf("embedded field tag: %w", err)
 		}
 	}
+
+	fieldType, err := resolveFieldType(field.Type, imports)
+	if err != nil {
+		if len(field.Names) > 0 {
+			return nil, fmt.Errorf("field %q: %w", field.Names[0].Name, err)
+		}
+		return nil, fmt.Errorf("embedded field: %w", err)
+	}
+
 	if len(field.Names) == 0 {
-		return []Field{{Tag: tag, Embedded: true}}, nil
+		return []Field{{Tag: tag, Embedded: true, Type: fieldType}}, nil
 	}
 	result := make([]Field, len(field.Names))
 	for i, name := range field.Names {
-		result[i] = Field{Name: name.Name, Tag: tag}
+		result[i] = Field{Name: name.Name, Tag: tag, Type: fieldType}
 	}
 	return result, nil
+}
+
+// parseFileImports maps a file's import local names to their import paths.
+func parseFileImports(f *ast.File) (map[string]string, error) {
+	imports := make(map[string]string, len(f.Imports))
+	for _, imp := range f.Imports {
+		importPath, err := strconv.Unquote(imp.Path.Value)
+		if err != nil {
+			return nil, fmt.Errorf("unquoting import path %s: %w", imp.Path.Value, err)
+		}
+		// The local name is the import alias if one is given, otherwise the package name.
+		// We assume the latter equals the last path segment.
+		name := path.Base(importPath)
+		if imp.Name != nil {
+			name = imp.Name.Name
+		}
+		imports[name] = importPath
+	}
+	return imports, nil
+}
+
+// resolveFieldType renders a field's declared type as source and resolves the import path of
+// its package qualifier (empty when the type has no qualifier).
+func resolveFieldType(expr ast.Expr, imports map[string]string) (*FieldType, error) {
+	switch t := expr.(type) {
+	case *ast.Ident:
+		return &FieldType{Name: t.Name}, nil
+	case *ast.StarExpr:
+		inner, err := resolveFieldType(t.X, imports)
+		if err != nil {
+			return nil, err
+		}
+		return &FieldType{Name: "*" + inner.Name, ImportPath: inner.ImportPath}, nil
+	case *ast.ArrayType:
+		if t.Len != nil {
+			return nil, fmt.Errorf("unsupported fixed-size array field type")
+		}
+		inner, err := resolveFieldType(t.Elt, imports)
+		if err != nil {
+			return nil, err
+		}
+		return &FieldType{Name: "[]" + inner.Name, ImportPath: inner.ImportPath}, nil
+	case *ast.SelectorExpr:
+		pkg, ok := t.X.(*ast.Ident)
+		if !ok {
+			return nil, fmt.Errorf("unsupported field type")
+		}
+		return &FieldType{Name: pkg.Name + "." + t.Sel.Name, ImportPath: imports[pkg.Name]}, nil
+	default:
+		return nil, fmt.Errorf("unsupported field type %T", expr)
+	}
 }
 
 // parseNodeTag parses the node:"..." struct tag value.
@@ -183,7 +256,7 @@ func parseNodeTag(tag reflect.StructTag) (*NodeTag, error) {
 	case "child":
 		return parseChildTag(parts[1:])
 	case "children":
-		return &NodeTag{IsChildren: true}, nil
+		return parseChildrenTag(parts[1:])
 	default:
 		return nil, fmt.Errorf("unknown node tag kind %q", parts[0])
 	}
@@ -198,6 +271,25 @@ func parseChildTag(opts []string) (*NodeTag, error) {
 			t.Nilable = true
 		default:
 			return nil, fmt.Errorf("unknown child tag option %q", opt)
+		}
+	}
+	return t, nil
+}
+
+// parseChildrenTag parses the comma-separated options after "children".
+func parseChildrenTag(opts []string) (*NodeTag, error) {
+	t := &NodeTag{IsChildren: true}
+	for _, opt := range opts {
+		switch {
+		case strings.HasPrefix(opt, "min="):
+			raw := strings.TrimPrefix(opt, "min=")
+			minChildren, err := strconv.Atoi(raw)
+			if err != nil {
+				return nil, fmt.Errorf("invalid children min value %q", raw)
+			}
+			t.Min = minChildren
+		default:
+			return nil, fmt.Errorf("unknown children tag option %q", opt)
 		}
 	}
 	return t, nil

--- a/tools/node-gen/parser_test.go
+++ b/tools/node-gen/parser_test.go
@@ -70,6 +70,7 @@ func TestParser_FieldTags(t *testing.T) {
 			Inner    planning.Node   ` + "`" + `node:"child"` + "`" + `
 			Param    planning.Node   ` + "`" + `node:"child,nilable"` + "`" + `
 			Args     []planning.Node ` + "`" + `node:"children"` + "`" + `
+			Bounded  []planning.Node ` + "`" + `node:"children,min=1"` + "`" + `
 			Untagged int
 			*Embedded
 		}`})
@@ -77,7 +78,7 @@ func TestParser_FieldTags(t *testing.T) {
 
 	require.Len(t, pkg.NodeStructs, 1)
 	fields := pkg.NodeStructs[0].Fields
-	require.Len(t, fields, 5)
+	require.Len(t, fields, 6)
 
 	require.Equal(t, "Inner", fields[0].Name)
 	require.Equal(t, &NodeTag{IsChild: true}, fields[0].Tag)
@@ -88,11 +89,14 @@ func TestParser_FieldTags(t *testing.T) {
 	require.Equal(t, "Args", fields[2].Name)
 	require.Equal(t, &NodeTag{IsChildren: true}, fields[2].Tag)
 
-	require.Equal(t, "Untagged", fields[3].Name)
-	require.Nil(t, fields[3].Tag)
+	require.Equal(t, "Bounded", fields[3].Name)
+	require.Equal(t, &NodeTag{IsChildren: true, Min: 1}, fields[3].Tag)
 
-	require.True(t, fields[4].Embedded)
-	require.Equal(t, "", fields[4].Name)
+	require.Equal(t, "Untagged", fields[4].Name)
+	require.Nil(t, fields[4].Tag)
+
+	require.True(t, fields[5].Embedded)
+	require.Equal(t, "", fields[5].Name)
 }
 
 func TestParser_BadTag(t *testing.T) {
@@ -114,6 +118,20 @@ func TestParser_BadTag(t *testing.T) {
 					 //node:generate
 					 type S struct{ X int ` + "`" + `node:"child,bogus"` + "`" + ` }`,
 			errContains: `unknown child tag option "bogus"`,
+		},
+		{
+			name: "unknown children option",
+			source: `package core
+					 //node:generate
+					 type S struct{ X []int ` + "`" + `node:"children,bogus"` + "`" + ` }`,
+			errContains: `unknown children tag option "bogus"`,
+		},
+		{
+			name: "invalid children min",
+			source: `package core
+					 //node:generate
+					 type S struct{ X []int ` + "`" + `node:"children,min=abc"` + "`" + ` }`,
+			errContains: `invalid children min value "abc"`,
 		},
 	}
 

--- a/tools/node-gen/set_children_method.tmpl
+++ b/tools/node-gen/set_children_method.tmpl
@@ -26,11 +26,11 @@ func ({{.Receiver}} *{{.Type}}) SetChildren(children []planning.Node) error {
 	if len(children) != {{len .ChildFields}} {
 		return fmt.Errorf("node of type {{.Type}} expects {{if eq (len .ChildFields) 1}}one child{{else}}{{len .ChildFields}} children{{end}}, but got %d", len(children))
 	}
-	{{range $i, $f := .ChildFields}}
+	{{- range $i, $f := .ChildFields}}
 	{{- if ne $f.Type "planning.Node"}}
 	child{{$i}}, ok := children[{{$i}}].({{$f.Type}})
 	if !ok {
-		return fmt.Errorf("node of type {{$.Type}} expects child {{$i}} to be of type {{$f.Type}}, but got %T", children[{{$i}}])
+		return fmt.Errorf("node of type {{$.Type}} expects child {{$f.Name}} to be of type {{$f.Type}}, but got %T", children[{{$i}}])
 	}
 	{{$.Receiver}}.{{$f.Name}} = child{{$i}}
 	{{- else}}
@@ -49,7 +49,7 @@ func ({{.Receiver}} *{{.Type}}) SetChildren(children []planning.Node) error {
 	{{- if ne $f.Type "planning.Node"}}
 		child{{$i}}, ok := children[{{$i}}].({{$f.Type}})
 		if !ok {
-			return fmt.Errorf("node of type {{$.Type}} expects child {{$i}} to be of type {{$f.Type}}, but got %T", children[{{$i}}])
+			return fmt.Errorf("node of type {{$.Type}} expects child {{$f.Name}} to be of type {{$f.Type}}, but got %T", children[{{$i}}])
 		}
 		{{$.Receiver}}.{{$f.Name}} = child{{$i}}
 	{{- else}}
@@ -62,7 +62,7 @@ func ({{.Receiver}} *{{.Type}}) SetChildren(children []planning.Node) error {
 	{{- if ne $f.Type "planning.Node"}}
 		child{{$i}}, ok := children[{{$i}}].({{$f.Type}})
 		if !ok {
-			return fmt.Errorf("node of type {{$.Type}} expects child {{$i}} to be of type {{$f.Type}}, but got %T", children[{{$i}}])
+			return fmt.Errorf("node of type {{$.Type}} expects child {{$f.Name}} to be of type {{$f.Type}}, but got %T", children[{{$i}}])
 		}
 		{{$.Receiver}}.{{$f.Name}} = child{{$i}}
 	{{- else}}

--- a/tools/node-gen/set_children_method.tmpl
+++ b/tools/node-gen/set_children_method.tmpl
@@ -1,0 +1,77 @@
+{{- /*gotype: github.com/grafana/mimir/tools/node-gen.templateStructData*/ -}}
+
+{{define "children_field" -}}
+func ({{.Receiver}} *{{.Type}}) SetChildren(children []planning.Node) error {
+{{- if .ChildrenMin }}
+	if len(children) < {{.ChildrenMin}} {
+		return fmt.Errorf("node of type {{.Type}} expects at least {{if eq .ChildrenMin 1}}one child{{else}}{{.ChildrenMin}} children{{end}}, but got %d", len(children))
+	}
+{{ end }}
+	{{.Receiver}}.{{.ChildrenField}} = children
+	return nil
+}
+{{- end }}
+
+{{define "no_fields" -}}
+func ({{.Receiver}} *{{.Type}}) SetChildren(children []planning.Node) error {
+	if len(children) != 0 {
+		return fmt.Errorf("node of type {{.Type}} expects 0 children, but got %d", len(children))
+	}
+	return nil
+}
+{{- end }}
+
+{{define "child_fields" -}}
+func ({{.Receiver}} *{{.Type}}) SetChildren(children []planning.Node) error {
+	if len(children) != {{len .ChildFields}} {
+		return fmt.Errorf("node of type {{.Type}} expects {{if eq (len .ChildFields) 1}}one child{{else}}{{len .ChildFields}} children{{end}}, but got %d", len(children))
+	}
+	{{range $i, $f := .ChildFields}}
+	{{- if ne $f.Type "planning.Node"}}
+	child{{$i}}, ok := children[{{$i}}].({{$f.Type}})
+	if !ok {
+		return fmt.Errorf("node of type {{$.Type}} expects child {{$i}} to be of type {{$f.Type}}, but got %T", children[{{$i}}])
+	}
+	{{$.Receiver}}.{{$f.Name}} = child{{$i}}
+	{{- else}}
+	{{$.Receiver}}.{{$f.Name}} = children[{{$i}}]
+	{{- end}}
+	{{- end}}
+	return nil
+}
+{{- end }}
+
+{{define "nilable_last" -}}
+func ({{.Receiver}} *{{.Type}}) SetChildren(children []planning.Node) error {
+	switch len(children) {
+	case {{.CountWithoutLast}}:
+	{{- range $i, $f := slice .ChildFields 0 $.CountWithoutLast}}
+	{{- if ne $f.Type "planning.Node"}}
+		child{{$i}}, ok := children[{{$i}}].({{$f.Type}})
+		if !ok {
+			return fmt.Errorf("node of type {{$.Type}} expects child {{$i}} to be of type {{$f.Type}}, but got %T", children[{{$i}}])
+		}
+		{{$.Receiver}}.{{$f.Name}} = child{{$i}}
+	{{- else}}
+		{{$.Receiver}}.{{$f.Name}} = children[{{$i}}]
+	{{- end}}
+	{{- end}}
+		{{.Receiver}}.{{.LastField.Name}} = nil
+	case {{len .ChildFields}}:
+	{{- range $i, $f := .ChildFields}}
+	{{- if ne $f.Type "planning.Node"}}
+		child{{$i}}, ok := children[{{$i}}].({{$f.Type}})
+		if !ok {
+			return fmt.Errorf("node of type {{$.Type}} expects child {{$i}} to be of type {{$f.Type}}, but got %T", children[{{$i}}])
+		}
+		{{$.Receiver}}.{{$f.Name}} = child{{$i}}
+	{{- else}}
+		{{$.Receiver}}.{{$f.Name}} = children[{{$i}}]
+	{{- end}}
+	{{- end}}
+	default:
+		return fmt.Errorf("node of type {{.Type}} expects {{.CountWithoutLast}} or {{len .ChildFields}} children, but got %d", len(children))
+	}
+	return nil
+}
+{{- end }}


### PR DESCRIPTION
#### What this PR does

Adds a `SetChildren` generator to `node-gen` (alongside `Child` and `ChildCount`), replacing the hand-written implementations with generated `node_gen.go` while preserving their existing validation. This also extends the parser to resolve field types and their imports.

This is the **second** PR in a series (after #15294, which bootstrapped `node-gen` with `Child`/`ChildCount`). Follow-up PRs will add generators for the remaining planning node methods — `ReplaceChild`, `ChildrenLabels`, and `EquivalentToIgnoringHintsAndChildren`.

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical codegen migration with broad test coverage; runtime behavior should match prior validation, with only minor error-message wording changes.
> 
> **Overview**
> Extends **node-gen** with a **`SetChildren`** generator (alongside **`Child`** / **`ChildCount`**) and moves **`SetChildren`** implementations from hand-written **`node.go`** files into generated **`node_gen.go`** across core and optimize planning packages.
> 
> The generator validates child counts (including optional **`node:"children,min=N"`**, used on **`RemoteExecutionGroup`**) and emits type assertions for typed child fields (e.g. **`*core.FunctionCall`**, **`*Duplicate`**). The **node-gen** parser now resolves field types and import paths from struct tags to support that output. README and unit tests document the new generator and tag options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e90d16570c6005701183d56a3a0704124a8b3e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->