### PR TITLE
storage/ingest: support for kfake.VirtualNetwork

### DIFF
--- a/pkg/blockbuilder/blockbuilder_test.go
+++ b/pkg/blockbuilder/blockbuilder_test.go
@@ -9,12 +9,14 @@ import (
 	"path"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kfake"
 	"github.com/twmb/franz-go/pkg/kgo"
 
 	"github.com/grafana/mimir/pkg/blockbuilder/schedulerpb"
@@ -24,9 +26,6 @@ import (
 )
 
 func TestBlockBuilder(t *testing.T) {
-	ctx, cancel := context.WithCancelCause(context.Background())
-	t.Cleanup(func() { cancel(errors.New("test done")) })
-
 	tenants := []string{"1", "2", "3"}
 	samplesPerTenant := 10
 
@@ -80,75 +79,92 @@ func TestBlockBuilder(t *testing.T) {
 		t.Run(fm.name, func(t *testing.T) {
 			for _, c := range cases {
 				t.Run(c.name, func(t *testing.T) {
-					_, kafkaAddr := testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, numPartitions, testTopic)
-					kafkaClient := mustKafkaClient(t, kafkaAddr)
-					kafkaClient.AddConsumeTopics(testTopic)
+					t.Parallel()
 
-					cfg, overrides := blockBuilderConfig(t, kafkaAddr, nil)
-					cfg.GenerateSparseIndexHeaders = true
-					cfg.Kafka.FetchConcurrencyMax = fm.fetchConcurrencyMax
-					// Lower FetchMaxWait so concurrent fetchers don't block on speculative reads
-					// past the job's end offset in tests where no further records arrive.
-					cfg.Kafka.FetchMaxWait = 500 * time.Millisecond
+					synctest.Test(t, func(t *testing.T) {
+						ctx := t.Context()
 
-					producedSamples := make(map[string][]mimirpb.Sample, 0)
-					recsPerTenant := 0
-					kafkaRecTime := time.Now().Add(-time.Hour)
-					for range samplesPerTenant {
-						for _, tenant := range tenants {
-							samples := produceSamples(ctx, t, kafkaClient, 1, kafkaRecTime, tenant, kafkaRecTime.Add(-time.Minute))
-							producedSamples[tenant] = append(producedSamples[tenant], samples...)
-						}
-						recsPerTenant++
+						var vnet kfake.VirtualNetwork
 
-						kafkaRecTime = kafkaRecTime.Add(10 * time.Minute)
-					}
-					require.NotEmpty(t, producedSamples)
+						_, kafkaAddr := testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, numPartitions, testTopic, testkafka.WithVirtualNetwork(&vnet))
 
-					scheduler := &mockSchedulerClient{}
-					scheduler.addJob(
-						schedulerpb.JobKey{
-							Id:    "test-job-4898",
-							Epoch: 90000,
-						},
-						schedulerpb.JobSpec{
-							Topic:       testTopic,
-							Partition:   1,
-							StartOffset: c.startOffset,
-							EndOffset:   c.endOffset,
-						},
-					)
-
-					bb, err := newWithSchedulerClient(cfg, test.NewTestingLogger(t), prometheus.NewPedanticRegistry(), overrides, scheduler)
-					require.NoError(t, err)
-
-					require.NoError(t, services.StartAndAwaitRunning(ctx, bb))
-					t.Cleanup(func() {
-						require.NoError(t, services.StopAndAwaitTerminated(ctx, bb))
-					})
-
-					require.Eventually(t, func() bool {
-						return scheduler.completeJobCallCount() > 0
-					}, 5*time.Second, 100*time.Millisecond, "expected job completion")
-
-					require.EqualValues(t,
-						[]schedulerpb.JobKey{{Id: "test-job-4898", Epoch: 90000}},
-						scheduler.completeJobCalls,
-					)
-
-					for _, tenant := range tenants {
-						tenantBucketDir := path.Join(cfg.BlocksStorage.Bucket.Filesystem.Directory, tenant)
-						if bb.cfg.GenerateSparseIndexHeaders {
-							validateSparseIndexHeadersInDir(t, ctx, tenantBucketDir, cfg)
-						}
-
-						expSamples := producedSamples[tenant][c.expSampleRangeStart:c.expSampleRangeEnd]
-						compareQueryWithDir(t,
-							tenantBucketDir,
-							expSamples, nil,
-							labels.MustNewMatcher(labels.MatchRegexp, "foo", ".*"),
+						kafkaClient, err := kgo.NewClient(
+							kgo.SeedBrokers(kafkaAddr),
+							kgo.Dialer(vnet.DialContext),
+							kgo.RecordPartitioner(kgo.ManualPartitioner()), // we will choose the partition of each record
 						)
-					}
+						require.NoError(t, err)
+						t.Cleanup(kafkaClient.Close)
+
+						kafkaClient.AddConsumeTopics(testTopic)
+
+						cfg, overrides := blockBuilderConfig(t, kafkaAddr, nil)
+						cfg.GenerateSparseIndexHeaders = true
+						cfg.Kafka.Dialer = vnet.DialContext
+						cfg.Kafka.FetchConcurrencyMax = fm.fetchConcurrencyMax
+						// Lower FetchMaxWait so concurrent fetchers don't block on speculative reads
+						// past the job's end offset in tests where no further records arrive.
+						cfg.Kafka.FetchMaxWait = 500 * time.Millisecond
+
+						producedSamples := make(map[string][]mimirpb.Sample, 0)
+						recsPerTenant := 0
+						kafkaRecTime := time.Now().Add(-time.Hour)
+						for range samplesPerTenant {
+							for _, tenant := range tenants {
+								samples := produceSamples(ctx, t, kafkaClient, 1, kafkaRecTime, tenant, kafkaRecTime.Add(-time.Minute))
+								producedSamples[tenant] = append(producedSamples[tenant], samples...)
+							}
+							recsPerTenant++
+
+							kafkaRecTime = kafkaRecTime.Add(10 * time.Minute)
+						}
+						require.NotEmpty(t, producedSamples)
+
+						scheduler := &mockSchedulerClient{}
+						scheduler.addJob(
+							schedulerpb.JobKey{
+								Id:    "test-job-4898",
+								Epoch: 90000,
+							},
+							schedulerpb.JobSpec{
+								Topic:       testTopic,
+								Partition:   1,
+								StartOffset: c.startOffset,
+								EndOffset:   c.endOffset,
+							},
+						)
+
+						bb, err := newWithSchedulerClient(cfg, test.NewTestingLogger(t), prometheus.NewPedanticRegistry(), overrides, scheduler)
+						require.NoError(t, err)
+
+						require.NoError(t, services.StartAndAwaitRunning(ctx, bb))
+						t.Cleanup(func() {
+							require.NoError(t, services.StopAndAwaitTerminated(context.Background(), bb))
+						})
+
+						require.Eventually(t, func() bool {
+							return scheduler.completeJobCallCount() > 0
+						}, 5*time.Second, 100*time.Millisecond, "expected job completion")
+
+						require.EqualValues(t,
+							[]schedulerpb.JobKey{{Id: "test-job-4898", Epoch: 90000}},
+							scheduler.completeJobCalls,
+						)
+
+						for _, tenant := range tenants {
+							tenantBucketDir := path.Join(cfg.BlocksStorage.Bucket.Filesystem.Directory, tenant)
+							if bb.cfg.GenerateSparseIndexHeaders {
+								validateSparseIndexHeadersInDir(t, ctx, tenantBucketDir, cfg)
+							}
+
+							expSamples := producedSamples[tenant][c.expSampleRangeStart:c.expSampleRangeEnd]
+							compareQueryWithDir(t,
+								tenantBucketDir,
+								expSamples, nil,
+								labels.MustNewMatcher(labels.MatchRegexp, "foo", ".*"),
+							)
+						}
+					})
 				})
 			}
 		})
@@ -194,17 +210,6 @@ func produceSamples(ctx context.Context, t *testing.T, kafkaClient *kgo.Client, 
 
 	produceRecords(ctx, t, kafkaClient, ts, tenantID, testTopic, partition, val)
 	return samples
-}
-
-func mustKafkaClient(t *testing.T, addrs ...string) *kgo.Client {
-	writeClient, err := kgo.NewClient(
-		kgo.SeedBrokers(addrs...),
-		// We will choose the partition of each record.
-		kgo.RecordPartitioner(kgo.ManualPartitioner()),
-	)
-	require.NoError(t, err)
-	t.Cleanup(writeClient.Close)
-	return writeClient
 }
 
 func produceRecords(

--- a/pkg/blockbuilder/scheduler/scheduler_test.go
+++ b/pkg/blockbuilder/scheduler/scheduler_test.go
@@ -8,9 +8,11 @@ import (
 	"fmt"
 	"iter"
 	"math/rand"
+	"net"
 	"slices"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/grafana/dskit/flagext"
@@ -20,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kfake"
 	"github.com/twmb/franz-go/pkg/kgo"
 
 	"github.com/grafana/mimir/pkg/blockbuilder/schedulerpb"
@@ -28,22 +31,21 @@ import (
 	"github.com/grafana/mimir/pkg/util/testkafka"
 )
 
-func mustKafkaClient(t *testing.T, addrs ...string) *kgo.Client {
-	writeClient, err := kgo.NewClient(
-		kgo.SeedBrokers(addrs...),
-		// We will choose the partition of each record.
-		kgo.RecordPartitioner(kgo.ManualPartitioner()),
+type dialerFunc func(ctx context.Context, network string, address string) (net.Conn, error)
+
+func mustSchedulerWithKafkaAddrAndDialer(t *testing.T, addr string, dialer dialerFunc) (*BlockBuilderScheduler, *kgo.Client) {
+	cli, err := kgo.NewClient(
+		kgo.SeedBrokers(addr),
+		kgo.Dialer(dialer),
+		kgo.RecordPartitioner(kgo.ManualPartitioner()), // we will choose the partition of each record
 	)
 	require.NoError(t, err)
-	t.Cleanup(writeClient.Close)
-	return writeClient
-}
+	t.Cleanup(cli.Close)
 
-func mustSchedulerWithKafkaAddr(t *testing.T, addr string) (*BlockBuilderScheduler, *kgo.Client) {
-	cli := mustKafkaClient(t, addr)
 	cfg := Config{
 		Kafka: ingest.KafkaConfig{
 			Address:      flagext.StringSliceCSV{addr},
+			Dialer:       dialer,
 			Topic:        "ingest",
 			FetchMaxWait: 10 * time.Millisecond,
 		},
@@ -61,8 +63,9 @@ func mustSchedulerWithKafkaAddr(t *testing.T, addr string) (*BlockBuilderSchedul
 }
 
 func mustScheduler(t *testing.T, partitions int32) (*BlockBuilderScheduler, *kgo.Client) {
-	_, kafkaAddr := testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, partitions, "ingest")
-	return mustSchedulerWithKafkaAddr(t, kafkaAddr)
+	var vnet kfake.VirtualNetwork
+	_, kafkaAddr := testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, partitions, "ingest", testkafka.WithVirtualNetwork(&vnet))
+	return mustSchedulerWithKafkaAddrAndDialer(t, kafkaAddr, vnet.DialContext)
 }
 
 // observationCompleteLocked: a getter for tests.
@@ -74,77 +77,106 @@ func (s *BlockBuilderScheduler) observationCompleteLocked() bool {
 
 // TestService tests the scheduler in a very basic way through its Service interface.
 func TestService(t *testing.T) {
-	_, kafkaAddr := testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, 4, "ingest")
-	sched, cli := mustSchedulerWithKafkaAddr(t, kafkaAddr)
+	synctest.Test(t, func(t *testing.T) {
+		var vnet kfake.VirtualNetwork
 
-	// Signal our channel any time the schedule is updated.
-	scheduleUpdated := make(chan struct{})
-	sched.onScheduleUpdated = func() {
-		select {
-		case scheduleUpdated <- struct{}{}:
-		default:
-		}
-	}
+		_, kafkaAddr := testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, 4, "ingest", testkafka.WithVirtualNetwork(&vnet))
 
-	// Configure all timers and intervals to be muy rapido.
-	sched.cfg.SchedulingInterval = 5 * time.Millisecond
-	sched.cfg.EnqueueInterval = 5 * time.Millisecond
-	sched.cfg.StartupObserveTime = 10 * time.Millisecond
-	sched.cfg.JobLeaseExpiry = 10 * time.Millisecond
-	sched.cfg.LookbackOnNoCommit = 1 * time.Minute
-	sched.cfg.MaxScanAge = 1 * time.Hour
-	sched.cfg.JobSize = 3 * time.Millisecond
-
-	ctx := context.Background()
-	require.NoError(t, services.StartAndAwaitRunning(ctx, sched))
-
-	t.Cleanup(func() {
-		require.NoError(t, services.StopAndAwaitTerminated(context.WithoutCancel(ctx), sched))
-	})
-
-	require.Eventually(t, sched.observationCompleteLocked, 5*time.Second, 10*time.Millisecond)
-
-	// Partition i gets 10*i records.
-	for i := range int32(4) {
-		for n := range 10 * i {
-			<-scheduleUpdated
-
-			produceResult := cli.ProduceSync(ctx, &kgo.Record{
-				Timestamp: time.Now(),
-				Value:     fmt.Appendf(nil, "value-%d-%d", i, n),
-				Topic:     "ingest",
-				Partition: i,
-			})
-			require.NoError(t, produceResult.FirstErr())
-		}
-	}
-
-	require.Eventually(t, func() bool {
-		return sched.jobs.count() > 0
-	}, 30*time.Second, 10*time.Millisecond)
-
-	var spec schedulerpb.JobSpec
-	clientDone := make(chan struct{})
-
-	// Simulate a client doing some client stuff.
-	go func() {
-		var key jobKey
-		var err error
-		key, spec, err = sched.assignJob("w0")
+		cli, err := kgo.NewClient(
+			kgo.SeedBrokers(kafkaAddr),
+			kgo.Dialer(vnet.DialContext),
+			kgo.RecordPartitioner(kgo.ManualPartitioner()),
+		)
 		require.NoError(t, err)
-		require.NoError(t, sched.updateJob(key, "w0", true, spec))
-		close(clientDone)
-	}()
-	<-clientDone
+		t.Cleanup(cli.Close)
 
-	require.NoError(t, sched.flushOffsetsToKafka(ctx))
+		cfg := Config{
+			Kafka: ingest.KafkaConfig{
+				Address:      flagext.StringSliceCSV{kafkaAddr},
+				Topic:        "ingest",
+				FetchMaxWait: 10 * time.Millisecond,
+				Dialer:       vnet.DialContext,
+			},
+			ConsumerGroup:       "test-builder",
+			SchedulingInterval:  1000000 * time.Hour,
+			JobSize:             1 * time.Hour,
+			MaxJobsPerPartition: 1,
+		}
 
-	// And our offsets should have advanced.
-	offs, err := sched.fetchCommittedOffsets(ctx)
-	require.NoError(t, err)
-	o, ok := offs.Lookup(spec.Topic, spec.Partition)
-	require.True(t, ok)
-	require.Equal(t, spec.EndOffset, o.At)
+		reg := prometheus.NewPedanticRegistry()
+		sched, err := New(cfg, test.NewTestingLogger(t), reg)
+		require.NoError(t, err)
+		sched.adminClient = kadm.NewClient(cli)
+
+		// Signal our channel any time the schedule is updated.
+		scheduleUpdated := make(chan struct{})
+		sched.onScheduleUpdated = func() {
+			select {
+			case scheduleUpdated <- struct{}{}:
+			default:
+			}
+		}
+
+		// Configure all timers and intervals to be muy rapido.
+		sched.cfg.SchedulingInterval = 5 * time.Millisecond
+		sched.cfg.EnqueueInterval = 5 * time.Millisecond
+		sched.cfg.StartupObserveTime = 10 * time.Millisecond
+		sched.cfg.JobLeaseExpiry = 10 * time.Millisecond
+		sched.cfg.LookbackOnNoCommit = 1 * time.Minute
+		sched.cfg.MaxScanAge = 1 * time.Hour
+		sched.cfg.JobSize = 3 * time.Millisecond
+
+		ctx := context.Background()
+		require.NoError(t, services.StartAndAwaitRunning(ctx, sched))
+
+		t.Cleanup(func() {
+			require.NoError(t, services.StopAndAwaitTerminated(context.WithoutCancel(ctx), sched))
+		})
+
+		require.Eventually(t, sched.observationCompleteLocked, 5*time.Second, 10*time.Millisecond)
+
+		// Partition i gets 10*i records.
+		for i := range int32(4) {
+			for n := range 10 * i {
+				<-scheduleUpdated
+
+				produceResult := cli.ProduceSync(ctx, &kgo.Record{
+					Timestamp: time.Now(),
+					Value:     fmt.Appendf(nil, "value-%d-%d", i, n),
+					Topic:     "ingest",
+					Partition: i,
+				})
+				require.NoError(t, produceResult.FirstErr())
+			}
+		}
+
+		require.Eventually(t, func() bool {
+			return sched.jobs.count() > 0
+		}, 30*time.Second, 10*time.Millisecond)
+
+		var spec schedulerpb.JobSpec
+		clientDone := make(chan struct{})
+
+		// Simulate a client doing some client stuff.
+		go func() {
+			var key jobKey
+			var err error
+			key, spec, err = sched.assignJob("w0")
+			require.NoError(t, err)
+			require.NoError(t, sched.updateJob(key, "w0", true, spec))
+			close(clientDone)
+		}()
+		<-clientDone
+
+		require.NoError(t, sched.flushOffsetsToKafka(ctx))
+
+		// And our offsets should have advanced.
+		offs, err := sched.fetchCommittedOffsets(ctx)
+		require.NoError(t, err)
+		o, ok := offs.Lookup(spec.Topic, spec.Partition)
+		require.True(t, ok)
+		require.Equal(t, spec.EndOffset, o.At)
+	})
 }
 
 func TestStartup(t *testing.T) {
@@ -653,8 +685,10 @@ func TestUpdateSchedule(t *testing.T) {
 	ctx, cancel := context.WithCancelCause(context.Background())
 	t.Cleanup(func() { cancel(errors.New("test done")) })
 
-	_, kafkaAddr := testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, 4, "ingest")
-	sched, cli := mustSchedulerWithKafkaAddr(t, kafkaAddr)
+	var vnet kfake.VirtualNetwork
+
+	_, kafkaAddr := testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, 4, "ingest", testkafka.WithVirtualNetwork(&vnet))
+	sched, cli := mustSchedulerWithKafkaAddrAndDialer(t, kafkaAddr, vnet.DialContext)
 	reg := sched.register.(*prometheus.Registry)
 
 	sched.completeObservationMode(ctx)
@@ -1171,7 +1205,6 @@ func TestPartitionState_PartitionBecomesInactive(t *testing.T) {
 }
 
 func TestPartitionState_ParallelJobs(t *testing.T) {
-
 	t.Run("planned job order required", func(t *testing.T) {
 		sched, _ := mustScheduler(t, 4)
 		ps := sched.getPartitionState("ingest", 1)

--- a/pkg/storage/ingest/config.go
+++ b/pkg/storage/ingest/config.go
@@ -3,11 +3,13 @@
 package ingest
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"flag"
 	"fmt"
 	"math"
+	"net"
 	"slices"
 	"strconv"
 	"strings"
@@ -193,6 +195,10 @@ type KafkaConfig struct {
 	// MaxInflightProduceRequests is the max number of in-flight Produce requests per broker.
 	// This setting is just used in tests. 0 uses the default.
 	MaxInflightProduceRequests int `yaml:"-"`
+
+	// Dialer replaces the default TCP dialer with a custom dialer function.
+	// Used in tests with kfake.VirtualNetwork for testing/synctest support.
+	Dialer func(ctx context.Context, network, address string) (net.Conn, error) `yaml:"-"`
 }
 
 func (cfg *KafkaConfig) RegisterFlags(f *flag.FlagSet) {
@@ -342,6 +348,13 @@ func (cfg *KafkaConfig) Validate() error {
 	// the overhead; below that the split stops making sense.
 	if cfg.Backend == KafkaBackendWarpstream && cfg.WriteTimeout <= writerRequestTimeoutOverhead*2 {
 		return ErrInvalidWarpstreamWriteTimeout
+	}
+
+	// The dialer is only expected to be used in tests.
+	if cfg.Dialer != nil {
+		if cfg.TLSEnabled {
+			return fmt.Errorf("kafka config: can't enable TSL with custom dialer")
+		}
 	}
 
 	return nil

--- a/pkg/storage/ingest/util.go
+++ b/pkg/storage/ingest/util.go
@@ -200,6 +200,10 @@ func commonKafkaClientOptions(cfg KafkaConfig, metrics *kprom.Metrics, logger lo
 		opts = append(opts, kgo.DialTLSConfig(tlsConfig))
 	}
 
+	if cfg.Dialer != nil {
+		opts = append(opts, kgo.Dialer(cfg.Dialer))
+	}
+
 	opts = append(opts, kgo.WithHooks(newSampledOnlyTracer()))
 
 	if metrics != nil {

--- a/pkg/util/testkafka/cluster.go
+++ b/pkg/util/testkafka/cluster.go
@@ -63,6 +63,13 @@ func WithListener(ln net.Listener) Opt {
 	}
 }
 
+// WithVirtualNetwork configures the cluster to use the given kfake.VirtualNetwork for in-memory networking.
+func WithVirtualNetwork(vnet *kfake.VirtualNetwork) Opt {
+	return func() []kfake.Opt {
+		return []kfake.Opt{kfake.ListenFn(vnet.Listen)}
+	}
+}
+
 // CreateCluster returns a fake Kafka cluster for unit testing.
 func CreateCluster(t testing.TB, numPartitions int32, topicName string, opts ...Opt) (*kfake.Cluster, string) {
 	cluster, addr := CreateClusterWithoutCustomConsumerGroupsSupport(t, numPartitions, topicName, opts...)


### PR DESCRIPTION
#### What this PR does

This PR updates `pkg/storage/ingest` with the support for `kfake.VirtualNetwork`.

`kfake.VirtualNetwork` is an in-memory networking implementation, that can be used in tandem with `testing/syntest` ([example in franz-go][1]). Besides that, an additional benefit of using an in-memory network with `kfake` clusters is that this allows more tests to run in parallel, w/o the need to orchestrate how the tests use TCP ports.

As a proof of work — to simplify the review — the PR only updates the tests in `pkg/blockbuilder` to use the `VirtualNetwork`. In my local testing this cuts a tiny bit of time of the overall test (3s-5s). My idea, is that expanding the pattern to other packages, that use Kafka, and that rely on sleep to synchronize state between goroutines (notable the `pkg/storage/ingest` itself), will improve the overall time further. This will be the follow-up work.

[1]: https://github.com/twmb/franz-go/blob/v1.21.0/examples/testing_with_kfake_and_synctest/main_test.go