### PR TITLE
MQE: pass query time range to AST optimization passes

### DIFF
--- a/pkg/streamingpromql/optimize/ast/collapse_constants.go
+++ b/pkg/streamingpromql/optimize/ast/collapse_constants.go
@@ -8,6 +8,8 @@ import (
 	"math"
 
 	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
 )
 
 type CollapseConstants struct{}
@@ -16,7 +18,7 @@ func (c *CollapseConstants) Name() string {
 	return "Collapse constants"
 }
 
-func (c *CollapseConstants) Apply(_ context.Context, expr parser.Expr) (parser.Expr, error) {
+func (c *CollapseConstants) Apply(_ context.Context, expr parser.Expr, _ types.QueryTimeRange) (parser.Expr, error) {
 	return c.apply(expr), nil
 }
 

--- a/pkg/streamingpromql/optimize/ast/insert_omitted_target_info_selector.go
+++ b/pkg/streamingpromql/optimize/ast/insert_omitted_target_info_selector.go
@@ -11,6 +11,8 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/promql/parser/posrange"
+
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
 )
 
 const (
@@ -23,7 +25,7 @@ func (h *InsertOmittedTargetInfoSelector) Name() string {
 	return "Insert omitted target info selector"
 }
 
-func (h *InsertOmittedTargetInfoSelector) Apply(_ context.Context, root parser.Expr) (parser.Expr, error) {
+func (h *InsertOmittedTargetInfoSelector) Apply(_ context.Context, root parser.Expr, _ types.QueryTimeRange) (parser.Expr, error) {
 	if err := parser.Walk(h, root, nil); err != nil {
 		return nil, err
 	}

--- a/pkg/streamingpromql/optimize/ast/prune_toggles.go
+++ b/pkg/streamingpromql/optimize/ast/prune_toggles.go
@@ -10,6 +10,7 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/grafana/mimir/pkg/frontend/querymiddleware/astmapper"
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
 )
 
 // PruneToggles optimizes queries by pruning expressions that are toggled off, only
@@ -39,7 +40,7 @@ func (p *PruneToggles) Name() string {
 	return "Toggled off expressions pruning"
 }
 
-func (p *PruneToggles) Apply(ctx context.Context, expr parser.Expr) (parser.Expr, error) {
+func (p *PruneToggles) Apply(ctx context.Context, expr parser.Expr, _ types.QueryTimeRange) (parser.Expr, error) {
 	p.pruneTogglesAttempts.Inc()
 	mapper := NewPruneTogglesMapper()
 	newExpr, err := mapper.Map(ctx, expr)

--- a/pkg/streamingpromql/optimize/ast/reduce_matchers.go
+++ b/pkg/streamingpromql/optimize/ast/reduce_matchers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/planning/core"
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
 	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/spanlogger"
 )
@@ -44,7 +45,7 @@ func (c *ReduceMatchers) Name() string {
 	return "Reduce matchers"
 }
 
-func (c *ReduceMatchers) Apply(ctx context.Context, root parser.Expr) (parser.Expr, error) {
+func (c *ReduceMatchers) Apply(ctx context.Context, root parser.Expr, _ types.QueryTimeRange) (parser.Expr, error) {
 	spanlog := spanlogger.FromContext(ctx, c.logger)
 	c.attempts.Inc()
 

--- a/pkg/streamingpromql/optimize/ast/sharding/optimization_pass.go
+++ b/pkg/streamingpromql/optimize/ast/sharding/optimization_pass.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/mimir/pkg/frontend/querymiddleware/astmapper"
 	"github.com/grafana/mimir/pkg/streamingpromql/optimize"
 	"github.com/grafana/mimir/pkg/streamingpromql/requestoptions"
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
 )
 
 type OptimizationPass struct {
@@ -34,7 +35,7 @@ func (o *OptimizationPass) Name() string {
 	return "Sharding"
 }
 
-func (o *OptimizationPass) Apply(ctx context.Context, expr parser.Expr) (parser.Expr, error) {
+func (o *OptimizationPass) Apply(ctx context.Context, expr parser.Expr, _ types.QueryTimeRange) (parser.Expr, error) {
 	if containsSpunOffSubquery(expr) {
 		return expr, nil
 	}

--- a/pkg/streamingpromql/optimize/ast/sharding/optimization_pass_test.go
+++ b/pkg/streamingpromql/optimize/ast/sharding/optimization_pass_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/mimir/pkg/frontend/querymiddleware"
 	"github.com/grafana/mimir/pkg/frontend/querymiddleware/astmapper"
 	"github.com/grafana/mimir/pkg/streamingpromql/requestoptions"
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
 	"github.com/grafana/mimir/pkg/util/promqlext"
 )
 
@@ -90,7 +91,7 @@ func TestOptimizationPass(t *testing.T) {
 
 			ctx = querymiddleware.ContextWithRequestHints(ctx, testCase.hints)
 			ctx = requestoptions.ContextWithOptions(ctx, testCase.options)
-			output, err := pass.Apply(ctx, afterRewrite)
+			output, err := pass.Apply(ctx, afterRewrite, types.QueryTimeRange{})
 			require.NoError(t, err)
 			require.Equal(t, testCase.expectedOutput, output.String())
 		})

--- a/pkg/streamingpromql/optimize/ast/sort_labels_and_matchers.go
+++ b/pkg/streamingpromql/optimize/ast/sort_labels_and_matchers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/planning/core"
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
 )
 
 // SortLabelsAndMatchers is an optimization pass that ensures that all label names and matchers are sorted.
@@ -22,7 +23,7 @@ func (s *SortLabelsAndMatchers) Name() string {
 	return "Sort labels and matchers"
 }
 
-func (s *SortLabelsAndMatchers) Apply(_ context.Context, expr parser.Expr) (parser.Expr, error) {
+func (s *SortLabelsAndMatchers) Apply(_ context.Context, expr parser.Expr, _ types.QueryTimeRange) (parser.Expr, error) {
 	parser.Inspect(expr, func(node parser.Node, _ []parser.Node) error {
 		switch expr := node.(type) {
 		case *parser.VectorSelector:

--- a/pkg/streamingpromql/optimize/interface.go
+++ b/pkg/streamingpromql/optimize/interface.go
@@ -8,11 +8,12 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/planning"
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
 )
 
 type ASTOptimizationPass interface {
 	Name() string
-	Apply(ctx context.Context, expr parser.Expr) (parser.Expr, error)
+	Apply(ctx context.Context, expr parser.Expr, timeRange types.QueryTimeRange) (parser.Expr, error)
 }
 
 type QueryPlanOptimizationPass interface {

--- a/pkg/streamingpromql/planning.go
+++ b/pkg/streamingpromql/planning.go
@@ -261,7 +261,7 @@ func (p *QueryPlanner) ParseAndApplyASTOptimizationPasses(ctx context.Context, q
 	}
 
 	for _, o := range p.astOptimizationPasses {
-		expr, err = p.runASTStage(o.Name(), observer, func() (parser.Expr, error) { return o.Apply(ctx, expr) })
+		expr, err = p.runASTStage(o.Name(), observer, func() (parser.Expr, error) { return o.Apply(ctx, expr, timeRange) })
 
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
#### What this PR does

The subquery spin-off AST optimization pass (coming in a later PR) must only act on instant queries, but AST passes currently have no access to the query time range. 

This PR passes the query time range to AST optimization passes, mirroring what is done for plan optimization passes.

This change has no user impact, so I've chosen not to add a changelog entry.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
