### PR TITLE
Distributor: only start the ingest-storage writer when the process pushes

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -522,7 +522,7 @@ func (m *PushMetrics) deleteUserMetrics(user string) {
 }
 
 // New constructs a new Distributor
-func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Overrides, activeGroupsCleanupService *util.ActiveGroupsCleanupService, costAttributionMgr *costattribution.Manager, ingestersRing ring.ReadRing, partitionInstanceRings *ingest.PartitionInstanceRings, partitionRings *ingest.PartitionRingWatchers, canJoinDistributorsRing bool, usageTrackerPartitionRing *ring.MultiPartitionInstanceRing, usageTrackerInstanceRing ring.ReadRing, reg prometheus.Registerer, log log.Logger) (*Distributor, error) {
+func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Overrides, activeGroupsCleanupService *util.ActiveGroupsCleanupService, costAttributionMgr *costattribution.Manager, ingestersRing ring.ReadRing, partitionInstanceRings *ingest.PartitionInstanceRings, partitionRings *ingest.PartitionRingWatchers, canJoinDistributorsRing bool, writerEnabled bool, usageTrackerPartitionRing *ring.MultiPartitionInstanceRing, usageTrackerInstanceRing ring.ReadRing, reg prometheus.Registerer, log log.Logger) (*Distributor, error) {
 	clientMetrics := ingester_client.NewMetrics(reg)
 	if cfg.IngesterClientFactory == nil {
 		cfg.IngesterClientFactory = ring_client.PoolInstFunc(func(inst ring.InstanceDesc) (ring_client.PoolClient, error) {
@@ -850,8 +850,14 @@ func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Ove
 			}
 		}
 
-		d.ingestStorageWriter = ingest.NewWriter(writerKafkaCfg, log, reg, writerOpts...)
-		subservices = append(subservices, d.ingestStorageWriter)
+		// Only components that push (distributor, ruler) run the writer. A query-only distributor — e.g. the
+		// one the querier embeds to query ingesters — must not start it: it never pushes, and starting it
+		// would needlessly connect to Kafka and (under compartments) try to auto-create topics it has no
+		// write-compartment context for.
+		if writerEnabled {
+			d.ingestStorageWriter = ingest.NewWriter(writerKafkaCfg, log, reg, writerOpts...)
+			subservices = append(subservices, d.ingestStorageWriter)
+		}
 	}
 
 	// Init usage-tracker client (if enabled).

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -2534,7 +2534,7 @@ func BenchmarkDistributor_Push(b *testing.B) {
 							}
 
 							// Start the distributor.
-							distributor, err := New(distributorCfg, clientConfig, overrides, nil, cam, ingestersRing, nil, nil, true, nil, nil, nil, log.NewNopLogger())
+							distributor, err := New(distributorCfg, clientConfig, overrides, nil, cam, ingestersRing, nil, nil, true, true, nil, nil, nil, log.NewNopLogger())
 							require.NoError(b, err)
 							require.NoError(b, services.StartAndAwaitRunning(context.Background(), distributor))
 
@@ -6618,7 +6618,7 @@ func prepare(t testing.TB, cfg prepConfig) ([]*Distributor, []*mockIngester, []*
 		if reg == nil {
 			reg = prometheus.NewPedanticRegistry()
 		}
-		d, err := New(distributorCfg, clientConfig, overrides, nil, cfg.costAttributionMgr, ingestersRing, partitionInstanceRings, partitionRings, true, nil, nil, reg, logger)
+		d, err := New(distributorCfg, clientConfig, overrides, nil, cfg.costAttributionMgr, ingestersRing, partitionInstanceRings, partitionRings, true, true, nil, nil, reg, logger)
 		require.NoError(t, err)
 		if !cfg.disableDistributorService {
 			require.NoError(t, services.StartAndAwaitRunning(ctx, d))

--- a/pkg/distributor/push_test.go
+++ b/pkg/distributor/push_test.go
@@ -1303,7 +1303,7 @@ func setupTestDistributor(t *testing.T) (*Distributor, func()) {
 	})
 
 	overrides := validation.NewOverrides(limits, nil)
-	distributor, err := New(distributorConfig, clientConfig, overrides, nil, nil, ingestersRing, nil, nil, true, nil, nil, nil, log.NewNopLogger())
+	distributor, err := New(distributorConfig, clientConfig, overrides, nil, nil, ingestersRing, nil, nil, true, true, nil, nil, nil, log.NewNopLogger())
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), distributor))
 

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -518,6 +518,12 @@ func (t *Mimir) initDistributorService() (serv services.Service, err error) {
 	// ruler's dependency)
 	canJoinDistributorsRing := t.Cfg.isDistributorEnabled()
 
+	// Only run the ingest-storage writer in processes that actually push (the distributor and the ruler,
+	// which writes rule results). When the distributor is used purely as a query dependency (querier), the
+	// writer is unnecessary and, under compartments, would fail to start trying to auto-create topics it
+	// has no write-compartment context for.
+	writerEnabled := t.Cfg.isDistributorEnabled() || t.Cfg.isRulerEnabled()
+
 	t.Cfg.Distributor.StreamingChunksPerIngesterSeriesBufferSize = t.Cfg.Querier.StreamingChunksPerIngesterSeriesBufferSize
 	t.Cfg.Distributor.MinimizeIngesterRequests = t.Cfg.Querier.MinimizeIngesterRequests
 	t.Cfg.Distributor.MinimiseIngesterRequestsHedgingDelay = t.Cfg.Querier.MinimiseIngesterRequestsHedgingDelay
@@ -528,7 +534,7 @@ func (t *Mimir) initDistributorService() (serv services.Service, err error) {
 
 	t.Distributor, err = distributor.New(t.Cfg.Distributor, t.Cfg.IngesterClient, t.Overrides,
 		t.ActiveGroupsCleanup, t.CostAttributionManager, t.IngesterRing, t.IngesterPartitionInstanceRings, t.IngesterPartitionRingWatchers,
-		canJoinDistributorsRing, t.UsageTrackerPartitionRing, t.UsageTrackerInstanceRing, t.Registerer, util_log.Logger)
+		canJoinDistributorsRing, writerEnabled, t.UsageTrackerPartitionRing, t.UsageTrackerInstanceRing, t.Registerer, util_log.Logger)
 	if err != nil {
 		return
 	}

--- a/pkg/streamingpromql/benchmarks/comparison_test.go
+++ b/pkg/streamingpromql/benchmarks/comparison_test.go
@@ -245,7 +245,7 @@ func createIngesterQueryable(t testing.TB, address string) storage.Queryable {
 
 	overrides := validation.NewOverrides(limits, nil)
 
-	d, err := distributor.New(distributorCfg, clientCfg, overrides, nil, nil, ingestersRing, nil, nil, false, nil, nil, nil, logger)
+	d, err := distributor.New(distributorCfg, clientCfg, overrides, nil, nil, ingestersRing, nil, nil, false, false, nil, nil, nil, logger)
 	require.NoError(t, err)
 
 	queryMetrics := stats.NewQueryMetrics(nil)


### PR DESCRIPTION
#### What this PR does

The distributor is also instantiated as a query-time dependency (for example by the querier), where it never pushes. It nonetheless created and started the ingest-storage writer, which is unnecessary — and under the experimental compartments setup it makes the process fail on startup: a query-only process has no write-compartment context, so its writer tries to auto-create the read-compartment topics with a malformed `CreateTopics` request and the broker rejects it with `INVALID_REQUEST`.

This adds a `writerEnabled` argument to `distributor.New` and creates the ingest-storage writer only when it is set. In Mimir it is enabled for the processes that actually push: the distributor and the ruler.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the only user-visible startup failure was under the hidden/experimental compartments feature; otherwise this just stops the querier from running an unused writer, so `changelog-not-needed`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
