### PR TITLE
Add jsonnet support for the experimental compartments architecture

### DIFF
--- a/operations/mimir-tests/test-compartments-generated.yaml
+++ b/operations/mimir-tests/test-compartments-generated.yaml
@@ -1,0 +1,4367 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: alertmanager
+  name: alertmanager
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: alertmanager
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: compactor
+  name: compactor
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: compactor
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: distributor-zone-a-wc-0
+  name: distributor-zone-a-wc-0
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: distributor-zone-a-wc-0
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: distributor-zone-a-wc-1
+  name: distributor-zone-a-wc-1
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: distributor-zone-a-wc-1
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: distributor-zone-b-wc-0
+  name: distributor-zone-b-wc-0
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: distributor-zone-b-wc-0
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: distributor-zone-b-wc-1
+  name: distributor-zone-b-wc-1
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: distributor-zone-b-wc-1
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: memcached
+  name: memcached
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: memcached
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: memcached-frontend
+  name: memcached-frontend
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: memcached-frontend
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: memcached-index-queries
+  name: memcached-index-queries
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: memcached-index-queries
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: memcached-metadata
+  name: memcached-metadata
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: memcached-metadata
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: querier
+  name: querier
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: querier
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: query-frontend
+  name: query-frontend
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: query-frontend
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: query-scheduler
+  name: query-scheduler
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: query-scheduler
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: rollout-operator
+  name: rollout-operator
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: rollout-operator
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: ruler
+  name: ruler
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: ruler
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: ruler-querier
+  name: ruler-querier
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: ruler-querier
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: ruler-query-frontend
+  name: ruler-query-frontend
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: ruler-query-frontend
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: ruler-query-scheduler
+  name: ruler-query-scheduler
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: ruler-query-scheduler
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rollout-operator
+  namespace: default
+---
+apiVersion: v1
+data:
+  overrides.yaml: |
+    overrides: {}
+kind: ConfigMap
+metadata:
+  name: overrides
+  namespace: default
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: replicatemplates.rollout-operator.grafana.com
+spec:
+  group: rollout-operator.grafana.com
+  names:
+    categories:
+    - all
+    kind: ReplicaTemplate
+    plural: replicatemplates
+    singular: replicatemplate
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Status replicas
+      jsonPath: .status.replicas
+      name: StatusReplicas
+      type: string
+    - description: Spec replicas
+      jsonPath: .spec.replicas
+      name: SpecReplicas
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              labelSelector:
+                type: string
+              replicas:
+                default: 1
+                minimum: 0
+                type: integer
+            type: object
+          status:
+            properties:
+              replicas:
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .spec.labelSelector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rollout-operator-default-webhook-cert-update-role
+rules:
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  - mutatingwebhookconfigurations
+  verbs:
+  - list
+  - patch
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rollout-operator-default-webhook-cert-secret-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rollout-operator-default-webhook-cert-update-role
+subjects:
+- kind: ServiceAccount
+  name: rollout-operator
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: rollout-operator-role
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - get
+  - watch
+  - delete
+  - patch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - list
+  - get
+  - watch
+  - patch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - update
+  - create
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - replicatemplates/scale
+  - replicatemplates/status
+  verbs:
+  - get
+  - patch
+- apiGroups:
+  - rollout-operator.grafana.com
+  resources:
+  - zoneawarepoddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: rollout-operator-webhook-cert-secret-role
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resourceNames:
+  - rollout-operator-self-signed-certificate
+  resources:
+  - secrets
+  verbs:
+  - update
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rollout-operator-rolebinding
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rollout-operator-role
+subjects:
+- kind: ServiceAccount
+  name: rollout-operator
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rollout-operator-webhook-cert-secret-rolebinding
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rollout-operator-webhook-cert-secret-role
+subjects:
+- kind: ServiceAccount
+  name: rollout-operator
+  namespace: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: alertmanager
+  name: alertmanager
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: alertmanager-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: alertmanager-grpc
+    port: 9095
+    targetPort: 9095
+  - name: alertmanager-gossip-ring
+    port: 7946
+    targetPort: 7946
+  selector:
+    name: alertmanager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: compactor
+  name: compactor
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: compactor-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: compactor-grpc
+    port: 9095
+    targetPort: 9095
+  - name: compactor-gossip-ring
+    port: 7946
+    targetPort: 7946
+  selector:
+    name: compactor
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: distributor-zone-a
+  name: distributor-zone-a
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: distributor-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: distributor-grpc
+    port: 9095
+    targetPort: 9095
+  - name: distributor-gossip-ring
+    port: 7946
+    targetPort: 7946
+  selector:
+    mimir-service: distributor-zone-a
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: distributor-zone-b
+  name: distributor-zone-b
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: distributor-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: distributor-grpc
+    port: 9095
+    targetPort: 9095
+  - name: distributor-gossip-ring
+    port: 7946
+    targetPort: 7946
+  selector:
+    mimir-service: distributor-zone-b
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gossip-ring
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - appProtocol: tcp
+    name: gossip-ring
+    port: 7946
+    protocol: TCP
+    targetPort: 7946
+  selector:
+    gossip_ring_member: "true"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: ingester-zone-a-rc-0
+  name: ingester-zone-a-rc-0
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: ingester-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: ingester-grpc
+    port: 9095
+    targetPort: 9095
+  - name: ingester-gossip-ring
+    port: 7946
+    targetPort: 7946
+  selector:
+    mimir-rc: "0"
+    name: ingester-zone-a-rc-0
+    rollout-group: ingester-rc-0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: ingester-zone-a-rc-1
+  name: ingester-zone-a-rc-1
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: ingester-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: ingester-grpc
+    port: 9095
+    targetPort: 9095
+  - name: ingester-gossip-ring
+    port: 7946
+    targetPort: 7946
+  selector:
+    mimir-rc: "1"
+    name: ingester-zone-a-rc-1
+    rollout-group: ingester-rc-1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: ingester-zone-b-rc-0
+  name: ingester-zone-b-rc-0
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: ingester-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: ingester-grpc
+    port: 9095
+    targetPort: 9095
+  - name: ingester-gossip-ring
+    port: 7946
+    targetPort: 7946
+  selector:
+    mimir-rc: "0"
+    name: ingester-zone-b-rc-0
+    rollout-group: ingester-rc-0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: ingester-zone-b-rc-1
+  name: ingester-zone-b-rc-1
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: ingester-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: ingester-grpc
+    port: 9095
+    targetPort: 9095
+  - name: ingester-gossip-ring
+    port: 7946
+    targetPort: 7946
+  selector:
+    mimir-rc: "1"
+    name: ingester-zone-b-rc-1
+    rollout-group: ingester-rc-1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: memcached
+  name: memcached
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: memcached-client
+    port: 11211
+    targetPort: 11211
+  - name: exporter-http-metrics
+    port: 9150
+    targetPort: 9150
+  selector:
+    name: memcached
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: memcached-frontend
+  name: memcached-frontend
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: memcached-client
+    port: 11211
+    targetPort: 11211
+  - name: exporter-http-metrics
+    port: 9150
+    targetPort: 9150
+  selector:
+    name: memcached-frontend
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: memcached-index-queries
+  name: memcached-index-queries
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: memcached-client
+    port: 11211
+    targetPort: 11211
+  - name: exporter-http-metrics
+    port: 9150
+    targetPort: 9150
+  selector:
+    name: memcached-index-queries
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: memcached-metadata
+  name: memcached-metadata
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: memcached-client
+    port: 11211
+    targetPort: 11211
+  - name: exporter-http-metrics
+    port: 9150
+    targetPort: 9150
+  selector:
+    name: memcached-metadata
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: querier
+  name: querier
+  namespace: default
+spec:
+  ports:
+  - name: querier-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: querier-grpc
+    port: 9095
+    targetPort: 9095
+  - name: querier-gossip-ring
+    port: 7946
+    targetPort: 7946
+  selector:
+    name: querier
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: query-frontend
+  name: query-frontend
+  namespace: default
+spec:
+  ports:
+  - name: query-frontend-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: query-frontend-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: query-frontend
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: query-scheduler
+  name: query-scheduler
+  namespace: default
+spec:
+  ports:
+  - name: query-scheduler-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: query-scheduler-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: query-scheduler
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: query-scheduler
+  name: query-scheduler-discovery
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: query-scheduler-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: query-scheduler-grpc
+    port: 9095
+    targetPort: 9095
+  publishNotReadyAddresses: true
+  selector:
+    name: query-scheduler
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rollout-operator
+  namespace: default
+spec:
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    name: rollout-operator
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: ruler
+  name: ruler
+  namespace: default
+spec:
+  ports:
+  - name: ruler-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: ruler-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: ruler
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: ruler-querier
+  name: ruler-querier
+  namespace: default
+spec:
+  ports:
+  - name: ruler-querier-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: ruler-querier-grpc
+    port: 9095
+    targetPort: 9095
+  - name: ruler-querier-gossip-ring
+    port: 7946
+    targetPort: 7946
+  selector:
+    name: ruler-querier
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: ruler-query-frontend
+  name: ruler-query-frontend
+  namespace: default
+spec:
+  ports:
+  - name: ruler-query-frontend-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: ruler-query-frontend-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: ruler-query-frontend
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: ruler-query-frontend
+  name: ruler-query-frontend-headless
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: ruler-query-frontend-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: ruler-query-frontend-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: ruler-query-frontend
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: ruler-query-scheduler
+  name: ruler-query-scheduler
+  namespace: default
+spec:
+  ports:
+  - name: ruler-query-scheduler-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: ruler-query-scheduler-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: ruler-query-scheduler
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: ruler-query-scheduler
+  name: ruler-query-scheduler-discovery
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: ruler-query-scheduler-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: ruler-query-scheduler-grpc
+    port: 9095
+    targetPort: 9095
+  publishNotReadyAddresses: true
+  selector:
+    name: ruler-query-scheduler
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: store-gateway-multi-zone
+  name: store-gateway-multi-zone
+  namespace: default
+spec:
+  ports:
+  - name: store-gateway-http-metrics
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    rollout-group: store-gateway
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: store-gateway-zone-a
+  name: store-gateway-zone-a
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: store-gateway-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: store-gateway-grpc
+    port: 9095
+    targetPort: 9095
+  - name: store-gateway-gossip-ring
+    port: 7946
+    targetPort: 7946
+  selector:
+    name: store-gateway-zone-a
+    rollout-group: store-gateway
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: store-gateway-zone-b
+  name: store-gateway-zone-b
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: store-gateway-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: store-gateway-grpc
+    port: 9095
+    targetPort: 9095
+  - name: store-gateway-gossip-ring
+    port: 7946
+    targetPort: 7946
+  selector:
+    name: store-gateway-zone-b
+    rollout-group: store-gateway
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: store-gateway-zone-c
+  name: store-gateway-zone-c
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: store-gateway-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: store-gateway-grpc
+    port: 9095
+    targetPort: 9095
+  - name: store-gateway-gossip-ring
+    port: 7946
+    targetPort: 7946
+  selector:
+    name: store-gateway-zone-c
+    rollout-group: store-gateway
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    mimir-service: distributor-zone-a
+  name: distributor-zone-a-wc-0
+  namespace: default
+spec:
+  minReadySeconds: 10
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: distributor-zone-a-wc-0
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        mimir-service: distributor-zone-a
+        mimir-wc: "0"
+        name: distributor-zone-a-wc-0
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2a
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: mimir-wc
+                operator: Exists
+              - key: mimir-wc
+                operator: NotIn
+                values:
+                - "0"
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -compartments.enabled=true
+        - -compartments.read.num-compartments=2
+        - -compartments.write.num-compartments=2
+        - -distributor.ha-tracker.enable=true
+        - -distributor.ha-tracker.enable-for-all-users=true
+        - -distributor.ha-tracker.prefix=prom_ha/
+        - -distributor.ha-tracker.store=memberlist
+        - -distributor.health-check-ingesters=true
+        - -distributor.ingestion-burst-size=200000
+        - -distributor.ingestion-rate-limit=10000
+        - -distributor.ingestion-tenant-shard-size=3
+        - -distributor.remote-timeout=5s
+        - -distributor.ring.heartbeat-period=1m
+        - -distributor.ring.heartbeat-timeout=4m
+        - -distributor.ring.prefix=
+        - -distributor.ring.store=memberlist
+        - -distributor.write-compartment-id=0
+        - -ingest-storage.enabled=true
+        - -ingest-storage.ingestion-partition-tenant-shard-size=1
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.producer-record-version=2
+        - -ingest-storage.kafka.topic=ingest-rc-<read-compartment-id>
+        - -ingester.partition-ring.prefix=
+        - -ingester.ring.heartbeat-timeout=10m
+        - -ingester.ring.prefix=partition-ingesters/
+        - -ingester.ring.replication-factor=3
+        - -ingester.ring.store=memberlist
+        - -ingester.ring.zone-awareness-enabled=true
+        - -mem-ballast-size-bytes=1073741824
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc-max-concurrent-streams=1000
+        - -server.grpc.keepalive.max-connection-age=60s
+        - -server.grpc.keepalive.max-connection-age-grace=5m
+        - -server.grpc.keepalive.max-connection-idle=1m
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -shutdown-delay=90s
+        - -target=distributor
+        - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOMAXPROCS
+          value: "8"
+        image: grafana/mimir:3.1.1
+        imagePullPolicy: IfNotPresent
+        name: distributor
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 4Gi
+          requests:
+            cpu: "2"
+            memory: 2Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      terminationGracePeriodSeconds: 100
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: distributor-zone-a-wc-0
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    mimir-service: distributor-zone-a
+  name: distributor-zone-a-wc-1
+  namespace: default
+spec:
+  minReadySeconds: 10
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: distributor-zone-a-wc-1
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        mimir-service: distributor-zone-a
+        mimir-wc: "1"
+        name: distributor-zone-a-wc-1
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2a
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: mimir-wc
+                operator: Exists
+              - key: mimir-wc
+                operator: NotIn
+                values:
+                - "1"
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -compartments.enabled=true
+        - -compartments.read.num-compartments=2
+        - -compartments.write.num-compartments=2
+        - -distributor.ha-tracker.enable=true
+        - -distributor.ha-tracker.enable-for-all-users=true
+        - -distributor.ha-tracker.prefix=prom_ha/
+        - -distributor.ha-tracker.store=memberlist
+        - -distributor.health-check-ingesters=true
+        - -distributor.ingestion-burst-size=200000
+        - -distributor.ingestion-rate-limit=10000
+        - -distributor.ingestion-tenant-shard-size=3
+        - -distributor.remote-timeout=5s
+        - -distributor.ring.heartbeat-period=1m
+        - -distributor.ring.heartbeat-timeout=4m
+        - -distributor.ring.prefix=
+        - -distributor.ring.store=memberlist
+        - -distributor.write-compartment-id=1
+        - -ingest-storage.enabled=true
+        - -ingest-storage.ingestion-partition-tenant-shard-size=1
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.producer-record-version=2
+        - -ingest-storage.kafka.topic=ingest-rc-<read-compartment-id>
+        - -ingester.partition-ring.prefix=
+        - -ingester.ring.heartbeat-timeout=10m
+        - -ingester.ring.prefix=partition-ingesters/
+        - -ingester.ring.replication-factor=3
+        - -ingester.ring.store=memberlist
+        - -ingester.ring.zone-awareness-enabled=true
+        - -mem-ballast-size-bytes=1073741824
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc-max-concurrent-streams=1000
+        - -server.grpc.keepalive.max-connection-age=60s
+        - -server.grpc.keepalive.max-connection-age-grace=5m
+        - -server.grpc.keepalive.max-connection-idle=1m
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -shutdown-delay=90s
+        - -target=distributor
+        - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOMAXPROCS
+          value: "8"
+        image: grafana/mimir:3.1.1
+        imagePullPolicy: IfNotPresent
+        name: distributor
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 4Gi
+          requests:
+            cpu: "2"
+            memory: 2Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      terminationGracePeriodSeconds: 100
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: distributor-zone-a-wc-1
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    mimir-service: distributor-zone-b
+  name: distributor-zone-b-wc-0
+  namespace: default
+spec:
+  minReadySeconds: 10
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: distributor-zone-b-wc-0
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        mimir-service: distributor-zone-b
+        mimir-wc: "0"
+        name: distributor-zone-b-wc-0
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2b
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: mimir-wc
+                operator: Exists
+              - key: mimir-wc
+                operator: NotIn
+                values:
+                - "0"
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -compartments.enabled=true
+        - -compartments.read.num-compartments=2
+        - -compartments.write.num-compartments=2
+        - -distributor.ha-tracker.enable=true
+        - -distributor.ha-tracker.enable-for-all-users=true
+        - -distributor.ha-tracker.prefix=prom_ha/
+        - -distributor.ha-tracker.store=memberlist
+        - -distributor.health-check-ingesters=true
+        - -distributor.ingestion-burst-size=200000
+        - -distributor.ingestion-rate-limit=10000
+        - -distributor.ingestion-tenant-shard-size=3
+        - -distributor.remote-timeout=5s
+        - -distributor.ring.heartbeat-period=1m
+        - -distributor.ring.heartbeat-timeout=4m
+        - -distributor.ring.prefix=
+        - -distributor.ring.store=memberlist
+        - -distributor.write-compartment-id=0
+        - -ingest-storage.enabled=true
+        - -ingest-storage.ingestion-partition-tenant-shard-size=1
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.producer-record-version=2
+        - -ingest-storage.kafka.topic=ingest-rc-<read-compartment-id>
+        - -ingester.partition-ring.prefix=
+        - -ingester.ring.heartbeat-timeout=10m
+        - -ingester.ring.prefix=partition-ingesters/
+        - -ingester.ring.replication-factor=3
+        - -ingester.ring.store=memberlist
+        - -ingester.ring.zone-awareness-enabled=true
+        - -mem-ballast-size-bytes=1073741824
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc-max-concurrent-streams=1000
+        - -server.grpc.keepalive.max-connection-age=60s
+        - -server.grpc.keepalive.max-connection-age-grace=5m
+        - -server.grpc.keepalive.max-connection-idle=1m
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -shutdown-delay=90s
+        - -target=distributor
+        - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOMAXPROCS
+          value: "8"
+        image: grafana/mimir:3.1.1
+        imagePullPolicy: IfNotPresent
+        name: distributor
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 4Gi
+          requests:
+            cpu: "2"
+            memory: 2Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      terminationGracePeriodSeconds: 100
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: distributor-zone-b-wc-0
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    mimir-service: distributor-zone-b
+  name: distributor-zone-b-wc-1
+  namespace: default
+spec:
+  minReadySeconds: 10
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: distributor-zone-b-wc-1
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        mimir-service: distributor-zone-b
+        mimir-wc: "1"
+        name: distributor-zone-b-wc-1
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2b
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: mimir-wc
+                operator: Exists
+              - key: mimir-wc
+                operator: NotIn
+                values:
+                - "1"
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -compartments.enabled=true
+        - -compartments.read.num-compartments=2
+        - -compartments.write.num-compartments=2
+        - -distributor.ha-tracker.enable=true
+        - -distributor.ha-tracker.enable-for-all-users=true
+        - -distributor.ha-tracker.prefix=prom_ha/
+        - -distributor.ha-tracker.store=memberlist
+        - -distributor.health-check-ingesters=true
+        - -distributor.ingestion-burst-size=200000
+        - -distributor.ingestion-rate-limit=10000
+        - -distributor.ingestion-tenant-shard-size=3
+        - -distributor.remote-timeout=5s
+        - -distributor.ring.heartbeat-period=1m
+        - -distributor.ring.heartbeat-timeout=4m
+        - -distributor.ring.prefix=
+        - -distributor.ring.store=memberlist
+        - -distributor.write-compartment-id=1
+        - -ingest-storage.enabled=true
+        - -ingest-storage.ingestion-partition-tenant-shard-size=1
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.producer-record-version=2
+        - -ingest-storage.kafka.topic=ingest-rc-<read-compartment-id>
+        - -ingester.partition-ring.prefix=
+        - -ingester.ring.heartbeat-timeout=10m
+        - -ingester.ring.prefix=partition-ingesters/
+        - -ingester.ring.replication-factor=3
+        - -ingester.ring.store=memberlist
+        - -ingester.ring.zone-awareness-enabled=true
+        - -mem-ballast-size-bytes=1073741824
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc-max-concurrent-streams=1000
+        - -server.grpc.keepalive.max-connection-age=60s
+        - -server.grpc.keepalive.max-connection-age-grace=5m
+        - -server.grpc.keepalive.max-connection-idle=1m
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -shutdown-delay=90s
+        - -target=distributor
+        - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOMAXPROCS
+          value: "8"
+        image: grafana/mimir:3.1.1
+        imagePullPolicy: IfNotPresent
+        name: distributor
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 4Gi
+          requests:
+            cpu: "2"
+            memory: 2Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      terminationGracePeriodSeconds: 100
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: distributor-zone-b-wc-1
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: querier
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 6
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: querier
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: querier
+    spec:
+      containers:
+      - args:
+        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
+        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
+        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
+        - -blocks-storage.bucket-store.sync-interval=15m
+        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -common.storage.backend=gcs
+        - -compartments.enabled=true
+        - -compartments.read.num-compartments=2
+        - -compartments.write.num-compartments=2
+        - -distributor.health-check-ingesters=true
+        - -distributor.ingestion-tenant-shard-size=3
+        - -ingest-storage.enabled=true
+        - -ingest-storage.ingestion-partition-tenant-shard-size=1
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.topic=ingest-rc-<read-compartment-id>
+        - -ingester.partition-ring.prefix=
+        - -ingester.ring.heartbeat-timeout=10m
+        - -ingester.ring.prefix=partition-ingesters/
+        - -ingester.ring.replication-factor=3
+        - -ingester.ring.store=memberlist
+        - -ingester.ring.zone-awareness-enabled=true
+        - -mem-ballast-size-bytes=268435456
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -querier.frontend-client.grpc-max-send-msg-size=104857600
+        - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
+        - -querier.scheduler-address=query-scheduler-discovery.default.svc.cluster.local.:9095
+        - -querier.store-gateway-client.grpc-max-recv-msg-size=209715200
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -store-gateway.sharding-ring.heartbeat-timeout=10m
+        - -store-gateway.sharding-ring.prefix=multi-zone/
+        - -store-gateway.sharding-ring.replication-factor=3
+        - -store-gateway.sharding-ring.store=memberlist
+        - -store-gateway.sharding-ring.zone-awareness-enabled=true
+        - -store-gateway.tenant-shard-size=3
+        - -target=querier
+        - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOMAXPROCS
+          value: "5"
+        image: grafana/mimir:3.1.1
+        imagePullPolicy: IfNotPresent
+        name: querier
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "1"
+            memory: 12Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      terminationGracePeriodSeconds: 180
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: querier
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: query-frontend
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: query-frontend
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        name: query-frontend
+    spec:
+      containers:
+      - args:
+        - -ingest-storage.enabled=true
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
+        - -ingest-storage.kafka.topic=ingest
+        - -ingester.partition-ring.prefix=
+        - -query-frontend.cache-results=true
+        - -query-frontend.max-cache-freshness=10m
+        - -query-frontend.max-queriers-per-tenant=10
+        - -query-frontend.max-total-query-length=12000h
+        - -query-frontend.query-sharding-target-series-per-shard=2500
+        - -query-frontend.results-cache.backend=memcached
+        - -query-frontend.results-cache.memcached.addresses=dnssrvnoa+memcached-frontend.default.svc.cluster.local.:11211
+        - -query-frontend.results-cache.memcached.max-item-size=26214400
+        - -query-frontend.results-cache.memcached.timeout=500ms
+        - -query-frontend.scheduler-address=query-scheduler-discovery.default.svc.cluster.local.:9095
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.max-connection-age=30s
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -shutdown-delay=90s
+        - -target=query-frontend
+        - -usage-stats.installation-mode=jsonnet
+        image: grafana/mimir:3.1.1
+        imagePullPolicy: IfNotPresent
+        name: query-frontend
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 4Gi
+          requests:
+            cpu: "2"
+            memory: 2Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      terminationGracePeriodSeconds: 390
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: query-frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: query-scheduler
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: query-scheduler
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        name: query-scheduler
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: query-scheduler
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -ingest-storage.enabled=true
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.topic=ingest
+        - -query-frontend.max-queriers-per-tenant=10
+        - -query-scheduler.max-outstanding-requests-per-tenant=100
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -target=query-scheduler
+        - -usage-stats.installation-mode=jsonnet
+        image: grafana/mimir:3.1.1
+        imagePullPolicy: IfNotPresent
+        name: query-scheduler
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 2Gi
+          requests:
+            cpu: "2"
+            memory: 1Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      terminationGracePeriodSeconds: 180
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rollout-operator
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: rollout-operator
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        name: rollout-operator
+    spec:
+      containers:
+      - args:
+        - -kubernetes.namespace=default
+        - -server-tls.enabled=true
+        - -use-zone-tracker=true
+        - -zone-tracker.config-map-name=rollout-operator-zone-tracker
+        - -zpdb.pod-ready-annotation-patch-timeout=5s
+        image: grafana/rollout-operator:v0.38.0
+        imagePullPolicy: IfNotPresent
+        name: rollout-operator
+        ports:
+        - containerPort: 8001
+          name: http-metrics
+        - containerPort: 8443
+          name: https
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8001
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+      serviceAccountName: rollout-operator
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ruler
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: ruler
+  strategy:
+    rollingUpdate:
+      maxSurge: 50%
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: ruler
+    spec:
+      containers:
+      - args:
+        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
+        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
+        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
+        - -blocks-storage.bucket-store.sync-interval=15m
+        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -common.storage.backend=gcs
+        - -distributor.health-check-ingesters=true
+        - -distributor.ingestion-tenant-shard-size=3
+        - -distributor.remote-timeout=10s
+        - -ingest-storage.enabled=true
+        - -ingest-storage.ingestion-partition-tenant-shard-size=1
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.producer-max-buffered-bytes=1073741824
+        - -ingest-storage.kafka.producer-record-version=2
+        - -ingest-storage.kafka.topic=ingest
+        - -ingester.partition-ring.prefix=
+        - -ingester.ring.heartbeat-timeout=10m
+        - -ingester.ring.prefix=partition-ingesters/
+        - -ingester.ring.replication-factor=3
+        - -ingester.ring.store=memberlist
+        - -ingester.ring.zone-awareness-enabled=true
+        - -mem-ballast-size-bytes=1073741824
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -querier.max-partial-query-length=768h
+        - -ruler-storage.cache.backend=memcached
+        - -ruler-storage.cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
+        - -ruler-storage.cache.memcached.max-async-concurrency=50
+        - -ruler-storage.cache.memcached.max-item-size=1048576
+        - -ruler-storage.cache.memcached.timeout=500ms
+        - -ruler-storage.gcs.bucket-name=rules-bucket
+        - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local./alertmanager
+        - -ruler.max-rule-groups-per-tenant=85
+        - -ruler.max-rules-per-rule-group=20
+        - -ruler.query-frontend.address=dns:///ruler-query-frontend-headless.default.svc.cluster.local.:9095
+        - -ruler.query-frontend.grpc-client-config.grpc-max-recv-msg-size=104857600
+        - -ruler.ring.store=memberlist
+        - -ruler.rule-path=/rules
+        - -ruler.tenant-shard-size=2
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -store-gateway.sharding-ring.heartbeat-timeout=10m
+        - -store-gateway.sharding-ring.prefix=multi-zone/
+        - -store-gateway.sharding-ring.replication-factor=3
+        - -store-gateway.sharding-ring.store=memberlist
+        - -store-gateway.sharding-ring.zone-awareness-enabled=true
+        - -store-gateway.tenant-shard-size=3
+        - -target=ruler
+        - -usage-stats.installation-mode=jsonnet
+        image: grafana/mimir:3.1.1
+        imagePullPolicy: IfNotPresent
+        name: ruler
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: "16"
+            memory: 16Gi
+          requests:
+            cpu: "1"
+            memory: 6Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      terminationGracePeriodSeconds: 600
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ruler-querier
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 6
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: ruler-querier
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: ruler-querier
+    spec:
+      containers:
+      - args:
+        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
+        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
+        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
+        - -blocks-storage.bucket-store.sync-interval=15m
+        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -common.storage.backend=gcs
+        - -compartments.enabled=true
+        - -compartments.read.num-compartments=2
+        - -compartments.write.num-compartments=2
+        - -distributor.health-check-ingesters=true
+        - -distributor.ingestion-tenant-shard-size=3
+        - -ingest-storage.enabled=true
+        - -ingest-storage.ingestion-partition-tenant-shard-size=1
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.topic=ingest-rc-<read-compartment-id>
+        - -ingester.partition-ring.prefix=
+        - -ingester.ring.heartbeat-timeout=10m
+        - -ingester.ring.prefix=partition-ingesters/
+        - -ingester.ring.replication-factor=3
+        - -ingester.ring.store=memberlist
+        - -ingester.ring.zone-awareness-enabled=true
+        - -mem-ballast-size-bytes=268435456
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -querier.frontend-client.grpc-max-send-msg-size=104857600
+        - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
+        - -querier.ring.prefix=ruler-querier/
+        - -querier.scheduler-address=ruler-query-scheduler-discovery.default.svc.cluster.local.:9095
+        - -querier.store-gateway-client.grpc-max-recv-msg-size=209715200
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -store-gateway.sharding-ring.heartbeat-timeout=10m
+        - -store-gateway.sharding-ring.prefix=multi-zone/
+        - -store-gateway.sharding-ring.replication-factor=3
+        - -store-gateway.sharding-ring.store=memberlist
+        - -store-gateway.sharding-ring.zone-awareness-enabled=true
+        - -store-gateway.tenant-shard-size=3
+        - -target=querier
+        - -usage-stats.installation-mode=jsonnet
+        env: []
+        image: grafana/mimir:3.1.1
+        imagePullPolicy: IfNotPresent
+        name: ruler-querier
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "1"
+            memory: 12Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      terminationGracePeriodSeconds: 180
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler-querier
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ruler-query-frontend
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: ruler-query-frontend
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        name: ruler-query-frontend
+    spec:
+      containers:
+      - args:
+        - -ingest-storage.enabled=true
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
+        - -ingest-storage.kafka.topic=ingest
+        - -ingester.partition-ring.prefix=
+        - -querier.ring.prefix=ruler-querier/
+        - -query-frontend.cache-results=false
+        - -query-frontend.max-cache-freshness=10m
+        - -query-frontend.max-queriers-per-tenant=10
+        - -query-frontend.max-total-query-length=12000h
+        - -query-frontend.query-sharding-target-series-per-shard=2500
+        - -query-frontend.results-cache.backend=memcached
+        - -query-frontend.results-cache.memcached.addresses=dnssrvnoa+memcached-frontend.default.svc.cluster.local.:11211
+        - -query-frontend.results-cache.memcached.max-item-size=26214400
+        - -query-frontend.results-cache.memcached.timeout=500ms
+        - -query-frontend.scheduler-address=ruler-query-scheduler-discovery.default.svc.cluster.local.:9095
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc-max-concurrent-streams=300
+        - -server.grpc-max-recv-msg-size-bytes=104857600
+        - -server.grpc-max-send-msg-size-bytes=104857600
+        - -server.grpc.keepalive.max-connection-age=30s
+        - -server.grpc.keepalive.max-connection-age-grace=5m
+        - -server.grpc.keepalive.max-connection-idle=1m
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -shutdown-delay=90s
+        - -target=query-frontend
+        - -usage-stats.installation-mode=jsonnet
+        image: grafana/mimir:3.1.1
+        imagePullPolicy: IfNotPresent
+        name: ruler-query-frontend
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 4Gi
+          requests:
+            cpu: "2"
+            memory: 2Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      terminationGracePeriodSeconds: 390
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler-query-frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ruler-query-scheduler
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: ruler-query-scheduler
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        name: ruler-query-scheduler
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: ruler-query-scheduler
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -ingest-storage.enabled=true
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.topic=ingest
+        - -query-frontend.max-queriers-per-tenant=10
+        - -query-scheduler.max-outstanding-requests-per-tenant=100
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -target=query-scheduler
+        - -usage-stats.installation-mode=jsonnet
+        image: grafana/mimir:3.1.1
+        imagePullPolicy: IfNotPresent
+        name: ruler-query-scheduler
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 2Gi
+          requests:
+            cpu: "2"
+            memory: 1Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      terminationGracePeriodSeconds: 180
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    name: alertmanager
+  name: alertmanager
+  namespace: default
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      name: alertmanager
+  serviceName: alertmanager
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: alertmanager
+    spec:
+      containers:
+      - args:
+        - -alertmanager-storage.gcs.bucket-name=alerts-bucket
+        - -alertmanager.sharding-ring.replication-factor=3
+        - -alertmanager.sharding-ring.store=memberlist
+        - -alertmanager.storage.path=/data
+        - -alertmanager.web.external-url=http://test/alertmanager
+        - -common.storage.backend=gcs
+        - -ingest-storage.enabled=true
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.topic=ingest
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-idle-timeout=6m
+        - -server.http-listen-port=8080
+        - -target=alertmanager
+        - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: grafana/mimir:3.1.1
+        imagePullPolicy: IfNotPresent
+        name: alertmanager
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 15Gi
+          requests:
+            cpu: "2"
+            memory: 10Gi
+        volumeMounts:
+        - mountPath: /data
+          name: alertmanager-data
+        - mountPath: /etc/mimir
+          name: overrides
+      securityContext:
+        runAsUser: 0
+      terminationGracePeriodSeconds: 900
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: alertmanager-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 100Gi
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    name: compactor
+  name: compactor
+  namespace: default
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      name: compactor
+  serviceName: compactor
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: compactor
+    spec:
+      containers:
+      - args:
+        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -common.storage.backend=gcs
+        - -compactor.block-ranges=2h,12h,24h
+        - -compactor.blocks-retention-period=0
+        - -compactor.cleanup-interval=15m
+        - -compactor.compaction-concurrency=1
+        - -compactor.compaction-interval=30m
+        - -compactor.compactor-tenant-shard-size=1
+        - -compactor.data-dir=/data
+        - -compactor.deletion-delay=2h
+        - -compactor.first-level-compaction-wait-period=25m
+        - -compactor.max-closing-blocks-concurrency=2
+        - -compactor.max-opening-blocks-concurrency=4
+        - -compactor.ring.heartbeat-period=1m
+        - -compactor.ring.heartbeat-timeout=4m
+        - -compactor.ring.prefix=
+        - -compactor.ring.store=memberlist
+        - -compactor.ring.wait-stability-min-duration=1m
+        - -compactor.split-and-merge-shards=0
+        - -compactor.split-groups=1
+        - -compactor.symbols-flushers-concurrency=4
+        - -ingest-storage.enabled=true
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.topic=ingest
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -target=compactor
+        - -usage-stats.installation-mode=jsonnet
+        image: grafana/mimir:3.1.1
+        imagePullPolicy: IfNotPresent
+        name: compactor
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 6Gi
+          requests:
+            cpu: 1
+            memory: 6Gi
+        volumeMounts:
+        - mountPath: /data
+          name: compactor-data
+        - mountPath: /etc/mimir
+          name: overrides
+      securityContext:
+        runAsUser: 0
+      terminationGracePeriodSeconds: 900
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: compactor-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 250Gi
+      storageClassName: standard
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-delayed-downscale: 13h
+    grafana.com/rollout-mirror-replicas-from-resource-api-version: rollout-operator.grafana.com/v1
+    grafana.com/rollout-mirror-replicas-from-resource-kind: ReplicaTemplate
+    grafana.com/rollout-mirror-replicas-from-resource-name: ingester-zone-a-rc-0
+    grafana.com/rollout-prepare-delayed-downscale-url: http://pod/ingester/prepare-partition-downscale
+    rollout-max-unavailable: "50"
+  labels:
+    grafana.com/min-time-between-zones-downscale: "0"
+    grafana.com/prepare-downscale: "true"
+    mimir-rc: "0"
+    name: ingester-zone-a-rc-0
+    rollout-group: ingester-rc-0
+  name: ingester-zone-a-rc-0
+  namespace: default
+spec:
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      name: ingester-zone-a-rc-0
+      rollout-group: ingester-rc-0
+  serviceName: ingester-zone-a-rc-0
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        mimir-rc: "0"
+        name: ingester-zone-a-rc-0
+        rollout-group: ingester-rc-0
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2a
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: mimir-rc
+                operator: Exists
+              - key: mimir-rc
+                operator: NotIn
+                values:
+                - "0"
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-ranges-period=2h
+        - -blocks-storage.tsdb.dir=/data/tsdb
+        - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.wal-replay-concurrency=3
+        - -common.storage.backend=gcs
+        - -compartments.enabled=true
+        - -compartments.read.num-compartments=2
+        - -compartments.write.num-compartments=2
+        - -distributor.health-check-ingesters=true
+        - -distributor.ingestion-tenant-shard-size=3
+        - -ingest-storage.enabled=true
+        - -ingest-storage.ingestion-partition-tenant-shard-size=1
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.client-rack=zone-a
+        - -ingest-storage.kafka.consumer-group-offset-commit-interval=5s
+        - -ingest-storage.kafka.ingestion-concurrency-estimated-bytes-per-sample=200
+        - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
+        - -ingest-storage.kafka.topic=ingest-rc-<read-compartment-id>
+        - -ingester.max-global-metadata-per-metric=10
+        - -ingester.max-global-metadata-per-user=30000
+        - -ingester.max-global-series-per-user=150000
+        - -ingester.partition-ring.delete-inactive-partition-after=13h
+        - -ingester.partition-ring.prefix=
+        - -ingester.push-grpc-method-enabled=false
+        - -ingester.read-compartment-id=0
+        - -ingester.ring.heartbeat-period=2m
+        - -ingester.ring.heartbeat-timeout=10m
+        - -ingester.ring.instance-availability-zone=zone-a
+        - -ingester.ring.num-tokens=0
+        - -ingester.ring.prefix=partition-ingesters/
+        - -ingester.ring.replication-factor=3
+        - -ingester.ring.store=memberlist
+        - -ingester.ring.unregister-on-shutdown=true
+        - -ingester.ring.zone-awareness-enabled=true
+        - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc-max-concurrent-streams=500
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -target=ingester
+        - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: A
+          value: ingester-a-only
+        - name: GOGC
+          value: "off"
+        - name: GOMAXPROCS
+          value: "9"
+        - name: GOMEMLIMIT
+          value: 1Gi
+        - name: Z
+          value: "123"
+        image: grafana/mimir:3.1.1
+        imagePullPolicy: IfNotPresent
+        name: ingester
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 25Gi
+          requests:
+            cpu: "4"
+            memory: 15Gi
+        volumeMounts:
+        - mountPath: /data
+          name: ingester-data
+        - mountPath: /etc/mimir
+          name: overrides
+      securityContext:
+        runAsUser: 0
+      terminationGracePeriodSeconds: 1200
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+  updateStrategy:
+    type: OnDelete
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: ingester-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 100Gi
+      storageClassName: fast
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-delayed-downscale: 13h
+    grafana.com/rollout-mirror-replicas-from-resource-api-version: rollout-operator.grafana.com/v1
+    grafana.com/rollout-mirror-replicas-from-resource-kind: ReplicaTemplate
+    grafana.com/rollout-mirror-replicas-from-resource-name: ingester-zone-a-rc-1
+    grafana.com/rollout-prepare-delayed-downscale-url: http://pod/ingester/prepare-partition-downscale
+    rollout-max-unavailable: "50"
+  labels:
+    grafana.com/min-time-between-zones-downscale: "0"
+    grafana.com/prepare-downscale: "true"
+    mimir-rc: "1"
+    name: ingester-zone-a-rc-1
+    rollout-group: ingester-rc-1
+  name: ingester-zone-a-rc-1
+  namespace: default
+spec:
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      name: ingester-zone-a-rc-1
+      rollout-group: ingester-rc-1
+  serviceName: ingester-zone-a-rc-1
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        mimir-rc: "1"
+        name: ingester-zone-a-rc-1
+        rollout-group: ingester-rc-1
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2a
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: mimir-rc
+                operator: Exists
+              - key: mimir-rc
+                operator: NotIn
+                values:
+                - "1"
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-ranges-period=2h
+        - -blocks-storage.tsdb.dir=/data/tsdb
+        - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.wal-replay-concurrency=3
+        - -common.storage.backend=gcs
+        - -compartments.enabled=true
+        - -compartments.read.num-compartments=2
+        - -compartments.write.num-compartments=2
+        - -distributor.health-check-ingesters=true
+        - -distributor.ingestion-tenant-shard-size=3
+        - -ingest-storage.enabled=true
+        - -ingest-storage.ingestion-partition-tenant-shard-size=1
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.client-rack=zone-a
+        - -ingest-storage.kafka.consumer-group-offset-commit-interval=5s
+        - -ingest-storage.kafka.ingestion-concurrency-estimated-bytes-per-sample=200
+        - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
+        - -ingest-storage.kafka.topic=ingest-rc-<read-compartment-id>
+        - -ingester.max-global-metadata-per-metric=10
+        - -ingester.max-global-metadata-per-user=30000
+        - -ingester.max-global-series-per-user=150000
+        - -ingester.partition-ring.delete-inactive-partition-after=13h
+        - -ingester.partition-ring.prefix=
+        - -ingester.push-grpc-method-enabled=false
+        - -ingester.read-compartment-id=1
+        - -ingester.ring.heartbeat-period=2m
+        - -ingester.ring.heartbeat-timeout=10m
+        - -ingester.ring.instance-availability-zone=zone-a
+        - -ingester.ring.num-tokens=0
+        - -ingester.ring.prefix=partition-ingesters/
+        - -ingester.ring.replication-factor=3
+        - -ingester.ring.store=memberlist
+        - -ingester.ring.unregister-on-shutdown=true
+        - -ingester.ring.zone-awareness-enabled=true
+        - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc-max-concurrent-streams=500
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -target=ingester
+        - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: A
+          value: ingester-a-only
+        - name: GOGC
+          value: "off"
+        - name: GOMAXPROCS
+          value: "9"
+        - name: GOMEMLIMIT
+          value: 1Gi
+        - name: Z
+          value: "123"
+        image: grafana/mimir:3.1.1
+        imagePullPolicy: IfNotPresent
+        name: ingester
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 25Gi
+          requests:
+            cpu: "4"
+            memory: 15Gi
+        volumeMounts:
+        - mountPath: /data
+          name: ingester-data
+        - mountPath: /etc/mimir
+          name: overrides
+      securityContext:
+        runAsUser: 0
+      terminationGracePeriodSeconds: 1200
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+  updateStrategy:
+    type: OnDelete
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: ingester-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 100Gi
+      storageClassName: fast
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: ingester-zone-a-rc-0
+    rollout-max-unavailable: "50"
+  labels:
+    grafana.com/min-time-between-zones-downscale: "0"
+    grafana.com/prepare-downscale: "true"
+    mimir-rc: "0"
+    name: ingester-zone-b-rc-0
+    rollout-group: ingester-rc-0
+  name: ingester-zone-b-rc-0
+  namespace: default
+spec:
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      name: ingester-zone-b-rc-0
+      rollout-group: ingester-rc-0
+  serviceName: ingester-zone-b-rc-0
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        mimir-rc: "0"
+        name: ingester-zone-b-rc-0
+        rollout-group: ingester-rc-0
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2b
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: mimir-rc
+                operator: Exists
+              - key: mimir-rc
+                operator: NotIn
+                values:
+                - "0"
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-ranges-period=2h
+        - -blocks-storage.tsdb.dir=/data/tsdb
+        - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.wal-replay-concurrency=3
+        - -common.storage.backend=gcs
+        - -compartments.enabled=true
+        - -compartments.read.num-compartments=2
+        - -compartments.write.num-compartments=2
+        - -distributor.health-check-ingesters=true
+        - -distributor.ingestion-tenant-shard-size=3
+        - -ingest-storage.enabled=true
+        - -ingest-storage.ingestion-partition-tenant-shard-size=1
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.client-rack=zone-b
+        - -ingest-storage.kafka.consumer-group-offset-commit-interval=5s
+        - -ingest-storage.kafka.ingestion-concurrency-estimated-bytes-per-sample=200
+        - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
+        - -ingest-storage.kafka.topic=ingest-rc-<read-compartment-id>
+        - -ingester.max-global-metadata-per-metric=10
+        - -ingester.max-global-metadata-per-user=30000
+        - -ingester.max-global-series-per-user=150000
+        - -ingester.partition-ring.delete-inactive-partition-after=13h
+        - -ingester.partition-ring.prefix=
+        - -ingester.push-grpc-method-enabled=false
+        - -ingester.read-compartment-id=0
+        - -ingester.ring.heartbeat-period=2m
+        - -ingester.ring.heartbeat-timeout=10m
+        - -ingester.ring.instance-availability-zone=zone-b
+        - -ingester.ring.num-tokens=0
+        - -ingester.ring.prefix=partition-ingesters/
+        - -ingester.ring.replication-factor=3
+        - -ingester.ring.store=memberlist
+        - -ingester.ring.unregister-on-shutdown=true
+        - -ingester.ring.zone-awareness-enabled=true
+        - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc-max-concurrent-streams=500
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -target=ingester
+        - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: A
+          value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
+        image: grafana/mimir:3.1.1
+        imagePullPolicy: IfNotPresent
+        name: ingester
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 25Gi
+          requests:
+            cpu: "4"
+            memory: 15Gi
+        volumeMounts:
+        - mountPath: /data
+          name: ingester-data
+        - mountPath: /etc/mimir
+          name: overrides
+      securityContext:
+        runAsUser: 0
+      terminationGracePeriodSeconds: 1200
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+  updateStrategy:
+    type: OnDelete
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: ingester-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 100Gi
+      storageClassName: fast
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
+    grafana.com/rollout-downscale-leader: ingester-zone-a-rc-1
+    rollout-max-unavailable: "50"
+  labels:
+    grafana.com/min-time-between-zones-downscale: "0"
+    grafana.com/prepare-downscale: "true"
+    mimir-rc: "1"
+    name: ingester-zone-b-rc-1
+    rollout-group: ingester-rc-1
+  name: ingester-zone-b-rc-1
+  namespace: default
+spec:
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      name: ingester-zone-b-rc-1
+      rollout-group: ingester-rc-1
+  serviceName: ingester-zone-b-rc-1
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        mimir-rc: "1"
+        name: ingester-zone-b-rc-1
+        rollout-group: ingester-rc-1
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2b
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: mimir-rc
+                operator: Exists
+              - key: mimir-rc
+                operator: NotIn
+                values:
+                - "1"
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-ranges-period=2h
+        - -blocks-storage.tsdb.dir=/data/tsdb
+        - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.wal-replay-concurrency=3
+        - -common.storage.backend=gcs
+        - -compartments.enabled=true
+        - -compartments.read.num-compartments=2
+        - -compartments.write.num-compartments=2
+        - -distributor.health-check-ingesters=true
+        - -distributor.ingestion-tenant-shard-size=3
+        - -ingest-storage.enabled=true
+        - -ingest-storage.ingestion-partition-tenant-shard-size=1
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.client-rack=zone-b
+        - -ingest-storage.kafka.consumer-group-offset-commit-interval=5s
+        - -ingest-storage.kafka.ingestion-concurrency-estimated-bytes-per-sample=200
+        - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
+        - -ingest-storage.kafka.topic=ingest-rc-<read-compartment-id>
+        - -ingester.max-global-metadata-per-metric=10
+        - -ingester.max-global-metadata-per-user=30000
+        - -ingester.max-global-series-per-user=150000
+        - -ingester.partition-ring.delete-inactive-partition-after=13h
+        - -ingester.partition-ring.prefix=
+        - -ingester.push-grpc-method-enabled=false
+        - -ingester.read-compartment-id=1
+        - -ingester.ring.heartbeat-period=2m
+        - -ingester.ring.heartbeat-timeout=10m
+        - -ingester.ring.instance-availability-zone=zone-b
+        - -ingester.ring.num-tokens=0
+        - -ingester.ring.prefix=partition-ingesters/
+        - -ingester.ring.replication-factor=3
+        - -ingester.ring.store=memberlist
+        - -ingester.ring.unregister-on-shutdown=true
+        - -ingester.ring.zone-awareness-enabled=true
+        - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc-max-concurrent-streams=500
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -target=ingester
+        - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: A
+          value: all-ingesters
+        - name: GOMAXPROCS
+          value: "9"
+        image: grafana/mimir:3.1.1
+        imagePullPolicy: IfNotPresent
+        name: ingester
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 25Gi
+          requests:
+            cpu: "4"
+            memory: 15Gi
+        volumeMounts:
+        - mountPath: /data
+          name: ingester-data
+        - mountPath: /etc/mimir
+          name: overrides
+      securityContext:
+        runAsUser: 0
+      terminationGracePeriodSeconds: 1200
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+  updateStrategy:
+    type: OnDelete
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: ingester-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 100Gi
+      storageClassName: fast
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: memcached
+  namespace: default
+spec:
+  minReadySeconds: 60
+  replicas: 3
+  selector:
+    matchLabels:
+      name: memcached
+  serviceName: memcached
+  template:
+    metadata:
+      labels:
+        name: memcached
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: memcached
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -m 6144
+        - -I 1m
+        - -c 16384
+        - -v
+        image: memcached:1.6.34-alpine
+        imagePullPolicy: IfNotPresent
+        name: memcached
+        ports:
+        - containerPort: 11211
+          name: client
+        resources:
+          limits:
+            memory: 9Gi
+          requests:
+            cpu: 500m
+            memory: 6552Mi
+      - args:
+        - --memcached.address=localhost:11211
+        - --web.listen-address=0.0.0.0:9150
+        image: prom/memcached-exporter:v0.15.3
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9150
+          name: http-metrics
+        resources:
+          limits:
+            memory: 250Mi
+          requests:
+            cpu: "0.05"
+            memory: 50Mi
+  updateStrategy:
+    type: RollingUpdate
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: memcached-frontend
+  namespace: default
+spec:
+  minReadySeconds: 60
+  replicas: 3
+  selector:
+    matchLabels:
+      name: memcached-frontend
+  serviceName: memcached-frontend
+  template:
+    metadata:
+      labels:
+        name: memcached-frontend
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: memcached-frontend
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -m 1024
+        - -I 25m
+        - -c 16384
+        - -v
+        image: memcached:1.6.34-alpine
+        imagePullPolicy: IfNotPresent
+        name: memcached
+        ports:
+        - containerPort: 11211
+          name: client
+        resources:
+          limits:
+            memory: 1536Mi
+          requests:
+            cpu: 500m
+            memory: 1176Mi
+      - args:
+        - --memcached.address=localhost:11211
+        - --web.listen-address=0.0.0.0:9150
+        image: prom/memcached-exporter:v0.15.3
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9150
+          name: http-metrics
+        resources:
+          limits:
+            memory: 250Mi
+          requests:
+            cpu: "0.05"
+            memory: 50Mi
+  updateStrategy:
+    type: RollingUpdate
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: memcached-index-queries
+  namespace: default
+spec:
+  minReadySeconds: 60
+  replicas: 3
+  selector:
+    matchLabels:
+      name: memcached-index-queries
+  serviceName: memcached-index-queries
+  template:
+    metadata:
+      labels:
+        name: memcached-index-queries
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: memcached-index-queries
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -m 1024
+        - -I 5m
+        - -c 16384
+        - -v
+        image: memcached:1.6.34-alpine
+        imagePullPolicy: IfNotPresent
+        name: memcached
+        ports:
+        - containerPort: 11211
+          name: client
+        resources:
+          limits:
+            memory: 1536Mi
+          requests:
+            cpu: 500m
+            memory: 1176Mi
+      - args:
+        - --memcached.address=localhost:11211
+        - --web.listen-address=0.0.0.0:9150
+        image: prom/memcached-exporter:v0.15.3
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9150
+          name: http-metrics
+        resources:
+          limits:
+            memory: 250Mi
+          requests:
+            cpu: "0.05"
+            memory: 50Mi
+  updateStrategy:
+    type: RollingUpdate
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: memcached-metadata
+  namespace: default
+spec:
+  minReadySeconds: 60
+  replicas: 3
+  selector:
+    matchLabels:
+      name: memcached-metadata
+  serviceName: memcached-metadata
+  template:
+    metadata:
+      labels:
+        name: memcached-metadata
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: memcached-metadata
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -m 512
+        - -I 1m
+        - -c 16384
+        - -v
+        image: memcached:1.6.34-alpine
+        imagePullPolicy: IfNotPresent
+        name: memcached
+        ports:
+        - containerPort: 11211
+          name: client
+        resources:
+          limits:
+            memory: 768Mi
+          requests:
+            cpu: 500m
+            memory: 638Mi
+      - args:
+        - --memcached.address=localhost:11211
+        - --web.listen-address=0.0.0.0:9150
+        image: prom/memcached-exporter:v0.15.3
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9150
+          name: http-metrics
+        resources:
+          limits:
+            memory: 250Mi
+          requests:
+            cpu: "0.05"
+            memory: 50Mi
+  updateStrategy:
+    type: RollingUpdate
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    rollout-max-unavailable: "50"
+  labels:
+    rollout-group: store-gateway
+  name: store-gateway-zone-a
+  namespace: default
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      name: store-gateway-zone-a
+      rollout-group: store-gateway
+  serviceName: store-gateway-zone-a
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: store-gateway-zone-a
+        rollout-group: store-gateway
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: rollout-group
+                operator: In
+                values:
+                - store-gateway
+              - key: name
+                operator: NotIn
+                values:
+                - store-gateway-zone-a
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -blocks-storage.bucket-store.chunks-cache.backend=memcached
+        - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-concurrency=100
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-idle-connections=150
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-item-size=1048576
+        - -blocks-storage.bucket-store.chunks-cache.memcached.timeout=750ms
+        - -blocks-storage.bucket-store.index-cache.backend=memcached
+        - -blocks-storage.bucket-store.index-cache.memcached.addresses=dnssrvnoa+memcached-index-queries.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.index-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-concurrency=100
+        - -blocks-storage.bucket-store.index-cache.memcached.max-idle-connections=150
+        - -blocks-storage.bucket-store.index-cache.memcached.max-item-size=5242880
+        - -blocks-storage.bucket-store.index-cache.memcached.timeout=750ms
+        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
+        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-concurrency=100
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-idle-connections=150
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
+        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
+        - -blocks-storage.bucket-store.sync-interval=15m
+        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -common.storage.backend=gcs
+        - -ingest-storage.enabled=true
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.topic=ingest
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc-max-send-msg-size-bytes=209715200
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -store-gateway.sharding-ring.heartbeat-period=1m
+        - -store-gateway.sharding-ring.heartbeat-timeout=10m
+        - -store-gateway.sharding-ring.instance-availability-zone=zone-a
+        - -store-gateway.sharding-ring.prefix=multi-zone/
+        - -store-gateway.sharding-ring.replication-factor=3
+        - -store-gateway.sharding-ring.store=memberlist
+        - -store-gateway.sharding-ring.tokens-file-path=/data/tokens
+        - -store-gateway.sharding-ring.unregister-on-shutdown=false
+        - -store-gateway.sharding-ring.wait-stability-min-duration=1m
+        - -store-gateway.sharding-ring.zone-awareness-enabled=true
+        - -store-gateway.tenant-shard-size=3
+        - -target=store-gateway
+        - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: A
+          value: all-store-gateways
+        - name: GOMAXPROCS
+          value: "5"
+        - name: GOMEMLIMIT
+          value: "12884901888"
+        image: grafana/mimir:3.1.1
+        imagePullPolicy: IfNotPresent
+        name: store-gateway
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 18Gi
+          requests:
+            cpu: "1"
+            memory: 12Gi
+        volumeMounts:
+        - mountPath: /data
+          name: store-gateway-data
+        - mountPath: /etc/mimir
+          name: overrides
+      securityContext:
+        runAsUser: 0
+      terminationGracePeriodSeconds: 120
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+  updateStrategy:
+    type: OnDelete
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: store-gateway-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 50Gi
+      storageClassName: standard
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    rollout-max-unavailable: "50"
+  labels:
+    rollout-group: store-gateway
+  name: store-gateway-zone-b
+  namespace: default
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      name: store-gateway-zone-b
+      rollout-group: store-gateway
+  serviceName: store-gateway-zone-b
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: store-gateway-zone-b
+        rollout-group: store-gateway
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: rollout-group
+                operator: In
+                values:
+                - store-gateway
+              - key: name
+                operator: NotIn
+                values:
+                - store-gateway-zone-b
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -blocks-storage.bucket-store.chunks-cache.backend=memcached
+        - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-concurrency=100
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-idle-connections=150
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-item-size=1048576
+        - -blocks-storage.bucket-store.chunks-cache.memcached.timeout=750ms
+        - -blocks-storage.bucket-store.index-cache.backend=memcached
+        - -blocks-storage.bucket-store.index-cache.memcached.addresses=dnssrvnoa+memcached-index-queries.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.index-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-concurrency=100
+        - -blocks-storage.bucket-store.index-cache.memcached.max-idle-connections=150
+        - -blocks-storage.bucket-store.index-cache.memcached.max-item-size=5242880
+        - -blocks-storage.bucket-store.index-cache.memcached.timeout=750ms
+        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
+        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-concurrency=100
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-idle-connections=150
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
+        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
+        - -blocks-storage.bucket-store.sync-interval=15m
+        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -common.storage.backend=gcs
+        - -ingest-storage.enabled=true
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.topic=ingest
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc-max-send-msg-size-bytes=209715200
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -store-gateway.sharding-ring.heartbeat-period=1m
+        - -store-gateway.sharding-ring.heartbeat-timeout=10m
+        - -store-gateway.sharding-ring.instance-availability-zone=zone-b
+        - -store-gateway.sharding-ring.prefix=multi-zone/
+        - -store-gateway.sharding-ring.replication-factor=3
+        - -store-gateway.sharding-ring.store=memberlist
+        - -store-gateway.sharding-ring.tokens-file-path=/data/tokens
+        - -store-gateway.sharding-ring.unregister-on-shutdown=false
+        - -store-gateway.sharding-ring.wait-stability-min-duration=1m
+        - -store-gateway.sharding-ring.zone-awareness-enabled=true
+        - -store-gateway.tenant-shard-size=3
+        - -target=store-gateway
+        - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: A
+          value: zone-b
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "5"
+        - name: GOMEMLIMIT
+          value: "12884901888"
+        image: grafana/mimir:3.1.1
+        imagePullPolicy: IfNotPresent
+        name: store-gateway
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 18Gi
+          requests:
+            cpu: "1"
+            memory: 12Gi
+        volumeMounts:
+        - mountPath: /data
+          name: store-gateway-data
+        - mountPath: /etc/mimir
+          name: overrides
+      securityContext:
+        runAsUser: 0
+      terminationGracePeriodSeconds: 120
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+  updateStrategy:
+    type: OnDelete
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: store-gateway-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 50Gi
+      storageClassName: standard
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    rollout-max-unavailable: "50"
+  labels:
+    rollout-group: store-gateway
+  name: store-gateway-zone-c
+  namespace: default
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      name: store-gateway-zone-c
+      rollout-group: store-gateway
+  serviceName: store-gateway-zone-c
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: store-gateway-zone-c
+        rollout-group: store-gateway
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: rollout-group
+                operator: In
+                values:
+                - store-gateway
+              - key: name
+                operator: NotIn
+                values:
+                - store-gateway-zone-c
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -blocks-storage.bucket-store.chunks-cache.backend=memcached
+        - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-concurrency=100
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-idle-connections=150
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-item-size=1048576
+        - -blocks-storage.bucket-store.chunks-cache.memcached.timeout=750ms
+        - -blocks-storage.bucket-store.index-cache.backend=memcached
+        - -blocks-storage.bucket-store.index-cache.memcached.addresses=dnssrvnoa+memcached-index-queries.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.index-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-concurrency=100
+        - -blocks-storage.bucket-store.index-cache.memcached.max-idle-connections=150
+        - -blocks-storage.bucket-store.index-cache.memcached.max-item-size=5242880
+        - -blocks-storage.bucket-store.index-cache.memcached.timeout=750ms
+        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
+        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-concurrency=100
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-idle-connections=150
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
+        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
+        - -blocks-storage.bucket-store.sync-interval=15m
+        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -common.storage.backend=gcs
+        - -ingest-storage.enabled=true
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.topic=ingest
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc-max-send-msg-size-bytes=209715200
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -store-gateway.sharding-ring.heartbeat-period=1m
+        - -store-gateway.sharding-ring.heartbeat-timeout=10m
+        - -store-gateway.sharding-ring.instance-availability-zone=zone-c
+        - -store-gateway.sharding-ring.prefix=multi-zone/
+        - -store-gateway.sharding-ring.replication-factor=3
+        - -store-gateway.sharding-ring.store=memberlist
+        - -store-gateway.sharding-ring.tokens-file-path=/data/tokens
+        - -store-gateway.sharding-ring.unregister-on-shutdown=false
+        - -store-gateway.sharding-ring.wait-stability-min-duration=1m
+        - -store-gateway.sharding-ring.zone-awareness-enabled=true
+        - -store-gateway.tenant-shard-size=3
+        - -target=store-gateway
+        - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: A
+          value: all-store-gateways
+        - name: GOMAXPROCS
+          value: "5"
+        - name: GOMEMLIMIT
+          value: "12884901888"
+        image: grafana/mimir:3.1.1
+        imagePullPolicy: IfNotPresent
+        name: store-gateway
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 18Gi
+          requests:
+            cpu: "1"
+            memory: 12Gi
+        volumeMounts:
+        - mountPath: /data
+          name: store-gateway-data
+        - mountPath: /etc/mimir
+          name: overrides
+      securityContext:
+        runAsUser: 0
+      terminationGracePeriodSeconds: 120
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+  updateStrategy:
+    type: OnDelete
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: store-gateway-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 50Gi
+      storageClassName: standard
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: prepare-downscale-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/prepare-downscale
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: prepare-downscale-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - UPDATE
+    resources:
+    - statefulsets
+    - statefulsets/scale
+    scope: Namespaced
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10
+---
+apiVersion: rollout-operator.grafana.com/v1
+kind: ReplicaTemplate
+metadata:
+  name: ingester-zone-a-rc-0
+  namespace: default
+spec:
+  labelSelector: name=ingester-zone-a-rc-0
+---
+apiVersion: rollout-operator.grafana.com/v1
+kind: ReplicaTemplate
+metadata:
+  name: ingester-zone-a-rc-1
+  namespace: default
+spec:
+  labelSelector: name=ingester-zone-a-rc-1
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: distributor-zone-a-wc-0
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 120
+            type: Percent
+            value: 10
+          stabilizationWindowSeconds: 1800
+        scaleUp:
+          policies:
+          - periodSeconds: 120
+            type: Percent
+            value: 50
+          - periodSeconds: 120
+            type: Pods
+            value: 15
+          stabilizationWindowSeconds: 120
+  maxReplicaCount: 5
+  minReplicaCount: 1
+  pollingInterval: 10
+  scaleTargetRef:
+    name: distributor-zone-a-wc-0
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_distributor_zone_a_wc_0_cpu_hpa_default
+      query: |-
+        (quantile_over_time(0.95,
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="distributor",namespace="default",pod=~"distributor-zone-a.*"}[5m]))
+            and
+            max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"distributor-zone-a.*"}[1m])) > 0
+          )[15m:]
+        ) * 1000
+        ) * 0.50
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "2000"
+    name: cortex_distributor_zone_a_wc_0_cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_distributor_zone_a_wc_0_memory_hpa_default
+      query: |-
+        (quantile_over_time(0.95,
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="distributor",namespace="default",pod=~"distributor-zone-a.*"})
+              and
+              max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"distributor-zone-a.*"}[1m])) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="distributor", namespace="default", resource="memory",pod=~"distributor-zone-a.*"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="distributor", namespace="default",pod=~"distributor-zone-a.*"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="distributor", namespace="default", reason="OOMKilled",pod=~"distributor-zone-a.*"})
+          or vector(0)
+        )
+        ) * 0.50
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "2147483648"
+    name: cortex_distributor_zone_a_wc_0_memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: distributor-zone-a-wc-1
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 120
+            type: Percent
+            value: 10
+          stabilizationWindowSeconds: 1800
+        scaleUp:
+          policies:
+          - periodSeconds: 120
+            type: Percent
+            value: 50
+          - periodSeconds: 120
+            type: Pods
+            value: 15
+          stabilizationWindowSeconds: 120
+  maxReplicaCount: 5
+  minReplicaCount: 1
+  pollingInterval: 10
+  scaleTargetRef:
+    name: distributor-zone-a-wc-1
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_distributor_zone_a_wc_1_cpu_hpa_default
+      query: |-
+        (quantile_over_time(0.95,
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="distributor",namespace="default",pod=~"distributor-zone-a.*"}[5m]))
+            and
+            max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"distributor-zone-a.*"}[1m])) > 0
+          )[15m:]
+        ) * 1000
+        ) * 0.50
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "2000"
+    name: cortex_distributor_zone_a_wc_1_cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_distributor_zone_a_wc_1_memory_hpa_default
+      query: |-
+        (quantile_over_time(0.95,
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="distributor",namespace="default",pod=~"distributor-zone-a.*"})
+              and
+              max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"distributor-zone-a.*"}[1m])) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="distributor", namespace="default", resource="memory",pod=~"distributor-zone-a.*"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="distributor", namespace="default",pod=~"distributor-zone-a.*"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="distributor", namespace="default", reason="OOMKilled",pod=~"distributor-zone-a.*"})
+          or vector(0)
+        )
+        ) * 0.50
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "2147483648"
+    name: cortex_distributor_zone_a_wc_1_memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: distributor-zone-b-wc-0
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 120
+            type: Percent
+            value: 10
+          stabilizationWindowSeconds: 1800
+        scaleUp:
+          policies:
+          - periodSeconds: 120
+            type: Percent
+            value: 50
+          - periodSeconds: 120
+            type: Pods
+            value: 15
+          stabilizationWindowSeconds: 120
+  maxReplicaCount: 5
+  minReplicaCount: 1
+  pollingInterval: 10
+  scaleTargetRef:
+    name: distributor-zone-b-wc-0
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_distributor_zone_b_wc_0_cpu_hpa_default
+      query: |-
+        (quantile_over_time(0.95,
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="distributor",namespace="default",pod=~"distributor-zone-b.*"}[5m]))
+            and
+            max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"distributor-zone-b.*"}[1m])) > 0
+          )[15m:]
+        ) * 1000
+        ) * 0.50
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "2000"
+    name: cortex_distributor_zone_b_wc_0_cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_distributor_zone_b_wc_0_memory_hpa_default
+      query: |-
+        (quantile_over_time(0.95,
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="distributor",namespace="default",pod=~"distributor-zone-b.*"})
+              and
+              max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"distributor-zone-b.*"}[1m])) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="distributor", namespace="default", resource="memory",pod=~"distributor-zone-b.*"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="distributor", namespace="default",pod=~"distributor-zone-b.*"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="distributor", namespace="default", reason="OOMKilled",pod=~"distributor-zone-b.*"})
+          or vector(0)
+        )
+        ) * 0.50
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "2147483648"
+    name: cortex_distributor_zone_b_wc_0_memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: distributor-zone-b-wc-1
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 120
+            type: Percent
+            value: 10
+          stabilizationWindowSeconds: 1800
+        scaleUp:
+          policies:
+          - periodSeconds: 120
+            type: Percent
+            value: 50
+          - periodSeconds: 120
+            type: Pods
+            value: 15
+          stabilizationWindowSeconds: 120
+  maxReplicaCount: 5
+  minReplicaCount: 1
+  pollingInterval: 10
+  scaleTargetRef:
+    name: distributor-zone-b-wc-1
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_distributor_zone_b_wc_1_cpu_hpa_default
+      query: |-
+        (quantile_over_time(0.95,
+          sum(
+            sum by (pod) (rate(container_cpu_usage_seconds_total{container="distributor",namespace="default",pod=~"distributor-zone-b.*"}[5m]))
+            and
+            max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"distributor-zone-b.*"}[1m])) > 0
+          )[15m:]
+        ) * 1000
+        ) * 0.50
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "2000"
+    name: cortex_distributor_zone_b_wc_1_cpu_hpa_default
+    type: prometheus
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_distributor_zone_b_wc_1_memory_hpa_default
+      query: |-
+        (quantile_over_time(0.95,
+          sum(
+            (
+              sum by (pod) (container_memory_working_set_bytes{container="distributor",namespace="default",pod=~"distributor-zone-b.*"})
+              and
+              max by (pod) (min_over_time(kube_pod_status_ready{namespace="default",condition="true",pod=~"distributor-zone-b.*"}[1m])) > 0
+            ) or vector(0)
+          )[15m:]
+        )
+        +
+        sum(
+          sum by (pod) (max_over_time(kube_pod_container_resource_requests{container="distributor", namespace="default", resource="memory",pod=~"distributor-zone-b.*"}[15m]))
+          and
+          max by (pod) (changes(kube_pod_container_status_restarts_total{container="distributor", namespace="default",pod=~"distributor-zone-b.*"}[15m]) > 0)
+          and
+          max by (pod) (kube_pod_container_status_last_terminated_reason{container="distributor", namespace="default", reason="OOMKilled",pod=~"distributor-zone-b.*"})
+          or vector(0)
+        )
+        ) * 0.50
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "2147483648"
+    name: cortex_distributor_zone_b_wc_1_memory_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: ingester-zone-a-rc-0
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 1800
+            type: Percent
+            value: 15
+          selectPolicy: Max
+          stabilizationWindowSeconds: 3600
+        scaleUp:
+          policies:
+          - periodSeconds: 600
+            type: Percent
+            value: 100
+          selectPolicy: Min
+          stabilizationWindowSeconds: 1800
+  maxReplicaCount: 10
+  minReplicaCount: 1
+  pollingInterval: 10
+  scaleTargetRef:
+    apiVersion: rollout-operator.grafana.com/v1
+    kind: ReplicaTemplate
+    name: ingester-zone-a-rc-0
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_ingester_zone_a_rc_0_replicas_hpa_default_0
+      query: |-
+        max_over_time(min_over_time((
+            max(
+                sum by (pod) (cortex_ingester_owned_series{cluster="test-cluster", namespace="default", job="default/ingester-zone-a-rc-0", container="ingester"})
+                and
+                sum by (pod) (kube_pod_status_ready{cluster="test-cluster", namespace="default", pod=~"ingester-zone-a-rc-0.*", condition="true"}) > 0
+            )
+            *
+            max(cortex_partition_ring_partitions{cluster="test-cluster", namespace="default", state="Active", container="distributor", name="ingester-partitions-rc-0"})
+        )
+        [5m:])[2h:5m])
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "1800000"
+    metricType: AverageValue
+    name: cortex_ingester_zone_a_rc_0_replicas_hpa_default_0
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: ingester-zone-a-rc-1
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 1800
+            type: Percent
+            value: 15
+          selectPolicy: Max
+          stabilizationWindowSeconds: 3600
+        scaleUp:
+          policies:
+          - periodSeconds: 600
+            type: Percent
+            value: 100
+          selectPolicy: Min
+          stabilizationWindowSeconds: 1800
+  maxReplicaCount: 10
+  minReplicaCount: 1
+  pollingInterval: 10
+  scaleTargetRef:
+    apiVersion: rollout-operator.grafana.com/v1
+    kind: ReplicaTemplate
+    name: ingester-zone-a-rc-1
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_ingester_zone_a_rc_1_replicas_hpa_default_0
+      query: |-
+        max_over_time(min_over_time((
+            max(
+                sum by (pod) (cortex_ingester_owned_series{cluster="test-cluster", namespace="default", job="default/ingester-zone-a-rc-1", container="ingester"})
+                and
+                sum by (pod) (kube_pod_status_ready{cluster="test-cluster", namespace="default", pod=~"ingester-zone-a-rc-1.*", condition="true"}) > 0
+            )
+            *
+            max(cortex_partition_ring_partitions{cluster="test-cluster", namespace="default", state="Active", container="distributor", name="ingester-partitions-rc-1"})
+        )
+        [5m:])[2h:5m])
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "1800000"
+    metricType: AverageValue
+    name: cortex_ingester_zone_a_rc_1_replicas_hpa_default_0
+    type: prometheus
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: no-downscale-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/no-downscale
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: no-downscale-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - UPDATE
+    resources:
+    - statefulsets
+    - statefulsets/scale
+    scope: Namespaced
+  sideEffects: None
+  timeoutSeconds: 10
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: pod-eviction-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/pod-eviction
+      port: 443
+  failurePolicy: Fail
+  name: pod-eviction-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods/eviction
+    scope: Namespaced
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    grafana.com/inject-rollout-operator-ca: "true"
+    grafana.com/namespace: default
+  name: zpdb-validation-default
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rollout-operator
+      namespace: default
+      path: /admission/zpdb-validation
+      port: 443
+  failurePolicy: Fail
+  name: zpdb-validation-default.grafana.com
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: default
+  rules:
+  - apiGroups:
+    - rollout-operator.grafana.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - zoneawarepoddisruptionbudgets
+    scope: Namespaced
+  sideEffects: None
+---
+apiVersion: rollout-operator.grafana.com/v1
+kind: ZoneAwarePodDisruptionBudget
+metadata:
+  labels:
+    name: ingester-rollout-rc-0
+  name: ingester-rollout-rc-0
+  namespace: default
+spec:
+  maxUnavailable: 1
+  podNamePartitionRegex: '[a-z\-]+-zone-[a-z]-rc-[0-9]+-([0-9]+)'
+  podNameRegexGroup: 1
+  selector:
+    matchLabels:
+      mimir-rc: "0"
+      rollout-group: ingester-rc-0
+---
+apiVersion: rollout-operator.grafana.com/v1
+kind: ZoneAwarePodDisruptionBudget
+metadata:
+  labels:
+    name: ingester-rollout-rc-1
+  name: ingester-rollout-rc-1
+  namespace: default
+spec:
+  maxUnavailable: 1
+  podNamePartitionRegex: '[a-z\-]+-zone-[a-z]-rc-[0-9]+-([0-9]+)'
+  podNameRegexGroup: 1
+  selector:
+    matchLabels:
+      mimir-rc: "1"
+      rollout-group: ingester-rc-1
+---
+apiVersion: rollout-operator.grafana.com/v1
+kind: ZoneAwarePodDisruptionBudget
+metadata:
+  labels:
+    name: store-gateway-rollout
+  name: store-gateway-rollout
+  namespace: default
+spec:
+  maxUnavailable: 50
+  selector:
+    matchLabels:
+      rollout-group: store-gateway

