### PR TITLE
compactor: skip compaction job estimation in scheduler mode

### DIFF
--- a/pkg/compactor/blocks_cleaner.go
+++ b/pkg/compactor/blocks_cleaner.go
@@ -51,6 +51,7 @@ type BlocksCleanerConfig struct {
 	GetDeletionMarkersConcurrency int
 	UpdateBlocksConcurrency       int
 	CompactionBlockRanges         mimir_tsdb.DurationList // Used for estimating compaction jobs.
+	EstimateCompactionJobs        bool
 }
 
 type BlocksCleaner struct {
@@ -149,15 +150,17 @@ func NewBlocksCleaner(cfg BlocksCleanerConfig, bucketClient objstore.Bucket, own
 			Name: "cortex_bucket_index_last_successful_update_timestamp_seconds",
 			Help: "Timestamp of the last successful update of a tenant's bucket index.",
 		}, []string{"user"}),
+	}
 
-		bucketIndexCompactionJobs: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+	if cfg.EstimateCompactionJobs {
+		c.bucketIndexCompactionJobs = promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cortex_bucket_index_estimated_compaction_jobs",
 			Help: "Estimated number of compaction jobs based on latest version of bucket index.",
-		}, []string{"user", "type"}),
-		bucketIndexCompactionPlanningErrors: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		}, []string{"user", "type"})
+		c.bucketIndexCompactionPlanningErrors = promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "cortex_bucket_index_estimated_compaction_jobs_errors_total",
 			Help: "Total number of failed executions of compaction job estimation based on latest version of bucket index.",
-		}),
+		})
 	}
 
 	c.Service = services.NewTimerService(cfg.CleanupInterval, c.starting, c.ticker, c.stopping)
@@ -281,8 +284,10 @@ func (c *BlocksCleaner) refreshOwnedUsers(ctx context.Context) (*ownedUsers, err
 			c.tenantMarkedBlocks.DeleteLabelValues(userID)
 			c.tenantPartialBlocks.DeleteLabelValues(userID)
 			c.tenantBucketIndexLastUpdate.DeleteLabelValues(userID)
-			c.bucketIndexCompactionJobs.DeleteLabelValues(userID, string(stageSplit))
-			c.bucketIndexCompactionJobs.DeleteLabelValues(userID, string(stageMerge))
+			if c.cfg.EstimateCompactionJobs {
+				c.bucketIndexCompactionJobs.DeleteLabelValues(userID, string(stageSplit))
+				c.bucketIndexCompactionJobs.DeleteLabelValues(userID, string(stageMerge))
+			}
 		}
 	}
 	c.lastOwnedUsers = allUsers
@@ -391,8 +396,10 @@ func (c *BlocksCleaner) deleteUserMarkedForDeletion(ctx context.Context, userID 
 	c.tenantBlocks.DeleteLabelValues(userID)
 	c.tenantMarkedBlocks.DeleteLabelValues(userID)
 	c.tenantPartialBlocks.DeleteLabelValues(userID)
-	c.bucketIndexCompactionJobs.DeleteLabelValues(userID, string(stageSplit))
-	c.bucketIndexCompactionJobs.DeleteLabelValues(userID, string(stageMerge))
+	if c.cfg.EstimateCompactionJobs {
+		c.bucketIndexCompactionJobs.DeleteLabelValues(userID, string(stageSplit))
+		c.bucketIndexCompactionJobs.DeleteLabelValues(userID, string(stageMerge))
+	}
 
 	if deletedBlocks > 0 {
 		level.Info(userLogger).Log("msg", "deleted blocks for tenant marked for deletion", "deletedBlocks", deletedBlocks)
@@ -517,21 +524,22 @@ func (c *BlocksCleaner) cleanUser(ctx context.Context, userID string, userLogger
 	c.tenantPartialBlocks.WithLabelValues(userID).Set(float64(len(partials)))
 	c.tenantBucketIndexLastUpdate.WithLabelValues(userID).Set(float64(idx.UpdatedAt))
 
-	// Compute pending compaction jobs based on current index.
-	jobs, err := estimateCompactionJobsFromBucketIndex(ctx, userID, userBucket, idx, c.cfg.CompactionBlockRanges, c.cfgProvider)
-	if err != nil {
-		// When compactor is shutting down, we get context cancellation. There's no reason to report that as error.
-		if !errors.Is(err, context.Canceled) {
-			level.Error(userLogger).Log("msg", "failed to compute compaction jobs from bucket index for user", "err", err)
-			c.bucketIndexCompactionPlanningErrors.Inc()
-			c.bucketIndexCompactionJobs.DeleteLabelValues(userID, string(stageSplit))
-			c.bucketIndexCompactionJobs.DeleteLabelValues(userID, string(stageMerge))
-		}
-	} else {
-		splitJobs, mergeJobs := computeSplitAndMergeJobs(jobs)
+	if c.cfg.EstimateCompactionJobs {
+		jobs, err := estimateCompactionJobsFromBucketIndex(ctx, userID, userBucket, idx, c.cfg.CompactionBlockRanges, c.cfgProvider)
+		if err != nil {
+			// When compactor is shutting down, we get context cancellation. There's no reason to report that as error.
+			if !errors.Is(err, context.Canceled) {
+				level.Error(userLogger).Log("msg", "failed to compute compaction jobs from bucket index for user", "err", err)
+				c.bucketIndexCompactionPlanningErrors.Inc()
+				c.bucketIndexCompactionJobs.DeleteLabelValues(userID, string(stageSplit))
+				c.bucketIndexCompactionJobs.DeleteLabelValues(userID, string(stageMerge))
+			}
+		} else {
+			splitJobs, mergeJobs := computeSplitAndMergeJobs(jobs)
 
-		c.bucketIndexCompactionJobs.WithLabelValues(userID, string(stageSplit)).Set(float64(splitJobs))
-		c.bucketIndexCompactionJobs.WithLabelValues(userID, string(stageMerge)).Set(float64(mergeJobs))
+			c.bucketIndexCompactionJobs.WithLabelValues(userID, string(stageSplit)).Set(float64(splitJobs))
+			c.bucketIndexCompactionJobs.WithLabelValues(userID, string(stageMerge)).Set(float64(mergeJobs))
+		}
 	}
 
 	return nil

--- a/pkg/compactor/blocks_cleaner_test.go
+++ b/pkg/compactor/blocks_cleaner_test.go
@@ -108,6 +108,7 @@ func testBlocksCleanerWithOptions(t *testing.T, options testBlocksCleanerOptions
 		TenantCleanupDelay:            options.tenantDeletionDelay,
 		DeleteBlocksConcurrency:       1,
 		GetDeletionMarkersConcurrency: 1,
+		EstimateCompactionJobs:        true,
 	}
 
 	reg := prometheus.NewPedanticRegistry()
@@ -218,6 +219,19 @@ func testBlocksCleanerWithOptions(t *testing.T, options testBlocksCleanerOptions
 		"cortex_bucket_blocks_marked_for_deletion_count",
 		"cortex_bucket_blocks_partials_count",
 		"cortex_bucket_index_estimated_compaction_jobs",
+	))
+}
+
+func TestBlocksCleaner_ShouldNotRegisterCompactionJobMetricsWhenEstimationDisabled(t *testing.T) {
+	bucketClient, _ := mimir_testutil.PrepareFilesystemBucket(t)
+
+	reg := prometheus.NewPedanticRegistry()
+	_ = NewBlocksCleaner(BlocksCleanerConfig{EstimateCompactionJobs: false}, bucketClient, tsdb.AllUsers, newMockConfigProvider(), log.NewNopLogger(), reg)
+
+	// With estimation disabled neither the gauge nor the error counter are registered.
+	assert.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(""),
+		"cortex_bucket_index_estimated_compaction_jobs",
+		"cortex_bucket_index_estimated_compaction_jobs_errors_total",
 	))
 }
 
