### PR TITLE
mixin: Add early compaction threshold to Tenants dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 * [ENHANCEMENT] Alerts: Add a native histogram variant of the `MimirRequestLatency` alert, distinguished by the `histogram` label (`classic` or `native`). #15413
 * [ENHANCEMENT] Dashboards: Add 100th percentile to query expression percentiles graph. #15421
 * [ENHANCEMENT] Dashboards: Add the experimental streaming search API endpoints to the "Overview" per-endpoint query breakdown, and include the ingester `SearchLabelNames`/`SearchLabelValues` gRPC routes in the ingester panels of the "Reads", "Queries", and "Remote ruler reads" dashboards. #15571
+* [ENHANCEMENT] Dashboards: Show the `early_head_compaction_owned_series_threshold` limit on the "Owned & in-memory series" panel of the "Tenants" dashboard.
 * [BUGFIX] Dashboards: Fix the classic/ingest-storage split in the "Tenants", "Top tenants" and "Writes" dashboards so that selecting multiple clusters with a mix of architectures no longer drops the classic clusters' data. The `unless on (job)` filter against `cortex_partition_ring_partitions` now also matches on the cluster aggregation labels. #15400
 
 ### Jsonnet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@
 * [ENHANCEMENT] Alerts: Add a native histogram variant of the `MimirRequestLatency` alert, distinguished by the `histogram` label (`classic` or `native`). #15413
 * [ENHANCEMENT] Dashboards: Add 100th percentile to query expression percentiles graph. #15421
 * [ENHANCEMENT] Dashboards: Add the experimental streaming search API endpoints to the "Overview" per-endpoint query breakdown, and include the ingester `SearchLabelNames`/`SearchLabelValues` gRPC routes in the ingester panels of the "Reads", "Queries", and "Remote ruler reads" dashboards. #15571
-* [ENHANCEMENT] Dashboards: Show the `early_head_compaction_owned_series_threshold` limit on the "Owned & in-memory series" panel of the "Tenants" dashboard.
+* [ENHANCEMENT] Dashboards: Show the `early_head_compaction_owned_series_threshold` limit on the "Owned & in-memory series" panel of the "Tenants" dashboard. #15615
 * [BUGFIX] Dashboards: Fix the classic/ingest-storage split in the "Tenants", "Top tenants" and "Writes" dashboards so that selecting multiple clusters with a mix of architectures no longer drops the classic clusters' data. The `unless on (job)` filter against `cortex_partition_ring_partitions` now also matches on the cluster aggregation labels. #15400
 
 ### Jsonnet

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/grafana-dashboards.yaml
@@ -39729,6 +39729,24 @@ data:
                                      }
                                   }
                                ]
+                            },
+                            {
+                               "matcher": {
+                                  "id": "byName",
+                                  "options": "early compaction threshold"
+                               },
+                               "properties": [
+                                  {
+                                     "id": "custom.fillOpacity",
+                                     "value": 0
+                                  },
+                                  {
+                                     "id": "custom.lineStyle",
+                                     "value": {
+                                        "fill": "dash"
+                                     }
+                                  }
+                               ]
                             }
                          ]
                       },
@@ -39761,6 +39779,12 @@ data:
                             "expr": "max(cortex_limits_overrides{cluster=~\"$cluster\", job=~\"($namespace)/((overrides-exporter))\", limit_name=\"max_global_series_per_user\", user=\"$user\"})\nor\nmax(cortex_limits_defaults{cluster=~\"$cluster\", job=~\"($namespace)/((overrides-exporter))\", limit_name=\"max_global_series_per_user\"})\n",
                             "format": "time_series",
                             "legendFormat": "ingester limit",
+                            "legendLink": null
+                         },
+                         {
+                            "expr": "max(cortex_limits_overrides{cluster=~\"$cluster\", job=~\"($namespace)/((overrides-exporter))\", limit_name=\"early_head_compaction_owned_series_threshold\", user=\"$user\"})\nor\nmax(cortex_limits_defaults{cluster=~\"$cluster\", job=~\"($namespace)/((overrides-exporter))\", limit_name=\"early_head_compaction_owned_series_threshold\"} != 0)\n",
+                            "format": "time_series",
+                            "legendFormat": "early compaction threshold",
                             "legendLink": null
                          }
                       ],

