### PR TITLE
block-builder-scheduler: separate offset and time tracking in partitionState

### DIFF
--- a/pkg/blockbuilder/scheduler/jobs.go
+++ b/pkg/blockbuilder/scheduler/jobs.go
@@ -15,12 +15,13 @@ import (
 )
 
 var (
-	errNoJobAvailable        = errors.New("no job available")
-	errJobNotFound           = errors.New("job not found")
-	errJobNotAssigned        = errors.New("job not assigned to given worker")
-	errBadEpoch              = errors.New("bad epoch")
-	errJobAlreadyExists      = errors.New("job already exists")
-	errJobCreationDisallowed = errors.New("job creation policy disallowed job")
+	errNoJobAvailable         = errors.New("no job available")
+	errJobNotFound            = errors.New("job not found")
+	errJobNotAssigned         = errors.New("job not assigned to given worker")
+	errBadEpoch               = errors.New("bad epoch")
+	errJobAlreadyExists       = errors.New("job already exists")
+	errJobCreationDisallowed  = errors.New("job creation policy disallowed job")
+	errEndOffsetWentBackwards = errors.New("end offset went backwards")
 )
 
 type jobQueue[T any] struct {

--- a/pkg/blockbuilder/scheduler/jobs.go
+++ b/pkg/blockbuilder/scheduler/jobs.go
@@ -15,13 +15,12 @@ import (
 )
 
 var (
-	errNoJobAvailable         = errors.New("no job available")
-	errJobNotFound            = errors.New("job not found")
-	errJobNotAssigned         = errors.New("job not assigned to given worker")
-	errBadEpoch               = errors.New("bad epoch")
-	errJobAlreadyExists       = errors.New("job already exists")
-	errJobCreationDisallowed  = errors.New("job creation policy disallowed job")
-	errEndOffsetWentBackwards = errors.New("end offset went backwards")
+	errNoJobAvailable        = errors.New("no job available")
+	errJobNotFound           = errors.New("job not found")
+	errJobNotAssigned        = errors.New("job not assigned to given worker")
+	errBadEpoch              = errors.New("bad epoch")
+	errJobAlreadyExists      = errors.New("job already exists")
+	errJobCreationDisallowed = errors.New("job creation policy disallowed job")
 )
 
 type jobQueue[T any] struct {

--- a/pkg/blockbuilder/scheduler/partition_state.go
+++ b/pkg/blockbuilder/scheduler/partition_state.go
@@ -54,8 +54,8 @@ func newPartitionState(topic string, partition int32, metrics *schedulerMetrics,
 
 // updateEndOffset records the latest observed end offset for the partition. It
 // is expected to be called with monotonically increasing end offsets.
-func (s *partitionState) updateEndOffset(end int64) {
-	s.offsets.updateEndOffset(end)
+func (s *partitionState) updateEndOffset(end int64) error {
+	return s.offsets.updateEndOffset(end)
 }
 
 // updateTime advances the partition's time bucket to the bucket containing ts
@@ -198,11 +198,15 @@ func newSingleClusterOffsets(metrics *schedulerMetrics, logger log.Logger) singl
 // updateEndOffset records the latest observed end offset for the cluster. The
 // first observed offset also seeds the start offset of the first job. It is
 // expected to be called with monotonically increasing end offsets.
-func (o *singleClusterOffsets) updateEndOffset(end int64) {
+func (o *singleClusterOffsets) updateEndOffset(end int64) error {
+	if o.latestOffset != offsetEmpty && end < o.latestOffset {
+		return fmt.Errorf("%w: %d < %d", errEndOffsetWentBackwards, end, o.latestOffset)
+	}
 	if o.startOffset == offsetEmpty {
 		o.startOffset = end
 	}
 	o.latestOffset = end
+	return nil
 }
 
 // advancingOffset keeps track of an offset that is expected to advance

--- a/pkg/blockbuilder/scheduler/partition_state.go
+++ b/pkg/blockbuilder/scheduler/partition_state.go
@@ -54,8 +54,8 @@ func newPartitionState(topic string, partition int32, metrics *schedulerMetrics,
 
 // updateEndOffset records the latest observed end offset for the partition. It
 // is expected to be called with monotonically increasing end offsets.
-func (s *partitionState) updateEndOffset(end int64) error {
-	return s.offsets.updateEndOffset(end)
+func (s *partitionState) updateEndOffset(end int64) {
+	s.offsets.updateEndOffset(end)
 }
 
 // updateTime advances the partition's time bucket to the bucket containing ts
@@ -198,15 +198,14 @@ func newSingleClusterOffsets(metrics *schedulerMetrics, logger log.Logger) singl
 // updateEndOffset records the latest observed end offset for the cluster. The
 // first observed offset also seeds the start offset of the first job. It is
 // expected to be called with monotonically increasing end offsets.
-func (o *singleClusterOffsets) updateEndOffset(end int64) error {
+func (o *singleClusterOffsets) updateEndOffset(end int64) {
 	if o.endOffset != offsetEmpty && end < o.endOffset {
-		return fmt.Errorf("%w: %d < %d", errEndOffsetWentBackwards, end, o.endOffset)
+		panic(fmt.Sprintf("end offset went backwards: %d < %d", end, o.endOffset))
 	}
 	if o.startOffset == offsetEmpty {
 		o.startOffset = end
 	}
 	o.endOffset = end
-	return nil
 }
 
 // advancingOffset keeps track of an offset that is expected to advance

--- a/pkg/blockbuilder/scheduler/partition_state.go
+++ b/pkg/blockbuilder/scheduler/partition_state.go
@@ -74,7 +74,7 @@ func (s *partitionState) updateTime(ts time.Time, jobSize time.Duration) (*sched
 	case bucketBefore:
 		// New bucket is before our current one. This should only happen if our
 		// Kafka's end offsets aren't monotonically increasing.
-		return nil, fmt.Errorf("time went backwards: %s < %s (%d, %d)", newJobBucket, s.jobBucket, s.offsets.startOffset, s.offsets.latestOffset)
+		return nil, fmt.Errorf("time went backwards: %s < %s (%d, %d)", newJobBucket, s.jobBucket, s.offsets.startOffset, s.offsets.endOffset)
 	case bucketSame:
 		// Observation is in the currently tracked bucket. No action needed.
 	case bucketAfter:
@@ -82,15 +82,15 @@ func (s *partitionState) updateTime(ts time.Time, jobSize time.Duration) (*sched
 		// bucket if it has data and start a new one.
 
 		var job *schedulerpb.JobSpec
-		if s.offsets.startOffset != offsetEmpty && s.offsets.startOffset < s.offsets.latestOffset {
+		if s.offsets.startOffset != offsetEmpty && s.offsets.startOffset < s.offsets.endOffset {
 			job = &schedulerpb.JobSpec{
 				Topic:       s.topic,
 				Partition:   s.partition,
 				StartOffset: s.offsets.startOffset,
-				EndOffset:   s.offsets.latestOffset,
+				EndOffset:   s.offsets.endOffset,
 			}
 		}
-		s.offsets.startOffset = s.offsets.latestOffset
+		s.offsets.startOffset = s.offsets.endOffset
 		s.jobBucket = newJobBucket
 		return job, nil
 	}
@@ -179,8 +179,8 @@ type singleClusterOffsets struct {
 	// startOffset is the start offset of the next job to emit.
 	// It is offsetEmpty until the first end offset is observed.
 	startOffset int64
-	// latestOffset is the most recently observed end offset.
-	latestOffset int64
+	// endOffset is the most recently observed end offset.
+	endOffset int64
 
 	committed *advancingOffset
 	planned   *advancingOffset
@@ -188,10 +188,10 @@ type singleClusterOffsets struct {
 
 func newSingleClusterOffsets(metrics *schedulerMetrics, logger log.Logger) singleClusterOffsets {
 	return singleClusterOffsets{
-		startOffset:  offsetEmpty,
-		latestOffset: offsetEmpty,
-		committed:    newAdvancingOffset(offsetNameCommitted, metrics, logger),
-		planned:      newAdvancingOffset(offsetNamePlanned, metrics, logger),
+		startOffset: offsetEmpty,
+		endOffset:   offsetEmpty,
+		committed:   newAdvancingOffset(offsetNameCommitted, metrics, logger),
+		planned:     newAdvancingOffset(offsetNamePlanned, metrics, logger),
 	}
 }
 
@@ -199,13 +199,13 @@ func newSingleClusterOffsets(metrics *schedulerMetrics, logger log.Logger) singl
 // first observed offset also seeds the start offset of the first job. It is
 // expected to be called with monotonically increasing end offsets.
 func (o *singleClusterOffsets) updateEndOffset(end int64) error {
-	if o.latestOffset != offsetEmpty && end < o.latestOffset {
-		return fmt.Errorf("%w: %d < %d", errEndOffsetWentBackwards, end, o.latestOffset)
+	if o.endOffset != offsetEmpty && end < o.endOffset {
+		return fmt.Errorf("%w: %d < %d", errEndOffsetWentBackwards, end, o.endOffset)
 	}
 	if o.startOffset == offsetEmpty {
 		o.startOffset = end
 	}
-	o.latestOffset = end
+	o.endOffset = end
 	return nil
 }
 

--- a/pkg/blockbuilder/scheduler/partition_state.go
+++ b/pkg/blockbuilder/scheduler/partition_state.go
@@ -59,10 +59,9 @@ func (s *partitionState) updateEndOffset(end int64) {
 }
 
 // updateTime advances the partition's time bucket to the bucket containing ts
-// and returns a consumption job spec if one is ready. When a new bucket begins,
-// it emits a job covering the offsets accumulated during the previous bucket, if
-// any. It is expected to be called frequently with monotonically increasing
-// timestamps, even in the absence of new data.
+// and returns a consumption job spec if one is ready. It is expected to be
+// called frequently with monotonically increasing timestamps, even in the
+// absence of new data.
 func (s *partitionState) updateTime(ts time.Time, jobSize time.Duration) (*schedulerpb.JobSpec, error) {
 	newJobBucket := ts.Truncate(jobSize)
 

--- a/pkg/blockbuilder/scheduler/partition_state.go
+++ b/pkg/blockbuilder/scheduler/partition_state.go
@@ -17,11 +17,9 @@ type partitionState struct {
 	topic     string
 	partition int32
 
-	offset    int64
 	jobBucket time.Time
 
-	committed *advancingOffset
-	planned   *advancingOffset
+	offsets singleClusterOffsets
 
 	// pendingJobs are jobs that are waiting to be enqueued. The job creation policy is what allows them to advance to the plannedJobs list.
 	pendingJobs *list.List
@@ -47,22 +45,28 @@ func newPartitionState(topic string, partition int32, metrics *schedulerMetrics,
 	return &partitionState{
 		topic:          topic,
 		partition:      partition,
+		offsets:        newSingleClusterOffsets(metrics, logger),
 		pendingJobs:    list.New(),
 		plannedJobs:    list.New(),
 		plannedJobsMap: make(map[string]*jobState),
-		planned:        newAdvancingOffset(offsetNamePlanned, metrics, logger),
-		committed:      newAdvancingOffset(offsetNameCommitted, metrics, logger),
 	}
 }
 
-// updateEndOffset processes an end offset and returns a consumption job spec if
-// one is ready. This is expected to be called with monotonically increasing
-// end offsets, and called frequently, even in the absence of new data.
-func (s *partitionState) updateEndOffset(end int64, ts time.Time, jobSize time.Duration) (*schedulerpb.JobSpec, error) {
+// updateEndOffset records the latest observed end offset for the partition. It
+// is expected to be called with monotonically increasing end offsets.
+func (s *partitionState) updateEndOffset(end int64) {
+	s.offsets.updateEndOffset(end)
+}
+
+// updateTime advances the partition's time bucket to the bucket containing ts
+// and returns a consumption job spec if one is ready. When a new bucket begins,
+// it emits a job covering the offsets accumulated during the previous bucket, if
+// any. It is expected to be called frequently with monotonically increasing
+// timestamps, even in the absence of new data.
+func (s *partitionState) updateTime(ts time.Time, jobSize time.Duration) (*schedulerpb.JobSpec, error) {
 	newJobBucket := ts.Truncate(jobSize)
 
 	if s.jobBucket.IsZero() {
-		s.offset = end
 		s.jobBucket = newJobBucket
 		return nil, nil
 	}
@@ -71,7 +75,7 @@ func (s *partitionState) updateEndOffset(end int64, ts time.Time, jobSize time.D
 	case bucketBefore:
 		// New bucket is before our current one. This should only happen if our
 		// Kafka's end offsets aren't monotonically increasing.
-		return nil, fmt.Errorf("time went backwards: %s < %s (%d, %d)", newJobBucket, s.jobBucket, s.offset, end)
+		return nil, fmt.Errorf("time went backwards: %s < %s (%d, %d)", newJobBucket, s.jobBucket, s.offsets.startOffset, s.offsets.latestOffset)
 	case bucketSame:
 		// Observation is in the currently tracked bucket. No action needed.
 	case bucketAfter:
@@ -79,15 +83,15 @@ func (s *partitionState) updateEndOffset(end int64, ts time.Time, jobSize time.D
 		// bucket if it has data and start a new one.
 
 		var job *schedulerpb.JobSpec
-		if s.offset < end {
+		if s.offsets.startOffset != offsetEmpty && s.offsets.startOffset < s.offsets.latestOffset {
 			job = &schedulerpb.JobSpec{
 				Topic:       s.topic,
 				Partition:   s.partition,
-				StartOffset: s.offset,
-				EndOffset:   end,
+				StartOffset: s.offsets.startOffset,
+				EndOffset:   s.offsets.latestOffset,
 			}
 		}
-		s.offset = end
+		s.offsets.startOffset = s.offsets.latestOffset
 		s.jobBucket = newJobBucket
 		return job, nil
 	}
@@ -96,9 +100,9 @@ func (s *partitionState) updateEndOffset(end int64, ts time.Time, jobSize time.D
 }
 
 func (s *partitionState) initCommit(commit int64) {
-	s.committed.set(commit)
+	s.offsets.committed.set(commit)
 	// Initially, the planned offset is the committed offset.
-	s.planned.set(commit)
+	s.offsets.planned.set(commit)
 }
 
 func (s *partitionState) addPendingJob(job *schedulerpb.JobSpec) {
@@ -106,17 +110,17 @@ func (s *partitionState) addPendingJob(job *schedulerpb.JobSpec) {
 }
 
 func (s *partitionState) addPlannedJob(id string, spec schedulerpb.JobSpec) {
-	if s.planned.beyondSpec(spec) {
+	if s.offsets.planned.beyondSpec(spec) {
 		// This shouldn't happen. All callers of addPlannedJob must do so in
 		// increasing offset order.
 		panic(fmt.Sprintf("given spec %d [%d, %d) is behind the current planned offset %d",
-			spec.Partition, spec.StartOffset, spec.EndOffset, s.planned.offset()))
+			spec.Partition, spec.StartOffset, spec.EndOffset, s.offsets.planned.offset()))
 	}
 
 	js := &jobState{jobID: id, spec: spec, complete: false}
 	s.plannedJobs.PushBack(js)
 	s.plannedJobsMap[js.jobID] = js
-	s.planned.advance(id, spec)
+	s.offsets.planned.advance(id, spec)
 }
 
 func (s *partitionState) completeJob(jobID string) error {
@@ -138,37 +142,68 @@ func (s *partitionState) completeJob(jobID string) error {
 		}
 		s.plannedJobs.Remove(elem)
 		delete(s.plannedJobsMap, js.jobID)
-		s.committed.advance(js.jobID, js.spec)
+		s.offsets.committed.advance(js.jobID, js.spec)
 	}
 	return nil
 }
 
 func (s *partitionState) committedOffset() int64 {
-	return s.committed.offset()
+	return s.offsets.committed.offset()
 }
 
 func (s *partitionState) committedEmpty() bool {
-	return s.committed.empty()
+	return s.offsets.committed.empty()
 }
 
 func (s *partitionState) committedBeyondSpec(spec schedulerpb.JobSpec) bool {
-	return s.committed.beyondSpec(spec)
+	return s.offsets.committed.beyondSpec(spec)
 }
 
 func (s *partitionState) plannedOffset() int64 {
-	return s.planned.offset()
+	return s.offsets.planned.offset()
 }
 
 func (s *partitionState) plannedEmpty() bool {
-	return s.planned.empty()
+	return s.offsets.planned.empty()
 }
 
 func (s *partitionState) plannedBeyondSpec(spec schedulerpb.JobSpec) bool {
-	return s.planned.beyondSpec(spec)
+	return s.offsets.planned.beyondSpec(spec)
 }
 
 func (s *partitionState) plannedValidNextSpec(spec schedulerpb.JobSpec) bool {
-	return s.planned.validNextSpec(spec)
+	return s.offsets.planned.validNextSpec(spec)
+}
+
+// singleClusterOffsets tracks the offsets for a single Kafka cluster.
+type singleClusterOffsets struct {
+	// startOffset is the start offset of the next job to emit.
+	// It is offsetEmpty until the first end offset is observed.
+	startOffset int64
+	// latestOffset is the most recently observed end offset.
+	latestOffset int64
+
+	committed *advancingOffset
+	planned   *advancingOffset
+}
+
+func newSingleClusterOffsets(metrics *schedulerMetrics, logger log.Logger) singleClusterOffsets {
+	return singleClusterOffsets{
+		startOffset:  offsetEmpty,
+		latestOffset: offsetEmpty,
+		committed:    newAdvancingOffset(offsetNameCommitted, metrics, logger),
+		planned:      newAdvancingOffset(offsetNamePlanned, metrics, logger),
+	}
+}
+
+// updateEndOffset records the latest observed end offset for the cluster. The
+// first observed offset also seeds the start offset of the first job. It is
+// expected to be called with monotonically increasing end offsets.
+func (o *singleClusterOffsets) updateEndOffset(end int64) {
+	if o.startOffset == offsetEmpty {
+		o.startOffset = end
+	}
+	o.latestOffset = end
 }
 
 // advancingOffset keeps track of an offset that is expected to advance

--- a/pkg/blockbuilder/scheduler/partition_state_test.go
+++ b/pkg/blockbuilder/scheduler/partition_state_test.go
@@ -367,25 +367,25 @@ func TestNewSingleClusterOffsets(t *testing.T) {
 
 	// Before observing any end offset, both offsets are empty.
 	require.Equal(t, offsetEmpty, o.startOffset)
-	require.Equal(t, offsetEmpty, o.latestOffset)
+	require.Equal(t, offsetEmpty, o.endOffset)
 
 	// The first observed end offset seeds the start offset, so they're equal.
 	require.NoError(t, o.updateEndOffset(100))
 	require.Equal(t, int64(100), o.startOffset)
-	require.Equal(t, int64(100), o.latestOffset)
+	require.Equal(t, int64(100), o.endOffset)
 
 	// Subsequent observations only advance the latest offset, so they diverge.
 	require.NoError(t, o.updateEndOffset(200))
 	require.Equal(t, int64(100), o.startOffset)
-	require.Equal(t, int64(200), o.latestOffset)
+	require.Equal(t, int64(200), o.endOffset)
 
 	// Observing the same offset again is allowed and changes nothing.
 	require.NoError(t, o.updateEndOffset(200))
 	require.Equal(t, int64(100), o.startOffset)
-	require.Equal(t, int64(200), o.latestOffset)
+	require.Equal(t, int64(200), o.endOffset)
 
 	// An end offset that moves backwards is reported and leaves the offsets unchanged.
 	require.ErrorIs(t, o.updateEndOffset(150), errEndOffsetWentBackwards)
 	require.Equal(t, int64(100), o.startOffset)
-	require.Equal(t, int64(200), o.latestOffset)
+	require.Equal(t, int64(200), o.endOffset)
 }

--- a/pkg/blockbuilder/scheduler/partition_state_test.go
+++ b/pkg/blockbuilder/scheduler/partition_state_test.go
@@ -28,11 +28,11 @@ func TestPartitionState(t *testing.T) {
 	var job *schedulerpb.JobSpec
 	var err error
 
-	require.NoError(t, pt.updateEndOffset(100))
+	pt.updateEndOffset(100)
 	job, err = pt.updateTime(time.Date(2025, 3, 1, 10, 1, 10, 0, time.UTC), sz)
 	require.Nil(t, job)
 	require.Nil(t, err)
-	require.NoError(t, pt.updateEndOffset(200))
+	pt.updateEndOffset(200)
 	job, err = pt.updateTime(time.Date(2025, 3, 1, 11, 1, 10, 0, time.UTC), sz)
 	require.Equal(t, &schedulerpb.JobSpec{
 		Topic:       "topic",
@@ -42,20 +42,20 @@ func TestPartitionState(t *testing.T) {
 	}, job)
 	require.Nil(t, err)
 
-	require.NoError(t, pt.updateEndOffset(201))
+	pt.updateEndOffset(201)
 	job, err = pt.updateTime(time.Date(2025, 3, 1, 11, 1, 10, 0, time.UTC), sz)
 	require.Nil(t, job)
 	require.NoError(t, err)
-	require.NoError(t, pt.updateEndOffset(202))
+	pt.updateEndOffset(202)
 	job, err = pt.updateTime(time.Date(2025, 3, 1, 11, 2, 10, 0, time.UTC), sz)
 	require.NoError(t, err)
 	require.Nil(t, job)
-	require.NoError(t, pt.updateEndOffset(203))
+	pt.updateEndOffset(203)
 	job, err = pt.updateTime(time.Date(2025, 3, 1, 11, 3, 10, 0, time.UTC), sz)
 	require.Nil(t, job)
 	require.Nil(t, err)
 
-	require.NoError(t, pt.updateEndOffset(300))
+	pt.updateEndOffset(300)
 	job, err = pt.updateTime(z.Add(2*time.Hour), sz)
 	require.Equal(t, &schedulerpb.JobSpec{
 		Topic:       "topic",
@@ -66,7 +66,7 @@ func TestPartitionState(t *testing.T) {
 	require.NoError(t, err)
 
 	// And, if the time goes backwards, we return an error.
-	require.NoError(t, pt.updateEndOffset(300))
+	pt.updateEndOffset(300)
 	job, err = pt.updateTime(z.Add(-2*time.Hour), sz)
 	require.Nil(t, job)
 	require.ErrorContains(t, err, "time went backwards")
@@ -79,7 +79,7 @@ func TestPartitionState_TerminallyDormantPartition(t *testing.T) {
 
 	for i := 0; i < 1000; i++ {
 		z = z.Add(7 * time.Minute)
-		require.NoError(t, pt.updateEndOffset(0))
+		pt.updateEndOffset(0)
 		j, err := pt.updateTime(z, sz)
 		assert.Nil(t, j)
 		assert.NoError(t, err)
@@ -93,26 +93,26 @@ func TestPartitionState_PartitionBecomesInactive(t *testing.T) {
 	// A bunch of data observed:
 	var j *schedulerpb.JobSpec
 	var err error
-	require.NoError(t, pt.updateEndOffset(10))
+	pt.updateEndOffset(10)
 	j, err = pt.updateTime(time.Date(2025, 3, 1, 10, 1, 10, 0, time.UTC), sz)
 	assert.Nil(t, j)
 	assert.NoError(t, err)
-	require.NoError(t, pt.updateEndOffset(11))
+	pt.updateEndOffset(11)
 	j, err = pt.updateTime(time.Date(2025, 3, 1, 10, 1, 11, 0, time.UTC), sz)
 	assert.Nil(t, j)
 	assert.NoError(t, err)
-	require.NoError(t, pt.updateEndOffset(12))
+	pt.updateEndOffset(12)
 	j, err = pt.updateTime(time.Date(2025, 3, 1, 10, 1, 12, 0, time.UTC), sz)
 	assert.Nil(t, j)
 	assert.NoError(t, err)
 	// data ceases. continue to get observations in the same bucket.
-	require.NoError(t, pt.updateEndOffset(12))
+	pt.updateEndOffset(12)
 	j, err = pt.updateTime(time.Date(2025, 3, 1, 10, 1, 13, 0, time.UTC), sz)
 	assert.Nil(t, j)
 	assert.NoError(t, err)
 
 	// as we cross into the next bucket, there's still no new data.
-	require.NoError(t, pt.updateEndOffset(12))
+	pt.updateEndOffset(12)
 	j, err = pt.updateTime(time.Date(2025, 3, 1, 11, 1, 0, 0, time.UTC), sz)
 	assert.Equal(t, &schedulerpb.JobSpec{
 		Topic:       "topic",
@@ -122,17 +122,17 @@ func TestPartitionState_PartitionBecomesInactive(t *testing.T) {
 	}, j)
 	assert.NoError(t, err)
 	// and we keep getting the same offset.
-	require.NoError(t, pt.updateEndOffset(12))
+	pt.updateEndOffset(12)
 	j, err = pt.updateTime(time.Date(2025, 3, 1, 11, 2, 0, 0, time.UTC), sz)
 	assert.Nil(t, j)
 	assert.NoError(t, err)
-	require.NoError(t, pt.updateEndOffset(12))
+	pt.updateEndOffset(12)
 	j, err = pt.updateTime(time.Date(2025, 3, 1, 11, 3, 0, 0, time.UTC), sz)
 	assert.Nil(t, j)
 	assert.NoError(t, err)
 
 	// And in the next job bucket, still no new data.
-	require.NoError(t, pt.updateEndOffset(12))
+	pt.updateEndOffset(12)
 	j, err = pt.updateTime(time.Date(2025, 3, 1, 12, 1, 0, 0, time.UTC), sz)
 	assert.Nil(t, j)
 	assert.NoError(t, err)
@@ -144,15 +144,15 @@ func TestPartitionState_MultipleOffsetsBeforeTimeUpdate(t *testing.T) {
 	ts := time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC)
 
 	// Seed the start offset and the current bucket.
-	require.NoError(t, ps.updateEndOffset(100))
+	ps.updateEndOffset(100)
 	job, err := ps.updateTime(ts, jobSize)
 	require.NoError(t, err)
 	require.Nil(t, job)
 
 	// Several observations within the same bucket, with no time update between them.
-	require.NoError(t, ps.updateEndOffset(150))
-	require.NoError(t, ps.updateEndOffset(175))
-	require.NoError(t, ps.updateEndOffset(200))
+	ps.updateEndOffset(150)
+	ps.updateEndOffset(175)
+	ps.updateEndOffset(200)
 
 	// Crossing into the next bucket emits a single job spanning the seeded start
 	// offset to the latest observed offset.
@@ -370,22 +370,20 @@ func TestNewSingleClusterOffsets(t *testing.T) {
 	require.Equal(t, offsetEmpty, o.endOffset)
 
 	// The first observed end offset seeds the start offset, so they're equal.
-	require.NoError(t, o.updateEndOffset(100))
+	o.updateEndOffset(100)
 	require.Equal(t, int64(100), o.startOffset)
 	require.Equal(t, int64(100), o.endOffset)
 
 	// Subsequent observations only advance the latest offset, so they diverge.
-	require.NoError(t, o.updateEndOffset(200))
+	o.updateEndOffset(200)
 	require.Equal(t, int64(100), o.startOffset)
 	require.Equal(t, int64(200), o.endOffset)
 
 	// Observing the same offset again is allowed and changes nothing.
-	require.NoError(t, o.updateEndOffset(200))
+	o.updateEndOffset(200)
 	require.Equal(t, int64(100), o.startOffset)
 	require.Equal(t, int64(200), o.endOffset)
 
-	// An end offset that moves backwards is reported and leaves the offsets unchanged.
-	require.ErrorIs(t, o.updateEndOffset(150), errEndOffsetWentBackwards)
-	require.Equal(t, int64(100), o.startOffset)
-	require.Equal(t, int64(200), o.endOffset)
+	// An end offset that moves backwards is a logical error and panics.
+	require.Panics(t, func() { o.updateEndOffset(150) })
 }

--- a/pkg/blockbuilder/scheduler/partition_state_test.go
+++ b/pkg/blockbuilder/scheduler/partition_state_test.go
@@ -28,10 +28,12 @@ func TestPartitionState(t *testing.T) {
 	var job *schedulerpb.JobSpec
 	var err error
 
-	job, err = pt.updateEndOffset(100, time.Date(2025, 3, 1, 10, 1, 10, 0, time.UTC), sz)
+	pt.updateEndOffset(100)
+	job, err = pt.updateTime(time.Date(2025, 3, 1, 10, 1, 10, 0, time.UTC), sz)
 	require.Nil(t, job)
 	require.Nil(t, err)
-	job, err = pt.updateEndOffset(200, time.Date(2025, 3, 1, 11, 1, 10, 0, time.UTC), sz)
+	pt.updateEndOffset(200)
+	job, err = pt.updateTime(time.Date(2025, 3, 1, 11, 1, 10, 0, time.UTC), sz)
 	require.Equal(t, &schedulerpb.JobSpec{
 		Topic:       "topic",
 		Partition:   0,
@@ -40,17 +42,21 @@ func TestPartitionState(t *testing.T) {
 	}, job)
 	require.Nil(t, err)
 
-	job, err = pt.updateEndOffset(201, time.Date(2025, 3, 1, 11, 1, 10, 0, time.UTC), sz)
+	pt.updateEndOffset(201)
+	job, err = pt.updateTime(time.Date(2025, 3, 1, 11, 1, 10, 0, time.UTC), sz)
 	require.Nil(t, job)
 	require.NoError(t, err)
-	job, err = pt.updateEndOffset(202, time.Date(2025, 3, 1, 11, 2, 10, 0, time.UTC), sz)
+	pt.updateEndOffset(202)
+	job, err = pt.updateTime(time.Date(2025, 3, 1, 11, 2, 10, 0, time.UTC), sz)
 	require.NoError(t, err)
 	require.Nil(t, job)
-	job, err = pt.updateEndOffset(203, time.Date(2025, 3, 1, 11, 3, 10, 0, time.UTC), sz)
+	pt.updateEndOffset(203)
+	job, err = pt.updateTime(time.Date(2025, 3, 1, 11, 3, 10, 0, time.UTC), sz)
 	require.Nil(t, job)
 	require.Nil(t, err)
 
-	job, err = pt.updateEndOffset(300, z.Add(2*time.Hour), sz)
+	pt.updateEndOffset(300)
+	job, err = pt.updateTime(z.Add(2*time.Hour), sz)
 	require.Equal(t, &schedulerpb.JobSpec{
 		Topic:       "topic",
 		Partition:   0,
@@ -60,7 +66,8 @@ func TestPartitionState(t *testing.T) {
 	require.NoError(t, err)
 
 	// And, if the time goes backwards, we return an error.
-	job, err = pt.updateEndOffset(300, z.Add(-2*time.Hour), sz)
+	pt.updateEndOffset(300)
+	job, err = pt.updateTime(z.Add(-2*time.Hour), sz)
 	require.Nil(t, job)
 	require.ErrorContains(t, err, "time went backwards")
 }
@@ -72,7 +79,8 @@ func TestPartitionState_TerminallyDormantPartition(t *testing.T) {
 
 	for i := 0; i < 1000; i++ {
 		z = z.Add(7 * time.Minute)
-		j, err := pt.updateEndOffset(0, z, sz)
+		pt.updateEndOffset(0)
+		j, err := pt.updateTime(z, sz)
 		assert.Nil(t, j)
 		assert.NoError(t, err)
 	}
@@ -85,22 +93,27 @@ func TestPartitionState_PartitionBecomesInactive(t *testing.T) {
 	// A bunch of data observed:
 	var j *schedulerpb.JobSpec
 	var err error
-	j, err = pt.updateEndOffset(10, time.Date(2025, 3, 1, 10, 1, 10, 0, time.UTC), sz)
+	pt.updateEndOffset(10)
+	j, err = pt.updateTime(time.Date(2025, 3, 1, 10, 1, 10, 0, time.UTC), sz)
 	assert.Nil(t, j)
 	assert.NoError(t, err)
-	j, err = pt.updateEndOffset(11, time.Date(2025, 3, 1, 10, 1, 11, 0, time.UTC), sz)
+	pt.updateEndOffset(11)
+	j, err = pt.updateTime(time.Date(2025, 3, 1, 10, 1, 11, 0, time.UTC), sz)
 	assert.Nil(t, j)
 	assert.NoError(t, err)
-	j, err = pt.updateEndOffset(12, time.Date(2025, 3, 1, 10, 1, 12, 0, time.UTC), sz)
+	pt.updateEndOffset(12)
+	j, err = pt.updateTime(time.Date(2025, 3, 1, 10, 1, 12, 0, time.UTC), sz)
 	assert.Nil(t, j)
 	assert.NoError(t, err)
 	// data ceases. continue to get observations in the same bucket.
-	j, err = pt.updateEndOffset(12, time.Date(2025, 3, 1, 10, 1, 13, 0, time.UTC), sz)
+	pt.updateEndOffset(12)
+	j, err = pt.updateTime(time.Date(2025, 3, 1, 10, 1, 13, 0, time.UTC), sz)
 	assert.Nil(t, j)
 	assert.NoError(t, err)
 
 	// as we cross into the next bucket, there's still no new data.
-	j, err = pt.updateEndOffset(12, time.Date(2025, 3, 1, 11, 1, 0, 0, time.UTC), sz)
+	pt.updateEndOffset(12)
+	j, err = pt.updateTime(time.Date(2025, 3, 1, 11, 1, 0, 0, time.UTC), sz)
 	assert.Equal(t, &schedulerpb.JobSpec{
 		Topic:       "topic",
 		Partition:   0,
@@ -109,17 +122,62 @@ func TestPartitionState_PartitionBecomesInactive(t *testing.T) {
 	}, j)
 	assert.NoError(t, err)
 	// and we keep getting the same offset.
-	j, err = pt.updateEndOffset(12, time.Date(2025, 3, 1, 11, 2, 0, 0, time.UTC), sz)
+	pt.updateEndOffset(12)
+	j, err = pt.updateTime(time.Date(2025, 3, 1, 11, 2, 0, 0, time.UTC), sz)
 	assert.Nil(t, j)
 	assert.NoError(t, err)
-	j, err = pt.updateEndOffset(12, time.Date(2025, 3, 1, 11, 3, 0, 0, time.UTC), sz)
+	pt.updateEndOffset(12)
+	j, err = pt.updateTime(time.Date(2025, 3, 1, 11, 3, 0, 0, time.UTC), sz)
 	assert.Nil(t, j)
 	assert.NoError(t, err)
 
 	// And in the next job bucket, still no new data.
-	j, err = pt.updateEndOffset(12, time.Date(2025, 3, 1, 12, 1, 0, 0, time.UTC), sz)
+	pt.updateEndOffset(12)
+	j, err = pt.updateTime(time.Date(2025, 3, 1, 12, 1, 0, 0, time.UTC), sz)
 	assert.Nil(t, j)
 	assert.NoError(t, err)
+}
+
+func TestPartitionState_MultipleOffsetsBeforeTimeUpdate(t *testing.T) {
+	pt := newTestPartitionState(t, "topic", 0)
+	sz := time.Hour
+	z := time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC)
+
+	// Seed the start offset and the current bucket.
+	pt.updateEndOffset(100)
+	job, err := pt.updateTime(z, sz)
+	require.NoError(t, err)
+	require.Nil(t, job)
+
+	// Several observations within the same bucket, with no time update between them.
+	pt.updateEndOffset(150)
+	pt.updateEndOffset(175)
+	pt.updateEndOffset(200)
+
+	// Crossing into the next bucket emits a single job spanning the seeded start
+	// offset to the latest observed offset.
+	job, err = pt.updateTime(z.Add(sz), sz)
+	require.NoError(t, err)
+	require.Equal(t, &schedulerpb.JobSpec{
+		Topic:       "topic",
+		Partition:   0,
+		StartOffset: 100,
+		EndOffset:   200,
+	}, job)
+}
+
+func TestPartitionState_TimeAdvancesBeforeAnyOffset(t *testing.T) {
+	pt := newTestPartitionState(t, "topic", 0)
+	sz := time.Hour
+	z := time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC)
+
+	// Advance time across several buckets without ever observing an end offset.
+	// No jobs should be emitted.
+	for i := 0; i < 5; i++ {
+		job, err := pt.updateTime(z.Add(time.Duration(i)*sz), sz)
+		require.NoError(t, err)
+		require.Nil(t, job)
+	}
 }
 
 func TestPartitionState_ParallelJobs(t *testing.T) {
@@ -167,7 +225,7 @@ func TestPartitionState_ParallelJobs(t *testing.T) {
 		ps.addPlannedJob("job1", jobSpec)
 		require.Equal(t, 1, ps.plannedJobs.Len())
 		require.Len(t, ps.plannedJobsMap, 1)
-		require.Equal(t, int64(100), ps.committed.offset())
+		require.Equal(t, int64(100), ps.offsets.committed.offset())
 
 		err := ps.completeJob("job1")
 		require.NoError(t, err)
@@ -175,7 +233,7 @@ func TestPartitionState_ParallelJobs(t *testing.T) {
 		// Verify job was completed and garbage collected
 		require.Equal(t, 0, ps.plannedJobs.Len())
 		require.Len(t, ps.plannedJobsMap, 0)
-		require.Equal(t, int64(200), ps.committed.offset())
+		require.Equal(t, int64(200), ps.offsets.committed.offset())
 	})
 
 	t.Run("complete_nonexistent_job", func(t *testing.T) {
@@ -217,28 +275,28 @@ func TestPartitionState_ParallelJobs(t *testing.T) {
 		// Verify initial state
 		require.Equal(t, 3, ps.plannedJobs.Len())
 		require.Len(t, ps.plannedJobsMap, 3)
-		require.Equal(t, int64(100), ps.committed.offset())
+		require.Equal(t, int64(100), ps.offsets.committed.offset())
 
 		// Complete first job - should be garbage collected
 		err := ps.completeJob("job1")
 		require.NoError(t, err)
 		require.Equal(t, 2, ps.plannedJobs.Len())
 		require.Len(t, ps.plannedJobsMap, 2)
-		require.Equal(t, int64(200), ps.committed.offset())
+		require.Equal(t, int64(200), ps.offsets.committed.offset())
 
 		// Complete second job - should be garbage collected
 		err = ps.completeJob("job2")
 		require.NoError(t, err)
 		require.Equal(t, 1, ps.plannedJobs.Len())
 		require.Len(t, ps.plannedJobsMap, 1)
-		require.Equal(t, int64(300), ps.committed.offset())
+		require.Equal(t, int64(300), ps.offsets.committed.offset())
 
 		// Complete third job - should be garbage collected
 		err = ps.completeJob("job3")
 		require.NoError(t, err)
 		require.Equal(t, 0, ps.plannedJobs.Len())
 		require.Len(t, ps.plannedJobsMap, 0)
-		require.Equal(t, int64(400), ps.committed.offset())
+		require.Equal(t, int64(400), ps.offsets.committed.offset())
 	})
 
 	// Test 4: Complete jobs out of order (only front jobs get garbage collected)
@@ -274,14 +332,14 @@ func TestPartitionState_ParallelJobs(t *testing.T) {
 		// Job2 should be marked complete but not garbage collected yet
 		require.Equal(t, 3, ps.plannedJobs.Len(), "expecting no garbage collection yet")
 		require.Len(t, ps.plannedJobsMap, 3, "expecting no garbage collection yet")
-		require.Equal(t, int64(100), ps.committed.offset(), "should be no advancement yet")
+		require.Equal(t, int64(100), ps.offsets.committed.offset(), "should be no advancement yet")
 
 		// Complete job1 - should garbage collect both job1 and job2
 		err = ps.completeJob("job1")
 		require.NoError(t, err)
 		require.Equal(t, 1, ps.plannedJobs.Len(), "expecting garbage collection of job1 and job2")
 		require.Len(t, ps.plannedJobsMap, 1, "expecting garbage collection of job1 and job2")
-		require.Equal(t, int64(300), ps.committed.offset(), "should be advanced commit to the end of job3")
+		require.Equal(t, int64(300), ps.offsets.committed.offset(), "should be advanced commit to the end of job3")
 		require.Equal(t, "job3", ps.plannedJobs.Front().Value.(*jobState).jobID, "expecting job3 to be the remaining planned job")
 	})
 
@@ -299,6 +357,25 @@ func TestPartitionState_ParallelJobs(t *testing.T) {
 		// Verify state remains unchanged
 		require.Equal(t, 0, ps.plannedJobs.Len())
 		require.Len(t, ps.plannedJobsMap, 0)
-		require.Equal(t, int64(100), ps.committed.offset())
+		require.Equal(t, int64(100), ps.offsets.committed.offset())
 	})
+}
+
+func TestNewSingleClusterOffsets(t *testing.T) {
+	m := newSchedulerMetrics(prometheus.NewPedanticRegistry())
+	o := newSingleClusterOffsets(&m, test.NewTestingLogger(t))
+
+	// Before observing any end offset, both offsets are empty.
+	require.Equal(t, offsetEmpty, o.startOffset)
+	require.Equal(t, offsetEmpty, o.latestOffset)
+
+	// The first observed end offset seeds the start offset, so they're equal.
+	o.updateEndOffset(100)
+	require.Equal(t, int64(100), o.startOffset)
+	require.Equal(t, int64(100), o.latestOffset)
+
+	// Subsequent observations only advance the latest offset, so they diverge.
+	o.updateEndOffset(200)
+	require.Equal(t, int64(100), o.startOffset)
+	require.Equal(t, int64(200), o.latestOffset)
 }

--- a/pkg/blockbuilder/scheduler/partition_state_test.go
+++ b/pkg/blockbuilder/scheduler/partition_state_test.go
@@ -139,24 +139,24 @@ func TestPartitionState_PartitionBecomesInactive(t *testing.T) {
 }
 
 func TestPartitionState_MultipleOffsetsBeforeTimeUpdate(t *testing.T) {
-	pt := newTestPartitionState(t, "topic", 0)
-	sz := time.Hour
-	z := time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC)
+	ps := newTestPartitionState(t, "topic", 0)
+	jobSize := time.Hour
+	ts := time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC)
 
 	// Seed the start offset and the current bucket.
-	pt.updateEndOffset(100)
-	job, err := pt.updateTime(z, sz)
+	ps.updateEndOffset(100)
+	job, err := ps.updateTime(ts, jobSize)
 	require.NoError(t, err)
 	require.Nil(t, job)
 
 	// Several observations within the same bucket, with no time update between them.
-	pt.updateEndOffset(150)
-	pt.updateEndOffset(175)
-	pt.updateEndOffset(200)
+	ps.updateEndOffset(150)
+	ps.updateEndOffset(175)
+	ps.updateEndOffset(200)
 
 	// Crossing into the next bucket emits a single job spanning the seeded start
 	// offset to the latest observed offset.
-	job, err = pt.updateTime(z.Add(sz), sz)
+	job, err = ps.updateTime(ts.Add(jobSize), jobSize)
 	require.NoError(t, err)
 	require.Equal(t, &schedulerpb.JobSpec{
 		Topic:       "topic",

--- a/pkg/blockbuilder/scheduler/partition_state_test.go
+++ b/pkg/blockbuilder/scheduler/partition_state_test.go
@@ -28,11 +28,11 @@ func TestPartitionState(t *testing.T) {
 	var job *schedulerpb.JobSpec
 	var err error
 
-	pt.updateEndOffset(100)
+	require.NoError(t, pt.updateEndOffset(100))
 	job, err = pt.updateTime(time.Date(2025, 3, 1, 10, 1, 10, 0, time.UTC), sz)
 	require.Nil(t, job)
 	require.Nil(t, err)
-	pt.updateEndOffset(200)
+	require.NoError(t, pt.updateEndOffset(200))
 	job, err = pt.updateTime(time.Date(2025, 3, 1, 11, 1, 10, 0, time.UTC), sz)
 	require.Equal(t, &schedulerpb.JobSpec{
 		Topic:       "topic",
@@ -42,20 +42,20 @@ func TestPartitionState(t *testing.T) {
 	}, job)
 	require.Nil(t, err)
 
-	pt.updateEndOffset(201)
+	require.NoError(t, pt.updateEndOffset(201))
 	job, err = pt.updateTime(time.Date(2025, 3, 1, 11, 1, 10, 0, time.UTC), sz)
 	require.Nil(t, job)
 	require.NoError(t, err)
-	pt.updateEndOffset(202)
+	require.NoError(t, pt.updateEndOffset(202))
 	job, err = pt.updateTime(time.Date(2025, 3, 1, 11, 2, 10, 0, time.UTC), sz)
 	require.NoError(t, err)
 	require.Nil(t, job)
-	pt.updateEndOffset(203)
+	require.NoError(t, pt.updateEndOffset(203))
 	job, err = pt.updateTime(time.Date(2025, 3, 1, 11, 3, 10, 0, time.UTC), sz)
 	require.Nil(t, job)
 	require.Nil(t, err)
 
-	pt.updateEndOffset(300)
+	require.NoError(t, pt.updateEndOffset(300))
 	job, err = pt.updateTime(z.Add(2*time.Hour), sz)
 	require.Equal(t, &schedulerpb.JobSpec{
 		Topic:       "topic",
@@ -66,7 +66,7 @@ func TestPartitionState(t *testing.T) {
 	require.NoError(t, err)
 
 	// And, if the time goes backwards, we return an error.
-	pt.updateEndOffset(300)
+	require.NoError(t, pt.updateEndOffset(300))
 	job, err = pt.updateTime(z.Add(-2*time.Hour), sz)
 	require.Nil(t, job)
 	require.ErrorContains(t, err, "time went backwards")
@@ -79,7 +79,7 @@ func TestPartitionState_TerminallyDormantPartition(t *testing.T) {
 
 	for i := 0; i < 1000; i++ {
 		z = z.Add(7 * time.Minute)
-		pt.updateEndOffset(0)
+		require.NoError(t, pt.updateEndOffset(0))
 		j, err := pt.updateTime(z, sz)
 		assert.Nil(t, j)
 		assert.NoError(t, err)
@@ -93,26 +93,26 @@ func TestPartitionState_PartitionBecomesInactive(t *testing.T) {
 	// A bunch of data observed:
 	var j *schedulerpb.JobSpec
 	var err error
-	pt.updateEndOffset(10)
+	require.NoError(t, pt.updateEndOffset(10))
 	j, err = pt.updateTime(time.Date(2025, 3, 1, 10, 1, 10, 0, time.UTC), sz)
 	assert.Nil(t, j)
 	assert.NoError(t, err)
-	pt.updateEndOffset(11)
+	require.NoError(t, pt.updateEndOffset(11))
 	j, err = pt.updateTime(time.Date(2025, 3, 1, 10, 1, 11, 0, time.UTC), sz)
 	assert.Nil(t, j)
 	assert.NoError(t, err)
-	pt.updateEndOffset(12)
+	require.NoError(t, pt.updateEndOffset(12))
 	j, err = pt.updateTime(time.Date(2025, 3, 1, 10, 1, 12, 0, time.UTC), sz)
 	assert.Nil(t, j)
 	assert.NoError(t, err)
 	// data ceases. continue to get observations in the same bucket.
-	pt.updateEndOffset(12)
+	require.NoError(t, pt.updateEndOffset(12))
 	j, err = pt.updateTime(time.Date(2025, 3, 1, 10, 1, 13, 0, time.UTC), sz)
 	assert.Nil(t, j)
 	assert.NoError(t, err)
 
 	// as we cross into the next bucket, there's still no new data.
-	pt.updateEndOffset(12)
+	require.NoError(t, pt.updateEndOffset(12))
 	j, err = pt.updateTime(time.Date(2025, 3, 1, 11, 1, 0, 0, time.UTC), sz)
 	assert.Equal(t, &schedulerpb.JobSpec{
 		Topic:       "topic",
@@ -122,17 +122,17 @@ func TestPartitionState_PartitionBecomesInactive(t *testing.T) {
 	}, j)
 	assert.NoError(t, err)
 	// and we keep getting the same offset.
-	pt.updateEndOffset(12)
+	require.NoError(t, pt.updateEndOffset(12))
 	j, err = pt.updateTime(time.Date(2025, 3, 1, 11, 2, 0, 0, time.UTC), sz)
 	assert.Nil(t, j)
 	assert.NoError(t, err)
-	pt.updateEndOffset(12)
+	require.NoError(t, pt.updateEndOffset(12))
 	j, err = pt.updateTime(time.Date(2025, 3, 1, 11, 3, 0, 0, time.UTC), sz)
 	assert.Nil(t, j)
 	assert.NoError(t, err)
 
 	// And in the next job bucket, still no new data.
-	pt.updateEndOffset(12)
+	require.NoError(t, pt.updateEndOffset(12))
 	j, err = pt.updateTime(time.Date(2025, 3, 1, 12, 1, 0, 0, time.UTC), sz)
 	assert.Nil(t, j)
 	assert.NoError(t, err)
@@ -144,15 +144,15 @@ func TestPartitionState_MultipleOffsetsBeforeTimeUpdate(t *testing.T) {
 	ts := time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC)
 
 	// Seed the start offset and the current bucket.
-	ps.updateEndOffset(100)
+	require.NoError(t, ps.updateEndOffset(100))
 	job, err := ps.updateTime(ts, jobSize)
 	require.NoError(t, err)
 	require.Nil(t, job)
 
 	// Several observations within the same bucket, with no time update between them.
-	ps.updateEndOffset(150)
-	ps.updateEndOffset(175)
-	ps.updateEndOffset(200)
+	require.NoError(t, ps.updateEndOffset(150))
+	require.NoError(t, ps.updateEndOffset(175))
+	require.NoError(t, ps.updateEndOffset(200))
 
 	// Crossing into the next bucket emits a single job spanning the seeded start
 	// offset to the latest observed offset.
@@ -370,12 +370,22 @@ func TestNewSingleClusterOffsets(t *testing.T) {
 	require.Equal(t, offsetEmpty, o.latestOffset)
 
 	// The first observed end offset seeds the start offset, so they're equal.
-	o.updateEndOffset(100)
+	require.NoError(t, o.updateEndOffset(100))
 	require.Equal(t, int64(100), o.startOffset)
 	require.Equal(t, int64(100), o.latestOffset)
 
 	// Subsequent observations only advance the latest offset, so they diverge.
-	o.updateEndOffset(200)
+	require.NoError(t, o.updateEndOffset(200))
+	require.Equal(t, int64(100), o.startOffset)
+	require.Equal(t, int64(200), o.latestOffset)
+
+	// Observing the same offset again is allowed and changes nothing.
+	require.NoError(t, o.updateEndOffset(200))
+	require.Equal(t, int64(100), o.startOffset)
+	require.Equal(t, int64(200), o.latestOffset)
+
+	// An end offset that moves backwards is reported and leaves the offsets unchanged.
+	require.ErrorIs(t, o.updateEndOffset(150), errEndOffsetWentBackwards)
 	require.Equal(t, int64(100), o.startOffset)
 	require.Equal(t, int64(200), o.latestOffset)
 }

--- a/pkg/blockbuilder/scheduler/scheduler.go
+++ b/pkg/blockbuilder/scheduler/scheduler.go
@@ -214,13 +214,7 @@ func (s *BlockBuilderScheduler) updateSchedule(ctx context.Context) {
 		defer s.mu.Unlock()
 
 		ps := s.getPartitionState(o.Topic, o.Partition)
-		if err := ps.updateEndOffset(o.Offset); err != nil {
-			if !errors.Is(err, errEndOffsetWentBackwards) {
-				level.Error(s.logger).Log("msg", "failed to update end offset", "partition", ps.partition, "err", err)
-				return
-			}
-			level.Warn(s.logger).Log("msg", "ignoring end offset that went backwards", "partition", ps.partition, "err", err)
-		}
+		ps.updateEndOffset(o.Offset)
 		job, err := ps.updateTime(now, s.cfg.JobSize)
 
 		if err != nil {
@@ -333,13 +327,7 @@ func (s *BlockBuilderScheduler) populateInitialJobs(ctx context.Context, consume
 		ps := s.getPartitionState(off.topic, off.partition)
 
 		for _, io := range o {
-			if err := ps.updateEndOffset(io.offset); err != nil {
-				if !errors.Is(err, errEndOffsetWentBackwards) {
-					level.Error(s.logger).Log("msg", "failed to update end offset", "partition", ps.partition, "err", err)
-					continue
-				}
-				level.Warn(s.logger).Log("msg", "ignoring end offset that went backwards", "partition", ps.partition, "err", err)
-			}
+			ps.updateEndOffset(io.offset)
 			if job, err := ps.updateTime(io.time, s.cfg.JobSize); err != nil {
 				level.Warn(s.logger).Log("msg", "failed to update partition time", "partition", ps.partition, "err", err)
 			} else if job != nil {

--- a/pkg/blockbuilder/scheduler/scheduler.go
+++ b/pkg/blockbuilder/scheduler/scheduler.go
@@ -214,7 +214,8 @@ func (s *BlockBuilderScheduler) updateSchedule(ctx context.Context) {
 		defer s.mu.Unlock()
 
 		ps := s.getPartitionState(o.Topic, o.Partition)
-		job, err := ps.updateEndOffset(o.Offset, now, s.cfg.JobSize)
+		ps.updateEndOffset(o.Offset)
+		job, err := ps.updateTime(now, s.cfg.JobSize)
 
 		if err != nil {
 			level.Warn(s.logger).Log("msg", "failed to observe end offset", "err", err)
@@ -306,8 +307,8 @@ func (s *BlockBuilderScheduler) populateInitialJobs(ctx context.Context, consume
 	// ~correctly-sized jobs that may exist between the partition's commit and
 	// end offsets.
 	// We do that by performing a one-time probe of <offset, time> pairs between
-	// those two offsets and seeding the schedule by calling updateEndOffset for
-	// each of them- just like we do during normal operation.
+	// those two offsets and seeding the schedule by calling updateEndOffset and
+	// updateTime for each of them- just like we do during normal operation.
 
 	minScanTime := endTime.Add(-s.cfg.MaxScanAge)
 
@@ -326,7 +327,8 @@ func (s *BlockBuilderScheduler) populateInitialJobs(ctx context.Context, consume
 		ps := s.getPartitionState(off.topic, off.partition)
 
 		for _, io := range o {
-			if job, err := ps.updateEndOffset(io.offset, io.time, s.cfg.JobSize); err != nil {
+			ps.updateEndOffset(io.offset)
+			if job, err := ps.updateTime(io.time, s.cfg.JobSize); err != nil {
 				level.Warn(s.logger).Log("msg", "failed to observe end offset", "partition", ps.partition, "err", err)
 			} else if job != nil {
 				ps.addPendingJob(job)

--- a/pkg/blockbuilder/scheduler/scheduler.go
+++ b/pkg/blockbuilder/scheduler/scheduler.go
@@ -214,11 +214,17 @@ func (s *BlockBuilderScheduler) updateSchedule(ctx context.Context) {
 		defer s.mu.Unlock()
 
 		ps := s.getPartitionState(o.Topic, o.Partition)
-		ps.updateEndOffset(o.Offset)
+		if err := ps.updateEndOffset(o.Offset); err != nil {
+			if !errors.Is(err, errEndOffsetWentBackwards) {
+				level.Error(s.logger).Log("msg", "failed to update end offset", "partition", ps.partition, "err", err)
+				return
+			}
+			level.Warn(s.logger).Log("msg", "ignoring end offset that went backwards", "partition", ps.partition, "err", err)
+		}
 		job, err := ps.updateTime(now, s.cfg.JobSize)
 
 		if err != nil {
-			level.Warn(s.logger).Log("msg", "failed to observe end offset", "err", err)
+			level.Warn(s.logger).Log("msg", "failed to update partition time", "err", err)
 			return
 		}
 		if job != nil {
@@ -327,9 +333,15 @@ func (s *BlockBuilderScheduler) populateInitialJobs(ctx context.Context, consume
 		ps := s.getPartitionState(off.topic, off.partition)
 
 		for _, io := range o {
-			ps.updateEndOffset(io.offset)
+			if err := ps.updateEndOffset(io.offset); err != nil {
+				if !errors.Is(err, errEndOffsetWentBackwards) {
+					level.Error(s.logger).Log("msg", "failed to update end offset", "partition", ps.partition, "err", err)
+					continue
+				}
+				level.Warn(s.logger).Log("msg", "ignoring end offset that went backwards", "partition", ps.partition, "err", err)
+			}
 			if job, err := ps.updateTime(io.time, s.cfg.JobSize); err != nil {
-				level.Warn(s.logger).Log("msg", "failed to observe end offset", "partition", ps.partition, "err", err)
+				level.Warn(s.logger).Log("msg", "failed to update partition time", "partition", ps.partition, "err", err)
 			} else if job != nil {
 				ps.addPendingJob(job)
 			}

--- a/pkg/blockbuilder/scheduler/scheduler_test.go
+++ b/pkg/blockbuilder/scheduler/scheduler_test.go
@@ -1481,7 +1481,7 @@ func TestStartupToRegularModeJobProduction(t *testing.T) {
 			ps := sched.getPartitionState("topic", 0)
 
 			for _, obs := range tt.futureObservations {
-				ps.updateEndOffset(obs.offset)
+				require.NoError(t, ps.updateEndOffset(obs.offset))
 				job, err := ps.updateTime(obs.timestamp, sched.cfg.JobSize)
 				require.NoError(t, err)
 				if job != nil {

--- a/pkg/blockbuilder/scheduler/scheduler_test.go
+++ b/pkg/blockbuilder/scheduler/scheduler_test.go
@@ -583,7 +583,7 @@ func TestObservations(t *testing.T) {
 func (s *BlockBuilderScheduler) requireOffset(t *testing.T, topic string, partition int32, expected int64, msgAndArgs ...any) {
 	t.Helper()
 	ps := s.getPartitionState(topic, partition)
-	require.Equal(t, expected, ps.committed.offset(), msgAndArgs...)
+	require.Equal(t, expected, ps.offsets.committed.offset(), msgAndArgs...)
 }
 
 func TestOffsetMovement(t *testing.T) {
@@ -613,7 +613,7 @@ func TestOffsetMovement(t *testing.T) {
 	sched.requireOffset(t, "ingest", 1, 6000, "re-completing the same job shouldn't change the commit")
 
 	p1 := sched.getPartitionState("ingest", 1)
-	p1.committed.advance("ancient_job", schedulerpb.JobSpec{
+	p1.offsets.committed.advance("ancient_job", schedulerpb.JobSpec{
 		Topic:       "ingest",
 		Partition:   1,
 		StartOffset: 1000,
@@ -622,7 +622,7 @@ func TestOffsetMovement(t *testing.T) {
 	sched.requireOffset(t, "ingest", 1, 6000, "committed offsets cannot rewind")
 
 	p2 := sched.getPartitionState("ingest", 2)
-	p2.committed.advance("ancient_job2", schedulerpb.JobSpec{
+	p2.offsets.committed.advance("ancient_job2", schedulerpb.JobSpec{
 		Topic:       "ingest",
 		Partition:   2,
 		StartOffset: 6000,
@@ -1257,11 +1257,11 @@ func TestBlockBuilderScheduler_EnqueuePendingJobs_GapDetection(t *testing.T) {
 
 	assert.Equal(t, 3, pt.pendingJobs.Len())
 	assert.Equal(t, 0, sched.jobs.count())
-	assert.True(t, pt.planned.empty())
+	assert.True(t, pt.offsets.planned.empty())
 	sched.enqueuePendingJobs()
 	assert.Equal(t, 0, pt.pendingJobs.Len())
 	assert.Equal(t, 3, sched.jobs.count())
-	assert.Equal(t, int64(50), pt.planned.offset())
+	assert.Equal(t, int64(50), pt.offsets.planned.offset())
 
 	requireGaps(t, reg, 0, 0)
 
@@ -1270,11 +1270,11 @@ func TestBlockBuilderScheduler_EnqueuePendingJobs_GapDetection(t *testing.T) {
 
 	assert.Equal(t, 1, pt.pendingJobs.Len())
 	assert.Equal(t, 3, sched.jobs.count())
-	assert.Equal(t, int64(50), pt.planned.offset())
+	assert.Equal(t, int64(50), pt.offsets.planned.offset())
 	sched.enqueuePendingJobs()
 	assert.Equal(t, 0, pt.pendingJobs.Len())
 	assert.Equal(t, 4, sched.jobs.count(), "a gap should not interfere with job queueing")
-	assert.Equal(t, int64(70), pt.planned.offset())
+	assert.Equal(t, int64(70), pt.offsets.planned.offset())
 
 	requireGaps(t, reg, 1, 0)
 
@@ -1286,11 +1286,11 @@ func TestBlockBuilderScheduler_EnqueuePendingJobs_GapDetection(t *testing.T) {
 
 	assert.Equal(t, 3, pt.pendingJobs.Len())
 	assert.Equal(t, 4, sched.jobs.count())
-	assert.Equal(t, int64(70), pt.planned.offset())
+	assert.Equal(t, int64(70), pt.offsets.planned.offset())
 	sched.enqueuePendingJobs()
 	assert.Equal(t, 0, pt.pendingJobs.Len())
 	assert.Equal(t, 7, sched.jobs.count(), "a gap should not interfere with job queueing")
-	assert.Equal(t, int64(120), pt.planned.offset())
+	assert.Equal(t, int64(120), pt.offsets.planned.offset())
 
 	requireGaps(t, reg, 2, 0)
 
@@ -1323,8 +1323,8 @@ func TestBlockBuilderScheduler_NoCommit_NoGap(t *testing.T) {
 	requireGaps(t, reg, 0, 0)
 
 	pp := sched.getPartitionState("ingest", part)
-	require.True(t, pp.planned.empty())
-	require.True(t, pp.committed.empty())
+	require.True(t, pp.offsets.planned.empty())
+	require.True(t, pp.offsets.committed.empty())
 
 	k := jobKey{"myjob5", 5}
 	spec := schedulerpb.JobSpec{
@@ -1334,10 +1334,10 @@ func TestBlockBuilderScheduler_NoCommit_NoGap(t *testing.T) {
 		EndOffset:   20,
 	}
 
-	pp.planned.advance(k.id, spec)
+	pp.offsets.planned.advance(k.id, spec)
 	requireGaps(t, reg, 0, 0, "advancing an empty planned offset should not register a gap")
 
-	pp.committed.advance(k.id, spec)
+	pp.offsets.committed.advance(k.id, spec)
 	requireGaps(t, reg, 0, 0, "advancing an empty committed offset should not register a gap")
 
 	// Now create a gap:
@@ -1349,10 +1349,10 @@ func TestBlockBuilderScheduler_NoCommit_NoGap(t *testing.T) {
 		EndOffset:   50,
 	}
 
-	pp.planned.advance(k2.id, spec2)
+	pp.offsets.planned.advance(k2.id, spec2)
 	requireGaps(t, reg, 1, 0, "a gap after a non-empty planned offset should register a gap")
 
-	pp.committed.advance(k2.id, spec2)
+	pp.offsets.committed.advance(k2.id, spec2)
 	requireGaps(t, reg, 1, 1, "a gap after a non-empty committed offset should register a gap")
 }
 
@@ -1477,11 +1477,12 @@ func TestStartupToRegularModeJobProduction(t *testing.T) {
 
 			collectedJobs := []*schedulerpb.JobSpec{}
 
-			// Apply future end offset observations and collect jobs returned from updateEndOffset
+			// Apply future end offset observations and collect jobs returned from updateTime
 			ps := sched.getPartitionState("topic", 0)
 
 			for _, obs := range tt.futureObservations {
-				job, err := ps.updateEndOffset(obs.offset, obs.timestamp, sched.cfg.JobSize)
+				ps.updateEndOffset(obs.offset)
+				job, err := ps.updateTime(obs.timestamp, sched.cfg.JobSize)
 				require.NoError(t, err)
 				if job != nil {
 					collectedJobs = append(collectedJobs, job)

--- a/pkg/blockbuilder/scheduler/scheduler_test.go
+++ b/pkg/blockbuilder/scheduler/scheduler_test.go
@@ -1481,7 +1481,7 @@ func TestStartupToRegularModeJobProduction(t *testing.T) {
 			ps := sched.getPartitionState("topic", 0)
 
 			for _, obs := range tt.futureObservations {
-				require.NoError(t, ps.updateEndOffset(obs.offset))
+				ps.updateEndOffset(obs.offset)
 				job, err := ps.updateTime(obs.timestamp, sched.cfg.JobSize)
 				require.NoError(t, err)
 				if job != nil {


### PR DESCRIPTION
Builds on top of #15836.

Splits the combined `updateEndOffset` in the block-builder scheduler's `partitionState` into two functions — `updateEndOffset` (records the latest observed end offset) and `updateTime` (advances the time bucket and emits jobs) — and groups a partition's per-cluster consumption offsets into a `singleClusterOffsets` struct.

This decouples offset observation from job-bucket sizing and sets up tracking offsets per Kafka cluster, as groundwork for per-compartment block builders. No behaviour change.