### PR TITLE
[release-3.0] ci: add missing permissions in push-mimir-build-image

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, labeled, unlabeled]
 
+permissions:
+  contents: read         # actions/checkout
+  pull-requests: read    # `gh pr view --json labels` in the check-label step
+
 jobs:
   check-changelog:
     runs-on: ubuntu-latest

--- a/.github/workflows/push-mimir-build-image.yml
+++ b/.github/workflows/push-mimir-build-image.yml
@@ -11,6 +11,8 @@ name: Build and Push mimir-build-image
 on:
   pull_request:
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -122,6 +124,9 @@ jobs:
     needs:
       - prepare
     if: needs.prepare.outputs.need_to_build == 'true'
+    permissions:
+      contents: read
+      id-token: write
     uses: grafana/shared-workflows/.github/workflows/docker-build-push-multiarch.yml@638f24848a49edb0bd14f771b6dd37b4455f1591 # main
     with:
       context: mimir-build-image

--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,7 @@ mimir-build-image/$(UPTODATE): mimir-build-image/*
 # All the boiler plate for building golang follows:
 SUDO := $(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 BUILD_IN_CONTAINER ?= true
-LATEST_BUILD_IMAGE_TAG ?= pr15660-d9dd7cb0f3@sha256:6ae6fc0ec2dc54f3df24d890dbdf9792b8516a847b10cda1727eec0b7b1c80b5
+LATEST_BUILD_IMAGE_TAG ?= pr15703-4639e689fb@sha256:0f454e21054557eb29738f15332a0a8b4448f631f8067c2d5e0dcba0c8c16c85
 
 # TTY is parameterized to allow CI and scripts to run builds,
 # as it currently disallows TTY devices.


### PR DESCRIPTION
Backport https://github.com/grafana/mimir/pull/15677 to release-3.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI workflow permissions and the default Docker build image reference; no Mimir runtime or application logic is modified.
> 
> **Overview**
> Backports CI hardening so workflows no longer rely on the default broad `GITHUB_TOKEN` scope.
> 
> **`changelog-check.yml`** and **`push-mimir-build-image.yml`** now set workflow-level `permissions: {}` and grant only what each job needs (e.g. `contents: read`, and for the multi-arch build job `id-token: write` for registry OIDC). The **`build-push-multiarch`** job explicitly adds those permissions so the shared Docker push workflow can authenticate to GAR.
> 
> The **`Makefile`** `LATEST_BUILD_IMAGE_TAG` default is bumped to a newer `mimir-build-image` tag/digest (`pr15703-…`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99e9e694108da1ac69a033f80112e10b874b3df7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->