--- a/operations/mimir-tests/test-compartments-generated.yaml
+++ b/operations/mimir-tests/test-compartments-generated.yaml
@@ -2493,6 +2493,17 @@ spec:
                 values:
                 - "0"
             topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchExpressions:
+              - key: rollout-group
+                operator: In
+                values:
+                - ingester-rc-0
+              - key: name
+                operator: NotIn
+                values:
+                - ingester-zone-a-rc-0
+            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
@@ -2662,6 +2673,17 @@ spec:
                 values:
                 - "1"
             topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchExpressions:
+              - key: rollout-group
+                operator: In
+                values:
+                - ingester-rc-1
+              - key: name
+                operator: NotIn
+                values:
+                - ingester-zone-a-rc-1
+            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
@@ -2827,6 +2849,17 @@ spec:
                 values:
                 - "0"
             topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchExpressions:
+              - key: rollout-group
+                operator: In
+                values:
+                - ingester-rc-0
+              - key: name
+                operator: NotIn
+                values:
+                - ingester-zone-b-rc-0
+            topologyKey: kubernetes.io/hostname
       containers:
       - args:
         - -blocks-storage.gcs.bucket-name=blocks-bucket
@@ -2985,6 +3018,17 @@ spec:
                 operator: NotIn
                 values:
                 - "1"
