### PR TITLE
Refactor existing subquery spinoff logic so it can be used by MQE as well

### DIFF
--- a/pkg/frontend/querymiddleware/astmapper/subquery_spin_off.go
+++ b/pkg/frontend/querymiddleware/astmapper/subquery_spin_off.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/pkg/errors"
-	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 )
 
@@ -25,6 +23,7 @@ const (
 )
 
 type subquerySpinOffMapper struct {
+	wrapper         SubquerySpinOffWrapper
 	defaultStepFunc func(rangeMillis int64) int64
 
 	logger log.Logger
@@ -32,9 +31,13 @@ type subquerySpinOffMapper struct {
 }
 
 // NewSubquerySpinOffMapper creates a new instant query mapper.
-func NewSubquerySpinOffMapper(defaultStepFunc func(rangeMillis int64) int64, logger log.Logger, stats *SubquerySpinOffMapperStats) ASTMapper {
+//
+// wrapper controls how the spun-off subqueries and downstream queries are represented in the mapped
+// query.
+func NewSubquerySpinOffMapper(wrapper SubquerySpinOffWrapper, defaultStepFunc func(rangeMillis int64) int64, logger log.Logger, stats *SubquerySpinOffMapperStats) ASTMapper {
 	queryMapper := NewASTExprMapper(
 		&subquerySpinOffMapper{
+			wrapper:         wrapper,
 			defaultStepFunc: defaultStepFunc,
 			logger:          logger,
 			stats:           stats,
@@ -48,11 +51,12 @@ func NewSubquerySpinOffMapper(defaultStepFunc func(rangeMillis int64) int64, log
 
 // MapExpr implements the ASTMapper interface.
 // The strategy here is to look for aggregated subqueries (all subqueries should be aggregated) and spin them off into separate queries.
-// The frontend does not have internal control of the engine,
-// so MapExpr has to remap subqueries into "fake metrics" that can be queried by a Queryable that we can inject into the engine.
-// This "fake metric selector" is the "__subquery_spinoff__" metric.
-// For everything else, we have to pass it through to the downstream execution path (other instant middlewares),
-// so we remap them into a "__downstream_query__" selector.
+// Subqueries that are worth spinning off are handed to the wrapper's WrapSubquery; everything else is passed through to
+// the downstream execution path via the wrapper's WrapDownstreamQuery.
+// How those spun-off subqueries and downstream queries are represented in the mapped query is up to the wrapper.
+// For example, the query-frontend middleware uses the selectorSubquerySpinOffWrapper, which remaps them into the
+// "fake metric" selectors "__subquery_spinoff__" and "__downstream_query__" that are resolved by a Queryable injected
+// into the engine, because the frontend does not have internal control of the engine.
 //
 // See sharding.go and embedded.go for another example of mapping into a fake metric selector.
 func (m *subquerySpinOffMapper) MapExpr(ctx context.Context, expr parser.Expr) (mapped parser.Expr, finished bool, err error) {
@@ -66,15 +70,8 @@ func (m *subquerySpinOffMapper) MapExpr(ctx context.Context, expr parser.Expr) (
 		if countSelectors(expr) == 0 {
 			return expr, false, nil
 		}
-		selector := &parser.VectorSelector{
-			Name: DownstreamQueryMetricName,
-			LabelMatchers: []*labels.Matcher{
-				labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, DownstreamQueryMetricName),
-				labels.MustNewMatcher(labels.MatchEqual, DownstreamQueryLabelName, expr.String()),
-			},
-		}
 		m.stats.AddDownstreamQuery()
-		return selector, false, nil
+		return m.wrapper.WrapDownstreamQuery(expr), false, nil
 	}
 
 	switch e := expr.(type) {
@@ -108,25 +105,7 @@ func (m *subquerySpinOffMapper) MapExpr(ctx context.Context, expr parser.Expr) (
 				return downstreamQuery(expr)
 			}
 
-			selector := &parser.VectorSelector{
-				Name: SubqueryMetricName,
-				LabelMatchers: []*labels.Matcher{
-					labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, SubqueryMetricName),
-					labels.MustNewMatcher(labels.MatchEqual, SubqueryQueryLabelName, sq.Expr.String()),
-					labels.MustNewMatcher(labels.MatchEqual, SubqueryRangeLabelName, sq.Range.String()),
-					labels.MustNewMatcher(labels.MatchEqual, SubqueryStepLabelName, step.String()),
-				},
-			}
-
-			if sq.OriginalOffset != 0 {
-				selector.LabelMatchers = append(selector.LabelMatchers, labels.MustNewMatcher(labels.MatchEqual, SubqueryOffsetLabelName, sq.OriginalOffset.String()))
-				selector.OriginalOffset = sq.OriginalOffset
-			}
-
-			e.Args[lastArgIdx] = &parser.MatrixSelector{
-				VectorSelector: selector,
-				Range:          sq.Range,
-			}
+			e.Args[lastArgIdx] = m.wrapper.WrapSubquery(sq, step)
 			m.stats.AddSpunOffSubquery()
 			return e, true, nil
 		}

--- a/pkg/frontend/querymiddleware/astmapper/subquery_spin_off.go
+++ b/pkg/frontend/querymiddleware/astmapper/subquery_spin_off.go
@@ -68,10 +68,10 @@ func (m *subquerySpinOffMapper) MapExpr(ctx context.Context, expr parser.Expr) (
 
 	downstreamQuery := func(expr parser.Expr) (mapped parser.Expr, finished bool, err error) {
 		if countSelectors(expr) == 0 {
-			return expr, false, nil
+			return expr, true, nil
 		}
 		m.stats.AddDownstreamQuery()
-		return m.wrapper.WrapDownstreamQuery(expr), false, nil
+		return m.wrapper.WrapDownstreamQuery(expr), true, nil
 	}
 
 	switch e := expr.(type) {
@@ -85,7 +85,7 @@ func (m *subquerySpinOffMapper) MapExpr(ctx context.Context, expr parser.Expr) (
 		if sq, ok := e.Args[lastArgIdx].(*parser.SubqueryExpr); ok {
 			canBeSpunOff, isConstant := subqueryCanBeSpunOff(*sq)
 			if isConstant {
-				return expr, false, nil
+				return expr, true, nil
 			}
 			if !canBeSpunOff {
 				return downstreamQuery(expr)

--- a/pkg/frontend/querymiddleware/astmapper/subquery_spin_off_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/subquery_spin_off_test.go
@@ -272,7 +272,7 @@ func TestSubquerySpinOffMapper(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 			stats := NewSubquerySpinOffMapperStats()
-			mapper := NewSubquerySpinOffMapper(defaultStepFunc, log.NewNopLogger(), stats)
+			mapper := NewSubquerySpinOffMapper(NewSelectorSubquerySpinOffWrapper(), defaultStepFunc, log.NewNopLogger(), stats)
 			ctx := context.Background()
 			parser := promqlext.NewPromQLParser()
 			expr, err := parser.ParseExpr(tt.in)

--- a/pkg/frontend/querymiddleware/astmapper/subquery_spin_off_wrapper.go
+++ b/pkg/frontend/querymiddleware/astmapper/subquery_spin_off_wrapper.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package astmapper
+
+import (
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+// SubquerySpinOffWrapper decides how the subquerySpinOffMapper represents the queries it spins off.
+//
+// The mapper itself is responsible for deciding which parts of a query should be spun off into separate
+// subqueries and which should be passed through to the downstream execution path. It delegates the actual
+// construction of the replacement expressions to a SubquerySpinOffWrapper, so that the same mapping logic
+// can produce different representations depending on the caller. For example, the query-frontend middleware
+// wraps them into fake metric selectors that are resolved by an injected Queryable.
+type SubquerySpinOffWrapper interface {
+	// WrapDownstreamQuery returns the expression to use in place of expr to execute it through the
+	// downstream execution path rather than spinning it off.
+	WrapDownstreamQuery(expr parser.Expr) parser.Expr
+
+	// WrapSubquery returns the expression to use in place of the given subquery to spin it off into a
+	// separate query. step is the resolved step of the subquery (the subquery's own step, or the default
+	// step if it does not specify one).
+	WrapSubquery(subquery *parser.SubqueryExpr, step time.Duration) parser.Expr
+}
+
+// selectorSubquerySpinOffWrapper is the SubquerySpinOffWrapper used by the query-frontend middleware.
+// It wraps downstream queries and spun-off subqueries into fake metric selectors (__downstream_query__
+// and __subquery_spinoff__ respectively) that are resolved by a Queryable injected into the engine.
+type selectorSubquerySpinOffWrapper struct{}
+
+// NewSelectorSubquerySpinOffWrapper returns a SubquerySpinOffWrapper that wraps downstream queries and
+// spun-off subqueries into fake metric selectors resolved by an injected Queryable.
+func NewSelectorSubquerySpinOffWrapper() SubquerySpinOffWrapper {
+	return selectorSubquerySpinOffWrapper{}
+}
+
+func (selectorSubquerySpinOffWrapper) WrapDownstreamQuery(expr parser.Expr) parser.Expr {
+	return &parser.VectorSelector{
+		Name: DownstreamQueryMetricName,
+		LabelMatchers: []*labels.Matcher{
+			labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, DownstreamQueryMetricName),
+			labels.MustNewMatcher(labels.MatchEqual, DownstreamQueryLabelName, expr.String()),
+		},
+	}
+}
+
+func (selectorSubquerySpinOffWrapper) WrapSubquery(subquery *parser.SubqueryExpr, step time.Duration) parser.Expr {
+	selector := &parser.VectorSelector{
+		Name: SubqueryMetricName,
+		LabelMatchers: []*labels.Matcher{
+			labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, SubqueryMetricName),
+			labels.MustNewMatcher(labels.MatchEqual, SubqueryQueryLabelName, subquery.Expr.String()),
+			labels.MustNewMatcher(labels.MatchEqual, SubqueryRangeLabelName, subquery.Range.String()),
+			labels.MustNewMatcher(labels.MatchEqual, SubqueryStepLabelName, step.String()),
+		},
+	}
+
+	if subquery.OriginalOffset != 0 {
+		selector.LabelMatchers = append(selector.LabelMatchers, labels.MustNewMatcher(labels.MatchEqual, SubqueryOffsetLabelName, subquery.OriginalOffset.String()))
+		selector.OriginalOffset = subquery.OriginalOffset
+	}
+
+	return &parser.MatrixSelector{
+		VectorSelector: selector,
+		Range:          subquery.Range,
+	}
+}

--- a/pkg/frontend/querymiddleware/spin_off_subqueries.go
+++ b/pkg/frontend/querymiddleware/spin_off_subqueries.go
@@ -4,28 +4,19 @@ package querymiddleware
 
 import (
 	"context"
-	"errors"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/tenant"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/promql"
 
 	apierror "github.com/grafana/mimir/pkg/api/error"
 	"github.com/grafana/mimir/pkg/frontend/querymiddleware/astmapper"
-	"github.com/grafana/mimir/pkg/querier/stats"
+	"github.com/grafana/mimir/pkg/frontend/querymiddleware/subqueryspinoff"
 	"github.com/grafana/mimir/pkg/storage/lazyquery"
 	"github.com/grafana/mimir/pkg/util/spanlogger"
 	"github.com/grafana/mimir/pkg/util/validation"
-)
-
-const (
-	subquerySpinoffSkippedReasonParsingFailed     = "parsing-failed"
-	subquerySpinoffSkippedReasonMappingFailed     = "mapping-failed"
-	subquerySpinoffSkippedReasonNoSubqueries      = "no-subqueries"
-	subquerySpinoffSkippedReasonDownstreamQueries = "too-many-downstream-queries"
 )
 
 type spinOffSubqueriesMiddleware struct {
@@ -36,54 +27,9 @@ type spinOffSubqueriesMiddleware struct {
 
 	engine          promql.QueryEngine
 	defaultStepFunc func(int64) int64
+	wrapper         astmapper.SubquerySpinOffWrapper
 
-	metrics spinOffSubqueriesMetrics
-}
-
-type spinOffSubqueriesMetrics struct {
-	spinOffAttempts           prometheus.Counter
-	spinOffSuccesses          prometheus.Counter
-	spinOffSkipped            *prometheus.CounterVec
-	spunOffSubqueries         prometheus.Counter
-	spunOffSubqueriesPerQuery prometheus.Histogram
-}
-
-func newSpinOffSubqueriesMetrics(registerer prometheus.Registerer) spinOffSubqueriesMetrics {
-	m := spinOffSubqueriesMetrics{
-		spinOffAttempts: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
-			Name: "cortex_frontend_subquery_spinoff_attempts_total",
-			Help: "Total number of queries the query-frontend attempted to spin-off subqueries from.",
-		}),
-		spinOffSuccesses: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
-			Name: "cortex_frontend_subquery_spinoff_successes_total",
-			Help: "Total number of queries the query-frontend successfully spun off subqueries from.",
-		}),
-		spinOffSkipped: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
-			Name: "cortex_frontend_subquery_spinoff_skipped_total",
-			Help: "Total number of queries the query-frontend skipped or failed to spin-off subqueries from.",
-		}, []string{"reason"}),
-		spunOffSubqueries: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
-			Name: "cortex_frontend_spun_off_subqueries_total",
-			Help: "Total number of subqueries that were spun off.",
-		}),
-		spunOffSubqueriesPerQuery: promauto.With(registerer).NewHistogram(prometheus.HistogramOpts{
-			Name:    "cortex_frontend_spun_off_subqueries_per_query",
-			Help:    "Number of subqueries spun off from a single query.",
-			Buckets: prometheus.ExponentialBuckets(2, 2, 10),
-		}),
-	}
-
-	// Initialize known label values.
-	for _, reason := range []string{
-		subquerySpinoffSkippedReasonParsingFailed,
-		subquerySpinoffSkippedReasonMappingFailed,
-		subquerySpinoffSkippedReasonNoSubqueries,
-		subquerySpinoffSkippedReasonDownstreamQueries,
-	} {
-		m.spinOffSkipped.WithLabelValues(reason)
-	}
-
-	return m
+	metrics subqueryspinoff.Metrics
 }
 
 func newSpinOffSubqueriesMiddleware(
@@ -94,7 +40,8 @@ func newSpinOffSubqueriesMiddleware(
 	rangeMiddleware MetricsQueryMiddleware,
 	defaultStepFunc func(int64) int64,
 ) MetricsQueryMiddleware {
-	metrics := newSpinOffSubqueriesMetrics(registerer)
+	metrics := subqueryspinoff.NewMetrics(registerer)
+	wrapper := astmapper.NewSelectorSubquerySpinOffWrapper()
 	return MetricsQueryMiddlewareFunc(func(next MetricsQueryHandler) MetricsQueryHandler {
 		rangeNext := next
 		if rangeMiddleware != nil {
@@ -108,6 +55,7 @@ func newSpinOffSubqueriesMiddleware(
 			logger:          logger,
 			engine:          engine,
 			metrics:         metrics,
+			wrapper:         wrapper,
 			defaultStepFunc: defaultStepFunc,
 		}
 	})
@@ -133,56 +81,20 @@ func (s *spinOffSubqueriesMiddleware) Do(ctx context.Context, req MetricsQueryRe
 	}
 
 	// Increment total number of instant queries attempted to spin-off subqueries from.
-	s.metrics.spinOffAttempts.Inc()
-
-	mapperStats := astmapper.NewSubquerySpinOffMapperStats()
-	mapperCtx, cancel := context.WithTimeout(ctx, shardingTimeout)
-	defer cancel()
-	mapper := astmapper.NewSubquerySpinOffMapper(s.defaultStepFunc, spanLog, mapperStats)
+	s.metrics.SpinOffAttempts.Inc()
 
 	expr, err := req.GetClonedParsedQuery()
 	if err != nil {
 		level.Warn(spanLog).Log("msg", "failed to parse query", "err", err)
-		s.metrics.spinOffSkipped.WithLabelValues(subquerySpinoffSkippedReasonParsingFailed).Inc()
+		s.metrics.SpinOffSkipped.WithLabelValues(subqueryspinoff.SkippedReasonParsingFailed).Inc()
 		return nil, apierror.New(apierror.TypeBadData, DecorateWithParamName(err, "query").Error())
 	}
 
-	spinOffQuery, err := mapper.Map(mapperCtx, expr)
-	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
-			level.Error(spanLog).Log("msg", "timeout while spinning off subqueries, please fill in a bug report with this query, falling back to try executing without spin-off", "err", err)
-		} else {
-			level.Error(spanLog).Log("msg", "failed to map the input query, falling back to try executing without spin-off", "err", err)
-		}
-		s.metrics.spinOffSkipped.WithLabelValues(subquerySpinoffSkippedReasonMappingFailed).Inc()
+	spinOffQuery, ok := subqueryspinoff.Map(ctx, expr, s.wrapper, s.metrics, s.defaultStepFunc, shardingTimeout, spanLog)
+	if !ok {
+		// Spinning off subqueries was not possible or not worthwhile, so fall back to executing the query downstream.
 		return s.next.Do(ctx, req)
 	}
-
-	if mapperStats.SpunOffSubqueries() == 0 {
-		// the query has no subqueries, so continue downstream
-		spanLog.DebugLog("msg", "input query resulted in a no operation, falling back to try executing without spinning off subqueries")
-		s.metrics.spinOffSkipped.WithLabelValues(subquerySpinoffSkippedReasonNoSubqueries).Inc()
-		return s.next.Do(ctx, req)
-	}
-
-	if mapperStats.DownstreamQueries() > mapperStats.SpunOffSubqueries() {
-		// the query has more downstream queries than subqueries, so continue downstream
-		// It's probably more efficient to just execute the query as is
-		spanLog.DebugLog("msg", "input query resulted in more downstream queries than subqueries, falling back to try executing without spinning off subqueries")
-		s.metrics.spinOffSkipped.WithLabelValues(subquerySpinoffSkippedReasonDownstreamQueries).Inc()
-		return s.next.Do(ctx, req)
-	}
-
-	spanLog.DebugLog("msg", "instant query has been rewritten to spin-off subqueries", "rewritten", spinOffQuery, "regular_downstream_queries", mapperStats.DownstreamQueries(), "subqueries_spun_off", mapperStats.SpunOffSubqueries())
-
-	// Update query stats.
-	queryStats := stats.FromContext(ctx)
-	queryStats.AddSpunOffSubqueries(uint32(mapperStats.SpunOffSubqueries()))
-
-	// Update metrics.
-	s.metrics.spinOffSuccesses.Inc()
-	s.metrics.spunOffSubqueries.Add(float64(mapperStats.SpunOffSubqueries()))
-	s.metrics.spunOffSubqueriesPerQuery.Observe(float64(mapperStats.SpunOffSubqueries()))
 
 	// Send hint with number of embedded queries to the sharding middleware
 	req, err = req.WithExpr(spinOffQuery)

--- a/pkg/frontend/querymiddleware/subqueryspinoff/metrics.go
+++ b/pkg/frontend/querymiddleware/subqueryspinoff/metrics.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package subqueryspinoff
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Reasons recorded against the "reason" label of the spin-off-skipped metric when a query is not spun off.
+const (
+	SkippedReasonParsingFailed     = "parsing-failed"
+	SkippedReasonMappingFailed     = "mapping-failed"
+	SkippedReasonNoSubqueries      = "no-subqueries"
+	SkippedReasonDownstreamQueries = "too-many-downstream-queries"
+)
+
+// Metrics holds the metrics recorded while spinning off subqueries from a query.
+type Metrics struct {
+	SpinOffAttempts           prometheus.Counter
+	SpinOffSuccesses          prometheus.Counter
+	SpinOffSkipped            *prometheus.CounterVec
+	SpunOffSubqueries         prometheus.Counter
+	SpunOffSubqueriesPerQuery prometheus.Histogram
+}
+
+// NewMetrics creates and registers the metrics used while spinning off subqueries.
+func NewMetrics(registerer prometheus.Registerer) Metrics {
+	m := Metrics{
+		SpinOffAttempts: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
+			Name: "cortex_frontend_subquery_spinoff_attempts_total",
+			Help: "Total number of queries the query-frontend attempted to spin-off subqueries from.",
+		}),
+		SpinOffSuccesses: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
+			Name: "cortex_frontend_subquery_spinoff_successes_total",
+			Help: "Total number of queries the query-frontend successfully spun off subqueries from.",
+		}),
+		SpinOffSkipped: promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
+			Name: "cortex_frontend_subquery_spinoff_skipped_total",
+			Help: "Total number of queries the query-frontend skipped or failed to spin-off subqueries from.",
+		}, []string{"reason"}),
+		SpunOffSubqueries: promauto.With(registerer).NewCounter(prometheus.CounterOpts{
+			Name: "cortex_frontend_spun_off_subqueries_total",
+			Help: "Total number of subqueries that were spun off.",
+		}),
+		SpunOffSubqueriesPerQuery: promauto.With(registerer).NewHistogram(prometheus.HistogramOpts{
+			Name:    "cortex_frontend_spun_off_subqueries_per_query",
+			Help:    "Number of subqueries spun off from a single query.",
+			Buckets: prometheus.ExponentialBuckets(2, 2, 10),
+		}),
+	}
+
+	// Initialize known label values.
+	for _, reason := range []string{
+		SkippedReasonParsingFailed,
+		SkippedReasonMappingFailed,
+		SkippedReasonNoSubqueries,
+		SkippedReasonDownstreamQueries,
+	} {
+		m.SpinOffSkipped.WithLabelValues(reason)
+	}
+
+	return m
+}

