### PR TITLE
Compartments: let distributors auto-create read-compartment topics

### DIFF
--- a/development/mimir-compartments/docker-compose.jsonnet
+++ b/development/mimir-compartments/docker-compose.jsonnet
@@ -41,9 +41,6 @@ std.manifestYamlDoc({
         '-distributor.write-compartment-id=%d' % id,
         "-ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092'",
         "-ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>'",
-        // The writer's topic is the read-compartment template, which cannot be auto-created; the resolved
-        // topics are created by the ingesters' readers. Compartments config validation requires this.
-        '-ingest-storage.kafka.auto-create-topic-enabled=false',
       ],
     }) + {
       // Share a "distributor" network alias so nginx (DISTRIBUTOR_HOST=distributor) balances across both.

--- a/development/mimir-compartments/docker-compose.yml
+++ b/development/mimir-compartments/docker-compose.yml
@@ -106,7 +106,7 @@
     "command":
       - "sh"
       - "-c"
-      - "exec ./mimir -config.file=./config/mimir.yaml -target=distributor -activity-tracker.filepath=/activity/distributor-wc-0 -distributor.write-compartment-id=0 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>' -ingest-storage.kafka.auto-create-topic-enabled=false"
+      - "exec ./mimir -config.file=./config/mimir.yaml -target=distributor -activity-tracker.filepath=/activity/distributor-wc-0 -distributor.write-compartment-id=0 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>'"
     "depends_on":
       "kafka-wc-0":
         "condition": "service_healthy"
@@ -135,7 +135,7 @@
     "command":
       - "sh"
       - "-c"
-      - "exec ./mimir -config.file=./config/mimir.yaml -target=distributor -activity-tracker.filepath=/activity/distributor-wc-1 -distributor.write-compartment-id=1 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>' -ingest-storage.kafka.auto-create-topic-enabled=false"
+      - "exec ./mimir -config.file=./config/mimir.yaml -target=distributor -activity-tracker.filepath=/activity/distributor-wc-1 -distributor.write-compartment-id=1 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>'"
     "depends_on":
       "kafka-wc-0":
         "condition": "service_healthy"

--- a/pkg/compartments/router.go
+++ b/pkg/compartments/router.go
@@ -113,6 +113,11 @@ func (r *Router) TopicForCompartment(compartmentID int) string {
 	return r.topics[compartmentID]
 }
 
+// Topics returns the Kafka topic of every read compartment.
+func (r *Router) Topics() []string {
+	return slices.Clone(r.topics)
+}
+
 // appendUnique appends v to s only if absent, deduplicating because several matched metric names can
 // hash to the same compartment.
 func appendUnique[T comparable](s []T, v T) []T {

--- a/pkg/compartments/router_test.go
+++ b/pkg/compartments/router_test.go
@@ -26,6 +26,15 @@ func TestRouter_TopicForCompartment(t *testing.T) {
 	assert.Equal(t, "mimir-rc-2", r.TopicForCompartment(2))
 }
 
+func TestRouter_Topics(t *testing.T) {
+	r := newTestRouter(3)
+	assert.Equal(t, []string{"mimir-rc-0", "mimir-rc-1", "mimir-rc-2"}, r.Topics())
+
+	// The returned slice is a copy: mutating it must not affect the router.
+	r.Topics()[0] = "mutated"
+	assert.Equal(t, "mimir-rc-0", r.TopicForCompartment(0))
+}
+
 func TestRouter_CompartmentForMetric(t *testing.T) {
 	r := newTestRouter(4)
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -825,17 +825,12 @@ func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Ove
 
 	if cfg.IngestStorageConfig.Enabled {
 		writerKafkaCfg := d.cfg.IngestStorageConfig.KafkaConfig
+		var writerOpts []ingest.WriterOption
+
 		if cfg.Compartments.Enabled {
 			// Resolve the writer's Kafka address and credentials for this distributor's write compartment.
-			// Topic auto-creation is required to be disabled by config validation, because the writer's topic
-			// is the read-compartment template; the resolved topics are created by the ingesters' readers.
 			writerKafkaCfg = writerKafkaCfg.WriteCompartmentConfig(cfg.WriteCompartmentID)
-		}
 
-		d.ingestStorageWriter = ingest.NewWriter(writerKafkaCfg, log, reg)
-		subservices = append(subservices, d.ingestStorageWriter)
-
-		if cfg.Compartments.Enabled {
 			d.compartmentRouter = compartments.NewRouter(cfg.Compartments.Read.NumCompartments, cfg.IngestStorageConfig.KafkaConfig.Topic)
 
 			d.queryIngesterCompartmentsHit = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
@@ -846,7 +841,17 @@ func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Ove
 				ConstLabels: prometheus.Labels{"storage": "ingester"},
 				Buckets:     prometheus.LinearBuckets(1, 1, cfg.Compartments.Read.NumCompartments),
 			})
+
+			// The writer's configured topic is the read-compartment template, which is not a real topic
+			// name. Auto-create every resolved read-compartment topic in this distributor's write
+			// compartment's Kafka cluster instead.
+			if writerKafkaCfg.AutoCreateTopicEnabled {
+				writerOpts = append(writerOpts, ingest.WithAutoCreateTopics(d.compartmentRouter.Topics()))
+			}
 		}
+
+		d.ingestStorageWriter = ingest.NewWriter(writerKafkaCfg, log, reg, writerOpts...)
+		subservices = append(subservices, d.ingestStorageWriter)
 	}
 
 	// Init usage-tracker client (if enabled).

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -316,12 +316,6 @@ func (c *Config) Validate(log log.Logger) error {
 				}
 			}
 		}
