### PR TITLE
Ingest storage: track enqueued records when rejecting batch with record Timestamp set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * [BUGFIX] MQE: Fix issue where subqueries unnecessarily compute and then discard an additional step if the parent query is not aligned to the step. #15438
 * [BUGFIX] Upgrade Go to 1.26.4 to address [CVE-2026-42507](https://pkg.go.dev/vuln/GO-2026-5039). #15566
 * [BUGFIX] Memcached: Disable TCP DNS connection pooling used for service discovery by default. #15573
+* [BUGFIX] Ingest storage: Fix `cortex_ingest_storage_writer_produce_records_enqueued_total` not being incremented when `KafkaProducer.ProduceSync()` rejects a batch because a record has its `Timestamp` set by the caller. #15610
 
 ### Mixin
 

--- a/pkg/storage/ingest/writer_client.go
+++ b/pkg/storage/ingest/writer_client.go
@@ -277,7 +277,11 @@ func (c *KafkaProducer) ProduceSync(ctx context.Context, records []*kgo.Record) 
 	// use a Kafka record header instead.
 	for _, record := range records {
 		if !record.Timestamp.IsZero() {
-			c.produceRecordsFailedTotal.WithLabelValues("record-timestamp-set").Add(float64(len(records)))
+			recordsCount := float64(len(records))
+
+			c.produceRecordsEnqueuedTotal.Add(recordsCount)
+			c.produceRecordsFailedTotal.WithLabelValues("record-timestamp-set").Add(recordsCount)
+
 			return newFailedProduceResultsFromRecords(records, errors.New("Kafka record Timestamp must not be set by the caller; it is reserved for the Kafka client to track produce time"))
 		}
 	}

--- a/pkg/storage/ingest/writer_client_test.go
+++ b/pkg/storage/ingest/writer_client_test.go
@@ -287,10 +287,15 @@ func TestKafkaProducer_ProduceSync_ShouldRejectRecordsWithTimestampSet(t *testin
 	require.Equal(t, int64(0), producer.bufferedBytes.Load())
 
 	assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
+		# HELP cortex_ingest_storage_writer_produce_records_enqueued_total Total number of Kafka records enqueued to be sent to the Kafka backend (includes records that fail to be successfully sent to the Kafka backend).
+		# TYPE cortex_ingest_storage_writer_produce_records_enqueued_total counter
+		cortex_ingest_storage_writer_produce_records_enqueued_total 2
+
 		# HELP cortex_ingest_storage_writer_produce_records_failed_total Total number of Kafka records that failed to be sent to the Kafka backend.
 		# TYPE cortex_ingest_storage_writer_produce_records_failed_total counter
 		cortex_ingest_storage_writer_produce_records_failed_total{reason="record-timestamp-set"} 2
 	`),
+		"cortex_ingest_storage_writer_produce_records_enqueued_total",
 		"cortex_ingest_storage_writer_produce_records_failed_total"))
 }
 


### PR DESCRIPTION
#### What this PR does

`KafkaProducer.ProduceSync()` rejects a batch up-front when any record has its `Timestamp` set by the caller. This path incremented `produce_records_failed_total{reason="record-timestamp-set"}` but, unlike the other pre-produce rejection path (context already done), it did not increment `produce_records_enqueued_total`.

The enqueued counter is documented to include records that fail to be sent, so leaving it untracked here made the two metrics inconsistent and could understate the true number of records that entered the producer. This aligns the timestamp-rejection path with the context-cancelled path, and extends the existing test to assert on the enqueued counter.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated.