### PR TITLE
Allow Alertmanager fallback config from an existing Kubernetes secret

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -43,6 +43,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [CHANGE] Set docker.io as the default registry for mimir image. #13267
 * [CHANGE] Query-frontend: Increase default query-frontend cache size limit to 25MB. #14857
 * [CHANGE] Query-frontend: Increase default query-frontend memory limit to 4GiB. #15688
+* [CHANGE] Allow the Mimir Alertmanager to use a fallback configuration from an existing Kubernetes secret. #12157
 * [ENHANCEMENT] Add Support to customize gossip ring k8s service annotations. #12718
 * [ENHANCEMENT] Ruler querier and query-frontend: Add support for newly-introduced querier ring, which is used when performing query planning in query-frontends and distributing portions of the plan to queriers for execution. #13017
 * [ENHANCEMENT] Upgrade rollout-operator chart to [0.38.0](https://github.com/grafana/helm-charts/blob/main/charts/rollout-operator/README.md#upgrade-of-grafana-rollout-operator--v0380). Note required actions for upgrading the rollout-operator chart. #13245, #15626

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -32,6 +32,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 * [CHANGE] Querier: Reduce the default concurrency of queriers, `querier.max_concurrent`, to 8. #15984
 * [BUGFIX] Fix bug in `ScaledObject` templates when using `kedaAutoscaling.fallback` #15793
+* [CHANGE] Allow the Mimir Alertmanager to use a fallback configuration from an existing Kubernetes secret. #15723
 
 ## 6.1.0
 
@@ -43,7 +44,6 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [CHANGE] Set docker.io as the default registry for mimir image. #13267
 * [CHANGE] Query-frontend: Increase default query-frontend cache size limit to 25MB. #14857
 * [CHANGE] Query-frontend: Increase default query-frontend memory limit to 4GiB. #15688
-* [CHANGE] Allow the Mimir Alertmanager to use a fallback configuration from an existing Kubernetes secret. #12157
 * [ENHANCEMENT] Add Support to customize gossip ring k8s service annotations. #12718
 * [ENHANCEMENT] Ruler querier and query-frontend: Add support for newly-introduced querier ring, which is used when performing query planning in query-frontends and distributing portions of the plan to queriers for execution. #13017
 * [ENHANCEMENT] Upgrade rollout-operator chart to [0.38.0](https://github.com/grafana/helm-charts/blob/main/charts/rollout-operator/README.md#upgrade-of-grafana-rollout-operator--v0380). Note required actions for upgrading the rollout-operator chart. #13245, #15626

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-config.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-config.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.alertmanager.enabled -}}
+{{- if and .Values.alertmanager.enabled (not .Values.alertmanager.fallbackConfigExistingSecret)-}}
 {{- if .Values.alertmanager.fallbackConfig -}}
 apiVersion: v1
 kind: ConfigMap
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "mimir.labels" (dict "ctx" . "component" "alertmanager" "memberlist" true) | nindent 4 }}
   annotations:
-  {{- toYaml .Values.alertmanager.annotations | nindent 4 }} 
+  {{- toYaml .Values.alertmanager.annotations | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
 data:
   alertmanager_fallback_config.yaml: |

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-config.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-config.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.alertmanager.enabled (not .Values.alertmanager.fallbackConfigExistingSecret)-}}
+{{- if and .Values.alertmanager.enabled (not .Values.alertmanager.externalFallbackConfigSecret)-}}
 {{- if .Values.alertmanager.fallbackConfig -}}
 apiVersion: v1
 kind: ConfigMap

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-dep.yaml
@@ -73,7 +73,7 @@ spec:
               {{- if .Values.alertmanager.persistence.subPath }}
               subPath: {{ .Values.alertmanager.persistence.subPath }}
               {{- end }}
-            {{- if .Values.alertmanager.fallbackConfig }}
+            {{- if or .Values.alertmanager.fallbackConfig .Values.alertmanager.externalFallbackConfigSecret }}
             - name: alertmanager-fallback-config
               mountPath: /configs/
             {{- end }}
@@ -139,10 +139,18 @@ spec:
           emptyDir: {}
         - name: active-queries
           emptyDir: {}
-        {{- if .Values.alertmanager.fallbackConfig }}
+        {{- if and .Values.alertmanager.fallbackConfig (not .Values.alertmanager.externalFallbackConfigSecret) }}
         - name: alertmanager-fallback-config
           configMap:
             name: {{ include "mimir.resourceName" (dict "ctx" . "component" "alertmanager") }}-fallback-config
+        {{- end }}
+        {{- with .Values.alertmanager.externalFallbackConfigSecret }}
+        - name: alertmanager-fallback-config
+          secret:
+            secretName: {{ .name }}
+            items:
+              - key: {{ .key }}
+                path: alertmanager_fallback_config.yaml
         {{- end }}
 {{- end -}}
 {{- end -}}

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -134,15 +134,18 @@ spec:
           emptyDir: {}
         - name: active-queries
           emptyDir: {}
