### PR TITLE
compactor scheduler: rotator preserves round-robin order on removal

### DIFF
--- a/pkg/compactor/scheduler/rotator.go
+++ b/pkg/compactor/scheduler/rotator.go
@@ -193,7 +193,7 @@ func (r *Rotator) LeaseJob(ctx context.Context) (*compactorschedulerpb.LeaseJobR
 }
 
 // advanceCursor atomically advances the cursor by one and returns its previous element.
-// Must be called under the read lock with a non-empty rotation.
+// Must be called while holding the lock, with a non-empty rotation.
 func (r *Rotator) advanceCursor() *list.Element {
 	for {
 		elem := r.cursor.Load()
@@ -417,14 +417,10 @@ func (r *Rotator) addToRotation(tenant string, tenantState *TenantRotationState)
 func (r *Rotator) removeFromRotation(tenantState *TenantRotationState) {
 	elem := tenantState.element
 	if r.cursor.Load() == elem {
-		next := elem.Next()
-		if next == nil {
-			next = r.rotation.Front() // wrap
+		r.advanceCursor()
+		if r.cursor.Load() == elem {
+			r.cursor.Store(nil)
 		}
-		if next == elem {
-			next = nil // removing the last remaining element
-		}
-		r.cursor.Store(next)
 	}
 	r.rotation.Remove(elem)
 	tenantState.element = nil

--- a/pkg/compactor/scheduler/rotator.go
+++ b/pkg/compactor/scheduler/rotator.go
@@ -405,7 +405,7 @@ func (r *Rotator) possiblyRemoveFromRotation(tenant string) {
 	}
 }
 
-// addToRotation appends the specified tenant to the rotation. A write lock must be held.
+// addToRotation appends the specified tenant to the rotation. A write lock must be held in order to call this function.
 func (r *Rotator) addToRotation(tenant string, tenantState *TenantRotationState) {
 	tenantState.element = r.rotation.PushBack(tenant)
 	if r.cursor.Load() == nil {

--- a/pkg/compactor/scheduler/rotator.go
+++ b/pkg/compactor/scheduler/rotator.go
@@ -50,15 +50,14 @@ type Rotator struct {
 	mtx            sync.RWMutex
 	tenantStateMap map[string]*TenantRotationState
 	rotation       *list.List
-	// cursor points to the next rotation element to be leased. It is advanced via CAS by concurrent
-	// readers of LeaseJob so each rotation cycle visits every tenant exactly once.
-	// Invariant: cursor is nil if and only if rotation is empty.
+	// cursor points to the next element in 'rotation' to be leased.
+	// it is nil iff 'rotation' is empty.
 	cursor atomic.Pointer[list.Element]
 }
 
 type TenantRotationState struct {
 	tracker *JobTracker
-	// element is the tenant's slot in the rotation, or nil when the tenant is outside the rotation.
+	// element is the tenant's slot in 'rotation', or nil outside the rotation.
 	element *list.Element
 }
 
@@ -164,10 +163,9 @@ func (r *Rotator) LeaseJob(ctx context.Context) (*compactorschedulerpb.LeaseJobR
 		return nil, false, nil
 	}
 
-	// Pick a starting tenant via the shared cursor for fairness across concurrent callers, then walk
-	// the rotation locally so a concurrent LeaseJob advancing the shared cursor cannot cause us to
-	// skip a tenant we have not yet tried. A tenant may transition to having no pending jobs on the
-	// Lease call itself, which returns a nil response and we move on to the next.
+	// Take a starting tenant from the shared cursor for fairness across concurrent callers, then walk
+	// the rotation locally: walking the shared cursor instead would let a concurrent caller advance it
+	// past tenants we never tried, including one with pending work.
 	elem := r.advanceCursor()
 	for range length {
 		tenant := elem.Value.(string)
@@ -194,8 +192,8 @@ func (r *Rotator) LeaseJob(ctx context.Context) (*compactorschedulerpb.LeaseJobR
 	return nil, false, nil
 }
 
-// advanceCursor atomically swaps the cursor to the next rotation element and returns the element
-// that was at the cursor before the swap. Must be called under the read lock with a non-empty rotation.
+// advanceCursor atomically advances the cursor by one and returns its previous element.
+// Must be called under the read lock with a non-empty rotation.
 func (r *Rotator) advanceCursor() *list.Element {
 	for {
 		elem := r.cursor.Load()
@@ -415,8 +413,7 @@ func (r *Rotator) addToRotation(tenant string, tenantState *TenantRotationState)
 	}
 }
 
-// removeFromRotation removes the specified tenant from the rotation in O(1) while preserving the
-// order of the remaining tenants. A write lock must be held.
+// removeFromRotation removes the specified tenant from the rotation. A write lock must be held in order to call this function.
 func (r *Rotator) removeFromRotation(tenantState *TenantRotationState) {
 	elem := tenantState.element
 	if r.cursor.Load() == elem {

--- a/pkg/compactor/scheduler/rotator.go
+++ b/pkg/compactor/scheduler/rotator.go
@@ -3,6 +3,7 @@
 package scheduler
 
 import (
+	"container/list"
 	"context"
 	"sync"
 	"time"
@@ -16,8 +17,6 @@ import (
 
 	"github.com/grafana/mimir/pkg/compactor/scheduler/compactorschedulerpb"
 )
-
-const outsideRotation int = -1
 
 type rotationTransition int
 
@@ -45,18 +44,22 @@ type Rotator struct {
 	intervalsBeforeLeaseExpiration   int
 	intervalsBeforeColdStartPlanning int
 	clock                            clock.Clock
-	rotationIndexCounter             *atomic.Int32 // only increments, overflow is okay
 	pendingJobsLastEmpty             prometheus.Gauge
 	logger                           log.Logger
 
 	mtx            sync.RWMutex
 	tenantStateMap map[string]*TenantRotationState
-	rotation       []string
+	rotation       *list.List
+	// cursor points to the next rotation element to be leased. It is advanced via CAS by concurrent
+	// readers of LeaseJob so each rotation cycle visits every tenant exactly once.
+	// Invariant: cursor is nil if and only if rotation is empty.
+	cursor atomic.Pointer[list.Element]
 }
 
 type TenantRotationState struct {
-	tracker       *JobTracker
-	rotationIndex int
+	tracker *JobTracker
+	// element is the tenant's slot in the rotation, or nil when the tenant is outside the rotation.
+	element *list.Element
 }
 
 func NewRotator(leaseDuration, planningInterval, compactionWaitPeriod, maintenanceInterval time.Duration, intervalsBeforeLeaseExpiration, intervalsBeforeColdStartPlanning int, pendingJobsLastEmpty prometheus.Gauge, logger log.Logger) *Rotator {
@@ -68,11 +71,10 @@ func NewRotator(leaseDuration, planningInterval, compactionWaitPeriod, maintenan
 		intervalsBeforeLeaseExpiration:   intervalsBeforeLeaseExpiration,
 		intervalsBeforeColdStartPlanning: intervalsBeforeColdStartPlanning,
 		clock:                            clock.New(),
-		rotationIndexCounter:             atomic.NewInt32(0),
 		pendingJobsLastEmpty:             pendingJobsLastEmpty,
 		mtx:                              sync.RWMutex{},
 		tenantStateMap:                   make(map[string]*TenantRotationState),
-		rotation:                         make([]string, 0, 10), // initial size doesn't really matter
+		rotation:                         list.New(),
 		logger:                           logger,
 	}
 
@@ -114,7 +116,8 @@ func (r *Rotator) PrepareForShutdown() {
 	defer r.mtx.Unlock()
 
 	r.tenantStateMap = make(map[string]*TenantRotationState)
-	r.rotation = []string{}
+	r.rotation = list.New()
+	r.cursor.Store(nil)
 }
 
 func (r *Rotator) RecoverFrom(jobTrackers map[string]*JobTracker, creationTime time.Time) {
@@ -139,8 +142,7 @@ func (r *Rotator) RecoverFrom(jobTrackers map[string]*JobTracker, creationTime t
 	// Place recovered tenants that have pending work in the rotation
 	for tenant, jobTracker := range jobTrackers {
 		rotationState := &TenantRotationState{
-			tracker:       jobTracker,
-			rotationIndex: outsideRotation,
+			tracker: jobTracker,
 		}
 		r.tenantStateMap[tenant] = rotationState
 		if !jobTracker.isPendingEmpty() {
@@ -148,7 +150,7 @@ func (r *Rotator) RecoverFrom(jobTrackers map[string]*JobTracker, creationTime t
 		}
 	}
 
-	if len(r.rotation) == 0 {
+	if r.rotation.Len() == 0 {
 		r.pendingJobsLastEmpty.Set(float64(r.clock.Now().Unix()))
 	}
 }
@@ -156,20 +158,19 @@ func (r *Rotator) RecoverFrom(jobTrackers map[string]*JobTracker, creationTime t
 func (r *Rotator) LeaseJob(ctx context.Context) (*compactorschedulerpb.LeaseJobResponse, bool, error) {
 	r.mtx.RLock()
 
-	length := len(r.rotation)
+	length := r.rotation.Len()
 	if length == 0 {
-		// avoid divide by zero
 		r.mtx.RUnlock()
 		return nil, false, nil
 	}
 
-	// Handle potential overflow of rotationIndexCounter
-	i := ((int(r.rotationIndexCounter.Add(1)) % length) + length) % length
-
-	// Check possibly all tenants. Tenants get removed from the rotation once they are out of work,
-	// but this may still encounter some due to holding the read lock
+	// Pick a starting tenant via the shared cursor for fairness across concurrent callers, then walk
+	// the rotation locally so a concurrent LeaseJob advancing the shared cursor cannot cause us to
+	// skip a tenant we have not yet tried. A tenant may transition to having no pending jobs on the
+	// Lease call itself, which returns a nil response and we move on to the next.
+	elem := r.advanceCursor()
 	for range length {
-		tenant := r.rotation[i]
+		tenant := elem.Value.(string)
 		response, transition, err := r.tenantStateMap[tenant].tracker.Lease()
 		if err != nil {
 			r.mtx.RUnlock()
@@ -182,16 +183,30 @@ func (r *Rotator) LeaseJob(ctx context.Context) (*compactorschedulerpb.LeaseJobR
 				r.possiblyRemoveFromRotation(tenant)
 			}
 			return response, true, nil
-
 		}
-		i += 1
-		if i == length {
-			i = 0
+		elem = elem.Next()
+		if elem == nil {
+			elem = r.rotation.Front()
 		}
 	}
 
 	r.mtx.RUnlock()
 	return nil, false, nil
+}
+
+// advanceCursor atomically swaps the cursor to the next rotation element and returns the element
+// that was at the cursor before the swap. Must be called under the read lock with a non-empty rotation.
+func (r *Rotator) advanceCursor() *list.Element {
+	for {
+		elem := r.cursor.Load()
+		next := elem.Next()
+		if next == nil {
+			next = r.rotation.Front()
+		}
+		if r.cursor.CompareAndSwap(elem, next) {
+			return elem
+		}
+	}
 }
 
 func (r *Rotator) RenewJobLease(tenant string, key string, epoch int64) bool {
@@ -235,7 +250,7 @@ func (r *Rotator) CancelJobLease(tenant string, key string, epoch int64) (bool, 
 		return canceled, nil
 	}
 
-	if tenantState.rotationIndex == outsideRotation && !tenantState.tracker.isPendingEmpty() {
+	if tenantState.element == nil && !tenantState.tracker.isPendingEmpty() {
 		r.addToRotation(tenant, tenantState)
 	}
 
@@ -256,21 +271,21 @@ func (r *Rotator) OfferCompactionJobs(tenant string, jobs []*TrackedCompactionJo
 		return 0, found, err
 	}
 
-	// Must still be holding the read lock to read rotation index
+	// Must still be holding the read lock to read rotation membership
 	switch transition {
 	case rotationAddTracker:
-		if tenantState.rotationIndex == outsideRotation {
+		if tenantState.element == nil {
 			r.mtx.RUnlock() // drop read lock to acquire write lock
 			r.mtx.Lock()
 			// Double check still present, not in rotation, and there are pending jobs
-			if tenantState, ok := r.tenantStateMap[tenant]; ok && tenantState.rotationIndex == outsideRotation && !tenantState.tracker.isPendingEmpty() {
+			if tenantState, ok := r.tenantStateMap[tenant]; ok && tenantState.element == nil && !tenantState.tracker.isPendingEmpty() {
 				r.addToRotation(tenant, tenantState)
 			}
 			r.mtx.Unlock()
 			return added, found, nil
 		}
 	case rotationRemoveTracker:
-		if tenantState.rotationIndex != outsideRotation {
+		if tenantState.element != nil {
 			r.mtx.RUnlock() // drop read lock to acquire write lock
 			r.possiblyRemoveFromRotation(tenant)
 			return added, found, nil
@@ -313,8 +328,7 @@ func (r *Rotator) AddTenant(tenant string, jobTracker *JobTracker) {
 	}
 
 	rotationState := &TenantRotationState{
-		tracker:       jobTracker,
-		rotationIndex: outsideRotation,
+		tracker: jobTracker,
 	}
 
 	r.tenantStateMap[tenant] = rotationState
@@ -335,7 +349,7 @@ func (r *Rotator) RemoveTenant(tenant string) (*JobTracker, bool) {
 	// Note: don't care if there are active/pending jobs in this tenant.
 	// A caller would only call this function if it sees the tenant as entirely empty. We could still be
 	// generating plan jobs that achieve nothing in that case.
-	if tenantState.rotationIndex != outsideRotation {
+	if tenantState.element != nil {
 		r.removeFromRotation(tenantState)
 	}
 	delete(r.tenantStateMap, tenant)
@@ -357,7 +371,7 @@ func (r *Rotator) Maintenance(ctx context.Context, enforceLeaseExpiration, plan 
 			addRotationFor = append(addRotationFor, tenant)
 		}
 	}
-	stayingEmpty := len(addRotationFor) == 0 && len(r.rotation) == 0
+	stayingEmpty := len(addRotationFor) == 0 && r.rotation.Len() == 0
 	r.mtx.RUnlock()
 
 	if len(addRotationFor) == 0 || ctx.Err() != nil {
@@ -374,7 +388,7 @@ func (r *Rotator) Maintenance(ctx context.Context, enforceLeaseExpiration, plan 
 	defer r.mtx.Unlock()
 	for _, tenant := range addRotationFor {
 		tenantState, ok := r.tenantStateMap[tenant]
-		if ok && tenantState.rotationIndex == outsideRotation && !tenantState.tracker.isPendingEmpty() {
+		if ok && tenantState.element == nil && !tenantState.tracker.isPendingEmpty() {
 			r.addToRotation(tenant, tenantState)
 		}
 	}
@@ -388,30 +402,37 @@ func (r *Rotator) possiblyRemoveFromRotation(tenant string) {
 	// Since we hold the write lock, we have exclusive access to all trackers.
 	// Therefore, the tracker lock isn't necessary for isPendingEmpty(). Be quick.
 	tenantState, ok := r.tenantStateMap[tenant]
-	if ok && tenantState.rotationIndex != outsideRotation && tenantState.tracker.isPendingEmpty() {
+	if ok && tenantState.element != nil && tenantState.tracker.isPendingEmpty() {
 		r.removeFromRotation(tenantState)
 	}
 }
 
-// Adds the specified tenant to the rotation. A write lock must be held in order to call this function.
+// addToRotation appends the specified tenant to the rotation. A write lock must be held.
 func (r *Rotator) addToRotation(tenant string, tenantState *TenantRotationState) {
-	tenantState.rotationIndex = len(r.rotation)
-	r.rotation = append(r.rotation, tenant)
+	tenantState.element = r.rotation.PushBack(tenant)
+	if r.cursor.Load() == nil {
+		r.cursor.Store(tenantState.element)
+	}
 }
 
-// Removes the specified tenant from the rotation. A write lock must be held in order to call this function.
+// removeFromRotation removes the specified tenant from the rotation in O(1) while preserving the
+// order of the remaining tenants. A write lock must be held.
 func (r *Rotator) removeFromRotation(tenantState *TenantRotationState) {
-	length := len(r.rotation)
-	if tenantState.rotationIndex != length-1 {
-		// Swap with the last tenant. This causes an imperfect rotation, but such is life
-		r.rotation[tenantState.rotationIndex] = r.rotation[length-1]
-		r.tenantStateMap[r.rotation[length-1]].rotationIndex = tenantState.rotationIndex
+	elem := tenantState.element
+	if r.cursor.Load() == elem {
+		next := elem.Next()
+		if next == nil {
+			next = r.rotation.Front() // wrap
+		}
+		if next == elem {
+			next = nil // removing the last remaining element
+		}
+		r.cursor.Store(next)
 	}
-	// Remove the tenant from the rotation
-	r.rotation = r.rotation[:length-1]
-	tenantState.rotationIndex = outsideRotation
+	r.rotation.Remove(elem)
+	tenantState.element = nil
 
-	if len(r.rotation) == 0 {
+	if r.rotation.Len() == 0 {
 		r.pendingJobsLastEmpty.Set(float64(r.clock.Now().Unix()))
 	}
 }

--- a/pkg/compactor/scheduler/rotator_test.go
+++ b/pkg/compactor/scheduler/rotator_test.go
@@ -129,17 +129,6 @@ func TestRotator_RemoveFromRotation_PreservesOrder(t *testing.T) {
 	require.Nil(t, r.cursor.Load())
 }
 
-func TestRotator_AdvanceCursor_RoundRobin(t *testing.T) {
-	r := newRotatorForTest()
-	seedRotation(r, "a", "b", "c")
-
-	var seen []string
-	for range 9 {
-		seen = append(seen, r.advanceCursor().Value.(string))
-	}
-	require.Equal(t, []string{"a", "b", "c", "a", "b", "c", "a", "b", "c"}, seen)
-}
-
 func TestRotator_RemoveFromRotation_AdvancesCursor(t *testing.T) {
 	r := newRotatorForTest()
 	states := seedRotation(r, "a", "b", "c", "d", "e")

--- a/pkg/compactor/scheduler/rotator_test.go
+++ b/pkg/compactor/scheduler/rotator_test.go
@@ -87,74 +87,86 @@ func newRotatorForTest() *Rotator {
 	return NewRotator(0, 0, 0, time.Minute, 0, 0, metrics.pendingJobsLastEmpty, log.NewNopLogger())
 }
 
-func seedRotation(r *Rotator, tenants ...string) map[string]*TenantRotationState {
-	states := make(map[string]*TenantRotationState, len(tenants))
-	for _, tenant := range tenants {
-		state := &TenantRotationState{}
-		r.tenantStateMap[tenant] = state
-		r.addToRotation(tenant, state)
-		states[tenant] = state
+// addTenantWithPendingJobs adds a tenant to the rotation with numJobs pending compaction jobs
+func addTenantWithPendingJobs(r *Rotator, clk clock.Clock, name string, numJobs int) {
+	metrics := newSchedulerMetrics(prometheus.NewPedanticRegistry())
+	jt := NewJobTracker(&NopJobPersister{}, name, clk, infiniteLeases, infiniteLeases, metrics.newTrackerMetricsForTenant(name), log.NewNopLogger())
+	for j := range numJobs {
+		id := fmt.Sprintf("%s-%d", name, j)
+		jt.incompleteJobs[id] = jt.pending.PushBack(
+			NewTrackedCompactionJob(id, &CompactionJob{}, uint32(j), 0, clk.Now()))
 	}
-	return states
+	r.AddTenant(name, jt)
 }
 
-func rotationOrder(r *Rotator) []string {
-	tenants := make([]string, 0, r.rotation.Len())
-	for e := r.rotation.Front(); e != nil; e = e.Next() {
-		tenants = append(tenants, e.Value.(string))
-	}
-	return tenants
+// leaseTenant leases one job and returns the tenant it was leased from.
+func leaseTenant(t *testing.T, r *Rotator) string {
+	t.Helper()
+	resp, ok, err := r.LeaseJob(context.Background())
+	require.NoError(t, err)
+	require.True(t, ok)
+	return resp.Spec.Tenant
 }
 
-func TestRotator_RemoveFromRotation_PreservesOrder(t *testing.T) {
-	r := newRotatorForTest()
-	states := seedRotation(r, "a", "b", "c", "d", "e")
-	require.Equal(t, []string{"a", "b", "c", "d", "e"}, rotationOrder(r))
+// TestRotator_RemoveTenant checks that RemoveTenant does not alter the order of the remaining tenants.
+func TestRotator_RemoveTenant(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		tenants    []string
+		leaseFirst int
+		remove     string
+		want       []string
+	}{
+		{
+			name:       "tenant the cursor already passed keeps order",
+			tenants:    []string{"a", "b", "c", "d", "e"},
+			leaseFirst: 5, // full cycle: cursor back on "a"
+			remove:     "c",
+			want:       []string{"a", "b", "d", "e", "a", "b", "d", "e"},
+		},
+		{
+			name:       "next-up middle tenant does not skip",
+			tenants:    []string{"a", "b", "c", "d", "e"},
+			leaseFirst: 2, // next up is "c"
+			remove:     "c",
+			want:       []string{"d", "e", "a", "b", "d"},
+		},
+		{
+			name:       "next-up tail tenant wraps to front",
+			tenants:    []string{"a", "b", "c"},
+			leaseFirst: 2, // next up is "c"
+			remove:     "c",
+			want:       []string{"a", "b", "a", "b"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clk := clock.NewMock()
+			clk.Set(time.Now())
+			r := newRotatorForTest()
+			r.clock = clk
 
-	// Remove from the middle: remaining tenants keep their relative order.
-	r.removeFromRotation(states["c"])
-	require.Equal(t, []string{"a", "b", "d", "e"}, rotationOrder(r))
-	require.Nil(t, states["c"].element)
+			for _, name := range tc.tenants {
+				addTenantWithPendingJobs(r, clk, name, 10)
+			}
+			for range tc.leaseFirst {
+				leaseTenant(t, r)
+			}
 
-	// Remove the head and the tail.
-	r.removeFromRotation(states["a"])
-	require.Equal(t, []string{"b", "d", "e"}, rotationOrder(r))
-	r.removeFromRotation(states["e"])
-	require.Equal(t, []string{"b", "d"}, rotationOrder(r))
+			_, ok := r.RemoveTenant(tc.remove)
+			require.True(t, ok)
 
-	// Drain the rotation: cursor goes back to nil.
-	r.removeFromRotation(states["b"])
-	r.removeFromRotation(states["d"])
-	require.Equal(t, 0, r.rotation.Len())
-	require.Nil(t, r.cursor.Load())
-}
-
-func TestRotator_RemoveFromRotation_AdvancesCursor(t *testing.T) {
-	r := newRotatorForTest()
-	states := seedRotation(r, "a", "b", "c", "d", "e")
-
-	// Consume two slots so the cursor lands on "c".
-	require.Equal(t, "a", r.advanceCursor().Value.(string))
-	require.Equal(t, "b", r.advanceCursor().Value.(string))
-	require.Equal(t, "c", r.cursor.Load().Value.(string))
-
-	// Removing the tenant the cursor points to advances it to the next tenant, preserving order.
-	r.removeFromRotation(states["c"])
-	require.Equal(t, "d", r.cursor.Load().Value.(string))
-
-	// Round-robin continues in the original relative order.
-	var seen []string
-	for range 8 {
-		seen = append(seen, r.advanceCursor().Value.(string))
+			var seen []string
+			for range tc.want {
+				seen = append(seen, leaseTenant(t, r))
+			}
+			require.Equal(t, tc.want, seen)
+		})
 	}
-	require.Equal(t, []string{"d", "e", "a", "b", "d", "e", "a", "b"}, seen)
 }
 
 // TestRotator_LeaseJob_ConcurrentLeasersDoNotSkipPendingWork is a regression test for a bug where
-// LeaseJob's loop advanced the shared cursor on every iteration. Under contention, a concurrent
-// leaser's advances could interleave with this leaser's advances, causing it to revisit some
-// tenants and skip others — including the one with pending work. With K pending jobs and K
-// concurrent leasers, all K leasers must succeed.
+// LeaseJob's loop advanced the shared cursor on every iteration. Under contention, this could cause
+// it to skip over tenants with pending jobs.
 func TestRotator_LeaseJob_ConcurrentLeasersDoNotSkipPendingWork(t *testing.T) {
 	const (
 		numEmpties = 8
@@ -217,20 +229,6 @@ func TestRotator_LeaseJob_ConcurrentLeasersDoNotSkipPendingWork(t *testing.T) {
 		require.Equal(t, int32(leasers), successes.Load(),
 			"trial %d: every leaser must succeed because the rotation has at least %d pending jobs", trial, leasers)
 	}
-}
-
-func TestRotator_RemoveFromRotation_CursorWrapsOnTailRemoval(t *testing.T) {
-	r := newRotatorForTest()
-	states := seedRotation(r, "a", "b", "c")
-
-	// Advance cursor to the tail ("c").
-	require.Equal(t, "a", r.advanceCursor().Value.(string))
-	require.Equal(t, "b", r.advanceCursor().Value.(string))
-	require.Equal(t, "c", r.cursor.Load().Value.(string))
-
-	// Removing the tail under the cursor wraps to the front.
-	r.removeFromRotation(states["c"])
-	require.Equal(t, "a", r.cursor.Load().Value.(string))
 }
 
 func TestRotator_PendingJobsLastEmpty(t *testing.T) {

--- a/pkg/compactor/scheduler/rotator_test.go
+++ b/pkg/compactor/scheduler/rotator_test.go
@@ -87,8 +87,9 @@ func newRotatorForTest() *Rotator {
 	return NewRotator(0, 0, 0, time.Minute, 0, 0, metrics.pendingJobsLastEmpty, log.NewNopLogger())
 }
 
-// addTenantWithPendingJobs adds a tenant to the rotation with numJobs pending compaction jobs
-func addTenantWithPendingJobs(r *Rotator, clk clock.Clock, name string, numJobs int) {
+// newTrackerWithPendingJobs builds a JobTracker for the named tenant holding numJobs pending
+// compaction jobs (numJobs == 0 yields an empty tracker).
+func newTrackerWithPendingJobs(clk clock.Clock, name string, numJobs int) *JobTracker {
 	metrics := newSchedulerMetrics(prometheus.NewPedanticRegistry())
 	jt := NewJobTracker(&NopJobPersister{}, name, clk, infiniteLeases, infiniteLeases, metrics.newTrackerMetricsForTenant(name), log.NewNopLogger())
 	for j := range numJobs {
@@ -96,7 +97,12 @@ func addTenantWithPendingJobs(r *Rotator, clk clock.Clock, name string, numJobs 
 		jt.incompleteJobs[id] = jt.pending.PushBack(
 			NewTrackedCompactionJob(id, &CompactionJob{}, uint32(j), 0, clk.Now()))
 	}
-	r.AddTenant(name, jt)
+	return jt
+}
+
+// addTenantWithPendingJobs adds a tenant to the rotation with numJobs pending compaction jobs
+func addTenantWithPendingJobs(r *Rotator, clk clock.Clock, name string, numJobs int) {
+	r.AddTenant(name, newTrackerWithPendingJobs(clk, name, numJobs))
 }
 
 // leaseTenant leases one job and returns the tenant it was leased from.
@@ -170,7 +176,7 @@ func TestRotator_RemoveTenant(t *testing.T) {
 func TestRotator_LeaseJob_ConcurrentLeasersDoNotSkipPendingWork(t *testing.T) {
 	const (
 		numEmpties = 8
-		leasers    = 16
+		jobCount   = 16
 		trials     = 50
 	)
 
@@ -181,41 +187,28 @@ func TestRotator_LeaseJob_ConcurrentLeasersDoNotSkipPendingWork(t *testing.T) {
 		r := newRotatorForTest()
 		r.clock = clk
 
-		// Build [empty, ..., empty, pending(leasers jobs), empty, ..., empty]. Put the pending
-		// tenant in the middle so a leaser must traverse empties before reaching it.
-		midIdx := numEmpties / 2
-		seeded := make([]struct {
-			name string
-			jt   *JobTracker
-		}, 0, numEmpties+1)
+		// lets us easily setup a rotation with tenants with no work for the test
+		forceIntoRotation := func(name string, jt *JobTracker) {
+			state := &TenantRotationState{tracker: jt}
+			r.tenantStateMap[name] = state
+			r.addToRotation(name, state)
+		}
+
+		// Setup a rotation like so: [empty, ..., empty, pending(jobCount jobs), empty, ..., empty]
+		// The pending tenant sits in the middle so a leaser must traverse empties before reaching it.
 		for i := range numEmpties + 1 {
-			jt, _ := newTestJobTracker(clk)
-			name := fmt.Sprintf("empty%d", i)
-			if i == midIdx {
-				name = "pending"
-				for j := range leasers {
-					id := fmt.Sprintf("job-%d-%d", trial, j)
-					jt.incompleteJobs[id] = jt.pending.PushBack(
-						NewTrackedCompactionJob(id, &CompactionJob{}, uint32(j), 0, clk.Now()))
-				}
+			name, numJobs := fmt.Sprintf("empty%d", i), 0
+			if i == numEmpties/2 {
+				name, numJobs = "pending", jobCount
 			}
-			seeded = append(seeded, struct {
-				name string
-				jt   *JobTracker
-			}{name, jt})
+			forceIntoRotation(name, newTrackerWithPendingJobs(clk, name, numJobs))
 		}
 
-		// Seed the rotation directly so the empties are in it (AddTenant would skip them).
-		for _, s := range seeded {
-			state := &TenantRotationState{tracker: s.jt}
-			r.tenantStateMap[s.name] = state
-			r.addToRotation(s.name, state)
-		}
-
+		// Spin up jobCount concurrent leasers, we should have exactly jobCount successful leases
 		var wg sync.WaitGroup
 		var successes atomic.Int32
 		start := make(chan struct{})
-		for range leasers {
+		for range jobCount {
 			wg.Go(func() {
 				<-start
 				if _, ok, _ := r.LeaseJob(context.Background()); ok {
@@ -226,8 +219,8 @@ func TestRotator_LeaseJob_ConcurrentLeasersDoNotSkipPendingWork(t *testing.T) {
 		close(start)
 		wg.Wait()
 
-		require.Equal(t, int32(leasers), successes.Load(),
-			"trial %d: every leaser must succeed because the rotation has at least %d pending jobs", trial, leasers)
+		require.Equal(t, int32(jobCount), successes.Load(),
+			"trial %d: every leaser must succeed because the rotation has at least %d pending jobs", trial, jobCount)
 	}
 }
 

--- a/pkg/compactor/scheduler/rotator_test.go
+++ b/pkg/compactor/scheduler/rotator_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	prom_testutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 )
 
 func TestRotator_RecoverFrom_ColdStartDelay(t *testing.T) {
@@ -77,6 +79,169 @@ func TestRotator_RecoverFrom_ColdStartDelay(t *testing.T) {
 			require.Equal(t, tc.expectedIntervals, r.intervalsBeforeColdStartPlanning)
 		})
 	}
+}
+
+func newRotatorForTest() *Rotator {
+	reg := prometheus.NewPedanticRegistry()
+	metrics := newSchedulerMetrics(reg)
+	return NewRotator(0, 0, 0, time.Minute, 0, 0, metrics.pendingJobsLastEmpty, log.NewNopLogger())
+}
+
+func seedRotation(r *Rotator, tenants ...string) map[string]*TenantRotationState {
+	states := make(map[string]*TenantRotationState, len(tenants))
+	for _, tenant := range tenants {
+		state := &TenantRotationState{}
+		r.tenantStateMap[tenant] = state
+		r.addToRotation(tenant, state)
+		states[tenant] = state
+	}
+	return states
+}
+
+func rotationOrder(r *Rotator) []string {
+	tenants := make([]string, 0, r.rotation.Len())
+	for e := r.rotation.Front(); e != nil; e = e.Next() {
+		tenants = append(tenants, e.Value.(string))
+	}
+	return tenants
+}
+
+func TestRotator_RemoveFromRotation_PreservesOrder(t *testing.T) {
+	r := newRotatorForTest()
+	states := seedRotation(r, "a", "b", "c", "d", "e")
+	require.Equal(t, []string{"a", "b", "c", "d", "e"}, rotationOrder(r))
+
+	// Remove from the middle: remaining tenants keep their relative order.
+	r.removeFromRotation(states["c"])
+	require.Equal(t, []string{"a", "b", "d", "e"}, rotationOrder(r))
+	require.Nil(t, states["c"].element)
+
+	// Remove the head and the tail.
+	r.removeFromRotation(states["a"])
+	require.Equal(t, []string{"b", "d", "e"}, rotationOrder(r))
+	r.removeFromRotation(states["e"])
+	require.Equal(t, []string{"b", "d"}, rotationOrder(r))
+
+	// Drain the rotation: cursor goes back to nil.
+	r.removeFromRotation(states["b"])
+	r.removeFromRotation(states["d"])
+	require.Equal(t, 0, r.rotation.Len())
+	require.Nil(t, r.cursor.Load())
+}
+
+func TestRotator_AdvanceCursor_RoundRobin(t *testing.T) {
+	r := newRotatorForTest()
+	seedRotation(r, "a", "b", "c")
+
+	var seen []string
+	for range 9 {
+		seen = append(seen, r.advanceCursor().Value.(string))
+	}
+	require.Equal(t, []string{"a", "b", "c", "a", "b", "c", "a", "b", "c"}, seen)
+}
+
+func TestRotator_RemoveFromRotation_AdvancesCursor(t *testing.T) {
+	r := newRotatorForTest()
+	states := seedRotation(r, "a", "b", "c", "d", "e")
+
+	// Consume two slots so the cursor lands on "c".
+	require.Equal(t, "a", r.advanceCursor().Value.(string))
+	require.Equal(t, "b", r.advanceCursor().Value.(string))
+	require.Equal(t, "c", r.cursor.Load().Value.(string))
+
+	// Removing the tenant the cursor points to advances it to the next tenant, preserving order.
+	r.removeFromRotation(states["c"])
+	require.Equal(t, "d", r.cursor.Load().Value.(string))
+
+	// Round-robin continues in the original relative order.
+	var seen []string
+	for range 8 {
+		seen = append(seen, r.advanceCursor().Value.(string))
+	}
+	require.Equal(t, []string{"d", "e", "a", "b", "d", "e", "a", "b"}, seen)
+}
+
+// TestRotator_LeaseJob_ConcurrentLeasersDoNotSkipPendingWork is a regression test for a bug where
+// LeaseJob's loop advanced the shared cursor on every iteration. Under contention, a concurrent
+// leaser's advances could interleave with this leaser's advances, causing it to revisit some
+// tenants and skip others — including the one with pending work. With K pending jobs and K
+// concurrent leasers, all K leasers must succeed.
+func TestRotator_LeaseJob_ConcurrentLeasersDoNotSkipPendingWork(t *testing.T) {
+	const (
+		numEmpties = 8
+		leasers    = 16
+		trials     = 50
+	)
+
+	for trial := range trials {
+		clk := clock.NewMock()
+		clk.Set(time.Now())
+
+		r := newRotatorForTest()
+		r.clock = clk
+
+		// Build [empty, ..., empty, pending(leasers jobs), empty, ..., empty]. Put the pending
+		// tenant in the middle so a leaser must traverse empties before reaching it.
+		midIdx := numEmpties / 2
+		seeded := make([]struct {
+			name string
+			jt   *JobTracker
+		}, 0, numEmpties+1)
+		for i := range numEmpties + 1 {
+			jt, _ := newTestJobTracker(clk)
+			name := fmt.Sprintf("empty%d", i)
+			if i == midIdx {
+				name = "pending"
+				for j := range leasers {
+					id := fmt.Sprintf("job-%d-%d", trial, j)
+					jt.incompleteJobs[id] = jt.pending.PushBack(
+						NewTrackedCompactionJob(id, &CompactionJob{}, uint32(j), 0, clk.Now()))
+				}
+			}
+			seeded = append(seeded, struct {
+				name string
+				jt   *JobTracker
+			}{name, jt})
+		}
+
+		// Seed the rotation directly so the empties are in it (AddTenant would skip them).
+		for _, s := range seeded {
+			state := &TenantRotationState{tracker: s.jt}
+			r.tenantStateMap[s.name] = state
+			r.addToRotation(s.name, state)
+		}
+
+		var wg sync.WaitGroup
+		var successes atomic.Int32
+		start := make(chan struct{})
+		for range leasers {
+			wg.Go(func() {
+				<-start
+				if _, ok, _ := r.LeaseJob(context.Background()); ok {
+					successes.Add(1)
+				}
+			})
+		}
+		close(start)
+		wg.Wait()
+
+		require.Equal(t, int32(leasers), successes.Load(),
+			"trial %d: every leaser must succeed because the rotation has at least %d pending jobs", trial, leasers)
+	}
+}
+
+func TestRotator_RemoveFromRotation_CursorWrapsOnTailRemoval(t *testing.T) {
+	r := newRotatorForTest()
+	states := seedRotation(r, "a", "b", "c")
+
+	// Advance cursor to the tail ("c").
+	require.Equal(t, "a", r.advanceCursor().Value.(string))
+	require.Equal(t, "b", r.advanceCursor().Value.(string))
+	require.Equal(t, "c", r.cursor.Load().Value.(string))
+
+	// Removing the tail under the cursor wraps to the front.
+	r.removeFromRotation(states["c"])
+	require.Equal(t, "a", r.cursor.Load().Value.(string))
 }
 
 func TestRotator_PendingJobsLastEmpty(t *testing.T) {


### PR DESCRIPTION
#### What this PR does



Addresses the "imperfect" round robin that currently exists when a tenant is removed, where we swapped the removed tenant with the last one for performance reasons. This seemed quite harmless, but it happens more often than what it appears to, and has noticeable impact. Consider the following scenario with the existing logic:

Starting point. This is the rotation:

```
user A -> plan
user B -> plan
user C -> plan
```

Worker takes next job. User A is removed from the rotation, and the imperfect round robin swaps the order of B and C

```
user C -> plan
user B -> plan
```

Worker finishes plan:
```
user C -> plan
user B -> plan
user A -> compaction1, compaction 2
```

Worker takes next job. A and B swap positions.

```
user A -> compaction1, compaction 2
user B -> plan
```

Now user A compactions are in front of B's plan, while ideally we'd process all plans before moving to compactions. In practice we've observed this happens on every planning cycle, see how plan jobs are delayed in the following screenshot:



<details>
<summary>Screenshot (before)</summary>

<img width="1860" height="972" alt="image" src="https://github.com/user-attachments/assets/55ac97de-6747-4a08-b99a-b1f81118facf" />


</details>

In the worst scenario, a plan is postponed repeatedly and rolls over the next planning cycle without being reached.


_With_ the fix it looks like this. You can see how all plans are processed before starting with compaction jobs.

<details>
<summary>Screenshot (after fix)</summary>

<img width="1896" height="986" alt="image" src="https://github.com/user-attachments/assets/47e79509-fb03-46cd-8e3a-422c354d822b" />


</details>

---

The proposed fix is to change the slice+index that holds rotation for a linked list + iterator ("cursor"), keeping the removal logic O(1). This makes the concurrency handling a bit trickier, since we want to avoid a global write lock to be acquired on every lease. The solution is to advance the cursor via CAS loop under the read lock (which we already held) and unlink the element in place without altering the order.

Worth noting that we are already going through several CAS loops through the prometheus client, e.g. https://github.com/prometheus/client_golang/blob/e839fbaf72ad0cd876d06b056bc6ba3455d8d6b1/prometheus/gauge.go#L123-L131 (and maybe even within the http/grpc packages?). All this to say, it should not be a performance regression.


#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - not needed (unreleased compactor scheduler internals).
- [n/a] [`about-versioning.md`] updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core compactor scheduler fairness and concurrency in `LeaseJob`; behavior is well covered by new tests but affects job ordering under load.
> 
> **Overview**
> Replaces the compactor scheduler **Rotator** tenant queue from a slice plus per-tenant index (with swap-with-last on removal) to a **`container/list`** plus an atomic **cursor**. Removals unlink in place so relative tenant order stays stable across planning cycles—avoiding plan jobs being repeatedly deferred behind compactions.
> 
> **`LeaseJob`** now takes one starting tenant from the shared cursor via **`advanceCursor`** (CAS under the read lock), then walks the list locally for empty tenants instead of advancing the shared cursor on every loop iteration—fixing concurrent leasers skipping tenants that still have pending work.
> 
> Tests add **`TestRotator_RemoveTenant`** (order after removal) and **`TestRotator_LeaseJob_ConcurrentLeasersDoNotSkipPendingWork`** (50-trial regression).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 564052b426ac5d4507388e7f15aabfb196d13450. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->