+            topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchExpressions:
+              - key: rollout-group
+                operator: In
+                values:
+                - ingester-rc-1
+              - key: name
+                operator: NotIn
+                values:
+                - ingester-zone-b-rc-1
             topologyKey: kubernetes.io/hostname
       containers:
       - args:

--- a/operations/mimir-tests/test-compartments.jsonnet
+++ b/operations/mimir-tests/test-compartments.jsonnet
@@ -1,0 +1,22 @@
+// Renders Mimir with the experimental compartments architecture enabled.
+// Based on test-ingest-storage-autoscaling-one-trigger.jsonnet.
+(import 'test-ingest-storage-autoscaling-one-trigger.jsonnet') {
+  _config+:: {
+    multi_zone_availability_zones: ['us-east-2a', 'us-east-2b'],
+    ingest_storage_ingester_zones: 2,
+
+    // Multi-AZ write path.
+    multi_zone_ingester_multi_az_enabled: true,
+    multi_zone_write_path_enabled: true,
+
+    // Exercise the per-compartment distributor scaled objects.
+    autoscaling_distributor_enabled: true,
+    autoscaling_distributor_min_replicas_per_zone: 2,
+    autoscaling_distributor_max_replicas_per_zone: 10,
+
+    // Compartments.
+    compartments_enabled: true,
+    compartments_read_count: 2,
+    compartments_write_count: 2,
+  },
+}

