### PR TITLE
Compartments: don't require Kafka address placeholder for single-cluster components

### DIFF
--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -302,14 +302,6 @@ func (c *Config) Validate(log log.Logger) error {
 			if !strings.Contains(c.IngestStorage.KafkaConfig.Topic, compartments.ReadCompartmentIDPlaceholder) {
 				return fmt.Errorf("when compartments are enabled, -ingest-storage.kafka.topic must contain the %q placeholder for the distributor and ingester", compartments.ReadCompartmentIDPlaceholder)
 			}
-			// The address is resolved per write compartment. Without the placeholder every write compartment
-			// resolves to the same Kafka cluster, so the ingester would ingest each partition once per write
-			// compartment. Each configured address is resolved independently, so they must all contain it.
-			for _, addr := range c.IngestStorage.KafkaConfig.Address {
-				if !strings.Contains(addr, compartments.WriteCompartmentIDPlaceholder) {
-					return fmt.Errorf("when compartments are enabled, every -ingest-storage.kafka.address must contain the %q placeholder for the distributor and ingester", compartments.WriteCompartmentIDPlaceholder)
-				}
-			}
 		}
 		// The distributor's writer is configured with the read-compartment-templated topic, which is not a
 		// real topic name and so cannot be auto-created; the resolved per-compartment topics are created by

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -303,6 +303,19 @@ func (c *Config) Validate(log log.Logger) error {
 				return fmt.Errorf("when compartments are enabled, -ingest-storage.kafka.topic must contain the %q placeholder for the distributor and ingester", compartments.ReadCompartmentIDPlaceholder)
 			}
 		}
+		// The ingester consumes its partition from every write compartment's Kafka cluster, resolving each
+		// configured address per write compartment. With more than one write compartment and an address
+		// without the placeholder, every compartment resolves to the same cluster, so the ingester would
+		// consume each partition once per write compartment and duplicate samples. A single write
+		// compartment (or other components, like the distributor, that target just one cluster) doesn't
+		// need the placeholder.
+		if c.isIngesterEnabled() && c.Compartments.Write.NumCompartments > 1 {
+			for _, addr := range c.IngestStorage.KafkaConfig.Address {
+				if !strings.Contains(addr, compartments.WriteCompartmentIDPlaceholder) {
+					return fmt.Errorf("when compartments are enabled with more than one write compartment, every -ingest-storage.kafka.address must contain the %q placeholder for the ingester", compartments.WriteCompartmentIDPlaceholder)
+				}
+			}
+		}
 		// The distributor's writer is configured with the read-compartment-templated topic, which is not a
 		// real topic name and so cannot be auto-created; the resolved per-compartment topics are created by
 		// the ingesters' partition readers. The distributor must therefore have topic auto-creation disabled.

--- a/pkg/mimir/mimir_test.go
+++ b/pkg/mimir/mimir_test.go
@@ -597,9 +597,39 @@ func TestConfigValidation(t *testing.T) {
 			expectAnyError: true,
 		},
 		{
-			name: "should pass if compartments are enabled but the Kafka address is not parameterised by write compartment",
+			name: "should fail if the ingester is enabled with more than one write compartment but the Kafka address is not parameterised by write compartment",
 			getTestConfig: func() *Config {
 				cfg := validCompartmentsConfig()
+				cfg.IngestStorage.KafkaConfig.Address = flagext.StringSliceCSV{"localhost:9092"}
+				return cfg
+			},
+			expectAnyError: true,
+		},
+		{
+			name: "should fail if the ingester is enabled with more than one write compartment but only some of the Kafka addresses are parameterised by write compartment",
+			getTestConfig: func() *Config {
+				cfg := validCompartmentsConfig()
+				cfg.IngestStorage.KafkaConfig.Address = flagext.StringSliceCSV{"kafka-wc-<write-compartment-id>:9092", "localhost:9092"}
+				return cfg
+			},
+			expectAnyError: true,
+		},
+		{
+			name: "should pass if there is a single write compartment and the Kafka address is not parameterised by write compartment",
+			getTestConfig: func() *Config {
+				cfg := validCompartmentsConfig()
+				cfg.Compartments.Write.NumCompartments = 1
+				cfg.Distributor.WriteCompartmentID = 0
+				cfg.IngestStorage.KafkaConfig.Address = flagext.StringSliceCSV{"localhost:9092"}
+				return cfg
+			},
+			expectAnyError: false,
+		},
+		{
+			name: "should pass if the ingester is not enabled and the Kafka address is not parameterised by write compartment",
+			getTestConfig: func() *Config {
+				cfg := validCompartmentsConfig()
+				cfg.Target = flagext.StringSliceCSV{Distributor}
 				cfg.IngestStorage.KafkaConfig.Address = flagext.StringSliceCSV{"localhost:9092"}
 				return cfg
 			},

--- a/pkg/mimir/mimir_test.go
+++ b/pkg/mimir/mimir_test.go
@@ -597,22 +597,13 @@ func TestConfigValidation(t *testing.T) {
 			expectAnyError: true,
 		},
 		{
-			name: "should fail if compartments are enabled but the Kafka address is not parameterised by write compartment",
+			name: "should pass if compartments are enabled but the Kafka address is not parameterised by write compartment",
 			getTestConfig: func() *Config {
 				cfg := validCompartmentsConfig()
 				cfg.IngestStorage.KafkaConfig.Address = flagext.StringSliceCSV{"localhost:9092"}
 				return cfg
 			},
-			expectAnyError: true,
-		},
-		{
-			name: "should fail if compartments are enabled but only some of the Kafka addresses are parameterised by write compartment",
-			getTestConfig: func() *Config {
-				cfg := validCompartmentsConfig()
-				cfg.IngestStorage.KafkaConfig.Address = flagext.StringSliceCSV{"kafka-wc-<write-compartment-id>:9092", "localhost:9092"}
-				return cfg
-			},
-			expectAnyError: true,
+			expectAnyError: false,
 		},
 		{
 			name: "should fail if compartments and the distributor are enabled but Kafka topic auto-creation is on",


### PR DESCRIPTION
#### What this PR does

When compartments are enabled, `-ingest-storage.kafka.address` was required to contain the `<write-compartment-id>` placeholder. This is too strict: components that only need to connect to a single Kafka cluster (e.g. the distributor, or any setup with a single write compartment) are simpler to configure and operate with an explicit address.

The placeholder is now required only where it actually matters: when the ingester is enabled **and** there is more than one write compartment. In that case each address is resolved per write compartment, so without the placeholder every compartment would resolve to the same cluster and the ingester would consume (and duplicate) each partition once per write compartment.

The compartments feature is still experimental and undocumented, so no CHANGELOG entry is needed.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.