### PR TITLE
MQE: extend `OperatorEvaluationStats.AddSubRange` for subsets and wider source instances

### DIFF
--- a/pkg/streamingpromql/types/stats.go
+++ b/pkg/streamingpromql/types/stats.go
@@ -217,33 +217,39 @@ func (s *OperatorEvaluationStats) AddSingleStep(other *OperatorEvaluationStats) 
 //
 // This instance is modified in-place.
 //
-// The other instance's steps must align with a sub-range of this instance's steps.
+// The other instance's steps must align with this instance's steps. Steps outside the range of this instance's time range are ignored.
 //
-// Both instances must not have subsets.
+// Both instances must have the same number of subsets.
 func (s *OperatorEvaluationStats) AddSubRange(other *OperatorEvaluationStats) error {
-	if len(s.subsets) > 0 {
-		return errors.New("cannot add a sub-range to an OperatorEvaluationStats instance that has subsets")
-	}
-
-	if len(other.subsets) > 0 {
-		return errors.New("cannot add a sub-range from an OperatorEvaluationStats instance that has subsets")
+	if len(s.subsets) != len(other.subsets) {
+		return fmt.Errorf("cannot add a sub-range with %d subset(s) to an OperatorEvaluationStats instance with %d subset(s)", len(other.subsets), len(s.subsets))
 	}
 
 	if s.timeRange.StepCount > 1 && other.timeRange.StepCount > 1 && other.timeRange.IntervalMilliseconds != s.timeRange.IntervalMilliseconds {
 		return fmt.Errorf("cannot add a sub-range from an OperatorEvaluationStats instance with multiple steps and interval %v ms to another instance with multiple steps and interval %v ms", other.timeRange.IntervalMilliseconds, s.timeRange.IntervalMilliseconds)
 	}
 
-	if other.timeRange.StartT < s.timeRange.StartT || other.timeRange.EndT > s.timeRange.EndT {
-		return fmt.Errorf("cannot add a sub-range from an OperatorEvaluationStats instance with time range [%v, %v] to another instance with time range [%v, %v]", other.timeRange.StartT, other.timeRange.EndT, s.timeRange.StartT, s.timeRange.EndT)
-	}
-
 	firstIndexInThisInstance := s.timeRange.PointIndex(other.timeRange.StartT)
-	if s.timeRange.IndexTime(firstIndexInThisInstance) != other.timeRange.StartT {
+	if s.timeRange.IndexTime(firstIndexInThisInstance) != other.timeRange.StartT || s.timeRange.StartT > other.timeRange.EndT || s.timeRange.EndT < other.timeRange.StartT {
 		return fmt.Errorf("cannot add a sub-range from an OperatorEvaluationStats instance with time range [%v, %v] and interval %v ms to another instance with time range [%v, %v] and interval %v ms", other.timeRange.StartT, other.timeRange.EndT, other.timeRange.IntervalMilliseconds, s.timeRange.StartT, s.timeRange.EndT, s.timeRange.IntervalMilliseconds)
 	}
 
-	for otherIndex := range other.timeRange.StepCount {
-		s.allSeries.Add(firstIndexInThisInstance+int64(otherIndex), other.allSeries.samplesProcessedPerStep[otherIndex], other.allSeries.samplesReadIfSubsequentStep[otherIndex], other.allSeries.samplesReadIfFirstStep[otherIndex])
+	firstOtherIndex := int64(0)
+	lastOtherIndex := int64(other.timeRange.StepCount - 1)
+	if other.timeRange.StartT < s.timeRange.StartT {
+		firstOtherIndex = other.timeRange.PointIndex(s.timeRange.StartT)
+	}
+	if other.timeRange.EndT > s.timeRange.EndT {
+		lastOtherIndex = other.timeRange.PointIndex(s.timeRange.EndT)
+	}
+
+	for otherIndex := firstOtherIndex; otherIndex <= lastOtherIndex; otherIndex++ {
+		s.allSeries.Add(firstIndexInThisInstance+otherIndex, other.allSeries.samplesProcessedPerStep[otherIndex], other.allSeries.samplesReadIfSubsequentStep[otherIndex], other.allSeries.samplesReadIfFirstStep[otherIndex])
+
+		for subsetIdx, subset := range s.subsets {
+			otherSubset := other.subsets[subsetIdx]
+			subset.Add(firstIndexInThisInstance+otherIndex, otherSubset.samplesProcessedPerStep[otherIndex], otherSubset.samplesReadIfSubsequentStep[otherIndex], otherSubset.samplesReadIfFirstStep[otherIndex])
+		}
 	}
 
 	return nil

--- a/pkg/streamingpromql/types/stats.go
+++ b/pkg/streamingpromql/types/stats.go
@@ -229,8 +229,7 @@ func (s *OperatorEvaluationStats) AddSubRange(other *OperatorEvaluationStats) er
 		return fmt.Errorf("cannot add a sub-range from an OperatorEvaluationStats instance with multiple steps and interval %v ms to another instance with multiple steps and interval %v ms", other.timeRange.IntervalMilliseconds, s.timeRange.IntervalMilliseconds)
 	}
 
-	firstIndexInThisInstance := s.timeRange.PointIndex(other.timeRange.StartT)
-	if s.timeRange.IndexTime(firstIndexInThisInstance) != other.timeRange.StartT || s.timeRange.StartT > other.timeRange.EndT || s.timeRange.EndT < other.timeRange.StartT {
+	if s.timeRange.IndexTime(s.timeRange.PointIndex(other.timeRange.StartT)) != other.timeRange.StartT || s.timeRange.StartT > other.timeRange.EndT || s.timeRange.EndT < other.timeRange.StartT {
 		return fmt.Errorf("cannot add a sub-range from an OperatorEvaluationStats instance with time range [%v, %v] and interval %v ms to another instance with time range [%v, %v] and interval %v ms", other.timeRange.StartT, other.timeRange.EndT, other.timeRange.IntervalMilliseconds, s.timeRange.StartT, s.timeRange.EndT, s.timeRange.IntervalMilliseconds)
 	}
 
@@ -243,13 +242,17 @@ func (s *OperatorEvaluationStats) AddSubRange(other *OperatorEvaluationStats) er
 		lastOtherIndex = other.timeRange.PointIndex(s.timeRange.EndT)
 	}
 
+	nextIndexInThisInstance := s.timeRange.PointIndex(other.timeRange.IndexTime(firstOtherIndex))
+
 	for otherIndex := firstOtherIndex; otherIndex <= lastOtherIndex; otherIndex++ {
-		s.allSeries.Add(firstIndexInThisInstance+otherIndex, other.allSeries.samplesProcessedPerStep[otherIndex], other.allSeries.samplesReadIfSubsequentStep[otherIndex], other.allSeries.samplesReadIfFirstStep[otherIndex])
+		s.allSeries.Add(nextIndexInThisInstance, other.allSeries.samplesProcessedPerStep[otherIndex], other.allSeries.samplesReadIfSubsequentStep[otherIndex], other.allSeries.samplesReadIfFirstStep[otherIndex])
 
 		for subsetIdx, subset := range s.subsets {
 			otherSubset := other.subsets[subsetIdx]
-			subset.Add(firstIndexInThisInstance+otherIndex, otherSubset.samplesProcessedPerStep[otherIndex], otherSubset.samplesReadIfSubsequentStep[otherIndex], otherSubset.samplesReadIfFirstStep[otherIndex])
+			subset.Add(nextIndexInThisInstance, otherSubset.samplesProcessedPerStep[otherIndex], otherSubset.samplesReadIfSubsequentStep[otherIndex], otherSubset.samplesReadIfFirstStep[otherIndex])
 		}
+
+		nextIndexInThisInstance++
 	}
 
 	return nil

--- a/pkg/streamingpromql/types/stats.go
+++ b/pkg/streamingpromql/types/stats.go
@@ -217,9 +217,10 @@ func (s *OperatorEvaluationStats) AddSingleStep(other *OperatorEvaluationStats) 
 //
 // This instance is modified in-place.
 //
-// The other instance's steps must align with this instance's steps. Steps outside the range of this instance's time range are ignored.
+// An error is returned if the other instance's steps do not align with this instance's steps.
+// Steps outside the range of this instance's time range are ignored.
 //
-// Both instances must have the same number of subsets.
+// An error is returned if the instances have a different number of subsets.
 func (s *OperatorEvaluationStats) AddSubRange(other *OperatorEvaluationStats) error {
 	if len(s.subsets) != len(other.subsets) {
 		return fmt.Errorf("cannot add a sub-range with %d subset(s) to an OperatorEvaluationStats instance with %d subset(s)", len(other.subsets), len(s.subsets))

--- a/pkg/streamingpromql/types/stats_test.go
+++ b/pkg/streamingpromql/types/stats_test.go
@@ -711,6 +711,38 @@ func TestOperatorEvaluationStats_AddSubRange_Subsets(t *testing.T) {
 	require.Equal(t, []int64{0, 0, 222, 0}, destination.subsets[0].samplesReadIfFirstStep)
 }
 
+func TestOperatorEvaluationStats_AddSubRange_SingleStepDestination(t *testing.T) {
+	ctx := context.Background()
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
+
+	startT := timestamp.Time(0).Add(2 * time.Minute)
+	destination, err := NewOperatorEvaluationStats(ctx, NewInstantQueryTimeRange(startT), memoryConsumptionTracker, 0)
+	require.NoError(t, err)
+
+	source, err := NewOperatorEvaluationStats(ctx, NewRangeQueryTimeRange(startT.Add(-2*time.Minute), startT.Add(2*time.Minute), time.Minute), memoryConsumptionTracker, 0)
+	require.NoError(t, err)
+	source.allSeries.samplesProcessedPerStep[0] = 1
+	source.allSeries.samplesProcessedPerStep[1] = 2
+	source.allSeries.samplesProcessedPerStep[2] = 3
+	source.allSeries.samplesProcessedPerStep[3] = 4
+	source.allSeries.samplesProcessedPerStep[4] = 5
+	source.allSeries.samplesReadIfSubsequentStep[0] = 11
+	source.allSeries.samplesReadIfSubsequentStep[1] = 12
+	source.allSeries.samplesReadIfSubsequentStep[2] = 13
+	source.allSeries.samplesReadIfSubsequentStep[3] = 14
+	source.allSeries.samplesReadIfSubsequentStep[4] = 15
+	source.allSeries.samplesReadIfFirstStep[0] = 101
+	source.allSeries.samplesReadIfFirstStep[1] = 102
+	source.allSeries.samplesReadIfFirstStep[2] = 103
+	source.allSeries.samplesReadIfFirstStep[3] = 104
+	source.allSeries.samplesReadIfFirstStep[4] = 105
+
+	require.NoError(t, destination.AddSubRange(source))
+	require.Equal(t, []int64{3}, destination.allSeries.samplesProcessedPerStep)
+	require.Equal(t, []int64{13}, destination.allSeries.samplesReadIfSubsequentStep)
+	require.Equal(t, []int64{103}, destination.allSeries.samplesReadIfFirstStep)
+}
+
 func TestOperatorEvaluationStats_AddSubRange_ErrorCases(t *testing.T) {
 	create := func(timeRange QueryTimeRange, subsetCount int) *OperatorEvaluationStats {
 		ctx := context.Background()

--- a/pkg/streamingpromql/types/stats_test.go
+++ b/pkg/streamingpromql/types/stats_test.go
@@ -642,10 +642,73 @@ func TestOperatorEvaluationStats_AddSubRange(t *testing.T) {
 	singleStepSource.allSeries.samplesReadIfFirstStep[0] = 104
 
 	require.NoError(t, destination.AddSubRange(singleStepSource))
-	require.Equal(t, []int64{0, 1, 2, 3, 4, 0}, destination.allSeries.samplesProcessedPerStep)
-	require.Equal(t, []int64{0, 11, 12, 13, 14, 0}, destination.allSeries.samplesReadIfSubsequentStep)
-	require.Equal(t, []int64{0, 101, 102, 103, 104, 0}, destination.allSeries.samplesReadIfFirstStep)
+	require.Equal(t, []int64{0, 1, 2, 3, 0 + 4, 0}, destination.allSeries.samplesProcessedPerStep)
+	require.Equal(t, []int64{0, 11, 12, 13, 0 + 14, 0}, destination.allSeries.samplesReadIfSubsequentStep)
+	require.Equal(t, []int64{0, 101, 102, 103, 0 + 104, 0}, destination.allSeries.samplesReadIfFirstStep)
 
+	wideSource, err := NewOperatorEvaluationStats(ctx, NewRangeQueryTimeRange(startT.Add(-2*time.Minute), startT.Add(7*time.Minute), time.Minute), memoryConsumptionTracker, 0)
+	require.NoError(t, err)
+	wideSource.allSeries.samplesProcessedPerStep[0] = 1
+	wideSource.allSeries.samplesProcessedPerStep[1] = 2
+	wideSource.allSeries.samplesProcessedPerStep[2] = 3
+	wideSource.allSeries.samplesProcessedPerStep[3] = 4
+	wideSource.allSeries.samplesProcessedPerStep[4] = 5
+	wideSource.allSeries.samplesProcessedPerStep[5] = 6
+	wideSource.allSeries.samplesProcessedPerStep[6] = 7
+	wideSource.allSeries.samplesProcessedPerStep[7] = 8
+	wideSource.allSeries.samplesProcessedPerStep[8] = 9
+	wideSource.allSeries.samplesProcessedPerStep[9] = 10
+	wideSource.allSeries.samplesReadIfSubsequentStep[0] = 11
+	wideSource.allSeries.samplesReadIfSubsequentStep[1] = 12
+	wideSource.allSeries.samplesReadIfSubsequentStep[2] = 13
+	wideSource.allSeries.samplesReadIfSubsequentStep[3] = 14
+	wideSource.allSeries.samplesReadIfSubsequentStep[4] = 15
+	wideSource.allSeries.samplesReadIfSubsequentStep[5] = 16
+	wideSource.allSeries.samplesReadIfSubsequentStep[6] = 17
+	wideSource.allSeries.samplesReadIfSubsequentStep[7] = 18
+	wideSource.allSeries.samplesReadIfSubsequentStep[8] = 19
+	wideSource.allSeries.samplesReadIfSubsequentStep[9] = 20
+	wideSource.allSeries.samplesReadIfFirstStep[0] = 101
+	wideSource.allSeries.samplesReadIfFirstStep[1] = 102
+	wideSource.allSeries.samplesReadIfFirstStep[2] = 103
+	wideSource.allSeries.samplesReadIfFirstStep[3] = 104
+	wideSource.allSeries.samplesReadIfFirstStep[4] = 105
+	wideSource.allSeries.samplesReadIfFirstStep[5] = 106
+	wideSource.allSeries.samplesReadIfFirstStep[6] = 107
+	wideSource.allSeries.samplesReadIfFirstStep[7] = 108
+	wideSource.allSeries.samplesReadIfFirstStep[8] = 109
+	wideSource.allSeries.samplesReadIfFirstStep[9] = 110
+
+	require.NoError(t, destination.AddSubRange(wideSource))
+	require.Equal(t, []int64{0 + 3, 1 + 4, 2 + 5, 3 + 6, 4 + 7, 0 + 8}, destination.allSeries.samplesProcessedPerStep)
+	require.Equal(t, []int64{0 + 13, 11 + 14, 12 + 15, 13 + 16, 14 + 17, 0 + 18}, destination.allSeries.samplesReadIfSubsequentStep)
+	require.Equal(t, []int64{0 + 103, 101 + 104, 102 + 105, 103 + 106, 104 + 107, 0 + 108}, destination.allSeries.samplesReadIfFirstStep)
+}
+
+func TestOperatorEvaluationStats_AddSubRange_Subsets(t *testing.T) {
+	ctx := context.Background()
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
+
+	startT := timestamp.Time(0)
+	destination, err := NewOperatorEvaluationStats(ctx, NewRangeQueryTimeRange(startT, startT.Add(3*time.Minute), time.Minute), memoryConsumptionTracker, 1)
+	require.NoError(t, err)
+
+	source, err := NewOperatorEvaluationStats(ctx, NewInstantQueryTimeRange(startT.Add(2*time.Minute)), memoryConsumptionTracker, 1)
+	require.NoError(t, err)
+	source.allSeries.samplesProcessedPerStep[0] = 1
+	source.allSeries.samplesReadIfSubsequentStep[0] = 11
+	source.allSeries.samplesReadIfFirstStep[0] = 111
+	source.subsets[0].samplesProcessedPerStep[0] = 2
+	source.subsets[0].samplesReadIfSubsequentStep[0] = 22
+	source.subsets[0].samplesReadIfFirstStep[0] = 222
+
+	require.NoError(t, destination.AddSubRange(source))
+	require.Equal(t, []int64{0, 0, 1, 0}, destination.allSeries.samplesProcessedPerStep)
+	require.Equal(t, []int64{0, 0, 11, 0}, destination.allSeries.samplesReadIfSubsequentStep)
+	require.Equal(t, []int64{0, 0, 111, 0}, destination.allSeries.samplesReadIfFirstStep)
+	require.Equal(t, []int64{0, 0, 2, 0}, destination.subsets[0].samplesProcessedPerStep)
+	require.Equal(t, []int64{0, 0, 22, 0}, destination.subsets[0].samplesReadIfSubsequentStep)
+	require.Equal(t, []int64{0, 0, 222, 0}, destination.subsets[0].samplesReadIfFirstStep)
 }
 
 func TestOperatorEvaluationStats_AddSubRange_ErrorCases(t *testing.T) {
@@ -664,42 +727,27 @@ func TestOperatorEvaluationStats_AddSubRange_ErrorCases(t *testing.T) {
 		"receiver has no subsets, other does": {
 			receiver:      create(NewInstantQueryTimeRange(time.Now()), 0),
 			other:         create(NewInstantQueryTimeRange(time.Now()), 1),
-			expectedError: "cannot add a sub-range from an OperatorEvaluationStats instance that has subsets",
+			expectedError: "cannot add a sub-range with 1 subset(s) to an OperatorEvaluationStats instance with 0 subset(s)",
 		},
 		"receiver has subsets, other does not": {
 			receiver:      create(NewInstantQueryTimeRange(time.Now()), 1),
 			other:         create(NewInstantQueryTimeRange(time.Now()), 0),
-			expectedError: "cannot add a sub-range to an OperatorEvaluationStats instance that has subsets",
-		},
-		"both have subsets": {
-			receiver:      create(NewInstantQueryTimeRange(time.Now()), 1),
-			other:         create(NewInstantQueryTimeRange(time.Now()), 1),
-			expectedError: "cannot add a sub-range to an OperatorEvaluationStats instance that has subsets",
+			expectedError: "cannot add a sub-range with 0 subset(s) to an OperatorEvaluationStats instance with 1 subset(s)",
 		},
 		"both have multiple steps and a different interval": {
 			receiver:      create(NewRangeQueryTimeRange(timestamp.Time(1), timestamp.Time(50), time.Millisecond), 0),
 			other:         create(NewRangeQueryTimeRange(timestamp.Time(3), timestamp.Time(7), 2*time.Millisecond), 0),
 			expectedError: "cannot add a sub-range from an OperatorEvaluationStats instance with multiple steps and interval 2 ms to another instance with multiple steps and interval 1 ms",
 		},
-		"both have the same step, but other instance ends after receiver": {
-			receiver:      create(NewRangeQueryTimeRange(timestamp.Time(100), timestamp.Time(500), 10*time.Millisecond), 0),
-			other:         create(NewRangeQueryTimeRange(timestamp.Time(300), timestamp.Time(700), 10*time.Millisecond), 0),
-			expectedError: "cannot add a sub-range from an OperatorEvaluationStats instance with time range [300, 700] to another instance with time range [100, 500]",
-		},
 		"both have the same step, but other instance is entirely after receiver": {
 			receiver:      create(NewRangeQueryTimeRange(timestamp.Time(100), timestamp.Time(500), 10*time.Millisecond), 0),
 			other:         create(NewRangeQueryTimeRange(timestamp.Time(1000), timestamp.Time(1500), 10*time.Millisecond), 0),
-			expectedError: "cannot add a sub-range from an OperatorEvaluationStats instance with time range [1000, 1500] to another instance with time range [100, 500]",
-		},
-		"both have the same step, but other instance starts before receiver": {
-			receiver:      create(NewRangeQueryTimeRange(timestamp.Time(100), timestamp.Time(500), 10*time.Millisecond), 0),
-			other:         create(NewRangeQueryTimeRange(timestamp.Time(50), timestamp.Time(300), 10*time.Millisecond), 0),
-			expectedError: "cannot add a sub-range from an OperatorEvaluationStats instance with time range [50, 300] to another instance with time range [100, 500]",
+			expectedError: "cannot add a sub-range from an OperatorEvaluationStats instance with time range [1000, 1500] and interval 10 ms to another instance with time range [100, 500] and interval 10 ms",
 		},
 		"both have the same step, but other instance is entirely before receiver": {
 			receiver:      create(NewRangeQueryTimeRange(timestamp.Time(100), timestamp.Time(500), 10*time.Millisecond), 0),
 			other:         create(NewRangeQueryTimeRange(timestamp.Time(50), timestamp.Time(80), 10*time.Millisecond), 0),
-			expectedError: "cannot add a sub-range from an OperatorEvaluationStats instance with time range [50, 80] to another instance with time range [100, 500]",
+			expectedError: "cannot add a sub-range from an OperatorEvaluationStats instance with time range [50, 80] and interval 10 ms to another instance with time range [100, 500] and interval 10 ms",
 		},
 		"both have the same step and other instance is within receiver, but steps do not align": {
 			receiver:      create(NewRangeQueryTimeRange(timestamp.Time(100), timestamp.Time(500), 10*time.Millisecond), 0),


### PR DESCRIPTION
#### What this PR does

This PR modifies the `OperatorEvaluationStats.AddSubRange` to support subsets and support adding stats from a source that extends beyond the destination instance.

This has no user-facing impact, I've extracted this out of a larger future PR.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal streaming PromQL sample-stat aggregation only; behavior is expanded with focused unit tests and no described user-facing impact.
> 
> **Overview**
> **`OperatorEvaluationStats.AddSubRange`** now merges **per-subset** counters when source and destination share the same subset count, instead of rejecting any stats that use subsets.
> 
> Sources whose time range **extends past** the destination are allowed: only the overlapping, step-aligned window is added; steps outside the destination range are **ignored**. Validation still errors on misaligned steps, mismatched subset counts, and non-overlapping ranges.
> 
> Tests cover wide sources, subset merging, instant-query destinations, and updated error expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4278e8ccf3251b0804569406a959d8e17d7b0b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->