### PR TITLE
fix(helm): remove right chomp modifier from mimir.kedaFallback includes

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -30,6 +30,8 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
+* [BUGFIX]: Fix bug in `ScaledObject` templates when using `kedaAutoscaling.fallback` #15793
+
 ## 6.1.0
 
 * [CHANGE] Upgrade Mimir to [3.1.2](https://github.com/grafana/mimir/blob/release-3.1/CHANGELOG.md). #15839

--- a/operations/helm/charts/mimir-distributed/ci/offline/keda-autoscaling-values.yaml
+++ b/operations/helm/charts/mimir-distributed/ci/offline/keda-autoscaling-values.yaml
@@ -16,6 +16,11 @@ distributor:
     maxReplicaCount: 10
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
+    fallback:
+      enabled: true
+      failureThreshold: 3
+      replicas: 6
+      behavior: "static"
 
 ruler:
   remoteEvaluationDedicatedQueryPath: true
@@ -26,6 +31,11 @@ ruler:
     maxReplicaCount: 10
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
+    fallback:
+      enabled: true
+      failureThreshold: 3
+      replicas: 6
+      behavior: "static"
 
 querier:
   kedaAutoscaling:
@@ -34,6 +44,11 @@ querier:
     minReplicaCount: 2
     maxReplicaCount: 10
     querySchedulerInflightRequestsThreshold: 6
+    fallback:
+      enabled: true
+      failureThreshold: 3
+      replicas: 6
+      behavior: "static"
 
 query_frontend:
   kedaAutoscaling:
@@ -43,6 +58,11 @@ query_frontend:
     maxReplicaCount: 10
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
+    fallback:
+      enabled: true
+      failureThreshold: 3
+      replicas: 6
+      behavior: "static"
 
 ruler_querier:
   kedaAutoscaling:
@@ -51,6 +71,11 @@ ruler_querier:
     minReplicaCount: 1
     maxReplicaCount: 10
     querySchedulerInflightRequestsThreshold: 13
+    fallback:
+      enabled: true
+      failureThreshold: 3
+      replicas: 6
+      behavior: "static"
 
 ruler_query_frontend:
   kedaAutoscaling:
@@ -60,3 +85,8 @@ ruler_query_frontend:
     preserveReplicas: true
     targetCPUUtilizationPercentage: 75
     targetMemoryUtilizationPercentage: 100
+    fallback:
+      enabled: true
+      failureThreshold: 3
+      replicas: 6
+      behavior: "static"

--- a/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/_helpers.tpl
@@ -733,7 +733,7 @@ Params:
 */}}
 {{- define "mimir.kedaFallback" -}}
 {{- $fallback := .componentFallback | default .ctx.Values.kedaAutoscaling.fallback -}}
-{{- if and $fallback $fallback.enabled }}
+{{- if and $fallback $fallback.enabled -}}
 fallback:
   failureThreshold: {{ required "kedaAutoscaling.fallback.failureThreshold is required when fallback is enabled" $fallback.failureThreshold }}
   replicas: {{ required "kedaAutoscaling.fallback.replicas is required when fallback is enabled" $fallback.replicas }}

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-so.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-so.yaml
@@ -18,7 +18,9 @@ spec:
   maxReplicaCount: {{ .Values.distributor.kedaAutoscaling.maxReplicaCount }}
   minReplicaCount: {{ .Values.distributor.kedaAutoscaling.minReplicaCount }}
   pollingInterval: {{ .Values.kedaAutoscaling.pollingInterval }}
-  {{- include "mimir.kedaFallback" (dict "ctx" . "componentFallback" .Values.distributor.kedaAutoscaling.fallback) | nindent 2 -}}
+  {{- with (include "mimir.kedaFallback" (dict "ctx" . "componentFallback" .Values.distributor.kedaAutoscaling.fallback)) }}
+  {{- . | nindent 2 }}
+  {{- end }}
   scaleTargetRef:
     name: {{ include "mimir.resourceName" (dict "ctx" . "component" "distributor") }}
     apiVersion: apps/v1

