### PR TITLE
[release-3.0] ci: Push images to GAR for Dockerhub mirroring

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -461,8 +461,12 @@ jobs:
           for f in built-images/**/images.tar; do
             tar xvf $f -C /tmp/images
           done
-      - name: Login to DockerHub
-        uses: grafana/shared-workflows/actions/dockerhub-login@13fb504e3bfe323c1188bf244970d94b2d336e86 # v1.0.1
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+      - name: Log into GAR
+        uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1
+        with:
+          registry: us-docker.pkg.dev
       - name: Push Docker Images
         run: |
-          ./.github/workflows/scripts/push-images.sh /tmp/images grafana/ $(make image-tag)
+          ./.github/workflows/scripts/push-images.sh /tmp/images us-docker.pkg.dev/grafanalabs-global/dockerhub-mimir-prod-mirror/ $(make image-tag)


### PR DESCRIPTION
Manually backport https://github.com/grafana/mimir/commit/0ff62949943505fcfd8aed8dc6ca68d17ad3e207 from https://github.com/grafana/mimir/pull/15442

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> It changes how release images are published; misconfigured GAR auth or registry path would break deploy pushes, though only CI/release plumbing is touched.
> 
> **Overview**
> The **deploy** job in `test-build-deploy.yml` no longer logs into Docker Hub or pushes to `grafana/`. It now authenticates to **Google Artifact Registry** (`setup-gcloud` + `login-to-gar`) and runs `push-images.sh` against `us-docker.pkg.dev/grafanalabs-global/dockerhub-mimir-prod-mirror/` so release images land in the GAR mirror used for Docker Hub mirroring.
> 
> This is a manual backport to **release-3.0** of the same CI change from main; runtime Mimir behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3b0ced86369fdf0023bafbc65449bb110844635. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->