--- a/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled-baremetal/dashboards/mimir-tenants.json
@@ -179,6 +179,24 @@
                                  }
                               }
                            ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byName",
+                              "options": "early compaction threshold"
+                           },
+                           "properties": [
+                              {
+                                 "id": "custom.fillOpacity",
+                                 "value": 0
+                              },
+                              {
+                                 "id": "custom.lineStyle",
+                                 "value": {
+                                    "fill": "dash"
+                                 }
+                              }
+                           ]
                         }
                      ]
                   },
@@ -211,6 +229,12 @@
                         "expr": "max(cortex_limits_overrides{cluster=~\"$cluster\", job=~\"($namespace)/((overrides-exporter))\", limit_name=\"max_global_series_per_user\", user=\"$user\"})\nor\nmax(cortex_limits_defaults{cluster=~\"$cluster\", job=~\"($namespace)/((overrides-exporter))\", limit_name=\"max_global_series_per_user\"})\n",
                         "format": "time_series",
                         "legendFormat": "ingester limit",
+                        "legendLink": null
+                     },
+                     {
+                        "expr": "max(cortex_limits_overrides{cluster=~\"$cluster\", job=~\"($namespace)/((overrides-exporter))\", limit_name=\"early_head_compaction_owned_series_threshold\", user=\"$user\"})\nor\nmax(cortex_limits_defaults{cluster=~\"$cluster\", job=~\"($namespace)/((overrides-exporter))\", limit_name=\"early_head_compaction_owned_series_threshold\"} != 0)\n",
+                        "format": "time_series",
+                        "legendFormat": "early compaction threshold",
                         "legendLink": null
                      }
                   ],

--- a/operations/mimir-mixin-compiled-gem/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled-gem/dashboards/mimir-tenants.json
@@ -180,6 +180,24 @@
                                  }
                               }
                            ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byName",
+                              "options": "early compaction threshold"
+                           },
+                           "properties": [
+                              {
+                                 "id": "custom.fillOpacity",
+                                 "value": 0
+                              },
+                              {
+                                 "id": "custom.lineStyle",
+                                 "value": {
+                                    "fill": "dash"
+                                 }
+                              }
+                           ]
                         }
                      ]
                   },
@@ -212,6 +230,12 @@
                         "expr": "max(cortex_limits_overrides{cluster=~\"$cluster\", job=~\"($namespace)/((overrides-exporter))\", limit_name=\"max_global_series_per_user\", user=\"$user\"})\nor\nmax(cortex_limits_defaults{cluster=~\"$cluster\", job=~\"($namespace)/((overrides-exporter))\", limit_name=\"max_global_series_per_user\"})\n",
                         "format": "time_series",
                         "legendFormat": "ingester limit",
+                        "legendLink": null
+                     },
+                     {
+                        "expr": "max(cortex_limits_overrides{cluster=~\"$cluster\", job=~\"($namespace)/((overrides-exporter))\", limit_name=\"early_head_compaction_owned_series_threshold\", user=\"$user\"})\nor\nmax(cortex_limits_defaults{cluster=~\"$cluster\", job=~\"($namespace)/((overrides-exporter))\", limit_name=\"early_head_compaction_owned_series_threshold\"} != 0)\n",
+                        "format": "time_series",
+                        "legendFormat": "early compaction threshold",
                         "legendLink": null
                      }
                   ],

--- a/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
+++ b/operations/mimir-mixin-compiled/dashboards/mimir-tenants.json
@@ -179,6 +179,24 @@
                                  }
                               }
                            ]
+                        },
+                        {
+                           "matcher": {
+                              "id": "byName",
+                              "options": "early compaction threshold"
+                           },
+                           "properties": [
+                              {
+                                 "id": "custom.fillOpacity",
+                                 "value": 0
+                              },
+                              {
+                                 "id": "custom.lineStyle",
+                                 "value": {
+                                    "fill": "dash"
+                                 }
+                              }
+                           ]
                         }
                      ]
                   },
