### PR TITLE
[release-3.0] Update Docker image bases to distroless Debian 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Grafana Mimir
 
+* [CHANGE] Update Docker image bases from Debian 12 to Debian 13 (`gcr.io/distroless/static-debian13`; race images use `base-nossl-debian13`). #15629
 * [BUGFIX] Distributor: Fix nil pointer panic in `WriteRequest.Unmarshal` when receiving a Remote Write 2.0 request with zero timeseries. #14698
 * [BUGFIX] Update to Go v1.26.3 to address high-severity CVEs [CVE-2026-42501](https://pkg.go.dev/vuln/GO-2026-4984), [CVE-2026-39836](https://pkg.go.dev/vuln/GO-2026-4971), [CVE-2026-33811](https://pkg.go.dev/vuln/GO-2026-4981), [CVE-2026-33814](https://pkg.go.dev/vuln/GO-2026-4918), [CVE-2026-42499](https://pkg.go.dev/vuln/GO-2026-4977), [CVE-2026-39820](https://pkg.go.dev/vuln/GO-2026-4986) and other lower-severity CVEs. #15402
 

--- a/Makefile
+++ b/Makefile
@@ -111,13 +111,13 @@ SED ?= $(shell which gsed 2>/dev/null || which sed)
 
 %/$(UPTODATE_RACE): GOOS=linux
 %/$(UPTODATE_RACE): %/Dockerfile
-	# We need gcompat -- compatibility layer with glibc, as race-detector currently requires glibc.
+	# The race detector requires glibc, so we use the distroless base-nossl image rather than static.
 	$(SUDO) docker build \
 		--build-arg=revision=$(GIT_REVISION) \
 		--build-arg=goproxyValue=$(GOPROXY_VALUE) \
 		--build-arg=USE_BINARY_SUFFIX=true \
 		--build-arg=BINARY_SUFFIX=_race \
-		--build-arg=BASEIMG="gcr.io/distroless/base-nossl-debian12" \
+		--build-arg=BASEIMG="gcr.io/distroless/base-nossl-debian13@sha256:792f51c506fc67f7eaa38093f6d4937a053cebb79ec0e7c3b7746f6bbba85606" \
 		-t $(IMAGE_PREFIX)$(shell basename $(@D)):$(IMAGE_TAG_RACE) $(@D)/
 	@echo
 	@echo Go binaries were built using GOOS=$(GOOS) and GOARCH=$(GOARCH)

--- a/cmd/metaconvert/Dockerfile
+++ b/cmd/metaconvert/Dockerfile
@@ -3,10 +3,7 @@
 # Provenance-includes-license: Apache-2.0
 # Provenance-includes-copyright: The Cortex Authors.
 
-ARG        BASEIMG=gcr.io/distroless/static-debian12
-# TODO(rwwiv): Remove once CA bundle is updated upstream.
-FROM debian:testing AS updated-ca-bundle
-RUN apt update && apt install -y ca-certificates && update-ca-certificates && apt clean
+ARG        BASEIMG=gcr.io/distroless/static-debian13@sha256:3592aa8171c77482f62bbc4164e6a2d141c6122554ace66e5cc910cadb961ff0
 
 FROM       ${BASEIMG}
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
@@ -16,8 +13,6 @@ ARG        BINARY_SUFFIX="_${TARGETOS}_${TARGETARCH}"
 # Set to non-empty value to use ${BINARY_SUFFIX} when copying binary, leave unset to use no suffix.
 ARG        USE_BINARY_SUFFIX
 COPY       metaconvert${USE_BINARY_SUFFIX:+${BINARY_SUFFIX}} /metaconvert
-# Copy the updated CA bundle from the updated-ca-bundle stage
-COPY --from=updated-ca-bundle /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 ENTRYPOINT ["/metaconvert"]
 
 ARG revision

--- a/cmd/mimir/Dockerfile
+++ b/cmd/mimir/Dockerfile
@@ -2,10 +2,7 @@
 # We use different base images for mimir and mimir race images since race-detector needs glibc packages.
 # See difference between distroless static and base-nossl at https://github.com/GoogleContainerTools/distroless/blob/main/base/README.md.
 
-ARG        BASEIMG=gcr.io/distroless/static-debian12
-# TODO(rwwiv): Remove once CA bundle is updated upstream.
-FROM debian:testing AS updated-ca-bundle
-RUN apt update && apt install -y ca-certificates && update-ca-certificates && apt clean
+ARG        BASEIMG=gcr.io/distroless/static-debian13@sha256:3592aa8171c77482f62bbc4164e6a2d141c6122554ace66e5cc910cadb961ff0
 
 FROM       ${BASEIMG}
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
@@ -15,8 +12,6 @@ ARG        BINARY_SUFFIX="_${TARGETOS}_${TARGETARCH}"
 # Set to non-empty value to use ${BINARY_SUFFIX} when copying mimir binary, leave unset to use no suffix.
 ARG        USE_BINARY_SUFFIX
 COPY       mimir${USE_BINARY_SUFFIX:+${BINARY_SUFFIX}} /bin/mimir
-# Copy the updated CA bundle from the updated-ca-bundle stage
-COPY --from=updated-ca-bundle /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 EXPOSE     8080
 ENTRYPOINT [ "/bin/mimir" ]
 

--- a/cmd/mimirtool/Dockerfile
+++ b/cmd/mimirtool/Dockerfile
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
-ARG        BASEIMG=gcr.io/distroless/static-debian12
-# TODO(rwwiv): Remove once CA bundle is updated upstream.
-FROM debian:testing AS updated-ca-bundle
-RUN apt update && apt install -y ca-certificates && update-ca-certificates && apt clean
+ARG        BASEIMG=gcr.io/distroless/static-debian13@sha256:3592aa8171c77482f62bbc4164e6a2d141c6122554ace66e5cc910cadb961ff0
 
 FROM       ${BASEIMG}
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
@@ -13,8 +10,6 @@ ARG        BINARY_SUFFIX="_${TARGETOS}_${TARGETARCH}"
 # Set to non-empty value to use ${BINARY_SUFFIX} when copying binary, leave unset to use no suffix.
 ARG        USE_BINARY_SUFFIX
 COPY       mimirtool${USE_BINARY_SUFFIX:+${BINARY_SUFFIX}} /bin/mimirtool
-# Copy the updated CA bundle from the updated-ca-bundle stage
-COPY --from=updated-ca-bundle /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 ENTRYPOINT [ "/bin/mimirtool" ]
 
 ARG revision

--- a/cmd/query-tee/Dockerfile
+++ b/cmd/query-tee/Dockerfile
@@ -3,10 +3,7 @@
 # Provenance-includes-license: Apache-2.0
 # Provenance-includes-copyright: The Cortex Authors.
 
-ARG        BASEIMG=gcr.io/distroless/static-debian12
-# TODO(rwwiv): Remove once CA bundle is updated upstream.
-FROM debian:testing AS updated-ca-bundle
-RUN apt update && apt install -y ca-certificates && update-ca-certificates && apt clean
+ARG        BASEIMG=gcr.io/distroless/static-debian13@sha256:3592aa8171c77482f62bbc4164e6a2d141c6122554ace66e5cc910cadb961ff0
 
 FROM       ${BASEIMG}
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
@@ -16,8 +13,6 @@ ARG        BINARY_SUFFIX="_${TARGETOS}_${TARGETARCH}"
 # Set to non-empty value to use ${BINARY_SUFFIX} when copying binary, leave unset to use no suffix.
 ARG        USE_BINARY_SUFFIX
 COPY       query-tee${USE_BINARY_SUFFIX:+${BINARY_SUFFIX}} /query-tee
-# Copy the updated CA bundle from the updated-ca-bundle stage
-COPY --from=updated-ca-bundle /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 ENTRYPOINT ["/query-tee"]
 
 ARG revision

--- a/tools/copyblocks/Dockerfile
+++ b/tools/copyblocks/Dockerfile
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
-ARG        BASEIMG=gcr.io/distroless/static-debian12
-# TODO(rwwiv): Remove once CA bundle is updated upstream.
-FROM debian:testing AS updated-ca-bundle
-RUN apt update && apt install -y ca-certificates && update-ca-certificates && apt clean
+ARG        BASEIMG=gcr.io/distroless/static-debian13@sha256:3592aa8171c77482f62bbc4164e6a2d141c6122554ace66e5cc910cadb961ff0
 
 FROM       ${BASEIMG}
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
@@ -13,8 +10,6 @@ ARG        BINARY_SUFFIX="_${TARGETOS}_${TARGETARCH}"
 # Set to non-empty value to use ${BINARY_SUFFIX} when copying binary, leave unset to use no suffix.
 ARG        USE_BINARY_SUFFIX
 COPY       copyblocks${USE_BINARY_SUFFIX:+${BINARY_SUFFIX}} /copyblocks
-# Copy the updated CA bundle from the updated-ca-bundle stage
-COPY --from=updated-ca-bundle /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 EXPOSE     8080
 ENTRYPOINT ["/copyblocks"]
 

--- a/tools/usage-tracker-load-generator/Dockerfile
+++ b/tools/usage-tracker-load-generator/Dockerfile
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
-ARG        BASEIMG=gcr.io/distroless/static-debian12
-# TODO(rwwiv): Remove once CA bundle is updated upstream.
-FROM debian:testing AS updated-ca-bundle
-RUN apt update && apt install -y ca-certificates && update-ca-certificates && apt clean
+ARG        BASEIMG=gcr.io/distroless/static-debian13@sha256:3592aa8171c77482f62bbc4164e6a2d141c6122554ace66e5cc910cadb961ff0
 
 FROM       ${BASEIMG}
 # Expose TARGETOS and TARGETARCH variables. These are supported by Docker when using BuildKit, but must be "enabled" using ARG.
@@ -13,8 +10,6 @@ ARG        BINARY_SUFFIX="_${TARGETOS}_${TARGETARCH}"
 # Set to non-empty value to use ${BINARY_SUFFIX} when copying binary, leave unset to use no suffix.
 ARG        USE_BINARY_SUFFIX
 COPY       usage-tracker-load-generator${USE_BINARY_SUFFIX:+${BINARY_SUFFIX}} /usage-tracker-load-generator
-# Copy the updated CA bundle from the updated-ca-bundle stage
-COPY --from=updated-ca-bundle /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 EXPOSE     8080
 ENTRYPOINT ["/usage-tracker-load-generator"]
 


### PR DESCRIPTION
Backport 2c90f9f04073d134729389c8b4f3061b5d2c8d42 from #15629

---

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Debian 12 (bookworm) regular security support ended on 2026-06-10 (#15627), and distroless publishes Debian 13 (trixie) variants. Renovate cannot cross this boundary on its own because the Debian version is part of the image name, so bump the bases manually: static-debian13 for published images, base-nossl-debian13 for race images.

Trixie ships ca-certificates 20250419, which includes the SSL.com TLS RSA Root CA 2022 whose absence from bookworm motivated the updated-ca-bundle override stage (#12247), so remove that stage and use the base image's bundle.

Distroless Debian 12 EOL is [September 2026](https://github.com/GoogleContainerTools/distroless/blob/main/SUPPORT_POLICY.md), so for security reasons we should backport the Debian 13 upgrade.

#### Which issue(s) this PR fixes or relates to

Fixes #15627

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change (base OS and Dockerfile simplification); application binaries and runtime behavior are unchanged aside from the updated OS/CA bundle in the image.
> 
> **Overview**
> Moves published Mimir-related container images from **distroless Debian 12** to **Debian 13**, with pinned digests on `static-debian13` and on race builds via `base-nossl-debian13` in the Makefile.
> 
> Because Trixie’s bundled CA certificates cover the roots that previously required a custom stage, the PR **drops the `debian:testing` / `updated-ca-bundle` build stage** and the extra `COPY` of `ca-certificates.crt` from **mimir**, **mimirtool**, **metaconvert**, **query-tee**, **copyblocks**, and **usage-tracker-load-generator** Dockerfiles. The unreleased **CHANGELOG** records the base image change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2da4704bfa1db12aa55fc3d3d9e7e94c1f3d0539. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->