### PR TITLE
Deduplicate PostingsOffset calls in labelValuesFromPostings

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1709,7 +1709,7 @@ func labelValuesFromPostings(ctx context.Context, labelName string, indexr *buck
 		keys[i] = labels.Label{Name: labelName, Value: value.LabelValue}
 	}
 
-	fetchedPostings, err := indexr.FetchPostings(ctx, keys, stats)
+	fetchedPostings, err := indexr.buildPostingsFromKnownOffsets(ctx, keys, map[string][]streamindex.PostingListOffset{labelName: allValues}, stats)
 	if err != nil {
 		return nil, errors.Wrap(err, "get postings")
 	}

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1708,8 +1708,7 @@ func labelValuesFromPostings(ctx context.Context, labelName string, indexr *buck
 	for i, value := range allValues {
 		keys[i] = labels.Label{Name: labelName, Value: value.LabelValue}
 	}
-
-	fetchedPostings, err := indexr.buildPostingsFromKnownOffsets(ctx, keys, map[string][]streamindex.PostingListOffset{labelName: allValues}, stats)
+	fetchedPostings, err := indexr.FetchPostingsForKnownOffsets(ctx, keys, map[string][]streamindex.PostingListOffset{labelName: allValues}, stats)
 	if err != nil {
 		return nil, errors.Wrap(err, "get postings")
 	}

--- a/pkg/storegateway/bucket_index_reader.go
+++ b/pkg/storegateway/bucket_index_reader.go
@@ -397,11 +397,13 @@ func toPostingGroups(ctx context.Context, ms []*labels.Matcher, indexhdr indexhe
 	return postingGroups, nil
 }
 
-// FetchPostings fills postings requested by posting groups.
+// FetchPostingsForKnownOffsets fills postings requested by posting groups.
 // It returns one postings for each key, in the same order.
-// If postings for given key is not fetched, entry at given index will be an ErrPostings
-func (r *bucketIndexReader) FetchPostings(ctx context.Context, keys []labels.Label, stats *safeQueryStats) ([]index.Postings, error) {
-	ps, err := r.fetchPostings(ctx, keys, stats)
+// If postings for given key is not fetched, entry at given index will be an EmptyPostings.
+// NOTE: On cache misses, knownOffsets will be used to fetch postings for that label name, not the index header.
+// Thus, knownOffsetsForLabel should only be passed if the caller has provided all the offsets required to fulfill the request.
+func (r *bucketIndexReader) FetchPostingsForKnownOffsets(ctx context.Context, keys []labels.Label, knownOffsetsForLabel map[string][]streamindex.PostingListOffset, stats *safeQueryStats) ([]index.Postings, error) {
+	ps, err := r.fetchPostingsForKnownOffsets(ctx, keys, knownOffsetsForLabel, stats)
 	if err != nil {
 		return nil, err
 	}
@@ -414,35 +416,106 @@ func (r *bucketIndexReader) FetchPostings(ctx context.Context, keys []labels.Lab
 	}
 	for i := range ps {
 		ps[i] = checkNilPosting(keys[i], ps[i])
-		if version >= 2 {
+		if version >= index.FormatV2 {
 			ps[i] = paddedPostings{ps[i]}
 		}
 	}
 	return ps, nil
 }
 
-func (r *bucketIndexReader) buildPostingsFromKnownOffsets(ctx context.Context, keys []labels.Label, knownOffsets map[string][]streamindex.PostingListOffset, stats *safeQueryStats) ([]index.Postings, error) {
-	output := make([]index.Postings, len(keys))
-	ptrs := make([]postingPtr, 0, len(knownOffsets))
+// decodePostingsForKeyFromCache decodes bytes read from the cache into index.Postings. If the postings cannot be decoded,
+// a warning is logged, but no error is returned.
+func (r *bucketIndexReader) decodePostingsForKeyFromCache(b []byte, key labels.Label, stats *safeQueryStats) (index.Postings, error) {
+	stats.update(func(stats *queryStats) {
+		stats.postingsTouched++
+		stats.postingsTouchedSizeSum += len(b)
+	})
+
+	l, cachedLabelsKey, pendingMatchers, err := r.decodePostings(b, stats)
+	if len(pendingMatchers) > 0 {
+		return nil, fmt.Errorf("not expecting matchers on non-expanded postings for %s=%s in block %s, but got %s",
+			key.Name, key.Value, r.block.meta.ULID, util.MatchersStringer(pendingMatchers))
+	}
+	if err == nil && cachedLabelsKey == encodeLabelForPostingsCache(key) {
+		return l, nil
+	}
+
+	level.Warn(r.block.logger).Log(
+		"msg", "can't decode cached postings",
+		"err", err,
+		"key", fmt.Sprintf("%+v", key),
+		"labels_key", cachedLabelsKey,
+		"block", r.block.meta.ULID,
+		"bytes_len", len(b),
+		"bytes_head_hex", hex.EncodeToString(b[:min(8, len(b))]),
+	)
+	// If we can't decode cached postings, we log a warning but don't error,
+	// since errors terminate postings fetch.
+	return nil, nil
+}
+
+// fetchPostingsForKnownOffsets, much like fetchPostings, fetches postings for the given keys.
+// However, it resolves postings offsets using knownOffsets[key.Name] rather than the index-header PostingsOffset lookup.
+// Keys whose label name or value isn't in known offsets are treated as having an empty postings result.
+func (r *bucketIndexReader) fetchPostingsForKnownOffsets(ctx context.Context, keys []labels.Label, knownOffsets map[string][]streamindex.PostingListOffset, stats *safeQueryStats) ([]index.Postings, error) {
+	postings := make([]index.Postings, len(keys))
+	var ptrs []postingPtr
+
+	// Fetch postings from the cache with a single call.
+	fromCache := r.block.indexCache.FetchMultiPostings(ctx, r.block.userID, r.block.meta.ULID, keys)
+
+	// Iterate over all keys and fetch postings from cache.
+	// If we have a miss, resolve the offset from knownOffsets and mark the key to be fetched in `ptrs`.
 	for ix, key := range keys {
-		if offsets, ok := knownOffsets[key.Name]; ok {
-			foundPos := sort.Search(len(knownOffsets[key.Name]), func(i int) bool {
-				return offsets[i].LabelValue >= key.Value
-			})
-			if foundPos < len(knownOffsets[key.Name]) && offsets[foundPos].LabelValue == key.Value {
-				ptrs = append(ptrs, postingPtr{
-					keyID: ix,
-					ptr:   offsets[foundPos].Off,
-				})
+		// Get postings for the given key from cache first.
+		if b, _ := fromCache.Next(); b != nil {
+			p, err := r.decodePostingsForKeyFromCache(b, key, stats)
+			if err != nil {
+				return nil, err
+			}
+			if p != nil {
+				postings[ix] = p
+				continue
 			}
 		}
+
+		// Cache miss; resolve the byte range from the known offsets
+		offsets, ok := knownOffsets[key.Name]
+
+		// If there are no known offsets for this label, we set postings to empty for this key
+		if !ok {
+			postings[ix] = index.EmptyPostings()
+			continue
+		}
+		foundPos := sort.Search(len(offsets), func(i int) bool {
+			return offsets[i].LabelValue >= key.Value
+		})
+		// Again, if we can't find offsets in knownOffsets, we treat these postings as empty.
+		if foundPos >= len(offsets) || offsets[foundPos].LabelValue != key.Value {
+			postings[ix] = index.EmptyPostings()
+			continue
+		}
+
+		stats.update(func(stats *queryStats) {
+			stats.postingsToFetch++
+		})
+
+		ptrs = append(ptrs, postingPtr{ptr: offsets[foundPos].Off, keyID: ix})
 	}
+
+	return r.fetchPostingsForPtrs(ctx, ptrs, keys, postings, stats)
+}
+
+// fetchPostingsForPtrs reads the byte offset in the index header given by each postingPtr.ptr,
+// and fills the resulting postings in at position postingPtr.keyID in output.
+// It also caches these postings before returning.
+func (r *bucketIndexReader) fetchPostingsForPtrs(ctx context.Context, ptrs []postingPtr, keys []labels.Label, output []index.Postings, stats *safeQueryStats) ([]index.Postings, error) {
 	slices.SortFunc(ptrs, func(a, b postingPtr) int {
 		return cmp.Compare(a.ptr.Start, b.ptr.Start)
 	})
 
-	// TODO(bwplotka): Asses how large in worst case scenario this can be. (e.g fetch for AllPostingsKeys)
-	// Consider sub split if too big.
+	// TODO(bwplotka): Assess how large in worst case scenario this can be (e.g fetch for AllPostingsKeys).
+	//  Consider sub split if too big.
 	parts := r.block.partitioners.postings.Partition(len(ptrs), func(i int) (start, end uint64) {
 		return uint64(ptrs[i].ptr.Start), uint64(ptrs[i].ptr.End)
 	})
@@ -532,21 +605,12 @@ func (r *bucketIndexReader) buildPostingsFromKnownOffsets(ctx context.Context, k
 		return nil, err
 	}
 
-	version, err := r.block.indexHeaderReader.IndexVersion(ctx)
-	if err != nil {
-		return nil, errors.Wrap(err, "get index version")
-	}
-	for i := range output {
-		output[i] = checkNilPosting(keys[i], output[i])
-		if version >= index.FormatV2 {
-			output[i] = paddedPostings{output[i]}
-		}
-	}
 	return output, nil
 }
 
-// fetchPostings is the version-unaware private implementation of FetchPostings.
-// callers of this method may need to add padding to the results.
+// fetchPostings fills postings requested by posting groups.
+// It returns one postings for each key, in the same order.
+// Callers of this method may need to add padding to the results.
 // If postings for given key is not fetched, entry at given index will be nil.
 func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Label, stats *safeQueryStats) ([]index.Postings, error) {
 	timer := prometheus.NewTimer(r.block.metrics.postingsFetchDuration)
@@ -565,30 +629,14 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 	for ix, key := range keys {
 		// Get postings for the given key from cache first.
 		if b, _ := fromCache.Next(); b != nil {
-			stats.update(func(stats *queryStats) {
-				stats.postingsTouched++
-				stats.postingsTouchedSizeSum += len(b)
-			})
-
-			l, cachedLabelsKey, pendingMatchers, err := r.decodePostings(b, stats)
-			if len(pendingMatchers) > 0 {
-				return nil, fmt.Errorf("not expecting matchers on non-expanded postings for %s=%s in block %s, but got %s",
-					key.Name, key.Value, r.block.meta.ULID, util.MatchersStringer(pendingMatchers))
+			p, err := r.decodePostingsForKeyFromCache(b, key, stats)
+			if err != nil {
+				return nil, err
 			}
-			if err == nil && cachedLabelsKey == encodeLabelForPostingsCache(key) {
-				output[ix] = l
+			if p != nil {
+				output[ix] = p
 				continue
 			}
-
-			level.Warn(r.block.logger).Log(
-				"msg", "can't decode cached postings",
-				"err", err,
-				"key", fmt.Sprintf("%+v", key),
-				"labels_key", cachedLabelsKey,
-				"block", r.block.meta.ULID,
-				"bytes_len", len(b),
-				"bytes_head_hex", hex.EncodeToString(b[:min(8, len(b))]),
-			)
 		}
 
 		// Cache miss; save pointer for actual posting in index stored in object store.
@@ -610,98 +658,7 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 		ptrs = append(ptrs, postingPtr{ptr: ptr, keyID: ix})
 	}
 
-	slices.SortFunc(ptrs, func(a, b postingPtr) int {
-		return cmp.Compare(a.ptr.Start, b.ptr.Start)
-	})
-
-	// TODO(bwplotka): Asses how large in worst case scenario this can be. (e.g fetch for AllPostingsKeys)
-	// Consider sub split if too big.
-	parts := r.block.partitioners.postings.Partition(len(ptrs), func(i int) (start, end uint64) {
-		return uint64(ptrs[i].ptr.Start), uint64(ptrs[i].ptr.End)
-	})
-
-	// Use a different TTL for postings based on the duration of the block.
-	postingsTTL := indexcache.BlockTTL(r.block.meta)
-
-	g, ctx := errgroup.WithContext(ctx)
-	for _, part := range parts {
-		i, j := part.ElemRng[0], part.ElemRng[1]
-
-		start := int64(part.Start)
-		// We assume index does not have any ptrs that has 0 length.
-		length := int64(part.End) - start
-
-		// Fetch from object storage concurrently and update stats and posting list.
-		g.Go(func() error {
-			begin := time.Now()
-
-			b, err := r.block.readIndexRange(ctx, start, length)
-			if err != nil {
-				return errors.Wrap(err, "read postings range")
-			}
-			fetchTime := time.Since(begin)
-
-			stats.update(func(stats *queryStats) {
-				stats.postingsFetchCount++
-				stats.postingsFetched += j - i
-				stats.postingsFetchDurationSum += fetchTime
-				stats.postingsFetchedSizeSum += int(length)
-			})
-
-			for _, p := range ptrs[i:j] {
-				// index-header can estimate endings, which means we need to resize the endings.
-				pBytes, err := resizePostings(b[p.ptr.Start-start : p.ptr.End-start])
-				if err != nil {
-					return err
-				}
-
-				compressionTime := time.Duration(0)
-				compressions, compressionErrors, compressedSize := 0, 0, 0
-
-				// Reencode postings before storing to cache. If that fails, we store original bytes.
-				// This can only fail, if postings data was somehow corrupted,
-				// and there is nothing we can do about it.
-				// Errors from corrupted postings will be reported when postings are used.
-				compressions++
-				s := time.Now()
-				bep := newBigEndianPostings(pBytes[4:])
-				dataToCache, err := diffVarintSnappyWithMatchersEncode(bep, bep.length(), encodeLabelForPostingsCache(keys[p.keyID]), nil)
-				compressionTime = time.Since(s)
-				if err == nil {
-					compressedSize = len(dataToCache)
-					r.block.indexCache.StorePostings(r.block.userID, r.block.meta.ULID, keys[p.keyID], dataToCache, postingsTTL)
-				} else {
-					compressionErrors = 1
-					level.Warn(r.block.logger).Log(
-						"msg", "couldn't encode postings for cache",
-						"err", err,
-						"user", r.block.userID,
-						"block", r.block.meta.ULID,
-						"label", keys[p.keyID],
-					)
-				}
-
-				// Return postings. Truncate first 4 bytes which are length of posting.
-				// Access to output is not protected by a mutex because each goroutine
-				// is expected to handle a different set of keys.
-				output[p.keyID] = newBigEndianPostings(pBytes[4:])
-
-				// If we just fetched it we still have to update the stats for touched postings.
-				stats.update(func(stats *queryStats) {
-					stats.postingsTouched++
-					stats.postingsTouchedSizeSum += len(pBytes)
-					stats.cachedPostingsCompressions += compressions
-					stats.cachedPostingsCompressionErrors += compressionErrors
-					stats.cachedPostingsOriginalSizeSum += len(pBytes)
-					stats.cachedPostingsCompressedSizeSum += compressedSize
-					stats.cachedPostingsCompressionTimeSum += compressionTime
-				})
-			}
-			return nil
-		})
-	}
-
-	return output, g.Wait()
+	return r.fetchPostingsForPtrs(ctx, ptrs, keys, output, stats)
 }
 
 func encodeLabelForPostingsCache(l labels.Label) indexcache.LabelMatchersKey {

--- a/pkg/storegateway/bucket_index_reader.go
+++ b/pkg/storegateway/bucket_index_reader.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"slices"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -418,6 +419,130 @@ func (r *bucketIndexReader) FetchPostings(ctx context.Context, keys []labels.Lab
 		}
 	}
 	return ps, nil
+}
+
+func (r *bucketIndexReader) buildPostingsFromKnownOffsets(ctx context.Context, keys []labels.Label, knownOffsets map[string][]streamindex.PostingListOffset, stats *safeQueryStats) ([]index.Postings, error) {
+	output := make([]index.Postings, len(keys))
+	ptrs := make([]postingPtr, 0, len(knownOffsets))
+	for ix, key := range keys {
+		if offsets, ok := knownOffsets[key.Name]; ok {
+			foundPos := sort.Search(len(knownOffsets[key.Name]), func(i int) bool {
+				return offsets[i].LabelValue >= key.Value
+			})
+			if foundPos < len(knownOffsets[key.Name]) && offsets[foundPos].LabelValue == key.Value {
+				ptrs = append(ptrs, postingPtr{
+					keyID: ix,
+					ptr:   offsets[foundPos].Off,
+				})
+			}
+		}
+	}
+	slices.SortFunc(ptrs, func(a, b postingPtr) int {
+		return cmp.Compare(a.ptr.Start, b.ptr.Start)
+	})
+
+	// TODO(bwplotka): Asses how large in worst case scenario this can be. (e.g fetch for AllPostingsKeys)
+	// Consider sub split if too big.
+	parts := r.block.partitioners.postings.Partition(len(ptrs), func(i int) (start, end uint64) {
+		return uint64(ptrs[i].ptr.Start), uint64(ptrs[i].ptr.End)
+	})
+
+	// Use a different TTL for postings based on the duration of the block.
+	postingsTTL := indexcache.BlockTTL(r.block.meta)
+
+	g, ctx := errgroup.WithContext(ctx)
+	for _, part := range parts {
+		i, j := part.ElemRng[0], part.ElemRng[1]
+
+		start := int64(part.Start)
+		// We assume index does not have any ptrs that has 0 length.
+		length := int64(part.End) - start
+
+		// Fetch from object storage concurrently and update stats and posting list.
+		g.Go(func() error {
+			begin := time.Now()
+
+			b, err := r.block.readIndexRange(ctx, start, length)
+			if err != nil {
+				return errors.Wrap(err, "read postings range")
+			}
+			fetchTime := time.Since(begin)
+
+			stats.update(func(stats *queryStats) {
+				stats.postingsFetchCount++
+				stats.postingsFetched += j - i
+				stats.postingsFetchDurationSum += fetchTime
+				stats.postingsFetchedSizeSum += int(length)
+			})
+
+			for _, p := range ptrs[i:j] {
+				// index-header can estimate endings, which means we need to resize the endings.
+				pBytes, err := resizePostings(b[p.ptr.Start-start : p.ptr.End-start])
+				if err != nil {
+					return err
+				}
+
+				compressionTime := time.Duration(0)
+				compressions, compressionErrors, compressedSize := 0, 0, 0
+
+				// Reencode postings before storing to cache. If that fails, we store original bytes.
+				// This can only fail, if postings data was somehow corrupted,
+				// and there is nothing we can do about it.
+				// Errors from corrupted postings will be reported when postings are used.
+				compressions++
+				s := time.Now()
+				bep := newBigEndianPostings(pBytes[4:])
+				dataToCache, err := diffVarintSnappyWithMatchersEncode(bep, bep.length(), encodeLabelForPostingsCache(keys[p.keyID]), nil)
+				compressionTime = time.Since(s)
+				if err == nil {
+					compressedSize = len(dataToCache)
+					r.block.indexCache.StorePostings(r.block.userID, r.block.meta.ULID, keys[p.keyID], dataToCache, postingsTTL)
+				} else {
+					compressionErrors = 1
+					level.Warn(r.block.logger).Log(
+						"msg", "couldn't encode postings for cache",
+						"err", err,
+						"user", r.block.userID,
+						"block", r.block.meta.ULID,
+						"label", keys[p.keyID],
+					)
+				}
+
+				// Return postings. Truncate first 4 bytes which are length of posting.
+				// Access to output is not protected by a mutex because each goroutine
+				// is expected to handle a different set of keys.
+				output[p.keyID] = newBigEndianPostings(pBytes[4:])
+
+				// If we just fetched it we still have to update the stats for touched postings.
+				stats.update(func(stats *queryStats) {
+					stats.postingsTouched++
+					stats.postingsTouchedSizeSum += len(pBytes)
+					stats.cachedPostingsCompressions += compressions
+					stats.cachedPostingsCompressionErrors += compressionErrors
+					stats.cachedPostingsOriginalSizeSum += len(pBytes)
+					stats.cachedPostingsCompressedSizeSum += compressedSize
+					stats.cachedPostingsCompressionTimeSum += compressionTime
+				})
+			}
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	version, err := r.block.indexHeaderReader.IndexVersion(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "get index version")
+	}
+	for i := range output {
+		output[i] = checkNilPosting(keys[i], output[i])
+		if version >= index.FormatV2 {
+			output[i] = paddedPostings{output[i]}
+		}
+	}
+	return output, nil
 }
 
 // fetchPostings is the version-unaware private implementation of FetchPostings.

--- a/pkg/storegateway/bucket_index_reader.go
+++ b/pkg/storegateway/bucket_index_reader.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"io"
 	"slices"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -487,11 +486,13 @@ func (r *bucketIndexReader) fetchPostingsForKnownOffsets(ctx context.Context, ke
 			postings[ix] = index.EmptyPostings()
 			continue
 		}
-		foundPos := sort.Search(len(offsets), func(i int) bool {
-			return offsets[i].LabelValue >= key.Value
+
+		foundPos, ok := slices.BinarySearchFunc(offsets, key.Value, func(offset streamindex.PostingListOffset, value string) int {
+			return strings.Compare(offset.LabelValue, value)
 		})
+
 		// Again, if we can't find offsets in knownOffsets, we treat these postings as empty.
-		if foundPos >= len(offsets) || offsets[foundPos].LabelValue != key.Value {
+		if !ok {
 			postings[ix] = index.EmptyPostings()
 			continue
 		}
@@ -510,6 +511,9 @@ func (r *bucketIndexReader) fetchPostingsForKnownOffsets(ctx context.Context, ke
 // and fills the resulting postings in at position postingPtr.keyID in output.
 // It also caches these postings before returning.
 func (r *bucketIndexReader) fetchPostingsForPtrs(ctx context.Context, ptrs []postingPtr, keys []labels.Label, output []index.Postings, stats *safeQueryStats) ([]index.Postings, error) {
+	timer := prometheus.NewTimer(r.block.metrics.postingsFetchDuration)
+	defer timer.ObserveDuration()
+
 	slices.SortFunc(ptrs, func(a, b postingPtr) int {
 		return cmp.Compare(a.ptr.Start, b.ptr.Start)
 	})
@@ -613,9 +617,6 @@ func (r *bucketIndexReader) fetchPostingsForPtrs(ctx context.Context, ptrs []pos
 // Callers of this method may need to add padding to the results.
 // If postings for given key is not fetched, entry at given index will be nil.
 func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Label, stats *safeQueryStats) ([]index.Postings, error) {
-	timer := prometheus.NewTimer(r.block.metrics.postingsFetchDuration)
-	defer timer.ObserveDuration()
-
 	var ptrs []postingPtr
 
 	output := make([]index.Postings, len(keys))

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -1092,6 +1092,140 @@ func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 	})
 }
 
+func TestBucketIndexReader_FetchPostingsForKnownOffsets(t *testing.T) {
+	const (
+		series    = 50000
+		labelName = "n"
+	)
+	ctx := context.Background()
+
+	tb := test.NewTB(t)
+	testBlock := fixtures.SetupTestBlock(tb, fixtures.AppendTestSeries(series))
+	newTestBucketBlock := testBlockToBucketBlock(tb, testBlock)
+
+	// Used to set up known offsets
+	offsetsForLabel := func(b *bucketBlock, name, prefix string) []streamindex.PostingListOffset {
+		offsets, err := b.indexHeaderReader.LabelValuesOffsets(ctx, name, prefix, nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, offsets)
+		return offsets
+	}
+
+	keysFromOffsets := func(name string, offsets []streamindex.PostingListOffset) []labels.Label {
+		keys := make([]labels.Label, len(offsets))
+		for i, o := range offsets {
+			keys[i] = labels.Label{Name: name, Value: o.LabelValue}
+		}
+		return keys
+	}
+
+	// expectedRefs resolves the series refs for a single label/value pair independently, through
+	// ExpandedPostings, to compare against the FetchPostingsForKnownOffsets output for the same key.
+	expectedRefs := func(b *bucketBlock, name, value string) []storage.SeriesRef {
+		matcher := labels.MustNewMatcher(labels.MatchEqual, name, value)
+		refs, _, err := b.indexReader(selectAllStrategy{}).ExpandedPostings(ctx, []*labels.Matcher{matcher}, newSafeQueryStats())
+		require.NoError(t, err)
+		require.NotEmpty(t, refs, "test setup: expected some series for %s=%s", name, value)
+		return refs
+	}
+
+	expandPostings := func(p index.Postings) []storage.SeriesRef {
+		refs, err := index.ExpandPostings(p)
+		require.NoError(t, err)
+		return refs
+	}
+
+	t.Run("returns postings matching the index for every known offset", func(t *testing.T) {
+		b := newTestBucketBlock()
+		offsets := offsetsForLabel(b, labelName, "")
+		keys := keysFromOffsets(labelName, offsets)
+
+		ps, err := b.indexReader(selectAllStrategy{}).FetchPostingsForKnownOffsets(ctx, keys, map[string][]streamindex.PostingListOffset{labelName: offsets}, newSafeQueryStats())
+		require.NoError(t, err)
+		require.Len(t, ps, len(keys))
+
+		for i, key := range keys {
+			assert.Equal(t, expectedRefs(b, key.Name, key.Value), expandPostings(ps[i]), "postings for %s=%s", key.Name, key.Value)
+		}
+	})
+
+	t.Run("returns empty postings for label name with no known offsets", func(t *testing.T) {
+		b := newTestBucketBlock()
+		offsets := offsetsForLabel(b, labelName, "")
+		keys := keysFromOffsets(labelName, offsets)
+
+		// Request a label name other than the one we have known offsets for.
+		ps, err := b.indexReader(selectAllStrategy{}).FetchPostingsForKnownOffsets(ctx, keys, map[string][]streamindex.PostingListOffset{"other": offsets}, newSafeQueryStats())
+		require.NoError(t, err)
+		require.Len(t, ps, len(keys))
+		for i, key := range keys {
+			assert.Empty(t, expandPostings(ps[i]), "expected empty postings for %s=%s", key.Name, key.Value)
+		}
+	})
+
+	t.Run("returns empty postings for values not matching the prefix", func(t *testing.T) {
+		b := newTestBucketBlock()
+		prefix := "1"
+		offsets := offsetsForLabel(b, labelName, "")
+		offsetsWithPrefix := offsetsForLabel(b, labelName, prefix)
+
+		var keys []labels.Label
+		var wantFound []bool
+		for _, o := range offsets {
+			keys = append(keys, labels.Label{Name: labelName, Value: o.LabelValue})
+			wantFound = append(wantFound, strings.HasPrefix(o.LabelValue, prefix))
+		}
+
+		ps, err := b.indexReader(selectAllStrategy{}).FetchPostingsForKnownOffsets(ctx, keys, map[string][]streamindex.PostingListOffset{labelName: offsetsWithPrefix}, newSafeQueryStats())
+		require.NoError(t, err)
+		require.Len(t, ps, len(keys))
+
+		for i, key := range keys {
+			if wantFound[i] {
+				assert.Equal(t, expectedRefs(b, key.Name, key.Value), expandPostings(ps[i]), "postings for %s=%s", key.Name, key.Value)
+			} else {
+				assert.Empty(t, expandPostings(ps[i]), "expected empty postings for %s=%s", key.Name, key.Value)
+			}
+		}
+	})
+
+	t.Run("no keys returns no postings", func(t *testing.T) {
+		b := newTestBucketBlock()
+		offsets := offsetsForLabel(b, labelName, "")
+
+		ps, err := b.indexReader(selectAllStrategy{}).FetchPostingsForKnownOffsets(ctx, nil, map[string][]streamindex.PostingListOffset{labelName: offsets}, newSafeQueryStats())
+		require.NoError(t, err)
+		require.Empty(t, ps)
+	})
+
+	t.Run("postings are served from the cache", func(t *testing.T) {
+		b := newTestBucketBlock()
+		b.indexCache = newInMemoryIndexCache(t)
+		offsets := offsetsForLabel(b, labelName, "")
+		keys := keysFromOffsets(labelName, offsets)
+
+		// The first call fetches the postings from the bucket and stores them in the cache.
+		first, err := b.indexReader(selectAllStrategy{}).FetchPostingsForKnownOffsets(ctx, keys, map[string][]streamindex.PostingListOffset{labelName: offsets}, newSafeQueryStats())
+		require.NoError(t, err)
+		require.Len(t, first, len(keys))
+
+		// The second call passes no known offsets: if the cache wasn't consulted, every key would
+		// resolve to empty postings. Instead, postings must be served from the cache.
+		stats := newSafeQueryStats()
+		second, err := b.indexReader(selectAllStrategy{}).FetchPostingsForKnownOffsets(ctx, keys, nil, stats)
+		require.NoError(t, err)
+		require.Len(t, second, len(keys))
+
+		for i, key := range keys {
+			assert.Equal(t, expandPostings(first[i]), expandPostings(second[i]), "postings for %s=%s", key.Name, key.Value)
+		}
+
+		// All postings were served from the cache, so nothing should have been fetched from the bucket.
+		assert.Zero(t, stats.export().postingsFetchCount)
+	})
+
+}
+
 func newInMemoryIndexCache(t testing.TB) indexcache.IndexCache {
 	cache, err := indexcache.NewInMemoryIndexCacheWithConfig(
 		indexcache.InMemoryIndexCacheConfig{

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -1103,7 +1103,6 @@ func TestBucketIndexReader_FetchPostingsForKnownOffsets(t *testing.T) {
 	testBlock := fixtures.SetupTestBlock(tb, fixtures.AppendTestSeries(series))
 	newTestBucketBlock := testBlockToBucketBlock(tb, testBlock)
 
-	// Used to set up known offsets
 	offsetsForLabel := func(b *bucketBlock, name, prefix string) []streamindex.PostingListOffset {
 		offsets, err := b.indexHeaderReader.LabelValuesOffsets(ctx, name, prefix, nil)
 		require.NoError(t, err)
@@ -1119,8 +1118,6 @@ func TestBucketIndexReader_FetchPostingsForKnownOffsets(t *testing.T) {
 		return keys
 	}
 
-	// expectedRefs resolves the series refs for a single label/value pair independently, through
-	// ExpandedPostings, to compare against the FetchPostingsForKnownOffsets output for the same key.
 	expectedRefs := func(b *bucketBlock, name, value string) []storage.SeriesRef {
 		matcher := labels.MustNewMatcher(labels.MatchEqual, name, value)
 		refs, _, err := b.indexReader(selectAllStrategy{}).ExpandedPostings(ctx, []*labels.Matcher{matcher}, newSafeQueryStats())
@@ -1166,12 +1163,12 @@ func TestBucketIndexReader_FetchPostingsForKnownOffsets(t *testing.T) {
 	t.Run("returns empty postings for values not matching the prefix", func(t *testing.T) {
 		b := newTestBucketBlock()
 		prefix := "1"
-		offsets := offsetsForLabel(b, labelName, "")
+		allOffsets := offsetsForLabel(b, labelName, "")
 		offsetsWithPrefix := offsetsForLabel(b, labelName, prefix)
 
 		var keys []labels.Label
 		var wantFound []bool
-		for _, o := range offsets {
+		for _, o := range allOffsets {
 			keys = append(keys, labels.Label{Name: labelName, Value: o.LabelValue})
 			wantFound = append(wantFound, strings.HasPrefix(o.LabelValue, prefix))
 		}
@@ -1204,15 +1201,14 @@ func TestBucketIndexReader_FetchPostingsForKnownOffsets(t *testing.T) {
 		offsets := offsetsForLabel(b, labelName, "")
 		keys := keysFromOffsets(labelName, offsets)
 
-		// The first call fetches the postings from the bucket and stores them in the cache.
+		// First call misses cache, does the fetch
 		first, err := b.indexReader(selectAllStrategy{}).FetchPostingsForKnownOffsets(ctx, keys, map[string][]streamindex.PostingListOffset{labelName: offsets}, newSafeQueryStats())
 		require.NoError(t, err)
 		require.Len(t, first, len(keys))
 
-		// The second call passes no known offsets: if the cache wasn't consulted, every key would
-		// resolve to empty postings. Instead, postings must be served from the cache.
-		stats := newSafeQueryStats()
-		second, err := b.indexReader(selectAllStrategy{}).FetchPostingsForKnownOffsets(ctx, keys, nil, stats)
+		// The second call passes no known offsets, but should still hit the cache when resolving postings offsets to postings
+		secondCallStats := newSafeQueryStats()
+		second, err := b.indexReader(selectAllStrategy{}).FetchPostingsForKnownOffsets(ctx, keys, nil, secondCallStats)
 		require.NoError(t, err)
 		require.Len(t, second, len(keys))
 
@@ -1221,9 +1217,8 @@ func TestBucketIndexReader_FetchPostingsForKnownOffsets(t *testing.T) {
 		}
 
 		// All postings were served from the cache, so nothing should have been fetched from the bucket.
-		assert.Zero(t, stats.export().postingsFetchCount)
+		assert.Zero(t, secondCallStats.export().postingsFetchCount)
 	})
-
 }
 
 func newInMemoryIndexCache(t testing.TB) indexcache.IndexCache {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Before, when we called `labelValuesFromPostings`, we immediately issued a `FetchPostings`. This is cheap for disk-based index header readers, but for the bucket-based reader, it costs bucket ops to fetch offsets (and their postings) which we'd already fetched while expanding postings in `blockLabelValues`

This PR introduces `FetchPostingsForKnownOffsets` which takes a set of offsets and attempts to resolve those from the cache, before fetching the postings on a cache miss, and calls it from `labelValuesFromPostings` to save on some duplicated bucket reads.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the LabelValues postings-fetch path in the store-gateway query engine; behavior is intended to be equivalent when callers supply complete offsets, with new tests, but incorrect offset maps could change results.
> 
> **Overview**
> **LabelValues** with matchers no longer re-resolves posting byte ranges through the index header when `blockLabelValues` already collected `LabelValuesOffsets`.
> 
> `labelValuesFromPostings` now calls **`FetchPostingsForKnownOffsets`**, passing the offset list gathered earlier. On cache miss, offsets are resolved via binary search on that map instead of **`PostingsOffset`**, which avoids extra object-store / bucket-backed index-header work that duplicated what **`ExpandedPostings`** had already done.
> 
> The index reader is refactored: shared **`decodePostingsForKeyFromCache`** and **`fetchPostingsForPtrs`** (object-store read, partition, cache) back both the new path and existing **`fetchPostings`**. Missing label names or values in the known-offset set yield **`EmptyPostings`** rather than a header lookup. Tests cover correctness, empty cases, prefix-limited offset lists, and cache hits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9466e48b842cef2fa7e6d4bf9cfc7d1449e7d368. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->