### PR TITLE
Add compartments integration test for ingester querying

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/google/gopacket v1.1.19
 	github.com/gorilla/mux v1.8.1
 	github.com/grafana/dskit v0.0.0-20260623061522-5cb97901f08d
-	github.com/grafana/e2e v0.1.2-0.20260309174126-b5393d4e610f
+	github.com/grafana/e2e v0.1.2-0.20260625124721-70f74c4b3a54
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/influxdata/influxdb/v2 v2.9.1
 	github.com/json-iterator/go v1.1.12

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/google/gopacket v1.1.19
 	github.com/gorilla/mux v1.8.1
 	github.com/grafana/dskit v0.0.0-20260623061522-5cb97901f08d
-	github.com/grafana/e2e v0.1.2-0.20260625124721-70f74c4b3a54
+	github.com/grafana/e2e v0.1.2-0.20260625155804-481ec71161b5
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/influxdata/influxdb/v2 v2.9.1
 	github.com/json-iterator/go v1.1.12

--- a/go.sum
+++ b/go.sum
@@ -568,10 +568,6 @@ github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5T
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/grafana/dskit v0.0.0-20260623061522-5cb97901f08d h1:i8M92vWcZmvMEsXnBsTPHwoW6SexkDIzwKGui4QojOs=
 github.com/grafana/dskit v0.0.0-20260623061522-5cb97901f08d/go.mod h1:T0r0vLv/JwmOoSc/EOZw/5ni7r/djCoCdJ3/JnHDAjQ=
-github.com/grafana/e2e v0.1.2-0.20260309174126-b5393d4e610f h1:gxaqz5StufMU078tWFuf8CUi4PZtITBxjM2TZV7NOFw=
-github.com/grafana/e2e v0.1.2-0.20260309174126-b5393d4e610f/go.mod h1:KFvJP5m5GQ837CN7rUbWIiPdw1JZgeRJTEyp2O5U0is=
-github.com/grafana/e2e v0.1.2-0.20260625124721-70f74c4b3a54 h1:Fm4m5pDJOw69fAl3ud1hzVou2aZap4wg069TCUrBB2M=
-github.com/grafana/e2e v0.1.2-0.20260625124721-70f74c4b3a54/go.mod h1:o6aUPNFrl7H0XjIdBpXSU2Gou6vVwctVBuSvWPN7Ogg=
 github.com/grafana/e2e v0.1.2-0.20260625155804-481ec71161b5 h1:0S5T70bIDAh5ttBp/JIzFZiVvQqfuL3xkFXYlIx1Zuo=
 github.com/grafana/e2e v0.1.2-0.20260625155804-481ec71161b5/go.mod h1:o6aUPNFrl7H0XjIdBpXSU2Gou6vVwctVBuSvWPN7Ogg=
 github.com/grafana/go-yaml/v3 v3.0.0-20260130164322-e3c24e8f4c87 h1:Op5/Kd8Ae90IC7Ow+CNwGo/oq87cJX2iE+U8Dw4a8Bc=

--- a/go.sum
+++ b/go.sum
@@ -572,6 +572,8 @@ github.com/grafana/e2e v0.1.2-0.20260309174126-b5393d4e610f h1:gxaqz5StufMU078tW
 github.com/grafana/e2e v0.1.2-0.20260309174126-b5393d4e610f/go.mod h1:KFvJP5m5GQ837CN7rUbWIiPdw1JZgeRJTEyp2O5U0is=
 github.com/grafana/e2e v0.1.2-0.20260625124721-70f74c4b3a54 h1:Fm4m5pDJOw69fAl3ud1hzVou2aZap4wg069TCUrBB2M=
 github.com/grafana/e2e v0.1.2-0.20260625124721-70f74c4b3a54/go.mod h1:o6aUPNFrl7H0XjIdBpXSU2Gou6vVwctVBuSvWPN7Ogg=
