### PR TITLE
tests: initialize all struct fields in query stats copy test

### DIFF
--- a/pkg/querier/stats/stats.pb.go
+++ b/pkg/querier/stats/stats.pb.go
@@ -5,16 +5,17 @@ package stats
 
 import (
 	fmt "fmt"
-	_ "github.com/gogo/protobuf/gogoproto"
-	proto "github.com/gogo/protobuf/proto"
-	github_com_gogo_protobuf_types "github.com/gogo/protobuf/types"
-	_ "google.golang.org/protobuf/types/known/durationpb"
 	io "io"
 	math "math"
 	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 	time "time"
+
+	_ "github.com/gogo/protobuf/gogoproto"
+	proto "github.com/gogo/protobuf/proto"
+	github_com_gogo_protobuf_types "github.com/gogo/protobuf/types"
+	_ "google.golang.org/protobuf/types/known/durationpb"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/pkg/querier/stats/stats.pb.go
+++ b/pkg/querier/stats/stats.pb.go
@@ -5,17 +5,16 @@ package stats
 
 import (
 	fmt "fmt"
+	_ "github.com/gogo/protobuf/gogoproto"
+	proto "github.com/gogo/protobuf/proto"
+	github_com_gogo_protobuf_types "github.com/gogo/protobuf/types"
+	_ "google.golang.org/protobuf/types/known/durationpb"
 	io "io"
 	math "math"
 	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
 	time "time"
-
-	_ "github.com/gogo/protobuf/gogoproto"
-	proto "github.com/gogo/protobuf/proto"
-	github_com_gogo_protobuf_types "github.com/gogo/protobuf/types"
-	_ "google.golang.org/protobuf/types/known/durationpb"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/pkg/querier/stats/stats_test.go
+++ b/pkg/querier/stats/stats_test.go
@@ -7,6 +7,7 @@ package stats
 
 import (
 	"context"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -265,23 +266,23 @@ func TestStats_Merge(t *testing.T) {
 }
 
 func TestStats_Copy(t *testing.T) {
-	s1 := &SafeStats{
-		Stats: Stats{
-			WallTime:                    1,
-			FetchedSeriesCount:          2,
-			FetchedChunkBytes:           3,
-			FetchedChunksCount:          4,
-			ShardedQueries:              5,
-			SplitQueries:                6,
-			FetchedIndexBytes:           7,
-			EstimatedSeriesCount:        8,
-			QueueTime:                   9,
-			SamplesProcessed:            10,
-			RemoteExecutionRequestCount: 12,
-			EquivalentSamplesRead:       13,
-			PhysicalSamplesRead:         14,
-		},
+	s1 := &SafeStats{}
+
+	// Set every field of the Stats struct to a unique non-zero value (its ordinal) via
+	// reflection, so this test fails if Copy() doesn't copy a newly added field.
+	statsValue := reflect.ValueOf(&s1.Stats).Elem()
+	for i := 0; i < statsValue.NumField(); i++ {
+		field := statsValue.Field(i)
+		switch field.Kind() {
+		case reflect.Int64: // Covers time.Duration fields.
+			field.SetInt(int64(i + 1))
+		case reflect.Uint32, reflect.Uint64:
+			field.SetUint(uint64(i + 1))
+		default:
+			t.Fatalf("field %s has unsupported kind %s, please update this test", statsValue.Type().Field(i).Name, field.Kind())
+		}
 	}
+
 	s2 := s1.Copy()
 	assert.NotSame(t, s1, s2)
 	assert.EqualValues(t, s1, s2)

--- a/pkg/querier/stats/stats_test.go
+++ b/pkg/querier/stats/stats_test.go
@@ -265,6 +265,7 @@ func TestStats_Merge(t *testing.T) {
 }
 
 func TestStats_Copy(t *testing.T) {
+	//exhaustruct:enforce
 	s1 := &SafeStats{
 		Stats: Stats{
 			WallTime:                    1,
@@ -276,10 +277,13 @@ func TestStats_Copy(t *testing.T) {
 			FetchedIndexBytes:           7,
 			EstimatedSeriesCount:        8,
 			QueueTime:                   9,
-			SamplesProcessed:            10,
-			RemoteExecutionRequestCount: 12,
-			EquivalentSamplesRead:       13,
-			PhysicalSamplesRead:         14,
+			EncodeTime:                  10,
+			SamplesProcessed:            11,
+			SpunOffSubqueries:           12,
+			RemoteExecutionRequestCount: 13,
+			SplitRangeVectors:           14,
+			EquivalentSamplesRead:       15,
+			PhysicalSamplesRead:         16,
 		},
 	}
 	s2 := s1.Copy()

--- a/pkg/querier/stats/stats_test.go
+++ b/pkg/querier/stats/stats_test.go
@@ -7,7 +7,6 @@ package stats
 
 import (
 	"context"
-	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -266,23 +265,23 @@ func TestStats_Merge(t *testing.T) {
 }
 
 func TestStats_Copy(t *testing.T) {
-	s1 := &SafeStats{}
-
-	// Set every field of the Stats struct to a unique non-zero value (its ordinal) via
-	// reflection, so this test fails if Copy() doesn't copy a newly added field.
-	statsValue := reflect.ValueOf(&s1.Stats).Elem()
-	for i := 0; i < statsValue.NumField(); i++ {
-		field := statsValue.Field(i)
-		switch field.Kind() {
-		case reflect.Int64: // Covers time.Duration fields.
-			field.SetInt(int64(i + 1))
-		case reflect.Uint32, reflect.Uint64:
-			field.SetUint(uint64(i + 1))
-		default:
-			t.Fatalf("field %s has unsupported kind %s, please update this test", statsValue.Type().Field(i).Name, field.Kind())
-		}
+	s1 := &SafeStats{
+		Stats: Stats{
+			WallTime:                    1,
+			FetchedSeriesCount:          2,
+			FetchedChunkBytes:           3,
+			FetchedChunksCount:          4,
+			ShardedQueries:              5,
+			SplitQueries:                6,
+			FetchedIndexBytes:           7,
+			EstimatedSeriesCount:        8,
+			QueueTime:                   9,
+			SamplesProcessed:            10,
+			RemoteExecutionRequestCount: 12,
+			EquivalentSamplesRead:       13,
+			PhysicalSamplesRead:         14,
+		},
 	}
-
 	s2 := s1.Copy()
 	assert.NotSame(t, s1, s2)
 	assert.EqualValues(t, s1, s2)


### PR DESCRIPTION
#### What this PR does

`TestStats_Copy`: New fields were added to the struct without them being mirrored in this test. This makes sure they don't get out of sync.

With just the `exhaustruct` annotation, linting fails like so:

```
CGO_ENABLED=0 GOFLAGS="-tags=netgo,stringlabels" golangci-lint run
pkg/querier/stats/stats_test.go:270:10: stats.Stats is missing fields EncodeTime, SpunOffSubqueries, SplitRangeVectors (exhaustruct)
                Stats: Stats{
                       ^
1 issues:
* exhaustruct: 1
make: *** [Makefile:351: lint] Error 1
```

#### Checklist

- [x] Tests updated.
- (n/a) Documentation added.
- (n/a) `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- (n/a) [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production or runtime behavior impact.
> 
> **Overview**
> Updates **`TestStats_Copy`** so the `Stats` literal includes **`EncodeTime`**, **`SpunOffSubqueries`**, and **`SplitRangeVectors`**, which had been added to the type but not mirrored in the test.
> 
> Adds **`//exhaustruct:enforce`** so **`golangci-lint`** fails if new `Stats` fields are introduced without updating this composite literal, keeping the copy test aligned with the struct.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07eb1529972cfa98879ea5ec27935195db887045. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->