--- a/pkg/frontend/querymiddleware/subqueryspinoff/spinoff.go
+++ b/pkg/frontend/querymiddleware/subqueryspinoff/spinoff.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package subqueryspinoff
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/grafana/mimir/pkg/frontend/querymiddleware/astmapper"
+	"github.com/grafana/mimir/pkg/querier/stats"
+	"github.com/grafana/mimir/pkg/util/spanlogger"
+)
+
+// Map rewrites expr to spin off its subqueries and decides whether doing so is worthwhile, recording the
+// outcome in metrics and (on success) in the query stats found in ctx.
+//
+// It returns the rewritten expression and true when the query should be executed with its subqueries spun
+// off.
+//
+// It returns (nil, false) when the caller should fall back to executing the original query through the
+// regular downstream path, which happens when mapping failed, the query had no subqueries to spin off, or
+// spinning off was not deemed worthwhile. The original expression is not modified in this case.
+func Map(ctx context.Context, expr parser.Expr, wrapper astmapper.SubquerySpinOffWrapper, metrics Metrics, defaultStepFunc func(rangeMillis int64) int64, timeout time.Duration, logger *spanlogger.SpanLogger) (parser.Expr, bool) {
+	mapperStats := astmapper.NewSubquerySpinOffMapperStats()
+	mapperCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	mapper := astmapper.NewSubquerySpinOffMapper(wrapper, defaultStepFunc, logger, mapperStats)
+
+	spinOffQuery, err := mapper.Map(mapperCtx, expr)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
+			level.Error(logger).Log("msg", "timeout while spinning off subqueries, please fill in a bug report with this query, falling back to try executing without spin-off", "err", err)
+		} else {
+			level.Error(logger).Log("msg", "failed to map the input query, falling back to try executing without spin-off", "err", err)
+		}
+		metrics.SpinOffSkipped.WithLabelValues(SkippedReasonMappingFailed).Inc()
+		return nil, false
+	}
+
+	if mapperStats.SpunOffSubqueries() == 0 {
+		// the query has no subqueries, so continue downstream
+		logger.DebugLog("msg", "input query resulted in a no operation, falling back to try executing without spinning off subqueries")
+		metrics.SpinOffSkipped.WithLabelValues(SkippedReasonNoSubqueries).Inc()
+		return nil, false
+	}
+
+	if mapperStats.DownstreamQueries() > mapperStats.SpunOffSubqueries() {
+		// the query has more downstream queries than subqueries, so continue downstream
+		// It's probably more efficient to just execute the query as is
+		logger.DebugLog("msg", "input query resulted in more downstream queries than subqueries, falling back to try executing without spinning off subqueries")
+		metrics.SpinOffSkipped.WithLabelValues(SkippedReasonDownstreamQueries).Inc()
+		return nil, false
+	}
+
+	logger.DebugLog("msg", "instant query has been rewritten to spin-off subqueries", "rewritten", spinOffQuery, "regular_downstream_queries", mapperStats.DownstreamQueries(), "subqueries_spun_off", mapperStats.SpunOffSubqueries())
+
+	// Update query stats.
+	queryStats := stats.FromContext(ctx)
+	queryStats.AddSpunOffSubqueries(uint32(mapperStats.SpunOffSubqueries()))
+
+	// Update metrics.
+	metrics.SpinOffSuccesses.Inc()
+	metrics.SpunOffSubqueries.Add(float64(mapperStats.SpunOffSubqueries()))
+	metrics.SpunOffSubqueriesPerQuery.Observe(float64(mapperStats.SpunOffSubqueries()))
+
+	return spinOffQuery, true
+}