--- a/operations/helm/charts/mimir-distributed/templates/querier/querier-so.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/querier/querier-so.yaml
@@ -21,7 +21,9 @@ spec:
   maxReplicaCount: {{ .Values.querier.kedaAutoscaling.maxReplicaCount }}
   minReplicaCount: {{ .Values.querier.kedaAutoscaling.minReplicaCount }}
   pollingInterval: {{ .Values.kedaAutoscaling.pollingInterval }}
-  {{- include "mimir.kedaFallback" (dict "ctx" . "componentFallback" .Values.querier.kedaAutoscaling.fallback) | nindent 2 -}}
+  {{- with (include "mimir.kedaFallback" (dict "ctx" . "componentFallback" .Values.querier.kedaAutoscaling.fallback)) }}
+  {{- . | nindent 2 }}
+  {{- end }}
   scaleTargetRef:
     name: {{ include "mimir.resourceName" (dict "ctx" . "component" "querier") }}
     apiVersion: apps/v1

--- a/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-so.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-so.yaml
@@ -18,7 +18,9 @@ spec:
   maxReplicaCount: {{ .Values.query_frontend.kedaAutoscaling.maxReplicaCount }}
   minReplicaCount: {{ .Values.query_frontend.kedaAutoscaling.minReplicaCount }}
   pollingInterval: {{ .Values.kedaAutoscaling.pollingInterval }}
-  {{- include "mimir.kedaFallback" (dict "ctx" . "componentFallback" .Values.query_frontend.kedaAutoscaling.fallback) | nindent 2 -}}
+  {{- with (include "mimir.kedaFallback" (dict "ctx" . "componentFallback" .Values.query_frontend.kedaAutoscaling.fallback)) }}
+  {{- . | nindent 2 }}
+  {{- end }}
   scaleTargetRef:
     name: {{ include "mimir.resourceName" (dict "ctx" . "component" "query-frontend") }}
     apiVersion: apps/v1

--- a/operations/helm/charts/mimir-distributed/templates/ruler-querier/ruler-querier-so.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler-querier/ruler-querier-so.yaml
@@ -19,7 +19,9 @@ spec:
   maxReplicaCount: {{ .Values.ruler_querier.kedaAutoscaling.maxReplicaCount }}
   minReplicaCount: {{ .Values.ruler_querier.kedaAutoscaling.minReplicaCount }}
   pollingInterval: {{ .Values.kedaAutoscaling.pollingInterval }}
-  {{- include "mimir.kedaFallback" (dict "ctx" . "componentFallback" .Values.ruler_querier.kedaAutoscaling.fallback) | nindent 2 -}}
+  {{- with (include "mimir.kedaFallback" (dict "ctx" . "componentFallback" .Values.ruler_querier.kedaAutoscaling.fallback)) }}
+  {{- . | nindent 2 }}
+  {{- end }}
   scaleTargetRef:
     name: {{ include "mimir.resourceName" (dict "ctx" . "component" "ruler-querier") }}
     apiVersion: apps/v1

--- a/operations/helm/charts/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-so.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-so.yaml
@@ -19,7 +19,9 @@ spec:
   maxReplicaCount: {{ .Values.ruler_query_frontend.kedaAutoscaling.maxReplicaCount }}
   minReplicaCount: {{ .Values.ruler_query_frontend.kedaAutoscaling.minReplicaCount }}
   pollingInterval: {{ .Values.kedaAutoscaling.pollingInterval }}
-  {{- include "mimir.kedaFallback" (dict "ctx" . "componentFallback" .Values.ruler_query_frontend.kedaAutoscaling.fallback) | nindent 2 -}}
+  {{- with (include "mimir.kedaFallback" (dict "ctx" . "componentFallback" .Values.ruler_query_frontend.kedaAutoscaling.fallback)) }}
+  {{- . | nindent 2 }}
+  {{- end }}
   scaleTargetRef:
     name: {{ include "mimir.resourceName" (dict "ctx" . "component" "ruler-query-frontend") }}
     apiVersion: apps/v1

