### PR TITLE
fix: ci: allow an empty set of images for backwards compat tests

### DIFF
--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -31,7 +31,7 @@ import (
 // If MIMIR_PREVIOUS_IMAGES is set to a JSON, it supports mapping flags for those versions,
 // see TestParsePreviousImageVersionOverrides for the JSON format to use.
 func previousVersionImages(t *testing.T) map[string]e2emimir.FlagMapper {
-	if overrides := previousImageVersionOverrides(t); len(overrides) > 0 {
+	if overrides, overridesSet := previousImageVersionOverrides(t); len(overrides) > 0 || overridesSet {
 		for key, mapper := range overrides {
 			overrides[key] = e2emimir.ChainFlagMappers(mapper, defaultPreviousVersionGlobalOverrides)
 		}
@@ -361,10 +361,16 @@ type remoteReadRequestTest struct {
 
 type testingLogger interface{ Logf(string, ...interface{}) }
 
-func previousImageVersionOverrides(t *testing.T) map[string]e2emimir.FlagMapper {
-	overrides, err := parsePreviousImageVersionOverrides(os.Getenv("MIMIR_PREVIOUS_IMAGES"), t)
+func previousImageVersionOverrides(t *testing.T) (overrides map[string]e2emimir.FlagMapper, overridesSet bool) {
+	envVal, present := os.LookupEnv("MIMIR_PREVIOUS_IMAGES")
+	if !present {
+		return nil, false
+	}
+
+	var err error
+	overrides, err = parsePreviousImageVersionOverrides(envVal, t)
 	require.NoError(t, err)
-	return overrides
+	return overrides, true
 }
 
 func parsePreviousImageVersionOverrides(env string, logger testingLogger) (map[string]e2emimir.FlagMapper, error) {


### PR DESCRIPTION
#### What this PR does

Allow overriding the images to test for backwards compatibility with an empty map of images. This allows us to skip backwards compabitility tests when we run them in GEM since there are no more public releases of GEM.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only integration harness behavior; no production runtime impact.
> 
> **Overview**
> Backward compatibility integration tests now treat **`MIMIR_PREVIOUS_IMAGES` being set** as an explicit override, even when it resolves to an **empty** image map (e.g. `{}` or an empty value). Previously, an empty override fell through to **`DefaultPreviousVersionImages`**, so CI could not skip those tests.
> 
> **`previousImageVersionOverrides`** now uses **`os.LookupEnv`** and returns an **`overridesSet`** flag; **`previousVersionImages`** uses overrides when **`len(overrides) > 0 || overridesSet`**, so GEM pipelines can run zero backward-compat subtests when there are no public prior releases to test against.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e88a25934b25b4877d3fcbff85dbfdff2ff250e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->