-        {{- if and .Values.alertmanager.fallbackConfig (not .Values.alertmanager.fallbackConfigExistingSecret) }}
+        {{- if and .Values.alertmanager.fallbackConfig (not .Values.alertmanager.externalFallbackConfigSecret) }}
         - name: alertmanager-fallback-config
           configMap:
             name: {{ include "mimir.resourceName" (dict "ctx" . "component" "alertmanager") }}-fallback-config
         {{- end }}
-        {{- with .Values.alertmanager.fallbackConfigExistingSecret }}
+        {{- with .Values.alertmanager.externalFallbackConfigSecret }}
         - name: alertmanager-fallback-config
           secret:
-            secretName: {{ . }}
+            secretName: {{ .name }}
+            items:
+              - key: {{ .key }}
+                path: alertmanager_fallback_config.yaml
         {{- end }}
         {{- if .Values.alertmanager.extraVolumes }}
         {{ toYaml .Values.alertmanager.extraVolumes | nindent 8 }}
@@ -191,7 +194,7 @@ spec:
               {{- if .Values.alertmanager.persistentVolume.subPath }}
               subPath: {{ .Values.alertmanager.persistentVolume.subPath }}
               {{- end }}
-            {{- if .Values.alertmanager.fallbackConfig }}
+            {{- if or .Values.alertmanager.fallbackConfig .Values.alertmanager.externalFallbackConfigSecret }}
             - name: alertmanager-fallback-config
               mountPath: /configs/
             {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -134,10 +134,15 @@ spec:
           emptyDir: {}
         - name: active-queries
           emptyDir: {}
-        {{- if .Values.alertmanager.fallbackConfig }}
+        {{- if and .Values.alertmanager.fallbackConfig (not .Values.alertmanager.fallbackConfigExistingSecret) }}
         - name: alertmanager-fallback-config
           configMap:
             name: {{ include "mimir.resourceName" (dict "ctx" . "component" "alertmanager") }}-fallback-config
+        {{- end }}
+        {{- with .Values.alertmanager.fallbackConfigExistingSecret }}
+        - name: alertmanager-fallback-config
+          secret:
+            secretName: {{ . }}
         {{- end }}
         {{- if .Values.alertmanager.extraVolumes }}
         {{ toYaml .Values.alertmanager.extraVolumes | nindent 8 }}

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -132,7 +132,7 @@ mimir:
       sharding_ring:
         zone_awareness_enabled: true
       {{- end }}
-      {{- if .Values.alertmanager.fallbackConfig }}
+      {{- if or .Values.alertmanager.fallbackConfig .Values.alertmanager.externalFallbackConfigSecret }}
       fallback_config_file: /configs/alertmanager_fallback_config.yaml
       {{- end }}
 
@@ -519,6 +519,7 @@ alertmanager:
 
   # -- Fallback config for alertmanager.
   # When a tenant doesn't have an Alertmanager configuration, the Grafana Mimir Alertmanager uses the fallback configuration.
+  # Ignored when alertmanager.externalFallbackConfigSecret is set.
   fallbackConfig: |
     receivers:
         - name: default-receiver
@@ -526,8 +527,10 @@ alertmanager:
         receiver: default-receiver
 
   # -- use an existing Kubernetes secret for the fallback config for alertmanager.
-  # if set, ignores alertmanager.fallbackConfig
-  fallbackConfigExistingSecret: ""
+  # If set, overrides alertmanager.fallbackConfig
+  externalFallbackConfigSecret: {}
+  #   name: secret-name
+  #   key: secret-key
 
   extraArgs: {}
 

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -525,6 +525,10 @@ alertmanager:
     route:
         receiver: default-receiver
 
+  # -- use an existing Kubernetes secret for the fallback config for alertmanager.
+  # if set, ignores alertmanager.fallbackConfig
+  fallbackConfigExistingSecret: ""
+
   extraArgs: {}
 
   # Pod Labels


### PR DESCRIPTION
#### What this PR does

Adds a `alertmanager.externalFallbackConfigSecret` helm parameter so users can pass in their alertmanager config from an existing Kubernetes Secret (this is important as the alertmanager config can contain API tokens that should be secret and not checked directly into git repos).

#### Which issue(s) this PR fixes or relates to

Continues #12157
Provides alternative for #12153

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Default behavior is unchanged when `externalFallbackConfigSecret` is empty; misconfigured secret name/key could break Alertmanager startup for operators who opt in.
> 
> **Overview**
> Adds **`alertmanager.externalFallbackConfigSecret`** (`name` + `key`) so the Mimir Alertmanager fallback config can come from an existing Kubernetes **Secret** instead of the inline **`fallbackConfig`** value rendered into a ConfigMap.
> 
> When the secret is set, the chart **skips** the fallback ConfigMap, still sets **`fallback_config_file`** in Mimir config, and mounts the secret key as **`alertmanager_fallback_config.yaml`** under **`/configs/`** on both Alertmanager **Deployment** and **StatefulSet** workloads. **`fallbackConfig`** is documented as ignored in that mode. CHANGELOG records the behavior as a **[CHANGE]**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 085e61af2d16071a40fd9ab1203a8e3bc178a519. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->