### PR TITLE
Fix alertmanager ingress when zone-aware replication is enabled

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -36,6 +36,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [ENHANCEMENT] Add support for `revisionHistoryLimit` on StatefulSet-based components: `alertmanager`, `ingester`, `store_gateway`, `compactor`, and the `chunks-cache`, `index-cache`, `metadata-cache`, and `results-cache` memcached StatefulSets. Previously `revisionHistoryLimit` was only honored on Deployment-based components. #PR
 * [ENHANCEMENT] Add support for `revisionHistoryLimit` on StatefulSet-based components: `alertmanager`, `ingester`, `store_gateway`, `compactor`, and the `chunks-cache`, `index-cache`, `metadata-cache`, and `results-cache` memcached StatefulSets. Previously `revisionHistoryLimit` was only honored on Deployment-based components. #15950
 * [BUGFIX]: Fix bug in `ScaledObject` templates when using `kedaAutoscaling.fallback` #15793
+* [BUGFIX] Alertmanager: Create a plain `<release>-alertmanager` ClusterIP service when `alertmanager.zoneAwareReplication.enabled=true` so that the Ingress and other consumers that reference the stable service name keep working. Previously only per-zone services were created, which broke the Ingress with `services <release>-alertmanager not found`. #15740
 
 ## 6.1.0
 

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-svc-zone-aware.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-svc-zone-aware.yaml
@@ -1,12 +1,13 @@
 {{- /*
 When zone-aware replication is enabled (and migration is not in progress) the
 alertmanager only gets per-zone services and a headless service; the plain
-"mimir-alertmanager" ClusterIP service is not created. The Ingress and other
-consumers still reference that name, so without it those routes break with
+"mimir-alertmanager" service is not created. The Ingress and other consumers
+still reference that name, so without it those routes break with
 "services mimir-alertmanager not found".
 
-This renders a plain ClusterIP service that load-balances across all zones so
-the stable name keeps working. It is excluded from metrics scraping via the
+This renders a service (type taken from alertmanager.service.type, ClusterIP by
+default) that load-balances across all zones so the stable name keeps working.
+It is excluded from metrics scraping via the
 prometheus.io/service-monitor label because the per-zone services already
 expose the pods to the ServiceMonitor and scraping here too would produce
 duplicate metrics.

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-svc-zone-aware.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-svc-zone-aware.yaml
@@ -1,0 +1,48 @@
+{{- /*
+When zone-aware replication is enabled (and migration is not in progress) the
+alertmanager only gets per-zone services and a headless service; the plain
+"mimir-alertmanager" ClusterIP service is not created. The Ingress and other
+consumers still reference that name, so without it those routes break with
+"services mimir-alertmanager not found".
+
+This renders a plain ClusterIP service that load-balances across all zones so
+the stable name keeps working. It is excluded from metrics scraping via the
+prometheus.io/service-monitor label because the per-zone services already
+expose the pods to the ServiceMonitor and scraping here too would produce
+duplicate metrics.
+*/ -}}
+{{- if and .Values.alertmanager.enabled .Values.alertmanager.zoneAwareReplication.enabled (not .Values.alertmanager.zoneAwareReplication.migration.enabled) -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" . "component" "alertmanager") }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" . "component" "alertmanager" "memberlist" true) | nindent 4 }}
+    # Prevent scraping PODs via this service as the per-zone services already scrape all PODs and you get duplicate metrics.
+    prometheus.io/service-monitor: "false"
+    {{- with .Values.alertmanager.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- toYaml .Values.alertmanager.service.annotations | nindent 4 }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  type: {{ .Values.alertmanager.service.type }}
+  {{- if semverCompare ">= 1.22-0" (include "mimir.kubeVersion" .) }}
+  internalTrafficPolicy: {{ .Values.alertmanager.service.internalTrafficPolicy }}
+  {{- end }}
+  ports:
+    - port: {{ include "mimir.serverHttpListenPort" . }}
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: {{ include "mimir.serverGrpcListenPort" . }}
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+    {{- if .Values.alertmanager.service.extraPorts }}
+    {{- toYaml .Values.alertmanager.service.extraPorts | nindent 4 }}
+    {{- end }}
+  selector:
+    {{- include "mimir.selectorLabels" (dict "ctx" . "component" "alertmanager") | nindent 4 }}
+{{- end }}

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc-zone-aware.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc-zone-aware.yaml
@@ -1,0 +1,34 @@
+---
+# Source: mimir-distributed/templates/alertmanager/alertmanager-svc-zone-aware.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-logical-multizone-values-mimir-alertmanager
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-logical-multizone-values
+    app.kubernetes.io/component: alertmanager
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    # Prevent scraping PODs via this service as the per-zone services already scrape all PODs and you get duplicate metrics.
+    prometheus.io/service-monitor: "false"
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  internalTrafficPolicy: Cluster
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-logical-multizone-values
+    app.kubernetes.io/component: alertmanager
+

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc-zone-aware.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/alertmanager/alertmanager-svc-zone-aware.yaml
@@ -1,0 +1,34 @@
+---
+# Source: mimir-distributed/templates/alertmanager/alertmanager-svc-zone-aware.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-oss-multizone-values-mimir-alertmanager
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-values
+    app.kubernetes.io/component: alertmanager
+    app.kubernetes.io/part-of: memberlist
+    app.kubernetes.io/managed-by: Helm
+    # Prevent scraping PODs via this service as the per-zone services already scrape all PODs and you get duplicate metrics.
+    prometheus.io/service-monitor: "false"
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  internalTrafficPolicy: Cluster
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http-metrics
+      targetPort: http-metrics
+    - port: 9095
+      protocol: TCP
+      name: grpc
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-oss-multizone-values
+    app.kubernetes.io/component: alertmanager
+


### PR DESCRIPTION
#### What this PR does

When alertmanager.zoneAwareReplication.enabled is true and migration is not in progress, the mimir-distributed chart only creates the per-zone services (mimir-alertmanager-zone-a/b/c) and the headless service. It does not create the plain mimir-alertmanager ClusterIP service, because the zone-aware replication map only adds the default (zone-less) entry while migration is enabled.

The Ingress template references the stable name mimir-alertmanager for the alertmanager paths, so with zone-aware replication enabled the Ingress points at a service that does not exist and the routes break with:

    error: services "mimir-alertmanager" not found

This adds a plain ClusterIP service named mimir-alertmanager that selects alertmanager pods across all zones (the selector omits the zone label), so the stable name resolves again and load-balances over every zone.

A few details:

- The service is only rendered when zone-aware replication is enabled and migration is off. With zone-awareness disabled, or during migration, the existing alertmanager-svc.yaml already renders the plain service, so this does not create a duplicate.
- It carries the prometheus.io/service-monitor: "false" label so the ServiceMonitor does not scrape it. The per-zone services already expose the pods, and scraping this one too would produce duplicate metrics. This mirrors what the headless service already does.

This is the approach suggested by a maintainer in the issue discussion (create a regular ClusterIP service rather than routing the Ingress to the headless service, which was the approach in the earlier, now-closed #14868).

The helm golden records were regenerated with make build-helm-tests; the new service shows up only in the two multizone test cases and nothing else changed.

#### Which issue(s) this PR fixes or relates to

Fixes #14334

#### Checklist

- [x] Tests updated. Helm golden records regenerated; the new service is covered by the existing multizone test cases.
- [x] Documentation added. Not needed, no user-facing configuration change.
- [x] `CHANGELOG.md` updated - chart CHANGELOG has a [BUGFIX] entry.
- [x] [`about-versioning.md`] updated with experimental features. Not needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Helm-only bugfix with guarded render conditions to avoid duplicate services during migration or when zone-awareness is disabled; golden tests cover multizone outputs.
> 
> **Overview**
> With **alertmanager zone-aware replication** enabled (and migration off), the chart no longer leaves Ingress and other clients pointing at a missing `<release>-alertmanager` Service—only per-zone and headless services were rendered before, which caused `services "<release>-alertmanager" not found`.
> 
> This PR adds **`alertmanager-svc-zone-aware.yaml`**, which creates that stable **ClusterIP** Service with a zone-agnostic pod selector so traffic load-balances across all zones. It reuses **`alertmanager.service`** settings (type, ports, labels, annotations) and sets **`prometheus.io/service-monitor: "false"`** so ServiceMonitor scraping stays on the per-zone services and metrics are not duplicated.
> 
> The chart **CHANGELOG** documents the fix, and **helm golden tests** for the two multizone OSS fixtures were regenerated to include the new manifest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3b11176dcfe67b0b06af3bc2969ccb3b03aaa01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->