### PR TITLE
[release-3.0] fix: disable slow MQE test blocking CI

### DIFF
--- a/pkg/streamingpromql/benchmarks/comparison_test.go
+++ b/pkg/streamingpromql/benchmarks/comparison_test.go
@@ -92,6 +92,8 @@ func BenchmarkQuery(b *testing.B) {
 }
 
 func TestBothEnginesReturnSameResultsForBenchmarkQueries(t *testing.T) {
+	t.Skip("disabled because the time and resource usage is causing CI failures for very little value.")
+
 	metricSizes := []int{1, 100} // Don't bother with 2000 series test here: these test cases take a while and they're most interesting as benchmarks, not correctness tests.
 	q := createBenchmarkQueryable(t, metricSizes)
 	cases := TestCases(metricSizes)


### PR DESCRIPTION
#### What this PR does

Disable TestBothEnginesReturnSameResultsForBenchmarkQueries which is
known to be slow. The underlying performance issues are fixed in the
main branch so this isn't telling us anything.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that removes a heavy CI job; no production or query-engine behavior changes.
> 
> **Overview**
> Skips **`TestBothEnginesReturnSameResultsForBenchmarkQueries`** at the start of the test with a note that runtime and resource use are failing CI without enough benefit.
> 
> The test body is unchanged; it still compares Prometheus vs Mimir streaming PromQL results on benchmark queries when run locally. **BenchmarkQuery** and other tests in the same file are not affected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f23a586f8839c4e8581b0e019086fa750dd386f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->