### PR TITLE
fix(mimirtool): add collectors/ prefix to partition ring KV client

### DIFF
--- a/pkg/mimirtool/commands/partition_ring.go
+++ b/pkg/mimirtool/commands/partition_ring.go
@@ -500,6 +500,12 @@ func initMemberlistKV(ctx context.Context, joinAddrs []string, clusterLabel stri
 		return nil, nil, errors.Wrap(err, "failed to create memberlist client")
 	}
 
+	// Wrap the KV client with the "collectors/" prefix to match the key used by ingesters.
+	// Ingesters register the partition ring with KV store using RegisterFlagsWithPrefix
+	// which adds "collectors/" to all keys. Without this prefix, mimirtool operations
+	// target the wrong key (e.g. "ingester-partitions" instead of "collectors/ingester-partitions").
+	kvClient = kv.PrefixClient(kvClient, "collectors/")
+
 	return kvClient, cleanup, nil
 }
 

--- a/pkg/mimirtool/commands/partition_ring_test.go
+++ b/pkg/mimirtool/commands/partition_ring_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/dns"
 	"github.com/grafana/dskit/flagext"
+	"github.com/grafana/dskit/kv"
 	"github.com/grafana/dskit/kv/codec"
 	"github.com/grafana/dskit/kv/memberlist"
 	"github.com/grafana/dskit/ring"
@@ -854,6 +855,9 @@ func startMemberlistKV(t *testing.T) (*memberlist.KV, *memberlist.Client) {
 
 	client, err := memberlist.NewClient(mkv, ring.GetPartitionRingCodec())
 	require.NoError(t, err)
+
+	// Wrap the client with the "collectors/" prefix to match the key used by ingesters.
+	client = kv.PrefixClient(client, "collectors/")
 
 	return mkv, client
 }


### PR DESCRIPTION
The mimirtool partition-ring commands (`add-partition`, `remove-partition`, `add-owner`, `remove-owner`) use a raw memberlist KV client without the `"collectors/"` prefix that ingesters use. So mimirtool looks for `ingester-partitions` but the ingester stores the ring under `collectors/ingester-partitions`.

This wraps the KV client with `kv.PrefixClient(client, "collectors/")` so mimirtool reads and writes the same keys as the ingester.

Fixes #15696