### PR TITLE
Add release-3.1 to renovate.json5

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -86,8 +86,8 @@ If something is not clear, you can get back to this document to learn more about
   - [ ] Remove "main / unreleased" section from the CHANGELOG
   - [ ] If a new minor or major version is being released, adjust the settings in the `renovate.json5` configuration on the `main` branch by adding the new version.
         This way we ensure that dependency updates maintain the new version, as well as the latest two minor versions.
-        For instance, if versions 3.0 and 2.10 are configured in `renovate.json`, and version 3.1 is being released,
-        during the release process `renovate.json5` should keep updated the following branches: `main`, `release-3.1`, `release-3.0` and `release-2.10`.
+        For instance, if versions 3.1, 3.0 and 2.10 are configured in `renovate.json`, and version 3.2 is being released,
+        during the release process `renovate.json5` should keep updated the following branches: `main`, `release-3.2`, `release-3.1`, `release-3.0`, and `release-2.10`.
 - [ ] Publish the Mimir release candidate
   - [ ] Update VERSION in the release branch and update CHANGELOG with version and release date.
     - Keep in mind this is a release candidate, so the version string in VERSION and CHANGELOG must end in `-rc.#`, where `#` is the release candidate number, starting at 0.
@@ -142,9 +142,9 @@ If something is not clear, you can get back to this document to learn more about
     ```
     This prepares a PR into `main` branch. On approval, **use** the `merge-approved-pr-branch-to-main.sh` script, following the [instruction](https://github.com/grafana/mimir/blob/main/RELEASE.md#merging-release-branch-into-main) on how to merge the PR with "Merge commit" (i.e. we DO NOT "Squash and merge" this one).
   - [ ] If during the release process settings in the `renovate.json5` have been modified in such a way that dependency updates maintain more than the latest two minor versions,
-        modify it again to ensure that only the latest two minor versions get updated.
-        For instance, if versions 3.1, 3.0 and 2.10 are configured in `renovate.json5`, `renovate.json5` should keep updated the following branches:
-        `main`, `release-3.1` and `release-3.0`.
+        modify it again to ensure that only the latest two minor versions get updated, plus any older major version that we still want to keep updated.
+        For instance, if versions 3.2, 3.1, 3.0 and 2.10 are configured in `renovate.json5`, `renovate.json5` should keep updated the following branches:
+        `main`, `release-3.2`, `release-3.1`, and `release-2.10`.
   - [ ] Announce the release on socials
   - [ ] Open a PR to add the new version to the backward compatibility integration test (`integration/backward_compatibility.go`)
     - Keep the last 3 minor releases

--- a/renovate.json5
+++ b/renovate.json5
@@ -50,6 +50,7 @@
   ],
   baseBranchPatterns: [
     'main',
+    'release-3.1',
     'release-3.0',
     'release-2.17',
   ],
@@ -60,6 +61,7 @@
   packageRules: [
     {
       matchBaseBranches: [
+        'release-3.1',
         'release-3.0',
         'release-2.17',
       ],


### PR DESCRIPTION
#### What this PR does

Adds the latest release branch to renovate.json5, as per the release process.

#### Which issue(s) this PR fixes or relates to

Part of https://github.com/grafana/mimir/issues/14392

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-process and Renovate configuration only; no runtime or application code changes.
> 
> **Overview**
> Part of the **3.1 release checklist**: `renovate.json5` now includes **`release-3.1`** in `baseBranchPatterns` and in the release-branch `packageRules` block (same pattern as `release-3.0` and `release-2.17`), so Renovate tracks the new branch during the release window.
> 
> **`RELEASE.md`** updates the Renovate examples only—when cutting a new minor (e.g. 3.2) and when trimming branches after a stable release—to reflect the current line (3.1 / 3.0 / 2.10) and to note that post-release config should keep the latest two minors **plus** any older major branch you still want dependency updates on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a01c2ec7a4e2c9c65e2e818fa57b768678d16489. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->