### PR TITLE
Compartments: clarify Kafka topology in architecture diagram

### DIFF
--- a/docs/internal/compartments/README.md
+++ b/docs/internal/compartments/README.md
@@ -54,32 +54,58 @@ There are two independent sets of compartments, and their counts do not need to 
 A **global query layer** — query-frontend, query-scheduler, querier and ruler — spans all compartments
 and is not part of either set.
 
+Compartments and their per-compartment resources follow a `wc-<id>` / `rc-<id>` naming convention; see
+[Naming conventions](./naming.md).
+
 ## Overall architecture
 
 ```mermaid
 flowchart LR
     GW["Ingress auth gateway<br/>or load balancer"]
 
-    subgraph WC["Write compartments"]
+    subgraph WC0["Write compartment wc-0"]
         direction TB
-        WC0["distributors + dedicated Kafka cluster #0"]
-        WC1["distributors + dedicated Kafka cluster #1"]
+        D0["distributor-wc-0"]
+        subgraph K0["kafka-wc-0"]
+            direction TB
+            K0T0["&quot;ingest-rc-0&quot; topic"]
+            K0T1["&quot;ingest-rc-1&quot; topic"]
+        end
+        D0 --> K0T0
+        D0 --> K0T1
     end
 
-    subgraph RC["Read compartments"]
+    subgraph WC1["Write compartment wc-1"]
         direction TB
-        RC0["read compartment #0<br/>(ingesters, store-gateways,<br/>block-builders, compactors)<br/>topic: read-comp-0"]
-        RC1["read compartment #1<br/>(ingesters, store-gateways,<br/>block-builders, compactors)<br/>topic: read-comp-1"]
+        D1["distributor-wc-1"]
+        subgraph K1["kafka-wc-1"]
+            direction TB
+            K1T0["&quot;ingest-rc-0&quot; topic"]
+            K1T1["&quot;ingest-rc-1&quot; topic"]
+        end
+        D1 --> K1T0
+        D1 --> K1T1
+    end
+
+    subgraph RC0["Read compartment rc-0"]
+        RC0C["ingesters, store-gateways,<br/>block-builders, compactors"]
+    end
+    subgraph RC1["Read compartment rc-1"]
+        RC1C["ingesters, store-gateways,<br/>block-builders, compactors"]
     end
 
     QL["Global query layer<br/>(query-frontend, query-scheduler,<br/>querier, ruler)"]
 
-    GW -->|random write compartment| WC0
-    GW -->|random write compartment| WC1
-    WC --> RC0
-    WC --> RC1
-    QL -.queries.-> RC0
-    QL -.queries.-> RC1
+    GW -->|random write compartment| D0
+    GW -->|random write compartment| D1
+
+    K0T0 --> RC0C
+    K1T0 --> RC0C
+    K0T1 --> RC1C
+    K1T1 --> RC1C
+
+    RC0C -.->|queried by| QL
+    RC1C -.->|queried by| QL
 ```
 
 At a high level:
@@ -92,9 +118,12 @@ At a high level:
   series label-hash sharding. See [Sharding](./sharding.md).
 - **Read path.** Each read compartment runs its storage components against a dedicated topic.
 
-> **Note:** compartments are still under development and not everything described in this
-> documentation is implemented yet. See [Status and limitations](./status-and-limitations.md) for the
-> current state.
+Each write compartment has its own Kafka cluster (`kafka-wc-<id>`), and every cluster contains one
+topic per read compartment (`ingest-rc-<id>`); a read compartment's ingesters consume their topic from
+every write compartment's cluster.
+
+An `ingest-rc-<id>` topic exists once in **every** write compartment's Kafka cluster, because every
+write compartment writes to every read compartment (see [Write compartments](./write-compartments.md)).
 
 ## Multi-zone
 
@@ -107,6 +136,8 @@ components (both write and read compartments) across availability zones.
   metric name is used as the segmentation label.
 - [Write compartments](./write-compartments.md) — the write-compartment design.
 - [Read compartments](./read-compartments.md) — the read-compartment design.
