### PR TITLE
feat(jsonnet): do not give the remote-evaluation ruler the blocks read path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,8 +72,8 @@
 * [CHANGE] Query-frontend: Increase default query-frontend cache size limit to 25MB. #14857
 * [CHANGE] Query-frontend: Increase memory requested and limit to 2GiB and 4GiB respectively. #15688
 * [CHANGE] Continuous-test: Don't explicitly set `tests.write-read-series-test.num-series` and `tests.write-read-series-test.max-query-age` to their default values. #15705
+* [CHANGE] Ruler: When remote rule evaluation is enabled, stop passing the now-unused store-gateway and blocks-storage client flags (`-store-gateway.sharding-ring.*`, `-store-gateway.tenant-shard-size*`, `-blocks-storage.bucket-store.*`, `-blocks-storage.<backend>.bucket-name`) to the ruler. Only deploy this once all ruler pods run a Mimir build that does not read blocks storage for a remote-evaluation ruler; dropping these flags against an older binary makes the ruler fall back to defaults and fail to start. #15717
 * [ENHANCEMENT] Updated rollout-operator jsonnet library to v0.38.0. #15328, #15626
-
 
 ### Documentation
 

--- a/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-custom-target-utilization-generated.yaml
@@ -962,13 +962,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.remote-timeout=10s
@@ -997,10 +990,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=
-        - -store-gateway.sharding-ring.replication-factor=3
-        - -store-gateway.sharding-ring.store=memberlist
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-autoscaling-generated.yaml
+++ b/operations/mimir-tests/test-autoscaling-generated.yaml
@@ -962,13 +962,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.remote-timeout=10s
@@ -997,10 +990,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=
-        - -store-gateway.sharding-ring.replication-factor=3
-        - -store-gateway.sharding-ring.store=memberlist
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-ingest-storage-auto-client-rack-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-auto-client-rack-generated.yaml
@@ -1362,13 +1362,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.remote-timeout=10s
@@ -1405,11 +1398,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=3
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-custom-stabilization-window-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-custom-stabilization-window-generated.yaml
@@ -1428,13 +1428,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -1474,12 +1467,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=3
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-multiple-triggers-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-multiple-triggers-generated.yaml
@@ -1352,13 +1352,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -1398,12 +1391,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=3
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-one-trigger-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-one-trigger-generated.yaml
@@ -1352,13 +1352,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -1398,12 +1391,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=3
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-ingest-storage-migration-step-0-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-0-generated.yaml
@@ -1345,13 +1345,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -1383,12 +1376,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=3
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-ingest-storage-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-1-generated.yaml
@@ -1416,13 +1416,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -1455,12 +1448,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=3
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
@@ -1405,13 +1405,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -1451,12 +1444,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=3
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
@@ -1405,13 +1405,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -1451,12 +1444,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=3
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-ingest-storage-migration-step-12-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-12-generated.yaml
@@ -1405,13 +1405,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -1451,12 +1444,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=3
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-2-generated.yaml
@@ -1424,13 +1424,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -1470,12 +1463,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=3
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-3-generated.yaml
@@ -1435,13 +1435,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -1481,12 +1474,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=3
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-4-generated.yaml
@@ -1434,13 +1434,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -1479,12 +1472,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=3
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-ingest-storage-migration-step-5a-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-5a-generated.yaml
@@ -1434,13 +1434,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -1479,12 +1472,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=3
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-ingest-storage-migration-step-5b-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-5b-generated.yaml
@@ -1434,13 +1434,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -1479,12 +1472,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=3
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-6-generated.yaml
@@ -1365,13 +1365,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -1410,12 +1403,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=3
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
@@ -1369,13 +1369,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -1415,12 +1408,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=3
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
@@ -1369,13 +1369,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -1415,12 +1408,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=3
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
@@ -1346,13 +1346,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -1392,12 +1385,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=3
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
@@ -1428,13 +1428,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -1474,12 +1467,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=3
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-multi-az-read-path-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-generated.yaml
@@ -3025,13 +3025,6 @@ spec:
                 - us-east-2a
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata-zone-a.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.remote-timeout=10s
@@ -3068,11 +3061,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=3
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1
@@ -3149,13 +3137,6 @@ spec:
                 - us-east-2b
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata-zone-b.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.remote-timeout=10s
@@ -3192,11 +3173,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=3
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-0-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-0-generated.yaml
@@ -1822,13 +1822,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -1867,12 +1860,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=3
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-1-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-1-generated.yaml
@@ -3195,13 +3195,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -3240,12 +3233,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=3
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2-generated.yaml
@@ -3244,13 +3244,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -3289,12 +3282,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=4
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2a-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2a-generated.yaml
@@ -3244,13 +3244,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -3289,12 +3282,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=4
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2b-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2b-generated.yaml
@@ -3244,13 +3244,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -3289,12 +3282,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=4
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2c-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2c-generated.yaml
@@ -3244,13 +3244,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -3289,12 +3282,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=4
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2d-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2d-generated.yaml
@@ -3244,13 +3244,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -3289,12 +3282,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=4
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2e-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2e-generated.yaml
@@ -3221,13 +3221,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -3266,12 +3259,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=4
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-2f-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-2f-generated.yaml
@@ -3221,13 +3221,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -3266,12 +3259,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=4
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-3-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-3-generated.yaml
@@ -3221,13 +3221,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -3266,12 +3259,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=4
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-4-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-4-generated.yaml
@@ -3221,13 +3221,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -3266,12 +3259,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=4
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-5-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-5-generated.yaml
@@ -3283,13 +3283,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -3328,12 +3321,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=4
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1
@@ -4344,13 +4331,6 @@ spec:
                 - us-east-2a
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata-zone-a.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -4389,12 +4369,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=4
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1
@@ -4471,13 +4445,6 @@ spec:
                 - us-east-2b
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata-zone-b.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -4516,12 +4483,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=4
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-6-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-6-generated.yaml
@@ -3283,13 +3283,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -3328,12 +3321,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=4
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1
@@ -4344,13 +4331,6 @@ spec:
                 - us-east-2a
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata-zone-a.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -4389,12 +4369,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=4
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1
@@ -4471,13 +4445,6 @@ spec:
                 - us-east-2b
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata-zone-b.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -4516,12 +4483,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=4
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-7-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-7-generated.yaml
@@ -4200,13 +4200,6 @@ spec:
                 - us-east-2a
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata-zone-a.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -4245,12 +4238,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=4
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1
@@ -4327,13 +4314,6 @@ spec:
                 - us-east-2b
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata-zone-b.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -4372,12 +4352,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=4
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-8-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-8-generated.yaml
@@ -3235,13 +3235,6 @@ spec:
                 - us-east-2a
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata-zone-a.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -3280,12 +3273,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=4
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1
@@ -3362,13 +3349,6 @@ spec:
                 - us-east-2b
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata-zone-b.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -3407,12 +3387,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=4
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-multi-az-read-path-migration-step-final-generated.yaml
+++ b/operations/mimir-tests/test-multi-az-read-path-migration-step-final-generated.yaml
@@ -3235,13 +3235,6 @@ spec:
                 - us-east-2a
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata-zone-a.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -3280,12 +3273,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=4
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1
@@ -3362,13 +3349,6 @@ spec:
                 - us-east-2b
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata-zone-b.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
@@ -3407,12 +3387,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=4
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
-        - -store-gateway.tenant-shard-size=3
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-query-scheduler-memberlist-ring-and-ruler-remote-evaluation-generated.yaml
@@ -1005,13 +1005,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.s3.bucket-name=blocks-bucket
         - -common.storage.backend=s3
         - -common.storage.s3.endpoint=s3.dualstack.eu-west-1.amazonaws.com
         - -distributor.health-check-ingesters=true
