### PR TITLE
mimirtool: add optional partition-ring.key flag to partition-ring commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@
 ### Tools
 
 * [FEATURE] Copyblocks: add support for the block upload API as a copy destination. #15330
+* [ENHANCEMENT] Mimirtool: `partition-ring` subcommands now accept an optional `--partition-ring.key` flag to select the KV store key of the partition ring to operate on. It defaults to `ingester-partitions`. #15719
 * [ENHANCEMENT] Makefile: `build-mixin` and `mixin-screenshots` can now be configured to use native histograms for latency panels in dashboards. #15269
 
 ### Query-tee

--- a/docs/sources/mimir/manage/tools/mimirtool.md
+++ b/docs/sources/mimir/manage/tools/mimirtool.md
@@ -1259,6 +1259,7 @@ Forcefully adds one or more partitions to the partition ring.
 | `--memberlist.join`          | Required. Address of a memberlist node to join. Can be specified multiple times.                            |
 | `--memberlist.cluster-label` | The cluster label to use when joining the memberlist cluster.                                               |
 | `--memberlist.bind-port`     | Port to listen on for memberlist gossip messages. Default: `7946`. Use `0` to pick a random available port. |
+| `--partition-ring.key`       | The KV store key under which the partition ring is stored. Default: `ingester-partitions`.                  |
 | `--verbose`                  | Enable verbose logging.                                                                                     |
 
 ##### Example
@@ -1282,6 +1283,7 @@ Forcefully removes one or more partitions from the partition ring. A partition c
 | `--memberlist.join`          | Required. Address of a memberlist node to join. Can be specified multiple times.                            |
 | `--memberlist.cluster-label` | The cluster label to use when joining the memberlist cluster.                                               |
 | `--memberlist.bind-port`     | Port to listen on for memberlist gossip messages. Default: `7946`. Use `0` to pick a random available port. |
+| `--partition-ring.key`       | The KV store key under which the partition ring is stored. Default: `ingester-partitions`.                  |
 | `--verbose`                  | Enable verbose logging.                                                                                     |
 
 ##### Example
@@ -1305,6 +1307,7 @@ Forcefully adds one or more owners (ingester instances) to the partition ring, a
 | `--memberlist.join`          | Required. Address of a memberlist node to join. Can be specified multiple times.                            |
 | `--memberlist.cluster-label` | The cluster label to use when joining the memberlist cluster.                                               |
 | `--memberlist.bind-port`     | Port to listen on for memberlist gossip messages. Default: `7946`. Use `0` to pick a random available port. |
+| `--partition-ring.key`       | The KV store key under which the partition ring is stored. Default: `ingester-partitions`.                  |
 | `--verbose`                  | Enable verbose logging.                                                                                     |
 
 ##### Example
@@ -1328,6 +1331,7 @@ Forcefully removes one or more owners (ingester instances) from the partition ri
 | `--memberlist.join`          | Required. Address of a memberlist node to join. Can be specified multiple times.                            |
 | `--memberlist.cluster-label` | The cluster label to use when joining the memberlist cluster.                                               |
 | `--memberlist.bind-port`     | Port to listen on for memberlist gossip messages. Default: `7946`. Use `0` to pick a random available port. |
+| `--partition-ring.key`       | The KV store key under which the partition ring is stored. Default: `ingester-partitions`.                  |
 | `--verbose`                  | Enable verbose logging.                                                                                     |
 
 ##### Example

--- a/pkg/mimirtool/commands/partition_ring.go
+++ b/pkg/mimirtool/commands/partition_ring.go
@@ -235,7 +235,7 @@ About to add partition(s) %v with state '%s' to the ring.`, partitionIDs, state.
 	fmt.Fprintln(os.Stderr, "Successfully joined memberlist cluster.")
 
 	// Perform the CAS operation to add the partitions.
-	if err := addPartitions(ctx, kvClient, resolveRingKey(c.ringKey), partitionIDs, state); err != nil {
+	if err := addPartitions(ctx, kvClient, c.ringKey, partitionIDs, state); err != nil {
 		return err
 	}
 
@@ -272,7 +272,7 @@ About to remove partition(s) %v from the ring.`, partitionIDs)
 	fmt.Fprintln(os.Stderr, "Successfully joined memberlist cluster.")
 
 	// Perform the CAS operation to remove the partitions.
