### PR TITLE
MQE: Avoid allocating FloatHistogram in CSE if possible

### DIFF
--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator.go
@@ -632,9 +632,17 @@ func (b *RangeVectorDuplicationBuffer) mergeStepData(stepData *types.RangeVector
 	for _, section := range [][]promql.HPoint{headH, tailH} {
 		for _, p := range section {
 			if histograms != nil && (histograms.Count() == 0 || p.T > lastH.T) {
-				_, err := histograms.Append(promql.HPoint{T: p.T, H: p.H.Copy()})
+				// Try to reuse an existing HPoint and FloatHistogram if possible.
+				dest, _, err := histograms.NextPoint()
 				if err != nil {
 					return bufferedRangeVectorStepData{}, err
+				}
+
+				dest.T = p.T
+				if dest.H != nil {
+					p.H.CopyTo(dest.H)
+				} else {
+					dest.H = p.H.Copy()
 				}
 			}
 		}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Follow up to https://github.com/grafana/mimir/pull/15412#discussion_r3285929293, try to avoid allocating a FloatHistogram when buffering HPoints for a series.

#### Which issue(s) this PR fixes or relates to

Related #15412

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving allocation optimization in MQE CSE buffering; no API or query semantics change.
> 
> **Overview**
> When **common subexpression elimination** merges histogram points into a shared per-series ring buffer in `mergeStepData`, it no longer always calls `Append` with `p.H.Copy()`.
> 
> It now uses `HPointRingBuffer.NextPoint()` to take the next slot, sets `dest.T`, and copies histogram data with `CopyTo(dest.H)` when a `FloatHistogram` already exists in that slot—allocating via `Copy()` only when `dest.H` is nil. This cuts redundant `FloatHistogram` allocations while buffering range-vector steps for duplicated inner operators.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee627b9c9461261b1ba208fd67b5ea21b9cc0d55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->