### PR TITLE
Fix issue where LBAC is not respected by range vector splitting cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 * [BUGFIX] Ingest storage: Cap maximum Kafka protocol version, the client negotiates with the broker to v3.9.0. #15745
 * [BUGFIX] MQE: Report a query that panics during evaluation as failed in the `evaluation stats` log, instead of logging it as successful. The querier still re-panics afterwards, crash behaviour is unchanged. #15753
 * [BUGFIX] Memcached: Fix issue where cache-related trace spans included events emitted with an empty `name` label. #15794
+* [BUGFIX] MQE: Fix issue LBAC is not respected by range vector splitting cache. #15802
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@
 * [BUGFIX] Ingest storage: Cap maximum Kafka protocol version, the client negotiates with the broker to v3.9.0. #15745
 * [BUGFIX] MQE: Report a query that panics during evaluation as failed in the `evaluation stats` log, instead of logging it as successful. The querier still re-panics afterwards, crash behaviour is unchanged. #15753
 * [BUGFIX] Memcached: Fix issue where cache-related trace spans included events emitted with an empty `name` label. #15794
-* [BUGFIX] MQE: Fix issue LBAC is not respected by range vector splitting cache. #15802
+* [BUGFIX] MQE: Fix issue where LBAC is not respected by range vector splitting cache. #15802
 
 ### Mixin
 

--- a/integration/range_vector_splitting_test.go
+++ b/integration/range_vector_splitting_test.go
@@ -18,9 +18,37 @@ import (
 )
 
 func TestQuerySplittingWithRangeVectorFunction(t *testing.T) {
+	querier, queryClient, now := setupRangeVectorSplittingTest(t, nil)
+
+	result, err := queryClient.Query("sum_over_time(test_metric[15m])", now)
+	require.NoError(t, err)
+	require.Equal(t, model.ValVector, result.Type())
+
+	vec := result.(model.Vector)
+	require.Len(t, vec, 1)
+
+	// 15m range at `now` covers samples in (now-15m, now], which is 15 samples with values 7 through 21.
+	expectedSum := model.SampleValue(210)
+	assert.Equal(t, expectedSum, vec[0].Value)
+
+	require.NoError(t, querier.WaitSumMetrics(e2e.Equals(1), "cortex_mimir_query_engine_range_vector_splitting_nodes_introduced_total"))
+
+	// Run the same query again to verify cached intermediate results are read back correctly.
+	result2, err := queryClient.Query("sum_over_time(test_metric[15m])", now)
+	require.NoError(t, err)
+	require.Equal(t, model.ValVector, result2.Type())
+
+	vec2 := result2.(model.Vector)
+	require.Len(t, vec2, 1)
+	assert.Equal(t, expectedSum, vec2[0].Value)
+
+	require.NoError(t, querier.WaitSumMetrics(e2e.Greater(0), "mimir_query_engine_intermediate_result_cache_hits_total"))
+}
+
+func setupRangeVectorSplittingTest(t *testing.T, extraFlags map[string]string) (*e2emimir.MimirService, *e2emimir.Client, time.Time) {
 	s, err := e2e.NewScenario(networkName)
 	require.NoError(t, err)
-	defer s.Close()
+	t.Cleanup(s.Close)
 
 	memcached := e2ecache.NewMemcached()
 	require.NoError(t, s.StartAndWaitReady(memcached))
@@ -32,7 +60,7 @@ func TestQuerySplittingWithRangeVectorFunction(t *testing.T) {
 		"-querier.mimir-query-engine.range-vector-splitting.backend":                                   "memcached",
 		"-querier.mimir-query-engine.range-vector-splitting.memcached.addresses":                       "dns+" + memcached.NetworkEndpoint(e2ecache.MemcachedPort),
 		"-querier.mimir-query-engine.enable-range-query-range-vector-common-subexpression-elimination": "true",
-	})
+	}, extraFlags)
 
 	consul := e2edb.NewConsul()
 	minio := e2edb.NewMinio(9000, flags["-blocks-storage.s3.bucket-name"])
@@ -78,27 +106,5 @@ func TestQuerySplittingWithRangeVectorFunction(t *testing.T) {
 	queryClient, err := e2emimir.NewClient("", querier.HTTPEndpoint(), "", "", "user-1")
 	require.NoError(t, err)
 
-	result, err := queryClient.Query("sum_over_time(test_metric[15m])", now)
-	require.NoError(t, err)
-	require.Equal(t, model.ValVector, result.Type())
-
-	vec := result.(model.Vector)
-	require.Len(t, vec, 1)
-
-	// 15m range at `now` covers samples in (now-15m, now], which is 15 samples with values 7 through 21.
-	expectedSum := model.SampleValue(210)
-	assert.Equal(t, expectedSum, vec[0].Value)
-
-	require.NoError(t, querier.WaitSumMetrics(e2e.Equals(1), "cortex_mimir_query_engine_range_vector_splitting_nodes_introduced_total"))
-
-	// Run the same query again to verify cached intermediate results are read back correctly.
-	result2, err := queryClient.Query("sum_over_time(test_metric[15m])", now)
-	require.NoError(t, err)
-	require.Equal(t, model.ValVector, result2.Type())
-
-	vec2 := result2.(model.Vector)
-	require.Len(t, vec2, 1)
-	assert.Equal(t, expectedSum, vec2[0].Value)
-
-	require.NoError(t, querier.WaitSumMetrics(e2e.Greater(0), "mimir_query_engine_intermediate_result_cache_hits_total"))
+	return querier, queryClient, now
 }

--- a/integration/range_vector_splitting_test.go
+++ b/integration/range_vector_splitting_test.go
@@ -18,7 +18,9 @@ import (
 )
 
 func TestQuerySplittingWithRangeVectorFunction(t *testing.T) {
-	querier, queryClient, now := setupRangeVectorSplittingTest(t, nil)
+	tenantID := "user-1"
+	querier, now := setupRangeVectorSplittingTest(t, tenantID, nil)
+	queryClient := createQueryClient(t, querier, tenantID)
 
 	result, err := queryClient.Query("sum_over_time(test_metric[15m])", now)
 	require.NoError(t, err)
@@ -45,7 +47,52 @@ func TestQuerySplittingWithRangeVectorFunction(t *testing.T) {
 	require.NoError(t, querier.WaitSumMetrics(e2e.Greater(0), "mimir_query_engine_intermediate_result_cache_hits_total"))
 }
 
-func setupRangeVectorSplittingTest(t *testing.T, extraFlags map[string]string) (*e2emimir.MimirService, *e2emimir.Client, time.Time) {
+func TestQuerySplittingWithRangeVectorFunctionAndLBAC(t *testing.T) {
+	tenantID := "user-1"
+	flags := map[string]string{
+		"-auth.label-access-control-enabled": "true",
+	}
+	querier, now := setupRangeVectorSplittingTest(t, tenantID, flags)
+	queryClientWithoutLBAC := createQueryClient(t, querier, tenantID)
+
+	// Run the query without any LBAC policy to populate the cache.
+	result, err := queryClientWithoutLBAC.Query("sum_over_time(test_metric[15m])", now)
+	require.NoError(t, err)
+	require.Equal(t, model.ValVector, result.Type())
+
+	vec := result.(model.Vector)
+	require.Len(t, vec, 1)
+
+	// 15m range at `now` covers samples in (now-15m, now], which is 15 samples with values 7 through 21.
+	expectedSum := model.SampleValue(210)
+	assert.Equal(t, expectedSum, vec[0].Value)
+
+	require.NoError(t, querier.WaitSumMetrics(e2e.Equals(1), "cortex_mimir_query_engine_range_vector_splitting_nodes_introduced_total"))
+
+	// Run the same query again to verify cached intermediate results are read back correctly.
+	result2, err := queryClientWithoutLBAC.Query("sum_over_time(test_metric[15m])", now)
+	require.NoError(t, err)
+	require.Equal(t, model.ValVector, result2.Type())
+
+	vec2 := result2.(model.Vector)
+	require.Len(t, vec2, 1)
+	assert.Equal(t, expectedSum, vec2[0].Value)
+
+	require.NoError(t, querier.WaitSumMetrics(e2e.Greater(0), "mimir_query_engine_intermediate_result_cache_hits_total"))
+
+	// Run the same query again but with an LBAC policy and verify that the cached results are not used.
+	policy := tenantID + ":%7B__name__!=%22test_metric%22%7D"
+	queryClientWithLBAC := createQueryClient(t, querier, tenantID, e2emimir.WithAddHeader("X-Prom-Label-Policy", policy))
+
+	resultWithLBACPolicy, err := queryClientWithLBAC.Query("sum_over_time(test_metric[15m])", now)
+	require.NoError(t, err)
+	require.Equal(t, model.ValVector, resultWithLBACPolicy.Type())
+
+	vec3 := resultWithLBACPolicy.(model.Vector)
+	require.Len(t, vec3, 0, "the test_metric series should be filtered out by the LBAC policy applied to the request")
+}
+
+func setupRangeVectorSplittingTest(t *testing.T, tenantID string, extraFlags map[string]string) (*e2emimir.MimirService, time.Time) {
 	s, err := e2e.NewScenario(networkName)
 	require.NoError(t, err)
 	t.Cleanup(s.Close)
@@ -74,7 +121,7 @@ func setupRangeVectorSplittingTest(t *testing.T, extraFlags map[string]string) (
 	require.NoError(t, distributor.WaitSumMetrics(e2e.Equals(512+1), "cortex_ring_tokens_total"))
 	require.NoError(t, querier.WaitSumMetrics(e2e.Equals(512), "cortex_ring_tokens_total"))
 
-	writeClient, err := e2emimir.NewClient(distributor.HTTPEndpoint(), "", "", "", "user-1")
+	writeClient, err := e2emimir.NewClient(distributor.HTTPEndpoint(), "", "", "", tenantID)
 	require.NoError(t, err)
 
 	now := time.Now()
@@ -103,8 +150,11 @@ func setupRangeVectorSplittingTest(t *testing.T, extraFlags map[string]string) (
 	require.NoError(t, err)
 	require.Equal(t, 200, res.StatusCode)
 
-	queryClient, err := e2emimir.NewClient("", querier.HTTPEndpoint(), "", "", "user-1")
-	require.NoError(t, err)
+	return querier, now
+}
 
-	return querier, queryClient, now
+func createQueryClient(t *testing.T, querier *e2emimir.MimirService, tenantID string, opts ...e2emimir.ClientOption) *e2emimir.Client {
+	client, err := e2emimir.NewClient("", querier.HTTPEndpoint(), "", "", tenantID, opts...)
+	require.NoError(t, err)
+	return client
 }

--- a/pkg/frontend/labelaccess/tripperware.go
+++ b/pkg/frontend/labelaccess/tripperware.go
@@ -151,7 +151,7 @@ func CachePrefixGenerator(delegate caching.PrefixGenerator) caching.PrefixGenera
 			return inner, nil
 		}
 
-		return inner + labelPolicySeparator + labelPolicyHash, nil
+		return labelPolicyHash + labelPolicySeparator + inner, nil
 	}
 }
 

--- a/pkg/frontend/labelaccess/tripperware.go
+++ b/pkg/frontend/labelaccess/tripperware.go
@@ -146,11 +146,28 @@ func CachePrefixGenerator(delegate caching.PrefixGenerator) caching.PrefixGenera
 			return "", err
 		}
 