--- a/operations/mimir/compartments-common.libsonnet
+++ b/operations/mimir/compartments-common.libsonnet
@@ -1,0 +1,48 @@
+{
+  _config+:: {
+    // Whether the compartments architecture is enabled.
+    compartments_enabled: false,
+
+    // Number of read and write compartments.
+    compartments_read_count: 1,
+    compartments_write_count: 1,
+
+    // Kafka topic produced/consumed per read compartment. Must contain the '<read-compartment-id>'
+    // placeholder, which Mimir replaces with the read compartment index at runtime.
+    compartments_ingest_storage_kafka_topic: 'ingest-rc-<read-compartment-id>',
+  },
+
+  assert $._config.compartments_read_count >= 1 : 'compartments_read_count must be >= 1',
+  assert $._config.compartments_write_count >= 1 : 'compartments_write_count must be >= 1',
+
+  assert !$._config.compartments_enabled || $._config.ruler_remote_evaluation_enabled
+         : 'compartments require ruler remote rule evaluation (ruler_remote_evaluation_enabled)',
+
+  // Common CLI args shared by every compartment-aware Mimir component.
+  mimirCompartmentsCommonArgs:: {
+    'compartments.enabled': true,
+    'compartments.read.num-compartments': $._config.compartments_read_count,
+    'compartments.write.num-compartments': $._config.compartments_write_count,
+    'ingest-storage.kafka.topic': $._config.compartments_ingest_storage_kafka_topic,
+  },
+
+  // Apply a mixin to every compartment entry in a compartments resource map.
+  // Pass super.fieldName as compartmentMap to match the established super-in-for-clause convention.
+  // mixin can be either a static object applied to all compartments, or a function(compartmentIdx)
+  // that returns a per-compartment mixin.
+  // Example: foo_zone_a_deployments+: $.mimirCompartmentsOverrides(super.foo_zone_a_deployments, someMixin),
+  // Example: foo_zone_a_compartments_args+: $.mimirCompartmentsOverrides(super.foo_zone_a_compartments_args, function(compartmentIdx) { 'compartment-id': compartmentIdx }),
+  mimirCompartmentsOverrides(compartmentMap, mixin):: {
+    [compartmentKey]+: if std.isFunction(mixin) then mixin(std.parseInt(std.split(compartmentKey, '_')[1])) else mixin
+    for compartmentKey in std.objectFields(compartmentMap)
+  },
+
+  // Creates a { compartment_0: …, compartment_1: … } resource map when enabled, otherwise returns {}.
+  // fn is called with the compartment index (integer) for each compartment in [0, numCompartments).
+  // Usage: foo_zone_a_deployments: $.mimirCompartmentsCreateIf(isEnabled && isZoneAEnabled, numCompartments,
+  //          function(compartment) $.newFooCompartmentDeployment('a', compartment, …)),
+  mimirCompartmentsCreateIf(enabled, numCompartments, fn):: if !enabled then {} else {
+    ['compartment_%d' % compartment]: fn(compartment)
+    for compartment in std.range(0, numCompartments - 1)
+  },
+}

