### PR TITLE
Ingester: grace-aware per-tenant TSDB head future metric and alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * [ENHANCEMENT] MQE: Respect the `Cache-Control: no-store` request header when caching intermediate results for range vector splitting. #15148
 * [ENHANCEMENT] Ingest storage: skip per-record tracing span and attribute allocations on the Kafka fetch path when the producer trace is not sampled. The producer's trace context is still extracted from record headers for every record. #15614
 * [ENHANCEMENET] Runtimeconfig: The HTTP client used to fetch runtime configurations from HTTP endpoints now has keep-alives disabled by default. New CLI flag `-runtime-config.http-client-disable-keep-alives` is enabled by default, an can be set to `false` in-order to re-enable keep-alives. #15695
+* [ENHANCEMENT] Ingester: Add the `cortex_ingester_tsdb_head_max_timestamp_too_far_in_future_seconds` per-tenant gauge, reporting the number of seconds by which a tenant's TSDB head max timestamp exceeds the furthest-into-the-future timestamp accepted for that tenant (now + `creation_grace_period`). It is only emitted while a tenant is in violation. #15684
 * [BUGFIX] Query-frontend: Fix `cardinality_analysis_max_results` being ignored when set higher than the default of 500. #15581
 * [BUGFIX] Ingest storage: Fix `KafkaProducer.ProduceSync()` returning a single result with a nil record when the context is canceled, instead of one result per input record (with the record set) as the underlying franz-go client does. #15199
 * [BUGFIX] Ingest storage: Fix `cortex_ingest_storage_reader_receive_delay_seconds` inflation by no longer setting the Kafka record `Timestamp` on the distributor side; the Kafka client now sets it at produce time. #15572
@@ -64,6 +65,7 @@
 * [ENHANCEMENT] Dashboards: Add the experimental streaming search API endpoints to the "Overview" per-endpoint query breakdown, and include the ingester `SearchLabelNames`/`SearchLabelValues` gRPC routes in the ingester panels of the "Reads", "Queries", and "Remote ruler reads" dashboards. #15571
 * [ENHANCEMENT] Dashboards: Add "p90 compaction delay by level" and "Store-gateway blocks queried by level" panels to the "Compaction" row of the "Compactor" dashboard. #15619
 * [BUGFIX] Dashboards: Fix the classic/ingest-storage split in the "Tenants", "Top tenants" and "Writes" dashboards so that selecting multiple clusters with a mix of architectures no longer drops the classic clusters' data. The `unless on (job)` filter against `cortex_partition_ring_partitions` now also matches on the cluster aggregation labels. #15400
