### PR TITLE
tsdb: expose prometheus_tsdb_head_chunks_max_mmapped via the ingester

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [FEATURE] MQE: Add `cortex_querier_inflight_query_max_age_seconds` metric reporting the age of the oldest in-flight query memory consumption tracker. #15300
 * [FEATURE] MQE: Add experimental support for splitting and caching `present_over_time` over range vectors in instant queries. #15386
 * [FEATURE] Query-scheduler: Add experimental `cortex_query_scheduler_inflight_max_age_seconds` metric reporting how long the oldest inflight request has been waiting since it was enqueued. Reports 0 when no requests are inflight. Enabled by default; can be disabled with `-query-scheduler.inflight-max-age-metric-enabled=false`. #15419
+* [FEATURE] Ingester: Add experimental `cortex_ingester_tsdb_head_chunks_max_mmapped` gauge reporting the maximum, across all per-tenant TSDBs, of the maximum number of head chunks memory-mapped for any individual series during the last memory-mapping pass. Temporary measurement metric; will be removed once we have collected enough data. #15616
 * [ENHANCEMENT] Store-gateway, Ingester: Add read support for XOR2 chunk encoding. XOR2 is a new Prometheus TSDB encoding that provides better compression than XOR, particularly for stale markers. #15371
 * [ENHANCEMENT] MQE: Improve experimental support for reporting the number of samples read per query. #14838 #15179 #15191 #15220 #15223 #15232 #15237 #15255 #15276 #15282 #15285
 * [ENHANCEMENT] Distributor: Relabel middleware returns early if neither label dropping nor relabeling is configured. #15246

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -118,6 +118,7 @@ The following features are currently experimental:
   - Evaluate HA deduplication per timeseries within a write request instead of using the first series' labels for the whole request
     - `-distributor.ha-tracker.per-sample-dedupe`
 - Ingester
+  - `cortex_ingester_tsdb_head_chunks_max_mmapped` metric. Reports the maximum, across all per-tenant TSDBs, of the maximum number of head chunks memory-mapped for any individual series during the last memory-mapping pass. Temporary measurement metric; will be removed once we have collected enough data.
   - Add variance to chunks end time to spread writing across time (`-blocks-storage.tsdb.head-chunks-end-time-variance`)
   - Snapshotting of in-memory TSDB data on disk when shutting down (`-blocks-storage.tsdb.memory-snapshot-on-shutdown`)
   - Out-of-order samples ingestion (`-ingester.out-of-order-time-window`)

