### PR TITLE
Use suffix instead of prefix for read compartment ring key/name

### DIFF
--- a/pkg/compartments/config.go
+++ b/pkg/compartments/config.go
@@ -84,20 +84,21 @@ func ReplaceWriteCompartment(s string, writeCompartmentID int) string {
 	return strings.ReplaceAll(s, WriteCompartmentIDPlaceholder, strconv.Itoa(writeCompartmentID))
 }
 
-// readCompartmentRingPrefix builds the "rc-<id>-" prefix prepended to a ring key or name to
-// scope it to a single read compartment.
-func readCompartmentRingPrefix(compartmentID int) string {
-	return "rc-" + strconv.Itoa(compartmentID) + "-"
+// readCompartmentRingSuffix builds the "-rc-<id>" suffix appended to a ring key or name to
+// scope it to a single read compartment. A suffix is used for consistency with how the read
+// compartment ID is appended elsewhere (e.g. Kubernetes resource names, offset filenames).
+func readCompartmentRingSuffix(compartmentID int) string {
+	return "-rc-" + strconv.Itoa(compartmentID)
 }
 
 // ReadCompartmentRingKey returns the KVStore key for the partition ring of the given read
 // compartment, derived from the non-compartment ring key.
 func ReadCompartmentRingKey(compartmentID int, ringKey string) string {
-	return readCompartmentRingPrefix(compartmentID) + ringKey
+	return ringKey + readCompartmentRingSuffix(compartmentID)
 }
 
 // ReadCompartmentRingName returns the ring name for the given read compartment, derived from the
 // non-compartment ring name.
 func ReadCompartmentRingName(compartmentID int, ringName string) string {
-	return readCompartmentRingPrefix(compartmentID) + ringName
+	return ringName + readCompartmentRingSuffix(compartmentID)
 }

--- a/pkg/compartments/config_test.go
+++ b/pkg/compartments/config_test.go
@@ -65,8 +65,8 @@ func TestReplaceWriteCompartment(t *testing.T) {
 }
 
 func TestReadCompartmentRingKeyAndName(t *testing.T) {
-	assert.Equal(t, "rc-0-ingester-partitions", ReadCompartmentRingKey(0, "ingester-partitions"))
-	assert.Equal(t, "rc-3-ingester-partitions", ReadCompartmentRingKey(3, "ingester-partitions"))
-	assert.Equal(t, "rc-0-partition-ring", ReadCompartmentRingName(0, "partition-ring"))
-	assert.Equal(t, "rc-2-partition-ring", ReadCompartmentRingName(2, "partition-ring"))
+	assert.Equal(t, "ingester-partitions-rc-0", ReadCompartmentRingKey(0, "ingester-partitions"))
+	assert.Equal(t, "ingester-partitions-rc-3", ReadCompartmentRingKey(3, "ingester-partitions"))
+	assert.Equal(t, "partition-ring-rc-0", ReadCompartmentRingName(0, "partition-ring"))
+	assert.Equal(t, "partition-ring-rc-2", ReadCompartmentRingName(2, "partition-ring"))
 }


### PR DESCRIPTION
#### What this PR does

Read compartment ring keys/names were scoped with an `rc-<id>-` prefix (e.g. `rc-0-ingester-partitions`). Everywhere else the read compartment ID is appended as a suffix (Kubernetes resource names, offset filenames, Kafka topics), so this switches the ring key/name to the same convention: `ingester-partitions-rc-0`.

This keeps naming consistent across the feature. The read compartments feature is internal/experimental and not yet released, so this is not a user-visible change.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.