### PR TITLE
kafkatool: add dump analyse-series command

### DIFF
--- a/tools/kafkatool/dump.go
+++ b/tools/kafkatool/dump.go
@@ -31,6 +31,7 @@ type DumpCommand struct {
 	printer           Printer
 	printFormat       string
 	dupTenant         string
+	seriesTenant      string
 }
 
 // Register is used to register the command to a parent command.
@@ -59,6 +60,9 @@ func (c *DumpCommand) Register(app *kingpin.Application, getKafkaClient func() *
 
 	findDuplicatesCmd := cmd.Command("find-duplicates", "Print occurrences where a series sends a sample identical (timestamp+value) to its previous one").Action(c.doFindDuplicates)
 	findDuplicatesCmd.Flag("tenant", "Only analyse this tenant (Kafka record key).").StringVar(&c.dupTenant)
+
+	analyseSeriesCmd := cmd.Command("analyse-series", "For a tenant, report per-series sample counts and timestamp delta stats (min/max/avg)").Action(c.doAnalyseSeries)
+	analyseSeriesCmd.Flag("tenant", "Tenant (Kafka record key) to analyse.").Required().StringVar(&c.seriesTenant)
 }
 
 type key int

--- a/tools/kafkatool/dump_analyse_series.go
+++ b/tools/kafkatool/dump_analyse_series.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package main
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/twmb/franz-go/pkg/kgo"
+
+	"github.com/grafana/mimir/pkg/mimirpb"
+	"github.com/grafana/mimir/pkg/storage/ingest"
+)
+
+// seriesStats accumulates, for a single series of one tenant, how many samples
+// were ingested and the distribution of deltas (in milliseconds) between
+// consecutive sample timestamps as they arrive in the dump.
+type seriesStats struct {
+	labels  string
+	samples int
+
+	lastTS  int64
+	hasLast bool
+
+	minDelta   int64
+	maxDelta   int64
+	sumDelta   int64
+	deltaCount int
+}
+
+// observe records a sample at timestamp ts (ms). Samples must be observed in
+// arrival order so the delta against the previous sample is meaningful.
+func (s *seriesStats) observe(ts int64) {
+	if s.hasLast {
+		delta := ts - s.lastTS
+		if s.deltaCount == 0 || delta < s.minDelta {
+			s.minDelta = delta
+		}
+		if s.deltaCount == 0 || delta > s.maxDelta {
+			s.maxDelta = delta
+		}
+		s.sumDelta += delta
+		s.deltaCount++
+	}
+	s.lastTS = ts
+	s.hasLast = true
+	s.samples++
+}
+
+// doAnalyseSeries scans every write request for the requested tenant and, for
+// each series, reports the number of ingested samples and the min/max/avg delta
+// between consecutive sample timestamps. Detection is per-tenant by definition
+// (the command operates on a single tenant), keyed by series hash.
+func (c *DumpCommand) doAnalyseSeries(*kingpin.ParseContext) error {
+	series := make(map[uint64]*seriesStats)
+	hashBuf := make([]byte, 0, 1024)
+
+	err := c.parseWriteRequestsFromDumpFile(
+		func(_ int, record *kgo.Record, req *mimirpb.WriteRequest) {
+			if string(record.Key) != c.seriesTenant {
+				return
+			}
+
+			for _, ts := range req.Timeseries {
+				var h uint64
+				hashBuf, h = ingest.LabelAdaptersHash(hashBuf, ts.Labels)
+
+				st, ok := series[h]
+				if !ok {
+					// labels.String() builds a fresh string, so it's safe to retain
+					// beyond the request buffer's lifetime (see yoloString caveat).
+					st = &seriesStats{labels: mimirpb.FromLabelAdaptersToLabels(ts.Labels).String()}
+					series[h] = st
+				}
+
+				for _, s := range ts.Samples {
+					st.observe(s.TimestampMs)
+				}
+				for _, hp := range ts.Histograms {
+					st.observe(hp.Timestamp)
+				}
+			}
+		},
+		func(recordIdx int, err error) {
+			c.printer.PrintLine(fmt.Sprintf("corrupted record %d: %v", recordIdx, err))
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	c.printSeriesAnalysis(series)
+	return nil
+}
+
+func (c *DumpCommand) printSeriesAnalysis(series map[uint64]*seriesStats) {
+	stats := make([]*seriesStats, 0, len(series))
+	var totalSamples int
+	for _, s := range series {
+		stats = append(stats, s)
+		totalSamples += s.samples
+	}
+
+	// Most active series first; ties broken by labels for deterministic output.
+	sort.Slice(stats, func(i, j int) bool {
+		if stats[i].samples != stats[j].samples {
+			return stats[i].samples > stats[j].samples
+		}
+		return stats[i].labels < stats[j].labels
+	})
+
+	c.printer.PrintLine(fmt.Sprintf("=== SERIES ANALYSIS (tenant: %s) ===", c.seriesTenant))
+	c.printer.PrintLine(fmt.Sprintf("%-15s %d", "Unique series:", len(stats)))
+	c.printer.PrintLine(fmt.Sprintf("%-15s %d", "Total samples:", totalSamples))
+	c.printer.PrintLine("")
+	c.printer.PrintLine(fmt.Sprintf("%10s %15s %15s %15s  %s", "Samples", "MinDelta", "MaxDelta", "AvgDelta", "Labels"))
+	for _, s := range stats {
+		c.printer.PrintLine(fmt.Sprintf("%10d %15s %15s %15s  %s",
+			s.samples,
+			formatDelta(s.minDelta, s.deltaCount),
+			formatDelta(s.maxDelta, s.deltaCount),
+			formatAvgDelta(s.sumDelta, s.deltaCount),
+			s.labels,
+		))
+	}
+}
+
+// formatDelta renders a delta in milliseconds as a duration, or "-" when the
+// series has a single sample and therefore no delta.
+func formatDelta(deltaMs int64, deltaCount int) string {
+	if deltaCount == 0 {
+		return "-"
+	}
+	return (time.Duration(deltaMs) * time.Millisecond).String()
+}
+
+func formatAvgDelta(sumMs int64, deltaCount int) string {
+	if deltaCount == 0 {
+		return "-"
+	}
+	avgMs := float64(sumMs) / float64(deltaCount)
+	return time.Duration(avgMs * float64(time.Millisecond)).String()
+}

--- a/tools/kafkatool/dump_analyse_series_test.go
+++ b/tools/kafkatool/dump_analyse_series_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kgo"
+
+	"github.com/grafana/mimir/pkg/mimirpb"
+)
+
+func TestDumpCommand_AnalyseSeries(t *testing.T) {
+	mkLabels := func(nameValue ...string) []mimirpb.LabelAdapter {
+		labels := make([]mimirpb.LabelAdapter, 0, len(nameValue)/2)
+		for i := 0; i < len(nameValue); i += 2 {
+			labels = append(labels, mimirpb.LabelAdapter{Name: nameValue[i], Value: nameValue[i+1]})
+		}
+		return labels
+	}
+	mkSeries := func(labels []mimirpb.LabelAdapter, samples ...mimirpb.Sample) mimirpb.PreallocTimeseries {
+		return mimirpb.PreallocTimeseries{TimeSeries: &mimirpb.TimeSeries{Labels: labels, Samples: samples}}
+	}
+
+	seriesA := mkLabels("__name__", "metric_a", "job", "test")
+	seriesB := mkLabels("__name__", "metric_b", "job", "test")
+
+	at := time.Date(2026, 5, 29, 11, 0, 0, 0, time.UTC)
+
+	// series A (tenant-1): samples at 0, 10s, 40s -> deltas 10s and 30s.
+	//   min=10s, max=30s, avg=20s, samples=3.
+	// series B (tenant-1): a single sample -> no deltas.
+	// tenant-2: must be ignored entirely.
+	records := []dumpRecord{
+		{tenantID: "tenant-1", at: at, req: &mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{
+			mkSeries(seriesA, mimirpb.Sample{TimestampMs: 0, Value: 1}),
+			mkSeries(seriesB, mimirpb.Sample{TimestampMs: 0, Value: 1}),
+		}}},
+		{tenantID: "tenant-1", at: at, req: &mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{
+			mkSeries(seriesA, mimirpb.Sample{TimestampMs: 10_000, Value: 2}),
+		}}},
+		{tenantID: "tenant-1", at: at, req: &mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{
+			mkSeries(seriesA, mimirpb.Sample{TimestampMs: 40_000, Value: 3}),
+		}}},
+		{tenantID: "tenant-2", at: at, req: &mimirpb.WriteRequest{Timeseries: []mimirpb.PreallocTimeseries{
+			mkSeries(seriesA, mimirpb.Sample{TimestampMs: 0, Value: 1}, mimirpb.Sample{TimestampMs: 99_000, Value: 1}),
+		}}},
+	}
+
+	dumpFile := createTestDumpFileWithTimestamps(t, records)
+
+	app := newTestApp()
+	cmd := &DumpCommand{}
+	printer := &BufferedPrinter{}
+	cmd.Register(app, func() *kgo.Client { return nil }, printer)
+
+	_, err := app.Parse([]string{"dump", "analyse-series", "--file", dumpFile, "--tenant", "tenant-1"})
+	require.NoError(t, err)
+
+	lines := printer.GetLines()
+	output := strings.Join(lines, "\n")
+
+	assert.Contains(t, output, "Unique series:  2")
+	assert.Contains(t, output, "Total samples:  4")
+
+	// tenant-2 not scanned: its 99s gap must not appear.
+	assert.NotContains(t, output, "1m39s")
+
+	// series A row: 3 samples, min 10s, max 30s, avg 20s.
+	var seriesARow, seriesBRow string
+	for _, l := range lines {
+		if strings.Contains(l, `metric_a`) {
+			seriesARow = l
+		}
+		if strings.Contains(l, `metric_b`) {
+			seriesBRow = l
+		}
+	}
+	require.NotEmpty(t, seriesARow)
+	assert.Equal(t, []string{"3", "10s", "30s", "20s"}, strings.Fields(seriesARow)[:4])
+
+	// series B row: single sample -> deltas rendered as "-".
+	require.NotEmpty(t, seriesBRow)
+	assert.Equal(t, []string{"1", "-", "-", "-"}, strings.Fields(seriesBRow)[:4])
+}
+
+func TestDumpCommand_AnalyseSeries_RequiresTenant(t *testing.T) {
+	dumpFile := createTestDumpFileWithTimestamps(t, nil)
+
+	app := newTestApp()
+	cmd := &DumpCommand{}
+	cmd.Register(app, func() *kgo.Client { return nil }, &BufferedPrinter{})
+
+	_, err := app.Parse([]string{"dump", "analyse-series", "--file", dumpFile})
+	require.Error(t, err)
+}


### PR DESCRIPTION
#### What this PR does

Adds a `dump analyse-series` command to `kafkatool`. For a given tenant it scans every write request in a dump and, for each series, reports the number of ingested samples and the min/max/avg delta between consecutive sample timestamps.

This makes it easy to understand a tenant's scrape intervals and sample distribution directly from a Kafka dump, without reconstructing it from raw `print` output.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - internal tooling only, `changelog-not-needed`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
