### PR TITLE
ingest: skip fetch-path record tracing for unsampled traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * [ENHANCEMENT] Memberlist: Reduce per-call allocations on the compression and TCP state-sync receive paths via internal buffer pools. #15357
 * [ENHANCEMENT] Memberlist: Add `memberlist.processed-messages-queue-size` flag to set the size of the per-key internal queue for processing messages received from other nodes. Increasing this value may help to avoid dropping per-key updates when the node is processing many updates for the same key. #15536
 * [ENHANCEMENT] MQE: Respect the `Cache-Control: no-store` request header when caching intermediate results for range vector splitting. #15148
+* [ENHANCEMENT] Ingest storage: skip per-record tracing span and attribute allocations on the Kafka fetch path when the producer trace is not sampled. The producer's trace context is still extracted from record headers for every record. #15614
 * [BUGFIX] Query-frontend: Fix `cardinality_analysis_max_results` being ignored when set higher than the default of 500. #15581
 * [BUGFIX] Ingest storage: Fix `KafkaProducer.ProduceSync()` returning a single result with a nil record when the context is canceled, instead of one result per input record (with the record set) as the underlying franz-go client does. #15199
 * [BUGFIX] Ingest storage: Fix `cortex_ingest_storage_reader_receive_delay_seconds` inflation by no longer setting the Kafka record `Timestamp` on the distributor side; the Kafka client now sets it at produce time. #15572

--- a/pkg/storage/ingest/util.go
+++ b/pkg/storage/ingest/util.go
@@ -64,17 +64,21 @@ var (
 )
 
 // sampledOnlyTracer wraps a kotel.Tracer and skips span creation and header
-// injection on the produce path for unsampled traces. Fetch hooks always
-// delegate to the parent tracer because the consume side needs to extract
-// trace context from record headers regardless of local sampling. Without
-// this wrapper, kotel creates spans for every produced Kafka record regardless
-// of sampling, which is expensive at high volume.
+// injection for unsampled traces, on both the produce and the fetch path.
+// Without this wrapper, kotel creates a span with attributes for every Kafka
+// record regardless of sampling, which is expensive at high volume.
+//
+// On the fetch path the trace context is still extracted from record headers
+// for every record — consumers rely on the record context carrying the
+// producer's span context (see pusher.go) — but the per-record "receive" span
+// and its attributes are only created when the producer trace was sampled.
 type sampledOnlyTracer struct {
-	parent *kotel.Tracer
+	parent     *kotel.Tracer
+	propagator propagation.TextMapPropagator
 }
 
 func newSampledOnlyTracer() *sampledOnlyTracer {
-	return &sampledOnlyTracer{parent: recordsTracer()}
+	return &sampledOnlyTracer{parent: recordsTracer(), propagator: recordsPropagator()}
 }
 
 func (t *sampledOnlyTracer) OnProduceRecordBuffered(r *kgo.Record) {
@@ -95,10 +99,30 @@ func (t *sampledOnlyTracer) OnProduceRecordUnbuffered(r *kgo.Record, err error) 
 }
 
 func (t *sampledOnlyTracer) OnFetchRecordBuffered(r *kgo.Record) {
+	if r.Context == nil {
+		r.Context = context.Background()
+	}
+	// Always extract the trace context from the record headers (cheap), so that
+	// the consume side observes the producer's span context even when we skip
+	// the "receive" span below.
+	ctx := t.propagator.Extract(r.Context, kotel.NewRecordCarrier(r))
+	if !trace.SpanContextFromContext(ctx).IsSampled() {
+		r.Context = ctx
+		return
+	}
+	// Sampled: delegate to kotel for the full "receive" span. The parent
+	// re-extracts from headers, which is redundant but only paid for the
+	// sampled fraction of records.
 	t.parent.OnFetchRecordBuffered(r)
 }
 
+// OnFetchRecordUnbuffered is safe to skip when OnFetchRecordBuffered was also skipped:
+// the record's context carries the (unsampled) remote span context, so the parent's
+// OnFetchRecordUnbuffered would only call End() on a no-op span.
 func (t *sampledOnlyTracer) OnFetchRecordUnbuffered(r *kgo.Record, polled bool) {
+	if !trace.SpanContextFromContext(r.Context).IsSampled() {
+		return
+	}
 	t.parent.OnFetchRecordUnbuffered(r, polled)
 }
 
@@ -318,8 +342,15 @@ func requestJSONFromSocket[T any](ctx context.Context, socketPath string, timeou
 	return a, nil
 }
 
+// recordsPropagator returns the propagator used for Kafka record headers. It must be
+// shared by recordsTracer and sampledOnlyTracer so that header injection and extraction
+// stay in sync.
+func recordsPropagator() propagation.TextMapPropagator {
+	return propagation.NewCompositeTextMapPropagator(sampledOnlyPropagator{propagation.TraceContext{}})
+}
+
 func recordsTracer() *kotel.Tracer {
-	return kotel.NewTracer(kotel.TracerPropagator(propagation.NewCompositeTextMapPropagator(sampledOnlyPropagator{propagation.TraceContext{}})))
+	return kotel.NewTracer(kotel.TracerPropagator(recordsPropagator()))
 }
 
 // resultPromise is a simple utility to have multiple goroutines waiting for a result from another one.