--- a/operations/helm/charts/mimir-distributed/templates/ruler/ruler-so.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler/ruler-so.yaml
@@ -18,7 +18,9 @@ spec:
   maxReplicaCount: {{ .Values.ruler.kedaAutoscaling.maxReplicaCount }}
   minReplicaCount: {{ .Values.ruler.kedaAutoscaling.minReplicaCount }}
   pollingInterval: {{ .Values.kedaAutoscaling.pollingInterval }}
-  {{- include "mimir.kedaFallback" (dict "ctx" . "componentFallback" .Values.ruler.kedaAutoscaling.fallback) | nindent 2 -}}
+  {{- with (include "mimir.kedaFallback" (dict "ctx" . "componentFallback" .Values.ruler.kedaAutoscaling.fallback)) }}
+  {{- . | nindent 2 }}
+  {{- end }}
   scaleTargetRef:
     name: {{ include "mimir.resourceName" (dict "ctx" . "component" "ruler") }}
     apiVersion: apps/v1

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/distributor/distributor-so.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/distributor/distributor-so.yaml
@@ -24,6 +24,10 @@ spec:
   maxReplicaCount: 10
   minReplicaCount: 1
   pollingInterval: 10
+  fallback:
+    failureThreshold: 3
+    replicas: 6
+    behavior: "static"
   scaleTargetRef:
     name: keda-autoscaling-values-mimir-distributor
     apiVersion: apps/v1

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/querier/querier-so.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/querier/querier-so.yaml
@@ -34,6 +34,10 @@ spec:
   maxReplicaCount: 10
   minReplicaCount: 2
   pollingInterval: 10
+  fallback:
+    failureThreshold: 3
+    replicas: 6
+    behavior: "static"
   scaleTargetRef:
     name: keda-autoscaling-values-mimir-querier
     apiVersion: apps/v1

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/query-frontend/query-frontend-so.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/query-frontend/query-frontend-so.yaml
@@ -24,6 +24,10 @@ spec:
   maxReplicaCount: 10
   minReplicaCount: 1
   pollingInterval: 10
+  fallback:
+    failureThreshold: 3
+    replicas: 6
+    behavior: "static"
   scaleTargetRef:
     name: keda-autoscaling-values-mimir-query-frontend
     apiVersion: apps/v1

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler-querier/ruler-querier-so.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler-querier/ruler-querier-so.yaml
@@ -34,6 +34,10 @@ spec:
   maxReplicaCount: 10
   minReplicaCount: 1
   pollingInterval: 10
+  fallback:
+    failureThreshold: 3
+    replicas: 6
+    behavior: "static"
   scaleTargetRef:
     name: keda-autoscaling-values-mimir-ruler-querier
     apiVersion: apps/v1

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-so.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-so.yaml
@@ -24,6 +24,10 @@ spec:
   maxReplicaCount: 10
   minReplicaCount: 1
   pollingInterval: 10
+  fallback:
+    failureThreshold: 3
+    replicas: 6
+    behavior: "static"
   scaleTargetRef:
     name: keda-autoscaling-values-mimir-ruler-query-frontend
     apiVersion: apps/v1

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler/ruler-so.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ruler/ruler-so.yaml
@@ -24,6 +24,10 @@ spec:
   maxReplicaCount: 10
   minReplicaCount: 1
   pollingInterval: 10
+  fallback:
+    failureThreshold: 3
+    replicas: 6
+    behavior: "static"
   scaleTargetRef:
     name: keda-autoscaling-values-mimir-ruler
     apiVersion: apps/v1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Removes right chomp modifier on `mimir.kedaFallback` include functions

After enabling `kedaAutoscaling.fallback`, I observed the chart renders invalid `ScaledObject` resources. Removing the chomp will prevent `scaledTargetRef` from being rendered on the same line as `behavior`.

```yaml
# mimir-distributed/templates/distributor/distributor-so.yaml
...
    fallback:
      failureThreshold: 3
      replicas: 50
      behavior: "currentReplicas"scaleTargetRef:
      name: mimir-distributor
      apiVersion: apps/v1
      kind: Deployment
    triggers:
...
```

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