+- [Naming conventions](./naming.md) — the names used for compartments and their per-compartment
+  resources.
 - [Configuration](./configuration.md) — the rationale behind where compartments configuration lives.
 - [Status and limitations](./status-and-limitations.md) — what is implemented today and what is not.
 - [Authoring guide for the compartments documentation](./AGENTS.md) — rules for keeping this

--- a/docs/internal/compartments/naming.md
+++ b/docs/internal/compartments/naming.md
@@ -1,0 +1,12 @@
+# Naming conventions
+
+Compartments and their per-compartment resources are named with a `wc-<id>` / `rc-<id>` suffix, where
+`<id>` is the zero-based compartment index.
+
+| Resource                             | Convention            | Example            |
+| ------------------------------------ | --------------------- | ------------------ |
+| Write compartment                    | `wc-<id>`             | `wc-0`, `wc-1`     |
+| Read compartment                     | `rc-<id>`             | `rc-0`, `rc-1`     |
+| Distributors of a write compartment  | `distributor-wc-<id>` | `distributor-wc-0` |
+| Kafka cluster of a write compartment | `kafka-wc-<id>`       | `kafka-wc-0`       |
+| Ingest topic of a read compartment   | `ingest-rc-<id>`      | `ingest-rc-0`      |

--- a/docs/internal/compartments/read-compartments.md
+++ b/docs/internal/compartments/read-compartments.md
@@ -21,11 +21,11 @@ store-gateways, block-builders and compactors, and is responsible for the series
 flowchart LR
     subgraph WCk["Write compartments (Kafka clusters)"]
         direction TB
-        K0["Kafka cluster #0<br/>topic read-comp-1, partition 0"]
-        K1["Kafka cluster #1<br/>topic read-comp-1, partition 0"]
+        K0["kafka-wc-0<br/>&quot;ingest-rc-1&quot; topic, partition 0"]
+        K1["kafka-wc-1<br/>&quot;ingest-rc-1&quot; topic, partition 0"]
     end
 
-    ING["ingester-0 of read compartment #1<br/>owns partition 0"]
+    ING["ingester-0 of rc-1<br/>owns partition 0"]
 
     K0 --> ING
     K1 --> ING
@@ -84,9 +84,9 @@ A dedicated topic per read compartment simplifies partition management: each com
 are an independent topic, so there is a clear, per-compartment mapping between a partition and the
 ingester that owns it.
 
-For example, with two read compartments there are two topics, `read-comp-0` and `read-comp-1`. The
-ingester that owns partition 0 of read compartment 0 consumes `read-comp-0` partition 0, while the
-ingester that owns partition 0 of read compartment 1 consumes `read-comp-1` partition 0 — two distinct
+For example, with two read compartments there are two topics, `ingest-rc-0` and `ingest-rc-1`. The
+ingester that owns partition 0 of rc-0 consumes `ingest-rc-0` partition 0, while the
+ingester that owns partition 0 of rc-1 consumes `ingest-rc-1` partition 0 — two distinct
 topic-partitions owned by two distinct ingesters, even though both are "partition 0".
 
 ## Warpstream specifics


### PR DESCRIPTION
**What this PR does**

The compartments architecture diagram didn't make the Kafka topology obvious: that there is **one Kafka cluster per write compartment**, and **one topic per read compartment** within each cluster.

This reworks the overall-architecture diagram so each write compartment shows its distributors plus a dedicated Kafka cluster containing one topic per read compartment, with the cross-cluster consume fan-in into each read compartment. It also adopts the `wc-<id>` / `rc-<id>` naming conventions consistently across the compartments docs and documents them in a new `naming.md`.

These are internal design docs, so there is no user-facing change and no CHANGELOG entry.

**Which issue(s) this PR fixes or relates to**

N/A

**Checklist**

- [ ] Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated.
- [ ] `about-versioning.md` updated with experimental features.