### PR TITLE
MQE: fix issue where queries running splitting inside MQE are logged with `split_queries=0` in query stats logs

### DIFF
--- a/pkg/streamingpromql/engine.go
+++ b/pkg/streamingpromql/engine.go
@@ -314,7 +314,7 @@ func (e *Engine) materializeAndCreateEvaluator(ctx context.Context, queryable st
 
 	materializer := planning.NewMaterializer(operatorParams, e.nodeMaterializers)
 	for idx, req := range nodeRequests {
-		op, err := materializer.ConvertNodeToOperator(req.Node, req.TimeRange)
+		op, err := materializer.ConvertNodeToOperator(ctx, req.Node, req.TimeRange)
 		if err != nil {
 			e.memoryConsumptionTrackerFactory.Deregister(operatorParams.MemoryConsumptionTracker)
 			return nil, err

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -5972,6 +5972,6 @@ func TestStepInvariantMetrics(t *testing.T) {
 
 type dummyMaterializer struct{}
 
-func (d dummyMaterializer) Materialize(n planning.Node, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters, overrideTimeParams planning.RangeParams) (planning.OperatorFactory, error) {
+func (d dummyMaterializer) Materialize(ctx context.Context, n planning.Node, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters, overrideRangeParams planning.RangeParams) (planning.OperatorFactory, error) {
 	panic("not implemented")
 }

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/node.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/node.go
@@ -3,6 +3,7 @@
 package commonsubexpressionelimination
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"strconv"
@@ -105,8 +106,8 @@ func (d *Duplicate) GetRangeParams() planning.RangeParams {
 
 var _ planning.SplitNode = &Duplicate{}
 
-func MaterializeDuplicate(d *Duplicate, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters, overrideTimeParams planning.RangeParams) (planning.OperatorFactory, error) {
-	inner, err := materializer.ConvertNodeToOperatorWithSubRange(d.Inner, timeRange, overrideTimeParams)
+func MaterializeDuplicate(ctx context.Context, d *Duplicate, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters, overrideTimeParams planning.RangeParams) (planning.OperatorFactory, error) {
+	inner, err := materializer.ConvertNodeToOperatorWithSubRange(ctx, d.Inner, timeRange, overrideTimeParams)
 	if err != nil {
 		return nil, err
 	}
@@ -208,8 +209,8 @@ func (f *DuplicateFilter) GetRangeParams() planning.RangeParams {
 
 var _ planning.SplitNode = &DuplicateFilter{}
 
-func MaterializeDuplicateFilter(f *DuplicateFilter, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters, overrideTimeParams planning.RangeParams) (planning.OperatorFactory, error) {
-	operator, err := materializer.ConvertNodeToOperatorWithSubRange(f.Inner, timeRange, overrideTimeParams)
+func MaterializeDuplicateFilter(ctx context.Context, f *DuplicateFilter, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters, overrideTimeParams planning.RangeParams) (planning.OperatorFactory, error) {
+	operator, err := materializer.ConvertNodeToOperatorWithSubRange(ctx, f.Inner, timeRange, overrideTimeParams)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/streamingpromql/optimize/plan/multiaggregation/node.go
+++ b/pkg/streamingpromql/optimize/plan/multiaggregation/node.go
@@ -3,6 +3,7 @@
 package multiaggregation
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"strconv"
@@ -172,8 +173,8 @@ func (a *MultiAggregationInstance) MinimumRequiredPlanVersion(types.QueryTimeRan
 	return planning.QueryPlanV5, nil
 }
 
-func MaterializeMultiAggregationGroup(node *MultiAggregationGroup, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
-	inner, err := materializer.ConvertNodeToInstantVectorOperator(node.Inner, timeRange)
+func MaterializeMultiAggregationGroup(ctx context.Context, node *MultiAggregationGroup, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
+	inner, err := materializer.ConvertNodeToInstantVectorOperator(ctx, node.Inner, timeRange)
 	if err != nil {
 		return nil, err
 	}
@@ -191,8 +192,8 @@ func (m *MultiAggregationInstanceFactory) Produce() (types.Operator, error) {
 	return m.group.AddInstance(), nil
 }
 
-func MaterializeMultiAggregationInstance(node *MultiAggregationInstance, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
-	operator, err := materializer.ConvertNodeToInstantVectorOperator(node.Group, timeRange)
+func MaterializeMultiAggregationInstance(ctx context.Context, node *MultiAggregationInstance, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
+	operator, err := materializer.ConvertNodeToInstantVectorOperator(ctx, node.Group, timeRange)
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +215,7 @@ func MaterializeMultiAggregationInstance(node *MultiAggregationInstance, materia
 
 	var param types.ScalarOperator
 	if node.Param != nil {
-		param, err = materializer.ConvertNodeToScalarOperator(node.Param, timeRange)
+		param, err = materializer.ConvertNodeToScalarOperator(ctx, node.Param, timeRange)
 		if err != nil {
 			return nil, fmt.Errorf("could not create parameter operator for MultiAggregationInstance %s: %w", node.Aggregation.Op.String(), err)
 		}

--- a/pkg/streamingpromql/optimize/plan/rangevectorsplitting/node.go
+++ b/pkg/streamingpromql/optimize/plan/rangevectorsplitting/node.go
@@ -3,6 +3,7 @@
 package rangevectorsplitting
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"slices"
@@ -120,7 +121,7 @@ func NewMaterializer(enabled bool, cache *cache.CacheFactory, logger log.Logger)
 	}
 }
 
-func (m Materializer) Materialize(n planning.Node, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters, overrideRangeParams planning.RangeParams) (planning.OperatorFactory, error) {
+func (m Materializer) Materialize(ctx context.Context, n planning.Node, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters, overrideRangeParams planning.RangeParams) (planning.OperatorFactory, error) {
 	if overrideRangeParams.IsSet {
 		return nil, errors.New("overrideRangeParams not supported for rangevectorsplitting.Materialize")
 	}
@@ -131,7 +132,7 @@ func (m Materializer) Materialize(n planning.Node, materializer *planning.Materi
 
 	if !m.enabled {
 		level.Warn(m.logger).Log("msg", "split function node is present but range vector splitting is disabled, falling back to unsplit execution; this can happen if splitting is enabled on the query-frontend but not yet on the querier")
-		return materializer.FactoryForNode(s.Inner, timeRange)
+		return materializer.FactoryForNode(ctx, s.Inner, timeRange)
 	}
 
 	splitFactory, exists := SplitFunctionRegistry[s.Inner.Function]

--- a/pkg/streamingpromql/optimize/plan/rangevectorsplitting/operator.go
+++ b/pkg/streamingpromql/optimize/plan/rangevectorsplitting/operator.go
@@ -185,7 +185,7 @@ func (m *FunctionOverRangeVectorSplit[T]) createSplits(ctx context.Context) erro
 			return nil
 		}
 
-		split, err := NewUncachedSplit(currentUncachedRanges, currentRangeLength, m)
+		split, err := NewUncachedSplit(ctx, currentUncachedRanges, currentRangeLength, m)
 		if err != nil {
 			return err
 		}
@@ -235,7 +235,7 @@ func (m *FunctionOverRangeVectorSplit[T]) createSplits(ctx context.Context) erro
 	return flushCurrentUncachedRanges()
 }
 
-func (m *FunctionOverRangeVectorSplit[T]) materializeOperatorForTimeRange(start int64, end int64, step int64) (types.RangeVectorOperator, error) {
+func (m *FunctionOverRangeVectorSplit[T]) materializeOperatorForTimeRange(ctx context.Context, start int64, end int64, step int64) (types.RangeVectorOperator, error) {
 	subRange := time.Duration(step) * time.Millisecond
 
 	overrideTimeParams := planning.RangeParams{
@@ -257,7 +257,7 @@ func (m *FunctionOverRangeVectorSplit[T]) materializeOperatorForTimeRange(start 
 		splitTimeRange = types.NewRangeQueryTimeRange(promts.Time(start).Add(subRange), promts.Time(end), subRange)
 	}
 
-	op, err := m.materializer.ConvertNodeToOperatorWithSubRange(m.innerNode, splitTimeRange, overrideTimeParams)
+	op, err := m.materializer.ConvertNodeToOperatorWithSubRange(ctx, m.innerNode, splitTimeRange, overrideTimeParams)
 	if err != nil {
 		return nil, err
 	}
@@ -733,11 +733,12 @@ func (p *UncachedSplit[T]) RangeCount() int {
 }
 
 func NewUncachedSplit[T any](
+	ctx context.Context,
 	ranges []Range,
 	rangeLength int64,
 	parent *FunctionOverRangeVectorSplit[T],
 ) (*UncachedSplit[T], error) {
-	operator, err := parent.materializeOperatorForTimeRange(ranges[0].Start, ranges[len(ranges)-1].End, rangeLength)
+	operator, err := parent.materializeOperatorForTimeRange(ctx, ranges[0].Start, ranges[len(ranges)-1].End, rangeLength)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/streamingpromql/optimize/plan/remoteexec/node.go
+++ b/pkg/streamingpromql/optimize/plan/remoteexec/node.go
@@ -3,6 +3,7 @@
 package remoteexec
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -188,7 +189,7 @@ func NewRemoteExecutionGroupMaterializer(groupEvaluatorFactory GroupEvaluatorFac
 	return &RemoteExecutionGroupMaterializer{groupEvaluatorFactory: groupEvaluatorFactory}
 }
 
-func (m *RemoteExecutionGroupMaterializer) Materialize(n planning.Node, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters, _ planning.RangeParams) (planning.OperatorFactory, error) {
+func (m *RemoteExecutionGroupMaterializer) Materialize(ctx context.Context, n planning.Node, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters, overrideRangeParams planning.RangeParams) (planning.OperatorFactory, error) {
 	g, ok := n.(*RemoteExecutionGroup)
 	if !ok {
 		return nil, fmt.Errorf("expected node of type RemoteExecutionGroup, got %T", n)
@@ -259,7 +260,7 @@ func NewRemoteExecutionConsumerMaterializer() planning.NodeMaterializer {
 	return &RemoteExecutionConsumerMaterializer{}
 }
 
-func (m *RemoteExecutionConsumerMaterializer) Materialize(n planning.Node, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters, overrideRangeParams planning.RangeParams) (planning.OperatorFactory, error) {
+func (m *RemoteExecutionConsumerMaterializer) Materialize(ctx context.Context, n planning.Node, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters, overrideRangeParams planning.RangeParams) (planning.OperatorFactory, error) {
 	if overrideRangeParams.IsSet {
 		return nil, fmt.Errorf("overrideRangeParams is not supported for RemoteExecutionConsumerMaterializer")
 	}
@@ -269,7 +270,7 @@ func (m *RemoteExecutionConsumerMaterializer) Materialize(n planning.Node, mater
 		return nil, fmt.Errorf("expected node of type RemoteExecutionConsumer, got %T", n)
 	}
 
-	f, err := materializer.FactoryForNode(c.Group, timeRange)
+	f, err := materializer.FactoryForNode(ctx, c.Group, timeRange)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/streamingpromql/optimize/plan/splitandcache/node.go
+++ b/pkg/streamingpromql/optimize/plan/splitandcache/node.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/promql/parser/posrange"
 
+	"github.com/grafana/mimir/pkg/querier/stats"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning"
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
 )
@@ -95,6 +96,9 @@ func MaterializeSplit(ctx context.Context, node *TimeRangeSplit, materializer *p
 		ranges = append(ranges, newSplitRange(inner, params.MemoryConsumptionTracker))
 		start = end + timeRange.IntervalMilliseconds
 	}
+
+	queryStats := stats.FromContext(ctx)
+	queryStats.AddSplitQueries(uint32(len(ranges)))
 
 	if len(ranges) == 1 {
 		// If we have just one range, return the inner operator without wrapping it.

--- a/pkg/streamingpromql/optimize/plan/splitandcache/node.go
+++ b/pkg/streamingpromql/optimize/plan/splitandcache/node.go
@@ -3,6 +3,7 @@
 package splitandcache
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -73,7 +74,7 @@ func (s *TimeRangeSplit) MinimumRequiredPlanVersion(timeRange types.QueryTimeRan
 }
 
 // The logic below is based on the equivalent middleware logic in splitQueryByInterval.
-func MaterializeSplit(node *TimeRangeSplit, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
+func MaterializeSplit(ctx context.Context, node *TimeRangeSplit, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
 	ranges := make([]*splitRange, 0, (timeRange.EndT-timeRange.StartT)/timeRange.IntervalMilliseconds+1) // Over-allocate in case the time range straddles an interval boundary.
 
 	for start := timeRange.StartT; start <= timeRange.EndT; {
@@ -86,7 +87,7 @@ func MaterializeSplit(node *TimeRangeSplit, materializer *planning.Materializer,
 		}
 
 		innerTimeRange := types.NewRangeQueryTimeRange(timestamp.Time(start), timestamp.Time(end), time.Duration(timeRange.IntervalMilliseconds)*time.Millisecond)
-		inner, err := materializer.ConvertNodeToInstantVectorOperator(node.Inner, innerTimeRange)
+		inner, err := materializer.ConvertNodeToInstantVectorOperator(ctx, node.Inner, innerTimeRange)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/streamingpromql/optimize/plan/splitandcache/node_test.go
+++ b/pkg/streamingpromql/optimize/plan/splitandcache/node_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/mimir/pkg/querier/stats"
 	"github.com/grafana/mimir/pkg/streamingpromql/operators/selectors"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning/core"
@@ -205,12 +206,14 @@ func TestMaterializeSplit(t *testing.T) {
 				planning.NODE_TYPE_TIME_RANGE_SPLIT: planning.NodeMaterializerFunc[*TimeRangeSplit](MaterializeSplit),
 			})
 
-			ctx := context.Background()
+			queryStats, ctx := stats.ContextWithEmptyStats(context.Background())
 			resultFactory, err := MaterializeSplit(ctx, splitNode, materializer, testCase.timeRange, params)
 			require.NoError(t, err)
 
 			result, err := resultFactory.Produce()
 			require.NoError(t, err)
+
+			require.Equal(t, len(testCase.expectedTimeRanges), int(queryStats.LoadSplitQueries()))
 
 			if len(testCase.expectedTimeRanges) == 1 {
 				require.IsType(t, &selectors.InstantVectorSelector{}, result, "should return inner operator directly if only one range")

--- a/pkg/streamingpromql/optimize/plan/splitandcache/node_test.go
+++ b/pkg/streamingpromql/optimize/plan/splitandcache/node_test.go
@@ -3,6 +3,7 @@
 package splitandcache
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -204,7 +205,8 @@ func TestMaterializeSplit(t *testing.T) {
 				planning.NODE_TYPE_TIME_RANGE_SPLIT: planning.NodeMaterializerFunc[*TimeRangeSplit](MaterializeSplit),
 			})
 
-			resultFactory, err := MaterializeSplit(splitNode, materializer, testCase.timeRange, params)
+			ctx := context.Background()
+			resultFactory, err := MaterializeSplit(ctx, splitNode, materializer, testCase.timeRange, params)
 			require.NoError(t, err)
 
 			result, err := resultFactory.Produce()

--- a/pkg/streamingpromql/optimize/plan/splitandcache/split_operator.go
+++ b/pkg/streamingpromql/optimize/plan/splitandcache/split_operator.go
@@ -10,7 +10,6 @@ import (
 	"github.com/prometheus/prometheus/promql/parser/posrange"
 	"github.com/prometheus/prometheus/util/annotations"
 
-	"github.com/grafana/mimir/pkg/querier/stats"
 	"github.com/grafana/mimir/pkg/streamingpromql/operators"
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
 	"github.com/grafana/mimir/pkg/util/limiter"
@@ -66,9 +65,6 @@ func newSplitRange(operator types.InstantVectorOperator, memoryConsumptionTracke
 }
 
 func (s *TimeRangeSplitOperator) Prepare(ctx context.Context, params *types.PrepareParams) error {
-	queryStats := stats.FromContext(ctx)
-	queryStats.AddSplitQueries(uint32(len(s.ranges)))
-
 	for _, r := range s.ranges {
 		if err := r.operator.Prepare(ctx, params); err != nil {
 			return err

--- a/pkg/streamingpromql/optimize/plan/splitandcache/split_operator_test.go
+++ b/pkg/streamingpromql/optimize/plan/splitandcache/split_operator_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/prometheus/prometheus/util/annotations"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/mimir/pkg/querier/stats"
 	"github.com/grafana/mimir/pkg/streamingpromql/operators"
 	"github.com/grafana/mimir/pkg/streamingpromql/testutils"
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
@@ -601,7 +600,7 @@ func TestSplitOperator(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			queryStats, ctx := stats.ContextWithEmptyStats(context.Background())
+			ctx := context.Background()
 			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
 
 			innerOperators := make([]*operators.TestOperator, len(testCase.ranges))
@@ -626,7 +625,6 @@ func TestSplitOperator(t *testing.T) {
 			o := newTimeRangeSplitOperator(ranges, memoryConsumptionTracker, testCase.expectedStats.TimeRange.Decode())
 
 			require.NoError(t, o.Prepare(ctx, &types.PrepareParams{}))
-			require.Equal(t, len(testCase.ranges), int(queryStats.LoadSplitQueries()))
 			for i, o := range innerOperators {
 				require.Truef(t, o.Prepared, "expected inner operator %d to be prepared", i)
 			}

--- a/pkg/streamingpromql/planning/core/aggregate_expression.go
+++ b/pkg/streamingpromql/planning/core/aggregate_expression.go
@@ -3,6 +3,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"strings"
@@ -92,8 +93,8 @@ func (a *AggregateExpressionDetails) MergeHints(other *AggregateExpressionDetail
 	return nil
 }
 
-func MaterializeAggregateExpression(a *AggregateExpression, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
-	inner, err := materializer.ConvertNodeToInstantVectorOperator(a.Inner, timeRange)
+func MaterializeAggregateExpression(ctx context.Context, a *AggregateExpression, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
+	inner, err := materializer.ConvertNodeToInstantVectorOperator(ctx, a.Inner, timeRange)
 	if err != nil {
 		return nil, fmt.Errorf("could not create inner operator for AggregateExpression: %w", err)
 	}
@@ -102,7 +103,7 @@ func MaterializeAggregateExpression(a *AggregateExpression, materializer *planni
 
 	switch a.Op {
 	case AGGREGATION_TOPK, AGGREGATION_BOTTOMK:
-		param, err := materializer.ConvertNodeToScalarOperator(a.Param, timeRange)
+		param, err := materializer.ConvertNodeToScalarOperator(ctx, a.Param, timeRange)
 		if err != nil {
 			return nil, fmt.Errorf("could not create parameter operator for AggregateExpression %s: %w", a.Op.String(), err)
 		}
@@ -110,7 +111,7 @@ func MaterializeAggregateExpression(a *AggregateExpression, materializer *planni
 		o = topkbottomk.New(inner, param, timeRange, a.Grouping, a.Without, a.Op == AGGREGATION_TOPK, params.MemoryConsumptionTracker, a.GetExpressionPosition().ToPrometheusType())
 
 	case AGGREGATION_LIMITK:
-		param, err := materializer.ConvertNodeToScalarOperator(a.Param, timeRange)
+		param, err := materializer.ConvertNodeToScalarOperator(ctx, a.Param, timeRange)
 		if err != nil {
 			return nil, fmt.Errorf("could not create parameter operator for AggregateExpression %s: %w", a.Op.String(), err)
 		}
@@ -118,7 +119,7 @@ func MaterializeAggregateExpression(a *AggregateExpression, materializer *planni
 		o = limitklimitratio.NewLimitK(inner, param, timeRange, a.Grouping, a.Without, params.MemoryConsumptionTracker, a.GetExpressionPosition().ToPrometheusType())
 
 	case AGGREGATION_LIMIT_RATIO:
-		param, err := materializer.ConvertNodeToScalarOperator(a.Param, timeRange)
+		param, err := materializer.ConvertNodeToScalarOperator(ctx, a.Param, timeRange)
 		if err != nil {
 			return nil, fmt.Errorf("could not create parameter operator for AggregateExpression %s: %w", a.Op.String(), err)
 		}
@@ -126,7 +127,7 @@ func MaterializeAggregateExpression(a *AggregateExpression, materializer *planni
 		o = limitklimitratio.NewLimitRatio(inner, param, timeRange, a.Grouping, a.Without, params.MemoryConsumptionTracker, a.GetExpressionPosition().ToPrometheusType())
 
 	case AGGREGATION_QUANTILE:
-		param, err := materializer.ConvertNodeToScalarOperator(a.Param, timeRange)
+		param, err := materializer.ConvertNodeToScalarOperator(ctx, a.Param, timeRange)
 		if err != nil {
 			return nil, fmt.Errorf("could not create parameter operator for AggregateExpression %s: %w", a.Op.String(), err)
 		}
@@ -137,7 +138,7 @@ func MaterializeAggregateExpression(a *AggregateExpression, materializer *planni
 		}
 
 	case AGGREGATION_COUNT_VALUES:
-		param, err := materializer.ConvertNodeToStringOperator(a.Param, timeRange)
+		param, err := materializer.ConvertNodeToStringOperator(ctx, a.Param, timeRange)
 		if err != nil {
 			return nil, fmt.Errorf("could not create parameter operator for AggregateExpression %s: %w", a.Op.String(), err)
 		}

--- a/pkg/streamingpromql/planning/core/binary_expression.go
+++ b/pkg/streamingpromql/planning/core/binary_expression.go
@@ -3,6 +3,7 @@
 package core
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"slices"
@@ -172,18 +173,18 @@ func (b *BinaryExpression) MergeHints(other planning.Node) error {
 	return errCannotMergeBinaryExpressionHints
 }
 
-func MaterializeBinaryExpression(b *BinaryExpression, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
+func MaterializeBinaryExpression(ctx context.Context, b *BinaryExpression, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
 	op, ok := b.Op.ToItemType()
 	if !ok {
 		return nil, compat.NewNotSupportedError(fmt.Sprintf("'%v' binary expression", b.Op.String()))
 	}
 
-	lhsVector, lhsScalar, err := b.getChildOperator(b.LHS, timeRange, materializer, "left")
+	lhsVector, lhsScalar, err := b.getChildOperator(ctx, b.LHS, timeRange, materializer, "left")
 	if err != nil {
 		return nil, err
 	}
 
-	rhsVector, rhsScalar, err := b.getChildOperator(b.RHS, timeRange, materializer, "right")
+	rhsVector, rhsScalar, err := b.getChildOperator(ctx, b.RHS, timeRange, materializer, "right")
 	if err != nil {
 		return nil, err
 	}
@@ -227,8 +228,8 @@ func MaterializeBinaryExpression(b *BinaryExpression, materializer *planning.Mat
 	return planning.NewSingleUseOperatorFactory(o), nil
 }
 
-func (b *BinaryExpression) getChildOperator(node planning.Node, timeRange types.QueryTimeRange, materializer *planning.Materializer, side string) (types.InstantVectorOperator, types.ScalarOperator, error) {
-	o, err := materializer.ConvertNodeToOperator(node, timeRange)
+func (b *BinaryExpression) getChildOperator(ctx context.Context, node planning.Node, timeRange types.QueryTimeRange, materializer *planning.Materializer, side string) (types.InstantVectorOperator, types.ScalarOperator, error) {
+	o, err := materializer.ConvertNodeToOperator(ctx, node, timeRange)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/streamingpromql/planning/core/deduplicate_and_merge.go
+++ b/pkg/streamingpromql/planning/core/deduplicate_and_merge.go
@@ -3,6 +3,7 @@
 package core
 
 import (
+	"context"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -63,8 +64,8 @@ func (d *DeduplicateAndMerge) MinimumRequiredPlanVersion(types.QueryTimeRange) (
 	return planning.QueryPlanVersionZero, nil
 }
 
-func MaterializeDeduplicateAndMerge(d *DeduplicateAndMerge, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
-	inner, err := materializer.ConvertNodeToInstantVectorOperator(d.Inner, timeRange)
+func MaterializeDeduplicateAndMerge(ctx context.Context, d *DeduplicateAndMerge, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
+	inner, err := materializer.ConvertNodeToInstantVectorOperator(ctx, d.Inner, timeRange)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/streamingpromql/planning/core/drop_name.go
+++ b/pkg/streamingpromql/planning/core/drop_name.go
@@ -3,6 +3,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -64,8 +65,8 @@ func (n *DropName) MinimumRequiredPlanVersion(types.QueryTimeRange) (planning.Qu
 	return planning.QueryPlanV1, nil
 }
 
-func MaterializeDropName(n *DropName, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
-	inner, err := materializer.ConvertNodeToOperator(n.Inner, timeRange)
+func MaterializeDropName(ctx context.Context, n *DropName, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
+	inner, err := materializer.ConvertNodeToOperator(ctx, n.Inner, timeRange)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/streamingpromql/planning/core/function_call.go
+++ b/pkg/streamingpromql/planning/core/function_call.go
@@ -3,6 +3,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"time"
@@ -60,7 +61,7 @@ func (f *FunctionCall) MergeHints(_ planning.Node) error {
 	return nil
 }
 
-func MaterializeFunctionCall(f *FunctionCall, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
+func MaterializeFunctionCall(ctx context.Context, f *FunctionCall, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
 	fnc, ok := functions.RegisteredFunctions[f.Function]
 	if !ok {
 		return nil, compat.NewNotSupportedError(fmt.Sprintf("'%v' function", f.Function.PromQLName()))
@@ -68,7 +69,7 @@ func MaterializeFunctionCall(f *FunctionCall, materializer *planning.Materialize
 
 	children := make([]types.Operator, 0, len(f.Args))
 	for _, arg := range f.Args {
-		o, err := materializer.ConvertNodeToOperator(arg, timeRange)
+		o, err := materializer.ConvertNodeToOperator(ctx, arg, timeRange)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/streamingpromql/planning/core/info.go
+++ b/pkg/streamingpromql/planning/core/info.go
@@ -3,6 +3,7 @@
 package core
 
 import (
+	"context"
 	"slices"
 	"time"
 
@@ -67,7 +68,7 @@ func (t *DataLabelSelector) MinimumRequiredPlanVersion(types.QueryTimeRange) (pl
 	return planning.QueryPlanV12, nil
 }
 
-func MaterializeDataLabelSelector(t *DataLabelSelector, _ *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
+func MaterializeDataLabelSelector(_ context.Context, t *DataLabelSelector, _ *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
 	selector := &selectors.Selector{
 		Queryable:                params.Queryable,
 		TimeRange:                timeRange,

--- a/pkg/streamingpromql/planning/core/matrix_selector.go
+++ b/pkg/streamingpromql/planning/core/matrix_selector.go
@@ -3,6 +3,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"time"
@@ -81,7 +82,7 @@ func (m *MatrixSelector) MergeHints(other planning.Node) error {
 	return nil
 }
 
-func MaterializeMatrixSelector(m *MatrixSelector, _ *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters, overrideTimeParams planning.RangeParams) (planning.OperatorFactory, error) {
+func MaterializeMatrixSelector(_ context.Context, m *MatrixSelector, _ *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters, overrideTimeParams planning.RangeParams) (planning.OperatorFactory, error) {
 	selectorRange := m.Range
 	selectorTs := m.Timestamp
 	selectorOffset := m.Offset.Milliseconds()

--- a/pkg/streamingpromql/planning/core/no_op.go
+++ b/pkg/streamingpromql/planning/core/no_op.go
@@ -3,6 +3,7 @@
 package core
 
 import (
+	"context"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -71,7 +72,7 @@ func (n *NoOp) MinimumRequiredPlanVersion(types.QueryTimeRange) (planning.QueryP
 	return planning.QueryPlanV10, nil
 }
 
-func MaterializeNoOp(n *NoOp, _ *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
+func MaterializeNoOp(_ context.Context, n *NoOp, _ *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
 	var o types.Operator
 
 	if n.MatrixSelector {

--- a/pkg/streamingpromql/planning/core/number_literal.go
+++ b/pkg/streamingpromql/planning/core/number_literal.go
@@ -3,6 +3,7 @@
 package core
 
 import (
+	"context"
 	"strconv"
 	"time"
 
@@ -47,7 +48,7 @@ func (n *NumberLiteral) MergeHints(_ planning.Node) error {
 	return nil
 }
 
-func MaterializeNumberLiteral(n *NumberLiteral, _ *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
+func MaterializeNumberLiteral(_ context.Context, n *NumberLiteral, _ *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
 	o := scalars.NewScalarConstant(n.Value, timeRange, params.MemoryConsumptionTracker, n.GetExpressionPosition().ToPrometheusType())
 
 	return planning.NewSingleUseOperatorFactory(o), nil

--- a/pkg/streamingpromql/planning/core/step_invariant_expression.go
+++ b/pkg/streamingpromql/planning/core/step_invariant_expression.go
@@ -3,6 +3,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -69,7 +70,7 @@ func (s *StepInvariantExpression) ExpressionPosition() (posrange.PositionRange, 
 	return s.Inner.ExpressionPosition()
 }
 
-func MaterializeStepInvariantExpression(s *StepInvariantExpression, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
+func MaterializeStepInvariantExpression(ctx context.Context, s *StepInvariantExpression, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
 	resultType, err := s.Inner.ResultType()
 	if err != nil {
 		return nil, err
@@ -80,7 +81,7 @@ func MaterializeStepInvariantExpression(s *StepInvariantExpression, materializer
 		// This has since been fixed, but new queriers might still get incorrect plans from old query-frontends.
 		// If this happens, materialize the inner node as if the step-invariant node does not exist: both the range
 		// vector selector operator and subquery operator behave correctly in this case.
-		op, err := materializer.ConvertNodeToRangeVectorOperator(s.Inner, timeRange)
+		op, err := materializer.ConvertNodeToRangeVectorOperator(ctx, s.Inner, timeRange)
 		if err != nil {
 			return nil, err
 		}
@@ -90,7 +91,7 @@ func MaterializeStepInvariantExpression(s *StepInvariantExpression, materializer
 
 	adjustedTimeRange := s.ChildrenTimeRange(timeRange)
 
-	op, err := materializer.ConvertNodeToOperator(s.Inner, adjustedTimeRange)
+	op, err := materializer.ConvertNodeToOperator(ctx, s.Inner, adjustedTimeRange)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/streamingpromql/planning/core/string_literal.go
+++ b/pkg/streamingpromql/planning/core/string_literal.go
@@ -3,6 +3,7 @@
 package core
 
 import (
+	"context"
 	"strconv"
 	"time"
 
@@ -47,7 +48,7 @@ func (s *StringLiteral) MergeHints(_ planning.Node) error {
 	return nil
 }
 
-func MaterializeStringLiteral(s *StringLiteral, _ *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
+func MaterializeStringLiteral(_ context.Context, s *StringLiteral, _ *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
 	o := operators.NewStringLiteral(s.Value, timeRange, params.MemoryConsumptionTracker, s.GetExpressionPosition().ToPrometheusType())
 
 	return planning.NewSingleUseOperatorFactory(o), nil

--- a/pkg/streamingpromql/planning/core/subquery.go
+++ b/pkg/streamingpromql/planning/core/subquery.go
@@ -3,6 +3,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -120,9 +121,9 @@ func (s *Subquery) MergeHints(_ planning.Node) error {
 	return nil
 }
 
-func MaterializeSubquery(s *Subquery, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
+func MaterializeSubquery(ctx context.Context, s *Subquery, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
 	innerTimeRange := s.ChildrenTimeRange(timeRange)
-	inner, err := materializer.ConvertNodeToInstantVectorOperator(s.Inner, innerTimeRange)
+	inner, err := materializer.ConvertNodeToInstantVectorOperator(ctx, s.Inner, innerTimeRange)
 	if err != nil {
 		return nil, fmt.Errorf("could not create inner operator for Subquery: %w", err)
 	}

--- a/pkg/streamingpromql/planning/core/unary_expression.go
+++ b/pkg/streamingpromql/planning/core/unary_expression.go
@@ -3,6 +3,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -51,8 +52,8 @@ func (u *UnaryExpression) MergeHints(_ planning.Node) error {
 	return nil
 }
 
-func MaterializeUnaryExpression(u *UnaryExpression, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
-	inner, err := materializer.ConvertNodeToOperator(u.Inner, timeRange)
+func MaterializeUnaryExpression(ctx context.Context, u *UnaryExpression, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
+	inner, err := materializer.ConvertNodeToOperator(ctx, u.Inner, timeRange)
 	if err != nil {
 		return nil, fmt.Errorf("could not create inner operator for UnaryExpression: %w", err)
 	}

--- a/pkg/streamingpromql/planning/core/vector_selector.go
+++ b/pkg/streamingpromql/planning/core/vector_selector.go
@@ -3,6 +3,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"time"
@@ -82,7 +83,7 @@ func (v *VectorSelector) MergeHints(other planning.Node) error {
 	return nil
 }
 
-func MaterializeVectorSelector(v *VectorSelector, _ *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
+func MaterializeVectorSelector(_ context.Context, v *VectorSelector, _ *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters) (planning.OperatorFactory, error) {
 	subsets, err := SubsetsToSelectorType(v.Subsets)
 	if err != nil {
 		return nil, err

--- a/pkg/streamingpromql/planning/materialize.go
+++ b/pkg/streamingpromql/planning/materialize.go
@@ -3,6 +3,7 @@
 package planning
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
@@ -31,12 +32,12 @@ func NewMaterializer(params *OperatorParameters, nodeMaterializers map[NodeType]
 	}
 }
 
-func (m *Materializer) FactoryForNode(node Node, timeRange types.QueryTimeRange) (OperatorFactory, error) {
-	return m.FactoryForNodeWithSubRange(node, timeRange, RangeParams{IsSet: false})
+func (m *Materializer) FactoryForNode(ctx context.Context, node Node, timeRange types.QueryTimeRange) (OperatorFactory, error) {
+	return m.FactoryForNodeWithSubRange(ctx, node, timeRange, RangeParams{IsSet: false})
 }
 
 // FactoryForNodeWithSubRange returns a factory for the given node with optional sub-range parameters.
-func (m *Materializer) FactoryForNodeWithSubRange(node Node, timeRange types.QueryTimeRange, overrideTimeParams RangeParams) (OperatorFactory, error) {
+func (m *Materializer) FactoryForNodeWithSubRange(ctx context.Context, node Node, timeRange types.QueryTimeRange, overrideTimeParams RangeParams) (OperatorFactory, error) {
 	key := OperatorFactoryKey{
 		node:               node,
 		timeRange:          timeRange,
@@ -51,7 +52,7 @@ func (m *Materializer) FactoryForNodeWithSubRange(node Node, timeRange types.Que
 		return nil, fmt.Errorf("no registered node materializer for node of type %s", node.NodeType())
 	}
 
-	f, err := nm.Materialize(node, m, timeRange, m.operatorParams, overrideTimeParams)
+	f, err := nm.Materialize(ctx, node, m, timeRange, m.operatorParams, overrideTimeParams)
 	if err != nil {
 		return nil, err
 	}
@@ -61,12 +62,12 @@ func (m *Materializer) FactoryForNodeWithSubRange(node Node, timeRange types.Que
 	return f, nil
 }
 
-func (m *Materializer) ConvertNodeToOperator(node Node, timeRange types.QueryTimeRange) (types.Operator, error) {
-	return m.ConvertNodeToOperatorWithSubRange(node, timeRange, RangeParams{IsSet: false})
+func (m *Materializer) ConvertNodeToOperator(ctx context.Context, node Node, timeRange types.QueryTimeRange) (types.Operator, error) {
+	return m.ConvertNodeToOperatorWithSubRange(ctx, node, timeRange, RangeParams{IsSet: false})
 }
 
-func (m *Materializer) ConvertNodeToOperatorWithSubRange(node Node, timeRange types.QueryTimeRange, overrideTimeParams RangeParams) (types.Operator, error) {
-	f, err := m.FactoryForNodeWithSubRange(node, timeRange, overrideTimeParams)
+func (m *Materializer) ConvertNodeToOperatorWithSubRange(ctx context.Context, node Node, timeRange types.QueryTimeRange, overrideTimeParams RangeParams) (types.Operator, error) {
+	f, err := m.FactoryForNodeWithSubRange(ctx, node, timeRange, overrideTimeParams)
 	if err != nil {
 		return nil, err
 	}
@@ -74,8 +75,8 @@ func (m *Materializer) ConvertNodeToOperatorWithSubRange(node Node, timeRange ty
 	return f.Produce()
 }
 
-func (m *Materializer) ConvertNodeToInstantVectorOperator(node Node, timeRange types.QueryTimeRange) (types.InstantVectorOperator, error) {
-	o, err := m.ConvertNodeToOperator(node, timeRange)
+func (m *Materializer) ConvertNodeToInstantVectorOperator(ctx context.Context, node Node, timeRange types.QueryTimeRange) (types.InstantVectorOperator, error) {
+	o, err := m.ConvertNodeToOperator(ctx, node, timeRange)
 	if err != nil {
 		return nil, err
 	}
@@ -88,8 +89,8 @@ func (m *Materializer) ConvertNodeToInstantVectorOperator(node Node, timeRange t
 	return ivo, nil
 }
 
-func (m *Materializer) ConvertNodeToRangeVectorOperator(node Node, timeRange types.QueryTimeRange) (types.RangeVectorOperator, error) {
-	o, err := m.ConvertNodeToOperator(node, timeRange)
+func (m *Materializer) ConvertNodeToRangeVectorOperator(ctx context.Context, node Node, timeRange types.QueryTimeRange) (types.RangeVectorOperator, error) {
+	o, err := m.ConvertNodeToOperator(ctx, node, timeRange)
 	if err != nil {
 		return nil, err
 	}
@@ -102,8 +103,8 @@ func (m *Materializer) ConvertNodeToRangeVectorOperator(node Node, timeRange typ
 	return rvo, nil
 }
 
-func (m *Materializer) ConvertNodeToScalarOperator(node Node, timeRange types.QueryTimeRange) (types.ScalarOperator, error) {
-	o, err := m.ConvertNodeToOperator(node, timeRange)
+func (m *Materializer) ConvertNodeToScalarOperator(ctx context.Context, node Node, timeRange types.QueryTimeRange) (types.ScalarOperator, error) {
+	o, err := m.ConvertNodeToOperator(ctx, node, timeRange)
 	if err != nil {
 		return nil, err
 	}
@@ -116,8 +117,8 @@ func (m *Materializer) ConvertNodeToScalarOperator(node Node, timeRange types.Qu
 	return so, nil
 }
 
-func (m *Materializer) ConvertNodeToStringOperator(node Node, timeRange types.QueryTimeRange) (types.StringOperator, error) {
-	o, err := m.ConvertNodeToOperator(node, timeRange)
+func (m *Materializer) ConvertNodeToStringOperator(ctx context.Context, node Node, timeRange types.QueryTimeRange) (types.StringOperator, error) {
+	o, err := m.ConvertNodeToOperator(ctx, node, timeRange)
 	if err != nil {
 		return nil, err
 	}
@@ -135,12 +136,12 @@ type NodeMaterializer interface {
 	// Materialize returns a factory that produces operators for the given node.
 	//
 	// Implementations may retain the provided Materializer for later use.
-	Materialize(n Node, materializer *Materializer, timeRange types.QueryTimeRange, params *OperatorParameters, overrideRangeParams RangeParams) (OperatorFactory, error)
+	Materialize(ctx context.Context, n Node, materializer *Materializer, timeRange types.QueryTimeRange, params *OperatorParameters, overrideRangeParams RangeParams) (OperatorFactory, error)
 }
 
-type NodeMaterializerFunc[T Node] func(n T, materializer *Materializer, timeRange types.QueryTimeRange, params *OperatorParameters) (OperatorFactory, error)
+type NodeMaterializerFunc[T Node] func(ctx context.Context, n T, materializer *Materializer, timeRange types.QueryTimeRange, params *OperatorParameters) (OperatorFactory, error)
 
-func (f NodeMaterializerFunc[T]) Materialize(n Node, materializer *Materializer, timeRange types.QueryTimeRange, params *OperatorParameters, overrideRangeParams RangeParams) (OperatorFactory, error) {
+func (f NodeMaterializerFunc[T]) Materialize(ctx context.Context, n Node, materializer *Materializer, timeRange types.QueryTimeRange, params *OperatorParameters, overrideRangeParams RangeParams) (OperatorFactory, error) {
 	if overrideRangeParams.IsSet {
 		return nil, fmt.Errorf("overrideRangeParams is not supported for NodeMaterializerFunc")
 	}
@@ -150,16 +151,16 @@ func (f NodeMaterializerFunc[T]) Materialize(n Node, materializer *Materializer,
 		return nil, fmt.Errorf("unexpected type passed to node materializer: expected %T, got %T", new(T), n)
 	}
 
-	return f(node, materializer, timeRange, params)
+	return f(ctx, node, materializer, timeRange, params)
 }
 
-type RangeAwareNodeMaterializerFunc[T Node] func(n T, materializer *Materializer, timeRange types.QueryTimeRange, params *OperatorParameters, overrideRangeParams RangeParams) (OperatorFactory, error)
+type RangeAwareNodeMaterializerFunc[T Node] func(ctx context.Context, n T, materializer *Materializer, timeRange types.QueryTimeRange, params *OperatorParameters, overrideRangeParams RangeParams) (OperatorFactory, error)
 
-func (f RangeAwareNodeMaterializerFunc[T]) Materialize(n Node, materializer *Materializer, timeRange types.QueryTimeRange, params *OperatorParameters, overrideRangeParams RangeParams) (OperatorFactory, error) {
+func (f RangeAwareNodeMaterializerFunc[T]) Materialize(ctx context.Context, n Node, materializer *Materializer, timeRange types.QueryTimeRange, params *OperatorParameters, overrideRangeParams RangeParams) (OperatorFactory, error) {
 	node, ok := n.(T)
 	if !ok {
 		return nil, fmt.Errorf("unexpected type passed to range aware node materializer: expected %T, got %T", new(T), n)
 	}
 
-	return f(node, materializer, timeRange, params, overrideRangeParams)
+	return f(ctx, node, materializer, timeRange, params, overrideRangeParams)
 }


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue where query-frontends would log `split_queries=0` in query stats logs if splitting inside MQE is enabled and the query fit entirely within one interval.

Most of this PR is refactoring the materialization machinery to pass the context to each materializer (first commit, 41ee6f4). I'd suggest reviewing the two commits separately.

I'll add this to the changelog entry in https://github.com/grafana/mimir/pull/15787.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
