### PR TITLE
Add kmeta package and version-dispatching EncodedOffsets.Lookup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -448,6 +448,7 @@ lint: check-makefiles check-merge-conflicts
 		./pkg/alertmanager/alertspb/... \
 		./pkg/ruler/rulespb/... \
 		./pkg/storage/sharding/... \
+		./pkg/storage/ingest/kmeta/... \
 		./pkg/querier/engine/... \
 		./pkg/querier/api/... \
 		./pkg/util/math/...

--- a/pkg/frontend/querymiddleware/codec_test.go
+++ b/pkg/frontend/querymiddleware/codec_test.go
@@ -35,6 +35,7 @@ import (
 	apierror "github.com/grafana/mimir/pkg/api/error"
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/querier/api"
+	"github.com/grafana/mimir/pkg/storage/ingest/kmeta"
 	"github.com/grafana/mimir/pkg/streamingpromql"
 	"github.com/grafana/mimir/pkg/streamingpromql/compat"
 	"github.com/grafana/mimir/pkg/streamingpromql/requestoptions"
@@ -974,9 +975,9 @@ func TestCodec_EncodeMetricsQueryRequest_ShouldPropagateHeadersInAllowList(t *te
 	require.Len(t, req.Header.Values(api.ReadConsistencyOffsetsHeader), 1)
 	actualOffsets := api.EncodedOffsets(req.Header.Values(api.ReadConsistencyOffsetsHeader)[0])
 	for partitionID, expectedOffset := range expectedOffsets {
-		actualOffset, ok := actualOffsets.Lookup(partitionID)
+		actualOffset, ok := actualOffsets.Lookup(0, partitionID)
 		require.True(t, ok)
-		require.Equal(t, expectedOffset, actualOffset)
+		require.Equal(t, kmeta.NewSingleClusterPartitionOffsets(expectedOffset), actualOffset)
 	}
 }
 

--- a/pkg/frontend/querymiddleware/codec_test.go
+++ b/pkg/frontend/querymiddleware/codec_test.go
@@ -959,7 +959,7 @@ func TestCodec_EncodeMetricsQueryRequest_ShouldPropagateHeadersInAllowList(t *te
 			// Allowed.
 			{Name: compat.ForceFallbackHeaderName, Values: []string{"true"}},
 			{Name: chunkinfologger.ChunkInfoLoggingHeader, Values: []string{"label"}},
-			{Name: api.ReadConsistencyOffsetsHeader, Values: []string{string(api.EncodeOffsets(expectedOffsets))}},
+			{Name: api.ReadConsistencyOffsetsHeader, Values: []string{string(api.EncodeOffsetsV1(expectedOffsets))}},
 
 			// Not allowed.
 			{Name: notAllowedHeader, Values: []string{"some-value"}},

--- a/pkg/frontend/querymiddleware/limits_test.go
+++ b/pkg/frontend/querymiddleware/limits_test.go
@@ -1285,7 +1285,7 @@ func TestEngineQueryRequestRoundTripperHandler(t *testing.T) {
 		return expr
 	}
 
-	encodedOffsets := string(api.EncodeOffsets(map[int32]int64{0: 1, 1: 2}))
+	encodedOffsets := string(api.EncodeOffsetsV1(map[int32]int64{0: 1, 1: 2}))
 
 	requestHeaders := []*PrometheusHeader{
 		{Name: compat.ForceFallbackHeaderName, Values: []string{"true"}},

--- a/pkg/frontend/querymiddleware/read_consistency.go
+++ b/pkg/frontend/querymiddleware/read_consistency.go
@@ -66,7 +66,7 @@ func (r *readConsistencyRoundTripper) RoundTrip(req *http.Request) (_ *http.Resp
 		return nil, errors.Wrapf(err, "wait for last produced offsets of topic '%s'", r.offsetsReader.Topic())
 	}
 
-	headerValue := string(querierapi.EncodeOffsets(offsets))
+	headerValue := string(querierapi.EncodeOffsetsV1(offsets))
 	req.Header.Add(querierapi.ReadConsistencyOffsetsHeader, headerValue)
 
 	spanLog.DebugLog("msg", "got offsets for strong read consistency", "header", querierapi.ReadConsistencyOffsetsHeader, "value", headerValue)

--- a/pkg/frontend/querymiddleware/read_consistency_test.go
+++ b/pkg/frontend/querymiddleware/read_consistency_test.go
@@ -23,6 +23,7 @@ import (
 
 	querierapi "github.com/grafana/mimir/pkg/querier/api"
 	"github.com/grafana/mimir/pkg/storage/ingest"
+	"github.com/grafana/mimir/pkg/storage/ingest/kmeta"
 	"github.com/grafana/mimir/pkg/util/testkafka"
 	"github.com/grafana/mimir/pkg/util/validation"
 )
@@ -113,9 +114,9 @@ func TestReadConsistencyRoundTripper(t *testing.T) {
 				offsets := querierapi.EncodedOffsets(downstreamReq.Header.Get(querierapi.ReadConsistencyOffsetsHeader))
 
 				for partitionID, expectedOffset := range expectedOffsets {
-					actual, ok := offsets.Lookup(partitionID)
+					actual, ok := offsets.Lookup(0, partitionID)
 					assert.True(t, ok)
-					assert.Equal(t, expectedOffset, actual)
+					assert.Equal(t, kmeta.NewSingleClusterPartitionOffsets(expectedOffset), actual)
 				}
 			} else {
 				assert.Empty(t, downstreamReq.Header.Get(querierapi.ReadConsistencyOffsetsHeader))

--- a/pkg/frontend/querymiddleware/roundtrip_test.go
+++ b/pkg/frontend/querymiddleware/roundtrip_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/grafana/mimir/pkg/querier"
 	querierapi "github.com/grafana/mimir/pkg/querier/api"
 	"github.com/grafana/mimir/pkg/storage/ingest"
+	"github.com/grafana/mimir/pkg/storage/ingest/kmeta"
 	"github.com/grafana/mimir/pkg/streamingpromql"
 	"github.com/grafana/mimir/pkg/util/limiter"
 	"github.com/grafana/mimir/pkg/util/testkafka"
@@ -1035,9 +1036,9 @@ func TestTripperware_ShouldSupportReadConsistencyOffsetsInjection(t *testing.T) 
 						offsets := querierapi.EncodedOffsets(downstreamReq.Header.Get(querierapi.ReadConsistencyOffsetsHeader))
 
 						for partitionID, expectedOffset := range expectedOffsets {
-							actual, ok := offsets.Lookup(partitionID)
+							actual, ok := offsets.Lookup(0, partitionID)
 							assert.True(t, ok)
-							assert.Equal(t, expectedOffset, actual)
+							assert.Equal(t, kmeta.NewSingleClusterPartitionOffsets(expectedOffset), actual)
 						}
 					} else {
 						assert.Empty(t, downstreamReq.Header.Get(querierapi.ReadConsistencyOffsetsHeader))

--- a/pkg/ingester/ingester_compartments_test.go
+++ b/pkg/ingester/ingester_compartments_test.go
@@ -410,7 +410,7 @@ func TestIngester_Compartments_QueryStream_ReadConsistency(t *testing.T) {
 
 				// Inject the requested offsets (if any).
 				if len(testData.readConsistencyOffsets) > 0 {
-					queryCtx = api.ContextWithReadConsistencyEncodedOffsets(queryCtx, api.EncodeOffsets(testData.readConsistencyOffsets))
+					queryCtx = api.ContextWithReadConsistencyEncodedOffsets(queryCtx, api.EncodeOffsetsV1(testData.readConsistencyOffsets))
 				}
 
 				close(queryIssued)

--- a/pkg/ingester/ingester_ingest_storage_test.go
+++ b/pkg/ingester/ingester_ingest_storage_test.go
@@ -463,7 +463,7 @@ func TestIngester_QueryStream_IngestStorageReadConsistency(t *testing.T) {
 
 				// Inject the requested offsets (if any).
 				if len(testData.readConsistencyOffsets) > 0 {
-					queryCtx = api.ContextWithReadConsistencyEncodedOffsets(queryCtx, api.EncodeOffsets(testData.readConsistencyOffsets))
+					queryCtx = api.ContextWithReadConsistencyEncodedOffsets(queryCtx, api.EncodeOffsetsV1(testData.readConsistencyOffsets))
 				}
 
 				close(queryIssued)

--- a/pkg/ingester/ingester_query.go
+++ b/pkg/ingester/ingester_query.go
@@ -929,10 +929,10 @@ func (i *Ingester) enforceReadConsistency(ctx context.Context, tenantID string) 
 		if !i.cfg.Compartments.Enabled {
 			// Check if request already contains the minimum offset we have to guarantee being queried
 			// for our partition.
-			if offsets, ok := api.ReadConsistencyEncodedOffsetsFromContext(ctx); ok {
-				if offset, ok := offsets.Lookup(i.ingestPartitionID); ok {
-					spanLog.DebugLog("msg", "enforcing strong read consistency", "offset", offset)
-					return errors.Wrap(i.ingestReader.WaitReadConsistencyUntilOffsets(ctx, ingest.NewSingleClusterPartitionOffsets(offset)), "wait for read consistency")
+			if encoded, ok := api.ReadConsistencyEncodedOffsetsFromContext(ctx); ok {
+				if offsets, ok := encoded.Lookup(0, i.ingestPartitionID); ok {
+					spanLog.DebugLog("msg", "enforcing strong read consistency", "offsets", offsets)
+					return errors.Wrap(i.ingestReader.WaitReadConsistencyUntilOffsets(ctx, ingest.NewMultiClusterPartitionOffsets(offsets)), "wait for read consistency")
 				}
 			}
 		}

--- a/pkg/querier/api/consistency.go
+++ b/pkg/querier/api/consistency.go
@@ -233,9 +233,7 @@ func (ss ctxStream) Context() context.Context {
 // EncodedOffsets holds the encoded partition offsets.
 type EncodedOffsets string
 
-// Lookup returns the offsets for the input read compartment and partition, detecting the encoding version
-// and dispatching accordingly. Only the v1 encoding is supported for now; it has no read compartment
-// dimension, so it is only matched when readCompartment is 0.
+// Lookup returns the offsets for the input read compartment and partition.
 func (p EncodedOffsets) Lookup(readCompartment int, partitionID int32) (kmeta.PartitionOffsets, bool) {
 	const versionLen = 3
 	if len(p) < versionLen {
@@ -257,7 +255,7 @@ func (p EncodedOffsets) Lookup(readCompartment int, partitionID int32) (kmeta.Pa
 	}
 }
 
-// lookupV1 returns the offset for the input partitionID, as encoded by EncodeOffsets.
+// lookupV1 returns the offset for the input partitionID, as encoded by EncodeOffsetsV1.
 func (p EncodedOffsets) lookupV1(partitionID int32) (int64, bool) {
 	const versionLen = 3
 
@@ -301,9 +299,9 @@ func (p EncodedOffsets) lookupV1(partitionID int32) (int64, bool) {
 	return offset, true
 }
 
-// EncodeOffsets serialise the input offsets into a string which is safe to be used as HTTP header value.
+// EncodeOffsetsV1 serialise the input offsets into a string which is safe to be used as HTTP header value.
 // Empty partitions (offset is -1) are NOT skipped.
-func EncodeOffsets(offsets map[int32]int64) EncodedOffsets {
+func EncodeOffsetsV1(offsets map[int32]int64) EncodedOffsets {
 	const versionLen = 3
 
 	if len(offsets) == 0 {

--- a/pkg/querier/api/consistency.go
+++ b/pkg/querier/api/consistency.go
@@ -13,6 +13,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
+	//lint:ignore faillint Allow importing the kmeta package, since it's an isolated package (doesn't come with many other dependencies).
+	"github.com/grafana/mimir/pkg/storage/ingest/kmeta"
 	//lint:ignore faillint Allow to import the math util package, since it's an isolated package (doesn't come with many other deps).
 	"github.com/grafana/mimir/pkg/util/math"
 	//lint:ignore faillint Allow importing the propagation package, since it's an isolated package (doesn't come with many other dependencies).
@@ -231,8 +233,32 @@ func (ss ctxStream) Context() context.Context {
 // EncodedOffsets holds the encoded partition offsets.
 type EncodedOffsets string
 
-// Lookup the offset for the input partitionID.
-func (p EncodedOffsets) Lookup(partitionID int32) (int64, bool) {
+// Lookup returns the offsets for the input read compartment and partition, detecting the encoding version
+// and dispatching accordingly. Only the v1 encoding is supported for now; it has no read compartment
+// dimension, so it is only matched when readCompartment is 0.
+func (p EncodedOffsets) Lookup(readCompartment int, partitionID int32) (kmeta.PartitionOffsets, bool) {
+	const versionLen = 3
+	if len(p) < versionLen {
+		return kmeta.PartitionOffsets{}, false
+	}
+
+	switch p[:versionLen] {
+	case "v1=":
+		if readCompartment != 0 {
+			return kmeta.PartitionOffsets{}, false
+		}
+		offset, ok := p.lookupV1(partitionID)
+		if !ok {
+			return kmeta.PartitionOffsets{}, false
+		}
+		return kmeta.NewSingleClusterPartitionOffsets(offset), true
+	default:
+		return kmeta.PartitionOffsets{}, false
+	}
+}
+
+// lookupV1 returns the offset for the input partitionID, as encoded by EncodeOffsets.
+func (p EncodedOffsets) lookupV1(partitionID int32) (int64, bool) {
 	const versionLen = 3
 
 	if len(p) < versionLen {

--- a/pkg/querier/api/consistency.go
+++ b/pkg/querier/api/consistency.go
@@ -255,19 +255,9 @@ func (p EncodedOffsets) Lookup(readCompartment int, partitionID int32) (kmeta.Pa
 	}
 }
 
-// lookupV1 returns the offset for the input partitionID, as encoded by EncodeOffsetsV1.
+// lookupV1 returns the offset for the input partitionID from the v1 encoding produced by EncodeOffsetsV1.
+// It assumes the caller has already verified the "v1=" version prefix and so doesn't re-check it.
 func (p EncodedOffsets) lookupV1(partitionID int32) (int64, bool) {
-	const versionLen = 3
-
-	if len(p) < versionLen {
-		return 0, false
-	}
-
-	// Check the version.
-	if p[:3] != "v1=" {
-		return 0, false
-	}
-
 	// Find the position of the partition. The partition can either be:
 	// - At the beginning, right after the version (so after "=")
 	// - In the middle or end, right after another partition (so after ",")

--- a/pkg/querier/api/consistency_test.go
+++ b/pkg/querier/api/consistency_test.go
@@ -17,6 +17,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
+	//lint:ignore faillint Allow importing the kmeta package, since it's an isolated package (doesn't come with many other dependencies).
+	"github.com/grafana/mimir/pkg/storage/ingest/kmeta"
 	//lint:ignore faillint Allow importing the propagation package, since it's an isolated package (doesn't come with many other dependencies).
 	"github.com/grafana/mimir/pkg/util/propagation"
 )
@@ -265,7 +267,7 @@ func TestEncodeOffsets(t *testing.T) {
 	})
 }
 
-func TestEncodedOffsets_Lookup_SpecialCases(t *testing.T) {
+func TestEncodedOffsets_LookupV1_SpecialCases(t *testing.T) {
 	tests := map[string]struct {
 		encoded              EncodedOffsets
 		expectedPartitions   map[int32]int64
@@ -320,33 +322,33 @@ func TestEncodedOffsets_Lookup_SpecialCases(t *testing.T) {
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
 			for expectedPartitionID, expectedOffset := range testData.expectedPartitions {
-				actualOffset, ok := testData.encoded.Lookup(expectedPartitionID)
+				actualOffset, ok := testData.encoded.lookupV1(expectedPartitionID)
 				require.True(t, ok)
 				assert.Equalf(t, expectedOffset, actualOffset, "partition ID: %d", expectedPartitionID)
 			}
 
 			for _, unexpectedPartitionID := range testData.unexpectedPartitions {
-				_, ok := testData.encoded.Lookup(unexpectedPartitionID)
+				_, ok := testData.encoded.lookupV1(unexpectedPartitionID)
 				assert.Falsef(t, ok, "partition ID: %d", unexpectedPartitionID)
 			}
 		})
 	}
 }
 
-func TestEncodedOffsets_Lookup_First1000Partitions(t *testing.T) {
+func TestEncodedOffsets_LookupV1_First1000Partitions(t *testing.T) {
 	const numPartitions = 1000
 
 	offsets := generateTestOffsets(numPartitions)
 	encoded := EncodeOffsets(offsets)
 
 	for partitionID, expected := range offsets {
-		actual, ok := encoded.Lookup(partitionID)
+		actual, ok := encoded.lookupV1(partitionID)
 		assert.True(t, ok)
 		assert.Equal(t, expected, actual)
 	}
 }
 
-func TestEncodedOffsets_Lookup_Fuzzy(t *testing.T) {
+func TestEncodedOffsets_LookupV1_Fuzzy(t *testing.T) {
 	const (
 		numRuns       = 100
 		numPartitions = 1000
@@ -366,7 +368,7 @@ func TestEncodedOffsets_Lookup_Fuzzy(t *testing.T) {
 		encoded := EncodeOffsets(offsets)
 
 		for partitionID, expected := range offsets {
-			actual, ok := encoded.Lookup(partitionID)
+			actual, ok := encoded.lookupV1(partitionID)
 			assert.True(t, ok)
 			assert.Equal(t, expected, actual)
 		}
@@ -386,7 +388,7 @@ func BenchmarkEncodeOffsets(b *testing.B) {
 	}
 }
 
-func BenchmarkEncodedOffsets_Lookup(b *testing.B) {
+func BenchmarkEncodedOffsets_LookupV1(b *testing.B) {
 	for _, numPartitions := range []int{1, 10, 100, 1000} {
 		b.Run(fmt.Sprintf("num partitions: %d", numPartitions), func(b *testing.B) {
 			encoded := EncodeOffsets(generateTestOffsets(numPartitions))
@@ -394,9 +396,62 @@ func BenchmarkEncodedOffsets_Lookup(b *testing.B) {
 			b.ResetTimer()
 			for n := 0; n < b.N; n++ {
 				partitionID := int32(n % numPartitions)
-				_, ok := encoded.Lookup(partitionID)
+				_, ok := encoded.lookupV1(partitionID)
 				if !ok {
 					b.Fatalf("not found offset for partition %d", partitionID)
+				}
+			}
+		})
+	}
+}
+
+func TestEncodedOffsets_Lookup(t *testing.T) {
+	type lookup struct {
+		readCompartment int
+		partition       int32
+		expected        kmeta.PartitionOffsets
+		found           bool
+	}
+
+	tests := map[string]struct {
+		encoded EncodedOffsets
+		lookups []lookup
+	}{
+		"empty": {
+			encoded: "",
+			lookups: []lookup{{0, 0, kmeta.PartitionOffsets{}, false}},
+		},
+		"unknown version": {
+			encoded: "v3=0/0:1",
+			lookups: []lookup{{0, 0, kmeta.PartitionOffsets{}, false}},
+		},
+		"v1 single cluster, read compartment 0": {
+			encoded: EncodeOffsets(map[int32]int64{0: 123, 1: -1}),
+			lookups: []lookup{
+				{0, 0, kmeta.NewSingleClusterPartitionOffsets(123), true},
+				{0, 1, kmeta.NewSingleClusterPartitionOffsets(-1), true},
+				{0, 2, kmeta.PartitionOffsets{}, false},
+			},
+		},
+		"v1 is only matched for read compartment 0": {
+			encoded: EncodeOffsets(map[int32]int64{0: 123}),
+			lookups: []lookup{
+				{1, 0, kmeta.PartitionOffsets{}, false},
+			},
+		},
+		"v1 corruption when reading the offset": {
+			encoded: "v1=0:x",
+			lookups: []lookup{{0, 0, kmeta.PartitionOffsets{}, false}},
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			for _, l := range testData.lookups {
+				actual, ok := testData.encoded.Lookup(l.readCompartment, l.partition)
+				assert.Equalf(t, l.found, ok, "read compartment: %d partition: %d", l.readCompartment, l.partition)
+				if l.found {
+					assert.Equalf(t, l.expected, actual, "read compartment: %d partition: %d", l.readCompartment, l.partition)
 				}
 			}
 		})

--- a/pkg/querier/api/consistency_test.go
+++ b/pkg/querier/api/consistency_test.go
@@ -273,14 +273,6 @@ func TestEncodedOffsets_LookupV1_SpecialCases(t *testing.T) {
 		expectedPartitions   map[int32]int64
 		unexpectedPartitions []int32
 	}{
-		"empty": {
-			encoded:              "",
-			unexpectedPartitions: []int32{0},
-		},
-		"missing version": {
-			encoded:              "0:1",
-			unexpectedPartitions: []int32{0},
-		},
 		"corruption when reading the partition ID": {
 			encoded:              "v1=x",
 			unexpectedPartitions: []int32{0},

--- a/pkg/querier/api/consistency_test.go
+++ b/pkg/querier/api/consistency_test.go
@@ -234,7 +234,7 @@ func (m serverStreamMock) Context() context.Context {
 	return m.ctx
 }
 
-func TestEncodeOffsets(t *testing.T) {
+func TestEncodeOffsetsV1(t *testing.T) {
 	t.Run("empty offsets", func(t *testing.T) {
 		assert.Equal(t, EncodedOffsets(""), EncodeOffsetsV1(nil))
 		assert.Equal(t, EncodedOffsets(""), EncodeOffsetsV1(map[int32]int64{}))
@@ -375,7 +375,7 @@ func TestEncodedOffsets_LookupV1_Fuzzy(t *testing.T) {
 	}
 }
 
-func BenchmarkEncodeOffsets(b *testing.B) {
+func BenchmarkEncodeOffsetsV1(b *testing.B) {
 	for _, numPartitions := range []int{1, 10, 100, 1000} {
 		b.Run(fmt.Sprintf("num partitions: %d", numPartitions), func(b *testing.B) {
 			offsets := generateTestOffsets(numPartitions)

--- a/pkg/querier/api/consistency_test.go
+++ b/pkg/querier/api/consistency_test.go
@@ -36,7 +36,7 @@ var (
 )
 
 func TestConsistencyExtractor(t *testing.T) {
-	encodedOffsets := EncodeOffsets(map[int32]int64{0: 1, 1: 2})
+	encodedOffsets := EncodeOffsetsV1(map[int32]int64{0: 1, 1: 2})
 	headers := http.Header{}
 	headers.Set(ReadConsistencyHeader, ReadConsistencyStrong)
 	headers.Set(ReadConsistencyOffsetsHeader, string(encodedOffsets))
@@ -64,7 +64,7 @@ func TestConsistencyInjector(t *testing.T) {
 	ctx := context.Background()
 	ctx = ContextWithReadConsistencyLevel(ctx, ReadConsistencyStrong)
 	ctx = ContextWithReadConsistencyMaxDelay(ctx, time.Minute)
-	ctx = ContextWithReadConsistencyEncodedOffsets(ctx, EncodeOffsets(map[int32]int64{0: 1, 1: 2}))
+	ctx = ContextWithReadConsistencyEncodedOffsets(ctx, EncodeOffsetsV1(map[int32]int64{0: 1, 1: 2}))
 
 	headers := http.Header{}
 
@@ -79,7 +79,7 @@ func TestConsistencyInjector(t *testing.T) {
 }
 
 func TestReadConsistencyClientUnaryInterceptor_And_ReadConsistencyServerUnaryInterceptor(t *testing.T) {
-	encodedOffsets := EncodeOffsets(map[int32]int64{0: 1, 1: 2})
+	encodedOffsets := EncodeOffsetsV1(map[int32]int64{0: 1, 1: 2})
 
 	// Run the gRPC client interceptor.
 	clientIncomingCtx := context.Background()
@@ -126,7 +126,7 @@ func TestReadConsistencyClientUnaryInterceptor_And_ReadConsistencyServerUnaryInt
 }
 
 func TestReadConsistencyClientStreamInterceptor_And_ReadConsistencyServerStreamInterceptor(t *testing.T) {
-	encodedOffsets := EncodeOffsets(map[int32]int64{0: 1, 1: 2})
+	encodedOffsets := EncodeOffsetsV1(map[int32]int64{0: 1, 1: 2})
 
 	// Run the gRPC client interceptor.
 	clientIncomingCtx := context.Background()
@@ -181,7 +181,7 @@ func BenchmarkReadConsistencyServerUnaryInterceptor(b *testing.B) {
 			if withReadConsistency {
 				md = metadata.Join(md, metadata.New(map[string]string{
 					consistencyLevelGrpcMdKey:    ReadConsistencyStrong,
-					consistencyOffsetsGrpcMdKey:  string(EncodeOffsets(generateTestOffsets(numPartitions))),
+					consistencyOffsetsGrpcMdKey:  string(EncodeOffsetsV1(generateTestOffsets(numPartitions))),
 					consistencyMaxDelayGrpcMdKey: "1m",
 				}))
 			}
@@ -207,7 +207,7 @@ func BenchmarkReadConsistencyServerStreamInterceptor(b *testing.B) {
 			if withReadConsistency {
 				md = metadata.Join(md, metadata.New(map[string]string{
 					consistencyLevelGrpcMdKey:    ReadConsistencyStrong,
-					consistencyOffsetsGrpcMdKey:  string(EncodeOffsets(generateTestOffsets(numPartitions))),
+					consistencyOffsetsGrpcMdKey:  string(EncodeOffsetsV1(generateTestOffsets(numPartitions))),
 					consistencyMaxDelayGrpcMdKey: "1m",
 				}))
 			}
@@ -236,21 +236,21 @@ func (m serverStreamMock) Context() context.Context {
 
 func TestEncodeOffsets(t *testing.T) {
 	t.Run("empty offsets", func(t *testing.T) {
-		assert.Equal(t, EncodedOffsets(""), EncodeOffsets(nil))
-		assert.Equal(t, EncodedOffsets(""), EncodeOffsets(map[int32]int64{}))
+		assert.Equal(t, EncodedOffsets(""), EncodeOffsetsV1(nil))
+		assert.Equal(t, EncodedOffsets(""), EncodeOffsetsV1(map[int32]int64{}))
 	})
 
 	t.Run("1 offset", func(t *testing.T) {
-		assert.Equal(t, EncodedOffsets("v1=0:1000"), EncodeOffsets(map[int32]int64{0: 1000}))
-		assert.Equal(t, EncodedOffsets("v1=123456:654321"), EncodeOffsets(map[int32]int64{123456: 654321}))
+		assert.Equal(t, EncodedOffsets("v1=0:1000"), EncodeOffsetsV1(map[int32]int64{0: 1000}))
+		assert.Equal(t, EncodedOffsets("v1=123456:654321"), EncodeOffsetsV1(map[int32]int64{123456: 654321}))
 	})
 
 	t.Run("multiple offsets", func(t *testing.T) {
-		assert.ElementsMatch(t, []string{"1:1", "2:2", "10:9", "123:456"}, strings.Split(string(EncodeOffsets(map[int32]int64{1: 1, 2: 2, 10: 9, 123: 456})[3:]), ","))
+		assert.ElementsMatch(t, []string{"1:1", "2:2", "10:9", "123:456"}, strings.Split(string(EncodeOffsetsV1(map[int32]int64{1: 1, 2: 2, 10: 9, 123: 456})[3:]), ","))
 	})
 
 	t.Run("should not skip empty partitions", func(t *testing.T) {
-		assert.ElementsMatch(t, []string{"123:321", "456:-1"}, strings.Split(string(EncodeOffsets(map[int32]int64{123: 321, 456: -1})[3:]), ","))
+		assert.ElementsMatch(t, []string{"123:321", "456:-1"}, strings.Split(string(EncodeOffsetsV1(map[int32]int64{123: 321, 456: -1})[3:]), ","))
 	})
 
 	t.Run("should allocate only once", func(t *testing.T) {
@@ -259,7 +259,7 @@ func TestEncodeOffsets(t *testing.T) {
 				offsets := generateTestOffsets(numPartitions)
 
 				assert.Equal(t, 1.0, testing.AllocsPerRun(100, func() {
-					EncodeOffsets(offsets)
+					EncodeOffsetsV1(offsets)
 				}))
 			})
 		}
@@ -290,21 +290,21 @@ func TestEncodedOffsets_LookupV1_SpecialCases(t *testing.T) {
 			unexpectedPartitions: []int32{0},
 		},
 		"single partition": {
-			encoded: EncodeOffsets(map[int32]int64{
+			encoded: EncodeOffsetsV1(map[int32]int64{
 				0: 123,
 			}),
 			expectedPartitions:   map[int32]int64{0: 123},
 			unexpectedPartitions: []int32{1},
 		},
 		"single partition with negative offset": {
-			encoded: EncodeOffsets(map[int32]int64{
+			encoded: EncodeOffsetsV1(map[int32]int64{
 				0: -123,
 			}),
 			expectedPartitions:   map[int32]int64{0: -123},
 			unexpectedPartitions: []int32{1},
 		},
 		"multiple partitions": {
-			encoded: EncodeOffsets(map[int32]int64{
+			encoded: EncodeOffsetsV1(map[int32]int64{
 				0: -123,
 				1: 456,
 				2: math.MaxInt64,
@@ -339,7 +339,7 @@ func TestEncodedOffsets_LookupV1_First1000Partitions(t *testing.T) {
 	const numPartitions = 1000
 
 	offsets := generateTestOffsets(numPartitions)
-	encoded := EncodeOffsets(offsets)
+	encoded := EncodeOffsetsV1(offsets)
 
 	for partitionID, expected := range offsets {
 		actual, ok := encoded.lookupV1(partitionID)
@@ -365,7 +365,7 @@ func TestEncodedOffsets_LookupV1_Fuzzy(t *testing.T) {
 			offsets[rnd.Int31n(math.MaxInt32)] = rnd.Int63n(math.MaxInt64)
 		}
 
-		encoded := EncodeOffsets(offsets)
+		encoded := EncodeOffsetsV1(offsets)
 
 		for partitionID, expected := range offsets {
 			actual, ok := encoded.lookupV1(partitionID)
@@ -382,7 +382,7 @@ func BenchmarkEncodeOffsets(b *testing.B) {
 
 			b.ResetTimer()
 			for n := 0; n < b.N; n++ {
-				EncodeOffsets(offsets)
+				EncodeOffsetsV1(offsets)
 			}
 		})
 	}
@@ -391,7 +391,7 @@ func BenchmarkEncodeOffsets(b *testing.B) {
 func BenchmarkEncodedOffsets_LookupV1(b *testing.B) {
 	for _, numPartitions := range []int{1, 10, 100, 1000} {
 		b.Run(fmt.Sprintf("num partitions: %d", numPartitions), func(b *testing.B) {
-			encoded := EncodeOffsets(generateTestOffsets(numPartitions))
+			encoded := EncodeOffsetsV1(generateTestOffsets(numPartitions))
 
 			b.ResetTimer()
 			for n := 0; n < b.N; n++ {
@@ -426,7 +426,7 @@ func TestEncodedOffsets_Lookup(t *testing.T) {
 			lookups: []lookup{{0, 0, kmeta.PartitionOffsets{}, false}},
 		},
 		"v1 single cluster, read compartment 0": {
-			encoded: EncodeOffsets(map[int32]int64{0: 123, 1: -1}),
+			encoded: EncodeOffsetsV1(map[int32]int64{0: 123, 1: -1}),
 			lookups: []lookup{
 				{0, 0, kmeta.NewSingleClusterPartitionOffsets(123), true},
 				{0, 1, kmeta.NewSingleClusterPartitionOffsets(-1), true},
@@ -434,7 +434,7 @@ func TestEncodedOffsets_Lookup(t *testing.T) {
 			},
 		},
 		"v1 is only matched for read compartment 0": {
-			encoded: EncodeOffsets(map[int32]int64{0: 123}),
+			encoded: EncodeOffsetsV1(map[int32]int64{0: 123}),
 			lookups: []lookup{
 				{1, 0, kmeta.PartitionOffsets{}, false},
 			},

--- a/pkg/storage/ingest/kmeta/doc.go
+++ b/pkg/storage/ingest/kmeta/doc.go
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Package kmeta (short for "kafka metadata") holds Kafka metadata value types shared across packages —
+// currently the partition offset types (see PartitionOffsets). It is intentionally a dependency-free leaf
+// — it must not import other internal packages — so that other packages with strict import rules can
+// import it.
+package kmeta

--- a/pkg/storage/ingest/kmeta/partitions_offsets.go
+++ b/pkg/storage/ingest/kmeta/partitions_offsets.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package kmeta
+
+// PartitionOffsets carries the offset of a single partition across one or more Kafka clusters, indexed by
+// Kafka cluster ID. Offsets live in independent per-cluster offset spaces, so the same partition has a
+// distinct offset in each Kafka cluster. The offset of Kafka cluster N is held at index N; in the
+// single-cluster case there is only cluster 0.
+type PartitionOffsets []int64
+
+// NewMultiClusterPartitionOffsets returns a PartitionOffsets holding one offset per Kafka cluster,
+// indexed by Kafka cluster ID. It does not copy offsets: the returned value shares the backing array, so
+// the caller must not mutate offsets afterwards.
+func NewMultiClusterPartitionOffsets(offsets []int64) PartitionOffsets {
+	return PartitionOffsets(offsets)
+}
+
+// NewSingleClusterPartitionOffsets returns a PartitionOffsets holding a single offset for Kafka cluster
+// 0. It is used in the single Kafka cluster case.
+func NewSingleClusterPartitionOffsets(offset int64) PartitionOffsets {
+	return PartitionOffsets{offset}
+}

--- a/pkg/storage/ingest/kmeta/partitions_offsets_test.go
+++ b/pkg/storage/ingest/kmeta/partitions_offsets_test.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package kmeta
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSingleClusterPartitionOffsets(t *testing.T) {
+	assert.Equal(t, PartitionOffsets{7}, NewSingleClusterPartitionOffsets(7))
+}
+
+func TestNewMultiClusterPartitionOffsets(t *testing.T) {
+	assert.Equal(t, PartitionOffsets{10, 20, -1}, NewMultiClusterPartitionOffsets([]int64{10, 20, -1}))
+}


### PR DESCRIPTION
#### What this PR does

Preliminary refactoring extracted from #15762 to shrink that PR and make it easier to review.

It introduces a dependency-free `kmeta` (Kafka metadata) leaf package holding the `PartitionOffsets` value type, and reworks `EncodedOffsets.Lookup` to detect the encoding version and dispatch accordingly, returning per-Kafka-cluster offsets keyed by read compartment. Only the v1 encoding is wired up for now (it has no read compartment dimension, so it only matches read compartment 0); the v2 encoding lands with #15762.

No behaviour change: v1 encoding/decoding and the strong read consistency path produce identical results.

#### Which issue(s) this PR fixes or relates to

Relates to #15762

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.