### PR TITLE
Vendor v0.38.0 rollout-operator and update helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@
 ### Jsonnet
 
 * [CHANGE] Query-frontend: Increase default query-frontend cache size limit to 25MB. #14857
-* [ENHANCEMENT] Updated rollout-operator jsonnet library to v0.37.0. #15328
+* [ENHANCEMENT] Updated rollout-operator jsonnet library to v0.38.0. #15328, #TODO
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@
 ### Jsonnet
 
 * [CHANGE] Query-frontend: Increase default query-frontend cache size limit to 25MB. #14857
-* [ENHANCEMENT] Updated rollout-operator jsonnet library to v0.38.0. #15328, #TODO
+* [ENHANCEMENT] Updated rollout-operator jsonnet library to v0.38.0. #15328, #15626
 
 ### Documentation
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -38,7 +38,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [CHANGE] Query-frontend: Increase default query-frontend cache size limit to 25MB. #14857
 * [ENHANCEMENT] Add Support to customize gossip ring k8s service annotations. #12718
 * [ENHANCEMENT] Ruler querier and query-frontend: Add support for newly-introduced querier ring, which is used when performing query planning in query-frontends and distributing portions of the plan to queriers for execution. #13017
-* [ENHANCEMENT] Upgrade rollout-operator chart to [0.37.0](https://github.com/grafana/helm-charts/blob/main/charts/rollout-operator/README.md#upgrade-of-grafana-rollout-operator). Note required actions for upgrading the rollout-operator chart. #13245
+* [ENHANCEMENT] Upgrade rollout-operator chart to [0.38.0](https://github.com/grafana/helm-charts/blob/main/charts/rollout-operator/README.md#upgrade-of-grafana-rollout-operator--v0380). Note required actions for upgrading the rollout-operator chart. #13245, #TODO
 * [ENHANCEMENT] Set `minReadySeconds` for Memcached statefulsets to slow down rollouts. #13495
 * [ENHANCEMENT] Add support for KEDA ScaledObject fallback configuration. This allows configuring fallback behavior when the scaler fails to get metrics from the source. #13467
 * [ENHANCEMENT] Upgrade to Helm v4. #13661

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -38,7 +38,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [CHANGE] Query-frontend: Increase default query-frontend cache size limit to 25MB. #14857
 * [ENHANCEMENT] Add Support to customize gossip ring k8s service annotations. #12718
 * [ENHANCEMENT] Ruler querier and query-frontend: Add support for newly-introduced querier ring, which is used when performing query planning in query-frontends and distributing portions of the plan to queriers for execution. #13017
-* [ENHANCEMENT] Upgrade rollout-operator chart to [0.38.0](https://github.com/grafana/helm-charts/blob/main/charts/rollout-operator/README.md#upgrade-of-grafana-rollout-operator--v0380). Note required actions for upgrading the rollout-operator chart. #13245, #TODO
+* [ENHANCEMENT] Upgrade rollout-operator chart to [0.38.0](https://github.com/grafana/helm-charts/blob/main/charts/rollout-operator/README.md#upgrade-of-grafana-rollout-operator--v0380). Note required actions for upgrading the rollout-operator chart. #13245, #15626
 * [ENHANCEMENT] Set `minReadySeconds` for Memcached statefulsets to slow down rollouts. #13495
 * [ENHANCEMENT] Add support for KEDA ScaledObject fallback configuration. This allows configuring fallback behavior when the scaler fails to get metrics from the source. #13467
 * [ENHANCEMENT] Upgrade to Helm v4. #13661

--- a/operations/helm/charts/mimir-distributed/Chart.lock
+++ b/operations/helm/charts/mimir-distributed/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 0.5.2
 - name: rollout-operator
   repository: https://grafana.github.io/helm-charts
-  version: 0.49.0
-digest: sha256:01aaab8bc34ebe248604611e6a56a65cc436ebeb2eff08a4fb9ec91cdded0774
-generated: "2026-05-30T02:06:49.110677735Z"
+  version: 0.50.0
+digest: sha256:b13b81ff2fea0bcecb910f5141b9c117a9224a74bf5cf36867f7d5aaad2844a2
+generated: "2026-06-11T02:05:36.819770427Z"

--- a/operations/helm/charts/mimir-distributed/Chart.yaml
+++ b/operations/helm/charts/mimir-distributed/Chart.yaml
@@ -20,5 +20,5 @@ dependencies:
   - name: rollout-operator
     alias: rollout_operator
     repository: https://grafana.github.io/helm-charts
-    version: 0.49.0
+    version: 0.50.0
     condition: rollout_operator.enabled

--- a/operations/helm/charts/mimir-distributed/README.md
+++ b/operations/helm/charts/mimir-distributed/README.md
@@ -26,7 +26,7 @@ Kubernetes: `^1.32.0-0`
 |------------|------|---------|
 | https://charts.min.io/ | minio(minio) | 5.4.0 |
 | https://grafana.github.io/helm-charts | grafana-agent-operator(grafana-agent-operator) | 0.5.2 |
-| https://grafana.github.io/helm-charts | rollout_operator(rollout-operator) | 0.49.0 |
+| https://grafana.github.io/helm-charts | rollout_operator(rollout-operator) | 0.50.0 |
 
 # Contributing and releasing
 

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: classic-architecture-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: classic-architecture-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,10 +46,11 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.36.2
+          image: docker.io/grafana/rollout-operator:v0.38.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -zpdb.pod-ready-annotation-patch-timeout=5s
           - -server-tls.enabled=true
           - -server-tls.self-signed-cert.secret-name=certificate
           - -server-tls.self-signed-cert.dns-name=classic-architecture-values-rollout-operator.citestns.svc

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: classic-architecture-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: classic-architecture-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: classic-architecture-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: classic-architecture-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: classic-architecture-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -21,6 +21,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: classic-architecture-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: classic-architecture-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: classic-architecture-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: classic-architecture-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: classic-architecture-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: classic-architecture-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: classic-architecture-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: gateway-nginx-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,10 +46,11 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.36.2
+          image: docker.io/grafana/rollout-operator:v0.38.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -zpdb.pod-ready-annotation-patch-timeout=5s
           - -server-tls.enabled=true
           - -server-tls.self-signed-cert.secret-name=certificate
           - -server-tls.self-signed-cert.dns-name=gateway-nginx-values-rollout-operator.citestns.svc

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: gateway-nginx-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -21,6 +21,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: gateway-nginx-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: gateway-nginx-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: gateway-nginx-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: gateway-nginx-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-global-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-global-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,10 +46,11 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.36.2
+          image: docker.io/grafana/rollout-operator:v0.38.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -zpdb.pod-ready-annotation-patch-timeout=5s
           - -server-tls.enabled=true
           - -server-tls.self-signed-cert.secret-name=certificate
           - -server-tls.self-signed-cert.dns-name=keda-autoscaling-global-values-rollout-operator.citestns.svc

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-global-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-global-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-global-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-global-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-global-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -21,6 +21,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-global-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-global-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-global-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-global-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: keda-autoscaling-global-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-global-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-global-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-metamonitoring-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,10 +46,11 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.36.2
+          image: docker.io/grafana/rollout-operator:v0.38.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -zpdb.pod-ready-annotation-patch-timeout=5s
           - -server-tls.enabled=true
           - -server-tls.self-signed-cert.secret-name=certificate
           - -server-tls.self-signed-cert.dns-name=keda-autoscaling-metamonitoring-values-rollout-operator.citestns.svc

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-metamonitoring-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -21,6 +21,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-metamonitoring-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-metamonitoring-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: keda-autoscaling-metamonitoring-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-metamonitoring-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,10 +46,11 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.36.2
+          image: docker.io/grafana/rollout-operator:v0.38.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -zpdb.pod-ready-annotation-patch-timeout=5s
           - -server-tls.enabled=true
           - -server-tls.self-signed-cert.secret-name=certificate
           - -server-tls.self-signed-cert.dns-name=keda-autoscaling-values-rollout-operator.citestns.svc

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -21,6 +21,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: keda-autoscaling-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: keda-autoscaling-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: keda-autoscaling-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: large-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,10 +46,11 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.36.2
+          image: docker.io/grafana/rollout-operator:v0.38.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -zpdb.pod-ready-annotation-patch-timeout=5s
           - -server-tls.enabled=true
           - -server-tls.self-signed-cert.secret-name=certificate
           - -server-tls.self-signed-cert.dns-name=large-values-rollout-operator.citestns.svc

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: large-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -21,6 +21,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: large-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: large-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: large-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: large-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: openshift-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: openshift-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,10 +46,11 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.36.2
+          image: docker.io/grafana/rollout-operator:v0.38.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -zpdb.pod-ready-annotation-patch-timeout=5s
           - -server-tls.enabled=true
           - -server-tls.self-signed-cert.secret-name=certificate
           - -server-tls.self-signed-cert.dns-name=openshift-values-rollout-operator.citestns.svc

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: openshift-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: openshift-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: openshift-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: openshift-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: openshift-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -21,6 +21,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: openshift-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: openshift-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: openshift-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: openshift-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: openshift-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: openshift-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: openshift-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: scheduler-name-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,10 +46,11 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.36.2
+          image: docker.io/grafana/rollout-operator:v0.38.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -zpdb.pod-ready-annotation-patch-timeout=5s
           - -server-tls.enabled=true
           - -server-tls.self-signed-cert.secret-name=certificate
           - -server-tls.self-signed-cert.dns-name=scheduler-name-values-rollout-operator.citestns.svc

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: scheduler-name-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -21,6 +21,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: scheduler-name-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: scheduler-name-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: scheduler-name-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: scheduler-name-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: small-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,10 +46,11 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.36.2
+          image: docker.io/grafana/rollout-operator:v0.38.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -zpdb.pod-ready-annotation-patch-timeout=5s
           - -server-tls.enabled=true
           - -server-tls.self-signed-cert.secret-name=certificate
           - -server-tls.self-signed-cert.dns-name=small-values-rollout-operator.citestns.svc

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: small-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -21,6 +21,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: small-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: small-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: small-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: small-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-extra-args-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-args-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,10 +46,11 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.36.2
+          image: docker.io/grafana/rollout-operator:v0.38.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -zpdb.pod-ready-annotation-patch-timeout=5s
           - -server-tls.enabled=true
           - -server-tls.self-signed-cert.secret-name=certificate
           - -server-tls.self-signed-cert.dns-name=test-extra-args-values-rollout-operator.citestns.svc

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-args-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-args-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-args-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-extra-args-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-args-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -21,6 +21,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-extra-args-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-args-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-extra-args-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-args-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: test-extra-args-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-args-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-args-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-extra-objects-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-objects-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,10 +46,11 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.36.2
+          image: docker.io/grafana/rollout-operator:v0.38.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -zpdb.pod-ready-annotation-patch-timeout=5s
           - -server-tls.enabled=true
           - -server-tls.self-signed-cert.secret-name=certificate
           - -server-tls.self-signed-cert.dns-name=test-extra-objects-values-rollout-operator.citestns.svc

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-objects-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-objects-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-objects-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-extra-objects-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-objects-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -21,6 +21,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-extra-objects-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-objects-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-extra-objects-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-objects-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: test-extra-objects-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-objects-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-extra-objects-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-gomaxprocs-override-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-gomaxprocs-override-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,10 +46,11 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.36.2
+          image: docker.io/grafana/rollout-operator:v0.38.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -zpdb.pod-ready-annotation-patch-timeout=5s
           - -server-tls.enabled=true
           - -server-tls.self-signed-cert.secret-name=certificate
           - -server-tls.self-signed-cert.dns-name=test-gomaxprocs-override-values-rollout-operator.citestns.svc

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-gomaxprocs-override-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-gomaxprocs-override-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-gomaxprocs-override-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-gomaxprocs-override-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-gomaxprocs-override-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -21,6 +21,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-gomaxprocs-override-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-gomaxprocs-override-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-gomaxprocs-override-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-gomaxprocs-override-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: test-gomaxprocs-override-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-gomaxprocs-override-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-gomaxprocs-override-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ingest-storage-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingest-storage-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,10 +46,11 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.36.2
+          image: docker.io/grafana/rollout-operator:v0.38.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -zpdb.pod-ready-annotation-patch-timeout=5s
           - -server-tls.enabled=true
           - -server-tls.self-signed-cert.secret-name=certificate
           - -server-tls.self-signed-cert.dns-name=test-ingest-storage-values-rollout-operator.citestns.svc

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingest-storage-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingest-storage-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingest-storage-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ingest-storage-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingest-storage-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -21,6 +21,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ingest-storage-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingest-storage-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ingest-storage-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingest-storage-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: test-ingest-storage-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingest-storage-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingest-storage-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ingress-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingress-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,10 +46,11 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.36.2
+          image: docker.io/grafana/rollout-operator:v0.38.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -zpdb.pod-ready-annotation-patch-timeout=5s
           - -server-tls.enabled=true
           - -server-tls.self-signed-cert.secret-name=certificate
           - -server-tls.self-signed-cert.dns-name=test-ingress-values-rollout-operator.citestns.svc

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingress-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingress-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingress-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ingress-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingress-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -21,6 +21,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ingress-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingress-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ingress-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingress-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: test-ingress-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingress-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ingress-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-component-image-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-component-image-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,10 +46,11 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.36.2
+          image: docker.io/grafana/rollout-operator:v0.38.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -zpdb.pod-ready-annotation-patch-timeout=5s
           - -server-tls.enabled=true
           - -server-tls.self-signed-cert.secret-name=certificate
           - -server-tls.self-signed-cert.dns-name=test-oss-component-image-values-rollout-operator.citestns.svc

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-component-image-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-component-image-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-component-image-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-component-image-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-component-image-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -21,6 +21,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-component-image-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-component-image-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-component-image-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-component-image-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: test-oss-component-image-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-component-image-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-component-image-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-emptydir-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-emptydir-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,10 +46,11 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.36.2
+          image: docker.io/grafana/rollout-operator:v0.38.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -zpdb.pod-ready-annotation-patch-timeout=5s
           - -server-tls.enabled=true
           - -server-tls.self-signed-cert.secret-name=certificate
           - -server-tls.self-signed-cert.dns-name=test-oss-emptydir-values-rollout-operator.citestns.svc

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-emptydir-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-emptydir-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-emptydir-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-emptydir-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-emptydir-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -21,6 +21,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-emptydir-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-emptydir-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-emptydir-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-emptydir-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: test-oss-emptydir-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-emptydir-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-emptydir-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-logical-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,10 +46,11 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.36.2
+          image: docker.io/grafana/rollout-operator:v0.38.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -zpdb.pod-ready-annotation-patch-timeout=5s
           - -server-tls.enabled=true
           - -server-tls.self-signed-cert.secret-name=certificate
           - -server-tls.self-signed-cert.dns-name=test-oss-logical-multizone-values-rollout-operator.citestns.svc

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-logical-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -21,6 +21,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-logical-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-logical-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: test-oss-logical-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-logical-multizone-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,10 +46,11 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.36.2
+          image: docker.io/grafana/rollout-operator:v0.38.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -zpdb.pod-ready-annotation-patch-timeout=5s
           - -server-tls.enabled=true
           - -server-tls.self-signed-cert.secret-name=certificate
           - -server-tls.self-signed-cert.dns-name=test-oss-multizone-values-rollout-operator.citestns.svc

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -21,6 +21,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: test-oss-multizone-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-multizone-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-pvc-name-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-pvc-name-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,10 +46,11 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.36.2
+          image: docker.io/grafana/rollout-operator:v0.38.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -zpdb.pod-ready-annotation-patch-timeout=5s
           - -server-tls.enabled=true
           - -server-tls.self-signed-cert.secret-name=certificate
           - -server-tls.self-signed-cert.dns-name=test-oss-pvc-name-values-rollout-operator.citestns.svc

--- a/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-pvc-name-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-pvc-name-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-pvc-name-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-pvc-name-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-pvc-name-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -21,6 +21,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:

--- a/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-pvc-name-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-pvc-name-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-pvc-name-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-pvc-name-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: test-oss-pvc-name-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-pvc-name-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-pvc-name-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-topology-spread-constraints-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,10 +46,11 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.36.2
+          image: docker.io/grafana/rollout-operator:v0.38.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -zpdb.pod-ready-annotation-patch-timeout=5s
           - -server-tls.enabled=true
           - -server-tls.self-signed-cert.secret-name=certificate
           - -server-tls.self-signed-cert.dns-name=test-oss-topology-spread-constraints-values-rollout-operator.citestns.svc

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-topology-spread-constraints-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -21,6 +21,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-topology-spread-constraints-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-oss-topology-spread-constraints-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: test-oss-topology-spread-constraints-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-oss-topology-spread-constraints-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-requests-and-limits-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-requests-and-limits-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,10 +46,11 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.36.2
+          image: docker.io/grafana/rollout-operator:v0.38.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -zpdb.pod-ready-annotation-patch-timeout=5s
           - -server-tls.enabled=true
           - -server-tls.self-signed-cert.secret-name=certificate
           - -server-tls.self-signed-cert.dns-name=test-requests-and-limits-values-rollout-operator.citestns.svc

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-requests-and-limits-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-requests-and-limits-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-requests-and-limits-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-requests-and-limits-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-requests-and-limits-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -21,6 +21,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-requests-and-limits-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-requests-and-limits-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-requests-and-limits-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-requests-and-limits-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: test-requests-and-limits-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-requests-and-limits-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-requests-and-limits-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-revisionhistorylimit-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-revisionhistorylimit-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,10 +46,11 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.36.2
+          image: docker.io/grafana/rollout-operator:v0.38.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -zpdb.pod-ready-annotation-patch-timeout=5s
           - -server-tls.enabled=true
           - -server-tls.self-signed-cert.secret-name=certificate
           - -server-tls.self-signed-cert.dns-name=test-revisionhistorylimit-values-rollout-operator.citestns.svc

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-revisionhistorylimit-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-revisionhistorylimit-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-revisionhistorylimit-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-revisionhistorylimit-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-revisionhistorylimit-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -21,6 +21,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-revisionhistorylimit-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-revisionhistorylimit-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-revisionhistorylimit-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-revisionhistorylimit-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: test-revisionhistorylimit-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-revisionhistorylimit-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-revisionhistorylimit-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ruler-dedicated-query-path-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,10 +46,11 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.36.2
+          image: docker.io/grafana/rollout-operator:v0.38.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -zpdb.pod-ready-annotation-patch-timeout=5s
           - -server-tls.enabled=true
           - -server-tls.self-signed-cert.secret-name=certificate
           - -server-tls.self-signed-cert.dns-name=test-ruler-dedicated-query-path-values-rollout-operator.citestns.svc

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ruler-dedicated-query-path-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -21,6 +21,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ruler-dedicated-query-path-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-ruler-dedicated-query-path-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: test-ruler-dedicated-query-path-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-ruler-dedicated-query-path-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-vault-agent-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-vault-agent-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -46,10 +46,11 @@ spec:
               drop:
               - ALL
             readOnlyRootFilesystem: true
-          image: docker.io/grafana/rollout-operator:v0.36.2
+          image: docker.io/grafana/rollout-operator:v0.38.0
           imagePullPolicy: IfNotPresent
           args:
           - -kubernetes.namespace=citestns
+          - -zpdb.pod-ready-annotation-patch-timeout=5s
           - -server-tls.enabled=true
           - -server-tls.self-signed-cert.secret-name=certificate
           - -server-tls.self-signed-cert.dns-name=test-vault-agent-values-rollout-operator.citestns.svc

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/no-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-vault-agent-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: no-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/pod-eviction-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-vault-agent-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: pod-eviction-citestns.grafana.com

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/prepare-downscale-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-vault-agent-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: prepare-downscale-citestns.grafana.com

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/role.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-vault-agent-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-vault-agent-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -21,6 +21,7 @@ rules:
   - get
   - watch
   - delete
+  - patch
 - apiGroups:
   - apps
   resources:

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-vault-agent-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-vault-agent-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-vault-agent-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-vault-agent-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/serviceaccount.yaml
@@ -6,9 +6,9 @@ metadata:
   name: test-vault-agent-values-rollout-operator
   namespace: "citestns"
   labels:
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-vault-agent-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/charts/rollout_operator/templates/zone-aware-pod-disruption-budget-validating-webhook.yaml
@@ -7,10 +7,10 @@ metadata:
   labels:
     grafana.com/inject-rollout-operator-ca: "true"
     grafana.com/namespace: "citestns"
-    helm.sh/chart: rollout-operator-0.49.0
+    helm.sh/chart: rollout-operator-0.50.0
     app.kubernetes.io/name: rollout-operator
     app.kubernetes.io/instance: test-vault-agent-values
-    app.kubernetes.io/version: "v0.36.2"
+    app.kubernetes.io/version: "v0.38.0"
     app.kubernetes.io/managed-by: Helm
 webhooks:
   - name: zpdb-validation-citestns.grafana.com

--- a/operations/mimir-tests/test-automated-downscale-v2-generated.yaml
+++ b/operations/mimir-tests/test-automated-downscale-v2-generated.yaml
@@ -1142,7 +1142,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-autoscaling-store-gateway-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-store-gateway-generated.yaml
@@ -1083,7 +1083,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-compactor-concurrent-rollout-generated.yaml
+++ b/operations/mimir-tests/test-compactor-concurrent-rollout-generated.yaml
@@ -850,7 +850,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-compactor-concurrent-rollout-max-unavailable-percent-generated.yaml
+++ b/operations/mimir-tests/test-compactor-concurrent-rollout-max-unavailable-percent-generated.yaml
@@ -850,7 +850,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-consul-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-consul-multi-zone-generated.yaml
@@ -1454,7 +1454,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-auto-client-rack-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-auto-client-rack-generated.yaml
@@ -1316,7 +1316,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-custom-stabilization-window-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-custom-stabilization-window-generated.yaml
@@ -1382,7 +1382,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-multiple-triggers-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-multiple-triggers-generated.yaml
@@ -1306,7 +1306,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-one-trigger-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-one-trigger-generated.yaml
@@ -1306,7 +1306,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-0-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-0-generated.yaml
@@ -1299,7 +1299,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-1-generated.yaml
@@ -1370,7 +1370,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
@@ -1359,7 +1359,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
@@ -1359,7 +1359,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-12-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-12-generated.yaml
@@ -1359,7 +1359,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
@@ -1378,7 +1378,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
@@ -1389,7 +1389,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
@@ -1388,7 +1388,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-5a-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-5a-generated.yaml
@@ -1388,7 +1388,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-5b-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-5b-generated.yaml
@@ -1388,7 +1388,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
@@ -1319,7 +1319,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
@@ -1323,7 +1323,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
@@ -1323,7 +1323,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
@@ -1300,7 +1300,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
@@ -1382,7 +1382,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-generated.yaml
@@ -2327,7 +2327,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-0-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-0-generated.yaml
@@ -1777,7 +1777,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-1-generated.yaml
@@ -3150,7 +3150,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2-generated.yaml
@@ -3199,7 +3199,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2a-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2a-generated.yaml
@@ -3199,7 +3199,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2b-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2b-generated.yaml
@@ -3199,7 +3199,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2c-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2c-generated.yaml
@@ -3199,7 +3199,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2d-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2d-generated.yaml
@@ -3199,7 +3199,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2e-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2e-generated.yaml
@@ -3176,7 +3176,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2f-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2f-generated.yaml
@@ -3176,7 +3176,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-3-generated.yaml
@@ -3176,7 +3176,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-4-generated.yaml
@@ -3176,7 +3176,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-5-generated.yaml
@@ -3238,7 +3238,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-6-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-6-generated.yaml
@@ -3238,7 +3238,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-7-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-7-generated.yaml
@@ -3207,7 +3207,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-8-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-8-generated.yaml
@@ -2527,7 +2527,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-final-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-final-generated.yaml
@@ -2527,7 +2527,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-write-path-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-write-path-generated.yaml
@@ -1315,7 +1315,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-az-write-path-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-write-path-migration-generated.yaml
@@ -1444,7 +1444,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-generated.yaml
@@ -1159,7 +1159,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-ongoing-migration-generated.yaml
@@ -1227,7 +1227,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
+++ b/operations/mimir-tests/test-multi-zone-with-store-gateway-automated-downscaling-generated.yaml
@@ -1159,7 +1159,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-pvc-auto-deletion-generated.yaml
+++ b/operations/mimir-tests/test-pvc-auto-deletion-generated.yaml
@@ -1093,7 +1093,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-range-vector-splitting-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-range-vector-splitting-multi-zone-generated.yaml
@@ -2411,7 +2411,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir-tests/test-replica-template-generated.yaml
+++ b/operations/mimir-tests/test-replica-template-generated.yaml
@@ -317,7 +317,7 @@ spec:
         - -use-zone-tracker=true
         - -zone-tracker.config-map-name=rollout-operator-zone-tracker
         - -zpdb.pod-ready-annotation-patch-timeout=5s
-        image: grafana/rollout-operator:v0.37.0
+        image: grafana/rollout-operator:v0.38.0
         imagePullPolicy: IfNotPresent
         name: rollout-operator
         ports:

--- a/operations/mimir/jsonnetfile.json
+++ b/operations/mimir/jsonnetfile.json
@@ -35,7 +35,7 @@
           "subdir": "operations/rollout-operator"
         }
       },
-      "version": "v0.37.0"
+      "version": "v0.38.0"
     },
     {
       "source": {

--- a/operations/mimir/jsonnetfile.lock.json
+++ b/operations/mimir/jsonnetfile.lock.json
@@ -38,8 +38,19 @@
           "subdir": "operations/rollout-operator"
         }
       },
-      "version": "196524018a531ab373af641cfd98af6d7be6f049",
-      "sum": "oCWkgEn08jQRkBnv6sczQaNJew+IPBp6HQCdiYhnz8U="
+      "version": "1e28f3a4bc231e6855b0defb26b283aeabfa6f0e",
+      "sum": "kPKdfBrIU/o4W1CIzcaswwFY+LoWMJtovUHUbW+48/E="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/jsonnet-libs/keda-libsonnet.git",
+          "subdir": "2.15"
+        }
+      },
+      "version": "dbc8cf1a9847f123d8325378111155fb135983ab",
+      "sum": "EVCNg9VpU9ghIYHZtbQffHbZs+EqKOD0cw+ZPilWR48=",
+      "name": "keda-libsonnet"
     },
     {
       "source": {


### PR DESCRIPTION
#### What this PR does

This PR vendors the v0.38.0 jsonnet and updates the mimir-distributed helm-chart to use the latest rollout-operator chart.

This PR was created following the rollout-operator RELEASE guide at https://github.com/grafana/rollout-operator/blob/main/RELEASE.md

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Rollout-operator admission webhooks and RBAC changes affect StatefulSet rollouts and zone-aware downscales; the v0.38.0 upgrade may require manual steps called out in upstream docs.
> 
> **Overview**
> Bumps the **rollout-operator** subchart in `mimir-distributed` from **0.49.0** to **0.50.0**, pulling in operator **v0.38.0** (was v0.36.2). Changelog entries in the root `CHANGELOG.md` and the helm chart now reference jsonnet/helm **v0.38.0** and link to the upstream upgrade notes for that release.
> 
> Regenerated helm test fixtures reflect what the new subchart emits: the deployment uses `docker.io/grafana/rollout-operator:v0.38.0`, adds `-zpdb.pod-ready-annotation-patch-timeout=5s`, and the operator **Role** gains **`patch`** on **pods** (for ZPDB pod-ready annotation behavior). Everything else in the diff is version label churn on the bundled webhook/RBAC manifests.
> 
> Reviewers upgrading clusters should follow the [rollout-operator v0.38.0 upgrade guide](https://github.com/grafana/helm-charts/blob/main/charts/rollout-operator/README.md#upgrade-of-grafana-rollout-operator--v0380) called out in the helm `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db72ab9b7c5f138a31e417168202174edc28e62f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->