### PR TITLE
Update warpstream-go and configure the Warpstream client via functional options

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853
-	github.com/grafana/warpstream-go v0.0.0-20260619124953-a3d5500ae79e
+	github.com/grafana/warpstream-go v0.0.0-20260623082500-8f2f72d7ebfd
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/hashicorp/vault/api v1.23.0
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db

--- a/go.sum
+++ b/go.sum
@@ -589,8 +589,8 @@ github.com/grafana/pyroscope-go/godeltaprof v0.1.9 h1:c1Us8i6eSmkW+Ez05d3co8kasn
 github.com/grafana/pyroscope-go/godeltaprof v0.1.9/go.mod h1:2+l7K7twW49Ct4wFluZD3tZ6e0SjanjcUUBPVD/UuGU=
 github.com/grafana/regexp v0.0.0-20250905101755-5eb4f3acbf71 h1:A4D22zZV7+EeQk9TeATDDY/PG2wnzdqKcj4IZq+PcwA=
 github.com/grafana/regexp v0.0.0-20250905101755-5eb4f3acbf71/go.mod h1:+JKpmjMGhpgPL+rXZ5nsZieVzvarn86asRlBg4uNGnk=
-github.com/grafana/warpstream-go v0.0.0-20260619124953-a3d5500ae79e h1:Qt/ihe4Ru1P/tSqKbycUWTr02wOxJhR4z3Hpystc1xU=
-github.com/grafana/warpstream-go v0.0.0-20260619124953-a3d5500ae79e/go.mod h1:LwTt3TT0fIgUyJKugMrPc78mWb80LU25biIPIwXiN/8=
+github.com/grafana/warpstream-go v0.0.0-20260623082500-8f2f72d7ebfd h1:0/liF0cK/jxoiHbbx7HSbh6vvFRf6CvSJ28gjerVMek=
+github.com/grafana/warpstream-go v0.0.0-20260623082500-8f2f72d7ebfd/go.mod h1:S2Q6EVHUSkS6gJOzsskK4VhCXax8BmhTK+O+sI6YXvs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=

--- a/pkg/storage/ingest/config.go
+++ b/pkg/storage/ingest/config.go
@@ -205,13 +205,13 @@ func (cfg *KafkaConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) 
 	f.StringVar(&cfg.Backend, prefix+"backend", KafkaBackendKafka, fmt.Sprintf("The Kafka backend implementation. Supported values: %s.", util.JoinStrings(kafkaBackendOptions, ", ")))
 	f.Var(&cfg.Address, prefix+"address", "The Kafka seed broker address, or a comma-separated list of seed broker addresses.")
 
-	f.Float64Var(&cfg.WarpstreamHealthCheckSlowMultiplier, prefix+"warpstream-health-check-slow-multiplier", 2.0, "Mark an agent as slow when its window-average latency exceeds this multiple of the cluster baseline. Only applies when -"+prefix+"backend=warpstream.")
-	f.Float64Var(&cfg.WarpstreamHealthCheckMaxSlowFraction, prefix+"warpstream-health-check-max-slow-fraction", 0.3, "Suppress slow-based hedging when more than this fraction of agents are slow (cluster-wide issue). Only applies when -"+prefix+"backend=warpstream.")
-	f.Float64Var(&cfg.WarpstreamHealthCheckFaultyThreshold, prefix+"warpstream-health-check-faulty-threshold", 0.2, "Mark an agent as faulty when its observed error rate exceeds this fraction. Only applies when -"+prefix+"backend=warpstream.")
-	f.Float64Var(&cfg.WarpstreamHealthCheckMaxFaultyFraction, prefix+"warpstream-health-check-max-faulty-fraction", 0.3, "Suppress faulty-based hedging and demotion when more than this fraction of agents are faulty (cluster-wide issue). Only applies when -"+prefix+"backend=warpstream.")
-	f.DurationVar(&cfg.WarpstreamHedgeMinDelay, prefix+"warpstream-hedge-min-delay", 500*time.Millisecond, "Floor on the dynamically-computed hedge delay. Only applies when -"+prefix+"backend=warpstream.")
-	f.IntVar(&cfg.WarpstreamHedgeMaxAgents, prefix+"warpstream-hedge-max-agents", 3, "Cap on how many per-partition candidates the hedge fanout considers when picking a fallback (excluding the primary and any agent already tried). Only applies when -"+prefix+"backend=warpstream.")
-	f.DurationVar(&cfg.WarpstreamDemoterProbeInterval, prefix+"warpstream-demoter-probe-interval", time.Second, "Minimum wall-clock gap between probes to a demoted agent. Only applies when -"+prefix+"backend=warpstream.")
+	f.Float64Var(&cfg.WarpstreamHealthCheckSlowMultiplier, prefix+"warpstream-health-check-slow-multiplier", wgo.DefaultHealthCheckSlowMultiplier, "Mark an agent as slow when its window-average latency exceeds this multiple of the cluster baseline. Only applies when -"+prefix+"backend=warpstream.")
+	f.Float64Var(&cfg.WarpstreamHealthCheckMaxSlowFraction, prefix+"warpstream-health-check-max-slow-fraction", wgo.DefaultHealthCheckMaxSlowFraction, "Suppress slow-based hedging when more than this fraction of agents are slow (cluster-wide issue). Only applies when -"+prefix+"backend=warpstream.")
+	f.Float64Var(&cfg.WarpstreamHealthCheckFaultyThreshold, prefix+"warpstream-health-check-faulty-threshold", wgo.DefaultHealthCheckFaultyThreshold, "Mark an agent as faulty when its observed error rate exceeds this fraction. Only applies when -"+prefix+"backend=warpstream.")
+	f.Float64Var(&cfg.WarpstreamHealthCheckMaxFaultyFraction, prefix+"warpstream-health-check-max-faulty-fraction", wgo.DefaultHealthCheckMaxFaultyFraction, "Suppress faulty-based hedging and demotion when more than this fraction of agents are faulty (cluster-wide issue). Only applies when -"+prefix+"backend=warpstream.")
+	f.DurationVar(&cfg.WarpstreamHedgeMinDelay, prefix+"warpstream-hedge-min-delay", wgo.DefaultHedgerMinHedgeDelay, "Floor on the dynamically-computed hedge delay. Only applies when -"+prefix+"backend=warpstream.")
+	f.IntVar(&cfg.WarpstreamHedgeMaxAgents, prefix+"warpstream-hedge-max-agents", wgo.DefaultHedgerMaxHedgeAgents, "Cap on how many per-partition candidates the hedge fanout considers when picking a fallback (excluding the primary and any agent already tried). Only applies when -"+prefix+"backend=warpstream.")
+	f.DurationVar(&cfg.WarpstreamDemoterProbeInterval, prefix+"warpstream-demoter-probe-interval", wgo.DefaultDemoterProbeInterval, "Minimum wall-clock gap between probes to a demoted agent. Only applies when -"+prefix+"backend=warpstream.")
 
 	f.StringVar(&cfg.Topic, prefix+"topic", "", "The Kafka topic name.")
 	f.StringVar(&cfg.ClientID, prefix+"client-id", "", "The Kafka client ID.")
@@ -347,52 +347,45 @@ func (cfg *KafkaConfig) Validate() error {
 	return nil
 }
 
