### PR TITLE
Fix flaky TestBackwardCompatibility store consistency check

### DIFF
--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -139,7 +139,9 @@ func runBackwardCompatibilityTest(t *testing.T, previousImage string, oldFlagsMa
 	compactor := e2emimir.NewCompactor("compactor", consul.NetworkHTTPEndpoint(), flags)
 	require.NoError(t, s.StartAndWaitReady(compactor))
 
-	checkQueries(t, consul, previousImage, flags, oldFlagsMapper, s, 1,
+	// series_1 and series_2 have been shipped to the storage as 2 distinct blocks (series_3 is still
+	// in the ingester), so the store-gateway is expected to load at least 2 blocks before querying.
+	checkQueries(t, consul, previousImage, flags, oldFlagsMapper, s, 1, 2,
 		[]instantQueryTest{
 			{
 				expr:           "series_1",
@@ -217,7 +219,9 @@ func runNewDistributorsCanPushToOldIngestersWithReplication(t *testing.T, previo
 	require.NoError(t, err)
 	require.Equal(t, 200, res.StatusCode)
 
-	checkQueries(t, consul, previousImage, flags, oldFlagsMapper, s, 3, []instantQueryTest{{
+	// No blocks have been shipped to the storage: all data is still in the ingesters, so the
+	// store-gateway is not expected to load any block.
+	checkQueries(t, consul, previousImage, flags, oldFlagsMapper, s, 3, 0, []instantQueryTest{{
 		time:           now,
 		expr:           "series_1",
 		expectedVector: expectedVector,
@@ -232,6 +236,7 @@ func checkQueries(
 	oldFlagsMapper e2emimir.FlagMapper,
 	s *e2e.Scenario,
 	numIngesters int,
+	expectedStoreGatewayBlocks int,
 	instantQueries []instantQueryTest,
 	remoteReadRequests []remoteReadRequestTest,
 ) {
@@ -295,6 +300,23 @@ func checkQueries(
 			require.NoError(t, querier.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
 				labels.MustNewMatcher(labels.MatchEqual, "name", "store-gateway-client"),
 				labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+
+			// Wait until the store-gateway has loaded the blocks before querying.
+			//
+			// The store-gateway switches to ACTIVE in the ring only after its initial block sync completes,
+			// but if that sync runs before the compactor has published the per-tenant bucket index, the
+			// missing bucket index is treated as a legit empty result: the store-gateway becomes ACTIVE
+			// having loaded zero blocks and only loads them on a later periodic sync. Since we start the
+			// compactor and the store-gateway at roughly the same time, the querier (which only waits for the
+			// store-gateway to be ACTIVE) may query in that window and fail the store consistency check
+			// ("err-mimir-store-consistency-check-failed").
+			//
+			// The number of loaded blocks may be higher than expectedStoreGatewayBlocks if the compactor has
+			// already compacted the source blocks into new ones (the source blocks are retained until the
+			// deletion delay elapses), so we only require that at least the expected number have been loaded.
+			if expectedStoreGatewayBlocks > 0 {
+				require.NoError(t, storeGateway.WaitSumMetricsWithOptions(e2e.GreaterOrEqual(float64(expectedStoreGatewayBlocks)), []string{"cortex_bucket_store_blocks_loaded"}, e2e.WaitMissingMetrics))
+			}
 
 			// Query the series.
 			for _, endpoint := range []string{queryFrontend.HTTPEndpoint(), querier.HTTPEndpoint()} {


### PR DESCRIPTION
#### What this PR does

Fixes a flaky failure in `TestBackwardCompatibility` (integration test).

`checkQueries()` started the query path and queried the series as soon as the querier saw the store-gateway `ACTIVE` in the ring.

The store-gateway switches to `ACTIVE` only after its initial block sync completes — but that is **not** enough to guarantee the relevant blocks are loaded. If the initial sync runs before the compactor has published the per-tenant bucket index, the missing bucket index is treated as a legit empty result (`bucketindex.ErrIndexNotFound` → 0 blocks, no error), so the initial sync completes having loaded zero blocks and the store-gateway becomes `ACTIVE` anyway. The blocks are then loaded only on a later periodic sync (`-blocks-storage.bucket-store.sync-interval`, 5s in the integration config).

Because the test starts the compactor and the store-gateway at roughly the same time, the querier could query in the window where the store-gateway is `ACTIVE` but has not yet loaded the blocks referenced by the (by then published) bucket index, failing the store consistency check (`err-mimir-store-consistency-check-failed`) and returning a 500.

The fix waits for the store-gateway to have loaded the expected blocks before querying, mirroring what the other block-querying integration tests (e.g. `querier_test.go`) already do.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - N/A, test-only change (`changelog-not-needed`).