--- a/operations/mimir/compartments-distributor.libsonnet
+++ b/operations/mimir/compartments-distributor.libsonnet
@@ -1,0 +1,130 @@
+{
+  _config+:: {
+    compartments_distributor_enabled: $._config.compartments_enabled,
+    no_compartments_distributor_enabled: !self.compartments_distributor_enabled,
+  },
+
+  assert !$._config.compartments_distributor_enabled || $._config.multi_zone_distributor_enabled
+         : 'compartments_distributor_enabled requires multi_zone_distributor_enabled',
+  assert !$._config.compartments_distributor_enabled || $._config.ingest_storage_enabled
+         : 'compartments_distributor_enabled requires ingest_storage_enabled',
+  assert !$._config.compartments_distributor_enabled || $._config.autoscaling_distributor_enabled
+         : 'compartments_distributor_enabled requires autoscaling_distributor_enabled',
+
+  local deployment = $.apps.v1.deployment,
+  local service = $.core.v1.service,
+  local podAntiAffinity = deployment.mixin.spec.template.spec.affinity.podAntiAffinity,
+
+  local isEnabled = $._config.compartments_distributor_enabled,
+  local numCompartments = $._config.compartments_write_count,
+  local isZoneAEnabled = $._config.multi_zone_distributor_enabled && std.length($._config.multi_zone_availability_zones) >= 1,
+  local isZoneBEnabled = $._config.multi_zone_distributor_enabled && std.length($._config.multi_zone_availability_zones) >= 2,
+  local isZoneCEnabled = $._config.multi_zone_distributor_enabled && std.length($._config.multi_zone_availability_zones) >= 3,
+  local isAutoscalingEnabled = $._config.autoscaling_distributor_enabled,
+  local isNoCompartmentsEnabled = $._config.no_compartments_distributor_enabled,
+
+  newDistributorCompartmentContainer(zone, compartmentIdx, args, extraEnvVarMap={})::
+    $.newDistributorZoneContainer(zone, args, extraEnvVarMap),
+
+  newDistributorCompartmentDeployment(zone, compartmentIdx, container, nodeAffinityMatchers=[])::
+    local compartmentName = '%s-wc-%d' % [zone, compartmentIdx];
+    local zoneName = 'distributor-zone-%s' % zone;
+
+    $.newDistributorZoneDeployment(compartmentName, container, nodeAffinityMatchers) +
+    // Add mimir-service label matching the zone so the zone service selects all compartments.
+    deployment.mixin.metadata.withLabelsMixin({ 'mimir-service': zoneName }) +
+    deployment.mixin.spec.template.metadata.withLabelsMixin({ 'mimir-service': zoneName }) +
+    // Label identifying the write compartment — used by the write-path anti-affinity below.
+    deployment.mixin.spec.template.metadata.withLabelsMixin({ 'mimir-wc': std.toString(compartmentIdx) }) +
+    // Spread write compartments across nodes: don't schedule onto a node already running a pod with a different mimir-wc value.
+    { spec+: podAntiAffinity.withRequiredDuringSchedulingIgnoredDuringExecution([
+      podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecutionType.new() +
+      podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecutionType.mixin.labelSelector.withMatchExpressions([
+        { key: 'mimir-wc', operator: 'Exists' },
+        { key: 'mimir-wc', operator: 'NotIn', values: [std.toString(compartmentIdx)] },
+      ]) +
+      podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecutionType.withTopologyKey('kubernetes.io/hostname'),
+    ]).spec } +
+    (if !isAutoscalingEnabled then {} else $.removeReplicasFromSpec),
+
+  newDistributorCompartmentScaledObject(name, zone, numCompartments)::
+    $.newDistributorScaledObject(
+      name=name,
+      extra_matchers='pod=~"distributor-zone-%s.*"' % zone,
+      weight=1.0 / numCompartments,  // scale each compartment to 1/N of the total zone load
+    ),
+
+  // Null out no-compartment Deployments, PDBs, and ScaledObjects when decommissioning.
+  distributor_zone_a_deployment: if !isNoCompartmentsEnabled && isZoneAEnabled then null else super.distributor_zone_a_deployment,
+  distributor_zone_b_deployment: if !isNoCompartmentsEnabled && isZoneBEnabled then null else super.distributor_zone_b_deployment,
+  distributor_zone_c_deployment: if !isNoCompartmentsEnabled && isZoneCEnabled then null else super.distributor_zone_c_deployment,
+
+  distributor_zone_a_pdb: if !isNoCompartmentsEnabled && isZoneAEnabled then null else super.distributor_zone_a_pdb,
+  distributor_zone_b_pdb: if !isNoCompartmentsEnabled && isZoneBEnabled then null else super.distributor_zone_b_pdb,
+  distributor_zone_c_pdb: if !isNoCompartmentsEnabled && isZoneCEnabled then null else super.distributor_zone_c_pdb,
+
+  distributor_zone_a_scaled_object: if !isNoCompartmentsEnabled && isZoneAEnabled then null else super.distributor_zone_a_scaled_object,
+  distributor_zone_b_scaled_object: if !isNoCompartmentsEnabled && isZoneBEnabled then null else super.distributor_zone_b_scaled_object,
+  distributor_zone_c_scaled_object: if !isNoCompartmentsEnabled && isZoneCEnabled then null else super.distributor_zone_c_scaled_object,
+
+  // When decommissioning, the zone deployment is null, so super.distributor_zone_X_service
+  // can't be accessed (it calls util.serviceFor on the null deployment). Re-create the
+  // service from scratch instead, deriving ports from compartment_0 and overriding the name/selector
+  // so the service covers all compartments in the zone.
+  local newZoneService(zone, compartmentDeploy) =
+    $.util.serviceFor(compartmentDeploy, $._config.service_ignored_labels) +
+    service.mixin.metadata.withName('distributor-zone-%s' % zone) +
+    service.mixin.metadata.withLabels({ name: 'distributor-zone-%s' % zone }) +
+    service.mixin.spec.withSelector({ 'mimir-service': 'distributor-zone-%s' % zone }) +
+    service.mixin.spec.withClusterIp('None'),
+
+  distributor_zone_a_service: if !isNoCompartmentsEnabled && isZoneAEnabled then
+    newZoneService('a', $.distributor_zone_a_deployments.compartment_0)
+  else super.distributor_zone_a_service,
+  distributor_zone_b_service: if !isNoCompartmentsEnabled && isZoneBEnabled then
+    newZoneService('b', $.distributor_zone_b_deployments.compartment_0)
+  else super.distributor_zone_b_service,
+  distributor_zone_c_service: if !isNoCompartmentsEnabled && isZoneCEnabled then
+    newZoneService('c', $.distributor_zone_c_deployments.compartment_0)
+  else super.distributor_zone_c_service,
+
+  // Args. Per write compartment the distributor inherits the single -ingest-storage.kafka.address and
+  // is tagged with its write-compartment id. Operators running each write compartment on a distinct
+  // Kafka cluster are responsible for overriding -ingest-storage.kafka.address per compartment.
+  local perCompartmentDistributorArgs(compartmentIdx) =
+    $.mimirCompartmentsCommonArgs {
+      'distributor.write-compartment-id': compartmentIdx,
+    },
+
+  distributor_zone_a_compartments_args:: $.mimirCompartmentsCreateIf(isEnabled && isZoneAEnabled, numCompartments, function(compartment) $.distributor_zone_a_args + perCompartmentDistributorArgs(compartment)),
+  distributor_zone_b_compartments_args:: $.mimirCompartmentsCreateIf(isEnabled && isZoneBEnabled, numCompartments, function(compartment) $.distributor_zone_b_args + perCompartmentDistributorArgs(compartment)),
+  distributor_zone_c_compartments_args:: $.mimirCompartmentsCreateIf(isEnabled && isZoneCEnabled, numCompartments, function(compartment) $.distributor_zone_c_args + perCompartmentDistributorArgs(compartment)),
+
+  // Containers.
+  distributor_zone_a_containers:: $.mimirCompartmentsCreateIf(isEnabled && isZoneAEnabled, numCompartments, function(compartment) $.newDistributorCompartmentContainer('a', compartment, $.distributor_zone_a_compartments_args['compartment_%d' % compartment], $.distributor_zone_a_env_map)),
+  distributor_zone_b_containers:: $.mimirCompartmentsCreateIf(isEnabled && isZoneBEnabled, numCompartments, function(compartment) $.newDistributorCompartmentContainer('b', compartment, $.distributor_zone_b_compartments_args['compartment_%d' % compartment], $.distributor_zone_b_env_map)),
+  distributor_zone_c_containers:: $.mimirCompartmentsCreateIf(isEnabled && isZoneCEnabled, numCompartments, function(compartment) $.newDistributorCompartmentContainer('c', compartment, $.distributor_zone_c_compartments_args['compartment_%d' % compartment], $.distributor_zone_c_env_map)),
+
+  // Deployments.
+  distributor_zone_a_deployments: $.mimirCompartmentsCreateIf(isEnabled && isZoneAEnabled, numCompartments, function(compartment) $.newDistributorCompartmentDeployment('a', compartment, $.distributor_zone_a_containers['compartment_%d' % compartment], $.distributor_zone_a_node_affinity_matchers)),
+  distributor_zone_b_deployments: $.mimirCompartmentsCreateIf(isEnabled && isZoneBEnabled, numCompartments, function(compartment) $.newDistributorCompartmentDeployment('b', compartment, $.distributor_zone_b_containers['compartment_%d' % compartment], $.distributor_zone_b_node_affinity_matchers)),
+  distributor_zone_c_deployments: $.mimirCompartmentsCreateIf(isEnabled && isZoneCEnabled, numCompartments, function(compartment) $.newDistributorCompartmentDeployment('c', compartment, $.distributor_zone_c_containers['compartment_%d' % compartment], $.distributor_zone_c_node_affinity_matchers)),
+
+  // PDBs.
+  distributor_zone_a_pdbs: $.mimirCompartmentsCreateIf(isEnabled && isZoneAEnabled, numCompartments, function(compartment) $.newMimirPdb('distributor-zone-a-wc-%d' % compartment)),
+  distributor_zone_b_pdbs: $.mimirCompartmentsCreateIf(isEnabled && isZoneBEnabled, numCompartments, function(compartment) $.newMimirPdb('distributor-zone-b-wc-%d' % compartment)),
+  distributor_zone_c_pdbs: $.mimirCompartmentsCreateIf(isEnabled && isZoneCEnabled, numCompartments, function(compartment) $.newMimirPdb('distributor-zone-c-wc-%d' % compartment)),
+
+  // Scaled objects.
+  distributor_zone_a_scaled_objects: $.mimirCompartmentsCreateIf(isEnabled && isZoneAEnabled && isAutoscalingEnabled, numCompartments, function(compartment) $.newDistributorCompartmentScaledObject('distributor-zone-a-wc-%d' % compartment, 'a', numCompartments)),
+  distributor_zone_b_scaled_objects: $.mimirCompartmentsCreateIf(isEnabled && isZoneBEnabled && isAutoscalingEnabled, numCompartments, function(compartment) $.newDistributorCompartmentScaledObject('distributor-zone-b-wc-%d' % compartment, 'b', numCompartments)),
+  distributor_zone_c_scaled_objects: $.mimirCompartmentsCreateIf(isEnabled && isZoneCEnabled && isAutoscalingEnabled, numCompartments, function(compartment) $.newDistributorCompartmentScaledObject('distributor-zone-c-wc-%d' % compartment, 'c', numCompartments)),
+
+  // Ensure all configured addresses on per-compartment distributor Deployments are zonal ones.
+  local distributorCompartmentMultiZoneError = $.validateMimirMultiZoneConfig([
+    'distributor_zone_a_deployments',
+    'distributor_zone_b_deployments',
+    'distributor_zone_c_deployments',
+  ]),
+  assert distributorCompartmentMultiZoneError == null : distributorCompartmentMultiZoneError,
+}

