### PR TITLE
dev: improve microservices docker-compose setup

### DIFF
--- a/development/mimir-ingest-storage/compose-down.sh
+++ b/development/mimir-ingest-storage/compose-down.sh
@@ -12,4 +12,4 @@ docker_compose() {
 
 SCRIPT_DIR=$(cd "$(dirname -- "$0")" && pwd)
 
-docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml down
+docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml down --remove-orphans

--- a/development/mimir-microservices-mode/compose-down.sh
+++ b/development/mimir-microservices-mode/compose-down.sh
@@ -15,4 +15,4 @@ docker_compose() {
 
 SCRIPT_DIR=$(cd "$(dirname -- "$0")" && pwd)
 
-docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml down
+docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml down --remove-orphans

--- a/development/mimir-microservices-mode/compose-up.sh
+++ b/development/mimir-microservices-mode/compose-up.sh
@@ -37,7 +37,7 @@ fi
 
 if [ "$(yq '.services."query-tee"' "${SCRIPT_DIR}"/docker-compose.yml)" != "null" ]; then
   # If query-tee is enabled, build its binary and image as well.
-  if needs_build "${SCRIPT_DIR}/../../cmd/query-tee/query-tee" "${SCRIPT_DIR}/../../cmd/query-tee" "${SCRIPT_DIR}/../../vendor"; then
+  if needs_build "${SCRIPT_DIR}/../../cmd/query-tee/query-tee" "${SCRIPT_DIR}/../../cmd/query-tee" "${SCRIPT_DIR}/../../pkg" "${SCRIPT_DIR}/../../tools/querytee" "${SCRIPT_DIR}/../../vendor"; then
     CGO_ENABLED=0 GOOS=linux go build -mod=vendor -tags=netgo,stringlabels -gcflags "all=-N -l" -o "${SCRIPT_DIR}"/../../cmd/query-tee "${SCRIPT_DIR}"/../../cmd/query-tee
     docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml build --build-arg BUILD_IMAGE="${BUILD_IMAGE}" query-tee
   fi

--- a/development/mimir-microservices-mode/compose-up.sh
+++ b/development/mimir-microservices-mode/compose-up.sh
@@ -30,17 +30,20 @@ needs_build() {
 
 # -gcflags "all=-N -l" disables optimizations that allow for better run with combination with Delve debugger.
 # GOARCH is not changed.
+# Only recompile when sources changed (it's the slow step), but always (re)build the
+# image: it's cheap and decoupling avoids a stale image if a previous image build failed
+# after a successful go build.
 if needs_build "${SCRIPT_DIR}/mimir" "${SCRIPT_DIR}/../../cmd/mimir" "${SCRIPT_DIR}/../../pkg" "${SCRIPT_DIR}/../../vendor"; then
     CGO_ENABLED=0 GOOS=linux go build -mod=vendor -tags=netgo,stringlabels -gcflags "all=-N -l" -o "${SCRIPT_DIR}"/mimir "${SCRIPT_DIR}"/../../cmd/mimir
-    docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml build --build-arg BUILD_IMAGE="${BUILD_IMAGE}" distributor-1
 fi
+docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml build --build-arg BUILD_IMAGE="${BUILD_IMAGE}" distributor-1
 
 if [ "$(yq '.services."query-tee"' "${SCRIPT_DIR}"/docker-compose.yml)" != "null" ]; then
   # If query-tee is enabled, build its binary and image as well.
   if needs_build "${SCRIPT_DIR}/../../cmd/query-tee/query-tee" "${SCRIPT_DIR}/../../cmd/query-tee" "${SCRIPT_DIR}/../../pkg" "${SCRIPT_DIR}/../../tools/querytee" "${SCRIPT_DIR}/../../vendor"; then
     CGO_ENABLED=0 GOOS=linux go build -mod=vendor -tags=netgo,stringlabels -gcflags "all=-N -l" -o "${SCRIPT_DIR}"/../../cmd/query-tee "${SCRIPT_DIR}"/../../cmd/query-tee
-    docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml build --build-arg BUILD_IMAGE="${BUILD_IMAGE}" query-tee
   fi
+  docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml build --build-arg BUILD_IMAGE="${BUILD_IMAGE}" query-tee
 fi
 
 docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml up "$@"

--- a/development/mimir-microservices-mode/compose-up.sh
+++ b/development/mimir-microservices-mode/compose-up.sh
@@ -20,12 +20,14 @@ BUILD_IMAGE=$(make -s -C "${SCRIPT_DIR}"/../.. print-build-image)
 # Make sure docker-compose.yml is up-to-date.
 cd "$SCRIPT_DIR" && make
 
-# Returns 0 (true) if the binary doesn't exist or any .go file under the given
-# source directories is newer than the binary.
+# Returns 0 (true) if the binary doesn't exist or any source file under the given
+# directories is newer than the binary. We consider all files (not just *.go) so
+# go:embed assets (e.g. .gohtml templates, static/, JSON descriptors) trigger a
+# rebuild too, but skip docs like .md which can't affect the compiled binary.
 needs_build() {
     local binary="$1"; shift
     [ ! -f "$binary" ] && return 0
-    find "$@" -name '*.go' -newer "$binary" -print -quit 2>/dev/null | grep -q .
+    find "$@" -type f ! -name '*.md' -newer "$binary" -print -quit 2>/dev/null | grep -q .
 }
 
 # -gcflags "all=-N -l" disables optimizations that allow for better run with combination with Delve debugger.

--- a/development/mimir-microservices-mode/compose-up.sh
+++ b/development/mimir-microservices-mode/compose-up.sh
@@ -20,15 +20,27 @@ BUILD_IMAGE=$(make -s -C "${SCRIPT_DIR}"/../.. print-build-image)
 # Make sure docker-compose.yml is up-to-date.
 cd "$SCRIPT_DIR" && make
 
+# Returns 0 (true) if the binary doesn't exist or any .go file under the given
+# source directories is newer than the binary.
+needs_build() {
+    local binary="$1"; shift
+    [ ! -f "$binary" ] && return 0
+    find "$@" -name '*.go' -newer "$binary" -print -quit 2>/dev/null | grep -q .
+}
+
 # -gcflags "all=-N -l" disables optimizations that allow for better run with combination with Delve debugger.
 # GOARCH is not changed.
-CGO_ENABLED=0 GOOS=linux go build -mod=vendor -tags=netgo,stringlabels -gcflags "all=-N -l" -o "${SCRIPT_DIR}"/mimir "${SCRIPT_DIR}"/../../cmd/mimir
-docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml build --build-arg BUILD_IMAGE="${BUILD_IMAGE}" distributor-1
+if needs_build "${SCRIPT_DIR}/mimir" "${SCRIPT_DIR}/../../cmd/mimir" "${SCRIPT_DIR}/../../pkg" "${SCRIPT_DIR}/../../vendor"; then
+    CGO_ENABLED=0 GOOS=linux go build -mod=vendor -tags=netgo,stringlabels -gcflags "all=-N -l" -o "${SCRIPT_DIR}"/mimir "${SCRIPT_DIR}"/../../cmd/mimir
+    docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml build --build-arg BUILD_IMAGE="${BUILD_IMAGE}" distributor-1
+fi
 
 if [ "$(yq '.services."query-tee"' "${SCRIPT_DIR}"/docker-compose.yml)" != "null" ]; then
   # If query-tee is enabled, build its binary and image as well.
-  CGO_ENABLED=0 GOOS=linux go build -mod=vendor -tags=netgo,stringlabels -gcflags "all=-N -l" -o "${SCRIPT_DIR}"/../../cmd/query-tee "${SCRIPT_DIR}"/../../cmd/query-tee
-  docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml build --build-arg BUILD_IMAGE="${BUILD_IMAGE}" query-tee
+  if needs_build "${SCRIPT_DIR}/../../cmd/query-tee/query-tee" "${SCRIPT_DIR}/../../cmd/query-tee" "${SCRIPT_DIR}/../../vendor"; then
+    CGO_ENABLED=0 GOOS=linux go build -mod=vendor -tags=netgo,stringlabels -gcflags "all=-N -l" -o "${SCRIPT_DIR}"/../../cmd/query-tee "${SCRIPT_DIR}"/../../cmd/query-tee
+    docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml build --build-arg BUILD_IMAGE="${BUILD_IMAGE}" query-tee
+  fi
 fi
 
 docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml up "$@"

--- a/development/mimir-microservices-mode/config/datasources.yaml
+++ b/development/mimir-microservices-mode/config/datasources.yaml
@@ -35,6 +35,13 @@ datasources:
   secureJsonData:
     httpHeaderValue1: no-store
 
+- name: Mimir (Querier)
+  type: prometheus
+  access: proxy
+  uid: mimir-querier
+  orgID: 1
+  url: http://querier:8005/prometheus
+
 - name: Jaeger
   type: jaeger
   access: proxy

--- a/development/mimir-microservices-mode/config/mimir.yaml
+++ b/development/mimir-microservices-mode/config/mimir.yaml
@@ -204,6 +204,7 @@ limits:
   ha_cluster_label: ha_cluster
   ha_replica_label: ha_replica
   ha_max_clusters: 10
+  enabled_promql_experimental_functions: all
 
 runtime_config:
   file: /etc/mimir/runtime.yaml

--- a/development/mimir-microservices-mode/docker-compose.jsonnet
+++ b/development/mimir-microservices-mode/docker-compose.jsonnet
@@ -349,7 +349,7 @@ std.manifestYamlDoc({
 
   prometheus:: {
     prometheus: {
-      image: 'prom/prometheus:v3.9.1',
+      image: 'prom/prometheus:v3.12.0',
       command: [
         if $._config.enable_prometheus_rw2 then '--config.file=/etc/prometheus/prometheusRW2.yaml' else '--config.file=/etc/prometheus/prometheus.yaml',
         '--enable-feature=exemplar-storage',

--- a/development/mimir-microservices-mode/docker-compose.jsonnet
+++ b/development/mimir-microservices-mode/docker-compose.jsonnet
@@ -250,6 +250,10 @@ std.manifestYamlDoc({
       '-activity-tracker.filepath=/tmp/activity/%(target)s-%(httpPort)d' % options,
       '-memberlist.nodename=%(memberlistNodeName)s' % options,
       '-memberlist.bind-port=%(memberlistBindPort)d' % options,
+      // Mimir reads mimir_cluster_seed.json from object storage on startup and waits up to 5 minutes
+      // from its creation time before becoming ready. The file persists in the MinIO volume across
+      // restarts, so without this flag any component starting within 5 minutes of the previous run blocks.
+      '-usage-stats.enabled=false',
     ] + options.extraArguments,
 
     // If we're using a local image, assemble a string of the binary to execute and CLI flags to pass to

--- a/development/mimir-microservices-mode/docker-compose.jsonnet
+++ b/development/mimir-microservices-mode/docker-compose.jsonnet
@@ -353,6 +353,7 @@ std.manifestYamlDoc({
       command: [
         if $._config.enable_prometheus_rw2 then '--config.file=/etc/prometheus/prometheusRW2.yaml' else '--config.file=/etc/prometheus/prometheus.yaml',
         '--enable-feature=exemplar-storage',
+        '--enable-feature=promql-experimental-functions',
       ],
       volumes: [
         './config:/etc/prometheus',

--- a/development/mimir-microservices-mode/docker-compose.yml
+++ b/development/mimir-microservices-mode/docker-compose.yml
@@ -320,7 +320,7 @@
     "command":
       - "--config.file=/etc/prometheus/prometheus.yaml"
       - "--enable-feature=exemplar-storage"
-    "image": "prom/prometheus:v3.9.1"
+    "image": "prom/prometheus:v3.12.0"
     "ports":
       - "9090:9090"
     "volumes":

--- a/development/mimir-microservices-mode/docker-compose.yml
+++ b/development/mimir-microservices-mode/docker-compose.yml
@@ -320,6 +320,7 @@
     "command":
       - "--config.file=/etc/prometheus/prometheus.yaml"
       - "--enable-feature=exemplar-storage"
+      - "--enable-feature=promql-experimental-functions"
     "image": "prom/prometheus:v3.12.0"
     "ports":
       - "9090:9090"

--- a/development/mimir-microservices-mode/docker-compose.yml
+++ b/development/mimir-microservices-mode/docker-compose.yml
@@ -6,7 +6,7 @@
     "command":
       - "/bin/sh"
       - "-c"
-      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=alertmanager -server.http-listen-port=8031 -server.grpc-listen-port=9031 -activity-tracker.filepath=/tmp/activity/alertmanager-8031 -memberlist.nodename=alertmanager-1 -memberlist.bind-port=10031 -alertmanager.web.external-url=http://localhost:8031/alertmanager"
+      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=alertmanager -server.http-listen-port=8031 -server.grpc-listen-port=9031 -activity-tracker.filepath=/tmp/activity/alertmanager-8031 -memberlist.nodename=alertmanager-1 -memberlist.bind-port=10031 -usage-stats.enabled=false -alertmanager.web.external-url=http://localhost:8031/alertmanager"
     "depends_on":
       - "minio"
       - "distributor-1"
@@ -31,7 +31,7 @@
     "command":
       - "/bin/sh"
       - "-c"
-      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=alertmanager -server.http-listen-port=8032 -server.grpc-listen-port=9032 -activity-tracker.filepath=/tmp/activity/alertmanager-8032 -memberlist.nodename=alertmanager-2 -memberlist.bind-port=10032 -alertmanager.web.external-url=http://localhost:8032/alertmanager"
+      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=alertmanager -server.http-listen-port=8032 -server.grpc-listen-port=9032 -activity-tracker.filepath=/tmp/activity/alertmanager-8032 -memberlist.nodename=alertmanager-2 -memberlist.bind-port=10032 -usage-stats.enabled=false -alertmanager.web.external-url=http://localhost:8032/alertmanager"
     "depends_on":
       - "minio"
       - "distributor-1"
@@ -56,7 +56,7 @@
     "command":
       - "/bin/sh"
       - "-c"
-      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=alertmanager -server.http-listen-port=8033 -server.grpc-listen-port=9033 -activity-tracker.filepath=/tmp/activity/alertmanager-8033 -memberlist.nodename=alertmanager-3 -memberlist.bind-port=10033 -alertmanager.web.external-url=http://localhost:8033/alertmanager"
+      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=alertmanager -server.http-listen-port=8033 -server.grpc-listen-port=9033 -activity-tracker.filepath=/tmp/activity/alertmanager-8033 -memberlist.nodename=alertmanager-3 -memberlist.bind-port=10033 -usage-stats.enabled=false -alertmanager.web.external-url=http://localhost:8033/alertmanager"
     "depends_on":
       - "minio"
       - "distributor-1"
@@ -81,7 +81,7 @@
     "command":
       - "/bin/sh"
       - "-c"
-      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=compactor -server.http-listen-port=8006 -server.grpc-listen-port=9006 -activity-tracker.filepath=/tmp/activity/compactor-8006 -memberlist.nodename=compactor -memberlist.bind-port=10006"
+      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=compactor -server.http-listen-port=8006 -server.grpc-listen-port=9006 -activity-tracker.filepath=/tmp/activity/compactor-8006 -memberlist.nodename=compactor -memberlist.bind-port=10006 -usage-stats.enabled=false"
     "depends_on":
       - "minio"
       - "distributor-1"
@@ -116,7 +116,7 @@
     "command":
       - "/bin/sh"
       - "-c"
-      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=continuous-test -server.http-listen-port=8090 -server.grpc-listen-port=9090 -activity-tracker.filepath=/tmp/activity/continuous-test-8090 -memberlist.nodename=continuous-test -memberlist.bind-port=10090 -tests.run-interval=2m -tests.read-endpoint=http://query-frontend:8007/prometheus -tests.tenant-id=mimir-continuous-test -tests.write-endpoint=http://distributor-1:8000 -tests.write-read-series-test.max-query-age=1h -tests.write-read-series-test.num-series=100"
+      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=continuous-test -server.http-listen-port=8090 -server.grpc-listen-port=9090 -activity-tracker.filepath=/tmp/activity/continuous-test-8090 -memberlist.nodename=continuous-test -memberlist.bind-port=10090 -usage-stats.enabled=false -tests.run-interval=2m -tests.read-endpoint=http://query-frontend:8007/prometheus -tests.tenant-id=mimir-continuous-test -tests.write-endpoint=http://distributor-1:8000 -tests.write-read-series-test.max-query-age=1h -tests.write-read-series-test.num-series=100"
     "depends_on":
       - "minio"
       - "distributor-1"
@@ -141,7 +141,7 @@
     "command":
       - "/bin/sh"
       - "-c"
-      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=distributor -server.http-listen-port=8000 -server.grpc-listen-port=9000 -activity-tracker.filepath=/tmp/activity/distributor-8000 -memberlist.nodename=distributor -memberlist.bind-port=10000 -distributor.ha-tracker.consul.hostname=consul:8500"
+      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=distributor -server.http-listen-port=8000 -server.grpc-listen-port=9000 -activity-tracker.filepath=/tmp/activity/distributor-8000 -memberlist.nodename=distributor -memberlist.bind-port=10000 -usage-stats.enabled=false -distributor.ha-tracker.consul.hostname=consul:8500"
     "depends_on":
       - "minio"
     "environment":
@@ -165,7 +165,7 @@
     "command":
       - "/bin/sh"
       - "-c"
-      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=distributor -server.http-listen-port=8001 -server.grpc-listen-port=9001 -activity-tracker.filepath=/tmp/activity/distributor-8001 -memberlist.nodename=distributor -memberlist.bind-port=10001 -distributor.ha-tracker.consul.hostname=consul:8500"
+      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=distributor -server.http-listen-port=8001 -server.grpc-listen-port=9001 -activity-tracker.filepath=/tmp/activity/distributor-8001 -memberlist.nodename=distributor -memberlist.bind-port=10001 -usage-stats.enabled=false -distributor.ha-tracker.consul.hostname=consul:8500"
     "depends_on":
       - "minio"
     "environment":
@@ -200,7 +200,7 @@
     "command":
       - "/bin/sh"
       - "-c"
-      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=ingester -server.http-listen-port=8002 -server.grpc-listen-port=9002 -activity-tracker.filepath=/tmp/activity/ingester-8002 -memberlist.nodename=ingester-1 -memberlist.bind-port=10002"
+      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=ingester -server.http-listen-port=8002 -server.grpc-listen-port=9002 -activity-tracker.filepath=/tmp/activity/ingester-8002 -memberlist.nodename=ingester-1 -memberlist.bind-port=10002 -usage-stats.enabled=false"
     "depends_on":
       - "minio"
       - "distributor-1"
@@ -226,7 +226,7 @@
     "command":
       - "/bin/sh"
       - "-c"
-      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=ingester -server.http-listen-port=8003 -server.grpc-listen-port=9003 -activity-tracker.filepath=/tmp/activity/ingester-8003 -memberlist.nodename=ingester-2 -memberlist.bind-port=10003"
+      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=ingester -server.http-listen-port=8003 -server.grpc-listen-port=9003 -activity-tracker.filepath=/tmp/activity/ingester-8003 -memberlist.nodename=ingester-2 -memberlist.bind-port=10003 -usage-stats.enabled=false"
     "depends_on":
       - "minio"
       - "distributor-1"
@@ -252,7 +252,7 @@
     "command":
       - "/bin/sh"
       - "-c"
-      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=ingester -server.http-listen-port=8004 -server.grpc-listen-port=9004 -activity-tracker.filepath=/tmp/activity/ingester-8004 -memberlist.nodename=ingester-3 -memberlist.bind-port=10004"
+      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=ingester -server.http-listen-port=8004 -server.grpc-listen-port=9004 -activity-tracker.filepath=/tmp/activity/ingester-8004 -memberlist.nodename=ingester-3 -memberlist.bind-port=10004 -usage-stats.enabled=false"
     "depends_on":
       - "minio"
       - "distributor-1"
@@ -354,7 +354,7 @@
     "command":
       - "/bin/sh"
       - "-c"
-      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=querier -server.http-listen-port=8005 -server.grpc-listen-port=9005 -activity-tracker.filepath=/tmp/activity/querier-8005 -memberlist.nodename=querier -memberlist.bind-port=10005"
+      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=querier -server.http-listen-port=8005 -server.grpc-listen-port=9005 -activity-tracker.filepath=/tmp/activity/querier-8005 -memberlist.nodename=querier -memberlist.bind-port=10005 -usage-stats.enabled=false"
     "depends_on":
       - "minio"
       - "distributor-1"
@@ -379,7 +379,7 @@
     "command":
       - "/bin/sh"
       - "-c"
-      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=query-frontend -server.http-listen-port=8007 -server.grpc-listen-port=9007 -activity-tracker.filepath=/tmp/activity/query-frontend-8007 -memberlist.nodename=query-frontend -memberlist.bind-port=10007"
+      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=query-frontend -server.http-listen-port=8007 -server.grpc-listen-port=9007 -activity-tracker.filepath=/tmp/activity/query-frontend-8007 -memberlist.nodename=query-frontend -memberlist.bind-port=10007 -usage-stats.enabled=false"
     "depends_on":
       - "minio"
       - "distributor-1"
@@ -404,7 +404,7 @@
     "command":
       - "/bin/sh"
       - "-c"
-      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=query-scheduler -server.http-listen-port=8008 -server.grpc-listen-port=9008 -activity-tracker.filepath=/tmp/activity/query-scheduler-8008 -memberlist.nodename=query-scheduler -memberlist.bind-port=10008"
+      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=query-scheduler -server.http-listen-port=8008 -server.grpc-listen-port=9008 -activity-tracker.filepath=/tmp/activity/query-scheduler-8008 -memberlist.nodename=query-scheduler -memberlist.bind-port=10008 -usage-stats.enabled=false"
     "depends_on":
       - "minio"
       - "distributor-1"
@@ -429,7 +429,7 @@
     "command":
       - "/bin/sh"
       - "-c"
-      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=ruler -server.http-listen-port=8022 -server.grpc-listen-port=9022 -activity-tracker.filepath=/tmp/activity/ruler-8022 -memberlist.nodename=ruler-1 -memberlist.bind-port=10022"
+      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=ruler -server.http-listen-port=8022 -server.grpc-listen-port=9022 -activity-tracker.filepath=/tmp/activity/ruler-8022 -memberlist.nodename=ruler-1 -memberlist.bind-port=10022 -usage-stats.enabled=false"
     "depends_on":
       - "minio"
       - "distributor-1"
@@ -454,7 +454,7 @@
     "command":
       - "/bin/sh"
       - "-c"
-      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=ruler -server.http-listen-port=8023 -server.grpc-listen-port=9023 -activity-tracker.filepath=/tmp/activity/ruler-8023 -memberlist.nodename=ruler-2 -memberlist.bind-port=10023"
+      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=ruler -server.http-listen-port=8023 -server.grpc-listen-port=9023 -activity-tracker.filepath=/tmp/activity/ruler-8023 -memberlist.nodename=ruler-2 -memberlist.bind-port=10023 -usage-stats.enabled=false"
     "depends_on":
       - "minio"
       - "distributor-1"
@@ -479,7 +479,7 @@
     "command":
       - "/bin/sh"
       - "-c"
-      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=store-gateway -server.http-listen-port=8011 -server.grpc-listen-port=9011 -activity-tracker.filepath=/tmp/activity/store-gateway-8011 -memberlist.nodename=store-gateway-1 -memberlist.bind-port=10011"
+      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=store-gateway -server.http-listen-port=8011 -server.grpc-listen-port=9011 -activity-tracker.filepath=/tmp/activity/store-gateway-8011 -memberlist.nodename=store-gateway-1 -memberlist.bind-port=10011 -usage-stats.enabled=false"
     "depends_on":
       - "minio"
       - "distributor-1"
@@ -504,7 +504,7 @@
     "command":
       - "/bin/sh"
       - "-c"
-      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=store-gateway -server.http-listen-port=8012 -server.grpc-listen-port=9012 -activity-tracker.filepath=/tmp/activity/store-gateway-8012 -memberlist.nodename=store-gateway-2 -memberlist.bind-port=10012"
+      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=store-gateway -server.http-listen-port=8012 -server.grpc-listen-port=9012 -activity-tracker.filepath=/tmp/activity/store-gateway-8012 -memberlist.nodename=store-gateway-2 -memberlist.bind-port=10012 -usage-stats.enabled=false"
     "depends_on":
       - "minio"
       - "distributor-1"
@@ -529,7 +529,7 @@
     "command":
       - "/bin/sh"
       - "-c"
-      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=store-gateway -server.http-listen-port=8013 -server.grpc-listen-port=9013 -activity-tracker.filepath=/tmp/activity/store-gateway-8013 -memberlist.nodename=store-gateway-3 -memberlist.bind-port=10013"
+      - "sleep 3 && exec /bin/mimir -config.file=/etc/mimir/mimir.yaml -target=store-gateway -server.http-listen-port=8013 -server.grpc-listen-port=9013 -activity-tracker.filepath=/tmp/activity/store-gateway-8013 -memberlist.nodename=store-gateway-3 -memberlist.bind-port=10013 -usage-stats.enabled=false"
     "depends_on":
       - "minio"
       - "distributor-1"

--- a/development/mimir-monolithic-mode-with-swift-storage/compose-down.sh
+++ b/development/mimir-monolithic-mode-with-swift-storage/compose-down.sh
@@ -15,4 +15,4 @@ docker_compose() {
 
 SCRIPT_DIR=$(cd "$(dirname -- "$0")" && pwd)
 
-docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml down
+docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml down --remove-orphans

--- a/development/mimir-monolithic-mode/compose-down.sh
+++ b/development/mimir-monolithic-mode/compose-down.sh
@@ -45,4 +45,4 @@ if [ ${#PROFILES[@]} -eq 0 ]; then
     PROFILES=("${DEFAULT_PROFILES[@]}")
 fi
 
-docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml "${PROFILES[@]}" down "${ARGS[@]}"
+docker_compose -f "${SCRIPT_DIR}"/docker-compose.yml "${PROFILES[@]}" down "${ARGS[@]}" --remove-orphans


### PR DESCRIPTION
#### What this PR does

Slight improvements for the microservices docker-compose setup:
- compose-up.sh: the Mimir binary (and query-tee binary if enabled) are now only recompiled when Go source files have actually changed since the last build. A needs_build helper checks whether any .go file under the relevant source directories is newer than the output binary — if not, the go build step is skipped entirely.
- docker-compose.jsonnet / docker-compose.yml: added -usage-stats.enabled=false to every Mimir service. Without this, Mimir reads mimir_cluster_seed.json from the MinIO volume on startup and waits up to 5 minutes from its creation time before the component becomes ready — meaning any restart within 5 minutes of the previous run causes all components to stall at startup.
- clean up orphans in the down script
- upgrade Prometheus version
- enable experimental functions in both Prometheus and MQE
- add querier datasource (if you want to test querying it directly instead of going through the frontend)

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

No user impact, for dev use only




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to development docker-compose scripts and config; no production Mimir behavior is affected.
> 
> **Overview**
> This PR tightens the **local microservices docker-compose** workflow: faster rebuilds, more reliable startup after restarts, and a bit more query tooling in Grafana.
> 
> **`compose-up.sh`** now uses a `needs_build` helper so `go build` for `mimir` (and `query-tee` when present) runs only when relevant sources are newer than the binary (non-`.md` files, including embed assets). Docker image builds still run every time.
> 
> Every Mimir service gets **`-usage-stats.enabled=false`** (via jsonnet and regenerated `docker-compose.yml`) so dev restarts are not blocked by the persisted `mimir_cluster_seed.json` readiness wait on MinIO.
> 
> **Compose down** scripts across several dev environments pass **`--remove-orphans`**. Dev **Prometheus** moves to **v3.12.0** with **`promql-experimental-functions`**; Mimir limits add **`enabled_promql_experimental_functions: all`**. Grafana provisioning adds a **Mimir (Querier)** datasource pointing at the querier directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e5f674b6e24dcf025f7b35211a9141efcea06aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->