### PR TITLE
block-builder-scheduler: refactor probeInitialOffsets and explicitly handle no offset time case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
 * [BUGFIX] MQE: Report a query that panics during evaluation as failed in the `evaluation stats` log, instead of logging it as successful. The querier still re-panics afterwards, crash behaviour is unchanged. #15753
 * [BUGFIX] Memcached: Fix issue where cache-related trace spans included events emitted with an empty `name` label. #15794
 * [BUGFIX] MQE: Fix issue where LBAC is not respected by range vector splitting cache. #15802
+* [BUGFIX] Block-builder-scheduler: Fix a spurious "time went backwards" warning logged at startup when a partition has no records after the scan time. #15855
 
 ### Mixin
 

--- a/pkg/blockbuilder/scheduler/metrics.go
+++ b/pkg/blockbuilder/scheduler/metrics.go
@@ -32,7 +32,7 @@ func newSchedulerMetrics(reg prometheus.Registerer) schedulerMetrics {
 			NativeHistogramBucketFactor: 1.1,
 		}),
 		probeRecordTimeDelta: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
-			Name: "cortex_blockbuilder_scheduler_probe_record_time_delta_seconds",
+			Name: "cortex_blockbuilder_scheduler_initial_probe_record_time_delta_seconds",
 			Help: "Delta between a probe's requested time and the timestamp of the record at the returned offset, during initial offset probing.",
 
 			NativeHistogramBucketFactor: 1.1,

--- a/pkg/blockbuilder/scheduler/metrics.go
+++ b/pkg/blockbuilder/scheduler/metrics.go
@@ -33,7 +33,7 @@ func newSchedulerMetrics(reg prometheus.Registerer) schedulerMetrics {
 		}),
 		probeRecordTimeDelta: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 			Name: "cortex_blockbuilder_scheduler_probe_record_time_delta_seconds",
-			Help: "Delta between a probe's requested time and the timestamp of the record at the returned offset, during initial offset probing. Smaller values mean probes land closer to actual data.",
+			Help: "Delta between a probe's requested time and the timestamp of the record at the returned offset, during initial offset probing.",
 
 			NativeHistogramBucketFactor: 1.1,
 		}),

--- a/pkg/blockbuilder/scheduler/metrics.go
+++ b/pkg/blockbuilder/scheduler/metrics.go
@@ -9,6 +9,7 @@ import (
 
 type schedulerMetrics struct {
 	updateScheduleDuration   prometheus.Histogram
+	probeRecordTimeDelta     prometheus.Histogram
 	partitionStartOffset     *prometheus.GaugeVec
 	partitionCommittedOffset *prometheus.GaugeVec
 	partitionPlannedOffset   *prometheus.GaugeVec
@@ -27,6 +28,12 @@ func newSchedulerMetrics(reg prometheus.Registerer) schedulerMetrics {
 		updateScheduleDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 			Name: "cortex_blockbuilder_scheduler_schedule_update_seconds",
 			Help: "Time spent updating the schedule.",
+
+			NativeHistogramBucketFactor: 1.1,
+		}),
+		probeRecordTimeDelta: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Name: "cortex_blockbuilder_scheduler_probe_record_time_delta_seconds",
+			Help: "Delta between a probe's requested time and the timestamp of the record at the returned offset, during initial offset probing. Smaller values mean probes land closer to actual data.",
 
 			NativeHistogramBucketFactor: 1.1,
 		}),