--- a/pkg/frontend/querymiddleware/subqueryspinoff/spinoff_test.go
+++ b/pkg/frontend/querymiddleware/subqueryspinoff/spinoff_test.go
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package subqueryspinoff
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/frontend/querymiddleware/astmapper"
+	"github.com/grafana/mimir/pkg/querier/stats"
+	"github.com/grafana/mimir/pkg/util/promqlext"
+	"github.com/grafana/mimir/pkg/util/spanlogger"
+)
+
+var testDefaultStepFunc = func(int64) int64 { return (1 * time.Minute).Milliseconds() }
+
+func TestMap(t *testing.T) {
+	const mapperTimeout = 10 * time.Second
+
+	for _, tt := range []struct {
+		name string
+		in   string
+		// cancelContext cancels the context before Map runs, to exercise the mapping-failure path.
+		cancelContext bool
+
+		expectedOK         bool
+		expectedOut        string // only checked when expectedOK is true
+		expectedSpunOff    int    // number of subqueries spun off, recorded on success
+		expectedSkipReason string // skip reason recorded when expectedOK is false
+	}{
+		{
+			name:            "spin-off worthwhile",
+			in:              `avg_over_time((foo * bar)[3d:1m])`,
+			expectedOK:      true,
+			expectedOut:     `avg_over_time(__subquery_spinoff__{__query__="(foo * bar)",__range__="72h0m0s",__step__="1m0s"}[3d])`,
+			expectedSpunOff: 1,
+		},
+		{
+			name:            "both downstream queries and spun-off subqueries",
+			in:              `avg_over_time((foo * bar)[3d:1m]) * avg_over_time(foo[3d])`,
+			expectedOK:      true,
+			expectedOut:     `avg_over_time(__subquery_spinoff__{__query__="(foo * bar)",__range__="72h0m0s",__step__="1m0s"}[3d]) * __downstream_query__{__query__="avg_over_time(foo[3d])"}`,
+			expectedSpunOff: 1,
+		},
+		{
+			name:            "many spun-off subqueries",
+			in:              `avg_over_time((foo * bar)[3d:1m]) * max_over_time((foo * bar)[2d:5m])`,
+			expectedOK:      true,
+			expectedOut:     `avg_over_time(__subquery_spinoff__{__query__="(foo * bar)",__range__="72h0m0s",__step__="1m0s"}[3d]) * max_over_time(__subquery_spinoff__{__query__="(foo * bar)",__range__="48h0m0s",__step__="5m0s"}[2d])`,
+			expectedSpunOff: 2,
+		},
+		// The following cases mirror the queries exercised by TestSubquerySpinOff_Correctness in the
+		// querymiddleware package, to make sure they are mapped as expected.
+		{
+			name:            "spin-off subquery with offset",
+			in:              `max_over_time(rate(metric_counter[1m])[2h:1m] offset 1h)`,
+			expectedOK:      true,
+			expectedOut:     `max_over_time(__subquery_spinoff__{__offset__="1h0m0s",__query__="rate(metric_counter[1m])",__range__="2h0m0s",__step__="1m0s"}[2h] offset 1h)`,
+			expectedSpunOff: 1,
+		},
+		{
+			name:            "spin-off subquery with inner aggregation",
+			in:              `min_over_time(sum by(group_1) (rate(metric_counter[5m]))[2h:])`,
+			expectedOK:      true,
+			expectedOut:     `min_over_time(__subquery_spinoff__{__query__="sum by (group_1) (rate(metric_counter[5m]))",__range__="2h0m0s",__step__="1m0s"}[2h])`,
+			expectedSpunOff: 1,
+		},
+		{
+			name:            "spin-off nested subqueries (double)",
+			in:              `max_over_time(deriv(rate(metric_counter[10m])[5m:1m])[2h:])`,
+			expectedOK:      true,
+			expectedOut:     `max_over_time(__subquery_spinoff__{__query__="deriv(rate(metric_counter[10m])[5m:1m])",__range__="2h0m0s",__step__="1m0s"}[2h])`,
+			expectedSpunOff: 1,
+		},
+		{
+			name:            "spin-off nested subqueries (triple)",
+			in:              `max_over_time(stddev_over_time(deriv(rate(metric_counter[10m])[5m:1m])[2m:])[2h:])`,
+			expectedOK:      true,
+			expectedOut:     `max_over_time(__subquery_spinoff__{__query__="stddev_over_time(deriv(rate(metric_counter[10m])[5m:1m])[2m:])",__range__="2h0m0s",__step__="1m0s"}[2h])`,
+			expectedSpunOff: 1,
+		},
+		{
+			name:            "spin-off subquery alongside a downstream join",
+			in:              `max_over_time(rate(metric_counter[1m])[2h:1m]) * on (group_1) group_left() max by (group_1)(rate(metric_counter[1m]))`,
+			expectedOK:      true,
+			expectedOut:     `max_over_time(__subquery_spinoff__{__query__="rate(metric_counter[1m])",__range__="2h0m0s",__step__="1m0s"}[2h]) * on (group_1) group_left () __downstream_query__{__query__="max by (group_1) (rate(metric_counter[1m]))"}`,
+			expectedSpunOff: 1,
+		},
+		{
+			name:            "spin-off subquery with offset shorter than step alongside a downstream query",
+			in:              `sum by (group_1) (sum_over_time(avg by (group_1) (metric_counter{group_2="1"})[1h:5m] offset 1m) * avg by (group_1) (avg_over_time(metric_counter{group_2="2"}[1h:5m] offset 1m)) * 0.083333)`,
+			expectedOK:      true,
+			expectedOut:     `sum by (group_1) (sum_over_time(__subquery_spinoff__{__offset__="1m0s",__query__="avg by (group_1) (metric_counter{group_2=\"1\"})",__range__="1h0m0s",__step__="5m0s"}[1h] offset 1m) * __downstream_query__{__query__="avg by (group_1) (avg_over_time(metric_counter{group_2=\"2\"}[1h:5m] offset 1m))"} * 0.083333)`,
+			expectedSpunOff: 1,
+		},
+		{
+			name:               "no subqueries to spin off",
+			in:                 `avg_over_time(foo[3d:1m])`,
+			expectedOK:         false,
+			expectedSkipReason: SkippedReasonNoSubqueries,
+		},
+		{
+			name:               "no subquery present at all",
+			in:                 `sum(count(count(metric_counter) by (group_1, group_2)) by (group_1))`,
+			expectedOK:         false,
+			expectedSkipReason: SkippedReasonNoSubqueries,
+		},
+		{
+			name:               "subquery range too short to spin off",
+			in:                 `max_over_time(rate(metric_counter[1m])[30m:1m])`,
+			expectedOK:         false,
+			expectedSkipReason: SkippedReasonNoSubqueries,
+		},
+		{
+			name:               "subquery has too few steps to spin off",
+			in:                 `max_over_time(rate(metric_counter[1m])[2h:15m])`,
+			expectedOK:         false,
+			expectedSkipReason: SkippedReasonNoSubqueries,
+		},
+		{
+			name:               "more downstream queries than spun-off subqueries",
+			in:                 `avg_over_time((foo * bar)[3d:1m]) * avg_over_time(foo[3d]) * avg_over_time(baz[3d])`,
+			expectedOK:         false,
+			expectedSkipReason: SkippedReasonDownstreamQueries,
+		},
+		{
+			name:               "mapping cancelled",
+			in:                 `avg_over_time((foo * bar)[3d:1m])`,
+			cancelContext:      true,
+			expectedOK:         false,
+			expectedSkipReason: SkippedReasonMappingFailed,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := prometheus.NewPedanticRegistry()
+			metrics := NewMetrics(reg)
+			wrapper := astmapper.NewSelectorSubquerySpinOffWrapper()
+
+			queryStats, ctx := stats.ContextWithEmptyStats(context.Background())
+			if tt.cancelContext {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithCancel(ctx)
+				cancel()
+			}
+
+			logger := spanlogger.FromContext(ctx, log.NewNopLogger())
+			expr, err := promqlext.NewPromQLParser().ParseExpr(tt.in)
+			require.NoError(t, err)
+
+			// Capture the original expression so we can assert it is not modified when Map returns false.
+			originalExpr := expr.String()
+
+			out, ok := Map(ctx, expr, wrapper, metrics, testDefaultStepFunc, mapperTimeout, logger)
+
+			require.Equal(t, tt.expectedOK, ok)
+
+			if tt.expectedOK {
+				require.NotNil(t, out)
+				expectedOut, err := promqlext.NewPromQLParser().ParseExpr(tt.expectedOut)
+				require.NoError(t, err)
+				require.Equal(t, expectedOut.String(), out.String())
+
+				require.Equal(t, uint32(tt.expectedSpunOff), queryStats.LoadSpunOffSubqueries())
+				require.Equal(t, float64(1), testutil.ToFloat64(metrics.SpinOffSuccesses))
+				require.Equal(t, float64(tt.expectedSpunOff), testutil.ToFloat64(metrics.SpunOffSubqueries))
+				require.Equal(t, uint64(1), histogramSampleCount(t, metrics.SpunOffSubqueriesPerQuery))
+				assertSkippedCounts(t, metrics, nil)
+			} else {
+				require.Nil(t, out)
+				require.Equal(t, originalExpr, expr.String(), "the original expression must not be modified when Map returns false")
+				require.Equal(t, uint32(0), queryStats.LoadSpunOffSubqueries())
+				require.Equal(t, float64(0), testutil.ToFloat64(metrics.SpinOffSuccesses))
+				require.Equal(t, float64(0), testutil.ToFloat64(metrics.SpunOffSubqueries))
+				require.Equal(t, uint64(0), histogramSampleCount(t, metrics.SpunOffSubqueriesPerQuery))
+				assertSkippedCounts(t, metrics, map[string]float64{tt.expectedSkipReason: 1})
+			}
+		})
+	}
+}
+
+// assertSkippedCounts asserts the value of every reason of the spin-off-skipped metric, defaulting to 0 for
+// any reason not present in expected.
+func assertSkippedCounts(t *testing.T, metrics Metrics, expected map[string]float64) {
+	t.Helper()
+	for _, reason := range []string{
+		SkippedReasonParsingFailed,
+		SkippedReasonMappingFailed,
+		SkippedReasonNoSubqueries,
+		SkippedReasonDownstreamQueries,
+	} {
+		require.Equalf(t, expected[reason], testutil.ToFloat64(metrics.SpinOffSkipped.WithLabelValues(reason)), "skipped reason %q", reason)
+	}
+}
+
+func histogramSampleCount(t *testing.T, h prometheus.Histogram) uint64 {
+	t.Helper()
+	m := &dto.Metric{}
+	require.NoError(t, h.Write(m))
+	return m.GetHistogram().GetSampleCount()
+}

