### PR TITLE
[release-3.1] ci: add missing permissions in push-mimir-build-image

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, labeled, unlabeled]
 
+permissions:
+  contents: read         # actions/checkout
+  pull-requests: read    # `gh pr view --json labels` in the check-label step
+
 jobs:
   check-changelog:
     runs-on: ubuntu-latest

--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -11,6 +11,8 @@ name: Build and Push mimir-build-image
 on:
   pull_request:
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -122,6 +124,9 @@ jobs:
     needs:
       - prepare
     if: needs.prepare.outputs.need_to_build == 'true'
+    permissions:
+      contents: read
+      id-token: write
     uses: grafana/shared-workflows/.github/workflows/docker-build-push-multiarch.yml@638f24848a49edb0bd14f771b6dd37b4455f1591 # main
     with:
       context: mimir-build-image

--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr15659-b89cff175d@sha256:502782397a9f04bc474fffe3b5144e6ce7724988c8602762d8cd703cab5e2fab
+LATEST_BUILD_IMAGE_TAG ?= pr15702-2ffd7572c7@sha256:22bbf945197047109add595abb3afbb540a8461d73382b18f667ec803710c8a2
 
 # TTY is parameterized to allow CI and scripts to run builds,
 # as it currently disallows TTY devices.


### PR DESCRIPTION
Backport https://github.com/grafana/mimir/pull/15677 to release-3.1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI token scoping and a build-image tag pin; no runtime Mimir behavior is affected.
> 
> **Overview**
> Backports CI hardening to **release-3.1**: GitHub Actions workflows now default to **no workflow-wide permissions** and grant only what each job needs.
> 
> **Changelog Check** sets `permissions: {}` at the workflow level and limits the job to `contents: read` for checkout and label/changelog checks.
> 
> **Build and Push mimir-build-image** adds the same workflow default and gives the reusable **build-push-multiarch** job `contents: read` and `id-token: write` for registry push via OIDC (aligning with the existing permission model described in the workflow comments).
> 
> The diff also bumps **`LATEST_BUILD_IMAGE_TAG`** in the `Makefile` to a new `mimir-build-image` digest/tag (`pr15702-…`), consistent with an automated Makefile update from that workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9f77ef8c726d32b90dba036b6118b2f47f20540. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->