-	if err := removePartitions(ctx, kvClient, resolveRingKey(c.ringKey), partitionIDs); err != nil {
+	if err := removePartitions(ctx, kvClient, c.ringKey, partitionIDs); err != nil {
 		return err
 	}
 
@@ -374,7 +374,7 @@ About to add owner(s) %v to partition %d.`, ownerIDs, partitionID)
 	fmt.Fprintln(os.Stderr, "Successfully joined memberlist cluster.")
 
 	// Perform the CAS operation to add the owners.
-	if err := addOwners(ctx, kvClient, resolveRingKey(c.ringKey), ownerIDs, ring.OwnerActive, partitionID); err != nil {
+	if err := addOwners(ctx, kvClient, c.ringKey, ownerIDs, ring.OwnerActive, partitionID); err != nil {
 		return err
 	}
 
@@ -418,7 +418,7 @@ About to remove owner(s) %v from the ring.`, ownerIDs)
 	fmt.Fprintln(os.Stderr, "Successfully joined memberlist cluster.")
 
 	// Perform the CAS operation to remove the owners.
-	if err := removeOwners(ctx, kvClient, resolveRingKey(c.ringKey), ownerIDs); err != nil {
+	if err := removeOwners(ctx, kvClient, c.ringKey, ownerIDs); err != nil {
 		return err
 	}
 
@@ -512,15 +512,6 @@ func initMemberlistKV(ctx context.Context, joinAddrs []string, clusterLabel stri
 	}
 
 	return kvClient, cleanup, nil
-}
-
-// resolveRingKey returns the ring key to operate on, falling back to the default
-// (non-compartment) partition ring key when none is explicitly provided.
-func resolveRingKey(ringKey string) string {
-	if ringKey == "" {
-		return ingester.PartitionRingKey
-	}
-	return ringKey
 }
 
 func addPartitions(ctx context.Context, kvClient kv.Client, ringKey string, partitionIDs []int32, state ring.PartitionState) error {

--- a/pkg/mimirtool/commands/partition_ring.go
+++ b/pkg/mimirtool/commands/partition_ring.go
@@ -34,6 +34,7 @@ type AddPartitionCommand struct {
 	memberlistJoin         []string
 	memberlistClusterLabel string
 	memberlistBindPort     int
+	ringKey                string
 	partitionIDs           string
 	partitionState         string
 	verbose                bool
@@ -46,6 +47,7 @@ type RemovePartitionCommand struct {
 	memberlistJoin         []string
 	memberlistClusterLabel string
 	memberlistBindPort     int
+	ringKey                string
 	partitionIDs           string
 	verbose                bool
 	logger                 log.Logger
@@ -57,6 +59,7 @@ type AddOwnerCommand struct {
 	memberlistJoin         []string
 	memberlistClusterLabel string
 	memberlistBindPort     int
+	ringKey                string
 	ownerIDs               string
 	partitionID            string
 	verbose                bool
@@ -69,6 +72,7 @@ type RemoveOwnerCommand struct {
 	memberlistJoin         []string
 	memberlistClusterLabel string
 	memberlistBindPort     int
+	ringKey                string
 	ownerIDs               string
 	verbose                bool
 	logger                 log.Logger
@@ -164,12 +168,13 @@ func (c *PartitionRingCommand) Register(app *kingpin.Application, _ EnvVarNames,
 		memberlistJoin         *[]string
 		memberlistClusterLabel *string
 		memberlistBindPort     *int
+		ringKey                *string
 		verbose                *bool
 	}{
-		{addPartitionCmd, &addCmd.memberlistJoin, &addCmd.memberlistClusterLabel, &addCmd.memberlistBindPort, &addCmd.verbose},
-		{removePartitionCmd, &removeCmd.memberlistJoin, &removeCmd.memberlistClusterLabel, &removeCmd.memberlistBindPort, &removeCmd.verbose},
-		{addOwnerCmdClause, &addOwnerCmd.memberlistJoin, &addOwnerCmd.memberlistClusterLabel, &addOwnerCmd.memberlistBindPort, &addOwnerCmd.verbose},
-		{removeOwnerCmdClause, &removeOwnerCmd.memberlistJoin, &removeOwnerCmd.memberlistClusterLabel, &removeOwnerCmd.memberlistBindPort, &removeOwnerCmd.verbose},
+		{addPartitionCmd, &addCmd.memberlistJoin, &addCmd.memberlistClusterLabel, &addCmd.memberlistBindPort, &addCmd.ringKey, &addCmd.verbose},
+		{removePartitionCmd, &removeCmd.memberlistJoin, &removeCmd.memberlistClusterLabel, &removeCmd.memberlistBindPort, &removeCmd.ringKey, &removeCmd.verbose},
+		{addOwnerCmdClause, &addOwnerCmd.memberlistJoin, &addOwnerCmd.memberlistClusterLabel, &addOwnerCmd.memberlistBindPort, &addOwnerCmd.ringKey, &addOwnerCmd.verbose},
+		{removeOwnerCmdClause, &removeOwnerCmd.memberlistJoin, &removeOwnerCmd.memberlistClusterLabel, &removeOwnerCmd.memberlistBindPort, &removeOwnerCmd.ringKey, &removeOwnerCmd.verbose},
 	} {
 		cfg.cmd.Flag("memberlist.join", "Address of a memberlist node to join. Can be specified multiple times.").
 			Required().
@@ -182,6 +187,12 @@ func (c *PartitionRingCommand) Register(app *kingpin.Application, _ EnvVarNames,
 		cfg.cmd.Flag("memberlist.bind-port", "Port to listen on for memberlist gossip messages.").
 			Default("7946").
 			IntVar(cfg.memberlistBindPort)
+
+		// The ring key defaults to the default (non-compartment) partition ring. With compartments,
+		// each compartment has its own partition ring stored under a different key.
+		cfg.cmd.Flag("partition-ring.key", "The KV store key under which the partition ring is stored.").
+			Default(ingester.PartitionRingKey).
+			StringVar(cfg.ringKey)
 
 		cfg.cmd.Flag("verbose", "Enable verbose logging.").
 			Default("false").
@@ -224,7 +235,7 @@ About to add partition(s) %v with state '%s' to the ring.`, partitionIDs, state.
 	fmt.Fprintln(os.Stderr, "Successfully joined memberlist cluster.")
 
 	// Perform the CAS operation to add the partitions.
-	if err := addPartitions(ctx, kvClient, partitionIDs, state); err != nil {
+	if err := addPartitions(ctx, kvClient, resolveRingKey(c.ringKey), partitionIDs, state); err != nil {
 		return err
 	}
 
@@ -261,7 +272,7 @@ About to remove partition(s) %v from the ring.`, partitionIDs)
 	fmt.Fprintln(os.Stderr, "Successfully joined memberlist cluster.")
 
 	// Perform the CAS operation to remove the partitions.
-	if err := removePartitions(ctx, kvClient, partitionIDs); err != nil {
+	if err := removePartitions(ctx, kvClient, resolveRingKey(c.ringKey), partitionIDs); err != nil {
 		return err
 	}
 
@@ -363,7 +374,7 @@ About to add owner(s) %v to partition %d.`, ownerIDs, partitionID)
 	fmt.Fprintln(os.Stderr, "Successfully joined memberlist cluster.")
 
 	// Perform the CAS operation to add the owners.
-	if err := addOwners(ctx, kvClient, ownerIDs, ring.OwnerActive, partitionID); err != nil {
+	if err := addOwners(ctx, kvClient, resolveRingKey(c.ringKey), ownerIDs, ring.OwnerActive, partitionID); err != nil {
 		return err
 	}
 
@@ -407,7 +418,7 @@ About to remove owner(s) %v from the ring.`, ownerIDs)
 	fmt.Fprintln(os.Stderr, "Successfully joined memberlist cluster.")
 
 	// Perform the CAS operation to remove the owners.
-	if err := removeOwners(ctx, kvClient, ownerIDs); err != nil {
+	if err := removeOwners(ctx, kvClient, resolveRingKey(c.ringKey), ownerIDs); err != nil {
 		return err
 	}
 
@@ -503,8 +514,17 @@ func initMemberlistKV(ctx context.Context, joinAddrs []string, clusterLabel stri
 	return kvClient, cleanup, nil
 }
 
-func addPartitions(ctx context.Context, kvClient kv.Client, partitionIDs []int32, state ring.PartitionState) error {
-	return kvClient.CAS(ctx, ingester.PartitionRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
+// resolveRingKey returns the ring key to operate on, falling back to the default
+// (non-compartment) partition ring key when none is explicitly provided.
+func resolveRingKey(ringKey string) string {
+	if ringKey == "" {
+		return ingester.PartitionRingKey
+	}
+	return ringKey
+}
+
+func addPartitions(ctx context.Context, kvClient kv.Client, ringKey string, partitionIDs []int32, state ring.PartitionState) error {
+	return kvClient.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
 		ringDesc := ring.GetOrCreatePartitionRingDesc(in)
 
 		// First pass: validate ALL partitions before making any changes.
@@ -524,8 +544,8 @@ func addPartitions(ctx context.Context, kvClient kv.Client, partitionIDs []int32
 	})
 }
 
-func removePartitions(ctx context.Context, kvClient kv.Client, partitionIDs []int32) error {
-	return kvClient.CAS(ctx, ingester.PartitionRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
+func removePartitions(ctx context.Context, kvClient kv.Client, ringKey string, partitionIDs []int32) error {
+	return kvClient.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
 		ringDesc := ring.GetOrCreatePartitionRingDesc(in)
 
 		// First pass: validate ALL partitions before making any changes.
@@ -547,8 +567,8 @@ func removePartitions(ctx context.Context, kvClient kv.Client, partitionIDs []in
 	})
 }
 
-func addOwners(ctx context.Context, kvClient kv.Client, ownerIDs []string, state ring.OwnerState, partitionID int32) error {
-	return kvClient.CAS(ctx, ingester.PartitionRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
+func addOwners(ctx context.Context, kvClient kv.Client, ringKey string, ownerIDs []string, state ring.OwnerState, partitionID int32) error {
+	return kvClient.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
 		ringDesc := ring.GetOrCreatePartitionRingDesc(in)
 
 		// Validate the target partition exists before making any changes.
@@ -573,8 +593,8 @@ func addOwners(ctx context.Context, kvClient kv.Client, ownerIDs []string, state
 	})
 }
 
-func removeOwners(ctx context.Context, kvClient kv.Client, ownerIDs []string) error {
-	return kvClient.CAS(ctx, ingester.PartitionRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
+func removeOwners(ctx context.Context, kvClient kv.Client, ringKey string, ownerIDs []string) error {
+	return kvClient.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
 		ringDesc := ring.GetOrCreatePartitionRingDesc(in)
 
 		// First pass: validate ALL owners before making any changes.

--- a/pkg/mimirtool/commands/partition_ring_test.go
+++ b/pkg/mimirtool/commands/partition_ring_test.go
@@ -761,6 +761,48 @@ func TestRemoveOwnerCommand(t *testing.T) {
 	})
 }
 
+func TestPartitionRingCommand_CustomRingKey(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	const customRingKey = "ingester-partitions-compartment-1"
+
+	// Start a seed memberlist node.
+	seedKV, seedClient := startMemberlistKV(t)
+	seedAddr := net.JoinHostPort("127.0.0.1", strconv.Itoa(seedKV.GetListeningPort()))
+
+	// Add a partition under a custom ring key.
+	cmd := &AddPartitionCommand{
+		memberlistJoin:     []string{seedAddr},
+		memberlistBindPort: 0, // random port
+		ringKey:            customRingKey,
+		partitionIDs:       "0",
+		partitionState:     "active",
+		stdin:              strings.NewReader("yes\n"),
+		logger:             log.NewNopLogger(),
+	}
+	require.NoError(t, cmd.run())
+
+	// Verify the partition was added under the custom ring key.
+	require.Eventually(t, func() bool {
+		val, err := seedClient.Get(ctx, customRingKey)
+		if err != nil || val == nil {
+			return false
+		}
+		ringDesc, ok := val.(*ring.PartitionRingDesc)
+		return ok && ringDesc.HasPartition(0)
+	}, 5*time.Second, 100*time.Millisecond, "partition 0 should be added under the custom ring key")
+
+	// Verify nothing was written under the default ring key.
+	val, err := seedClient.Get(ctx, ingester.PartitionRingKey)
+	require.NoError(t, err)
+	if val != nil {
+		ringDesc, ok := val.(*ring.PartitionRingDesc)
+		require.True(t, ok)
+		require.False(t, ringDesc.HasPartition(0), "partition must not be added under the default ring key")
+	}
+}
+
 func TestParsePartitionIDs(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/mimirtool/commands/partition_ring_test.go
+++ b/pkg/mimirtool/commands/partition_ring_test.go
@@ -39,6 +39,7 @@ func TestAddPartitionCommand(t *testing.T) {
 		cmd := &AddPartitionCommand{
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0, // random port
+			ringKey:            ingester.PartitionRingKey,
 			partitionIDs:       "0",
 			partitionState:     "active",
 			stdin:              strings.NewReader("yes\n"),
@@ -90,6 +91,7 @@ func TestAddPartitionCommand(t *testing.T) {
 		cmd := &AddPartitionCommand{
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
+			ringKey:            ingester.PartitionRingKey,
 			partitionIDs:       "0",
 			partitionState:     "active",
 			stdin:              strings.NewReader("yes\n"),
@@ -123,6 +125,7 @@ func TestAddPartitionCommand(t *testing.T) {
 		cmd := &AddPartitionCommand{
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
+			ringKey:            ingester.PartitionRingKey,
 			partitionIDs:       "2",
 			partitionState:     "active",
 			stdin:              strings.NewReader("yes\n"),
@@ -160,6 +163,7 @@ func TestAddPartitionCommand(t *testing.T) {
 		cmd := &AddPartitionCommand{
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
+			ringKey:            ingester.PartitionRingKey,
 			partitionIDs:       "0, 1, 2",
 			partitionState:     "active",
 			stdin:              strings.NewReader("yes\n"),
@@ -206,6 +210,7 @@ func TestAddPartitionCommand(t *testing.T) {
 		cmd := &AddPartitionCommand{
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
+			ringKey:            ingester.PartitionRingKey,
 			partitionIDs:       "0,1,2",
 			partitionState:     "active",
 			stdin:              strings.NewReader("yes\n"),
@@ -223,6 +228,46 @@ func TestAddPartitionCommand(t *testing.T) {
 		require.False(t, ringDesc.HasPartition(0), "partition 0 should not be added when operation fails")
 		require.True(t, ringDesc.HasPartition(1), "partition 1 should still exist")
 		require.False(t, ringDesc.HasPartition(2), "partition 2 should not be added when operation fails")
+	})
+
+	t.Run("operates on the partition ring identified by the custom ring key", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+
+		const customRingKey = "custom-partition-ring"
+
+		// Start a seed memberlist node.
+		seedKV, seedClient := startMemberlistKV(t)
+		seedAddr := net.JoinHostPort("127.0.0.1", strconv.Itoa(seedKV.GetListeningPort()))
+
+		// Add a partition to the ring identified by the custom ring key.
+		cmd := &AddPartitionCommand{
+			memberlistJoin:     []string{seedAddr},
+			memberlistBindPort: 0,
+			ringKey:            customRingKey,
+			partitionIDs:       "0",
+			partitionState:     "active",
+			stdin:              strings.NewReader("yes\n"),
+			logger:             log.NewNopLogger(),
+		}
+		require.NoError(t, cmd.run())
+
+		// The partition is added under the custom ring key.
+		require.Eventually(t, func() bool {
+			val, err := seedClient.Get(ctx, customRingKey)
+			if err != nil || val == nil {
+				return false
+			}
+			ringDesc, ok := val.(*ring.PartitionRingDesc)
+			return ok && ringDesc.HasPartition(0)
+		}, 5*time.Second, 100*time.Millisecond, "partition 0 should be added under the custom ring key")
+
+		// The default ring key is left untouched.
+		val, err := seedClient.Get(ctx, ingester.PartitionRingKey)
+		require.NoError(t, err)
+		if val != nil {
+			require.False(t, val.(*ring.PartitionRingDesc).HasPartition(0), "partition must not be added under the default ring key")
+		}
 	})
 }
 
@@ -251,6 +296,7 @@ func TestRemovePartitionCommand(t *testing.T) {
 		cmd := &RemovePartitionCommand{
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0, // random port
+			ringKey:            ingester.PartitionRingKey,
 			partitionIDs:       "0",
 			stdin:              strings.NewReader("yes\n"),
 			logger:             log.NewNopLogger(),
@@ -287,6 +333,7 @@ func TestRemovePartitionCommand(t *testing.T) {
 		cmd := &RemovePartitionCommand{
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
+			ringKey:            ingester.PartitionRingKey,
 			partitionIDs:       "0",
 			stdin:              strings.NewReader("yes\n"),
 			logger:             log.NewNopLogger(),
@@ -321,6 +368,7 @@ func TestRemovePartitionCommand(t *testing.T) {
 		cmd := &RemovePartitionCommand{
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
+			ringKey:            ingester.PartitionRingKey,
 			partitionIDs:       "0",
 			stdin:              strings.NewReader("yes\n"),
 			logger:             log.NewNopLogger(),
@@ -356,6 +404,7 @@ func TestRemovePartitionCommand(t *testing.T) {
 		cmd := &RemovePartitionCommand{
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
+			ringKey:            ingester.PartitionRingKey,
 			partitionIDs:       "0,2",
 			stdin:              strings.NewReader("yes\n"),
 			logger:             log.NewNopLogger(),
@@ -404,6 +453,7 @@ func TestRemovePartitionCommand(t *testing.T) {
 		cmd := &RemovePartitionCommand{
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
+			ringKey:            ingester.PartitionRingKey,
 			partitionIDs:       "0,1,2",
 			stdin:              strings.NewReader("yes\n"),
 			logger:             log.NewNopLogger(),
@@ -420,6 +470,46 @@ func TestRemovePartitionCommand(t *testing.T) {
 		require.True(t, ringDesc.HasPartition(0), "partition 0 should still exist when operation fails")
 		require.True(t, ringDesc.HasPartition(1), "partition 1 should still exist")
 		require.True(t, ringDesc.HasPartition(2), "partition 2 should still exist when operation fails")
+	})
+
+	t.Run("operates on the partition ring identified by the custom ring key", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+
+		const customRingKey = "custom-partition-ring"
+
+		// Start a seed memberlist node.
+		seedKV, seedClient := startMemberlistKV(t)
+		seedAddr := net.JoinHostPort("127.0.0.1", strconv.Itoa(seedKV.GetListeningPort()))
+
+		// Pre-create partition 0 in the ring identified by the custom ring key.
+		err := seedClient.CAS(ctx, customRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
+			ringDesc := ring.GetOrCreatePartitionRingDesc(in)
+			ringDesc.AddPartition(0, ring.PartitionInactive, time.Now())
+			return ringDesc, true, nil
+		})
+		require.NoError(t, err)
+
+		// Remove the partition from the ring identified by the custom ring key.
+		cmd := &RemovePartitionCommand{
+			memberlistJoin:     []string{seedAddr},
+			memberlistBindPort: 0,
+			ringKey:            customRingKey,
+			partitionIDs:       "0",
+			stdin:              strings.NewReader("yes\n"),
+			logger:             log.NewNopLogger(),
+		}
+		require.NoError(t, cmd.run())
+
+		// The partition is removed from the custom ring key.
+		require.Eventually(t, func() bool {
+			val, err := seedClient.Get(ctx, customRingKey)
+			if err != nil || val == nil {
+				return false
+			}
+			ringDesc, ok := val.(*ring.PartitionRingDesc)
+			return ok && !ringDesc.HasPartition(0)
+		}, 5*time.Second, 100*time.Millisecond, "partition 0 should be removed from the custom ring key")
 	})
 }
 
@@ -448,6 +538,7 @@ func TestAddOwnerCommand(t *testing.T) {
 		cmd := &AddOwnerCommand{
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
+			ringKey:            ingester.PartitionRingKey,
 			ownerIDs:           "ingester-zone-a-0",
 			partitionID:        "0",
 			stdin:              strings.NewReader("yes\n"),
@@ -499,6 +590,7 @@ func TestAddOwnerCommand(t *testing.T) {
 		cmd := &AddOwnerCommand{
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
+			ringKey:            ingester.PartitionRingKey,
 			ownerIDs:           "ingester-zone-a-0",
 			partitionID:        "0",
 			stdin:              strings.NewReader("yes\n"),
@@ -532,6 +624,7 @@ func TestAddOwnerCommand(t *testing.T) {
 		cmd := &AddOwnerCommand{
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
+			ringKey:            ingester.PartitionRingKey,
 			ownerIDs:           "ingester-zone-a-0,ingester-zone-b-0",
 			partitionID:        "0",
 			stdin:              strings.NewReader("yes\n"),
@@ -579,6 +672,7 @@ func TestAddOwnerCommand(t *testing.T) {
 		cmd := &AddOwnerCommand{
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
+			ringKey:            ingester.PartitionRingKey,
 			ownerIDs:           "ingester-zone-a-0,ingester-zone-b-0",
 			partitionID:        "0",
 			stdin:              strings.NewReader("yes\n"),
@@ -595,6 +689,47 @@ func TestAddOwnerCommand(t *testing.T) {
 		ringDesc := val.(*ring.PartitionRingDesc)
 		require.False(t, ringDesc.HasOwner("ingester-zone-a-0"), "zone-a owner should not be added when operation fails")
 		require.True(t, ringDesc.HasOwner("ingester-zone-b-0"), "zone-b owner should still exist")
+	})
+
+	t.Run("operates on the partition ring identified by the custom ring key", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+
+		const customRingKey = "custom-partition-ring"
+
+		// Start a seed memberlist node.
+		seedKV, seedClient := startMemberlistKV(t)
+		seedAddr := net.JoinHostPort("127.0.0.1", strconv.Itoa(seedKV.GetListeningPort()))
+
+		// Pre-create partition 0 in the ring identified by the custom ring key.
+		err := seedClient.CAS(ctx, customRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
+			ringDesc := ring.GetOrCreatePartitionRingDesc(in)
+			ringDesc.AddPartition(0, ring.PartitionActive, time.Now())
+			return ringDesc, true, nil
+		})
+		require.NoError(t, err)
+
+		// Add an owner to the ring identified by the custom ring key.
+		cmd := &AddOwnerCommand{
+			memberlistJoin:     []string{seedAddr},
+			memberlistBindPort: 0,
+			ringKey:            customRingKey,
+			ownerIDs:           "ingester-zone-a-0",
+			partitionID:        "0",
+			stdin:              strings.NewReader("yes\n"),
+			logger:             log.NewNopLogger(),
+		}
+		require.NoError(t, cmd.run())
+
+		// The owner is added under the custom ring key.
+		require.Eventually(t, func() bool {
+			val, err := seedClient.Get(ctx, customRingKey)
+			if err != nil || val == nil {
+				return false
+			}
+			ringDesc, ok := val.(*ring.PartitionRingDesc)
+			return ok && ringDesc.HasOwner("ingester-zone-a-0")
+		}, 5*time.Second, 100*time.Millisecond, "owner should be added under the custom ring key")
 	})
 }
 
@@ -625,6 +760,7 @@ func TestRemoveOwnerCommand(t *testing.T) {
 		cmd := &RemoveOwnerCommand{
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
+			ringKey:            ingester.PartitionRingKey,
 			ownerIDs:           "ingester-zone-c-0",
 			stdin:              strings.NewReader("yes\n"),
 			logger:             log.NewNopLogger(),
@@ -660,6 +796,7 @@ func TestRemoveOwnerCommand(t *testing.T) {
 		cmd := &RemoveOwnerCommand{
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
+			ringKey:            ingester.PartitionRingKey,
 			ownerIDs:           "ingester-zone-c-0",
 			stdin:              strings.NewReader("yes\n"),
 			logger:             log.NewNopLogger(),
@@ -696,6 +833,7 @@ func TestRemoveOwnerCommand(t *testing.T) {
 		cmd := &RemoveOwnerCommand{
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
+			ringKey:            ingester.PartitionRingKey,
 			ownerIDs:           "ingester-zone-b-0,ingester-zone-c-0",
 			stdin:              strings.NewReader("yes\n"),
 			logger:             log.NewNopLogger(),
@@ -744,6 +882,7 @@ func TestRemoveOwnerCommand(t *testing.T) {
 		cmd := &RemoveOwnerCommand{
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
+			ringKey:            ingester.PartitionRingKey,
 			ownerIDs:           "ingester-zone-a-0,ingester-zone-b-0",
 			stdin:              strings.NewReader("yes\n"),
 			logger:             log.NewNopLogger(),
@@ -759,48 +898,48 @@ func TestRemoveOwnerCommand(t *testing.T) {
 		ringDesc := val.(*ring.PartitionRingDesc)
 		require.True(t, ringDesc.HasOwner("ingester-zone-a-0"), "zone-a owner should still exist when operation fails")
 	})
-}
 
-func TestPartitionRingCommand_CustomRingKey(t *testing.T) {
-	t.Parallel()
-	ctx := context.Background()
+	t.Run("operates on the partition ring identified by the custom ring key", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
 
-	const customRingKey = "ingester-partitions-compartment-1"
+		const customRingKey = "custom-partition-ring"
 
-	// Start a seed memberlist node.
-	seedKV, seedClient := startMemberlistKV(t)
-	seedAddr := net.JoinHostPort("127.0.0.1", strconv.Itoa(seedKV.GetListeningPort()))
+		// Start a seed memberlist node.
+		seedKV, seedClient := startMemberlistKV(t)
+		seedAddr := net.JoinHostPort("127.0.0.1", strconv.Itoa(seedKV.GetListeningPort()))
 
-	// Add a partition under a custom ring key.
-	cmd := &AddPartitionCommand{
-		memberlistJoin:     []string{seedAddr},
-		memberlistBindPort: 0, // random port
-		ringKey:            customRingKey,
-		partitionIDs:       "0",
-		partitionState:     "active",
-		stdin:              strings.NewReader("yes\n"),
-		logger:             log.NewNopLogger(),
-	}
-	require.NoError(t, cmd.run())
+		// Pre-create partition 0 with an owner in the ring identified by the custom ring key.
+		err := seedClient.CAS(ctx, customRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
+			ringDesc := ring.GetOrCreatePartitionRingDesc(in)
+			now := time.Now()
+			ringDesc.AddPartition(0, ring.PartitionActive, now)
+			ringDesc.AddOrUpdateOwner("ingester-zone-c-0", ring.OwnerActive, 0, now)
+			return ringDesc, true, nil
+		})
+		require.NoError(t, err)
 
-	// Verify the partition was added under the custom ring key.
-	require.Eventually(t, func() bool {
-		val, err := seedClient.Get(ctx, customRingKey)
-		if err != nil || val == nil {
-			return false
+		// Remove the owner from the ring identified by the custom ring key.
+		cmd := &RemoveOwnerCommand{
+			memberlistJoin:     []string{seedAddr},
+			memberlistBindPort: 0,
+			ringKey:            customRingKey,
+			ownerIDs:           "ingester-zone-c-0",
+			stdin:              strings.NewReader("yes\n"),
+			logger:             log.NewNopLogger(),
 		}
-		ringDesc, ok := val.(*ring.PartitionRingDesc)
-		return ok && ringDesc.HasPartition(0)
-	}, 5*time.Second, 100*time.Millisecond, "partition 0 should be added under the custom ring key")
+		require.NoError(t, cmd.run())
 
-	// Verify nothing was written under the default ring key.
-	val, err := seedClient.Get(ctx, ingester.PartitionRingKey)
-	require.NoError(t, err)
-	if val != nil {
-		ringDesc, ok := val.(*ring.PartitionRingDesc)
-		require.True(t, ok)
-		require.False(t, ringDesc.HasPartition(0), "partition must not be added under the default ring key")
-	}
+		// The owner is removed from the custom ring key.
+		require.Eventually(t, func() bool {
+			val, err := seedClient.Get(ctx, customRingKey)
+			if err != nil || val == nil {
+				return false
+			}
+			ringDesc, ok := val.(*ring.PartitionRingDesc)
+			return ok && !ringDesc.HasOwner("ingester-zone-c-0")
+		}, 5*time.Second, 100*time.Millisecond, "owner should be removed from the custom ring key")
+	})
 }
 
 func TestParsePartitionIDs(t *testing.T) {


### PR DESCRIPTION
#### What this PR does

With multiple partition rings (one per ring key), the `mimirtool partition-ring` subcommands could only operate on the default partition ring KV key (`ingester-partitions`).

This PR adds an optional `--partition-ring.key` flag to all four `partition-ring` subcommands (`add-partition`, `remove-partition`, `add-owner`, `remove-owner`) so they can target a partition ring stored under a different key. The default is unchanged (`ingester-partitions`), so existing usage is unaffected.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.