### PR TITLE
storage/ingest: cap maximum kafka protocol version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 * [BUGFIX] Ingest storage: Fix `cortex_ingest_storage_writer_produce_records_enqueued_total` not being incremented when `KafkaProducer.ProduceSync()` rejects a batch because a record has its `Timestamp` set by the caller. #15610
 * [BUGFIX] Compactor: Remove temporary block upload validation directories left behind in the data directory when the compactor crashes mid-validation. This prevents leaking disk space. #15647
 * [BUGFIX] Continuous-test: Fix a crash when histogram tests were enabled in combination with the OTLP-HTTP write protocol. #15641
+* [BUGFIX] Ingest storage: Cap maximum Kafka protocol version, the client negotiates with the broker to v3.9.0. #15745
 
 ### Mixin
 

--- a/pkg/storage/ingest/util.go
+++ b/pkg/storage/ingest/util.go
@@ -20,6 +20,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
+	"github.com/twmb/franz-go/pkg/kversion"
 	"github.com/twmb/franz-go/pkg/sasl"
 	awssasl "github.com/twmb/franz-go/pkg/sasl/aws"
 	"github.com/twmb/franz-go/pkg/sasl/oauth"
@@ -145,6 +146,11 @@ func commonKafkaClientOptions(cfg KafkaConfig, metrics *kprom.Metrics, logger lo
 		kgo.ClientID(cfg.ClientID),
 		kgo.SeedBrokers(cfg.Address...),
 		kgo.DialTimeout(cfg.DialTimeout),
+
+		// Mimir 3.1 and earlier doesn't fully support the newest Kafka protocols, resulting in failures to commit the offsets.
+		// As a workaround, we cap the maximum Kafka protocol version to negotiate with the broker to the older one.
+		// Ref to https://github.com/grafana/mimir/issues/15319
+		kgo.MaxVersions(kversion.V3_9_0()),
 
 		// A cluster metadata update is a request sent to a broker and getting back the map of partitions and
 		// the leader broker for each partition. The cluster metadata can be updated (a) periodically or


### PR DESCRIPTION
#### What this PR does

The PR caps the maximum Kafka protocol version, the ingest storage Kafka clients negotiate with the broker to v3.9.0.

As shown in https://github.com/grafana/mimir/issues/15319, the most recent Kafka versions introduced some complexity in the protocol. It appears that there was a degradation, somewhere between Mimir 3.0 and 3.1, which resulted in failures to commit consumed offset:

```
UNKNOWN_TOPIC_ID: This server does not host this topic ID.
```

I suspect the underlying problem stems from one of many kgo updates, but I don't have capacity to investigate this in details.

Note, that we've recently fixed at least one issue with kgo/kadm (https://github.com/grafana/mimir/pull/15428), which was related to failures in metadata clients management. But as reported in [the follow-up comment][1] in the issue, there are still problems with stale clients metadata in mimir main

```
fetch request failed with error: FENCED_LEADER_EPOCH: The leader epoch in the request is older than the epoch on the broker
```

In order to unblock release-3.1, I propose we cap the Kafka clients protocol to v3.9.0.

I did a round of local testing against Kafka broker 4.3.0. In both Mimir `main` and `release-3.1`, the changes fixes the ability of Mimir to commit the offsets:

<img width="1462" height="820" alt="Screenshot 2026-06-18 at 20 17 33" src="https://github.com/user-attachments/assets/3580d32a-893d-4214-9914-03c490575e54" />

If accepted, this changes must be backported to release-3.1.

[1]: https://github.com/grafana/mimir/issues/15319#issuecomment-4669917916

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/issues/15319

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
