### PR TITLE
Fix duplicate metrics collector panic with ingest storage in single-process deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@
 * [BUGFIX] MQE: Fix the binary operation narrow-selectors optimization incorrectly using binary operation matchers across an `on()` / `on(...) group_left`/`group_right` join boundary, which could cause some queries to unexpectedly evaluate as an empty result. #16155
 * [BUGFIX] Packaging: Fix the DEB/RPM packages shipping the `mimir`, `mimirtool`, `metaconvert`, and `query-tee` binaries without the executable bit set, which caused `mimir.service` to fail to start. #16166
 * [BUGFIX] Query-frontend: Fix a goroutine leak when a querier's streaming response arrives just as the query is cancelled: the goroutine handling the response could stay blocked forever writing a response body that would never be read. #16151
+* [BUGFIX] Ingest storage: Fix a panic on startup ("duplicate metrics collector registration attempted") when ingest storage is enabled with the single-binary `-target=all`, caused by the ingester's partition reader and the query path's offsets reader both registering the fixed-name `cortex_ingest_storage_reader_last_produced_offset_*` and `cortex_ingest_storage_reader_partition_start_offset_*` metrics on the same registry. The partition offset client now disambiguates these metrics with a `component` label, mirroring the existing Kafka client metrics. #15744
 
 ### Mixin
 

