### PR TITLE
Refactor `SplitOperator` and `CacheOperator` to share the same method for merging `SeriesMetadata`

### DIFF
--- a/pkg/streamingpromql/optimize/plan/splitandcache/cache_operator.go
+++ b/pkg/streamingpromql/optimize/plan/splitandcache/cache_operator.go
@@ -403,10 +403,14 @@ func (c *CacheOperator) AfterPrepare(ctx context.Context) error {
 }
 
 func (c *CacheOperator) SeriesMetadata(ctx context.Context, _ types.Matchers) ([]types.SeriesMetadata, error) {
-	series, err := c.computeMergedSeriesMetadata(ctx)
+	// Pass nil matchers: unlike TimeRangeSplitOperator, CacheOperator does not push matchers down, as we
+	// need the full set of series to store in the cache.
+	series, outputSeries, err := mergeSeriesMetadata(ctx, c.extents.inDesiredTimeRange, nil, c.MemoryConsumptionTracker)
 	if err != nil {
 		return nil, err
 	}
+
+	c.outputSeries = outputSeries
 
 	if c.extents.shouldWriteCacheEntry {
 		if err := c.bufferSeriesMetadataForCacheEntry(series); err != nil {
@@ -417,96 +421,6 @@ func (c *CacheOperator) SeriesMetadata(ctx context.Context, _ types.Matchers) ([
 	}
 
 	return series, nil
-}
-
-func (c *CacheOperator) computeMergedSeriesMetadata(ctx context.Context) ([]types.SeriesMetadata, error) {
-	// Use the slice from the first extent as the base for the returned series metadata.
-	allSeries, err := c.extents.inDesiredTimeRange[0].SeriesMetadata(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(c.extents.inDesiredTimeRange) == 1 {
-		// There are no extents to merge, so just return the series metadata from the first extent.
-		return allSeries, nil
-	}
-
-	// Build up a map of the series labels to their index in the output.
-	seriesIndices := make(map[string]int, len(allSeries))
-	labelBytesBuf := make([]byte, 0, 1024)
-	for seriesIdx, series := range allSeries {
-		labelBytesBuf = series.Labels.Bytes(labelBytesBuf)
-		seriesIndices[string(labelBytesBuf)] = seriesIdx // Important: don't extract the string(...) call here - passing it directly allows us to avoid allocating it.
-
-		if err := c.addNewOutputSeries(0, seriesIdx); err != nil {
-			return nil, err
-		}
-	}
-
-	// Now go through the remaining extents.
-	for extentIdx := 1; extentIdx < len(c.extents.inDesiredTimeRange); extentIdx++ {
-		e := c.extents.inDesiredTimeRange[extentIdx]
-		extentSeries, err := e.SeriesMetadata(ctx)
-		if err != nil {
-			return nil, err
-		}
-
-		for extentSeriesIdx, series := range extentSeries {
-			labelBytesBuf = series.Labels.Bytes(labelBytesBuf)
-
-			// Important: don't extract the string(...) call in the map lookup below - passing it directly allows us to avoid allocating it.
-			if outputSeriesIdx, seenAlready := seriesIndices[string(labelBytesBuf)]; seenAlready {
-				if series.DropName != allSeries[outputSeriesIdx].DropName {
-					return nil, fmt.Errorf("series with labels %s has conflicting drop name values in different extents", series.Labels.String())
-				}
-
-				c.outputSeries[outputSeriesIdx].sourceSeriesIndices[extentIdx] = extentSeriesIdx
-
-				// We're not going to keep this labels instance (we already have it from a previous extent), so
-				// decrease memory consumption now.
-				c.MemoryConsumptionTracker.DecreaseMemoryConsumptionForLabels(series.Labels)
-			} else {
-				seriesIndices[string(labelBytesBuf)] = len(allSeries)
-				allSeries, err = types.SeriesMetadataSlicePool.AppendToSlice(allSeries, c.MemoryConsumptionTracker, series)
-				if err != nil {
-					return nil, err
-				}
-
-				if err := c.addNewOutputSeries(extentIdx, extentSeriesIdx); err != nil {
-					return nil, err
-				}
-			}
-
-			// We've already accounted for the memory consumption of this series' labels with the DecreaseMemoryConsumptionForLabels
-			// or AppendToSlice calls above, so clear the labels now so they're not double-decremented when we return the series
-			// slice to the pool below.
-			extentSeries[extentSeriesIdx] = types.SeriesMetadata{}
-		}
-
-		types.SeriesMetadataSlicePool.Put(&extentSeries, c.MemoryConsumptionTracker)
-	}
-
-	return allSeries, nil
-}
-
-func (c *CacheOperator) addNewOutputSeries(sourceExtentIndex int, sourceExtentSeriesIndex int) error {
-	sourceSeriesIndices, err := types.IntSlicePool.Get(len(c.extents.inDesiredTimeRange), c.MemoryConsumptionTracker)
-	if err != nil {
-		return err
-	}
-
-	sourceSeriesIndices = sourceSeriesIndices[:len(c.extents.inDesiredTimeRange)]
-
-	for idx := range c.extents.inDesiredTimeRange {
-		if idx == sourceExtentIndex {
-			sourceSeriesIndices[idx] = sourceExtentSeriesIndex
-		} else {
-			sourceSeriesIndices[idx] = -1
-		}
-	}
-
-	c.outputSeries = append(c.outputSeries, splitOrCacheOutputSeries{sourceSeriesIndices: sourceSeriesIndices})
-	return nil
 }
 
 func (c *CacheOperator) bufferSeriesMetadataForCacheEntry(series []types.SeriesMetadata) error {
@@ -976,7 +890,7 @@ type extent interface {
 
 	// SeriesMetadata returns the metadata for all series in this extent.
 	// Callers may modify the returned slice.
-	SeriesMetadata(ctx context.Context) ([]types.SeriesMetadata, error)
+	SeriesMetadata(ctx context.Context, matchers types.Matchers) ([]types.SeriesMetadata, error)
 
 	// GetSeries returns the samples for the series at the given index.
 	// Callers may modify the returned slices.
@@ -1017,7 +931,7 @@ func (c *cachedExtentReader) AfterPrepare(_ context.Context) error {
 	return nil
 }
 
-func (c *cachedExtentReader) SeriesMetadata(_ context.Context) ([]types.SeriesMetadata, error) {
+func (c *cachedExtentReader) SeriesMetadata(_ context.Context, _ types.Matchers) ([]types.SeriesMetadata, error) {
 	seriesMetadata, err := types.SeriesMetadataSlicePool.Get(len(c.extent.SeriesMetadata), c.parent.MemoryConsumptionTracker)
 	if err != nil {
 		return nil, err
@@ -1122,8 +1036,8 @@ func (e *evaluatedExtent) AfterPrepare(ctx context.Context) error {
 	return e.inner.AfterPrepare(ctx)
 }
 
-func (e *evaluatedExtent) SeriesMetadata(ctx context.Context) ([]types.SeriesMetadata, error) {
-	metadata, err := e.inner.SeriesMetadata(ctx, nil)
+func (e *evaluatedExtent) SeriesMetadata(ctx context.Context, matchers types.Matchers) ([]types.SeriesMetadata, error) {
+	metadata, err := e.inner.SeriesMetadata(ctx, matchers)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/streamingpromql/optimize/plan/splitandcache/cache_operator.go
+++ b/pkg/streamingpromql/optimize/plan/splitandcache/cache_operator.go
@@ -405,7 +405,7 @@ func (c *CacheOperator) AfterPrepare(ctx context.Context) error {
 func (c *CacheOperator) SeriesMetadata(ctx context.Context, _ types.Matchers) ([]types.SeriesMetadata, error) {
 	// Pass nil matchers: unlike TimeRangeSplitOperator, CacheOperator does not push matchers down, as we
 	// need the full set of series to store in the cache.
-	series, outputSeries, err := mergeSeriesMetadata(ctx, c.extents.inDesiredTimeRange, nil, c.MemoryConsumptionTracker)
+	series, outputSeries, err := mergeSeriesMetadataFromMultipleSources(ctx, c.extents.inDesiredTimeRange, nil, c.MemoryConsumptionTracker)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/streamingpromql/optimize/plan/splitandcache/merge_series_metadata.go
+++ b/pkg/streamingpromql/optimize/plan/splitandcache/merge_series_metadata.go
@@ -16,7 +16,7 @@ type seriesMetadataSource interface {
 	SeriesMetadata(ctx context.Context, matchers types.Matchers) ([]types.SeriesMetadata, error)
 }
 
-// mergeSeriesMetadata merges the series metadata from each of sources into a single deduplicated slice, returning that
+// mergeSeriesMetadataFromMultipleSources merges the series metadata from each of sources into a single deduplicated slice, returning that
 // slice along with a mapping from each output series to the corresponding series index in each source.
 //
 // The provided matchers are passed through to each source's SeriesMetadata method.
@@ -26,7 +26,7 @@ type seriesMetadataSource interface {
 // the series' data.
 //
 // sources must not be empty.
-func mergeSeriesMetadata[S seriesMetadataSource](ctx context.Context, sources []S, matchers types.Matchers, memoryConsumptionTracker *limiter.MemoryConsumptionTracker) ([]types.SeriesMetadata, []splitOrCacheOutputSeries, error) {
+func mergeSeriesMetadataFromMultipleSources[S seriesMetadataSource](ctx context.Context, sources []S, matchers types.Matchers, memoryConsumptionTracker *limiter.MemoryConsumptionTracker) ([]types.SeriesMetadata, []splitOrCacheOutputSeries, error) {
 	// Use the slice from the first source as the base for the returned series metadata.
 	allSeries, err := sources[0].SeriesMetadata(ctx, matchers)
 	if err != nil {

--- a/pkg/streamingpromql/optimize/plan/splitandcache/merge_series_metadata.go
+++ b/pkg/streamingpromql/optimize/plan/splitandcache/merge_series_metadata.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package splitandcache
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+	"github.com/grafana/mimir/pkg/util/limiter"
+)
+
+// seriesMetadataSource provides the series metadata for a single source (a range for TimeRangeSplitOperator,
+// or an extent for CacheOperator) that is to be merged with the other sources.
+type seriesMetadataSource interface {
+	SeriesMetadata(ctx context.Context, matchers types.Matchers) ([]types.SeriesMetadata, error)
+}
+
+// mergeSeriesMetadata merges the series metadata from each of sources into a single deduplicated slice, returning that
+// slice along with a mapping from each output series to the corresponding series index in each source.
+//
+// The provided matchers are passed through to each source's SeriesMetadata method.
+//
+// If there is only a single source, the fast path is taken: that source's series metadata is returned directly and the
+// returned []splitOrCacheOutputSeries is nil, as there is nothing to merge. Callers must handle this case when reading
+// the series' data.
+//
+// sources must not be empty.
+func mergeSeriesMetadata[S seriesMetadataSource](ctx context.Context, sources []S, matchers types.Matchers, memoryConsumptionTracker *limiter.MemoryConsumptionTracker) ([]types.SeriesMetadata, []splitOrCacheOutputSeries, error) {
+	// Use the slice from the first source as the base for the returned series metadata.
+	allSeries, err := sources[0].SeriesMetadata(ctx, matchers)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if len(sources) == 1 {
+		// There are no other sources to merge, so just return the series metadata from the first source.
+		return allSeries, nil, nil
+	}
+
+	var outputSeries []splitOrCacheOutputSeries
+
+	addNewOutputSeries := func(sourceIdx int, sourceSeriesIdx int) error {
+		sourceSeriesIndices, err := types.IntSlicePool.Get(len(sources), memoryConsumptionTracker)
+		if err != nil {
+			return err
+		}
+
+		sourceSeriesIndices = sourceSeriesIndices[:len(sources)]
+
+		for idx := range sources {
+			if idx == sourceIdx {
+				sourceSeriesIndices[idx] = sourceSeriesIdx
+			} else {
+				sourceSeriesIndices[idx] = -1
+			}
+		}
+
+		outputSeries = append(outputSeries, splitOrCacheOutputSeries{sourceSeriesIndices: sourceSeriesIndices})
+		return nil
+	}
+
+	// Build up a map of the series labels to their index in the output.
+	seriesIndices := make(map[string]int, len(allSeries))
+	labelBytesBuf := make([]byte, 0, 1024)
+	for seriesIdx, series := range allSeries {
+		labelBytesBuf = series.Labels.Bytes(labelBytesBuf)
+		seriesIndices[string(labelBytesBuf)] = seriesIdx // Important: don't extract the string(...) call here - passing it directly allows us to avoid allocating it.
+
+		if err := addNewOutputSeries(0, seriesIdx); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	// Now go through the remaining sources.
+	for sourceIdx := 1; sourceIdx < len(sources); sourceIdx++ {
+		sourceSeries, err := sources[sourceIdx].SeriesMetadata(ctx, matchers)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		for seriesIdx, series := range sourceSeries {
+			labelBytesBuf = series.Labels.Bytes(labelBytesBuf)
+
+			// Important: don't extract the string(...) call in the map lookup below - passing it directly allows us to avoid allocating it.
+			if outputSeriesIdx, seenAlready := seriesIndices[string(labelBytesBuf)]; seenAlready {
+				if series.DropName != allSeries[outputSeriesIdx].DropName {
+					return nil, nil, fmt.Errorf("series with labels %s has conflicting drop name values in different ranges", series.Labels.String())
+				}
+
+				outputSeries[outputSeriesIdx].sourceSeriesIndices[sourceIdx] = seriesIdx
+
+				// We're not going to keep this labels instance (we already have it from a previous source), so
+				// decrease memory consumption now.
+				memoryConsumptionTracker.DecreaseMemoryConsumptionForLabels(series.Labels)
+			} else {
+				seriesIndices[string(labelBytesBuf)] = len(allSeries)
+				allSeries, err = types.SeriesMetadataSlicePool.AppendToSlice(allSeries, memoryConsumptionTracker, series)
+				if err != nil {
+					return nil, nil, err
+				}
+
+				if err := addNewOutputSeries(sourceIdx, seriesIdx); err != nil {
+					return nil, nil, err
+				}
+			}
+
+			// We've already accounted for the memory consumption of this series' labels with the DecreaseMemoryConsumptionForLabels
+			// or AppendToSlice calls above, so clear the labels now so they're not double-decremented when we return the series
+			// slice to the pool below.
+			sourceSeries[seriesIdx] = types.SeriesMetadata{}
+		}
+
+		types.SeriesMetadataSlicePool.Put(&sourceSeries, memoryConsumptionTracker)
+	}
+
+	return allSeries, outputSeries, nil
+}

--- a/pkg/streamingpromql/optimize/plan/splitandcache/merge_series_metadata.go
+++ b/pkg/streamingpromql/optimize/plan/splitandcache/merge_series_metadata.go
@@ -85,7 +85,7 @@ func mergeSeriesMetadata[S seriesMetadataSource](ctx context.Context, sources []
 			// Important: don't extract the string(...) call in the map lookup below - passing it directly allows us to avoid allocating it.
 			if outputSeriesIdx, seenAlready := seriesIndices[string(labelBytesBuf)]; seenAlready {
 				if series.DropName != allSeries[outputSeriesIdx].DropName {
-					return nil, nil, fmt.Errorf("series with labels %s has conflicting drop name values in different ranges", series.Labels.String())
+					return nil, nil, fmt.Errorf("series with labels %s has conflicting drop name values in different ranges / extents", series.Labels.String())
 				}
 
 				outputSeries[outputSeriesIdx].sourceSeriesIndices[sourceIdx] = seriesIdx

--- a/pkg/streamingpromql/optimize/plan/splitandcache/merge_series_metadata_test.go
+++ b/pkg/streamingpromql/optimize/plan/splitandcache/merge_series_metadata_test.go
@@ -157,7 +157,7 @@ func TestMergeSeriesMetadata_ConflictingDropNameValuesForSameSeries(t *testing.T
 	}
 
 	_, _, err := mergeSeriesMetadata(ctx, sources, nil, memoryConsumptionTracker)
-	require.EqualError(t, err, `series with labels {idx="0"} has conflicting drop name values in different ranges`)
+	require.EqualError(t, err, `series with labels {idx="0"} has conflicting drop name values in different ranges / extents`)
 }
 
 func TestMergeSeriesMetadata_PassesMatchersToSources(t *testing.T) {

--- a/pkg/streamingpromql/optimize/plan/splitandcache/merge_series_metadata_test.go
+++ b/pkg/streamingpromql/optimize/plan/splitandcache/merge_series_metadata_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/grafana/mimir/pkg/util/limiter"
 )
 
-// These test cases mirror the scenarios covered by TestSplitOperator, but exercise the shared mergeSeriesMetadata
+// These test cases mirror the scenarios covered by TestSplitOperator, but exercise the shared mergeSeriesMetadataFromMultipleSources
 // helper directly: they verify both the merged series metadata and the mapping from each output series back to the
 // corresponding series index in each source.
 func TestMergeSeriesMetadata(t *testing.T) {
@@ -108,7 +108,7 @@ func TestMergeSeriesMetadata(t *testing.T) {
 
 			sources := newSplitRangeSources(testCase.sources, memoryConsumptionTracker)
 
-			series, outputSeries, err := mergeSeriesMetadata(ctx, sources, nil, memoryConsumptionTracker)
+			series, outputSeries, err := mergeSeriesMetadataFromMultipleSources(ctx, sources, nil, memoryConsumptionTracker)
 			require.NoError(t, err)
 			require.Equal(t, testutils.LabelsToSeriesMetadata(testCase.expectedMergedLabels), series, "expected merged series metadata to match expected")
 			require.Equal(t, testCase.expectedOutputSeries, outputSeries, "expected output series to match expected")
@@ -126,7 +126,7 @@ func TestMergeSeriesMetadata_SingleSourceFastPath(t *testing.T) {
 	sourceLabels := []labels.Labels{labelsForIdx(0), labelsForIdx(1), labelsForIdx(2)}
 	sources := newSplitRangeSources([][]labels.Labels{sourceLabels}, memoryConsumptionTracker)
 
-	series, outputSeries, err := mergeSeriesMetadata(ctx, sources, nil, memoryConsumptionTracker)
+	series, outputSeries, err := mergeSeriesMetadataFromMultipleSources(ctx, sources, nil, memoryConsumptionTracker)
 	require.NoError(t, err)
 	require.Equal(t, testutils.LabelsToSeriesMetadata(sourceLabels), series, "expected the sole source's series metadata to be returned unchanged")
 	require.Nil(t, outputSeries, "expected the fast path to leave the output series mapping unpopulated")
@@ -156,7 +156,7 @@ func TestMergeSeriesMetadata_ConflictingDropNameValuesForSameSeries(t *testing.T
 		newSplitRange(source2, memoryConsumptionTracker),
 	}
 
-	_, _, err := mergeSeriesMetadata(ctx, sources, nil, memoryConsumptionTracker)
+	_, _, err := mergeSeriesMetadataFromMultipleSources(ctx, sources, nil, memoryConsumptionTracker)
 	require.EqualError(t, err, `series with labels {idx="0"} has conflicting drop name values in different ranges / extents`)
 }
 
@@ -176,7 +176,7 @@ func TestMergeSeriesMetadata_PassesMatchersToSources(t *testing.T) {
 
 	matchers := types.Matchers{{Type: labels.MatchEqual, Name: "foo", Value: "bar"}}
 
-	series, outputSeries, err := mergeSeriesMetadata(ctx, sources, matchers, memoryConsumptionTracker)
+	series, outputSeries, err := mergeSeriesMetadataFromMultipleSources(ctx, sources, matchers, memoryConsumptionTracker)
 	require.NoError(t, err)
 
 	for i, o := range innerOperators {

--- a/pkg/streamingpromql/optimize/plan/splitandcache/merge_series_metadata_test.go
+++ b/pkg/streamingpromql/optimize/plan/splitandcache/merge_series_metadata_test.go
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package splitandcache
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/streamingpromql/operators"
+	"github.com/grafana/mimir/pkg/streamingpromql/testutils"
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+	"github.com/grafana/mimir/pkg/util/limiter"
+)
+
+// These test cases mirror the scenarios covered by TestSplitOperator, but exercise the shared mergeSeriesMetadata
+// helper directly: they verify both the merged series metadata and the mapping from each output series back to the
+// corresponding series index in each source.
+func TestMergeSeriesMetadata(t *testing.T) {
+	testCases := map[string]struct {
+		sources              [][]labels.Labels
+		expectedMergedLabels []labels.Labels
+		expectedOutputSeries []splitOrCacheOutputSeries
+	}{
+		"all sources return no series": {
+			sources: [][]labels.Labels{
+				{},
+				{},
+				{},
+			},
+			expectedMergedLabels: nil,
+			expectedOutputSeries: nil,
+		},
+		"all sources have the same series": {
+			sources: [][]labels.Labels{
+				{labelsForIdx(0), labelsForIdx(1), labelsForIdx(2)},
+				{labelsForIdx(0), labelsForIdx(1), labelsForIdx(2)},
+				{labelsForIdx(0), labelsForIdx(1), labelsForIdx(2)},
+			},
+			expectedMergedLabels: []labels.Labels{labelsForIdx(0), labelsForIdx(1), labelsForIdx(2)},
+			expectedOutputSeries: []splitOrCacheOutputSeries{
+				{sourceSeriesIndices: []int{0, 0, 0}},
+				{sourceSeriesIndices: []int{1, 1, 1}},
+				{sourceSeriesIndices: []int{2, 2, 2}},
+			},
+		},
+		"each source has different series": {
+			sources: [][]labels.Labels{
+				{labelsForIdx(0), labelsForIdx(1), labelsForIdx(2)},
+				{labelsForIdx(3), labelsForIdx(4), labelsForIdx(5)},
+				{labelsForIdx(6), labelsForIdx(7), labelsForIdx(8)},
+			},
+			expectedMergedLabels: []labels.Labels{
+				labelsForIdx(0),
+				labelsForIdx(1),
+				labelsForIdx(2),
+				labelsForIdx(3),
+				labelsForIdx(4),
+				labelsForIdx(5),
+				labelsForIdx(6),
+				labelsForIdx(7),
+				labelsForIdx(8),
+			},
+			expectedOutputSeries: []splitOrCacheOutputSeries{
+				{sourceSeriesIndices: []int{0, -1, -1}},
+				{sourceSeriesIndices: []int{1, -1, -1}},
+				{sourceSeriesIndices: []int{2, -1, -1}},
+				{sourceSeriesIndices: []int{-1, 0, -1}},
+				{sourceSeriesIndices: []int{-1, 1, -1}},
+				{sourceSeriesIndices: []int{-1, 2, -1}},
+				{sourceSeriesIndices: []int{-1, -1, 0}},
+				{sourceSeriesIndices: []int{-1, -1, 1}},
+				{sourceSeriesIndices: []int{-1, -1, 2}},
+			},
+		},
+		"sources have some same, some different series": {
+			sources: [][]labels.Labels{
+				{labelsForIdx(0), labelsForIdx(1), labelsForIdx(2)},
+				{labelsForIdx(0), labelsForIdx(3)},
+				{labelsForIdx(4), labelsForIdx(0), labelsForIdx(1)},
+			},
+			expectedMergedLabels: []labels.Labels{
+				labelsForIdx(0),
+				labelsForIdx(1),
+				labelsForIdx(2),
+				labelsForIdx(3),
+				labelsForIdx(4),
+			},
+			expectedOutputSeries: []splitOrCacheOutputSeries{
+				{sourceSeriesIndices: []int{0, 0, 1}},
+				{sourceSeriesIndices: []int{1, -1, 2}},
+				{sourceSeriesIndices: []int{2, -1, -1}},
+				{sourceSeriesIndices: []int{-1, 1, -1}},
+				{sourceSeriesIndices: []int{-1, -1, 0}},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			require.Equalf(t, len(testCase.expectedMergedLabels), len(testCase.expectedOutputSeries), "invalid test case: should have same number of output series in list of series labels and sources")
+
+			ctx := context.Background()
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
+
+			sources := newSplitRangeSources(testCase.sources, memoryConsumptionTracker)
+
+			series, outputSeries, err := mergeSeriesMetadata(ctx, sources, nil, memoryConsumptionTracker)
+			require.NoError(t, err)
+			require.Equal(t, testutils.LabelsToSeriesMetadata(testCase.expectedMergedLabels), series, "expected merged series metadata to match expected")
+			require.Equal(t, testCase.expectedOutputSeries, outputSeries, "expected output series to match expected")
+
+			releaseMergeSeriesMetadata(&series, outputSeries, memoryConsumptionTracker)
+			require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes(), "expected all instances to be returned to pool, current memory consumption is:\n%v", memoryConsumptionTracker.DescribeCurrentMemoryConsumption())
+		})
+	}
+}
+
+func TestMergeSeriesMetadata_SingleSourceFastPath(t *testing.T) {
+	ctx := context.Background()
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
+
+	sourceLabels := []labels.Labels{labelsForIdx(0), labelsForIdx(1), labelsForIdx(2)}
+	sources := newSplitRangeSources([][]labels.Labels{sourceLabels}, memoryConsumptionTracker)
+
+	series, outputSeries, err := mergeSeriesMetadata(ctx, sources, nil, memoryConsumptionTracker)
+	require.NoError(t, err)
+	require.Equal(t, testutils.LabelsToSeriesMetadata(sourceLabels), series, "expected the sole source's series metadata to be returned unchanged")
+	require.Nil(t, outputSeries, "expected the fast path to leave the output series mapping unpopulated")
+
+	releaseMergeSeriesMetadata(&series, outputSeries, memoryConsumptionTracker)
+	require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes(), "expected all instances to be returned to pool, current memory consumption is:\n%v", memoryConsumptionTracker.DescribeCurrentMemoryConsumption())
+}
+
+func TestMergeSeriesMetadata_ConflictingDropNameValuesForSameSeries(t *testing.T) {
+	ctx := context.Background()
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
+
+	source1 := &operators.TestOperator{
+		Series:                   []labels.Labels{labelsForIdx(0)},
+		DropName:                 []bool{true},
+		MemoryConsumptionTracker: memoryConsumptionTracker,
+	}
+
+	source2 := &operators.TestOperator{
+		Series:                   []labels.Labels{labelsForIdx(0)},
+		DropName:                 []bool{false},
+		MemoryConsumptionTracker: memoryConsumptionTracker,
+	}
+
+	sources := []*splitRange{
+		newSplitRange(source1, memoryConsumptionTracker),
+		newSplitRange(source2, memoryConsumptionTracker),
+	}
+
+	_, _, err := mergeSeriesMetadata(ctx, sources, nil, memoryConsumptionTracker)
+	require.EqualError(t, err, `series with labels {idx="0"} has conflicting drop name values in different ranges`)
+}
+
+func TestMergeSeriesMetadata_PassesMatchersToSources(t *testing.T) {
+	ctx := context.Background()
+	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
+
+	innerOperators := []*operators.TestOperator{
+		{Series: []labels.Labels{labelsForIdx(0)}, MemoryConsumptionTracker: memoryConsumptionTracker},
+		{Series: []labels.Labels{labelsForIdx(1)}, MemoryConsumptionTracker: memoryConsumptionTracker},
+	}
+
+	sources := []*splitRange{
+		newSplitRange(innerOperators[0], memoryConsumptionTracker),
+		newSplitRange(innerOperators[1], memoryConsumptionTracker),
+	}
+
+	matchers := types.Matchers{{Type: labels.MatchEqual, Name: "foo", Value: "bar"}}
+
+	series, outputSeries, err := mergeSeriesMetadata(ctx, sources, matchers, memoryConsumptionTracker)
+	require.NoError(t, err)
+
+	for i, o := range innerOperators {
+		require.Equalf(t, matchers, o.MatchersProvided, "expected matchers to be passed through to source %d", i)
+	}
+
+	releaseMergeSeriesMetadata(&series, outputSeries, memoryConsumptionTracker)
+	require.Zero(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes(), "expected all instances to be returned to pool, current memory consumption is:\n%v", memoryConsumptionTracker.DescribeCurrentMemoryConsumption())
+}
+
+func newSplitRangeSources(sources [][]labels.Labels, memoryConsumptionTracker *limiter.MemoryConsumptionTracker) []*splitRange {
+	ranges := make([]*splitRange, len(sources))
+	for i, sourceLabels := range sources {
+		o := &operators.TestOperator{
+			Series:                   sourceLabels,
+			MemoryConsumptionTracker: memoryConsumptionTracker,
+		}
+		ranges[i] = newSplitRange(o, memoryConsumptionTracker)
+	}
+	return ranges
+}
+
+func releaseMergeSeriesMetadata(series *[]types.SeriesMetadata, outputSeries []splitOrCacheOutputSeries, memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
+	for i := range outputSeries {
+		types.IntSlicePool.Put(&outputSeries[i].sourceSeriesIndices, memoryConsumptionTracker)
+	}
+
+	types.SeriesMetadataSlicePool.Put(series, memoryConsumptionTracker)
+}
+
+func labelsForIdx(idx int) labels.Labels {
+	return labels.FromStrings("idx", strconv.Itoa(idx))
+}

--- a/pkg/streamingpromql/optimize/plan/splitandcache/node.go
+++ b/pkg/streamingpromql/optimize/plan/splitandcache/node.go
@@ -91,7 +91,7 @@ func MaterializeSplit(node *TimeRangeSplit, materializer *planning.Materializer,
 			return nil, err
 		}
 
-		ranges = append(ranges, newSplitRange(inner))
+		ranges = append(ranges, newSplitRange(inner, params.MemoryConsumptionTracker))
 		start = end + timeRange.IntervalMilliseconds
 	}
 

--- a/pkg/streamingpromql/optimize/plan/splitandcache/split_operator.go
+++ b/pkg/streamingpromql/optimize/plan/splitandcache/split_operator.go
@@ -28,8 +28,20 @@ type TimeRangeSplitOperator struct {
 var _ types.InstantVectorOperator = &TimeRangeSplitOperator{}
 
 type splitRange struct {
-	operator types.InstantVectorOperator
-	buffer   *operators.InstantVectorOperatorBuffer
+	operator                 types.InstantVectorOperator
+	buffer                   *operators.InstantVectorOperatorBuffer
+	memoryConsumptionTracker *limiter.MemoryConsumptionTracker
+}
+
+func (r *splitRange) SeriesMetadata(ctx context.Context, matchers types.Matchers) ([]types.SeriesMetadata, error) {
+	series, err := r.operator.SeriesMetadata(ctx, matchers)
+	if err != nil {
+		return nil, err
+	}
+
+	r.buffer = operators.NewInstantVectorOperatorBuffer(r.operator, nil, len(series)-1, r.memoryConsumptionTracker)
+
+	return series, nil
 }
 
 type splitOrCacheOutputSeries struct {
@@ -48,8 +60,8 @@ func newTimeRangeSplitOperator(ranges []*splitRange, memoryConsumptionTracker *l
 	}
 }
 
-func newSplitRange(operator types.InstantVectorOperator) *splitRange {
-	return &splitRange{operator: operator}
+func newSplitRange(operator types.InstantVectorOperator, memoryConsumptionTracker *limiter.MemoryConsumptionTracker) *splitRange {
+	return &splitRange{operator: operator, memoryConsumptionTracker: memoryConsumptionTracker}
 }
 
 func (s *TimeRangeSplitOperator) Prepare(ctx context.Context, params *types.PrepareParams) error {
@@ -75,12 +87,10 @@ func (s *TimeRangeSplitOperator) AfterPrepare(ctx context.Context) error {
 
 func (s *TimeRangeSplitOperator) SeriesMetadata(ctx context.Context, matchers types.Matchers) ([]types.SeriesMetadata, error) {
 	// Use the slice from the first range as the base for the returned series metadata.
-	allSeries, err := s.ranges[0].operator.SeriesMetadata(ctx, matchers)
+	allSeries, err := s.ranges[0].SeriesMetadata(ctx, matchers)
 	if err != nil {
 		return nil, err
 	}
-
-	s.ranges[0].buffer = operators.NewInstantVectorOperatorBuffer(s.ranges[0].operator, nil, len(allSeries)-1, s.MemoryConsumptionTracker)
 
 	seriesIndices := make(map[string]int, len(allSeries))
 	labelBytesBuf := make([]byte, 0, 1024)
@@ -96,7 +106,7 @@ func (s *TimeRangeSplitOperator) SeriesMetadata(ctx context.Context, matchers ty
 	// Now go through the remaining ranges.
 	for rangeIdx := 1; rangeIdx < len(s.ranges); rangeIdx++ {
 		r := s.ranges[rangeIdx]
-		rangeSeries, err := r.operator.SeriesMetadata(ctx, matchers)
+		rangeSeries, err := r.SeriesMetadata(ctx, matchers)
 		if err != nil {
 			return nil, err
 		}
@@ -133,7 +143,6 @@ func (s *TimeRangeSplitOperator) SeriesMetadata(ctx context.Context, matchers ty
 			rangeSeries[rangeSeriesIdx] = types.SeriesMetadata{}
 		}
 
-		r.buffer = operators.NewInstantVectorOperatorBuffer(r.operator, nil, len(rangeSeries)-1, s.MemoryConsumptionTracker)
 		types.SeriesMetadataSlicePool.Put(&rangeSeries, s.MemoryConsumptionTracker)
 	}
 

--- a/pkg/streamingpromql/optimize/plan/splitandcache/split_operator.go
+++ b/pkg/streamingpromql/optimize/plan/splitandcache/split_operator.go
@@ -51,7 +51,8 @@ type splitOrCacheOutputSeries struct {
 // newTimeRangeSplitOperator creates a new TimeRangeSplitOperator.
 //
 // ranges must be sorted in descending time order and must not overlap.
-// ranges must not be empty.
+// ranges must contain at least two ranges: when there is only a single range, callers should use the inner operator
+// directly rather than wrapping it in a TimeRangeSplitOperator.
 func newTimeRangeSplitOperator(ranges []*splitRange, memoryConsumptionTracker *limiter.MemoryConsumptionTracker, timeRange types.QueryTimeRange) *TimeRangeSplitOperator {
 	return &TimeRangeSplitOperator{
 		MemoryConsumptionTracker: memoryConsumptionTracker,
@@ -86,87 +87,22 @@ func (s *TimeRangeSplitOperator) AfterPrepare(ctx context.Context) error {
 }
 
 func (s *TimeRangeSplitOperator) SeriesMetadata(ctx context.Context, matchers types.Matchers) ([]types.SeriesMetadata, error) {
-	// Use the slice from the first range as the base for the returned series metadata.
-	allSeries, err := s.ranges[0].SeriesMetadata(ctx, matchers)
+	if len(s.ranges) < 2 {
+		// mergeSeriesMetadata takes a fast path for a single source that leaves outputSeries unpopulated, but
+		// TimeRangeSplitOperator's NextSeries relies on outputSeries being populated. In production this is never
+		// hit, as MaterializeSplit returns the inner operator directly rather than constructing a
+		// TimeRangeSplitOperator when there is only one range.
+		return nil, fmt.Errorf("TimeRangeSplitOperator requires at least two ranges, but has %d", len(s.ranges))
+	}
+
+	series, outputSeries, err := mergeSeriesMetadata(ctx, s.ranges, matchers, s.MemoryConsumptionTracker)
 	if err != nil {
 		return nil, err
 	}
 
-	seriesIndices := make(map[string]int, len(allSeries))
-	labelBytesBuf := make([]byte, 0, 1024)
-	for seriesIdx, series := range allSeries {
-		labelBytesBuf = series.Labels.Bytes(labelBytesBuf)
-		seriesIndices[string(labelBytesBuf)] = seriesIdx // Important: don't extract the string(...) call here - passing it directly allows us to avoid allocating it.
+	s.outputSeries = outputSeries
 
-		if err := s.addNewOutputSeries(0, seriesIdx); err != nil {
-			return nil, err
-		}
-	}
-
-	// Now go through the remaining ranges.
-	for rangeIdx := 1; rangeIdx < len(s.ranges); rangeIdx++ {
-		r := s.ranges[rangeIdx]
-		rangeSeries, err := r.SeriesMetadata(ctx, matchers)
-		if err != nil {
-			return nil, err
-		}
-
-		for rangeSeriesIdx, series := range rangeSeries {
-			labelBytesBuf = series.Labels.Bytes(labelBytesBuf)
-
-			// Important: don't extract the string(...) call in the map lookup below - passing it directly allows us to avoid allocating it.
-			if outputSeriesIdx, seenAlready := seriesIndices[string(labelBytesBuf)]; seenAlready {
-				if series.DropName != allSeries[outputSeriesIdx].DropName {
-					return nil, fmt.Errorf("series with labels %s has conflicting drop name values in different ranges", series.Labels.String())
-				}
-
-				s.outputSeries[outputSeriesIdx].sourceSeriesIndices[rangeIdx] = rangeSeriesIdx
-
-				// We're not going to keep this labels instance (we already have it from a previous range), so
-				// decrease memory consumption now.
-				s.MemoryConsumptionTracker.DecreaseMemoryConsumptionForLabels(series.Labels)
-			} else {
-				seriesIndices[string(labelBytesBuf)] = len(allSeries)
-				allSeries, err = types.SeriesMetadataSlicePool.AppendToSlice(allSeries, s.MemoryConsumptionTracker, series)
-				if err != nil {
-					return nil, err
-				}
-
-				if err := s.addNewOutputSeries(rangeIdx, rangeSeriesIdx); err != nil {
-					return nil, err
-				}
-			}
-
-			// We've already accounted for the memory consumption of this series' labels with the DecreaseMemoryConsumptionForLabels
-			// or AppendToSlice calls above, so clear the labels now so they're not double-decremented when we return the series
-			// slice to the pool below.
-			rangeSeries[rangeSeriesIdx] = types.SeriesMetadata{}
-		}
-
-		types.SeriesMetadataSlicePool.Put(&rangeSeries, s.MemoryConsumptionTracker)
-	}
-
-	return allSeries, nil
-}
-
-func (s *TimeRangeSplitOperator) addNewOutputSeries(sourceRangeIndex int, sourceRangeSeriesIndex int) error {
-	sourceSeriesIndices, err := types.IntSlicePool.Get(len(s.ranges), s.MemoryConsumptionTracker)
-	if err != nil {
-		return err
-	}
-
-	sourceSeriesIndices = sourceSeriesIndices[:len(s.ranges)]
-
-	for idx := range s.ranges {
-		if idx == sourceRangeIndex {
-			sourceSeriesIndices[idx] = sourceRangeSeriesIndex
-		} else {
-			sourceSeriesIndices[idx] = -1
-		}
-	}
-
-	s.outputSeries = append(s.outputSeries, splitOrCacheOutputSeries{sourceSeriesIndices: sourceSeriesIndices})
-	return nil
+	return series, nil
 }
 
 func (s *TimeRangeSplitOperator) NextSeries(ctx context.Context) (types.InstantVectorSeriesData, error) {

--- a/pkg/streamingpromql/optimize/plan/splitandcache/split_operator.go
+++ b/pkg/streamingpromql/optimize/plan/splitandcache/split_operator.go
@@ -88,14 +88,14 @@ func (s *TimeRangeSplitOperator) AfterPrepare(ctx context.Context) error {
 
 func (s *TimeRangeSplitOperator) SeriesMetadata(ctx context.Context, matchers types.Matchers) ([]types.SeriesMetadata, error) {
 	if len(s.ranges) < 2 {
-		// mergeSeriesMetadata takes a fast path for a single source that leaves outputSeries unpopulated, but
+		// mergeSeriesMetadataFromMultipleSources takes a fast path for a single source that leaves outputSeries unpopulated, but
 		// TimeRangeSplitOperator's NextSeries relies on outputSeries being populated. In production this is never
 		// hit, as MaterializeSplit returns the inner operator directly rather than constructing a
 		// TimeRangeSplitOperator when there is only one range.
 		return nil, fmt.Errorf("TimeRangeSplitOperator requires at least two ranges, but has %d", len(s.ranges))
 	}
 
-	series, outputSeries, err := mergeSeriesMetadata(ctx, s.ranges, matchers, s.MemoryConsumptionTracker)
+	series, outputSeries, err := mergeSeriesMetadataFromMultipleSources(ctx, s.ranges, matchers, s.MemoryConsumptionTracker)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/streamingpromql/optimize/plan/splitandcache/split_operator_test.go
+++ b/pkg/streamingpromql/optimize/plan/splitandcache/split_operator_test.go
@@ -620,7 +620,7 @@ func TestSplitOperator(t *testing.T) {
 
 			ranges := make([]*splitRange, len(testCase.ranges))
 			for i, o := range innerOperators {
-				ranges[i] = newSplitRange(o)
+				ranges[i] = newSplitRange(o, memoryConsumptionTracker)
 			}
 
 			o := newTimeRangeSplitOperator(ranges, memoryConsumptionTracker, testCase.expectedStats.TimeRange.Decode())
@@ -685,7 +685,14 @@ func TestSplitOperator_ConflictingDropNameValuesForSameSeries(t *testing.T) {
 		MemoryConsumptionTracker: memoryConsumptionTracker,
 	}
 
-	o := newTimeRangeSplitOperator([]*splitRange{newSplitRange(range1), newSplitRange(range2)}, memoryConsumptionTracker, types.NewInstantQueryTimeRange(time.Now()))
+	o := newTimeRangeSplitOperator(
+		[]*splitRange{
+			newSplitRange(range1, memoryConsumptionTracker),
+			newSplitRange(range2, memoryConsumptionTracker),
+		},
+		memoryConsumptionTracker,
+		types.NewInstantQueryTimeRange(time.Now()),
+	)
 
 	require.NoError(t, o.Prepare(ctx, &types.PrepareParams{}))
 	require.NoError(t, o.AfterPrepare(ctx))

--- a/pkg/streamingpromql/optimize/plan/splitandcache/split_operator_test.go
+++ b/pkg/streamingpromql/optimize/plan/splitandcache/split_operator_test.go
@@ -698,7 +698,7 @@ func TestSplitOperator_ConflictingDropNameValuesForSameSeries(t *testing.T) {
 	require.NoError(t, o.AfterPrepare(ctx))
 
 	_, err := o.SeriesMetadata(ctx, nil)
-	require.EqualError(t, err, `series with labels {idx="0"} has conflicting drop name values in different ranges`)
+	require.EqualError(t, err, `series with labels {idx="0"} has conflicting drop name values in different ranges / extents`)
 }
 
 type testRange struct {


### PR DESCRIPTION
#### What this PR does

This PR stacks upon #15720. It refactors `SplitOperator` and `CacheOperator` to share the same method for merging `SeriesMetadata`.

They previously used very similar implementations.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes query-plan operator behavior for multi-range splits and multi-extent cache reads (series ordering and index mapping must stay correct); behavior is intended to be equivalent but is central to streaming PromQL evaluation.
> 
> **Overview**
> **TimeRangeSplitOperator** and **CacheOperator** no longer each carry their own label-dedup and `splitOrCacheOutputSeries` mapping logic; both call a new generic **`mergeSeriesMetadata`** helper that merges metadata from multiple sources, forwards **matchers** to each source, and returns the per-source index map.
> 
> **CacheOperator** drops `computeMergedSeriesMetadata` / `addNewOutputSeries` and always passes **nil matchers** so the full series set is kept for cache writes. The **`extent`** interface’s **`SeriesMetadata`** now takes matchers (cached extents ignore them; evaluated extents pass them to the inner operator).
> 
> **TimeRangeSplitOperator** delegates merging to the helper and gains a guard requiring **at least two ranges** (single-range cases stay unwrapped in **`MaterializeSplit`**). **`splitRange`** implements **`seriesMetadataSource`**: it fetches metadata with matchers and creates the **`InstantVectorOperatorBuffer`** there instead of inside the split operator’s merge loop. **`newSplitRange`** now takes a memory tracker for that buffering.
> 
> New unit tests cover merge scenarios, the single-source fast path (nil output mapping), conflicting **`DropName`**, and matcher pass-through.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83c225a9c2d2eed2a3429a28746c6f4573bd87d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->