--- a/operations/mimir/compartments-ingester.libsonnet
+++ b/operations/mimir/compartments-ingester.libsonnet
@@ -52,7 +52,11 @@
     statefulSet.mixin.spec.template.metadata.withLabelsMixin({ 'mimir-rc': compartmentIdxStr }) +
     // Multi-compartment ingesters require multi-AZ too, so we can always configure the multi-zone toleration.
     statefulSet.spec.template.spec.withTolerationsMixin($.newMimirMultiZoneToleration()) +
-    // Spread read compartments across nodes: don't schedule onto a node already running a pod with a different mimir-rc value.
+    // Per-compartment node anti-affinity, replacing the base ingester rule. Keep different read
+    // compartments off the same node so a node failure only affects one compartment, and keep different
+    // zones of the same compartment off the same node. The latter is already enforced by per-AZ node
+    // affinity today (compartments require multi-AZ), but we keep the rule as a safety net in case that
+    // requirement is ever relaxed.
     { spec+: podAntiAffinity.withRequiredDuringSchedulingIgnoredDuringExecution([
       podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecutionType.new() +
       podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecutionType.mixin.labelSelector.withMatchExpressions([
@@ -60,7 +64,16 @@
         { key: 'mimir-rc', operator: 'NotIn', values: [compartmentIdxStr] },
       ]) +
       podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecutionType.withTopologyKey('kubernetes.io/hostname'),
-    ]).spec },
+    ] + (
+      if $._config.ingester_allow_multiple_replicas_on_same_node then [] else [
+        podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecutionType.new() +
+        podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecutionType.mixin.labelSelector.withMatchExpressions([
+          { key: 'rollout-group', operator: 'In', values: [rolloutGroup] },
+          { key: 'name', operator: 'NotIn', values: [name] },
+        ]) +
+        podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecutionType.withTopologyKey('kubernetes.io/hostname'),
+      ]
+    )).spec },
 
   // Null out no-compartment StatefulSets, Services, PDBs, and ScaledObjects when decommissioning.
   ingester_zone_a_statefulset: if !isNoCompartmentsEnabled && isZoneAEnabled then null else super.ingester_zone_a_statefulset,