+github.com/grafana/e2e v0.1.2-0.20260625155804-481ec71161b5 h1:0S5T70bIDAh5ttBp/JIzFZiVvQqfuL3xkFXYlIx1Zuo=
+github.com/grafana/e2e v0.1.2-0.20260625155804-481ec71161b5/go.mod h1:o6aUPNFrl7H0XjIdBpXSU2Gou6vVwctVBuSvWPN7Ogg=
 github.com/grafana/go-yaml/v3 v3.0.0-20260130164322-e3c24e8f4c87 h1:Op5/Kd8Ae90IC7Ow+CNwGo/oq87cJX2iE+U8Dw4a8Bc=
 github.com/grafana/go-yaml/v3 v3.0.0-20260130164322-e3c24e8f4c87/go.mod h1:FWqXKmpTKh7spGdV89XqWZN+kdZL8NZJJWyZQtuTXiI=
 github.com/grafana/goautoneg v0.0.0-20240607115440-f335c04c58ce h1:WI1olbgS+sEl77qxEYbmt9TgRUz7iLqmjh8lYPpGlKQ=

--- a/go.sum
+++ b/go.sum
@@ -570,6 +570,8 @@ github.com/grafana/dskit v0.0.0-20260623061522-5cb97901f08d h1:i8M92vWcZmvMEsXnB
 github.com/grafana/dskit v0.0.0-20260623061522-5cb97901f08d/go.mod h1:T0r0vLv/JwmOoSc/EOZw/5ni7r/djCoCdJ3/JnHDAjQ=
 github.com/grafana/e2e v0.1.2-0.20260309174126-b5393d4e610f h1:gxaqz5StufMU078tWFuf8CUi4PZtITBxjM2TZV7NOFw=
 github.com/grafana/e2e v0.1.2-0.20260309174126-b5393d4e610f/go.mod h1:KFvJP5m5GQ837CN7rUbWIiPdw1JZgeRJTEyp2O5U0is=
+github.com/grafana/e2e v0.1.2-0.20260625124721-70f74c4b3a54 h1:Fm4m5pDJOw69fAl3ud1hzVou2aZap4wg069TCUrBB2M=
+github.com/grafana/e2e v0.1.2-0.20260625124721-70f74c4b3a54/go.mod h1:o6aUPNFrl7H0XjIdBpXSU2Gou6vVwctVBuSvWPN7Ogg=
 github.com/grafana/go-yaml/v3 v3.0.0-20260130164322-e3c24e8f4c87 h1:Op5/Kd8Ae90IC7Ow+CNwGo/oq87cJX2iE+U8Dw4a8Bc=
 github.com/grafana/go-yaml/v3 v3.0.0-20260130164322-e3c24e8f4c87/go.mod h1:FWqXKmpTKh7spGdV89XqWZN+kdZL8NZJJWyZQtuTXiI=
 github.com/grafana/goautoneg v0.0.0-20240607115440-f335c04c58ce h1:WI1olbgS+sEl77qxEYbmt9TgRUz7iLqmjh8lYPpGlKQ=

