### PR TITLE
ci: add missing persmissions in push-mimir-build-image

### DIFF
--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -11,6 +11,8 @@ name: Build and Push mimir-build-image
 on:
   pull_request:
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -122,6 +124,9 @@ jobs:
     needs:
       - prepare
     if: needs.prepare.outputs.need_to_build == 'true'
+    permissions:
+      contents: read
+      id-token: write
     uses: grafana/shared-workflows/.github/workflows/docker-build-push-multiarch.yml@638f24848a49edb0bd14f771b6dd37b4455f1591 # main
     with:
       context: mimir-build-image

--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr15666-af3c8c6257@sha256:b920e6b501babc3c328f6cfe28b7d509c38ee0c203c8c8342429b4b9069f77c0
+LATEST_BUILD_IMAGE_TAG ?= pr15677-44af42b3d1@sha256:6fd90bee91e497c4106cd1199ffa6db9b5284ac61722775d7a9cdd5a6b0747e5
 
 # TTY is parameterized to allow CI and scripts to run builds,
 # as it currently disallows TTY devices.


### PR DESCRIPTION
#### What this PR does

This PR adds missing `GITHUB_TOKEN` permissions in the "push-mimir-build-image" workflow, as spotted by the [CI comments][1]:

```
The workflow jobs listed below don't declare a permissions: block and may break when the organization's default GITHUB_TOKEN permissions are restricted to read-only.
```

This is required in preparation for updating the default `GITHUB_TOKEN` permissions across the Grafana org.

[1]: https://github.com/grafana/mimir/pull/15674#issuecomment-4700412706

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only permission hardening with no runtime or application logic changes; the Makefile tag bump is mechanical from the same workflow.
> 
> **Overview**
> Prepares the **push-mimir-build-image** workflow for Grafana org-wide read-only default `GITHUB_TOKEN` permissions by declaring explicit scopes instead of inheriting broad defaults.
> 
> The workflow now sets a top-level **`permissions: {}`** so jobs only get what they declare. The reusable **build-push-multiarch** job gains **`contents: read`** and **`id-token: write`** for registry push via OIDC. The **prepare** and **build_and_push** jobs already had job-level permissions; this fills the gap CI flagged.
> 
> The **`Makefile`** **`LATEST_BUILD_IMAGE_TAG`** update is the usual bot commit from this workflow after a new build image was produced for the PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e07a8569c753a0735e7b9af3b8be645c46d14a2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->