### PR TITLE
Parameterise ingester partition autoscaling jsonnet

### DIFF
--- a/operations/mimir/ingest-storage-ingester-autoscaling.libsonnet
+++ b/operations/mimir/ingest-storage-ingester-autoscaling.libsonnet
@@ -34,40 +34,7 @@
 
     // Make triggers configurable so that we can add more. Each object needs to have: query, threshold, metric_type.
     ingest_storage_ingester_autoscaling_triggers: [
-      {
-        // We want to target a maximum number of owned series per ingester pod.
-        // However, we can't use a `Value` metric because the HPA will also count pods assigned to read-only partitions when calculating the desired number of replicas.
-        // This means we need to use an `AverageValue` metric, which doesn't use the current replica count at all.
-        // To do this, we fake a "total owned series" value by multiplying the max owned series per pod by the number of active partitions.
-        // The HPA then calculates the desired replica count as this total value / threshold.
-
-        // Calculate the "total owned series" as the owned series on the worst pod multiplied by the number of active partitions.
-        local max_owned_series_x_active_partitions = |||
-          (
-              max(
-                  sum by (pod) (cortex_ingester_owned_series{cluster="%(cluster)s", namespace="%(namespace)s", job="%(namespace)s/%(primary_zone)s", container="ingester"})
-                  and
-                  sum by (pod) (kube_pod_status_ready{cluster="%(cluster)s", namespace="%(namespace)s", pod=~"%(primary_zone)s.*", condition="true"}) > 0
-              )
-              *
-              max(cortex_partition_ring_partitions{cluster="%(cluster)s", namespace="%(namespace)s", state="Active", container="distributor", name="ingester-partitions"})
-          )
-        |||,
-
-        // Our compaction cycles are 2h long, but the max stabilizationWindowSeconds is only 1h. This means that we'll react to a scale-down
-        // after compaction half-way through a cycle, when the series counts in ingesters are still growing, resulting in partitions being put into read-only
-        // mode only to be taken back out of it a short time later. To artificially increase our stabilization window to 3h, we use a `max_over_time`
-        // of 2h. However, because this query uses both the max-owned-series-per-pod and the partition count, and the max-owned-series-per-pod doesn't decrease
-        // until some time after the partition count increases, we see brief spikes in the artificial "total series" we calculate after a scale-up. To
-        // mitigate this, we first use a `min_over_time` of 5m.
-        query: ('max_over_time(min_over_time(' + max_owned_series_x_active_partitions + '[5m:])[2h:5m])') % {
-          cluster: $._config.cluster,
-          namespace: $._config.namespace,
-          primary_zone: $._config.ingest_storage_ingester_autoscaling_primary_zone,
-        },
-        threshold: std.toString($._config.ingest_storage_ingester_autoscaling_max_owned_series_threshold),
-        metric_type: 'AverageValue',  // HPA will compute desired replicas as "<query result> / <threshold>".
-      },
+      $.ingesterPartitionAutoscalingOwnedSeriesTrigger($._config.ingest_storage_ingester_autoscaling_primary_zone, 'ingester-partitions'),
     ],
 
     // When set to false, metrics used by scaling triggers are only indexed if there is more than 1 trigger.
@@ -96,37 +63,79 @@
   // Create resource that will be targetted by ScaledObject.
   ingester_primary_zone_replica_template: if !$._config.ingest_storage_ingester_autoscaling_enabled then null else $.replicaTemplate($._config.ingest_storage_ingester_autoscaling_primary_zone, replicas=-1, label_selector=$._config.ingest_storage_replica_template_label_selector),
 