--- a/pkg/blockbuilder/scheduler/offset_scanner.go
+++ b/pkg/blockbuilder/scheduler/offset_scanner.go
@@ -23,8 +23,10 @@ type offsetTime struct {
 // offsetScanner computes an initial set of <offset, time> pairs for each
 // partition, used to seed the scheduler at startup.
 type offsetScanner struct {
-	offs            offsetStore
-	endTime         time.Time
+	store   offsetStore
+	endTime time.Time
+	// probeTimes are the timestamps to query Kafka offsets at, in descending
+	// order so the scan stops once it reaches the partition's resume offset.
 	probeTimes      []time.Time
 	recordTimeDelta prometheus.Observer
 }
@@ -32,7 +34,7 @@ type offsetScanner struct {
 func newOffsetScanner(offs offsetStore, endTime time.Time, jobSize, maxScanAge time.Duration, recordTimeDelta prometheus.Observer) *offsetScanner {
 	minScanTime := endTime.Add(-maxScanAge)
 	return &offsetScanner{
-		offs:            offs,
+		store:           offs,
 		endTime:         endTime,
 		probeTimes:      scanProbeTimes(endTime, jobSize, minScanTime),
 		recordTimeDelta: recordTimeDelta,
@@ -42,10 +44,10 @@ func newOffsetScanner(offs offsetStore, endTime time.Time, jobSize, maxScanAge t
 // probeInitialOffsets computes an initial set of <offset, time> pairs that exist between this
 // partition's resume and end offsets. These pairs can be used to seed a bunch of
 // end offset observations to start the scheduler.
-func (s *offsetScanner) probeInitialOffsets(ctx context.Context, off partitionOffsets, logger log.Logger) ([]*offsetTime, error) {
-	if off.resume >= off.end || off.start >= off.end {
+func (s *offsetScanner) probeInitialOffsets(ctx context.Context, po partitionOffsets, logger log.Logger) ([]*offsetTime, error) {
+	if po.resume >= po.end || po.start >= po.end {
 		// No new data to consume. Return the single end offset so it is initially registered.
-		return []*offsetTime{{offset: off.end, time: s.endTime}}, nil
+		return []*offsetTime{{offset: po.end, time: s.endTime}}, nil
 	}
 
 	reachedResume := false
@@ -56,15 +58,15 @@ func (s *offsetScanner) probeInitialOffsets(ctx context.Context, off partitionOf
 	// given a timestamp, so we iteratively call that API for each probe time
 	// until we reach the resume offset.
 	for _, pb := range s.probeTimes {
-		offset, t, isEndOffset, err := s.offs.offsetAfterTime(ctx, off.topic, off.partition, pb)
+		offset, t, isEndOffset, err := s.store.offsetAfterTime(ctx, po.topic, po.partition, pb)
 		if err != nil {
 			return nil, err
 		}
 		level.Debug(logger).Log("msg", "found next boundary offset", "ts", pb,
-			"topic", off.topic, "partition", off.partition, "offset", offset, "isEndOffset", isEndOffset)
+			"topic", po.topic, "partition", po.partition, "offset", offset, "isEndOffset", isEndOffset)
 
 		// Don't want to probe for offsets before the resume offset.
-		offset = max(offset, off.resume)
+		offset = max(offset, po.resume)
 
 		if len(sentinels) == 0 || offset != sentinels[len(sentinels)-1].offset {
 			// The end offset has no real record timestamp, so register its
@@ -77,7 +79,7 @@ func (s *offsetScanner) probeInitialOffsets(ctx context.Context, off partitionOf
 			sentinels = append(sentinels, &offsetTime{offset: offset, time: t})
 		}
 
-		if offset == off.resume {
+		if offset == po.resume {
 			// We've reached the resume offset, so we're done.
 			reachedResume = true
 			break
@@ -89,7 +91,7 @@ func (s *offsetScanner) probeInitialOffsets(ctx context.Context, off partitionOf
 		if len(sentinels) > 0 {
 			lastOffset = sentinels[len(sentinels)-1].offset
 		}
-		level.Warn(logger).Log("msg", "probe offsets: probe did not reach commit offset due to limited scan age", "partition", off.partition, "lastOffset", lastOffset, "resumeOffset", off.resume)
+		level.Warn(logger).Log("msg", "probe offsets: probe did not reach commit offset due to limited scan age", "partition", po.partition, "lastOffset", lastOffset, "resumeOffset", po.resume)
 	}
 
 	// Return them in increasing order of offset.

--- a/pkg/blockbuilder/scheduler/offset_scanner.go
+++ b/pkg/blockbuilder/scheduler/offset_scanner.go
@@ -18,8 +18,6 @@ import (
 type offsetTime struct {
 	offset int64
 	time   time.Time
-	// skipTimeUpdate means the end offset should be registered without advancing the time bucket.
-	skipTimeUpdate bool
 }
 
 // offsetScanner computes an initial set of <offset, time> pairs for each
@@ -70,13 +68,13 @@ func (s *offsetScanner) probeInitialOffsets(ctx context.Context, off partitionOf
 
 		if len(sentinels) == 0 || offset != sentinels[len(sentinels)-1].offset {
 			// The end offset has no real record timestamp, so register its
-			// offset but skip the time update rather than bucket from a
-			// non-existent record.
-			sentinels = append(sentinels, &offsetTime{offset: offset, time: t, skipTimeUpdate: isEndOffset})
-
-			if !isEndOffset {
+			// offset at the current time.
+			if isEndOffset {
+				t = s.endTime
+			} else {
 				s.recordTimeDelta.Observe(t.Sub(pb).Seconds())
 			}
+			sentinels = append(sentinels, &offsetTime{offset: offset, time: t})
 		}
 
 		if offset == off.resume {

--- a/pkg/blockbuilder/scheduler/offset_scanner.go
+++ b/pkg/blockbuilder/scheduler/offset_scanner.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/twmb/franz-go/pkg/kadm"
 )
 
@@ -19,54 +20,79 @@ type offsetTime struct {
 	time   time.Time
 }
 
-// probeInitialOffsets computes an initial set of <offset, time> pairs that
-// exist between this partition's commit and end offsets. These pairs can be
-// used to seed a bunch of end offset observations to start the scheduler.
-func probeInitialOffsets(ctx context.Context, offs offsetStore, topic string, partition int32, start, commit, end int64,
-	endTime time.Time, jobSize time.Duration, minScanTime time.Time, logger log.Logger) ([]*offsetTime, error) {
+// offsetScanner computes an initial set of <offset, time> pairs for each
+// partition, used to seed the scheduler at startup.
+type offsetScanner struct {
+	offs            offsetStore
+	endTime         time.Time
+	probeTimes      []time.Time
+	recordTimeDelta prometheus.Observer
+}
 
-	if commit >= end || start >= end {
+func newOffsetScanner(offs offsetStore, endTime time.Time, jobSize, maxScanAge time.Duration, recordTimeDelta prometheus.Observer) *offsetScanner {
+	minScanTime := endTime.Add(-maxScanAge)
+	return &offsetScanner{
+		offs:            offs,
+		endTime:         endTime,
+		probeTimes:      scanProbeTimes(endTime, jobSize, minScanTime),
+		recordTimeDelta: recordTimeDelta,
+	}
+}
+
+// probeInitialOffsets computes an initial set of <offset, time> pairs that exist between this
+// partition's resume and end offsets. These pairs can be used to seed a bunch of
+// end offset observations to start the scheduler.
+func (s *offsetScanner) probeInitialOffsets(ctx context.Context, off partitionOffsets, logger log.Logger) ([]*offsetTime, error) {
+	if off.resume >= off.end || off.start >= off.end {
 		// No new data to consume. Return the single end offset so it is initially registered.
-		return []*offsetTime{{offset: end, time: endTime}}, nil
+		return []*offsetTime{{offset: off.end, time: s.endTime}}, nil
 	}
 
-	// Pick a more high-resolution interval to scan for the sentinel offsets.
-	scanStep := jobSize / 4
-	reachedCommit := false
+	if len(s.probeTimes) == 0 {
+		// No scan window, so there's nothing to probe.
+		return []*offsetTime{}, nil
+	}
+
+	reachedResume := false
 	sentinels := []*offsetTime{}
 
-	// The general idea is that we know the commit offset, but we don't know
+	// The general idea is that we know the resume offset, but we don't know
 	// that offset's timestamp. We have an API (offsetAfterTime) to get offsets
-	// given a timestamp, so we iteratively call that API until we reach either
-	// the commit offset or the min scan time.
-	for pb := endTime; minScanTime.Before(pb); pb = pb.Add(-scanStep) {
-		off, t, err := offs.offsetAfterTime(ctx, topic, partition, pb)
+	// given a timestamp, so we iteratively call that API for each probe time
+	// until we reach the resume offset.
+	for _, pb := range s.probeTimes {
+		offset, t, err := s.offs.offsetAfterTime(ctx, off.topic, off.partition, pb)
 		if err != nil {
 			return nil, err
 		}
 		level.Debug(logger).Log("msg", "found next boundary offset", "ts", pb,
-			"topic", topic, "partition", partition, "offset", off)
+			"topic", off.topic, "partition", off.partition, "offset", offset)
 
-		// Don't want to probe for offsets before the commit.
-		off = max(off, commit)
+		// Don't want to probe for offsets before the resume offset.
+		offset = max(offset, off.resume)
 
-		if len(sentinels) == 0 || off != sentinels[len(sentinels)-1].offset {
-			sentinels = append(sentinels, &offsetTime{offset: off, time: t})
+		// Only append sentinel if it's the first time we've seen it.
+		if len(sentinels) == 0 || offset != sentinels[len(sentinels)-1].offset {
+			sentinels = append(sentinels, &offsetTime{offset: offset, time: t})
+
+			// The high watermark is returned with ts == 0, that's not a real timestamp to observe.
+			if !t.IsZero() {
+				s.recordTimeDelta.Observe(t.Sub(pb).Seconds())
+			}
 		}
 
-		if off == commit {
-			// We've reached the commit offset, so we're done.
-			reachedCommit = true
+		if offset == off.resume {
+			// We've reached the resume offset, so we're done.
+			reachedResume = true
 			break
 		}
 	}
 
-	if !reachedCommit {
-		lastOffset := int64(-1)
-		if len(sentinels) > 0 {
-			lastOffset = sentinels[len(sentinels)-1].offset
-		}
-		level.Warn(logger).Log("msg", "probe offsets: probe did not reach commit offset due to limited scan age", "partition", partition, "lastOffset", lastOffset, "commitOffset", commit)
+	// We have at least one sentinel if we reach this point.
+	if !reachedResume {
+		lowestOffset := sentinels[len(sentinels)-1].offset
+		level.Warn(logger).Log("msg", "probe offsets: probe did not reach resume offset due to limited scan age",
+			"partition", off.partition, "lowestOffset", lowestOffset, "resumeOffset", off.resume)
 	}
 
 	// Return them in increasing order of offset.
@@ -77,6 +103,19 @@ func probeInitialOffsets(ctx context.Context, offs offsetStore, topic string, pa
 	return sentinels, nil
 }
 
+// scanProbeTimes returns the times at which the scanner probes for offsets, in
+// decreasing order.
+// TODO: anchor the probe times to job boundaries instead, so offsets returned are more aligned with the boundaries.
+// TODO: append a final probe at minScanTime, so the bottom of the scan window is covered.
+func scanProbeTimes(endTime time.Time, jobSize time.Duration, minScanTime time.Time) []time.Time {
+	scanStep := jobSize / 4
+	var probeTimes []time.Time
+	for pb := endTime; minScanTime.Before(pb); pb = pb.Add(-scanStep) {
+		probeTimes = append(probeTimes, pb)
+	}
+	return probeTimes
+}
+
 type offsetStore interface {
 	offsetAfterTime(context.Context, string, int32, time.Time) (int64, time.Time, error)
 }
@@ -84,14 +123,12 @@ type offsetStore interface {
 type offsetFinder struct {
 	offsets     map[time.Time]kadm.ListedOffsets
 	adminClient *kadm.Client
-	logger      log.Logger
 }
 
-func newOffsetFinder(adminClient *kadm.Client, logger log.Logger) *offsetFinder {
+func newOffsetFinder(adminClient *kadm.Client) *offsetFinder {
 	return &offsetFinder{
 		offsets:     make(map[time.Time]kadm.ListedOffsets),
 		adminClient: adminClient,
-		logger:      logger,
 	}
 }
 

--- a/pkg/blockbuilder/scheduler/offset_scanner.go
+++ b/pkg/blockbuilder/scheduler/offset_scanner.go
@@ -18,6 +18,8 @@ import (
 type offsetTime struct {
 	offset int64
 	time   time.Time
+	// skipTimeUpdate means the end offset should be registered without advancing the time bucket.
+	skipTimeUpdate bool
 }
 
 // offsetScanner computes an initial set of <offset, time> pairs for each
@@ -48,11 +50,6 @@ func (s *offsetScanner) probeInitialOffsets(ctx context.Context, off partitionOf
 		return []*offsetTime{{offset: off.end, time: s.endTime}}, nil
 	}
 
-	if len(s.probeTimes) == 0 {
-		// No scan window, so there's nothing to probe.
-		return []*offsetTime{}, nil
-	}
-
 	reachedResume := false
 	sentinels := []*offsetTime{}
 
@@ -61,22 +58,23 @@ func (s *offsetScanner) probeInitialOffsets(ctx context.Context, off partitionOf
 	// given a timestamp, so we iteratively call that API for each probe time
 	// until we reach the resume offset.
 	for _, pb := range s.probeTimes {
-		offset, t, err := s.offs.offsetAfterTime(ctx, off.topic, off.partition, pb)
+		offset, t, isEndOffset, err := s.offs.offsetAfterTime(ctx, off.topic, off.partition, pb)
 		if err != nil {
 			return nil, err
 		}
 		level.Debug(logger).Log("msg", "found next boundary offset", "ts", pb,
-			"topic", off.topic, "partition", off.partition, "offset", offset)
+			"topic", off.topic, "partition", off.partition, "offset", offset, "isEndOffset", isEndOffset)
 
 		// Don't want to probe for offsets before the resume offset.
 		offset = max(offset, off.resume)
 
-		// Only append sentinel if it's the first time we've seen it.
 		if len(sentinels) == 0 || offset != sentinels[len(sentinels)-1].offset {
-			sentinels = append(sentinels, &offsetTime{offset: offset, time: t})
+			// The end offset has no real record timestamp, so register its
+			// offset but skip the time update rather than bucket from a
+			// non-existent record.
+			sentinels = append(sentinels, &offsetTime{offset: offset, time: t, skipTimeUpdate: isEndOffset})
 
-			// The high watermark is returned with ts == 0, that's not a real timestamp to observe.
-			if !t.IsZero() {
+			if !isEndOffset {
 				s.recordTimeDelta.Observe(t.Sub(pb).Seconds())
 			}
 		}
@@ -88,11 +86,12 @@ func (s *offsetScanner) probeInitialOffsets(ctx context.Context, off partitionOf
 		}
 	}
 
-	// We have at least one sentinel if we reach this point.
 	if !reachedResume {
-		lowestOffset := sentinels[len(sentinels)-1].offset
-		level.Warn(logger).Log("msg", "probe offsets: probe did not reach resume offset due to limited scan age",
-			"partition", off.partition, "lowestOffset", lowestOffset, "resumeOffset", off.resume)
+		lastOffset := int64(-1)
+		if len(sentinels) > 0 {
+			lastOffset = sentinels[len(sentinels)-1].offset
+		}
+		level.Warn(logger).Log("msg", "probe offsets: probe did not reach commit offset due to limited scan age", "partition", off.partition, "lastOffset", lastOffset, "resumeOffset", off.resume)
 	}
 
 	// Return them in increasing order of offset.
@@ -117,7 +116,7 @@ func scanProbeTimes(endTime time.Time, jobSize time.Duration, minScanTime time.T
 }
 
 type offsetStore interface {
-	offsetAfterTime(context.Context, string, int32, time.Time) (int64, time.Time, error)
+	offsetAfterTime(context.Context, string, int32, time.Time) (int64, time.Time, bool, error)
 }
 
 type offsetFinder struct {
@@ -134,16 +133,18 @@ func newOffsetFinder(adminClient *kadm.Client) *offsetFinder {
 
 // offsetAfterTime is a cached version of adminClient.ListOffsetsAfterMilli that
 // makes use of the fact that we want to ask about the same times for all partitions.
-func (o *offsetFinder) offsetAfterTime(ctx context.Context, topic string, partition int32, t time.Time) (int64, time.Time, error) {
+// The returned bool reports whether the offset is the partition's end offset
+// (no record at or after t); when true, the returned time is not meaningful.
+func (o *offsetFinder) offsetAfterTime(ctx context.Context, topic string, partition int32, t time.Time) (int64, time.Time, bool, error) {
 	offs, ok := o.offsets[t]
 	if !ok {
 		var err error
 		offs, err = o.adminClient.ListOffsetsAfterMilli(ctx, t.UnixMilli(), topic)
 		if err != nil {
-			return 0, time.Time{}, err
+			return 0, time.Time{}, false, err
 		}
 		if offs.Error() != nil {
-			return 0, time.Time{}, offs.Error()
+			return 0, time.Time{}, false, offs.Error()
 		}
 
 		o.offsets[t] = offs
@@ -151,13 +152,25 @@ func (o *offsetFinder) offsetAfterTime(ctx context.Context, topic string, partit
 
 	po, ok := offs.Lookup(topic, partition)
 	if !ok {
-		return 0, time.Time{}, fmt.Errorf("failed to get offset for partition %d at time %s: not present", partition, t)
+		return 0, time.Time{}, false, fmt.Errorf("failed to get offset for partition %d at time %s: not present", partition, t)
 	}
 	if po.Err != nil {
-		return 0, time.Time{}, fmt.Errorf("failed to get offset for partition %d at time %s: %w", partition, t, po.Err)
+		return 0, time.Time{}, false, fmt.Errorf("failed to get offset for partition %d at time %s: %w", partition, t, po.Err)
 	}
 
-	return po.Offset, time.UnixMilli(po.Timestamp), nil
+	if po.Timestamp == -1 {
+		// When there's no record at or after the requested time, kadm returns the
+		// end offset with a -1 timestamp. The timestamp is meaningless here, so
+		// report it as the end offset.
+		return po.Offset, time.Time{}, true, nil
+	}
+	if po.Timestamp < -1 {
+		// ListOffsetsAfterMilli should only ever return a real record timestamp or
+		// the -1 sentinel, so anything below -1 means a malformed response.
+		panic(fmt.Sprintf("unexpected timestamp %d for partition %d at time %s: timestamps below -1 should never be returned", po.Timestamp, partition, t))
+	}
+
+	return po.Offset, time.UnixMilli(po.Timestamp), false, nil
 }
 
 var _ offsetStore = (*offsetFinder)(nil)

--- a/pkg/blockbuilder/scheduler/offset_scanner_test.go
+++ b/pkg/blockbuilder/scheduler/offset_scanner_test.go
@@ -8,9 +8,15 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kgo"
 
 	"github.com/grafana/mimir/pkg/util/test"
+	"github.com/grafana/mimir/pkg/util/testkafka"
 )
 
 func TestInitialOffsetProbing(t *testing.T) {
@@ -53,7 +59,7 @@ func TestInitialOffsetProbing(t *testing.T) {
 			minScanTime: time.Date(2025, 2, 20, 10, 0, 0, 600*1000000, time.UTC),
 			expectedRanges: []*offsetTime{
 				{offset: 2000, time: time.Date(2025, 3, 1, 10, 0, 0, 200*1000000, time.UTC)},
-				{offset: 2001, time: time.Time{}},
+				{offset: 2001, skipTimeUpdate: true},
 			},
 		},
 		"one record: no new data": {
@@ -110,7 +116,7 @@ func TestInitialOffsetProbing(t *testing.T) {
 				{offset: 1013, time: time.Date(2025, 3, 1, 10, 0, 0, 500*1000000, time.UTC)},
 				{offset: 1014, time: time.Date(2025, 3, 1, 10, 0, 0, 501*1000000, time.UTC)},
 				{offset: 1017, time: time.Date(2025, 3, 1, 10, 0, 0, 600*1000000, time.UTC)},
-				{offset: 1020, time: time.Time{}},
+				{offset: 1020, skipTimeUpdate: true},
 			},
 		},
 		"records with duplicate timestamps": {
@@ -133,7 +139,7 @@ func TestInitialOffsetProbing(t *testing.T) {
 			expectedRanges: []*offsetTime{
 				{offset: 1000, time: time.Date(2025, 3, 1, 10, 0, 0, 100*1000000, time.UTC)},
 				{offset: 1001, time: time.Date(2025, 3, 1, 10, 0, 0, 101*1000000, time.UTC)},
-				{offset: 1009, time: time.Time{}},
+				{offset: 1009, skipTimeUpdate: true},
 			},
 		},
 		"resumption offset is before min scan time": {
@@ -151,7 +157,7 @@ func TestInitialOffsetProbing(t *testing.T) {
 			expectedRanges: []*offsetTime{
 				{offset: 1002, time: time.Date(2025, 3, 1, 10, 0, 0, 200*1000000, time.UTC)},
 				{offset: 1003, time: time.Date(2025, 3, 1, 10, 0, 0, 300*1000000, time.UTC)},
-				{offset: 1004, time: time.Time{}},
+				{offset: 1004, skipTimeUpdate: true},
 			},
 		},
 		"min scan time later than any data": {
@@ -190,7 +196,7 @@ func TestInitialOffsetProbing(t *testing.T) {
 			minScanTime: time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC),
 			expectedRanges: []*offsetTime{
 				{offset: 1003, time: time.Date(2025, 3, 1, 10, 3, 0, 0, time.UTC)},
-				{offset: 1004, time: time.Time{}},
+				{offset: 1004, skipTimeUpdate: true},
 			},
 		},
 		"resume == start == end": {
@@ -217,7 +223,7 @@ func TestInitialOffsetProbing(t *testing.T) {
 			expectedRanges: []*offsetTime{
 				{offset: 2000, time: time.Date(2025, 3, 1, 11, 0, 0, 0, time.UTC)},
 				{offset: 3000, time: time.Date(2025, 3, 1, 12, 0, 0, 0, time.UTC)},
-				{offset: 10001, time: time.Time{}},
+				{offset: 10001, skipTimeUpdate: true},
 			},
 			msg: "if resumption offset has fallen off the retention window, we should produce jobs beginning at start",
 		},
@@ -226,7 +232,7 @@ func TestInitialOffsetProbing(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			f := &mockOffsetFinder{offsets: tt.offsets, end: tt.end, distinctTimes: make(map[time.Time]struct{})}
-			scanner := newOffsetScanner(f, tt.endTime, tt.jobSize, tt.endTime.Sub(tt.minScanTime), prometheus.NewHistogram(prometheus.HistogramOpts{}))
+			scanner := newOffsetScanner(f, tt.endTime, tt.jobSize, tt.endTime.Sub(tt.minScanTime), promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}))
 			j, err := scanner.probeInitialOffsets(ctx, partitionOffsets{topic: "topic", partition: 0, start: tt.start, resume: tt.resume, end: tt.end}, test.NewTestingLogger(t))
 			assert.NoError(t, err)
 			assert.EqualValues(t, tt.expectedRanges, j, tt.msg)
@@ -235,21 +241,123 @@ func TestInitialOffsetProbing(t *testing.T) {
 }
 
 func TestScanProbeTimes(t *testing.T) {
+	// jobSize of 1m means scanStep is jobSize/4 = 15s. Probes step back from
+	// endTime by scanStep, stopping once the next step would be at or before
+	// minScanTime.
 	jobSize := 1 * time.Minute
-	endTime := time.Date(2025, 3, 1, 10, 2, 50, 0, time.UTC)
-	minScanTime := time.Date(2025, 3, 1, 10, 1, 50, 0, time.UTC)
 
-	// Steps back from endTime by jobSize/4 (15s), stopping once the next step
-	// would be at or before minScanTime.
-	assert.Equal(t, []time.Time{
-		time.Date(2025, 3, 1, 10, 2, 50, 0, time.UTC),
-		time.Date(2025, 3, 1, 10, 2, 35, 0, time.UTC),
-		time.Date(2025, 3, 1, 10, 2, 20, 0, time.UTC),
-		time.Date(2025, 3, 1, 10, 2, 5, 0, time.UTC),
-	}, scanProbeTimes(endTime, jobSize, minScanTime))
+	tests := map[string]struct {
+		endTime     time.Time
+		minScanTime time.Time
+		expected    []time.Time
+	}{
+		"aligned to minScan time": {
+			// Window is exactly 60s (4 * scanStep), so the descending grid
+			// lands exactly on minScanTime, which is excluded.
+			endTime:     time.Date(2025, 3, 1, 10, 2, 50, 0, time.UTC),
+			minScanTime: time.Date(2025, 3, 1, 10, 1, 50, 0, time.UTC),
+			expected: []time.Time{
+				time.Date(2025, 3, 1, 10, 2, 50, 0, time.UTC),
+				time.Date(2025, 3, 1, 10, 2, 35, 0, time.UTC),
+				time.Date(2025, 3, 1, 10, 2, 20, 0, time.UTC),
+				time.Date(2025, 3, 1, 10, 2, 5, 0, time.UTC),
+			},
+		},
+		"unaligned to both": {
+			// Window is 65s (not a multiple of scanStep), so the lowest probe
+			// sits 5s above minScanTime.
+			endTime:     time.Date(2025, 3, 1, 10, 2, 50, 0, time.UTC),
+			minScanTime: time.Date(2025, 3, 1, 10, 1, 45, 0, time.UTC),
+			expected: []time.Time{
+				time.Date(2025, 3, 1, 10, 2, 50, 0, time.UTC),
+				time.Date(2025, 3, 1, 10, 2, 35, 0, time.UTC),
+				time.Date(2025, 3, 1, 10, 2, 20, 0, time.UTC),
+				time.Date(2025, 3, 1, 10, 2, 5, 0, time.UTC),
+				time.Date(2025, 3, 1, 10, 1, 50, 0, time.UTC),
+			},
+		},
+		"single step": {
+			// Window is 10s, shorter than one scanStep, so only endTime is probed.
+			endTime:     time.Date(2025, 3, 1, 10, 2, 50, 0, time.UTC),
+			minScanTime: time.Date(2025, 3, 1, 10, 2, 40, 0, time.UTC),
+			expected: []time.Time{
+				time.Date(2025, 3, 1, 10, 2, 50, 0, time.UTC),
+			},
+		},
+		"empty scan window": {
+			// minScanTime at endTime yields no probes.
+			endTime:     time.Date(2025, 3, 1, 10, 2, 50, 0, time.UTC),
+			minScanTime: time.Date(2025, 3, 1, 10, 2, 50, 0, time.UTC),
+			expected:    nil,
+		},
+	}
 
-	// An empty scan window (minScanTime at or after endTime) yields no probes.
-	assert.Empty(t, scanProbeTimes(endTime, jobSize, endTime))
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, scanProbeTimes(tt.endTime, jobSize, tt.minScanTime))
+		})
+	}
+}
+
+// TestOffsetFinder_offsetAfterTime runs against a kfake cluster, so it
+// exercises the method end-to-end including kadm's ListOffsetsAfterMilli.
+func TestOffsetFinder_offsetAfterTime(t *testing.T) {
+	ctx := context.Background()
+
+	var vnet kfake.VirtualNetwork
+	_, kafkaAddr := testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, 1, "ingest", testkafka.WithVirtualNetwork(&vnet))
+	cli, err := kgo.NewClient(
+		kgo.SeedBrokers(kafkaAddr),
+		kgo.Dialer(vnet.DialContext),
+		kgo.RecordPartitioner(kgo.ManualPartitioner()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(cli.Close)
+
+	require.NoError(t, cli.ProduceSync(ctx, &kgo.Record{Value: []byte("v"), Topic: "ingest", Partition: 0}).FirstErr())
+
+	finder := newOffsetFinder(kadm.NewClient(cli))
+
+	// A time before the record returns a real record offset and timestamp.
+	off, _, isEndOffset, err := finder.offsetAfterTime(ctx, "ingest", 0, time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), off)
+	assert.False(t, isEndOffset, "a real record at or after the time is not the end offset")
+
+	// A time after every record has no record after it, so ListOffsetsAfterMilli
+	// falls back to the end offset with Kafka's -1 timestamp sentinel, which
+	// offsetAfterTime reports as the end offset.
+	off, _, isEndOffset, err = finder.offsetAfterTime(ctx, "ingest", 0, time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), off, "should fall back to the end offset")
+	assert.True(t, isEndOffset, "no record after the time must be reported as the end offset")
+}
+
+func TestOffsetFinder_offsetAfterTime_negativeTimestamp(t *testing.T) {
+	ctx := context.Background()
+	probeTime := time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC)
+
+	// A -1 timestamp (no record at or after the time) is reported as the end
+	// offset, never an error, so the partition is still seeded and its backlog
+	// isn't dropped.
+	finder := newOffsetFinder(nil)
+	finder.offsets[probeTime] = kadm.ListedOffsets{
+		"ingest": {0: {Topic: "ingest", Partition: 0, Offset: 42, Timestamp: -1}},
+	}
+	off, _, isEndOffset, err := finder.offsetAfterTime(ctx, "ingest", 0, probeTime)
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), off)
+	assert.True(t, isEndOffset, "a -1 timestamp must be reported as the end offset")
+
+	// A timestamp below -1 should never be returned; it indicates a malformed
+	// response, so we fail loudly.
+	badFinder := newOffsetFinder(nil)
+	badFinder.offsets[probeTime] = kadm.ListedOffsets{
+		"ingest": {0: {Topic: "ingest", Partition: 0, Offset: 42, Timestamp: -2}},
+	}
+	assert.Panics(t, func() {
+		_, _, _, _ = badFinder.offsetAfterTime(ctx, "ingest", 0, probeTime)
+	})
 }
 
 // Create an offset finder that we can prepopulate with offset scenarios.
@@ -259,7 +367,7 @@ type mockOffsetFinder struct {
 	distinctTimes map[time.Time]struct{}
 }
 
-func (o *mockOffsetFinder) offsetAfterTime(_ context.Context, _ string, _ int32, t time.Time) (int64, time.Time, error) {
+func (o *mockOffsetFinder) offsetAfterTime(_ context.Context, _ string, _ int32, t time.Time) (int64, time.Time, bool, error) {
 	o.distinctTimes[t] = struct{}{}
 	// scan the offsets slice and return the lowest offset whose time is after t.
 	mint := time.Time{}
@@ -278,9 +386,9 @@ func (o *mockOffsetFinder) offsetAfterTime(_ context.Context, _ string, _ int32,
 	}
 	if off == -1 {
 		// Like ListOffsetsAfterMilli, we return the end offset if we don't find any new data.
-		return o.end, time.Time{}, nil
+		return o.end, time.Time{}, true, nil
 	}
-	return off, mint, nil
+	return off, mint, false, nil
 }
 
 var _ offsetStore = (*mockOffsetFinder)(nil)

--- a/pkg/blockbuilder/scheduler/offset_scanner_test.go
+++ b/pkg/blockbuilder/scheduler/offset_scanner_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/grafana/mimir/pkg/util/test"
@@ -225,11 +226,30 @@ func TestInitialOffsetProbing(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			f := &mockOffsetFinder{offsets: tt.offsets, end: tt.end, distinctTimes: make(map[time.Time]struct{})}
-			j, err := probeInitialOffsets(ctx, f, "topic", 0, tt.start, tt.resume, tt.end, tt.endTime, tt.jobSize, tt.minScanTime, test.NewTestingLogger(t))
+			scanner := newOffsetScanner(f, tt.endTime, tt.jobSize, tt.endTime.Sub(tt.minScanTime), prometheus.NewHistogram(prometheus.HistogramOpts{}))
+			j, err := scanner.probeInitialOffsets(ctx, partitionOffsets{topic: "topic", partition: 0, start: tt.start, resume: tt.resume, end: tt.end}, test.NewTestingLogger(t))
 			assert.NoError(t, err)
 			assert.EqualValues(t, tt.expectedRanges, j, tt.msg)
 		})
 	}
+}
+
+func TestScanProbeTimes(t *testing.T) {
+	jobSize := 1 * time.Minute
+	endTime := time.Date(2025, 3, 1, 10, 2, 50, 0, time.UTC)
+	minScanTime := time.Date(2025, 3, 1, 10, 1, 50, 0, time.UTC)
+
+	// Steps back from endTime by jobSize/4 (15s), stopping once the next step
+	// would be at or before minScanTime.
+	assert.Equal(t, []time.Time{
+		time.Date(2025, 3, 1, 10, 2, 50, 0, time.UTC),
+		time.Date(2025, 3, 1, 10, 2, 35, 0, time.UTC),
+		time.Date(2025, 3, 1, 10, 2, 20, 0, time.UTC),
+		time.Date(2025, 3, 1, 10, 2, 5, 0, time.UTC),
+	}, scanProbeTimes(endTime, jobSize, minScanTime))
+
+	// An empty scan window (minScanTime at or after endTime) yields no probes.
+	assert.Empty(t, scanProbeTimes(endTime, jobSize, endTime))
 }
 
 // Create an offset finder that we can prepopulate with offset scenarios.

--- a/pkg/blockbuilder/scheduler/offset_scanner_test.go
+++ b/pkg/blockbuilder/scheduler/offset_scanner_test.go
@@ -59,7 +59,7 @@ func TestInitialOffsetProbing(t *testing.T) {
 			minScanTime: time.Date(2025, 2, 20, 10, 0, 0, 600*1000000, time.UTC),
 			expectedRanges: []*offsetTime{
 				{offset: 2000, time: time.Date(2025, 3, 1, 10, 0, 0, 200*1000000, time.UTC)},
-				{offset: 2001, skipTimeUpdate: true},
+				{offset: 2001, time: time.Date(2025, 3, 1, 10, 0, 0, 600*1000000, time.UTC)},
 			},
 		},
 		"one record: no new data": {
@@ -116,7 +116,7 @@ func TestInitialOffsetProbing(t *testing.T) {
 				{offset: 1013, time: time.Date(2025, 3, 1, 10, 0, 0, 500*1000000, time.UTC)},
 				{offset: 1014, time: time.Date(2025, 3, 1, 10, 0, 0, 501*1000000, time.UTC)},
 				{offset: 1017, time: time.Date(2025, 3, 1, 10, 0, 0, 600*1000000, time.UTC)},
-				{offset: 1020, skipTimeUpdate: true},
+				{offset: 1020, time: time.Date(2025, 3, 1, 10, 0, 0, 600*1000000, time.UTC)},
 			},
 		},
 		"records with duplicate timestamps": {
@@ -139,7 +139,7 @@ func TestInitialOffsetProbing(t *testing.T) {
 			expectedRanges: []*offsetTime{
 				{offset: 1000, time: time.Date(2025, 3, 1, 10, 0, 0, 100*1000000, time.UTC)},
 				{offset: 1001, time: time.Date(2025, 3, 1, 10, 0, 0, 101*1000000, time.UTC)},
-				{offset: 1009, skipTimeUpdate: true},
+				{offset: 1009, time: time.Date(2025, 3, 1, 10, 0, 0, 600*1000000, time.UTC)},
 			},
 		},
 		"resumption offset is before min scan time": {
@@ -157,7 +157,7 @@ func TestInitialOffsetProbing(t *testing.T) {
 			expectedRanges: []*offsetTime{
 				{offset: 1002, time: time.Date(2025, 3, 1, 10, 0, 0, 200*1000000, time.UTC)},
 				{offset: 1003, time: time.Date(2025, 3, 1, 10, 0, 0, 300*1000000, time.UTC)},
-				{offset: 1004, skipTimeUpdate: true},
+				{offset: 1004, time: time.Date(2025, 3, 1, 10, 0, 0, 600*1000000, time.UTC)},
 			},
 		},
 		"min scan time later than any data": {
@@ -196,7 +196,7 @@ func TestInitialOffsetProbing(t *testing.T) {
 			minScanTime: time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC),
 			expectedRanges: []*offsetTime{
 				{offset: 1003, time: time.Date(2025, 3, 1, 10, 3, 0, 0, time.UTC)},
-				{offset: 1004, skipTimeUpdate: true},
+				{offset: 1004, time: time.Date(2025, 3, 1, 10, 3, 40, 0, time.UTC)},
 			},
 		},
 		"resume == start == end": {
@@ -223,7 +223,7 @@ func TestInitialOffsetProbing(t *testing.T) {
 			expectedRanges: []*offsetTime{
 				{offset: 2000, time: time.Date(2025, 3, 1, 11, 0, 0, 0, time.UTC)},
 				{offset: 3000, time: time.Date(2025, 3, 1, 12, 0, 0, 0, time.UTC)},
-				{offset: 10001, skipTimeUpdate: true},
+				{offset: 10001, time: time.Date(2025, 3, 1, 15, 0, 0, 0, time.UTC)},
 			},
 			msg: "if resumption offset has fallen off the retention window, we should produce jobs beginning at start",
 		},

--- a/pkg/blockbuilder/scheduler/scheduler.go
+++ b/pkg/blockbuilder/scheduler/scheduler.go
@@ -327,10 +327,7 @@ func (s *BlockBuilderScheduler) populateInitialJobs(ctx context.Context, consume
 		for _, io := range o {
 			ps.updateEndOffset(io.offset)
 
-			if io.time.IsZero() {
-				// A sentinel without a timestamp marks the partition's high
-				// watermark (end offset). Record the offset, but don't advance the
-				// time bucket since there's no actual time supplied.
+			if io.skipTimeUpdate {
 				continue
 			}
 

--- a/pkg/blockbuilder/scheduler/scheduler.go
+++ b/pkg/blockbuilder/scheduler/scheduler.go
@@ -182,7 +182,8 @@ func (s *BlockBuilderScheduler) completeObservationMode(ctx context.Context) {
 		return
 	}
 
-	s.populateInitialJobs(ctx, consumeOffs, newOffsetFinder(s.adminClient, s.logger), time.Now())
+	scanner := newOffsetScanner(newOffsetFinder(s.adminClient), time.Now(), s.cfg.JobSize, s.cfg.MaxScanAge, s.metrics.probeRecordTimeDelta)
+	s.populateInitialJobs(ctx, consumeOffs, scanner)
 	s.observations = nil
 	s.observationComplete = true
 }
@@ -299,7 +300,7 @@ func (s *BlockBuilderScheduler) enqueuePendingJobs() {
 	}
 }
 
-func (s *BlockBuilderScheduler) populateInitialJobs(ctx context.Context, consumeOffs []partitionOffsets, offStore offsetStore, endTime time.Time) {
+func (s *BlockBuilderScheduler) populateInitialJobs(ctx context.Context, consumeOffs []partitionOffsets, scanner *offsetScanner) {
 	// (Note that the lock is already held because we're in startup mode.)
 
 	// While during normal operation we are periodically asking about every
@@ -310,11 +311,8 @@ func (s *BlockBuilderScheduler) populateInitialJobs(ctx context.Context, consume
 	// those two offsets and seeding the schedule by calling updateEndOffset and
 	// updateTime for each of them- just like we do during normal operation.
 
-	minScanTime := endTime.Add(-s.cfg.MaxScanAge)
-
 	for _, off := range consumeOffs {
-		o, err := probeInitialOffsets(ctx, offStore, off.topic, off.partition,
-			off.start, off.resume, off.end, endTime, s.cfg.JobSize, minScanTime, s.logger)
+		o, err := scanner.probeInitialOffsets(ctx, off, s.logger)
 		if err != nil {
 			level.Warn(s.logger).Log("msg", "failed to probe initial offsets", "partition", off.partition, "err", err)
 			continue
@@ -328,6 +326,14 @@ func (s *BlockBuilderScheduler) populateInitialJobs(ctx context.Context, consume
 
 		for _, io := range o {
 			ps.updateEndOffset(io.offset)
+
+			if io.time.IsZero() {
+				// A sentinel without a timestamp marks the partition's high
+				// watermark (end offset). Record the offset, but don't advance the
+				// time bucket since there's no actual time supplied.
+				continue
+			}
+
 			if job, err := ps.updateTime(io.time, s.cfg.JobSize); err != nil {
 				level.Warn(s.logger).Log("msg", "failed to update partition time", "partition", ps.partition, "err", err)
 			} else if job != nil {

--- a/pkg/blockbuilder/scheduler/scheduler.go
+++ b/pkg/blockbuilder/scheduler/scheduler.go
@@ -326,11 +326,6 @@ func (s *BlockBuilderScheduler) populateInitialJobs(ctx context.Context, consume
 
 		for _, io := range o {
 			ps.updateEndOffset(io.offset)
-
-			if io.skipTimeUpdate {
-				continue
-			}
-
 			if job, err := ps.updateTime(io.time, s.cfg.JobSize); err != nil {
 				level.Warn(s.logger).Log("msg", "failed to update partition time", "partition", ps.partition, "err", err)
 			} else if job != nil {

--- a/pkg/blockbuilder/scheduler/scheduler_test.go
+++ b/pkg/blockbuilder/scheduler/scheduler_test.go
@@ -761,8 +761,10 @@ func TestPopulateInitialJobs_ProbeTimesReused(t *testing.T) {
 		{topic: "topic", partition: 3, start: 100, resume: 100, end: 1000},
 	}
 
-	sched.populateInitialJobs(context.Background(), consumeOffs, finder, time.Date(2025, 3, 1, 11, 0, 0, 0, time.UTC))
-	require.Len(t, finder.distinctTimes, 4, "four partitions will each be probed four times, but the probe times should be the same across each partition")
+	endTime := time.Date(2025, 3, 1, 11, 0, 0, 0, time.UTC)
+	scanner := newOffsetScanner(finder, endTime, sched.cfg.JobSize, sched.cfg.MaxScanAge, sched.metrics.probeRecordTimeDelta)
+	sched.populateInitialJobs(context.Background(), consumeOffs, scanner)
+	require.Len(t, finder.distinctTimes, 4, "four partitions will each be probed at the same times, so the probe times should be shared across partitions")
 }
 
 func TestLimitNPolicy(t *testing.T) {
@@ -1220,7 +1222,8 @@ func TestStartupToRegularModeJobProduction(t *testing.T) {
 			}
 
 			// Call populateInitialJobs to set up initial state
-			sched.populateInitialJobs(context.Background(), consumeOffs, finder, tt.initialTime)
+			scanner := newOffsetScanner(finder, tt.initialTime, sched.cfg.JobSize, sched.cfg.MaxScanAge, sched.metrics.probeRecordTimeDelta)
+			sched.populateInitialJobs(context.Background(), consumeOffs, scanner)
 
 			collectedJobs := []*schedulerpb.JobSpec{}
 


### PR DESCRIPTION
This PR does two things:
1. It moves the startup offset-probing code into an `offsetScanner` type that holds the cached offset lookup and the precomputed probe times. That part is a pure refactor and does not change the jobs the scheduler produces. This is in preparation for compartments support.
   
2. It updates how Kafka's "no offset after this time" response is handled. If there are no records `ListOffsetsAfterMilli()` returns -1 as the record time, as well as the current end offset. Previously, there was no edge casing for this, and instead we'd sort the offsets, which would lead to the end offset being the last offset to be replayed. On replay we'd end up calling `updateEndOffset()` with `(end offset, time: time.UnixMilli(-1))`. This would lead to time going backwards, which we handle by logging an error and ignoring the update. 
   
While this does not cause issues, I'm now explicitly handling the end offset case mostly because of compartments support. There, record timestamps are more important as we need to group offsets from different clusters by time and replay them together, so we need to cater for the -1 record time case. I've changed the behaviour to now explicitly flag the time is to be ignored, which means the offset is replayed in `updateEndOffset()`, but the time is not updated (meaning no new jobs will be cut). This maintains the same behaviour as before, just without the time going backwards warning.

Additionally, added a panic if any timestamps below -1 are seen. From my understanding this is not possible - Kafka only returns a non-negative timestamp or -1.

Where the `-1` comes from:
- franz-go detects the empty result and re-lists the end offset: [kadm/metadata.go#L541](https://github.com/grafana/mimir/blob/d0990fead3dce714cd85b4fa60b45dea48ba1c45/vendor/github.com/twmb/franz-go/pkg/kadm/metadata.go#L541) (it sees the offset come back as `-1`) and [#L576](https://github.com/grafana/mimir/blob/d0990fead3dce714cd85b4fa60b45dea48ba1c45/vendor/github.com/twmb/franz-go/pkg/kadm/metadata.go#L576)("we always list end offsets when rerequesting").
- The timestamp on that answer is `-1`: [kmsg generated.go#L6522](https://github.com/grafana/mimir/blob/d0990fead3dce714cd85b4fa60b45dea48ba1c45/vendor/github.com/twmb/franz-go/pkg/kmsg/generated.go#L6522) — "If the request was for the earliest or latest timestamp (-2 or -1), or if an offset could not be found after the requested one, this will be -1."

Additionally, I'm adding a `cortex_blockbuilder_scheduler_probe_record_time_delta_seconds` metric measuring how far each probe lands from the record it finds.

There are also a couple of TODO comments added to change the probe timestamp calculations, to be done later. The TODOs are independent of compartments work.