### PR TITLE
Add integration test for vertical block compaction

### DIFF
--- a/integration/compactor_test.go
+++ b/integration/compactor_test.go
@@ -3,11 +3,13 @@
 package integration
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"testing"
 	"time"
@@ -181,6 +183,181 @@ func TestCompactBlocksContainingNativeHistograms(t *testing.T) {
 	}
 
 	require.Equal(t, expectedSeries, compactedSeries)
+}
+
+// TestCompactVerticallyOverlappingBlocks verifies that the compactor vertically
+// compacts multiple blocks that cover the same time range and contain the same
+// series, merging their samples into a single block. This exercises the
+// deduplicating vertical compaction path, which is distinct from the horizontal
+// compaction of adjacent time ranges covered by other tests.
+func TestCompactVerticallyOverlappingBlocks(t *testing.T) {
+	// Each source block carries the same single series, with samples at
+	// different timestamps within the same 2h compaction range, so the
+	// compactor has to merge them into one block with the union of samples.
+	const numBlocks = 3
+
+	s, err := e2e.NewScenario(networkName)
+	require.NoError(t, err)
+	defer s.Close()
+
+	// Start dependencies.
+	consul := e2edb.NewConsul()
+	minio := e2edb.NewMinio(9000, blocksBucketName)
+	require.NoError(t, s.StartAndWaitReady(consul, minio))
+
+	// inDir stages blocks we upload to the bucket; outDir stages blocks we
+	// download back after compaction.
+	inDir := t.TempDir()
+	outDir := t.TempDir()
+
+	bkt, err := s3.NewBucketClient(s3.Config{
+		Endpoint:        minio.HTTPEndpoint(),
+		Insecure:        true,
+		BucketName:      blocksBucketName,
+		AccessKeyID:     e2edb.MinioAccessKey,
+		SecretAccessKey: flagext.SecretWithValue(e2edb.MinioSecretKey),
+	}, "test", log.NewNopLogger())
+	require.NoError(t, err)
+	bktClient := bucket.NewPrefixedBucketClient(bkt, userID)
+	defer func() {
+		require.NoError(t, bktClient.Close())
+	}()
+
+	// All source blocks share this series. Each block contributes two samples
+	// at distinct, non-overlapping timestamps so the merged result is simply
+	// the union of all samples sorted by timestamp.
+	seriesLabels := labels.FromStrings("case", "vertical_compaction", "series", "a")
+
+	metas := make([]*block.Meta, 0, numBlocks)
+	var expectedSamples []test.Sample
+
+	for i := 0; i < numBlocks; i++ {
+		// Two samples per block, spaced so blocks overlap within the same 2h
+		// range but no two samples share a timestamp.
+		ts1 := int64(i*1000 + 100)
+		ts2 := int64(i*1000 + 200)
+
+		spec := block.SeriesSpec{
+			Labels: seriesLabels,
+			Chunks: []chunks.Meta{
+				must(chunks.ChunkFromSamples([]chunks.Sample{
+					test.Sample{TS: ts1, Val: float64(i) + 0.1},
+					test.Sample{TS: ts2, Val: float64(i) + 0.2},
+				})),
+			},
+		}
+
+		expectedSamples = append(expectedSamples,
+			test.Sample{TS: ts1, Val: float64(i) + 0.1},
+			test.Sample{TS: ts2, Val: float64(i) + 0.2},
+		)
+
+		meta, err := block.GenerateBlockFromSpec(inDir, []*block.SeriesSpec{&spec})
+		require.NoError(t, err)
+
+		_, err = block.Upload(context.Background(), log.NewNopLogger(), bktClient, filepath.Join(inDir, meta.ULID.String()), meta)
+		require.NoError(t, err)
+
+		metas = append(metas, meta)
+	}
+
+	// Start compactor.
+	compactor := e2emimir.NewCompactor("compactor", consul.NetworkHTTPEndpoint(), mergeFlags(BlocksStorageFlags(), BlocksStorageS3Flags()))
+	require.NoError(t, s.StartAndWaitReady(compactor))
+
+	// Wait for the compactor to run at least once.
+	require.NoError(t, compactor.WaitSumMetrics(e2e.Greater(0), "cortex_compactor_runs_completed_total"))
+
+	// Collect the blocks currently in the bucket.
+	var blocks []string
+	require.NoError(t, bktClient.Iter(context.Background(), "", func(name string) error {
+		baseName := filepath.Base(name)
+		if len(baseName) == ulid.EncodedSize {
+			blocks = append(blocks, filepath.Base(name))
+		}
+		return nil
+	}))
+
+	// Read back the samples of the series from every block that is not a
+	// source block marked for deletion. After vertical compaction there must
+	// be exactly one such block, and it must contain the union of all samples.
+	var compactedSeries []test.Series
+	compactedBlocks := 0
+
+	for _, blockID := range blocks {
+		require.NoError(t, block.Download(context.Background(), log.NewNopLogger(), bktClient, ulid.MustParseStrict(blockID), filepath.Join(outDir, blockID)))
+
+		if isMarkedForDeletionDueToCompaction(t, path.Join(outDir, blockID)) {
+			// The source blocks are marked for deletion but not deleted yet; skip them.
+			continue
+		}
+
+		compactedBlocks++
+
+		chkReader, err := chunks.NewDirReader(filepath.Join(outDir, blockID, block.ChunksDirname), nil)
+		require.NoError(t, err)
+
+		ixReader, err := index.NewFileReader(filepath.Join(outDir, blockID, block.IndexFilename), index.DecodePostingsRaw)
+		require.NoError(t, err)
+
+		n, v := index.AllPostingsKey()
+		all, err := ixReader.Postings(context.Background(), n, v)
+		require.NoError(t, err)
+
+		for p := ixReader.SortedPostings(all); p.Next(); {
+			var lbls labels.ScratchBuilder
+			var chks []chunks.Meta
+			var samples []test.Sample
+
+			require.NoError(t, ixReader.Series(p.At(), &lbls, &chks))
+
+			for _, c := range chks {
+				chunk, iter, err := chkReader.ChunkOrIterable(c)
+				require.NoError(t, err)
+				require.Nil(t, iter)
+				c.Chunk = chunk
+
+				it := c.Chunk.Iterator(nil)
+				for {
+					valType := it.Next()
+					if valType == chunkenc.ValNone {
+						break
+					} else if valType == chunkenc.ValFloat {
+						ts, val := it.At()
+						samples = append(samples, test.Sample{TS: ts, Val: val})
+					} else {
+						t.Error("Unexpected chunkenc.ValueType (we're expecting only floats): " + string(valType))
+					}
+				}
+				require.NoError(t, it.Err())
+			}
+
+			compactedSeries = append(compactedSeries, test.Series{Labels: lbls.Labels(), Samples: samples})
+		}
+
+		require.NoError(t, ixReader.Close())
+		require.NoError(t, chkReader.Close())
+
+		// The compacted block must be a newly created one, not any of the sources.
+		for _, m := range metas {
+			require.NotEqual(t, m.ULID.String(), blockID)
+		}
+	}
+
+	// Vertical compaction must collapse the overlapping source blocks into a
+	// single block holding exactly one series with all samples merged.
+	require.Equal(t, 1, compactedBlocks)
+	require.Len(t, compactedSeries, 1)
+	require.Equal(t, seriesLabels, compactedSeries[0].Labels)
+
+	// Compare samples independent of ordering: the merged block must contain
+	// exactly the union of samples, but the order in which we read them back
+	// across chunks is not part of the behavior under test.
+	sortByTS := func(a, b test.Sample) int { return cmp.Compare(a.TS, b.TS) }
+	gotSamples := compactedSeries[0].Samples
+	slices.SortFunc(gotSamples, sortByTS)
+	slices.SortFunc(expectedSamples, sortByTS)
+	require.Equal(t, expectedSamples, gotSamples)
 }
 
 func isMarkedForDeletionDueToCompaction(t *testing.T, blockPath string) bool {


### PR DESCRIPTION
**What this PR does**

This adds an integration test for the compactor that covers vertical compaction, addressing part of #108 (the compactor having little integration coverage).

The existing compactor integration test (TestCompactBlocksContainingNativeHistograms) covers horizontal compaction of native histogram blocks. This adds TestCompactVerticallyOverlappingBlocks, which uploads three blocks that all contain the same series within the same compaction range and asserts that the compactor merges them into a single block holding the union of the samples. That exercises the deduplicating vertical compaction path rather than the adjacent-range horizontal one.

The new test follows the same structure as the existing one (generate blocks from a spec, upload to MinIO, run the compactor, download the result and read the series back), so it reuses the same helpers and conventions.

**Which issue(s) this PR fixes or relates to**

Relates to #108

**Checklist**

- [x] Tests updated.
- [x] Documentation added. (not needed, test-only)
- [x] CHANGELOG.md updated. (not needed, test-only change with no user-facing impact)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production or runtime behavior modifications.
> 
> **Overview**
> Adds **`TestCompactVerticallyOverlappingBlocks`** in `integration/compactor_test.go` to cover **deduplicating vertical compaction**: three blocks with the same series in the same 2h range are uploaded to MinIO, the compactor runs, and the test asserts there is **one** surviving block whose float samples are the **union** of all sources (compared with timestamp sorting via `cmp` / `slices.SortFunc`).
> 
> This complements the existing native-histogram test, which targets **horizontal** compaction across adjacent ranges. Imports add `cmp` and `slices` only for the new assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7c6527c8b6de2ebf6e27043b1359be1d1fc3232. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->