### PR TITLE
fix(querier): meter remote read consistently across response types

### DIFF
--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -3889,7 +3889,7 @@ When looking at `msg="query stats"` consider the following attributes;
 - estimated_series_count — pre-execution estimate of series count
 - samples_processed — total individual samples evaluated
 - equivalent_samples_read — equivalent number of samples that would have been read from storage to execute a query, if no caching or other optimizations were applied to the query
-- physical_samples_read — the number of samples read from storage. Excludes any samples not read due to caching or other optimizations.
+- physical_samples_read — the number of samples read from storage. Excludes any samples not read due to caching or other optimizations. Remote read requests contribute to this counter and to `equivalent_samples_read`. For streamed-chunks remote read responses, the count reflects samples within the requested query range.
 - results_cache_hit_bytes — the number of bytes returned from the query results cache
 - results_cache_miss_bytes — the number of bytes fetched from storage and written to the query results cache
 - read_consistency — the read consistency level requested, if any

--- a/pkg/querier/remote_read.go
+++ b/pkg/querier/remote_read.go
@@ -167,8 +167,9 @@ func remoteReadStreamedXORChunks(
 
 	// Process all queries concurrently and collect their ChunkSeriesSet results
 	type queryResult struct {
-		series  storage.ChunkSeriesSet
-		querier io.Closer
+		series     storage.ChunkSeriesSet
+		querier    io.Closer
+		minT, maxT int64
 	}
 
 	results := make([]queryResult, len(req.Queries))
@@ -184,7 +185,7 @@ func remoteReadStreamedXORChunks(
 
 	run := func(_ context.Context, idx int) error {
 		qr := req.Queries[idx]
-		start, end, _, _, matchers, hints, err := queryFromRemoteReadQuery(qr)
+		start, end, minT, maxT, matchers, hints, err := queryFromRemoteReadQuery(qr)
 		if err != nil {
 			return err
 		}
@@ -198,7 +199,7 @@ func remoteReadStreamedXORChunks(
 		// Use the original ctx instead of jobCtx because ForEachJob cancels jobCtx before returning,
 		// but we need the SeriesSet to remain valid for streaming later.
 		seriesSet := querier.Select(ctx, true, hints, matchers...)
-		results[idx] = queryResult{series: seriesSet, querier: querier}
+		results[idx] = queryResult{series: seriesSet, querier: querier, minT: int64(minT), maxT: int64(maxT)}
 		return nil
 	}
 
@@ -224,6 +225,8 @@ func remoteReadStreamedXORChunks(
 			result.series,
 			i,
 			maxBytesInFrame,
+			result.minT,
+			result.maxT,
 		)
 		// Report stats incrementally so that already-streamed queries are counted
 		// even if a later query errors or the client disconnects.
@@ -340,7 +343,7 @@ func negotiateResponseType(accepted []prompb.ReadRequest_ResponseType) (prompb.R
 	return 0, errors.Errorf("server does not support any of the requested response types: %v; supported: %v", accepted, supported)
 }
 
-func streamChunkedReadResponses(stream io.Writer, ss storage.ChunkSeriesSet, queryIndex, maxBytesInFrame int) (uint64, uint64, error) {
+func streamChunkedReadResponses(stream io.Writer, ss storage.ChunkSeriesSet, queryIndex, maxBytesInFrame int, minTMs, maxTMs int64) (uint64, uint64, error) {
 	var (
 		chks                  []prompb.Chunk
 		lbls                  []prompb.Label
@@ -364,11 +367,16 @@ func streamChunkedReadResponses(stream io.Writer, ss storage.ChunkSeriesSet, que
 				return 0, 0, errors.Errorf("found not populated chunk returned by SeriesSet at ref: %v", chk.Ref)
 			}
 
-			physicalSampleCount += uint64(chk.Chunk.NumSamples())
-			eqCount, err := equivalentSampleCountForChunk(chk.Chunk)
+			// Count only samples within the queried range, excluding stale markers, to match the
+			// samples response path. The whole chunk is still streamed to the
+			// client (chunks are atomic in the streaming protocol), so a streamed-chunks client can
+			// receive slightly more raw samples than are metered. This is intentional: metering
+			// reflects the logical query range, not the bytes delivered.
+			physicalCount, eqCount, err := sampleCountsForChunk(chk.Chunk, minTMs, maxTMs)
 			if err != nil {
-				return 0, 0, errors.Wrap(err, "compute equivalent sample count")
+				return 0, 0, errors.Wrap(err, "compute sample counts")
 			}
+			physicalSampleCount += physicalCount
 			equivalentSampleCount += eqCount
 
 			// Cut the chunk.
@@ -412,37 +420,52 @@ func streamChunkedReadResponses(stream io.Writer, ss storage.ChunkSeriesSet, que
 	return physicalSampleCount, equivalentSampleCount, ss.Err()
 }
 
-// equivalentSampleCountForChunk returns the equivalent float sample count for a chunk.
-// Float chunks return NumSamples() directly. Histogram chunks only decode the first sample because all samples in
-// a chunk share the same bucket layout, we then multiply its cost by NumSamples() to get the total count.
-func equivalentSampleCountForChunk(chk chunkenc.Chunk) (uint64, error) {
-	enc := chk.Encoding()
-
-	if enc == chunkenc.EncXOR || enc == chunkenc.EncXOR2 {
-		return uint64(chk.NumSamples()), nil
-	}
-
-	numSamples := chk.NumSamples()
-	if numSamples == 0 {
-		return 0, nil
-	}
-
+// sampleCountsForChunk returns the physical and equivalent float sample counts for the samples in
+// chk that fall within [minTMs, maxTMs], excluding stale markers. It mirrors the per-sample counting
+// on the samples response path so that the same data is metered  identically regardless of the negotiated response type.
+//
+// All samples in a histogram chunk share a single bucket layout, so their equivalent weight is
+// identical; we compute it once from the first non-stale histogram sample and reuse it.
+func sampleCountsForChunk(chk chunkenc.Chunk, minTMs, maxTMs int64) (physical, equivalent uint64, err error) {
 	it := chk.Iterator(nil)
+	var (
+		fh                  histogram.FloatHistogram
+		histogramWeight     uint64
+		haveHistogramWeight bool
+	)
 	for valType := it.Next(); valType != chunkenc.ValNone; valType = it.Next() {
-		var fh histogram.FloatHistogram
-		_, h := it.AtFloatHistogram(&fh)
-		// We skip stale/NaN values because their bucket layouts are empty, using them would result in undercounting (really
-		// just not counting at all).
-		if value.IsStaleNaN(h.Sum) {
+		// We can over-read chunks that only partially overlap the queried range, so skip samples
+		// outside it; we must not meter samples that weren't queried for.
+		if t := it.AtT(); t < minTMs || t > maxTMs {
 			continue
 		}
-		perSample := types.EquivalentFloatSampleCount(h)
-		return uint64(perSample) * uint64(numSamples), nil
+
+		switch valType {
+		case chunkenc.ValFloat:
+			if _, v := it.At(); !value.IsStaleNaN(v) {
+				physical++
+				equivalent++
+			}
+		case chunkenc.ValHistogram, chunkenc.ValFloatHistogram:
+			_, h := it.AtFloatHistogram(&fh)
+			// Skip stale markers: their bucket layout is empty, so they carry no equivalent weight.
+			if value.IsStaleNaN(h.Sum) {
+				continue
+			}
+			if !haveHistogramWeight {
+				histogramWeight = uint64(types.EquivalentFloatSampleCount(h))
+				haveHistogramWeight = true
+			}
+			physical++
+			equivalent += histogramWeight
+		default:
+			return 0, 0, fmt.Errorf("unsupported value type: %v", valType)
+		}
 	}
 	if err := it.Err(); err != nil {
-		return 0, err
+		return 0, 0, err
 	}
-	return 0, nil
+	return physical, equivalent, nil
 }
 
 func initializedFrameBytesRemaining(maxBytesInFrame int, lbls []prompb.Label) int {

--- a/pkg/querier/remote_read_test.go
+++ b/pkg/querier/remote_read_test.go
@@ -367,6 +367,7 @@ func TestRemoteReadSamples_SampleCountStats(t *testing.T) {
 	tests := map[string]struct {
 		queries                       []*prompb.Query
 		seriesSets                    func() []storage.SeriesSet
+		expectedStatusCode            int
 		expectedPhysicalSampleCount   uint64
 		expectedEquivalentSampleCount uint64
 	}{
@@ -492,8 +493,37 @@ func TestRemoteReadSamples_SampleCountStats(t *testing.T) {
 			expectedPhysicalSampleCount:   3,
 			expectedEquivalentSampleCount: 3,
 		},
+		"stats reported after partial read error": {
+			queries: []*prompb.Query{
+				{StartTimestampMs: 0, EndTimestampMs: 10},
+			},
+			seriesSets: func() []storage.SeriesSet {
+				// The SeriesSet yields one series and then fails on Err(); the already-read
+				// series must still be counted, matching the streaming path's behaviour.
+				return []storage.SeriesSet{
+					&partiallyFailingSeriesSet{
+						ss: series.NewConcreteSeriesSetFromUnsortedSeries([]storage.Series{
+							series.NewConcreteSeries(
+								labels.FromStrings("foo", "bar"),
+								[]model.SamplePair{{Timestamp: 1, Value: 1}, {Timestamp: 2, Value: 2}},
+								nil,
+							),
+							series.NewConcreteSeries(
+								labels.FromStrings("foo", "baz"),
+								[]model.SamplePair{{Timestamp: 3, Value: 3}},
+								nil,
+							),
+						}),
+						failAfter: 1,
+						err:       errors.New("partial series set failure"),
+					},
+				}
+			},
+			expectedStatusCode:            http.StatusInternalServerError,
+			expectedPhysicalSampleCount:   2,
+			expectedEquivalentSampleCount: 2,
+		},
 	}
-
 	for testName, tc := range tests {
 		t.Run(testName, func(t *testing.T) {
 			seriesSets := tc.seriesSets()
@@ -510,13 +540,17 @@ func TestRemoteReadSamples_SampleCountStats(t *testing.T) {
 				},
 			}
 
-			queryStats, ctx := stats.ContextWithEmptyStats(context.Background())
+			queryStats, ctx := stats.ContextWithEmptyStats(t.Context())
 			w := httptest.NewRecorder()
 			req := &prompb.ReadRequest{Queries: tc.queries}
 
 			remoteReadSamples(ctx, q, w, req, 0, log.NewNopLogger())
 
-			require.Equal(t, http.StatusOK, w.Code)
+			expectedCode := tc.expectedStatusCode
+			if expectedCode == 0 {
+				expectedCode = http.StatusOK
+			}
+			require.Equal(t, expectedCode, w.Code)
 			require.Equal(t, tc.expectedPhysicalSampleCount, queryStats.LoadPhysicalSamplesRead())
 			require.Equal(t, tc.expectedEquivalentSampleCount, queryStats.LoadEquivalentSamplesRead())
 		})
@@ -628,6 +662,55 @@ func TestRemoteReadStreamedXORChunks_SampleCountStats(t *testing.T) {
 			expectedPhysicalSampleCount:   3,
 			expectedEquivalentSampleCount: 3,
 		},
+		"stale samples are not counted": {
+			queries: []*prompb.Query{
+				{StartTimestampMs: 0, EndTimestampMs: 10},
+			},
+			chunkSeriesSets: func() []storage.ChunkSeriesSet {
+				staleNaN := model.SampleValue(math.Float64frombits(value.StaleNaN))
+				return []storage.ChunkSeriesSet{
+					storage.NewSeriesSetToChunkSet(
+						series.NewConcreteSeriesSetFromUnsortedSeries([]storage.Series{
+							series.NewConcreteSeries(
+								labels.FromStrings("foo", "bar"),
+								[]model.SamplePair{
+									{Timestamp: 1, Value: 1},
+									{Timestamp: 2, Value: staleNaN},
+									{Timestamp: 3, Value: 3},
+									{Timestamp: 4, Value: staleNaN},
+									{Timestamp: 5, Value: 5},
+								},
+								nil,
+							),
+						}),
+					),
+				}
+			},
+			expectedPhysicalSampleCount:   3,
+			expectedEquivalentSampleCount: 3,
+		},
+		"over-read samples outside the query range are not counted": {
+			queries: []*prompb.Query{
+				{StartTimestampMs: 0, EndTimestampMs: 10},
+			},
+			chunkSeriesSets: func() []storage.ChunkSeriesSet {
+				// The querier can over-read whole chunks; the series spans t=1..20 but the
+				// query only asks for [0,10], so only 10 samples must be metered.
+				samples := make([]model.SamplePair, 0, 20)
+				for ts := int64(1); ts <= 20; ts++ {
+					samples = append(samples, model.SamplePair{Timestamp: model.Time(ts), Value: model.SampleValue(ts)})
+				}
+				return []storage.ChunkSeriesSet{
+					storage.NewSeriesSetToChunkSet(
+						series.NewConcreteSeriesSetFromUnsortedSeries([]storage.Series{
+							series.NewConcreteSeries(labels.FromStrings("foo", "bar"), samples, nil),
+						}),
+					),
+				}
+			},
+			expectedPhysicalSampleCount:   10,
+			expectedEquivalentSampleCount: 10,
+		},
 		"empty series set": {
 			queries: []*prompb.Query{
 				{StartTimestampMs: 0, EndTimestampMs: 10},
@@ -643,7 +726,6 @@ func TestRemoteReadStreamedXORChunks_SampleCountStats(t *testing.T) {
 			expectedEquivalentSampleCount: 0,
 		},
 	}
-
 	for testName, tc := range tests {
 		t.Run(testName, func(t *testing.T) {
 			chunkSeriesSets := tc.chunkSeriesSets()
@@ -660,7 +742,7 @@ func TestRemoteReadStreamedXORChunks_SampleCountStats(t *testing.T) {
 				},
 			}
 
-			queryStats, ctx := stats.ContextWithEmptyStats(context.Background())
+			queryStats, ctx := stats.ContextWithEmptyStats(t.Context())
 			w := httptest.NewRecorder()
 			req := &prompb.ReadRequest{
 				Queries:               tc.queries,
@@ -1303,8 +1385,8 @@ func equivalentSampleCountDecodeAll(chk chunkenc.Chunk) uint64 {
 }
 
 // makeChunk creates a chunkenc.Chunk with n samples of the given encoding.
-func makeChunk(b *testing.B, encoding chunkenc.Encoding, n int) chunkenc.Chunk {
-	b.Helper()
+func makeChunk(tb testing.TB, encoding chunkenc.Encoding, n int) chunkenc.Chunk {
+	tb.Helper()
 
 	var chk chunkenc.Chunk
 	switch encoding {
@@ -1315,79 +1397,146 @@ func makeChunk(b *testing.B, encoding chunkenc.Encoding, n int) chunkenc.Chunk {
 	case chunkenc.EncFloatHistogram:
 		chk = chunkenc.NewFloatHistogramChunk()
 	default:
-		b.Fatalf("unsupported encoding: %v", encoding)
+		tb.Fatalf("unsupported encoding: %v", encoding)
 	}
 
 	ap, err := chk.Appender()
-	require.NoError(b, err)
+	require.NoError(tb, err)
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		switch encoding {
 		case chunkenc.EncXOR:
 			ap.Append(0, int64(i), float64(i))
 		case chunkenc.EncHistogram:
 			_, _, _, err = ap.AppendHistogram(nil, 0, int64(i), test.GenerateTestHistogram(i), true)
-			require.NoError(b, err)
+			require.NoError(tb, err)
 		case chunkenc.EncFloatHistogram:
 			_, _, _, err = ap.AppendFloatHistogram(nil, 0, int64(i), test.GenerateTestFloatHistogram(i), true)
-			require.NoError(b, err)
+			require.NoError(tb, err)
 		}
 	}
 
 	return chk
 }
 
-func TestEquivalentSampleCountForChunk_StaleNaN(t *testing.T) {
+func TestSampleCountsForChunk(t *testing.T) {
 	staleSum := math.Float64frombits(value.StaleNaN)
+	// Wide bounds that include every sample, for cases not exercising the time filter.
+	const allTimes, allTimesEnd = int64(math.MinInt64), int64(math.MaxInt64)
+
+	t.Run("float samples within range are counted", func(t *testing.T) {
+		chk := chunkenc.NewXORChunk()
+		ap, err := chk.Appender()
+		require.NoError(t, err)
+		for i := range 5 {
+			ap.Append(0, int64(i), float64(i))
+		}
+
+		physical, equivalent, err := sampleCountsForChunk(chk, allTimes, allTimesEnd)
+		require.NoError(t, err)
+		require.Equal(t, uint64(5), physical)
+		require.Equal(t, uint64(5), equivalent)
+	})
+
+	t.Run("float samples outside the range are excluded", func(t *testing.T) {
+		chk := chunkenc.NewXORChunk()
+		ap, err := chk.Appender()
+		require.NoError(t, err)
+		for i := range 10 {
+			ap.Append(0, int64(i), float64(i)) // timestamps 0..9
+		}
+
+		// Only timestamps 3,4,5,6 are within [3,6].
+		physical, equivalent, err := sampleCountsForChunk(chk, 3, 6)
+		require.NoError(t, err)
+		require.Equal(t, uint64(4), physical)
+		require.Equal(t, uint64(4), equivalent)
+	})
+
+	t.Run("stale float samples are skipped including mid-chunk", func(t *testing.T) {
+		chk := chunkenc.NewXORChunk()
+		ap, err := chk.Appender()
+		require.NoError(t, err)
+		ap.Append(0, 0, 1)
+		ap.Append(0, 1, staleSum)
+		ap.Append(0, 2, 3)
+		ap.Append(0, 3, staleSum)
+		ap.Append(0, 4, 5)
+
+		physical, equivalent, err := sampleCountsForChunk(chk, allTimes, allTimesEnd)
+		require.NoError(t, err)
+		require.Equal(t, uint64(3), physical)
+		require.Equal(t, uint64(3), equivalent)
+	})
 
 	t.Run("all stale float histogram samples return zero", func(t *testing.T) {
 		chk := chunkenc.NewFloatHistogramChunk()
 		ap, err := chk.Appender()
 		require.NoError(t, err)
-
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			_, _, _, err = ap.AppendFloatHistogram(nil, 0, int64(i), &histogram.FloatHistogram{Sum: staleSum}, true)
 			require.NoError(t, err)
 		}
-
 		require.Equal(t, 3, chk.NumSamples())
-		count, err := equivalentSampleCountForChunk(chk)
+
+		physical, equivalent, err := sampleCountsForChunk(chk, allTimes, allTimesEnd)
 		require.NoError(t, err)
-		require.Equal(t, uint64(0), count)
+		require.Equal(t, uint64(0), physical)
+		require.Equal(t, uint64(0), equivalent)
 	})
 
 	t.Run("all stale integer histogram samples return zero", func(t *testing.T) {
 		chk := chunkenc.NewHistogramChunk()
 		ap, err := chk.Appender()
 		require.NoError(t, err)
-
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			_, _, _, err = ap.AppendHistogram(nil, 0, int64(i), &histogram.Histogram{Sum: staleSum}, true)
 			require.NoError(t, err)
 		}
-
 		require.Equal(t, 3, chk.NumSamples())
-		count, err := equivalentSampleCountForChunk(chk)
+
+		physical, equivalent, err := sampleCountsForChunk(chk, allTimes, allTimesEnd)
 		require.NoError(t, err)
-		require.Equal(t, uint64(0), count)
+		require.Equal(t, uint64(0), physical)
+		require.Equal(t, uint64(0), equivalent)
 	})
 
-	t.Run("non-stale histogram returns nonzero cost", func(t *testing.T) {
+	t.Run("histogram samples are counted and weighted within range", func(t *testing.T) {
 		chk := chunkenc.NewFloatHistogramChunk()
 		ap, err := chk.Appender()
 		require.NoError(t, err)
+		for i := range 5 {
+			_, _, _, err = ap.AppendFloatHistogram(nil, 0, int64(i), test.GenerateTestFloatHistogram(i), true)
+			require.NoError(t, err)
+		}
 
-		h := test.GenerateTestFloatHistogram(1)
-		_, _, _, err = ap.AppendFloatHistogram(nil, 0, 0, h, true)
-		require.NoError(t, err)
+		// All samples in the chunk share one bucket layout, so each has the same weight.
+		perSample := uint64(types.EquivalentFloatSampleCount(test.GenerateTestFloatHistogram(0)))
+		require.Greater(t, perSample, uint64(0))
 
-		count, err := equivalentSampleCountForChunk(chk)
+		// Only timestamps 2,3,4 are within [2,10].
+		physical, equivalent, err := sampleCountsForChunk(chk, 2, 10)
 		require.NoError(t, err)
-		require.Greater(t, count, uint64(0))
+		require.Equal(t, uint64(3), physical)
+		require.Equal(t, perSample*3, equivalent)
+	})
+
+	t.Run("cached histogram weight matches per-sample decode", func(t *testing.T) {
+		// sampleCountsForChunk reuses the first non-stale sample's weight for the whole chunk;
+		// that must equal summing every sample's weight, since all samples in a histogram chunk
+		// share one bucket layout. Guards the optimization against regressions.
+		for _, enc := range []chunkenc.Encoding{chunkenc.EncHistogram, chunkenc.EncFloatHistogram} {
+			for _, n := range []int{120, 500} {
+				chk := makeChunk(t, enc, n)
+				_, equivalent, err := sampleCountsForChunk(chk, allTimes, allTimesEnd)
+				require.NoError(t, err)
+				require.Equal(t, equivalentSampleCountDecodeAll(chk), equivalent)
+			}
+		}
 	})
 }
 
-func BenchmarkEquivalentSampleCount(b *testing.B) {
+func BenchmarkSampleCountsForChunk(b *testing.B) {
 	floatChunk120 := makeChunk(b, chunkenc.EncXOR, 120)
 	histChunk120 := makeChunk(b, chunkenc.EncHistogram, 120)
 	histChunk500 := makeChunk(b, chunkenc.EncHistogram, 500)
@@ -1397,24 +1546,24 @@ func BenchmarkEquivalentSampleCount(b *testing.B) {
 	require.Equal(b, 120, histChunk120.NumSamples())
 	require.Equal(b, 500, histChunk500.NumSamples())
 
+	const allTimes, allTimesEnd = int64(math.MinInt64), int64(math.MaxInt64)
+
 	// --- Float 120 ---
 
 	b.Run("float_120/NumSamples", func(b *testing.B) {
-		var v int
-		for i := 0; i < b.N; i++ {
-			v = floatChunk120.NumSamples()
+		for b.Loop() {
+			_ = floatChunk120.NumSamples()
 		}
-		_ = v
 	})
 
-	b.Run("float_120/DecodeFirst", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			_, _ = equivalentSampleCountForChunk(floatChunk120)
+	b.Run("float_120/SampleCounts", func(b *testing.B) {
+		for b.Loop() {
+			_, _, _ = sampleCountsForChunk(floatChunk120, allTimes, allTimesEnd)
 		}
 	})
 
 	b.Run("float_120/DecodeAll", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			_ = equivalentSampleCountDecodeAll(floatChunk120)
 		}
 	})
@@ -1422,21 +1571,19 @@ func BenchmarkEquivalentSampleCount(b *testing.B) {
 	// --- Histogram 120 ---
 
 	b.Run("hist_120/NumSamples", func(b *testing.B) {
-		var v int
-		for i := 0; i < b.N; i++ {
-			v = histChunk120.NumSamples()
+		for b.Loop() {
+			_ = histChunk120.NumSamples()
 		}
-		_ = v
 	})
 
-	b.Run("hist_120/DecodeFirst", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			_, _ = equivalentSampleCountForChunk(histChunk120)
+	b.Run("hist_120/SampleCounts", func(b *testing.B) {
+		for b.Loop() {
+			_, _, _ = sampleCountsForChunk(histChunk120, allTimes, allTimesEnd)
 		}
 	})
 
 	b.Run("hist_120/DecodeAll", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			_ = equivalentSampleCountDecodeAll(histChunk120)
 		}
 	})
@@ -1444,51 +1591,20 @@ func BenchmarkEquivalentSampleCount(b *testing.B) {
 	// --- Histogram 500 ---
 
 	b.Run("hist_500/NumSamples", func(b *testing.B) {
-		var v int
-		for i := 0; i < b.N; i++ {
-			v = histChunk500.NumSamples()
+		for b.Loop() {
+			_ = histChunk500.NumSamples()
 		}
-		_ = v
 	})
 
-	b.Run("hist_500/DecodeFirst", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			_, _ = equivalentSampleCountForChunk(histChunk500)
+	b.Run("hist_500/SampleCounts", func(b *testing.B) {
+		for b.Loop() {
+			_, _, _ = sampleCountsForChunk(histChunk500, allTimes, allTimesEnd)
 		}
 	})
 
 	b.Run("hist_500/DecodeAll", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			_ = equivalentSampleCountDecodeAll(histChunk500)
-		}
-	})
-
-	// --- Report accuracy values ---
-
-	b.Run("accuracy_report", func(b *testing.B) {
-		type chunkInfo struct {
-			name string
-			chk  chunkenc.Chunk
-		}
-		chunks := []chunkInfo{
-			{"float_120", floatChunk120},
-			{"hist_120", histChunk120},
-			{"hist_500", histChunk500},
-		}
-
-		for _, ci := range chunks {
-			numSamples := uint64(ci.chk.NumSamples())
-			decodeFirst, err := equivalentSampleCountForChunk(ci.chk)
-			require.NoError(b, err)
-			decodeAll := equivalentSampleCountDecodeAll(ci.chk)
-
-			b.Logf("%s: NumSamples=%d  DecodeFirst=%d  DecodeAll=%d  (first_vs_all_diff=%d)",
-				ci.name, numSamples, decodeFirst, decodeAll, int64(decodeFirst)-int64(decodeAll))
-		}
-
-		// Run a trivial loop so the sub-benchmark is valid.
-		for i := 0; i < b.N; i++ {
-			_ = i
 		}
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

The streamed-chunks remote read path metered whole chunks via `NumSamples()`, counting over-read samples outside the query range and stale markers, while the samples path counts only in-range, non-stale samples. The same data was therefore metered differently depending on the negotiated response type. The samples path also dropped already-computed counts when a series set failed on `Err()` after yielding some series.

Count per-sample in the streamed-chunks path, filtering to the query range and excluding stale markers so it matches the samples path and MQE; the whole chunk is still streamed to the client. Record samples-path counts before returning the error so partial work is metered. Document the metering change in the runbook.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit bd66b3bb02c1813b3ef97caeb835b8f48b8daad2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->