### PR TITLE
MQE: emit trace spans for `Prepare` and `Finalize` phases

### DIFF
--- a/pkg/streamingpromql/evaluator.go
+++ b/pkg/streamingpromql/evaluator.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/cancellation"
+	"github.com/grafana/dskit/tracing"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/util/annotations"
 
@@ -136,12 +137,8 @@ func (e *Evaluator) Evaluate(ctx context.Context, observer EvaluationObserver) (
 		defer e.closeOperators()
 	}
 
-	prepareParams := &types.PrepareParams{}
-
-	for _, req := range e.nodeRequests {
-		if err := req.operator.Prepare(ctx, prepareParams); err != nil {
-			return fmt.Errorf("failed to prepare query: %w", err)
-		}
+	if err := e.prepare(ctx); err != nil {
+		return err
 	}
 
 	for _, req := range e.nodeRequests {
@@ -195,11 +192,37 @@ func (e *Evaluator) Evaluate(ctx context.Context, observer EvaluationObserver) (
 		}
 	}
 
+	nodeInfo, err := e.finalize(ctx)
+	if err != nil {
+		return err
+	}
+
+	return observer.EvaluationCompleted(ctx, e, nodeInfo)
+}
+
+func (e *Evaluator) prepare(ctx context.Context) error {
+	span, ctx := tracing.StartSpanFromContext(ctx, "Evaluator.prepare")
+	defer span.Finish()
+
+	prepareParams := &types.PrepareParams{}
+
+	for _, req := range e.nodeRequests {
+		if err := req.operator.Prepare(ctx, prepareParams); err != nil {
+			return fmt.Errorf("failed to prepare query: %w", err)
+		}
+	}
+	return nil
+}
+
+func (e *Evaluator) finalize(ctx context.Context) (map[planning.Node]NodeCompletionInfo, error) {
+	span, ctx := tracing.StartSpanFromContext(ctx, "Evaluator.finalize")
+	defer span.Finish()
+
 	nodeInfo := make(map[planning.Node]NodeCompletionInfo, len(e.nodeRequests))
 	for _, req := range e.nodeRequests {
 		s, a, err := req.operator.Finalize(ctx)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		nodeInfo[req.Node] = NodeCompletionInfo{
@@ -208,7 +231,7 @@ func (e *Evaluator) Evaluate(ctx context.Context, observer EvaluationObserver) (
 		}
 	}
 
-	return observer.EvaluationCompleted(ctx, e, nodeInfo)
+	return nodeInfo, nil
 }
 
 func (e *Evaluator) closeOperators() {


### PR DESCRIPTION
#### What this PR does

This PR modifies the `Evaluator.Evaluate` method to emit trace spans for the `Prepare` and `Finalize` phases of the query.

While these are currently fast and generally don't have many events associated with them, this will change with the migration of splitting and caching into MQE.

Given this isn't a user-facing change, I've chosen not to add a changelog entry.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