--- a/pkg/storage/tsdb/tsdb_metrics.go
+++ b/pkg/storage/tsdb/tsdb_metrics.go
@@ -37,6 +37,7 @@ type TSDBMetrics struct {
 	tsdbMmapChunkCorruptionTotal      *prometheus.Desc
 	tsdbMmapChunkQueueOperationsTotal *prometheus.Desc
 	tsdbMmapChunksTotal               *prometheus.Desc
+	tsdbHeadChunksMaxMmapped          *prometheus.Desc // TODO(krajorama): experimental, remove once we have measurements.
 	tsdbOOOHistogram                  *prometheus.Desc
 
 	tsdbExemplarsTotal          *prometheus.Desc
@@ -158,6 +159,11 @@ func NewTSDBMetrics(r prometheus.Registerer, logger log.Logger) *TSDBMetrics {
 		tsdbMmapChunksTotal: prometheus.NewDesc(
 			"tsdb_mmap_chunks_total",
 			"Total number of chunks that were memory-mapped.",
+			nil, nil),
+		// TODO(krajorama): experimental, remove once we have measurements.
+		tsdbHeadChunksMaxMmapped: prometheus.NewDesc(
+			"tsdb_head_chunks_max_mmapped",
+			"Experimental. Maximum, across all per-tenant TSDBs, of the maximum number of head chunks memory-mapped for any individual series during the last memory-mapping pass.",
 			nil, nil),
 		tsdbOOOHistogram: prometheus.NewDesc(
 			"tsdb_sample_out_of_order_delta_seconds",
@@ -297,6 +303,7 @@ func (sm *TSDBMetrics) Describe(out chan<- *prometheus.Desc) {
 	out <- sm.tsdbMmapChunkCorruptionTotal
 	out <- sm.tsdbMmapChunkQueueOperationsTotal
 	out <- sm.tsdbMmapChunksTotal
+	out <- sm.tsdbHeadChunksMaxMmapped
 	out <- sm.tsdbOOOHistogram
 	out <- sm.tsdbLoadedBlocks
 	out <- sm.tsdbSymbolTableSize
@@ -352,6 +359,7 @@ func (sm *TSDBMetrics) Collect(out chan<- prometheus.Metric) {
 	data.SendSumOfCounters(out, sm.tsdbMmapChunkCorruptionTotal, "prometheus_tsdb_mmap_chunk_corruptions_total")
 	data.SendSumOfCountersWithLabels(out, sm.tsdbMmapChunkQueueOperationsTotal, "prometheus_tsdb_chunk_write_queue_operations_total", "operation")
 	data.SendSumOfCounters(out, sm.tsdbMmapChunksTotal, "prometheus_tsdb_mmap_chunks_total")
+	data.SendMaxOfGauges(out, sm.tsdbHeadChunksMaxMmapped, "prometheus_tsdb_head_chunks_max_mmapped")
 	data.SendSumOfHistograms(out, sm.tsdbOOOHistogram, "prometheus_tsdb_sample_ooo_delta")
 	data.SendSumOfGauges(out, sm.tsdbLoadedBlocks, "prometheus_tsdb_blocks_loaded")
 	data.SendSumOfGaugesPerTenant(out, sm.tsdbSymbolTableSize, "prometheus_tsdb_symbol_table_size_bytes")

--- a/pkg/storage/tsdb/tsdb_metrics_test.go
+++ b/pkg/storage/tsdb/tsdb_metrics_test.go
@@ -170,6 +170,11 @@ func TestTSDBMetrics(t *testing.T) {
 			# TYPE cortex_ingester_tsdb_mmap_chunks_total counter
 			cortex_ingester_tsdb_mmap_chunks_total 2973930
 
+			# HELP cortex_ingester_tsdb_head_chunks_max_mmapped Experimental. Maximum, across all per-tenant TSDBs, of the maximum number of head chunks memory-mapped for any individual series during the last memory-mapping pass.
+			# TYPE cortex_ingester_tsdb_head_chunks_max_mmapped gauge
+			# max of (31*12345, 31*85787, 31*999) = 31*85787 = 2659397
+			cortex_ingester_tsdb_head_chunks_max_mmapped 2659397
+
 			# HELP cortex_ingester_tsdb_blocks_loaded Number of currently loaded data blocks
 			# TYPE cortex_ingester_tsdb_blocks_loaded gauge
 			cortex_ingester_tsdb_blocks_loaded 15
@@ -393,6 +398,11 @@ func TestTSDBMetricsWithRemoval(t *testing.T) {
 			# HELP cortex_ingester_tsdb_mmap_chunks_total Total number of chunks that were memory-mapped.
 			# TYPE cortex_ingester_tsdb_mmap_chunks_total counter
 			cortex_ingester_tsdb_mmap_chunks_total 2973930
+
+			# HELP cortex_ingester_tsdb_head_chunks_max_mmapped Experimental. Maximum, across all per-tenant TSDBs, of the maximum number of head chunks memory-mapped for any individual series during the last memory-mapping pass.
+			# TYPE cortex_ingester_tsdb_head_chunks_max_mmapped gauge
+			# user3 removed; max of (31*12345, 31*85787) = 31*85787 = 2659397
+			cortex_ingester_tsdb_head_chunks_max_mmapped 2659397
 
 			# HELP cortex_ingester_tsdb_wal_truncate_duration_seconds Duration of TSDB WAL truncation.
 			# TYPE cortex_ingester_tsdb_wal_truncate_duration_seconds summary
@@ -743,6 +753,12 @@ func populateTSDBMetrics(base float64) *prometheus.Registry {
 		Help: "Total number of chunks that were memory-mapped.",
 	})
 	chunksMmappedTotal.Add(30 * base)
+
+	headChunksMaxMmapped := promauto.With(r).NewGauge(prometheus.GaugeOpts{
+		Name: "prometheus_tsdb_head_chunks_max_mmapped",
+		Help: "Maximum number of head chunks memory-mapped for any individual series during the last memory-mapping pass.",
+	})
+	headChunksMaxMmapped.Set(31 * base)
 
 	tsdbWalReplayUnknownRefsTotal := promauto.With(r).NewCounterVec(prometheus.CounterOpts{
 		Name: "prometheus_tsdb_wal_replay_unknown_refs_total",


### PR DESCRIPTION
## Summary

- Re-exports the per-TSDB gauge `prometheus_tsdb_head_chunks_max_mmapped` (added to mimir-prometheus in [grafana/mimir-prometheus#1209](https://github.com/grafana/mimir-prometheus/pull/1209), vendored in #15613) at the Mimir level as `cortex_ingester_tsdb_head_chunks_max_mmapped`.
- Aggregates across per-tenant TSDBs with `SendMaxOfGauges`, so the output is a single global gauge with the max value across all tenants on the ingester. No `user` label — per-tenant breakdown is not needed for this measurement.
- Documented as experimental in `docs/sources/mimir/configure/about-versioning.md` and called out as a temporary measurement metric, to be removed once we have collected enough data to size the head-chunk mmap stripe locks.

## Test plan

- [x] `go test ./pkg/storage/tsdb/ -run 'TestTSDBMetrics$|TestTSDBMetricsWithRemoval'` passes — both tests assert the aggregated max value (with and without a removed tenant)
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change with no ingestion or query path impact; metric is explicitly experimental and may be removed later.
> 
> **Overview**
> Adds an **experimental** ingester metric **`cortex_ingester_tsdb_head_chunks_max_mmapped`** by wiring through the per-TSDB **`prometheus_tsdb_head_chunks_max_mmapped`** gauge from vendored Prometheus TSDB.
> 
> Aggregation uses **`SendMaxOfGauges`** across all per-tenant TSDB registries on the ingester, so scrapers see a **single global gauge** (the worst per-series mmap count from the last head-chunk mmap pass), with **no `user` label**.
> 
> **CHANGELOG** and **about-versioning** document the metric as a temporary measurement aid (intended removal after data is collected for sizing head-chunk mmap stripe locks). **`tsdb_metrics_test`** expectations and **`populateTSDBMetrics`** are updated to cover multi-tenant max aggregation and tenant removal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e83a3dd6963a4aa417040cc9578d8b63418c364. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->