### PR TITLE
fix(querier): Stop querying partitions inactive longer than -querier.query-ingesters-within

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@
 * [BUGFIX] MQE: Fix `this indicates something has been returned to a pool more than once` panic when a `sum()` or `avg()` group contains, at the same output step, a float sample and native histograms that cannot be added together (e.g. exponential and custom bucket schemas). #16059
 * [BUGFIX] Query-frontend: Fix issue where series for a range query can be returned in the wrong order if splitting applies and splitting is not running inside MQE. #16036
 * [BUGFIX] Querier: Fix issue where exemplars can be returned in the wrong order if a series contains a label that is a prefix of another (eg. `env="foo"` and `env="foobar"`). #16036
+* [BUGFIX] Querier: Stop querying a partition that has been inactive for longer than `-querier.query-ingesters-within`, preventing query failures when the partition is still registered but has no available ingesters to serve the queries. #15721
 
 ### Mixin
 

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -140,17 +140,31 @@ func (d *Distributor) getIngesterReplicationSetsForQuery(ctx context.Context, ma
 			shardSize = d.limits.IngestionPartitionsTenantShardSize(userID)
 		}
 
+		// Cap the inactive-partition lookback at query-ingesters-within:
+		//   - past that window, a partition's data isn't queried from ingesters, and its owners may be
+		//     gone; an ownerless partition would otherwise fail the query.
+		//   - 0 means unbounded, so it only tightens the bound when set and below the lookback period.
+		lookbackPeriod := d.cfg.IngestersLookbackPeriod
+		if queryIngestersWithin := d.limits.QueryIngestersWithin(userID); queryIngestersWithin > 0 && queryIngestersWithin < lookbackPeriod {
+			lookbackPeriod = queryIngestersWithin
+		}
+
+		now := time.Now()
+
 		// When compartments are enabled, try to restrict the pool of compartments that need to be queried.
 		if d.cfg.Compartments.Enabled {
 			targets := d.compartmentRouter.CompartmentsForMatchers(userID, matchers)
 			var replicationSets []ring.ReplicationSet
 
 			for _, c := range targets {
-				r, err := d.partitionInstanceRings.Get(c).ShuffleShardWithLookback(userID, shardSize, d.cfg.IngestersLookbackPeriod, time.Now())
+				r, err := d.partitionInstanceRings.Get(c).ShuffleShardWithLookback(userID, shardSize, lookbackPeriod, now)
 				if err != nil {
 					return nil, err
 				}
 
+				// If the lookback cap filters out every partition in a targeted compartment,
+				// GetReplicationSetsForOperation returns ring.ErrEmptyRing and the query fails. Skipping
+				// empty compartments (serving that data from storage instead) is left to a follow-up.
 				sets, err := r.GetReplicationSetsForOperation(readNoExtend)
 				if err != nil {
 					return nil, err
@@ -163,7 +177,7 @@ func (d *Distributor) getIngesterReplicationSetsForQuery(ctx context.Context, ma
 		}
 
 		// Compartments are disabled.
-		r, err := d.partitionInstanceRings.Get(0).ShuffleShardWithLookback(userID, shardSize, d.cfg.IngestersLookbackPeriod, time.Now())
+		r, err := d.partitionInstanceRings.Get(0).ShuffleShardWithLookback(userID, shardSize, lookbackPeriod, now)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/distributor/query_compartments_test.go
+++ b/pkg/distributor/query_compartments_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/dskit/kv/consul"
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/test"
 	"github.com/grafana/dskit/user"
@@ -21,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/compartments"
+	"github.com/grafana/mimir/pkg/ingester"
 	ingester_client "github.com/grafana/mimir/pkg/ingester/client"
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/querier/stats"
@@ -209,6 +211,81 @@ func TestDistributor_getIngesterReplicationSetsForQuery_Compartments(t *testing.
 		cortex_querier_compartments_hit_per_query_count{storage="ingester"} 3
 	`
 	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expectedMetrics), "cortex_querier_compartments_hit_per_query"))
+}
+
+// TestDistributor_getIngesterReplicationSetsForQuery_CompartmentsQueryIngestersWithin verifies that,
+// with read compartments enabled, the query-ingesters-within bound is applied per compartment: a
+// partition inactive for longer than query-ingesters-within is dropped from its compartment's shard,
+// even though it is still within the (longer) ingesters lookback period.
+func TestDistributor_getIngesterReplicationSetsForQuery_CompartmentsQueryIngestersWithin(t *testing.T) {
+	const (
+		tenantID             = "user"
+		lookbackPeriod       = 12 * time.Hour
+		queryIngestersWithin = 2 * time.Hour
+	)
+
+	ctx := user.InjectOrgID(context.Background(), tenantID)
+
+	limits := prepareDefaultLimits()
+	limits.QueryIngestersWithin = model.Duration(queryIngestersWithin)
+
+	distributors, _, _, _ := prepare(t, prepConfig{
+		numDistributors:         1,
+		ingestStorageEnabled:    true,
+		ingestStoragePartitions: 2,
+		ingesterStateByZone: map[string]ingesterZoneState{
+			"zone-a": {states: []ingesterState{ingesterStateHappy, ingesterStateHappy}},
+		},
+		ingesterDataTenantID:        tenantID,
+		replicationFactor:           1,
+		numCompartments:             1,
+		compartmentActivePartitions: map[int][]int32{0: {0, 1}},
+		limits:                      limits,
+		configure: func(cfg *Config) {
+			cfg.Compartments.Enabled = true
+			cfg.Compartments.Read.NumCompartments = 1
+			cfg.IngestStorageConfig.KafkaConfig.Topic = compartmentsTestTopicFormat
+			cfg.IngestersLookbackPeriod = lookbackPeriod
+		},
+	})
+	require.Len(t, distributors, 1)
+	d := distributors[0]
+
+	// Wait for compartment 0's partition ring to discover both partitions.
+	test.Poll(t, 5*time.Second, 2, func() interface{} {
+		return d.partitionInstanceRings.Get(0).PartitionRing().PartitionsCount()
+	})
+
+	// Switch partition 1 to Inactive since longer ago than query-ingesters-within, but within the
+	// ingesters lookback period.
+	partitionsStore := d.cfg.DistributorRing.Common.KVStore.Mock.(*consul.Client).WithCodec(ring.GetPartitionRingCodec())
+	key := compartments.WithReadCompartmentSuffix(ingester.PartitionRingKey, 0)
+	now := time.Now()
+	require.NoError(t, partitionsStore.CAS(ctx, key, func(in interface{}) (interface{}, bool, error) {
+		desc := ring.GetOrCreatePartitionRingDesc(in)
+		if _, err := desc.UpdatePartitionState(1, ring.PartitionInactive, now.Add(-6*time.Hour)); err != nil {
+			return nil, false, err
+		}
+		return desc, true, nil
+	}))
+
+	// Wait for the watcher to see partition 1 leave the active set.
+	test.Poll(t, 5*time.Second, 1, func() interface{} {
+		return d.partitionInstanceRings.Get(0).PartitionRing().ActivePartitionsCount()
+	})
+
+	replicationSets, err := d.getIngesterReplicationSetsForQuery(ctx, nil)
+	require.NoError(t, err)
+
+	var partitionIDs []int
+	for _, rs := range replicationSets {
+		require.NotEmpty(t, rs.Instances)
+		partitionID, err := ingest.IngesterPartitionID(rs.Instances[0].Addr)
+		require.NoError(t, err)
+		partitionIDs = append(partitionIDs, int(partitionID))
+	}
+	sort.Ints(partitionIDs)
+	assert.Equal(t, []int{0}, partitionIDs, "partition 1 must be excluded because it is inactive longer than query-ingesters-within")
 }
 
 // TestDistributor_QueryExemplars_Compartments verifies that the exemplars API, which accepts multiple

--- a/pkg/distributor/query_compartments_test.go
+++ b/pkg/distributor/query_compartments_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/dskit/kv/consul"
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/test"
 	"github.com/grafana/dskit/user"
@@ -22,7 +21,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/compartments"
-	"github.com/grafana/mimir/pkg/ingester"
 	ingester_client "github.com/grafana/mimir/pkg/ingester/client"
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/querier/stats"
@@ -211,81 +209,6 @@ func TestDistributor_getIngesterReplicationSetsForQuery_Compartments(t *testing.
 		cortex_querier_compartments_hit_per_query_count{storage="ingester"} 3
 	`
 	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expectedMetrics), "cortex_querier_compartments_hit_per_query"))
-}
-
-// TestDistributor_getIngesterReplicationSetsForQuery_CompartmentsQueryIngestersWithin verifies that,
-// with read compartments enabled, the query-ingesters-within bound is applied per compartment: a
-// partition inactive for longer than query-ingesters-within is dropped from its compartment's shard,
-// even though it is still within the (longer) ingesters lookback period.
-func TestDistributor_getIngesterReplicationSetsForQuery_CompartmentsQueryIngestersWithin(t *testing.T) {
-	const (
-		tenantID             = "user"
-		lookbackPeriod       = 12 * time.Hour
-		queryIngestersWithin = 2 * time.Hour
-	)
-
-	ctx := user.InjectOrgID(context.Background(), tenantID)
-
-	limits := prepareDefaultLimits()
-	limits.QueryIngestersWithin = model.Duration(queryIngestersWithin)
-
-	distributors, _, _, _ := prepare(t, prepConfig{
-		numDistributors:         1,
-		ingestStorageEnabled:    true,
-		ingestStoragePartitions: 2,
-		ingesterStateByZone: map[string]ingesterZoneState{
-			"zone-a": {states: []ingesterState{ingesterStateHappy, ingesterStateHappy}},
-		},
-		ingesterDataTenantID:        tenantID,
-		replicationFactor:           1,
-		numCompartments:             1,
-		compartmentActivePartitions: map[int][]int32{0: {0, 1}},
-		limits:                      limits,
-		configure: func(cfg *Config) {
-			cfg.Compartments.Enabled = true
-			cfg.Compartments.Read.NumCompartments = 1
-			cfg.IngestStorageConfig.KafkaConfig.Topic = compartmentsTestTopicFormat
-			cfg.IngestersLookbackPeriod = lookbackPeriod
-		},
-	})
-	require.Len(t, distributors, 1)
-	d := distributors[0]
-
-	// Wait for compartment 0's partition ring to discover both partitions.
-	test.Poll(t, 5*time.Second, 2, func() interface{} {
-		return d.partitionInstanceRings.Get(0).PartitionRing().PartitionsCount()
-	})
-
-	// Switch partition 1 to Inactive since longer ago than query-ingesters-within, but within the
-	// ingesters lookback period.
-	partitionsStore := d.cfg.DistributorRing.Common.KVStore.Mock.(*consul.Client).WithCodec(ring.GetPartitionRingCodec())
-	key := compartments.WithReadCompartmentSuffix(ingester.PartitionRingKey, 0)
-	now := time.Now()
-	require.NoError(t, partitionsStore.CAS(ctx, key, func(in interface{}) (interface{}, bool, error) {
-		desc := ring.GetOrCreatePartitionRingDesc(in)
-		if _, err := desc.UpdatePartitionState(1, ring.PartitionInactive, now.Add(-6*time.Hour)); err != nil {
-			return nil, false, err
-		}
-		return desc, true, nil
-	}))
-
-	// Wait for the watcher to see partition 1 leave the active set.
-	test.Poll(t, 5*time.Second, 1, func() interface{} {
-		return d.partitionInstanceRings.Get(0).PartitionRing().ActivePartitionsCount()
-	})
-
-	replicationSets, err := d.getIngesterReplicationSetsForQuery(ctx, nil)
-	require.NoError(t, err)
-
-	var partitionIDs []int
-	for _, rs := range replicationSets {
-		require.NotEmpty(t, rs.Instances)
-		partitionID, err := ingest.IngesterPartitionID(rs.Instances[0].Addr)
-		require.NoError(t, err)
-		partitionIDs = append(partitionIDs, int(partitionID))
-	}
-	sort.Ints(partitionIDs)
-	assert.Equal(t, []int{0}, partitionIDs, "partition 1 must be excluded because it is inactive longer than query-ingesters-within")
 }
 
 // TestDistributor_QueryExemplars_Compartments verifies that the exemplars API, which accepts multiple