+  ingesterPartitionAutoscalingOwnedSeriesTrigger(podSelector, ringName):: {
+    // We want to target a maximum number of owned series per ingester pod.
+    // However, we can't use a `Value` metric because the HPA will also count pods assigned to read-only partitions when calculating the desired number of replicas.
+    // This means we need to use an `AverageValue` metric, which doesn't use the current replica count at all.
+    // To do this, we fake a "total owned series" value by multiplying the max owned series per pod by the number of active partitions.
+    // The HPA then calculates the desired replica count as this total value / threshold.
+
+    // Calculate the "total owned series" as the owned series on the worst pod multiplied by the number of active partitions.
+    local max_owned_series_x_active_partitions = |||
+      (
+          max(
+              sum by (pod) (cortex_ingester_owned_series{cluster="%(cluster)s", namespace="%(namespace)s", job="%(namespace)s/%(pod_selector)s", container="ingester"})
+              and
+              sum by (pod) (kube_pod_status_ready{cluster="%(cluster)s", namespace="%(namespace)s", pod=~"%(pod_selector)s.*", condition="true"}) > 0
+          )
+          *
+          max(cortex_partition_ring_partitions{cluster="%(cluster)s", namespace="%(namespace)s", state="Active", container="distributor", name="%(ring)s"})
+      )
+    |||,
+
+    // Our compaction cycles are 2h long, but the max stabilizationWindowSeconds is only 1h. This means that we'll react to a scale-down
+    // after compaction half-way through a cycle, when the series counts in ingesters are still growing, resulting in partitions being put into read-only
+    // mode only to be taken back out of it a short time later. To artificially increase our stabilization window to 3h, we use a `max_over_time`
+    // of 2h. However, because this query uses both the max-owned-series-per-pod and the partition count, and the max-owned-series-per-pod doesn't decrease
+    // until some time after the partition count increases, we see brief spikes in the artificial "total series" we calculate after a scale-up. To
+    // mitigate this, we first use a `min_over_time` of 5m.
+    query: ('max_over_time(min_over_time(' + max_owned_series_x_active_partitions + '[5m:])[2h:5m])') % {
+      cluster: $._config.cluster,
+      namespace: $._config.namespace,
+      pod_selector: podSelector,
+      ring: ringName,
+    },
+    threshold: std.toString($._config.ingest_storage_ingester_autoscaling_max_owned_series_threshold),
+    metric_type: 'AverageValue',  // HPA will compute desired replicas as "<query result> / <threshold>".
+  },
+
   //
   // Configure prepare-shutdown endpoint in all ingesters.
   //
 