--- a/integration/compartments_test.go
+++ b/integration/compartments_test.go
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package integration
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/grafana/dskit/test"
+	"github.com/grafana/e2e"
+	e2edb "github.com/grafana/e2e/db"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/integration/e2emimir"
+	"github.com/grafana/mimir/pkg/compartments"
+)
+
+// TestIngesterQuerying_ShouldSupportCompartments runs the compartments architecture end to end with
+// two read and two write compartments, and verifies queries served from ingesters work across it.
+//
+// Series shard by metric name across read compartments; each write compartment is an independent Kafka
+// cluster. For each read compartment, two series are produced through different write compartments, so
+// the compartment's single ingester returns both only if it consumed its topic from both clusters. The
+// queries run through the query-frontend with strong read consistency and no sleep, so they pass only
+// if the query-frontend propagated the per-cluster produced offsets and the ingester waited for them.
+func TestIngesterQuerying_ShouldSupportCompartments(t *testing.T) {
+	const (
+		numWriteCompartments = 2
+		numReadCompartments  = 2
+	)
+
+	s, err := e2e.NewScenario(networkName)
+	require.NoError(t, err)
+	defer s.Close()
+
+	baseFlags := mergeFlags(
+		BlocksStorageFlags(),
+		BlocksStorageS3Flags(),
+		IngestStorageFlags(e2edb.KafkaAuthNone),
+		CompartmentsFlags(numWriteCompartments, numReadCompartments),
+	)
+
+	// Start dependencies: Consul, MinIO, and one Kafka cluster per write compartment.
+	consul := e2edb.NewConsul()
+	minio := e2edb.NewMinio(9000, baseFlags["-blocks-storage.s3.bucket-name"])
+	require.NoError(t, s.StartAndWaitReady(consul, minio))
+
+	kafkas := make([]e2e.Service, numWriteCompartments)
+	for wc := range kafkas {
+		kafkas[wc] = e2edb.NewKafka(e2edb.WithKafkaName(fmt.Sprintf("kafka-wc-%d", wc)))
+	}
+	require.NoError(t, s.StartAndWaitReady(kafkas...))
+
+	// Start the query-scheduler and wire the query-frontend and querier to it.
+	queryScheduler := e2emimir.NewQueryScheduler("query-scheduler", baseFlags)
+	require.NoError(t, s.StartAndWaitReady(queryScheduler))
+	baseFlags = mergeFlags(baseFlags, map[string]string{
+		"-query-frontend.scheduler-address": queryScheduler.NetworkGRPCEndpoint(),
+		"-querier.scheduler-address":        queryScheduler.NetworkGRPCEndpoint(),
+	})
+
+	// One distributor per write compartment, each producing to its own Kafka cluster.
+	distributors := make([]*e2emimir.MimirService, numWriteCompartments)
+	for wc := range distributors {
+		distributors[wc] = e2emimir.NewDistributor(fmt.Sprintf("distributor-wc-%d", wc), consul.NetworkHTTPEndpoint(), mergeFlags(baseFlags, map[string]string{
+			"-distributor.write-compartment-id": strconv.Itoa(wc),
+		}))
+	}
+
+	// One ingester (partition 0) per read compartment. The trailing "-0" sets the partition ID to 0,
+	// and -ingester.read-compartment-id selects the compartment ring it registers into.
+	ingesters := make([]*e2emimir.MimirService, numReadCompartments)
+	for rc := range ingesters {
+		ingesters[rc] = e2emimir.NewIngester(fmt.Sprintf("ingester-rc-%d-0", rc), consul.NetworkHTTPEndpoint(), mergeFlags(baseFlags, map[string]string{
+			"-ingester.read-compartment-id": strconv.Itoa(rc),
+		}))
+	}
+
+	queryFrontend := e2emimir.NewQueryFrontend("query-frontend", consul.NetworkHTTPEndpoint(), baseFlags)
+	querier := e2emimir.NewQuerier("querier", consul.NetworkHTTPEndpoint(), baseFlags)
+
+	mimirServices := []e2e.Service{queryFrontend, querier}
+	for _, d := range distributors {
+		mimirServices = append(mimirServices, d)
+	}
+	for _, i := range ingesters {
+		mimirServices = append(mimirServices, i)
+	}
+	require.NoError(t, s.StartAndWaitReady(mimirServices...))
+
+	// The ingester instance ring is shared across compartments, so the distributor and querier should
+	// see every ingester ACTIVE in it.
+	for _, svc := range []*e2emimir.MimirService{distributors[0], querier} {
+		require.NoErrorf(t, svc.WaitSumMetricsWithOptions(e2e.Equals(numReadCompartments), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+			labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
+			labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))),
+			"service: %s", svc.Name())
+	}
+
+	// Each read compartment has its own partition ring; wait until its partition is ACTIVE, observed
+	// from the components that route to it.
+	for rc := 0; rc < numReadCompartments; rc++ {
+		ringName := fmt.Sprintf("ingester-partitions-rc-%d", rc)
+		for _, svc := range []*e2emimir.MimirService{distributors[0], querier, queryFrontend} {
+			require.NoErrorf(t, svc.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_partition_ring_partitions"}, e2e.WithLabelMatchers(
+				labels.MustNewMatcher(labels.MatchEqual, "name", ringName),
+				labels.MustNewMatcher(labels.MatchEqual, "state", "Active"))),
+				"service: %s ring: %s", svc.Name(), ringName)
+		}
+	}
+
+	// Wait until the query-frontend has fetched the last produced offsets from every write compartment's
+	// Kafka cluster at least once. This avoids querying before the topics exist in every cluster.
+	waitQueryFrontendToFetchOffsetsPerWriteCompartment(t, queryFrontend, numWriteCompartments)
+
+	// Pick, per read compartment, one distinct metric name to produce through each write compartment.
+	// All names of a compartment route to that compartment regardless of which distributor produces them.
+	router := compartments.NewRouter(numReadCompartments, "mimir-ingest-rc-<read-compartment-id>")
+	namesByCompartment := metricNamesPerCompartment(router, numReadCompartments, numWriteCompartments)
+
+	pushClients := make([]*e2emimir.Client, numWriteCompartments)
+	for wc := range pushClients {
+		client, err := e2emimir.NewClient(distributors[wc].HTTPEndpoint(), "", "", "", userID)
+		require.NoError(t, err)
+		pushClients[wc] = client
+	}
+
+	now := time.Now()
+	expectedVectors := map[string]model.Vector{}
+
+	for rc := 0; rc < numReadCompartments; rc++ {
+		for wc := 0; wc < numWriteCompartments; wc++ {
+			name := namesByCompartment[rc][wc]
+			series, expectedVector, _ := generateFloatSeries(name, now)
+
+			// Retry the push: right after a topic is auto-created, its partition leader may briefly be
+			// unavailable, which fails the produce with a 500.
+			client := pushClients[wc]
+			test.Poll(t, 10*time.Second, true, func() interface{} {
+				res, err := client.Push(series)
+				return err == nil && res.StatusCode == 200
+			})
+
+			expectedVectors[name] = expectedVector
+		}
+	}
+
+	// Query every series back through the query-frontend with strong read consistency (the default set
+	// by IngestStorageFlags). There is no sleep: strong consistency makes the just-written samples
+	// visible only if the per-cluster produced offsets were propagated to and awaited by the ingester.
+	queryClient, err := e2emimir.NewClient("", queryFrontend.HTTPEndpoint(), "", "", userID)
+	require.NoError(t, err)
+
+	for name, expectedVector := range expectedVectors {
+		result, err := queryClient.Query(name, now)
+		require.NoErrorf(t, err, "metric: %s", name)
+		require.Equalf(t, model.ValVector, result.Type(), "metric: %s", name)
+		assert.Equalf(t, expectedVector, result.(model.Vector), "metric: %s", name)
+	}
+
+	// Sharding: each compartment's ingester holds only its own series (one produced through each write
+	// compartment), confirming series sharded by metric name across read compartments.
+	for rc := 0; rc < numReadCompartments; rc++ {
+		require.NoErrorf(t, ingesters[rc].WaitSumMetrics(e2e.Equals(numWriteCompartments), "cortex_ingester_memory_series"),
+			"read compartment: %d", rc)
+	}
+}
+
+// metricNamesPerCompartment returns perCompartment distinct metric names for each read compartment,
+// using the router to classify names exactly as the distributor does.
+func metricNamesPerCompartment(router *compartments.Router, numReadCompartments, perCompartment int) [][]string {
+	names := make([][]string, numReadCompartments)
+
+	for i := 0; ; i++ {
+		name := fmt.Sprintf("compartment_series_%d", i)
+		if c := router.CompartmentForMetric(userID, name); len(names[c]) < perCompartment {
+			names[c] = append(names[c], name)
+		}
+
+		complete := true
+		for _, n := range names {
+			if len(n) < perCompartment {
+				complete = false
+				break
+			}
+		}
+		if complete {
+			return names
+		}
+	}
+}
+
+// waitQueryFrontendToFetchOffsetsPerWriteCompartment waits until the query-frontend has successfully
+// fetched the last produced offsets from each write compartment's Kafka cluster at least once. With
+// compartments the offset reader emits its metrics per write_compartment, so success must be checked
+// per cluster rather than in aggregate.
+func waitQueryFrontendToFetchOffsetsPerWriteCompartment(t *testing.T, queryFrontend *e2emimir.MimirService, numWriteCompartments int) {
+	test.Poll(t, 30*time.Second, true, func() interface{} {
+		for wc := 0; wc < numWriteCompartments; wc++ {
+			matcher := e2e.WithLabelMatchers(labels.MustNewMatcher(labels.MatchEqual, "write_compartment", strconv.Itoa(wc)))
+
+			requests, requestsErr := queryFrontend.SumMetrics([]string{"cortex_ingest_storage_reader_last_produced_offset_request_duration_seconds"}, e2e.WithMetricCount, matcher, e2e.WaitMissingMetrics)
+			failures, failuresErr := queryFrontend.SumMetrics([]string{"cortex_ingest_storage_reader_last_produced_offset_failures_total"}, matcher, e2e.WaitMissingMetrics)
+
+			t.Logf("Waiting query-frontend to fetch last produced offsets for write compartment %d – requestsErr: %v requests: %v failuresErr: %v failures: %v", wc, requestsErr, requests, failuresErr, failures)
+			if requestsErr != nil || failuresErr != nil || len(requests) != 1 || len(failures) != 1 || requests[0] <= failures[0] {
+				return false
+			}
+		}
+		return true
+	})
+}

