### PR TITLE
Merge release-3.1 to main

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -86,8 +86,8 @@ If something is not clear, you can get back to this document to learn more about
   - [ ] Remove "main / unreleased" section from the CHANGELOG
   - [ ] If a new minor or major version is being released, adjust the settings in the `renovate.json5` configuration on the `main` branch by adding the new version.
         This way we ensure that dependency updates maintain the new version, as well as the latest two minor versions.
-        For instance, if versions 3.0 and 2.10 are configured in `renovate.json`, and version 3.1 is being released,
-        during the release process `renovate.json5` should keep updated the following branches: `main`, `release-3.1`, `release-3.0` and `release-2.10`.
+        For instance, if versions 3.1, 3.0 and 2.10 are configured in `renovate.json`, and version 3.2 is being released,
+        during the release process `renovate.json5` should keep updated the following branches: `main`, `release-3.2`, `release-3.1`, `release-3.0`, and `release-2.10`.
 - [ ] Publish the Mimir release candidate
   - [ ] Update VERSION in the release branch and update CHANGELOG with version and release date.
     - Keep in mind this is a release candidate, so the version string in VERSION and CHANGELOG must end in `-rc.#`, where `#` is the release candidate number, starting at 0.
@@ -142,9 +142,9 @@ If something is not clear, you can get back to this document to learn more about
     ```
     This prepares a PR into `main` branch. On approval, **use** the `merge-approved-pr-branch-to-main.sh` script, following the [instruction](https://github.com/grafana/mimir/blob/main/RELEASE.md#merging-release-branch-into-main) on how to merge the PR with "Merge commit" (i.e. we DO NOT "Squash and merge" this one).
   - [ ] If during the release process settings in the `renovate.json5` have been modified in such a way that dependency updates maintain more than the latest two minor versions,
-        modify it again to ensure that only the latest two minor versions get updated.
-        For instance, if versions 3.1, 3.0 and 2.10 are configured in `renovate.json5`, `renovate.json5` should keep updated the following branches:
-        `main`, `release-3.1` and `release-3.0`.
+        modify it again to ensure that only the latest two minor versions get updated, plus any older major version that we still want to keep updated.
+        For instance, if versions 3.2, 3.1, 3.0 and 2.10 are configured in `renovate.json5`, `renovate.json5` should keep updated the following branches:
+        `main`, `release-3.2`, `release-3.1`, and `release-2.10`.
   - [ ] Announce the release on socials
   - [ ] Open a PR to add the new version to the backward compatibility integration test (`integration/backward_compatibility.go`)
     - Keep the last 3 minor releases

--- a/renovate.json5
+++ b/renovate.json5
@@ -50,6 +50,7 @@
   ],
   baseBranchPatterns: [
     'main',
+    'release-3.1',
     'release-3.0',
     'release-2.17',
   ],
@@ -60,6 +61,7 @@
   packageRules: [
     {
       matchBaseBranches: [
+        'release-3.1',
         'release-3.0',
         'release-2.17',
       ],


### PR DESCRIPTION
In this PR I'm merging the release-3.1 branch to main branch. Please merge this PR using a **merge commit** or by using `tools/release/merge-approved-pr-branch-to-main.sh` script.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and Renovate branch-list updates only; no runtime or application logic changes in this diff.
> 
> **Overview**
> Brings **release-3.1** into `main` as part of the standard release merge (use a merge commit, not squash).
> 
> **Renovate:** Adds `release-3.1` to `baseBranchPatterns` and to the release-branch `packageRules` block (still **disabled** for dependency PRs on release lines, same as `release-3.0` and `release-2.17`).
> 
> **RELEASE.md:** Updates Renovate maintenance examples for a **3.2** cut (which branches to keep during RC) and for **post-stable** cleanup—keep the latest two minors **plus** any older major still supported (example: `main`, `release-3.2`, `release-3.1`, `release-2.10`, dropping `release-3.0` from the list).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff41c670d57517027be479c6bdd51c5665c35f9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->