### PR TITLE
ci: fix vendoring Slack notification by bumping send-slack-message to v3

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -765,20 +765,22 @@ jobs:
     steps:
       - name: Send Slack message for successful PR
         if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
-        uses: grafana/shared-workflows/actions/send-slack-message@7b628e7352c2dea057c565cc4fcd5564d5f396c0 #v1.0.0
+        uses: grafana/shared-workflows/actions/send-slack-message@551bc8d50017d3e95d5da3f8a4826e733a208dc0 # send-slack-message/v3.0.2
         with:
-          channel-id: C04AF91LPFX #mimir-ci-notifications
+          method: chat.postMessage
           payload: |
             {
+              "channel": "C04AF91LPFX",
               "text": ":happy-mac: *Automated vendoring of mimir-prometheus into Mimir has succeeded and is awaiting approval.*\n<!subteam^S03C2P8659U> please review <${{ github.event.pull_request.html_url }}|the PR>, then approve and merge it."
             }
       - name: Send Slack message for failed PR
         if: ${{ contains(needs.*.result, 'failure') }}
-        uses: grafana/shared-workflows/actions/send-slack-message@7b628e7352c2dea057c565cc4fcd5564d5f396c0 #v1.0.0
+        uses: grafana/shared-workflows/actions/send-slack-message@551bc8d50017d3e95d5da3f8a4826e733a208dc0 # send-slack-message/v3.0.2
         with:
-          channel-id: C04AF91LPFX #mimir-ci-notifications
+          method: chat.postMessage
           payload: |
             {
+              "channel": "C04AF91LPFX",
               "text": ":sadcomputer: *Automated vendoring of mimir-prometheus into Mimir has failed.*\n<!subteam^S03C2P8659U> please check <${{ github.event.pull_request.html_url }}|the PR> and <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|build logs> and coordinate fixes for any issues."
             }
 


### PR DESCRIPTION
The send-slack-notification-on-automated-vendoring job was failing with "Need to provide at least one botToken or webhookUrl" on mimir-prometheus vendoring PRs.

The job pinned send-slack-message@v1.0.0, which sources SLACK_BOT_TOKEN by calling get-vault-secrets@main (a floating ref) and reading the secret back from the job env. get-vault-secrets@main has since changed to no longer export secrets to the environment (exportEnv: false), so SLACK_BOT_TOKEN arrived empty at the Slack step even though OIDC/Vault auth succeeded.

Bump to send-slack-message/v3.0.2, which pins get-vault-secrets to a SHA and passes the token via step outputs instead of the env. v3 also changes the input API: drop channel-id/slack-message, add the required method input, and move the channel into the payload.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [N/A] Tests updated.
- [N/A] Documentation added.
- [N/A] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [N/A] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change for Slack notifications on labeled vendoring PRs; no application runtime impact.
> 
> **Overview**
> Fixes **automated mimir-prometheus vendoring Slack notifications** in `send-slack-notification-on-automated-vendoring` by upgrading **`send-slack-message` from v1.0.0 to v3.0.2** for both success and failure steps.
> 
> v3 restores a working **Slack bot token** path (pinned Vault secret fetch via step outputs instead of job env), which stopped working when the old action’s floating **`get-vault-secrets@main`** no longer exported `SLACK_BOT_TOKEN`.
> 
> The action inputs are updated to the v3 API: **`method: chat.postMessage`**, **`channel-id` removed**, and **`"channel": "C04AF91LPFX"`** added inside each JSON **`payload`** (message text unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7775fc1c3a53d4a461f6be55e8b99b0ea7dfd989. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->