-		labelPolicyHash, _ := ctx.Value(contextKeyLabelPolicyHash).(string)
+		labelPolicyHash := getPolicyHash(ctx)
 		if len(labelPolicyHash) == 0 {
 			return inner, nil
 		}
 
 		return inner + labelPolicySeparator + labelPolicyHash, nil
 	}
+}
+
+func getPolicyHash(ctx context.Context) string {
+	// If we're running on a query-frontend, then the hash is available in the context.
+	labelPolicyHash, ok := ctx.Value(contextKeyLabelPolicyHash).(string)
+	if ok {
+		return labelPolicyHash
+	}
+
+	// If we're running on a querier, then the hash isn't available in the context, but we
+	// can compute it.
+	labelPolicies, _ := shared.ExtractLabelMatchersContext(ctx)
+	if len(labelPolicies) == 0 {
+		return ""
+	}
+
+	return labelPolicies.Hash()
 }

--- a/pkg/frontend/labelaccess/tripperware.go
+++ b/pkg/frontend/labelaccess/tripperware.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/grafana/mimir/pkg/frontend/querymiddleware"
 	shared "github.com/grafana/mimir/pkg/labelaccess"
+	"github.com/grafana/mimir/pkg/streamingpromql/caching"
 	"github.com/grafana/mimir/pkg/util/propagation"
 )
 
@@ -136,4 +137,20 @@ func (c CacheKeyGenerator) LabelValuesCardinality(r *http.Request) (*querymiddle
 		return nil, fmt.Errorf("label values cardinality caching is not supported with LBAC: %w", querymiddleware.ErrUnsupportedRequest)
 	}
 	return c.delegate.LabelValuesCardinality(r)