--- a/pkg/distributor/query_ingest_storage_test.go
+++ b/pkg/distributor/query_ingest_storage_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/mimir/pkg/compartments"
 	"github.com/grafana/mimir/pkg/ingester"
 	ingester_client "github.com/grafana/mimir/pkg/ingester/client"
 	"github.com/grafana/mimir/pkg/mimirpb"
@@ -557,9 +558,12 @@ func TestDistributor_QueryStream_InactivePartitionsLookback(t *testing.T) {
 
 	selectAllSeriesMatcher := mustEqualMatcher("bar", "baz")
 
+	// The compartmentsEnabled variants put all partitions in a single read compartment, so the topology
+	// matches the single-ring case and the per-scenario expectations below hold for both query paths.
 	shardingConfigs := map[string]struct {
 		shuffleShardingEnabled bool
 		tenantShardSize        int
+		compartmentsEnabled    bool
 	}{
 		"shuffle sharding disabled": {
 			shuffleShardingEnabled: false,
@@ -572,6 +576,11 @@ func TestDistributor_QueryStream_InactivePartitionsLookback(t *testing.T) {
 		"shuffle sharding enabled with shard size > 0": {
 			shuffleShardingEnabled: true,
 			tenantShardSize:        10, // Larger than partition count, so all partitions are included.
+		},
+		"compartments enabled": {
+			shuffleShardingEnabled: false,
+			tenantShardSize:        0,
+			compartmentsEnabled:    true,
 		},
 	}
 
@@ -640,10 +649,22 @@ func TestDistributor_QueryStream_InactivePartitionsLookback(t *testing.T) {
 					ingester3Data = makeWriteRequest(0, 1, 0, false, false, "foo3")
 				}
 
+				// When compartments are enabled, put all 4 partitions in a single read compartment so the
+				// topology matches the single-ring case and the same scenarios and expectations apply to
+				// both query paths.
+				numCompartments := 0
+				var compartmentActivePartitions map[int][]int32
+				if shardingCfg.compartmentsEnabled {
+					numCompartments = 1
+					compartmentActivePartitions = map[int][]int32{0: {0, 1, 2, 3}}
+				}
+
 				cfg := prepConfig{
-					numDistributors:         1,
-					ingestStorageEnabled:    true,
-					ingestStoragePartitions: 4,
+					numDistributors:             1,
+					ingestStorageEnabled:        true,
+					ingestStoragePartitions:     4,
+					numCompartments:             numCompartments,
+					compartmentActivePartitions: compartmentActivePartitions,
 					ingesterStateByZone: map[string]ingesterZoneState{
 						"zone-a": {states: []ingesterState{ingesterStateHappy, ingesterStateHappy, ingesterStateHappy, ingester3State}},
 					},
@@ -661,6 +682,11 @@ func TestDistributor_QueryStream_InactivePartitionsLookback(t *testing.T) {
 					configure: func(config *Config) {
 						config.ShuffleShardingEnabled = shardingCfg.shuffleShardingEnabled
 						config.IngestersLookbackPeriod = lookbackPeriod
+						if shardingCfg.compartmentsEnabled {
+							config.Compartments.Enabled = true
+							config.Compartments.Read.NumCompartments = 1
+							config.IngestStorageConfig.KafkaConfig.Topic = compartmentsTestTopicFormat
+						}
 					},
 				}
 
@@ -679,7 +705,11 @@ func TestDistributor_QueryStream_InactivePartitionsLookback(t *testing.T) {
 				// - Partition 3: Inactive since scenario.partition3InactiveSince
 				now := time.Now()
 				partitionsStore := d.cfg.DistributorRing.Common.KVStore.Mock.(*consul.Client).WithCodec(ring.GetPartitionRingCodec())
-				err := partitionsStore.CAS(ctx, ingester.PartitionRingKey, func(in interface{}) (interface{}, bool, error) {
+				ringKey := ingester.PartitionRingKey
+				if shardingCfg.compartmentsEnabled {
+					ringKey = compartments.WithReadCompartmentSuffix(ingester.PartitionRingKey, 0)
+				}
+				err := partitionsStore.CAS(ctx, ringKey, func(in interface{}) (interface{}, bool, error) {
 					desc := ring.GetOrCreatePartitionRingDesc(in)
 					if _, err := desc.UpdatePartitionState(2, ring.PartitionInactive, now.Add(-1*time.Hour)); err != nil {
 						return nil, false, err

--- a/pkg/distributor/query_ingest_storage_test.go
+++ b/pkg/distributor/query_ingest_storage_test.go
@@ -576,27 +576,45 @@ func TestDistributor_QueryStream_InactivePartitionsLookback(t *testing.T) {
 	}
 
 	scenarios := map[string]struct {
+		queryIngestersWithin    time.Duration // Per-tenant -querier.query-ingesters-within. 0 means no additional bound.
 		partition3InactiveSince time.Duration // How long ago partition 3 became inactive.
 		partition3Healthy       bool          // Whether the ingester owning partition 3 is healthy.
 		expectedPartitionIDs    []int         // Expected partition IDs returned by getIngesterReplicationSetsForQuery.
 		expectQueryError        bool          // Whether the query should fail.
 	}{
 		"partition outside lookback with unhealthy ingester": {
+			queryIngestersWithin:    13 * time.Hour, // Larger than lookback (12h), so lookback is the binding bound.
 			partition3InactiveSince: 24 * time.Hour, // Outside lookback (12h).
 			partition3Healthy:       false,
 			expectedPartitionIDs:    []int{0, 1, 2}, // Partition 3 excluded due to lookback.
 			expectQueryError:        false,          // Query succeeds because partition 3 is not queried.
 		},
 		"partition outside lookback with healthy ingester": {
+			queryIngestersWithin:    13 * time.Hour, // Larger than lookback (12h), so lookback is the binding bound.
 			partition3InactiveSince: 24 * time.Hour, // Outside lookback (12h).
 			partition3Healthy:       true,
 			expectedPartitionIDs:    []int{0, 1, 2}, // Partition 3 excluded due to lookback.
 			expectQueryError:        false,          // Query succeeds, partition 3 is not queried anyway.
 		},
 		"partition within lookback with unhealthy ingester": {
-			partition3InactiveSince: 1 * time.Hour, // Within lookback (12h).
+			queryIngestersWithin:    13 * time.Hour, // Larger than lookback (12h), so lookback is the binding bound.
+			partition3InactiveSince: 1 * time.Hour,  // Within lookback (12h).
 			partition3Healthy:       false,
 			expectedPartitionIDs:    []int{0, 1, 2, 3}, // Partition 3 included because within lookback.
+			expectQueryError:        true,              // Query fails because partition 3 must be queried but ingester is unhealthy.
+		},
+		"partition within lookback but outside query-ingesters-within with unhealthy ingester": {
+			queryIngestersWithin:    2 * time.Hour, // Smaller than lookback (12h), so it is the binding bound.
+			partition3InactiveSince: 6 * time.Hour, // Within lookback (12h) but outside query-ingesters-within (2h).
+			partition3Healthy:       false,
+			expectedPartitionIDs:    []int{0, 1, 2}, // Partition 3 excluded due to query-ingesters-within.
+			expectQueryError:        false,          // Query succeeds because partition 3 is not queried.
+		},
+		"partition within query-ingesters-within with unhealthy ingester": {
+			queryIngestersWithin:    2 * time.Hour, // Smaller than lookback (12h), so it is the binding bound.
+			partition3InactiveSince: 1 * time.Hour, // Within query-ingesters-within (2h).
+			partition3Healthy:       false,
+			expectedPartitionIDs:    []int{0, 1, 2, 3}, // Partition 3 included because within query-ingesters-within.
 			expectQueryError:        true,              // Query fails because partition 3 must be queried but ingester is unhealthy.
 		},
 	}
@@ -613,6 +631,7 @@ func TestDistributor_QueryStream_InactivePartitionsLookback(t *testing.T) {
 
 				limits := prepareDefaultLimits()
 				limits.IngestionPartitionsTenantShardSize = shardingCfg.tenantShardSize
+				limits.QueryIngestersWithin = model.Duration(scenario.queryIngestersWithin)
 
 				ingester3State := ingesterStateFailed
 				var ingester3Data *mimirpb.WriteRequest


### PR DESCRIPTION
Queriers stop querying a partition that has been `Inactive` for longer than `-querier.query-ingesters-within`.

- When ingest storage is enabled, the querier selected partitions using the ingesters lookback period (TSDB retention), so a partition inactive longer than `-querier.query-ingesters-within` was still queried even though no query routes to its ingesters for data that old.
- If that partition's owning ingesters had been scaled down, it remained registered with no healthy owners and the whole query failed.
- The inactive-partition lookback is now capped at `-querier.query-ingesters-within`, dropping such partitions from the query set; their data is served from blocks storage instead.
- A `-querier.query-ingesters-within` of `0` (unbounded) leaves behavior unchanged, as does the default where TSDB retention equals `-querier.query-ingesters-within`.
- Scoped to the ingest-storage partition path; the classic ingester ring is unchanged.