--- a/pkg/streamingpromql/optimize/ast/sharding/optimization_pass_test.go
+++ b/pkg/streamingpromql/optimize/ast/sharding/optimization_pass_test.go
@@ -123,7 +123,7 @@ func (m *mockLimits) CompactorSplitAndMergeShards(userID string) int {
 func rewriteForSubquerySpinoff(ctx context.Context, expr string) (parser.Expr, error) {
 	stats := astmapper.NewSubquerySpinOffMapperStats()
 	defaultStepFunc := func(rangeMillis int64) int64 { return 1000 }
-	mapper := astmapper.NewSubquerySpinOffMapper(defaultStepFunc, log.NewNopLogger(), stats)
+	mapper := astmapper.NewSubquerySpinOffMapper(astmapper.NewSelectorSubquerySpinOffWrapper(), defaultStepFunc, log.NewNopLogger(), stats)
 	ast, err := promqlext.NewPromQLParser().ParseExpr(expr)
 	if err != nil {
 		return nil, err

--- a/pkg/streamingpromql/optimize/plan/remoteexec/optimization_pass_test.go
+++ b/pkg/streamingpromql/optimize/plan/remoteexec/optimization_pass_test.go
@@ -586,7 +586,7 @@ func rewriteForQuerySharding(ctx context.Context, expr string) (string, error) {
 func rewriteForSubquerySpinoff(ctx context.Context, expr string) (string, error) {
 	stats := astmapper.NewSubquerySpinOffMapperStats()
 	defaultStepFunc := func(rangeMillis int64) int64 { return 1000 }
-	mapper := astmapper.NewSubquerySpinOffMapper(defaultStepFunc, log.NewNopLogger(), stats)
+	mapper := astmapper.NewSubquerySpinOffMapper(astmapper.NewSelectorSubquerySpinOffWrapper(), defaultStepFunc, log.NewNopLogger(), stats)
 	ast, err := promqlext.NewPromQLParser().ParseExpr(expr)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
#### What this PR does

This PR refactors the existing subquery spin-off logic so that the vast majority can also be used from MQE. (This will follow in a separate PR.)

This has no user-visible impact, and so I haven't added a changelog entry.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
