### PR TITLE
MQE: evaluate all step-invariant expressions at T=0

### DIFF
--- a/pkg/streamingpromql/operators/step_invariant_instant_vector_operator.go
+++ b/pkg/streamingpromql/operators/step_invariant_instant_vector_operator.go
@@ -59,6 +59,15 @@ func (s *StepInvariantInstantVectorOperator) NextSeries(ctx context.Context) (ty
 	}
 
 	if s.originalTimeRange.IsInstant || s.originalTimeRange.StepCount <= 1 {
+		// The inner operator will be evaluated at T=0, so we still need to set the correct timestamp for any output samples.
+		for i := range data.Floats {
+			data.Floats[i].T = s.originalTimeRange.StartT
+		}
+
+		for i := range data.Histograms {
+			data.Histograms[i].T = s.originalTimeRange.StartT
+		}
+
 		return data, nil
 	}
 
@@ -94,7 +103,7 @@ func (s *StepInvariantInstantVectorOperator) NextSeries(ctx context.Context) (ty
 			return types.InstantVectorSeriesData{}, err
 		}
 
-		histograms = append(histograms, promql.HPoint{T: data.Histograms[0].T, H: data.Histograms[0].H})
+		histograms = append(histograms, promql.HPoint{T: s.originalTimeRange.StartT, H: data.Histograms[0].H})
 		// Note that we create a copy of the histogram for each step as we can not re-use the same *FloatHistogram in the slice from the pool.
 		for ts := s.originalTimeRange.StartT + s.originalTimeRange.IntervalMilliseconds; ts <= s.originalTimeRange.EndT; ts += s.originalTimeRange.IntervalMilliseconds {
 			histograms = append(histograms, promql.HPoint{

--- a/pkg/streamingpromql/operators/step_invariant_scalar_operator.go
+++ b/pkg/streamingpromql/operators/step_invariant_scalar_operator.go
@@ -55,6 +55,11 @@ func (s *StepInvariantScalarOperator) GetValues(ctx context.Context) (types.Scal
 	}
 
 	if s.originalTimeRange.IsInstant || s.originalTimeRange.StepCount <= 1 {
+		// The inner operator will be evaluated at T=0, so we still need to set the correct timestamp for any output samples.
+		for i := range data.Samples {
+			data.Samples[i].T = s.originalTimeRange.StartT
+		}
+
 		return data, nil
 	}
 
@@ -69,9 +74,7 @@ func (s *StepInvariantScalarOperator) GetValues(ctx context.Context) (types.Scal
 			return types.ScalarData{}, err
 		}
 
-		floats = append(floats, data.Samples[0])
-
-		for ts := s.originalTimeRange.StartT + s.originalTimeRange.IntervalMilliseconds; ts <= s.originalTimeRange.EndT; ts += s.originalTimeRange.IntervalMilliseconds {
+		for ts := s.originalTimeRange.StartT; ts <= s.originalTimeRange.EndT; ts += s.originalTimeRange.IntervalMilliseconds {
 			floats = append(floats, promql.FPoint{
 				T: ts,
 				F: data.Samples[0].F,

--- a/pkg/streamingpromql/planning/core/step_invariant_expression.go
+++ b/pkg/streamingpromql/planning/core/step_invariant_expression.go
@@ -57,6 +57,18 @@ func (s *StepInvariantExpression) MergeHints(_ planning.Node) error {
 	return nil
 }
 
+func (s *StepInvariantExpression) ResultType() (parser.ValueType, error) {
+	return s.Inner.ResultType()
+}
+
+func (s *StepInvariantExpression) QueriedTimeRange(queryTimeRange types.QueryTimeRange, lookbackDelta time.Duration) (planning.QueriedTimeRange, error) {
+	return s.Inner.QueriedTimeRange(s.ChildrenTimeRange(queryTimeRange), lookbackDelta)
+}
+
+func (s *StepInvariantExpression) ExpressionPosition() (posrange.PositionRange, error) {
+	return s.Inner.ExpressionPosition()
+}
+
 func MaterializeStepInvariantExpression(s *StepInvariantExpression, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
 	resultType, err := s.Inner.ResultType()
 	if err != nil {
@@ -91,16 +103,4 @@ func MaterializeStepInvariantExpression(s *StepInvariantExpression, materializer
 	}
 
 	return nil, fmt.Errorf("unable to materialize step invariant expression with inner node type %T", op)
-}
-
-func (s *StepInvariantExpression) ResultType() (parser.ValueType, error) {
-	return s.Inner.ResultType()
-}
-
-func (s *StepInvariantExpression) QueriedTimeRange(queryTimeRange types.QueryTimeRange, lookbackDelta time.Duration) (planning.QueriedTimeRange, error) {
-	return s.Inner.QueriedTimeRange(s.ChildrenTimeRange(queryTimeRange), lookbackDelta)
-}
-
-func (s *StepInvariantExpression) ExpressionPosition() (posrange.PositionRange, error) {
-	return s.Inner.ExpressionPosition()
 }

--- a/pkg/streamingpromql/planning/core/step_invariant_expression.go
+++ b/pkg/streamingpromql/planning/core/step_invariant_expression.go
@@ -29,9 +29,10 @@ func (s *StepInvariantExpression) Describe() string {
 	return ""
 }
 
-func (s *StepInvariantExpression) ChildrenTimeRange(timeRange types.QueryTimeRange) types.QueryTimeRange {
-	// note that we set the StartT == EndT with a single step count.
-	return types.NewInstantQueryTimeRange(timestamp.Time(timeRange.StartT))
+func (s *StepInvariantExpression) ChildrenTimeRange(_ types.QueryTimeRange) types.QueryTimeRange {
+	// The time range used doesn't matter as long as it is a single step, given the expression is step invariant.
+	// So use T=0, to ensure there's no accidental dependency on the actual time range.
+	return types.NewInstantQueryTimeRange(timestamp.Time(0))
 }
 
 func (s *StepInvariantExpression) Details() proto.Message {

--- a/pkg/streamingpromql/testdata/ours/at_modifier.test
+++ b/pkg/streamingpromql/testdata/ours/at_modifier.test
@@ -26,6 +26,9 @@ eval range from 0 to 50s step 10s metric @ end()
 eval range from 0 to 60s step 10s metric @ end()
   metric 5 5 5 5 5 5 5
 
+eval range from 30s to 30s step 10s metric @ 20
+  metric 2
+
 clear
 
 load 5m
@@ -82,3 +85,10 @@ eval range from 0 to 60s step 10s avg_over_time(rate(metric[1m])[1s:60s])
   {job="web"} _ _ _ _ _ _ 20
 
 clear
+
+load 1m
+  single_histogram {{schema:0 sum:5 count:4 buckets:[1 2 1]}} {{schema:0 sum:20 count:7 buckets:[9 10 1]}} {{schema:0 sum:30 count:10 buckets:[12 15 3]}}
+
+eval range from 1m to 5m step 1m single_histogram @ 60
+  single_histogram {{schema:0 sum:20 count:7 buckets:[9 10 1]}} {{schema:0 sum:20 count:7 buckets:[9 10 1]}} {{schema:0 sum:20 count:7 buckets:[9 10 1]}} {{schema:0 sum:20 count:7 buckets:[9 10 1]}} {{schema:0 sum:20 count:7 buckets:[9 10 1]}}
+


### PR DESCRIPTION
#### What this PR does

This PR changes the behaviour of step-invariant expressions so they are all evaluated at T=0.

Previously they were evaluated at the start timestamp of the query request. 

With splitting and caching running inside MQE, this meant they were evaluated multiple times (once per split interval) rather than once per request.

This has no user-visible impact, so I've chosen not to add a changelog entry.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