-// ToWarpstreamClientConfig maps the Warpstream-relevant subset of
-// KafkaConfig to a wgo.Config.
-func (cfg *KafkaConfig) ToWarpstreamClientConfig() (wgo.Config, error) {
-	wsCfg := wgo.Config{
-		Address:       cfg.Address,
-		Topic:         cfg.Topic,
-		ClientID:      cfg.ClientID,
-		DialTimeout:   cfg.DialTimeout,
-		WriteTimeout:  cfg.WriteTimeout,
-		TLSEnabled:    cfg.TLSEnabled,
-		SASLOptions:   kafkaAuthOptions(cfg.SASL),
-		Linger:        defaultProducerLinger,
-		MaxBatchBytes: producerBatchMaxBytes,
-		HealthCheck: wgo.HealthCheckConfig{
-			SlowMultiplier:    cfg.WarpstreamHealthCheckSlowMultiplier,
-			MaxSlowFraction:   cfg.WarpstreamHealthCheckMaxSlowFraction,
-			FaultyThreshold:   cfg.WarpstreamHealthCheckFaultyThreshold,
-			MaxFaultyFraction: cfg.WarpstreamHealthCheckMaxFaultyFraction,
-		},
-		Hedger: wgo.HedgerConfig{
-			MinHedgeDelay:  cfg.WarpstreamHedgeMinDelay,
-			MaxHedgeAgents: cfg.WarpstreamHedgeMaxAgents,
-		},
-		Demoter: wgo.DemoterConfig{
-			ProbeInterval: cfg.WarpstreamDemoterProbeInterval,
-		},
-		ClusterStatsTTL:         time.Second,
-		MetadataRefreshInterval: defaultMetadataRefreshInterval,
-		DirectProducer: wgo.KafkaDirectProducerConfig{
-			// WriteTimeout bounds the whole hedge cascade, so the per-attempt
-			// produce timeout plus its overhead must fit within it (wgo rejects a
-			// config where they don't). Validate guarantees WriteTimeout exceeds
-			// twice the overhead, so the per-attempt timeout stays larger than the
-			// overhead.
-			ProduceRequestTimeout:         cfg.WriteTimeout - writerRequestTimeoutOverhead,
-			ProduceRequestTimeoutOverhead: writerRequestTimeoutOverhead,
-		},
+// ToWarpstreamClientOptions maps the Warpstream-relevant subset of KafkaConfig
+// to wgo client options. The returned options start from wgo.DefaultConfig and
+// override only the fields Mimir controls.
+func (cfg *KafkaConfig) ToWarpstreamClientOptions() ([]wgo.Opt, error) {
+	opts := []wgo.Opt{
+		wgo.WithAddress(cfg.Address...),
+		wgo.WithTopic(cfg.Topic),
+		wgo.WithClientID(cfg.ClientID),
+		wgo.WithDialTimeout(cfg.DialTimeout),
+		wgo.WithWriteTimeout(cfg.WriteTimeout),
+		wgo.WithSASL(kafkaAuthOptions(cfg.SASL)...),
+		wgo.WithLinger(defaultProducerLinger),
+		wgo.WithBatchMaxBytes(producerBatchMaxBytes),
+		wgo.WithHealthCheckSlowMultiplier(cfg.WarpstreamHealthCheckSlowMultiplier),
+		wgo.WithHealthCheckMaxSlowFraction(cfg.WarpstreamHealthCheckMaxSlowFraction),
+		wgo.WithHealthCheckFaultyThreshold(cfg.WarpstreamHealthCheckFaultyThreshold),
+		wgo.WithHealthCheckMaxFaultyFraction(cfg.WarpstreamHealthCheckMaxFaultyFraction),
+		wgo.WithHedgerMinHedgeDelay(cfg.WarpstreamHedgeMinDelay),
+		wgo.WithHedgerMaxHedgeAgents(cfg.WarpstreamHedgeMaxAgents),
+		wgo.WithDemoterProbeInterval(cfg.WarpstreamDemoterProbeInterval),
+		wgo.WithClusterStatsTTL(time.Second),
+		wgo.WithMetadataRefreshInterval(defaultMetadataRefreshInterval),
+		// WriteTimeout bounds the whole hedge cascade, so the per-attempt produce
+		// timeout plus its overhead must fit within it (wgo rejects a config where
+		// they don't). Validate guarantees WriteTimeout exceeds twice the overhead,
+		// so the per-attempt timeout stays larger than the overhead.
+		wgo.WithProduceRequestTimeout(cfg.WriteTimeout - writerRequestTimeoutOverhead),
+		wgo.WithProduceRequestTimeoutOverhead(writerRequestTimeoutOverhead),
 	}
+
 	if cfg.TLSEnabled {
 		tlsConfig, err := cfg.TLS.GetTLSConfig()
 		if err != nil {
-			return wgo.Config{}, fmt.Errorf("invalid Kafka TLS config: %w", err)
+			return nil, fmt.Errorf("invalid Kafka TLS config: %w", err)
 		}
-		wsCfg.TLSConfig = tlsConfig
+		opts = append(opts, wgo.WithTLSConfig(tlsConfig))
 	}
-	return wsCfg, nil
+
+	return opts, nil
 }
 
 // GetConsumerGroup returns the consumer group to use for the given instanceID and partitionID.

--- a/pkg/storage/ingest/config_test.go
+++ b/pkg/storage/ingest/config_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/grafana/dskit/flagext"
+	"github.com/grafana/warpstream-go/pkg/wgo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -545,9 +546,9 @@ func TestKafkaConfig_WriteCompartmentConfig(t *testing.T) {
 	}
 }
 