+* [BUGFIX] Alerts: `MimirIngestedDataTooFarInTheFuture` now respects each tenant's `creation_grace_period` and reports the affected tenant in the `user` label, eliminating false positives for tenants configured with a large creation grace period. It alerts on the new per-tenant `cortex_ingester_tsdb_head_max_timestamp_too_far_in_future_seconds` metric instead of the global `cortex_ingester_tsdb_head_max_timestamp_seconds`. #XXXX
 
 ### Jsonnet
 

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -1683,22 +1683,24 @@ See [rollout-operator runbook](https://github.com/grafana/rollout-operator/blob/
 
 ### MimirIngestedDataTooFarInTheFuture
 
-This alert fires when one or more Mimir ingesters accepts a sample with timestamp that is too far in the future.
-This is typically a result of processing of corrupted message, and it can cause rejection of other samples with timestamp close to "now" (real-world time).
+This alert fires when a tenant's TSDB head in one or more Mimir ingesters holds samples whose timestamp is further into the future than that tenant's configured creation grace period allows.
+It can cause rejection of other samples with timestamp close to "now" (real-world time) for the affected tenant.
 
 How it **works**:
 
-- The metric exported by the ingester computes the maximum timestamp from all TSDBs open in the ingester.
-- The alert checks the metric and fires if the maximum timestamp is more than 1h in the future.
-- This alert doesn't respect the per-user creation grace period.
+- The ingester exports the per-tenant gauge `cortex_ingester_tsdb_head_max_timestamp_too_far_in_future_seconds`, set to the number of seconds by which a tenant's TSDB head max timestamp exceeds `now + creation_grace_period` for that tenant. It is only emitted while a tenant is in violation.
+- The alert fires when this gauge is `> 0` (sustained for 5m). The affected tenant is reported in the `user` label.
+- Because the limit is per-tenant, this alert respects each tenant's creation grace period: a tenant configured with a large `creation_grace_period` legitimately ingesting future-dated samples within that window does **not** trigger it.
+- Admission already rejects samples beyond `now + creation_grace_period` (in the distributor and ingester), so in normal operation the gauge stays at 0. It becomes positive mainly when a tenant's `creation_grace_period` was recently **reduced** below the spread of already-admitted data, or when older future-dated data re-enters the head (for example via WAL replay, head compaction, or a corrupted message).
 
 How to **investigate**
 
-- Find an affected ingester pod and connect to its http API. For example, using `kubectl port-forward <pod> 8080:80`.
-- Find the tenant with a bad sample on the ingester's tenants list, which you can get through the `/ingester/tenants` endpoint. The sample should display the warning "TSDB Head max timestamp too far in the future".
-- If there are no warnings, the sample is likely within the tenant's grace interval and the alert is a false positive.
+- The firing alert names the affected tenant in the `user` label. It is aggregated per tenant and does not carry a `pod` label; to find which ingesters hold the offending data, query `cortex_ingester_tsdb_head_max_timestamp_too_far_in_future_seconds{user="<tenant>"}`, which retains the `pod` label.
+- Connect to an affected ingester pod's http API. For example, using `kubectl port-forward <pod> 8080:80`.
+- Confirm the tenant on the ingester's tenants list, which you can get through the `/ingester/tenants` endpoint. The tenant displays the warning "TSDB Head max timestamp too far in the future" together with the grace interval and the head's max timestamp.
+- Check whether the tenant's `creation_grace_period` override was recently lowered. If the future data is in fact legitimate, widening the grace period back resolves the alert.
 
-If it's not a false positive:
+If the future-dated data is not legitimate:
 
 - Flush the tenant's data to blocks storage through the `/ingester/flush?wait=true&tenant=foo` endpoint.
 - Remove the tenant's directory on disk and restart the ingester.

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -272,14 +272,12 @@ spec:
               severity: warning
           - alert: MimirIngestedDataTooFarInTheFuture
             annotations:
-              message: Mimir ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has ingested samples with timestamps more than 1h in the future.
+              message: Mimir ingester in {{ $labels.cluster }}/{{ $labels.namespace }} has ingested samples for tenant {{ $labels.user }} with timestamps beyond the tenant's accepted future window (now + creation_grace_period); currently {{ $value | humanizeDuration }} beyond it.
               runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesteddatatoofarinthefuture
             expr: |
-              max by(cluster, namespace, pod) (
-                  cortex_ingester_tsdb_head_max_timestamp_seconds - time()
-                  and
-                  cortex_ingester_tsdb_head_max_timestamp_seconds > 0
-              ) > 60*60
+              max by(cluster, namespace, user) (
+                  cortex_ingester_tsdb_head_max_timestamp_too_far_in_future_seconds
+              ) > 0
             for: 5m
             labels:
               severity: warning

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -260,14 +260,12 @@ groups:
             severity: warning
         - alert: MimirIngestedDataTooFarInTheFuture
           annotations:
-            message: Mimir ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has ingested samples with timestamps more than 1h in the future.
+            message: Mimir ingester in {{ $labels.cluster }}/{{ $labels.namespace }} has ingested samples for tenant {{ $labels.user }} with timestamps beyond the tenant's accepted future window (now + creation_grace_period); currently {{ $value | humanizeDuration }} beyond it.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesteddatatoofarinthefuture
           expr: |
-            max by(cluster, namespace, instance) (
-                cortex_ingester_tsdb_head_max_timestamp_seconds - time()
-                and
-                cortex_ingester_tsdb_head_max_timestamp_seconds > 0
-            ) > 60*60
+            max by(cluster, namespace, user) (
+                cortex_ingester_tsdb_head_max_timestamp_too_far_in_future_seconds
+            ) > 0
           for: 5m
           labels:
             severity: warning

--- a/operations/mimir-mixin-compiled-gem/alerts.yaml
+++ b/operations/mimir-mixin-compiled-gem/alerts.yaml
@@ -260,14 +260,12 @@ groups:
             severity: warning
         - alert: MimirIngestedDataTooFarInTheFuture
           annotations:
-            message: GEM ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has ingested samples with timestamps more than 1h in the future.
+            message: GEM ingester in {{ $labels.cluster }}/{{ $labels.namespace }} has ingested samples for tenant {{ $labels.user }} with timestamps beyond the tenant's accepted future window (now + creation_grace_period); currently {{ $value | humanizeDuration }} beyond it.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesteddatatoofarinthefuture
           expr: |
-            max by(cluster, namespace, pod) (
-                cortex_ingester_tsdb_head_max_timestamp_seconds - time()
-                and
-                cortex_ingester_tsdb_head_max_timestamp_seconds > 0
-            ) > 60*60
+            max by(cluster, namespace, user) (
+                cortex_ingester_tsdb_head_max_timestamp_too_far_in_future_seconds
+            ) > 0
           for: 5m
           labels:
             severity: warning

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -260,14 +260,12 @@ groups:
             severity: warning
         - alert: MimirIngestedDataTooFarInTheFuture
           annotations:
-            message: Mimir ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has ingested samples with timestamps more than 1h in the future.
+            message: Mimir ingester in {{ $labels.cluster }}/{{ $labels.namespace }} has ingested samples for tenant {{ $labels.user }} with timestamps beyond the tenant's accepted future window (now + creation_grace_period); currently {{ $value | humanizeDuration }} beyond it.
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesteddatatoofarinthefuture
           expr: |
-            max by(cluster, namespace, pod) (
-                cortex_ingester_tsdb_head_max_timestamp_seconds - time()
-                and
-                cortex_ingester_tsdb_head_max_timestamp_seconds > 0
-            ) > 60*60
+            max by(cluster, namespace, user) (
+                cortex_ingester_tsdb_head_max_timestamp_too_far_in_future_seconds
+            ) > 0
           for: 5m
           labels:
             severity: warning

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -401,24 +401,23 @@ local utils = import 'mixin-utils/utils.libsonnet';
           },
         },
         {
-          // Alert if a ruler instance has no rule groups assigned while other instances in the same cell do.
+          // Alert when an ingester holds TSDB head data whose max timestamp is beyond the per-tenant
+          // accepted future window (now + creation_grace_period). The metric is only emitted while a
+          // tenant is in violation, so this respects each tenant's configured creation grace period.
           alert: $.alertName('IngestedDataTooFarInTheFuture'),
           'for': '5m',
           expr: |||
-            max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (
-                cortex_ingester_tsdb_head_max_timestamp_seconds - time()
-                and
-                cortex_ingester_tsdb_head_max_timestamp_seconds > 0
-            ) > 60*60
+            max by(%(alert_aggregation_labels)s, user) (
+                cortex_ingester_tsdb_head_max_timestamp_too_far_in_future_seconds
+            ) > 0
           ||| % {
             alert_aggregation_labels: $._config.alert_aggregation_labels,
-            per_instance_label: $._config.per_instance_label,
           },
           labels: {
             severity: 'warning',
           },
           annotations: {
-            message: '%(product)s ingester %(alert_instance_variable)s in %(alert_aggregation_variables)s has ingested samples with timestamps more than 1h in the future.' % $._config,
+            message: "%(product)s ingester in %(alert_aggregation_variables)s has ingested samples for tenant {{ $labels.user }} with timestamps beyond the tenant's accepted future window (now + creation_grace_period); currently {{ $value | humanizeDuration }} beyond it." % $._config,
           },
         },
         {

--- a/pkg/ingester/ingester_metrics_update.go
+++ b/pkg/ingester/ingester_metrics_update.go
@@ -228,6 +228,8 @@ func (i *Ingester) updateUsageStats() {
 }
 
 func (i *Ingester) updateLimitMetrics() {
+	nowMillis := time.Now().UnixMilli()
+
 	for _, userID := range i.getTSDBUsers() {
 		db := i.getTSDB(userID)
 		if db == nil {
@@ -246,5 +248,13 @@ func (i *Ingester) updateLimitMetrics() {
 
 		localLimit := i.limiter.maxSeriesPerUser(userID, minLocalSeriesLimit)
 		i.metrics.maxLocalSeriesPerUser.WithLabelValues(userID).Set(float64(localLimit))
+
+		// Report how far the head's max timestamp is beyond what the tenant's creation grace period
+		// allows. Only emitted while positive, so the series exists exactly for tenants in violation.
+		if excessMs := headMaxTimestampFutureExcessMillis(db.Head().MaxTime(), nowMillis, i.limits.CreationGracePeriod(userID)); excessMs > 0 {
+			i.metrics.headMaxTimestampTooFarInFuture.WithLabelValues(userID).Set(float64(excessMs) / 1000)
+		} else {
+			i.metrics.headMaxTimestampTooFarInFuture.DeleteLabelValues(userID)
+		}
 	}
 }

--- a/pkg/ingester/ingester_test.go
+++ b/pkg/ingester/ingester_test.go
@@ -12452,3 +12452,81 @@ func makeTestRW2WriteRequest(syms *rw2util.SymbolTableBuilder) *mimirpb.WriteReq
 
 	return req
 }
+
+func TestHeadMaxTimestampFutureExcessMillis(t *testing.T) {
+	const nowMs = int64(1_700_000_000_000)
+	const grace = time.Hour
+
+	for name, tc := range map[string]struct {
+		headMaxMs int64
+		grace     time.Duration
+		expected  int64
+	}{
+		"within grace":             {headMaxMs: nowMs + (30 * time.Minute).Milliseconds(), grace: grace, expected: -(30 * time.Minute).Milliseconds()},
+		"exactly at grace bound":   {headMaxMs: nowMs + grace.Milliseconds(), grace: grace, expected: 0},
+		"beyond grace":             {headMaxMs: nowMs + (90 * time.Minute).Milliseconds(), grace: grace, expected: (30 * time.Minute).Milliseconds()},
+		"head in the past":         {headMaxMs: nowMs - (10 * time.Minute).Milliseconds(), grace: grace, expected: -(70 * time.Minute).Milliseconds()},
+		"zero grace, sample now":   {headMaxMs: nowMs, grace: 0, expected: 0},
+		"zero grace, future":       {headMaxMs: nowMs + time.Minute.Milliseconds(), grace: 0, expected: time.Minute.Milliseconds()},
+		"empty head not in future": {headMaxMs: math.MinInt64, grace: grace, expected: 0},
+		// A head ~400 years ahead overflows an int64-nanosecond time.Duration but is correct in
+		// milliseconds; regression guard for the overflow this helper was changed to avoid.
+		"far future beyond ns range": {headMaxMs: nowMs + 400*365*24*time.Hour.Milliseconds(), grace: grace, expected: 400*365*24*time.Hour.Milliseconds() - time.Hour.Milliseconds()},
+	} {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.expected, headMaxTimestampFutureExcessMillis(tc.headMaxMs, nowMs, tc.grace))
+		})
+	}
+}
+
+func TestIngester_HeadMaxTimestampTooFarInFutureMetric(t *testing.T) {
+	const userID = "test-user"
+
+	cfg := defaultIngesterTestConfig(t)
+	// Pin the background limit-metrics updater far out so the test deterministically controls when
+	// updateLimitMetrics runs (we call it explicitly below).
+	cfg.limitMetricsUpdatePeriod = time.Hour
+
+	// Per-tenant limits we can mutate at runtime. Start with a generous creation grace period so the
+	// future-dated sample is accepted, then tighten it to reproduce the real trigger (grace reduced
+	// below already-admitted data).
+	defaults := defaultLimitsTestConfig()
+	tenantLimits := defaultLimitsTestConfig()
+	tenantLimits.CreationGracePeriod = model.Duration(2 * time.Hour)
+	override := validation.NewOverrides(defaults, validation.NewMockTenantLimits(map[string]*validation.Limits{userID: &tenantLimits}))
+
+	i, r, err := prepareIngesterWithBlockStorageAndOverrides(t, cfg, override, nil, "", "", nil)
+	require.NoError(t, err)
+	startAndWaitHealthy(t, i, r)
+
+	gauge := i.metrics.headMaxTimestampTooFarInFuture
+
+	// Admit a sample 30m in the future (within the 2h grace).
+	ctx := user.InjectOrgID(t.Context(), userID)
+	futureMs := time.Now().Add(30 * time.Minute).UnixMilli()
+	_, err = i.Push(ctx, mockWriteRequest(t, labels.FromStrings(model.MetricNameLabel, "test_metric"), 1, futureMs))
+	require.NoError(t, err)
+
+	// Within grace: the head is ahead of now but inside the tenant's 2h grace, so nothing is emitted.
+	i.updateLimitMetrics()
+	require.Equal(t, 0, testutil.CollectAndCount(gauge), "no series expected while the head is within the tenant's creation grace period")
+
+	// Tighten the grace to 5m: the already-admitted +30m sample now exceeds it, so the gauge appears.
+	tenantLimits.CreationGracePeriod = model.Duration(5 * time.Minute)
+	i.updateLimitMetrics()
+	require.Equal(t, 1, testutil.CollectAndCount(gauge))
+	require.InDelta(t, (25 * time.Minute).Seconds(), testutil.ToFloat64(gauge.WithLabelValues(userID)), 60,
+		"gauge should report ~ (30m head offset - 5m grace) seconds")
+
+	// Widen the grace again: the head is back within grace and the series is removed.
+	tenantLimits.CreationGracePeriod = model.Duration(2 * time.Hour)
+	i.updateLimitMetrics()
+	require.Equal(t, 0, testutil.CollectAndCount(gauge), "series should be removed once the head is within grace again")
+
+	// Re-trigger, then confirm per-tenant cleanup removes the series (TSDB close / tenant removal path).
+	tenantLimits.CreationGracePeriod = model.Duration(5 * time.Minute)
+	i.updateLimitMetrics()
+	require.Equal(t, 1, testutil.CollectAndCount(gauge))
+	i.metrics.deletePerUserMetrics(userID)
+	require.Equal(t, 0, testutil.CollectAndCount(gauge), "deletePerUserMetrics should remove the tenant's series")
+}