@@ -1041,10 +1034,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=
-        - -store-gateway.sharding-ring.replication-factor=3
-        - -store-gateway.sharding-ring.store=memberlist
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-range-vector-splitting-multi-zone-generated.yaml
+++ b/operations/mimir-tests/test-range-vector-splitting-multi-zone-generated.yaml
@@ -3129,13 +3129,6 @@ spec:
                 - us-east-2a
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata-zone-a.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.remote-timeout=10s
@@ -3172,11 +3165,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=3
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1
@@ -3253,13 +3241,6 @@ spec:
                 - us-east-2b
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata-zone-b.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.remote-timeout=10s
@@ -3296,11 +3277,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=multi-zone/
-        - -store-gateway.sharding-ring.replication-factor=3
-        - -store-gateway.sharding-ring.store=memberlist
-        - -store-gateway.sharding-ring.zone-awareness-enabled=true
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
+++ b/operations/mimir-tests/test-ruler-remote-evaluation-generated.yaml
@@ -966,13 +966,6 @@ spec:
     spec:
       containers:
       - args:
-        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
-        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
-        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
-        - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
         - -distributor.health-check-ingesters=true
         - -distributor.remote-timeout=10s
@@ -1001,10 +994,6 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
-        - -store-gateway.sharding-ring.heartbeat-timeout=10m
-        - -store-gateway.sharding-ring.prefix=
-        - -store-gateway.sharding-ring.replication-factor=3
-        - -store-gateway.sharding-ring.store=memberlist
         - -target=ruler
         - -usage-stats.installation-mode=jsonnet
         image: grafana/mimir:3.1.1