-		// The distributor's writer is configured with the read-compartment-templated topic, which is not a
-		// real topic name and so cannot be auto-created; the resolved per-compartment topics are created by
-		// the ingesters' partition readers. The distributor must therefore have topic auto-creation disabled.
-		if c.isDistributorEnabled() && c.IngestStorage.KafkaConfig.AutoCreateTopicEnabled {
-			return errors.New("when compartments are enabled, -ingest-storage.kafka.auto-create-topic-enabled must be false on the distributor")
-		}
 		// The offset catalogue tracks a single Kafka offset per block, which is not representable when an
 		// ingester consumes from more than one write compartment's Kafka cluster (each has its own offset
 		// space). Multi-cluster support for the offset catalogue is not implemented yet.

--- a/pkg/mimir/mimir_test.go
+++ b/pkg/mimir/mimir_test.go
@@ -636,13 +636,13 @@ func TestConfigValidation(t *testing.T) {
 			expectAnyError: false,
 		},
 		{
-			name: "should fail if compartments and the distributor are enabled but Kafka topic auto-creation is on",
+			name: "should pass if compartments and the distributor are enabled with Kafka topic auto-creation on",
 			getTestConfig: func() *Config {
 				cfg := validCompartmentsConfig()
 				cfg.IngestStorage.KafkaConfig.AutoCreateTopicEnabled = true
 				return cfg
 			},
-			expectAnyError: true,
+			expectAnyError: false,
 		},
 		{
 			name: "should fail if the offset catalogue is enabled together with more than one write compartment",

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -217,7 +217,7 @@ func (r *SingleClusterPartitionReader) LastCommittedOffset() int64 {
 
 func (r *SingleClusterPartitionReader) start(ctx context.Context) (returnErr error) {
 	if r.kafkaCfg.AutoCreateTopicEnabled {
-		if err := CreateTopic(r.kafkaCfg, r.logger); err != nil {
+		if err := CreateTopics(r.kafkaCfg, r.logger, r.kafkaCfg.Topic); err != nil {
 			return err
 		}
 	}

--- a/pkg/storage/ingest/util.go
+++ b/pkg/storage/ingest/util.go
@@ -386,9 +386,9 @@ func (w *resultPromise[T]) wait(ctx context.Context) (T, error) {
 	}
 }
 
-// CreateTopic creates the topic in the Kafka cluster. If creating the topic fails, then an error is returned.
-// If the topic already exists, then the function logs a message and returns nil.
-func CreateTopic(cfg KafkaConfig, logger log.Logger) error {
+// CreateTopics creates the given topics in the Kafka cluster. A topic that already exists is treated as
+// success. If creating any topic fails for another reason, then an error is returned.
+func CreateTopics(cfg KafkaConfig, logger log.Logger, topics ...string) error {
 	logger = log.With(logger, "task", "autocreate_topic")
 
 	cl, err := kgo.NewClient(commonKafkaClientOptions(cfg, nil, logger)...)
@@ -402,28 +402,32 @@ func CreateTopic(cfg KafkaConfig, logger log.Logger) error {
 
 	// As of kafka 2.4 we can pass -1 and the broker will use its default configuration.
 	const defaultReplication = -1
-	resp, err := adm.CreateTopic(ctx, int32(cfg.AutoCreateTopicDefaultPartitions), defaultReplication, nil, cfg.Topic)
-	if err == nil {
-		err = resp.Err
-	}
+	resps, err := adm.CreateTopics(ctx, int32(cfg.AutoCreateTopicDefaultPartitions), defaultReplication, nil, topics...)
 	if err != nil {
-		if errors.Is(err, kerr.TopicAlreadyExists) {
-			level.Info(logger).Log(
-				"msg", "topic already exists",
-				"topic", resp.Topic,
-				"num_partitions", resp.NumPartitions,
-				"replication_factor", resp.ReplicationFactor,
-			)
-			return nil
-		}
-		return fmt.Errorf("failed to create topic %s: %w", cfg.Topic, err)
+		return fmt.Errorf("failed to create topics %v: %w", topics, err)
 	}
 
-	level.Info(logger).Log(
-		"msg", "successfully created topic",
-		"topic", resp.Topic,
-		"num_partitions", resp.NumPartitions,
-		"replication_factor", resp.ReplicationFactor,
-	)
+	for _, topic := range topics {
+		resp, ok := resps[topic]
+		if !ok {
+			// The broker should return a response for every requested topic; a missing one means we
+			// can't confirm it was created, so fail rather than report a success we didn't observe.
+			return fmt.Errorf("failed to create topic %s: not part of the create topics response", topic)
+		}
+		if resp.Err != nil {
+			if errors.Is(resp.Err, kerr.TopicAlreadyExists) {
+				level.Info(logger).Log("msg", "skipped Kafka topic creation because it already exists", "topic", topic)
+				continue
+			}
+			return fmt.Errorf("failed to create topic %s: %w", topic, resp.Err)
+		}
+
+		level.Info(logger).Log(
+			"msg", "successfully created Kafka topic",
+			"topic", resp.Topic,
+			"num_partitions", resp.NumPartitions,
+			"replication_factor", resp.ReplicationFactor,
+		)
+	}
 	return nil
 }

--- a/pkg/storage/ingest/util_test.go
+++ b/pkg/storage/ingest/util_test.go
@@ -259,7 +259,7 @@ func TestResultPromise(t *testing.T) {
 	})
 }
 
-func TestCreateTopic(t *testing.T) {
+func TestCreateTopics(t *testing.T) {
 	createKafkaCluster := func(t *testing.T) (string, *kfake.Cluster) {
 		cluster, err := kfake.NewCluster(kfake.NumBrokers(1))
 		require.NoError(t, err)
@@ -306,7 +306,91 @@ func TestCreateTopic(t *testing.T) {
 
 		logger := log.NewNopLogger()
 
-		require.NoError(t, CreateTopic(cfg, logger))
+		require.NoError(t, CreateTopics(cfg, logger, cfg.Topic))
+	})
+
+	t.Run("should create all the requested topics", func(t *testing.T) {
+		var (
+			addr, cluster = createKafkaCluster(t)
+			cfg           = KafkaConfig{
+				AutoCreateTopicDefaultPartitions: 100,
+			}
+			topics = []string{"topic-a", "topic-b"}
+		)
+		require.NoError(t, cfg.Address.Set(addr))
+
+		cluster.ControlKey(kmsg.CreateTopics.Int16(), func(request kmsg.Request) (kmsg.Response, error, bool) {
+			r := request.(*kmsg.CreateTopicsRequest)
+
+			require.Len(t, r.Topics, 2)
+			respTopics := make([]kmsg.CreateTopicsResponseTopic, 0, len(r.Topics))
+			for _, res := range r.Topics {
+				assert.Equal(t, int32(100), res.NumPartitions)
+				assert.Equal(t, int16(-1), res.ReplicationFactor)
+				respTopics = append(respTopics, kmsg.CreateTopicsResponseTopic{
+					Topic:             res.Topic,
+					NumPartitions:     res.NumPartitions,
+					ReplicationFactor: 3,
+				})
+			}
+
+			return &kmsg.CreateTopicsResponse{Version: r.Version, Topics: respTopics}, nil, true
+		})
+
+		require.NoError(t, CreateTopics(cfg, log.NewNopLogger(), topics...))
+	})
+
+	t.Run("should return an error if one of multiple topics fails to be created", func(t *testing.T) {
+		var (
+			addr, cluster = createKafkaCluster(t)
+			cfg           = KafkaConfig{
+				AutoCreateTopicDefaultPartitions: 100,
+			}
+			topics = []string{"topic-a", "topic-b"}
+		)
+		require.NoError(t, cfg.Address.Set(addr))
+
+		// topic-a already exists (tolerated), topic-b genuinely fails: the call must surface topic-b's error.
+		cluster.ControlKey(kmsg.CreateTopics.Int16(), func(request kmsg.Request) (kmsg.Response, error, bool) {
+			r := request.(*kmsg.CreateTopicsRequest)
+			return &kmsg.CreateTopicsResponse{
+				Version: r.Version,
+				Topics: []kmsg.CreateTopicsResponseTopic{
+					{Topic: "topic-a", ErrorCode: kerr.TopicAlreadyExists.Code},
+					{Topic: "topic-b", ErrorCode: kerr.NotLeaderForPartition.Code},
+				},
+			}, nil, true
+		})
+
+		err := CreateTopics(cfg, log.NewNopLogger(), topics...)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "topic-b")
+	})
+
+	t.Run("should return an error if a requested topic is missing from the response", func(t *testing.T) {
+		var (
+			addr, cluster = createKafkaCluster(t)
+			cfg           = KafkaConfig{
+				AutoCreateTopicDefaultPartitions: 100,
+			}
+			topics = []string{"topic-a", "topic-b"}
+		)
+		require.NoError(t, cfg.Address.Set(addr))
+
+		// The broker omits topic-b from the response: we can't confirm its creation, so it must error.
+		cluster.ControlKey(kmsg.CreateTopics.Int16(), func(request kmsg.Request) (kmsg.Response, error, bool) {
+			r := request.(*kmsg.CreateTopicsRequest)
+			return &kmsg.CreateTopicsResponse{
+				Version: r.Version,
+				Topics: []kmsg.CreateTopicsResponseTopic{
+					{Topic: "topic-a", NumPartitions: 100, ReplicationFactor: 3},
+				},
+			}, nil, true
+		})
+
+		err := CreateTopics(cfg, log.NewNopLogger(), topics...)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "topic-b")
 	})
 
 	t.Run("should return an error if the request fails", func(t *testing.T) {
@@ -318,8 +402,10 @@ func TestCreateTopic(t *testing.T) {
 		)
 		require.NoError(t, cfg.Address.Set(addr))
 
-		cluster.ControlKey(kmsg.CreateTopics.Int16(), func(_ kmsg.Request) (kmsg.Response, error, bool) {
+		cluster.ControlKey(kmsg.CreateTopics.Int16(), func(request kmsg.Request) (kmsg.Response, error, bool) {
+			r := request.(*kmsg.CreateTopicsRequest)
 			return &kmsg.CreateTopicsResponse{
+				Version: r.Version,
 				Topics: []kmsg.CreateTopicsResponseTopic{
 					{
 						Topic:     cfg.Topic,
@@ -331,7 +417,7 @@ func TestCreateTopic(t *testing.T) {
 
 		logger := log.NewNopLogger()
 
-		require.Error(t, CreateTopic(cfg, logger))
+		require.Error(t, CreateTopics(cfg, logger, cfg.Topic))
 	})
 
 	t.Run("should return an error if the request succeed but the response contains an error", func(t *testing.T) {
@@ -368,7 +454,7 @@ func TestCreateTopic(t *testing.T) {
 
 		logger := log.NewNopLogger()
 
-		require.NoError(t, CreateTopic(cfg, logger))
+		require.NoError(t, CreateTopics(cfg, logger, cfg.Topic))
 	})
 
 	t.Run("should not return error when topic already exists", func(t *testing.T) {
@@ -383,10 +469,10 @@ func TestCreateTopic(t *testing.T) {
 		require.NoError(t, cfg.Address.Set(addr))
 
 		// First call should create the topic
-		assert.NoError(t, CreateTopic(cfg, logger))
+		assert.NoError(t, CreateTopics(cfg, logger, cfg.Topic))
 
 		// Second call should succeed because topic already exists
-		assert.NoError(t, CreateTopic(cfg, logger))
+		assert.NoError(t, CreateTopics(cfg, logger, cfg.Topic))
 	})
 }
 

--- a/pkg/storage/ingest/writer.go
+++ b/pkg/storage/ingest/writer.go
@@ -63,6 +63,10 @@ type Writer struct {
 	logger     log.Logger
 	registerer prometheus.Registerer
 
+	// autoCreateTopics is the set of topics to auto-create on startup. It defaults to the configured
+	// kafkaCfg.Topic and can be overridden via WithAutoCreateTopics.
+	autoCreateTopics []string
+
 	client     atomic.Pointer[KafkaProducer]
 	serializer recordSerializer
 
@@ -75,7 +79,16 @@ type Writer struct {
 	serializeDuration   prometheus.Histogram
 }
 
-func NewWriter(kafkaCfg KafkaConfig, logger log.Logger, reg prometheus.Registerer) *Writer {
+// WriterOption customizes a Writer built by NewWriter.
+type WriterOption func(*Writer)
+
+// WithAutoCreateTopics sets the explicit set of topics the writer auto-creates on startup, instead of
+// the single configured KafkaConfig.Topic.
+func WithAutoCreateTopics(topics []string) WriterOption {
+	return func(w *Writer) { w.autoCreateTopics = topics }
+}
+
+func NewWriter(kafkaCfg KafkaConfig, logger log.Logger, reg prometheus.Registerer, opts ...WriterOption) *Writer {
 	writeLatency := promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 		Name:                            "cortex_ingest_storage_writer_latency_seconds",
 		Help:                            "Latency to write an incoming request to Kafka partitions.",
@@ -86,10 +99,11 @@ func NewWriter(kafkaCfg KafkaConfig, logger log.Logger, reg prometheus.Registere
 	}, []string{"outcome"})
 
 	w := &Writer{
-		kafkaCfg:   kafkaCfg,
-		logger:     logger,
-		registerer: reg,
-		serializer: recordSerializerFromCfg(kafkaCfg),
+		kafkaCfg:         kafkaCfg,
+		logger:           logger,
+		registerer:       reg,
+		serializer:       recordSerializerFromCfg(kafkaCfg),
+		autoCreateTopics: []string{kafkaCfg.Topic},
 
 		// Metrics.
 		writeSuccessLatency: writeLatency.WithLabelValues("success"),
@@ -117,6 +131,10 @@ func NewWriter(kafkaCfg KafkaConfig, logger log.Logger, reg prometheus.Registere
 		}),
 	}
 
+	for _, opt := range opts {
+		opt(w)
+	}
+
 	w.Service = services.NewIdleService(w.starting, w.stopping)
 
 	return w
@@ -124,7 +142,7 @@ func NewWriter(kafkaCfg KafkaConfig, logger log.Logger, reg prometheus.Registere
 
 func (w *Writer) starting(_ context.Context) error {
 	if w.kafkaCfg.AutoCreateTopicEnabled {
-		if err := CreateTopic(w.kafkaCfg, w.logger); err != nil {
+		if err := CreateTopics(w.kafkaCfg, w.logger, w.autoCreateTopics...); err != nil {
 			return err
 		}
 	}

--- a/pkg/storage/ingest/writer_test.go
+++ b/pkg/storage/ingest/writer_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
@@ -1697,6 +1698,59 @@ func assertHistogramSampleCount(t *testing.T, reg prometheus.Gatherer, metricNam
 	hist, err := dskit_metrics.FindHistogramWithNameAndLabels(mfm, metricName)
 	require.NoError(t, err)
 	assert.Equal(t, expected, hist.GetSampleCount())
+}
+
+func TestWriter_AutoCreateTopics(t *testing.T) {
+	const baseTopic = "test"
+
+	listTopics := func(t *testing.T, clusterAddr string) map[string]struct{} {
+		client, err := kgo.NewClient(commonKafkaClientOptions(createTestKafkaConfig(clusterAddr, baseTopic), nil, test.NewTestingLogger(t))...)
+		require.NoError(t, err)
+		t.Cleanup(client.Close)
+
+		adm := kadm.NewClient(client)
+		details, err := adm.ListTopics(context.Background())
+		require.NoError(t, err)
+
+		names := make(map[string]struct{}, len(details))
+		for name := range details {
+			names[name] = struct{}{}
+		}
+		return names
+	}
+
+	t.Run("auto-creates the configured topic when no explicit set is provided", func(t *testing.T) {
+		_, clusterAddr := testkafka.CreateCluster(t, 1, baseTopic)
+
+		cfg := createTestKafkaConfig(clusterAddr, "auto-created")
+		cfg.AutoCreateTopicEnabled = true
+		cfg.AutoCreateTopicDefaultPartitions = 1
+
+		writer := NewWriter(cfg, test.NewTestingLogger(t), prometheus.NewPedanticRegistry())
+		require.NoError(t, services.StartAndAwaitRunning(context.Background(), writer))
+		t.Cleanup(func() { require.NoError(t, services.StopAndAwaitTerminated(context.Background(), writer)) })
+
+		topics := listTopics(t, clusterAddr)
+		assert.Contains(t, topics, "auto-created")
+	})
+
+	t.Run("auto-creates the explicit set of topics, not the configured topic", func(t *testing.T) {
+		_, clusterAddr := testkafka.CreateCluster(t, 1, baseTopic)
+
+		// The configured topic is a template that must never be created literally.
+		cfg := createTestKafkaConfig(clusterAddr, "mimir-ingest-rc-<read-compartment-id>")
+		cfg.AutoCreateTopicEnabled = true
+		cfg.AutoCreateTopicDefaultPartitions = 1
+
+		writer := NewWriter(cfg, test.NewTestingLogger(t), prometheus.NewPedanticRegistry(), WithAutoCreateTopics([]string{"mimir-ingest-rc-0", "mimir-ingest-rc-1"}))
+		require.NoError(t, services.StartAndAwaitRunning(context.Background(), writer))
+		t.Cleanup(func() { require.NoError(t, services.StopAndAwaitTerminated(context.Background(), writer)) })
+
+		topics := listTopics(t, clusterAddr)
+		assert.Contains(t, topics, "mimir-ingest-rc-0")
+		assert.Contains(t, topics, "mimir-ingest-rc-1")
+		assert.NotContains(t, topics, "mimir-ingest-rc-<read-compartment-id>")
+	})
 }
 
 func createTestWriter(t *testing.T, cfg KafkaConfig) (*Writer, prometheus.Gatherer) {

--- a/pkg/usagetracker/tracker.go
+++ b/pkg/usagetracker/tracker.go
@@ -283,7 +283,7 @@ func NewUsageTracker(cfg Config, instanceRing *ring.Ring, partitionRing *ring.Mu
 
 	// Create Kafka writer for events storage.
 	if t.cfg.EventsStorageWriter.AutoCreateTopicEnabled {
-		if err := ingest.CreateTopic(t.cfg.EventsStorageWriter, t.logger); err != nil {
+		if err := ingest.CreateTopics(t.cfg.EventsStorageWriter, t.logger, t.cfg.EventsStorageWriter.Topic); err != nil {
 			return nil, errors.Wrap(err, "failed to create Kafka topic for usage-tracker events")
 		}
 	}
@@ -296,7 +296,7 @@ func NewUsageTracker(cfg Config, instanceRing *ring.Ring, partitionRing *ring.Mu
 
 	// Create Kafka writer for snapshots metadata storage.
 	if t.cfg.SnapshotsMetadataWriter.AutoCreateTopicEnabled {
-		if err := ingest.CreateTopic(t.cfg.SnapshotsMetadataWriter, t.logger); err != nil {
+		if err := ingest.CreateTopics(t.cfg.SnapshotsMetadataWriter, t.logger, t.cfg.SnapshotsMetadataWriter.Topic); err != nil {
 			return nil, errors.Wrap(err, "failed to create Kafka topic for usage-tracker snapshots metadata")
 		}
 	}


### PR DESCRIPTION
#### What this PR does

When compartments are enabled, a distributor's Kafka writer targets a single write compartment's cluster, but its configured topic is the read-compartment template (e.g. `mimir-ingest-rc-<read-compartment-id>`), which is not a real topic name. Until now that forced topic auto-creation to be disabled on the distributor, so the read-compartment topics were created only by the ingesters' readers. This left a startup-ordering gap: a distributor couldn't accept writes for a read compartment before any ingester had created that topic in the distributor's write cluster, causing produce failures.

This lets the distributor auto-create every resolved read-compartment topic in its own write compartment's cluster on startup, reusing the existing `-ingest-storage.kafka.auto-create-topic-enabled` and `-ingest-storage.kafka.auto-create-topic-default-partitions` flags. `CreateTopic` becomes `CreateTopics` so the writer can create the whole set; the distributor derives the set from the compartments router and passes it via a new `WithAutoCreateTopics` writer option. The validation that forbade auto-creation on the distributor under compartments is removed.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.