### PR TITLE
Add fanout support to continuous test

### DIFF
--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -3685,6 +3685,8 @@ Usage of ./cmd/mimir/mimir:
     	How back in the past metrics can be queried at most. (default 168h0m0s)
   -tests.write-read-ooo-test.num-series int
     	Number of series used for the test. (default 5000)
+  -tests.write-read-series-test.fan-out-query-enabled
+    	Set to true to additionally run each test query with a regex metric-name matcher. This prevents the query from being pinned to a single ingest-storage compartment, forcing the read path to fan out across all compartments and validating cross-compartment query result merging. Roughly doubles the number of queries issued per run.
   -tests.write-read-series-test.float-samples-enabled
     	Set to true to use float samples (default true)
   -tests.write-read-series-test.histogram-samples-enabled

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -967,6 +967,8 @@ Usage of ./cmd/mimir/mimir:
     	How back in the past metrics can be queried at most. (default 168h0m0s)
   -tests.write-read-ooo-test.num-series int
     	Number of series used for the test. (default 5000)
+  -tests.write-read-series-test.fan-out-query-enabled
+    	Set to true to additionally run each test query with a regex metric-name matcher. This prevents the query from being pinned to a single ingest-storage compartment, forcing the read path to fan out across all compartments and validating cross-compartment query result merging. Roughly doubles the number of queries issued per run.
   -tests.write-read-series-test.float-samples-enabled
     	Set to true to use float samples (default true)
   -tests.write-read-series-test.histogram-samples-enabled

--- a/pkg/continuoustest/util.go
+++ b/pkg/continuoustest/util.go
@@ -165,6 +165,20 @@ func querySumHist(metricName string) string {
 	return fmt.Sprintf("sum(%s)", metricName)
 }
 
+// The fan-out query variants below match the metric by name using a regex (=~) matcher instead of an
+// exact (=) matcher. The matched series — and therefore the query result — are identical (the regex
+// matches exactly the one metric name, which contains no regex metacharacters), but the regex matcher
+// prevents the query from being pinned to a single ingest-storage compartment. This forces the read
+// path to fan out across all compartments and merge their results, letting continuous-test validate
+// cross-compartment query merging while reusing the same result verification as the pinned queries.
+func querySumFloatFanOut(metricName string) string {
+	return fmt.Sprintf(`sum(max_over_time({__name__=~"%s"}[1s]))`, metricName)
+}
+
+func querySumHistFanOut(metricName string) string {
+	return fmt.Sprintf(`sum({__name__=~"%s"})`, metricName)
+}
+
 func alignTimestampToInterval(ts time.Time, interval time.Duration) time.Time {
 	return ts.Truncate(interval)
 }

--- a/pkg/continuoustest/util.go
+++ b/pkg/continuoustest/util.go
@@ -165,18 +165,17 @@ func querySumHist(metricName string) string {
 	return fmt.Sprintf("sum(%s)", metricName)
 }
 