-func TestKafkaConfig_ToWarpstreamClientConfig(t *testing.T) {
-	t.Run("maps warpstream-relevant fields", func(t *testing.T) {
-		cfg := KafkaConfig{
+func TestKafkaConfig_ToWarpstreamClientOptions(t *testing.T) {
+	baseConfig := func() KafkaConfig {
+		return KafkaConfig{
 			Backend:                                KafkaBackendWarpstream,
 			Address:                                []string{"a:9092", "b:9092"},
 			Topic:                                  "ingest",
@@ -562,18 +563,26 @@ func TestKafkaConfig_ToWarpstreamClientConfig(t *testing.T) {
 			WarpstreamHedgeMaxAgents:               4,
 			WarpstreamDemoterProbeInterval:         2 * time.Second,
 		}
+	}
 
-		wsCfg, err := cfg.ToWarpstreamClientConfig()
+	t.Run("maps warpstream-relevant fields onto the applied config", func(t *testing.T) {
+		cfg := baseConfig()
+
+		opts, err := cfg.ToWarpstreamClientOptions()
 		require.NoError(t, err)
-		assert.Equal(t, []string{"a:9092", "b:9092"}, []string(wsCfg.Address))
+
+		// wgo.NewConfig applies the options on top of its defaults, so we can
+		// assert the resulting config field by field.
+		wsCfg := wgo.NewConfig(opts...)
+		assert.Equal(t, []string{"a:9092", "b:9092"}, wsCfg.Address)
 		assert.Equal(t, "ingest", wsCfg.Topic)
 		assert.Equal(t, "client-1", wsCfg.ClientID)
 		assert.Equal(t, 3*time.Second, wsCfg.DialTimeout)
 		assert.Equal(t, 7*time.Second, wsCfg.WriteTimeout)
-		// Linger, max batch bytes, and metadata refresh interval mirror the
+		// Linger, batch max bytes, and metadata refresh interval mirror the
 		// kafka-backend defaults; ClusterStatsTTL is hardcoded to 1s.
 		assert.Equal(t, defaultProducerLinger, wsCfg.Linger)
-		assert.Equal(t, int32(producerBatchMaxBytes), wsCfg.MaxBatchBytes)
+		assert.Equal(t, int32(producerBatchMaxBytes), wsCfg.BatchMaxBytes)
 		assert.Equal(t, defaultMetadataRefreshInterval, wsCfg.MetadataRefreshInterval)
 		assert.Equal(t, time.Second, wsCfg.ClusterStatsTTL)
 		assert.Equal(t, 1.5, wsCfg.HealthCheck.SlowMultiplier)
@@ -590,7 +599,30 @@ func TestKafkaConfig_ToWarpstreamClientConfig(t *testing.T) {
 		assert.False(t, wsCfg.TLSEnabled)
 		assert.Nil(t, wsCfg.TLSConfig)
 
-		// The mapped config must satisfy wgo's own validation.
+		// The applied config must satisfy wgo's own validation.
 		require.NoError(t, wsCfg.Validate())
+	})
+
+	t.Run("enables TLS on the applied config when configured", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.TLSEnabled = true
+		cfg.TLS.InsecureSkipVerify = true
+
+		opts, err := cfg.ToWarpstreamClientOptions()
+		require.NoError(t, err)
+
+		wsCfg := wgo.NewConfig(opts...)
+		assert.True(t, wsCfg.TLSEnabled)
+		assert.NotNil(t, wsCfg.TLSConfig)
+	})
+
+	t.Run("fails when TLS is enabled but misconfigured", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.TLSEnabled = true
+		// A client cert without a key fails GetTLSConfig.
+		cfg.TLS.CertPath = "/does/not/exist.crt"
+
+		_, err := cfg.ToWarpstreamClientOptions()
+		require.Error(t, err)
 	})
 }

--- a/pkg/storage/ingest/writer_client.go
+++ b/pkg/storage/ingest/writer_client.go
@@ -36,11 +36,11 @@ func newKafkaProducerForBackend(cfg KafkaConfig, maxInflight int, logger log.Log
 
 	switch cfg.Backend {
 	case KafkaBackendWarpstream:
-		warpstreamConfig, err := cfg.ToWarpstreamClientConfig()
+		warpstreamOpts, err := cfg.ToWarpstreamClientOptions()
 		if err != nil {
 			return nil, err
 		}
-		warpstreamClient, err := wgo.NewWarpstreamClient(warpstreamConfig, logger, reg)
+		warpstreamClient, err := wgo.NewWarpstreamClient(logger, reg, warpstreamOpts...)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/storage/ingest/writer_client_test.go
+++ b/pkg/storage/ingest/writer_client_test.go
@@ -35,32 +35,60 @@ func TestNewKafkaWriterClient_ShouldSupportSASLPlainAuthentication(t *testing.T)
 
 	_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName, testkafka.WithSASLPlain(username, password))
 
-	t.Run("should fail if the provided auth is wrong", func(t *testing.T) {
-		t.Parallel()
+	t.Run("franz-go", func(t *testing.T) {
+		t.Run("should fail if the provided auth is wrong", func(t *testing.T) {
+			t.Parallel()
 
-		cfg := createTestKafkaConfig(clusterAddr, topicName)
-		cfg.SASL.Username = username
-		require.NoError(t, cfg.SASL.Password.Set("wrong"))
+			cfg := createTestKafkaConfig(clusterAddr, topicName)
+			cfg.SASL.Username = username
+			require.NoError(t, cfg.SASL.Password.Set("wrong"))
 
-		client, err := NewKafkaWriterClient(cfg, 1, log.NewNopLogger(), prometheus.NewPedanticRegistry())
-		require.NoError(t, err)
-		t.Cleanup(client.Close)
+			client, err := NewKafkaWriterClient(cfg, 1, log.NewNopLogger(), prometheus.NewPedanticRegistry())
+			require.NoError(t, err)
+			t.Cleanup(client.Close)
 
-		require.Error(t, client.Ping(context.Background()))
+			require.Error(t, client.Ping(context.Background()))
+		})
+
+		t.Run("should succeed if the provided auth is good", func(t *testing.T) {
+			t.Parallel()
+
+			cfg := createTestKafkaConfig(clusterAddr, topicName)
+			cfg.SASL.Username = username
+			require.NoError(t, cfg.SASL.Password.Set(password))
+
+			client, err := NewKafkaWriterClient(cfg, 1, log.NewNopLogger(), prometheus.NewPedanticRegistry())
+			require.NoError(t, err)
+			t.Cleanup(client.Close)
+
+			require.NoError(t, client.Ping(context.Background()))
+		})
 	})
 
-	t.Run("should succeed if the provided auth is good", func(t *testing.T) {
-		t.Parallel()
+	// The Warpstream client refreshes metadata synchronously on construction, so
+	// bad credentials surface as a construction error rather than via a later Ping.
+	t.Run("warpstream", func(t *testing.T) {
+		t.Run("should fail to build the client if the provided auth is wrong", func(t *testing.T) {
+			cfg := createTestKafkaConfigForBackend(KafkaBackendWarpstream, clusterAddr, topicName)
+			cfg.SASL.Username = username
+			require.NoError(t, cfg.SASL.Password.Set("wrong"))
 
-		cfg := createTestKafkaConfig(clusterAddr, topicName)
-		cfg.SASL.Username = username
-		require.NoError(t, cfg.SASL.Password.Set(password))
+			_, err := newKafkaProducerForBackend(cfg, defaultMaxInflightProduceRequests, log.NewNopLogger(), prometheus.NewPedanticRegistry())
+			require.Error(t, err)
+		})
 
-		client, err := NewKafkaWriterClient(cfg, 1, log.NewNopLogger(), prometheus.NewPedanticRegistry())
-		require.NoError(t, err)
-		t.Cleanup(client.Close)
+		t.Run("should build a usable client if the provided auth is good", func(t *testing.T) {
+			cfg := createTestKafkaConfigForBackend(KafkaBackendWarpstream, clusterAddr, topicName)
+			cfg.SASL.Username = username
+			require.NoError(t, cfg.SASL.Password.Set(password))
 
-		require.NoError(t, client.Ping(context.Background()))
+			producer, err := newKafkaProducerForBackend(cfg, defaultMaxInflightProduceRequests, log.NewNopLogger(), prometheus.NewPedanticRegistry())
+			require.NoError(t, err)
+			t.Cleanup(producer.Close)
+
+			res := producer.ProduceSync(context.Background(), []*kgo.Record{{Topic: topicName, Key: []byte("test"), Value: []byte("message 1")}})
+			require.NoError(t, res.FirstErr())
+		})
 	})
 }
 
@@ -107,23 +135,21 @@ func TestNewKafkaWriterClient_ShouldTrackExtendedKafkaClientMetrics(t *testing.T
 }
 
 func TestKafkaProducer_ShouldExposeBufferedBytesLimit(t *testing.T) {
+	runForEachKafkaBackend(t, testKafkaProducer_ShouldExposeBufferedBytesLimit)
+}
+
+func testKafkaProducer_ShouldExposeBufferedBytesLimit(t *testing.T, backend string) {
 	const (
 		numPartitions = 1
 		topicName     = "test"
 	)
 
 	_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
-	cfg := createTestKafkaConfig(clusterAddr, topicName)
-	cfg.ProducerMaxBufferedBytes = 1024 * 1024
 
 	reg := prometheus.NewPedanticRegistry()
-	prefixedReg := prometheus.WrapRegistererWithPrefix(writerMetricsPrefix, reg)
-
-	client, err := NewKafkaWriterClient(cfg, 1, log.NewNopLogger(), prefixedReg)
-	require.NoError(t, err)
-
-	producer := NewKafkaProducer(client, cfg.ProducerMaxBufferedBytes, prefixedReg)
-	t.Cleanup(producer.Close)
+	createTestKafkaProducerForBackend(t, backend, clusterAddr, topicName, reg, func(cfg *KafkaConfig) {
+		cfg.ProducerMaxBufferedBytes = 1024 * 1024
+	})
 
 	assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
 		# HELP cortex_ingest_storage_writer_buffered_produce_bytes_limit The bytes limit on buffered produce records. Produce requests fail once this limit is reached.
@@ -133,6 +159,10 @@ func TestKafkaProducer_ShouldExposeBufferedBytesLimit(t *testing.T) {
 }
 
 func TestKafkaProducer_ProduceSync_ShouldTrackBufferedProduceBytes(t *testing.T) {
+	runForEachKafkaBackend(t, testKafkaProducer_ProduceSync_ShouldTrackBufferedProduceBytes)
+}
+
+func testKafkaProducer_ProduceSync_ShouldTrackBufferedProduceBytes(t *testing.T, backend string) {
 	const (
 		numPartitions = 1
 		topicName     = "test"
@@ -148,15 +178,9 @@ func TestKafkaProducer_ProduceSync_ShouldTrackBufferedProduceBytes(t *testing.T)
 	})
 
 	ctx := context.Background()
-	cfg := createTestKafkaConfig(clusterAddr, topicName)
 	reg := prometheus.NewPedanticRegistry()
-	prefixedReg := prometheus.WrapRegistererWithPrefix(writerMetricsPrefix, reg)
-
-	client, err := NewKafkaWriterClient(cfg, 1, log.NewNopLogger(), prefixedReg)
-	require.NoError(t, err)
-
-	producer := NewKafkaProducer(client, cfg.ProducerMaxBufferedBytes, prefixedReg)
-	t.Cleanup(producer.Close)
+	producer := createTestKafkaProducerForBackend(t, backend, clusterAddr, topicName, reg, nil)
+	client := producer.client
 
 	wg := sync.WaitGroup{}
 
@@ -167,7 +191,7 @@ func TestKafkaProducer_ProduceSync_ShouldTrackBufferedProduceBytes(t *testing.T)
 
 	// Produce a 1st record.
 	wg.Add(1)
-	client.Produce(ctx, &kgo.Record{Key: []byte("test"), Value: []byte("message 1")}, func(_ *kgo.Record, err error) {
+	client.Produce(ctx, &kgo.Record{Topic: topicName, Key: []byte("test"), Value: []byte("message 1")}, func(_ *kgo.Record, err error) {
 		defer wg.Done()
 		require.NoError(t, err)
 	})
@@ -184,7 +208,7 @@ func TestKafkaProducer_ProduceSync_ShouldTrackBufferedProduceBytes(t *testing.T)
 
 	// Produce a 2nd record, while the 1st is still in-flight (because in this test Produce requests are blocked on Kafka side).
 	wg.Add(1)
-	client.Produce(ctx, &kgo.Record{Key: []byte("test"), Value: []byte("message 1")}, func(_ *kgo.Record, err error) {
+	client.Produce(ctx, &kgo.Record{Topic: topicName, Key: []byte("test"), Value: []byte("message 1")}, func(_ *kgo.Record, err error) {
 		defer wg.Done()
 		require.NoError(t, err)
 	})
@@ -200,6 +224,10 @@ func TestKafkaProducer_ProduceSync_ShouldTrackBufferedProduceBytes(t *testing.T)
 }
 
 func TestKafkaProducer_ProduceSync_ShouldCircuitBreakIfContextIsDone(t *testing.T) {
+	runForEachKafkaBackend(t, testKafkaProducer_ProduceSync_ShouldCircuitBreakIfContextIsDone)
+}
+
+func testKafkaProducer_ProduceSync_ShouldCircuitBreakIfContextIsDone(t *testing.T, backend string) {
 	const (
 		numPartitions = 1
 		topicName     = "test"
@@ -207,22 +235,14 @@ func TestKafkaProducer_ProduceSync_ShouldCircuitBreakIfContextIsDone(t *testing.
 
 	_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
 
-	ctx := context.Background()
-	cfg := createTestKafkaConfig(clusterAddr, topicName)
 	reg := prometheus.NewPedanticRegistry()
-	prefixedReg := prometheus.WrapRegistererWithPrefix(writerMetricsPrefix, reg)
-
-	client, err := NewKafkaWriterClient(cfg, defaultMaxInflightProduceRequests, log.NewNopLogger(), prefixedReg)
-	require.NoError(t, err)
-
-	producer := NewKafkaProducer(client, cfg.ProducerMaxBufferedBytes, prefixedReg)
-	t.Cleanup(producer.Close)
+	producer := createTestKafkaProducerForBackend(t, backend, clusterAddr, topicName, reg, nil)
 
 	// Create a context with an expired deadline.
-	expiredCtx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
+	expiredCtx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
 	t.Cleanup(cancel)
 
-	res := producer.ProduceSync(expiredCtx, []*kgo.Record{{Key: []byte("test"), Value: []byte("message 1")}})
+	res := producer.ProduceSync(expiredCtx, []*kgo.Record{{Topic: topicName, Key: []byte("test"), Value: []byte("message 1")}})
 	require.ErrorIs(t, res.FirstErr(), context.DeadlineExceeded)
 
 	// We expect no records buffered in the Kafka client, because of the circuit breaker.
@@ -252,6 +272,10 @@ func TestKafkaProducer_ProduceSync_ShouldCircuitBreakIfContextIsDone(t *testing.
 }
 
 func TestKafkaProducer_ProduceSync_ShouldRejectRecordsWithTimestampSet(t *testing.T) {
+	runForEachKafkaBackend(t, testKafkaProducer_ProduceSync_ShouldRejectRecordsWithTimestampSet)
+}
+
+func testKafkaProducer_ProduceSync_ShouldRejectRecordsWithTimestampSet(t *testing.T, backend string) {
 	const (
 		numPartitions = 1
 		topicName     = "test"
@@ -259,19 +283,12 @@ func TestKafkaProducer_ProduceSync_ShouldRejectRecordsWithTimestampSet(t *testin
 
 	_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
 
-	cfg := createTestKafkaConfig(clusterAddr, topicName)
 	reg := prometheus.NewPedanticRegistry()
-	prefixedReg := prometheus.WrapRegistererWithPrefix(writerMetricsPrefix, reg)
-
-	client, err := NewKafkaWriterClient(cfg, defaultMaxInflightProduceRequests, log.NewNopLogger(), prefixedReg)
-	require.NoError(t, err)
-
-	producer := NewKafkaProducer(client, cfg.ProducerMaxBufferedBytes, prefixedReg)
-	t.Cleanup(producer.Close)
+	producer := createTestKafkaProducerForBackend(t, backend, clusterAddr, topicName, reg, nil)
 
 	records := []*kgo.Record{
-		{Key: []byte("test"), Value: []byte("message 1")},
-		{Key: []byte("test"), Value: []byte("message 2"), Timestamp: time.Now()},
+		{Topic: topicName, Key: []byte("test"), Value: []byte("message 1")},
+		{Topic: topicName, Key: []byte("test"), Value: []byte("message 2"), Timestamp: time.Now()},
 	}
 
 	res := producer.ProduceSync(context.Background(), records)
@@ -300,6 +317,10 @@ func TestKafkaProducer_ProduceSync_ShouldRejectRecordsWithTimestampSet(t *testin
 }
 
 func TestKafkaProducer_ProduceSync_ShouldRejectWholeBatchIfBufferIsFull(t *testing.T) {
+	runForEachKafkaBackend(t, testKafkaProducer_ProduceSync_ShouldRejectWholeBatchIfBufferIsFull)
+}
+
+func testKafkaProducer_ProduceSync_ShouldRejectWholeBatchIfBufferIsFull(t *testing.T, backend string) {
 	const (
 		numPartitions = 1
 		topicName     = "test"
@@ -308,23 +329,16 @@ func TestKafkaProducer_ProduceSync_ShouldRejectWholeBatchIfBufferIsFull(t *testi
 
 	_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
 
-	cfg := createTestKafkaConfig(clusterAddr, topicName)
-	// Set the limit lower than the size of a 3-record batch so the batch must be rejected as a whole.
-	cfg.ProducerMaxBufferedBytes = int64(2 * len(recordValue))
-
 	reg := prometheus.NewPedanticRegistry()
-	prefixedReg := prometheus.WrapRegistererWithPrefix(writerMetricsPrefix, reg)
-
-	client, err := NewKafkaWriterClient(cfg, 1, log.NewNopLogger(), prefixedReg)
-	require.NoError(t, err)
-
-	producer := NewKafkaProducer(client, cfg.ProducerMaxBufferedBytes, prefixedReg)
-	t.Cleanup(producer.Close)
+	producer := createTestKafkaProducerForBackend(t, backend, clusterAddr, topicName, reg, func(cfg *KafkaConfig) {
+		// Set the limit lower than the size of a 3-record batch so the batch must be rejected as a whole.
+		cfg.ProducerMaxBufferedBytes = int64(2 * len(recordValue))
+	})
 
 	batch := []*kgo.Record{
-		{Key: []byte("test"), Value: []byte(recordValue)},
-		{Key: []byte("test"), Value: []byte(recordValue)},
-		{Key: []byte("test"), Value: []byte(recordValue)},
+		{Topic: topicName, Key: []byte("test"), Value: []byte(recordValue)},
+		{Topic: topicName, Key: []byte("test"), Value: []byte(recordValue)},
+		{Topic: topicName, Key: []byte("test"), Value: []byte(recordValue)},
 	}
 
 	res := producer.ProduceSync(context.Background(), batch)
@@ -352,11 +366,15 @@ func TestKafkaProducer_ProduceSync_ShouldRejectWholeBatchIfBufferIsFull(t *testi
 		"cortex_ingest_storage_writer_produce_records_failed_total"))
 
 	// A subsequent batch that fits in the buffer should succeed.
-	res = producer.ProduceSync(context.Background(), []*kgo.Record{{Key: []byte("test"), Value: []byte(recordValue)}})
+	res = producer.ProduceSync(context.Background(), []*kgo.Record{{Topic: topicName, Key: []byte("test"), Value: []byte(recordValue)}})
 	require.NoError(t, res.FirstErr())
 }
 
 func TestKafkaProducer_ProduceSync_ShouldReturnOneResultPerRecordOnContextCancellation(t *testing.T) {
+	runForEachKafkaBackend(t, testKafkaProducer_ProduceSync_ShouldReturnOneResultPerRecordOnContextCancellation)
+}
+
+func testKafkaProducer_ProduceSync_ShouldReturnOneResultPerRecordOnContextCancellation(t *testing.T, backend string) {
 	const (
 		numPartitions = 1
 		topicName     = "test"
@@ -365,23 +383,16 @@ func TestKafkaProducer_ProduceSync_ShouldReturnOneResultPerRecordOnContextCancel
 	t.Run("context is already done before producing", func(t *testing.T) {
 		_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
 
-		cfg := createTestKafkaConfig(clusterAddr, topicName)
 		reg := prometheus.NewPedanticRegistry()
-		prefixedReg := prometheus.WrapRegistererWithPrefix(writerMetricsPrefix, reg)
-
-		client, err := NewKafkaWriterClient(cfg, defaultMaxInflightProduceRequests, log.NewNopLogger(), prefixedReg)
-		require.NoError(t, err)
-
-		producer := NewKafkaProducer(client, cfg.ProducerMaxBufferedBytes, prefixedReg)
-		t.Cleanup(producer.Close)
+		producer := createTestKafkaProducerForBackend(t, backend, clusterAddr, topicName, reg, nil)
 
 		// Cancel the context before producing.
 		cancelCtx, cancel := context.WithCancel(context.Background())
 		cancel()
 
 		records := []*kgo.Record{
-			{Key: []byte("key-1"), Value: []byte("message 1")},
-			{Key: []byte("key-2"), Value: []byte("message 2")},
+			{Topic: topicName, Key: []byte("key-1"), Value: []byte("message 1")},
+			{Topic: topicName, Key: []byte("key-2"), Value: []byte("message 2")},
 		}
 		res := producer.ProduceSync(cancelCtx, records)
 
@@ -396,15 +407,8 @@ func TestKafkaProducer_ProduceSync_ShouldReturnOneResultPerRecordOnContextCancel
 	t.Run("context is already done before producing with a non-Canceled cause", func(t *testing.T) {
 		_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
 
-		cfg := createTestKafkaConfig(clusterAddr, topicName)
 		reg := prometheus.NewPedanticRegistry()
-		prefixedReg := prometheus.WrapRegistererWithPrefix(writerMetricsPrefix, reg)
-
-		client, err := NewKafkaWriterClient(cfg, defaultMaxInflightProduceRequests, log.NewNopLogger(), prefixedReg)
-		require.NoError(t, err)
-
-		producer := NewKafkaProducer(client, cfg.ProducerMaxBufferedBytes, prefixedReg)
-		t.Cleanup(producer.Close)
+		producer := createTestKafkaProducerForBackend(t, backend, clusterAddr, topicName, reg, nil)
 
 		// Cancel the context before producing, with a custom cause that wraps something other than context.Canceled.
 		customCause := errors.New("custom cancellation cause")
@@ -412,8 +416,8 @@ func TestKafkaProducer_ProduceSync_ShouldReturnOneResultPerRecordOnContextCancel
 		cancel(customCause)
 
 		records := []*kgo.Record{
-			{Key: []byte("key-1"), Value: []byte("message 1")},
-			{Key: []byte("key-2"), Value: []byte("message 2")},
+			{Topic: topicName, Key: []byte("key-1"), Value: []byte("message 1")},
+			{Topic: topicName, Key: []byte("key-2"), Value: []byte("message 2")},
 		}
 		res := producer.ProduceSync(cancelCtx, records)
 
@@ -444,22 +448,15 @@ func TestKafkaProducer_ProduceSync_ShouldReturnOneResultPerRecordOnContextCancel
 			return nil, nil, false
 		})
 
-		cfg := createTestKafkaConfig(clusterAddr, topicName)
 		reg := prometheus.NewPedanticRegistry()
-		prefixedReg := prometheus.WrapRegistererWithPrefix(writerMetricsPrefix, reg)
-
-		client, err := NewKafkaWriterClient(cfg, defaultMaxInflightProduceRequests, log.NewNopLogger(), prefixedReg)
-		require.NoError(t, err)
-
-		producer := NewKafkaProducer(client, cfg.ProducerMaxBufferedBytes, prefixedReg)
-		t.Cleanup(producer.Close)
+		producer := createTestKafkaProducerForBackend(t, backend, clusterAddr, topicName, reg, nil)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
 
 		records := []*kgo.Record{
-			{Key: []byte("key-1"), Value: []byte("message 1")},
-			{Key: []byte("key-2"), Value: []byte("message 2")},
+			{Topic: topicName, Key: []byte("key-1"), Value: []byte("message 1")},
+			{Topic: topicName, Key: []byte("key-2"), Value: []byte("message 2")},
 		}
 
 		// Snapshot the input partitions so the assertions below don't read the live records,
@@ -498,12 +495,21 @@ func TestKafkaProducer_ProduceSync_ShouldReturnOneResultPerRecordOnContextCancel
 			assert.Equal(t, expectedPartitions[i], r.Record.Partition)
 			assert.ErrorIs(t, r.Err, context.Canceled)
 		}
+
+		// Unblock the in-flight produce so cleanup is fast: the Warpstream client's
+		// Close() waits for in-flight flushes, which would otherwise block until the
+		// per-flush WriteTimeout elapses.
+		close(unblockProduceRequests)
 	})
 }
 
 func TestKafkaProducer_ProduceSync_LatencyShouldBeDrivenByKafkaProduceLatency(t *testing.T) {
-	t.Parallel()
+	// Not parallel: this test measures wall-clock produce latency, so contention
+	// with other tests would make it flaky.
+	runForEachKafkaBackend(t, testKafkaProducer_ProduceSync_LatencyShouldBeDrivenByKafkaProduceLatency)
+}
 
+func testKafkaProducer_ProduceSync_LatencyShouldBeDrivenByKafkaProduceLatency(t *testing.T, backend string) {
 	const (
 		topicName                     = "test"
 		tenantID                      = "user-1"
@@ -552,13 +558,8 @@ func TestKafkaProducer_ProduceSync_LatencyShouldBeDrivenByKafkaProduceLatency(t 
 		return nil, nil, false
 	})
 
-	cfg := createTestKafkaConfig(clusterAddr, topicName)
 	reg := prometheus.NewPedanticRegistry()
-	client, err := NewKafkaWriterClient(cfg, defaultMaxInflightProduceRequests, log.NewNopLogger(), reg)
-	require.NoError(t, err)
-
-	producer := NewKafkaProducer(client, cfg.ProducerMaxBufferedBytes, reg)
-	t.Cleanup(producer.Close)
+	producer := createTestKafkaProducerForBackend(t, backend, clusterAddr, topicName, reg, nil)
 
 	// Generate a random payload to reduce its compression ratio.
 	recordPayload, err := generateRandomBytes(produceRecordSizeBytes)
@@ -574,6 +575,7 @@ func TestKafkaProducer_ProduceSync_LatencyShouldBeDrivenByKafkaProduceLatency(t 
 
 		for recordID := 0; recordID < int(produceRecordsTotal); recordID++ {
 			producer.client.Produce(ctx, &kgo.Record{
+				Topic:     topicName,
 				Key:       []byte(tenantID),
 				Value:     recordPayload,
 				Partition: int32(recordID % numPartitions), // Round robin across partitions.
@@ -610,6 +612,26 @@ func TestKafkaProducer_ProduceSync_LatencyShouldBeDrivenByKafkaProduceLatency(t 
 	averageProduceLatencySeconds := produceLatencySecondsSum.Load() / float64(produceRecordsTotal)
 	t.Logf("average produce latency seconds: %.2f", averageProduceLatencySeconds)
 	require.InDelta(t, produceLatency.Seconds(), averageProduceLatencySeconds, 1.)
+}
+
+// createTestKafkaProducerForBackend builds a *KafkaProducer for the given backend
+// the same way the Writer does, registering metrics under writerMetricsPrefix on
+// reg so the cortex_ingest_storage_writer_* assertions resolve. mutate may adjust
+// the config (e.g. ProducerMaxBufferedBytes) before the client is built.
+func createTestKafkaProducerForBackend(t *testing.T, backend, clusterAddr, topic string, reg prometheus.Registerer, mutate func(*KafkaConfig)) *KafkaProducer {
+	t.Helper()
+
+	cfg := createTestKafkaConfigForBackend(backend, clusterAddr, topic)
+	if mutate != nil {
+		mutate(&cfg)
+	}
+
+	prefixedReg := prometheus.WrapRegistererWithPrefix(writerMetricsPrefix, reg)
+	producer, err := newKafkaProducerForBackend(cfg, defaultMaxInflightProduceRequests, log.NewNopLogger(), prefixedReg)
+	require.NoError(t, err)
+	t.Cleanup(producer.Close)
+
+	return producer
 }
 
 func getSummaryQuantileValue(t require.TestingT, reg prometheus.Gatherer, metricName string, quantile float64) float64 {

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/agent_record_buffer.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/agent_record_buffer.go
@@ -58,7 +58,7 @@ type AgentFlushFunc func(ctx context.Context, nodeID int32, partitions []routedT
 type AgentRecordBuffer struct {
 	nodeID        int32
 	linger        time.Duration
-	maxBatchBytes int32
+	batchMaxBytes int32
 	flush         AgentFlushFunc
 	metrics       *metrics
 
@@ -77,12 +77,12 @@ type AgentRecordBuffer struct {
 
 // NewAgentRecordBuffer returns a buffer for records destined to nodeID.
 // flush runs in a background goroutine when a batch is ready.
-func NewAgentRecordBuffer(nodeID int32, linger time.Duration, maxBatchBytes int32, flush AgentFlushFunc, m *metrics) *AgentRecordBuffer {
+func NewAgentRecordBuffer(nodeID int32, linger time.Duration, batchMaxBytes int32, flush AgentFlushFunc, m *metrics) *AgentRecordBuffer {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &AgentRecordBuffer{
 		nodeID:         nodeID,
 		linger:         linger,
-		maxBatchBytes:  maxBatchBytes,
+		batchMaxBytes:  batchMaxBytes,
 		flush:          flush,
 		metrics:        m,
 		flushCtx:       ctx,
@@ -101,14 +101,14 @@ func (a *AgentRecordBuffer) Add(partitions []promisedRoutedTopicPartitionRecords
 		return
 	}
 
-	// Split any group whose own RecordBatch would exceed maxBatchBytes into
+	// Split any group whose own RecordBatch would exceed batchMaxBytes into
 	// chunks that each fit, so no single flushed per-partition batch can be
 	// rejected MessageTooLarge. Chunks are then added one at a time below, and
-	// because each is <= maxBatchBytes the overflow check keeps nextProduceWireBytes
+	// because each is <= batchMaxBytes the overflow check keeps nextProduceWireBytes
 	// (and therefore every per-partition batch) within the cap.
 	chunks := make([]promisedRoutedTopicPartitionRecords, 0, len(partitions))
 	for _, p := range partitions {
-		chunks = append(chunks, splitPromisedRoutedTopicPartitionRecordsByMaxBatchBytes(p, a.maxBatchBytes)...)
+		chunks = append(chunks, splitPromisedRoutedTopicPartitionRecordsByBatchMaxBytes(p, a.batchMaxBytes)...)
 	}
 
 	a.mu.Lock()
@@ -131,14 +131,14 @@ func (a *AgentRecordBuffer) Add(partitions []promisedRoutedTopicPartitionRecords
 	a.mu.Unlock()
 }
 
-// addToNextProduceLocked appends one group (already <= maxBatchBytes) to the
+// addToNextProduceLocked appends one group (already <= batchMaxBytes) to the
 // pending produce, flushing first when it wouldn't fit. Groups are never merged
 // here: same-partition entries are coalesced into one wire batch at flush time
 // (startFlushLocked), which keeps each group's done untouched. Caller must hold
 // a.mu.
 func (a *AgentRecordBuffer) addToNextProduceLocked(p promisedRoutedTopicPartitionRecords) {
 	addBytes, firstTS := a.computeAddCostLocked(p.records)
-	if a.nextProduceRecords > 0 && a.nextProduceWireBytes+addBytes > int64(a.maxBatchBytes) {
+	if a.nextProduceRecords > 0 && a.nextProduceWireBytes+addBytes > int64(a.batchMaxBytes) {
 		// Re-cost after the forced flush: the batch overhead and offsetDelta
 		// values reset, so the original addBytes no longer applies.
 		a.startFlushLocked()

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/client.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/client.go
@@ -89,10 +89,12 @@ type WarpstreamClient struct {
 	refreshWG     sync.WaitGroup
 }
 
-// NewWarpstreamClient wires every component of the produce path. The initial
-// AgentPool refresh is synchronous: if Metadata cannot be reached on startup
-// we fail fast rather than serving traffic against an empty pool.
-func NewWarpstreamClient(cfg Config, logger log.Logger, reg prometheus.Registerer) (*WarpstreamClient, error) {
+// NewWarpstreamClient wires every component of the produce path. Config starts
+// from DefaultConfig and is overridden by opts. The initial AgentPool refresh
+// is synchronous: if Metadata cannot be reached on startup we fail fast rather
+// than serving traffic against an empty pool.
+func NewWarpstreamClient(logger log.Logger, reg prometheus.Registerer, opts ...Opt) (*WarpstreamClient, error) {
+	cfg := NewConfig(opts...)
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid warpstream client config: %w", err)
 	}
@@ -136,12 +138,12 @@ func NewWarpstreamClient(cfg Config, logger log.Logger, reg prometheus.Registere
 	// per-agent probe-timing state persists across refreshes.
 	lazy := NewLazyPartitionAssignmentStrategy(pool.Strategy)
 	c.demoter = NewDemoter(lazy, tracker, cfg.HealthCheck, cfg.Demoter, logger, reg)
-	c.hedger = NewHedger(trackingProducer, tracker, c.demoter, cfg.HealthCheck, cfg.Hedger, cfg.Linger, cfg.MaxBatchBytes, m)
+	c.hedger = NewHedger(trackingProducer, tracker, c.demoter, cfg.HealthCheck, cfg.Hedger, cfg.Linger, cfg.BatchMaxBytes, m)
 	// The cluster buffer's AgentFlushFunc is the Hedger, wrapped only to
 	// bound each flush by WriteTimeout. The Hedger is otherwise shaped
 	// like a DirectProducer (same signature as KafkaDirectProducer) so it
 	// composes directly with the buffer.
-	c.buffer = NewClusterRecordBuffer(cfg.Linger, cfg.MaxBatchBytes, c.flushBatch, m)
+	c.buffer = NewClusterRecordBuffer(cfg.Linger, cfg.BatchMaxBytes, c.flushBatch, m)
 	c.startBackgroundRefresh()
 	return c, nil
 }
@@ -150,7 +152,7 @@ func NewWarpstreamClient(cfg Config, logger log.Logger, reg prometheus.Registere
 // acknowledged or failed. Cancelling ctx detaches the caller; the record
 // is still produced in the background.
 func (c *WarpstreamClient) Produce(ctx context.Context, record *kgo.Record, promise func(*kgo.Record, error)) {
-	if singleRecordBatchEstimateBytes(record) > int64(c.cfg.MaxBatchBytes) {
+	if singleRecordBatchEstimateBytes(record) > int64(c.cfg.BatchMaxBytes) {
 		promise(record, errRecordTooLarge(record))
 		return
 	}
@@ -177,7 +179,7 @@ func (c *WarpstreamClient) ProduceSync(ctx context.Context, records []*kgo.Recor
 		wg        sync.WaitGroup
 	)
 	for i, r := range records {
-		if singleRecordBatchEstimateBytes(r) > int64(c.cfg.MaxBatchBytes) {
+		if singleRecordBatchEstimateBytes(r) > int64(c.cfg.BatchMaxBytes) {
 			results[i] = kgo.ProduceResult{Record: r, Err: errRecordTooLarge(r)}
 			continue
 		}
@@ -416,7 +418,7 @@ func newKgoClient(cfg Config) (*kgo.Client, error) {
 		// batching configuration. The wrapping ProduceSync path does not use
 		// kgo's producer, so these are no-ops in normal operation.
 		kgo.ProducerLinger(cfg.Linger),
-		kgo.ProducerBatchMaxBytes(cfg.MaxBatchBytes),
+		kgo.ProducerBatchMaxBytes(cfg.BatchMaxBytes),
 
 		// Pin Produce to produceAPIVersion: our wire builders set
 		// req.Version explicitly, but kgo.Broker.Request overrides it
@@ -445,7 +447,7 @@ func produceMaxVersions() *kversion.Versions {
 
 // errRecordTooLarge wraps kerr.MessageTooLarge so errors.Is matches. The
 // reported byte count is the wire-encoded estimate — what we actually
-// compared against MaxBatchBytes — to make the value directly comparable
+// compared against BatchMaxBytes — to make the value directly comparable
 // to the configured cap.
 func errRecordTooLarge(r *kgo.Record) error {
 	return fmt.Errorf("%w (uncompressed_bytes=%d)", kerr.MessageTooLarge, singleRecordBatchEstimateBytes(r))

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/cluster_record_buffer.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/cluster_record_buffer.go
@@ -44,7 +44,7 @@ import (
 // the buffer to reject work.
 type ClusterRecordBuffer struct {
 	linger        time.Duration
-	maxBatchBytes int32
+	batchMaxBytes int32
 	flush         AgentFlushFunc
 	metrics       *metrics
 
@@ -65,10 +65,10 @@ type ClusterRecordBuffer struct {
 
 // NewClusterRecordBuffer returns a buffer that lazily spawns one
 // AgentRecordBuffer per NodeID seen via Add, all sharing flush.
-func NewClusterRecordBuffer(linger time.Duration, maxBatchBytes int32, flush AgentFlushFunc, m *metrics) *ClusterRecordBuffer {
+func NewClusterRecordBuffer(linger time.Duration, batchMaxBytes int32, flush AgentFlushFunc, m *metrics) *ClusterRecordBuffer {
 	return &ClusterRecordBuffer{
 		linger:        linger,
-		maxBatchBytes: maxBatchBytes,
+		batchMaxBytes: batchMaxBytes,
 		flush:         flush,
 		metrics:       m,
 		agentBuffers:  make(map[int32]*AgentRecordBuffer),
@@ -238,7 +238,7 @@ func (c *ClusterRecordBuffer) agentRecordBufferFor(nodeID int32) (*AgentRecordBu
 	if a, ok := c.agentBuffers[nodeID]; ok {
 		return a, nil
 	}
-	a = NewAgentRecordBuffer(nodeID, c.linger, c.maxBatchBytes, c.flush, c.metrics)
+	a = NewAgentRecordBuffer(nodeID, c.linger, c.batchMaxBytes, c.flush, c.metrics)
 	c.agentBuffers[nodeID] = a
 	return a, nil
 }

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/config.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/config.go
@@ -29,13 +29,13 @@ type Config struct {
 	// produce before flushing it; zero flushes as soon as possible.
 	Linger time.Duration
 
-	// MaxBatchBytes caps the uncompressed wire size of a single per-partition
+	// BatchMaxBytes caps the uncompressed wire size of a single per-partition
 	// RecordBatch. It must be set at or below the WarpStream agents'
 	// message.max.bytes: the client guarantees no per-partition batch exceeds
 	// this value (splitting oversized partition groups across batches), so as
 	// long as the cap is <= the agent limit the broker never rejects a flush
 	// with MessageTooLarge.
-	MaxBatchBytes int32
+	BatchMaxBytes int32
 
 	// DirectProducer holds the per-attempt timing enforced at the kgo
 	// boundary by KafkaDirectProducer.
@@ -63,6 +63,67 @@ type Config struct {
 	MetadataRefreshInterval time.Duration
 }
 
+// Default values applied by DefaultConfig and the functional options. They are
+// exported so callers (e.g. a CLI) can reuse them as their own flag defaults.
+const (
+	DefaultDialTimeout                         = 500 * time.Millisecond
+	DefaultWriteTimeout                        = 4 * time.Second
+	DefaultLinger                              = 50 * time.Millisecond
+	DefaultBatchMaxBytes                 int32 = 16_000_000
+	DefaultProduceRequestTimeoutOverhead       = 2 * time.Second
+	DefaultProduceRequestTimeout               = DefaultWriteTimeout - DefaultProduceRequestTimeoutOverhead
+	DefaultHealthCheckSlowMultiplier           = 2.0
+	DefaultHealthCheckMaxSlowFraction          = 0.3
+	DefaultHealthCheckFaultyThreshold          = 0.2
+	DefaultHealthCheckMaxFaultyFraction        = 0.3
+	DefaultHedgerMinHedgeDelay                 = 500 * time.Millisecond
+	DefaultHedgerMaxHedgeAgents                = 3
+	DefaultDemoterProbeInterval                = time.Second
+	DefaultClusterStatsTTL                     = time.Second
+	DefaultMetadataRefreshInterval             = 10 * time.Second
+)
+
+// DefaultConfig returns a Config populated with the default values. Address and
+// Topic have no default: they must be set (via options or directly) before the
+// config passes Validate.
+func DefaultConfig() Config {
+	return Config{
+		DialTimeout:             DefaultDialTimeout,
+		WriteTimeout:            DefaultWriteTimeout,
+		Linger:                  DefaultLinger,
+		BatchMaxBytes:           DefaultBatchMaxBytes,
+		ClusterStatsTTL:         DefaultClusterStatsTTL,
+		MetadataRefreshInterval: DefaultMetadataRefreshInterval,
+		DirectProducer: KafkaDirectProducerConfig{
+			ProduceRequestTimeout:         DefaultProduceRequestTimeout,
+			ProduceRequestTimeoutOverhead: DefaultProduceRequestTimeoutOverhead,
+		},
+		HealthCheck: HealthCheckConfig{
+			SlowMultiplier:    DefaultHealthCheckSlowMultiplier,
+			MaxSlowFraction:   DefaultHealthCheckMaxSlowFraction,
+			FaultyThreshold:   DefaultHealthCheckFaultyThreshold,
+			MaxFaultyFraction: DefaultHealthCheckMaxFaultyFraction,
+		},
+		Hedger: HedgerConfig{
+			MinHedgeDelay:  DefaultHedgerMinHedgeDelay,
+			MaxHedgeAgents: DefaultHedgerMaxHedgeAgents,
+		},
+		Demoter: DemoterConfig{
+			ProbeInterval: DefaultDemoterProbeInterval,
+		},
+	}
+}
+
+// NewConfig returns DefaultConfig with opts applied. It does not validate the
+// result.
+func NewConfig(opts ...Opt) Config {
+	cfg := DefaultConfig()
+	for _, o := range opts {
+		o.apply(&cfg)
+	}
+	return cfg
+}
+
 // Validate returns an error if the config is invalid.
 func (c *Config) Validate() error {
 	if len(c.Address) == 0 {
@@ -77,11 +138,11 @@ func (c *Config) Validate() error {
 	if c.WriteTimeout <= 0 {
 		return errors.New("write timeout must be positive")
 	}
-	if c.MaxBatchBytes <= 0 {
-		return errors.New("max batch bytes must be positive")
+	if c.BatchMaxBytes <= 0 {
+		return errors.New("batch max bytes must be positive")
 	}
-	if c.MaxBatchBytes > maxBatchBytesCeiling {
-		return fmt.Errorf("max batch bytes must not exceed %d", maxBatchBytesCeiling)
+	if c.BatchMaxBytes > batchMaxBytesCeiling {
+		return fmt.Errorf("batch max bytes must not exceed %d", batchMaxBytesCeiling)
 	}
 	if c.Linger < 0 {
 		return errors.New("linger must be non-negative")
@@ -116,4 +177,130 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("write timeout (%s) must be at least the produce request timeout plus overhead (%s)", c.WriteTimeout, attempt)
 	}
 	return nil
+}
+
+// Opt configures a WarpstreamClient. Pass options to NewWarpstreamClient; each
+// overrides one field of the default Config.
+type Opt interface {
+	apply(*Config)
+}
+
+type opt struct{ fn func(*Config) }
+
+func (o opt) apply(c *Config) { o.fn(c) }
+
+// WithAddress sets the seed broker addresses to connect to. Required.
+func WithAddress(addrs ...string) Opt {
+	return opt{func(c *Config) { c.Address = addrs }}
+}
+
+// WithTopic sets the topic records are produced to. Required.
+func WithTopic(topic string) Opt {
+	return opt{func(c *Config) { c.Topic = topic }}
+}
+
+// WithClientID sets the Kafka client ID.
+func WithClientID(id string) Opt {
+	return opt{func(c *Config) { c.ClientID = id }}
+}
+
+// WithDialTimeout sets the timeout for establishing a connection to a broker.
+func WithDialTimeout(d time.Duration) Opt {
+	return opt{func(c *Config) { c.DialTimeout = d }}
+}
+
+// WithWriteTimeout sets the deadline bounding a full produce flush, including
+// the whole hedge cascade.
+func WithWriteTimeout(d time.Duration) Opt {
+	return opt{func(c *Config) { c.WriteTimeout = d }}
+}
+
+// WithTLSConfig enables TLS and dials brokers with tlsCfg.
+func WithTLSConfig(tlsCfg *tls.Config) Opt {
+	return opt{func(c *Config) {
+		c.TLSEnabled = true
+		c.TLSConfig = tlsCfg
+	}}
+}
+
+// WithSASL sets pre-built kgo options for SASL authentication.
+func WithSASL(opts ...kgo.Opt) Opt {
+	return opt{func(c *Config) { c.SASLOptions = opts }}
+}
+
+// WithLinger sets how long the buffer waits to coalesce more records into a
+// produce before flushing; zero flushes as soon as possible.
+func WithLinger(d time.Duration) Opt {
+	return opt{func(c *Config) { c.Linger = d }}
+}
+
+// WithBatchMaxBytes caps the uncompressed wire size of a single per-partition
+// RecordBatch. Set it at or below the agents' message.max.bytes.
+func WithBatchMaxBytes(n int32) Opt {
+	return opt{func(c *Config) { c.BatchMaxBytes = n }}
+}
+
+// WithProduceRequestTimeout sets the agent-side deadline written into each
+// ProduceRequest.
+func WithProduceRequestTimeout(d time.Duration) Opt {
+	return opt{func(c *Config) { c.DirectProducer.ProduceRequestTimeout = d }}
+}
+
+// WithProduceRequestTimeoutOverhead sets the slack added on top of the produce
+// request timeout to compute the client-side deadline.
+func WithProduceRequestTimeoutOverhead(d time.Duration) Opt {
+	return opt{func(c *Config) { c.DirectProducer.ProduceRequestTimeoutOverhead = d }}
+}
+
+// WithHealthCheckSlowMultiplier sets the factor over the cluster baseline
+// latency above which an agent is marked slow. Must be >= 1.
+func WithHealthCheckSlowMultiplier(v float64) Opt {
+	return opt{func(c *Config) { c.HealthCheck.SlowMultiplier = v }}
+}
+
+// WithHealthCheckMaxSlowFraction sets the fraction of slow agents at or above
+// which slow-based action is suppressed.
+func WithHealthCheckMaxSlowFraction(v float64) Opt {
+	return opt{func(c *Config) { c.HealthCheck.MaxSlowFraction = v }}
+}
+
+// WithHealthCheckFaultyThreshold sets the window error rate above which an agent
+// is marked faulty.
+func WithHealthCheckFaultyThreshold(v float64) Opt {
+	return opt{func(c *Config) { c.HealthCheck.FaultyThreshold = v }}
+}
+
+// WithHealthCheckMaxFaultyFraction sets the fraction of faulty agents at or
+// above which faulty-based action is suppressed.
+func WithHealthCheckMaxFaultyFraction(v float64) Opt {
+	return opt{func(c *Config) { c.HealthCheck.MaxFaultyFraction = v }}
+}
+
+// WithHedgerMinHedgeDelay sets the floor on the dynamically-computed hedge delay.
+func WithHedgerMinHedgeDelay(d time.Duration) Opt {
+	return opt{func(c *Config) { c.Hedger.MinHedgeDelay = d }}
+}
+
+// WithHedgerMaxHedgeAgents sets the maximum distinct agents tried per partition per
+// produce, counting the primary.
+func WithHedgerMaxHedgeAgents(n int) Opt {
+	return opt{func(c *Config) { c.Hedger.MaxHedgeAgents = n }}
+}
+
+// WithDemoterProbeInterval sets the minimum wall-clock gap between probes to the
+// same demoted agent.
+func WithDemoterProbeInterval(d time.Duration) Opt {
+	return opt{func(c *Config) { c.Demoter.ProbeInterval = d }}
+}
+
+// WithClusterStatsTTL sets how long a cluster-wide stats snapshot is reused
+// before being recomputed.
+func WithClusterStatsTTL(d time.Duration) Opt {
+	return opt{func(c *Config) { c.ClusterStatsTTL = d }}
+}
+
+// WithMetadataRefreshInterval sets how often the agent pool is refreshed in the
+// background.
+func WithMetadataRefreshInterval(d time.Duration) Opt {
+	return opt{func(c *Config) { c.MetadataRefreshInterval = d }}
 }

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/demoter.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/demoter.go
@@ -332,6 +332,14 @@ func (d *Demoter) Refresh(currentAgents []int32) {
 }
 
 func (d *Demoter) demotedAgentsCount() float64 {
+	// While demotion is suppressed isDemoted treats every agent as non-demoted,
+	// so no agent is actually being routed around: report 0 rather than the
+	// stale lastDemotedProbe entries left from before suppression tripped, which
+	// would otherwise contradict demoter_demotion_suppressed.
+	clusterStats, hasClusterStats := d.tracker.ClusterStats(d.now(), d.healthCfg.SlowMultiplier, d.healthCfg.FaultyThreshold)
+	if suppressed, _ := d.isDemotionSuppressed(clusterStats, hasClusterStats); suppressed {
+		return 0
+	}
 	d.lastDemotedProbeMu.Lock()
 	defer d.lastDemotedProbeMu.Unlock()
 	return float64(len(d.lastDemotedProbe))

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/hedger.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/hedger.go
@@ -82,7 +82,7 @@ type Hedger struct {
 }
 
 // NewHedger wraps inner with the orchestration described on Hedger.
-func NewHedger(inner DirectProducer, tracker AgentStatsReader, strategy PartitionAssignmentStrategy, health HealthCheckConfig, cfg HedgerConfig, linger time.Duration, maxBatchBytes int32, m *metrics) *Hedger {
+func NewHedger(inner DirectProducer, tracker AgentStatsReader, strategy PartitionAssignmentStrategy, health HealthCheckConfig, cfg HedgerConfig, linger time.Duration, batchMaxBytes int32, m *metrics) *Hedger {
 	h := &Hedger{
 		inner:    inner,
 		tracker:  tracker,
@@ -91,7 +91,7 @@ func NewHedger(inner DirectProducer, tracker AgentStatsReader, strategy Partitio
 		cfg:      cfg,
 		metrics:  m,
 	}
-	h.hedgeBuffer = NewClusterRecordBuffer(linger, maxBatchBytes, func(ctx context.Context, nodeID int32, parts []routedTopicPartitionRecords) ProduceResult {
+	h.hedgeBuffer = NewClusterRecordBuffer(linger, batchMaxBytes, func(ctx context.Context, nodeID int32, parts []routedTopicPartitionRecords) ProduceResult {
 		// Every hedge-buffer flush is one hedge wire request (possibly
 		// covering multiple partitions). The companion primary counter is
 		// incremented in ProduceSync.

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/produce.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/produce.go
@@ -49,10 +49,10 @@ const crcOffset = 17
 // batchFixedFieldsAfterLength.
 const recordBatchHeaderBytes = 4 + 8 + 4 + batchFixedFieldsAfterLength
 
-// maxBatchBytesCeiling is a sanity cap on Config.MaxBatchBytes. A value above
+// batchMaxBytesCeiling is a sanity cap on Config.BatchMaxBytes. A value above
 // this is almost certainly misconfiguration — the broker would reject such a
 // request anyway — so we fail validation early rather than buffer toward it.
-const maxBatchBytesCeiling int32 = 1 << 30 // 1 GiB
+const batchMaxBytesCeiling int32 = 1 << 30 // 1 GiB
 
 // ensureRecordTimestamp defaults an unset record timestamp to now (truncated to
 // the millisecond resolution Kafka stores), mirroring franz-go's bufferRecord.
@@ -85,7 +85,7 @@ func recordEstimateBytes(r *kgo.Record, offsetDelta int32, tsDelta int64) int64 
 
 // singleRecordBatchEstimateBytes returns the wire-byte size of a fresh single-
 // record batch carrying r. Used as the per-record rejection gate: a record
-// whose batch alone exceeds MaxBatchBytes can never be produced, so we fail
+// whose batch alone exceeds BatchMaxBytes can never be produced, so we fail
 // it synchronously instead of letting the broker reject the eventual
 // request. The estimate is on the uncompressed payload — Snappy can only
 // shrink it, so the gate stays sound under compression.

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/routed_topic_partition.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/routed_topic_partition.go
@@ -132,18 +132,18 @@ func mergePromisedRoutedTopicPartitionRecordsByTopicPartition(entries []promised
 	return out
 }
 
-// splitPromisedRoutedTopicPartitionRecordsByMaxBatchBytes splits in's records
-// so each returned group's standalone RecordBatch fits within maxBatchBytes.
+// splitPromisedRoutedTopicPartitionRecordsByBatchMaxBytes splits in's records
+// so each returned group's standalone RecordBatch fits within batchMaxBytes.
 //
 // The whole group is returned unchanged when it already fits (the common case).
 // When it must be split, the chunks share a fan-in done: in.done fires exactly once,
 // after every chunk has resolved, with a failing result if any chunk failed (else a
 // success).
 //
-// Each record's own batch is <= maxBatchBytes (enforced by the per-record gate), so
+// Each record's own batch is <= batchMaxBytes (enforced by the per-record gate), so
 // every chunk carries at least one record and the split always terminates.
-func splitPromisedRoutedTopicPartitionRecordsByMaxBatchBytes(in promisedRoutedTopicPartitionRecords, maxBatchBytes int32) []promisedRoutedTopicPartitionRecords {
-	if multiRecordBatchEstimateBytes(in.records) <= int64(maxBatchBytes) {
+func splitPromisedRoutedTopicPartitionRecordsByBatchMaxBytes(in promisedRoutedTopicPartitionRecords, batchMaxBytes int32) []promisedRoutedTopicPartitionRecords {
+	if multiRecordBatchEstimateBytes(in.records) <= int64(batchMaxBytes) {
 		return []promisedRoutedTopicPartitionRecords{in}
 	}
 
@@ -162,7 +162,7 @@ func splitPromisedRoutedTopicPartitionRecordsByMaxBatchBytes(in promisedRoutedTo
 		}
 
 		cost := recordEstimateBytes(r, int32(len(currRecords)), r.Timestamp.UnixMilli()-firstTS)
-		if currBytes+cost > int64(maxBatchBytes) {
+		if currBytes+cost > int64(batchMaxBytes) {
 			chunks = append(chunks, currRecords)
 			firstTS = r.Timestamp.UnixMilli()
 			currRecords = []*kgo.Record{r}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -731,7 +731,7 @@ github.com/grafana/pyroscope-go/godeltaprof/internal/pprof
 ## explicit; go 1.21
 github.com/grafana/regexp
 github.com/grafana/regexp/syntax
-# github.com/grafana/warpstream-go v0.0.0-20260619124953-a3d5500ae79e
+# github.com/grafana/warpstream-go v0.0.0-20260623082500-8f2f72d7ebfd
 ## explicit; go 1.25.10
 github.com/grafana/warpstream-go/pkg/wgo
 # github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0


### PR DESCRIPTION
**What this PR does**

Updates the vendored `warpstream-go` to the latest `main`, which replaces the `wgo.Config` struct passed to `NewWarpstreamClient` with functional options. Mimir now maps its `KafkaConfig` to those options in `ToWarpstreamClientOptions` and sources the `warpstream-*` flag defaults from the exported `wgo.Default*` constants, so they can't drift from the client.

It also extends producer test coverage so the franz-go and Warpstream clients are exercised side by side: the `TestKafkaProducer_*` tests (buffered bytes/records accounting, context cancellation, buffer-full admission, timestamp rejection, produce latency) and the SASL authentication test now run against both backends, and `TestKafkaConfig_ToWarpstreamClientOptions` asserts the resulting `wgo.Config` field by field. This guards against behavioural differences between the two clients.

**Which issue(s) this PR fixes or relates to**

N/A

**Checklist**
- [x] Tests updated.
- [ ] `CHANGELOG.md` updated - not needed: internal change to the experimental Warpstream backend with no user-facing behaviour change.