### PR TITLE
costattribution: avoid per-timeseries string allocation in IncrementReceivedSamples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * [ENHANCEMENT] MQE: Improve experimental support for reporting the number of samples read per query. #14838 #15179 #15191 #15220 #15223 #15232 #15237 #15255 #15276 #15282 #15285
 * [ENHANCEMENT] Distributor: Relabel middleware returns early if neither label dropping nor relabeling is configured. #15246
 * [ENHANCEMENT] Distributor: Improve distributor push middleware cleanup handling. #15245
+* [ENHANCEMENT] Distributor: Avoid allocating a string per received timeseries when aggregating cost attribution samples per attribution group in the write path. #15751
 * [ENHANCEMENT] Ingest storage: Reject the whole batch of records of a Kafka write call when the configured `-ingest-storage.kafka.producer-max-buffered-bytes` limit is reached, instead of rejecting individual records. #15227
 * [ENHANCEMENT] MQE: Simplify `unless` and `or` operations where one side can be proven to be empty by inspecting the expression. #15198
 * [ENHANCEMENT] Store-gateway: Remove outdated limit on caching LabelValues responses that contain more than 655360 values. The gob library panic which required workaround was fixed. #5021 #15271

--- a/pkg/costattribution/sample_tracker.go
+++ b/pkg/costattribution/sample_tracker.go
@@ -164,19 +164,29 @@ func (st *sampleTracker) IncrementReceivedSamples(req *mimirpb.WriteRequest, now
 
 	// We precompute the cost attribution per request before update Observations and State to avoid frequently update the atomic counters.
 	// This is based on the assumption that usually a single WriteRequest will have samples that belong to the same or few cost attribution groups.
-	dict := make(map[string]int)
+	// The map value is a pointer so that the hot path can look the key up without
+	// allocating a string for it (the `m[string(buf.Bytes())]` lookup is special-cased
+	// by the compiler to not allocate) and accumulate through the pointer. A string is
+	// only allocated when a new group is inserted, i.e. once per distinct group.
+	dict := make(map[string]*int)
 	buf := bufferPool.Get().(*bytes.Buffer)
 	buf.Reset()
 	defer bufferPool.Put(buf)
 	for _, ts := range req.Timeseries {
 		st.fillKeyFromLabelAdapters(ts.Labels, buf)
-		dict[string(buf.Bytes())] += len(ts.Samples) + len(ts.Histograms)
+		count := len(ts.Samples) + len(ts.Histograms)
+		if c := dict[string(buf.Bytes())]; c != nil {
+			*c += count
+		} else {
+			newCount := count
+			dict[string(buf.Bytes())] = &newCount
+		}
 	}
 
 	// Update the observations for each label set and update the state per request,
 	// this would be less precised than per sample but it's more efficient
 	for k, v := range dict {
-		count := float64(v)
+		count := float64(*v)
 		st.updateObservations(k, now, count, 0, nil)
 	}
 }

