### PR TITLE
MQE: skip storing empty series in the cache in `CacheOperator`

### DIFF
--- a/pkg/streamingpromql/optimize/plan/splitandcache/cache_operator.go
+++ b/pkg/streamingpromql/optimize/plan/splitandcache/cache_operator.go
@@ -773,11 +773,13 @@ func (c *CacheOperator) writeCacheEntry(ctx context.Context, stats *types.Operat
 
 	traceID, _ := c.getCurrentTraceID(ctx)
 
+	seriesMetadata, data := c.encodeSeriesForCacheEntry()
+
 	desiredTimeRangeExtent := CachedExtent{
 		StartT:                  c.extents.cacheableRangeStartT,
 		EndT:                    c.extents.cacheableRangeEndT,
-		SeriesMetadata:          querierpb.EncodeSeriesMetadataSlice(c.seriesMetadata),
-		Data:                    c.encodeDataForCacheEntry(),
+		SeriesMetadata:          seriesMetadata,
+		Data:                    data,
 		Annotations:             querierpb.EncodeAnnotations(annos, c.queryParameters.OriginalExpression),
 		Stats:                   stats.Encode(),
 		NewestEvaluationTraceID: traceID,
@@ -837,14 +839,27 @@ func (c *CacheOperator) determineNewExtentEvaluationTimestamp() int64 {
 	}).GetEvaluationTimestamp()
 }
 