--- a/pkg/storage/ingest/fetcher_test.go
+++ b/pkg/storage/ingest/fetcher_test.go
@@ -807,7 +807,7 @@ func TestConcurrentFetchers(t *testing.T) {
 			// This is usually done by franz-go, but since now we use the metrics ourselves, we need to instantiate the metrics ourselves.
 			kpromMetrics.OnNewClient(client)
 
-			offsetReader := newPartitionOffsetClient(client, reg, logger)
+			offsetReader := newPartitionOffsetClient(client, "test", reg, logger)
 
 			startOffsetsReader := NewGenericOffsetReader(func(ctx context.Context) (int64, error) {
 				return offsetReader.FetchPartitionStartOffset(ctx, topicName, partitionID)
@@ -1319,7 +1319,7 @@ func createConcurrentFetchers(ctx context.Context, t *testing.T, client *kgo.Cli
 	// This is usually done by franz-go, but since now we use the metrics ourselves, we need to instantiate the metrics ourselves.
 	kpromMetrics.OnNewClient(client)
 
-	offsetReader := newPartitionOffsetClient(client, reg, logger)
+	offsetReader := newPartitionOffsetClient(client, "test", reg, logger)
 
 	startOffsetsReader := NewGenericOffsetReader(func(ctx context.Context) (int64, error) {
 		return offsetReader.FetchPartitionStartOffset(ctx, topic, partition)

--- a/pkg/storage/ingest/partition_offset_client.go
+++ b/pkg/storage/ingest/partition_offset_client.go
@@ -35,7 +35,13 @@ type partitionOffsetClient struct {
 	partitionStartOffsetLatency       *prometheus.HistogramVec
 }
 
-func newPartitionOffsetClient(client *kgo.Client, reg prometheus.Registerer, logger log.Logger) *partitionOffsetClient {
+func newPartitionOffsetClient(client *kgo.Client, component string, reg prometheus.Registerer, logger log.Logger) *partitionOffsetClient {
+	// The metrics below have fixed names, so multiple offset clients sharing a registry
+	// (e.g. ingester's partition-reader + query-frontend's offsets reader in single-binary
+	// target=all) would collide and panic on duplicate registration. Disambiguate by
+	// component, mirroring the component label used for the Kafka client metrics. See
+	// grafana/mimir#13468.
+	reg = prometheus.WrapRegistererWith(prometheus.Labels{"component": component}, reg)
 	return &partitionOffsetClient{
 		client: client,
 		admin:  kadm.NewClient(client),

--- a/pkg/storage/ingest/partition_offset_client_test.go
+++ b/pkg/storage/ingest/partition_offset_client_test.go
@@ -42,7 +42,7 @@ func TestPartitionOffsetClient_FetchPartitionLastProducedOffset(t *testing.T) {
 			kafkaCfg       = createTestKafkaConfig(clusterAddr, topicName)
 			client         = createTestKafkaClient(t, kafkaCfg)
 			reg            = prometheus.NewPedanticRegistry()
-			reader         = newPartitionOffsetClient(client, reg, logger)
+			reader         = newPartitionOffsetClient(client, "test", reg, logger)
 		)
 
 		offset, err := reader.FetchPartitionLastProducedOffset(ctx, topicName, partitionID)
@@ -66,11 +66,11 @@ func TestPartitionOffsetClient_FetchPartitionLastProducedOffset(t *testing.T) {
 		assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
 			# HELP cortex_ingest_storage_reader_last_produced_offset_failures_total Total number of failed requests to get the last produced offset.
 			# TYPE cortex_ingest_storage_reader_last_produced_offset_failures_total counter
-			cortex_ingest_storage_reader_last_produced_offset_failures_total{partition="0",topic="test"} 0
+			cortex_ingest_storage_reader_last_produced_offset_failures_total{component="test",partition="0",topic="test"} 0
 
 			# HELP cortex_ingest_storage_reader_last_produced_offset_requests_total Total number of requests issued to get the last produced offset.
 			# TYPE cortex_ingest_storage_reader_last_produced_offset_requests_total counter
-			cortex_ingest_storage_reader_last_produced_offset_requests_total{partition="0",topic="test"} 3
+			cortex_ingest_storage_reader_last_produced_offset_requests_total{component="test",partition="0",topic="test"} 3
 		`), "cortex_ingest_storage_reader_last_produced_offset_requests_total",
 			"cortex_ingest_storage_reader_last_produced_offset_failures_total"))
 	})
@@ -83,7 +83,7 @@ func TestPartitionOffsetClient_FetchPartitionLastProducedOffset(t *testing.T) {
 			kafkaCfg             = createTestKafkaConfig(clusterAddr, topicName)
 			client               = createTestKafkaClient(t, kafkaCfg)
 			reg                  = prometheus.NewPedanticRegistry()
-			reader               = newPartitionOffsetClient(client, reg, logger)
+			reader               = newPartitionOffsetClient(client, "test", reg, logger)
 
 			firstRequest         = atomic.NewBool(true)
 			firstRequestReceived = make(chan struct{})
@@ -148,7 +148,7 @@ func TestPartitionOffsetClient_FetchPartitionStartOffset(t *testing.T) {
 			kafkaCfg       = createTestKafkaConfig(clusterAddr, topicName)
 			client         = createTestKafkaClient(t, kafkaCfg)
 			reg            = prometheus.NewPedanticRegistry()
-			reader         = newPartitionOffsetClient(client, reg, logger)
+			reader         = newPartitionOffsetClient(client, "test", reg, logger)
 		)
 
 		offset, err := reader.FetchPartitionStartOffset(ctx, topicName, partitionID)
@@ -184,11 +184,11 @@ func TestPartitionOffsetClient_FetchPartitionStartOffset(t *testing.T) {
 		assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
 			# HELP cortex_ingest_storage_reader_partition_start_offset_failures_total Total number of failed requests to get the partition start offset.
 			# TYPE cortex_ingest_storage_reader_partition_start_offset_failures_total counter
-			cortex_ingest_storage_reader_partition_start_offset_failures_total{partition="0",topic="test"} 0
+			cortex_ingest_storage_reader_partition_start_offset_failures_total{component="test",partition="0",topic="test"} 0
 
 			# HELP cortex_ingest_storage_reader_partition_start_offset_requests_total Total number of requests issued to get the partition start offset.
 			# TYPE cortex_ingest_storage_reader_partition_start_offset_requests_total counter
-			cortex_ingest_storage_reader_partition_start_offset_requests_total{partition="0",topic="test"} 4
+			cortex_ingest_storage_reader_partition_start_offset_requests_total{component="test",partition="0",topic="test"} 4
 		`), "cortex_ingest_storage_reader_partition_start_offset_requests_total",
 			"cortex_ingest_storage_reader_partition_start_offset_failures_total"))
 	})
@@ -201,7 +201,7 @@ func TestPartitionOffsetClient_FetchPartitionStartOffset(t *testing.T) {
 			kafkaCfg             = createTestKafkaConfig(clusterAddr, topicName)
 			client               = createTestKafkaClient(t, kafkaCfg)
 			reg                  = prometheus.NewPedanticRegistry()
-			reader               = newPartitionOffsetClient(client, reg, logger)
+			reader               = newPartitionOffsetClient(client, "test", reg, logger)
 
 			firstRequest         = atomic.NewBool(true)
 			firstRequestReceived = make(chan struct{})
@@ -276,7 +276,7 @@ func TestPartitionOffsetClient_FetchPartitionsLastProducedOffsets(t *testing.T) 
 			kafkaCfg       = createTestKafkaConfig(clusterAddr, topicName)
 			client         = createTestKafkaClient(t, kafkaCfg)
 			reg            = prometheus.NewPedanticRegistry()
-			reader         = newPartitionOffsetClient(client, reg, logger)
+			reader         = newPartitionOffsetClient(client, "test", reg, logger)
 		)
 
 		offsets, err := reader.FetchPartitionsLastProducedOffsets(ctx, map[string][]int32{topicName: allPartitionIDs})
@@ -310,11 +310,11 @@ func TestPartitionOffsetClient_FetchPartitionsLastProducedOffsets(t *testing.T) 
 		assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
 			# HELP cortex_ingest_storage_reader_last_produced_offset_failures_total Total number of failed requests to get the last produced offset.
 			# TYPE cortex_ingest_storage_reader_last_produced_offset_failures_total counter
-			cortex_ingest_storage_reader_last_produced_offset_failures_total{partition="mixed",topic="test"} 0
+			cortex_ingest_storage_reader_last_produced_offset_failures_total{component="test",partition="mixed",topic="test"} 0
 
 			# HELP cortex_ingest_storage_reader_last_produced_offset_requests_total Total number of requests issued to get the last produced offset.
 			# TYPE cortex_ingest_storage_reader_last_produced_offset_requests_total counter
-			cortex_ingest_storage_reader_last_produced_offset_requests_total{partition="mixed",topic="test"} 4
+			cortex_ingest_storage_reader_last_produced_offset_requests_total{component="test",partition="mixed",topic="test"} 4
 		`), "cortex_ingest_storage_reader_last_produced_offset_requests_total",
 			"cortex_ingest_storage_reader_last_produced_offset_failures_total"))
 	})
@@ -327,7 +327,7 @@ func TestPartitionOffsetClient_FetchPartitionsLastProducedOffsets(t *testing.T) 
 			kafkaCfg       = createTestKafkaConfig(clusterAddr, topicName)
 			client         = createTestKafkaClient(t, kafkaCfg)
 			reg            = prometheus.NewPedanticRegistry()
-			reader         = newPartitionOffsetClient(client, reg, logger)
+			reader         = newPartitionOffsetClient(client, "test", reg, logger)
 		)
 
 		// Write some records.
@@ -352,7 +352,7 @@ func TestPartitionOffsetClient_FetchPartitionsLastProducedOffsets(t *testing.T) 
 			kafkaCfg             = createTestKafkaConfig(clusterAddr, topicName)
 			client               = createTestKafkaClient(t, kafkaCfg)
 			reg                  = prometheus.NewPedanticRegistry()
-			reader               = newPartitionOffsetClient(client, reg, logger)
+			reader               = newPartitionOffsetClient(client, "test", reg, logger)
 
 			firstRequest         = atomic.NewBool(true)
 			firstRequestReceived = make(chan struct{})
@@ -407,7 +407,7 @@ func TestPartitionOffsetClient_FetchPartitionsLastProducedOffsets(t *testing.T) 
 
 		client := createTestKafkaClient(t, kafkaCfg)
 		reg := prometheus.NewPedanticRegistry()
-		reader := newPartitionOffsetClient(client, reg, logger)
+		reader := newPartitionOffsetClient(client, "test", reg, logger)
 
 		cluster.ControlKey(int16(kmsg.ListOffsets), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
 			cluster.KeepControl()
@@ -439,7 +439,7 @@ func TestPartitionOffsetClient_FetchPartitionsLastProducedOffsets(t *testing.T) 
 
 		client := createTestKafkaClient(t, kafkaCfg)
 		reg := prometheus.NewPedanticRegistry()
-		reader := newPartitionOffsetClient(client, reg, logger)
+		reader := newPartitionOffsetClient(client, "test", reg, logger)
 
 		cluster.ControlKey(int16(kmsg.ListOffsets), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
 			cluster.KeepControl()
@@ -470,7 +470,7 @@ func TestPartitionOffsetClient_FetchPartitionsLastProducedOffsets(t *testing.T) 
 
 		client := createTestKafkaClient(t, kafkaCfg)
 		reg := prometheus.NewPedanticRegistry()
-		reader := newPartitionOffsetClient(client, reg, logger)
+		reader := newPartitionOffsetClient(client, "test", reg, logger)
 
 		cluster.ControlKey(int16(kmsg.ListOffsets), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
 			cluster.KeepControl()
@@ -517,7 +517,7 @@ func TestPartitionOffsetClient_FetchPartitionsLastProducedOffsets(t *testing.T) 
 
 		reg := prometheus.NewPedanticRegistry()
 		client := createTestKafkaClient(t, createTestKafkaConfig(clusterAddr, topic0))
-		reader := newPartitionOffsetClient(client, reg, logger)
+		reader := newPartitionOffsetClient(client, "test", reg, logger)
 
 		// topic0: partition 0 → 2 records (last offset 1), partition 1 → 1 record (last offset 0).
 		// topic1: partition 0 → 1 record (last offset 0), partition 1 → empty (-1).
@@ -551,11 +551,11 @@ func TestPartitionOffsetClient_FetchPartitionsLastProducedOffsets(t *testing.T) 
 		assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
 			# HELP cortex_ingest_storage_reader_last_produced_offset_failures_total Total number of failed requests to get the last produced offset.
 			# TYPE cortex_ingest_storage_reader_last_produced_offset_failures_total counter
-			cortex_ingest_storage_reader_last_produced_offset_failures_total{partition="mixed",topic="mixed"} 0
+			cortex_ingest_storage_reader_last_produced_offset_failures_total{component="test",partition="mixed",topic="mixed"} 0
 
 			# HELP cortex_ingest_storage_reader_last_produced_offset_requests_total Total number of requests issued to get the last produced offset.
 			# TYPE cortex_ingest_storage_reader_last_produced_offset_requests_total counter
-			cortex_ingest_storage_reader_last_produced_offset_requests_total{partition="mixed",topic="mixed"} 1
+			cortex_ingest_storage_reader_last_produced_offset_requests_total{component="test",partition="mixed",topic="mixed"} 1
 		`), "cortex_ingest_storage_reader_last_produced_offset_requests_total",
 			"cortex_ingest_storage_reader_last_produced_offset_failures_total"))
 	})
