### PR TITLE
Compartments: validate per-compartment id flags in jsonnet

### DIFF
--- a/operations/mimir-tests/test-compartments-config-validation.jsonnet
+++ b/operations/mimir-tests/test-compartments-config-validation.jsonnet
@@ -1,0 +1,118 @@
+// Tests the validateMimirCompartmentsConfig() assertions.
+//
+// Strategy: build one valid compartments-enabled mimir environment, capture real per-compartment
+// distributor Deployments and ingester StatefulSets from it, then mutate the manifest (CLI flag or
+// metadata.name) and run the validator on a synthetic root. Each test asserts a non-null error
+// matching an expected substring; any mismatch fails this jsonnet build.
+
+local env = import 'test-compartments.jsonnet';
+local compartmentsCommon = import 'mimir/compartments-common.libsonnet';
+
+// Returns the flag name from an arg string like "-foo=bar" -> "-foo".
+local flagName(arg) =
+  local eq = std.findSubstr('=', arg);
+  if std.length(eq) > 0 then std.substr(arg, 0, eq[0]) else arg;
+
+// Overrides container args on every container of the resource. For each entry in "overrides", any
+// existing arg with the same flag name is removed and the override is appended. Other args are preserved.
+local overrideContainerArgs(resource, overrides) =
+  local overrideNames = [flagName(o) for o in overrides];
+  resource {
+    spec+: { template+: { spec+: {
+      containers: [
+        c { args: std.filter(function(arg) !std.member(overrideNames, flagName(arg)), c.args) + overrides }
+        for c in resource.spec.template.spec.containers
+      ],
+    } } },
+  };
+
+// Removes every arg with the given flag name from every container of the resource.
+local removeContainerArg(resource, flag) =
+  resource {
+    spec+: { template+: { spec+: {
+      containers: [
+        c { args: std.filter(function(arg) flagName(arg) != flag, c.args) }
+        for c in resource.spec.template.spec.containers
+      ],
+    } } },
+  };
+
+local isError(err, needle) = err != null && std.length(std.findSubstr(needle, err)) > 0;
+
+// Synthetic root carrying validateMimirCompartmentsConfig and the resource fields under test. Built
+// from compartments-common alone so the production assertions next to real callers don't fire on the
+// deliberately broken manifests.
+local validate(resources, resourceNames) =
+  (compartmentsCommon { _config+: env._config } + resources).validateMimirCompartmentsConfig(resourceNames);
+
+local distributor = env.distributor_zone_a_deployments.compartment_0;  // distributor-zone-a-wc-0
+local ingester = env.ingester_zone_a_statefulsets.compartment_1;  // ingester-zone-a-rc-1
+
+// 1. Write compartment whose "distributor.write-compartment-id" doesn't match its name.
+local err1 = validate(
+  { dist: overrideContainerArgs(distributor, ['-distributor.write-compartment-id=1']) },
+  ['dist'],
+);
+assert isError(err1, '-distributor.write-compartment-id=1') && isError(err1, 'must match the compartment') :
+       'case 1: expected write-compartment-id mismatch error, got: %s' % err1;
+
+// 2. Read compartment whose "ingester.read-compartment-id" doesn't match its name.
+local err2 = validate(
+  { ing: overrideContainerArgs(ingester, ['-ingester.read-compartment-id=0']) },
+  ['ing'],
+);
+assert isError(err2, '-ingester.read-compartment-id=0') && isError(err2, 'must match the compartment') :
+       'case 2: expected read-compartment-id mismatch error, got: %s' % err2;
+
+// 3. Resource set: one good entry, one bad. Validator must walk the map.
+local err3 = validate(
+  { dists: {
+    compartment_0: distributor,
+    compartment_1: overrideContainerArgs(env.distributor_zone_a_deployments.compartment_1, ['-distributor.write-compartment-id=0']),
+  } },
+  ['dists'],
+);
+assert isError(err3, '-distributor.write-compartment-id=0') && isError(err3, 'must match the compartment') :
+       'case 3: expected write-compartment-id mismatch error from resource set, got: %s' % err3;
+
+// 4. Correctly configured compartments produce no error.
+local err4 = validate(
+  { dist: distributor, ing: ingester },
+  ['dist', 'ing'],
+);
+assert err4 == null :
+       'case 4: expected no error for correctly configured compartments, got: %s' % err4;
+
+// 5. Compartment-id flag absent: the jsonnet validator tolerates it.
+local err5 = validate(
+  { dist: removeContainerArg(distributor, '-distributor.write-compartment-id') },
+  ['dist'],
+);
+assert err5 == null :
+       'case 5: expected no error when the compartment-id flag is absent, got: %s' % err5;
+
+// 6. validateAddress: write compartment pointed at another compartment's Kafka cluster.
+local err6 = validate(
+  { dist: overrideContainerArgs(distributor, ['-ingest-storage.kafka.address=kafka-wc-1.default.svc.cluster.local:9092']) },
+  ['dist'],
+);
+assert isError(err6, '-ingest-storage.kafka.address') && isError(err6, 'must target its own Kafka cluster') :
+       'case 6: expected Kafka address error, got: %s' % err6;
+
+// 7. validateTopic: read compartment whose topic keeps the unresolved placeholder.
+local err7 = validate(
+  { ing: overrideContainerArgs(ingester, ['-ingest-storage.kafka.topic=ingest-rc-<read-compartment-id>']) },
+  ['ing'],
+);
+assert isError(err7, '-ingest-storage.kafka.topic') && isError(err7, 'consumes a single topic') :
+       'case 7: expected Kafka topic error, got: %s' % err7;
+
+// 8. Resource name without a compartment marker.
+local err8 = validate(
+  { dist: distributor { metadata+: { name: 'distributor' } } },
+  ['dist'],
+);
+assert isError(err8, 'Unable to extract the compartment id') :
+       'case 8: expected compartment-id extraction error, got: %s' % err8;
+
+{}

