### PR TITLE
Fix flaky TestKafkaProducer_ProduceSync_LatencyShouldBeDrivenByKafkaProduceLatency

### DIFF
--- a/pkg/storage/ingest/writer_client_test.go
+++ b/pkg/storage/ingest/writer_client_test.go
@@ -505,13 +505,19 @@ func TestKafkaProducer_ProduceSync_LatencyShouldBeDrivenByKafkaProduceLatency(t 
 	t.Parallel()
 
 	const (
-		topicName                     = "test"
-		tenantID                      = "user-1"
-		numPartitions                 = 100
-		produceRecordsInterval        = 2 * time.Millisecond
-		produceRecordsDuration        = 10 * time.Second
-		produceRecordsTotal           = produceRecordsDuration / produceRecordsInterval
-		produceRecordsThroughputBytes = 50_000_000
+		topicName              = "test"
+		tenantID               = "user-1"
+		numPartitions          = 100
+		produceRecordsInterval = 2 * time.Millisecond
+		produceRecordsDuration = 10 * time.Second
+		produceRecordsTotal    = produceRecordsDuration / produceRecordsInterval
+
+		// The byte throughput is kept modest on purpose. The latency we measure does not depend on the
+		// record size (it's driven by the produce rate, linger and in-flight limit), but a high byte
+		// throughput makes the fake Kafka's single control loop spend significant CPU compressing,
+		// storing and copying payloads. On a busy CI runner this starves the control loop, delaying
+		// when Produce requests are evaluated and inflating the measured latency.
+		produceRecordsThroughputBytes = 5_000_000
 		produceRecordSizeBytes        = produceRecordsThroughputBytes / int(time.Second/produceRecordsInterval)
 
 		// produceLatency is the latency we simulate on each Produce request to the Kafka backend.

--- a/pkg/storage/ingest/writer_client_test.go
+++ b/pkg/storage/ingest/writer_client_test.go
@@ -513,7 +513,15 @@ func TestKafkaProducer_ProduceSync_LatencyShouldBeDrivenByKafkaProduceLatency(t 
 		produceRecordsTotal           = produceRecordsDuration / produceRecordsInterval
 		produceRecordsThroughputBytes = 50_000_000
 		produceRecordSizeBytes        = produceRecordsThroughputBytes / int(time.Second/produceRecordsInterval)
-		produceLatency                = 2 * time.Second
+
+		// produceLatency is the latency we simulate on each Produce request to the Kafka backend.
+		//
+		// It must stay within the Kafka client in-flight budget, which is "producer linger * max
+		// in-flight Produce requests" (50ms * defaultMaxInflightProduceRequests = 1s; see the rationale
+		// in NewKafkaWriterClient). If the simulated latency exceeds this budget, the client can't keep
+		// enough Produce requests in-flight to cover it: records then queue client side waiting for an
+		// in-flight slot, which adds latency on top of the backend latency.
+		produceLatency = 1 * time.Second
 	)
 
 	// Set a max execution time for this test.
@@ -609,7 +617,7 @@ func TestKafkaProducer_ProduceSync_LatencyShouldBeDrivenByKafkaProduceLatency(t 
 	// We expect the average produce latency to be close to the simulated Kafka produce latency.
 	averageProduceLatencySeconds := produceLatencySecondsSum.Load() / float64(produceRecordsTotal)
 	t.Logf("average produce latency seconds: %.2f", averageProduceLatencySeconds)
-	require.InDelta(t, produceLatency.Seconds(), averageProduceLatencySeconds, 1.)
+	require.InDelta(t, produceLatency.Seconds(), averageProduceLatencySeconds, 0.5)
 }
 
 func getSummaryQuantileValue(t require.TestingT, reg prometheus.Gatherer, metricName string, quantile float64) float64 {

--- a/pkg/storage/ingest/writer_test.go
+++ b/pkg/storage/ingest/writer_test.go
@@ -4,7 +4,6 @@ package ingest
 
 import (
 	"context"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"math/rand/v2"
@@ -1560,31 +1559,15 @@ func getProduceRequestHighestTimestamp(req *kmsg.ProduceRequest) (time.Time, err
 				return time.Time{}, err
 			}
 
-			// Decompress the batch of records.
-			records, err := kgo.DefaultDecompressor().Decompress(
-				batch.Records,
-				kgo.CompressionCodecType(batch.Attributes&0x0007),
-			)
-			if err != nil {
-				return time.Time{}, err
-			}
-
-			for range batch.NumRecords {
-				// Parse the record.
-				rec := kmsg.NewRecord()
-				err := rec.ReadFrom(records)
-				if err != nil {
-					return time.Time{}, err
-				}
-
-				recordTimestamp := time.UnixMilli(batch.FirstTimestamp + rec.TimestampDelta64)
-				if highestTimestamp.IsZero() || recordTimestamp.After(highestTimestamp) {
-					highestTimestamp = recordTimestamp
-				}
-
-				// Next record.
-				length, amt := binary.Varint(records)
-				records = records[length+int64(amt):]
+			// Read the highest timestamp from the record batch header (MaxTimestamp), which the Kafka
+			// client sets to the highest record timestamp in the batch. We intentionally avoid
+			// decompressing and parsing every record: doing so on the fake Kafka's single-threaded
+			// control loop is expensive (especially under the race detector with incompressible
+			// payloads) and makes the fake fall behind the produce rate, which distorts the latency
+			// this test measures.
+			batchHighestTimestamp := time.UnixMilli(batch.MaxTimestamp)
+			if highestTimestamp.IsZero() || batchHighestTimestamp.After(highestTimestamp) {
+				highestTimestamp = batchHighestTimestamp
 			}
 		}
 	}


### PR DESCRIPTION
#### What this PR does

`TestKafkaProducer_ProduceSync_LatencyShouldBeDrivenByKafkaProduceLatency` is flaky in CI. It produces records for 10s against a fake Kafka that injects a simulated produce latency, and asserts the average end-to-end latency stays close to that simulated latency.

There were three independent reasons the measured latency drifted above the tolerance, all fixed here:

1. **Simulated latency exceeded the client in-flight budget.** The test simulated a 2s produce latency, but `producer linger * max in-flight Produce requests` (50ms * 20 = 1s) is only half of that, so records queued client side waiting for an in-flight slot, adding latency on top of the backend latency. Fixed by simulating a latency within the budget (1s).

2. **The fake Kafka decompressed every record on its single control loop.** The control function called `getProduceRequestHighestTimestamp`, which Snappy-decompressed and parsed every record of every Produce request just to find the highest timestamp. Under load (and the race detector) this made the fake fall behind the produce rate; the simulated latency (`produceLatency - time.Since(highestTimestamp)`) then collapsed to 0 and the measured latency reflected the fake's backlog. Fixed by reading `MaxTimestamp` from the record batch header instead.

3. **High byte throughput starved the control loop.** Producing 50 MB/s of incompressible payload made the control loop spend significant CPU compressing/storing/copying data. The measured latency doesn't depend on record size, so the byte throughput is reduced.

After these changes the measured latency tracks the simulated latency with a small, CPU-insensitive overhead even under heavy contention, and the tolerance is tightened from 1s to 0.5s.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