@@ -211,6 +229,12 @@
                         "expr": "max(cortex_limits_overrides{cluster=~\"$cluster\", job=~\"($namespace)/((overrides-exporter))\", limit_name=\"max_global_series_per_user\", user=\"$user\"})\nor\nmax(cortex_limits_defaults{cluster=~\"$cluster\", job=~\"($namespace)/((overrides-exporter))\", limit_name=\"max_global_series_per_user\"})\n",
                         "format": "time_series",
                         "legendFormat": "ingester limit",
+                        "legendLink": null
+                     },
+                     {
+                        "expr": "max(cortex_limits_overrides{cluster=~\"$cluster\", job=~\"($namespace)/((overrides-exporter))\", limit_name=\"early_head_compaction_owned_series_threshold\", user=\"$user\"})\nor\nmax(cortex_limits_defaults{cluster=~\"$cluster\", job=~\"($namespace)/((overrides-exporter))\", limit_name=\"early_head_compaction_owned_series_threshold\"} != 0)\n",
+                        "format": "time_series",
+                        "legendFormat": "early compaction threshold",
                         "legendLink": null
                      }
                   ],

--- a/operations/mimir-mixin/dashboards/tenants.libsonnet
+++ b/operations/mimir-mixin/dashboards/tenants.libsonnet
@@ -28,6 +28,11 @@ local filename = 'mimir-tenants.json';
     $.overrideProperty('custom.lineStyle', { fill: 'dash' }),
   ]),
 
+  local earlyCompactionThresholdStyle = $.overrideFieldByName('early compaction threshold', [
+    $.overrideProperty('custom.fillOpacity', 0),
+    $.overrideProperty('custom.lineStyle', { fill: 'dash' }),
+  ]),
+
 
   [filename]:
     assert std.md5(filename) == '35fa247ce651ba189debf33d7ae41611' : 'UID of the dashboard has changed, please update references to dashboard.';
@@ -98,14 +103,16 @@ local filename = 'mimir-tenants.json';
             $.queries.ingester.ingestOrClassicDeduplicatedQuery(perIngesterInMemorySeries),
             $.queries.ingester.ingestOrClassicDeduplicatedQuery('cortex_ingester_owned_series{%s, user="$user"}' % [$.jobMatcher($._config.job_names.ingester)]),
             user_limits_overrides_query('max_global_series_per_user'),
+            user_limits_overrides_query('early_head_compaction_owned_series_threshold', non_zero=true),
           ],
           [
             'in-memory',
             'owned',
             'ingester limit',
+            'early compaction threshold',
           ],
         ) +
-        { fieldConfig+: { overrides+: [ingesterLimitStyle] } } +
+        { fieldConfig+: { overrides+: [ingesterLimitStyle, earlyCompactionThresholdStyle] } } +
         $.panelDescription(
           title,
           |||


### PR DESCRIPTION
#### What this PR does

When `early_head_compaction_owned_series_threshold` is set for a tenant, it can be useful to see when it's hit by the tenant's owned series.

<img width="401" height="292" alt="Screenshot 2026-06-10 at 16 26 10" src="https://github.com/user-attachments/assets/4cf8cb52-cae8-4e3f-8ffc-515450c3c150" />

#### Which issue(s) this PR fixes or relates to

—

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard and mixin-only changes with no runtime or ingestion behavior impact.
> 
> **Overview**
> The **Tenants** dashboard **Owned & in-memory series** panel now plots the tenant **`early_head_compaction_owned_series_threshold`** limit alongside owned/in-memory series and the ingester limit, so operators can see when owned series cross the early head-compaction trigger.
> 
> The mixin adds a limits query via the existing overrides-exporter helper (with **non-zero** default filtering), applies the same dashed reference-line styling as other limits, and regenerates the compiled dashboard JSON and Helm metamonitoring fixture. **CHANGELOG** records the mixin dashboard enhancement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54de8c323963697fb6053a45904f4c34cb97eed8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->