-// The fan-out query variants below match the metric by name using a regex (=~) matcher instead of an
-// exact (=) matcher. The matched series — and therefore the query result — are identical (the regex
-// matches exactly the one metric name, which contains no regex metacharacters), but the regex matcher
-// prevents the query from being pinned to a single ingest-storage compartment. This forces the read
-// path to fan out across all compartments and merge their results, letting continuous-test validate
-// cross-compartment query merging while reusing the same result verification as the pinned queries.
+// The fan-out query variants below use a regex (=~) name matcher to force the read path to fan out
+// across all ingest-storage compartments instead of pinning to one, so continuous-test can exercise
+// cross-compartment query merging. The trailing ".*" matters: a regex matching a single literal value
+// is optimized back into an equality matcher (which re-pins the query). Since no continuous-test metric
+// name is a prefix of another, the result still matches the pinned query and the same verification applies.
 func querySumFloatFanOut(metricName string) string {
-	return fmt.Sprintf(`sum(max_over_time({__name__=~"%s"}[1s]))`, metricName)
+	return fmt.Sprintf(`sum(max_over_time({__name__=~"%s.*"}[1s]))`, metricName)
 }
 
 func querySumHistFanOut(metricName string) string {
-	return fmt.Sprintf(`sum({__name__=~"%s"})`, metricName)
+	return fmt.Sprintf(`sum({__name__=~"%s.*"})`, metricName)
 }
 
 func alignTimestampToInterval(ts time.Time, interval time.Duration) time.Time {

--- a/pkg/continuoustest/write_read_series.go
+++ b/pkg/continuoustest/write_read_series.go
@@ -36,6 +36,7 @@ type WriteReadSeriesTestConfig struct {
 	MaxQueryAge    time.Duration
 	WithFloats     bool
 	WithHistograms bool
+	FanOutQuery    bool
 }
 
 func (cfg *WriteReadSeriesTestConfig) RegisterFlags(f *flag.FlagSet) {
@@ -43,6 +44,7 @@ func (cfg *WriteReadSeriesTestConfig) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.MaxQueryAge, "tests.write-read-series-test.max-query-age", 48*time.Hour, "How back in the past metrics can be queried at most.")
 	f.BoolVar(&cfg.WithFloats, "tests.write-read-series-test.float-samples-enabled", true, "Set to true to use float samples")
 	f.BoolVar(&cfg.WithHistograms, "tests.write-read-series-test.histogram-samples-enabled", false, "Set to true to use native histogram samples")
+	f.BoolVar(&cfg.FanOutQuery, "tests.write-read-series-test.fan-out-query-enabled", false, "Set to true to additionally run each test query with a regex metric-name matcher. This prevents the query from being pinned to a single ingest-storage compartment, forcing the read path to fan out across all compartments and validating cross-compartment query result merging. Roughly doubles the number of queries issued per run.")
 }
 
 type WriteReadSeriesTest struct {
@@ -140,19 +142,19 @@ func (t *WriteReadSeriesTest) Run(ctx context.Context, now time.Time) error {
 	errs := new(multierror.MultiError)
 
 	if t.cfg.WithFloats {
-		t.RunInner(ctx, now, writeLimiter, errs, floatMetricName, floatTypeLabel, floatMetricMetadata, querySumFloat, generateSineWaveSeries, generateSineWaveValue, nil, &t.floatMetric)
+		t.RunInner(ctx, now, writeLimiter, errs, floatMetricName, floatTypeLabel, floatMetricMetadata, querySumFloat, querySumFloatFanOut, generateSineWaveSeries, generateSineWaveValue, nil, &t.floatMetric)
 	}
 
 	if t.cfg.WithHistograms {
 		for i, histProfile := range t.histProfiles {
-			t.RunInner(ctx, now, writeLimiter, errs, histProfile.metricName, histProfile.typeLabel, histProfile.metadata, querySumHist, histProfile.generateSeries, histProfile.generateValue, histProfile.generateSampleHistogram, &t.histMetrics[i])
+			t.RunInner(ctx, now, writeLimiter, errs, histProfile.metricName, histProfile.typeLabel, histProfile.metadata, querySumHist, querySumHistFanOut, histProfile.generateSeries, histProfile.generateValue, histProfile.generateSampleHistogram, &t.histMetrics[i])
 		}
 	}
 
 	return errs.Err()
 }
 
-func (t *WriteReadSeriesTest) RunInner(ctx context.Context, now time.Time, writeLimiter *rate.Limiter, errs *multierror.MultiError, metricName, typeLabel string, metricMetadata []prompb.MetricMetadata, querySum querySumFunc, generateSeries generateSeriesFunc, generateValue generateValueFunc, generateSampleHistogram generateSampleHistogramFunc, records *MetricHistory) {
+func (t *WriteReadSeriesTest) RunInner(ctx context.Context, now time.Time, writeLimiter *rate.Limiter, errs *multierror.MultiError, metricName, typeLabel string, metricMetadata []prompb.MetricMetadata, querySum, querySumFanOut querySumFunc, generateSeries generateSeriesFunc, generateValue generateValueFunc, generateSampleHistogram generateSampleHistogramFunc, records *MetricHistory) {
 	// Write series for each expected timestamp until now.
 	for timestamp := t.nextWriteTimestamp(now, records); !timestamp.After(now); timestamp = t.nextWriteTimestamp(now, records) {
 		logger := log.With(t.logger, "timestamp", timestamp.UnixMilli(), "num_series", t.cfg.NumSeries, "metric_name", metricName)
@@ -174,18 +176,28 @@ func (t *WriteReadSeriesTest) RunInner(ctx context.Context, now time.Time, write
 		errs.Add(err)
 	}
 
-	queryMetric := querySum(metricName)
-	for _, timeRange := range queryRanges {
-		err := t.runRangeQueryAndVerifyResult(ctx, timeRange[0], timeRange[1], true, typeLabel, queryMetric, generateValue, generateSampleHistogram, records)
-		errs.Add(err)
-		err = t.runRangeQueryAndVerifyResult(ctx, timeRange[0], timeRange[1], false, typeLabel, queryMetric, generateValue, generateSampleHistogram, records)
-		errs.Add(err)
+	// The pinned query (exact metric-name matcher) is always run. When fan-out is enabled we
+	// additionally run a query that matches the same metric via a regex matcher, which forces the
+	// read path to fan out across all ingest-storage compartments rather than target a single one.
+	// Both produce identical results, so the same verification applies to each.
+	queryMetrics := []string{querySum(metricName)}
+	if t.cfg.FanOutQuery {
+		queryMetrics = append(queryMetrics, querySumFanOut(metricName))
 	}
-	for _, ts := range queryInstants {
-		err := t.runInstantQueryAndVerifyResult(ctx, ts, true, typeLabel, queryMetric, generateValue, generateSampleHistogram, records)
-		errs.Add(err)
-		err = t.runInstantQueryAndVerifyResult(ctx, ts, false, typeLabel, queryMetric, generateValue, generateSampleHistogram, records)
-		errs.Add(err)
+
+	for _, queryMetric := range queryMetrics {
+		for _, timeRange := range queryRanges {
+			err := t.runRangeQueryAndVerifyResult(ctx, timeRange[0], timeRange[1], true, typeLabel, queryMetric, generateValue, generateSampleHistogram, records)
+			errs.Add(err)
+			err = t.runRangeQueryAndVerifyResult(ctx, timeRange[0], timeRange[1], false, typeLabel, queryMetric, generateValue, generateSampleHistogram, records)
+			errs.Add(err)
+		}
+		for _, ts := range queryInstants {
+			err := t.runInstantQueryAndVerifyResult(ctx, ts, true, typeLabel, queryMetric, generateValue, generateSampleHistogram, records)
+			errs.Add(err)
+			err = t.runInstantQueryAndVerifyResult(ctx, ts, false, typeLabel, queryMetric, generateValue, generateSampleHistogram, records)
+			errs.Add(err)
+		}
 	}
 
 	err = t.runMetadataQueryAndVerifyResult(ctx, metricMetadata)

--- a/pkg/continuoustest/write_read_series_test.go
+++ b/pkg/continuoustest/write_read_series_test.go
@@ -151,9 +151,10 @@ func TestWriteReadSeriesTest_Run_FanOutQuery(t *testing.T) {
 	client.AssertCalled(t, "Query", mock.Anything, querySumFloat(floatMetricName), time.Unix(1000, 0), mock.Anything)
 	client.AssertCalled(t, "Query", mock.Anything, querySumFloatFanOut(floatMetricName), time.Unix(1000, 0), mock.Anything)
 
-	// The fan-out query must use a regex (=~) name matcher: that is what prevents the Mimir read
-	// path from pinning the query to a single compartment.
-	require.Contains(t, querySumFloatFanOut(floatMetricName), `{__name__=~"`+floatMetricName+`"}`)
+	// The fan-out query must use a regex (=~) name matcher with a trailing ".*": a regex matching a
+	// single literal value is optimized back into an equality matcher, which would re-pin the query to
+	// one compartment. The ".*" keeps it a set-matcher so the Mimir read path fans out.
+	require.Contains(t, querySumFloatFanOut(floatMetricName), `{__name__=~"`+floatMetricName+`.*"}`)
 }
 
 func testWriteReadSeriesTestRun(t *testing.T, cfg WriteReadSeriesTestConfig, testTuples []WriteReadSeriesTestTuple) {

--- a/pkg/continuoustest/write_read_series_test.go
+++ b/pkg/continuoustest/write_read_series_test.go
@@ -115,6 +115,47 @@ func TestWriteReadSeriesTest_Run(t *testing.T) {
 	})
 }
 
+func TestWriteReadSeriesTest_Run_FanOutQuery(t *testing.T) {
+	// With fan-out enabled, every test query is run twice: once pinned (exact metric-name matcher)
+	// and once with a regex metric-name matcher that forces the read path to fan out across all
+	// ingest-storage compartments. Verify both query variants are issued.
+	logger := log.NewNopLogger()
+
+	cfg := WriteReadSeriesTestConfig{}
+	flagext.DefaultValues(&cfg)
+	cfg.NumSeries = 2
+	cfg.WithFloats = true
+	cfg.WithHistograms = false
+	cfg.FanOutQuery = true
+
+	client := newMockClient()
+	client.On("WriteSeries", mock.Anything, mock.Anything, mock.Anything).Return(200, nil)
+	client.On("QueryRange", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(model.Matrix{}, nil)
+	client.On("Query", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(model.Vector{}, nil)
+	client.On("Metadata", mock.Anything, mock.Anything).Return(v1.Metadata{}, nil)
+
+	reg := prometheus.NewPedanticRegistry()
+	test := NewWriteReadSeriesTest(cfg, client, writeProtocolDefault, logger, reg)
+
+	now := time.Unix(1000, 0)
+	// Ignore this error. It will be non-nil because the query mock does not return any data.
+	_ = test.Run(context.Background(), now)
+
+	// Fan-out doubles the number of queries compared to a pinned-only run (4 -> 8 each).
+	client.AssertNumberOfCalls(t, "QueryRange", 8)
+	client.AssertNumberOfCalls(t, "Query", 8)
+
+	// Both the pinned and the fan-out query variants must be issued.
+	client.AssertCalled(t, "QueryRange", mock.Anything, querySumFloat(floatMetricName), time.Unix(1000, 0), time.Unix(1000, 0), writeInterval, mock.Anything)
+	client.AssertCalled(t, "QueryRange", mock.Anything, querySumFloatFanOut(floatMetricName), time.Unix(1000, 0), time.Unix(1000, 0), writeInterval, mock.Anything)
+	client.AssertCalled(t, "Query", mock.Anything, querySumFloat(floatMetricName), time.Unix(1000, 0), mock.Anything)
+	client.AssertCalled(t, "Query", mock.Anything, querySumFloatFanOut(floatMetricName), time.Unix(1000, 0), mock.Anything)
+
+	// The fan-out query must use a regex (=~) name matcher: that is what prevents the Mimir read
+	// path from pinning the query to a single compartment.
+	require.Contains(t, querySumFloatFanOut(floatMetricName), `{__name__=~"`+floatMetricName+`"}`)
+}
+
 func testWriteReadSeriesTestRun(t *testing.T, cfg WriteReadSeriesTestConfig, testTuples []WriteReadSeriesTestTuple) {
 	logger := log.NewNopLogger()
 	multiplier := len(testTuples)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Adds an option for queries that would trigger a fanout across compartments, to continuous test.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to optional continuous-test behavior (default disabled); enabling it only increases read/query load against the test target.
> 
> **Overview**
> Adds an **optional** fan-out mode to the write-read-series continuous test so Mimir can exercise **cross-compartment query merging** on ingest storage.
> 
> When `tests.write-read-series-test.fan-out-query-enabled` is true, each range and instant check runs twice: the existing **pinned** PromQL (exact metric name) plus a second query built with `{__name__=~"…"}` via new helpers `querySumFloatFanOut` and `querySumHistFanOut`. Results are expected to match, so verification is unchanged; only the query shape differs so the read path cannot pin to one compartment.
> 
> **Query volume roughly doubles** while the flag is on. Default remains off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cf5dc6706c47f98614df299fc75bcfca24e47cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->