@@ -362,6 +376,7 @@ func TestBlocksCleaner_ShouldRemoveMetricsForTenantsNotBelongingAnymoreToTheShar
 		CleanupConcurrency:            1,
 		DeleteBlocksConcurrency:       1,
 		GetDeletionMarkersConcurrency: 1,
+		EstimateCompactionJobs:        true,
 	}
 
 	ctx := context.Background()
@@ -446,6 +461,7 @@ func TestBlocksCleaner_ShouldNotCleanupUserThatDoesntBelongToShardAnymore(t *tes
 		CleanupInterval:         time.Minute,
 		CleanupConcurrency:      1,
 		DeleteBlocksConcurrency: 1,
+		EstimateCompactionJobs:  true,
 	}
 
 	ctx := context.Background()

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -616,6 +616,7 @@ func (c *MultitenantCompactor) starting(ctx context.Context) error {
 		GetDeletionMarkersConcurrency: defaultGetDeletionMarkersConcurrency,
 		UpdateBlocksConcurrency:       c.compactorCfg.UpdateBlocksConcurrency,
 		CompactionBlockRanges:         c.compactorCfg.BlockRanges,
+		EstimateCompactionJobs:        !c.compactorCfg.SchedulerClientConfig.Enabled,
 	}, c.bucketClient, c.shardingStrategy.blocksCleanerOwnsUser, c.cfgProvider, c.parentLogger, c.registerer)
 
 	// Start blocks cleaner asynchronously, don't wait until initial cleanup is finished.


### PR DESCRIPTION
#### What this PR does

When the compactor scheduler is enabled there is more visibility into pending compaction jobs. The job estimation based on the bucket index is then unnecessary, so this allows skipping registering and computing the values for those metrics.

I'm not adding a changelog entry because the scheduler configuration is still hidden. I think we're nearing the point where that can no longer be the case soon.

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to scheduler mode (experimental); it only removes optional metrics and CPU from bucket-index job estimation, with no impact on block cleanup or compaction execution.
> 
> **Overview**
> Adds **`EstimateCompactionJobs`** on `BlocksCleanerConfig` so bucket-index–based compaction job estimation can be turned off. When disabled, the blocks cleaner no longer registers **`cortex_bucket_index_estimated_compaction_jobs`** / **`cortex_bucket_index_estimated_compaction_jobs_errors_total`**, skips **`estimateCompactionJobsFromBucketIndex`** during tenant cleanup, and avoids deleting those series on shard or tenant removal.
> 
> **`MultitenantCompactor`** sets **`EstimateCompactionJobs: !SchedulerClientConfig.Enabled`**, so compactor scheduler mode drops redundant work and metrics while the scheduler exposes pending jobs. Standalone mode is unchanged (estimation stays on). Tests set the flag explicitly where metrics are asserted and add coverage that the two metrics are absent when estimation is disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efc7d21007ca0c90949b36b840423886f63b2480. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->