@@ -565,7 +565,7 @@ func TestPartitionOffsetClient_FetchPartitionsLastProducedOffsets(t *testing.T) 
 
 		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
 		client := createTestKafkaClient(t, createTestKafkaConfig(clusterAddr, topicName))
-		reader := newPartitionOffsetClient(client, prometheus.NewPedanticRegistry(), logger)
+		reader := newPartitionOffsetClient(client, "test", prometheus.NewPedanticRegistry(), logger)
 
 		// Return a successful response that only includes partition 0, omitting the other requested partitions.
 		cluster.ControlKey(int16(kmsg.ListOffsets), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
@@ -607,7 +607,7 @@ func TestPartitionOffsetClient_ListTopicPartitionIDs(t *testing.T) {
 			_, clusterAddr = testkafka.CreateCluster(t, numPartitions, topicName)
 			kafkaCfg       = createTestKafkaConfig(clusterAddr, topicName)
 			client         = createTestKafkaClient(t, kafkaCfg)
-			reader         = newPartitionOffsetClient(client, nil, logger)
+			reader         = newPartitionOffsetClient(client, "test", nil, logger)
 		)
 
 		actualIDs, actualErr := reader.ListTopicPartitionIDs(ctx, topicName)
@@ -624,7 +624,7 @@ func TestPartitionOffsetClient_ListTopicPartitionIDs(t *testing.T) {
 			cluster, clusterAddr = testkafka.CreateCluster(t, numPartitions, topicName)
 			kafkaCfg             = createTestKafkaConfig(clusterAddr, topicName)
 			client               = createTestKafkaClient(t, kafkaCfg)
-			reader               = newPartitionOffsetClient(client, nil, logger)
+			reader               = newPartitionOffsetClient(client, "test", nil, logger)
 		)
 
 		cluster.ControlKey(int16(kmsg.Metadata), func(kreq kmsg.Request) (kmsg.Response, error, bool) {

--- a/pkg/storage/ingest/partition_offset_reader.go
+++ b/pkg/storage/ingest/partition_offset_reader.go
@@ -125,8 +125,8 @@ type singleClusterPartitionOffsetReader struct {
 	partitionID int32
 }
 
-func newSingleClusterPartitionOffsetReader(client *kgo.Client, topic string, partitionID int32, pollInterval time.Duration, reg prometheus.Registerer, logger log.Logger) *singleClusterPartitionOffsetReader {
-	offsetClient := newPartitionOffsetClient(client, reg, logger)
+func newSingleClusterPartitionOffsetReader(client *kgo.Client, topic string, component string, partitionID int32, pollInterval time.Duration, reg prometheus.Registerer, logger log.Logger) *singleClusterPartitionOffsetReader {
+	offsetClient := newPartitionOffsetClient(client, component, reg, logger)
 	return newSingleClusterPartitionOffsetReaderWithOffsetClient(offsetClient, topic, partitionID, pollInterval, logger)
 }
 

--- a/pkg/storage/ingest/partition_offset_reader_multi_cluster.go
+++ b/pkg/storage/ingest/partition_offset_reader_multi_cluster.go
@@ -63,7 +63,7 @@ func NewMultiClusterOffsetsReader(clusterConfigs []KafkaConfig, topics []string,
 		}
 
 		clients = append(clients, client)
-		offsetClients = append(offsetClients, newPartitionOffsetClient(client, clusterReg, clusterLogger))
+		offsetClients = append(offsetClients, newPartitionOffsetClient(client, component, clusterReg, clusterLogger))
 	}
 
 	r := &MultiClusterOffsetsReader{

--- a/pkg/storage/ingest/partition_offset_reader_single_cluster.go
+++ b/pkg/storage/ingest/partition_offset_reader_single_cluster.go
@@ -37,7 +37,7 @@ func NewSingleClusterTopicOffsetsReader(cfg KafkaConfig, topic string, getPartit
 
 	r := &SingleClusterTopicOffsetsReader{
 		kafkaClient:        client,
-		offsetClient:       newPartitionOffsetClient(client, reg, logger),
+		offsetClient:       newPartitionOffsetClient(client, component, reg, logger),
 		subservicesWatcher: services.NewFailureWatcher(),
 		topic:              topic,
 		getPartitionIDs:    getPartitionIDs,

--- a/pkg/storage/ingest/partition_offset_reader_test.go
+++ b/pkg/storage/ingest/partition_offset_reader_test.go
@@ -37,7 +37,7 @@ func TestPartitionOffsetReader(t *testing.T) {
 		)
 
 		// Run with a very high polling interval, so that it will never run in this test.
-		reader := newSingleClusterPartitionOffsetReader(createTestKafkaClient(t, kafkaCfg), topicName, partitionID, time.Hour, nil, log.NewNopLogger())
+		reader := newSingleClusterPartitionOffsetReader(createTestKafkaClient(t, kafkaCfg), topicName, "test", partitionID, time.Hour, nil, log.NewNopLogger())
 		require.NoError(t, services.StartAndAwaitRunning(ctx, reader))
 
 		// Run few goroutines waiting for the last produced offset.
@@ -80,7 +80,7 @@ func TestPartitionOffsetReader_WaitNextFetchLastProducedOffset(t *testing.T) {
 			cluster, clusterAddr = testkafka.CreateCluster(t, numPartitions, topicName)
 			kafkaCfg             = createTestKafkaConfig(clusterAddr, topicName)
 			client               = createTestKafkaClient(t, kafkaCfg)
-			reader               = newSingleClusterPartitionOffsetReader(client, topicName, partitionID, pollInterval, nil, logger)
+			reader               = newSingleClusterPartitionOffsetReader(client, topicName, "test", partitionID, pollInterval, nil, logger)
 
 			lastOffset            = atomic.NewInt64(1)
 			firstRequestReceived  = make(chan struct{})
@@ -149,7 +149,7 @@ func TestPartitionOffsetReader_WaitNextFetchLastProducedOffset(t *testing.T) {
 		)
 
 		// Create the reader but do NOT start it, so that the "last produced offset" will be never fetched.
-		reader := newSingleClusterPartitionOffsetReader(client, topicName, partitionID, pollInterval, nil, logger)
+		reader := newSingleClusterPartitionOffsetReader(client, topicName, "test", partitionID, pollInterval, nil, logger)
 
 		canceledCtx, cancel := context.WithCancel(ctx)
 		cancel()

--- a/pkg/storage/ingest/reader.go
+++ b/pkg/storage/ingest/reader.go
@@ -251,7 +251,7 @@ func (r *SingleClusterPartitionReader) start(ctx context.Context) (returnErr err
 
 	r.committer = newPartitionCommitter(r.kafkaCfg, kadm.NewClient(r.client.Load()), r.partitionID, r.consumerGroup, r.notifier, r.offsetFile, r.logger, r.reg)
 
-	offsetsClient := newPartitionOffsetClient(r.client.Load(), r.reg, r.logger)
+	offsetsClient := newPartitionOffsetClient(r.client.Load(), "partition-reader", r.reg, r.logger)
 
 	// It's ok to have the start offset slightly outdated.
 	// We only need this offset accurate if we fall behind or if we start and the log gets truncated from beneath us.


### PR DESCRIPTION
## What this PR does

When ingest storage is enabled and a single process runs both the ingester and the query-frontend (the simplest case being monolithic `-target=all`, but also any co-location), Mimir panics on startup:

```
panic: duplicate metrics collector registration attempted
```

Root cause: `newPartitionOffsetClient` (`pkg/storage/ingest/partition_offset_client.go`) registers fixed-name metrics (`cortex_ingest_storage_reader_last_produced_offset_*`, `cortex_ingest_storage_reader_partition_start_offset_*`) against the registry it's handed. Multiple components construct one against the shared process registry:

- the ingester, via its `PartitionReader`
- the query-frontend, via `NewTopicOffsetsReader` (for strong read consistency)

The second registration collides and panics. The Kafka client supports multiple instances fine — this is purely a metric-naming collision.

## The fix

Add a `component` label to the offset-client metrics via `prometheus.WrapRegistererWith`, and thread a distinct `component` value through each call site (`partition-reader`, `query-frontend`). This mirrors the existing `NewStrongReadConsistencyMetrics` pattern in the same package, which already disambiguates the identical multi-caller situation with a `component` const-label.

## Testing

- `go build ./...` and `go vet` on the touched packages pass.
- `go test ./pkg/storage/ingest/ -run TestPartitionOffsetClient` passes (expected-metric fixtures updated for the new label).
- Verified manually: a monolithic `-target=all` instance with ingest storage now starts cleanly, ingests through Kafka, and serves queries; the metrics expose both `component="partition-reader"` and `component="query-frontend"` side by side.

Fixes #13468

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized metrics registration and API signature changes in ingest offset clients; no auth or data-path logic changes. Dashboards may need to account for the new `component` label on offset metrics.
> 
> **Overview**
> Fixes startup **panic: duplicate metrics collector registration attempted** when ingest storage runs in one process with both ingester and query-frontend (e.g. `-target=all`).
> 
> **`newPartitionOffsetClient`** now takes a **`component`** string and registers offset metrics via **`prometheus.WrapRegistererWith`** so each caller gets a distinct **`component`** const-label on `cortex_ingest_storage_reader_*` offset metrics. Production wiring passes **`partition-reader`** from the ingester read path and **`query-frontend`** from the query-frontend topic offsets reader.
> 
> **`NewTopicOffsetsReader`**, **`NewTopicOffsetsReaderForAllPartitions`**, and **`newPartitionOffsetReader`** thread the same parameter through; the “all partitions” helper uses a second client labeled **`{component}-partition-lister`** so two offset clients on one registry do not collide.
> 
> Tests and **CHANGELOG** are updated for the new label; metric behavior is unchanged aside from the extra dimension.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a677be4118be268b67d05b06e039404bee1e889a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->