--- a/operations/mimir/multi-zone-ruler.libsonnet
+++ b/operations/mimir/multi-zone-ruler.libsonnet
@@ -36,9 +36,12 @@
     'ruler.query-frontend.address': 'dns:///ruler-query-frontend-zone-%(zone)s-headless.%(namespace)s.svc.%(cluster_domain)s:9095' % ($._config { zone: zone }),
   },
 
-  ruler_zone_a_args:: $.ruler_args + $.ruler_storage_zone_a_caching_config + $.blocks_metadata_zone_a_caching_config + rulerQueryFrontendClientZoneArgs('a'),
-  ruler_zone_b_args:: $.ruler_args + $.ruler_storage_zone_b_caching_config + $.blocks_metadata_zone_b_caching_config + rulerQueryFrontendClientZoneArgs('b'),
-  ruler_zone_c_args:: $.ruler_args + $.ruler_storage_zone_c_caching_config + $.blocks_metadata_zone_c_caching_config + rulerQueryFrontendClientZoneArgs('c'),
+  // Multi-zone rulers always evaluate rules remotely (they set -ruler.query-frontend.address below
+  // and multi-zone requires remote evaluation per the assert above), so they never query blocks
+  // directly and don't need the blocks metadata cache. The ruler-storage cache (for rules) is kept.
+  ruler_zone_a_args:: $.ruler_args + $.ruler_storage_zone_a_caching_config + rulerQueryFrontendClientZoneArgs('a'),
+  ruler_zone_b_args:: $.ruler_args + $.ruler_storage_zone_b_caching_config + rulerQueryFrontendClientZoneArgs('b'),
+  ruler_zone_c_args:: $.ruler_args + $.ruler_storage_zone_c_caching_config + rulerQueryFrontendClientZoneArgs('c'),
 
   ruler_zone_a_env_map:: {},
   ruler_zone_b_env_map:: {},

