### PR TITLE
mimirtool: resolve Grafana library panels during analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * [ENHANCEMENT] MQE: Support for native histograms in `smoothed` and `anchored` extended range selector modifiers. #15398
 * [ENHANCEMENT] Mimir: Expose `ingest_storage` feature flag in the `/api/v1/status/buildinfo` endpoint, reflecting whether Mimir runs with ingest storage architecture. #15743
 * [BUGFIX] Query-frontend: Fix `cardinality_analysis_max_results` being ignored when set higher than the default of 500. #15581
+* [BUGFIX] Mimirtool: Resolve Grafana library panel references when running `mimirtool analyze grafana`, so metrics used only by library panels are included in the generated metrics report. #15763
 * [BUGFIX] Ingest storage: Fix `KafkaProducer.ProduceSync()` returning a single result with a nil record when the context is canceled, instead of one result per input record (with the record set) as the underlying franz-go client does. #15199
 * [BUGFIX] Ingest storage: Fix `cortex_ingest_storage_reader_receive_delay_seconds` inflation by no longer setting the Kafka record `Timestamp` on the distributor side; the Kafka client now sets it at produce time. #15572
 * [BUGFIX] Distributor: Return HTTP 200 with OTLP partial-success when only some samples in an OTLP request are rejected by distributor-level validation (e.g. `too_far_in_past`). #15253