--- a/operations/mimir/compartments-ingester.libsonnet
+++ b/operations/mimir/compartments-ingester.libsonnet
@@ -1,0 +1,162 @@
+{
+  _config+:: {
+    compartments_ingester_enabled: $._config.compartments_enabled,
+    no_compartments_ingester_enabled: !self.compartments_ingester_enabled,
+
+    // Compartment ingesters are autoscaled: min/max replicas apply per compartment, per zone.
+    compartments_ingester_autoscaling_min_replicas_per_compartment_zone: 1,
+    compartments_ingester_autoscaling_max_replicas_per_compartment_zone: 10,
+
+    // The regex to extract the ingester partition identifier from a pod name.
+    compartments_ingester_zpdb_partition_regex: '[a-z\\-]+-zone-[a-z]-rc-[0-9]+-([0-9]+)',
+
+    // The above regex has a single capturing group, so the partition is always group 1.
+    compartments_ingester_zpdb_partition_group: 1,
+  },
+
+  assert !$._config.compartments_ingester_enabled || $._config.multi_zone_ingester_enabled
+         : 'compartments_ingester_enabled requires multi_zone_ingester_enabled',
+  assert !$._config.compartments_ingester_enabled || $._config.multi_zone_ingester_multi_az_enabled
+         : 'compartments_ingester_enabled requires multi_zone_ingester_multi_az_enabled',
+  assert !$._config.compartments_ingester_enabled || $._config.ingest_storage_enabled
+         : 'compartments_ingester_enabled requires ingest_storage_enabled',
+  assert !$._config.compartments_ingester_enabled || $._config.ingest_storage_ingester_autoscaling_enabled
+         : 'compartments_ingester_enabled requires ingest_storage_ingester_autoscaling_enabled',
+
+  local statefulSet = $.apps.v1.statefulSet,
+  local podAntiAffinity = statefulSet.mixin.spec.template.spec.affinity.podAntiAffinity,
+  local podDisruptionBudget = $.policy.v1.podDisruptionBudget,
+
+  local isEnabled = $._config.compartments_ingester_enabled,
+  local numCompartments = $._config.compartments_read_count,
+  local isNoCompartmentsEnabled = $._config.no_compartments_ingester_enabled,
+  local isZoneAEnabled = $._config.multi_zone_ingester_enabled && std.length($._config.multi_zone_availability_zones) >= 1,
+  local isZoneBEnabled = $._config.multi_zone_ingester_enabled && std.length($._config.multi_zone_availability_zones) >= 2,
+  local isZoneCEnabled = $._config.multi_zone_ingester_enabled && std.length($._config.multi_zone_availability_zones) >= 3,
+
+  newIngesterCompartmentContainer(zone, compartmentIdx, args, extraEnvVarMap={})::
+    $.newIngesterZoneContainer(zone, args, extraEnvVarMap),
+
+  newIngesterCompartmentStatefulSet(zone, compartmentIdx, container, nodeAffinityMatchers=[])::
+    local name = 'ingester-zone-%s-rc-%d' % [zone, compartmentIdx];
+    local compartmentIdxStr = std.toString(compartmentIdx);
+    local rolloutGroup = 'ingester-rc-%d' % compartmentIdx;
+    $.newIngesterZoneStatefulSet(zone, container, nodeAffinityMatchers) +
+    statefulSet.mixin.metadata.withName(name) +
+    statefulSet.mixin.spec.withServiceName(name) +
+    statefulSet.mixin.metadata.withLabelsMixin({ name: name, 'mimir-rc': compartmentIdxStr, 'rollout-group': rolloutGroup }) +
+    statefulSet.mixin.spec.template.metadata.withLabels({ name: name, 'rollout-group': rolloutGroup }) +
+    statefulSet.mixin.spec.selector.withMatchLabels({ name: name, 'rollout-group': rolloutGroup }) +
+    statefulSet.mixin.spec.withReplicas($._config.compartments_ingester_autoscaling_min_replicas_per_compartment_zone) +
+    // Label identifying the read compartment — used by the read-path anti-affinity below.
+    statefulSet.mixin.spec.template.metadata.withLabelsMixin({ 'mimir-rc': compartmentIdxStr }) +
+    // Multi-compartment ingesters require multi-AZ too, so we can always configure the multi-zone toleration.
+    statefulSet.spec.template.spec.withTolerationsMixin($.newMimirMultiZoneToleration()) +
+    // Spread read compartments across nodes: don't schedule onto a node already running a pod with a different mimir-rc value.
+    { spec+: podAntiAffinity.withRequiredDuringSchedulingIgnoredDuringExecution([
+      podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecutionType.new() +
+      podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecutionType.mixin.labelSelector.withMatchExpressions([
+        { key: 'mimir-rc', operator: 'Exists' },
+        { key: 'mimir-rc', operator: 'NotIn', values: [compartmentIdxStr] },
+      ]) +
+      podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecutionType.withTopologyKey('kubernetes.io/hostname'),
+    ]).spec },
+
+  // Null out no-compartment StatefulSets, Services, PDBs, and ScaledObjects when decommissioning.
+  ingester_zone_a_statefulset: if !isNoCompartmentsEnabled && isZoneAEnabled then null else super.ingester_zone_a_statefulset,
+  ingester_zone_b_statefulset: if !isNoCompartmentsEnabled && isZoneBEnabled then null else super.ingester_zone_b_statefulset,
+  ingester_zone_c_statefulset: if !isNoCompartmentsEnabled && isZoneCEnabled then null else super.ingester_zone_c_statefulset,
+
+  ingester_zone_a_service: if !isNoCompartmentsEnabled && isZoneAEnabled then null else super.ingester_zone_a_service,
+  ingester_zone_b_service: if !isNoCompartmentsEnabled && isZoneBEnabled then null else super.ingester_zone_b_service,
+  ingester_zone_c_service: if !isNoCompartmentsEnabled && isZoneCEnabled then null else super.ingester_zone_c_service,
+
+  ingester_rollout_pdb: if !isNoCompartmentsEnabled then null else super.ingester_rollout_pdb,
+
+  ingester_primary_zone_replica_template: if !isNoCompartmentsEnabled then null else super.ingester_primary_zone_replica_template,
+  ingest_storage_ingester_primary_zone_scaling: if !isNoCompartmentsEnabled then null else super.ingest_storage_ingester_primary_zone_scaling,
+
+  // Args.
+  local perCompartmentIngesterArgs(compartmentIdx) =
+    $.mimirCompartmentsCommonArgs {
+      'ingester.read-compartment-id': compartmentIdx,
+    },
+
+  ingester_zone_a_compartments_args:: $.mimirCompartmentsCreateIf(isEnabled && isZoneAEnabled, numCompartments, function(compartment) $.ingester_zone_a_args + perCompartmentIngesterArgs(compartment)),
+  ingester_zone_b_compartments_args:: $.mimirCompartmentsCreateIf(isEnabled && isZoneBEnabled, numCompartments, function(compartment) $.ingester_zone_b_args + perCompartmentIngesterArgs(compartment)),
+  ingester_zone_c_compartments_args:: $.mimirCompartmentsCreateIf(isEnabled && isZoneCEnabled, numCompartments, function(compartment) $.ingester_zone_c_args + perCompartmentIngesterArgs(compartment)),
+
+  // Containers.
+  ingester_zone_a_containers:: $.mimirCompartmentsCreateIf(isEnabled && isZoneAEnabled, numCompartments, function(compartment) $.newIngesterCompartmentContainer('a', compartment, $.ingester_zone_a_compartments_args['compartment_%d' % compartment], $.ingester_zone_a_env_map)),
+  ingester_zone_b_containers:: $.mimirCompartmentsCreateIf(isEnabled && isZoneBEnabled, numCompartments, function(compartment) $.newIngesterCompartmentContainer('b', compartment, $.ingester_zone_b_compartments_args['compartment_%d' % compartment], $.ingester_zone_b_env_map)),
+  ingester_zone_c_containers:: $.mimirCompartmentsCreateIf(isEnabled && isZoneCEnabled, numCompartments, function(compartment) $.newIngesterCompartmentContainer('c', compartment, $.ingester_zone_c_compartments_args['compartment_%d' % compartment], $.ingester_zone_c_env_map)),
+
+  // StatefulSets.
+  ingester_zone_a_statefulsets: $.mimirCompartmentsCreateIf(isEnabled && isZoneAEnabled, numCompartments, function(compartment) $.newIngesterCompartmentStatefulSet('a', compartment, $.ingester_zone_a_containers['compartment_%d' % compartment], $.ingester_zone_a_node_affinity_matchers) + ingesterCompartmentAutoscalingStatefulSetMixin('a', compartment)),
+  ingester_zone_b_statefulsets: $.mimirCompartmentsCreateIf(isEnabled && isZoneBEnabled, numCompartments, function(compartment) $.newIngesterCompartmentStatefulSet('b', compartment, $.ingester_zone_b_containers['compartment_%d' % compartment], $.ingester_zone_b_node_affinity_matchers) + ingesterCompartmentAutoscalingStatefulSetMixin('b', compartment)),
+  ingester_zone_c_statefulsets: $.mimirCompartmentsCreateIf(isEnabled && isZoneCEnabled, numCompartments, function(compartment) $.newIngesterCompartmentStatefulSet('c', compartment, $.ingester_zone_c_containers['compartment_%d' % compartment], $.ingester_zone_c_node_affinity_matchers) + ingesterCompartmentAutoscalingStatefulSetMixin('c', compartment)),
+
+  // PDBs.
+  local newIngesterRolloutCompartmentPdb(compartmentIdx) =
+    local name = 'ingester-rollout-rc-%d' % compartmentIdx;
+    (
+      if $._config.multi_zone_ingester_zpdb_enabled then
+        $.newZPDB(
+          name,
+          'ingester',
+          $._config.multi_zone_ingester_zpdb_max_unavailable,
+          $._config.compartments_ingester_zpdb_partition_regex,
+          $._config.compartments_ingester_zpdb_partition_group,
+        )
+      else
+        podDisruptionBudget.new(name) +
+        podDisruptionBudget.mixin.spec.withMaxUnavailable(1)
+    )
+    + podDisruptionBudget.mixin.metadata.withLabels({ name: name })
+    + podDisruptionBudget.mixin.spec.selector.withMatchLabels({
+      'rollout-group': 'ingester-rc-%d' % compartmentIdx,
+      'mimir-rc': std.toString(compartmentIdx),
+    }),
+
+  ingester_rollout_pdbs: $.mimirCompartmentsCreateIf(isEnabled, numCompartments, function(compartment) newIngesterRolloutCompartmentPdb(compartment)),
+
+  local autoscalingEnabled = isEnabled && $._config.ingest_storage_ingester_autoscaling_enabled,
+  local autoscaledCompartments = if autoscalingEnabled then std.range(0, numCompartments - 1) else [],
+  local compartmentLeaderName(compartmentIdx) = 'ingester-zone-a-rc-%d' % compartmentIdx,
+
+  ingester_primary_zone_replica_templates: {
+    ['compartment_%d' % compartment]: $.replicaTemplate(compartmentLeaderName(compartment), -1, 'name=%s' % compartmentLeaderName(compartment))
+    for compartment in autoscaledCompartments
+  },
+
+  ingest_storage_ingester_primary_zone_scalings: {
+    ['compartment_%d' % compartment]: $.newPartitionsPrimaryIngesterZoneScaledObject(
+      compartmentLeaderName(compartment),
+      $._config.compartments_ingester_autoscaling_min_replicas_per_compartment_zone,
+      $._config.compartments_ingester_autoscaling_max_replicas_per_compartment_zone,
+      // Per-compartment partition ring name: ingester.PartitionRingName ("ingester-partitions") with
+      // the "-rc-<id>" suffix from compartments.ReadCompartmentRingName.
+      [$.ingesterPartitionAutoscalingOwnedSeriesTrigger(compartmentLeaderName(compartment), 'ingester-partitions-rc-%d' % compartment)],
+      $.ingester_primary_zone_replica_templates['compartment_%d' % compartment],
+      $._config.ingest_storage_ingester_autoscaling_index_metrics,
+    )
+    for compartment in autoscaledCompartments
+  },
+
+  local ingesterCompartmentAutoscalingStatefulSetMixin(zone, compartmentIdx) =
+    if !autoscalingEnabled then {} else
+      $.ingesterPartitionAutoscalingStatefulSetMixin(compartmentLeaderName(compartmentIdx), zone == 'a', $.ingester_primary_zone_replica_templates['compartment_%d' % compartmentIdx]),
+
+  // Governing headless services (required by Kubernetes for StatefulSet pod DNS).
+  ingester_zone_a_services: $.mimirCompartmentsCreateIf(isEnabled && isZoneAEnabled, numCompartments, function(compartment) $.newIngesterZoneService($.ingester_zone_a_statefulsets['compartment_%d' % compartment])),
+  ingester_zone_b_services: $.mimirCompartmentsCreateIf(isEnabled && isZoneBEnabled, numCompartments, function(compartment) $.newIngesterZoneService($.ingester_zone_b_statefulsets['compartment_%d' % compartment])),
+  ingester_zone_c_services: $.mimirCompartmentsCreateIf(isEnabled && isZoneCEnabled, numCompartments, function(compartment) $.newIngesterZoneService($.ingester_zone_c_statefulsets['compartment_%d' % compartment])),
+
+  // Ensure all configured addresses on per-compartment ingester StatefulSets are zonal ones.
+  local ingesterCompartmentMultiZoneError = $.validateMimirMultiZoneConfig([
+    'ingester_zone_a_statefulsets',
+    'ingester_zone_b_statefulsets',
+    'ingester_zone_c_statefulsets',
+  ]),
+  assert ingesterCompartmentMultiZoneError == null : ingesterCompartmentMultiZoneError,
+}

