### PR TITLE
Add filesystem support to objtools for copyblocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 ### Tools
 
 * [FEATURE] Copyblocks: add support for the block upload API as a copy destination. #15330
+* [FEATURE] Copyblocks: add support for copying to and from a filesystem. #15620
 * [ENHANCEMENT] Makefile: `build-mixin` and `mixin-screenshots` can now be configured to use native histograms for latency panels in dashboards. #15269
 
 ### Query-tee

--- a/integration/backfill_test.go
+++ b/integration/backfill_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
-	"github.com/thanos-io/objstore/providers/filesystem"
 	"golang.org/x/time/rate"
 
 	"github.com/grafana/mimir/integration/e2emimir"
@@ -34,6 +33,7 @@ import (
 	"github.com/grafana/mimir/pkg/storage/bucket"
 	"github.com/grafana/mimir/pkg/storage/bucket/s3"
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
+	"github.com/grafana/mimir/pkg/util/objtools" //lint:ignore faillint objtools is allowed in tools and their tests
 )
 
 func TestMimirtoolBackfill(t *testing.T) {
@@ -239,9 +239,9 @@ func TestBackfillSlowUploadSpeed(t *testing.T) {
 	// Initiate new block upload.
 	{
 		// client.GetBlockMetaFromBucket will generate correct meta.json file ready for initiating upload of our block.
-		fsBkt, err := filesystem.NewBucket(tmpDir)
+		fsBkt, err := (&objtools.FilesystemClientConfig{Directory: tmpDir}).ToBucket()
 		require.NoError(t, err)
-		meta, err := client.GetBlockMeta(context.Background(), fsBkt, block)
+		meta, err := client.GetBlockMeta(context.Background(), fsBkt, "", block)
 		require.NoError(t, err)
 
 		buf := bytes.NewBuffer(nil)

--- a/pkg/mimirtool/client/backfill.go
+++ b/pkg/mimirtool/client/backfill.go
@@ -19,10 +19,9 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/oklog/ulid/v2"
 	"github.com/pkg/errors"
-	"github.com/thanos-io/objstore"
-	"github.com/thanos-io/objstore/providers/filesystem"
 
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
+	"github.com/grafana/mimir/pkg/util/objtools" //lint:ignore faillint mimirtool is a tool, so it may use objtools.
 )
 
 var ErrBlockInvalid = errors.New("block is invalid")
@@ -51,7 +50,7 @@ func (c *MimirClient) Backfill(ctx context.Context, blocks []string, sleepTime t
 	// Upload each block
 	var succeeded, failed, alreadyExists int
 
-	buckets := make(map[string]objstore.BucketReader, 1)
+	buckets := make(map[string]objtools.Bucket, 1)
 	for _, b := range blocks {
 		logctx := log.With(c.logger, "path", b)
 
@@ -59,7 +58,8 @@ func (c *MimirClient) Backfill(ctx context.Context, blocks []string, sleepTime t
 		fsBkt, ok := buckets[dir]
 		if !ok {
 			var err error
-			fsBkt, err = filesystem.NewBucket(dir)
+			cfg := objtools.FilesystemClientConfig{Directory: dir}
+			fsBkt, err = cfg.ToBucket()
 			if err != nil {
 				level.Error(logctx).Log("msg", "failed to create filesystem bucket", "err", err)
 				failed++
@@ -75,7 +75,7 @@ func (c *MimirClient) Backfill(ctx context.Context, blocks []string, sleepTime t
 			continue
 		}
 
-		if err := c.backfillBlock(ctx, fsBkt, blockID, logctx, sleepTime); err != nil {
+		if err := c.backfillBlock(ctx, fsBkt, "", blockID, logctx, sleepTime); err != nil {
 			if errors.Is(err, ErrConflict) {
 				level.Warn(logctx).Log("msg", "block already exists on the server")
 				alreadyExists++
@@ -100,9 +100,10 @@ func (c *MimirClient) Backfill(ctx context.Context, blocks []string, sleepTime t
 }
 
 // BackfillBlock uploads a single TSDB block from a bucket to a Mimir instance
-// via the block upload API.
-func (c *MimirClient) BackfillBlock(ctx context.Context, bkt objstore.BucketReader, blockID ulid.ULID, sleepTime time.Duration) error {
-	return c.backfillBlock(ctx, bkt, blockID, c.logger, sleepTime)
+// via the block upload API. The block's objects are read from prefix/blockID
+// within the bucket; pass a blank prefix when the block sits at the bucket root.
+func (c *MimirClient) BackfillBlock(ctx context.Context, bkt objtools.Bucket, prefix string, blockID ulid.ULID, sleepTime time.Duration) error {
+	return c.backfillBlock(ctx, bkt, prefix, blockID, c.logger, sleepTime)
 }
 
 // drainAndCloseBody drains and closes the body to let the transport reuse the connection.
@@ -111,8 +112,8 @@ func drainAndCloseBody(resp *http.Response) {
 	_ = resp.Body.Close()
 }
 
-func (c *MimirClient) backfillBlock(ctx context.Context, bkt objstore.BucketReader, blockID ulid.ULID, logctx log.Logger, sleepTime time.Duration) error {
-	blockMeta, err := GetBlockMeta(ctx, bkt, blockID)
+func (c *MimirClient) backfillBlock(ctx context.Context, bkt objtools.Bucket, prefix string, blockID ulid.ULID, logctx log.Logger, sleepTime time.Duration) error {
+	blockMeta, err := GetBlockMeta(ctx, bkt, prefix, blockID)
 	if err != nil {
 		return err
 	}
@@ -148,7 +149,7 @@ func (c *MimirClient) backfillBlock(ctx context.Context, bkt objstore.BucketRead
 			continue
 		}
 
-		if err := c.uploadBlockFile(ctx, bkt, blockID, tf, path.Join(blockPath, uploadFile), logctx); err != nil {
+		if err := c.uploadBlockFile(ctx, bkt, prefix, blockID, tf, path.Join(blockPath, uploadFile), logctx); err != nil {
 			return err
 		}
 	}
@@ -214,9 +215,9 @@ func (c *MimirClient) getBlockUpload(ctx context.Context, url string) (result, e
 	return r, nil
 }
 
-func (c *MimirClient) uploadBlockFile(ctx context.Context, bkt objstore.BucketReader, blockID ulid.ULID, tf block.File, fileUploadEndpoint string, logctx log.Logger) error {
-	objectName := path.Join(blockID.String(), tf.RelPath)
-	r, err := bkt.Get(ctx, objectName)
+func (c *MimirClient) uploadBlockFile(ctx context.Context, bkt objtools.Bucket, prefix string, blockID ulid.ULID, tf block.File, fileUploadEndpoint string, logctx log.Logger) error {
+	objectName := path.Join(prefix, blockID.String(), tf.RelPath)
+	r, err := bkt.Get(ctx, objectName, objtools.GetOptions{})
 	if err != nil {
 		return errors.Wrapf(err, "failed to read %q from bucket", objectName)
 	}
@@ -237,12 +238,14 @@ func (c *MimirClient) uploadBlockFile(ctx context.Context, bkt objstore.BucketRe
 
 // GetBlockMeta reads meta.json from the bucket and adds (or replaces)
 // the thanos.files section with the list of files from the block in the bucket.
-func GetBlockMeta(ctx context.Context, bkt objstore.BucketReader, blockID ulid.ULID) (block.Meta, error) {
+// The block's objects are read from prefix/blockID within the bucket; pass a
+// blank prefix when the block sits at the bucket root.
+func GetBlockMeta(ctx context.Context, bkt objtools.Bucket, prefix string, blockID ulid.ULID) (block.Meta, error) {
 	var blockMeta block.Meta
 
-	blockPrefix := blockID.String()
+	blockPrefix := path.Join(prefix, blockID.String())
 	metaPath := path.Join(blockPrefix, block.MetaFilename)
-	r, err := bkt.Get(ctx, metaPath)
+	r, err := bkt.Get(ctx, metaPath, objtools.GetOptions{})
 	if err != nil {
 		return blockMeta, errors.Wrapf(err, "failed to read %q", metaPath)
 	}
@@ -261,29 +264,31 @@ func GetBlockMeta(ctx context.Context, bkt objstore.BucketReader, blockID ulid.U
 			block.MetaFilename, blockMeta.Version)
 	}
 
-	blockMeta.Thanos.Files = []block.File{{RelPath: block.MetaFilename}}
-
-	appendFile := func(relPath string) error {
-		objPath := path.Join(blockPrefix, relPath)
-		attrs, err := bkt.Attributes(ctx, objPath)
-		if err != nil {
-			return errors.Wrapf(err, "failed to get attributes for %q", objPath)
-		}
-		blockMeta.Thanos.Files = append(blockMeta.Thanos.Files, block.File{RelPath: relPath, SizeBytes: attrs.Size})
-		return nil
-	}
-
-	if err := appendFile(block.IndexFilename); err != nil {
-		return blockMeta, err
-	}
-
-	chunksPrefix := path.Join(blockPrefix, block.ChunksDirname)
-	err = bkt.Iter(ctx, chunksPrefix, func(name string) error {
-		return appendFile(strings.TrimPrefix(name, blockPrefix+"/"))
-	})
+	listing, err := bkt.List(ctx, objtools.ListOptions{Prefix: blockPrefix, Recursive: true})
 	if err != nil {
-		return blockMeta, errors.Wrapf(err, "failed to list chunks in %q", chunksPrefix)
+		return blockMeta, errors.Wrapf(err, "failed to list files in block %q", blockID)
 	}
+
+	// We only upload the index and chunks; meta.json is sent separately during the upload.
+	blockMeta.Thanos.Files = []block.File{{RelPath: block.MetaFilename}}
+	var indexFound bool
+	var chunkFiles []block.File
+	trim := blockPrefix + objtools.Delim
+	for _, obj := range listing.Objects {
+		// List returns full object names; the upload API wants paths relative to the block.
+		relPath := strings.TrimPrefix(obj.Name, trim)
+		switch {
+		case relPath == block.IndexFilename:
+			indexFound = true
+			blockMeta.Thanos.Files = append(blockMeta.Thanos.Files, block.File{RelPath: relPath, SizeBytes: obj.Size})
+		case strings.HasPrefix(relPath, block.ChunksDirname+objtools.Delim):
+			chunkFiles = append(chunkFiles, block.File{RelPath: relPath, SizeBytes: obj.Size})
+		}
+	}
+	if !indexFound {
+		return blockMeta, errors.Errorf("failed to find %q in block %q", block.IndexFilename, blockID)
+	}
+	blockMeta.Thanos.Files = append(blockMeta.Thanos.Files, chunkFiles...)
 
 	return blockMeta, nil
 }

--- a/pkg/mimirtool/client/backfill_test.go
+++ b/pkg/mimirtool/client/backfill_test.go
@@ -18,62 +18,89 @@ import (
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/thanos-io/objstore"
 
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
+	"github.com/grafana/mimir/pkg/util/objtools" //lint:ignore faillint objtools is allowed in tools and their tests
 )
+
+// newTestBucket returns an objtools filesystem bucket backed by a temporary directory.
+func newTestBucket(t *testing.T) objtools.Bucket {
+	t.Helper()
+	cfg := objtools.FilesystemClientConfig{Directory: t.TempDir()}
+	bkt, err := cfg.ToBucket()
+	require.NoError(t, err)
+	return bkt
+}
+
+func uploadString(t *testing.T, bkt objtools.Bucket, name string, data []byte) {
+	t.Helper()
+	require.NoError(t, bkt.Upload(context.Background(), name, bytes.NewReader(data), int64(len(data))))
+}
 
 func TestGetBlockMeta(t *testing.T) {
 	blockID := ulid.MustNew(1000, nil)
-	bkt := objstore.NewInMemBucket()
 
-	meta := block.Meta{
-		BlockMeta: tsdb.BlockMeta{
-			ULID:    blockID,
-			Version: 1,
-			MinTime: 100,
-			MaxTime: 200,
-		},
+	for _, tc := range []struct {
+		name   string
+		prefix string
+	}{
+		{name: "no prefix", prefix: ""},
+		{name: "with tenant prefix", prefix: "tenant"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bkt := newTestBucket(t)
+
+			meta := block.Meta{
+				BlockMeta: tsdb.BlockMeta{
+					ULID:    blockID,
+					Version: 1,
+					MinTime: 100,
+					MaxTime: 200,
+				},
+			}
+			metaBytes, err := json.Marshal(meta)
+			require.NoError(t, err)
+
+			base := blockID.String()
+			if tc.prefix != "" {
+				base = tc.prefix + "/" + base
+			}
+			uploadString(t, bkt, base+"/meta.json", metaBytes)
+			uploadString(t, bkt, base+"/index", make([]byte, 1))
+			uploadString(t, bkt, base+"/chunks/000001", make([]byte, 2))
+			uploadString(t, bkt, base+"/chunks/000002", make([]byte, 3))
+
+			result, err := GetBlockMeta(context.Background(), bkt, tc.prefix, blockID)
+			require.NoError(t, err)
+
+			assert.Equal(t, blockID, result.ULID)
+			assert.Equal(t, int64(100), result.MinTime)
+			assert.Equal(t, int64(200), result.MaxTime)
+
+			fileSizes := map[string]int64{}
+			for _, f := range result.Thanos.Files {
+				fileSizes[f.RelPath] = f.SizeBytes
+			}
+			assert.Len(t, fileSizes, 4)
+			assert.Contains(t, fileSizes, "meta.json")
+			assert.Equal(t, int64(1), fileSizes["index"])
+			assert.Equal(t, int64(2), fileSizes["chunks/000001"])
+			assert.Equal(t, int64(3), fileSizes["chunks/000002"])
+		})
 	}
-	metaBytes, err := json.Marshal(meta)
-	require.NoError(t, err)
-
-	ctx := context.Background()
-	prefix := blockID.String()
-	require.NoError(t, bkt.Upload(ctx, prefix+"/meta.json", bytes.NewReader(metaBytes)))
-	require.NoError(t, bkt.Upload(ctx, prefix+"/index", bytes.NewReader(make([]byte, 1))))
-	require.NoError(t, bkt.Upload(ctx, prefix+"/chunks/000001", bytes.NewReader(make([]byte, 2))))
-	require.NoError(t, bkt.Upload(ctx, prefix+"/chunks/000002", bytes.NewReader(make([]byte, 3))))
-
-	result, err := GetBlockMeta(ctx, bkt, blockID)
-	require.NoError(t, err)
-
-	assert.Equal(t, blockID, result.ULID)
-	assert.Equal(t, int64(100), result.MinTime)
-	assert.Equal(t, int64(200), result.MaxTime)
-
-	fileSizes := map[string]int64{}
-	for _, f := range result.Thanos.Files {
-		fileSizes[f.RelPath] = f.SizeBytes
-	}
-	assert.Len(t, fileSizes, 4)
-	assert.Contains(t, fileSizes, "meta.json")
-	assert.Equal(t, int64(1), fileSizes["index"])
-	assert.Equal(t, int64(2), fileSizes["chunks/000001"])
-	assert.Equal(t, int64(3), fileSizes["chunks/000002"])
 }
 
 func TestGetBlockMeta_RejectsUnsupportedVersion(t *testing.T) {
 	blockID := ulid.MustNew(1000, nil)
-	bkt := objstore.NewInMemBucket()
+	bkt := newTestBucket(t)
 
 	meta := block.Meta{BlockMeta: tsdb.BlockMeta{ULID: blockID, Version: 99}}
 	metaBytes, err := json.Marshal(meta)
 	require.NoError(t, err)
 
-	require.NoError(t, bkt.Upload(context.Background(), blockID.String()+"/meta.json", bytes.NewReader(metaBytes)))
+	uploadString(t, bkt, blockID.String()+"/meta.json", metaBytes)
 
-	_, err = GetBlockMeta(context.Background(), bkt, blockID)
+	_, err = GetBlockMeta(context.Background(), bkt, "", blockID)
 	require.Error(t, err)
 }
 
@@ -83,7 +110,7 @@ func TestBackfillBlock(t *testing.T) {
 	indexData := []byte("index-content")
 	chunkData := []byte("chunk-content")
 
-	bkt := objstore.NewInMemBucket()
+	bkt := newTestBucket(t)
 	meta := block.Meta{
 		BlockMeta: tsdb.BlockMeta{
 			ULID:    blockID,
@@ -96,9 +123,9 @@ func TestBackfillBlock(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	require.NoError(t, bkt.Upload(ctx, prefix+"/meta.json", bytes.NewReader(metaBytes)))
-	require.NoError(t, bkt.Upload(ctx, prefix+"/index", bytes.NewReader(indexData)))
-	require.NoError(t, bkt.Upload(ctx, prefix+"/chunks/000001", bytes.NewReader(chunkData)))
+	uploadString(t, bkt, prefix+"/meta.json", metaBytes)
+	uploadString(t, bkt, prefix+"/index", indexData)
+	uploadString(t, bkt, prefix+"/chunks/000001", chunkData)
 
 	type recorded struct {
 		method string
@@ -126,7 +153,7 @@ func TestBackfillBlock(t *testing.T) {
 	c, err := New(Config{Address: srv.URL, ID: "test"}, log.NewNopLogger())
 	require.NoError(t, err)
 
-	require.NoError(t, c.BackfillBlock(ctx, bkt, blockID, 0))
+	require.NoError(t, c.BackfillBlock(ctx, bkt, "", blockID, 0))
 
 	blockPath := "/api/v1/upload/block/" + prefix
 

--- a/pkg/util/objtools/abs.go
+++ b/pkg/util/objtools/abs.go
@@ -182,8 +182,12 @@ func checkCopyStatus(ctx context.Context, client *blob.Client) (*blob.CopyStatus
 	return response.CopyStatus, response.CopyStatusDescription, nil
 }
 
-func (bkt *azureBucket) Exists(ctx context.Context, objectName string) (bool, error) {
-	resp, err := bkt.containerClient.NewBlobClient(objectName).GetProperties(ctx, nil)
+func (bkt *azureBucket) Exists(ctx context.Context, objectName string, options ExistsOptions) (bool, error) {
+	client, err := bkt.containerClient.NewBlobClient(objectName).WithVersionID(options.VersionID)
+	if err != nil {
+		return false, fmt.Errorf("could not construct a client with the provided version ID: %s: %w", options.VersionID, err)
+	}
+	resp, err := client.GetProperties(ctx, nil)
 	if err == nil {
 		// Don't treat failed or pending copies as existing
 		if resp.CopyStatus != nil && *resp.CopyStatus != blob.CopyStatusTypeSuccess {

--- a/pkg/util/objtools/bucket.go
+++ b/pkg/util/objtools/bucket.go
@@ -10,12 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-kit/log"
-	"github.com/thanos-io/objstore"
-	"github.com/thanos-io/objstore/providers/azure"
-	"github.com/thanos-io/objstore/providers/gcs"
-	"github.com/thanos-io/objstore/providers/s3"
-
 	"github.com/grafana/mimir/pkg/storage/bucket"
 )
 
@@ -26,7 +20,7 @@ const (
 // Bucket is an object storage interface intended to be used by tools that require functionality that isn't in objstore
 type Bucket interface {
 	Get(ctx context.Context, objectName string, options GetOptions) (io.ReadCloser, error)
-	Exists(ctx context.Context, objectName string) (bool, error)
+	Exists(ctx context.Context, objectName string, options ExistsOptions) (bool, error)
 	ServerSideCopy(ctx context.Context, objectName string, dstBucket Bucket, options CopyOptions) error
 	ClientSideCopy(ctx context.Context, objectName string, dstBucket Bucket, options CopyOptions) error
 	List(ctx context.Context, options ListOptions) (*ListResult, error)
@@ -49,6 +43,10 @@ func (options *CopyOptions) destinationObjectName(sourceObjectName string) strin
 }
 
 type GetOptions struct {
+	VersionID string
+}
+
+type ExistsOptions struct {
 	VersionID string
 }
 
@@ -109,10 +107,11 @@ type VersionInfo struct {
 }
 
 type BucketConfig struct {
-	backend string
-	azure   AzureClientConfig
-	gcs     GCSClientConfig
-	s3      S3ClientConfig
+	backend    string
+	azure      AzureClientConfig
+	gcs        GCSClientConfig
+	s3         S3ClientConfig
+	filesystem FilesystemClientConfig
 }
 
 func (c *BucketConfig) RegisterFlags(f *flag.FlagSet) {
@@ -128,13 +127,14 @@ func ifNotEmptySuffix(s, suffix string) string {
 
 func (c *BucketConfig) registerFlags(descriptor string, f *flag.FlagSet, externalBackends []string) {
 	descriptorFlagPrefix := ifNotEmptySuffix(descriptor, ".")
-	allBackends := append([]string{bucket.Azure, bucket.GCS, bucket.S3}, externalBackends...)
+	allBackends := append([]string{bucket.Azure, bucket.GCS, bucket.S3, bucket.Filesystem}, externalBackends...)
 	acceptedBackends := strings.Join(allBackends[:len(allBackends)-1], ", ") + " or " + allBackends[len(allBackends)-1] + "."
 	f.StringVar(&c.backend, descriptorFlagPrefix+"backend", "",
 		fmt.Sprintf("The %sobject storage backend. Accepted values are: %s", ifNotEmptySuffix(descriptor, " "), acceptedBackends))
 	c.azure.RegisterFlags(bucket.Azure+"."+descriptorFlagPrefix, f)
 	c.gcs.RegisterFlags(bucket.GCS+"."+descriptorFlagPrefix, f)
 	c.s3.RegisterFlags(bucket.S3+"."+descriptorFlagPrefix, f)
+	c.filesystem.RegisterFlags(bucket.Filesystem+"."+descriptorFlagPrefix, f)
 }
 
 func (c *BucketConfig) Validate() error {
@@ -153,6 +153,8 @@ func (c *BucketConfig) validate(descriptor string) error {
 		return c.gcs.Validate(bucket.GCS + "." + descriptorFlagPrefix)
 	case bucket.S3:
 		return c.s3.Validate(bucket.S3 + "." + descriptorFlagPrefix)
+	case bucket.Filesystem:
+		return c.filesystem.Validate(bucket.Filesystem + "." + descriptorFlagPrefix)
 	default:
 		return fmt.Errorf("unknown backend provided in --%sbackend", descriptorFlagPrefix)
 	}
@@ -166,33 +168,8 @@ func (c *BucketConfig) ToBucket(ctx context.Context) (Bucket, error) {
 		return c.gcs.ToBucket(ctx)
 	case bucket.S3:
 		return c.s3.ToBucket()
-	default:
-		return nil, fmt.Errorf("unknown backend: %v", c.backend)
-	}
-}
-
-// ToObjstoreBucket is an adapter to objstore
-func (c *BucketConfig) ToObjstoreBucket(ctx context.Context, logger log.Logger) (objstore.Bucket, error) {
-	switch c.backend {
-	case bucket.S3:
-		return s3.NewBucketWithConfig(logger, s3.Config{
-			Bucket:    c.s3.BucketName,
-			Endpoint:  c.s3.Endpoint,
-			AccessKey: c.s3.AccessKeyID,
-			SecretKey: c.s3.SecretAccessKey,
-			Insecure:  !c.s3.Secure,
-			PartSize:  c.s3.PartSize,
-		}, "objtools-s3", nil)
-	case bucket.GCS:
-		return gcs.NewBucketWithConfig(ctx, logger, gcs.Config{
-			Bucket: c.gcs.BucketName,
-		}, "objtools-gcs", nil)
-	case bucket.Azure:
-		azCfg := azure.DefaultConfig
-		azCfg.StorageAccountName = c.azure.AccountName
-		azCfg.StorageAccountKey = c.azure.AccountKey
-		azCfg.ContainerName = c.azure.ContainerName
-		return azure.NewBucketWithConfig(logger, azCfg, "objtools-azure", nil)
+	case bucket.Filesystem:
+		return c.filesystem.ToBucket()
 	default:
 		return nil, fmt.Errorf("unknown backend: %v", c.backend)
 	}
@@ -225,11 +202,6 @@ func (c *CopyBucketConfig) Validate() error {
 // SourceBucket creates and returns only the source bucket.
 func (c *CopyBucketConfig) SourceBucket(ctx context.Context) (Bucket, error) {
 	return c.source.ToBucket(ctx)
-}
-
-// SourceObjstoreBucket creates an objstore.Bucket from the source configuration.
-func (c *CopyBucketConfig) SourceObjstoreBucket(ctx context.Context, logger log.Logger) (objstore.Bucket, error) {
-	return c.source.ToObjstoreBucket(ctx, logger)
 }
 
 // ValidateSource validates only the source bucket configuration.
@@ -265,6 +237,14 @@ func (c *CopyBucketConfig) toCopyFunc(source Bucket, destination Bucket) CopyFun
 	return func(ctx context.Context, objectName string, options CopyOptions) error {
 		return source.ServerSideCopy(ctx, objectName, destination, options)
 	}
+}
+
+// NewFilesystemCopyBucketConfig constructs a CopyBucketConfig that copies between two local directories.
+func NewFilesystemCopyBucketConfig(sourceDir, destDir string) CopyBucketConfig {
+	fs := func(dir string) BucketConfig {
+		return BucketConfig{backend: bucket.Filesystem, filesystem: FilesystemClientConfig{Directory: dir}}
+	}
+	return CopyBucketConfig{source: fs(sourceDir), destination: fs(destDir)}
 }
 
 func ensureDelimiterSuffix(prefix string) string {

--- a/pkg/util/objtools/fs.go
+++ b/pkg/util/objtools/fs.go
@@ -1,0 +1,419 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package objtools
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// tmpWriteDirName is the name of a directory under the bucket root used to hold
+// partially written objects before they are renamed into place. It is reserved and
+// excluded from bucket operations
+const tmpWriteDirName = ".objtools-tmp" // nolint:gosec // false positive for G101: Potential hardcoded credentials
+
+var (
+	errFilesystemVersioningUnsupported = errors.New("the filesystem backend does not support versioning")
+	errTmpWriteDirReserved             = fmt.Errorf("object names under %q are reserved by the filesystem backend", tmpWriteDirName)
+	errObjectIsDirectory               = errors.New("object name refers to an existing directory")
+	errNonCanonicalName                = errors.New("object name is not in canonical form: it must not contain empty, \".\", or \"..\" segments, repeated delimiters, or a trailing delimiter")
+)
+
+type FilesystemClientConfig struct {
+	Directory string
+}
+
+func (c *FilesystemClientConfig) RegisterFlags(prefix string, f *flag.FlagSet) {
+	f.StringVar(&c.Directory, prefix+"directory", "", "The directory that will be treated as if it were the root of an object storage bucket.")
+}
+
+func (c *FilesystemClientConfig) Validate(prefix string) error {
+	if c.Directory == "" {
+		return fmt.Errorf("the filesystem directory (%s) is required", prefix+"directory")
+	}
+	// A directory that doesn't exist yet is fine, but it can't be a file
+	info, err := os.Stat(c.Directory)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("the filesystem directory (%s) is not a directory: %s", prefix+"directory", c.Directory)
+	}
+	return nil
+}
+
+func (c *FilesystemClientConfig) ToBucket() (Bucket, error) {
+	return &fsBucket{
+		directory: filepath.Clean(c.Directory),
+	}, nil
+}
+
+// fsBucket is a Bucket implementation backed by a local filesystem. Object names are mapped to
+// paths relative to the configured directory.
+//
+// Intended for limited use by tools/testing only.
+//
+// Known limitations:
+//   - The filesystem has no notion of versioning, so versioned operations are not supported.
+//   - Files within the temporary write directory and empty directories may leak.
+//   - No fsync is performed.
+//   - Object names that do not map to canonical paths are rejected.
+//   - Containment is enforced lexically via the canonical name check, so a symlink
+//     within the directory that points elsewhere can still escape the bucket.
+type fsBucket struct {
+	directory string
+}
+
+func (bkt *fsBucket) fsPath(objectName string) string {
+	return filepath.Join(bkt.directory, filepath.FromSlash(objectName))
+}
+
+func (bkt *fsBucket) tempWriteDir() string {
+	return filepath.Join(bkt.directory, tmpWriteDirName)
+}
+
+// isCanonicalName reports whether name is in canonical slash-separated form: no
+// empty, ".", or ".." segments and no repeated delimiters. When allowTrailingDelim
+// is true a single trailing delimiter is permitted, as list prefixes may carry one.
+// This is the single source of truth for what makes a name well-formed, and because
+// it rejects ".." segments it also guarantees a mapped path cannot escape the bucket.
+func isCanonicalName(name string, allowTrailingDelim bool) bool {
+	if allowTrailingDelim {
+		name = strings.TrimSuffix(name, Delim)
+	}
+	// Anchor with a leading delimiter so path.Clean treats name as absolute; "."
+	// and ".." segments then change the cleaned result and fail the comparison.
+	return name != "" && path.Clean(Delim+name) == Delim+name
+}
+
+// isTemp reports whether fsPath is the temporary write directory or lies within it.
+func (bkt *fsBucket) isTemp(fsPath string) bool {
+	staging := bkt.tempWriteDir()
+	return fsPath == staging || strings.HasPrefix(fsPath, staging+string(filepath.Separator))
+}
+
+// resolveObject validates objectName as an object key and maps it to its
+// filesystem path. The name must be canonical and must not fall in the temporary write directory.
+func (bkt *fsBucket) resolveObject(objectName string) (string, error) {
+	if !isCanonicalName(objectName, false) {
+		return "", errNonCanonicalName
+	}
+	fsPath := bkt.fsPath(objectName)
+	if bkt.isTemp(fsPath) {
+		return "", errTmpWriteDirReserved
+	}
+	return fsPath, nil
+}
+
+// resolvePrefix validates a list prefix and maps it to the filesystem path of the
+// directory to list. An empty prefix maps to the bucket root; a non-empty prefix
+// must be canonical and may carry a trailing delimiter.
+func (bkt *fsBucket) resolvePrefix(prefix string) (string, error) {
+	if prefix != "" && !isCanonicalName(prefix, true) {
+		return "", errNonCanonicalName
+	}
+	fsPath := bkt.fsPath(ensureDelimiterSuffix(prefix))
+	if bkt.isTemp(fsPath) {
+		return "", errTmpWriteDirReserved
+	}
+	return fsPath, nil
+}
+
+func (bkt *fsBucket) ensureNotDirectory(fsPath string) error {
+	info, err := os.Stat(fsPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	if info.IsDir() {
+		return errObjectIsDirectory
+	}
+	return nil
+}
+
+func (bkt *fsBucket) Get(_ context.Context, objectName string, options GetOptions) (io.ReadCloser, error) {
+	if options.VersionID != "" {
+		return nil, errFilesystemVersioningUnsupported
+	}
+	fsPath, err := bkt.resolveObject(objectName)
+	if err != nil {
+		return nil, err
+	}
+	if err := bkt.ensureNotDirectory(fsPath); err != nil {
+		return nil, err
+	}
+	return os.Open(fsPath)
+}
+
+func (bkt *fsBucket) Exists(_ context.Context, objectName string, options ExistsOptions) (bool, error) {
+	if options.VersionID != "" {
+		return false, errFilesystemVersioningUnsupported
+	}
+	fsPath, err := bkt.resolveObject(objectName)
+	if err != nil {
+		return false, err
+	}
+	info, err := os.Stat(fsPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	return !info.IsDir(), nil
+}
+
+func (bkt *fsBucket) ServerSideCopy(_ context.Context, objectName string, dstBucket Bucket, options CopyOptions) error {
+	if options.SourceVersionID != "" {
+		return errFilesystemVersioningUnsupported
+	}
+	d, ok := dstBucket.(*fsBucket)
+	if !ok {
+		return errors.New("destination Bucket wasn't a filesystem Bucket")
+	}
+	src, err := bkt.resolveObject(objectName)
+	if err != nil {
+		return err
+	}
+	dst, err := d.resolveObject(options.destinationObjectName(objectName))
+	if err != nil {
+		return err
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	// Stage through the destination bucket: dst lives under d's directory, so the
+	// temporary write directory and rename must happen there too.
+	return d.stagedWrite(dst, func(w io.Writer) error {
+		_, err := io.Copy(w, in)
+		return err
+	})
+}
+
+func (bkt *fsBucket) ClientSideCopy(ctx context.Context, objectName string, dstBucket Bucket, options CopyOptions) error {
+	if options.SourceVersionID != "" {
+		return errFilesystemVersioningUnsupported
+	}
+	src, err := bkt.resolveObject(objectName)
+	if err != nil {
+		return err
+	}
+	info, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("failed to stat filesystem source object: %w", err)
+	}
+	reader, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("failed to open filesystem source object: %w", err)
+	}
+	if err := dstBucket.Upload(ctx, options.destinationObjectName(objectName), reader, info.Size()); err != nil {
+		_ = reader.Close()
+		return fmt.Errorf("failed to upload filesystem source object to destination: %w", err)
+	}
+	if err := reader.Close(); err != nil {
+		return fmt.Errorf("failed closing filesystem source object reader: %w", err)
+	}
+	return nil
+}
+
+func (bkt *fsBucket) List(_ context.Context, options ListOptions) (*ListResult, error) {
+	root, err := bkt.resolvePrefix(options.Prefix)
+	if err != nil {
+		return nil, err
+	}
+
+	if options.Recursive {
+		return bkt.listRecursive(root)
+	}
+	return bkt.listShallow(ensureDelimiterSuffix(options.Prefix), root)
+}
+
+// listShallow lists the immediate children of dir, returning files as objects and
+// subdirectories as prefixes
+func (bkt *fsBucket) listShallow(prefix string, dir string) (*ListResult, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return &ListResult{Objects: []ObjectAttributes{}, Prefixes: []string{}}, nil
+		}
+		return nil, err
+	}
+
+	objects := make([]ObjectAttributes, 0, len(entries))
+	prefixes := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			// Never surface the reserved staging directory as a prefix
+			if bkt.isTemp(filepath.Join(dir, entry.Name())) {
+				continue
+			}
+			prefixes = append(prefixes, prefix+entry.Name()+Delim)
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return nil, err
+		}
+		objects = append(objects, ObjectAttributes{
+			Name:         prefix + entry.Name(),
+			Size:         info.Size(),
+			LastModified: info.ModTime(),
+		})
+	}
+	return &ListResult{Objects: objects, Prefixes: prefixes}, nil
+}
+
+// listRecursive lists every file in the subtree of dir
+func (bkt *fsBucket) listRecursive(dir string) (*ListResult, error) {
+	objects := make([]ObjectAttributes, 0, 10)
+	err := filepath.WalkDir(dir, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return nil
+			}
+			return err
+		}
+		if entry.IsDir() {
+			// Ignore the staging directory
+			if bkt.isTemp(path) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		rel, err := filepath.Rel(bkt.directory, path)
+		if err != nil {
+			return err
+		}
+		info, err := entry.Info()
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return nil
+			}
+			return err
+		}
+		objects = append(objects, ObjectAttributes{
+			Name:         filepath.ToSlash(rel),
+			Size:         info.Size(),
+			LastModified: info.ModTime(),
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &ListResult{Objects: objects, Prefixes: []string{}}, nil
+}
+
+func (bkt *fsBucket) RestoreVersion(context.Context, string, VersionInfo) error {
+	return errFilesystemVersioningUnsupported
+}
+
+func (bkt *fsBucket) Upload(_ context.Context, objectName string, reader io.Reader, _ int64) error {
+	fsPath, err := bkt.resolveObject(objectName)
+	if err != nil {
+		return err
+	}
+	return bkt.stagedWrite(fsPath, func(w io.Writer) error {
+		if _, err := io.Copy(w, reader); err != nil {
+			return fmt.Errorf("failed writing filesystem object: %w", err)
+		}
+		return nil
+	})
+}
+
+func (bkt *fsBucket) Delete(_ context.Context, objectName string, options DeleteOptions) error {
+	if options.VersionID != "" {
+		return errFilesystemVersioningUnsupported
+	}
+	fsPath, err := bkt.resolveObject(objectName)
+	if err != nil {
+		return err
+	}
+	if err := bkt.ensureNotDirectory(fsPath); err != nil {
+		return err
+	}
+	if err := os.Remove(fsPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	bkt.pruneEmptyParents(filepath.Dir(fsPath))
+	return nil
+}
+
+func (bkt *fsBucket) pruneEmptyParents(dir string) {
+	for dir != bkt.directory && len(dir) > len(bkt.directory) {
+		// os.Remove only deletes a directory when it is empty
+		if err := os.Remove(dir); err != nil {
+			return
+		}
+		dir = filepath.Dir(dir)
+	}
+}
+
+func (bkt *fsBucket) Name() string {
+	return "filesystem"
+}
+
+// stagedWrite writes content to dst by staging it under bkt's temporary write directory and
+// renaming it into place to prevent partial write appearing in dst. dst must already
+// be resolved via resolveObject and belong to bkt.
+func (bkt *fsBucket) stagedWrite(dst string, write func(io.Writer) error) (retErr error) {
+	if err := bkt.ensureNotDirectory(dst); err != nil {
+		return err
+	}
+	tmpDir := bkt.tempWriteDir()
+	if err := os.MkdirAll(tmpDir, 0o755); err != nil {
+		return err
+	}
+	tmpPath, err := writeToTemp(tmpDir, write)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if retErr != nil {
+			_ = os.Remove(tmpPath)
+			bkt.pruneEmptyParents(filepath.Dir(dst))
+		}
+	}()
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, dst)
+}
+
+func writeToTemp(dir string, write func(io.Writer) error) (string, error) {
+	tmp, err := os.CreateTemp(dir, "tmp-*")
+	if err != nil {
+		return "", err
+	}
+	tmpPath := tmp.Name()
+	if err := write(tmp); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return "", err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return "", err
+	}
+	return tmpPath, nil
+}

--- a/pkg/util/objtools/fs.go
+++ b/pkg/util/objtools/fs.go
@@ -98,8 +98,8 @@ func isCanonicalName(name string, allowTrailingDelim bool) bool {
 
 // isTemp reports whether fsPath is the temporary write directory or lies within it.
 func (bkt *fsBucket) isTemp(fsPath string) bool {
-	staging := bkt.tempWriteDir()
-	return fsPath == staging || strings.HasPrefix(fsPath, staging+string(filepath.Separator))
+	tempDir := bkt.tempWriteDir()
+	return fsPath == tempDir || strings.HasPrefix(fsPath, tempDir+string(filepath.Separator))
 }
 
 // resolveObject validates objectName as an object key and maps it to its
@@ -257,7 +257,7 @@ func (bkt *fsBucket) listShallow(prefix string, dir string) (*ListResult, error)
 	prefixes := make([]string, 0, len(entries))
 	for _, entry := range entries {
 		if entry.IsDir() {
-			// Never surface the reserved staging directory as a prefix
+			// Never surface the reserved temporary write directory as a prefix
 			if bkt.isTemp(filepath.Join(dir, entry.Name())) {
 				continue
 			}
@@ -291,7 +291,7 @@ func (bkt *fsBucket) listRecursive(dir string) (*ListResult, error) {
 			return err
 		}
 		if entry.IsDir() {
-			// Ignore the staging directory
+			// Ignore the temporary write directory
 			if bkt.isTemp(path) {
 				return filepath.SkipDir
 			}

--- a/pkg/util/objtools/fs_test.go
+++ b/pkg/util/objtools/fs_test.go
@@ -1,0 +1,319 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package objtools
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testBlockID(ms uint64) ulid.ULID {
+	return ulid.MustNew(ms, rand.Reader)
+}
+
+// blockObj returns the canonical object name for a file inside a tenant's block directory
+func blockObj(tenant string, block ulid.ULID, file string) string {
+	return path.Join(tenant, block.String(), file)
+}
+
+func newTestFilesystemBucket(t *testing.T) *fsBucket {
+	t.Helper()
+	bkt, err := (&FilesystemClientConfig{Directory: t.TempDir()}).ToBucket()
+	require.NoError(t, err)
+	return bkt.(*fsBucket)
+}
+
+func uploadStringContent(t *testing.T, bkt Bucket, objectName, content string) {
+	t.Helper()
+	require.NoError(t, bkt.Upload(context.Background(), objectName, bytes.NewReader([]byte(content)), int64(len(content))))
+}
+
+func getStringContent(t *testing.T, bkt Bucket, objectName string) string {
+	t.Helper()
+	r, err := bkt.Get(context.Background(), objectName, GetOptions{})
+	require.NoError(t, err)
+	defer r.Close()
+	content, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(content)
+}
+
+func TestFilesystemBucket_UploadGetExists(t *testing.T) {
+	bkt := newTestFilesystemBucket(t)
+	ctx := context.Background()
+	block := testBlockID(1)
+
+	metaName := blockObj("tenant", block, "meta.json")
+	uploadStringContent(t, bkt, metaName, "foo")
+	assert.Equal(t, "foo", getStringContent(t, bkt, metaName))
+
+	exists, err := bkt.Exists(ctx, metaName, ExistsOptions{})
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	missing := blockObj("tenant", block, "missing.json")
+	exists, err = bkt.Exists(ctx, missing, ExistsOptions{})
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	_, err = bkt.Get(ctx, missing, GetOptions{})
+	assert.ErrorIs(t, err, os.ErrNotExist)
+
+	// A directory must not be treated as an object
+	exists, err = bkt.Exists(ctx, "tenant/"+block.String(), ExistsOptions{})
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func TestFilesystemBucket_List(t *testing.T) {
+	bkt := newTestFilesystemBucket(t)
+	ctx := context.Background()
+	block1 := testBlockID(1)
+	block2 := testBlockID(2)
+
+	uploadStringContent(t, bkt, blockObj("tenant1", block1, "meta.json"), "a")
+	uploadStringContent(t, bkt, blockObj("tenant1", block1, "index"), "b")
+	uploadStringContent(t, bkt, blockObj("tenant1", block2, "meta.json"), "c")
+	uploadStringContent(t, bkt, blockObj("tenant2", block1, "meta.json"), "d")
+
+	// Shallow listing of the whole bucket returns tenants
+	result, err := bkt.List(ctx, ListOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"tenant1", "tenant2"}, result.ToNames())
+
+	// Shallow listing of a tenant returns its blocks
+	result, err = bkt.List(ctx, ListOptions{Prefix: "tenant1"})
+	require.NoError(t, err)
+	names, err := result.ToNamesWithoutPrefix("tenant1")
+	require.NoError(t, err)
+	assert.Equal(t, []string{block1.String(), block2.String()}, names)
+
+	// Recursive listing
+	result, err = bkt.List(ctx, ListOptions{Prefix: "tenant1/" + block1.String(), Recursive: true})
+	require.NoError(t, err)
+	assert.Equal(t, []string{blockObj("tenant1", block1, "index"), blockObj("tenant1", block1, "meta.json")}, result.ToNames())
+
+	// Listing a nonexistent prefix returns an empty result rather than an error
+	result, err = bkt.List(ctx, ListOptions{Prefix: "missing"})
+	require.NoError(t, err)
+	assert.Empty(t, result.ToNames())
+
+	// The temporary write directory is never surfaced in listings
+	require.NoError(t, os.WriteFile(filepath.Join(bkt.tempWriteDir(), "leftover"), []byte("x"), 0o600))
+	result, err = bkt.List(ctx, ListOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"tenant1", "tenant2"}, result.ToNames())
+	result, err = bkt.List(ctx, ListOptions{Recursive: true})
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		blockObj("tenant1", block1, "index"),
+		blockObj("tenant1", block1, "meta.json"),
+		blockObj("tenant1", block2, "meta.json"),
+		blockObj("tenant2", block1, "meta.json"),
+	}, result.ToNames())
+	_, err = bkt.List(ctx, ListOptions{Prefix: tmpWriteDirName})
+	assert.ErrorIs(t, err, errTmpWriteDirReserved)
+}
+
+func TestFilesystemBucket_Copy(t *testing.T) {
+	block := testBlockID(1)
+	name := blockObj("tenant", block, "meta.json")
+
+	type copyFn func(src, dst *fsBucket, name string, opts CopyOptions) error
+
+	for _, tc := range []struct {
+		name string
+		copy copyFn
+	}{
+		{"server-side copy", func(src, dst *fsBucket, n string, opts CopyOptions) error {
+			return src.ServerSideCopy(context.Background(), n, dst, opts)
+		}},
+		{"client-side copy", func(src, dst *fsBucket, n string, opts CopyOptions) error {
+			return src.ClientSideCopy(context.Background(), n, dst, opts)
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			src := newTestFilesystemBucket(t)
+			dst := newTestFilesystemBucket(t)
+			uploadStringContent(t, src, name, "payload")
+
+			require.NoError(t, tc.copy(src, dst, name, CopyOptions{}))
+			assert.Equal(t, "payload", getStringContent(t, dst, name))
+
+			// With a renamed destination object
+			renamed := blockObj("other", block, "meta.json")
+			require.NoError(t, tc.copy(src, dst, name, CopyOptions{DestinationObjectName: renamed}))
+			assert.Equal(t, "payload", getStringContent(t, dst, renamed))
+		})
+	}
+}
+
+func TestFilesystemBucket_DeletePrunesEmptyParents(t *testing.T) {
+	bkt := newTestFilesystemBucket(t)
+	ctx := context.Background()
+	block := testBlockID(1)
+
+	lower := blockObj("tenant", block, "meta.json")
+	uploadStringContent(t, bkt, lower, "foo")
+
+	require.NoError(t, bkt.Delete(ctx, lower, DeleteOptions{}))
+
+	// The empty tenant is pruned
+	_, err := os.Stat(filepath.Join(bkt.directory, "tenant", block.String()))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+
+	// Reupload
+	uploadStringContent(t, bkt, lower, "foo")
+
+	upper := "tenant/keep.json"
+	uploadStringContent(t, bkt, upper, "bar")
+
+	require.NoError(t, bkt.Delete(ctx, lower, DeleteOptions{}))
+
+	// The empty block directory is pruned, but the tenant directory remains
+	_, err = os.Stat(filepath.Join(bkt.directory, "tenant", block.String()))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+	_, err = os.Stat(filepath.Join(bkt.directory, upper))
+	require.NoError(t, err)
+
+	// Delete the last file, which causes the tenant directory to be pruned
+	require.NoError(t, bkt.Delete(ctx, upper, DeleteOptions{}))
+	_, err = os.Stat(filepath.Join(bkt.directory, "tenant"))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestFilesystemBucket_InvalidNamesRejected(t *testing.T) {
+	bkt := newTestFilesystemBucket(t)
+	ctx := context.Background()
+	block := testBlockID(1)
+
+	uploadStringContent(t, bkt, blockObj("tenant", block, "meta.json"), "payload")
+	dst := newTestFilesystemBucket(t)
+
+	// All object-name operations reject names that resolve into the temporar write directory
+	// or that are not canonical paths.
+	for _, tc := range []struct {
+		name    string
+		wantErr error
+	}{
+		{tmpWriteDirName + "/object", errTmpWriteDirReserved},
+		{"tenant/" + block.String() + "/", errNonCanonicalName}, // trailing delimiter (directory-like)
+		{"tenant//" + block.String(), errNonCanonicalName},      // repeated delimiter
+		{"tenant/./" + block.String(), errNonCanonicalName},     // "." segment
+		{"tenant/../" + block.String(), errNonCanonicalName},    // ".." segment
+		{"./tenant", errNonCanonicalName},                       // leading "."
+		{"../escape", errNonCanonicalName},                      // escapes the bucket
+		{"/tenant/" + block.String(), errNonCanonicalName},      // leading delimiter (filepath.Join would map it onto the slash-less path)
+		{".", errNonCanonicalName},
+		{"", errNonCanonicalName},
+	} {
+		err := bkt.Upload(ctx, tc.name, bytes.NewReader([]byte("x")), 1)
+		assert.ErrorIsf(t, err, tc.wantErr, "Upload(%q)", tc.name)
+
+		err = bkt.Delete(ctx, tc.name, DeleteOptions{})
+		assert.ErrorIsf(t, err, tc.wantErr, "Delete(%q)", tc.name)
+
+		_, err = bkt.Get(ctx, tc.name, GetOptions{})
+		assert.ErrorIsf(t, err, tc.wantErr, "Get(%q)", tc.name)
+
+		_, err = bkt.Exists(ctx, tc.name, ExistsOptions{})
+		assert.ErrorIsf(t, err, tc.wantErr, "Exists(%q)", tc.name)
+
+		err = bkt.ServerSideCopy(ctx, tc.name, dst, CopyOptions{})
+		assert.ErrorIsf(t, err, tc.wantErr, "ServerSideCopy source %q", tc.name)
+
+		err = bkt.ClientSideCopy(ctx, tc.name, dst, CopyOptions{})
+		assert.ErrorIsf(t, err, tc.wantErr, "ClientSideCopy source %q", tc.name)
+
+		// An empty destination name falls back to the source object name, so only
+		// non-empty names are meaningful to test as copy destinations
+		if tc.name != "" {
+			err = bkt.ServerSideCopy(ctx, blockObj("tenant", block, "meta.json"), dst, CopyOptions{DestinationObjectName: tc.name})
+			assert.ErrorIsf(t, err, tc.wantErr, "ServerSideCopy destination %q", tc.name)
+
+			err = bkt.ClientSideCopy(ctx, blockObj("tenant", block, "meta.json"), dst, CopyOptions{DestinationObjectName: tc.name})
+			assert.ErrorIsf(t, err, tc.wantErr, "ClientSideCopy destination %q", tc.name)
+		}
+	}
+}
+
+func TestFilesystemBucket_ListPrefixContainment(t *testing.T) {
+	bkt := newTestFilesystemBucket(t)
+	ctx := context.Background()
+	block := testBlockID(1)
+
+	uploadStringContent(t, bkt, blockObj("tenant", block, "meta.json"), "payload")
+
+	// A non-canonical listing prefix is rejected. Because paths are treated as relative
+	// and canonical form forbids ".." segments, this also prevents a prefix from escaping the bucket directory.
+	_, err := bkt.List(ctx, ListOptions{Prefix: "../escape"})
+	assert.ErrorIs(t, err, errNonCanonicalName)
+
+	// A whole-bucket listing resolves to the bucket directory and is permitted,
+	result, err := bkt.List(ctx, ListOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"tenant"}, result.ToNames())
+}
+
+func TestFilesystemBucket_DirectoryTargetRejected(t *testing.T) {
+	bkt := newTestFilesystemBucket(t)
+	ctx := context.Background()
+	block := testBlockID(1)
+
+	name := blockObj("tenant", block, "meta.json")
+	uploadStringContent(t, bkt, name, "payload")
+	dirTarget := "tenant/" + block.String()
+
+	// dirTarget exists as a directory, so it can't be used as an object name
+	_, err := bkt.Get(ctx, dirTarget, GetOptions{})
+	assert.ErrorIs(t, err, errObjectIsDirectory)
+
+	err = bkt.Upload(ctx, dirTarget, bytes.NewReader([]byte("foo")), 1)
+	assert.ErrorIs(t, err, errObjectIsDirectory)
+
+	err = bkt.Delete(ctx, dirTarget, DeleteOptions{})
+	assert.ErrorIs(t, err, errObjectIsDirectory)
+
+	dst := newTestFilesystemBucket(t)
+	uploadStringContent(t, dst, blockObj("other", block, "keep.json"), "foo")
+	dstDir := "other/" + block.String()
+	err = bkt.ServerSideCopy(ctx, name, dst, CopyOptions{DestinationObjectName: dstDir})
+	assert.ErrorIs(t, err, errObjectIsDirectory)
+
+	err = bkt.ClientSideCopy(ctx, name, dst, CopyOptions{DestinationObjectName: dstDir})
+	assert.ErrorIs(t, err, errObjectIsDirectory)
+
+	// The directory and its contents are untouched
+	assert.Equal(t, "payload", getStringContent(t, bkt, name))
+}
+
+func TestFilesystemBucket_VersioningUnsupported(t *testing.T) {
+	bkt := newTestFilesystemBucket(t)
+	ctx := context.Background()
+	block := testBlockID(1)
+
+	name := blockObj("tenant", block, "meta.json")
+	uploadStringContent(t, bkt, name, "a")
+
+	_, err := bkt.Get(ctx, name, GetOptions{VersionID: "1"})
+	assert.ErrorIs(t, err, errFilesystemVersioningUnsupported)
+
+	_, err = bkt.Exists(ctx, name, ExistsOptions{VersionID: "1"})
+	assert.ErrorIs(t, err, errFilesystemVersioningUnsupported)
+
+	err = bkt.Delete(ctx, name, DeleteOptions{VersionID: "1"})
+	assert.ErrorIs(t, err, errFilesystemVersioningUnsupported)
+
+	err = bkt.RestoreVersion(ctx, name, VersionInfo{VersionID: "1"})
+	assert.ErrorIs(t, err, errFilesystemVersioningUnsupported)
+}

--- a/pkg/util/objtools/gcs.go
+++ b/pkg/util/objtools/gcs.go
@@ -56,8 +56,12 @@ func (bkt *gcsBucket) Get(ctx context.Context, objectName string, options GetOpt
 	return obj.NewReader(ctx)
 }
 
-func (bkt *gcsBucket) Exists(ctx context.Context, objectName string) (bool, error) {
-	_, err := bkt.client.Object(objectName).Attrs(ctx)
+func (bkt *gcsBucket) Exists(ctx context.Context, objectName string, options ExistsOptions) (bool, error) {
+	obj, err := bkt.objectHandle(objectName, options.VersionID)
+	if err != nil {
+		return false, err
+	}
+	_, err = obj.Attrs(ctx)
 	if err == nil {
 		return true, nil
 	}

--- a/pkg/util/objtools/s3.go
+++ b/pkg/util/objtools/s3.go
@@ -86,8 +86,10 @@ func (bkt *s3Bucket) Get(ctx context.Context, objectName string, options GetOpti
 	return obj, nil
 }
 
-func (bkt *s3Bucket) Exists(ctx context.Context, objectName string) (bool, error) {
-	_, err := bkt.client.StatObject(ctx, bkt.bucketName, objectName, minio.StatObjectOptions{})
+func (bkt *s3Bucket) Exists(ctx context.Context, objectName string, options ExistsOptions) (bool, error) {
+	_, err := bkt.client.StatObject(ctx, bkt.bucketName, objectName, minio.StatObjectOptions{
+		VersionID: options.VersionID,
+	})
 	if err != nil {
 		if minio.ToErrorResponse(err).Code == minio.NoSuchKey {
 			return false, nil

--- a/tools/copyblocks/README.md
+++ b/tools/copyblocks/README.md
@@ -4,7 +4,7 @@ This program can copy Mimir blocks between two buckets or from a bucket to a bac
 
 By default, a copy between two buckets will be attempted server-side if both the source and destination specify the same object storage service. If the buckets are on different object storage services, or if `--client-side-copy` is passed, then the copy will be performed client side.
 
-The currently supported object storage services are Amazon Simple Storage Service (S3 and S3-compatible), Azure Blob Storage (ABS), and Google Cloud Storage (GCS).
+The currently supported object storage services are Amazon Simple Storage Service (S3 and S3-compatible), Azure Blob Storage (ABS), and Google Cloud Storage (GCS). A local filesystem is also supported.
 
 ## Features
 
@@ -73,6 +73,21 @@ Consider passing `--client-side-copy` to avoid having to deal with that.
 ```
 
 If both `--s3.<source|destination>.access-key-id` and `--s3.<source|destination>.secret-access-key` are omitted, credentials are resolved from the environment. This supports IAM roles for service accounts (IRSA) on EKS, ECS task roles, and EC2 instance metadata, and lets a single role that has access to both buckets authenticate the source and destination clients without passing static credentials.
+
+### Example for a local filesystem
+
+The directory is treated as the root of the bucket, so it is expected to follow the same layout Mimir uses in object storage: one subdirectory per tenant, each containing the tenant's blocks and a `markers` directory (e.g. `<directory>/<tenant ID>/<block ULID>/meta.json` and `<directory>/<tenant ID>/markers/`).
+
+```bash
+./copyblocks \
+  --source.backend filesystem \
+  --destination.backend filesystem \
+  --filesystem.source.directory <source directory> \
+  --filesystem.destination.directory <destination directory> \
+  --copy-period 24h \
+  --min-block-duration 13h \
+  --dry-run
+```
 
 ### Example for copying between different object storage providers
 

--- a/tools/copyblocks/main.go
+++ b/tools/copyblocks/main.go
@@ -30,7 +30,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/thanos-io/objstore"
 
 	"github.com/grafana/mimir/pkg/mimirtool/client"
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
@@ -297,7 +296,7 @@ func newBucketBlockCopier(ctx context.Context, cfg config) (objtools.Bucket, *bl
 	return sourceBucket, &blockCopier{
 		name: destBucket.Name(),
 		copyBlock: func(ctx context.Context, srcTenant, dstTenant string, blockID ulid.ULID, markers blockMarkers) error {
-			exists, err := destBucket.Exists(ctx, metaObjectName(dstTenant, blockID))
+			exists, err := destBucket.Exists(ctx, metaObjectName(dstTenant, blockID), objtools.ExistsOptions{})
 			if err != nil {
 				return fmt.Errorf("failed to check if block already exists on destination: %w", err)
 			}
@@ -314,10 +313,6 @@ func newBackfillBlockCopier(ctx context.Context, cfg config, logger log.Logger) 
 	if err != nil {
 		return nil, nil, err
 	}
-	objstoreBkt, err := cfg.copyConfig.SourceObjstoreBucket(ctx, logger)
-	if err != nil {
-		return nil, nil, err
-	}
 	mimirClient, err := client.New(cfg.backfill.clientConfig, logger)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create Mimir client for backfill: %w", err)
@@ -325,8 +320,7 @@ func newBackfillBlockCopier(ctx context.Context, cfg config, logger log.Logger) 
 	return sourceBucket, &blockCopier{
 		name: "backfill",
 		copyBlock: func(ctx context.Context, srcTenant, _ string, blockID ulid.ULID, _ blockMarkers) error {
-			prefixedBkt := objstore.NewPrefixedBucket(objstoreBkt, srcTenant)
-			err := mimirClient.BackfillBlock(ctx, prefixedBkt, blockID, cfg.backfill.sleepTime)
+			err := mimirClient.BackfillBlock(ctx, sourceBucket, srcTenant, blockID, cfg.backfill.sleepTime)
 			if errors.Is(err, client.ErrConflict) {
 				return errBlockAlreadyExists
 			}

--- a/tools/copyblocks/main_test.go
+++ b/tools/copyblocks/main_test.go
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/flagext"
+	"github.com/oklog/ulid/v2"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/storage/tsdb/block"
+	"github.com/grafana/mimir/pkg/util/objtools"
+)
+
+// newFilesystemCopyConfig builds a config that copies between two local filesystem
+// buckets, leaving all other settings at their defaults.
+func newFilesystemCopyConfig(t *testing.T, sourceDir, destDir string) config {
+	t.Helper()
+	cfg := config{}
+	cfg.copyConfig = objtools.NewFilesystemCopyBucketConfig(sourceDir, destDir)
+	cfg.tenantConcurrency = 5
+	cfg.blockConcurrency = 5
+	require.NoError(t, cfg.validate())
+	return cfg
+}
+
+func blockObj(tenant string, id ulid.ULID, file string) string {
+	return tenant + objtools.Delim + id.String() + objtools.Delim + file
+}
+
+func markerPath(tenant, marker string) string {
+	return tenant + objtools.Delim + marker
+}
+
+func metaPath(tenant string, id ulid.ULID) string {
+	return blockObj(tenant, id, block.MetaFilename)
+}
+
+// newTestSetup creates a pair of temp-dir filesystem buckets and a ready-to-use copy config.
+func newTestSetup(t *testing.T) (cfg config, source, dest objtools.Bucket) {
+	t.Helper()
+	sourceDir, destDir := t.TempDir(), t.TempDir()
+	return newFilesystemCopyConfig(t, sourceDir, destDir), fsBucket(t, sourceDir), fsBucket(t, destDir)
+}
+
+func fsBucket(t *testing.T, dir string) objtools.Bucket {
+	t.Helper()
+	bkt, err := (&objtools.FilesystemClientConfig{Directory: dir}).ToBucket()
+	require.NoError(t, err)
+	return bkt
+}
+
+func writeBlock(t *testing.T, bkt objtools.Bucket, tenant string, minT, maxT int64) ulid.ULID {
+	t.Helper()
+	id := ulid.MustNew(uint64(maxT), rand.Reader)
+	meta := block.Meta{
+		BlockMeta: tsdb.BlockMeta{
+			Version: 1,
+			ULID:    id,
+			MinTime: minT,
+			MaxTime: maxT,
+		},
+	}
+	var buf bytes.Buffer
+	require.NoError(t, meta.Write(&buf))
+
+	upload(t, bkt, metaPath(tenant, id), buf.String())
+	upload(t, bkt, blockObj(tenant, id, block.IndexFilename), "foo")
+	upload(t, bkt, blockObj(tenant, id, block.ChunksDirname+objtools.Delim+"000001"), "bar")
+	return id
+}
+
+func upload(t *testing.T, bkt objtools.Bucket, name, content string) {
+	t.Helper()
+	require.NoError(t, bkt.Upload(context.Background(), name, bytes.NewReader([]byte(content)), int64(len(content))))
+}
+
+func exists(t *testing.T, bkt objtools.Bucket, name string) bool {
+	t.Helper()
+	ok, err := bkt.Exists(context.Background(), name, objtools.ExistsOptions{})
+	require.NoError(t, err)
+	return ok
+}
+
+// runOnce performs a single copy cycle and returns the metrics it recorded.
+func runOnce(t *testing.T, cfg config) *metrics {
+	t.Helper()
+	userMapping, err := cfg.parseUserMapping()
+	require.NoError(t, err)
+	m := newMetrics(prometheus.NewRegistry())
+	require.NoError(t, copyBlocks(context.Background(), cfg, userMapping, log.NewNopLogger(), m))
+	return m
+}
+
+func TestCopyBlocks(t *testing.T) {
+	cfg, source, dest := newTestSetup(t)
+
+	id := writeBlock(t, source, "tenant", 1, 2)
+
+	m := runOnce(t, cfg)
+	assert.Equal(t, 1.0, testutil.ToFloat64(m.blocksCopied))
+
+	// The block's files were all copied to the destination.
+	assert.True(t, exists(t, dest, metaPath("tenant", id)))
+	assert.True(t, exists(t, dest, blockObj("tenant", id, block.IndexFilename)))
+	assert.True(t, exists(t, dest, blockObj("tenant", id, block.ChunksDirname+objtools.Delim+"000001")))
+
+	// A copy marker was written to the source so the block isn't copied again.
+	assert.True(t, exists(t, source, markerPath("tenant", CopiedToBucketMarkFilename(id, dest.Name()))))
+
+	// Re-running is a no-op: the copy marker causes the block to be skipped.
+	m = runOnce(t, cfg)
+	assert.Equal(t, 0.0, testutil.ToFloat64(m.blocksCopied))
+}
+
+func TestCopyBlocksDryRun(t *testing.T) {
+	cfg, source, dest := newTestSetup(t)
+	cfg.dryRun = true
+
+	id := writeBlock(t, source, "tenant", 1, 2)
+
+	m := runOnce(t, cfg)
+	assert.Equal(t, 0.0, testutil.ToFloat64(m.blocksCopied))
+
+	// Nothing was copied and no marker was written.
+	assert.False(t, exists(t, dest, metaPath("tenant", id)))
+	assert.False(t, exists(t, source, markerPath("tenant", CopiedToBucketMarkFilename(id, dest.Name()))))
+}
+
+func TestCopyBlocksTimeFilters(t *testing.T) {
+	t.Run("min-time", func(t *testing.T) {
+		cfg, source, dest := newTestSetup(t)
+		cfg.minTime = flagext.Time(time.UnixMilli(5).UTC())
+
+		oldBlock := writeBlock(t, source, "tenant", 1, 2)   // entirely before the filter
+		newBlock := writeBlock(t, source, "tenant", 10, 20) // after the filter
+
+		m := runOnce(t, cfg)
+		assert.Equal(t, 1.0, testutil.ToFloat64(m.blocksCopied))
+		assert.False(t, exists(t, dest, metaPath("tenant", oldBlock)))
+		assert.True(t, exists(t, dest, metaPath("tenant", newBlock)))
+	})
+
+	t.Run("max-time", func(t *testing.T) {
+		cfg, source, dest := newTestSetup(t)
+		cfg.maxTime = flagext.Time(time.UnixMilli(15).UTC())
+
+		earlyBlock := writeBlock(t, source, "tenant", 1, 2)  // before the filter
+		lateBlock := writeBlock(t, source, "tenant", 10, 20) // after the filter
+
+		m := runOnce(t, cfg)
+		assert.Equal(t, 1.0, testutil.ToFloat64(m.blocksCopied))
+		assert.True(t, exists(t, dest, metaPath("tenant", earlyBlock)))
+		assert.False(t, exists(t, dest, metaPath("tenant", lateBlock)))
+	})
+}
+
+func TestCopyBlocksSkipsDeletionMarkedBlocks(t *testing.T) {
+	cfg, source, dest := newTestSetup(t)
+
+	id := writeBlock(t, source, "tenant", 1, 2)
+	// Write a global deletion marker for the block.
+	upload(t, source, markerPath("tenant", block.DeletionMarkFilepath(id)), "{}")
+
+	m := runOnce(t, cfg)
+	assert.Equal(t, 0.0, testutil.ToFloat64(m.blocksCopied))
+	assert.False(t, exists(t, dest, metaPath("tenant", id)))
+}
+
+func TestCopyBlocksAlreadyExistsOnDestination(t *testing.T) {
+	cfg, source, dest := newTestSetup(t)
+
+	id := writeBlock(t, source, "tenant", 1, 2)
+	// The block's meta.json already exists on the destination.
+	upload(t, dest, metaPath("tenant", id), "{}")
+
+	m := runOnce(t, cfg)
+	assert.Equal(t, 0.0, testutil.ToFloat64(m.blocksCopied))
+	assert.Equal(t, 1.0, testutil.ToFloat64(m.blocksAlreadyExist))
+
+	// A copy marker is still written so the block is skipped next time.
+	assert.True(t, exists(t, source, markerPath("tenant", CopiedToBucketMarkFilename(id, dest.Name()))))
+}
+
+func TestCopyBlocksUserMapping(t *testing.T) {
+	cfg, source, dest := newTestSetup(t)
+	cfg.userMapping = flagext.StringSliceCSV{"source-tenant:dest-tenant"}
+
+	id := writeBlock(t, source, "source-tenant", 1, 2)
+
+	m := runOnce(t, cfg)
+	assert.Equal(t, 1.0, testutil.ToFloat64(m.blocksCopied))
+
+	// The block is copied under the mapped destination tenant.
+	assert.True(t, exists(t, dest, metaPath("dest-tenant", id)))
+	assert.False(t, exists(t, dest, metaPath("source-tenant", id)))
+
+	// The copy marker is written under the source tenant.
+	assert.True(t, exists(t, source, markerPath("source-tenant", CopiedToBucketMarkFilename(id, dest.Name()))))
+}

--- a/tools/copyprefix/README.md
+++ b/tools/copyprefix/README.md
@@ -4,7 +4,7 @@ This program copies objects by prefix between two buckets. If your infrastructur
 
 By default, copying will be attempted server-side if both the source and destination specify the same object storage service. If the buckets are on different object storage services, or if `--client-side-copy` is passed, then the copy will be performed client side.
 
-The currently supported services are Amazon Simple Storage Service (S3 and S3-compatible), Azure Blob Storage (ABS), and Google Cloud Storage (GCS).
+The currently supported services are Amazon Simple Storage Service (S3 and S3-compatible), Azure Blob Storage (ABS), and Google Cloud Storage (GCS). A local filesystem is also supported.
 
 ## Features
 
@@ -49,7 +49,7 @@ Run `go build` in this directory to build the program. Then, use an example belo
 
 ### Example for Amazon Simple Storage Service
 
-The destination is called to intiate the server-side copy which may require setting up additional permissions for the copy to have access the source bucket.
+The destination is called to initiate the server-side copy which may require setting up additional permissions for the copy to have access the source bucket.
 Consider passing `--client-side-copy` to avoid having to deal with that.
 
 ```bash
@@ -65,6 +65,21 @@ Consider passing `--client-side-copy` to avoid having to deal with that.
   --s3.destination.secret-access-key <destination secret access key> \
   --s3.destination.endpoint <destination endpoint> \
   --source-prefix tenant2 \
+  --dry-run
+```
+
+### Example for a local filesystem
+
+The directory is treated as the root of the bucket, and prefixes are resolved relative to it (e.g. `--source-prefix tenant1` matches objects under `<directory>/tenant1/`).
+
+```bash
+./copyprefix \
+  --source.backend filesystem \
+  --destination.backend filesystem \
+  --filesystem.source.directory <source directory> \
+  --filesystem.destination.directory <destination directory> \
+  --source-prefix tenant1 \
+  --destination-prefix tenant2 \
   --dry-run
 ```
 


### PR DESCRIPTION
#### What this PR does

After #15330 `copyblocks` could backfill, but only from buckets. The goal of these changes is to allow `copyblocks` to replace the usage of `mimirtool backfill` in the local filesystem case as well. This is helpful because `copyblocks` gives concurrency support and client-side duplicate upload prevention without additional scripting. The lack of those features in `mimirtool backfill` has come up as a pain point multiple times in real use cases.

> [!NOTE] 
> `copyblocks` does not use the `objstore` object storage client library like most of Mimir does. It instead uses a small internal implementation located in `pkg/util/objtools` to support operations like server-side copying.

The primary change is adding a filesystem bucket implementation for `objtools`. This implementation diverges from `objstore` by enforcing canonical relative paths and additionally hardens against partial writes by having writes first happen in a reserved directory followed by a rename. The basic idea around the path enforcement is that the key space in object storage is flat, rather than hierarchical, so paths like `../` diverge in meaning (and we don't want to allow arbitrary escapes). Directories also can not be the target of operations object operations like `PUT`.

Some additional notes that may help with review:
- Supporting a filesystem backend allows for removing the awkward `objtools` -> `objstore` bucket conversion that was required in https://github.com/grafana/mimir/pull/15330
- `copyblocks` previously had no unit test because it only worked on actual buckets. These changes provide a pathway for unit testing it so a basic one was added in `tools/copyblocks/main_test.go`
- Added `ExistsOptions` to `Exists` to make the `objtools` bucket interface more uniform
- Although not the primary intent of these changes, `copyblocks` can now be used to pull blocks from a bucket to a local filesystem.

In draft until I run some manual tests as well.

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