--- a/pkg/storage/ingest/util_test.go
+++ b/pkg/storage/ingest/util_test.go
@@ -20,10 +20,15 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
 	"github.com/twmb/franz-go/pkg/sasl"
 	awssasl "github.com/twmb/franz-go/pkg/sasl/aws"
 	"github.com/twmb/franz-go/pkg/sasl/oauth"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func TestMSKIAMCredentials(t *testing.T) {
@@ -421,4 +426,156 @@ func serveSecretFromSocket(t *testing.T, secret any) string {
 	t.Cleanup(func() { _ = server.Close() })
 
 	return socketPath
+}
+
+// setupTestTracerProvider installs a global TracerProvider with a parent-based
+// sampler and a span recorder, restoring the previous provider on cleanup.
+// Tests using it must not run in parallel because the provider is global.
+func setupTestTracerProvider(t testing.TB) *tracetest.SpanRecorder {
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(recorder),
+		sdktrace.WithSampler(sdktrace.ParentBased(sdktrace.AlwaysSample())),
+	)
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prev)
+		_ = tp.Shutdown(t.Context())
+	})
+	return recorder
+}
+
+// fetchRecordWithTraceparent returns a fetched record carrying a traceparent
+// header with the given trace ID and sampled flag, as injected by a producer.
+func fetchRecordWithTraceparent(traceID string, sampled bool) *kgo.Record {
+	flags := "00"
+	if sampled {
+		flags = "01"
+	}
+	return &kgo.Record{
+		Topic: "test-topic",
+		Headers: []kgo.RecordHeader{
+			{Key: "traceparent", Value: []byte("00-" + traceID + "-00f067aa0ba902b7-" + flags)},
+		},
+	}
+}
+
+func TestSampledOnlyTracer_FetchHooks(t *testing.T) {
+	const traceID = "4bf92f3577b34da6a3ce929d0e0e4736"
+
+	t.Run("unsampled record: context carries the remote span context, no span is created", func(t *testing.T) {
+		recorder := setupTestTracerProvider(t)
+		tracer := newSampledOnlyTracer()
+
+		rec := fetchRecordWithTraceparent(traceID, false)
+		tracer.OnFetchRecordBuffered(rec)
+
+		require.NotNil(t, rec.Context)
+		sc := trace.SpanContextFromContext(rec.Context)
+		assert.Equal(t, traceID, sc.TraceID().String())
+		assert.False(t, sc.IsSampled())
+		assert.True(t, sc.IsRemote())
+		assert.Empty(t, recorder.Started())
+
+		tracer.OnFetchRecordUnbuffered(rec, true)
+		assert.Empty(t, recorder.Ended())
+	})
+
+	t.Run("sampled record: a receive span is created and ended", func(t *testing.T) {
+		recorder := setupTestTracerProvider(t)
+		tracer := newSampledOnlyTracer()
+
+		rec := fetchRecordWithTraceparent(traceID, true)
+		tracer.OnFetchRecordBuffered(rec)
+
+		require.Len(t, recorder.Started(), 1)
+		span := recorder.Started()[0]
+		assert.Equal(t, "test-topic receive", span.Name())
+		assert.Equal(t, traceID, span.Parent().TraceID().String())
+		assert.True(t, trace.SpanContextFromContext(rec.Context).IsSampled())
+
+		tracer.OnFetchRecordUnbuffered(rec, true)
+		require.Len(t, recorder.Ended(), 1)
+	})
+
+	t.Run("record without trace headers: context is set, no span is created", func(t *testing.T) {
+		recorder := setupTestTracerProvider(t)
+		tracer := newSampledOnlyTracer()
+
+		rec := &kgo.Record{Topic: "test-topic"}
+		tracer.OnFetchRecordBuffered(rec)
+
+		require.NotNil(t, rec.Context)
+		assert.False(t, trace.SpanContextFromContext(rec.Context).IsValid())
+		assert.Empty(t, recorder.Started())
+
+		tracer.OnFetchRecordUnbuffered(rec, true)
+		assert.Empty(t, recorder.Ended())
+	})
+}
+
+func TestSampledOnlyTracer_ProduceHooks(t *testing.T) {
+	t.Run("unsampled context: no span is created", func(t *testing.T) {
+		recorder := setupTestTracerProvider(t)
+		tracer := newSampledOnlyTracer()
+
+		rec := &kgo.Record{Topic: "test-topic", Context: trace.ContextWithSpanContext(t.Context(), trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID:    trace.TraceID{1},
+			SpanID:     trace.SpanID{1},
+			TraceFlags: 0,
+			Remote:     true,
+		}))}
+		tracer.OnProduceRecordBuffered(rec)
+		assert.Empty(t, recorder.Started())
+
+		tracer.OnProduceRecordUnbuffered(rec, nil)
+		assert.Empty(t, recorder.Ended())
+	})
+
+	t.Run("sampled context: a publish span is created and ended", func(t *testing.T) {
+		recorder := setupTestTracerProvider(t)
+		tracer := newSampledOnlyTracer()
+
+		ctx, parent := otel.Tracer("test").Start(t.Context(), "request")
+		defer parent.End()
+
+		rec := &kgo.Record{Topic: "test-topic", Context: ctx}
+		tracer.OnProduceRecordBuffered(rec)
+		require.Len(t, recorder.Started(), 2) // "request" + the publish span.
+		assert.Equal(t, "test-topic publish", recorder.Started()[1].Name())
+
+		tracer.OnProduceRecordUnbuffered(rec, nil)
+		require.Len(t, recorder.Ended(), 1)
+	})
+}
+
+// BenchmarkFetchRecordTracing compares the per-record fetch-hook cost for
+// unsampled traces (the overwhelmingly common case in production) between the
+// gated sampledOnlyTracer and the raw kotel tracer it wraps.
+func BenchmarkFetchRecordTracing(b *testing.B) {
+	const traceID = "4bf92f3577b34da6a3ce929d0e0e4736"
+	setupTestTracerProvider(b)
+
+	b.Run("sampledOnlyTracer unsampled", func(b *testing.B) {
+		tracer := newSampledOnlyTracer()
+		rec := fetchRecordWithTraceparent(traceID, false)
+		b.ReportAllocs()
+		for b.Loop() {
+			rec.Context = b.Context()
+			tracer.OnFetchRecordBuffered(rec)
+			tracer.OnFetchRecordUnbuffered(rec, true)
+		}
+	})
+
+	b.Run("kotel unsampled", func(b *testing.B) {
+		tracer := recordsTracer()
+		rec := fetchRecordWithTraceparent(traceID, false)
+		b.ReportAllocs()
+		for b.Loop() {
+			rec.Context = b.Context()
+			tracer.OnFetchRecordBuffered(rec)
+			tracer.OnFetchRecordUnbuffered(rec, true)
+		}
+	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

`sampledOnlyTracer` gated span creation on the produce path only; on the fetch path it delegated unconditionally to `kotel`, which builds an attribute set, stringifies the record key, starts a "receive" span, and wraps the record context for every fetched record -- ~8% of ingester allocations in production, despite virtually none of these traces being sampled.

Gate the fetch hooks the same way as the produce hooks: always extract the trace context from record headers (consumers rely on the record context carrying the producer's span context), but only create the "receive" span when the producer trace was sampled.

`benchstat`, this commit vs. main:

```console
goos: linux
goarch: amd64
pkg: github.com/grafana/mimir/pkg/storage/ingest
cpu: INTEL(R) XEON(R) GOLD 6548N
                                                  │  main.txt   │           optimized.txt            │
                                                  │   sec/op    │   sec/op     vs base               │
FetchRecordTracing/sampledOnlyTracer_unsampled-16   912.4n ± 1%   271.5n ± 2%  -70.24% (p=0.002 n=6)
FetchRecordTracing/kotel_unsampled-16               906.6n ± 2%   930.0n ± 3%   +2.57% (p=0.002 n=6)
geomean                                             909.5n        502.5n       -44.75%

                                                  │   main.txt   │             optimized.txt             │
                                                  │     B/op     │     B/op      vs base                 │
FetchRecordTracing/sampledOnlyTracer_unsampled-16    1072.0 ± 0%     192.0 ± 0%  -82.09% (p=0.002 n=6)
FetchRecordTracing/kotel_unsampled-16               1.047Ki ± 0%   1.047Ki ± 0%        ~ (p=1.000 n=6) ¹
geomean                                             1.047Ki          453.7       -57.68%
¹ all samples are equal

                                                  │  main.txt   │            optimized.txt            │
                                                  │  allocs/op  │ allocs/op   vs base                 │
FetchRecordTracing/sampledOnlyTracer_unsampled-16   11.000 ± 0%   3.000 ± 0%  -72.73% (p=0.002 n=6)
FetchRecordTracing/kotel_unsampled-16                11.00 ± 0%   11.00 ± 0%        ~ (p=1.000 n=6) ¹
geomean                                              11.00        5.745       -47.78%
¹ all samples are equal
```

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only optimization on the Kafka fetch hook path; sampled traces still get full kotel receive spans, and trace context extraction remains for every record.
> 
> **Overview**
> Extends **`sampledOnlyTracer`** so Kafka **fetch** hooks match the produce path: for unsampled producer traces it no longer delegates to kotel’s per-record **receive** span and attribute work, while still **extracting trace context from record headers** and setting `record.Context` so ingest consumers keep the producer span context.
> 
> Refactors header propagation via shared **`recordsPropagator()`** (used by both `recordsTracer` and `sampledOnlyTracer`). Adds unit tests for fetch/produce hooks, a fetch-path benchmark vs raw kotel, and a CHANGELOG ingest-storage enhancement entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 432af4282ba7ef6aaf2985880cec1965b7efef69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->