--- a/operations/mimir/compartments-querier.libsonnet
+++ b/operations/mimir/compartments-querier.libsonnet
@@ -1,0 +1,9 @@
+{
+  // Make queriers compartment-aware.
+  local perCompartmentQuerierArgs = if !$._config.compartments_ingester_enabled then {} else $.mimirCompartmentsCommonArgs,
+
+  querier_args+:: perCompartmentQuerierArgs,
+  querier_zone_a_args+:: perCompartmentQuerierArgs,
+  querier_zone_b_args+:: perCompartmentQuerierArgs,
+  querier_zone_c_args+:: perCompartmentQuerierArgs,
+}

--- a/operations/mimir/ingest-storage.libsonnet
+++ b/operations/mimir/ingest-storage.libsonnet
@@ -18,6 +18,13 @@
     // The version of the Kafka record wire format. Versions 0, 1, and 2 are stable.
     ingest_storage_kafka_producer_record_version: 2,
 
+    // Kafka is a single cluster shared across availability zones, so its address is intentionally
+    // non-zonal. Exclude it from the multi-zone config validation, which would otherwise flag it on
+    // zone-aware deployments (e.g. multi-AZ ingesters).
+    multi_zone_config_validation_excluded_args+: if !$._config.ingest_storage_enabled then [] else [
+      '-ingest-storage.kafka.address',
+    ],
+
     commonConfig+:: if !$._config.ingest_storage_enabled then {} else
       $.ingest_storage_args +
 

--- a/operations/mimir/memberlist.libsonnet
+++ b/operations/mimir/memberlist.libsonnet
@@ -103,18 +103,15 @@
   // Don't add label to matcher, only to pod labels.
   local gossipLabel = $.apps.v1.statefulSet.spec.template.metadata.withLabelsMixin({ [$._config.gossip_member_label]: 'true' }),
 
-  // Like overrideSuperIfExists, but merges the override into each entry of a per-compartment workload
-  // map. Inlined so memberlist.libsonnet works in environments without the compartments libraries.
-  local overrideSuperCompartmentsIfExists(name, override) =
-    if !( name in super) || !std.isObject(super[name]) then {}
-    else { [compartment]+: override for compartment in std.objectFields(super[name]) },
-
   alertmanager_statefulset: overrideSuperIfExists('alertmanager_statefulset', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
   compactor_statefulset: overrideSuperIfExists('compactor_statefulset', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
   distributor_deployment: overrideSuperIfExists('distributor_deployment', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
   distributor_zone_a_deployment: overrideSuperIfExists('distributor_zone_a_deployment', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
   distributor_zone_b_deployment: overrideSuperIfExists('distributor_zone_b_deployment', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
   distributor_zone_c_deployment: overrideSuperIfExists('distributor_zone_c_deployment', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
+  distributor_zone_a_deployments+: overrideSuperCompartmentsIfExists('distributor_zone_a_deployments', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
+  distributor_zone_b_deployments+: overrideSuperCompartmentsIfExists('distributor_zone_b_deployments', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
+  distributor_zone_c_deployments+: overrideSuperCompartmentsIfExists('distributor_zone_c_deployments', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
   ingester_statefulset: overrideSuperIfExists('ingester_statefulset', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
   ingester_zone_a_statefulset: overrideSuperIfExists('ingester_zone_a_statefulset', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
   ingester_zone_b_statefulset: overrideSuperIfExists('ingester_zone_b_statefulset', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
@@ -122,6 +119,9 @@
   ingester_partition_zone_a_statefulset: overrideSuperIfExists('ingester_partition_zone_a_statefulset', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
   ingester_partition_zone_b_statefulset: overrideSuperIfExists('ingester_partition_zone_b_statefulset', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
   ingester_partition_zone_c_statefulset: overrideSuperIfExists('ingester_partition_zone_c_statefulset', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
+  ingester_zone_a_statefulsets+: overrideSuperCompartmentsIfExists('ingester_zone_a_statefulsets', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
+  ingester_zone_b_statefulsets+: overrideSuperCompartmentsIfExists('ingester_zone_b_statefulsets', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
+  ingester_zone_c_statefulsets+: overrideSuperCompartmentsIfExists('ingester_zone_c_statefulsets', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
   querier_deployment: overrideSuperIfExists('querier_deployment', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
   querier_zone_a_deployment: overrideSuperIfExists('querier_zone_a_deployment', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
   querier_zone_b_deployment: overrideSuperIfExists('querier_zone_b_deployment', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
@@ -155,14 +155,6 @@
   store_gateway_zone_b_statefulset: overrideSuperIfExists('store_gateway_zone_b_statefulset', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
   store_gateway_zone_c_statefulset: overrideSuperIfExists('store_gateway_zone_c_statefulset', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
 
-  // Compartments: per-compartment Deployment/StatefulSet maps; label each entry's pod template.
-  distributor_zone_a_deployments+: overrideSuperCompartmentsIfExists('distributor_zone_a_deployments', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
-  distributor_zone_b_deployments+: overrideSuperCompartmentsIfExists('distributor_zone_b_deployments', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
-  distributor_zone_c_deployments+: overrideSuperCompartmentsIfExists('distributor_zone_c_deployments', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
-  ingester_zone_a_statefulsets+: overrideSuperCompartmentsIfExists('ingester_zone_a_statefulsets', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
-  ingester_zone_b_statefulsets+: overrideSuperCompartmentsIfExists('ingester_zone_b_statefulsets', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
-  ingester_zone_c_statefulsets+: overrideSuperCompartmentsIfExists('ingester_zone_c_statefulsets', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
-
   // Headless service (= no assigned IP, DNS returns all targets instead) pointing to gossip network members.
   gossip_ring_service:
     if !$._config.memberlist_ring_enabled then null
@@ -184,4 +176,9 @@
   // Utility used to override a field only if exists in super.
   local overrideSuperIfExists(name, override) = if !( name in super) || super[name] == null || super[name] == {} then null else
     super[name] + override,
+
+  // Like overrideSuperIfExists, but merges the override into each entry of a per-compartment workload map.
+  local overrideSuperCompartmentsIfExists(name, override) =
+    if !( name in super) || !std.isObject(super[name]) then {}
+    else { [compartment]+: override for compartment in std.objectFields(super[name]) },
 }

--- a/operations/mimir/memberlist.libsonnet
+++ b/operations/mimir/memberlist.libsonnet
@@ -103,6 +103,12 @@
   // Don't add label to matcher, only to pod labels.
   local gossipLabel = $.apps.v1.statefulSet.spec.template.metadata.withLabelsMixin({ [$._config.gossip_member_label]: 'true' }),
 
+  // Like overrideSuperIfExists, but merges the override into each entry of a per-compartment workload
+  // map. Inlined so memberlist.libsonnet works in environments without the compartments libraries.
+  local overrideSuperCompartmentsIfExists(name, override) =
+    if !( name in super) || !std.isObject(super[name]) then {}
+    else { [compartment]+: override for compartment in std.objectFields(super[name]) },
+
   alertmanager_statefulset: overrideSuperIfExists('alertmanager_statefulset', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
   compactor_statefulset: overrideSuperIfExists('compactor_statefulset', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
   distributor_deployment: overrideSuperIfExists('distributor_deployment', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
@@ -148,6 +154,14 @@
   store_gateway_zone_a_statefulset: overrideSuperIfExists('store_gateway_zone_a_statefulset', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
   store_gateway_zone_b_statefulset: overrideSuperIfExists('store_gateway_zone_b_statefulset', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
   store_gateway_zone_c_statefulset: overrideSuperIfExists('store_gateway_zone_c_statefulset', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
+
+  // Compartments: per-compartment Deployment/StatefulSet maps; label each entry's pod template.
+  distributor_zone_a_deployments+: overrideSuperCompartmentsIfExists('distributor_zone_a_deployments', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
+  distributor_zone_b_deployments+: overrideSuperCompartmentsIfExists('distributor_zone_b_deployments', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
+  distributor_zone_c_deployments+: overrideSuperCompartmentsIfExists('distributor_zone_c_deployments', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
+  ingester_zone_a_statefulsets+: overrideSuperCompartmentsIfExists('ingester_zone_a_statefulsets', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
+  ingester_zone_b_statefulsets+: overrideSuperCompartmentsIfExists('ingester_zone_b_statefulsets', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
+  ingester_zone_c_statefulsets+: overrideSuperCompartmentsIfExists('ingester_zone_c_statefulsets', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
 
   // Headless service (= no assigned IP, DNS returns all targets instead) pointing to gossip network members.
   gossip_ring_service:

--- a/operations/mimir/mimir.libsonnet
+++ b/operations/mimir/mimir.libsonnet
@@ -61,6 +61,13 @@
 (import 'ingest-storage-ingester-autoscaling.libsonnet') +
 (import 'ingest-storage-migration.libsonnet') +
 
+// Experimental compartments support. Must come after autoscaling, multi-zone and ingest-storage
+// because it overrides their components and builds on their helpers.
+(import 'compartments-common.libsonnet') +
+(import 'compartments-distributor.libsonnet') +
+(import 'compartments-ingester.libsonnet') +
+(import 'compartments-querier.libsonnet') +
+
 // Add memberlist support. Keep it at the end because it overrides all Mimir components.
 (import 'memberlist.libsonnet') +
 (import 'multi-zone-memberlist-bridge.libsonnet')


### PR DESCRIPTION
#### What this PR does

Adds jsonnet for the experimental compartments architecture, disabled by default behind `compartments_enabled`.

Compartments support is still being built out across Mimir, so this wires up only the components that support it today: per-write-compartment distributors and per-read-compartment ingesters (including their partition rings and autoscaling), plus making queriers compartment-aware. More components will be added as the architecture matures.

A `test-compartments` rendering test is included so the generated manifests can be diffed against `test-ingest-storage-autoscaling-one-trigger`.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added. Not applicable: experimental and disabled by default.
- [ ] `CHANGELOG.md` updated. Not needed (experimental, disabled by default, consistent with the rest of the compartments work) — adding the `changelog-not-needed` label.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features. Not applicable: no new Mimir configuration flags; the runtime feature flags are already hidden/experimental and unchanged here.
