### PR TITLE
Configure Renovate to automatically rebase build image PRs when other files in `mimir-build-image/` are modified

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -168,9 +168,9 @@
       ],
     },
     {
-      description: 'Automatically rebase all dependency update PRs touching mimir-build-image/Dockerfile, and ignore pushes from GitHub Actions with new image reference when considering if the PR is modified and can be rebased',
+      description: 'Automatically rebase all dependency update PRs touching the build image, and ignore pushes from GitHub Actions with new image reference when considering if the PR is modified and can be rebased',
       matchFileNames: [
-        'mimir-build-image/Dockerfile',
+        'mimir-build-image/**',
         'Makefile',
       ],
       rebaseWhen: 'behind-base-branch',


### PR DESCRIPTION
#### What this PR does

This PR extends the existing Renovate config for PRs that affect the build image to also allow rebasing PRs where files in `mimir-build-image/` are modified other than `Dockerfile`.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to Renovate matching; no runtime or CI logic changes.
> 
> **Overview**
> Renovate’s **auto-rebase** rule for build-image dependency PRs now matches **`mimir-build-image/**`** instead of only **`mimir-build-image/Dockerfile`**, while still including **`Makefile`**.
> 
> That keeps the same behavior—rebase when behind base and ignore **`mimir-github-bot`** image-reference commits—but applies when other files under the build image directory change, not just the Dockerfile. The package rule description was updated to say “the build image” instead of naming the Dockerfile only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5bc36fb9462ea51c371a93683d6c4bea6e8074e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->