+  ingesterPartitionAutoscalingStatefulSetMixin(leaderName, isLeader, replicaTemplate)::
+    local statefulSet = $.apps.v1.statefulSet;
+
+    $.removeReplicasFromSpec +
+    statefulSet.mixin.metadata.withLabelsMixin({
+      'grafana.com/prepare-downscale': 'true',
+      'grafana.com/min-time-between-zones-downscale': '0',  // Follower zones should adjust their number of instances based on leader zone immediately.
+    }) +
+    statefulSet.mixin.metadata.withAnnotationsMixin(
+      {
+        'grafana.com/prepare-downscale-http-path': 'ingester/prepare-shutdown',  // We want to tell ingesters that they are shutting down.
+        'grafana.com/prepare-downscale-http-port': '%(server_http_port)s' % $._config,
+      } + (
+        if isLeader then {
+          'grafana.com/rollout-mirror-replicas-from-resource-name': replicaTemplate.metadata.name,
+          'grafana.com/rollout-mirror-replicas-from-resource-kind': replicaTemplate.kind,
+          'grafana.com/rollout-mirror-replicas-from-resource-api-version': replicaTemplate.apiVersion,
+          'grafana.com/rollout-delayed-downscale': $._config.ingest_storage_ingester_downscale_delay,
+          'grafana.com/rollout-prepare-delayed-downscale-url': 'http://pod/ingester/prepare-partition-downscale',
+        } else {
+          'grafana.com/rollout-downscale-leader': leaderName,
+        }
+      )
+    ),
+
   local updateIngesterZone(zone) = overrideSuperIfExists(
     '%s_statefulset' % std.strReplace(zone, '-', '_'),
-    if !$._config.ingest_storage_ingester_autoscaling_ingester_annotations_enabled then {} else (
-      local statefulSet = $.apps.v1.statefulSet;
-
-      $.removeReplicasFromSpec +
-      statefulSet.mixin.metadata.withLabelsMixin({
-        'grafana.com/prepare-downscale': 'true',
-        'grafana.com/min-time-between-zones-downscale': '0',  // Follower zones should adjust their number of instances based on leader zone immediately.
-      }) +
-      statefulSet.mixin.metadata.withAnnotationsMixin(
-        {
-          'grafana.com/prepare-downscale-http-path': 'ingester/prepare-shutdown',  // We want to tell ingesters that they are shutting down.
-          'grafana.com/prepare-downscale-http-port': '%(server_http_port)s' % $._config,
-        } + (
-          if zone == $._config.ingest_storage_ingester_autoscaling_primary_zone then {
-            'grafana.com/rollout-mirror-replicas-from-resource-name': $._config.ingest_storage_ingester_autoscaling_primary_zone,
-            'grafana.com/rollout-mirror-replicas-from-resource-kind': $.ingester_primary_zone_replica_template.kind,
-            'grafana.com/rollout-mirror-replicas-from-resource-api-version': $.ingester_primary_zone_replica_template.apiVersion,
-            'grafana.com/rollout-delayed-downscale': $._config.ingest_storage_ingester_downscale_delay,
-            'grafana.com/rollout-prepare-delayed-downscale-url': 'http://pod/ingester/prepare-partition-downscale',
-          } else {
-            'grafana.com/rollout-downscale-leader': $._config.ingest_storage_ingester_autoscaling_primary_zone,
-          }
-        )
+    if !$._config.ingest_storage_ingester_autoscaling_ingester_annotations_enabled then {} else
+      $.ingesterPartitionAutoscalingStatefulSetMixin(
+        $._config.ingest_storage_ingester_autoscaling_primary_zone,
+        zone == $._config.ingest_storage_ingester_autoscaling_primary_zone,
+        $.ingester_primary_zone_replica_template,
       )
-    )
   ),
 
   ingester_zone_a_statefulset: updateIngesterZone('ingester-zone-a'),

--- a/operations/mimir/ingest-storage-ingester-autoscaling.libsonnet
+++ b/operations/mimir/ingest-storage-ingester-autoscaling.libsonnet
@@ -63,7 +63,7 @@
   // Create resource that will be targetted by ScaledObject.
   ingester_primary_zone_replica_template: if !$._config.ingest_storage_ingester_autoscaling_enabled then null else $.replicaTemplate($._config.ingest_storage_ingester_autoscaling_primary_zone, replicas=-1, label_selector=$._config.ingest_storage_replica_template_label_selector),
 
-  ingesterPartitionAutoscalingOwnedSeriesTrigger(podSelector, ringName):: {
+  ingesterPartitionAutoscalingOwnedSeriesTrigger(workloadSelector, ringName):: {
     // We want to target a maximum number of owned series per ingester pod.
     // However, we can't use a `Value` metric because the HPA will also count pods assigned to read-only partitions when calculating the desired number of replicas.
     // This means we need to use an `AverageValue` metric, which doesn't use the current replica count at all.
@@ -74,9 +74,9 @@
     local max_owned_series_x_active_partitions = |||
       (
           max(
-              sum by (pod) (cortex_ingester_owned_series{cluster="%(cluster)s", namespace="%(namespace)s", job="%(namespace)s/%(pod_selector)s", container="ingester"})
+              sum by (pod) (cortex_ingester_owned_series{cluster="%(cluster)s", namespace="%(namespace)s", job="%(namespace)s/%(workload_selector)s", container="ingester"})
               and
-              sum by (pod) (kube_pod_status_ready{cluster="%(cluster)s", namespace="%(namespace)s", pod=~"%(pod_selector)s.*", condition="true"}) > 0
+              sum by (pod) (kube_pod_status_ready{cluster="%(cluster)s", namespace="%(namespace)s", pod=~"%(workload_selector)s.*", condition="true"}) > 0
           )
           *
           max(cortex_partition_ring_partitions{cluster="%(cluster)s", namespace="%(namespace)s", state="Active", container="distributor", name="%(ring)s"})
@@ -92,7 +92,7 @@
     query: ('max_over_time(min_over_time(' + max_owned_series_x_active_partitions + '[5m:])[2h:5m])') % {
       cluster: $._config.cluster,
       namespace: $._config.namespace,
-      pod_selector: podSelector,
+      workload_selector: workloadSelector,
       ring: ringName,
     },
     threshold: std.toString($._config.ingest_storage_ingester_autoscaling_max_owned_series_threshold),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Jsonnet refactor for ingester partition autoscaling. Moved some autoscaling config into functions, so hardcoded values (e.g. ring name) can be modified. This is useful for https://github.com/grafana/mimir/compare/prototype-compartments-v2 where different read compartments can be autoscaled separately.

No output changes - ran `make build-jsonnet-tests` to confirm.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural jsonnet refactor only; default parameters preserve existing behavior and tests confirm no manifest diff.
> 
> **Overview**
> Refactors **ingest-storage ingester partition autoscaling** jsonnet by pulling inline logic into reusable helpers, without changing default rendered manifests (per `make build-jsonnet-tests`).
> 
> The owned-series KEDA/HPA trigger is now **`ingesterPartitionAutoscalingOwnedSeriesTrigger(workloadSelector, ringName)`**, so Prometheus job/pod selectors and the `cortex_partition_ring_partitions` ring name are arguments instead of being fixed to the primary zone and `ingester-partitions`. The default trigger list still calls it with the same values as before.
> 
> StatefulSet rollout/prepare-downscale annotations are centralized in **`ingesterPartitionAutoscalingStatefulSetMixin(leaderName, isLeader, replicaTemplate)`**, which takes the leader zone name and the replica template object for mirror-replicas metadata. Zone updates delegate to that mixin so future overlays (e.g. separate read compartments) can reuse the same pieces with different workload or ring settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6823b307a1c9fb38986a741d6016523c5f1118b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->