--- a/integration/compartments_test.go
+++ b/integration/compartments_test.go
@@ -22,12 +22,6 @@ import (
 
 // TestIngesterQuerying_ShouldSupportCompartments runs the compartments architecture end to end with
 // two read and two write compartments, and verifies queries served from ingesters work across it.
-//
-// Series shard by metric name across read compartments; each write compartment is an independent Kafka
-// cluster. For each read compartment, two series are produced through different write compartments, so
-// the compartment's single ingester returns both only if it consumed its topic from both clusters. The
-// queries run through the query-frontend with strong read consistency and no sleep, so they pass only
-// if the query-frontend propagated the per-cluster produced offsets and the ingester waited for them.
 func TestIngesterQuerying_ShouldSupportCompartments(t *testing.T) {
 	const (
 		numWriteCompartments = 2

--- a/integration/compartments_test.go
+++ b/integration/compartments_test.go
@@ -144,9 +144,7 @@ func TestIngesterQuerying_ShouldSupportCompartments(t *testing.T) {
 		}
 	}
 
-	// Query every series back through the query-frontend with strong read consistency (the default set
-	// by IngestStorageFlags). There is no sleep: strong consistency makes the just-written samples
-	// visible only if the per-cluster produced offsets were propagated to and awaited by the ingester.
+	// Query every series back through the query-frontend with strong read consistency.
 	queryClient, err := e2emimir.NewClient("", queryFrontend.HTTPEndpoint(), "", "", userID)
 	require.NoError(t, err)
 

--- a/integration/configs.go
+++ b/integration/configs.go
@@ -292,6 +292,18 @@ blocks_storage:
 		}
 		return flags
 	}
