### PR TITLE
store-gateway: add cortex_bucket_store_blocks_queried_per_request histogram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [ENHANCEMENT] Ingest storage: Reject the whole batch of records of a Kafka write call when the configured `-ingest-storage.kafka.producer-max-buffered-bytes` limit is reached, instead of rejecting individual records. #15227
 * [ENHANCEMENT] MQE: Simplify `unless` and `or` operations where one side can be proven to be empty by inspecting the expression. #15198
 * [ENHANCEMENT] Store-gateway: Remove outdated limit on caching LabelValues responses that contain more than 655360 values. The gob library panic which required workaround was fixed. #5021 #15271
+* [ENHANCEMENT] Store-gateway: Add `cortex_bucket_store_blocks_queried_per_request` native histogram tracking the total number of blocks queried by a single Series/LabelValues/LabelNames request, observed when it starts. #15726
 * [ENHANCEMENT] MQE: Reduce memory consumption of range vector splitting when many consecutive intervals are not cached. #15173
 * [ENHANCEMENT] Ingester: Make max concurrency for label values count endpoint configurable with `-ingester.label-values-count-max-concurrency`. #15299
 * [ENHANCEMENT] Ingest storage: Add `cortex_ingest_storage_writer_serialize_duration_seconds` native histogram metric tracking the time spent serializing an incoming request to Kafka records. #15527

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -621,6 +621,7 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, srv storegatewaypb.Stor
 	defer s.recordBucketIndexDiscoveryDiff(ctx)
 
 	blocks, indexReaders, chunkReaders := s.openBlocksForReading(ctx, req.SkipChunks, req.MinTime, req.MaxTime, reqBlockMatchers, stats)
