### PR TITLE
Add "ingest_storage" to the list of features reported with buildinfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * [ENHANCEMENT] Ingest storage: skip per-record tracing span and attribute allocations on the Kafka fetch path when the producer trace is not sampled. The producer's trace context is still extracted from record headers for every record. #15614
 * [ENHANCEMENT] Distributor: Add a tracing span around the OTLP to Prometheus conversion so its latency is independently visible in traces. #15682
 * [ENHANCEMENET] Runtimeconfig: The HTTP client used to fetch runtime configurations from HTTP endpoints now has keep-alives disabled by default. New CLI flag `-runtime-config.http-client-disable-keep-alives` is enabled by default, an can be set to `false` in-order to re-enable keep-alives. #15695
+* [ENHANCEMENT] Mimir: Expose `ingest_storage` feature flag in the `/api/v1/status/buildinfo` endpoint, reflecting whether Mimir runs with ingest storage architecture. #15743
 * [BUGFIX] Query-frontend: Fix `cardinality_analysis_max_results` being ignored when set higher than the default of 500. #15581
 * [BUGFIX] Ingest storage: Fix `KafkaProducer.ProduceSync()` returning a single result with a nil record when the context is canceled, instead of one result per input record (with the record set) as the underlying franz-go client does. #15199
 * [BUGFIX] Ingest storage: Fix `cortex_ingest_storage_reader_receive_delay_seconds` inflation by no longer setting the Kafka record `Timestamp` on the distributor side; the Kafka client now sets it at produce time. #15572

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -160,6 +160,7 @@ func (t *Mimir) initAPI() (services.Service, error) {
 			QuerySharding:         strconv.FormatBool(t.Cfg.Frontend.QueryMiddleware.ShardedQueries),
 			RulerConfigAPI:        strconv.FormatBool(t.Cfg.Ruler.EnableAPI),
 			FederatedRules:        strconv.FormatBool(t.Cfg.Ruler.TenantFederation.Enabled),
+			IngestStorage:         strconv.FormatBool(t.Cfg.IngestStorage.Enabled),
 		})
 
 	t.API = a

--- a/pkg/util/version/info_handler.go
+++ b/pkg/util/version/info_handler.go
@@ -27,6 +27,7 @@ type BuildInfoFeatures struct {
 	AlertmanagerConfigAPI string `json:"alertmanager_config_api,omitempty"`
 	QuerySharding         string `json:"query_sharding,omitempty"`
 	FederatedRules        string `json:"federated_rules,omitempty"`
+	IngestStorage         string `json:"ingest_storage,omitempty"`
 }
 
 func BuildInfoHandler(application string, features interface{}) http.Handler {


### PR DESCRIPTION
#### What this PR does

The PR adds a new "ingest_storage" feature, reported in the `/api/v1/status/buildinfo`.

Ran a quick test locally, seems working as expected

```
curl -s 'http://127.1:8080/api/v1/status/buildinfo' | jq .
{
  "status": "success",
  "data": {
    "application": "Grafana Mimir",
    "version": "unknown",
    "revision": "unknown",
    "branch": "unknown",
    "goVersion": "go1.26.4",
    "features": {
      "ruler_config_api": "true",
      "alertmanager_config_api": "true",
      "query_sharding": "false",
      "federated_rules": "false",
      "ingest_storage": "true"
    }
  }
}
```