--- a/operations/mimir/multi-zone-store-gateway.libsonnet
+++ b/operations/mimir/multi-zone-store-gateway.libsonnet
@@ -61,7 +61,9 @@
 
   ruler_args+:: (
     // During the migration, if read path switch is enabled we need to apply changes directly to rulers instead of queryBlocksStorageConfig.
-    if !($._config.multi_zone_store_gateway_enabled && $._config.multi_zone_store_gateway_read_path_enabled && $._config.multi_zone_store_gateway_migration_enabled) then {} else {
+    // Skip this for a ruler that doesn't query store-gateways directly (remote rule evaluation).
+    if !($._config.multi_zone_store_gateway_enabled && $._config.multi_zone_store_gateway_read_path_enabled && $._config.multi_zone_store_gateway_migration_enabled)
+       || !$._config.ruler_evaluates_queries_locally then {} else {
       'store-gateway.sharding-ring.zone-awareness-enabled': 'true',
       'store-gateway.sharding-ring.prefix': 'multi-zone/',
     }

--- a/operations/mimir/ruler-remote-evaluation.libsonnet
+++ b/operations/mimir/ruler-remote-evaluation.libsonnet
@@ -4,6 +4,13 @@
     ruler_remote_evaluation_enabled: false,
     ruler_remote_evaluation_migration_enabled: false,
 
+    // True when the ruler evaluates rules locally and therefore reads blocks storage directly (the
+    // store-gateway ring + blocks object store). False when remote rule evaluation is enabled (and
+    // not mid-migration), where the ruler delegates queries to the ruler-query-frontend and needs
+    // none of the blocks read-path config. Components compose their blocks read-path flags onto the
+    // ruler only when this is true.
+    ruler_evaluates_queries_locally: !($._config.ruler_remote_evaluation_enabled && !$._config.ruler_remote_evaluation_migration_enabled),
+
     // The maximum size (in bytes) supported for a rule evaluation query response executed through
     // the ruler's dedicated read-path.
     ruler_remote_evaluation_max_query_response_size_bytes: 100 * 1024 * 1024,
@@ -12,7 +19,7 @@
   },
 
   local rulerQuerySchedulerName = 'ruler-query-scheduler',
-  local useRulerQueryFrontend = $._config.ruler_remote_evaluation_enabled && !$._config.ruler_remote_evaluation_migration_enabled,
+  local useRulerQueryFrontend = !$._config.ruler_evaluates_queries_locally,
 
   ruler_args+:: if !useRulerQueryFrontend then {} else {
     // Note: We use a headless service because the ruler uses gRPC load balancing.

--- a/operations/mimir/ruler.libsonnet
+++ b/operations/mimir/ruler.libsonnet
@@ -6,16 +6,22 @@
     $._config.usageStatsConfig +
     $._config.grpcConfig +
     $._config.storageConfig +
-    $._config.blocksStorageConfig +
     $._config.rulerStorageConfig +
     $._config.queryConfig +
     $._config.queryEngineConfig +
     $._config.ingesterRingClientConfig +
     $._config.rulerLimitsConfig +
-    $._config.queryBlocksStorageConfig +
-    $.blocks_metadata_caching_config +
     $.ruler_storage_caching_config +
-    $.bucket_index_config
+    (
+      // The ruler reads blocks storage (the store-gateway ring + blocks object store) only when it
+      // evaluates rules locally. With remote rule evaluation it delegates queries to the
+      // ruler-query-frontend, so it doesn't need the blocks read-path config at all.
+      if !$._config.ruler_evaluates_queries_locally then {} else
+        $._config.blocksStorageConfig +
+        $._config.queryBlocksStorageConfig +
+        $.blocks_metadata_caching_config +
+        $.bucket_index_config
+    ) +
     {
       target: 'ruler',
 

--- a/operations/mimir/shuffle-sharding.libsonnet
+++ b/operations/mimir/shuffle-sharding.libsonnet
@@ -253,11 +253,13 @@
       'querier.shuffle-sharding-ingesters-enabled': 'false',
     }
   ) + (
-    if !$._config.shuffle_sharding.store_gateway_enabled then {} else {
+    // Store-gateway shuffle sharding only matters to the ruler when it queries store-gateways, i.e.
+    // when it evaluates rules locally.
+    if !$._config.shuffle_sharding.store_gateway_enabled || !$._config.ruler_evaluates_queries_locally then {} else {
       'store-gateway.tenant-shard-size': $._config.shuffle_sharding.store_gateway_shard_size,
     }
   ) + (
-    if !$._config.shuffle_sharding.store_gateway_enabled || !$._config.shuffle_sharding.store_gateway_shard_size_per_zone_defaults_enabled then {} else {
+    if !$._config.shuffle_sharding.store_gateway_enabled || !$._config.shuffle_sharding.store_gateway_shard_size_per_zone_defaults_enabled || !$._config.ruler_evaluates_queries_locally then {} else {
       'store-gateway.tenant-shard-size-per-zone': $._config.shuffle_sharding.store_gateway_shard_size_per_zone,
     }
   ),


### PR DESCRIPTION
#### What this PR does

Companion to #15716. When remote rule evaluation is enabled the ruler no longer reads blocks storage, so the jsonnet should stop passing it the now-unused store-gateway and blocks-storage client flags.

- Gate the blocks-storage and store-gateway args on a new `_config.ruler_evaluates_queries_locally`, which is false under remote evaluation (except during migration).
- Drop `-store-gateway.sharding-ring.*`, `-store-gateway.tenant-shard-size*`, `-blocks-storage.bucket-store.*`, and `-blocks-storage.<backend>.bucket-name` from the remote-evaluation ruler.
- Keep `common.storage.backend`, `ruler-storage.*`, memberlist, and the rings.

**Deploy order:** only deploy this after all ruler pods run a Mimir build that includes #15716. Dropping these flags against an older binary makes the ruler fall back to the default store-gateway ring config and fail to start.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
