### PR TITLE
docs/contributing: experimental features default off and behind a flag

### DIFF
--- a/docs/internal/contributing/README.md
+++ b/docs/internal/contributing/README.md
@@ -21,6 +21,10 @@ Before a piece of work is finished:
 - If you have made any changes to flags or config, run `make reference-help doc` and commit the changed files to update the config file documentation.
 - Follow the [pull request template](.github/PULL_REQUEST_TEMPLATE.md) when creating PRs.
 
+## Experimental features
+
+By default, new experimental features should be disabled and gated behind a per-tenant limit or configuration flag, so that they can be tested and introduced gradually. Document the feature in [`docs/sources/mimir/configure/about-versioning.md`](../../sources/mimir/configure/about-versioning.md#experimental-features) so that the no-backwards-compatibility guarantee for experimental features applies.
+
 ## Grafana Mimir Helm chart
 
 Please see the dedicated "[Contributing to Grafana Mimir helm chart](contributing-to-helm-chart.md)" page.

--- a/docs/internal/contributing/README.md
+++ b/docs/internal/contributing/README.md
@@ -23,7 +23,7 @@ Before a piece of work is finished:
 
 ## Experimental features
 
-By default, new experimental features should be disabled and gated behind a per-tenant limit or configuration flag, so that they can be tested and introduced gradually. Document the feature in [`docs/sources/mimir/configure/about-versioning.md`](../../sources/mimir/configure/about-versioning.md#experimental-features) so that the no-backwards-compatibility guarantee for experimental features applies.
+By default, new experimental features should be disabled and gated behind a per-tenant limit or configuration flag, so that they can be tested and introduced gradually. Document the feature in [`docs/sources/mimir/configure/about-versioning.md`](../../sources/mimir/configure/about-versioning.md#experimental-features).
 
 ## Grafana Mimir Helm chart
 


### PR DESCRIPTION
## Summary

Adds an "Experimental features" section to [`docs/internal/contributing/README.md`](https://github.com/grafana/mimir/blob/main/docs/internal/contributing/README.md) (also exposed as the repo-root `AGENTS.md` via symlink) stating that, by default, new experimental features should be **disabled** and gated behind a per-tenant limit or configuration flag so that they can be tested and introduced gradually.

### Why

This codifies an unwritten rule we already follow for most experimental knobs (`-querier.experimental-search-api-enabled`, the `enabled_promql_experimental_functions` per-tenant limit, etc.), but which has been bypassed at times — for example the experimental PromQL duration-expression feature, which Mimir keeps globally enabled in [`pkg/util/promqlext/promqlext.go`](https://github.com/grafana/mimir/blob/main/pkg/util/promqlext/promqlext.go#L37) and which therefore inflicted the upstream `min(...)` → `min_of(...)` / `max(...)` → `max_of(...)` rename on every tenant at once via #15593. Writing this expectation down should reduce the chance of similar breaking changes landing without an opt-in path.

### Non-redundant?

I checked — the existing PR checklist line about `about-versioning.md` ([.github/pull_request_template.md:18](https://github.com/grafana/mimir/blob/main/.github/pull_request_template.md#L18)) and the "convert config to per-tenant limit" guide ([docs/internal/contributing/how-to-convert-config-to-per-tenant-limit.md](https://github.com/grafana/mimir/blob/main/docs/internal/contributing/how-to-convert-config-to-per-tenant-limit.md)) cover procedural / migration details, but neither establishes the policy that new experimental features should be off by default.

## Test plan

- [x] Docs-only change; no code touched
- [x] Confirmed the relative link to `about-versioning.md#experimental-features` resolves (target file exists at `docs/sources/mimir/configure/about-versioning.md`)
- [x] No CHANGELOG entry: contributor-facing docs change, not user-visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only contributor guideline with no code, config, or user-facing product changes.
> 
> **Overview**
> Adds an **Experimental features** section to the internal contributing guide (before the Helm chart section) that states new experimental work should default to **disabled**, be gated behind a per-tenant limit or config flag for gradual rollout, and be documented in `about-versioning.md#experimental-features`.
> 
> This is contributor policy documentation only; no runtime or config behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d90958077b23eb1b058e704c33de0c943d99d90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->