### PR TITLE
[release-3.1] storage/ingest: cap maximum kafka protocol version (#15745)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
-## unreleased
+## 3.1.2
 
 ### Grafana Mimir
+
+* [BUGFIX] Ingest storage: Cap maximum Kafka protocol version, the client negotiates with the broker to v3.9.0. #15745
 
 ## 3.1.1
 

--- a/pkg/storage/ingest/util.go
+++ b/pkg/storage/ingest/util.go
@@ -20,6 +20,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
+	"github.com/twmb/franz-go/pkg/kversion"
 	"github.com/twmb/franz-go/pkg/sasl"
 	awssasl "github.com/twmb/franz-go/pkg/sasl/aws"
 	"github.com/twmb/franz-go/pkg/sasl/oauth"
@@ -121,6 +122,11 @@ func commonKafkaClientOptions(cfg KafkaConfig, metrics *kprom.Metrics, logger lo
 		kgo.ClientID(cfg.ClientID),
 		kgo.SeedBrokers(cfg.Address...),
 		kgo.DialTimeout(cfg.DialTimeout),
+
+		// Mimir 3.1 and earlier doesn't fully support the newest Kafka protocols, resulting in failures to commit the offsets.
+		// As a workaround, we cap the maximum Kafka protocol version to negotiate with the broker to the older one.
+		// Ref to https://github.com/grafana/mimir/issues/15319
+		kgo.MaxVersions(kversion.V3_9_0()),
 
 		// A cluster metadata update is a request sent to a broker and getting back the map of partitions and
 		// the leader broker for each partition. The cluster metadata can be updated (a) periodically or


### PR DESCRIPTION
Cherry-pick https://github.com/grafana/mimir/pull/15745 e74d44839046ee00ee89caf7fe151660f3ff7090 into release-3.1