--- a/pkg/mimirtool/analyze/grafana.go
+++ b/pkg/mimirtool/analyze/grafana.go
@@ -58,7 +58,12 @@ type DashboardMetrics struct {
 }
 
 func ParseMetricsInBoard(mig *MetricsInGrafana, board minisdk.Board, promqlParser parser.Parser, logger log.Logger) {
-	var parseErrors []error
+	ParseMetricsInBoardWithParseErrors(mig, board, nil, promqlParser, logger)
+}
+
+// ParseMetricsInBoardWithParseErrors parses the metrics used by a board and includes the supplied parse errors in the output.
+func ParseMetricsInBoardWithParseErrors(mig *MetricsInGrafana, board minisdk.Board, parseErrors []error, promqlParser parser.Parser, logger log.Logger) {
+	parseErrors = slices.Clone(parseErrors)
 	metrics := make(map[string]struct{})
 
 	// Iterate through all the panels and collect metrics

--- a/pkg/mimirtool/commands/analyse_grafana.go
+++ b/pkg/mimirtool/commands/analyse_grafana.go
@@ -83,13 +83,14 @@ func AnalyzeGrafana(ctx context.Context, c *minisdk.Client, folders []string, re
 	}
 
 	filterOnFolders := len(folders) > 0
+	libraryPanels := libraryPanelCache{}
 
 	for _, link := range boardLinks {
 		if filterOnFolders && !slices.Contains(folders, link.FolderTitle) {
 			continue
 		}
 
-		err := processDashboard(ctx, c, link, output, readTimeout, promqlParser, logger)
+		err := processDashboard(ctx, c, link, output, readTimeout, libraryPanels, promqlParser, logger)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s for %s %s\n", err, link.UID, link.Title)
 		}
@@ -105,8 +106,10 @@ func AnalyzeGrafana(ctx context.Context, c *minisdk.Client, folders []string, re
 	return output, nil
 }
 
+type libraryPanelCache map[string]minisdk.Panel
+
 // processDashboard fetches and processes a single Grafana dashboard.
-func processDashboard(ctx context.Context, c *minisdk.Client, link minisdk.FoundBoard, output *analyze.MetricsInGrafana, readTimeout time.Duration, promqlParser parser.Parser, logger log.Logger) error {
+func processDashboard(ctx context.Context, c *minisdk.Client, link minisdk.FoundBoard, output *analyze.MetricsInGrafana, readTimeout time.Duration, libraryPanels libraryPanelCache, promqlParser parser.Parser, logger log.Logger) error {
 	fetchCtx, cancel := context.WithTimeout(ctx, readTimeout)
 	defer cancel()
 
@@ -120,8 +123,68 @@ func processDashboard(ctx context.Context, c *minisdk.Client, link minisdk.Found
 		return err
 	}
 
-	analyze.ParseMetricsInBoard(output, board, promqlParser, logger)
+	parseErrors := resolveLibraryPanels(ctx, c, &board, libraryPanels, readTimeout)
+	analyze.ParseMetricsInBoardWithParseErrors(output, board, parseErrors, promqlParser, logger)
 	return nil
+}
+
+func resolveLibraryPanels(ctx context.Context, c *minisdk.Client, board *minisdk.Board, libraryPanels libraryPanelCache, readTimeout time.Duration) []error {
+	var parseErrors []error
+	for _, panel := range board.Panels {
+		if panel == nil {
+			continue
+		}
+		parseErrors = append(parseErrors, resolveLibraryPanel(ctx, c, panel, libraryPanels, readTimeout)...)
+	}
+
+	for _, row := range board.Rows {
+		if row == nil {
+			continue
+		}
+		for i := range row.Panels {
+			parseErrors = append(parseErrors, resolveLibraryPanel(ctx, c, &row.Panels[i], libraryPanels, readTimeout)...)
+		}
+	}
+
+	return parseErrors
+}
+
+func resolveLibraryPanel(ctx context.Context, c *minisdk.Client, panel *minisdk.Panel, libraryPanels libraryPanelCache, readTimeout time.Duration) []error {
+	var parseErrors []error
+	if panel.LibraryPanel != nil {
+		libraryPanel, err := getLibraryPanel(ctx, c, *panel.LibraryPanel, libraryPanels, readTimeout)
+		if err != nil {
+			parseErrors = append(parseErrors, err)
+		} else {
+			*panel = libraryPanel
+		}
+	}
+
+	for i := range panel.SubPanels {
+		parseErrors = append(parseErrors, resolveLibraryPanel(ctx, c, &panel.SubPanels[i], libraryPanels, readTimeout)...)
+	}
+
+	return parseErrors
+}
+
+func getLibraryPanel(ctx context.Context, c *minisdk.Client, ref minisdk.LibraryPanelRef, libraryPanels libraryPanelCache, readTimeout time.Duration) (minisdk.Panel, error) {
+	if ref.UID == "" {
+		return minisdk.Panel{}, fmt.Errorf("library panel %q has no uid", ref.Name)
+	}
+
+	if panel, ok := libraryPanels[ref.UID]; ok {
+		return panel, nil
+	}
+
+	fetchCtx, cancel := context.WithTimeout(ctx, readTimeout)
+	defer cancel()
+
+	panel, err := c.GetLibraryElementByUID(fetchCtx, ref.UID)
+	if err != nil {
+		return minisdk.Panel{}, fmt.Errorf("library panel %q (%s): %w", ref.Name, ref.UID, err)
+	}
+	libraryPanels[ref.UID] = panel
+	return panel, nil
 }
 
 func getAllDashboards(ctx context.Context, c *minisdk.Client) ([]minisdk.FoundBoard, error) {

--- a/pkg/mimirtool/commands/analyse_grafana_test.go
+++ b/pkg/mimirtool/commands/analyse_grafana_test.go
@@ -6,10 +6,15 @@
 package commands
 
 import (
+	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/go-kit/log"
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -64,6 +69,130 @@ func TestParseMetricsInBoard(t *testing.T) {
 	analyze.ParseMetricsInBoard(output, board, util.CreatePromQLParser(false), log.NewNopLogger())
 	assert.Equal(t, dashboardMetrics, output.Dashboards[0].Metrics)
 	assert.Equal(t, expectedParseErrors, output.Dashboards[0].ParseErrors)
+}
+
+func TestAnalyzeGrafana_ResolvesLibraryPanels(t *testing.T) {
+	libraryElementRequests := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/search":
+			require.Equal(t, http.MethodGet, r.Method)
+			if r.URL.Query().Get("page") == "1" {
+				_, err := w.Write([]byte(`[{"uid":"library-dashboard","title":"Library Dashboard"}]`))
+				require.NoError(t, err)
+				return
+			}
+			_, err := w.Write([]byte(`[]`))
+			require.NoError(t, err)
+		case "/api/dashboards/uid/library-dashboard":
+			require.Equal(t, http.MethodGet, r.Method)
+			_, err := w.Write([]byte(`{
+				"dashboard": {
+					"uid": "library-dashboard",
+					"title": "Library Dashboard",
+					"panels": [
+						{
+							"title": "CPU",
+							"libraryPanel": {
+								"name": "CPU",
+								"uid": "lib-cpu"
+							}
+						},
+						{
+							"title": "CPU copy",
+							"libraryPanel": {
+								"name": "CPU",
+								"uid": "lib-cpu"
+							}
+						}
+					]
+				}
+			}`))
+			require.NoError(t, err)
+		case "/api/library-elements/lib-cpu":
+			require.Equal(t, http.MethodGet, r.Method)
+			libraryElementRequests++
+			_, err := w.Write([]byte(`{
+				"result": {
+					"uid": "lib-cpu",
+					"kind": 1,
+					"model": {
+						"type": "timeseries",
+						"targets": [
+							{"expr": "node_cpu_seconds_total"}
+						]
+					}
+				}
+			}`))
+			require.NoError(t, err)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	c, err := minisdk.NewClient(ts.URL, "", ts.Client(), "")
+	require.NoError(t, err)
+
+	output, err := AnalyzeGrafana(context.Background(), c, nil, time.Second, util.CreatePromQLParser(false), log.NewNopLogger())
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, libraryElementRequests)
+	assert.Equal(t, model.LabelValues{"node_cpu_seconds_total"}, output.MetricsUsed)
+	require.Len(t, output.Dashboards, 1)
+	assert.Equal(t, []string{"node_cpu_seconds_total"}, output.Dashboards[0].Metrics)
+	assert.Empty(t, output.Dashboards[0].ParseErrors)
+}
+
+func TestAnalyzeGrafana_RecordsLibraryPanelFetchErrors(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/search":
+			require.Equal(t, http.MethodGet, r.Method)
+			if r.URL.Query().Get("page") == "1" {
+				_, err := w.Write([]byte(`[{"uid":"library-dashboard","title":"Library Dashboard"}]`))
+				require.NoError(t, err)
+				return
+			}
+			_, err := w.Write([]byte(`[]`))
+			require.NoError(t, err)
+		case "/api/dashboards/uid/library-dashboard":
+			require.Equal(t, http.MethodGet, r.Method)
+			_, err := w.Write([]byte(`{
+				"dashboard": {
+					"uid": "library-dashboard",
+					"title": "Library Dashboard",
+					"panels": [
+						{
+							"title": "Missing",
+							"libraryPanel": {
+								"name": "Missing",
+								"uid": "missing-lib"
+							}
+						}
+					]
+				}
+			}`))
+			require.NoError(t, err)
+		case "/api/library-elements/missing-lib":
+			require.Equal(t, http.MethodGet, r.Method)
+			http.Error(w, "not found", http.StatusNotFound)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	c, err := minisdk.NewClient(ts.URL, "", ts.Client(), "")
+	require.NoError(t, err)
+
+	output, err := AnalyzeGrafana(context.Background(), c, nil, time.Second, util.CreatePromQLParser(false), log.NewNopLogger())
+	require.NoError(t, err)
+
+	require.Len(t, output.Dashboards, 1)
+	assert.Empty(t, output.Dashboards[0].Metrics)
+	require.Len(t, output.Dashboards[0].ParseErrors, 1)
+	assert.Contains(t, output.Dashboards[0].ParseErrors[0], `library panel "Missing" (missing-lib): HTTP error 404`)
 }
 
 func BenchmarkParseMetricsInBoard(b *testing.B) {

--- a/pkg/mimirtool/minisdk/client.go
+++ b/pkg/mimirtool/minisdk/client.go
@@ -126,6 +126,31 @@ func (c *Client) GetRawDashboardByUID(ctx context.Context, uid string) ([]byte, 
 	return envelope.Board, nil
 }
 
+// GetLibraryElementByUID returns the panel model for a Grafana library element with the given UID.
+func (c *Client) GetLibraryElementByUID(ctx context.Context, uid string) (Panel, error) {
+	raw, code, err := c.get(ctx, "api/library-elements/"+uid, nil)
+	if err != nil {
+		return Panel{}, err
+	}
+	if code != http.StatusOK {
+		return Panel{}, fmt.Errorf("HTTP error %d: returns %s", code, raw)
+	}
+	var envelope struct {
+		Result struct {
+			Model json.RawMessage `json:"model"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return Panel{}, fmt.Errorf("unmarshal library element: %w", err)
+	}
+
+	var panel Panel
+	if err := json.Unmarshal(envelope.Result.Model, &panel); err != nil {
+		return Panel{}, fmt.Errorf("unmarshal library element model: %w", err)
+	}
+	return panel, nil
+}
+
 func (c *Client) get(ctx context.Context, query string, params url.Values) ([]byte, int, error) {
 	u, err := url.Parse(c.baseURL)
 	if err != nil {

--- a/pkg/mimirtool/minisdk/client_test.go
+++ b/pkg/mimirtool/minisdk/client_test.go
@@ -130,6 +130,50 @@ func TestClient_GetRawDashboardByUID_NonOKStatus(t *testing.T) {
 	assert.Contains(t, err.Error(), "HTTP error 404")
 }
 
+func TestClient_GetLibraryElementByUID(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/api/library-elements/lib-panel", r.URL.Path)
+		_, err := w.Write([]byte(`{
+			"result": {
+				"uid": "lib-panel",
+				"kind": 1,
+				"model": {
+					"type": "timeseries",
+					"targets": [
+						{"expr": "node_cpu_seconds_total"}
+					]
+				}
+			}
+		}`))
+		require.NoError(t, err)
+	}))
+	defer ts.Close()
+
+	c, err := minisdk.NewClient(ts.URL, "", ts.Client(), "")
+	require.NoError(t, err)
+
+	got, err := c.GetLibraryElementByUID(context.Background(), "lib-panel")
+	require.NoError(t, err)
+	assert.Equal(t, "timeseries", got.Type)
+	require.Len(t, got.Targets, 1)
+	assert.Equal(t, "node_cpu_seconds_total", got.Targets[0].Expr)
+}
+
+func TestClient_GetLibraryElementByUID_NonOKStatus(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	c, err := minisdk.NewClient(ts.URL, "", ts.Client(), "")
+	require.NoError(t, err)
+
+	_, err = c.GetLibraryElementByUID(context.Background(), "missing")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP error 404")
+}
+
 func TestNewClient_Auth(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/pkg/mimirtool/minisdk/panel.go
+++ b/pkg/mimirtool/minisdk/panel.go
@@ -135,9 +135,16 @@ var knownTypes = map[string]struct{}{
 
 // Panel represents panels of different types defined in a Grafana dashboard.
 type Panel struct {
-	Targets   []Target `json:"targets,omitempty"`
-	SubPanels []Panel  `json:"panels"`
-	Type      string   `json:"type"`
+	Targets      []Target         `json:"targets,omitempty"`
+	SubPanels    []Panel          `json:"panels"`
+	Type         string           `json:"type"`
+	LibraryPanel *LibraryPanelRef `json:"libraryPanel,omitempty"`
+}
+
+// LibraryPanelRef references a Grafana library panel.
+type LibraryPanelRef struct {
+	Name string `json:"name"`
+	UID  string `json:"uid"`
 }
 
 // Target describes an expression with which the Panel fetches data from a data source.


### PR DESCRIPTION
#### What this PR does

Updates `mimirtool analyze grafana` to resolve Grafana library panel references before parsing dashboard metrics. The Grafana client now fetches `GET /api/library-elements/:uid`, unwraps the returned panel `model`, caches library panel models by UID, and reuses the existing panel target parsing so metrics from library panels are included in `metricsUsed`.

The PR also records library panel resolution failures in the dashboard `parse_errors` list instead of silently omitting those metrics.

#### Which issue(s) this PR fixes or relates to

Fixes #15687

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features. Not applicable: this PR adds no experimental features or flags.

Validation:

- `go test ./pkg/mimirtool/...`
- `make BUILD_IN_CONTAINER=false format`
- `git diff --check origin/main..HEAD`

Note: plain `make format` could not run in this local environment because Docker was not running, so I used the supported local formatter path with `BUILD_IN_CONTAINER=false`.