+
+	// CompartmentsFlags returns the flags shared by all components to run the compartments
+	// architecture on top of ingest storage, with one Kafka cluster per write compartment.
+	CompartmentsFlags = func(numWriteCompartments, numReadCompartments int) map[string]string {
+		return map[string]string{
+			"-compartments.enabled":                "true",
+			"-compartments.write.num-compartments": strconv.Itoa(numWriteCompartments),
+			"-compartments.read.num-compartments":  strconv.Itoa(numReadCompartments),
+			"-ingest-storage.kafka.topic":          "mimir-ingest-rc-<read-compartment-id>",
+			"-ingest-storage.kafka.address":        fmt.Sprintf("%s-kafka-wc-<write-compartment-id>:9092", networkName),
+		}
+	}
 )
 
 func buildConfigFromTemplate(tmpl string, data interface{}) string {

--- a/vendor/github.com/grafana/e2e/db/kafka.go
+++ b/vendor/github.com/grafana/e2e/db/kafka.go
@@ -29,13 +29,37 @@ type KafkaService struct {
 	*kafkaTLSCA
 }
 
-func NewKafka() *KafkaService {
-	return KafkaConfig{}.New()
+// KafkaOption customizes the KafkaConfig used to create a Kafka service.
+type KafkaOption func(*KafkaConfig)
+
+// WithKafkaName overrides the Kafka service name and hostname, which default to "kafka". Use it to
+// run more than one Kafka cluster within the same network.
+func WithKafkaName(name string) KafkaOption {
+	return func(c *KafkaConfig) { c.name = name }
+}
+
+func NewKafka(opts ...KafkaOption) *KafkaService {
+	cfg := KafkaConfig{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg.New()
 }
 
 type KafkaConfig struct {
 	AuthMode    KafkaAuthMode
 	DexEndpoint string
+
+	// name is the Kafka service name and hostname. An empty value defaults to "kafka".
+	name string
+}
+
+// serviceName returns the Kafka service name, defaulting to "kafka".
+func (c KafkaConfig) serviceName() string {
+	if c.name == "" {
+		return "kafka"
+	}
+	return c.name
 }
 
 func (c KafkaConfig) ports() (clientPort, readinessPort int) {
@@ -58,7 +82,7 @@ func (c KafkaConfig) New() *KafkaService {
 
 	return &KafkaService{
 		HTTPService: e2e.NewHTTPService(
-			"kafka",
+			c.serviceName(),
 			images.Kafka,
 			nil, // No custom command.
 			c.NewReadinessProbe(),
@@ -89,13 +113,18 @@ const (
 )
 
 func (s *KafkaService) Start(networkName, sharedDir string) (err error) {
+	// brokerHost is the broker's address within the network. The controller quorum voter uses the
+	// container hostname (the service name), which resolves to the broker itself.
+	name := s.cfg.serviceName()
+	brokerHost := fmt.Sprintf("%s-%s", networkName, name)
+
 	vars := map[string]string{
 		// Configure Kafka to run in KRaft mode (without Zookeeper).
 		"CLUSTER_ID":                      "NqnEdODVKkiLTfJvqd1uqQ==", // A random ID (16 bytes of a base64-encoded UUID).
 		"KAFKA_BROKER_ID":                 "1",
 		"KAFKA_NODE_ID":                   "1",
 		"KAFKA_PROCESS_ROLES":             "broker,controller",
-		"KAFKA_CONTROLLER_QUORUM_VOTERS":  "1@kafka:29093",
+		"KAFKA_CONTROLLER_QUORUM_VOTERS":  fmt.Sprintf("1@%s:29093", name),
 		"KAFKA_CONTROLLER_LISTENER_NAMES": "CONTROLLER",
 
 		// RF=1.
@@ -113,13 +142,13 @@ func (s *KafkaService) Start(networkName, sharedDir string) (err error) {
 	switch s.cfg.AuthMode {
 	case KafkaAuthNone:
 		vars["KAFKA_LISTENERS"] = "PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:29093,PLAINTEXT_HOST://localhost:29092"
-		vars["KAFKA_ADVERTISED_LISTENERS"] = fmt.Sprintf("PLAINTEXT://%s-kafka:9092,PLAINTEXT_HOST://localhost:29092", networkName)
+		vars["KAFKA_ADVERTISED_LISTENERS"] = fmt.Sprintf("PLAINTEXT://%s:9092,PLAINTEXT_HOST://localhost:29092", brokerHost)
 		vars["KAFKA_LISTENER_SECURITY_PROTOCOL_MAP"] = "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT"
 		vars["KAFKA_INTER_BROKER_LISTENER_NAME"] = "PLAINTEXT"
 
 	case KafkaAuthSASLPlain:
 		vars["KAFKA_LISTENERS"] = "SASLPLAIN://0.0.0.0:9092,CONTROLLER://0.0.0.0:29093,PLAINTEXT://0.0.0.0:9093"
-		vars["KAFKA_ADVERTISED_LISTENERS"] = fmt.Sprintf("SASLPLAIN://%s-kafka:9092,PLAINTEXT://%s-kafka:9093", networkName, networkName)
+		vars["KAFKA_ADVERTISED_LISTENERS"] = fmt.Sprintf("SASLPLAIN://%s:9092,PLAINTEXT://%s:9093", brokerHost, brokerHost)
 		vars["KAFKA_LISTENER_SECURITY_PROTOCOL_MAP"] = "CONTROLLER:PLAINTEXT,SASLPLAIN:SASL_PLAINTEXT,PLAINTEXT:PLAINTEXT"
 		vars["KAFKA_INTER_BROKER_LISTENER_NAME"] = "PLAINTEXT"
 		vars["KAFKA_SASL_ENABLED_MECHANISMS"] = "PLAIN"
@@ -130,21 +159,21 @@ func (s *KafkaService) Start(networkName, sharedDir string) (err error) {
 
 	case KafkaAuthSASLScramSHA256:
 		vars["KAFKA_LISTENERS"] = "SASLSCRAM://0.0.0.0:9092,CONTROLLER://0.0.0.0:29093,PLAINTEXT://0.0.0.0:9093"
-		vars["KAFKA_ADVERTISED_LISTENERS"] = fmt.Sprintf("SASLSCRAM://%s-kafka:9092,PLAINTEXT://%s-kafka:9093", networkName, networkName)
+		vars["KAFKA_ADVERTISED_LISTENERS"] = fmt.Sprintf("SASLSCRAM://%s:9092,PLAINTEXT://%s:9093", brokerHost, brokerHost)
 		vars["KAFKA_LISTENER_SECURITY_PROTOCOL_MAP"] = "CONTROLLER:PLAINTEXT,SASLSCRAM:SASL_PLAINTEXT,PLAINTEXT:PLAINTEXT"
 		vars["KAFKA_INTER_BROKER_LISTENER_NAME"] = "PLAINTEXT"
 		vars["KAFKA_SASL_ENABLED_MECHANISMS"] = "SCRAM-SHA-256"
 
 	case KafkaAuthSASLScramSHA512:
 		vars["KAFKA_LISTENERS"] = "SASLSCRAM://0.0.0.0:9092,CONTROLLER://0.0.0.0:29093,PLAINTEXT://0.0.0.0:9093"
-		vars["KAFKA_ADVERTISED_LISTENERS"] = fmt.Sprintf("SASLSCRAM://%s-kafka:9092,PLAINTEXT://%s-kafka:9093", networkName, networkName)
+		vars["KAFKA_ADVERTISED_LISTENERS"] = fmt.Sprintf("SASLSCRAM://%s:9092,PLAINTEXT://%s:9093", brokerHost, brokerHost)
 		vars["KAFKA_LISTENER_SECURITY_PROTOCOL_MAP"] = "CONTROLLER:PLAINTEXT,SASLSCRAM:SASL_PLAINTEXT,PLAINTEXT:PLAINTEXT"
 		vars["KAFKA_INTER_BROKER_LISTENER_NAME"] = "PLAINTEXT"
 		vars["KAFKA_SASL_ENABLED_MECHANISMS"] = "SCRAM-SHA-512"
 
 	case KafkaAuthSASLOAuthToken, KafkaAuthSASLOAuthTokenFile:
 		vars["KAFKA_LISTENERS"] = "SASLOAUTH://0.0.0.0:9092,CONTROLLER://0.0.0.0:29093,PLAINTEXT://0.0.0.0:9093"
-		vars["KAFKA_ADVERTISED_LISTENERS"] = fmt.Sprintf("SASLOAUTH://%s-kafka:9092,PLAINTEXT://%s-kafka:9093", networkName, networkName)
+		vars["KAFKA_ADVERTISED_LISTENERS"] = fmt.Sprintf("SASLOAUTH://%s:9092,PLAINTEXT://%s:9093", brokerHost, brokerHost)
 		vars["KAFKA_LISTENER_SECURITY_PROTOCOL_MAP"] = "CONTROLLER:PLAINTEXT,SASLOAUTH:SASL_PLAINTEXT,PLAINTEXT:PLAINTEXT"
 		vars["KAFKA_INTER_BROKER_LISTENER_NAME"] = "PLAINTEXT"
 		vars["KAFKA_SASL_ENABLED_MECHANISMS"] = "OAUTHBEARER"
@@ -175,7 +204,7 @@ func (s *KafkaService) Start(networkName, sharedDir string) (err error) {
 		})
 
 		vars["KAFKA_LISTENERS"] = "SSL://0.0.0.0:9092,CONTROLLER://0.0.0.0:29093,PLAINTEXT://0.0.0.0:9093"
-		vars["KAFKA_ADVERTISED_LISTENERS"] = fmt.Sprintf("SSL://%s-kafka:9092,PLAINTEXT://%s-kafka:9093", networkName, networkName)
+		vars["KAFKA_ADVERTISED_LISTENERS"] = fmt.Sprintf("SSL://%s:9092,PLAINTEXT://%s:9093", brokerHost, brokerHost)
 		vars["KAFKA_LISTENER_SECURITY_PROTOCOL_MAP"] = "CONTROLLER:PLAINTEXT,SSL:SSL,PLAINTEXT:PLAINTEXT"
 		vars["KAFKA_INTER_BROKER_LISTENER_NAME"] = "PLAINTEXT"
 		vars["KAFKA_SSL_CLIENT_AUTH"] = "required"
@@ -335,11 +364,12 @@ func (s *KafkaService) generateTLSCerts(networkName, sharedDir string) error {
 		return fmt.Errorf("writing CA certificate: %w", err)
 	}
 
-	brokerHostname := fmt.Sprintf("%s-kafka", networkName)
+	name := s.cfg.serviceName()
+	brokerHostname := fmt.Sprintf("%s-%s", networkName, name)
 	serverKeyPath := filepath.Join(tlsDir, "server.key")
 	if err := ca.WriteCertificate(
 		&x509.Certificate{
-			Subject:     pkix.Name{CommonName: "kafka"},
+			Subject:     pkix.Name{CommonName: name},
 			DNSNames:    []string{brokerHostname},
 			ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		},

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -715,7 +715,7 @@ github.com/grafana/dskit/test
 github.com/grafana/dskit/timeutil
 github.com/grafana/dskit/tracing
 github.com/grafana/dskit/user
-# github.com/grafana/e2e v0.1.2-0.20260309174126-b5393d4e610f
+# github.com/grafana/e2e v0.1.2-0.20260625124721-70f74c4b3a54
 ## explicit; go 1.25.5
 github.com/grafana/e2e
 github.com/grafana/e2e/cache

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -715,7 +715,7 @@ github.com/grafana/dskit/test
 github.com/grafana/dskit/timeutil
 github.com/grafana/dskit/tracing
 github.com/grafana/dskit/user
-# github.com/grafana/e2e v0.1.2-0.20260625124721-70f74c4b3a54
+# github.com/grafana/e2e v0.1.2-0.20260625155804-481ec71161b5
 ## explicit; go 1.25.5
 github.com/grafana/e2e
 github.com/grafana/e2e/cache


### PR DESCRIPTION
#### What this PR does

Adds `TestIngesterQuerying_ShouldSupportCompartments`, the first integration test for the compartments architecture. It runs two read and two write compartments end to end (one Kafka cluster per write compartment) and verifies queries served from ingesters work across the topology with strong read consistency.

For each read compartment, two series are produced through different write compartments; they are queryable only if the compartment's ingester consumed its topic from both Kafka clusters and the query-frontend propagated the per-cluster produced offsets to it.

Also adds a `CompartmentsFlags` helper alongside `IngestStorageFlags`.

> [!NOTE]
> Depends on grafana/e2e#115 (now merged), which lets `NewKafka` take a custom name (`WithKafkaName`) so the test can start one Kafka cluster per write compartment.

#### Which issue(s) this PR fixes or relates to

Part of the compartments architecture work.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added. Not needed.
- [x] `CHANGELOG.md` updated - not needed (test-only); `changelog-not-needed` label added.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features. Not needed; the compartments feature is not yet user-facing.