-func (c *CacheOperator) encodeDataForCacheEntry() []querierpb.InstantVectorSeriesData {
-	encoded := make([]querierpb.InstantVectorSeriesData, 0, len(c.data))
-	for _, d := range c.data {
+// encodeSeriesForCacheEntry encodes the series metadata and data to be written to the cache.
+// Series with no samples in the cacheable time range are not stored: they would only consume cache space,
+// and an absent series is equivalent to an empty one when the extent is read back and merged with others.
+func (c *CacheOperator) encodeSeriesForCacheEntry() ([]querierpb.SeriesMetadata, []querierpb.InstantVectorSeriesData) {
+	seriesMetadata := make([]querierpb.SeriesMetadata, 0, len(c.data))
+	data := make([]querierpb.InstantVectorSeriesData, 0, len(c.data))
+
+	for i, d := range c.data {
+		if len(d.Floats) == 0 && len(d.Histograms) == 0 {
+			// Don't store empty series in the cache.
+			continue
+		}
+
+		seriesMetadata = append(seriesMetadata, querierpb.EncodeSeriesMetadata(c.seriesMetadata[i]))
+
 		// EncodeInstantVectorSeriesData does unsafe casts and does not copy the data from the slices, but this is OK as we're immediately
 		// serializing the message and writing it to the cache before these slices are returned to their respective pools.
-		encoded = append(encoded, querierpb.EncodeInstantVectorSeriesData(d))
+		data = append(data, querierpb.EncodeInstantVectorSeriesData(d))
 	}
-	return encoded
+
+	return seriesMetadata, data
 }
 
 func (c *CacheOperator) ExpressionPosition() posrange.PositionRange {

--- a/pkg/streamingpromql/optimize/plan/splitandcache/cache_operator_test.go
+++ b/pkg/streamingpromql/optimize/plan/splitandcache/cache_operator_test.go
@@ -744,6 +744,74 @@ func TestCacheOperator_DoesNotSaveCacheEntryIfFinishedReadingNotCalled(t *testin
 	require.Zerof(t, cache.setCount, "expected no cache entry to be written, but at least one was: %v", cache.entries)
 }
 
+func TestCacheOperator_DoesNotStoreEmptySeries(t *testing.T) {
+	floatSeries := types.SeriesMetadata{Labels: labels.FromStrings(model.MetricNameLabel, "with_floats")}
+	histogramSeries := types.SeriesMetadata{Labels: labels.FromStrings(model.MetricNameLabel, "with_histograms")}
+	emptySeries := types.SeriesMetadata{Labels: labels.FromStrings(model.MetricNameLabel, "empty")}
+
+	floatData := types.InstantVectorSeriesData{Floats: []promql.FPoint{{T: 1000, F: 1}}}
+	histogramData := types.InstantVectorSeriesData{Histograms: []promql.HPoint{{T: 2000, H: &histogram.FloatHistogram{Count: 3}}}}
+	emptyData := types.InstantVectorSeriesData{}
+
+	testCases := map[string]struct {
+		seriesMetadata   []types.SeriesMetadata
+		data             []types.InstantVectorSeriesData
+		expectedMetadata []querierpb.SeriesMetadata
+		expectedData     []querierpb.InstantVectorSeriesData
+	}{
+		"no series": {
+			seriesMetadata:   []types.SeriesMetadata{},
+			data:             []types.InstantVectorSeriesData{},
+			expectedMetadata: []querierpb.SeriesMetadata{},
+			expectedData:     []querierpb.InstantVectorSeriesData{},
+		},
+		"no empty series": {
+			seriesMetadata: []types.SeriesMetadata{floatSeries, histogramSeries},
+			data:           []types.InstantVectorSeriesData{floatData, histogramData},
+			expectedMetadata: []querierpb.SeriesMetadata{
+				querierpb.EncodeSeriesMetadata(floatSeries),
+				querierpb.EncodeSeriesMetadata(histogramSeries),
+			},
+			expectedData: []querierpb.InstantVectorSeriesData{
+				querierpb.EncodeInstantVectorSeriesData(floatData),
+				querierpb.EncodeInstantVectorSeriesData(histogramData),
+			},
+		},
+		"empty series interspersed with non-empty series": {
+			seriesMetadata: []types.SeriesMetadata{emptySeries, floatSeries, emptySeries, histogramSeries, emptySeries},
+			data:           []types.InstantVectorSeriesData{emptyData, floatData, emptyData, histogramData, emptyData},
+			expectedMetadata: []querierpb.SeriesMetadata{
+				querierpb.EncodeSeriesMetadata(floatSeries),
+				querierpb.EncodeSeriesMetadata(histogramSeries),
+			},
+			expectedData: []querierpb.InstantVectorSeriesData{
+				querierpb.EncodeInstantVectorSeriesData(floatData),
+				querierpb.EncodeInstantVectorSeriesData(histogramData),
+			},
+		},
+		"all series empty": {
+			seriesMetadata:   []types.SeriesMetadata{emptySeries, emptySeries},
+			data:             []types.InstantVectorSeriesData{emptyData, emptyData},
+			expectedMetadata: []querierpb.SeriesMetadata{},
+			expectedData:     []querierpb.InstantVectorSeriesData{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			o := &CacheOperator{
+				seriesMetadata: testCase.seriesMetadata,
+				data:           testCase.data,
+			}
+
+			seriesMetadata, data := o.encodeSeriesForCacheEntry()
+			require.Equal(t, testCase.expectedMetadata, seriesMetadata, "expected empty series to be excluded from the cached series metadata")
+			require.Equal(t, testCase.expectedData, data, "expected empty series to be excluded from the cached data")
+			require.Len(t, data, len(seriesMetadata), "expected metadata and data to remain aligned")
+		})
+	}
+}
+
 func sortAnnotations(cacheEntry *CacheEntry) {
 	for _, e := range cacheEntry.Extents {
 		slices.Sort(e.Annotations.Infos)


### PR DESCRIPTION
#### What this PR does

This PR modifies the behaviour of `CacheOperator` to not store empty series in the cache.

This reduces the size of cache entries where there are no samples in the cached time range, either due to filtering (eg. an expression like `series > X`), or because all samples fall in the freshness window and are therefore not eligible to be written to the cache.

I'll add this to the changelog entry included in https://github.com/grafana/mimir/pull/15787.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
