### PR TITLE
Docs: 2 small tweaks to refer to Otel concepts

### DIFF
--- a/docs/sources/mimir/configure/configure-otel-collector.md
+++ b/docs/sources/mimir/configure/configure-otel-collector.md
@@ -119,7 +119,7 @@ The `-distributor.otel-promote-resource-attributes` option is an experimental fe
 
 Mimir stores additional OTel resource attributes in a separate series called `target_info`, which you can query using a join query or the Prometheus `info()` function. Refer to [Functions](https://prometheus.io/docs/prometheus/latest/querying/functions/) in the Prometheus documentation for more information.
 
-To learn more about OpenTelemetry resource attributes, refer to [Resources](https://opentelemetry.io/docs/languages/js/resources/) in the OpenTelemetry documentation.
+To learn more about OpenTelemetry resource attributes, refer to [Resources](https://opentelemetry.io/docs/concepts/resources/) in the OpenTelemetry documentation.
 
 To learn more about ingesting OpenTelemetry data in Grafana Cloud, including how Grafana Cloud promotes OpenTelemetry resouce attributes to labels during ingestion, refer to [OTLP: OpenTelemetry Protocol format considerations](https://grafana.com/docs/grafana-cloud/send-data/otlp/otlp-format-considerations/).
 

--- a/docs/sources/mimir/configure/configure-tracing.md
+++ b/docs/sources/mimir/configure/configure-tracing.md
@@ -13,7 +13,7 @@ weight: 270
 
 Distributed tracing is a valuable tool for troubleshooting the behavior of Grafana Mimir in production.
 
-Grafana Mimir supports distributed tracing using [OpenTelemetry](https://opentelemetry.io/docs/languages/go/getting-started/) and provides backward compatibility with [Jaeger](https://www.jaegertracing.io/) configuration.
+Grafana Mimir supports distributed tracing using [OpenTelemetry](https://opentelemetry.io/docs/concepts/signals/traces/) and provides backward compatibility with [Jaeger](https://www.jaegertracing.io/) configuration.
 
 Mimir automatically detects which tracing configuration method to use based on the environment variables you set:
 


### PR DESCRIPTION
I think people meeting these things for the first time would rather read the high-level description than go to the language-specific pages.

Replacement for #14151 which is lost to some GitHub rule.
