### PR TITLE
Replace query-frontend topic offsets readers map with a single reader

### DIFF
--- a/pkg/frontend/querymiddleware/read_consistency.go
+++ b/pkg/frontend/querymiddleware/read_consistency.go
@@ -4,13 +4,11 @@ package querymiddleware
 
 import (
 	"net/http"
-	"sync"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/tenant"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"golang.org/x/sync/errgroup"
 
 	apierror "github.com/grafana/mimir/pkg/api/error"
 	querierapi "github.com/grafana/mimir/pkg/querier/api"
@@ -21,21 +19,20 @@ import (
 type readConsistencyRoundTripper struct {
 	next http.RoundTripper
 
-	// offsetsReaders is a map of offsets readers keyed by the request header the offsets get attached to.
-	offsetsReaders map[string]*ingest.TopicOffsetsReader
+	offsetsReader *ingest.TopicOffsetsReader
 
 	limits  Limits
 	logger  log.Logger
 	metrics *ingest.StrongReadConsistencyMetrics
 }
 
-func newReadConsistencyRoundTripper(next http.RoundTripper, offsetsReaders map[string]*ingest.TopicOffsetsReader, limits Limits, logger log.Logger, metrics *ingest.StrongReadConsistencyMetrics) http.RoundTripper {
+func newReadConsistencyRoundTripper(next http.RoundTripper, offsetsReader *ingest.TopicOffsetsReader, limits Limits, logger log.Logger, metrics *ingest.StrongReadConsistencyMetrics) http.RoundTripper {
 	return &readConsistencyRoundTripper{
-		next:           next,
-		offsetsReaders: offsetsReaders,
-		limits:         limits,
-		logger:         logger,
-		metrics:        metrics,
+		next:          next,
+		offsetsReader: offsetsReader,
+		limits:        limits,
+		logger:        logger,
+		metrics:       metrics,
 	}
 }
 
@@ -62,36 +59,17 @@ func (r *readConsistencyRoundTripper) RoundTrip(req *http.Request) (_ *http.Resp
 		return r.next.RoundTrip(req)
 	}
 
-	errGroup, ctx := errgroup.WithContext(ctx)
-	reqHeaderLock := &sync.Mutex{}
-
-	for headerKey, offsetsReader := range r.offsetsReaders {
-		headerKey := headerKey
-		offsetsReader := offsetsReader
-
-		errGroup.Go(func() error {
-			offsets, err := ingest.ObserveStrongReadConsistency(r.metrics, offsetsReader.Topic(), false, func() (map[int32]int64, error) {
-				return offsetsReader.WaitNextFetchLastProducedOffset(ctx)
-			})
-			if err != nil {
-				return errors.Wrapf(err, "wait for last produced offsets of topic '%s'", offsetsReader.Topic())
-			}
-
-			headerValue := string(querierapi.EncodeOffsets(offsets))
-			reqHeaderLock.Lock()
-			req.Header.Add(headerKey, headerValue)
-			reqHeaderLock.Unlock()
-
-			spanLog.DebugLog("msg", "got offsets for strong read consistency", "header", headerKey, "value", headerValue)
-
-			return nil
-		})
+	offsets, err := ingest.ObserveStrongReadConsistency(r.metrics, r.offsetsReader.Topic(), false, func() (map[int32]int64, error) {
+		return r.offsetsReader.WaitNextFetchLastProducedOffset(ctx)
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "wait for last produced offsets of topic '%s'", r.offsetsReader.Topic())
 	}
 
-	if err = errGroup.Wait(); err != nil {
-		return nil, err
-	}
+	headerValue := string(querierapi.EncodeOffsets(offsets))
+	req.Header.Add(querierapi.ReadConsistencyOffsetsHeader, headerValue)
 
+	spanLog.DebugLog("msg", "got offsets for strong read consistency", "header", querierapi.ReadConsistencyOffsetsHeader, "value", headerValue)
 	spanLog.DebugLog("msg", "evaluating query with strong read consistency")
 
 	return r.next.RoundTrip(req)
@@ -109,13 +87,9 @@ func getDefaultReadConsistency(tenantIDs []string, limits Limits) string {
 	return querierapi.ReadConsistencyEventual
 }
 
-func newReadConsistencyMetrics(reg prometheus.Registerer, offsetsReaders map[string]*ingest.TopicOffsetsReader) *ingest.StrongReadConsistencyMetrics {
+func newReadConsistencyMetrics(reg prometheus.Registerer, offsetsReader *ingest.TopicOffsetsReader) *ingest.StrongReadConsistencyMetrics {
 	const component = "query-frontend"
 
-	topics := make([]string, 0, len(offsetsReaders))
-	for _, r := range offsetsReaders {
-		topics = append(topics, r.Topic())
-	}
-
+	topics := []string{offsetsReader.Topic()}
 	return ingest.NewStrongReadConsistencyMetrics(reg, component, topics)
 }

--- a/pkg/frontend/querymiddleware/read_consistency_test.go
+++ b/pkg/frontend/querymiddleware/read_consistency_test.go
@@ -102,10 +102,8 @@ func TestReadConsistencyRoundTripper(t *testing.T) {
 				req = req.WithContext(querierapi.ContextWithReadConsistencyLevel(req.Context(), testData.reqConsistency))
 			}
 
-			offsetsReaders := map[string]*ingest.TopicOffsetsReader{querierapi.ReadConsistencyOffsetsHeader: reader}
-
 			reg := prometheus.NewPedanticRegistry()
-			rt := newReadConsistencyRoundTripper(downstream, offsetsReaders, testData.limits, log.NewNopLogger(), newReadConsistencyMetrics(reg, offsetsReaders))
+			rt := newReadConsistencyRoundTripper(downstream, reader, testData.limits, log.NewNopLogger(), newReadConsistencyMetrics(reg, reader))
 			_, err = rt.RoundTrip(req)
 			require.NoError(t, err)
 

--- a/pkg/frontend/querymiddleware/roundtrip.go
+++ b/pkg/frontend/querymiddleware/roundtrip.go
@@ -229,13 +229,13 @@ func NewTripperware(
 	cacheExtractor Extractor,
 	engine promql.QueryEngine,
 	engineOpts promql.EngineOpts,
-	ingestStorageTopicOffsetsReaders map[string]*ingest.TopicOffsetsReader,
+	ingestStorageTopicOffsetsReader *ingest.TopicOffsetsReader,
 	useRemoteExecution bool,
 	streamingEngine *streamingpromql.Engine,
 	registerer prometheus.Registerer,
 	memoryConsumptionTrackerFactory *limiter.InflightMemoryConsumptionTracker,
 ) (Tripperware, error) {
-	queryRangeTripperware, err := newQueryTripperware(cfg, log, limits, queryLimits, codec, cacheExtractor, engine, engineOpts, ingestStorageTopicOffsetsReaders, useRemoteExecution, streamingEngine, registerer, memoryConsumptionTrackerFactory)
+	queryRangeTripperware, err := newQueryTripperware(cfg, log, limits, queryLimits, codec, cacheExtractor, engine, engineOpts, ingestStorageTopicOffsetsReader, useRemoteExecution, streamingEngine, registerer, memoryConsumptionTrackerFactory)
 	if err != nil {
 		return nil, err
 	}
@@ -254,7 +254,7 @@ func newQueryTripperware(
 	cacheExtractor Extractor,
 	engine promql.QueryEngine,
 	engineOpts promql.EngineOpts,
-	ingestStorageTopicOffsetsReaders map[string]*ingest.TopicOffsetsReader,
+	ingestStorageTopicOffsetsReader *ingest.TopicOffsetsReader,
 	useRemoteExecution bool,
 	streamingEngine *streamingpromql.Engine,
 	registerer prometheus.Registerer,
@@ -333,18 +333,18 @@ func newQueryTripperware(
 		activeNativeHistogramMetrics = newShardActiveNativeHistogramMetricsMiddleware(activeNativeHistogramMetrics, limits, log)
 
 		// Enforce read consistency after caching.
-		if len(ingestStorageTopicOffsetsReaders) > 0 {
-			metrics := newReadConsistencyMetrics(registerer, ingestStorageTopicOffsetsReaders)
+		if ingestStorageTopicOffsetsReader != nil {
+			metrics := newReadConsistencyMetrics(registerer, ingestStorageTopicOffsetsReader)
 
-			queryrange = newReadConsistencyRoundTripper(queryrange, ingestStorageTopicOffsetsReaders, limits, log, metrics)
-			instant = newReadConsistencyRoundTripper(instant, ingestStorageTopicOffsetsReaders, limits, log, metrics)
-			cardinality = newReadConsistencyRoundTripper(cardinality, ingestStorageTopicOffsetsReaders, limits, log, metrics)
-			activeSeries = newReadConsistencyRoundTripper(activeSeries, ingestStorageTopicOffsetsReaders, limits, log, metrics)
-			activeNativeHistogramMetrics = newReadConsistencyRoundTripper(activeNativeHistogramMetrics, ingestStorageTopicOffsetsReaders, limits, log, metrics)
-			labels = newReadConsistencyRoundTripper(labels, ingestStorageTopicOffsetsReaders, limits, log, metrics)
-			series = newReadConsistencyRoundTripper(series, ingestStorageTopicOffsetsReaders, limits, log, metrics)
-			remoteRead = newReadConsistencyRoundTripper(remoteRead, ingestStorageTopicOffsetsReaders, limits, log, metrics)
-			next = newReadConsistencyRoundTripper(next, ingestStorageTopicOffsetsReaders, limits, log, metrics)
+			queryrange = newReadConsistencyRoundTripper(queryrange, ingestStorageTopicOffsetsReader, limits, log, metrics)
+			instant = newReadConsistencyRoundTripper(instant, ingestStorageTopicOffsetsReader, limits, log, metrics)
+			cardinality = newReadConsistencyRoundTripper(cardinality, ingestStorageTopicOffsetsReader, limits, log, metrics)
+			activeSeries = newReadConsistencyRoundTripper(activeSeries, ingestStorageTopicOffsetsReader, limits, log, metrics)
+			activeNativeHistogramMetrics = newReadConsistencyRoundTripper(activeNativeHistogramMetrics, ingestStorageTopicOffsetsReader, limits, log, metrics)
+			labels = newReadConsistencyRoundTripper(labels, ingestStorageTopicOffsetsReader, limits, log, metrics)
+			series = newReadConsistencyRoundTripper(series, ingestStorageTopicOffsetsReader, limits, log, metrics)
+			remoteRead = newReadConsistencyRoundTripper(remoteRead, ingestStorageTopicOffsetsReader, limits, log, metrics)
+			next = newReadConsistencyRoundTripper(next, ingestStorageTopicOffsetsReader, limits, log, metrics)
 		}
 
 		// Look up cache as first thing after validation.

--- a/pkg/frontend/querymiddleware/roundtrip_test.go
+++ b/pkg/frontend/querymiddleware/roundtrip_test.go
@@ -991,7 +991,7 @@ func TestTripperware_ShouldSupportReadConsistencyOffsetsInjection(t *testing.T) 
 		nil,
 		promEngine,
 		promOpts,
-		map[string]*ingest.TopicOffsetsReader{querierapi.ReadConsistencyOffsetsHeader: offsetsReader},
+		offsetsReader,
 		false,
 		nil,
 		nil,

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -907,49 +907,49 @@ type Mimir struct {
 	ServiceMap    map[string]services.Service
 	ModuleManager *modules.Manager
 
-	API                              *api.API
-	Server                           *server.Server
-	ServerMetrics                    *server.Metrics
-	IngesterRing                     *ring.Ring
-	IngesterPartitionRingWatchers    *ingest.PartitionRingWatchers
-	IngesterPartitionInstanceRings   *ingest.PartitionInstanceRings
-	TenantLimits                     validation.TenantLimits
-	Overrides                        *validation.Overrides
-	QueryLimitsProvider              streamingpromql.QueryLimitsProvider
-	ActiveGroupsCleanup              *util.ActiveGroupsCleanupService
-	Distributor                      *distributor.Distributor
-	Ingester                         *ingester.Ingester
-	RuntimeConfig                    *runtimeconfig.Manager
-	QuerierQueryable                 prom_storage.SampleAndChunkQueryable
-	ExemplarQueryable                prom_storage.ExemplarQueryable
-	StoreQueryable                   prom_storage.Queryable
-	MetadataSupplier                 querier.MetadataSupplier
-	QuerierEngine                    promql.QueryEngine
-	QuerierLifecycler                *ring.BasicLifecycler
-	QuerierRing                      *ring.Ring
-	QuerierStreamingEngine           *streamingpromql.Engine // The MQE instance in QuerierEngine (without fallback wrapper), or nil if MQE is disabled.
-	QueryFrontendStreamingEngine     *streamingpromql.Engine // The MQE instance used by the query-frontend (without fallback wrapper), or nil if MQE is disabled.
-	QueryFrontendTripperware         querymiddleware.Tripperware
-	QueryFrontendTopicOffsetsReaders map[string]*ingest.TopicOffsetsReader
-	QueryFrontendCodec               querymiddleware.Codec
-	Ruler                            *ruler.Ruler
-	RulerStorage                     rulestore.RuleStore
-	Alertmanager                     *alertmanager.MultitenantAlertmanager
-	Compactor                        *compactor.MultitenantCompactor
-	CompactorScheduler               *compactorscheduler.Scheduler
-	StoreGateway                     *storegateway.StoreGateway
-	MemberlistKV                     *memberlist.KVInitService
-	ActivityTracker                  *activitytracker.ActivityTracker
-	Vault                            *vault.Vault
-	UsageStatsReporter               *usagestats.Reporter
-	UsageTracker                     *usagetracker.UsageTracker
-	UsageTrackerPartitionRing        *ring.MultiPartitionInstanceRing
-	UsageTrackerInstanceRing         *ring.Ring
-	BlockBuilder                     *blockbuilder.BlockBuilder
-	BlockBuilderScheduler            *blockbuilderscheduler.BlockBuilderScheduler
-	ContinuousTestManager            *continuoustest.Manager
-	BuildInfoHandler                 http.Handler
-	CostAttributionManager           *costattribution.Manager
+	API                             *api.API
+	Server                          *server.Server
+	ServerMetrics                   *server.Metrics
+	IngesterRing                    *ring.Ring
+	IngesterPartitionRingWatchers   *ingest.PartitionRingWatchers
+	IngesterPartitionInstanceRings  *ingest.PartitionInstanceRings
+	TenantLimits                    validation.TenantLimits
+	Overrides                       *validation.Overrides
+	QueryLimitsProvider             streamingpromql.QueryLimitsProvider
+	ActiveGroupsCleanup             *util.ActiveGroupsCleanupService
+	Distributor                     *distributor.Distributor
+	Ingester                        *ingester.Ingester
+	RuntimeConfig                   *runtimeconfig.Manager
+	QuerierQueryable                prom_storage.SampleAndChunkQueryable
+	ExemplarQueryable               prom_storage.ExemplarQueryable
+	StoreQueryable                  prom_storage.Queryable
+	MetadataSupplier                querier.MetadataSupplier
+	QuerierEngine                   promql.QueryEngine
+	QuerierLifecycler               *ring.BasicLifecycler
+	QuerierRing                     *ring.Ring
+	QuerierStreamingEngine          *streamingpromql.Engine // The MQE instance in QuerierEngine (without fallback wrapper), or nil if MQE is disabled.
+	QueryFrontendStreamingEngine    *streamingpromql.Engine // The MQE instance used by the query-frontend (without fallback wrapper), or nil if MQE is disabled.
+	QueryFrontendTripperware        querymiddleware.Tripperware
+	QueryFrontendTopicOffsetsReader *ingest.TopicOffsetsReader
+	QueryFrontendCodec              querymiddleware.Codec
+	Ruler                           *ruler.Ruler
+	RulerStorage                    rulestore.RuleStore
+	Alertmanager                    *alertmanager.MultitenantAlertmanager
+	Compactor                       *compactor.MultitenantCompactor
+	CompactorScheduler              *compactorscheduler.Scheduler
+	StoreGateway                    *storegateway.StoreGateway
+	MemberlistKV                    *memberlist.KVInitService
+	ActivityTracker                 *activitytracker.ActivityTracker
+	Vault                           *vault.Vault
+	UsageStatsReporter              *usagestats.Reporter
+	UsageTracker                    *usagetracker.UsageTracker
+	UsageTrackerPartitionRing       *ring.MultiPartitionInstanceRing
+	UsageTrackerInstanceRing        *ring.Ring
+	BlockBuilder                    *blockbuilder.BlockBuilder
+	BlockBuilderScheduler           *blockbuilderscheduler.BlockBuilderScheduler
+	ContinuousTestManager           *continuoustest.Manager
+	BuildInfoHandler                http.Handler
+	CostAttributionManager          *costattribution.Manager
 
 	// Extractors are used by queriers to extract HTTP headers / metadata from incoming requests.
 	// We use an abstraction here to support both httpgrpc requests and Protobuf requests.

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -884,10 +884,7 @@ func (t *Mimir) initQueryFrontendTopicOffsetsReaders() (services.Service, error)
 
 	ingestTopicOffsetsReader := ingest.NewTopicOffsetsReader(kafkaClient, t.Cfg.IngestStorage.KafkaConfig.Topic, getPartitionIDs, t.Cfg.IngestStorage.KafkaConfig.LastProducedOffsetPollInterval, t.Registerer, util_log.Logger)
 
-	if t.QueryFrontendTopicOffsetsReaders == nil {
-		t.QueryFrontendTopicOffsetsReaders = make(map[string]*ingest.TopicOffsetsReader)
-	}
-	t.QueryFrontendTopicOffsetsReaders[querierapi.ReadConsistencyOffsetsHeader] = ingestTopicOffsetsReader
+	t.QueryFrontendTopicOffsetsReader = ingestTopicOffsetsReader
 
 	return ingestTopicOffsetsReader, nil
 }
@@ -951,7 +948,7 @@ func (t *Mimir) initQueryFrontendTripperware() (serv services.Service, err error
 		querymiddleware.PrometheusResponseExtractor{},
 		eng,
 		promOpts,
-		t.QueryFrontendTopicOffsetsReaders,
+		t.QueryFrontendTopicOffsetsReader,
 		t.Cfg.Frontend.QueryMiddleware.EnableRemoteExecution,
 		t.QueryFrontendStreamingEngine,
 		t.Registerer,


### PR DESCRIPTION
#### What this PR does

`Mimir.QueryFrontendTopicOffsetsReaders` was a `map[string]*ingest.TopicOffsetsReader` keyed by the response header the encoded offsets get attached to, but it has only ever held a single entry (the `X-Read-Consistency-Offsets` header), in both Mimir and GEM. That left the `errgroup`/`sync.Mutex` fan-out in the read-consistency round tripper, the lazy map init, and the per-entry iteration as pure overhead around a single value.

This replaces the map with a single nil-able `*ingest.TopicOffsetsReader`, referencing the header constant directly where the header is added. No behaviour change: same single header, same encoding, same metrics.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.