--- a/operations/mimir-tests/test-compartments-config-validation.jsonnet
+++ b/operations/mimir-tests/test-compartments-config-validation.jsonnet
@@ -5,8 +5,8 @@
 // metadata.name) and run the validator on a synthetic root. Each test asserts a non-null error
 // matching an expected substring; any mismatch fails this jsonnet build.
 
-local env = import 'test-compartments.jsonnet';
 local compartmentsCommon = import 'mimir/compartments-common.libsonnet';
+local env = import 'test-compartments.jsonnet';
 
 // Returns the flag name from an arg string like "-foo=bar" -> "-foo".
 local flagName(arg) =

--- a/operations/mimir/compartments-common.libsonnet
+++ b/operations/mimir/compartments-common.libsonnet
@@ -60,6 +60,8 @@ local jsonpath = import 'github.com/jsonnet-libs/xtd/jsonpath.libsonnet';
     local root = $;
     local addressFlag = '-ingest-storage.kafka.address';
     local topicFlag = '-ingest-storage.kafka.topic';
+    local writeIdSuffix = '.write-compartment-id';
+    local readIdSuffix = '.read-compartment-id';
     local writePlaceholder = '<write-compartment-id>';
     local readPlaceholder = '<read-compartment-id>';
 
@@ -98,6 +100,25 @@ local jsonpath = import 'github.com/jsonnet-libs/xtd/jsonpath.libsonnet';
       else
         null;
 
+    // First "-flag=value" CLI arg whose flag name ends with suffix, as {flag, value}, or null if absent.
+    local flagBySuffix(container, suffix) =
+      if !std.objectHas(container, 'args') then
+        null
+      else
+        local matching = std.filter(
+          function(arg)
+            std.isString(arg) && std.startsWith(arg, '-') &&
+            (local eq = std.findSubstr('=', arg);
+             std.length(eq) > 0 && std.endsWith(std.substr(arg, 0, eq[0]), suffix)),
+          container.args
+        );
+        if std.length(matching) == 0 then
+          null
+        else
+          local arg = matching[0];
+          local eq = std.findSubstr('=', arg)[0];
+          { flag: std.substr(arg, 0, eq), value: std.substr(arg, eq + 1, std.length(arg) - eq - 1) };
+
     local validateAddress(name, compartment, container) =
       local value = flagValue(container, addressFlag);
       if value == null then
@@ -130,10 +151,26 @@ local jsonpath = import 'github.com/jsonnet-libs/xtd/jsonpath.libsonnet';
       else
         null;
 
+    // The compartment id a component is configured for must match the id encoded in its name.
+    local validateCompartmentId(name, compartment, container, suffix) =
+      local found = flagBySuffix(container, suffix);
+      if found == null then
+        null
+      else if found.value != std.toString(compartment.id) then
+        'The Deployment or StatefulSet "%s" sets "%s=%s", but it belongs to %s compartment %d (the id must match the compartment).' % [name, found.flag, found.value, compartment.kind, compartment.id]
+      else
+        null;
+
+    local validateWriteCompartmentId(name, compartment, container) =
+      validateCompartmentId(name, compartment, container, writeIdSuffix);
+
+    local validateReadCompartmentId(name, compartment, container) =
+      validateCompartmentId(name, compartment, container, readIdSuffix);
+
     local validateContainer(name, compartment, container) =
       std.foldl(
         function(firstError, validator) if firstError != null then firstError else validator(name, compartment, container),
-        [validateAddress, validateTopic],
+        [validateAddress, validateTopic, validateWriteCompartmentId, validateReadCompartmentId],
         null
       );
 


### PR DESCRIPTION
#### What this PR does

Extends `validateMimirCompartmentsConfig` to also check the per-compartment id a component is configured for. A per-compartment distributor or ingester wired with the wrong compartment id would silently misroute data, the same failure mode the existing Kafka address/topic checks guard against, so this fails to compile instead.

The check is generic: it matches any CLI flag whose name ends with `.write-compartment-id` or `.read-compartment-id` and, when present, requires its value to match the id encoded in the resource name (`-wc-<id>` / `-rc-<id>`).

Also adds `test-compartments-config-validation.jsonnet`, the negative test for this validator (previously only its happy path was implicitly covered), with a smoke test per existing validation.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