+	s.metrics.blocksQueriedPerRequest.Observe(float64(len(blocks)))
 	// We must keep the readers open until all their data has been sent.
 	defer func() {
 		for _, r := range indexReaders {
@@ -1312,12 +1313,14 @@ func (s *BucketStore) LabelNames(ctx context.Context, req *storepb.LabelNamesReq
 
 	var setsMtx sync.Mutex
 	var sets [][]string
+	var numBlocks int
 	var blocksQueriedByBlockMeta = make(map[blockQueriedMeta]int)
 	seriesLimiter := s.seriesLimiterFactory(s.metrics.queriesDropped.WithLabelValues("series"))
 
 	s.blockSet.filter(req.Start, req.End, reqBlockMatchers, func(b *bucketBlock) {
 		resHints.AddQueriedBlock(b.meta.ULID)
 
+		numBlocks++
 		blocksQueriedByBlockMeta[newBlockQueriedMeta(b.meta)]++
 
 		// This indexReader is here to make sure its block is held open inside the goroutine below.
@@ -1342,6 +1345,7 @@ func (s *BucketStore) LabelNames(ctx context.Context, req *storepb.LabelNamesReq
 			return nil
 		})
 	})
+	s.metrics.blocksQueriedPerRequest.Observe(float64(numBlocks))
 
 	if err := g.Wait(); err != nil {
 		if errors.Is(err, context.Canceled) {
@@ -1506,8 +1510,11 @@ func (s *BucketStore) LabelValues(ctx context.Context, req *storepb.LabelValuesR
 
 	var setsMtx sync.Mutex
 	var sets [][]string
+	var numBlocks int
 	s.blockSet.filter(req.Start, req.End, reqBlockMatchers, func(b *bucketBlock) {
 		resHints.AddQueriedBlock(b.meta.ULID)
+
+		numBlocks++
 
 		// This index reader shouldn't be used for ExpandedPostings, since it doesn't have the correct strategy.
 		// It's here only to make sure the block is held open inside the goroutine below.
@@ -1532,6 +1539,7 @@ func (s *BucketStore) LabelValues(ctx context.Context, req *storepb.LabelValuesR
 			return nil
 		})
 	})
+	s.metrics.blocksQueriedPerRequest.Observe(float64(numBlocks))
 
 	if err := g.Wait(); err != nil {
 		if errors.Is(err, context.Canceled) {

--- a/pkg/storegateway/bucket_e2e_test.go
+++ b/pkg/storegateway/bucket_e2e_test.go
@@ -485,6 +485,7 @@ func assertQueryStatsMetricsRecorded(t *testing.T, numSeries int, numChunksPerSe
 
 		assert.NotZero(t, numObservationsForHistogram(t, "cortex_bucket_store_series_request_stage_duration_seconds", metrics))
 		assert.NotZero(t, numObservationsForSummaries(t, "cortex_bucket_store_series_blocks_queried", metrics, "source", "test", "level", "1"))
+		assert.NotZero(t, numObservationsForHistogram(t, "cortex_bucket_store_blocks_queried_per_request", metrics))
 	}
 	if numChunksPerSeries > 0 {
 		assert.NotZero(t, numObservationsForSummaries(t, "cortex_bucket_store_series_data_touched", metrics, "data_type", "chunks"))

--- a/pkg/storegateway/bucket_store_metrics.go
+++ b/pkg/storegateway/bucket_store_metrics.go
@@ -22,21 +22,22 @@ import (
 // can be passed to multiple BucketStore and metrics MUST be correct even after a
 // BucketStore is offloaded.
 type BucketStoreMetrics struct {
-	blockLoads            prometheus.Counter
-	blockLoadFailures     prometheus.Counter
-	blockDrops            prometheus.Counter
-	blockDropFailures     prometheus.Counter
-	blockDiscoveryLatency prometheus.Histogram
-	seriesDataTouched     *prometheus.SummaryVec
-	seriesDataFetched     *prometheus.SummaryVec
-	seriesDataSizeTouched *prometheus.SummaryVec
-	seriesDataSizeFetched *prometheus.SummaryVec
-	seriesBlocksQueried   *prometheus.SummaryVec
-	resultSeriesCount     prometheus.Summary
-	chunkSizeBytes        prometheus.Histogram
-	chunkSizeEstimateType *prometheus.CounterVec
-	queriesDropped        *prometheus.CounterVec
-	seriesRefetches       prometheus.Counter
+	blockLoads              prometheus.Counter
+	blockLoadFailures       prometheus.Counter
+	blockDrops              prometheus.Counter
+	blockDropFailures       prometheus.Counter
+	blockDiscoveryLatency   prometheus.Histogram
+	seriesDataTouched       *prometheus.SummaryVec
+	seriesDataFetched       *prometheus.SummaryVec
+	seriesDataSizeTouched   *prometheus.SummaryVec
+	seriesDataSizeFetched   *prometheus.SummaryVec
+	seriesBlocksQueried     *prometheus.SummaryVec
+	blocksQueriedPerRequest prometheus.Histogram
+	resultSeriesCount       prometheus.Summary
+	chunkSizeBytes          prometheus.Histogram
+	chunkSizeEstimateType   *prometheus.CounterVec
+	queriesDropped          *prometheus.CounterVec
+	seriesRefetches         prometheus.Counter
 
 	bucketIndexVersionDiffSeconds prometheus.Histogram
 
@@ -118,6 +119,15 @@ func NewBucketStoreMetrics(reg prometheus.Registerer) *BucketStoreMetrics {
 		Name: "cortex_bucket_store_series_blocks_queried",
 		Help: "Number of blocks in a bucket store that were touched to satisfy a query. level|source=unknown/old_block means that the block was created before we started collecting these statistics in 2.12.0.",
 	}, []string{"source", "level", "out_of_order"})
+	m.blocksQueriedPerRequest = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+		Name:    "cortex_bucket_store_blocks_queried_per_request",
+		Help:    "Total number of blocks queried by a single Series/LabelValues/LabelNames request, observed when it starts.",
+		Buckets: prometheus.ExponentialBuckets(1, 2, 13), // 1 to 4096 blocks.
+
+		NativeHistogramBucketFactor:     1.1,
+		NativeHistogramMaxBucketNumber:  100,
+		NativeHistogramMinResetDuration: 1 * time.Hour,
+	})
 	m.seriesRefetches = promauto.With(reg).NewCounter(prometheus.CounterOpts{
 		Name: "cortex_bucket_store_series_refetches_total",
 		Help: "Total number of cases where the built-in max series size was not enough to fetch series from index, resulting in refetch.",


### PR DESCRIPTION
#### What this PR does

Adds the `cortex_bucket_store_blocks_queried_per_request` histogram (classic + native), tracking the total number of blocks queried by a single Series/LabelValues/LabelNames request.

It is observed when the request starts, so it also accounts for requests that fail or are interrupted before completing. This complements the existing `cortex_bucket_store_series_blocks_queried` summary, which is sliced by block metadata and recorded only at the end of a request.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
