### PR TITLE
MQE: fix possible histogram corruption in `CacheOperator`

### DIFF
--- a/pkg/streamingpromql/AGENTS.md
+++ b/pkg/streamingpromql/AGENTS.md
@@ -1,0 +1,11 @@
+# Mimir Query Engine (MQE) conventions
+
+## Pooled `HPoint` slices must not share `FloatHistogram` instances
+
+Reusing `*histogram.FloatHistogram` instances (via `FloatHistogram.CopyTo`) is an intentional performance optimisation: it avoids re-allocating the histogram bucket slices on every copy. `HPointSlicePool` is configured with `clearOnGet=false`, and consumers such as `types.AppendHPointCopies` deliberately reuse the `FloatHistogram` instances already present in a slice obtained from the pool.
+
+The invariant that makes this safe: **any code that returns an `HPoint` slice to `HPointSlicePool` must ensure that no two points in the slice reference the same `FloatHistogram` instance, and that those instances are not still referenced by any other live slice.** Otherwise, the next caller to reuse the slice from the pool will alias those instances via `CopyTo` and corrupt unrelated results.
+
+In practice, when you move or append points out of a slice and then return the source slice to the pool — for example `pool.AppendToSlice(dest, ..., src[a:b]...)` followed by `HPointSlicePool.Put(&src, ...)` — you must `clear()` the transferred range of `src` first, because `AppendToSlice` copies the `HPoint` structs and therefore shares their `FloatHistogram` pointers with `dest`.
+
+Do **not** work around an aliasing bug by making `AppendHPointCopies` (or similar) always deep-copy: that would discard the optimisation. Fix the producer that violates the invariant instead.

--- a/pkg/streamingpromql/optimize/plan/splitandcache/cache_operator.go
+++ b/pkg/streamingpromql/optimize/plan/splitandcache/cache_operator.go
@@ -647,6 +647,11 @@ func (c *CacheOperator) accumulateDesiredHistograms(data types.InstantVectorSeri
 			return err
 		}
 
+		// AppendToSlice copied the desired points into desiredTimeRangeData, but those copies share their FloatHistogram
+		// instances with data.Histograms. Clear the copied range before returning data.Histograms to the pool so the
+		// pooled slice doesn't retain references to instances now owned by desiredTimeRangeData: otherwise a later reuse
+		// of the pooled slice could alias those instances and corrupt the result.
+		clear(data.Histograms[firstDesiredIndex : lastDesiredIndex+1])
 		types.HPointSlicePool.Put(&data.Histograms, c.MemoryConsumptionTracker)
 	}
 


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue in https://github.com/grafana/mimir/pull/15720 detected by flaky tests.

`HPoint` slices returned to the pool in `accumulateDesiredHistograms` could contain references to `FloatHistogram` instances retained in another slice.

I've chosen not to add a changelog entry given this feature is not yet documented in the changelog. (This will come in a later PR.)

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
