### PR TITLE
Make ingester query path compartment-aware

### DIFF
--- a/docs/internal/compartments/read-compartments.md
+++ b/docs/internal/compartments/read-compartments.md
@@ -31,6 +31,31 @@ flowchart LR
     K1 --> ING
 ```
 
+## Querying read compartments
+
+The global query layer queries the ingesters of read compartments through the same path used without
+compartments, extended to be compartment-aware. Because series are sharded to read compartments by
+metric name (see [Sharding](./sharding.md)), the layer narrows a query to only the compartments that
+can hold the selected series:
+
+- **When the query pins a single metric name** — that is, it filters the metric name with an equality
+  matcher — all of its series live in exactly one compartment, so only that compartment's ingesters are
+  queried.
+- **When the query restricts the metric name to a finite set** — for example a regex matcher equivalent
+  to an alternation like `a|b|c` — the query is sent to the union of the compartments owning those
+  names, which can still be a subset of all compartments.
+- **Otherwise** — whenever the metric name can't be reduced to a finite set of names (no metric-name
+  equality matcher and no enumerable regex, for example an open-ended regex like `.+`) — the query fans
+  out to **every** compartment and the results are merged. Metadata and whole-tenant statistics queries,
+  which carry no metric-name filter, always fan out.
+
+This targeting is what delivers the query blast-radius reduction: a problem in one compartment only
+affects queries whose metric name routes to it, while queries for other metric names are unaffected.
+
+Targeting relies on the read-compartment count being **static**: the metric-name-to-compartment mapping
+must match the one used on the write path, so a query reads from the same compartment the series were
+written to. Changing the number of compartments would shift that mapping and is out of scope.
+
 ## Why a dedicated topic per read compartment
 
 A dedicated topic per read compartment simplifies partition management: each compartment's partitions

--- a/docs/internal/compartments/status-and-limitations.md
+++ b/docs/internal/compartments/status-and-limitations.md
@@ -13,12 +13,14 @@ the other files is implemented today; this page tracks the gap.
 - **Multi-cluster consumption**: an ingester consumes its read compartment's topic from **every** write
   compartment's Kafka cluster and unions the records into its TSDB. Each per-cluster consumption tracks
   its own offsets independently.
+- **Compartment-aware querying of ingesters**: the query layer narrows a query to the compartments that
+  can hold the selected metric names (a single compartment for an equality matcher, the union for an
+  enumerable metric-name set) and fans out to all compartments otherwise (see
+  [Read compartments](./read-compartments.md)).
 - A local development environment (`development/mimir-compartments`).
 
-## The query path is not compartment-aware yet
+## Strong read consistency is not compartment-aware yet
 
-- Queries only consult **read compartment 0**. Series that hash to any other compartment are ingested
-  correctly but are **not queryable** yet.
 - Strong read consistency does not propagate per-compartment offsets from the query-frontend and querier
   to the ingester, so an ingester enforcing read consistency waits for the last produced offset of every
   Kafka cluster rather than for the specific requested offsets.
@@ -39,7 +41,5 @@ compartment has its own single-broker Kafka cluster, and each read compartment h
 ingester set. The ingesters of each read compartment consume that compartment's topic from both Kafka
 clusters.
 
-Because the query path only reads compartment 0, only metrics that hash to compartment 0 are queryable
-in this environment. In particular, the metric used to populate the bundled dashboards' template
-variables happens to hash to a different compartment, so those dashboards render blank. Querying metrics
-that hash to compartment 0 returns data as expected.
+Metrics in either compartment are queryable: a query that pins a metric name is served from the owning
+compartment, and a query without a metric-name equality matcher fans out to both.

--- a/pkg/compartments/router.go
+++ b/pkg/compartments/router.go
@@ -3,6 +3,11 @@
 package compartments
 
 import (
+	"slices"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+
 	"github.com/grafana/mimir/pkg/mimirpb"
 )
 
@@ -10,17 +15,26 @@ import (
 // on a hash of the user ID and metric name.
 type Router struct {
 	topics []string
+
+	// allReadCompartmentIDs holds every read compartment ID.
+	allReadCompartmentIDs []int
 }
 
 // NewRouter creates a Router. kafkaTopicTemplate is the Kafka topic name containing the
 // ReadCompartmentIDPlaceholder, which is replaced with each read compartment ID to derive
 // that compartment's topic.
 func NewRouter(numReadCompartments int, kafkaTopicTemplate string) *Router {
-	topics := make([]string, numReadCompartments)
+	var (
+		topics                = make([]string, numReadCompartments)
+		allReadCompartmentIDs = make([]int, numReadCompartments)
+	)
+
 	for id := range topics {
 		topics[id] = ReplaceReadCompartment(kafkaTopicTemplate, id)
+		allReadCompartmentIDs[id] = id
 	}
-	return &Router{topics: topics}
+
+	return &Router{topics: topics, allReadCompartmentIDs: allReadCompartmentIDs}
 }
 
 // CompartmentForMetric returns the read compartment ID for the given tenant's metric name. The
@@ -35,6 +49,60 @@ func (r *Router) TopicForMetric(userID, metricName string) string {
 	return r.topics[r.CompartmentForMetric(userID, metricName)]
 }
 
+// CompartmentsForMatchers returns the read compartments that may hold series matching the given matchers
+// (series shard across compartments by metric name). It returns all compartments when it can't restrict
+// the query.
+//
+// It restricts the query using __name__ matchers: an exact equality matcher maps to a single compartment,
+// and a regexp whose match set is enumerable (for example "a|b") maps to the compartments of those names.
+//
+// It assumes a static compartment count: a changing count would shift the metric→compartment mapping
+// and a targeted query could miss data until the rings settle.
+func (r *Router) CompartmentsForMatchers(userID string, matchers []*labels.Matcher) []int {
+	var (
+		exactName  string
+		setMatches []string
+	)
+
+	// Find the most restrictive enumerable set of candidate metric names from the __name__ matchers. An
+	// exact matcher fully determines the name, so it always wins over a regexp's match set.
+	for _, m := range matchers {
+		if m.Name != model.MetricNameLabel {
+			continue
+		}
+
+		switch m.Type {
+		case labels.MatchEqual:
+			// The first exact name fully determines the compartment. A different second exact name would
+			// match no series, so whichever compartment we pick is safe (the query returns nothing anyway).
+			if exactName == "" {
+				exactName = m.Value
+			}
+		case labels.MatchRegexp:
+			// SetMatches returns the finite set of names a regexp matches, or nil when it can't be reduced
+			// to one (open-ended like ".+"); in the latter case we can't restrict and fall through to all
+			// compartments. Among enumerable regexps, keep the smallest set.
+			if sm := m.SetMatches(); len(sm) > 0 && (setMatches == nil || len(sm) < len(setMatches)) {
+				setMatches = sm
+			}
+		}
+	}
+
+	if exactName != "" {
+		return []int{r.CompartmentForMetric(userID, exactName)}
+	}
+	if len(setMatches) == 0 {
+		// The query can't be restricted to a subset of compartments: query all of them.
+		return slices.Clone(r.allReadCompartmentIDs)
+	}
+
+	var compartments []int
+	for _, name := range setMatches {
+		compartments = appendUnique(compartments, r.CompartmentForMetric(userID, name))
+	}
+	return compartments
+}
+
 // NumCompartments returns the number of read compartments.
 func (r *Router) NumCompartments() int {
 	return len(r.topics)
@@ -43,4 +111,15 @@ func (r *Router) NumCompartments() int {
 // TopicForCompartment returns the Kafka topic for the given read compartment ID.
 func (r *Router) TopicForCompartment(compartmentID int) string {
 	return r.topics[compartmentID]
+}
+
+// appendUnique appends v to s only if absent, deduplicating because several matched metric names can
+// hash to the same compartment.
+func appendUnique[T comparable](s []T, v T) []T {
+	for _, existing := range s {
+		if existing == v {
+			return s
+		}
+	}
+	return append(s, v)
 }

--- a/pkg/compartments/router_test.go
+++ b/pkg/compartments/router_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -68,7 +69,7 @@ func TestRouter_CompartmentsForMatchers(t *testing.T) {
 
 	t.Run("exact __name__ matcher pins to the routing compartment", func(t *testing.T) {
 		want := r.CompartmentForMetric(userID, "my_metric")
-		got := r.CompartmentsForMatchers(userID, []*labels.Matcher{eq(labels.MetricName, "my_metric"), eq("job", "x")})
+		got := r.CompartmentsForMatchers(userID, []*labels.Matcher{eq(model.MetricNameLabel, "my_metric"), eq("job", "x")})
 		assert.Equal(t, []int{want}, got)
 	})
 
@@ -79,7 +80,7 @@ func TestRouter_CompartmentsForMatchers(t *testing.T) {
 			want[r.CompartmentForMetric(userID, n)] = struct{}{}
 		}
 
-		got := r.CompartmentsForMatchers(userID, []*labels.Matcher{re(labels.MetricName, strings.Join(names, "|"))})
+		got := r.CompartmentsForMatchers(userID, []*labels.Matcher{re(model.MetricNameLabel, strings.Join(names, "|"))})
 		assert.Len(t, got, len(want), "should return one entry per distinct compartment")
 		gotSet := map[int]struct{}{}
 		for _, c := range got {
@@ -90,13 +91,13 @@ func TestRouter_CompartmentsForMatchers(t *testing.T) {
 
 	t.Run("exact matcher wins over a regexp set", func(t *testing.T) {
 		want := r.CompartmentForMetric(userID, "metric_a")
-		got := r.CompartmentsForMatchers(userID, []*labels.Matcher{eq(labels.MetricName, "metric_a"), re(labels.MetricName, "metric_a|metric_b|metric_c")})
+		got := r.CompartmentsForMatchers(userID, []*labels.Matcher{eq(model.MetricNameLabel, "metric_a"), re(model.MetricNameLabel, "metric_a|metric_b|metric_c")})
 		assert.Equal(t, []int{want}, got)
 	})
 
 	t.Run("conflicting exact names pin to the first one (the query matches no series anyway)", func(t *testing.T) {
 		want := r.CompartmentForMetric(userID, "metric_a")
-		got := r.CompartmentsForMatchers(userID, []*labels.Matcher{eq(labels.MetricName, "metric_a"), eq(labels.MetricName, "metric_b")})
+		got := r.CompartmentsForMatchers(userID, []*labels.Matcher{eq(model.MetricNameLabel, "metric_a"), eq(model.MetricNameLabel, "metric_b")})
 		assert.Equal(t, []int{want}, got)
 	})
 
@@ -105,8 +106,8 @@ func TestRouter_CompartmentsForMatchers(t *testing.T) {
 		cases := map[string][]*labels.Matcher{
 			"no matchers":         nil,
 			"no __name__ matcher": {eq("job", "x")},
-			"unbounded regex":     {re(labels.MetricName, "foo.*")},
-			"negative __name__":   {neq(labels.MetricName, "x")},
+			"unbounded regex":     {re(model.MetricNameLabel, "foo.*")},
+			"negative __name__":   {neq(model.MetricNameLabel, "x")},
 		}
 		for name, matchers := range cases {
 			t.Run(name, func(t *testing.T) {

--- a/pkg/compartments/router_test.go
+++ b/pkg/compartments/router_test.go
@@ -5,8 +5,10 @@ package compartments
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -45,6 +47,71 @@ func TestRouter_CompartmentForMetric(t *testing.T) {
 		for i := 0; i < 100; i++ {
 			name := "metric_" + strconv.Itoa(i)
 			assert.Equal(t, r.TopicForCompartment(r.CompartmentForMetric("user-1", name)), r.TopicForMetric("user-1", name))
+		}
+	})
+}
+
+func TestRouter_CompartmentsForMatchers(t *testing.T) {
+	const (
+		numCompartments = 4
+		userID          = "user-1"
+	)
+	r := newTestRouter(numCompartments)
+
+	eq := func(name, value string) *labels.Matcher { return labels.MustNewMatcher(labels.MatchEqual, name, value) }
+	re := func(name, value string) *labels.Matcher {
+		return labels.MustNewMatcher(labels.MatchRegexp, name, value)
+	}
+	neq := func(name, value string) *labels.Matcher {
+		return labels.MustNewMatcher(labels.MatchNotEqual, name, value)
+	}
+
+	t.Run("exact __name__ matcher pins to the routing compartment", func(t *testing.T) {
+		want := r.CompartmentForMetric(userID, "my_metric")
+		got := r.CompartmentsForMatchers(userID, []*labels.Matcher{eq(labels.MetricName, "my_metric"), eq("job", "x")})
+		assert.Equal(t, []int{want}, got)
+	})
+
+	t.Run("enumerable regexp __name__ targets the union of the matched names' compartments", func(t *testing.T) {
+		names := []string{"metric_a", "metric_b", "metric_c", "metric_d", "metric_e"}
+		want := map[int]struct{}{}
+		for _, n := range names {
+			want[r.CompartmentForMetric(userID, n)] = struct{}{}
+		}
+
+		got := r.CompartmentsForMatchers(userID, []*labels.Matcher{re(labels.MetricName, strings.Join(names, "|"))})
+		assert.Len(t, got, len(want), "should return one entry per distinct compartment")
+		gotSet := map[int]struct{}{}
+		for _, c := range got {
+			gotSet[c] = struct{}{}
+		}
+		assert.Equal(t, want, gotSet)
+	})
+
+	t.Run("exact matcher wins over a regexp set", func(t *testing.T) {
+		want := r.CompartmentForMetric(userID, "metric_a")
+		got := r.CompartmentsForMatchers(userID, []*labels.Matcher{eq(labels.MetricName, "metric_a"), re(labels.MetricName, "metric_a|metric_b|metric_c")})
+		assert.Equal(t, []int{want}, got)
+	})
+
+	t.Run("conflicting exact names pin to the first one (the query matches no series anyway)", func(t *testing.T) {
+		want := r.CompartmentForMetric(userID, "metric_a")
+		got := r.CompartmentsForMatchers(userID, []*labels.Matcher{eq(labels.MetricName, "metric_a"), eq(labels.MetricName, "metric_b")})
+		assert.Equal(t, []int{want}, got)
+	})
+
+	t.Run("queries that cannot be restricted return all compartments", func(t *testing.T) {
+		allCompartments := []int{0, 1, 2, 3}
+		cases := map[string][]*labels.Matcher{
+			"no matchers":         nil,
+			"no __name__ matcher": {eq("job", "x")},
+			"unbounded regex":     {re(labels.MetricName, "foo.*")},
+			"negative __name__":   {neq(labels.MetricName, "x")},
+		}
+		for name, matchers := range cases {
+			t.Run(name, func(t *testing.T) {
+				assert.Equal(t, allCompartments, r.CompartmentsForMatchers(userID, matchers))
+			})
 		}
 	})
 }

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -3389,7 +3389,7 @@ func (d *Distributor) MetricsForLabelMatchers(ctx context.Context, from, through
 		}
 
 		// Adjust the limit passed with the downstream request to ingesters with respect to how series are sharded.
-		req.Limit = int64(d.adjustQueryRequestLimit(ctx, userID, resultLimit))
+		req.Limit = int64(d.adjustQueryRequestLimit(ctx, userID, matchers, resultLimit))
 	}
 
 	resps, err := forReplicationSets(ctx, d, replicationSets, func(ctx context.Context, client ingester_client.IngesterClient) (*ingester_client.MetricsForLabelMatchersResponse, error) {
@@ -3443,15 +3443,17 @@ respsLoop:
 
 // adjustQueryRequestLimit recalculated the query request limit.
 // The returned value is the approximation, a query to an individual shard needs to be limited with.
-func (d *Distributor) adjustQueryRequestLimit(ctx context.Context, userID string, limit int) int {
+func (d *Distributor) adjustQueryRequestLimit(ctx context.Context, userID string, matchers []*labels.Matcher, limit int) int {
 	if limit == 0 {
 		return limit
 	}
 
 	var shardSize int
 	if d.cfg.Compartments.Enabled {
-		// Get the number of active partitions in the ring, across all compartments.
-		for c := 0; c < d.partitionInstanceRings.Count(); c++ {
+		// Sum the active partitions only across the compartments this query actually targets (the same set
+		// getIngesterReplicationSetsForQuery queries), otherwise a query pinned to a subset of compartments
+		// would divide its limit by the whole cluster's partitions and cap results below the requested limit.
+		for _, c := range d.compartmentRouter.CompartmentsForMatchers(userID, matchers) {
 			// ShuffleShardSize handles cases when a tenant has 0 or negative number of shards, or more shards than
 			// the number of active partitions in the ring.
 			shardSize += d.partitionInstanceRings.Get(c).PartitionRing().ShuffleShardSize(d.limits.IngestionPartitionsTenantShardSize(userID))

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -162,6 +162,7 @@ type Distributor struct {
 
 	// Metrics
 	queryDuration                    *instrument.HistogramCollector
+	queryIngesterCompartmentsHit     prometheus.Histogram
 	receivedRequests                 *prometheus.CounterVec
 	receivedSamples                  *prometheus.CounterVec
 	receivedExemplars                *prometheus.CounterVec
@@ -836,6 +837,15 @@ func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Ove
 
 		if cfg.Compartments.Enabled {
 			d.compartmentRouter = compartments.NewRouter(cfg.Compartments.Read.NumCompartments, cfg.IngestStorageConfig.KafkaConfig.Topic)
+
+			d.queryIngesterCompartmentsHit = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+				Name: "cortex_querier_compartments_hit_per_query",
+				Help: "Number of read compartments queried for a single query.",
+				// The "storage" label denotes which query backend was queried, matching the convention of
+				// cortex_querier_queries_storage_type_total ("ingester" / "store-gateway").
+				ConstLabels: prometheus.Labels{"storage": "ingester"},
+				Buckets:     prometheus.LinearBuckets(1, 1, cfg.Compartments.Read.NumCompartments),
+			})
 		}
 	}
 
@@ -2590,7 +2600,7 @@ func queryIngesterPartitionsRingZoneSorter(preferredZones []string) ring.ZoneSor
 // LabelValuesForLabelName returns the label values associated with the given labelName, among all series with samples
 // timestamp between from and to, and series labels matching the optional matchers.
 func (d *Distributor) LabelValuesForLabelName(ctx context.Context, from, to model.Time, labelName model.LabelName, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, error) {
-	replicationSets, err := d.getIngesterReplicationSetsForQuery(ctx)
+	replicationSets, err := d.getIngesterReplicationSetsForQuery(ctx, matchers)
 	if err != nil {
 		return nil, err
 	}
@@ -2635,7 +2645,7 @@ func (d *Distributor) LabelValuesForLabelName(ctx context.Context, from, to mode
 //   - inmemory: in-memory series in ingesters.
 //   - active: in-memory series in ingesters which are also tracked as active ones.
 func (d *Distributor) LabelNamesAndValues(ctx context.Context, matchers []*labels.Matcher, countMethod cardinality.CountMethod) (*ingester_client.LabelNamesAndValuesResponse, error) {
-	replicationSets, err := d.getIngesterReplicationSetsForQuery(ctx)
+	replicationSets, err := d.getIngesterReplicationSetsForQuery(ctx, matchers)
 	if err != nil {
 		return nil, err
 	}
@@ -2791,7 +2801,7 @@ func (d *Distributor) LabelValuesCardinality(ctx context.Context, labelNames []m
 // labelValuesCardinality queries ingesters for label values cardinality of a set of labelNames
 // Returns a LabelValuesCardinalityResponse where each item contains an exclusive label name and associated label values
 func (d *Distributor) labelValuesCardinality(ctx context.Context, labelNames []model.LabelName, matchers []*labels.Matcher, countMethod cardinality.CountMethod) (*ingester_client.LabelValuesCardinalityResponse, error) {
-	replicationSets, err := d.getIngesterReplicationSetsForQuery(ctx)
+	replicationSets, err := d.getIngesterReplicationSetsForQuery(ctx, matchers)
 	if err != nil {
 		return nil, err
 	}
@@ -3015,7 +3025,7 @@ func (d *Distributor) ActiveNativeHistogramMetrics(ctx context.Context, matchers
 }
 
 func (d *Distributor) deduplicateActiveSeries(ctx context.Context, matchers []*labels.Matcher, nativeHistograms bool) (*activeSeriesResponse, error) {
-	replicationSets, err := d.getIngesterReplicationSetsForQuery(ctx)
+	replicationSets, err := d.getIngesterReplicationSetsForQuery(ctx, matchers)
 	if err != nil {
 		return nil, err
 	}
@@ -3318,7 +3328,7 @@ func maxFromZones[T ~float64 | ~uint64](seriesCountByZone map[string]T) (val T) 
 // LabelNames returns the names of all labels from series with samples timestamp between from and to, and matching
 // the input optional series label matchers. The returned label names are sorted.
 func (d *Distributor) LabelNames(ctx context.Context, from, to model.Time, hints *storage.LabelHints, matchers ...*labels.Matcher) ([]string, error) {
-	replicationSets, err := d.getIngesterReplicationSetsForQuery(ctx)
+	replicationSets, err := d.getIngesterReplicationSetsForQuery(ctx, matchers)
 	if err != nil {
 		return nil, err
 	}
@@ -3359,7 +3369,7 @@ func (d *Distributor) LabelNames(ctx context.Context, from, to model.Time, hints
 // MetricsForLabelMatchers returns a list of series with samples timestamps between from and through, and series labels
 // matching the optional label matchers. The returned series are not sorted.
 func (d *Distributor) MetricsForLabelMatchers(ctx context.Context, from, through model.Time, hints *storage.SelectHints, matchers ...*labels.Matcher) ([]labels.Labels, error) {
-	replicationSets, err := d.getIngesterReplicationSetsForQuery(ctx)
+	replicationSets, err := d.getIngesterReplicationSetsForQuery(ctx, matchers)
 	if err != nil {
 		return nil, err
 	}
@@ -3439,10 +3449,16 @@ func (d *Distributor) adjustQueryRequestLimit(ctx context.Context, userID string
 	}
 
 	var shardSize int
-	if d.cfg.IngestStorageConfig.Enabled {
+	if d.cfg.Compartments.Enabled {
+		// Get the number of active partitions in the ring, across all compartments.
+		for c := 0; c < d.partitionInstanceRings.Count(); c++ {
+			// ShuffleShardSize handles cases when a tenant has 0 or negative number of shards, or more shards than
+			// the number of active partitions in the ring.
+			shardSize += d.partitionInstanceRings.Get(c).PartitionRing().ShuffleShardSize(d.limits.IngestionPartitionsTenantShardSize(userID))
+		}
+	} else if d.cfg.IngestStorageConfig.Enabled {
 		// Get the number of active partitions in the ring. Here the ShuffleShardSize handles cases when a tenant has 0 or negative
 		// number of shards, or more shards than the number of active partitions in the ring.
-		// Read path is not compartment-aware yet, so it always uses read compartment 0.
 		shardSize = d.partitionInstanceRings.Get(0).PartitionRing().ShuffleShardSize(d.limits.IngestionPartitionsTenantShardSize(userID))
 	} else {
 		// The ShuffleShard filters out read-only instances, leaving us with the number of active ingesters.
@@ -3472,7 +3488,13 @@ func (d *Distributor) adjustQueryRequestLimit(ctx context.Context, userID string
 
 // MetricsMetadata returns the metrics metadata based on the provided req.
 func (d *Distributor) MetricsMetadata(ctx context.Context, req *ingester_client.MetricsMetadataRequest) ([]scrape.MetricMetadata, error) {
-	replicationSets, err := d.getIngesterReplicationSetsForQuery(ctx)
+	// The metadata request can include an optional filter on the metric name.
+	var matchers []*labels.Matcher
+	if req.Metric != "" {
+		matchers = []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, req.Metric)}
+	}
+
+	replicationSets, err := d.getIngesterReplicationSetsForQuery(ctx, matchers)
 	if err != nil {
 		return nil, err
 	}
@@ -3509,7 +3531,8 @@ func (d *Distributor) MetricsMetadata(ctx context.Context, req *ingester_client.
 
 // UserStats returns statistics about the current user.
 func (d *Distributor) UserStats(ctx context.Context, countMethod cardinality.CountMethod) (*UserStats, error) {
-	replicationSets, err := d.getIngesterReplicationSetsForQuery(ctx)
+	// UserStats counts all of a tenant's series, so there are no matchers to pass.
+	replicationSets, err := d.getIngesterReplicationSetsForQuery(ctx, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/distributor/distributor_search.go
+++ b/pkg/distributor/distributor_search.go
@@ -44,7 +44,7 @@ func (d *Distributor) SearchLabelNames(
 	hints *storage.SearchHints,
 	matchers []*labels.Matcher,
 ) storage.SearchResultSet {
-	replicationSets, err := d.getIngesterReplicationSetsForQuery(ctx)
+	replicationSets, err := d.getIngesterReplicationSetsForQuery(ctx, matchers)
 	if err != nil {
 		return storage.ErrSearchResultSet(err)
 	}
@@ -71,7 +71,7 @@ func (d *Distributor) SearchLabelValues(
 	hints *storage.SearchHints,
 	matchers []*labels.Matcher,
 ) storage.SearchResultSet {
-	replicationSets, err := d.getIngesterReplicationSetsForQuery(ctx)
+	replicationSets, err := d.getIngesterReplicationSetsForQuery(ctx, matchers)
 	if err != nil {
 		return storage.ErrSearchResultSet(err)
 	}

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -6399,12 +6399,24 @@ func prepareRingInstances(cfg prepConfig, ingesters []*mockIngester) *ring.Desc 
 
 // prepareCompartmentPartitionRing builds a partition ring desc with the given partitions set ACTIVE,
 // used to seed a single read compartment's partition ring in tests.
-func prepareCompartmentPartitionRing(activePartitions []int32) *ring.PartitionRingDesc {
+func prepareCompartmentPartitionRing(activePartitions []int32, ingesters []*mockIngester) *ring.PartitionRingDesc {
 	desc := ring.NewPartitionRingDesc()
 	timeBeforeShuffleShardingLookbackPeriod := time.Now().Add(-2 * time.Hour)
+
+	active := make(map[int32]struct{}, len(activePartitions))
 	for _, partitionID := range activePartitions {
 		desc.AddPartition(partitionID, ring.PartitionActive, timeBeforeShuffleShardingLookbackPeriod)
+		active[partitionID] = struct{}{}
 	}
+
+	// Add the ingesters owning this compartment's active partitions as owners, so the query path can
+	// resolve partition owners. An ingester owns the partition matching its instance ID.
+	for _, ingester := range ingesters {
+		if _, ok := active[ingester.partitionID()]; ok {
+			desc.AddOrUpdateOwner(ingester.instanceID(), ring.OwnerActive, ingester.partitionID(), timeBeforeShuffleShardingLookbackPeriod)
+		}
+	}
+
 	return desc
 }
 
@@ -6517,7 +6529,7 @@ func prepare(t testing.TB, cfg prepConfig) ([]*Distributor, []*mockIngester, []*
 				key := compartments.ReadCompartmentRingKey(c, ingester.PartitionRingKey)
 				activePartitions := cfg.compartmentActivePartitions[c]
 				require.NoError(t, partitionsStore.CAS(ctx, key, func(_ interface{}) (interface{}, bool, error) {
-					return prepareCompartmentPartitionRing(activePartitions), true, nil
+					return prepareCompartmentPartitionRing(activePartitions, ingesters), true, nil
 				}))
 			}
 		} else {

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -55,7 +55,18 @@ func (d *Distributor) QueryExemplars(ctx context.Context, from, to model.Time, m
 			return err
 		}
 
-		replicationSets, err := d.getIngesterReplicationSetsForQuery(ctx)
+		// The exemplars API accepts multiple matcher sets that are OR-ed together. With compartments
+		// enabled we only restrict the query when there's exactly one set: targeting the union of the
+		// per-set compartments isn't worth the extra complexity for the exemplars API, which is a secondary,
+		// infrequently used API in Mimir, so for multiple sets we let the query fan out to all compartments.
+		// Note we must not flatten the sets into one: distinct exact __name__ matchers from different sets
+		// would otherwise be read as conflicting and collapse to a single (wrong) compartment.
+		var compartmentMatchers []*labels.Matcher
+		if len(matchers) == 1 {
+			compartmentMatchers = matchers[0]
+		}
+
+		replicationSets, err := d.getIngesterReplicationSetsForQuery(ctx, compartmentMatchers)
 		if err != nil {
 			return err
 		}
@@ -92,7 +103,7 @@ func (d *Distributor) QueryStream(ctx context.Context, queryMetrics *stats.Query
 
 		req.StreamingChunksBatchSize = d.cfg.StreamingChunksPerIngesterSeriesBufferSize
 
-		replicationSets, err := d.getIngesterReplicationSetsForQuery(ctx)
+		replicationSets, err := d.getIngesterReplicationSetsForQuery(ctx, matchers)
 		if err != nil {
 			return err
 		}
@@ -114,16 +125,13 @@ func (d *Distributor) QueryStream(ctx context.Context, queryMetrics *stats.Query
 // that must be queried for a read operation.
 //
 // If multiple ring.ReplicationSets are returned, each must be queried separately, and results merged.
-func (d *Distributor) getIngesterReplicationSetsForQuery(ctx context.Context) ([]ring.ReplicationSet, error) {
+func (d *Distributor) getIngesterReplicationSetsForQuery(ctx context.Context, matchers []*labels.Matcher) ([]ring.ReplicationSet, error) {
 	userID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	if d.cfg.IngestStorageConfig.Enabled {
-		// Read path is not compartment-aware yet, so it always uses read compartment 0.
-		r := d.partitionInstanceRings.Get(0)
-
 		// Build a subring to query. We use ShuffleShardWithLookback() to limit the partitions to query
 		// to the tenant's shard (when shuffle sharding is enabled) and to filter out inactive partitions
 		// that have been inactive for longer than the lookback period.
@@ -131,7 +139,31 @@ func (d *Distributor) getIngesterReplicationSetsForQuery(ctx context.Context) ([
 		if d.cfg.ShuffleShardingEnabled {
 			shardSize = d.limits.IngestionPartitionsTenantShardSize(userID)
 		}
-		r, err = r.ShuffleShardWithLookback(userID, shardSize, d.cfg.IngestersLookbackPeriod, time.Now())
+
+		// When compartments are enabled, try to restrict the pool of compartments that need to be queried.
+		if d.cfg.Compartments.Enabled {
+			targets := d.compartmentRouter.CompartmentsForMatchers(userID, matchers)
+			var replicationSets []ring.ReplicationSet
+
+			for _, c := range targets {
+				r, err := d.partitionInstanceRings.Get(c).ShuffleShardWithLookback(userID, shardSize, d.cfg.IngestersLookbackPeriod, time.Now())
+				if err != nil {
+					return nil, err
+				}
+
+				sets, err := r.GetReplicationSetsForOperation(readNoExtend)
+				if err != nil {
+					return nil, err
+				}
+				replicationSets = append(replicationSets, sets...)
+			}
+
+			d.queryIngesterCompartmentsHit.Observe(float64(len(targets)))
+			return replicationSets, nil
+		}
+
+		// Compartments are disabled.
+		r, err := d.partitionInstanceRings.Get(0).ShuffleShardWithLookback(userID, shardSize, d.cfg.IngestersLookbackPeriod, time.Now())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/distributor/query_compartments_test.go
+++ b/pkg/distributor/query_compartments_test.go
@@ -1,0 +1,425 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package distributor
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/grafana/dskit/ring"
+	"github.com/grafana/dskit/test"
+	"github.com/grafana/dskit/user"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/compartments"
+	ingester_client "github.com/grafana/mimir/pkg/ingester/client"
+	"github.com/grafana/mimir/pkg/mimirpb"
+	"github.com/grafana/mimir/pkg/querier/stats"
+	"github.com/grafana/mimir/pkg/storage/ingest"
+	"github.com/grafana/mimir/pkg/util/limiter"
+)
+
+// TestDistributor_QueryStream_ShouldSupportCompartments verifies the end-to-end query path with read
+// compartments enabled: a query is served only from the compartments that can hold the selected metric
+// names, and from all compartments when it can't be restricted.
+func TestDistributor_QueryStream_ShouldSupportCompartments(t *testing.T) {
+	const (
+		tenantID        = "user"
+		numCompartments = 2
+	)
+
+	// Pick a metric name that routes to each compartment, and place its series in the ingester owning that
+	// compartment's partition (compartment c owns active partition c, owned by ingester-zone-a-c).
+	router := compartmentsTestRouter(numCompartments)
+	metricForCompartment := metricNamesByCompartment(t, router, tenantID, numCompartments)
+
+	compartmentData := make([]*mimirpb.WriteRequest, numCompartments)
+	activePartitions := make(map[int][]int32, numCompartments)
+	for c := 0; c < numCompartments; c++ {
+		compartmentData[c] = makeWriteRequest(0, 1, 0, false, false, metricForCompartment[c])
+		activePartitions[c] = []int32{int32(c)}
+	}
+
+	eqName := func(value string) *labels.Matcher {
+		return labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, value)
+	}
+	reName := func(value string) *labels.Matcher {
+		return labels.MustNewMatcher(labels.MatchRegexp, model.MetricNameLabel, value)
+	}
+
+	tests := map[string]struct {
+		matchers                 []*labels.Matcher
+		expectedResponse         model.Matrix
+		expectedCompartmentsHit  int // Number of compartments queried, as recorded by the compartments-hit metric.
+		expectedQueriedIngesters int // Equal to expectedCompartmentsHit here, since one ingester owns one compartment's partition.
+	}{
+		"a query pinned to compartment 0's metric is served only from compartment 0": {
+			matchers:                 []*labels.Matcher{eqName(metricForCompartment[0])},
+			expectedResponse:         expectedResponse(0, 1, false, metricForCompartment[0]),
+			expectedCompartmentsHit:  1,
+			expectedQueriedIngesters: 1,
+		},
+		"a query pinned to compartment 1's metric is served only from compartment 1": {
+			matchers:                 []*labels.Matcher{eqName(metricForCompartment[1])},
+			expectedResponse:         expectedResponse(0, 1, false, metricForCompartment[1]),
+			expectedCompartmentsHit:  1,
+			expectedQueriedIngesters: 1,
+		},
+		"a regexp metric-name set spanning both compartments is served from both": {
+			matchers:                 []*labels.Matcher{reName(strings.Join([]string{metricForCompartment[0], metricForCompartment[1]}, "|"))},
+			expectedResponse:         expectedResponse(0, 1, false, metricForCompartment[0], metricForCompartment[1]),
+			expectedCompartmentsHit:  2,
+			expectedQueriedIngesters: 2,
+		},
+		"a query without a metric-name matcher fans out to all compartments": {
+			matchers:                 []*labels.Matcher{mustEqualMatcher("bar", "baz")},
+			expectedResponse:         expectedResponse(0, 1, false, metricForCompartment[0], metricForCompartment[1]),
+			expectedCompartmentsHit:  2,
+			expectedQueriedIngesters: 2,
+		},
+		"a query pinned to a compartment is still targeted there even if it matches no series": {
+			matchers:                 []*labels.Matcher{eqName(metricForCompartment[0]), mustEqualMatcher("bar", "no-match")},
+			expectedResponse:         expectedResponse(0, 0, false),
+			expectedCompartmentsHit:  1,
+			expectedQueriedIngesters: 1,
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			ctx := user.InjectOrgID(context.Background(), tenantID)
+			ctx = limiter.ContextWithNewUnlimitedMemoryConsumptionTracker(ctx)
+			ctx = limiter.ContextWithNewSeriesLabelsDeduplicator(ctx, limiter.NewSeriesDeduplicatorMetrics(prometheus.NewPedanticRegistry()))
+
+			distributors, ingesters, distributorRegistries, _ := prepare(t, prepConfig{
+				numDistributors:         1,
+				ingestStorageEnabled:    true,
+				ingestStoragePartitions: numCompartments,
+				ingesterStateByZone: map[string]ingesterZoneState{
+					"zone-a": {numIngesters: numCompartments, happyIngesters: numCompartments},
+				},
+				ingesterDataByZone:          map[string][]*mimirpb.WriteRequest{"zone-a": compartmentData},
+				ingesterDataTenantID:        tenantID,
+				replicationFactor:           1,
+				numCompartments:             numCompartments,
+				compartmentActivePartitions: activePartitions,
+				limits:                      prepareDefaultLimits(),
+				configure: func(cfg *Config) {
+					cfg.Compartments.Enabled = true
+					cfg.Compartments.Read.NumCompartments = numCompartments
+					cfg.IngestStorageConfig.KafkaConfig.Topic = compartmentsTestTopicFormat
+				},
+			})
+			require.Len(t, distributors, 1)
+			d := distributors[0]
+
+			// Wait until each compartment's partition ring has discovered its active partition.
+			for c := 0; c < numCompartments; c++ {
+				test.Poll(t, 5*time.Second, 1, func() interface{} {
+					return d.partitionInstanceRings.Get(c).PartitionRing().ActivePartitionsCount()
+				})
+			}
+
+			queryMetrics := stats.NewQueryMetrics(distributorRegistries[0])
+			resp, err := d.QueryStream(ctx, queryMetrics, 0, 10, testData.matchers...)
+			require.NoError(t, err)
+
+			responseMatrix, err := ingester_client.StreamingSeriesToMatrixForTests(0, 5, resp.StreamingSeries)
+			require.NoError(t, err)
+			assert.Equal(t, testData.expectedResponse.String(), responseMatrix.String())
+
+			// Only the targeted compartments' ingesters should have been queried.
+			test.Poll(t, time.Second, testData.expectedQueriedIngesters, func() any {
+				return countMockIngestersCalls(ingesters, "QueryStream")
+			})
+
+			// The query recorded a single observation of the number of compartments it queried.
+			le1 := 0
+			if testData.expectedCompartmentsHit <= 1 {
+				le1 = 1
+			}
+			expectedMetrics := fmt.Sprintf(`
+				# HELP cortex_querier_compartments_hit_per_query Number of read compartments queried for a single query.
+				# TYPE cortex_querier_compartments_hit_per_query histogram
+				cortex_querier_compartments_hit_per_query_bucket{storage="ingester",le="1"} %d
+				cortex_querier_compartments_hit_per_query_bucket{storage="ingester",le="2"} 1
+				cortex_querier_compartments_hit_per_query_bucket{storage="ingester",le="+Inf"} 1
+				cortex_querier_compartments_hit_per_query_sum{storage="ingester"} %d
+				cortex_querier_compartments_hit_per_query_count{storage="ingester"} 1
+			`, le1, testData.expectedCompartmentsHit)
+			require.NoError(t, testutil.GatherAndCompare(distributorRegistries[0], strings.NewReader(expectedMetrics), "cortex_querier_compartments_hit_per_query"))
+		})
+	}
+}
+
+// TestDistributor_getIngesterReplicationSetsForQuery_Compartments verifies that, with read
+// compartments enabled, a query pinned to a single metric name targets only the owning compartment's
+// partition ring, while a non-pinnable query fans out to every compartment.
+func TestDistributor_getIngesterReplicationSetsForQuery_Compartments(t *testing.T) {
+	const (
+		tenantID        = "user"
+		numCompartments = 2
+	)
+
+	ctx := user.InjectOrgID(context.Background(), tenantID)
+	d, reg, metricForCompartment := prepareCompartmentsQueryTestDistributor(t, tenantID, numCompartments)
+
+	queriedPartitions := func(replicationSets []ring.ReplicationSet) []int {
+		var ids []int
+		for _, rs := range replicationSets {
+			require.NotEmpty(t, rs.Instances)
+			partitionID, err := ingest.IngesterPartitionID(rs.Instances[0].Addr)
+			require.NoError(t, err)
+			ids = append(ids, int(partitionID))
+		}
+		sort.Ints(ids)
+		return ids
+	}
+
+	// A query pinned to a metric name targets only the owning compartment.
+	for c := 0; c < numCompartments; c++ {
+		matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, metricForCompartment[c])}
+		replicationSets, err := d.getIngesterReplicationSetsForQuery(ctx, matchers)
+		require.NoError(t, err)
+		assert.Equal(t, []int{c}, queriedPartitions(replicationSets), "metric %q should be queried from compartment %d only", metricForCompartment[c], c)
+	}
+
+	// A query that can't be pinned fans out to all compartments.
+	replicationSets, err := d.getIngesterReplicationSetsForQuery(ctx, nil)
+	require.NoError(t, err)
+	assert.Equal(t, []int{0, 1}, queriedPartitions(replicationSets))
+
+	// The compartments-hit metric records 1 for each targeted query and numCompartments for the fan-out.
+	expectedMetrics := `
+		# HELP cortex_querier_compartments_hit_per_query Number of read compartments queried for a single query.
+		# TYPE cortex_querier_compartments_hit_per_query histogram
+		cortex_querier_compartments_hit_per_query_bucket{storage="ingester",le="1"} 2
+		cortex_querier_compartments_hit_per_query_bucket{storage="ingester",le="2"} 3
+		cortex_querier_compartments_hit_per_query_bucket{storage="ingester",le="+Inf"} 3
+		cortex_querier_compartments_hit_per_query_sum{storage="ingester"} 4
+		cortex_querier_compartments_hit_per_query_count{storage="ingester"} 3
+	`
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expectedMetrics), "cortex_querier_compartments_hit_per_query"))
+}
+
+// TestDistributor_QueryExemplars_Compartments verifies that the exemplars API, which accepts multiple
+// OR-ed matcher sets, targets a single compartment only when there's one set, and fans out to all
+// compartments for multiple sets (rather than collapsing distinct __name__ matchers to one compartment).
+func TestDistributor_QueryExemplars_Compartments(t *testing.T) {
+	const (
+		tenantID        = "user"
+		numCompartments = 2
+	)
+
+	eqName := func(value string) *labels.Matcher {
+		return labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, value)
+	}
+
+	t.Run("a single matcher set pinning a metric name targets only the owning compartment", func(t *testing.T) {
+		ctx := user.InjectOrgID(context.Background(), tenantID)
+		d, reg, metricForCompartment := prepareCompartmentsQueryTestDistributor(t, tenantID, numCompartments)
+
+		_, err := d.QueryExemplars(ctx, 0, 10, []*labels.Matcher{eqName(metricForCompartment[0])})
+		require.NoError(t, err)
+
+		// A single observation of 1 compartment hit.
+		expectedMetrics := `
+			# HELP cortex_querier_compartments_hit_per_query Number of read compartments queried for a single query.
+			# TYPE cortex_querier_compartments_hit_per_query histogram
+			cortex_querier_compartments_hit_per_query_bucket{storage="ingester",le="1"} 1
+			cortex_querier_compartments_hit_per_query_bucket{storage="ingester",le="2"} 1
+			cortex_querier_compartments_hit_per_query_bucket{storage="ingester",le="+Inf"} 1
+			cortex_querier_compartments_hit_per_query_sum{storage="ingester"} 1
+			cortex_querier_compartments_hit_per_query_count{storage="ingester"} 1
+		`
+		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expectedMetrics), "cortex_querier_compartments_hit_per_query"))
+	})
+
+	t.Run("multiple OR-ed sets spanning compartments must not collapse to one and fan out to all", func(t *testing.T) {
+		ctx := user.InjectOrgID(context.Background(), tenantID)
+		d, reg, metricForCompartment := prepareCompartmentsQueryTestDistributor(t, tenantID, numCompartments)
+
+		_, err := d.QueryExemplars(ctx, 0, 10, []*labels.Matcher{eqName(metricForCompartment[0])}, []*labels.Matcher{eqName(metricForCompartment[1])})
+		require.NoError(t, err)
+
+		// A single observation of all compartments hit (here, both).
+		expectedMetrics := `
+			# HELP cortex_querier_compartments_hit_per_query Number of read compartments queried for a single query.
+			# TYPE cortex_querier_compartments_hit_per_query histogram
+			cortex_querier_compartments_hit_per_query_bucket{storage="ingester",le="1"} 0
+			cortex_querier_compartments_hit_per_query_bucket{storage="ingester",le="2"} 1
+			cortex_querier_compartments_hit_per_query_bucket{storage="ingester",le="+Inf"} 1
+			cortex_querier_compartments_hit_per_query_sum{storage="ingester"} 2
+			cortex_querier_compartments_hit_per_query_count{storage="ingester"} 1
+		`
+		require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expectedMetrics), "cortex_querier_compartments_hit_per_query"))
+	})
+}
+
+// TestDistributor_MetricsMetadata_Compartments verifies that a metadata query for a single metric is
+// served only from the owning compartment (metadata is sharded by metric family name), while a query
+// without a metric filter fans out to all compartments.
+func TestDistributor_MetricsMetadata_Compartments(t *testing.T) {
+	const (
+		tenantID        = "user"
+		numCompartments = 2
+	)
+
+	t.Run("a request for a single metric targets its compartment", func(t *testing.T) {
+		ctx := user.InjectOrgID(context.Background(), tenantID)
+		d, reg, metricForCompartment := prepareCompartmentsQueryTestDistributor(t, tenantID, numCompartments)
+
+		_, err := d.MetricsMetadata(ctx, &ingester_client.MetricsMetadataRequest{Limit: -1, LimitPerMetric: -1, Metric: metricForCompartment[0]})
+		require.NoError(t, err)
+		assertCompartmentsHitObservation(t, reg, numCompartments, 1)
+	})
+
+	t.Run("a request without a metric fans out to all compartments", func(t *testing.T) {
+		ctx := user.InjectOrgID(context.Background(), tenantID)
+		d, reg, _ := prepareCompartmentsQueryTestDistributor(t, tenantID, numCompartments)
+
+		_, err := d.MetricsMetadata(ctx, &ingester_client.MetricsMetadataRequest{Limit: -1, LimitPerMetric: -1})
+		require.NoError(t, err)
+		assertCompartmentsHitObservation(t, reg, numCompartments, numCompartments)
+	})
+}
+
+// TestDistributor_LabelNames_Compartments covers a representative label query caller: matchers are
+// threaded into the compartment targeting just like the streaming query path.
+func TestDistributor_LabelNames_Compartments(t *testing.T) {
+	const (
+		tenantID        = "user"
+		numCompartments = 2
+	)
+
+	t.Run("a query pinned to a metric name targets its compartment", func(t *testing.T) {
+		ctx := user.InjectOrgID(context.Background(), tenantID)
+		d, reg, metricForCompartment := prepareCompartmentsQueryTestDistributor(t, tenantID, numCompartments)
+
+		_, err := d.LabelNames(ctx, 0, 10, nil, labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, metricForCompartment[0]))
+		require.NoError(t, err)
+		assertCompartmentsHitObservation(t, reg, numCompartments, 1)
+	})
+
+	t.Run("a query without a metric-name matcher fans out to all compartments", func(t *testing.T) {
+		ctx := user.InjectOrgID(context.Background(), tenantID)
+		d, reg, _ := prepareCompartmentsQueryTestDistributor(t, tenantID, numCompartments)
+
+		_, err := d.LabelNames(ctx, 0, 10, nil, labels.MustNewMatcher(labels.MatchEqual, "bar", "baz"))
+		require.NoError(t, err)
+		assertCompartmentsHitObservation(t, reg, numCompartments, numCompartments)
+	})
+}
+
+// TestDistributor_adjustQueryRequestLimit_Compartments verifies the per-query limit is divided by the
+// active partition count summed across all compartments, not just one compartment's.
+func TestDistributor_adjustQueryRequestLimit_Compartments(t *testing.T) {
+	const (
+		tenantID        = "user"
+		numCompartments = 2
+	)
+
+	ctx := user.InjectOrgID(context.Background(), tenantID)
+	d, _, _ := prepareCompartmentsQueryTestDistributor(t, tenantID, numCompartments)
+
+	// Each compartment has one active partition, so the shard size sums to numCompartments across them.
+	// A limit larger than that shard size is divided by it (rounded up); had it summed a single
+	// compartment (shard size 1) the limit would be returned unchanged.
+	assert.Equal(t, 5, d.adjustQueryRequestLimit(ctx, tenantID, 10))
+	// A limit not larger than the shard size is returned unchanged.
+	assert.Equal(t, numCompartments, d.adjustQueryRequestLimit(ctx, tenantID, numCompartments))
+	// A zero limit (no limit) is returned unchanged.
+	assert.Equal(t, 0, d.adjustQueryRequestLimit(ctx, tenantID, 0))
+}
+
+// assertCompartmentsHitObservation asserts the compartments-hit histogram recorded a single observation
+// of the given number of compartments.
+func assertCompartmentsHitObservation(t *testing.T, reg *prometheus.Registry, numCompartments, hit int) {
+	t.Helper()
+
+	var b strings.Builder
+	b.WriteString("# HELP cortex_querier_compartments_hit_per_query Number of read compartments queried for a single query.\n")
+	b.WriteString("# TYPE cortex_querier_compartments_hit_per_query histogram\n")
+	for le := 1; le <= numCompartments; le++ {
+		count := 0
+		if hit <= le {
+			count = 1
+		}
+		fmt.Fprintf(&b, "cortex_querier_compartments_hit_per_query_bucket{storage=\"ingester\",le=\"%d\"} %d\n", le, count)
+	}
+	b.WriteString("cortex_querier_compartments_hit_per_query_bucket{storage=\"ingester\",le=\"+Inf\"} 1\n")
+	fmt.Fprintf(&b, "cortex_querier_compartments_hit_per_query_sum{storage=\"ingester\"} %d\n", hit)
+	b.WriteString("cortex_querier_compartments_hit_per_query_count{storage=\"ingester\"} 1\n")
+
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(b.String()), "cortex_querier_compartments_hit_per_query"))
+}
+
+// prepareCompartmentsQueryTestDistributor builds a queryable distributor with read compartments enabled.
+// Each compartment c owns a single active partition (== c) owned by ingester-zone-a-c, so a returned
+// replication set's partition ID identifies the compartment it targets. It returns the distributor, its
+// metrics registry, and, indexed by compartment, a metric name that routes to it.
+func prepareCompartmentsQueryTestDistributor(t *testing.T, tenantID string, numCompartments int) (*Distributor, *prometheus.Registry, []string) {
+	t.Helper()
+
+	activePartitions := make(map[int][]int32, numCompartments)
+	for c := 0; c < numCompartments; c++ {
+		activePartitions[c] = []int32{int32(c)}
+	}
+
+	distributors, _, regs, _ := prepare(t, prepConfig{
+		numDistributors:         1,
+		ingestStorageEnabled:    true,
+		ingestStoragePartitions: int32(numCompartments),
+		ingesterStateByZone: map[string]ingesterZoneState{
+			"zone-a": {numIngesters: numCompartments, happyIngesters: numCompartments},
+		},
+		ingesterDataTenantID:        tenantID,
+		replicationFactor:           1,
+		numCompartments:             numCompartments,
+		compartmentActivePartitions: activePartitions,
+		limits:                      prepareDefaultLimits(),
+		configure: func(cfg *Config) {
+			cfg.Compartments.Enabled = true
+			cfg.Compartments.Read.NumCompartments = numCompartments
+			cfg.IngestStorageConfig.KafkaConfig.Topic = compartmentsTestTopicFormat
+		},
+	})
+	require.Len(t, distributors, 1)
+	d := distributors[0]
+
+	// Wait until each compartment's partition ring has discovered its active partition.
+	for c := 0; c < numCompartments; c++ {
+		test.Poll(t, 5*time.Second, 1, func() interface{} {
+			return d.partitionInstanceRings.Get(c).PartitionRing().ActivePartitionsCount()
+		})
+	}
+
+	return d, regs[0], metricNamesByCompartment(t, compartmentsTestRouter(numCompartments), tenantID, numCompartments)
+}
+
+// metricNamesByCompartment returns, indexed by compartment, a metric name that the router assigns to that
+// compartment for the given tenant.
+func metricNamesByCompartment(t *testing.T, router *compartments.Router, tenantID string, numCompartments int) []string {
+	t.Helper()
+
+	metricForCompartment := make([]string, numCompartments)
+	remaining := numCompartments
+	for i := 0; remaining > 0; i++ {
+		require.Less(t, i, 1000, "could not find a metric name for every compartment")
+		name := fmt.Sprintf("metric_%d", i)
+		if c := router.CompartmentForMetric(tenantID, name); metricForCompartment[c] == "" {
+			metricForCompartment[c] = name
+			remaining--
+		}
+	}
+	return metricForCompartment
+}

--- a/pkg/distributor/query_compartments_test.go
+++ b/pkg/distributor/query_compartments_test.go
@@ -321,7 +321,7 @@ func TestDistributor_LabelNames_Compartments(t *testing.T) {
 }
 
 // TestDistributor_adjustQueryRequestLimit_Compartments verifies the per-query limit is divided by the
-// active partition count summed across all compartments, not just one compartment's.
+// active partition count of only the compartments the query targets, not the whole cluster.
 func TestDistributor_adjustQueryRequestLimit_Compartments(t *testing.T) {
 	const (
 		tenantID        = "user"
@@ -329,16 +329,20 @@ func TestDistributor_adjustQueryRequestLimit_Compartments(t *testing.T) {
 	)
 
 	ctx := user.InjectOrgID(context.Background(), tenantID)
-	d, _, _ := prepareCompartmentsQueryTestDistributor(t, tenantID, numCompartments)
+	d, _, metricForCompartment := prepareCompartmentsQueryTestDistributor(t, tenantID, numCompartments)
 
-	// Each compartment has one active partition, so the shard size sums to numCompartments across them.
-	// A limit larger than that shard size is divided by it (rounded up); had it summed a single
-	// compartment (shard size 1) the limit would be returned unchanged.
-	assert.Equal(t, 5, d.adjustQueryRequestLimit(ctx, tenantID, 10))
+	// A fan-out query (no metric-name matcher) targets all compartments; with one active partition each,
+	// the shard size sums to numCompartments, so a larger limit is divided by it (rounded up).
+	assert.Equal(t, 5, d.adjustQueryRequestLimit(ctx, tenantID, nil, 10))
 	// A limit not larger than the shard size is returned unchanged.
-	assert.Equal(t, numCompartments, d.adjustQueryRequestLimit(ctx, tenantID, numCompartments))
+	assert.Equal(t, numCompartments, d.adjustQueryRequestLimit(ctx, tenantID, nil, numCompartments))
 	// A zero limit (no limit) is returned unchanged.
-	assert.Equal(t, 0, d.adjustQueryRequestLimit(ctx, tenantID, 0))
+	assert.Equal(t, 0, d.adjustQueryRequestLimit(ctx, tenantID, nil, 0))
+
+	// A query pinned to a single compartment is divided by only that compartment's shard size (1 active
+	// partition here), so the limit is left intact rather than over-divided by the whole cluster.
+	pinned := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, metricForCompartment[0])}
+	assert.Equal(t, 10, d.adjustQueryRequestLimit(ctx, tenantID, pinned, 10))
 }
 
 // assertCompartmentsHitObservation asserts the compartments-hit histogram recorded a single observation

--- a/pkg/distributor/query_ingest_storage_test.go
+++ b/pkg/distributor/query_ingest_storage_test.go
@@ -678,7 +678,7 @@ func TestDistributor_QueryStream_InactivePartitionsLookback(t *testing.T) {
 				})
 
 				// Verify getIngesterReplicationSetsForQuery returns the expected partitions.
-				replicationSets, err := d.getIngesterReplicationSetsForQuery(ctx)
+				replicationSets, err := d.getIngesterReplicationSetsForQuery(ctx, nil)
 				require.NoError(t, err)
 
 				var actualPartitionIDs []int


### PR DESCRIPTION
#### What this PR does

Makes the distributor's ingester query path compartment-aware. With read compartments enabled, series are sharded across compartments by metric name, but the query path always read from compartment 0, so only ~1/N of the data was queryable.

Queries now hit only the compartments that can hold the selected metric names: a single compartment for an exact `__name__` matcher, the union of compartments for an enumerable regexp set (e.g. `a|b`), and all compartments when the query can't be restricted (no/open-ended metric-name matcher, metadata and whole-tenant stats). This is what delivers the query blast-radius reduction the architecture aims for: a problem in one compartment only affects queries whose metric names route to it.

The compartment count is assumed static. Strong read consistency is out of scope and handled separately.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