--- a/pkg/ingester/ingester_tsdb.go
+++ b/pkg/ingester/ingester_tsdb.go
@@ -583,6 +583,21 @@ func (i *Ingester) maxTsdbHeadTimestamp() float64 {
 	return float64(maxTime) / 1000
 }
 
+// headMaxTimestampFutureExcessMillis returns by how many milliseconds a TSDB head's max timestamp
+// is further into the future than the furthest-into-the-future timestamp we currently accept for
+// the tenant, i.e. (now + creationGracePeriod). A positive result means the head holds data beyond
+// what the tenant's grace period permits; zero or negative means it's within grace.
+//
+// It works in milliseconds rather than a time.Duration to avoid the int64-nanosecond overflow that
+// would occur for a head very far in the future.
+func headMaxTimestampFutureExcessMillis(headMaxMs, nowMs int64, creationGracePeriod time.Duration) int64 {
+	// An empty head reports math.MinInt64 as its max time; treat it as not in the future.
+	if headMaxMs == math.MinInt64 {
+		return 0
+	}
+	return headMaxMs - nowMs - creationGracePeriod.Milliseconds()
+}
+
 func (i *Ingester) closeAndDeleteIdleUserTSDBs(ctx context.Context) error {
 	for _, userID := range i.getTSDBUsers() {
 		if ctx.Err() != nil {

--- a/pkg/ingester/metrics.go
+++ b/pkg/ingester/metrics.go
@@ -65,6 +65,8 @@ type ingesterMetrics struct {
 	// Local limit metrics
 	maxLocalSeriesPerUser *prometheus.GaugeVec
 
+	headMaxTimestampTooFarInFuture *prometheus.GaugeVec
+
 	// Head compactions metrics.
 	compactionsTriggered                   prometheus.Counter
 	compactionsFailed                      prometheus.Counter
@@ -321,6 +323,12 @@ func newIngesterMetrics(
 			ConstLabels: map[string]string{"limit": "max_global_series_per_user"},
 		}, []string{"user"}),
 
+		headMaxTimestampTooFarInFuture: promauto.With(r).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "cortex_ingester_tsdb_head_max_timestamp_too_far_in_future_seconds",
+			Help: "Number of seconds by which a tenant's TSDB head max timestamp exceeds the furthest-into-the-future " +
+				"timestamp currently accepted for that tenant (now + creation_grace_period). Only emitted when positive.",
+		}, []string{"user"}),
+
 		// Not registered automatically, but only if activeSeriesEnabled is true.
 		activeSeriesPerUser: promauto.With(activeSeriesReg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "cortex_ingester_active_series",
@@ -455,6 +463,7 @@ func (m *ingesterMetrics) deletePerUserMetrics(userID string) {
 	m.discardedMetadataPerMetricMetadataLimit.DeleteLabelValues(userID)
 
 	m.maxLocalSeriesPerUser.DeleteLabelValues(userID)
+	m.headMaxTimestampTooFarInFuture.DeleteLabelValues(userID)
 	m.ownedSeriesPerUser.DeleteLabelValues(userID)
 	m.earlyCompactionNonOwnedSeriesTriggered.DeleteLabelValues(userID)
 	m.attributedActiveSeriesFailuresPerUser.DeleteLabelValues(userID)

--- a/pkg/ingester/tenants_http.go
+++ b/pkg/ingester/tenants_http.go
@@ -98,8 +98,8 @@ func (i *Ingester) TenantsHandler(w http.ResponseWriter, req *http.Request) {
 		maxMillis := db.Head().MaxTime()
 		s.MaxTime = formatMillisTime(maxMillis)
 
-		if delta := maxMillis - nowMillis; delta > s.FutureGracePeriod.Milliseconds() {
-			deltaDuration := time.Duration(delta) * time.Millisecond
+		if excessMs := headMaxTimestampFutureExcessMillis(maxMillis, nowMillis, s.FutureGracePeriod); excessMs > 0 {
+			deltaDuration := time.Duration(maxMillis-nowMillis) * time.Millisecond
 			warning := fmt.Sprintf("TSDB Head max timestamp too far in the future: %v", deltaDuration)
 			warnings = append(warnings, warning)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

The `MimirIngestedDataTooFarInTheFuture` alert compared the ingester-wide max TSDB head timestamp against a fixed 1h threshold, ignoring each tenant's `creation_grace_period`. Tenants legitimately configured with a large creation grace period therefore tripped the alert even though their future-dated samples were accepted as intended, producing recurring false positives.

Add a per-tenant gauge
`cortex_ingester_tsdb_head_max_timestamp_too_far_in_future_seconds`, reporting the seconds by which a tenant's TSDB head max timestamp exceeds now + `creation_grace_period`, emitted only while in violation. Re-key the alert to fire on this metric (> 0), grouped by tenant, so it respects per-tenant grace and names the offending tenant via the user label.

The condition is computed by a shared helper also used by the `/ingester/tenants` page warning, so the metric and the human-facing warning cannot drift; the helper guards the empty-head sentinel (`math.MinInt64`) to avoid emitting a bogus value.

Fixes #11928

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ingester observability and alerting behavior for future-dated samples; operators must deploy ingesters before relying on the new metric, but logic is additive with tests and runbook updates.
> 
> **Overview**
> Replaces the fixed **1h** `MimirIngestedDataTooFarInTheFuture` alert with a **per-tenant**, **creation-grace-period-aware** signal so tenants with large `creation_grace_period` no longer false-positive.
> 
> The ingester now exports **`cortex_ingester_tsdb_head_max_timestamp_too_far_in_future_seconds`** (only while a tenant’s head max timestamp exceeds `now + creation_grace_period`), updated from **`updateLimitMetrics`** and cleared on tenant metric cleanup. Shared helper **`headMaxTimestampFutureExcessMillis`** drives that gauge and the **`/ingester/tenants`** “too far in the future” warning so they stay aligned.
> 
> **Mimir mixin**, compiled alert bundles, Helm metamonitoring, **CHANGELOG**, and the **runbook** are updated: alert expression fires when the new gauge is **> 0**, grouped by **`user`** (not pod/instance), with revised messaging and investigation steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ae1950456848b06d36304008d891e2ba01ffb86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->