+}
+
+func CachePrefixGenerator(delegate caching.PrefixGenerator) caching.PrefixGenerator {
+	return func(ctx context.Context) (string, error) {
+		inner, err := delegate(ctx)
+		if err != nil {
+			return "", err
+		}
+
+		labelPolicyHash, _ := ctx.Value(contextKeyLabelPolicyHash).(string)
+		if len(labelPolicyHash) == 0 {
+			return inner, nil
+		}
+
+		return inner + labelPolicySeparator + labelPolicyHash, nil
+	}
 }

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -65,6 +65,7 @@ import (
 	"github.com/grafana/mimir/pkg/storage/ingest"
 	"github.com/grafana/mimir/pkg/storegateway"
 	"github.com/grafana/mimir/pkg/streamingpromql"
+	"github.com/grafana/mimir/pkg/streamingpromql/caching"
 	streamingpromqlcompat "github.com/grafana/mimir/pkg/streamingpromql/compat"
 	"github.com/grafana/mimir/pkg/streamingpromql/optimize/ast/sharding"
 	"github.com/grafana/mimir/pkg/streamingpromql/optimize/plan/remoteexec"
@@ -92,6 +93,7 @@ const (
 	AlertManager                     string = "alertmanager"
 	BlockBuilder                     string = "block-builder"
 	BlockBuilderScheduler            string = "block-builder-scheduler"
+	CacheKeyGenerator                string = "cache-key-generator"
 	Compactor                        string = "compactor"
 	CompactorScheduler               string = "compactor-scheduler"
 	ContinuousTest                   string = "continuous-test"
@@ -895,6 +897,23 @@ func (t *Mimir) initQueryFrontendTopicOffsetsReaders() (services.Service, error)
 	return ingestTopicOffsetsReader, nil
 }
 
+func (t *Mimir) initCacheKeyGenerator() (services.Service, error) {
+	if t.Cfg.Frontend.QueryMiddleware.CacheKeyGenerator != nil {
+		// Already set in a downstream project, so don't override it.
+		return nil, nil
+	}
+
+	t.Cfg.Frontend.QueryMiddleware.CacheKeyGenerator = querymiddleware.NewDefaultCacheKeyGenerator(t.QueryFrontendCodec, t.Cfg.Frontend.QueryMiddleware.SplitQueriesByInterval)
+	t.Cfg.Querier.EngineConfig.MimirQueryEngine.CachePrefixGenerator = caching.TenantPrefixGenerator
+
+	if t.Cfg.LabelAccessControlEnabled {
+		t.Cfg.Frontend.QueryMiddleware.CacheKeyGenerator = frontend_labelaccess.NewCacheSplitter(t.Cfg.Frontend.QueryMiddleware.CacheKeyGenerator)
+		t.Cfg.Querier.EngineConfig.MimirQueryEngine.CachePrefixGenerator = frontend_labelaccess.CachePrefixGenerator(t.Cfg.Querier.EngineConfig.MimirQueryEngine.CachePrefixGenerator)
+	}
+
+	return nil, nil
+}
+
 // initQueryFrontendTripperware instantiates the tripperware used by the query frontend
 // to optimize Prometheus query requests.
 func (t *Mimir) initQueryFrontendTripperware() (serv services.Service, err error) {
@@ -935,14 +954,6 @@ func (t *Mimir) initQueryFrontendTripperware() (serv services.Service, err error
 		}
 	default:
 		panic(fmt.Sprintf("invalid config not caught by validation: unknown PromQL engine '%s'", t.Cfg.Frontend.QueryEngine))
-	}
-
-	if t.Cfg.LabelAccessControlEnabled {
-		cacheKeyGenerator := t.Cfg.Frontend.QueryMiddleware.CacheKeyGenerator
-		if cacheKeyGenerator == nil {
-			cacheKeyGenerator = querymiddleware.NewDefaultCacheKeyGenerator(t.QueryFrontendCodec, t.Cfg.Frontend.QueryMiddleware.SplitQueriesByInterval)
-		}
-		t.Cfg.Frontend.QueryMiddleware.CacheKeyGenerator = frontend_labelaccess.NewCacheSplitter(cacheKeyGenerator)
 	}
 
 	tripperware, err := querymiddleware.NewTripperware(
@@ -1546,6 +1557,7 @@ func (t *Mimir) setupModuleManager() error {
 	mm.RegisterModule(AlertManager, t.initAlertManager)
 	mm.RegisterModule(BlockBuilder, t.initBlockBuilder)
 	mm.RegisterModule(BlockBuilderScheduler, t.initBlockBuilderScheduler)
+	mm.RegisterModule(CacheKeyGenerator, t.initCacheKeyGenerator, modules.UserInvisibleModule)
 	mm.RegisterModule(Compactor, t.initCompactor)
 	mm.RegisterModule(CompactorScheduler, t.initCompactorScheduler)
 	mm.RegisterModule(ContinuousTest, t.initContinuousTest)
@@ -1593,6 +1605,7 @@ func (t *Mimir) setupModuleManager() error {
 		AlertManager:                     {API, MemberlistKV, Overrides, Vault},
 		BlockBuilder:                     {API, Overrides},
 		BlockBuilderScheduler:            {API},
+		CacheKeyGenerator:                {QueryFrontendCodec},
 		Compactor:                        {API, MemberlistKV, Overrides, Vault},
 		CompactorScheduler:               {API},
 		ContinuousTest:                   {API},
@@ -1608,12 +1621,12 @@ func (t *Mimir) setupModuleManager() error {
 		OverridesExporter:                {Overrides, MemberlistKV, Vault},
 		Querier:                          {TenantFederation, Vault, QuerierLifecycler},
 		QuerierLifecycler:                {API, RuntimeConfig, MemberlistKV, Vault},
-		QuerierQueryPlanner:              {API, Overrides},
+		QuerierQueryPlanner:              {API, Overrides, CacheKeyGenerator},
 		QuerierRing:                      {API, RuntimeConfig, MemberlistKV, Vault},
 		QueryFrontend:                    {QueryFrontendTripperware, MemberlistKV, Vault},
-		QueryFrontendQueryPlanner:        {API, Overrides, QuerierRing},
+		QueryFrontendQueryPlanner:        {API, Overrides, QuerierRing, CacheKeyGenerator},
 		QueryFrontendTopicOffsetsReaders: {IngesterPartitionRing},
-		QueryFrontendTripperware:         {API, Overrides, QueryFrontendCodec, QueryFrontendTopicOffsetsReaders, QueryFrontendQueryPlanner},
+		QueryFrontendTripperware:         {API, Overrides, QueryFrontendCodec, QueryFrontendTopicOffsetsReaders, QueryFrontendQueryPlanner, CacheKeyGenerator},
 		QueryScheduler:                   {API, Overrides, MemberlistKV, Vault},
 		Queryable:                        {Overrides, DistributorService, IngesterRing, IngesterPartitionRing, API, StoreQueryable, MemberlistKV, QuerierQueryPlanner},
 		Ruler:                            {DistributorService, StoreQueryable, RulerStorage, Vault, QuerierQueryPlanner},

--- a/pkg/streamingpromql/caching/adaptor.go
+++ b/pkg/streamingpromql/caching/adaptor.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package caching
+
+import (
+	"context"
+	"time"
+
+	"github.com/grafana/dskit/cache"
+)
+
+type Adaptor struct {
+	inner cache.Cache
+}
+
+// NewAdaptor wraps a dskit cache.Cache to satisfy caching.Backend.
+func NewAdaptor(inner cache.Cache) *Adaptor {
+	return &Adaptor{inner: inner}
+}
+
+func (a *Adaptor) GetMulti(ctx context.Context, keys []string, opts ...cache.Option) (map[string][]byte, error) {
+	return a.inner.GetMulti(ctx, keys, opts...), nil
+}
+
+func (a *Adaptor) SetAsync(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	a.inner.SetAsync(key, value, ttl)
+	return nil
+}

--- a/pkg/streamingpromql/caching/caching.go
+++ b/pkg/streamingpromql/caching/caching.go
@@ -12,8 +12,8 @@ import (
 )
 
 type Backend interface {
-	GetMulti(ctx context.Context, keys []string, opts ...cache.Option) map[string][]byte
-	SetAsync(key string, value []byte, ttl time.Duration)
+	GetMulti(ctx context.Context, keys []string, opts ...cache.Option) (map[string][]byte, error)
+	SetAsync(ctx context.Context, key string, value []byte, ttl time.Duration) error
 }
 
 // HashCacheKey returns a hashed version of key that is small enough to fit within the Memcached key limit

--- a/pkg/streamingpromql/caching/in_memory.go
+++ b/pkg/streamingpromql/caching/in_memory.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package caching
+
+import (
+	"context"
+	"slices"
+	"time"
+
+	"github.com/grafana/dskit/cache"
+)
+
+type InMemoryCache struct {
+	Entries map[string]InMemoryCacheEntry
+
+	GetCount int
+	HitCount int
+	SetCount int
+}
+
+// NewInMemoryCache creates a new in-memory cache.
+// This is intended for testing purposes only.
+func NewInMemoryCache() *InMemoryCache {
+	return &InMemoryCache{
+		Entries: make(map[string]InMemoryCacheEntry),
+	}
+}
+
+type InMemoryCacheEntry struct {
+	Value []byte
+	TTL   time.Duration
+}
+
+func (c *InMemoryCache) GetMulti(ctx context.Context, keys []string, opts ...cache.Option) (map[string][]byte, error) {
+	c.GetCount++
+	results := make(map[string][]byte, len(keys))
+
+	for _, key := range keys {
+		entry, ok := c.Entries[key]
+
+		if ok && len(entry.Value) > 0 {
+			// Clone bytes to simulate network serialization
+			results[key] = slices.Clone(entry.Value)
+			c.HitCount++
+		}
+	}
+
+	return results, nil
+}
+
+func (c *InMemoryCache) SetAsync(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	c.SetCount++
+	c.Entries[key] = InMemoryCacheEntry{Value: value, TTL: ttl}
+
+	return nil
+}
+
+func (c *InMemoryCache) Reset() {
+	c.Entries = make(map[string]InMemoryCacheEntry)
+	c.SetCount = 0
+	c.GetCount = 0
+	c.HitCount = 0
+}

--- a/pkg/streamingpromql/caching/prefix.go
+++ b/pkg/streamingpromql/caching/prefix.go
@@ -4,14 +4,18 @@ package caching
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/grafana/dskit/cache"
+	"github.com/grafana/dskit/tenant"
 )
+
+type PrefixGenerator func(ctx context.Context) (string, error)
 
 type PrefixingCache struct {
 	inner           Backend
-	prefixGenerator func(ctx context.Context) (string, error)
+	prefixGenerator PrefixGenerator
 }
 
 func NewPrefixingCache(inner Backend, prefixGenerator func(ctx context.Context) (string, error)) *PrefixingCache {
@@ -50,5 +54,13 @@ func (p *PrefixingCache) GetMulti(ctx context.Context, keys []string, opts ...ca
 	}
 
 	return results, nil
+}
 
+func TenantPrefixGenerator(ctx context.Context) (string, error) {
+	tenantIDs, err := tenant.TenantIDs(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%s:", tenant.JoinTenantIDs(tenantIDs)), nil
 }

--- a/pkg/streamingpromql/caching/prefix.go
+++ b/pkg/streamingpromql/caching/prefix.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package caching
+
+import (
+	"context"
+	"time"
+
+	"github.com/grafana/dskit/cache"
+)
+
+type PrefixingCache struct {
+	inner           Backend
+	prefixGenerator func(ctx context.Context) (string, error)
+}
+
+func NewPrefixingCache(inner Backend, prefixGenerator func(ctx context.Context) (string, error)) *PrefixingCache {
+	return &PrefixingCache{inner: inner, prefixGenerator: prefixGenerator}
+}
+
+func (p *PrefixingCache) SetAsync(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	prefix, err := p.prefixGenerator(ctx)
+	if err != nil {
+		return err
+	}
+
+	return p.inner.SetAsync(ctx, prefix+key, value, ttl)
+}
+
+func (p *PrefixingCache) GetMulti(ctx context.Context, keys []string, opts ...cache.Option) (map[string][]byte, error) {
+	prefix, err := p.prefixGenerator(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	prefixedKeys := make([]string, len(keys))
+
+	for i, key := range keys {
+		prefixedKeys[i] = prefix + key
+	}
+
+	prefixedResults, err := p.inner.GetMulti(ctx, prefixedKeys, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make(map[string][]byte, len(prefixedResults))
+	for key, value := range prefixedResults {
+		results[key[len(prefix):]] = value
+	}
+
+	return results, nil
+
+}

--- a/pkg/streamingpromql/caching/prefix_test.go
+++ b/pkg/streamingpromql/caching/prefix_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package caching
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrefixingCache(t *testing.T) {
+	prefix := "initial-prefix-"
+
+	backend := NewInMemoryCache()
+	prefixingCache := NewPrefixingCache(backend, func(ctx context.Context) (string, error) {
+		return prefix, nil
+	})
+
+	ctx := context.Background()
+	ttl := time.Hour
+	require.NoError(t, prefixingCache.SetAsync(ctx, "key", []byte("value-1"), ttl))
+
+	require.Equal(t, map[string]InMemoryCacheEntry{
+		"initial-prefix-key": {Value: []byte("value-1"), TTL: ttl},
+	}, backend.Entries)
+
+	prefix = "new-prefix-"
+	require.NoError(t, prefixingCache.SetAsync(ctx, "key", []byte("value-2"), ttl))
+	require.NoError(t, prefixingCache.SetAsync(ctx, "other-key", []byte("value-3"), ttl))
+
+	require.Equal(t, map[string]InMemoryCacheEntry{
+		"initial-prefix-key":   {Value: []byte("value-1"), TTL: ttl},
+		"new-prefix-key":       {Value: []byte("value-2"), TTL: ttl},
+		"new-prefix-other-key": {Value: []byte("value-3"), TTL: ttl},
+	}, backend.Entries)
+
+	results, err := prefixingCache.GetMulti(ctx, []string{"key", "other-key"})
+	require.NoError(t, err)
+	require.Equal(t, map[string][]byte{
+		"key":       []byte("value-2"),
+		"other-key": []byte("value-3"),
+	}, results)
+}

--- a/pkg/streamingpromql/config.go
+++ b/pkg/streamingpromql/config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/promql"
 
+	"github.com/grafana/mimir/pkg/streamingpromql/caching"
 	"github.com/grafana/mimir/pkg/streamingpromql/optimize/plan/rangevectorsplitting/cache"
 	"github.com/grafana/mimir/pkg/util/limiter"
 	"github.com/grafana/mimir/pkg/util/promqlext"
@@ -49,6 +50,10 @@ type EngineOpts struct {
 	EnableRemoveStaticallyEmptyExpressions                    bool `yaml:"enable_remove_statically_empty_expressions" category:"experimental"`
 
 	RangeVectorSplitting RangeVectorSplittingConfig `yaml:"range_vector_splitting" category:"experimental"`
+
+	// CachePrefixGenerator should return a prefix for all cache keys for a given context.
+	// It should contain the tenant ID and any other relevant information that should be used to partition cache entries.
+	CachePrefixGenerator caching.PrefixGenerator `yaml:"-"`
 }
 
 // RangeVectorSplittingConfig configures the splitting of functions over range vectors queries.
@@ -131,5 +136,7 @@ func NewTestEngineOpts() EngineOpts {
 		EnableMultiAggregation:                                    true,
 		EnableRemoveStaticallyEmptyExpressions:                    true,
 		EnableRangeQueryRangeVectorCommonSubexpressionElimination: true,
+
+		CachePrefixGenerator: caching.TenantPrefixGenerator,
 	}
 }

--- a/pkg/streamingpromql/engine.go
+++ b/pkg/streamingpromql/engine.go
@@ -49,7 +49,7 @@ func NewEngine(opts EngineOpts, metrics *stats.QueryMetrics, planner *QueryPlann
 	var cacheFactory *cache.CacheFactory
 	if opts.RangeVectorSplitting.Enabled {
 		var err error
-		cacheFactory, err = cache.NewCacheFactory(opts.RangeVectorSplitting.IntermediateResultsCache, opts.Limits, opts.Logger, opts.CommonOpts.Reg)
+		cacheFactory, err = cache.NewCacheFactory(opts.RangeVectorSplitting.IntermediateResultsCache, opts.Limits, opts.CachePrefixGenerator, opts.Logger, opts.CommonOpts.Reg)
 		if err != nil {
 			return nil, fmt.Errorf("failed to init range vector splitting cache, err: %w", err)
 		}

--- a/pkg/streamingpromql/optimize/plan/rangevectorsplitting/cache/cache.go
+++ b/pkg/streamingpromql/optimize/plan/rangevectorsplitting/cache/cache.go
@@ -51,7 +51,7 @@ func newCacheMetrics(reg prometheus.Registerer) *cacheMetrics {
 	}
 }
 
-func NewCacheFactory(cfg Config, ttlProvider TTLProvider, logger log.Logger, reg prometheus.Registerer) (*CacheFactory, error) {
+func NewCacheFactory(cfg Config, ttlProvider TTLProvider, prefixGenerator caching.PrefixGenerator, logger log.Logger, reg prometheus.Registerer) (*CacheFactory, error) {
 	client, err := cache.CreateClient("intermediate-result-cache", cfg.BackendConfig, logger, prometheus.WrapRegistererWithPrefix("mimir_", reg))
 	if err != nil {
 		return nil, err
@@ -66,7 +66,12 @@ func NewCacheFactory(cfg Config, ttlProvider TTLProvider, logger log.Logger, reg
 	)
 	backend = cache.NewCompression(cfg.Compression, backend, logger)
 
-	return NewCacheFactoryWithBackend(caching.NewAdaptor(backend), ttlProvider, reg, logger), nil
+	prefixedCache := caching.NewPrefixingCache(
+		caching.NewAdaptor(backend),
+		prefixGenerator,
+	)
+
+	return NewCacheFactoryWithBackend(prefixedCache, ttlProvider, reg, logger), nil
 }
 
 func NewCacheFactoryWithBackend(backend caching.Backend, ttlProvider TTLProvider, reg prometheus.Registerer, logger log.Logger) *CacheFactory {
@@ -78,14 +83,15 @@ func NewCacheFactoryWithBackend(backend caching.Backend, ttlProvider TTLProvider
 	}
 }
 
-func generateCacheKey(tenant string, function functions.Function, selector []byte, start, end int64) []byte {
-	return fmt.Appendf(nil, "%s:%d:%s:%d:%d", tenant, function, selector, start, end)
+func generateCacheKey(function functions.Function, selector []byte, start, end int64) []byte {
+	// We don't include the tenant ID here as that is expected to be done by the prefix generator configured on the cache above.
+	return fmt.Appendf(nil, "%d:%s:%d:%d", function, selector, start, end)
 }
 
 // TestGenerateHashedCacheKey generates a hashed cache key using the same logic as the cache internals.
 // This should only be used in tests.
-func TestGenerateHashedCacheKey(tenant string, function functions.Function, selector []byte, start, end int64) string {
-	return caching.HashCacheKey(generateCacheKey(tenant, function, selector, start, end))
+func TestGenerateHashedCacheKey(function functions.Function, selector []byte, start, end int64) string {
+	return caching.HashCacheKey(generateCacheKey(function, selector, start, end))
 }
 
 // SplitCodec handles serialization of intermediate results for query splitting.
@@ -128,7 +134,7 @@ func (c *Cache[T]) Get(
 	}
 
 	c.metrics.cacheRequests.Inc()
-	cacheKey := generateCacheKey(tenant, function, innerKey, start, end)
+	cacheKey := generateCacheKey(function, innerKey, start, end)
 	hashedKey := caching.HashCacheKey(cacheKey)
 
 	foundData, err := c.backend.GetMulti(ctx, []string{hashedKey})
@@ -177,17 +183,12 @@ func (c *Cache[T]) Set(
 	totalSeriesCount int,
 	stats *CacheStats,
 ) error {
-	tenant, err := user.ExtractOrgID(ctx)
-	if err != nil {
-		return err
-	}
-
 	ttl, err := c.ttlProvider.GetMinResultsCacheTTL(ctx)
 	if err != nil {
 		return fmt.Errorf("getting results cache TTL: %w", err)
 	}
 
-	cacheKey := generateCacheKey(tenant, function, innerKey, start, end)
+	cacheKey := generateCacheKey(function, innerKey, start, end)
 
 	resultBytes, err := c.codec.Marshal(results)
 	if err != nil {

--- a/pkg/streamingpromql/optimize/plan/rangevectorsplitting/cache/cache.go
+++ b/pkg/streamingpromql/optimize/plan/rangevectorsplitting/cache/cache.go
@@ -66,7 +66,7 @@ func NewCacheFactory(cfg Config, ttlProvider TTLProvider, logger log.Logger, reg
 	)
 	backend = cache.NewCompression(cfg.Compression, backend, logger)
 
-	return NewCacheFactoryWithBackend(backend, ttlProvider, reg, logger), nil
+	return NewCacheFactoryWithBackend(caching.NewAdaptor(backend), ttlProvider, reg, logger), nil
 }
 
 func NewCacheFactoryWithBackend(backend caching.Backend, ttlProvider TTLProvider, reg prometheus.Registerer, logger log.Logger) *CacheFactory {
@@ -131,7 +131,11 @@ func (c *Cache[T]) Get(
 	cacheKey := generateCacheKey(tenant, function, innerKey, start, end)
 	hashedKey := caching.HashCacheKey(cacheKey)
 
-	foundData := c.backend.GetMulti(ctx, []string{hashedKey})
+	foundData, err := c.backend.GetMulti(ctx, []string{hashedKey})
+	if err != nil {
+		return nil, querierpb.Annotations{}, nil, types.EncodedOperatorEvaluationStats{}, false, fmt.Errorf("getting cached results: %w", err)
+	}
+
 	data, ok := foundData[hashedKey]
 	if !ok || len(data) == 0 {
 		return nil, querierpb.Annotations{}, nil, types.EncodedOperatorEvaluationStats{}, false, nil
@@ -206,7 +210,9 @@ func (c *Cache[T]) Set(
 	}
 
 	hashedKey := caching.HashCacheKey(cacheKey)
-	c.backend.SetAsync(hashedKey, data, ttl)
+	if err := c.backend.SetAsync(ctx, hashedKey, data, ttl); err != nil {
+		return fmt.Errorf("storing cached results: %w", err)
+	}
 
 	seriesCount := len(seriesMetadata)
 	level.Debug(c.logger).Log("msg", "cache entry written", "hashed_cache_key", hashedKey, "series_count", seriesCount, "entry_size", len(data))

--- a/pkg/streamingpromql/optimize/plan/rangevectorsplitting/range_vector_splitting_test.go
+++ b/pkg/streamingpromql/optimize/plan/rangevectorsplitting/range_vector_splitting_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	dskitcache "github.com/grafana/dskit/cache"
 	"github.com/grafana/dskit/user"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/histogram"
@@ -28,6 +27,7 @@ import (
 	"github.com/grafana/mimir/pkg/querier/querierpb"
 	"github.com/grafana/mimir/pkg/querier/stats"
 	"github.com/grafana/mimir/pkg/streamingpromql"
+	"github.com/grafana/mimir/pkg/streamingpromql/caching"
 	"github.com/grafana/mimir/pkg/streamingpromql/operators/functions"
 	"github.com/grafana/mimir/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination"
 	"github.com/grafana/mimir/pkg/streamingpromql/optimize/plan/rangevectorsplitting"
@@ -465,7 +465,7 @@ func TestQuerySplitting_WithCSE(t *testing.T) {
 	}
 
 	require.Equal(t, expected, result)
-	require.Greater(t, testCache.sets, 0, "Cache should have been populated")
+	require.Greater(t, testCache.SetCount, 0, "Cache should have been populated")
 
 	// Verify CSE is working: with CSE, the MatrixSelector is shared between sum_over_time
 	// and count_over_time via Duplicate, so we should only query storage once, not twice
@@ -558,7 +558,7 @@ func TestQuerySplitting_WithSSE(t *testing.T) {
 	}
 	params := &planning.QueryParameters{LookbackDelta: streamingpromql.DefaultLookbackDelta}
 
-	require.Len(t, backend.items, 2)
+	require.Len(t, backend.Entries, 2)
 
 	expectedH := mimirpb.FromFloatHistogramToHistogramProto(0, h)
 	expectedIntermediate := rangevectorsplitting.FirstLastOverTimeIntermediate{H: &expectedH}
@@ -566,14 +566,14 @@ func TestQuerySplitting_WithSSE(t *testing.T) {
 	// Both keys must contain the full histogram (skip=false fetches buckets).
 	countKey := cache.TestGenerateHashedCacheKey("test-user", functions.FUNCTION_LAST_OVER_TIME, splittingCacheKey(t, countSplit, params), 2*hourInMs-1, 4*hourInMs-1)
 	var countEntry cache.CachedSeries
-	require.NoError(t, countEntry.Unmarshal(backend.items[countKey]))
+	require.NoError(t, countEntry.Unmarshal(backend.Entries[countKey].Value))
 	var countList rangevectorsplitting.FirstLastOverTimeIntermediateList
 	require.NoError(t, countList.Unmarshal(countEntry.Results))
 	require.Equal(t, []rangevectorsplitting.FirstLastOverTimeIntermediate{expectedIntermediate}, countList.Results)
 
 	fractionKey := cache.TestGenerateHashedCacheKey("test-user", functions.FUNCTION_LAST_OVER_TIME, splittingCacheKey(t, fractionSplit, params), 2*hourInMs-1, 4*hourInMs-1)
 	var fractionEntry cache.CachedSeries
-	require.NoError(t, fractionEntry.Unmarshal(backend.items[fractionKey]))
+	require.NoError(t, fractionEntry.Unmarshal(backend.Entries[fractionKey].Value))
 	var fractionList rangevectorsplitting.FirstLastOverTimeIntermediateList
 	require.NoError(t, fractionList.Unmarshal(fractionEntry.Results))
 	require.Equal(t, []rangevectorsplitting.FirstLastOverTimeIntermediate{expectedIntermediate}, fractionList.Results)
@@ -646,8 +646,8 @@ func TestQuerySplitting_CacheKeyReflectsPostOptimizationState(t *testing.T) {
 	}}
 	narrowKeyNoSSE := cache.TestGenerateHashedCacheKey("test-user", functions.FUNCTION_SUM_OVER_TIME, splittingCacheKey(t, narrowNoSSE, params), blockStart, blockEnd)
 	broadKeyNoSSE := cache.TestGenerateHashedCacheKey("test-user", functions.FUNCTION_SUM_OVER_TIME, splittingCacheKey(t, broadNoSSE, params), blockStart, blockEnd)
-	require.Contains(t, backendNoSSE.items, narrowKeyNoSSE, "expected bare-matchers cache key for narrow selector when SSE is off")
-	require.Contains(t, backendNoSSE.items, broadKeyNoSSE, "expected bare-matchers cache key for broad selector when SSE is off")
+	require.Contains(t, backendNoSSE.Entries, narrowKeyNoSSE, "expected bare-matchers cache key for narrow selector when SSE is off")
+	require.Contains(t, backendNoSSE.Entries, broadKeyNoSSE, "expected bare-matchers cache key for broad selector when SSE is off")
 
 	// With SSE: the narrow MatrixSelector is rewritten into DuplicateFilter -> Duplicate -> broad MatrixSelector,
 	// and the broad MatrixSelector picks up the narrow side's region="us" as a subset.
@@ -685,10 +685,10 @@ func TestQuerySplitting_CacheKeyReflectsPostOptimizationState(t *testing.T) {
 	}
 	narrowKeySSE := cache.TestGenerateHashedCacheKey("test-user", functions.FUNCTION_SUM_OVER_TIME, splittingCacheKey(t, narrowSSE, params), blockStart, blockEnd)
 	broadKeySSE := cache.TestGenerateHashedCacheKey("test-user", functions.FUNCTION_SUM_OVER_TIME, splittingCacheKey(t, broadSplitSSE, params), blockStart, blockEnd)
-	require.Contains(t, backendSSE.items, narrowKeySSE, "expected duplicate_filter cache key for narrow selector when SSE is on")
-	require.Contains(t, backendSSE.items, broadKeySSE, "expected subset-aware cache key for broad selector when SSE is on")
-	require.NotContains(t, backendNoSSE.items, narrowKeySSE, "narrow SSE cache key must not exist in no-SSE backend (key reflects post-optimization plan)")
-	require.NotContains(t, backendNoSSE.items, broadKeySSE, "broad SSE cache key must not exist in no-SSE backend (key reflects post-optimization plan)")
+	require.Contains(t, backendSSE.Entries, narrowKeySSE, "expected duplicate_filter cache key for narrow selector when SSE is on")
+	require.Contains(t, backendSSE.Entries, broadKeySSE, "expected subset-aware cache key for broad selector when SSE is on")
+	require.NotContains(t, backendNoSSE.Entries, narrowKeySSE, "narrow SSE cache key must not exist in no-SSE backend (key reflects post-optimization plan)")
+	require.NotContains(t, backendNoSSE.Entries, broadKeySSE, "broad SSE cache key must not exist in no-SSE backend (key reflects post-optimization plan)")
 }
 
 func TestQuerySplitting_ProjectionNotApplied(t *testing.T) {
@@ -881,7 +881,7 @@ func TestQuerySplitting_With3hRangeAndOffset_NoCacheableRanges(t *testing.T) {
 }
 
 func TestQuerySplitting_WithOOOWindow(t *testing.T) {
-	backend := newTestCacheBackend()
+	backend := caching.NewInMemoryCache()
 	irCache := cache.NewCacheFactoryWithBackend(backend, streamingpromql.NewStaticQueryLimitsProvider(), prometheus.NewRegistry(), log.NewNopLogger())
 
 	opts := defaultSplittingOpts()
@@ -1097,9 +1097,9 @@ func TestQuerySplitting_MiddleCacheEntryEvicted(t *testing.T) {
 	}}
 	params := &planning.QueryParameters{LookbackDelta: streamingpromql.DefaultLookbackDelta}
 	block2Key := cache.TestGenerateHashedCacheKey("test-user", functions.FUNCTION_SUM_OVER_TIME, splittingCacheKey(t, inner, params), 4*hourInMs-1, 6*hourInMs-1)
-	_, exists := testCache.items[block2Key]
+	_, exists := testCache.Entries[block2Key]
 	require.True(t, exists, "Block2 cache key should exist before eviction")
-	delete(testCache.items, block2Key)
+	delete(testCache.Entries, block2Key)
 
 	// Second query: Block1 and Block3 are cache hits, Block2 is a miss.
 	result2, stats, ranges2 := executeQuery(t, mimirEngine, promStorage, expr, ts)
@@ -1115,7 +1115,7 @@ func TestQuerySplitting_MiddleCacheEntryEvicted(t *testing.T) {
 }
 
 func TestQuerySplitting_DelayedNameRemoval(t *testing.T) {
-	sharedCache := newTestCacheBackend()
+	sharedCache := caching.NewInMemoryCache()
 	cacheFactory := cache.NewCacheFactoryWithBackend(sharedCache, streamingpromql.NewStaticQueryLimitsProvider(), prometheus.NewPedanticRegistry(), log.NewNopLogger())
 
 	engineDisabled := createSplittingEngine(t, prometheus.NewPedanticRegistry(), 2*time.Hour, false, true, cacheFactory)
@@ -1405,12 +1405,12 @@ func TestQuerySplitting_PerRangeSeriesMetadata(t *testing.T) {
 			require.NoError(t, result.Err)
 			verifyEvaluationStats(t, stats, 13, 13)
 
-			require.Len(t, testCache.items, 4, "unexpected number of entries in cache")
+			require.Len(t, testCache.Entries, 4, "unexpected number of entries in cache")
 
 			blockEnds := make([]int64, 0, 4)
-			for _, data := range testCache.items {
+			for _, data := range testCache.Entries {
 				var entry cache.CachedSeries
-				require.NoError(t, entry.Unmarshal(data))
+				require.NoError(t, entry.Unmarshal(data.Value))
 
 				switch entry.End {
 				case block1End:
@@ -1426,20 +1426,20 @@ func TestQuerySplitting_PerRangeSeriesMetadata(t *testing.T) {
 			require.Equal(t, []int64{block1End, block2End, block3End, block4End}, blockEnds, "expected all 4 blocks to be present in cache")
 
 			// Verify results are still correct on cache hit
-			hitsBeforeSecondQuery := testCache.hits
+			hitsBeforeSecondQuery := testCache.HitCount
 			cachedResult, stats, _ := executeQuery(t, mimirEngine, promStorage, tc.expr, ts)
 			require.NoError(t, cachedResult.Err)
 			require.Equal(t, result.Value, cachedResult.Value)
 			verifyEvaluationStats(t, stats, 13, 13)
-			require.Greater(t, testCache.hits, hitsBeforeSecondQuery, "expected cache to be hit on second query")
+			require.Greater(t, testCache.HitCount, hitsBeforeSecondQuery, "expected cache to be hit on second query")
 		})
 	}
 }
 
-func createSplittingEngineWithCache(t *testing.T, registry *prometheus.Registry, splitInterval time.Duration, enableDelayedNameRemoval bool, enableEliminateDeduplicateAndMerge bool) (promql.QueryEngine, *testCacheBackend) {
+func createSplittingEngineWithCache(t *testing.T, registry *prometheus.Registry, splitInterval time.Duration, enableDelayedNameRemoval bool, enableEliminateDeduplicateAndMerge bool) (promql.QueryEngine, *caching.InMemoryCache) {
 	t.Helper()
 
-	cacheBackend := newTestCacheBackend()
+	cacheBackend := caching.NewInMemoryCache()
 	cacheFactory := cache.NewCacheFactoryWithBackend(cacheBackend, streamingpromql.NewStaticQueryLimitsProvider(), registry, log.NewNopLogger())
 
 	engine := createSplittingEngine(t, registry, splitInterval, enableDelayedNameRemoval, enableEliminateDeduplicateAndMerge, cacheFactory)
@@ -1470,12 +1470,12 @@ func createSplittingEngine(t *testing.T, registry *prometheus.Registry, splitInt
 	return engine
 }
 
-func setupEngineAndCache(t *testing.T) (*testCacheBackend, promql.QueryEngine) {
+func setupEngineAndCache(t *testing.T) (*caching.InMemoryCache, promql.QueryEngine) {
 	return setupEngineAndCacheWithOpts(t, defaultSplittingOpts())
 }
 
-func setupEngineAndCacheWithOpts(t *testing.T, opts streamingpromql.EngineOpts) (*testCacheBackend, promql.QueryEngine) {
-	backend := newTestCacheBackend()
+func setupEngineAndCacheWithOpts(t *testing.T, opts streamingpromql.EngineOpts) (*caching.InMemoryCache, promql.QueryEngine) {
+	backend := caching.NewInMemoryCache()
 	irCache := cache.NewCacheFactoryWithBackend(backend, streamingpromql.NewStaticQueryLimitsProvider(), prometheus.NewRegistry(), log.NewNopLogger())
 
 	queryPlanner, err := streamingpromql.NewQueryPlanner(opts, streamingpromql.NewMaximumSupportedVersionQueryPlanVersionProvider())
@@ -1529,10 +1529,10 @@ func verifyEvaluationStats(t *testing.T, stats *promstats.QuerySamples, expected
 	require.Equal(t, expectedSamplesRead, stats.SamplesRead, "Expected %d samples read, got %d", expectedSamplesRead, stats.SamplesRead)
 }
 
-func verifyCacheStats(t *testing.T, backend *testCacheBackend, expectedGets, expectedHits, expectedSets int) {
-	require.Equal(t, expectedGets, backend.gets, "Expected %d cache gets, got %d", expectedGets, backend.gets)
-	require.Equal(t, expectedHits, backend.hits, "Expected %d cache hits, got %d", expectedHits, backend.hits)
-	require.Equal(t, expectedSets, backend.sets, "Expected %d cache sets, got %d", expectedSets, backend.sets)
+func verifyCacheStats(t *testing.T, backend *caching.InMemoryCache, expectedGets, expectedHits, expectedSets int) {
+	require.Equal(t, expectedGets, backend.GetCount, "Expected %d cache gets, got %d", expectedGets, backend.GetCount)
+	require.Equal(t, expectedHits, backend.HitCount, "Expected %d cache hits, got %d", expectedHits, backend.HitCount)
+	require.Equal(t, expectedSets, backend.SetCount, "Expected %d cache sets, got %d", expectedSets, backend.SetCount)
 }
 
 func defaultSplittingOpts() streamingpromql.EngineOpts {
@@ -1555,49 +1555,6 @@ func trackRanges(promStorage storage.Storage) *rangeTrackingQueryable {
 	return &rangeTrackingQueryable{
 		inner: promStorage,
 	}
-}
-
-type testCacheBackend struct {
-	items map[string][]byte
-
-	gets int
-	hits int
-	sets int
-}
-
-func newTestCacheBackend() *testCacheBackend {
-	return &testCacheBackend{
-		items: make(map[string][]byte),
-	}
-}
-
-func (c *testCacheBackend) GetMulti(_ context.Context, keys []string, _ ...dskitcache.Option) (map[string][]byte, error) {
-	c.gets++
-
-	result := make(map[string][]byte)
-	for _, key := range keys {
-		if data, ok := c.items[key]; ok && len(data) > 0 {
-			// Clone bytes to simulate network serialization
-			result[key] = slices.Clone(data)
-			c.hits++
-		}
-	}
-
-	return result, nil
-}
-
-func (c *testCacheBackend) SetAsync(_ context.Context, key string, value []byte, _ time.Duration) error {
-	c.sets++
-	c.items[key] = value
-
-	return nil
-}
-
-func (c *testCacheBackend) Reset() {
-	c.items = make(map[string][]byte)
-	c.hits = 0
-	c.sets = 0
-	c.gets = 0
 }
 
 type rangeTrackingQueryable struct {

--- a/pkg/streamingpromql/optimize/plan/rangevectorsplitting/range_vector_splitting_test.go
+++ b/pkg/streamingpromql/optimize/plan/rangevectorsplitting/range_vector_splitting_test.go
@@ -1571,7 +1571,7 @@ func newTestCacheBackend() *testCacheBackend {
 	}
 }
 
-func (c *testCacheBackend) GetMulti(_ context.Context, keys []string, _ ...dskitcache.Option) map[string][]byte {
+func (c *testCacheBackend) GetMulti(_ context.Context, keys []string, _ ...dskitcache.Option) (map[string][]byte, error) {
 	c.gets++
 
 	result := make(map[string][]byte)
@@ -1583,12 +1583,14 @@ func (c *testCacheBackend) GetMulti(_ context.Context, keys []string, _ ...dskit
 		}
 	}
 
-	return result
+	return result, nil
 }
 
-func (c *testCacheBackend) SetAsync(key string, value []byte, _ time.Duration) {
+func (c *testCacheBackend) SetAsync(_ context.Context, key string, value []byte, _ time.Duration) error {
 	c.sets++
 	c.items[key] = value
+
+	return nil
 }
 
 func (c *testCacheBackend) Reset() {

--- a/pkg/streamingpromql/optimize/plan/rangevectorsplitting/range_vector_splitting_test.go
+++ b/pkg/streamingpromql/optimize/plan/rangevectorsplitting/range_vector_splitting_test.go
@@ -564,14 +564,14 @@ func TestQuerySplitting_WithSSE(t *testing.T) {
 	expectedIntermediate := rangevectorsplitting.FirstLastOverTimeIntermediate{H: &expectedH}
 
 	// Both keys must contain the full histogram (skip=false fetches buckets).
-	countKey := cache.TestGenerateHashedCacheKey("test-user", functions.FUNCTION_LAST_OVER_TIME, splittingCacheKey(t, countSplit, params), 2*hourInMs-1, 4*hourInMs-1)
+	countKey := cache.TestGenerateHashedCacheKey(functions.FUNCTION_LAST_OVER_TIME, splittingCacheKey(t, countSplit, params), 2*hourInMs-1, 4*hourInMs-1)
 	var countEntry cache.CachedSeries
 	require.NoError(t, countEntry.Unmarshal(backend.Entries[countKey].Value))
 	var countList rangevectorsplitting.FirstLastOverTimeIntermediateList
 	require.NoError(t, countList.Unmarshal(countEntry.Results))
 	require.Equal(t, []rangevectorsplitting.FirstLastOverTimeIntermediate{expectedIntermediate}, countList.Results)
 
-	fractionKey := cache.TestGenerateHashedCacheKey("test-user", functions.FUNCTION_LAST_OVER_TIME, splittingCacheKey(t, fractionSplit, params), 2*hourInMs-1, 4*hourInMs-1)
+	fractionKey := cache.TestGenerateHashedCacheKey(functions.FUNCTION_LAST_OVER_TIME, splittingCacheKey(t, fractionSplit, params), 2*hourInMs-1, 4*hourInMs-1)
 	var fractionEntry cache.CachedSeries
 	require.NoError(t, fractionEntry.Unmarshal(backend.Entries[fractionKey].Value))
 	var fractionList rangevectorsplitting.FirstLastOverTimeIntermediateList
@@ -644,8 +644,8 @@ func TestQuerySplitting_CacheKeyReflectsPostOptimizationState(t *testing.T) {
 		Range:              5 * time.Hour,
 		ExpressionPosition: core.PositionRange{Start: 72, End: 99},
 	}}
-	narrowKeyNoSSE := cache.TestGenerateHashedCacheKey("test-user", functions.FUNCTION_SUM_OVER_TIME, splittingCacheKey(t, narrowNoSSE, params), blockStart, blockEnd)
-	broadKeyNoSSE := cache.TestGenerateHashedCacheKey("test-user", functions.FUNCTION_SUM_OVER_TIME, splittingCacheKey(t, broadNoSSE, params), blockStart, blockEnd)
+	narrowKeyNoSSE := cache.TestGenerateHashedCacheKey(functions.FUNCTION_SUM_OVER_TIME, splittingCacheKey(t, narrowNoSSE, params), blockStart, blockEnd)
+	broadKeyNoSSE := cache.TestGenerateHashedCacheKey(functions.FUNCTION_SUM_OVER_TIME, splittingCacheKey(t, broadNoSSE, params), blockStart, blockEnd)
 	require.Contains(t, backendNoSSE.Entries, narrowKeyNoSSE, "expected bare-matchers cache key for narrow selector when SSE is off")
 	require.Contains(t, backendNoSSE.Entries, broadKeyNoSSE, "expected bare-matchers cache key for broad selector when SSE is off")
 
@@ -683,8 +683,8 @@ func TestQuerySplitting_CacheKeyReflectsPostOptimizationState(t *testing.T) {
 		DuplicateDetails: &commonsubexpressionelimination.DuplicateDetails{},
 		Inner:            broadSSE,
 	}
-	narrowKeySSE := cache.TestGenerateHashedCacheKey("test-user", functions.FUNCTION_SUM_OVER_TIME, splittingCacheKey(t, narrowSSE, params), blockStart, blockEnd)
-	broadKeySSE := cache.TestGenerateHashedCacheKey("test-user", functions.FUNCTION_SUM_OVER_TIME, splittingCacheKey(t, broadSplitSSE, params), blockStart, blockEnd)
+	narrowKeySSE := cache.TestGenerateHashedCacheKey(functions.FUNCTION_SUM_OVER_TIME, splittingCacheKey(t, narrowSSE, params), blockStart, blockEnd)
+	broadKeySSE := cache.TestGenerateHashedCacheKey(functions.FUNCTION_SUM_OVER_TIME, splittingCacheKey(t, broadSplitSSE, params), blockStart, blockEnd)
 	require.Contains(t, backendSSE.Entries, narrowKeySSE, "expected duplicate_filter cache key for narrow selector when SSE is on")
 	require.Contains(t, backendSSE.Entries, broadKeySSE, "expected subset-aware cache key for broad selector when SSE is on")
 	require.NotContains(t, backendNoSSE.Entries, narrowKeySSE, "narrow SSE cache key must not exist in no-SSE backend (key reflects post-optimization plan)")
@@ -1096,7 +1096,7 @@ func TestQuerySplitting_MiddleCacheEntryEvicted(t *testing.T) {
 		ExpressionPosition: core.PositionRange{Start: 14, End: 29},
 	}}
 	params := &planning.QueryParameters{LookbackDelta: streamingpromql.DefaultLookbackDelta}
-	block2Key := cache.TestGenerateHashedCacheKey("test-user", functions.FUNCTION_SUM_OVER_TIME, splittingCacheKey(t, inner, params), 4*hourInMs-1, 6*hourInMs-1)
+	block2Key := cache.TestGenerateHashedCacheKey(functions.FUNCTION_SUM_OVER_TIME, splittingCacheKey(t, inner, params), 4*hourInMs-1, 6*hourInMs-1)
 	_, exists := testCache.Entries[block2Key]
 	require.True(t, exists, "Block2 cache key should exist before eviction")
 	delete(testCache.Entries, block2Key)

--- a/pkg/streamingpromql/optimize/plan/splitandcache/cache_operator.go
+++ b/pkg/streamingpromql/optimize/plan/splitandcache/cache_operator.go
@@ -190,7 +190,11 @@ func (c *CacheOperator) fetchExistingExtents(ctx context.Context) ([]CachedExten
 	c.hashedKey = caching.HashCacheKey(c.key)
 	keys := []string{c.hashedKey}
 
-	cacheHits := c.Backend.GetMulti(ctx, keys)
+	cacheHits, err := c.Backend.GetMulti(ctx, keys)
+	if err != nil {
+		return nil, fmt.Errorf("fetching cached results with key %q: %w", c.hashedKey, err)
+	}
+
 	cacheHit := cacheHits[c.hashedKey]
 
 	if cacheHit == nil {
@@ -805,7 +809,10 @@ func (c *CacheOperator) writeCacheEntry(ctx context.Context, stats *types.Operat
 		return err
 	}
 
-	c.Backend.SetAsync(c.hashedKey, value, ttl)
+	if err := c.Backend.SetAsync(ctx, c.hashedKey, value, ttl); err != nil {
+		return fmt.Errorf("storing cached results with key %q: %w", c.hashedKey, err)
+	}
+
 	return nil
 }
 

--- a/pkg/streamingpromql/optimize/plan/splitandcache/cache_operator_test.go
+++ b/pkg/streamingpromql/optimize/plan/splitandcache/cache_operator_test.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/grafana/dskit/cache"
 	"github.com/grafana/dskit/user"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/histogram"
@@ -538,7 +537,7 @@ func TestCacheOperator(t *testing.T) {
 
 			ctx := user.InjectOrgID(context.Background(), "some-user")
 			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
-			cache := newTestCache()
+			cache := caching.NewInMemoryCache()
 			materializer := &testMaterializer{
 				t:                        t,
 				ctx:                      ctx,
@@ -561,8 +560,8 @@ func TestCacheOperator(t *testing.T) {
 
 				b, err := testCase.existingCacheEntry.Marshal()
 				require.NoError(t, err)
-				cache.entries = map[string]testCacheEntry{
-					hashedCacheKey: {value: b},
+				cache.Entries = map[string]caching.InMemoryCacheEntry{
+					hashedCacheKey: {Value: b},
 				}
 			}
 
@@ -628,14 +627,14 @@ func TestCacheOperator(t *testing.T) {
 			require.Zerof(t, memoryConsumptionTracker.CurrentEstimatedMemoryConsumptionBytes(), "expected all instances to be returned to pool, current memory consumption is:\n%v", memoryConsumptionTracker.DescribeCurrentMemoryConsumption())
 
 			if testCase.expectedWrittenCacheEntry == nil {
-				require.Equal(t, 0, cache.setCount, "expected no cache entry to be written, but at least one was")
+				require.Equal(t, 0, cache.SetCount, "expected no cache entry to be written, but at least one was")
 			} else {
-				require.Equal(t, 1, cache.setCount, "expected cache entry to be written, but it was not")
-				require.Equal(t, []string{hashedCacheKey}, slices.Collect(maps.Keys(cache.entries)), "expected cache entry to be written with expected key")
-				require.Equal(t, testCase.expectedTTL, cache.entries[hashedCacheKey].ttl, "expected cache entry to have expected TTL")
+				require.Equal(t, 1, cache.SetCount, "expected cache entry to be written, but it was not")
+				require.Equal(t, []string{hashedCacheKey}, slices.Collect(maps.Keys(cache.Entries)), "expected cache entry to be written with expected key")
+				require.Equal(t, testCase.expectedTTL, cache.Entries[hashedCacheKey].TTL, "expected cache entry to have expected TTL")
 
 				testCase.expectedWrittenCacheEntry.CacheKey = cacheKey
-				actualBytes := cache.entries[hashedCacheKey].value
+				actualBytes := cache.Entries[hashedCacheKey].Value
 				actualEntry := &CacheEntry{}
 				require.NoError(t, actualEntry.Unmarshal(actualBytes))
 
@@ -652,7 +651,7 @@ func TestCacheOperator(t *testing.T) {
 func TestCacheOperator_DoesNotSaveCacheEntryIfSeriesMetadataNotCalled(t *testing.T) {
 	ctx := user.InjectOrgID(context.Background(), "some-user")
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
-	cache := newTestCache()
+	cache := caching.NewInMemoryCache()
 	materializer := &testMaterializer{
 		t:                        t,
 		ctx:                      ctx,
@@ -672,13 +671,13 @@ func TestCacheOperator_DoesNotSaveCacheEntryIfSeriesMetadataNotCalled(t *testing
 	_, _, err := o.Finalize(ctx)
 	require.NoError(t, err)
 
-	require.Zerof(t, cache.setCount, "expected no cache entry to be written, but at least one was: %v", cache.entries)
+	require.Zerof(t, cache.SetCount, "expected no cache entry to be written, but at least one was: %v", cache.Entries)
 }
 
 func TestCacheOperator_DoesNotSaveCacheEntryIfNotAllSeriesRead(t *testing.T) {
 	ctx := user.InjectOrgID(context.Background(), "some-user")
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
-	cache := newTestCache()
+	cache := caching.NewInMemoryCache()
 	materializer := &testMaterializer{
 		t:                        t,
 		ctx:                      ctx,
@@ -706,13 +705,13 @@ func TestCacheOperator_DoesNotSaveCacheEntryIfNotAllSeriesRead(t *testing.T) {
 	_, _, err = o.Finalize(ctx)
 	require.NoError(t, err)
 
-	require.Zerof(t, cache.setCount, "expected no cache entry to be written, but at least one was: %v", cache.entries)
+	require.Zerof(t, cache.SetCount, "expected no cache entry to be written, but at least one was: %v", cache.Entries)
 }
 
 func TestCacheOperator_DoesNotSaveCacheEntryIfFinishedReadingNotCalled(t *testing.T) {
 	ctx := user.InjectOrgID(context.Background(), "some-user")
 	memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
-	cache := newTestCache()
+	cache := caching.NewInMemoryCache()
 	materializer := &testMaterializer{
 		t:                        t,
 		ctx:                      ctx,
@@ -741,7 +740,7 @@ func TestCacheOperator_DoesNotSaveCacheEntryIfFinishedReadingNotCalled(t *testin
 	_, _, err = o.Finalize(ctx)
 	require.EqualError(t, err, "CacheOperator.writeCacheEntry() called (via Finalize()) before FinishedReading(), this should never happen")
 
-	require.Zerof(t, cache.setCount, "expected no cache entry to be written, but at least one was: %v", cache.entries)
+	require.Zerof(t, cache.SetCount, "expected no cache entry to be written, but at least one was: %v", cache.Entries)
 }
 
 func TestCacheOperator_DoesNotStoreEmptySeries(t *testing.T) {
@@ -970,44 +969,6 @@ func mangleSeriesData(data types.InstantVectorSeriesData) {
 		p.H.Count = rand.NormFloat64()
 		p.H.Sum = rand.NormFloat64()
 	}
-}
-
-type testCache struct {
-	entries map[string]testCacheEntry
-
-	setCount int
-}
-
-func newTestCache() *testCache {
-	return &testCache{
-		entries: make(map[string]testCacheEntry),
-	}
-}
-
-type testCacheEntry struct {
-	value []byte
-	ttl   time.Duration
-}
-
-func (t *testCache) GetMulti(ctx context.Context, keys []string, opts ...cache.Option) (map[string][]byte, error) {
-	results := make(map[string][]byte, len(keys))
-
-	for _, key := range keys {
-		entry, ok := t.entries[key]
-
-		if ok {
-			results[key] = entry.value
-		}
-	}
-
-	return results, nil
-}
-
-func (t *testCache) SetAsync(ctx context.Context, key string, value []byte, ttl time.Duration) error {
-	t.setCount++
-	t.entries[key] = testCacheEntry{value: value, ttl: ttl}
-
-	return nil
 }
 
 type mockLimitsProvider struct {

--- a/pkg/streamingpromql/optimize/plan/splitandcache/cache_operator_test.go
+++ b/pkg/streamingpromql/optimize/plan/splitandcache/cache_operator_test.go
@@ -989,7 +989,7 @@ type testCacheEntry struct {
 	ttl   time.Duration
 }
 
-func (t *testCache) GetMulti(ctx context.Context, keys []string, opts ...cache.Option) map[string][]byte {
+func (t *testCache) GetMulti(ctx context.Context, keys []string, opts ...cache.Option) (map[string][]byte, error) {
 	results := make(map[string][]byte, len(keys))
 
 	for _, key := range keys {
@@ -1000,12 +1000,14 @@ func (t *testCache) GetMulti(ctx context.Context, keys []string, opts ...cache.O
 		}
 	}
 
-	return results
+	return results, nil
 }
 
-func (t *testCache) SetAsync(key string, value []byte, ttl time.Duration) {
+func (t *testCache) SetAsync(ctx context.Context, key string, value []byte, ttl time.Duration) error {
 	t.setCount++
 	t.entries[key] = testCacheEntry{value: value, ttl: ttl}
+
+	return nil
 }
 
 type mockLimitsProvider struct {


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue in the experimental range vector splitting optimisation.

If LBAC was enabled, and the range vector splitting cache was populated by one user, and then that cache entry was used by a second user where an LBAC policy should apply, the second user would see the results from the first user, instead of the results applicable given their LBAC policy. Note that cache results for entire tenants were still isolated, the issue only allowed a user to see data from within their own tenant.

This PR fixes the issue by applying a prefix to all cache entries when an LBAC policy applies, mirroring the approach taken for other kinds of cached query results. 

I've chosen to implement this in a way that will make it easy to apply to the caching done by the `splitandcache` package (https://github.com/grafana/mimir/pull/15787) and other caching done by MQE in the future.

There were a number of refactoring steps required to implement this, I'd suggest reviewing each commit separately.

#### Which issue(s) this PR fixes or relates to

Related to https://github.com/grafana/mimir/pull/15787#discussion_r3463892681

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
