### PR TITLE
fix: continuous-test: fix a crash when writing float histograms to OTLP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * [BUGFIX] Upgrade Go to 1.26.4 to address [CVE-2026-42507](https://pkg.go.dev/vuln/GO-2026-5039). #15566
 * [BUGFIX] Memcached: Disable TCP DNS connection pooling used for service discovery by default. #15573
 * [BUGFIX] Ingest storage: Fix `cortex_ingest_storage_writer_produce_records_enqueued_total` not being incremented when `KafkaProducer.ProduceSync()` rejects a batch because a record has its `Timestamp` set by the caller. #15610
+* [BUGFIX] Continuous-test: Fix a crash when histogram tests were enabled in combination with the OTLP-HTTP write protocol. #15641
 
 ### Mixin
 

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -3651,7 +3651,7 @@ Usage of ./cmd/mimir/mimir:
     	The maximum number of series to write in a single request. (default 1000)
   -tests.write-endpoint string
     	The base endpoint on the write path. The URL should have no trailing slash. The specific API path is appended by the tool to the URL, for example /api/v1/push for the remote write API endpoint, so the configured URL must not include it.
-  -tests.write-protocol string
+  -tests.write-protocol value
     	The protocol to use to write series data. Supported values are: prometheus, prometheus2, otlp-http (default "prometheus")
   -tests.write-read-ooo-test.enabled
     	Enables a test that writes samples out-of-order and verifies query results.

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -957,7 +957,7 @@ Usage of ./cmd/mimir/mimir:
     	The maximum number of series to write in a single request. (default 1000)
   -tests.write-endpoint string
     	The base endpoint on the write path. The URL should have no trailing slash. The specific API path is appended by the tool to the URL, for example /api/v1/push for the remote write API endpoint, so the configured URL must not include it.
-  -tests.write-protocol string
+  -tests.write-protocol value
     	The protocol to use to write series data. Supported values are: prometheus, prometheus2, otlp-http (default "prometheus")
   -tests.write-read-ooo-test.enabled
     	Enables a test that writes samples out-of-order and verifies query results.

--- a/pkg/continuoustest/client.go
+++ b/pkg/continuoustest/client.go
@@ -30,6 +30,11 @@ const (
 	maxErrMsgLen     = 256
 	defaultTenant    = "anonymous"
 	defaultUserAgent = "mimir-continuous-test"
+
+	writeProtocolPrometheus  = WriteProtocol("prometheus")
+	writeProtocolPrometheus2 = WriteProtocol("prometheus2")
+	writeProtocolOtelHttp    = WriteProtocol("otlp-http")
+	writeProtocolDefault     = writeProtocolPrometheus
 )
 
 // MimirClient is the interface implemented by a client used to interact with Mimir.
@@ -48,7 +53,7 @@ type MimirClient interface {
 	Metadata(ctx context.Context, metricName string) (v1.Metadata, error)
 
 	// Protocol indicates the protocol used to write series data.
-	Protocol() string
+	Protocol() WriteProtocol
 }
 
 type ClientConfig struct {
@@ -60,7 +65,7 @@ type ClientConfig struct {
 	WriteBaseEndpoint flagext.URLValue
 	WriteBatchSize    int
 	WriteTimeout      time.Duration
-	WriteProtocol     string
+	WriteProtocol     WriteProtocol
 
 	ReadBaseEndpoint flagext.URLValue
 	ReadTimeout      time.Duration
@@ -81,7 +86,8 @@ func (cfg *ClientConfig) RegisterFlags(f *flag.FlagSet) {
 	f.Var(&cfg.WriteBaseEndpoint, "tests.write-endpoint", "The base endpoint on the write path. The URL should have no trailing slash. The specific API path is appended by the tool to the URL, for example /api/v1/push for the remote write API endpoint, so the configured URL must not include it.")
 	f.IntVar(&cfg.WriteBatchSize, "tests.write-batch-size", 1000, "The maximum number of series to write in a single request.")
 	f.DurationVar(&cfg.WriteTimeout, "tests.write-timeout", 5*time.Second, "The timeout for a single write request.")
-	f.StringVar(&cfg.WriteProtocol, "tests.write-protocol", "prometheus", "The protocol to use to write series data. Supported values are: prometheus, prometheus2, otlp-http")
+	f.Var(&cfg.WriteProtocol, "tests.write-protocol", fmt.Sprintf("The protocol to use to write series data. Supported values are: prometheus, prometheus2, otlp-http (default %q)", writeProtocolDefault))
+	_ = cfg.WriteProtocol.Set(string(writeProtocolDefault))
 
 	f.Var(&cfg.ReadBaseEndpoint, "tests.read-endpoint", "The base endpoint on the read path. The URL should have no trailing slash. The specific API path is appended by the tool to the URL, for example /api/v1/query_range for range query API, so the configured URL must not include it.")
 	f.DurationVar(&cfg.ReadTimeout, "tests.read-timeout", 60*time.Second, "The timeout for a single read request.")
@@ -91,7 +97,7 @@ func (cfg *ClientConfig) RegisterFlags(f *flag.FlagSet) {
 }
 
 type Client struct {
-	protocol    string
+	protocol    WriteProtocol
 	writeClient clientWriter
 	readClient  v1.API
 	cfg         ClientConfig
@@ -151,7 +157,7 @@ func NewClient(cfg ClientConfig, logger log.Logger, reg prometheus.Registerer) (
 	var writeClient clientWriter
 
 	switch cfg.WriteProtocol {
-	case "prometheus":
+	case writeProtocolPrometheus:
 		writeClient = &prometheusWriter{
 			httpClient:        &http.Client{Transport: rt},
 			writeBaseEndpoint: cfg.WriteBaseEndpoint,
@@ -159,7 +165,7 @@ func NewClient(cfg ClientConfig, logger log.Logger, reg prometheus.Registerer) (
 			writeTimeout:      cfg.WriteTimeout,
 		}
 
-	case "prometheus2":
+	case writeProtocolPrometheus2:
 		writeClient = &prometheus2Writer{
 			httpClient:        &http.Client{Transport: rt},
 			writeBaseEndpoint: cfg.WriteBaseEndpoint,
@@ -167,7 +173,7 @@ func NewClient(cfg ClientConfig, logger log.Logger, reg prometheus.Registerer) (
 			writeTimeout:      cfg.WriteTimeout,
 		}
 
-	case "otlp-http":
+	case writeProtocolOtelHttp:
 		writeClient = &otlpHTTPWriter{
 			httpClient:        &http.Client{Transport: rt},
 			writeBaseEndpoint: cfg.WriteBaseEndpoint,
@@ -289,7 +295,7 @@ func (c *Client) WriteSeries(ctx context.Context, series []prompb.TimeSeries, me
 }
 
 // Protocol implements MimirClient.
-func (c *Client) Protocol() string {
+func (c *Client) Protocol() WriteProtocol {
 	return c.protocol
 }
 
@@ -380,4 +386,22 @@ func (rt *clientRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 	}
 
 	return rt.rt.RoundTrip(req)
+}
+
+type WriteProtocol string
+
+func (w *WriteProtocol) String() string {
+	return string(*w)
+}
+
+func (w *WriteProtocol) Set(s string) error {
+	switch WriteProtocol(s) {
+	case writeProtocolPrometheus,
+		writeProtocolPrometheus2,
+		writeProtocolOtelHttp:
+		*w = WriteProtocol(s)
+		return nil
+	default:
+		return fmt.Errorf("invalid write protocol %q", s)
+	}
 }

--- a/pkg/continuoustest/client_test.go
+++ b/pkg/continuoustest/client_test.go
@@ -117,6 +117,61 @@ func TestOTLPHttpClient_WriteSeries(t *testing.T) {
 		assert.Equal(t, 2, receivedRequests[2].Metrics().MetricCount())
 	})
 
+	t.Run("write int histogram in single batch", func(t *testing.T) {
+		receivedRequests = nil
+		nextStatusCode = http.StatusOK
+
+		var gen generateHistogramFunc = func(t time.Time) prompb.Histogram {
+			ts := t.UnixMilli()
+			return prompb.FromIntHistogram(ts, generateIntHistogram(generateHistogramIntValue(t, false), 1, false))
+		}
+
+		series := generateHistogramSeriesInner("test_int_histogram", now, 10, gen)
+		metadata := []prompb.MetricMetadata{{
+			Type:             prompb.MetricMetadata_HISTOGRAM,
+			MetricFamilyName: "test_int_histogram",
+			Help:             "Test int histogram.",
+			Unit:             "u",
+		}}
+		statusCode, err := c.WriteSeries(ctx, series, metadata)
+		require.NoError(t, err)
+		assert.Equal(t, 200, statusCode)
+
+		require.Len(t, receivedRequests, 1)
+		assert.Equal(t, len(series), receivedRequests[0].Metrics().MetricCount())
+		receivedMetric := receivedRequests[0].Metrics().ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0)
+		assert.Equal(t, "test_int_histogram", receivedMetric.Name())
+		assert.Equal(t, "Test int histogram.", receivedMetric.Description())
+		assert.Equal(t, "u", receivedMetric.Unit())
+	})
+
+	t.Run("write float histogram in single batch", func(t *testing.T) {
+		receivedRequests = nil
+		nextStatusCode = http.StatusOK
+
+		var gen generateHistogramFunc = func(t time.Time) prompb.Histogram {
+			ts := t.UnixMilli()
+			return prompb.FromFloatHistogram(ts, generateFloatHistogram(generateHistogramFloatValue(t, false), 1, false))
+		}
+
+		series := generateHistogramSeriesInner("test_float_histogram", now, 10, gen)
+		metadata := []prompb.MetricMetadata{{
+			Type:             prompb.MetricMetadata_HISTOGRAM,
+			MetricFamilyName: "test_float_histogram",
+			Help:             "Test float histogram.",
+			Unit:             "u",
+		}}
+
+		// It doesn't make sense to attempt to write a float histogram in OTLP mode. We never
+		// convert a Prometheus histogram to OTEL histogram in production, only OTEL histogram
+		// into Prometheus histogram. We _can_ convert Prometheus integer histograms into OTEL
+		// histograms which we do to test in continuous-test. However, Prometheus float histograms
+		// can't be converted to OTEL histograms.
+		require.Panics(t, func() {
+			_, _ = c.WriteSeries(ctx, series, metadata)
+		})
+	})
+
 	t.Run("request failed with 4xx error", func(t *testing.T) {
 		receivedRequests = nil
 		nextStatusCode = http.StatusBadRequest
@@ -642,7 +697,7 @@ func (m *ClientMock) Metadata(ctx context.Context, metricName string) (v1.Metada
 	return args.Get(0).(v1.Metadata), args.Error(1)
 }
 
-func (m *ClientMock) Protocol() string {
+func (m *ClientMock) Protocol() WriteProtocol {
 	args := m.Called()
-	return args.String(0)
+	return args.Get(0).(WriteProtocol)
 }

--- a/pkg/continuoustest/util.go
+++ b/pkg/continuoustest/util.go
@@ -44,6 +44,7 @@ type skipTimestampFunc func(t time.Time) bool
 type histogramProfile struct {
 	metricName              string
 	typeLabel               string
+	otelCompatible          bool
 	metadata                []prompb.MetricMetadata
 	generateHistogram       generateHistogramFunc
 	generateSampleHistogram generateSampleHistogramFunc
@@ -52,10 +53,11 @@ type histogramProfile struct {
 }
 
 var (
-	histogramProfiles = []histogramProfile{
+	defaultHistogramProfiles = []histogramProfile{
 		{
-			metricName: "mimir_continuous_test_histogram_int_counter_v2",
-			typeLabel:  "histogram_int_counter",
+			metricName:     "mimir_continuous_test_histogram_int_counter_v2",
+			typeLabel:      "histogram_int_counter",
+			otelCompatible: true,
 			metadata: []prompb.MetricMetadata{{
 				Type:             prompb.MetricMetadata_HISTOGRAM,
 				MetricFamilyName: "mimir_continuous_test_histogram_int_counter_v2",
@@ -125,12 +127,28 @@ var (
 )
 
 func init() {
-	for i, histProfile := range histogramProfiles {
-		histogramProfiles[i].generateValue = nil
-		histogramProfiles[i].generateSeries = func(name string, t time.Time, numSeries int, extraLabels ...prompb.Label) []prompb.TimeSeries {
+	for i, histProfile := range defaultHistogramProfiles {
+		defaultHistogramProfiles[i].generateValue = nil
+		defaultHistogramProfiles[i].generateSeries = func(name string, t time.Time, numSeries int, extraLabels ...prompb.Label) []prompb.TimeSeries {
 			return generateHistogramSeriesInner(name, t, numSeries, histProfile.generateHistogram, extraLabels...)
 		}
 	}
+}
+
+func histogramProfilesForWriteProtocol(writeProtocol WriteProtocol) []histogramProfile {
+	var out []histogramProfile
+	for _, p := range defaultHistogramProfiles {
+		switch writeProtocol {
+		case writeProtocolOtelHttp:
+			if p.otelCompatible {
+				out = append(out, p)
+			}
+		default:
+			out = append(out, p)
+		}
+	}
+
+	return out
 }
 
 type querySumFunc func(metricName string) string

--- a/pkg/continuoustest/util_test.go
+++ b/pkg/continuoustest/util_test.go
@@ -51,7 +51,7 @@ func TestGetQueryStep(t *testing.T) {
 
 func TestVerifySamplesSum(t *testing.T) {
 	testVerifySamplesSumFloats(t, generateSineWaveValue, "generateSineWaveValue")
-	for _, histProfile := range histogramProfiles {
+	for _, histProfile := range histogramProfilesForWriteProtocol(writeProtocolPrometheus) {
 		testVerifySamplesSumHistograms(t, histProfile.generateValue, histProfile.generateSampleHistogram, fmt.Sprintf("generateHistogramValue for %s", histProfile.typeLabel))
 	}
 }

--- a/pkg/continuoustest/write_read_ooo.go
+++ b/pkg/continuoustest/write_read_ooo.go
@@ -146,7 +146,7 @@ func (t *WriteReadOOOTest) RunInner(ctx context.Context, now time.Time, writeLim
 			return
 		}
 
-		series := generateSeries(metricName, timestamp, t.cfg.NumSeries, prompb.Label{Name: "protocol", Value: t.client.Protocol()})
+		series := generateSeries(metricName, timestamp, t.cfg.NumSeries, prompb.Label{Name: "protocol", Value: string(t.client.Protocol())})
 		if err := writeSamples(ctx, floatTypeLabel, timestamp, series, oooMetricMetadata, &t.inOrderSamples, t.client, t.metrics, logger); err != nil {
 			errs.Add(err)
 			return
@@ -163,7 +163,7 @@ func (t *WriteReadOOOTest) RunInner(ctx context.Context, now time.Time, writeLim
 			return
 		}
 
-		series := generateSeries(metricName, timestamp, t.cfg.NumSeries, prompb.Label{Name: "protocol", Value: t.client.Protocol()})
+		series := generateSeries(metricName, timestamp, t.cfg.NumSeries, prompb.Label{Name: "protocol", Value: string(t.client.Protocol())})
 		if err := writeSamples(ctx, floatTypeLabel, timestamp, series, oooMetricMetadata, &t.outOfOrderSamples, t.client, t.metrics, logger); err != nil {
 			errs.Add(err)
 			return

--- a/pkg/continuoustest/write_read_series.go
+++ b/pkg/continuoustest/write_read_series.go
@@ -52,8 +52,9 @@ type WriteReadSeriesTest struct {
 	logger  log.Logger
 	metrics *TestMetrics
 
-	floatMetric MetricHistory
-	histMetrics []MetricHistory
+	floatMetric  MetricHistory
+	histMetrics  []MetricHistory
+	histProfiles []histogramProfile
 }
 
 type MetricHistory struct {
@@ -62,16 +63,19 @@ type MetricHistory struct {
 	queryMaxTime         time.Time
 }
 
-func NewWriteReadSeriesTest(cfg WriteReadSeriesTestConfig, client MimirClient, logger log.Logger, reg prometheus.Registerer) *WriteReadSeriesTest {
+func NewWriteReadSeriesTest(cfg WriteReadSeriesTestConfig, client MimirClient, writeProtocol WriteProtocol, logger log.Logger, reg prometheus.Registerer) *WriteReadSeriesTest {
 	const name = "write-read-series"
 
+	histProfiles := histogramProfilesForWriteProtocol(writeProtocol)
+
 	return &WriteReadSeriesTest{
-		name:        name,
-		cfg:         cfg,
-		client:      client,
-		logger:      log.With(logger, "test", name),
-		metrics:     NewTestMetrics(name, reg),
-		histMetrics: make([]MetricHistory, len(histogramProfiles)),
+		name:         name,
+		cfg:          cfg,
+		client:       client,
+		logger:       log.With(logger, "test", name),
+		metrics:      NewTestMetrics(name, reg),
+		histMetrics:  make([]MetricHistory, len(histProfiles)),
+		histProfiles: histProfiles,
 	}
 }
 
@@ -95,7 +99,7 @@ func (t *WriteReadSeriesTest) Init(ctx context.Context, now time.Time) error {
 		t.metrics.InitializeCountersToZero(floatTypeLabel)
 	}
 	if t.cfg.WithHistograms {
-		for i, histProfile := range histogramProfiles {
+		for i, histProfile := range t.histProfiles {
 			err := t.recoverPast(ctx, now, histProfile.metricName, querySumHist, histProfile.generateValue, histProfile.generateSampleHistogram, &t.histMetrics[i])
 			if err != nil {
 				return err
@@ -140,7 +144,7 @@ func (t *WriteReadSeriesTest) Run(ctx context.Context, now time.Time) error {
 	}
 
 	if t.cfg.WithHistograms {
-		for i, histProfile := range histogramProfiles {
+		for i, histProfile := range t.histProfiles {
 			t.RunInner(ctx, now, writeLimiter, errs, histProfile.metricName, histProfile.typeLabel, histProfile.metadata, querySumHist, histProfile.generateSeries, histProfile.generateValue, histProfile.generateSampleHistogram, &t.histMetrics[i])
 		}
 	}
@@ -158,7 +162,7 @@ func (t *WriteReadSeriesTest) RunInner(ctx context.Context, now time.Time, write
 			return
 		}
 
-		series := generateSeries(metricName, timestamp, t.cfg.NumSeries, prompb.Label{Name: "protocol", Value: t.client.Protocol()})
+		series := generateSeries(metricName, timestamp, t.cfg.NumSeries, prompb.Label{Name: "protocol", Value: string(t.client.Protocol())})
 		if err := writeSamples(ctx, typeLabel, timestamp, series, metricMetadata, records, t.client, t.metrics, logger); err != nil {
 			errs.Add(err)
 			break

--- a/pkg/continuoustest/write_read_series_test.go
+++ b/pkg/continuoustest/write_read_series_test.go
@@ -69,8 +69,10 @@ func init() {
 		},
 	}}
 
-	histTestTuples = make([]WriteReadSeriesTestTuple, len(histogramProfiles))
-	for i, histProfile := range histogramProfiles {
+	histProfiles := histogramProfilesForWriteProtocol(writeProtocolDefault)
+
+	histTestTuples = make([]WriteReadSeriesTestTuple, len(histProfiles))
+	for i, histProfile := range histProfiles {
 		histTestTuples[i] = WriteReadSeriesTestTuple{
 			metricName:              histProfile.metricName,
 			typeLabel:               histProfile.typeLabel,
@@ -125,7 +127,7 @@ func testWriteReadSeriesTestRun(t *testing.T, cfg WriteReadSeriesTestConfig, tes
 		client.On("Metadata", mock.Anything, mock.Anything).Return(v1.Metadata{}, nil)
 
 		reg := prometheus.NewPedanticRegistry()
-		test := NewWriteReadSeriesTest(cfg, client, logger, reg)
+		test := NewWriteReadSeriesTest(cfg, client, writeProtocolDefault, logger, reg)
 
 		now := time.Unix(1000, 0)
 		// Ignore this error. It will be non-nil because the query mock does not return any data.
@@ -163,7 +165,7 @@ func testWriteReadSeriesTestRun(t *testing.T, cfg WriteReadSeriesTestConfig, tes
 		client.On("Metadata", mock.Anything, mock.Anything).Return(v1.Metadata{}, nil)
 
 		reg := prometheus.NewPedanticRegistry()
-		test := NewWriteReadSeriesTest(cfg, client, logger, reg)
+		test := NewWriteReadSeriesTest(cfg, client, writeProtocolDefault, logger, reg)
 
 		now := time.Unix(999, 0)
 		// Ignore this error. It will be non-nil because the query mock does not return any data.
@@ -201,7 +203,7 @@ func testWriteReadSeriesTestRun(t *testing.T, cfg WriteReadSeriesTestConfig, tes
 		client.On("Metadata", mock.Anything, mock.Anything).Return(v1.Metadata{}, nil)
 
 		reg := prometheus.NewPedanticRegistry()
-		test := NewWriteReadSeriesTest(cfg, client, logger, reg)
+		test := NewWriteReadSeriesTest(cfg, client, writeProtocolDefault, logger, reg)
 
 		for _, tt := range testTuples {
 			records := tt.getMetricHistory(test)
@@ -246,7 +248,7 @@ func testWriteReadSeriesTestRun(t *testing.T, cfg WriteReadSeriesTestConfig, tes
 		client.On("Metadata", mock.Anything, mock.Anything).Return(v1.Metadata{}, nil)
 
 		reg := prometheus.NewPedanticRegistry()
-		test := NewWriteReadSeriesTest(cfg, client, logger, reg)
+		test := NewWriteReadSeriesTest(cfg, client, writeProtocolDefault, logger, reg)
 
 		for _, tt := range testTuples {
 			records := tt.getMetricHistory(test)
@@ -277,7 +279,7 @@ func testWriteReadSeriesTestRun(t *testing.T, cfg WriteReadSeriesTestConfig, tes
 		client.On("Metadata", mock.Anything, mock.Anything).Return(v1.Metadata{}, nil)
 
 		reg := prometheus.NewPedanticRegistry()
-		test := NewWriteReadSeriesTest(cfg, client, logger, reg)
+		test := NewWriteReadSeriesTest(cfg, client, writeProtocolDefault, logger, reg)
 
 		for _, tt := range testTuples {
 			records := tt.getMetricHistory(test)
@@ -310,7 +312,7 @@ func testWriteReadSeriesTestRun(t *testing.T, cfg WriteReadSeriesTestConfig, tes
 		client.On("Metadata", mock.Anything, mock.Anything).Return(v1.Metadata{}, nil)
 
 		reg := prometheus.NewPedanticRegistry()
-		test := NewWriteReadSeriesTest(cfg, client, logger, reg)
+		test := NewWriteReadSeriesTest(cfg, client, writeProtocolDefault, logger, reg)
 
 		for _, tt := range testTuples {
 			records := tt.getMetricHistory(test)
@@ -361,7 +363,7 @@ func testWriteReadSeriesTestRun(t *testing.T, cfg WriteReadSeriesTestConfig, tes
 			}, nil)
 		}
 		if cfg.WithHistograms {
-			for _, histProfile := range histogramProfiles {
+			for _, histProfile := range histogramProfilesForWriteProtocol(writeProtocolDefault) {
 				md := histProfile.metadata[0]
 				client.On("Metadata", mock.Anything, histProfile.metricName).Return(v1.Metadata{
 					Type: v1.MetricType(strings.ToLower(md.Type.String())),
@@ -390,7 +392,7 @@ func testWriteReadSeriesTestRun(t *testing.T, cfg WriteReadSeriesTestConfig, tes
 		}
 
 		reg := prometheus.NewPedanticRegistry()
-		test := NewWriteReadSeriesTest(cfg, client, logger, reg)
+		test := NewWriteReadSeriesTest(cfg, client, writeProtocolDefault, logger, reg)
 
 		err := test.Run(context.Background(), now)
 		assert.NoError(t, err)
@@ -447,7 +449,7 @@ func testWriteReadSeriesTestRun(t *testing.T, cfg WriteReadSeriesTestConfig, tes
 		}
 
 		reg := prometheus.NewPedanticRegistry()
-		test := NewWriteReadSeriesTest(cfg, client, logger, reg)
+		test := NewWriteReadSeriesTest(cfg, client, writeProtocolDefault, logger, reg)
 
 		err := test.Run(context.Background(), now)
 		assert.Error(t, err)
@@ -508,7 +510,7 @@ func testWriteReadSeriesTestInit(t *testing.T, cfg WriteReadSeriesTestConfig, te
 		}
 
 		reg := prometheus.NewPedanticRegistry()
-		test := NewWriteReadSeriesTest(cfg, client, logger, reg)
+		test := NewWriteReadSeriesTest(cfg, client, writeProtocolDefault, logger, reg)
 
 		require.NoError(t, test.Init(context.Background(), now))
 
@@ -544,7 +546,7 @@ func testWriteReadSeriesTestInit(t *testing.T, cfg WriteReadSeriesTestConfig, te
 			}
 		}
 
-		test := NewWriteReadSeriesTest(cfg, client, logger, nil)
+		test := NewWriteReadSeriesTest(cfg, client, writeProtocolDefault, logger, nil)
 
 		require.NoError(t, test.Init(context.Background(), now))
 
@@ -578,7 +580,7 @@ func testWriteReadSeriesTestInit(t *testing.T, cfg WriteReadSeriesTestConfig, te
 			}
 		}
 
-		test := NewWriteReadSeriesTest(cfg, client, logger, nil)
+		test := NewWriteReadSeriesTest(cfg, client, writeProtocolDefault, logger, nil)
 
 		require.NoError(t, test.Init(context.Background(), now))
 
@@ -614,7 +616,7 @@ func testWriteReadSeriesTestInit(t *testing.T, cfg WriteReadSeriesTestConfig, te
 			}
 		}
 
-		test := NewWriteReadSeriesTest(cfg, client, logger, nil)
+		test := NewWriteReadSeriesTest(cfg, client, writeProtocolDefault, logger, nil)
 
 		require.NoError(t, test.Init(context.Background(), now))
 
@@ -643,7 +645,7 @@ func testWriteReadSeriesTestInit(t *testing.T, cfg WriteReadSeriesTestConfig, te
 			client.On("QueryRange", mock.Anything, tt.querySum(tt.metricName), now.Add(-48*time.Hour).Add(writeInterval), now.Add(-24*time.Hour), writeInterval, mock.Anything).Return(model.Matrix{{}}, nil)
 		}
 
-		test := NewWriteReadSeriesTest(cfg, client, logger, nil)
+		test := NewWriteReadSeriesTest(cfg, client, writeProtocolDefault, logger, nil)
 
 		require.NoError(t, test.Init(context.Background(), now))
 
@@ -683,7 +685,7 @@ func testWriteReadSeriesTestInit(t *testing.T, cfg WriteReadSeriesTestConfig, te
 			}
 		}
 
-		test := NewWriteReadSeriesTest(cfg, client, logger, nil)
+		test := NewWriteReadSeriesTest(cfg, client, writeProtocolDefault, logger, nil)
 
 		require.NoError(t, test.Init(context.Background(), now))
 
@@ -713,7 +715,7 @@ func testWriteReadSeriesTestInit(t *testing.T, cfg WriteReadSeriesTestConfig, te
 
 		testCfg := cfg
 		testCfg.MaxQueryAge = 2 * time.Hour
-		test := NewWriteReadSeriesTest(testCfg, client, logger, nil)
+		test := NewWriteReadSeriesTest(testCfg, client, writeProtocolDefault, logger, nil)
 
 		require.NoError(t, test.Init(context.Background(), now))
 
@@ -741,7 +743,7 @@ func testWriteReadSeriesTestInit(t *testing.T, cfg WriteReadSeriesTestConfig, te
 			}
 		}
 
-		test := NewWriteReadSeriesTest(cfg, client, logger, nil)
+		test := NewWriteReadSeriesTest(cfg, client, writeProtocolDefault, logger, nil)
 
 		require.NoError(t, test.Init(context.Background(), now))
 
@@ -761,7 +763,7 @@ func testWriteReadSeriesTestInit(t *testing.T, cfg WriteReadSeriesTestConfig, te
 			client.On("QueryRange", mock.Anything, tt.querySum(tt.metricName), now.Add(-24*time.Hour).Add(writeInterval), now, writeInterval, mock.Anything).Return(model.Matrix{}, errors.New("failed"))
 		}
 
-		test := NewWriteReadSeriesTest(cfg, client, logger, nil)
+		test := NewWriteReadSeriesTest(cfg, client, writeProtocolDefault, logger, nil)
 
 		require.NoError(t, test.Init(context.Background(), now))
 
@@ -790,7 +792,7 @@ func testWriteReadSeriesTestInit(t *testing.T, cfg WriteReadSeriesTestConfig, te
 			client.On("QueryRange", mock.Anything, tt.querySum(tt.metricName), now.Add(-48*time.Hour).Add(writeInterval), now.Add(-24*time.Hour), writeInterval, mock.Anything).Return(model.Matrix{{}}, errors.New("failed"))
 		}
 
-		test := NewWriteReadSeriesTest(cfg, client, logger, nil)
+		test := NewWriteReadSeriesTest(cfg, client, writeProtocolDefault, logger, nil)
 
 		require.NoError(t, test.Init(context.Background(), now))
 
@@ -824,7 +826,7 @@ func testWriteReadSeriesTestInit(t *testing.T, cfg WriteReadSeriesTestConfig, te
 			}
 		}
 
-		test := NewWriteReadSeriesTest(cfg, client, logger, nil)
+		test := NewWriteReadSeriesTest(cfg, client, writeProtocolDefault, logger, nil)
 
 		require.NoError(t, test.Init(context.Background(), now))
 
@@ -864,7 +866,7 @@ func testWriteReadSeriesTestInit(t *testing.T, cfg WriteReadSeriesTestConfig, te
 			}
 		}
 
-		test := NewWriteReadSeriesTest(cfg, client, logger, nil)
+		test := NewWriteReadSeriesTest(cfg, client, writeProtocolDefault, logger, nil)
 
 		require.NoError(t, test.Init(context.Background(), now))
 
@@ -898,7 +900,7 @@ func testWriteReadSeriesTestInit(t *testing.T, cfg WriteReadSeriesTestConfig, te
 			}
 		}
 
-		test := NewWriteReadSeriesTest(cfg, client, logger, nil)
+		test := NewWriteReadSeriesTest(cfg, client, writeProtocolDefault, logger, nil)
 
 		require.NoError(t, test.Init(context.Background(), now))
 
@@ -921,7 +923,7 @@ func TestWriteReadSeriesTest_getRangeQueryTimeRanges(t *testing.T) {
 	now := time.Unix(int64((10*24*time.Hour)+(2*time.Second)), 0)
 
 	t.Run("min/max query time has not been set yet", func(t *testing.T) {
-		test := NewWriteReadSeriesTest(cfg, newMockClient(), log.NewNopLogger(), nil)
+		test := NewWriteReadSeriesTest(cfg, newMockClient(), writeProtocolDefault, log.NewNopLogger(), nil)
 
 		actualRanges, actualInstants, err := test.getQueryTimeRanges(now, &test.floatMetric)
 		assert.Error(t, err)
@@ -930,7 +932,7 @@ func TestWriteReadSeriesTest_getRangeQueryTimeRanges(t *testing.T) {
 	})
 
 	t.Run("min/max query time is older than max age", func(t *testing.T) {
-		test := NewWriteReadSeriesTest(cfg, newMockClient(), log.NewNopLogger(), nil)
+		test := NewWriteReadSeriesTest(cfg, newMockClient(), writeProtocolDefault, log.NewNopLogger(), nil)
 		test.floatMetric.queryMinTime = now.Add(-cfg.MaxQueryAge).Add(-time.Minute)
 		test.floatMetric.queryMaxTime = now.Add(-cfg.MaxQueryAge).Add(-time.Minute)
 
@@ -941,7 +943,7 @@ func TestWriteReadSeriesTest_getRangeQueryTimeRanges(t *testing.T) {
 	})
 
 	t.Run("min query time = max query time", func(t *testing.T) {
-		test := NewWriteReadSeriesTest(cfg, newMockClient(), log.NewNopLogger(), nil)
+		test := NewWriteReadSeriesTest(cfg, newMockClient(), writeProtocolDefault, log.NewNopLogger(), nil)
 		test.floatMetric.queryMinTime = now.Add(-time.Minute)
 		test.floatMetric.queryMaxTime = now.Add(-time.Minute)
 
@@ -958,7 +960,7 @@ func TestWriteReadSeriesTest_getRangeQueryTimeRanges(t *testing.T) {
 	})
 
 	t.Run("min and max query time are within the last 1h", func(t *testing.T) {
-		test := NewWriteReadSeriesTest(cfg, newMockClient(), log.NewNopLogger(), nil)
+		test := NewWriteReadSeriesTest(cfg, newMockClient(), writeProtocolDefault, log.NewNopLogger(), nil)
 		test.floatMetric.queryMinTime = now.Add(-30 * time.Minute)
 		test.floatMetric.queryMaxTime = now.Add(-time.Minute)
 
@@ -979,7 +981,7 @@ func TestWriteReadSeriesTest_getRangeQueryTimeRanges(t *testing.T) {
 	})
 
 	t.Run("min and max query time are within the last 2h", func(t *testing.T) {
-		test := NewWriteReadSeriesTest(cfg, newMockClient(), log.NewNopLogger(), nil)
+		test := NewWriteReadSeriesTest(cfg, newMockClient(), writeProtocolDefault, log.NewNopLogger(), nil)
 		test.floatMetric.queryMinTime = now.Add(-90 * time.Minute)
 		test.floatMetric.queryMaxTime = now.Add(-80 * time.Minute)
 
@@ -1000,7 +1002,7 @@ func TestWriteReadSeriesTest_getRangeQueryTimeRanges(t *testing.T) {
 	})
 
 	t.Run("min query time is older than 24h", func(t *testing.T) {
-		test := NewWriteReadSeriesTest(cfg, newMockClient(), log.NewNopLogger(), nil)
+		test := NewWriteReadSeriesTest(cfg, newMockClient(), writeProtocolDefault, log.NewNopLogger(), nil)
 		test.floatMetric.queryMinTime = now.Add(-30 * time.Hour)
 		test.floatMetric.queryMaxTime = now.Add(-time.Minute)
 
@@ -1024,7 +1026,7 @@ func TestWriteReadSeriesTest_getRangeQueryTimeRanges(t *testing.T) {
 	})
 
 	t.Run("max query time is older than 24h but more recent than max query age", func(t *testing.T) {
-		test := NewWriteReadSeriesTest(cfg, newMockClient(), log.NewNopLogger(), nil)
+		test := NewWriteReadSeriesTest(cfg, newMockClient(), writeProtocolDefault, log.NewNopLogger(), nil)
 		test.floatMetric.queryMinTime = now.Add(-30 * time.Hour)
 		test.floatMetric.queryMaxTime = now.Add(-25 * time.Hour)
 
@@ -1045,7 +1047,7 @@ func TestWriteReadSeriesTest_getRangeQueryTimeRanges(t *testing.T) {
 		cfg := cfg
 		cfg.MaxQueryAge = 10 * time.Minute
 
-		test := NewWriteReadSeriesTest(cfg, newMockClient(), log.NewNopLogger(), nil)
+		test := NewWriteReadSeriesTest(cfg, newMockClient(), writeProtocolDefault, log.NewNopLogger(), nil)
 		test.floatMetric.queryMinTime = now.Add(-30 * time.Hour)
 		test.floatMetric.queryMaxTime = now.Add(-time.Minute)
 
@@ -1068,6 +1070,6 @@ func TestWriteReadSeriesTest_getRangeQueryTimeRanges(t *testing.T) {
 
 func newMockClient() *ClientMock {
 	client := &ClientMock{}
-	client.On("Protocol").Return("prometheus")
+	client.On("Protocol").Return(writeProtocolDefault)
 	return client
 }

--- a/pkg/distributor/otel.go
+++ b/pkg/distributor/otel.go
@@ -756,9 +756,11 @@ func (c *otlpMimirConverter) Err() error {
 	return nil
 }
 
-// TimeseriesToOTLPRequest is used in tests.
-// If you provide exemplars they will be placed on the first float or
-// histogram sample.
+// TimeseriesToOTLPRequest is used in tests to convert Prometheus types to OTEL types.
+//
+// If you provide exemplars they will be placed on the first float histogram sample.
+//
+// NOTE: This should not be called from production code besides continuoustest.
 func TimeseriesToOTLPRequest(timeseries []prompb.TimeSeries, metadata []mimirpb.MetricMetadata) pmetricotlp.ExportRequest {
 	d := pmetric.NewMetrics()
 

--- a/pkg/distributor/otel.go
+++ b/pkg/distributor/otel.go
@@ -821,6 +821,10 @@ func TimeseriesToOTLPRequest(timeseries []prompb.TimeSeries, metadata []mimirpb.
 			}
 			metric.ExponentialHistogram().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 			for i, histogram := range ts.Histograms {
+				if _, isFloatCount := histogram.Count.(*prompb.Histogram_CountFloat); isFloatCount {
+					panic(fmt.Sprintf("prometheus histograms with float counts cannot be converted to OTEL exponential histograms, this is a bug. histogram: %+v", histogram))
+				}
+
 				datapoint := metric.ExponentialHistogram().DataPoints().AppendEmpty()
 				datapoint.SetTimestamp(pcommon.Timestamp(histogram.Timestamp * time.Millisecond.Nanoseconds()))
 				datapoint.SetScale(histogram.Schema)

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -1465,7 +1465,7 @@ func (t *Mimir) initContinuousTest() (services.Service, error) {
 	}
 
 	t.ContinuousTestManager = continuoustest.NewManager(t.Cfg.ContinuousTest.Manager, util_log.Logger)
-	t.ContinuousTestManager.AddTest(continuoustest.NewWriteReadSeriesTest(t.Cfg.ContinuousTest.WriteReadSeriesTest, client, util_log.Logger, t.Registerer))
+	t.ContinuousTestManager.AddTest(continuoustest.NewWriteReadSeriesTest(t.Cfg.ContinuousTest.WriteReadSeriesTest, client, t.Cfg.ContinuousTest.Client.WriteProtocol, util_log.Logger, t.Registerer))
 	t.ContinuousTestManager.AddTest(continuoustest.NewIngestStorageRecordTest(t.Cfg.ContinuousTest.IngestStorageRecordTest, util_log.Logger, t.Registerer))
 	t.ContinuousTestManager.AddTest(continuoustest.NewWriteReadOOOTest(t.Cfg.ContinuousTest.WriteReadOOOTest, client, util_log.Logger, t.Registerer))
 

--- a/tools/doc-generator/parse/parser.go
+++ b/tools/doc-generator/parse/parser.go
@@ -23,7 +23,6 @@ import (
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/thanos-io/objstore/providers/s3"
 
-	"github.com/grafana/mimir/pkg/continuoustest"
 	asmodel "github.com/grafana/mimir/pkg/ingester/activeseries/model"
 	"github.com/grafana/mimir/pkg/ruler/notifier"
 	"github.com/grafana/mimir/pkg/storage/tsdb"
@@ -389,8 +388,6 @@ func getFieldCustomType(t reflect.Type) (string, bool) {
 	case reflect.TypeOf(asmodel.CustomTrackersConfig{}).String():
 		return "map of tracker name (string) to matcher (string)", true
 	case reflect.TypeOf(validation.LabelValueLengthOverLimitStrategy(0)).String():
-		return "string", true
-	case reflect.TypeOf(continuoustest.WriteProtocol("")).String():
 		return "string", true
 	default:
 		return "", false

--- a/tools/doc-generator/parse/parser.go
+++ b/tools/doc-generator/parse/parser.go
@@ -23,6 +23,7 @@ import (
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/thanos-io/objstore/providers/s3"
 
+	"github.com/grafana/mimir/pkg/continuoustest"
 	asmodel "github.com/grafana/mimir/pkg/ingester/activeseries/model"
 	"github.com/grafana/mimir/pkg/ruler/notifier"
 	"github.com/grafana/mimir/pkg/storage/tsdb"
@@ -388,6 +389,8 @@ func getFieldCustomType(t reflect.Type) (string, bool) {
 	case reflect.TypeOf(asmodel.CustomTrackersConfig{}).String():
 		return "map of tracker name (string) to matcher (string)", true
 	case reflect.TypeOf(validation.LabelValueLengthOverLimitStrategy(0)).String():
+		return "string", true
+	case reflect.TypeOf(continuoustest.WriteProtocol("")).String():
 		return "string", true
 	default:
 		return "", false


### PR DESCRIPTION
#### What this PR does

Fixes a crash when trying to a convert a Prometheus FloatHistogram type to an OTLP Histogram which would require extra conversion logic. However, it's never the case in production code that we _want_ to convert a Prometheus FloatHistogram to an OTLP type: we convert OTLP types to Prometheus types in the distributor, this was a test-only problem.

#### Which issue(s) this PR fixes or relates to

Fixes grafana/mimir-squad#3725

#### Checklist

- [X] Tests updated.
- [X] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to continuous-test tooling and test-only OTLP conversion guards; production ingest paths are unchanged aside from clearer panic on invalid test conversions.
> 
> **Overview**
> Fixes a **continuous-test crash** when native histogram tests run with **`otlp-http`**: float Prometheus histograms cannot be converted to OTLP, so the write-read-series test now picks histogram profiles from the configured **write protocol** and only runs **OTEL-compatible** (integer) histograms for OTLP.
> 
> Adds a typed **`WriteProtocol`** flag (`prometheus`, `prometheus2`, `otlp-http`) with validation, wires it into **`NewWriteReadSeriesTest`**, and documents that **`TimeseriesToOTLPRequest`** panics on float-count histograms (test/continuous-test only). Tests cover OTLP int histogram writes and float histogram panic behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a76b3ae78e1a9008eb36ce33eb1d9d1f0fb6cf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->