--- a/pkg/costattribution/sample_tracker_test.go
+++ b/pkg/costattribution/sample_tracker_test.go
@@ -237,3 +237,35 @@ func TestSampleTracker_Concurrency(t *testing.T) {
 `
 	assert.NoError(t, testutil.GatherAndCompare(costAttributionReg, strings.NewReader(expectedMetrics), "cortex_distributor_received_attributed_samples_total", "cortex_discarded_attributed_samples_total"))
 }
+
+func BenchmarkSampleTracker_IncrementReceivedSamples(b *testing.B) {
+	const seriesPerRequest = 1000
+
+	// groups controls how many distinct cost-attribution keys the request maps to.
+	// In production a single WriteRequest usually maps to one or few groups, but we
+	// also measure the worst case where every series is its own group.
+	for _, groups := range []int{1, 10, 100, 1000} {
+		b.Run(fmt.Sprintf("groups=%d", groups), func(b *testing.B) {
+			st, err := newSampleTracker("tenant-1", costattributionmodel.DefaultTrackerName,
+				costattributionmodel.Labels{{Input: "platform", Output: "platform"}},
+				false, seriesPerRequest, time.Minute, log.NewNopLogger())
+			require.NoError(b, err)
+
+			data := make([]series, seriesPerRequest)
+			for i := range data {
+				data[i] = series{
+					LabelValues:  []string{"platform", fmt.Sprintf("platform-%d", i%groups), "pod", fmt.Sprintf("pod-%d", i)},
+					SamplesCount: 1,
+				}
+			}
+			req := createRequest(data)
+			now := time.Unix(0, 0)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				st.IncrementReceivedSamples(req, now)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does

`sampleTracker.IncrementReceivedSamples` runs once per timeseries in the distributor write path. It aggregates per-group sample counts in a map keyed by the cost-attribution label values. The previous code did `dict[string(buf.Bytes())] += n`, which is a map assign: the Go runtime cannot use the no-alloc `[]byte`-key lookup optimization on the assign path, so it allocated a fresh key string for **every** timeseries, even when the key already existed.

Switching the map to `map[string]*int` lets the lookup `dict[string(buf.Bytes())]` take the compiler's no-alloc path and accumulate through the pointer. A key string is allocated only when a new group is first seen, i.e. once per distinct attribution group instead of once per timeseries.

This trades the common case (few groups per request, the documented assumption) for the pathological all-distinct case, which regresses; in practice distinct groups per request are bounded by the cost-attribution label cardinality.

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/mimir/pkg/costattribution
cpu: Apple M3 Pro
                                                      │   main.txt   │         counter_pointer.txt         │
                                                      │    sec/op    │    sec/op     vs base               │
SampleTracker_IncrementReceivedSamples/groups=1-12      23.37µ ±  3%    12.14µ ± 4%  -48.08% (p=0.002 n=6)
SampleTracker_IncrementReceivedSamples/groups=10-12     25.08µ ±  7%    16.44µ ± 1%  -34.44% (p=0.002 n=6)
SampleTracker_IncrementReceivedSamples/groups=100-12    32.92µ ±  5%    24.20µ ± 5%  -26.49% (p=0.002 n=6)
SampleTracker_IncrementReceivedSamples/groups=1000-12   87.68µ ± 17%   105.08µ ± 4%  +19.85% (p=0.004 n=6)
geomean                                                 36.06µ          26.69µ       -26.00%

                                                      │   main.txt    │         counter_pointer.txt         │
                                                      │     B/op      │     B/op      vs base               │
SampleTracker_IncrementReceivedSamples/groups=1-12      16008.00 ± 0%     24.00 ± 0%  -99.85% (p=0.002 n=6)
SampleTracker_IncrementReceivedSamples/groups=10-12      16464.0 ± 0%     696.0 ± 0%  -95.77% (p=0.002 n=6)
SampleTracker_IncrementReceivedSamples/groups=100-12    22.176Ki ± 0%   8.888Ki ± 0%  -59.92% (p=0.002 n=6)
SampleTracker_IncrementReceivedSamples/groups=1000-12    121.9Ki ± 0%   129.7Ki ± 0%   +6.42% (p=0.002 n=6)
geomean                                                  28.71Ki        2.070Ki       -92.79%

                                                      │   main.txt    │        counter_pointer.txt         │
                                                      │   allocs/op   │  allocs/op   vs base               │
SampleTracker_IncrementReceivedSamples/groups=1-12      1000.000 ± 0%    2.000 ± 0%  -99.80% (p=0.002 n=6)
SampleTracker_IncrementReceivedSamples/groups=10-12      1003.00 ± 0%    23.00 ± 0%  -97.71% (p=0.002 n=6)
SampleTracker_IncrementReceivedSamples/groups=100-12      1009.0 ± 0%    209.0 ± 0%  -79.29% (p=0.002 n=6)
SampleTracker_IncrementReceivedSamples/groups=1000-12     1.020k ± 0%   2.020k ± 0%  +98.04% (p=0.002 n=6)
geomean                                                   1.008k         66.38       -93.41%
```

#### Which issue(s) this PR fixes or relates to

n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure performance refactor on aggregation internals with existing tests unchanged; worst case (every series a distinct group) may allocate slightly more but attribution cardinality is bounded in practice.
> 
> **Overview**
> **Optimizes cost-attribution sample counting on the distributor write path** by changing how per-request group totals are accumulated in `IncrementReceivedSamples`.
> 
> Previously each timeseries did `dict[string(buf.Bytes())] += count`, which forces a new map key string on every assign even when the attribution group already existed. The map is now `map[string]*int`: lookups use the compiler’s no-alloc `string([]byte)` path, counts are updated through pointers, and a key string is stored only when a **new** attribution group appears (typically one or few per `WriteRequest`).
> 
> Behavior and exported metrics are unchanged; this is allocation and CPU on a hot path. A new benchmark sweeps distinct group counts (1–1000 series per request) to capture the common case vs all-distinct keys. **CHANGELOG** records the distributor enhancement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcf104be888667edf0a0987ffc27a3151d8f5cfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->