### PR TITLE
storage/ingest: convert slow tests to synctest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/thanos-io/objstore v0.0.0-20250813080715-4e5fd4289b50
 	github.com/tjhop/slog-gokit v0.2.0
-	github.com/twmb/franz-go v1.21.3
+	github.com/twmb/franz-go v1.21.4
 	github.com/twmb/franz-go/pkg/kadm v1.18.1-0.20260529212035-11b03a277c72
 	github.com/twmb/franz-go/pkg/kfake v0.0.0-20260515175617-8268a5d078c0
 	github.com/twmb/franz-go/pkg/kmsg v1.13.1

--- a/go.sum
+++ b/go.sum
@@ -1011,8 +1011,8 @@ github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=
 github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
-github.com/twmb/franz-go v1.21.3 h1:q9Mo8ri+OwBQBjKqrerNCqNWJlJnUDe2qnYsj2V3hdI=
-github.com/twmb/franz-go v1.21.3/go.mod h1:rfoMTnVk7107fhTGxfEKIHP/e7tPe6oyij/ywzO0czk=
+github.com/twmb/franz-go v1.21.4 h1:skglTjGHOHHKxVdUG3A563gynBDhvSWFBBHXKOOMS8M=
+github.com/twmb/franz-go v1.21.4/go.mod h1:rfoMTnVk7107fhTGxfEKIHP/e7tPe6oyij/ywzO0czk=
 github.com/twmb/franz-go/pkg/kadm v1.18.1-0.20260529212035-11b03a277c72 h1:Uk0p3O2EPbqosXuSA6bhRMhbu+zt42Xv1G/h59fDX4s=
 github.com/twmb/franz-go/pkg/kadm v1.18.1-0.20260529212035-11b03a277c72/go.mod h1:cw/5ILOe0iIKJ81GwmCKwP11wnbU3YlMAa++wdZQHB4=
 github.com/twmb/franz-go/pkg/kfake v0.0.0-20260515175617-8268a5d078c0 h1:YWmvjmcidrKLLgObwU1k7K9KuesdYTV33OTIS0Ltj8o=

--- a/pkg/storage/ingest/config.go
+++ b/pkg/storage/ingest/config.go
@@ -284,7 +284,8 @@ func (cfg *KafkaConfig) Validate() error {
 	}
 	if cfg.ConsumeFromPositionAtStartup == consumeFromTimestamp {
 		// We only do a simple soundness check for the value be a millisecond precision timestamp.
-		if cfg.ConsumeFromTimestampAtStartup < 1e12 {
+		// This allows any timestamps after 2000-01-01, which is the initial time in a goroutine bubble (ref https://pkg.go.dev/testing/synctest#hdr-Time).
+		if cfg.ConsumeFromTimestampAtStartup < 9e11 {
 			return fmt.Errorf("%w: configured timestamp must be a millisecond timestamp", ErrInvalidConsumePosition)
 		}
 	} else {

--- a/pkg/storage/ingest/config.go
+++ b/pkg/storage/ingest/config.go
@@ -391,6 +391,11 @@ func (cfg *KafkaConfig) ToWarpstreamClientOptions() ([]wgo.Opt, error) {
 		wgo.WithProduceRequestTimeoutOverhead(writerRequestTimeoutOverhead),
 	}
 
+	// The dialer is only expected to be used in tests (e.g. kfake's virtual network).
+	if cfg.Dialer != nil {
+		opts = append(opts, wgo.WithDialer(cfg.Dialer))
+	}
+
 	if cfg.TLSEnabled {
 		tlsConfig, err := cfg.TLS.GetTLSConfig()
 		if err != nil {

--- a/pkg/storage/ingest/fetcher_test.go
+++ b/pkg/storage/ingest/fetcher_test.go
@@ -367,7 +367,7 @@ func TestConcurrentFetchers(t *testing.T) {
 		t.Parallel()
 
 		synctest.Test(t, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 			defer cancel()
 
 			var vnet kfake.VirtualNetwork
@@ -396,7 +396,7 @@ func TestConcurrentFetchers(t *testing.T) {
 			client := newKafkaProduceClient(t, clusterAddr, withWriteVirtualNetwork(&vnet))
 
 			// Produce some records before starting the fetchers
-			for i := 0; i < 5; i++ {
+			for i := range 5 {
 				produceRecord(ctx, t, client, topicName, partitionID, []byte(fmt.Sprintf("record-%d", i)))
 			}
 
@@ -423,7 +423,7 @@ func TestConcurrentFetchers(t *testing.T) {
 			fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0, true, OnRangeErrorResumeFromStart)
 
 			// Produce some records after starting the fetchers
-			for i := 0; i < 3; i++ {
+			for i := range 3 {
 				produceRecord(ctx, t, client, topicName, partitionID, []byte(fmt.Sprintf("record-%d", i)))
 			}
 
@@ -448,7 +448,7 @@ func TestConcurrentFetchers(t *testing.T) {
 			fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0, true, OnRangeErrorResumeFromStart)
 
 			// Produce some records
-			for i := 0; i < 5; i++ {
+			for i := range 5 {
 				produceRecord(ctx, t, client, topicName, partitionID, []byte(fmt.Sprintf("record-%d", i)))
 			}
 
@@ -501,7 +501,7 @@ func TestConcurrentFetchers(t *testing.T) {
 			fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0, true, OnRangeErrorResumeFromStart)
 
 			// Produce some records
-			for i := 0; i < 10; i++ {
+			for i := range 10 {
 				produceRecord(ctx, t, client, topicName, partitionID, []byte(fmt.Sprintf("record-%d", i)))
 			}
 
@@ -532,12 +532,14 @@ func TestConcurrentFetchers(t *testing.T) {
 					fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0, true, OnRangeErrorResumeFromStart)
 
 					// Produce some records
-					for i := 0; i < 20; i++ {
+					for i := range 20 {
 						produceRecord(ctx, t, client, topicName, partitionID, []byte(fmt.Sprintf("record-%d", i)))
 					}
 
 					fetches := longPollFetches(fetchers, 20, 2*time.Second)
 					totalRecords := fetches.NumRecords()
+
+					synctest.Wait()
 
 					assert.Equal(t, 20, totalRecords)
 
@@ -559,7 +561,7 @@ func TestConcurrentFetchers(t *testing.T) {
 			client := newKafkaProduceClient(t, clusterAddr, withWriteVirtualNetwork(&vnet))
 
 			// Produce some initial records
-			for i := 0; i < 5; i++ {
+			for i := range 5 {
 				produceRecord(ctx, t, client, topicName, partitionID, []byte(fmt.Sprintf("record-%d", i)))
 			}
 
@@ -570,7 +572,7 @@ func TestConcurrentFetchers(t *testing.T) {
 			fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, lastOffset-1, concurrency, 0, true, OnRangeErrorResumeFromStart)
 
 			// Produce some more records
-			for i := 0; i < 3; i++ {
+			for i := range 3 {
 				produceRecord(ctx, t, client, topicName, partitionID, []byte(fmt.Sprintf("new-record-%d", i)))
 			}
 
@@ -611,7 +613,7 @@ func TestConcurrentFetchers(t *testing.T) {
 				const recordsPerRound = 4
 				// Produce a few records
 				expectedRecords := make([]string, 0, recordsPerRound)
-				for i := 0; i < recordsPerRound; i++ {
+				for i := range recordsPerRound {
 					rec := []byte(fmt.Sprintf("round-%d-record-%d", round, i))
 					expectedRecords = append(expectedRecords, string(rec))
 					producedOffset := produceRecord(ctx, t, client, topicName, partitionID, rec)
@@ -656,7 +658,7 @@ func TestConcurrentFetchers(t *testing.T) {
 			// Produce enough records to saturate each fetcher.
 			const initiallyProducedRecords = concurrency * 10
 			var producedRecordsBytes [][]byte
-			for i := 0; i < initiallyProducedRecords; i++ {
+			for i := range initiallyProducedRecords {
 				record := []byte(fmt.Sprintf("record-%d", i+1))
 				produceRecord(ctx, t, client, topicName, partitionID, record)
 				producedRecordsBytes = append(producedRecordsBytes, record)
@@ -672,7 +674,7 @@ func TestConcurrentFetchers(t *testing.T) {
 
 			// Produce a few more records
 			const additionalRecords = 3
-			for i := 0; i < additionalRecords; i++ {
+			for i := range additionalRecords {
 				record := []byte(fmt.Sprintf("additional-record-%d", i+1))
 				produceRecord(ctx, t, client, topicName, partitionID, record)
 				producedRecordsBytes = append(producedRecordsBytes, record)
@@ -719,7 +721,7 @@ func TestConcurrentFetchers(t *testing.T) {
 
 			// Produce initial records
 			var producedRecordsBytes [][]byte
-			for i := 0; i < initialRecords; i++ {
+			for i := range initialRecords {
 				record := []byte(fmt.Sprintf("record-%d", i+1))
 				producedRecordsBytes = append(producedRecordsBytes, record)
 				offset := produceRecord(ctx, t, client, topicName, partitionID, record)
@@ -846,7 +848,7 @@ func TestConcurrentFetchers(t *testing.T) {
 			fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0, true, OnRangeErrorResumeFromStart)
 
 			// Produce some records.
-			for i := 0; i < 10; i++ {
+			for i := range 10 {
 				produceRecord(ctx, t, client, topicName, partitionID, []byte(fmt.Sprintf("record-%d", i)))
 			}
 
@@ -992,7 +994,7 @@ func TestConcurrentFetchers(t *testing.T) {
 
 			// Produce small records
 			smallValue := bytes.Repeat([]byte{'b'}, smallRecordSize)
-			for i := 0; i < smallRecordsCount; i++ {
+			for range smallRecordsCount {
 				produceRecord(ctx, t, client, topicName, partitionID, smallValue)
 			}
 

--- a/pkg/storage/ingest/fetcher_test.go
+++ b/pkg/storage/ingest/fetcher_test.go
@@ -364,6 +364,8 @@ func TestConcurrentFetchers(t *testing.T) {
 	)
 
 	t.Run("respect context cancellation", func(t *testing.T) {
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 			defer cancel()
@@ -384,6 +386,8 @@ func TestConcurrentFetchers(t *testing.T) {
 	})
 
 	t.Run("cold replay", func(t *testing.T) {
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			ctx := t.Context()
 
@@ -407,6 +411,8 @@ func TestConcurrentFetchers(t *testing.T) {
 	})
 
 	t.Run("fetch records produced after startup", func(t *testing.T) {
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			ctx := t.Context()
 
@@ -430,6 +436,8 @@ func TestConcurrentFetchers(t *testing.T) {
 	})
 
 	t.Run("slow processing of fetches", func(t *testing.T) {
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			ctx := t.Context()
 
@@ -481,6 +489,8 @@ func TestConcurrentFetchers(t *testing.T) {
 	})
 
 	t.Run("fast processing of fetches", func(t *testing.T) {
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			ctx := t.Context()
 
@@ -506,8 +516,12 @@ func TestConcurrentFetchers(t *testing.T) {
 	})
 
 	t.Run("fetch with different concurrency levels", func(t *testing.T) {
+		t.Parallel()
+
 		for _, concurrency := range []int{1, 2, 4} {
 			t.Run(fmt.Sprintf("concurrency-%d", concurrency), func(t *testing.T) {
+				t.Parallel()
+
 				synctest.Test(t, func(t *testing.T) {
 					ctx := t.Context()
 
@@ -535,6 +549,8 @@ func TestConcurrentFetchers(t *testing.T) {
 	})
 
 	t.Run("start from mid-stream offset", func(t *testing.T) {
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			ctx := t.Context()
 
@@ -579,6 +595,8 @@ func TestConcurrentFetchers(t *testing.T) {
 	})
 
 	t.Run("synchronous produce and fetch", func(t *testing.T) {
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			ctx := t.Context()
 
@@ -618,6 +636,8 @@ func TestConcurrentFetchers(t *testing.T) {
 	})
 
 	t.Run("staggered production", func(t *testing.T) {
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			ctx := t.Context()
 
@@ -675,6 +695,9 @@ func TestConcurrentFetchers(t *testing.T) {
 	t.Run("fetchers do not request offset beyond high watermark", func(t *testing.T) {
 		// In Warpstream fetching past the end induced more delays than MinBytesWaitTime.
 		// So we avoid dispatching a fetch for past the high watermark.
+
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			ctx := t.Context()
 
@@ -748,6 +771,8 @@ func TestConcurrentFetchers(t *testing.T) {
 	})
 
 	t.Run("starting to run against a broken broker fails creating the fetchers", func(t *testing.T) {
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			ctx := t.Context()
 
@@ -809,6 +834,8 @@ func TestConcurrentFetchers(t *testing.T) {
 	})
 
 	t.Run("should reset the buffered records count when stopping", func(t *testing.T) {
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			ctx := t.Context()
 
@@ -840,6 +867,8 @@ func TestConcurrentFetchers(t *testing.T) {
 	})
 
 	t.Run("respect maximum buffered bytes limit", func(t *testing.T) {
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			const (
 				topicName        = "test-topic"
@@ -914,6 +943,9 @@ func TestConcurrentFetchers(t *testing.T) {
 
 	t.Run("respect maximum buffered bytes limit with varying record sizes", func(t *testing.T) {
 		// This test makes sure that the buffer doesn't become inefficient when the size estimations change (from large records we switch to small records).
+
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			const (
 				topicName          = "test-topic"
@@ -995,6 +1027,8 @@ func TestConcurrentFetchers(t *testing.T) {
 	})
 
 	t.Run("out of range error aborts under abort policy", func(t *testing.T) {
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			ctx := t.Context()
 

--- a/pkg/storage/ingest/fetcher_test.go
+++ b/pkg/storage/ingest/fetcher_test.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/go-kit/log"
@@ -362,676 +363,662 @@ func TestConcurrentFetchers(t *testing.T) {
 		concurrency = 2
 	)
 
-	waitForStableBufferedRecords := func(t *testing.T, f fetcher) {
-		// Initialise the previous buffered records with an invalid value, so that at least
-		// we wait 1 tick before comparing values. If we would have initialised this value to 0
-		// and the first reading is 0, this function would return immediately without doing
-		// any real comparison.
-		previousBufferedRecords := int64(-1)
-
-		require.Eventually(t, func() bool {
-			bufferedRecords := f.BufferedRecords()
-			stabilized := bufferedRecords == previousBufferedRecords
-			previousBufferedRecords = bufferedRecords
-			return stabilized
-		}, 5*time.Second, 100*time.Millisecond)
-	}
-
 	t.Run("respect context cancellation", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-		defer cancel()
+		synctest.Test(t, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancel()
 
-		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
-		client := newKafkaProduceClient(t, clusterAddr)
+			var vnet kfake.VirtualNetwork
+			_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, testkafka.WithVirtualNetwork(&vnet))
+			client := newKafkaProduceClient(t, clusterAddr, withWriteVirtualNetwork(&vnet))
 
-		fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0, true, OnRangeErrorResumeFromStart)
+			fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0, true, OnRangeErrorResumeFromStart)
 
-		// This should not block forever now
-		fetches, fetchCtx := fetchers.PollFetches(ctx)
+			// This should not block forever now
+			fetches, fetchCtx := fetchers.PollFetches(ctx)
 
-		assert.Zero(t, fetches.NumRecords())
-		assert.Error(t, fetchCtx.Err(), "Expected context to be cancelled")
-		assert.Zero(t, fetchers.BufferedRecords())
+			assert.Zero(t, fetches.NumRecords())
+			assert.Error(t, fetchCtx.Err(), "Expected context to be cancelled")
+			assert.Zero(t, fetchers.BufferedRecords())
+		})
 	})
 
 	t.Run("cold replay", func(t *testing.T) {
-		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+			var vnet kfake.VirtualNetwork
+			_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, testkafka.WithVirtualNetwork(&vnet))
+			client := newKafkaProduceClient(t, clusterAddr, withWriteVirtualNetwork(&vnet))
 
-		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
-		client := newKafkaProduceClient(t, clusterAddr)
+			// Produce some records before starting the fetchers
+			for i := 0; i < 5; i++ {
+				produceRecord(ctx, t, client, topicName, partitionID, []byte(fmt.Sprintf("record-%d", i)))
+			}
 
-		// Produce some records before starting the fetchers
-		for i := 0; i < 5; i++ {
-			produceRecord(ctx, t, client, topicName, partitionID, []byte(fmt.Sprintf("record-%d", i)))
-		}
+			fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0, true, OnRangeErrorResumeFromStart)
 
-		fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0, true, OnRangeErrorResumeFromStart)
+			fetches := longPollFetches(fetchers, 5, 2*time.Second)
+			assert.Equal(t, fetches.NumRecords(), 5)
 
-		fetches := longPollFetches(fetchers, 5, 2*time.Second)
-		assert.Equal(t, fetches.NumRecords(), 5)
-
-		// We expect no more records returned by PollFetches() and no buffered records.
-		pollFetchesAndAssertNoRecords(t, fetchers)
+			// We expect no more records returned by PollFetches() and no buffered records.
+			pollFetchesAndAssertNoRecords(t, fetchers)
+		})
 	})
 
 	t.Run("fetch records produced after startup", func(t *testing.T) {
-		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+			var vnet kfake.VirtualNetwork
+			_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, testkafka.WithVirtualNetwork(&vnet))
+			client := newKafkaProduceClient(t, clusterAddr, withWriteVirtualNetwork(&vnet))
 
-		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
-		client := newKafkaProduceClient(t, clusterAddr)
+			fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0, true, OnRangeErrorResumeFromStart)
 
-		fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0, true, OnRangeErrorResumeFromStart)
+			// Produce some records after starting the fetchers
+			for i := 0; i < 3; i++ {
+				produceRecord(ctx, t, client, topicName, partitionID, []byte(fmt.Sprintf("record-%d", i)))
+			}
 
-		// Produce some records after starting the fetchers
-		for i := 0; i < 3; i++ {
-			produceRecord(ctx, t, client, topicName, partitionID, []byte(fmt.Sprintf("record-%d", i)))
-		}
+			fetches := longPollFetches(fetchers, 3, 2*time.Second)
+			assert.Equal(t, fetches.NumRecords(), 3)
 
-		fetches := longPollFetches(fetchers, 3, 2*time.Second)
-		assert.Equal(t, fetches.NumRecords(), 3)
-
-		// We expect no more records returned by PollFetches() and no buffered records.
-		pollFetchesAndAssertNoRecords(t, fetchers)
+			// We expect no more records returned by PollFetches() and no buffered records.
+			pollFetchesAndAssertNoRecords(t, fetchers)
+		})
 	})
 
 	t.Run("slow processing of fetches", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
 
-		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
-		client := newKafkaProduceClient(t, clusterAddr)
+			var vnet kfake.VirtualNetwork
+			_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, testkafka.WithVirtualNetwork(&vnet))
+			client := newKafkaProduceClient(t, clusterAddr, withWriteVirtualNetwork(&vnet))
 
-		fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0, true, OnRangeErrorResumeFromStart)
+			fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0, true, OnRangeErrorResumeFromStart)
 
-		// Produce some records
-		for i := 0; i < 5; i++ {
-			produceRecord(ctx, t, client, topicName, partitionID, []byte(fmt.Sprintf("record-%d", i)))
-		}
-
-		var wg sync.WaitGroup
-		wg.Add(1)
-
-		go func() {
-			defer wg.Done()
-			consumedRecords := 0
-			for consumedRecords < 10 {
-				fetches, _ := fetchers.PollFetches(ctx)
-				consumedRecords += fetches.NumRecords()
-
-				// Simulate slow processing.
-				time.Sleep(200 * time.Millisecond)
-			}
-			assert.Equal(t, 10, consumedRecords)
-		}()
-
-		// Slowly produce more records while processing is slow too. This increase the chances
-		// of progressive fetches done by the consumer.
-		wg.Add(1)
-
-		go func() {
-			defer wg.Done()
-
-			for i := 5; i < 10; i++ {
+			// Produce some records
+			for i := 0; i < 5; i++ {
 				produceRecord(ctx, t, client, topicName, partitionID, []byte(fmt.Sprintf("record-%d", i)))
-				time.Sleep(200 * time.Millisecond)
 			}
-		}()
 
-		wg.Wait()
+			var wg sync.WaitGroup
+			wg.Add(1)
 
-		// We expect no more records returned by PollFetches() and no buffered records.
-		pollFetchesAndAssertNoRecords(t, fetchers)
+			go func() {
+				defer wg.Done()
+				consumedRecords := 0
+				for consumedRecords < 10 {
+					fetches, _ := fetchers.PollFetches(ctx)
+					consumedRecords += fetches.NumRecords()
+
+					// Simulate slow processing.
+					time.Sleep(200 * time.Millisecond)
+				}
+				assert.Equal(t, 10, consumedRecords)
+			}()
+
+			// Slowly produce more records while processing is slow too. This increase the chances
+			// of progressive fetches done by the consumer.
+			wg.Add(1)
+
+			go func() {
+				defer wg.Done()
+
+				for i := 5; i < 10; i++ {
+					produceRecord(ctx, t, client, topicName, partitionID, []byte(fmt.Sprintf("record-%d", i)))
+					time.Sleep(200 * time.Millisecond)
+				}
+			}()
+
+			wg.Wait()
+
+			// We expect no more records returned by PollFetches() and no buffered records.
+			pollFetchesAndAssertNoRecords(t, fetchers)
+		})
 	})
 
 	t.Run("fast processing of fetches", func(t *testing.T) {
-		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+			var vnet kfake.VirtualNetwork
+			_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, testkafka.WithVirtualNetwork(&vnet))
+			client := newKafkaProduceClient(t, clusterAddr, withWriteVirtualNetwork(&vnet))
 
-		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
-		client := newKafkaProduceClient(t, clusterAddr)
+			fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0, true, OnRangeErrorResumeFromStart)
 
-		fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0, true, OnRangeErrorResumeFromStart)
+			// Produce some records
+			for i := 0; i < 10; i++ {
+				produceRecord(ctx, t, client, topicName, partitionID, []byte(fmt.Sprintf("record-%d", i)))
+			}
 
-		// Produce some records
-		for i := 0; i < 10; i++ {
-			produceRecord(ctx, t, client, topicName, partitionID, []byte(fmt.Sprintf("record-%d", i)))
-		}
+			// Consume all expected records.
+			fetches := longPollFetches(fetchers, 10, 2*time.Second)
+			consumedRecords := fetches.NumRecords()
+			assert.Equal(t, 10, consumedRecords)
 
-		// Consume all expected records.
-		fetches := longPollFetches(fetchers, 10, 2*time.Second)
-		consumedRecords := fetches.NumRecords()
-		assert.Equal(t, 10, consumedRecords)
-
-		// We expect no more records returned by PollFetches() and no buffered records.
-		pollFetchesAndAssertNoRecords(t, fetchers)
+			// We expect no more records returned by PollFetches() and no buffered records.
+			pollFetchesAndAssertNoRecords(t, fetchers)
+		})
 	})
 
 	t.Run("fetch with different concurrency levels", func(t *testing.T) {
-		t.Parallel()
-
 		for _, concurrency := range []int{1, 2, 4} {
-			concurrency := concurrency
-
 			t.Run(fmt.Sprintf("concurrency-%d", concurrency), func(t *testing.T) {
-				t.Parallel()
+				synctest.Test(t, func(t *testing.T) {
+					ctx := t.Context()
 
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
+					var vnet kfake.VirtualNetwork
+					_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, testkafka.WithVirtualNetwork(&vnet))
+					client := newKafkaProduceClient(t, clusterAddr, withWriteVirtualNetwork(&vnet))
 
-				_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
-				client := newKafkaProduceClient(t, clusterAddr)
+					fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0, true, OnRangeErrorResumeFromStart)
 
-				fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0, true, OnRangeErrorResumeFromStart)
+					// Produce some records
+					for i := 0; i < 20; i++ {
+						produceRecord(ctx, t, client, topicName, partitionID, []byte(fmt.Sprintf("record-%d", i)))
+					}
 
-				// Produce some records
-				for i := 0; i < 20; i++ {
-					produceRecord(ctx, t, client, topicName, partitionID, []byte(fmt.Sprintf("record-%d", i)))
-				}
+					fetches := longPollFetches(fetchers, 20, 2*time.Second)
+					totalRecords := fetches.NumRecords()
 
-				fetches := longPollFetches(fetchers, 20, 2*time.Second)
-				totalRecords := fetches.NumRecords()
+					assert.Equal(t, 20, totalRecords)
 
-				assert.Equal(t, 20, totalRecords)
-
-				// We expect no more records returned by PollFetches() and no buffered records.
-				pollFetchesAndAssertNoRecords(t, fetchers)
+					// We expect no more records returned by PollFetches() and no buffered records.
+					pollFetchesAndAssertNoRecords(t, fetchers)
+				})
 			})
 		}
 	})
 
 	t.Run("start from mid-stream offset", func(t *testing.T) {
-		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+			var vnet kfake.VirtualNetwork
+			_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, testkafka.WithVirtualNetwork(&vnet))
+			client := newKafkaProduceClient(t, clusterAddr, withWriteVirtualNetwork(&vnet))
 
-		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
-		client := newKafkaProduceClient(t, clusterAddr)
-
-		// Produce some initial records
-		for i := 0; i < 5; i++ {
-			produceRecord(ctx, t, client, topicName, partitionID, []byte(fmt.Sprintf("record-%d", i)))
-		}
-
-		// Get the offset of the last produced record
-		lastOffset := produceRecord(ctx, t, client, topicName, partitionID, []byte("last-initial-record"))
-
-		// Start fetchers from the offset after the initial records
-		fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, lastOffset-1, concurrency, 0, true, OnRangeErrorResumeFromStart)
-
-		// Produce some more records
-		for i := 0; i < 3; i++ {
-			produceRecord(ctx, t, client, topicName, partitionID, []byte(fmt.Sprintf("new-record-%d", i)))
-		}
-
-		const expectedRecords = 5
-		fetchedRecordsContents := make([]string, 0, expectedRecords)
-		fetches := longPollFetches(fetchers, expectedRecords, 2*time.Second)
-		fetches.EachRecord(func(r *kgo.Record) {
-			fetchedRecordsContents = append(fetchedRecordsContents, string(r.Value))
-		})
-
-		assert.Equal(t, []string{
-			"record-4",
-			"last-initial-record",
-			"new-record-0",
-			"new-record-1",
-			"new-record-2",
-		}, fetchedRecordsContents)
-
-		// We expect no more records returned by PollFetches() and no buffered records.
-		pollFetchesAndAssertNoRecords(t, fetchers)
-	})
-
-	t.Run("synchronous produce and fetch", func(t *testing.T) {
-		t.Parallel()
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
-		client := newKafkaProduceClient(t, clusterAddr)
-
-		fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0, true, OnRangeErrorResumeFromStart)
-
-		for round := 0; round < 3; round++ {
-			t.Log("starting round", round)
-			const recordsPerRound = 4
-			// Produce a few records
-			expectedRecords := make([]string, 0, recordsPerRound)
-			for i := 0; i < recordsPerRound; i++ {
-				rec := []byte(fmt.Sprintf("round-%d-record-%d", round, i))
-				expectedRecords = append(expectedRecords, string(rec))
-				producedOffset := produceRecord(ctx, t, client, topicName, partitionID, rec)
-				t.Log("produced", producedOffset, string(rec))
+			// Produce some initial records
+			for i := 0; i < 5; i++ {
+				produceRecord(ctx, t, client, topicName, partitionID, []byte(fmt.Sprintf("record-%d", i)))
 			}
 
-			// Poll for fetches and verify
-			fetchedRecords := make([]string, 0, recordsPerRound)
-			fetches := longPollFetches(fetchers, recordsPerRound, 2*time.Second)
+			// Get the offset of the last produced record
+			lastOffset := produceRecord(ctx, t, client, topicName, partitionID, []byte("last-initial-record"))
+
+			// Start fetchers from the offset after the initial records
+			fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, lastOffset-1, concurrency, 0, true, OnRangeErrorResumeFromStart)
+
+			// Produce some more records
+			for i := 0; i < 3; i++ {
+				produceRecord(ctx, t, client, topicName, partitionID, []byte(fmt.Sprintf("new-record-%d", i)))
+			}
+
+			const expectedRecords = 5
+			fetchedRecordsContents := make([]string, 0, expectedRecords)
+			fetches := longPollFetches(fetchers, expectedRecords, 2*time.Second)
 			fetches.EachRecord(func(r *kgo.Record) {
-				fetchedRecords = append(fetchedRecords, string(r.Value))
-				t.Log("fetched", r.Offset, string(r.Value))
+				fetchedRecordsContents = append(fetchedRecordsContents, string(r.Value))
 			})
 
-			// Verify fetched records
-			assert.Equal(t, expectedRecords, fetchedRecords, "Fetched records in round %d do not match expected", round)
+			assert.Equal(t, []string{
+				"record-4",
+				"last-initial-record",
+				"new-record-0",
+				"new-record-1",
+				"new-record-2",
+			}, fetchedRecordsContents)
 
 			// We expect no more records returned by PollFetches() and no buffered records.
 			pollFetchesAndAssertNoRecords(t, fetchers)
-		}
+		})
+	})
+
+	t.Run("synchronous produce and fetch", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
+
+			var vnet kfake.VirtualNetwork
+			_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, testkafka.WithVirtualNetwork(&vnet))
+			client := newKafkaProduceClient(t, clusterAddr, withWriteVirtualNetwork(&vnet))
+
+			fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0, true, OnRangeErrorResumeFromStart)
+
+			for round := range 3 {
+				t.Log("starting round", round)
+				const recordsPerRound = 4
+				// Produce a few records
+				expectedRecords := make([]string, 0, recordsPerRound)
+				for i := 0; i < recordsPerRound; i++ {
+					rec := []byte(fmt.Sprintf("round-%d-record-%d", round, i))
+					expectedRecords = append(expectedRecords, string(rec))
+					producedOffset := produceRecord(ctx, t, client, topicName, partitionID, rec)
+					t.Log("produced", producedOffset, string(rec))
+				}
+
+				// Poll for fetches and verify
+				fetchedRecords := make([]string, 0, recordsPerRound)
+				fetches := longPollFetches(fetchers, recordsPerRound, 2*time.Second)
+				fetches.EachRecord(func(r *kgo.Record) {
+					fetchedRecords = append(fetchedRecords, string(r.Value))
+					t.Log("fetched", r.Offset, string(r.Value))
+				})
+
+				// Verify fetched records
+				assert.Equal(t, expectedRecords, fetchedRecords, "Fetched records in round %d do not match expected", round)
+
+				// We expect no more records returned by PollFetches() and no buffered records.
+				pollFetchesAndAssertNoRecords(t, fetchers)
+			}
+		})
 	})
 
 	t.Run("staggered production", func(t *testing.T) {
-		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
+			const (
+				topicName   = "test-topic"
+				partitionID = 1
+				concurrency = 2
+			)
 
-		const (
-			topicName   = "test-topic"
-			partitionID = 1
-			concurrency = 2
-		)
+			var vnet kfake.VirtualNetwork
+			_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, testkafka.WithVirtualNetwork(&vnet))
+			client := newKafkaProduceClient(t, clusterAddr, withWriteVirtualNetwork(&vnet))
 
-		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
-		client := newKafkaProduceClient(t, clusterAddr)
+			fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0, true, OnRangeErrorResumeFromStart)
 
-		fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0, true, OnRangeErrorResumeFromStart)
+			// Produce enough records to saturate each fetcher.
+			const initiallyProducedRecords = concurrency * 10
+			var producedRecordsBytes [][]byte
+			for i := 0; i < initiallyProducedRecords; i++ {
+				record := []byte(fmt.Sprintf("record-%d", i+1))
+				produceRecord(ctx, t, client, topicName, partitionID, record)
+				producedRecordsBytes = append(producedRecordsBytes, record)
+			}
 
-		// Produce enough records to saturate each fetcher.
-		const initiallyProducedRecords = concurrency * 10
-		var producedRecordsBytes [][]byte
-		for i := 0; i < initiallyProducedRecords; i++ {
-			record := []byte(fmt.Sprintf("record-%d", i+1))
-			produceRecord(ctx, t, client, topicName, partitionID, record)
-			producedRecordsBytes = append(producedRecordsBytes, record)
-		}
+			// Expect that we've received all records.
+			var fetchedRecordsBytes [][]byte
+			fetches := longPollFetches(fetchers, initiallyProducedRecords, 2*time.Second)
+			assert.NoError(t, fetches.Err())
+			fetches.EachRecord(func(r *kgo.Record) {
+				fetchedRecordsBytes = append(fetchedRecordsBytes, r.Value)
+			})
 
-		// Expect that we've received all records.
-		var fetchedRecordsBytes [][]byte
-		fetches := longPollFetches(fetchers, initiallyProducedRecords, 2*time.Second)
-		assert.NoError(t, fetches.Err())
-		fetches.EachRecord(func(r *kgo.Record) {
-			fetchedRecordsBytes = append(fetchedRecordsBytes, r.Value)
+			// Produce a few more records
+			const additionalRecords = 3
+			for i := 0; i < additionalRecords; i++ {
+				record := []byte(fmt.Sprintf("additional-record-%d", i+1))
+				produceRecord(ctx, t, client, topicName, partitionID, record)
+				producedRecordsBytes = append(producedRecordsBytes, record)
+			}
+
+			// Fetchers shouldn't be stalled and should continue fetching as the HWM moves forward.
+			fetches = longPollFetches(fetchers, additionalRecords, 2*time.Second)
+			assert.NoError(t, fetches.Err())
+			fetches.EachRecord(func(r *kgo.Record) {
+				fetchedRecordsBytes = append(fetchedRecordsBytes, r.Value)
+			})
+
+			assert.Equal(t, producedRecordsBytes, fetchedRecordsBytes)
+
+			// We expect no more records returned by PollFetches() and no buffered records.
+			pollFetchesAndAssertNoRecords(t, fetchers)
 		})
-
-		// Produce a few more records
-		const additionalRecords = 3
-		for i := 0; i < additionalRecords; i++ {
-			record := []byte(fmt.Sprintf("additional-record-%d", i+1))
-			produceRecord(ctx, t, client, topicName, partitionID, record)
-			producedRecordsBytes = append(producedRecordsBytes, record)
-		}
-
-		// Fetchers shouldn't be stalled and should continue fetching as the HWM moves forward.
-		fetches = longPollFetches(fetchers, additionalRecords, 2*time.Second)
-		assert.NoError(t, fetches.Err())
-		fetches.EachRecord(func(r *kgo.Record) {
-			fetchedRecordsBytes = append(fetchedRecordsBytes, r.Value)
-		})
-
-		assert.Equal(t, producedRecordsBytes, fetchedRecordsBytes)
-
-		// We expect no more records returned by PollFetches() and no buffered records.
-		pollFetchesAndAssertNoRecords(t, fetchers)
 	})
 
 	t.Run("fetchers do not request offset beyond high watermark", func(t *testing.T) {
 		// In Warpstream fetching past the end induced more delays than MinBytesWaitTime.
 		// So we avoid dispatching a fetch for past the high watermark.
-		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
+			const (
+				topicName      = "test-topic"
+				partitionID    = 1
+				concurrency    = 2
+				initialRecords = 8
+			)
 
-		const (
-			topicName      = "test-topic"
-			partitionID    = 1
-			concurrency    = 2
-			initialRecords = 8
-		)
+			var vnet kfake.VirtualNetwork
+			cluster, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, testkafka.WithVirtualNetwork(&vnet))
+			client := newKafkaProduceClient(t, clusterAddr, withWriteVirtualNetwork(&vnet))
 
-		cluster, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
-		client := newKafkaProduceClient(t, clusterAddr)
+			fetchRequestCount := atomic.NewInt64(0)
+			maxRequestedOffset := atomic.NewInt64(-1)
 
-		fetchRequestCount := atomic.NewInt64(0)
-		maxRequestedOffset := atomic.NewInt64(-1)
+			fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0, true, OnRangeErrorResumeFromStart)
 
-		fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0, true, OnRangeErrorResumeFromStart)
+			// Produce initial records
+			var producedRecordsBytes [][]byte
+			for i := 0; i < initialRecords; i++ {
+				record := []byte(fmt.Sprintf("record-%d", i+1))
+				producedRecordsBytes = append(producedRecordsBytes, record)
+				offset := produceRecord(ctx, t, client, topicName, partitionID, record)
+				t.Log("Produced record at offset", offset)
+			}
 
-		// Produce initial records
-		var producedRecordsBytes [][]byte
-		for i := 0; i < initialRecords; i++ {
-			record := []byte(fmt.Sprintf("record-%d", i+1))
-			producedRecordsBytes = append(producedRecordsBytes, record)
-			offset := produceRecord(ctx, t, client, topicName, partitionID, record)
-			t.Log("Produced record at offset", offset)
-		}
+			// Fetch and verify records; this should unblock the fetchers.
+			var fetchedRecordsBytes [][]byte
+			fetches := longPollFetches(fetchers, initialRecords, 2*time.Second) // Ensure no more records are fetched.
+			assert.NoError(t, fetches.Err())
+			fetches.EachRecord(func(r *kgo.Record) {
+				fetchedRecordsBytes = append(fetchedRecordsBytes, r.Value)
+			})
 
-		// Fetch and verify records; this should unblock the fetchers.
-		var fetchedRecordsBytes [][]byte
-		fetches := longPollFetches(fetchers, initialRecords, 2*time.Second) // Ensure no more records are fetched.
-		assert.NoError(t, fetches.Err())
-		fetches.EachRecord(func(r *kgo.Record) {
-			fetchedRecordsBytes = append(fetchedRecordsBytes, r.Value)
+			// Set up control function to monitor fetch requests
+			var checkRequestOffset func(req kmsg.Request) (kmsg.Response, error, bool)
+			checkRequestOffset = func(req kmsg.Request) (kmsg.Response, error, bool) {
+				fetchReq := req.(*kmsg.FetchRequest)
+				cluster.KeepControl()
+				fetchRequestCount.Inc()
+				assert.Len(t, fetchReq.Topics, 1)
+				assert.Len(t, fetchReq.Topics[0].Partitions, 1)
+				requestedOffset := fetchReq.Topics[0].Partitions[0].FetchOffset
+				maxRequestedOffset.Store(fetchReq.Topics[0].Partitions[0].FetchOffset)
+				t.Log("Received fetch request for offset", requestedOffset)
+
+				cluster.DropControl()                                      // Let the cluster handle the request normally
+				cluster.ControlKey(kmsg.Fetch.Int16(), checkRequestOffset) // But register the function again so we can inspect the next request too.
+
+				return nil, nil, false
+			}
+			cluster.ControlKey(kmsg.Fetch.Int16(), checkRequestOffset)
+
+			// Wait for a few fetch requests
+			require.Eventually(t, func() bool {
+				return fetchRequestCount.Load() >= 10
+			}, 30*time.Second, 100*time.Millisecond, "Not enough fetch requests received")
+
+			// Verify that the max requested offset does not exceed the number of produced records
+			assert.LessOrEqualf(t, int(maxRequestedOffset.Load()), len(producedRecordsBytes),
+				"Requested offset (%d) should not exceed the number of produced records (%d)", maxRequestedOffset.Load(), len(producedRecordsBytes))
+
+			// Verify the number and content of fetched records
+			assert.Equal(t, producedRecordsBytes, fetchedRecordsBytes, "Should fetch all produced records")
+
+			// We expect no more records returned by PollFetches() and no buffered records.
+			pollFetchesAndAssertNoRecords(t, fetchers)
 		})
-
-		// Set up control function to monitor fetch requests
-		var checkRequestOffset func(req kmsg.Request) (kmsg.Response, error, bool)
-		checkRequestOffset = func(req kmsg.Request) (kmsg.Response, error, bool) {
-			fetchReq := req.(*kmsg.FetchRequest)
-			cluster.KeepControl()
-			fetchRequestCount.Inc()
-			assert.Len(t, fetchReq.Topics, 1)
-			assert.Len(t, fetchReq.Topics[0].Partitions, 1)
-			requestedOffset := fetchReq.Topics[0].Partitions[0].FetchOffset
-			maxRequestedOffset.Store(fetchReq.Topics[0].Partitions[0].FetchOffset)
-			t.Log("Received fetch request for offset", requestedOffset)
-
-			cluster.DropControl()                                      // Let the cluster handle the request normally
-			cluster.ControlKey(kmsg.Fetch.Int16(), checkRequestOffset) // But register the function again so we can inspect the next request too.
-
-			return nil, nil, false
-		}
-		cluster.ControlKey(kmsg.Fetch.Int16(), checkRequestOffset)
-
-		// Wait for a few fetch requests
-		require.Eventually(t, func() bool {
-			return fetchRequestCount.Load() >= 10
-		}, 30*time.Second, 100*time.Millisecond, "Not enough fetch requests received")
-
-		// Verify that the max requested offset does not exceed the number of produced records
-		assert.LessOrEqualf(t, int(maxRequestedOffset.Load()), len(producedRecordsBytes),
-			"Requested offset (%d) should not exceed the number of produced records (%d)", maxRequestedOffset.Load(), len(producedRecordsBytes))
-
-		// Verify the number and content of fetched records
-		assert.Equal(t, producedRecordsBytes, fetchedRecordsBytes, "Should fetch all produced records")
-
-		// We expect no more records returned by PollFetches() and no buffered records.
-		pollFetchesAndAssertNoRecords(t, fetchers)
 	})
 
 	t.Run("starting to run against a broken broker fails creating the fetchers", func(t *testing.T) {
-		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+			var vnet kfake.VirtualNetwork
+			cluster, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, testkafka.WithVirtualNetwork(&vnet))
+			mockErr := kerr.BrokerNotAvailable
+			cluster.ControlKey(kmsg.Metadata.Int16(), func(req kmsg.Request) (kmsg.Response, error, bool) {
+				cluster.KeepControl()
 
-		cluster, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
-		mockErr := kerr.BrokerNotAvailable
-		cluster.ControlKey(kmsg.Metadata.Int16(), func(req kmsg.Request) (kmsg.Response, error, bool) {
-			cluster.KeepControl()
+				respTopic := kmsg.NewMetadataResponseTopic()
+				topicName := topicName // can't take the address of a const, so we first write it to a variable
+				respTopic.Topic = &topicName
+				respTopic.TopicID = [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+				respTopic.ErrorCode = mockErr.Code
 
-			respTopic := kmsg.NewMetadataResponseTopic()
-			topicName := topicName // can't take the address of a const, so we first write it to a variable
-			respTopic.Topic = &topicName
-			respTopic.TopicID = [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
-			respTopic.ErrorCode = mockErr.Code
+				resp := kmsg.NewPtrMetadataResponse()
+				resp.Topics = append(resp.Topics, respTopic)
+				resp.Version = req.GetVersion()
+				return resp, nil, true
+			})
 
-			resp := kmsg.NewPtrMetadataResponse()
-			resp.Topics = append(resp.Topics, respTopic)
-			resp.Version = req.GetVersion()
-			return resp, nil, true
+			logger := log.NewNopLogger()
+			reg := prometheus.NewPedanticRegistry()
+			kpromMetrics := NewKafkaReaderClientMetrics(ReaderMetricsPrefix, "partition-reader", reg)
+			readerMetrics := NewReaderMetrics(reg, noopReaderMetricsSource{}, topicName, kpromMetrics)
+
+			client := newKafkaProduceClient(t, clusterAddr, withWriteVirtualNetwork(&vnet))
+
+			// This instantiates the fields of kprom.
+			// This is usually done by franz-go, but since now we use the metrics ourselves, we need to instantiate the metrics ourselves.
+			kpromMetrics.OnNewClient(client)
+
+			offsetReader := newPartitionOffsetClient(client, reg, logger)
+
+			startOffsetsReader := NewGenericOffsetReader(func(ctx context.Context) (int64, error) {
+				return offsetReader.FetchPartitionStartOffset(ctx, topicName, partitionID)
+			}, time.Second, logger)
+
+			_, err := NewConcurrentFetchers(
+				ctx,
+				client,
+				logger,
+				topicName,
+				partitionID,
+				0,
+				concurrency,
+				0,
+				false,
+				time.Second, // same order of magnitude as the real one (defaultMinBytesMaxWaitTime), but faster for tests
+				offsetReader,
+				OnRangeErrorResumeFromStart,
+				startOffsetsReader,
+				fastFetchBackoffConfig,
+				&readerMetrics,
+			)
+			assert.ErrorContains(t, err, "failed to find topic ID")
+			assert.ErrorIs(t, err, mockErr)
 		})
-
-		logger := log.NewNopLogger()
-		reg := prometheus.NewPedanticRegistry()
-		kpromMetrics := NewKafkaReaderClientMetrics(ReaderMetricsPrefix, "partition-reader", reg)
-		readerMetrics := NewReaderMetrics(reg, noopReaderMetricsSource{}, topicName, kpromMetrics)
-
-		client := newKafkaProduceClient(t, clusterAddr)
-
-		// This instantiates the fields of kprom.
-		// This is usually done by franz-go, but since now we use the metrics ourselves, we need to instantiate the metrics ourselves.
-		kpromMetrics.OnNewClient(client)
-
-		offsetReader := newPartitionOffsetClient(client, reg, logger)
-
-		startOffsetsReader := NewGenericOffsetReader(func(ctx context.Context) (int64, error) {
-			return offsetReader.FetchPartitionStartOffset(ctx, topicName, partitionID)
-		}, time.Second, logger)
-
-		_, err := NewConcurrentFetchers(
-			ctx,
-			client,
-			logger,
-			topicName,
-			partitionID,
-			0,
-			concurrency,
-			0,
-			false,
-			time.Second, // same order of magnitude as the real one (defaultMinBytesMaxWaitTime), but faster for tests
-			offsetReader,
-			OnRangeErrorResumeFromStart,
-			startOffsetsReader,
-			fastFetchBackoffConfig,
-			&readerMetrics,
-		)
-		assert.ErrorContains(t, err, "failed to find topic ID")
-		assert.ErrorIs(t, err, mockErr)
 	})
 
 	t.Run("should reset the buffered records count when stopping", func(t *testing.T) {
-		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+			var vnet kfake.VirtualNetwork
+			_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, testkafka.WithVirtualNetwork(&vnet))
+			client := newKafkaProduceClient(t, clusterAddr, withWriteVirtualNetwork(&vnet))
 
-		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
-		client := newKafkaProduceClient(t, clusterAddr)
+			fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0, true, OnRangeErrorResumeFromStart)
 
-		fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, 0, true, OnRangeErrorResumeFromStart)
+			// Produce some records.
+			for i := 0; i < 10; i++ {
+				produceRecord(ctx, t, client, topicName, partitionID, []byte(fmt.Sprintf("record-%d", i)))
+			}
 
-		// Produce some records.
-		for i := 0; i < 10; i++ {
-			produceRecord(ctx, t, client, topicName, partitionID, []byte(fmt.Sprintf("record-%d", i)))
-		}
+			// We are not consuming the records, so we expect the count of buffered records to increase.
+			// The actual number of buffered records may change due to concurrency, so we just check
+			// that there are some buffered records.
+			test.Poll(t, time.Second, true, func() interface{} {
+				return fetchers.BufferedRecords() > 0
+			})
 
-		// We are not consuming the records, so we expect the count of buffered records to increase.
-		// The actual number of buffered records may change due to concurrency, so we just check
-		// that there are some buffered records.
-		test.Poll(t, time.Second, true, func() interface{} {
-			return fetchers.BufferedRecords() > 0
+			// Stop the fetchers.
+			fetchers.Stop()
+
+			// Even if there were some buffered records we expect the count to be reset to 0 when stopping
+			// because the Stop() intentionally discard any buffered record.
+			require.Zero(t, fetchers.BufferedRecords())
 		})
-
-		// Stop the fetchers.
-		fetchers.Stop()
-
-		// Even if there were some buffered records we expect the count to be reset to 0 when stopping
-		// because the Stop() intentionally discard any buffered record.
-		require.Zero(t, fetchers.BufferedRecords())
 	})
 
 	t.Run("respect maximum buffered bytes limit", func(t *testing.T) {
-		// This test produces a large number of large records. Do NOT run it concurrently because it may cause
-		// some flakyness, due to assertion timeouts being hit, if slowed down excessively.
+		synctest.Test(t, func(t *testing.T) {
+			const (
+				topicName        = "test-topic"
+				partitionID      = 1
+				concurrency      = 3
+				maxInflightBytes = 10_000_000
 
-		const (
-			topicName        = "test-topic"
-			partitionID      = 1
-			concurrency      = 3
-			maxInflightBytes = 10_000_000
+				// Create records with a size equal to the initial estimation, to get predictable concurrency.
+				recordSizeBytes = initialBytesPerRecord
 
-			// Create records with a size equal to the initial estimation, to get predictable concurrency.
-			recordSizeBytes = initialBytesPerRecord
+				// Produce a lot of records so that the client is forced to split them into multiple fetches.
+				totalProducedRecords = 6000
 
-			// Produce a lot of records so that the client is forced to split them into multiple fetches.
-			totalProducedRecords = 6000
+				// produce records in batches to simulate a real world case.
+				produceRecordsBatchSize = forcedMinValueForMaxBytes / recordSizeBytes
+			)
 
-			// produce records in batches to simulate a real world case.
-			produceRecordsBatchSize = forcedMinValueForMaxBytes / recordSizeBytes
-		)
+			ctx := t.Context()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
+			var vnet kfake.VirtualNetwork
+			_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, testkafka.WithVirtualNetwork(&vnet))
+			client := newKafkaProduceClient(t, clusterAddr, withWriteVirtualNetwork(&vnet))
 
-		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
-		client := newKafkaProduceClient(t, clusterAddr)
+			// Produce records in batches.
+			t.Logf("Producing %d records", totalProducedRecords)
 
-		// Produce records in batches.
-		t.Logf("Producing %d records", totalProducedRecords)
+			recordValue := bytes.Repeat([]byte{'a'}, recordSizeBytes)
+			for i := 0; i < totalProducedRecords; i += produceRecordsBatchSize {
+				batchSize := min(totalProducedRecords-i, produceRecordsBatchSize)
+				records := make([]*kgo.Record, 0, batchSize)
+				for r := 0; r < batchSize; r++ {
+					records = append(records, createRecord(topicName, partitionID, recordValue, 0))
+				}
 
-		recordValue := bytes.Repeat([]byte{'a'}, recordSizeBytes)
-		for i := 0; i < totalProducedRecords; i += produceRecordsBatchSize {
-			batchSize := min(totalProducedRecords-i, produceRecordsBatchSize)
-			records := make([]*kgo.Record, 0, batchSize)
-			for r := 0; r < batchSize; r++ {
-				records = append(records, createRecord(topicName, partitionID, recordValue, 0))
+				client.ProduceSync(ctx, records...)
 			}
 
-			client.ProduceSync(ctx, records...)
-		}
+			t.Logf("Produced %d records", totalProducedRecords)
 
-		t.Logf("Produced %d records", totalProducedRecords)
+			// Create fetchers with tracking of uncompressed bytes
+			fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, maxInflightBytes, true, OnRangeErrorResumeFromStart)
 
-		// Create fetchers with tracking of uncompressed bytes
-		fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, maxInflightBytes, true, OnRangeErrorResumeFromStart)
+			// Once the fetchers are durably blocked the buffered records are stable, capped by the limit.
+			synctest.Wait()
 
-		// Wait for buffered records to stabilize, we expect that they stabilize because the limit is in effect.
-		waitForStableBufferedRecords(t, fetchers)
+			// Assert that we don't buffer more than maxInflightBytes
+			assert.LessOrEqualf(t, fetchers.BufferedBytes(), int64(maxInflightBytes), "Should not buffer more than %d bytes of records", maxInflightBytes)
 
-		// Assert that we don't buffer more than maxInflightBytes
-		assert.LessOrEqualf(t, fetchers.BufferedBytes(), int64(maxInflightBytes), "Should not buffer more than %d bytes of records", maxInflightBytes)
+			// Consume one batch of records
+			fetches, _ := fetchers.PollFetches(ctx)
+			totalConsumedRecords := fetches.NumRecords()
+			require.Greater(t, totalConsumedRecords, 0, "Should have received some records")
 
-		// Consume one batch of records
-		fetches, _ := fetchers.PollFetches(ctx)
-		totalConsumedRecords := fetches.NumRecords()
-		require.Greater(t, totalConsumedRecords, 0, "Should have received some records")
+			// Let the fetchers settle (durably blocked) so the buffered counters are stable.
+			synctest.Wait()
 
-		// Allow time for more fetches
-		waitForStableBufferedRecords(t, fetchers)
+			// Assert again that buffered bytes remain under limit
+			assert.LessOrEqualf(t, fetchers.BufferedRecords(), int64(maxInflightBytes), "Should still not buffer more than %d bytes after consuming some records", maxInflightBytes)
 
-		// Assert again that buffered bytes remain under limit
-		assert.LessOrEqualf(t, fetchers.BufferedRecords(), int64(maxInflightBytes), "Should still not buffer more than %d bytes after consuming some records", maxInflightBytes)
+			// Consume all remaining records and verify total
+			// We produce a lot of data, give enough time so that the slow CI doesn't flake
+			fetches = longPollFetches(fetchers, totalProducedRecords-totalConsumedRecords, 20*time.Second)
+			totalConsumedRecords += fetches.NumRecords()
 
-		// Consume all remaining records and verify total
-		// We produce a lot of data, give enough time so that the slow CI doesn't flake
-		fetches = longPollFetches(fetchers, totalProducedRecords-totalConsumedRecords, 20*time.Second)
-		totalConsumedRecords += fetches.NumRecords()
+			// Let the fetchers settle (durably blocked) so the buffered counters are stable.
+			synctest.Wait()
 
-		// Allow time for more fetches
-		waitForStableBufferedRecords(t, fetchers)
-
-		pollFetchesAndAssertNoRecords(t, fetchers)
-		assert.Equal(t, totalProducedRecords, totalConsumedRecords, "Should have received all records eventually")
+			pollFetchesAndAssertNoRecords(t, fetchers)
+			assert.Equal(t, totalProducedRecords, totalConsumedRecords, "Should have received all records eventually")
+		})
 	})
 
 	t.Run("respect maximum buffered bytes limit with varying record sizes", func(t *testing.T) {
 		// This test makes sure that the buffer doesn't become inefficient when the size estimations change (from large records we switch to small records).
-		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			const (
+				topicName          = "test-topic"
+				partitionID        = 1
+				concurrency        = 30
+				maxInflightBytes   = 5_000_000
+				perFetcherMaxBytes = maxInflightBytes / concurrency
 
-		const (
-			topicName          = "test-topic"
-			partitionID        = 1
-			concurrency        = 30
-			maxInflightBytes   = 5_000_000
-			perFetcherMaxBytes = maxInflightBytes / concurrency
+				largeRecordsCount = 100
+				largeRecordSize   = 100_000
+				smallRecordsCount = 10_000
+				smallRecordSize   = 1000
+			)
 
-			largeRecordsCount = 100
-			largeRecordSize   = 100_000
-			smallRecordsCount = 10_000
-			smallRecordSize   = 1000
-		)
+			require.True(t, smallRecordsCount%2 == 0, "we divide the smallRecordsCount by 2 later on, it must be divisible by 2")
 
-		require.True(t, smallRecordsCount%2 == 0, "we divide the smallRecordsCount by 2 later on, it must be divisible by 2")
+			ctx := t.Context()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
+			var vnet kfake.VirtualNetwork
+			_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, testkafka.WithVirtualNetwork(&vnet))
+			client := newKafkaProduceClient(t, clusterAddr, withWriteVirtualNetwork(&vnet))
 
-		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
-		client := newKafkaProduceClient(t, clusterAddr)
+			// Create fetchers early to ensure we don't miss any records
+			fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, maxInflightBytes, true, OnRangeErrorResumeFromStart)
 
-		// Create fetchers early to ensure we don't miss any records
-		fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, 0, concurrency, maxInflightBytes, true, OnRangeErrorResumeFromStart)
+			// Produce large records
+			largeValue := bytes.Repeat([]byte{'a'}, largeRecordSize)
+			for range largeRecordsCount {
+				produceRecord(ctx, t, client, topicName, partitionID, largeValue)
+			}
 
-		// Produce large records
-		largeValue := bytes.Repeat([]byte{'a'}, largeRecordSize)
-		for range largeRecordsCount {
-			produceRecord(ctx, t, client, topicName, partitionID, largeValue)
-		}
+			t.Logf("Produced %d large records", largeRecordsCount)
 
-		t.Logf("Produced %d large records", largeRecordsCount)
+			synctest.Wait()
+			t.Log("Buffered records stabilized")
 
-		waitForStableBufferedRecords(t, fetchers)
-		t.Log("Buffered records stabilized")
+			assert.LessOrEqualf(t, fetchers.BufferedBytes(), int64(maxInflightBytes), "Should not buffer more than %d bytes of large records", maxInflightBytes)
+			// Consume all large records
+			fetches := longPollFetches(fetchers, largeRecordsCount, 10*time.Second)
+			consumedRecords := fetches.NumRecords()
 
-		assert.LessOrEqualf(t, fetchers.BufferedBytes(), int64(maxInflightBytes), "Should not buffer more than %d bytes of large records", maxInflightBytes)
-		// Consume all large records
-		fetches := longPollFetches(fetchers, largeRecordsCount, 10*time.Second)
-		consumedRecords := fetches.NumRecords()
+			pollFetchesAndAssertNoRecords(t, fetchers)
+			t.Logf("Consumed %d large records", fetches.NumRecords())
 
-		pollFetchesAndAssertNoRecords(t, fetchers)
-		t.Logf("Consumed %d large records", fetches.NumRecords())
+			// Produce small records
+			smallValue := bytes.Repeat([]byte{'b'}, smallRecordSize)
+			for i := 0; i < smallRecordsCount; i++ {
+				produceRecord(ctx, t, client, topicName, partitionID, smallValue)
+			}
 
-		// Produce small records
-		smallValue := bytes.Repeat([]byte{'b'}, smallRecordSize)
-		for i := 0; i < smallRecordsCount; i++ {
-			produceRecord(ctx, t, client, topicName, partitionID, smallValue)
-		}
+			t.Logf("Produced %d small records", smallRecordsCount)
 
-		t.Logf("Produced %d small records", smallRecordsCount)
+			// Consume half of the small records. This should be enough to stabilize the records size estimation.
+			fetches = longPollFetches(fetchers, smallRecordsCount/2, 10*time.Second)
+			consumedRecords += fetches.NumRecords()
+			t.Logf("Consumed %d of the small records", fetches.NumRecords())
 
-		// Consume half of the small records. This should be enough to stabilize the records size estimation.
-		fetches = longPollFetches(fetchers, smallRecordsCount/2, 10*time.Second)
-		consumedRecords += fetches.NumRecords()
-		t.Logf("Consumed %d of the small records", fetches.NumRecords())
+			// Assert that the buffer is well utilized.
+			synctest.Wait()
+			t.Log("Buffered records stabilized")
 
-		// Assert that the buffer is well utilized.
-		waitForStableBufferedRecords(t, fetchers)
-		t.Log("Buffered records stabilized")
+			assert.LessOrEqualf(t, fetchers.BufferedBytes(), int64(maxInflightBytes), "Should not buffer more than %d bytes of small records", maxInflightBytes)
+			assert.GreaterOrEqual(t, fetchers.BufferedBytes(), int64(perFetcherMaxBytes), "At least one fetcher's worth of bytes should be buffered")
 
-		assert.LessOrEqualf(t, fetchers.BufferedBytes(), int64(maxInflightBytes), "Should not buffer more than %d bytes of small records", maxInflightBytes)
-		assert.GreaterOrEqual(t, fetchers.BufferedBytes(), int64(perFetcherMaxBytes), "At least one fetcher's worth of bytes should be buffered")
+			// Consume the rest of the small records.
+			fetches = longPollFetches(fetchers, smallRecordsCount/2, 10*time.Second)
+			consumedRecords += fetches.NumRecords()
+			t.Logf("Consumed %d more of the small records", fetches.NumRecords())
 
-		// Consume the rest of the small records.
-		fetches = longPollFetches(fetchers, smallRecordsCount/2, 10*time.Second)
-		consumedRecords += fetches.NumRecords()
-		t.Logf("Consumed %d more of the small records", fetches.NumRecords())
+			// Verify we received correct number of records
+			const totalProducedRecords = largeRecordsCount + smallRecordsCount
+			assert.Equal(t, totalProducedRecords, consumedRecords, "Should have consumed all records")
 
-		// Verify we received correct number of records
-		const totalProducedRecords = largeRecordsCount + smallRecordsCount
-		assert.Equal(t, totalProducedRecords, consumedRecords, "Should have consumed all records")
+			// Verify no more records are buffered, once the fetchers are durably blocked.
+			synctest.Wait()
 
-		// Verify no more records are buffered. First wait for the buffered records to stabilize.
-		waitForStableBufferedRecords(t, fetchers)
-
-		pollFetchesAndAssertNoRecords(t, fetchers)
+			pollFetchesAndAssertNoRecords(t, fetchers)
+		})
 	})
 
 	t.Run("out of range error aborts under abort policy", func(t *testing.T) {
-		t.Parallel()
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
 
-		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
-		client := newKafkaProduceClient(t, clusterAddr)
+			var vnet kfake.VirtualNetwork
+			_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, testkafka.WithVirtualNetwork(&vnet))
+			client := newKafkaProduceClient(t, clusterAddr, withWriteVirtualNetwork(&vnet))
 
-		// Produce some records before starting the fetchers
-		for i := range 5 {
-			produceRecord(ctx, t, client, topicName, partitionID, []byte(fmt.Sprintf("record-%d", i)))
-		}
-
-		const startOffset = 10_000_000 // an offset that is definitely out of range
-		fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, startOffset, concurrency, 0, true, OnRangeErrorAbort)
-		fetches, _ := fetchers.PollFetches(ctx)
-
-		hasRangeError := false
-		fetches.EachError(func(topic string, partition int32, err error) {
-			if errors.Is(err, kerr.OffsetOutOfRange) {
-				hasRangeError = true
+			// Produce some records before starting the fetchers
+			for i := range 5 {
+				produceRecord(ctx, t, client, topicName, partitionID, []byte(fmt.Sprintf("record-%d", i)))
 			}
+
+			const startOffset = 10_000_000 // an offset that is definitely out of range
+			fetchers, _ := createConcurrentFetchers(ctx, t, client, topicName, partitionID, startOffset, concurrency, 0, true, OnRangeErrorAbort)
+			fetches, _ := fetchers.PollFetches(ctx)
+
+			hasRangeError := false
+			fetches.EachError(func(topic string, partition int32, err error) {
+				if errors.Is(err, kerr.OffsetOutOfRange) {
+					hasRangeError = true
+				}
+			})
+			require.True(t, hasRangeError, "out of range error should be present among fetch errors")
 		})
-		require.True(t, hasRangeError, "out of range error should be present among fetch errors")
 	})
 }
 

--- a/pkg/storage/ingest/partition_offset_reader_single_cluster_test.go
+++ b/pkg/storage/ingest/partition_offset_reader_single_cluster_test.go
@@ -30,6 +30,8 @@ func TestSingleClusterTopicOffsetsReader(t *testing.T) {
 	allPartitionIDs := func(_ context.Context) ([]int32, error) { return []int32{0}, nil }
 
 	t.Run("should notify waiting goroutines when stopped", func(t *testing.T) {
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			ctx := t.Context()
 
@@ -83,6 +85,8 @@ func TestSingleClusterTopicOffsetsReader_WaitNextFetchLastProducedOffset(t *test
 	)
 
 	t.Run("should wait the result of the next request issued", func(t *testing.T) {
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			ctx := t.Context()
 
@@ -160,6 +164,8 @@ func TestSingleClusterTopicOffsetsReader_WaitNextFetchLastProducedOffset(t *test
 	})
 
 	t.Run("should immediately return if the context gets canceled", func(t *testing.T) {
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			ctx := t.Context()
 

--- a/pkg/storage/ingest/partition_offset_reader_single_cluster_test.go
+++ b/pkg/storage/ingest/partition_offset_reader_single_cluster_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/go-kit/log"
@@ -13,6 +14,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kfake"
 	"github.com/twmb/franz-go/pkg/kmsg"
 	"go.uber.org/atomic"
 
@@ -25,42 +27,46 @@ func TestSingleClusterTopicOffsetsReader(t *testing.T) {
 		topicName     = "test"
 	)
 
-	var (
-		ctx             = context.Background()
-		allPartitionIDs = func(_ context.Context) ([]int32, error) { return []int32{0}, nil }
-	)
+	allPartitionIDs := func(_ context.Context) ([]int32, error) { return []int32{0}, nil }
 
 	t.Run("should notify waiting goroutines when stopped", func(t *testing.T) {
-		var (
-			_, clusterAddr = testkafka.CreateCluster(t, numPartitions, topicName)
-			kafkaCfg       = createTestKafkaConfig(clusterAddr, topicName)
-		)
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
 
-		// Run with a very high polling interval, so that it will never run in this test.
-		kafkaCfg.LastProducedOffsetPollInterval = time.Hour
-		reader, err := NewSingleClusterTopicOffsetsReader(kafkaCfg, topicName, allPartitionIDs, "query-frontend", prometheus.NewPedanticRegistry(), log.NewNopLogger())
-		require.NoError(t, err)
-		require.NoError(t, services.StartAndAwaitRunning(ctx, reader))
+			var vnet kfake.VirtualNetwork
+			_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName, testkafka.WithVirtualNetwork(&vnet))
+			kafkaCfg := createTestKafkaConfig(clusterAddr, topicName)
+			kafkaCfg.Dialer = vnet.DialContext
 
-		// Run few goroutines waiting for the last produced offset.
-		wg := sync.WaitGroup{}
+			// Run with a very high polling interval, so that it will never run in this test.
+			kafkaCfg.LastProducedOffsetPollInterval = time.Hour
+			reader, err := NewSingleClusterTopicOffsetsReader(kafkaCfg, topicName, allPartitionIDs, "query-frontend", prometheus.NewPedanticRegistry(), log.NewNopLogger())
+			require.NoError(t, err)
+			require.NoError(t, services.StartAndAwaitRunning(ctx, reader))
 
-		for i := 0; i < 2; i++ {
-			runAsync(&wg, func() {
-				_, err := reader.WaitNextFetchLastProducedOffset(ctx)
-				assert.Equal(t, errPartitionOffsetReaderStopped, err)
-			})
-		}
+			// Run few goroutines waiting for the last produced offset.
+			wg := sync.WaitGroup{}
 
-		// Stop the reader.
-		require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
+			for i := 0; i < 2; i++ {
+				runAsync(&wg, func() {
+					_, err := reader.WaitNextFetchLastProducedOffset(ctx)
+					assert.Equal(t, errPartitionOffsetReaderStopped, err)
+				})
+			}
 
-		// At the point we expect the waiting goroutines to be unblocked.
-		wg.Wait()
+			// Wait until both goroutines are durably blocked waiting for the next produced offset.
+			synctest.Wait()
 
-		// The next call to WaitNextFetchLastProducedOffset() should return immediately.
-		_, err = reader.WaitNextFetchLastProducedOffset(ctx)
-		assert.Equal(t, errPartitionOffsetReaderStopped, err)
+			// Stop the reader.
+			require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
+
+			// At the point we expect the waiting goroutines to be unblocked.
+			wg.Wait()
+
+			// The next call to WaitNextFetchLastProducedOffset() should return immediately.
+			_, err = reader.WaitNextFetchLastProducedOffset(ctx)
+			assert.Equal(t, errPartitionOffsetReaderStopped, err)
+		})
 	})
 }
 
@@ -72,99 +78,110 @@ func TestSingleClusterTopicOffsetsReader_WaitNextFetchLastProducedOffset(t *test
 	)
 
 	var (
-		ctx             = context.Background()
 		logger          = log.NewNopLogger()
 		allPartitionIDs = func(_ context.Context) ([]int32, error) { return []int32{0}, nil }
 	)
 
 	t.Run("should wait the result of the next request issued", func(t *testing.T) {
-		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
-		kafkaCfg := createTestKafkaConfig(clusterAddr, topicName)
-		kafkaCfg.LastProducedOffsetPollInterval = pollInterval
-		reader, err := NewSingleClusterTopicOffsetsReader(kafkaCfg, topicName, allPartitionIDs, "query-frontend", prometheus.NewPedanticRegistry(), logger)
-		require.NoError(t, err)
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
 
-		var (
-			lastOffset            = atomic.NewInt64(1)
-			firstRequestReceived  = make(chan struct{})
-			secondRequestReceived = make(chan struct{})
-		)
-
-		cluster.ControlKey(int16(kmsg.ListOffsets), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
-			cluster.KeepControl()
-
-			switch lastOffset.Load() {
-			case 1:
-				close(firstRequestReceived)
-			case 3:
-				close(secondRequestReceived)
-			}
-
-			// Mock the response so that we can increase the offset each time.
-			req := kreq.(*kmsg.ListOffsetsRequest)
-			res := req.ResponseKind().(*kmsg.ListOffsetsResponse)
-			res.Topics = []kmsg.ListOffsetsResponseTopic{{
-				Topic: topicName,
-				Partitions: []kmsg.ListOffsetsResponseTopicPartition{{
-					Partition: 0,
-					ErrorCode: 0,
-					Offset:    lastOffset.Inc(),
-				}, {
-					Partition: 1,
-					ErrorCode: 0,
-					Offset:    lastOffset.Inc(),
-				}},
-			}}
-
-			return res, nil, true
-		})
-
-		wg := sync.WaitGroup{}
-
-		// The 1st WaitNextFetchLastProducedOffset() is called before the service starts.
-		// The service fetches the offset once at startup, so it's expected that the first wait
-		// to wait the result of the 2nd request.
-		// If we don't do synchronisation, then it's also possible that we fit in the first request, but we synchronise to avoid flaky tests
-		runAsyncAfter(&wg, firstRequestReceived, func() {
-			actual, err := reader.WaitNextFetchLastProducedOffset(ctx)
+			var vnet kfake.VirtualNetwork
+			cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName, testkafka.WithVirtualNetwork(&vnet))
+			kafkaCfg := createTestKafkaConfig(clusterAddr, topicName)
+			kafkaCfg.Dialer = vnet.DialContext
+			kafkaCfg.LastProducedOffsetPollInterval = pollInterval
+			reader, err := NewSingleClusterTopicOffsetsReader(kafkaCfg, topicName, allPartitionIDs, "query-frontend", prometheus.NewPedanticRegistry(), logger)
 			require.NoError(t, err)
-			assert.Equal(t, map[int32]int64{0: int64(3), 1: int64(4)}, actual)
-		})
 
-		// The 2nd WaitNextFetchLastProducedOffset() is called while the 1st is running, so it's expected
-		// to wait the result of the 3rd request.
-		runAsyncAfter(&wg, secondRequestReceived, func() {
-			actual, err := reader.WaitNextFetchLastProducedOffset(ctx)
-			require.NoError(t, err)
-			assert.Equal(t, map[int32]int64{0: int64(5), 1: int64(6)}, actual)
-		})
+			var (
+				lastOffset            = atomic.NewInt64(1)
+				firstRequestReceived  = make(chan struct{})
+				secondRequestReceived = make(chan struct{})
+			)
 
-		// Now we can start the service.
-		require.NoError(t, services.StartAndAwaitRunning(ctx, reader))
-		t.Cleanup(func() {
-			require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
-		})
+			cluster.ControlKey(int16(kmsg.ListOffsets), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+				cluster.KeepControl()
 
-		wg.Wait()
+				switch lastOffset.Load() {
+				case 1:
+					close(firstRequestReceived)
+				case 3:
+					close(secondRequestReceived)
+				}
+
+				// Mock the response so that we can increase the offset each time.
+				req := kreq.(*kmsg.ListOffsetsRequest)
+				res := req.ResponseKind().(*kmsg.ListOffsetsResponse)
+				res.Topics = []kmsg.ListOffsetsResponseTopic{{
+					Topic: topicName,
+					Partitions: []kmsg.ListOffsetsResponseTopicPartition{{
+						Partition: 0,
+						ErrorCode: 0,
+						Offset:    lastOffset.Inc(),
+					}, {
+						Partition: 1,
+						ErrorCode: 0,
+						Offset:    lastOffset.Inc(),
+					}},
+				}}
+
+				return res, nil, true
+			})
+
+			wg := sync.WaitGroup{}
+
+			// The 1st WaitNextFetchLastProducedOffset() is called before the service starts.
+			// The service fetches the offset once at startup, so it's expected that the first wait
+			// to wait the result of the 2nd request.
+			// If we don't do synchronisation, then it's also possible that we fit in the first request, but we synchronise to avoid flaky tests
+			runAsyncAfter(&wg, firstRequestReceived, func() {
+				actual, err := reader.WaitNextFetchLastProducedOffset(ctx)
+				require.NoError(t, err)
+				assert.Equal(t, map[int32]int64{0: int64(3), 1: int64(4)}, actual)
+			})
+
+			// The 2nd WaitNextFetchLastProducedOffset() is called while the 1st is running, so it's expected
+			// to wait the result of the 3rd request.
+			runAsyncAfter(&wg, secondRequestReceived, func() {
+				actual, err := reader.WaitNextFetchLastProducedOffset(ctx)
+				require.NoError(t, err)
+				assert.Equal(t, map[int32]int64{0: int64(5), 1: int64(6)}, actual)
+			})
+
+			// Now we can start the service.
+			require.NoError(t, services.StartAndAwaitRunning(ctx, reader))
+			t.Cleanup(func() {
+				require.NoError(t, services.StopAndAwaitTerminated(context.Background(), reader))
+			})
+
+			wg.Wait()
+		})
 	})
 
 	t.Run("should immediately return if the context gets canceled", func(t *testing.T) {
-		_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
-		kafkaCfg := createTestKafkaConfig(clusterAddr, topicName)
-		// Use a very high poll interval: the reader fetches once at startup, then never again, so the "next"
-		// offset never arrives and WaitNextFetchLastProducedOffset can only return via the context.
-		kafkaCfg.LastProducedOffsetPollInterval = time.Hour
-		reader, err := NewSingleClusterTopicOffsetsReader(kafkaCfg, topicName, allPartitionIDs, "query-frontend", prometheus.NewPedanticRegistry(), logger)
-		require.NoError(t, err)
-		require.NoError(t, services.StartAndAwaitRunning(ctx, reader))
-		t.Cleanup(func() {
-			require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
+
+			var vnet kfake.VirtualNetwork
+			_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName, testkafka.WithVirtualNetwork(&vnet))
+			kafkaCfg := createTestKafkaConfig(clusterAddr, topicName)
+			kafkaCfg.Dialer = vnet.DialContext
+			// Use a very high poll interval: the reader fetches once at startup, then never again, so the "next"
+			// offset never arrives and WaitNextFetchLastProducedOffset can only return via the context.
+			kafkaCfg.LastProducedOffsetPollInterval = time.Hour
+			reader, err := NewSingleClusterTopicOffsetsReader(kafkaCfg, topicName, allPartitionIDs, "query-frontend", prometheus.NewPedanticRegistry(), logger)
+			require.NoError(t, err)
+			require.NoError(t, services.StartAndAwaitRunning(ctx, reader))
+			t.Cleanup(func() {
+				require.NoError(t, services.StopAndAwaitTerminated(context.Background(), reader))
+			})
+
+			canceledCtx, cancel := context.WithCancel(ctx)
+			cancel()
+
+			_, err = reader.WaitNextFetchLastProducedOffset(canceledCtx)
+			assert.ErrorIs(t, err, context.Canceled)
 		})
-
-		canceledCtx, cancel := context.WithCancel(ctx)
-		cancel()
-
-		_, err = reader.WaitNextFetchLastProducedOffset(canceledCtx)
-		assert.ErrorIs(t, err, context.Canceled)
 	})
 }

--- a/pkg/storage/ingest/partition_offset_reader_single_cluster_test.go
+++ b/pkg/storage/ingest/partition_offset_reader_single_cluster_test.go
@@ -49,7 +49,7 @@ func TestSingleClusterTopicOffsetsReader(t *testing.T) {
 			// Run few goroutines waiting for the last produced offset.
 			wg := sync.WaitGroup{}
 
-			for i := 0; i < 2; i++ {
+			for range 2 {
 				runAsync(&wg, func() {
 					_, err := reader.WaitNextFetchLastProducedOffset(ctx)
 					assert.Equal(t, errPartitionOffsetReaderStopped, err)

--- a/pkg/storage/ingest/partition_offset_watcher_test.go
+++ b/pkg/storage/ingest/partition_offset_watcher_test.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/grafana/dskit/services"
@@ -18,116 +19,114 @@ import (
 )
 
 func TestPartitionOffsetWatcher(t *testing.T) {
-	const shortSleep = 100 * time.Millisecond
-
 	t.Run("should support a single goroutine waiting for an offset", func(t *testing.T) {
-		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			var (
+				ctx       = t.Context()
+				w         = NewPartitionOffsetWatcher()
+				firstDone = atomic.NewBool(false)
+			)
 
-		var (
-			ctx       = context.Background()
-			w         = NewPartitionOffsetWatcher()
-			firstDone = atomic.NewBool(false)
-		)
+			go func() {
+				assert.NoError(t, w.Wait(ctx, 2))
+				firstDone.Store(true)
+			}()
 
-		go func() {
-			assert.NoError(t, w.Wait(ctx, 2))
-			firstDone.Store(true)
-		}()
+			// Once the waiter is durably blocked, make sure wait() hasn't returned yet.
+			synctest.Wait()
+			assert.False(t, firstDone.Load())
 
-		// Wait a short time and then make sure the wait() hasn't returned yet.
-		time.Sleep(shortSleep)
-		assert.False(t, firstDone.Load())
+			// Notify an offset lower than the expected one. At this point the wait() shouldn't return yet.
+			w.Notify(1)
+			synctest.Wait()
+			assert.False(t, firstDone.Load())
 
-		// Notify an offset lower than the expected one. At this point the wait() shouldn't return yet.
-		w.Notify(1)
+			// Notify the expected offset. At this point wait() should return.
+			w.Notify(2)
+			synctest.Wait()
+			assert.True(t, firstDone.Load())
 
-		time.Sleep(shortSleep)
-		assert.False(t, firstDone.Load())
-
-		// Notify the expected offset. At this point wait() should return.
-		w.Notify(2)
-		assert.Eventually(t, firstDone.Load, shortSleep, shortSleep/10)
-
-		assert.Equal(t, 0, w.watchGroupsCount())
+			assert.Equal(t, 0, w.watchGroupsCount())
+		})
 	})
 
 	t.Run("should support two goroutines waiting for the same offset", func(t *testing.T) {
-		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			var (
+				ctx        = t.Context()
+				w          = NewPartitionOffsetWatcher()
+				firstDone  = atomic.NewBool(false)
+				secondDone = atomic.NewBool(false)
+			)
 
-		var (
-			ctx        = context.Background()
-			w          = NewPartitionOffsetWatcher()
-			firstDone  = atomic.NewBool(false)
-			secondDone = atomic.NewBool(false)
-		)
+			go func() {
+				assert.NoError(t, w.Wait(ctx, 2))
+				firstDone.Store(true)
+			}()
 
-		go func() {
-			assert.NoError(t, w.Wait(ctx, 2))
-			firstDone.Store(true)
-		}()
+			go func() {
+				assert.NoError(t, w.Wait(ctx, 2))
+				secondDone.Store(true)
+			}()
 
-		go func() {
-			assert.NoError(t, w.Wait(ctx, 2))
-			secondDone.Store(true)
-		}()
+			// Once the waiters are durably blocked, make sure wait() hasn't returned yet.
+			synctest.Wait()
+			assert.False(t, firstDone.Load())
+			assert.False(t, secondDone.Load())
 
-		// Wait a short time and then make sure the wait() hasn't returned yet.
-		time.Sleep(shortSleep)
-		assert.False(t, firstDone.Load())
-		assert.False(t, secondDone.Load())
+			// Notify an offset lower than the expected one. At this point the wait() shouldn't return yet.
+			w.Notify(1)
+			synctest.Wait()
+			assert.False(t, firstDone.Load())
+			assert.False(t, secondDone.Load())
 
-		// Notify an offset lower than the expected one. At this point the wait() shouldn't return yet.
-		w.Notify(1)
+			// Notify the expected offset. At this point wait() should return.
+			w.Notify(2)
+			synctest.Wait()
+			assert.True(t, firstDone.Load())
+			assert.True(t, secondDone.Load())
 
-		time.Sleep(shortSleep)
-		assert.False(t, firstDone.Load())
-		assert.False(t, secondDone.Load())
-
-		// Notify the expected offset. At this point wait() should return.
-		w.Notify(2)
-		assert.Eventually(t, firstDone.Load, shortSleep, shortSleep/10)
-		assert.Eventually(t, secondDone.Load, shortSleep, shortSleep/10)
-
-		assert.Equal(t, 0, w.watchGroupsCount())
+			assert.Equal(t, 0, w.watchGroupsCount())
+		})
 	})
 
 	t.Run("should support two goroutines waiting for a different offset", func(t *testing.T) {
-		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			var (
+				ctx        = t.Context()
+				w          = NewPartitionOffsetWatcher()
+				firstDone  = atomic.NewBool(false)
+				secondDone = atomic.NewBool(false)
+			)
 
-		var (
-			ctx        = context.Background()
-			w          = NewPartitionOffsetWatcher()
-			firstDone  = atomic.NewBool(false)
-			secondDone = atomic.NewBool(false)
-		)
+			go func() {
+				assert.NoError(t, w.Wait(ctx, 1))
+				firstDone.Store(true)
+			}()
 
-		go func() {
-			assert.NoError(t, w.Wait(ctx, 1))
-			firstDone.Store(true)
-		}()
+			go func() {
+				assert.NoError(t, w.Wait(ctx, 2))
+				secondDone.Store(true)
+			}()
 
-		go func() {
-			assert.NoError(t, w.Wait(ctx, 2))
-			secondDone.Store(true)
-		}()
+			// Once the waiters are durably blocked, make sure wait() hasn't returned yet.
+			synctest.Wait()
+			assert.False(t, firstDone.Load())
+			assert.False(t, secondDone.Load())
 
-		// Wait a short time and then make sure the wait() hasn't returned yet.
-		time.Sleep(shortSleep)
-		assert.False(t, firstDone.Load())
-		assert.False(t, secondDone.Load())
+			// Notify the offset expected by the 1st goroutine.
+			w.Notify(1)
+			synctest.Wait()
+			assert.True(t, firstDone.Load())
+			assert.False(t, secondDone.Load())
 
-		// Notify the offset expected by the 1st goroutine.
-		w.Notify(1)
-		assert.Eventually(t, firstDone.Load, shortSleep, shortSleep/10)
+			// Notify the offset expected by the 2nd goroutine.
+			w.Notify(2)
+			synctest.Wait()
+			assert.True(t, secondDone.Load())
 
-		time.Sleep(shortSleep)
-		assert.False(t, secondDone.Load())
-
-		// Notify the offset expected by the 2nd goroutine.
-		w.Notify(2)
-		assert.Eventually(t, secondDone.Load, shortSleep, shortSleep/10)
-
-		assert.Equal(t, 0, w.watchGroupsCount())
+			assert.Equal(t, 0, w.watchGroupsCount())
+		})
 	})
 
 	t.Run("Wait() should immediately return if the input offset has already been consumed", func(t *testing.T) {

--- a/pkg/storage/ingest/partition_offset_watcher_test.go
+++ b/pkg/storage/ingest/partition_offset_watcher_test.go
@@ -20,6 +20,8 @@ import (
 
 func TestPartitionOffsetWatcher(t *testing.T) {
 	t.Run("should support a single goroutine waiting for an offset", func(t *testing.T) {
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			var (
 				ctx       = t.Context()
@@ -51,6 +53,8 @@ func TestPartitionOffsetWatcher(t *testing.T) {
 	})
 
 	t.Run("should support two goroutines waiting for the same offset", func(t *testing.T) {
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			var (
 				ctx        = t.Context()
@@ -91,6 +95,8 @@ func TestPartitionOffsetWatcher(t *testing.T) {
 	})
 
 	t.Run("should support two goroutines waiting for a different offset", func(t *testing.T) {
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			var (
 				ctx        = t.Context()

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/go-kit/log"
@@ -29,6 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kfake"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
 	"go.uber.org/atomic"
@@ -142,8 +144,6 @@ func TestSingleClusterPartitionReader_logFetchErrors(t *testing.T) {
 }
 
 func TestSingleClusterPartitionReader_ConsumerError(t *testing.T) {
-	t.Parallel()
-
 	const (
 		topicName   = "test"
 		partitionID = 1
@@ -159,41 +159,43 @@ func TestSingleClusterPartitionReader_ConsumerError(t *testing.T) {
 		concurrencyVariant := concurrencyVariant
 
 		t.Run(concurrencyName, func(t *testing.T) {
-			t.Parallel()
-			ctx, cancel := context.WithCancelCause(context.Background())
-			t.Cleanup(func() { cancel(errors.New("test done")) })
+			synctest.Test(t, func(t *testing.T) {
+				var vnet kfake.VirtualNetwork
 
-			_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
+				_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, testkafka.WithVirtualNetwork(&vnet))
 
-			invocations := atomic.NewInt64(0)
-			returnErrors := atomic.NewBool(true)
-			trackingConsumer := newTestConsumer(2)
-			consumer := consumerFunc(func(ctx context.Context, records iter.Seq[*kgo.Record]) error {
-				invocations.Inc()
-				if !returnErrors.Load() {
-					return trackingConsumer.Consume(ctx, records)
-				}
-				// There may be more records, but we only care that the one we failed to consume in the first place is still there.
-				recs := slices.Collect(records)
-				assert.Equal(t, "1", string(recs[0].Value))
-				return errors.New("consumer error")
+				invocations := atomic.NewInt64(0)
+				returnErrors := atomic.NewBool(true)
+				trackingConsumer := newTestConsumer(2)
+				consumer := consumerFunc(func(ctx context.Context, records iter.Seq[*kgo.Record]) error {
+					invocations.Inc()
+					if !returnErrors.Load() {
+						return trackingConsumer.Consume(ctx, records)
+					}
+					// There may be more records, but we only care that the one we failed to consume in the first place is still there.
+					recs := slices.Collect(records)
+					assert.Equal(t, "1", string(recs[0].Value))
+					return errors.New("consumer error")
+				})
+				createAndStartReader(context.Background(), t, clusterAddr, topicName, partitionID, consumer, append(concurrencyVariant, withVirtualNetwork(&vnet))...)
+
+				// Write to Kafka.
+				writeClient := newKafkaProduceClient(t, clusterAddr, withWriteVirtualNetwork(&vnet))
+
+				ctx := t.Context()
+
+				produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("1"))
+				produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("2"))
+
+				// There are more than one invocation because the reader will retry.
+				assert.Eventually(t, func() bool { return invocations.Load() > 1 }, 5*time.Second, 100*time.Millisecond)
+
+				returnErrors.Store(false)
+
+				records, err := trackingConsumer.waitRecords(2, time.Second, 0)
+				assert.NoError(t, err)
+				assert.Equal(t, [][]byte{[]byte("1"), []byte("2")}, records)
 			})
-			createAndStartReader(ctx, t, clusterAddr, topicName, partitionID, consumer, concurrencyVariant...)
-
-			// Write to Kafka.
-			writeClient := newKafkaProduceClient(t, clusterAddr)
-
-			produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("1"))
-			produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("2"))
-
-			// There are more than one invocation because the reader will retry.
-			assert.Eventually(t, func() bool { return invocations.Load() > 1 }, 5*time.Second, 100*time.Millisecond)
-
-			returnErrors.Store(false)
-
-			records, err := trackingConsumer.waitRecords(2, time.Second, 0)
-			assert.NoError(t, err)
-			assert.Equal(t, [][]byte{[]byte("1"), []byte("2")}, records)
 		})
 	}
 }
@@ -211,64 +213,68 @@ func TestSingleClusterPartitionReader_ConsumerStopping(t *testing.T) {
 	}
 
 	for concurrencyName, concurrencyVariant := range concurrencyVariants {
-		concurrencyVariant := concurrencyVariant
-
 		t.Run(concurrencyName, func(t *testing.T) {
-			t.Parallel()
+			synctest.Test(t, func(t *testing.T) {
+				var vnet kfake.VirtualNetwork
 
-			ctx, cancel := context.WithCancelCause(context.Background())
-			t.Cleanup(func() { cancel(errors.New("test done")) })
+				_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, testkafka.WithVirtualNetwork(&vnet))
 
-			_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
-
-			// consumerErrs will store the last error returned by the consumer; its initial value doesn't matter, but it must be non-nil.
-			consumerErrs := atomic.NewError(errors.New("dummy error"))
-			type consumerCall struct {
-				f    func() []*kgo.Record
-				resp chan error
-			}
-			consumeCalls := make(chan consumerCall)
-			consumer := consumerFunc(func(ctx context.Context, records iter.Seq[*kgo.Record]) (err error) {
-				defer consumerErrs.Store(err)
-
-				call := consumerCall{
-					f:    func() []*kgo.Record { return slices.Collect(records) },
-					resp: make(chan error),
+				// consumerErrs will store the last error returned by the consumer; its initial value doesn't matter, but it must be non-nil.
+				consumerErrs := atomic.NewError(errors.New("dummy error"))
+				type consumerCall struct {
+					f    func() []*kgo.Record
+					resp chan error
 				}
-				consumeCalls <- call
-				err = <-call.resp
-				// The service is about to transition into its stopping phase. But the consumer must not observe it via the parent context.
-				assert.NoError(t, ctx.Err())
+				consumeCalls := make(chan consumerCall)
+				consumer := consumerFunc(func(ctx context.Context, records iter.Seq[*kgo.Record]) (err error) {
+					defer consumerErrs.Store(err)
 
-				return err
+					call := consumerCall{
+						f:    func() []*kgo.Record { return slices.Collect(records) },
+						resp: make(chan error),
+					}
+					consumeCalls <- call
+					err = <-call.resp
+					// The service is about to transition into its stopping phase. But the consumer must not observe it via the parent context.
+					assert.NoError(t, ctx.Err())
+
+					return err
+				})
+				reader := createReader(t, clusterAddr, topicName, partitionID, consumer, append(concurrencyVariant, withVirtualNetwork(&vnet))...)
+
+				ctx := t.Context()
+
+				require.NoError(t, services.StartAndAwaitRunning(ctx, reader))
+				t.Cleanup(func() {
+					require.NoError(t, services.StopAndAwaitTerminated(context.Background(), reader))
+				})
+
+				// Write to Kafka.
+				writeClient := newKafkaProduceClient(t, clusterAddr, withWriteVirtualNetwork(&vnet))
+
+				produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("1"))
+
+				// After this point, we know that the consumer is in the in-flight.
+				call := <-consumeCalls
+				// Explicitly begin to stop the service while it's still consuming the records. This shouldn't cancel the in-flight consumption.
+				reader.StopAsync()
+
+				go func() {
+					// Simulate a slow consumer, that blocks reader from stopping.
+					time.Sleep(time.Second)
+
+					defer close(call.resp)
+
+					records := call.f()
+					require.Len(t, records, 1)
+					require.Equal(t, []byte("1"), records[0].Value)
+				}()
+
+				// Wait for the reader to stop completely.
+				require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
+				// Checks the consumer returned a non-errored result.
+				require.NoError(t, consumerErrs.Load())
 			})
-			reader := createReader(t, clusterAddr, topicName, partitionID, consumer, concurrencyVariant...)
-			require.NoError(t, services.StartAndAwaitRunning(ctx, reader))
-
-			// Write to Kafka.
-			writeClient := newKafkaProduceClient(t, clusterAddr)
-			produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("1"))
-
-			// After this point, we know that the consumer is in the in-flight.
-			call := <-consumeCalls
-			// Explicitly begin to stop the service while it's still consuming the records. This shouldn't cancel the in-flight consumption.
-			reader.StopAsync()
-
-			go func() {
-				// Simulate a slow consumer, that blocks reader from stopping.
-				time.Sleep(time.Second)
-
-				defer close(call.resp)
-
-				records := call.f()
-				require.Len(t, records, 1)
-				require.Equal(t, []byte("1"), records[0].Value)
-			}()
-
-			// Wait for the reader to stop completely.
-			require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
-			// Checks the consumer returned a non-errored result.
-			require.NoError(t, consumerErrs.Load())
 		})
 	}
 }
@@ -279,74 +285,74 @@ func TestSingleClusterPartitionReader_WaitReadConsistencyUntilLastProducedOffset
 		partitionID = 0
 	)
 
-	ctx := t.Context()
-
 	setup := func(t *testing.T, consumer RecordConsumer, opts ...readerTestCfgOpt) (*SingleClusterPartitionReader, *kgo.Client, *prometheus.Registry) {
 		reg := prometheus.NewPedanticRegistry()
 
-		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
+		var vnet kfake.VirtualNetwork
+
+		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, testkafka.WithVirtualNetwork(&vnet))
 
 		// Configure the reader to poll the "last produced offset" frequently.
-		reader := createAndStartReader(ctx, t, clusterAddr, topicName, partitionID, consumer,
+		reader := createAndStartReader(context.Background(), t, clusterAddr, topicName, partitionID, consumer,
 			append([]readerTestCfgOpt{
 				withLastProducedOffsetPollInterval(100 * time.Millisecond),
 				withRegistry(reg),
+				withVirtualNetwork(&vnet),
 			}, opts...)...)
 
-		writeClient := newKafkaProduceClient(t, clusterAddr)
+		writeClient := newKafkaProduceClient(t, clusterAddr, withWriteVirtualNetwork(&vnet))
 
 		return reader, writeClient, reg
 	}
 
 	t.Run("should return after all produced records have been consumed", func(t *testing.T) {
-		t.Parallel()
-
 		for _, withOffset := range []bool{false, true} {
 			t.Run(fmt.Sprintf("with offset %v", withOffset), func(t *testing.T) {
-				t.Parallel()
+				synctest.Test(t, func(t *testing.T) {
+					ctx := t.Context()
 
-				consumedRecords := atomic.NewInt64(0)
+					consumedRecords := atomic.NewInt64(0)
 
-				// We define a custom consume function which introduces a delay once the 2nd record
-				// has been consumed but before the function returns. From the SingleClusterPartitionReader perspective,
-				// the 2nd record consumption will be delayed.
-				consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
-					for record := range records {
-						// Introduce a delay before returning from the consume function once
-						// the 2nd record has been consumed.
-						if consumedRecords.Load()+1 == 2 {
-							time.Sleep(time.Second)
+					// We define a custom consume function which introduces a delay once the 2nd record
+					// has been consumed but before the function returns. From the SingleClusterPartitionReader perspective,
+					// the 2nd record consumption will be delayed.
+					consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
+						for record := range records {
+							// Introduce a delay before returning from the consume function once
+							// the 2nd record has been consumed.
+							if consumedRecords.Load()+1 == 2 {
+								time.Sleep(time.Second)
+							}
+
+							consumedRecords.Inc()
+							assert.Equal(t, fmt.Sprintf("record-%d", consumedRecords.Load()), string(record.Value))
+							t.Logf("consumed record: %s", string(record.Value))
 						}
 
-						consumedRecords.Inc()
-						assert.Equal(t, fmt.Sprintf("record-%d", consumedRecords.Load()), string(record.Value))
-						t.Logf("consumed record: %s", string(record.Value))
+						return nil
+					})
+
+					reader, writeClient, reg := setup(t, consumer)
+
+					// Produce some records.
+					produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-1"))
+					lastRecordOffset := produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-2"))
+					t.Logf("produced 2 records (last record offset: %d)", lastRecordOffset)
+
+					// WaitReadConsistencyUntilLastProducedOffset() should return after all records produced up until this
+					// point have been consumed.
+					t.Log("started waiting for read consistency")
+
+					if withOffset {
+						require.NoError(t, reader.WaitReadConsistencyUntilOffsets(ctx, kmeta.NewSingleClusterPartitionOffsets(lastRecordOffset)))
+					} else {
+						require.NoError(t, reader.WaitReadConsistencyUntilLastProducedOffset(ctx))
 					}
 
-					return nil
-				})
+					assert.Equal(t, int64(2), consumedRecords.Load())
+					t.Log("finished waiting for read consistency")
 
-				reader, writeClient, reg := setup(t, consumer)
-
-				// Produce some records.
-				produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-1"))
-				lastRecordOffset := produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-2"))
-				t.Logf("produced 2 records (last record offset: %d)", lastRecordOffset)
-
-				// WaitReadConsistencyUntilLastProducedOffset() should return after all records produced up until this
-				// point have been consumed.
-				t.Log("started waiting for read consistency")
-
-				if withOffset {
-					require.NoError(t, reader.WaitReadConsistencyUntilOffsets(ctx, kmeta.NewSingleClusterPartitionOffsets(lastRecordOffset)))
-				} else {
-					require.NoError(t, reader.WaitReadConsistencyUntilLastProducedOffset(ctx))
-				}
-
-				assert.Equal(t, int64(2), consumedRecords.Load())
-				t.Log("finished waiting for read consistency")
-
-				assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
+					assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
 					# HELP cortex_ingest_storage_strong_consistency_requests_total Total number of requests for which strong consistency has been requested. The metric distinguishes between requests with an offset specified and requests requesting to enforce strong consistency up until the last produced offset.
 					# TYPE cortex_ingest_storage_strong_consistency_requests_total counter
 					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", topic="%s", with_offset="%t"} 1
@@ -356,47 +362,46 @@ func TestSingleClusterPartitionReader_WaitReadConsistencyUntilLastProducedOffset
 					# TYPE cortex_ingest_storage_strong_consistency_failures_total counter
 					cortex_ingest_storage_strong_consistency_failures_total{component="partition-reader", topic="%s"} 0
 				`, topicName, withOffset, topicName, !withOffset, topicName)),
-					"cortex_ingest_storage_strong_consistency_requests_total",
-					"cortex_ingest_storage_strong_consistency_failures_total"))
+						"cortex_ingest_storage_strong_consistency_requests_total",
+						"cortex_ingest_storage_strong_consistency_failures_total"))
+				})
 			})
 		}
-
 	})
 
 	t.Run("should block until the request context deadline is exceeded if produced records are not consumed", func(t *testing.T) {
-		t.Parallel()
-
 		for _, withOffset := range []bool{false, true} {
 			t.Run(fmt.Sprintf("with offset %v", withOffset), func(t *testing.T) {
-				t.Parallel()
+				synctest.Test(t, func(t *testing.T) {
+					ctx := t.Context()
 
-				// Create a consumer with no buffer capacity.
-				consumer := newTestConsumer(0)
+					// Create a consumer with no buffer capacity.
+					consumer := newTestConsumer(0)
 
-				reader, writeClient, reg := setup(t, consumer, withWaitStrongReadConsistencyTimeout(0))
+					reader, writeClient, reg := setup(t, consumer, withWaitStrongReadConsistencyTimeout(0))
 
-				// Produce some records.
-				lastRecordOffset := produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-1"))
-				t.Logf("produced 1 record (last record offset: %d)", lastRecordOffset)
+					// Produce some records.
+					lastRecordOffset := produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-1"))
+					t.Logf("produced 1 record (last record offset: %d)", lastRecordOffset)
 
-				waitCtx := createTestContextWithTimeout(t, time.Second)
-				var err error
+					waitCtx := createTestContextWithTimeout(t, time.Second)
+					var err error
 
-				if withOffset {
-					err = reader.WaitReadConsistencyUntilOffsets(waitCtx, kmeta.NewSingleClusterPartitionOffsets(lastRecordOffset))
-				} else {
-					err = reader.WaitReadConsistencyUntilLastProducedOffset(waitCtx)
-				}
+					if withOffset {
+						err = reader.WaitReadConsistencyUntilOffsets(waitCtx, kmeta.NewSingleClusterPartitionOffsets(lastRecordOffset))
+					} else {
+						err = reader.WaitReadConsistencyUntilLastProducedOffset(waitCtx)
+					}
 
-				require.ErrorIs(t, err, context.DeadlineExceeded)
-				require.NotErrorIs(t, err, errWaitStrongReadConsistencyTimeoutExceeded)
+					require.ErrorIs(t, err, context.DeadlineExceeded)
+					require.NotErrorIs(t, err, errWaitStrongReadConsistencyTimeoutExceeded)
 
-				// Consume the records.
-				records, err := consumer.waitRecords(1, 2*time.Second, 0)
-				assert.NoError(t, err)
-				assert.Equal(t, [][]byte{[]byte("record-1")}, records)
+					// Consume the records.
+					records, err := consumer.waitRecords(1, 2*time.Second, 0)
+					assert.NoError(t, err)
+					assert.Equal(t, [][]byte{[]byte("record-1")}, records)
 
-				assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
+					assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
 					# HELP cortex_ingest_storage_strong_consistency_requests_total Total number of requests for which strong consistency has been requested. The metric distinguishes between requests with an offset specified and requests requesting to enforce strong consistency up until the last produced offset.
 					# TYPE cortex_ingest_storage_strong_consistency_requests_total counter
 					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", topic="%s", with_offset="%t"} 1
@@ -406,50 +411,48 @@ func TestSingleClusterPartitionReader_WaitReadConsistencyUntilLastProducedOffset
 					# TYPE cortex_ingest_storage_strong_consistency_failures_total counter
 					cortex_ingest_storage_strong_consistency_failures_total{component="partition-reader", topic="%s"} 1
 				`, topicName, withOffset, topicName, !withOffset, topicName)),
-					"cortex_ingest_storage_strong_consistency_requests_total",
-					"cortex_ingest_storage_strong_consistency_failures_total"))
+						"cortex_ingest_storage_strong_consistency_requests_total",
+						"cortex_ingest_storage_strong_consistency_failures_total"))
 
-				// Now the WaitReadConsistencyUntilLastProducedOffset() should return soon.
-				err = reader.WaitReadConsistencyUntilLastProducedOffset(createTestContextWithTimeout(t, time.Second))
-				require.NoError(t, err)
+					// Now the WaitReadConsistencyUntilLastProducedOffset() should return soon.
+					err = reader.WaitReadConsistencyUntilLastProducedOffset(createTestContextWithTimeout(t, time.Second))
+					require.NoError(t, err)
+				})
 			})
 		}
 	})
 
 	t.Run("should block until the configured wait timeout is exceeded if produced records are not consumed", func(t *testing.T) {
-		t.Parallel()
-
 		for _, withOffset := range []bool{false, true} {
 			t.Run(fmt.Sprintf("with offset %v", withOffset), func(t *testing.T) {
-				t.Parallel()
+				synctest.Test(t, func(t *testing.T) {
+					ctx := t.Context()
 
-				// Create a consumer with no buffer capacity.
-				consumer := newTestConsumer(0)
+					// Create a consumer with no buffer capacity.
+					consumer := newTestConsumer(0)
 
-				reader, writeClient, reg := setup(t, consumer, withWaitStrongReadConsistencyTimeout(time.Second))
+					reader, writeClient, reg := setup(t, consumer, withWaitStrongReadConsistencyTimeout(time.Second))
 
-				// Produce some records.
-				lastRecordOffset := produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-1"))
-				t.Logf("produced 1 record (last record offset: %d)", lastRecordOffset)
+					// Produce some records.
+					lastRecordOffset := produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-1"))
+					t.Logf("produced 1 record (last record offset: %d)", lastRecordOffset)
 
-				ctx := context.Background()
-				var err error
+					var err error
+					if withOffset {
+						err = reader.WaitReadConsistencyUntilOffsets(ctx, kmeta.NewSingleClusterPartitionOffsets(lastRecordOffset))
+					} else {
+						err = reader.WaitReadConsistencyUntilLastProducedOffset(ctx)
+					}
 
-				if withOffset {
-					err = reader.WaitReadConsistencyUntilOffsets(ctx, kmeta.NewSingleClusterPartitionOffsets(lastRecordOffset))
-				} else {
-					err = reader.WaitReadConsistencyUntilLastProducedOffset(ctx)
-				}
+					require.ErrorIs(t, err, context.DeadlineExceeded)
+					require.ErrorIs(t, err, errWaitStrongReadConsistencyTimeoutExceeded)
 
-				require.ErrorIs(t, err, context.DeadlineExceeded)
-				require.ErrorIs(t, err, errWaitStrongReadConsistencyTimeoutExceeded)
+					// Consume the records.
+					records, err := consumer.waitRecords(1, 2*time.Second, 0)
+					assert.NoError(t, err)
+					assert.Equal(t, [][]byte{[]byte("record-1")}, records)
 
-				// Consume the records.
-				records, err := consumer.waitRecords(1, 2*time.Second, 0)
-				assert.NoError(t, err)
-				assert.Equal(t, [][]byte{[]byte("record-1")}, records)
-
-				assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
+					assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
 					# HELP cortex_ingest_storage_strong_consistency_requests_total Total number of requests for which strong consistency has been requested. The metric distinguishes between requests with an offset specified and requests requesting to enforce strong consistency up until the last produced offset.
 					# TYPE cortex_ingest_storage_strong_consistency_requests_total counter
 					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", topic="%s", with_offset="%t"} 1
@@ -459,34 +462,32 @@ func TestSingleClusterPartitionReader_WaitReadConsistencyUntilLastProducedOffset
 					# TYPE cortex_ingest_storage_strong_consistency_failures_total counter
 					cortex_ingest_storage_strong_consistency_failures_total{component="partition-reader", topic="%s"} 1
 				`, topicName, withOffset, topicName, !withOffset, topicName)),
-					"cortex_ingest_storage_strong_consistency_requests_total",
-					"cortex_ingest_storage_strong_consistency_failures_total"))
+						"cortex_ingest_storage_strong_consistency_requests_total",
+						"cortex_ingest_storage_strong_consistency_failures_total"))
 
-				// Now the WaitReadConsistencyUntilLastProducedOffset() should return soon.
-				err = reader.WaitReadConsistencyUntilLastProducedOffset(ctx)
-				require.NoError(t, err)
+					// Now the WaitReadConsistencyUntilLastProducedOffset() should return soon.
+					err = reader.WaitReadConsistencyUntilLastProducedOffset(ctx)
+					require.NoError(t, err)
+				})
 			})
 		}
 	})
 
 	t.Run("should return if no records have been produced yet", func(t *testing.T) {
-		t.Parallel()
-
 		for _, withOffset := range []bool{false, true} {
 			t.Run(fmt.Sprintf("with offset %v", withOffset), func(t *testing.T) {
-				t.Parallel()
+				synctest.Test(t, func(t *testing.T) {
+					reader, _, reg := setup(t, newTestConsumer(0))
+					waitCtx := createTestContextWithTimeout(t, time.Second)
+					createTestContextWithTimeout(t, time.Second)
 
-				reader, _, reg := setup(t, newTestConsumer(0))
-				waitCtx := createTestContextWithTimeout(t, time.Second)
-				createTestContextWithTimeout(t, time.Second)
+					if withOffset {
+						require.NoError(t, reader.WaitReadConsistencyUntilOffsets(waitCtx, kmeta.NewSingleClusterPartitionOffsets(-1)))
+					} else {
+						require.NoError(t, reader.WaitReadConsistencyUntilLastProducedOffset(waitCtx))
+					}
 
-				if withOffset {
-					require.NoError(t, reader.WaitReadConsistencyUntilOffsets(waitCtx, kmeta.NewSingleClusterPartitionOffsets(-1)))
-				} else {
-					require.NoError(t, reader.WaitReadConsistencyUntilLastProducedOffset(waitCtx))
-				}
-
-				assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
+					assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
 					# HELP cortex_ingest_storage_strong_consistency_requests_total Total number of requests for which strong consistency has been requested. The metric distinguishes between requests with an offset specified and requests requesting to enforce strong consistency up until the last produced offset.
 					# TYPE cortex_ingest_storage_strong_consistency_requests_total counter
 					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", topic="%s", with_offset="%t"} 1
@@ -496,34 +497,34 @@ func TestSingleClusterPartitionReader_WaitReadConsistencyUntilLastProducedOffset
 					# TYPE cortex_ingest_storage_strong_consistency_failures_total counter
 					cortex_ingest_storage_strong_consistency_failures_total{component="partition-reader", topic="%s"} 0
 				`, topicName, withOffset, topicName, !withOffset, topicName)),
-					"cortex_ingest_storage_strong_consistency_requests_total",
-					"cortex_ingest_storage_strong_consistency_failures_total"))
+						"cortex_ingest_storage_strong_consistency_requests_total",
+						"cortex_ingest_storage_strong_consistency_failures_total"))
+				})
 			})
 		}
 	})
 
 	t.Run("should return an error if the SingleClusterPartitionReader is not running", func(t *testing.T) {
-		t.Parallel()
-
 		for _, withOffset := range []bool{false, true} {
 			t.Run(fmt.Sprintf("with offset %v", withOffset), func(t *testing.T) {
-				t.Parallel()
+				synctest.Test(t, func(t *testing.T) {
+					ctx := t.Context()
 
-				reader, _, reg := setup(t, newTestConsumer(0))
-				require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
+					reader, _, reg := setup(t, newTestConsumer(0))
+					require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
 
-				waitCtx := createTestContextWithTimeout(t, time.Second)
-				var err error
+					waitCtx := createTestContextWithTimeout(t, time.Second)
+					var err error
 
-				if withOffset {
-					err = reader.WaitReadConsistencyUntilOffsets(waitCtx, kmeta.NewSingleClusterPartitionOffsets(-1))
-				} else {
-					err = reader.WaitReadConsistencyUntilLastProducedOffset(waitCtx)
-				}
+					if withOffset {
+						err = reader.WaitReadConsistencyUntilOffsets(waitCtx, kmeta.NewSingleClusterPartitionOffsets(-1))
+					} else {
+						err = reader.WaitReadConsistencyUntilLastProducedOffset(waitCtx)
+					}
 
-				require.ErrorContains(t, err, "partition reader service is not running")
+					require.ErrorContains(t, err, "partition reader service is not running")
 
-				assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
+					assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
 					# HELP cortex_ingest_storage_strong_consistency_requests_total Total number of requests for which strong consistency has been requested. The metric distinguishes between requests with an offset specified and requests requesting to enforce strong consistency up until the last produced offset.
 					# TYPE cortex_ingest_storage_strong_consistency_requests_total counter
 					cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", topic="%s", with_offset="%t"} 1
@@ -533,20 +534,23 @@ func TestSingleClusterPartitionReader_WaitReadConsistencyUntilLastProducedOffset
 					# TYPE cortex_ingest_storage_strong_consistency_failures_total counter
 					cortex_ingest_storage_strong_consistency_failures_total{component="partition-reader", topic="%s"} 1
 				`, topicName, withOffset, topicName, !withOffset, topicName)),
-					"cortex_ingest_storage_strong_consistency_requests_total",
-					"cortex_ingest_storage_strong_consistency_failures_total"))
+						"cortex_ingest_storage_strong_consistency_requests_total",
+						"cortex_ingest_storage_strong_consistency_failures_total"))
+				})
 			})
 		}
 	})
 
 	t.Run("should reject offsets for more than one Kafka cluster", func(t *testing.T) {
-		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
 
-		reader, _, _ := setup(t, newTestConsumer(0))
+			reader, _, _ := setup(t, newTestConsumer(0))
 
-		// A single-cluster reader given offsets for more than one Kafka cluster is an invariant violation.
-		err := reader.WaitReadConsistencyUntilOffsets(ctx, kmeta.NewMultiClusterPartitionOffsets([]int64{1, 2}))
-		require.ErrorContains(t, err, "single-cluster partition reader was given read consistency offsets for 2 Kafka clusters")
+			// A single-cluster reader given offsets for more than one Kafka cluster is an invariant violation.
+			err := reader.WaitReadConsistencyUntilOffsets(ctx, kmeta.NewMultiClusterPartitionOffsets([]int64{1, 2}))
+			require.ErrorContains(t, err, "single-cluster partition reader was given read consistency offsets for 2 Kafka clusters")
+		})
 	})
 }
 
@@ -556,22 +560,21 @@ func TestSingleClusterPartitionReader_EnforceReadMaxDelay(t *testing.T) {
 		partitionID = 0
 	)
 
-	ctx := t.Context()
-
 	setup := func(t *testing.T, consumer RecordConsumer) (*SingleClusterPartitionReader, *kgo.Client) {
-		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
-		reader := createAndStartReader(ctx, t, clusterAddr, topicName, partitionID, consumer)
+		var vnet kfake.VirtualNetwork
+
+		_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, testkafka.WithVirtualNetwork(&vnet))
+
+		reader := createAndStartReader(context.Background(), t, clusterAddr, topicName, partitionID, consumer, withVirtualNetwork(&vnet))
 
 		// In this test we produce records with an old timestamp. We need to set a very high write timeout
 		// otherwise records expire before the Kafka client even try to send them on the wire.
-		writeClient := newKafkaProduceClient(t, clusterAddr, withWriteTimeout(10*time.Minute))
+		writeClient := newKafkaProduceClient(t, clusterAddr, withWriteTimeout(10*time.Minute), withWriteVirtualNetwork(&vnet))
 
 		return reader, writeClient
 	}
 
 	t.Run("should succeed if no record has been consumed yet", func(t *testing.T) {
-		t.Parallel()
-
 		consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
 			return nil
 		})
@@ -583,98 +586,102 @@ func TestSingleClusterPartitionReader_EnforceReadMaxDelay(t *testing.T) {
 	})
 
 	t.Run("should succeed if the partition has been consumed until the end", func(t *testing.T) {
-		t.Parallel()
-
 		for _, recordTimestampAge := range []time.Duration{0, 5 * time.Minute} {
 			t.Run(fmt.Sprintf("record timestamp age: %s", recordTimestampAge.String()), func(t *testing.T) {
-				var (
-					consumedRecordsMx sync.Mutex
-					consumedRecords   []string
-				)
+				synctest.Test(t, func(t *testing.T) {
+					ctx := t.Context()
 
-				consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
-					consumedRecordsMx.Lock()
-					defer consumedRecordsMx.Unlock()
+					var (
+						consumedRecordsMx sync.Mutex
+						consumedRecords   []string
+					)
 
-					for r := range records {
-						consumedRecords = append(consumedRecords, string(r.Value))
-					}
-					return nil
+					consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
+						consumedRecordsMx.Lock()
+						defer consumedRecordsMx.Unlock()
+
+						for r := range records {
+							consumedRecords = append(consumedRecords, string(r.Value))
+						}
+						return nil
+					})
+
+					reader, writeClient := setup(t, consumer)
+
+					// Produce records.
+					produceRecordWithTimestamp(ctx, t, writeClient, topicName, partitionID, []byte("record-1"), time.Now().Add(-recordTimestampAge))
+					produceRecordWithTimestamp(ctx, t, writeClient, topicName, partitionID, []byte("record-2"), time.Now().Add(-recordTimestampAge))
+					t.Log("produced 2 records")
+
+					// Wait until they've been consumed.
+					test.Poll(t, time.Second, []string{"record-1", "record-2"}, func() interface{} {
+						consumedRecordsMx.Lock()
+						defer consumedRecordsMx.Unlock()
+						return slices.Clone(consumedRecords)
+					})
+
+					// Wait until highest consumed timestamp is reset to the zero value because we reached the
+					// end of the partition.
+					test.Poll(t, 5*time.Second, true, func() interface{} {
+						return reader.highestConsumedTimestampBeforePartitionEnd.Load().IsZero()
+					})
+
+					assert.NoError(t, reader.EnforceReadMaxDelay(time.Minute))
 				})
-
-				reader, writeClient := setup(t, consumer)
-
-				// Produce records.
-				produceRecordWithTimestamp(ctx, t, writeClient, topicName, partitionID, []byte("record-1"), time.Now().Add(-recordTimestampAge))
-				produceRecordWithTimestamp(ctx, t, writeClient, topicName, partitionID, []byte("record-2"), time.Now().Add(-recordTimestampAge))
-				t.Log("produced 2 records")
-
-				// Wait until they've been consumed.
-				test.Poll(t, time.Second, []string{"record-1", "record-2"}, func() interface{} {
-					consumedRecordsMx.Lock()
-					defer consumedRecordsMx.Unlock()
-					return slices.Clone(consumedRecords)
-				})
-
-				// Wait until highest consumed timestamp is reset to the zero value because we reached the
-				// end of the partition.
-				test.Poll(t, 5*time.Second, true, func() interface{} {
-					return reader.highestConsumedTimestampBeforePartitionEnd.Load().IsZero()
-				})
-
-				assert.NoError(t, reader.EnforceReadMaxDelay(time.Minute))
 			})
 		}
 	})
 
 	t.Run("should fail if the partition has not been consumed until the end and the current consumption delay is above the max delay", func(t *testing.T) {
-		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
 
-		var (
-			firstRecordConsumed     = atomic.NewBool(false)
-			firstRecordConsumedWait = make(chan struct{})
-		)
+			var (
+				firstRecordConsumed     = atomic.NewBool(false)
+				firstRecordConsumedWait = make(chan struct{})
+			)
 
-		// Mock the customer to stop processing records after the first one, to reproduce the case
-		// there are more records in Kafka and consumption hasn't reached the end of the partition.
-		consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
-			if firstRecordConsumed.CompareAndSwap(false, true) {
-				close(firstRecordConsumedWait)
-				return nil
+			// Mock the customer to stop processing records after the first one, to reproduce the case
+			// there are more records in Kafka and consumption hasn't reached the end of the partition.
+			consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
+				if firstRecordConsumed.CompareAndSwap(false, true) {
+					close(firstRecordConsumedWait)
+					return nil
+				}
+
+				return errors.New("mocked error to stop consuming records")
+			})
+
+			reader, writeClient := setup(t, consumer)
+
+			// Produce a large number of records with an old timestamp (total 1GB of data to make sure records end up in
+			// different fetches).
+			payload, err := generateRandomBytes(1024 * 1024)
+			require.NoError(t, err)
+
+			const numRecords = 1024
+			for range numRecords {
+				produceRecordWithTimestamp(ctx, t, writeClient, topicName, partitionID, payload, time.Now().Add(-5*time.Minute))
+			}
+			t.Logf("produced %d records", numRecords)
+
+			// Wait until the first record is consumed.
+			select {
+			case <-firstRecordConsumedWait:
+			case <-t.Context().Done():
+				t.Fatal("test timed out")
 			}
 
-			return errors.New("mocked error to stop consuming records")
+			// At this point we expect the max delay to not be honored. Due to async consumption it may not be immediate,
+			// so we wait until a timestamp is stored.
+			test.Poll(t, 5*time.Second, true, func() interface{} {
+				return !reader.highestConsumedTimestampBeforePartitionEnd.Load().IsZero()
+			})
+
+			require.NotZero(t, reader.highestConsumedTimestampBeforePartitionEnd.Load())
+			assert.Greater(t, time.Since(reader.highestConsumedTimestampBeforePartitionEnd.Load()), time.Minute)
+			assert.Error(t, reader.EnforceReadMaxDelay(time.Minute))
 		})
-
-		reader, writeClient := setup(t, consumer)
-
-		// Produce a large number of records with an old timestamp (total 1GB of data to make sure records end up in
-		// different fetches).
-		payload, err := generateRandomBytes(1024 * 1024)
-		require.NoError(t, err)
-
-		const numRecords = 1024
-		for range numRecords {
-			produceRecordWithTimestamp(ctx, t, writeClient, topicName, partitionID, payload, time.Now().Add(-5*time.Minute))
-		}
-		t.Logf("produced %d records", numRecords)
-
-		// Wait until the first record is consumed.
-		select {
-		case <-firstRecordConsumedWait:
-		case <-t.Context().Done():
-			t.Fatal("test timed out")
-		}
-
-		// At this point we expect the max delay to not be honored. Due to async consumption it may not be immediate,
-		// so we wait until a timestamp is stored.
-		test.Poll(t, 5*time.Second, true, func() interface{} {
-			return !reader.highestConsumedTimestampBeforePartitionEnd.Load().IsZero()
-		})
-
-		require.NotZero(t, reader.highestConsumedTimestampBeforePartitionEnd.Load())
-		assert.Greater(t, time.Since(reader.highestConsumedTimestampBeforePartitionEnd.Load()), time.Minute)
-		assert.Error(t, reader.EnforceReadMaxDelay(time.Minute))
 	})
 }
 
@@ -684,8 +691,6 @@ func TestSingleClusterPartitionReader_ConsumeAtStartup(t *testing.T) {
 		partitionID = 1
 	)
 
-	ctx := context.Background()
-
 	// We want to run all these tests with different concurrency config.
 	concurrencyVariants := map[string][]readerTestCfgOpt{
 		"without concurrency":      {withFetchConcurrency(0)},
@@ -693,379 +698,380 @@ func TestSingleClusterPartitionReader_ConsumeAtStartup(t *testing.T) {
 	}
 
 	t.Run("should immediately switch to Running state if partition is empty", func(t *testing.T) {
-		t.Parallel()
-
 		for concurrencyName, concurrencyVariant := range concurrencyVariants {
-			concurrencyVariant := concurrencyVariant
-
 			t.Run(concurrencyName, func(t *testing.T) {
-				t.Parallel()
+				synctest.Test(t, func(t *testing.T) {
+					var vnet kfake.VirtualNetwork
 
-				var (
-					_, clusterAddr = testkafka.CreateCluster(t, partitionID+1, topicName)
-					consumer       = consumerFunc(func(context.Context, iter.Seq[*kgo.Record]) error { return nil })
-					reg            = prometheus.NewPedanticRegistry()
-				)
+					_, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, testkafka.WithVirtualNetwork(&vnet))
+					consumer := consumerFunc(func(context.Context, iter.Seq[*kgo.Record]) error { return nil })
+					reg := prometheus.NewPedanticRegistry()
 
-				// Create and start the reader. We expect the reader to start even if partition is empty.
-				readerOpts := append([]readerTestCfgOpt{
-					withTargetAndMaxConsumerLagAtStartup(time.Second, time.Second),
-					withRegistry(reg),
-				}, concurrencyVariant...)
+					// Create and start the reader. We expect the reader to start even if partition is empty.
+					readerOpts := append([]readerTestCfgOpt{
+						withTargetAndMaxConsumerLagAtStartup(time.Second, time.Second),
+						withRegistry(reg),
+						withVirtualNetwork(&vnet),
+					}, concurrencyVariant...)
 
-				reader := createReader(t, clusterAddr, topicName, partitionID, consumer, readerOpts...)
-				require.NoError(t, services.StartAndAwaitRunning(ctx, reader))
-				require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
+					reader := createReader(t, clusterAddr, topicName, partitionID, consumer, readerOpts...)
+					require.NoError(t, services.StartAndAwaitRunning(t.Context(), reader))
 
-				// The last consumed offset should be -1, since nothing has been consumed yet.
-				assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
+					// Let the kgo client's internal goroutines settle after startup; otherwise, tearing down
+					// the reader can race with goroutines still being spawned by the client.
+					synctest.Wait()
+
+					require.NoError(t, services.StopAndAwaitTerminated(t.Context(), reader))
+
+					// The last consumed offset should be -1, since nothing has been consumed yet.
+					assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
 					# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
 					# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
 					cortex_ingest_storage_reader_last_consumed_offset{partition="1"} -1
-				`), "cortex_ingest_storage_reader_last_consumed_offset"))
+					`), "cortex_ingest_storage_reader_last_consumed_offset"))
+				})
 			})
 		}
 	})
 
 	t.Run("should immediately switch to Running state if configured target / max lag is 0", func(t *testing.T) {
-		t.Parallel()
-
 		for concurrencyName, concurrencyVariant := range concurrencyVariants {
-			concurrencyVariant := concurrencyVariant
-
 			t.Run(concurrencyName, func(t *testing.T) {
-				t.Parallel()
+				synctest.Test(t, func(t *testing.T) {
+					ctx := t.Context()
 
-				var (
-					cluster, clusterAddr = testkafka.CreateCluster(t, partitionID+1, topicName)
-					consumer             = consumerFunc(func(context.Context, iter.Seq[*kgo.Record]) error { return nil })
-					reg                  = prometheus.NewPedanticRegistry()
-				)
+					var vnet kfake.VirtualNetwork
 
-				// Mock Kafka to fail the Fetch request.
-				cluster.ControlKey(int16(kmsg.Fetch), func(kmsg.Request) (kmsg.Response, error, bool) {
-					cluster.KeepControl()
+					cluster, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, testkafka.WithVirtualNetwork(&vnet))
+					consumer := consumerFunc(func(context.Context, iter.Seq[*kgo.Record]) error { return nil })
+					reg := prometheus.NewPedanticRegistry()
 
-					return nil, errors.New("mocked error"), true
-				})
+					// Mock Kafka to fail the Fetch request.
+					cluster.ControlKey(int16(kmsg.Fetch), func(kmsg.Request) (kmsg.Response, error, bool) {
+						cluster.KeepControl()
 
-				// Produce some records.
-				writeClient := newKafkaProduceClient(t, clusterAddr)
-				produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-1"))
-				produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-2"))
-				t.Log("produced 2 records")
+						return nil, errors.New("mocked error"), true
+					})
 
-				// Create and start the reader. We expect the reader to start even if Fetch is failing.
-				readerOpts := append([]readerTestCfgOpt{
-					withTargetAndMaxConsumerLagAtStartup(0, 0),
-					withRegistry(reg),
-				}, concurrencyVariant...)
+					writeClient := newKafkaProduceClient(t, clusterAddr, withWriteVirtualNetwork(&vnet))
 
-				reader := createReader(t, clusterAddr, topicName, partitionID, consumer, readerOpts...)
-				require.NoError(t, services.StartAndAwaitRunning(ctx, reader))
-				require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
+					// Produce some records.
+					produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-1"))
+					produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-2"))
+					t.Log("produced 2 records")
 
-				// The last consumed offset should be -1, since nothing has been consumed yet (Fetch requests are failing).
-				assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
+					// Create and start the reader. We expect the reader to start even if Fetch is failing.
+					readerOpts := append([]readerTestCfgOpt{
+						withTargetAndMaxConsumerLagAtStartup(0, 0),
+						withRegistry(reg),
+						withVirtualNetwork(&vnet),
+					}, concurrencyVariant...)
+
+					reader := createReader(t, clusterAddr, topicName, partitionID, consumer, readerOpts...)
+					require.NoError(t, services.StartAndAwaitRunning(ctx, reader))
+
+					// Let the kgo client's internal goroutines settle after startup; otherwise, tearing down
+					// the reader can race with goroutines still being spawned by the client.
+					synctest.Wait()
+
+					require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
+
+					// The last consumed offset should be -1, since nothing has been consumed yet (Fetch requests are failing).
+					assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
 					# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
 					# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
 					cortex_ingest_storage_reader_last_consumed_offset{partition="1"} -1
-				`), "cortex_ingest_storage_reader_last_consumed_offset"))
+					`), "cortex_ingest_storage_reader_last_consumed_offset"))
+				})
 			})
 		}
 	})
 
 	t.Run("should consume partition from start if last committed offset is missing and wait until target lag is honored", func(t *testing.T) {
-		t.Parallel()
-
 		for concurrencyName, concurrencyVariant := range concurrencyVariants {
-			concurrencyVariant := concurrencyVariant
-
 			t.Run(concurrencyName, func(t *testing.T) {
-				t.Parallel()
+				synctest.Test(t, func(t *testing.T) {
+					ctx := t.Context()
 
-				var (
-					cluster, clusterAddr = testkafka.CreateCluster(t, partitionID+1, topicName)
-					fetchRequestsCount   = atomic.NewInt64(0)
-					fetchShouldFail      = atomic.NewBool(true)
-					consumedRecordsCount = atomic.NewInt64(0)
-				)
+					var vnet kfake.VirtualNetwork
 
-				consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
-					consumedRecordsCount.Add(int64(len(slices.Collect(records))))
-					return nil
-				})
+					cluster, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, testkafka.WithVirtualNetwork(&vnet))
+					fetchRequestsCount := atomic.NewInt64(0)
+					fetchShouldFail := atomic.NewBool(true)
+					consumedRecordsCount := atomic.NewInt64(0)
 
-				cluster.ControlKey(int16(kmsg.Fetch), func(kmsg.Request) (kmsg.Response, error, bool) {
-					cluster.KeepControl()
-					fetchRequestsCount.Inc()
+					consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
+						consumedRecordsCount.Add(int64(len(slices.Collect(records))))
+						return nil
+					})
 
-					if fetchShouldFail.Load() {
-						return nil, errors.New("mocked error"), true
-					}
+					cluster.ControlKey(int16(kmsg.Fetch), func(kmsg.Request) (kmsg.Response, error, bool) {
+						cluster.KeepControl()
+						fetchRequestsCount.Inc()
 
-					return nil, nil, false
-				})
+						if fetchShouldFail.Load() {
+							return nil, errors.New("mocked error"), true
+						}
 
-				// Produce some records.
-				writeClient := newKafkaProduceClient(t, clusterAddr)
-				produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-1"))
-				produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-2"))
-				t.Log("produced 2 records")
+						return nil, nil, false
+					})
 
-				// Create and start the reader.
-				reg := prometheus.NewPedanticRegistry()
-				logs := &concurrency.SyncBuffer{}
-				readerOpts := append([]readerTestCfgOpt{
-					withTargetAndMaxConsumerLagAtStartup(time.Second, 2*time.Second),
-					withRegistry(reg),
-					withLogger(log.NewLogfmtLogger(logs)),
-				}, concurrencyVariant...)
+					// Produce some records.
+					writeClient := newKafkaProduceClient(t, clusterAddr, withWriteVirtualNetwork(&vnet))
+					produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-1"))
+					produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-2"))
+					t.Log("produced 2 records")
 
-				reader := createReader(t, clusterAddr, topicName, partitionID, consumer, readerOpts...)
-				require.NoError(t, reader.StartAsync(ctx))
-				t.Cleanup(func() {
-					require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
-				})
+					// Create and start the reader.
+					reg := prometheus.NewPedanticRegistry()
+					logs := &concurrency.SyncBuffer{}
+					readerOpts := append([]readerTestCfgOpt{
+						withTargetAndMaxConsumerLagAtStartup(time.Second, 2*time.Second),
+						withRegistry(reg),
+						withLogger(log.NewLogfmtLogger(logs)),
+						withVirtualNetwork(&vnet),
+					}, concurrencyVariant...)
 
-				// Wait until the Kafka cluster received few Fetch requests.
-				test.Poll(t, 5*time.Second, true, func() interface{} {
-					return fetchRequestsCount.Load() > 2
-				})
+					reader := createReader(t, clusterAddr, topicName, partitionID, consumer, readerOpts...)
+					require.NoError(t, reader.StartAsync(ctx))
+					t.Cleanup(func() {
+						require.NoError(t, services.StopAndAwaitTerminated(context.Background(), reader))
+					})
 
-				// Since the mocked Kafka cluster is configured to fail any Fetch we expect the reader hasn't
-				// catched up yet, and it's still in Starting state.
-				assert.Equal(t, services.Starting, reader.State())
-				assert.Equal(t, int64(0), consumedRecordsCount.Load())
+					// Wait until the Kafka cluster received few Fetch requests.
+					test.Poll(t, 5*time.Second, true, func() interface{} {
+						return fetchRequestsCount.Load() > 2
+					})
 
-				// Unblock the Fetch requests. Now they will succeed.
-				fetchShouldFail.Store(false)
+					// Since the mocked Kafka cluster is configured to fail any Fetch we expect the reader hasn't
+					// catched up yet, and it's still in Starting state.
+					assert.Equal(t, services.Starting, reader.State())
+					assert.Equal(t, int64(0), consumedRecordsCount.Load())
 
-				// We expect the reader to catch up, and then switch to Running state.
-				test.Poll(t, 5*time.Second, services.Running, func() interface{} {
-					return reader.State()
-				})
+					// Unblock the Fetch requests. Now they will succeed.
+					fetchShouldFail.Store(false)
 
-				// We expect the reader to have switched to running because target consumer lag has been honored.
-				assert.Contains(t, logs.String(), "partition reader consumed partition and current lag is lower than configured target consumer lag")
+					// We expect the reader to catch up, and then switch to Running state.
+					test.Poll(t, 5*time.Second, services.Running, func() interface{} {
+						return reader.State()
+					})
 
-				assert.Equal(t, int64(2), consumedRecordsCount.Load())
+					// We expect the reader to have switched to running because target consumer lag has been honored.
+					assert.Contains(t, logs.String(), "partition reader consumed partition and current lag is lower than configured target consumer lag")
 
-				// We expect the last consumed offset to be tracked in a metric.
-				test.Poll(t, time.Second, nil, func() interface{} {
-					return promtest.GatherAndCompare(reg, strings.NewReader(`
-						# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
-						# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
-						cortex_ingest_storage_reader_last_consumed_offset{partition="1"} 1
+					assert.Equal(t, int64(2), consumedRecordsCount.Load())
 
-						# HELP cortex_ingest_storage_reader_buffered_fetch_records_total Total number of records buffered within the client ready to be consumed
-						# TYPE cortex_ingest_storage_reader_buffered_fetch_records_total gauge
-						cortex_ingest_storage_reader_buffered_fetch_records_total{component="partition-reader"} 0
-					`), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total")
+					// We expect the last consumed offset to be tracked in a metric.
+					test.Poll(t, time.Second, nil, func() interface{} {
+						return promtest.GatherAndCompare(reg, strings.NewReader(`
+							# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
+							# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
+							cortex_ingest_storage_reader_last_consumed_offset{partition="1"} 1
+
+							# HELP cortex_ingest_storage_reader_buffered_fetch_records_total Total number of records buffered within the client ready to be consumed
+							# TYPE cortex_ingest_storage_reader_buffered_fetch_records_total gauge
+							cortex_ingest_storage_reader_buffered_fetch_records_total{component="partition-reader"} 0
+						`), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total")
+					})
 				})
 			})
 		}
 	})
 
 	t.Run("should consume partition from start if last committed offset is missing and wait until target lag is honored and retry if a failure occurs when fetching last produced offset", func(t *testing.T) {
-		t.Parallel()
-
 		for concurrencyName, concurrencyVariant := range concurrencyVariants {
-			concurrencyVariant := concurrencyVariant
-
 			t.Run(concurrencyName, func(t *testing.T) {
-				t.Parallel()
+				synctest.Test(t, func(t *testing.T) {
+					ctx := t.Context()
 
-				var (
-					cluster, clusterAddr     = testkafka.CreateCluster(t, partitionID+1, topicName)
-					listOffsetsRequestsCount = atomic.NewInt64(0)
-					listOffsetsShouldFail    = atomic.NewBool(true)
-					consumedRecordsCount     = atomic.NewInt64(0)
-				)
+					var vnet kfake.VirtualNetwork
 
-				consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
-					consumedRecordsCount.Add(int64(len(slices.Collect(records))))
-					return nil
-				})
+					cluster, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, testkafka.WithVirtualNetwork(&vnet))
+					listOffsetsRequestsCount := atomic.NewInt64(0)
+					listOffsetsShouldFail := atomic.NewBool(true)
+					consumedRecordsCount := atomic.NewInt64(0)
 
-				cluster.ControlKey(int16(kmsg.ListOffsets), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
-					cluster.KeepControl()
-					listOffsetsRequestsCount.Inc()
+					consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
+						consumedRecordsCount.Add(int64(len(slices.Collect(records))))
+						return nil
+					})
 
-					if listOffsetsShouldFail.Load() {
-						req := kreq.(*kmsg.ListOffsetsRequest)
-						res := req.ResponseKind().(*kmsg.ListOffsetsResponse)
-						res.Default()
-						res.Topics = []kmsg.ListOffsetsResponseTopic{
-							{Topic: topicName, Partitions: []kmsg.ListOffsetsResponseTopicPartition{{ErrorCode: kerr.NotLeaderForPartition.Code}}},
+					cluster.ControlKey(int16(kmsg.ListOffsets), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+						cluster.KeepControl()
+						listOffsetsRequestsCount.Inc()
+
+						if listOffsetsShouldFail.Load() {
+							req := kreq.(*kmsg.ListOffsetsRequest)
+							res := req.ResponseKind().(*kmsg.ListOffsetsResponse)
+							res.Default()
+							res.Topics = []kmsg.ListOffsetsResponseTopic{
+								{Topic: topicName, Partitions: []kmsg.ListOffsetsResponseTopicPartition{{ErrorCode: kerr.NotLeaderForPartition.Code}}},
+							}
+							return res, nil, true
 						}
-						return res, nil, true
-					}
 
-					return nil, nil, false
-				})
+						return nil, nil, false
+					})
 
-				// Produce some records.
-				writeClient := newKafkaProduceClient(t, clusterAddr)
-				produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-1"))
-				produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-2"))
-				t.Log("produced 2 records")
+					// Produce some records.
+					writeClient := newKafkaProduceClient(t, clusterAddr, withWriteVirtualNetwork(&vnet))
+					produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-1"))
+					produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-2"))
+					t.Log("produced 2 records")
 
-				// Create and start the reader.
-				reg := prometheus.NewPedanticRegistry()
-				logs := &concurrency.SyncBuffer{}
-				readerOpts := append([]readerTestCfgOpt{
-					withTargetAndMaxConsumerLagAtStartup(time.Second, 2*time.Second),
-					withRegistry(reg),
-					withLogger(log.NewLogfmtLogger(logs)),
-				}, concurrencyVariant...)
+					// Create and start the reader.
+					reg := prometheus.NewPedanticRegistry()
+					logs := &concurrency.SyncBuffer{}
+					readerOpts := append([]readerTestCfgOpt{
+						withTargetAndMaxConsumerLagAtStartup(time.Second, 2*time.Second),
+						withRegistry(reg),
+						withLogger(log.NewLogfmtLogger(logs)),
+						withVirtualNetwork(&vnet),
+					}, concurrencyVariant...)
 
-				reader := createReader(t, clusterAddr, topicName, partitionID, consumer, readerOpts...)
-				require.NoError(t, reader.StartAsync(ctx))
-				t.Cleanup(func() {
-					require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
-				})
+					reader := createReader(t, clusterAddr, topicName, partitionID, consumer, readerOpts...)
+					require.NoError(t, reader.StartAsync(ctx))
+					t.Cleanup(func() {
+						require.NoError(t, services.StopAndAwaitTerminated(context.Background(), reader))
+					})
 
-				// Wait until the Kafka cluster received few ListOffsets requests.
-				test.Poll(t, 5*time.Second, true, func() interface{} {
-					return listOffsetsRequestsCount.Load() > 2
-				})
+					// Wait until the Kafka cluster received few ListOffsets requests.
+					test.Poll(t, 5*time.Second, true, func() interface{} {
+						return listOffsetsRequestsCount.Load() > 2
+					})
 
-				// Since the mocked Kafka cluster is configured to fail any ListOffsets request we expect the reader hasn't
-				// catched up yet, and it's still in Starting state.
-				assert.Equal(t, services.Starting.String(), reader.State().String())
-				assert.Equal(t, int64(0), consumedRecordsCount.Load())
+					// Since the mocked Kafka cluster is configured to fail any ListOffsets request we expect the reader hasn't
+					// catched up yet, and it's still in Starting state.
+					assert.Equal(t, services.Starting.String(), reader.State().String())
+					assert.Equal(t, int64(0), consumedRecordsCount.Load())
 
-				// Unblock the ListOffsets requests. Now they will succeed.
-				listOffsetsShouldFail.Store(false)
+					// Unblock the ListOffsets requests. Now they will succeed.
+					listOffsetsShouldFail.Store(false)
 
-				// We expect the reader to catch up, and then switch to Running state.
-				test.Poll(t, 5*time.Second, services.Running, func() interface{} {
-					return reader.State()
-				})
+					// We expect the reader to catch up, and then switch to Running state.
+					test.Poll(t, 5*time.Second, services.Running, func() interface{} {
+						return reader.State()
+					})
 
-				// We expect the reader to have switched to running because target consumer lag has been honored.
-				assert.Contains(t, logs.String(), "partition reader consumed partition and current lag is lower than configured target consumer lag")
+					// We expect the reader to have switched to running because target consumer lag has been honored.
+					assert.Contains(t, logs.String(), "partition reader consumed partition and current lag is lower than configured target consumer lag")
 
-				assert.Equal(t, int64(2), consumedRecordsCount.Load())
+					assert.Equal(t, int64(2), consumedRecordsCount.Load())
 
-				// We expect the last consumed offset to be tracked in a metric.
-				test.Poll(t, time.Second, nil, func() interface{} {
-					return promtest.GatherAndCompare(reg, strings.NewReader(`
-						# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
-						# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
-						cortex_ingest_storage_reader_last_consumed_offset{partition="1"} 1
+					// We expect the last consumed offset to be tracked in a metric.
+					test.Poll(t, time.Second, nil, func() interface{} {
+						return promtest.GatherAndCompare(reg, strings.NewReader(`
+							# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
+							# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
+							cortex_ingest_storage_reader_last_consumed_offset{partition="1"} 1
 
-						# HELP cortex_ingest_storage_reader_buffered_fetch_records_total Total number of records buffered within the client ready to be consumed
-						# TYPE cortex_ingest_storage_reader_buffered_fetch_records_total gauge
-						cortex_ingest_storage_reader_buffered_fetch_records_total{component="partition-reader"} 0
-					`), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total")
+							# HELP cortex_ingest_storage_reader_buffered_fetch_records_total Total number of records buffered within the client ready to be consumed
+							# TYPE cortex_ingest_storage_reader_buffered_fetch_records_total gauge
+							cortex_ingest_storage_reader_buffered_fetch_records_total{component="partition-reader"} 0
+						`), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total")
+					})
 				})
 			})
 		}
 	})
 
 	t.Run("should consume partition from end if position=end, and skip honoring target max lag", func(t *testing.T) {
-		t.Parallel()
-
 		for _, fileEnforced := range []bool{false, true} {
-			fileEnforced := fileEnforced
 			t.Run(fmt.Sprintf("file_enforced_%v", fileEnforced), func(t *testing.T) {
-				t.Parallel()
-
 				for concurrencyName, concurrencyVariant := range concurrencyVariants {
-					concurrencyVariant := concurrencyVariant
-
 					t.Run(concurrencyName, func(t *testing.T) {
-						t.Parallel()
+						synctest.Test(t, func(t *testing.T) {
+							ctx := t.Context()
 
-						var (
-							cluster, clusterAddr = testkafka.CreateCluster(t, partitionID+1, topicName)
-							reg                  = prometheus.NewPedanticRegistry()
-							fetchRequestsCount   = atomic.NewInt64(0)
-							fetchShouldFail      = atomic.NewBool(true)
-							consumedRecordsMx    sync.Mutex
-							consumedRecords      []string
-						)
+							var vnet kfake.VirtualNetwork
 
-						consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
-							consumedRecordsMx.Lock()
-							defer consumedRecordsMx.Unlock()
+							cluster, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, testkafka.WithVirtualNetwork(&vnet))
+							reg := prometheus.NewPedanticRegistry()
+							fetchRequestsCount := atomic.NewInt64(0)
+							fetchShouldFail := atomic.NewBool(true)
+							var consumedRecordsMx sync.Mutex
+							var consumedRecords []string
 
-							for r := range records {
-								consumedRecords = append(consumedRecords, string(r.Value))
-							}
-							return nil
-						})
+							consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
+								consumedRecordsMx.Lock()
+								defer consumedRecordsMx.Unlock()
 
-						cluster.ControlKey(int16(kmsg.Fetch), func(kmsg.Request) (kmsg.Response, error, bool) {
-							cluster.KeepControl()
+								for r := range records {
+									consumedRecords = append(consumedRecords, string(r.Value))
+								}
+								return nil
+							})
 
-							fetchRequestsCount.Inc()
-							if fetchShouldFail.Load() {
-								return nil, errors.New("mocked error"), true
-							}
+							cluster.ControlKey(int16(kmsg.Fetch), func(kmsg.Request) (kmsg.Response, error, bool) {
+								cluster.KeepControl()
 
-							return nil, nil, false
-						})
+								fetchRequestsCount.Inc()
+								if fetchShouldFail.Load() {
+									return nil, errors.New("mocked error"), true
+								}
 
-						// Produce some records.
-						writeClient := newKafkaProduceClient(t, clusterAddr)
-						produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-1"))
-						produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-2"))
-						t.Log("produced 2 records before starting the reader")
+								return nil, nil, false
+							})
 
-						// Create and start the reader.
-						readerOpts := append([]readerTestCfgOpt{
-							withFileBasedOffsetEnforcement(fileEnforced),
-							withConsumeFromPositionAtStartup(consumeFromEnd),
-							withTargetAndMaxConsumerLagAtStartup(time.Second, time.Second),
-							withRegistry(reg),
-						}, concurrencyVariant...)
+							// Produce some records.
+							writeClient := newKafkaProduceClient(t, clusterAddr, withWriteVirtualNetwork(&vnet))
+							produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-1"))
+							produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-2"))
+							t.Log("produced 2 records before starting the reader")
 
-						reader := createReader(t, clusterAddr, topicName, partitionID, consumer, readerOpts...)
-						require.NoError(t, reader.StartAsync(ctx))
-						t.Cleanup(func() {
-							require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
-						})
+							// Create and start the reader.
+							readerOpts := append([]readerTestCfgOpt{
+								withFileBasedOffsetEnforcement(fileEnforced),
+								withConsumeFromPositionAtStartup(consumeFromEnd),
+								withTargetAndMaxConsumerLagAtStartup(time.Second, time.Second),
+								withRegistry(reg),
+								withVirtualNetwork(&vnet),
+							}, concurrencyVariant...)
 
-						// The reader service should start even if Fetch is failing because max log is skipped.
-						test.Poll(t, time.Second, services.Running, func() interface{} {
-							return reader.State()
-						})
+							reader := createReader(t, clusterAddr, topicName, partitionID, consumer, readerOpts...)
+							require.NoError(t, reader.StartAsync(ctx))
+							t.Cleanup(func() {
+								require.NoError(t, services.StopAndAwaitTerminated(context.Background(), reader))
+							})
 
-						// Make Fetch working.
-						fetchShouldFail.Store(false)
+							// The reader service should start even if Fetch is failing because max log is skipped.
+							test.Poll(t, time.Second, services.Running, func() interface{} {
+								return reader.State()
+							})
 
-						// Wait until Fetch request has been issued at least once, in order to avoid any race condition
-						// (the problem is that we may produce the next record before the client fetched the partition end position).
-						require.Eventually(t, func() bool {
-							return fetchRequestsCount.Load() > 0
-						}, 5*time.Second, 10*time.Millisecond)
+							// Make Fetch working.
+							fetchShouldFail.Store(false)
 
-						// Produce one more record.
-						produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-3"))
-						t.Log("produced 1 record after starting the reader")
+							// Wait until Fetch request has been issued at least once, in order to avoid any race condition
+							// (the problem is that we may produce the next record before the client fetched the partition end position).
+							require.Eventually(t, func() bool {
+								return fetchRequestsCount.Load() > 0
+							}, 5*time.Second, 10*time.Millisecond)
 
-						// Since the reader has been configured with position=end we expect to consume only
-						// the record produced after reader has been started.
-						test.Poll(t, 5*time.Second, []string{"record-3"}, func() interface{} {
-							consumedRecordsMx.Lock()
-							defer consumedRecordsMx.Unlock()
-							return slices.Clone(consumedRecords)
-						})
+							// Produce one more record.
+							produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-3"))
+							t.Log("produced 1 record after starting the reader")
 
-						// We expect the last consumed offset to be tracked in a metric.
-						test.Poll(t, time.Second, nil, func() interface{} {
-							return promtest.GatherAndCompare(reg, strings.NewReader(`
-						# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
-						# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
-						cortex_ingest_storage_reader_last_consumed_offset{partition="1"} 2
+							// Since the reader has been configured with position=end we expect to consume only
+							// the record produced after reader has been started.
+							test.Poll(t, 5*time.Second, []string{"record-3"}, func() interface{} {
+								consumedRecordsMx.Lock()
+								defer consumedRecordsMx.Unlock()
+								return slices.Clone(consumedRecords)
+							})
 
-						# HELP cortex_ingest_storage_reader_buffered_fetch_records_total Total number of records buffered within the client ready to be consumed
-						# TYPE cortex_ingest_storage_reader_buffered_fetch_records_total gauge
-						cortex_ingest_storage_reader_buffered_fetch_records_total{component="partition-reader"} 0
-					`), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total")
+							// We expect the last consumed offset to be tracked in a metric.
+							test.Poll(t, time.Second, nil, func() interface{} {
+								return promtest.GatherAndCompare(reg, strings.NewReader(`
+									# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
+									# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
+									cortex_ingest_storage_reader_last_consumed_offset{partition="1"} 2
+		
+									# HELP cortex_ingest_storage_reader_buffered_fetch_records_total Total number of records buffered within the client ready to be consumed
+									# TYPE cortex_ingest_storage_reader_buffered_fetch_records_total gauge
+									cortex_ingest_storage_reader_buffered_fetch_records_total{component="partition-reader"} 0
+								`), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total")
+							})
 						})
 					})
 				}
@@ -1074,122 +1080,118 @@ func TestSingleClusterPartitionReader_ConsumeAtStartup(t *testing.T) {
 	})
 
 	t.Run("should consume partition from start if position=start, and wait until target lag is honored", func(t *testing.T) {
-		t.Parallel()
-
 		for _, fileEnforced := range []bool{false, true} {
-			fileEnforced := fileEnforced
 			t.Run(fmt.Sprintf("file_enforced_%v", fileEnforced), func(t *testing.T) {
-				t.Parallel()
-
 				for concurrencyName, concurrencyVariant := range concurrencyVariants {
-					concurrencyVariant := concurrencyVariant
-
 					t.Run(concurrencyName, func(t *testing.T) {
-						t.Parallel()
+						synctest.Test(t, func(t *testing.T) {
+							ctx := t.Context()
 
-						var (
-							cluster, clusterAddr = testkafka.CreateCluster(t, partitionID+1, topicName)
-							fetchRequestsCount   = atomic.NewInt64(0)
-							fetchShouldFail      = atomic.NewBool(false)
-							consumedRecordsMx    sync.Mutex
-							consumedRecords      []string
-						)
+							var vnet kfake.VirtualNetwork
 
-						consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
-							consumedRecordsMx.Lock()
-							defer consumedRecordsMx.Unlock()
+							cluster, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, testkafka.WithVirtualNetwork(&vnet))
+							fetchRequestsCount := atomic.NewInt64(0)
+							fetchShouldFail := atomic.NewBool(false)
+							var consumedRecordsMx sync.Mutex
+							var consumedRecords []string
 
-							for r := range records {
-								consumedRecords = append(consumedRecords, string(r.Value))
-							}
-							return nil
-						})
-
-						cluster.ControlKey(int16(kmsg.Fetch), func(kmsg.Request) (kmsg.Response, error, bool) {
-							cluster.KeepControl()
-							fetchRequestsCount.Inc()
-
-							if fetchShouldFail.Load() {
-								return nil, errors.New("mocked error"), true
-							}
-
-							return nil, nil, false
-						})
-
-						// Produce some records.
-						writeClient := newKafkaProduceClient(t, clusterAddr)
-						produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-1"))
-						produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-2"))
-						t.Log("produced 2 records")
-
-						// Run the test twice with the same Kafka cluster to show that second time it consumes all records again.
-						for run := 1; run <= 2; run++ {
-							t.Run(fmt.Sprintf("Run %d", run), func(t *testing.T) {
-								// Reset the test.
-								fetchShouldFail.Store(true)
-								fetchRequestsCount.Store(0)
+							consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
 								consumedRecordsMx.Lock()
-								consumedRecords = nil
-								consumedRecordsMx.Unlock()
+								defer consumedRecordsMx.Unlock()
 
-								// Create and start the reader.
-								reg := prometheus.NewPedanticRegistry()
-								logs := &concurrency.SyncBuffer{}
-								readerOpts := append([]readerTestCfgOpt{
-									withFileBasedOffsetEnforcement(fileEnforced),
-									withConsumeFromPositionAtStartup(consumeFromStart),
-									withTargetAndMaxConsumerLagAtStartup(time.Second, 2*time.Second),
-									withRegistry(reg),
-									withLogger(log.NewLogfmtLogger(logs)),
-								}, concurrencyVariant...)
-
-								reader := createReader(t, clusterAddr, topicName, partitionID, consumer, readerOpts...)
-								require.NoError(t, reader.StartAsync(ctx))
-								t.Cleanup(func() {
-									require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
-								})
-
-								// Wait until the Kafka cluster received few Fetch requests.
-								test.Poll(t, 5*time.Second, true, func() interface{} {
-									return fetchRequestsCount.Load() > 2
-								})
-
-								// Since the mocked Kafka cluster is configured to fail any Fetch we expect the reader hasn't
-								// catched up yet, and it's still in Starting state.
-								assert.Equal(t, services.Starting, reader.State())
-
-								// Unblock the Fetch requests. Now they will succeed.
-								fetchShouldFail.Store(false)
-
-								// We expect the reader to catch up, and then switch to Running state.
-								test.Poll(t, 5*time.Second, services.Running, func() interface{} {
-									return reader.State()
-								})
-
-								// We expect the reader to have switched to running because target consumer lag has been honored.
-								assert.Contains(t, logs.String(), "partition reader consumed partition and current lag is lower than configured target consumer lag")
-
-								// We expect the reader to have consumed the partition from start.
-								test.Poll(t, time.Second, []string{"record-1", "record-2"}, func() interface{} {
-									consumedRecordsMx.Lock()
-									defer consumedRecordsMx.Unlock()
-									return slices.Clone(consumedRecords)
-								})
-
-								// We expect the last consumed offset to be tracked in a metric.
-								test.Poll(t, time.Second, nil, func() interface{} {
-									return promtest.GatherAndCompare(reg, strings.NewReader(`
-								# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
-								# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
-								cortex_ingest_storage_reader_last_consumed_offset{partition="1"} 1
-
-								# HELP cortex_ingest_storage_reader_buffered_fetch_records_total Total number of records buffered within the client ready to be consumed
-								# TYPE cortex_ingest_storage_reader_buffered_fetch_records_total gauge
-								cortex_ingest_storage_reader_buffered_fetch_records_total{component="partition-reader"} 0
-							`), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total")
-								})
+								for r := range records {
+									consumedRecords = append(consumedRecords, string(r.Value))
+								}
+								return nil
 							})
-						}
+
+							cluster.ControlKey(int16(kmsg.Fetch), func(kmsg.Request) (kmsg.Response, error, bool) {
+								cluster.KeepControl()
+								fetchRequestsCount.Inc()
+
+								if fetchShouldFail.Load() {
+									return nil, errors.New("mocked error"), true
+								}
+
+								return nil, nil, false
+							})
+
+							// Produce some records.
+							writeClient := newKafkaProduceClient(t, clusterAddr, withWriteVirtualNetwork(&vnet))
+							produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-1"))
+							produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-2"))
+							t.Log("produced 2 records")
+
+							// Run the test twice with the same Kafka cluster to show that second time it consumes all records again.
+							for range 2 {
+								func(t *testing.T) {
+									// Reset the test.
+									fetchShouldFail.Store(true)
+									fetchRequestsCount.Store(0)
+									consumedRecordsMx.Lock()
+									consumedRecords = nil
+									consumedRecordsMx.Unlock()
+
+									// Create and start the reader.
+									reg := prometheus.NewPedanticRegistry()
+									logs := &concurrency.SyncBuffer{}
+									readerOpts := append([]readerTestCfgOpt{
+										withFileBasedOffsetEnforcement(fileEnforced),
+										withConsumeFromPositionAtStartup(consumeFromStart),
+										withTargetAndMaxConsumerLagAtStartup(time.Second, 2*time.Second),
+										withRegistry(reg),
+										withLogger(log.NewLogfmtLogger(logs)),
+										withVirtualNetwork(&vnet),
+									}, concurrencyVariant...)
+
+									reader := createReader(t, clusterAddr, topicName, partitionID, consumer, readerOpts...)
+									require.NoError(t, reader.StartAsync(ctx))
+									defer func() {
+										require.NoError(t, services.StopAndAwaitTerminated(context.Background(), reader))
+									}()
+
+									// Wait until the Kafka cluster received few Fetch requests.
+									test.Poll(t, 5*time.Second, true, func() interface{} {
+										return fetchRequestsCount.Load() > 2
+									})
+
+									// Since the mocked Kafka cluster is configured to fail any Fetch we expect the reader hasn't
+									// catched up yet, and it's still in Starting state.
+									assert.Equal(t, services.Starting, reader.State())
+
+									// Unblock the Fetch requests. Now they will succeed.
+									fetchShouldFail.Store(false)
+
+									// We expect the reader to catch up, and then switch to Running state.
+									test.Poll(t, 5*time.Second, services.Running, func() interface{} {
+										return reader.State()
+									})
+
+									// We expect the reader to have switched to running because target consumer lag has been honored.
+									assert.Contains(t, logs.String(), "partition reader consumed partition and current lag is lower than configured target consumer lag")
+
+									// We expect the reader to have consumed the partition from start.
+									test.Poll(t, time.Second, []string{"record-1", "record-2"}, func() interface{} {
+										consumedRecordsMx.Lock()
+										defer consumedRecordsMx.Unlock()
+										return slices.Clone(consumedRecords)
+									})
+
+									// We expect the last consumed offset to be tracked in a metric.
+									test.Poll(t, time.Second, nil, func() interface{} {
+										return promtest.GatherAndCompare(reg, strings.NewReader(`
+										# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
+										# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
+										cortex_ingest_storage_reader_last_consumed_offset{partition="1"} 1
+
+										# HELP cortex_ingest_storage_reader_buffered_fetch_records_total Total number of records buffered within the client ready to be consumed
+										# TYPE cortex_ingest_storage_reader_buffered_fetch_records_total gauge
+										cortex_ingest_storage_reader_buffered_fetch_records_total{component="partition-reader"} 0
+									`), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total")
+									})
+								}(t)
+							}
+						})
 					})
 				}
 			})
@@ -1197,137 +1199,133 @@ func TestSingleClusterPartitionReader_ConsumeAtStartup(t *testing.T) {
 	})
 
 	t.Run("should consume partition from start if position=start, and wait until target lag is honored, and then consume some records after lag is honored", func(t *testing.T) {
-		t.Parallel()
-
 		for _, fileEnforced := range []bool{false, true} {
-			fileEnforced := fileEnforced
 			t.Run(fmt.Sprintf("file_enforced_%v", fileEnforced), func(t *testing.T) {
-				t.Parallel()
-
 				for concurrencyName, concurrencyVariant := range concurrencyVariants {
-					concurrencyVariant := concurrencyVariant
-
 					t.Run(concurrencyName, func(t *testing.T) {
-						t.Parallel()
+						synctest.Test(t, func(t *testing.T) {
+							ctx := t.Context()
 
-						var (
-							cluster, clusterAddr = testkafka.CreateCluster(t, partitionID+1, topicName)
-							fetchRequestsCount   = atomic.NewInt64(0)
-							fetchShouldFail      = atomic.NewBool(false)
-							consumedRecordsMx    sync.Mutex
-							consumedRecords      []string
-						)
+							var vnet kfake.VirtualNetwork
 
-						consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
+							cluster, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, testkafka.WithVirtualNetwork(&vnet))
+							fetchRequestsCount := atomic.NewInt64(0)
+							fetchShouldFail := atomic.NewBool(false)
+							var consumedRecordsMx sync.Mutex
+							var consumedRecords []string
+
+							consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
+								consumedRecordsMx.Lock()
+								defer consumedRecordsMx.Unlock()
+
+								for r := range records {
+									consumedRecords = append(consumedRecords, string(r.Value))
+								}
+								return nil
+							})
+
+							cluster.ControlKey(int16(kmsg.Fetch), func(kmsg.Request) (kmsg.Response, error, bool) {
+								cluster.KeepControl()
+								fetchRequestsCount.Inc()
+
+								if fetchShouldFail.Load() {
+									return nil, errors.New("mocked error"), true
+								}
+
+								return nil, nil, false
+							})
+
+							// Produce some records.
+							writeClient := newKafkaProduceClient(t, clusterAddr, withWriteVirtualNetwork(&vnet))
+							produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-1"))
+							produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-2"))
+							t.Log("produced 2 records")
+
+							// Run the test twice with the same Kafka cluster to show that second time it consumes all records again.
+							// Reset the test.
+							fetchShouldFail.Store(true)
+							fetchRequestsCount.Store(0)
 							consumedRecordsMx.Lock()
-							defer consumedRecordsMx.Unlock()
+							consumedRecords = nil
+							consumedRecordsMx.Unlock()
 
-							for r := range records {
-								consumedRecords = append(consumedRecords, string(r.Value))
-							}
-							return nil
-						})
+							// Create and start the reader.
+							reg := prometheus.NewPedanticRegistry()
+							logs := &concurrency.SyncBuffer{}
+							readerOpts := append([]readerTestCfgOpt{
+								withFileBasedOffsetEnforcement(fileEnforced),
+								withConsumeFromPositionAtStartup(consumeFromStart),
+								withTargetAndMaxConsumerLagAtStartup(time.Second, 2*time.Second),
+								withRegistry(reg),
+								withLogger(log.NewLogfmtLogger(logs)),
+								withVirtualNetwork(&vnet),
+							}, concurrencyVariant...)
 
-						cluster.ControlKey(int16(kmsg.Fetch), func(kmsg.Request) (kmsg.Response, error, bool) {
-							cluster.KeepControl()
-							fetchRequestsCount.Inc()
+							reader := createReader(t, clusterAddr, topicName, partitionID, consumer, readerOpts...)
+							require.NoError(t, reader.StartAsync(ctx))
+							t.Cleanup(func() {
+								require.NoError(t, services.StopAndAwaitTerminated(context.Background(), reader))
+							})
 
-							if fetchShouldFail.Load() {
-								return nil, errors.New("mocked error"), true
-							}
+							// Wait until the Kafka cluster received few Fetch requests.
+							test.Poll(t, 5*time.Second, true, func() interface{} {
+								return fetchRequestsCount.Load() > 2
+							})
 
-							return nil, nil, false
-						})
+							// Since the mocked Kafka cluster is configured to fail any Fetch we expect the reader hasn't
+							// catched up yet, and it's still in Starting state.
+							assert.Equal(t, services.Starting, reader.State())
 
-						// Produce some records.
-						writeClient := newKafkaProduceClient(t, clusterAddr)
-						produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-1"))
-						produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-2"))
-						t.Log("produced 2 records")
+							// Unblock the Fetch requests. Now they will succeed.
+							fetchShouldFail.Store(false)
 
-						// Run the test twice with the same Kafka cluster to show that second time it consumes all records again.
-						// Reset the test.
-						fetchShouldFail.Store(true)
-						fetchRequestsCount.Store(0)
-						consumedRecordsMx.Lock()
-						consumedRecords = nil
-						consumedRecordsMx.Unlock()
+							// We expect the reader to catch up, and then switch to Running state.
+							test.Poll(t, 5*time.Second, services.Running, func() interface{} {
+								return reader.State()
+							})
 
-						// Create and start the reader.
-						reg := prometheus.NewPedanticRegistry()
-						logs := &concurrency.SyncBuffer{}
-						readerOpts := append([]readerTestCfgOpt{
-							withFileBasedOffsetEnforcement(fileEnforced),
-							withConsumeFromPositionAtStartup(consumeFromStart),
-							withTargetAndMaxConsumerLagAtStartup(time.Second, 2*time.Second),
-							withRegistry(reg),
-							withLogger(log.NewLogfmtLogger(logs)),
-						}, concurrencyVariant...)
+							// We expect the reader to have switched to running because target consumer lag has been honored.
+							assert.Contains(t, logs.String(), "partition reader consumed partition and current lag is lower than configured target consumer lag")
 
-						reader := createReader(t, clusterAddr, topicName, partitionID, consumer, readerOpts...)
-						require.NoError(t, reader.StartAsync(ctx))
-						t.Cleanup(func() {
-							require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
-						})
+							// We expect the reader to have consumed the partition from start.
+							test.Poll(t, time.Second, []string{"record-1", "record-2"}, func() interface{} {
+								consumedRecordsMx.Lock()
+								defer consumedRecordsMx.Unlock()
+								return slices.Clone(consumedRecords)
+							})
 
-						// Wait until the Kafka cluster received few Fetch requests.
-						test.Poll(t, 5*time.Second, true, func() interface{} {
-							return fetchRequestsCount.Load() > 2
-						})
+							// We expect the last consumed offset to be tracked in a metric.
+							test.Poll(t, time.Second, nil, func() interface{} {
+								return promtest.GatherAndCompare(reg, strings.NewReader(`
+									# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
+									# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
+									cortex_ingest_storage_reader_last_consumed_offset{partition="1"} 1
+								`), "cortex_ingest_storage_reader_last_consumed_offset")
+							})
 
-						// Since the mocked Kafka cluster is configured to fail any Fetch we expect the reader hasn't
-						// catched up yet, and it's still in Starting state.
-						assert.Equal(t, services.Starting, reader.State())
+							produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-3"))
+							produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-4"))
+							t.Log("produced 2 records")
 
-						// Unblock the Fetch requests. Now they will succeed.
-						fetchShouldFail.Store(false)
+							// We expect the reader to have consumed the partition from start.
+							test.Poll(t, time.Second, []string{"record-1", "record-2", "record-3", "record-4"}, func() interface{} {
+								consumedRecordsMx.Lock()
+								defer consumedRecordsMx.Unlock()
+								return slices.Clone(consumedRecords)
+							})
 
-						// We expect the reader to catch up, and then switch to Running state.
-						test.Poll(t, 5*time.Second, services.Running, func() interface{} {
-							return reader.State()
-						})
+							// We expect the last consumed offset to be tracked in a metric.
+							test.Poll(t, time.Second, nil, func() interface{} {
+								return promtest.GatherAndCompare(reg, strings.NewReader(`
+									# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
+									# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
+									cortex_ingest_storage_reader_last_consumed_offset{partition="1"} 3
 
-						// We expect the reader to have switched to running because target consumer lag has been honored.
-						assert.Contains(t, logs.String(), "partition reader consumed partition and current lag is lower than configured target consumer lag")
-
-						// We expect the reader to have consumed the partition from start.
-						test.Poll(t, time.Second, []string{"record-1", "record-2"}, func() interface{} {
-							consumedRecordsMx.Lock()
-							defer consumedRecordsMx.Unlock()
-							return slices.Clone(consumedRecords)
-						})
-
-						// We expect the last consumed offset to be tracked in a metric.
-						test.Poll(t, time.Second, nil, func() interface{} {
-							return promtest.GatherAndCompare(reg, strings.NewReader(`
-						# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
-						# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
-						cortex_ingest_storage_reader_last_consumed_offset{partition="1"} 1
-					`), "cortex_ingest_storage_reader_last_consumed_offset")
-						})
-
-						produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-3"))
-						produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-4"))
-						t.Log("produced 2 records")
-
-						// We expect the reader to have consumed the partition from start.
-						test.Poll(t, time.Second, []string{"record-1", "record-2", "record-3", "record-4"}, func() interface{} {
-							consumedRecordsMx.Lock()
-							defer consumedRecordsMx.Unlock()
-							return slices.Clone(consumedRecords)
-						})
-
-						// We expect the last consumed offset to be tracked in a metric.
-						test.Poll(t, time.Second, nil, func() interface{} {
-							return promtest.GatherAndCompare(reg, strings.NewReader(`
-						# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
-						# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
-						cortex_ingest_storage_reader_last_consumed_offset{partition="1"} 3
-
-						# HELP cortex_ingest_storage_reader_buffered_fetch_records_total Total number of records buffered within the client ready to be consumed
-						# TYPE cortex_ingest_storage_reader_buffered_fetch_records_total gauge
-						cortex_ingest_storage_reader_buffered_fetch_records_total{component="partition-reader"} 0
-					`), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total")
+									# HELP cortex_ingest_storage_reader_buffered_fetch_records_total Total number of records buffered within the client ready to be consumed
+									# TYPE cortex_ingest_storage_reader_buffered_fetch_records_total gauge
+									cortex_ingest_storage_reader_buffered_fetch_records_total{component="partition-reader"} 0
+								`), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total")
+							})
 						})
 					})
 				}
@@ -1336,218 +1334,215 @@ func TestSingleClusterPartitionReader_ConsumeAtStartup(t *testing.T) {
 	})
 
 	t.Run("should consume partition from the timestamp if position=timestamp, and wait until target lag is honored", func(t *testing.T) {
-		t.Parallel()
-
 		for concurrencyName, concurrencyVariant := range concurrencyVariants {
-			concurrencyVariant := concurrencyVariant
-
 			t.Run(concurrencyName, func(t *testing.T) {
-				t.Parallel()
+				synctest.Test(t, func(t *testing.T) {
+					ctx := t.Context()
 
-				var (
-					cluster, clusterAddr = testkafka.CreateCluster(t, partitionID+1, topicName)
-					fetchRequestsCount   = atomic.NewInt64(0)
-					fetchShouldFail      = atomic.NewBool(false)
-					consumedRecordsMx    sync.Mutex
-					consumedRecords      []string
-				)
+					var vnet kfake.VirtualNetwork
 
-				consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
+					cluster, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, testkafka.WithVirtualNetwork(&vnet))
+					fetchRequestsCount := atomic.NewInt64(0)
+					fetchShouldFail := atomic.NewBool(false)
+					var consumedRecordsMx sync.Mutex
+					var consumedRecords []string
+
+					consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
+						consumedRecordsMx.Lock()
+						defer consumedRecordsMx.Unlock()
+
+						for r := range records {
+							consumedRecords = append(consumedRecords, string(r.Value))
+						}
+						return nil
+					})
+
+					cluster.ControlKey(int16(kmsg.Fetch), func(kmsg.Request) (kmsg.Response, error, bool) {
+						cluster.KeepControl()
+						fetchRequestsCount.Inc()
+
+						if fetchShouldFail.Load() {
+							return nil, errors.New("mocked error"), true
+						}
+
+						return nil, nil, false
+					})
+
+					writeClient := newKafkaProduceClient(t, clusterAddr, withWriteVirtualNetwork(&vnet))
+
+					produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-1"))
+					produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-2"))
+
+					// Consume from after the records in the head. The sleep guaranties a full second gap between the head and tail of the topic.
+					time.Sleep(time.Second)
+					consumeFromTs := time.Now()
+
+					produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-3"))
+					produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-4"))
+
+					// Create and start the reader.
+					fetchShouldFail.Store(true)
+					fetchRequestsCount.Store(0)
 					consumedRecordsMx.Lock()
-					defer consumedRecordsMx.Unlock()
+					consumedRecords = nil
+					consumedRecordsMx.Unlock()
 
-					for r := range records {
-						consumedRecords = append(consumedRecords, string(r.Value))
-					}
-					return nil
-				})
+					reg := prometheus.NewPedanticRegistry()
+					logs := &concurrency.SyncBuffer{}
+					readerOpts := append([]readerTestCfgOpt{
+						withConsumeFromTimestampAtStartup(consumeFromTs.UnixMilli()),
+						withTargetAndMaxConsumerLagAtStartup(time.Second, 2*time.Second),
+						withRegistry(reg),
+						withLogger(log.NewLogfmtLogger(logs)),
+						withVirtualNetwork(&vnet),
+					}, concurrencyVariant...)
 
-				cluster.ControlKey(int16(kmsg.Fetch), func(kmsg.Request) (kmsg.Response, error, bool) {
-					cluster.KeepControl()
-					fetchRequestsCount.Inc()
+					reader := createReader(t, clusterAddr, topicName, partitionID, consumer, readerOpts...)
+					require.NoError(t, reader.StartAsync(ctx))
+					t.Cleanup(func() {
+						require.NoError(t, services.StopAndAwaitTerminated(context.Background(), reader))
+					})
 
-					if fetchShouldFail.Load() {
-						return nil, errors.New("mocked error"), true
-					}
+					// Wait until the Kafka cluster received few Fetch requests.
+					test.Poll(t, 5*time.Second, true, func() interface{} {
+						return fetchRequestsCount.Load() > 0
+					})
 
-					return nil, nil, false
-				})
+					// Since the mocked Kafka cluster is configured to fail any Fetch we expect the reader hasn't
+					// catched up yet, and it's still in Starting state.
+					assert.Equal(t, services.Starting, reader.State())
 
-				writeClient := newKafkaProduceClient(t, clusterAddr)
+					// Unblock the Fetch requests. Now they will succeed.
+					fetchShouldFail.Store(false)
 
-				produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-1"))
-				produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-2"))
+					// We expect the reader to catch up, and then switch to Running state.
+					test.Poll(t, 5*time.Second, services.Running, func() interface{} {
+						return reader.State()
+					})
 
-				// Consume from after the records in the head. The sleep guaranties a full second gap between the head and tail of the topic.
-				time.Sleep(time.Second)
-				consumeFromTs := time.Now()
+					// We expect the reader to have switched to running because target consumer lag has been honored.
+					assert.Contains(t, logs.String(), "partition reader consumed partition and current lag is lower than configured target consumer lag")
 
-				produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-3"))
-				produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-4"))
+					// We expect the reader to have consumed the partition from the third record.
+					test.Poll(t, time.Second, []string{"record-3", "record-4"}, func() interface{} {
+						consumedRecordsMx.Lock()
+						defer consumedRecordsMx.Unlock()
+						return slices.Clone(consumedRecords)
+					})
 
-				// Create and start the reader.
-				fetchShouldFail.Store(true)
-				fetchRequestsCount.Store(0)
-				consumedRecordsMx.Lock()
-				consumedRecords = nil
-				consumedRecordsMx.Unlock()
+					// We expect the last consumed offset to be tracked in a metric.
+					expectedConsumedOffset := 3
+					test.Poll(t, time.Second, nil, func() interface{} {
+						return promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
+							# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
+							# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
+							cortex_ingest_storage_reader_last_consumed_offset{partition="1"} %d
 
-				reg := prometheus.NewPedanticRegistry()
-				logs := &concurrency.SyncBuffer{}
-				readerOpts := append([]readerTestCfgOpt{
-					withConsumeFromTimestampAtStartup(consumeFromTs.UnixMilli()),
-					withTargetAndMaxConsumerLagAtStartup(time.Second, 2*time.Second),
-					withRegistry(reg),
-					withLogger(log.NewLogfmtLogger(logs)),
-				}, concurrencyVariant...)
-
-				reader := createReader(t, clusterAddr, topicName, partitionID, consumer, readerOpts...)
-				require.NoError(t, reader.StartAsync(ctx))
-				t.Cleanup(func() {
-					require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
-				})
-
-				// Wait until the Kafka cluster received few Fetch requests.
-				test.Poll(t, 5*time.Second, true, func() interface{} {
-					return fetchRequestsCount.Load() > 0
-				})
-
-				// Since the mocked Kafka cluster is configured to fail any Fetch we expect the reader hasn't
-				// catched up yet, and it's still in Starting state.
-				assert.Equal(t, services.Starting, reader.State())
-
-				// Unblock the Fetch requests. Now they will succeed.
-				fetchShouldFail.Store(false)
-
-				// We expect the reader to catch up, and then switch to Running state.
-				test.Poll(t, 5*time.Second, services.Running, func() interface{} {
-					return reader.State()
-				})
-
-				// We expect the reader to have switched to running because target consumer lag has been honored.
-				assert.Contains(t, logs.String(), "partition reader consumed partition and current lag is lower than configured target consumer lag")
-
-				// We expect the reader to have consumed the partition from the third record.
-				test.Poll(t, time.Second, []string{"record-3", "record-4"}, func() interface{} {
-					consumedRecordsMx.Lock()
-					defer consumedRecordsMx.Unlock()
-					return slices.Clone(consumedRecords)
-				})
-
-				// We expect the last consumed offset to be tracked in a metric.
-				expectedConsumedOffset := 3
-				test.Poll(t, time.Second, nil, func() interface{} {
-					return promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
-						# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
-						# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
-						cortex_ingest_storage_reader_last_consumed_offset{partition="1"} %d
-
-						# HELP cortex_ingest_storage_reader_buffered_fetch_records_total Total number of records buffered within the client ready to be consumed
-						# TYPE cortex_ingest_storage_reader_buffered_fetch_records_total gauge
-						cortex_ingest_storage_reader_buffered_fetch_records_total{component="partition-reader"} 0
-					`, expectedConsumedOffset)), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total")
+							# HELP cortex_ingest_storage_reader_buffered_fetch_records_total Total number of records buffered within the client ready to be consumed
+							# TYPE cortex_ingest_storage_reader_buffered_fetch_records_total gauge
+							cortex_ingest_storage_reader_buffered_fetch_records_total{component="partition-reader"} 0
+						`, expectedConsumedOffset)), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total")
+					})
 				})
 			})
 		}
 	})
 
 	t.Run("should consume partition from last committed offset if position=last-offset, and wait until target lag is honored", func(t *testing.T) {
-		t.Parallel()
-
 		for concurrencyName, concurrencyVariant := range concurrencyVariants {
-			concurrencyVariant := concurrencyVariant
-
 			t.Run(concurrencyName, func(t *testing.T) {
-				t.Parallel()
+				synctest.Test(t, func(t *testing.T) {
+					ctx := t.Context()
 
-				var (
-					cluster, clusterAddr = testkafka.CreateCluster(t, partitionID+1, topicName)
-					fetchRequestsCount   = atomic.NewInt64(0)
-					fetchShouldFail      = atomic.NewBool(false)
-					consumedRecordsMx    sync.Mutex
-					consumedRecords      []string
-				)
+					var vnet kfake.VirtualNetwork
 
-				consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
-					consumedRecordsMx.Lock()
-					defer consumedRecordsMx.Unlock()
+					cluster, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, testkafka.WithVirtualNetwork(&vnet))
+					fetchRequestsCount := atomic.NewInt64(0)
+					fetchShouldFail := atomic.NewBool(false)
+					var consumedRecordsMx sync.Mutex
+					var consumedRecords []string
 
-					for r := range records {
-						consumedRecords = append(consumedRecords, string(r.Value))
-					}
-					return nil
-				})
-
-				cluster.ControlKey(int16(kmsg.Fetch), func(kmsg.Request) (kmsg.Response, error, bool) {
-					cluster.KeepControl()
-					fetchRequestsCount.Inc()
-
-					if fetchShouldFail.Load() {
-						return nil, errors.New("mocked error"), true
-					}
-
-					return nil, nil, false
-				})
-
-				// Run the test twice with the same Kafka cluster to show that second time it consumes only new records.
-				for run := 1; run <= 2; run++ {
-					t.Run(fmt.Sprintf("Run %d", run), func(t *testing.T) {
-						// Reset the test.
-						fetchShouldFail.Store(true)
-						fetchRequestsCount.Store(0)
+					consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
 						consumedRecordsMx.Lock()
-						consumedRecords = nil
-						consumedRecordsMx.Unlock()
+						defer consumedRecordsMx.Unlock()
 
-						// Produce a record before each test run.
-						writeClient := newKafkaProduceClient(t, clusterAddr)
-						produceRecord(ctx, t, writeClient, topicName, partitionID, []byte(fmt.Sprintf("record-%d", run)))
-						t.Log("produced 1 record")
+						for r := range records {
+							consumedRecords = append(consumedRecords, string(r.Value))
+						}
+						return nil
+					})
 
-						// Create and start the reader.
-						reg := prometheus.NewPedanticRegistry()
-						logs := &concurrency.SyncBuffer{}
-						readerOpts := append([]readerTestCfgOpt{
-							withConsumeFromPositionAtStartup(consumeFromLastOffset),
-							withTargetAndMaxConsumerLagAtStartup(time.Second, 2*time.Second),
-							withRegistry(reg),
-							withLogger(log.NewLogfmtLogger(logs)),
-						}, concurrencyVariant...)
+					cluster.ControlKey(int16(kmsg.Fetch), func(kmsg.Request) (kmsg.Response, error, bool) {
+						cluster.KeepControl()
+						fetchRequestsCount.Inc()
 
-						reader := createReader(t, clusterAddr, topicName, partitionID, consumer, readerOpts...)
-						require.NoError(t, reader.StartAsync(ctx))
-						t.Cleanup(func() {
-							require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
-						})
+						if fetchShouldFail.Load() {
+							return nil, errors.New("mocked error"), true
+						}
 
-						// Wait until the Kafka cluster received few Fetch requests.
-						test.Poll(t, 5*time.Second, true, func() interface{} {
-							return fetchRequestsCount.Load() > 2
-						})
+						return nil, nil, false
+					})
 
-						// Since the mocked Kafka cluster is configured to fail any Fetch we expect the reader hasn't
-						// catched up yet, and it's still in Starting state.
-						assert.Equal(t, services.Starting, reader.State())
-
-						// Unblock the Fetch requests. Now they will succeed.
-						fetchShouldFail.Store(false)
-
-						// We expect the reader to catch up, and then switch to Running state.
-						test.Poll(t, 5*time.Second, services.Running, func() interface{} {
-							return reader.State()
-						})
-
-						// We expect the reader to have consumed the partition from last offset.
-						test.Poll(t, time.Second, []string{fmt.Sprintf("record-%d", run)}, func() interface{} {
+					// Run the test twice with the same Kafka cluster to show that second time it consumes only new records.
+					for run := 1; run <= 2; run++ {
+						func(t *testing.T) {
+							// Reset the test.
+							fetchShouldFail.Store(true)
+							fetchRequestsCount.Store(0)
 							consumedRecordsMx.Lock()
-							defer consumedRecordsMx.Unlock()
-							return slices.Clone(consumedRecords)
-						})
+							consumedRecords = nil
+							consumedRecordsMx.Unlock()
 
-						// We expect the last consumed offset to be tracked in a metric.
-						expectedConsumedOffset := run - 1
-						test.Poll(t, time.Second, nil, func() interface{} {
-							return promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
+							// Produce a record before each test run.
+							writeClient := newKafkaProduceClient(t, clusterAddr, withWriteVirtualNetwork(&vnet))
+							produceRecord(ctx, t, writeClient, topicName, partitionID, []byte(fmt.Sprintf("record-%d", run)))
+							t.Log("produced 1 record")
+
+							// Create and start the reader.
+							reg := prometheus.NewPedanticRegistry()
+							logs := &concurrency.SyncBuffer{}
+							readerOpts := append([]readerTestCfgOpt{
+								withConsumeFromPositionAtStartup(consumeFromLastOffset),
+								withTargetAndMaxConsumerLagAtStartup(time.Second, 2*time.Second),
+								withRegistry(reg),
+								withLogger(log.NewLogfmtLogger(logs)),
+								withVirtualNetwork(&vnet),
+							}, concurrencyVariant...)
+
+							reader := createReader(t, clusterAddr, topicName, partitionID, consumer, readerOpts...)
+							require.NoError(t, reader.StartAsync(ctx))
+							defer func() {
+								require.NoError(t, services.StopAndAwaitTerminated(context.Background(), reader))
+							}()
+
+							// Wait until the Kafka cluster received few Fetch requests.
+							test.Poll(t, 5*time.Second, true, func() interface{} {
+								return fetchRequestsCount.Load() > 2
+							})
+
+							// Since the mocked Kafka cluster is configured to fail any Fetch we expect the reader hasn't
+							// catched up yet, and it's still in Starting state.
+							assert.Equal(t, services.Starting, reader.State())
+
+							// Unblock the Fetch requests. Now they will succeed.
+							fetchShouldFail.Store(false)
+
+							// We expect the reader to catch up, and then switch to Running state.
+							test.Poll(t, 5*time.Second, services.Running, func() interface{} {
+								return reader.State()
+							})
+
+							// We expect the reader to have consumed the partition from last offset.
+							test.Poll(t, time.Second, []string{fmt.Sprintf("record-%d", run)}, func() interface{} {
+								consumedRecordsMx.Lock()
+								defer consumedRecordsMx.Unlock()
+								return slices.Clone(consumedRecords)
+							})
+
+							// We expect the last consumed offset to be tracked in a metric.
+							expectedConsumedOffset := run - 1
+							test.Poll(t, time.Second, nil, func() interface{} {
+								return promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
 								# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
 								# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
 								cortex_ingest_storage_reader_last_consumed_offset{partition="1"} %d
@@ -1556,340 +1551,331 @@ func TestSingleClusterPartitionReader_ConsumeAtStartup(t *testing.T) {
 								# TYPE cortex_ingest_storage_reader_buffered_fetch_records_total gauge
 								cortex_ingest_storage_reader_buffered_fetch_records_total{component="partition-reader"} 0
 							`, expectedConsumedOffset)), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total")
-						})
-					})
-				}
+							})
+						}(t)
+					}
+				})
 			})
 		}
 	})
 
 	t.Run("should consume partition from last committed offset if position=last-offset, and wait until max lag is honored if can't honor target lag", func(t *testing.T) {
-		t.Parallel()
-
 		for concurrencyName, concurrencyVariant := range concurrencyVariants {
-			concurrencyVariant := concurrencyVariant
-
 			t.Run(concurrencyName, func(t *testing.T) {
-				t.Parallel()
+				synctest.Test(t, func(t *testing.T) {
+					ctx := t.Context()
 
-				var (
-					cluster, clusterAddr = testkafka.CreateCluster(t, partitionID+1, topicName)
-					writeClient          = newKafkaProduceClient(t, clusterAddr)
-					nextRecordID         = atomic.NewInt32(0)
-					targetLag            = 500 * time.Millisecond
-					maxLag               = 2 * time.Second
-				)
+					var vnet kfake.VirtualNetwork
 
-				// Wait until all goroutines used in this test have done.
-				testRoutines := sync.WaitGroup{}
-				t.Cleanup(testRoutines.Wait)
+					cluster, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, testkafka.WithVirtualNetwork(&vnet))
+					writeClient := newKafkaProduceClient(t, clusterAddr, withWriteVirtualNetwork(&vnet))
+					nextRecordID := atomic.NewInt32(0)
+					targetLag := 500 * time.Millisecond
+					maxLag := 2 * time.Second
 
-				// Create a channel to signal goroutines once the test has done.
-				testDone := make(chan struct{})
-				t.Cleanup(func() {
-					close(testDone)
-				})
+					// Wait until all goroutines used in this test have done.
+					testRoutines := sync.WaitGroup{}
+					t.Cleanup(testRoutines.Wait)
 
-				consumer := consumerFunc(func(context.Context, iter.Seq[*kgo.Record]) error { return nil })
+					// Create a channel to signal goroutines once the test has done.
+					testDone := make(chan struct{})
+					t.Cleanup(func() {
+						close(testDone)
+					})
 
-				cluster.ControlKey(int16(kmsg.ListOffsets), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
-					cluster.KeepControl()
+					consumer := consumerFunc(func(context.Context, iter.Seq[*kgo.Record]) error { return nil })
 
-					// Slow down each ListOffsets request to take longer than the target lag.
-					req := kreq.(*kmsg.ListOffsetsRequest)
-					if len(req.Topics) > 0 && len(req.Topics[0].Partitions) > 0 && req.Topics[0].Partitions[0].Timestamp == kafkaOffsetEnd {
-						cluster.SleepControl(func() {
-							testRoutines.Add(1)
-							defer testRoutines.Done()
+					cluster.ControlKey(int16(kmsg.ListOffsets), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+						cluster.KeepControl()
 
-							delay := time.Duration(float64(targetLag) * 1.1)
-							t.Logf("artificially slowing down OffsetFetch request by %s", delay.String())
+						// Slow down each ListOffsets request to take longer than the target lag.
+						req := kreq.(*kmsg.ListOffsetsRequest)
+						if len(req.Topics) > 0 && len(req.Topics[0].Partitions) > 0 && req.Topics[0].Partitions[0].Timestamp == kafkaOffsetEnd {
+							cluster.SleepControl(func() {
+								testRoutines.Add(1)
+								defer testRoutines.Done()
 
+								delay := time.Duration(float64(targetLag) * 1.1)
+								t.Logf("artificially slowing down OffsetFetch request by %s", delay.String())
+
+								select {
+								case <-testDone:
+								case <-time.After(delay):
+								}
+							})
+						}
+
+						return nil, nil, false
+					})
+
+					// Produce a record.
+					produceRecord(ctx, t, writeClient, topicName, partitionID, []byte(fmt.Sprintf("record-%d", nextRecordID.Inc())))
+					t.Log("produced 1 record")
+
+					// Continue to produce records at a high pace, so that we simulate the case there are always new
+					// records to fetch.
+					testRoutines.Add(1)
+					go func() {
+						defer testRoutines.Done()
+
+						for {
 							select {
 							case <-testDone:
-							case <-time.After(delay):
+								return
+
+							case <-time.After(targetLag / 2):
+								produceRecord(ctx, t, writeClient, topicName, partitionID, []byte(fmt.Sprintf("record-%d", nextRecordID.Inc())))
+								t.Log("produced 1 record")
 							}
-						})
-					}
-
-					return nil, nil, false
-				})
-
-				// Produce a record.
-				produceRecord(ctx, t, writeClient, topicName, partitionID, []byte(fmt.Sprintf("record-%d", nextRecordID.Inc())))
-				t.Log("produced 1 record")
-
-				// Continue to produce records at a high pace, so that we simulate the case there are always new
-				// records to fetch.
-				testRoutines.Add(1)
-				go func() {
-					defer testRoutines.Done()
-
-					for {
-						select {
-						case <-testDone:
-							return
-
-						case <-time.After(targetLag / 2):
-							produceRecord(ctx, t, writeClient, topicName, partitionID, []byte(fmt.Sprintf("record-%d", nextRecordID.Inc())))
-							t.Log("produced 1 record")
 						}
-					}
-				}()
+					}()
 
-				// Create and start the reader.
-				reg := prometheus.NewPedanticRegistry()
-				logs := &concurrency.SyncBuffer{}
-				readerOpts := append([]readerTestCfgOpt{
-					withConsumeFromPositionAtStartup(consumeFromLastOffset),
-					withTargetAndMaxConsumerLagAtStartup(targetLag, maxLag),
-					withRegistry(reg),
-					withLogger(log.NewLogfmtLogger(logs)),
-				}, concurrencyVariant...)
+					// Create and start the reader.
+					reg := prometheus.NewPedanticRegistry()
+					logs := &concurrency.SyncBuffer{}
+					readerOpts := append([]readerTestCfgOpt{
+						withConsumeFromPositionAtStartup(consumeFromLastOffset),
+						withTargetAndMaxConsumerLagAtStartup(targetLag, maxLag),
+						withRegistry(reg),
+						withLogger(log.NewLogfmtLogger(logs)),
+						withVirtualNetwork(&vnet),
+					}, concurrencyVariant...)
 
-				reader := createReader(t, clusterAddr, topicName, partitionID, consumer, readerOpts...)
-				require.NoError(t, reader.StartAsync(ctx))
-				t.Cleanup(func() {
-					require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
+					reader := createReader(t, clusterAddr, topicName, partitionID, consumer, readerOpts...)
+					require.NoError(t, reader.StartAsync(ctx))
+					t.Cleanup(func() {
+						require.NoError(t, services.StopAndAwaitTerminated(context.Background(), reader))
+					})
+
+					// We expect the reader to catch up, and then switch to Running state.
+					test.Poll(t, maxLag*5, services.Running, func() interface{} {
+						return reader.State()
+					})
+
+					// We expect the reader to have switched to running because max consumer lag has been honored
+					// but target lag has not.
+					assert.Contains(t, logs.String(), "partition reader consumed partition and current lag is lower than configured max consumer lag but higher than target consumer lag")
 				})
-
-				// We expect the reader to catch up, and then switch to Running state.
-				test.Poll(t, maxLag*5, services.Running, func() interface{} {
-					return reader.State()
-				})
-
-				// We expect the reader to have switched to running because max consumer lag has been honored
-				// but target lag has not.
-				assert.Contains(t, logs.String(), "partition reader consumed partition and current lag is lower than configured max consumer lag but higher than target consumer lag")
 			})
 		}
 	})
 
 	t.Run("should not wait indefinitely if context is cancelled while fetching last produced offset", func(t *testing.T) {
-		t.Parallel()
-
 		for concurrencyName, concurrencyVariant := range concurrencyVariants {
-			concurrencyVariant := concurrencyVariant
-
 			t.Run(concurrencyName, func(t *testing.T) {
-				t.Parallel()
+				synctest.Test(t, func(t *testing.T) {
+					// Today this flakes: on some interleavings, when the reader shuts down it closes the franz-go
+					// client, and the client's Close->stopSession blocks forever because franz-go busy-re-queues the
+					// unresolved offset loads instead of draining them. So the service never reaches Failed and
+					// synctest's clock freezes. In franz-go the Client should not re-queue offset loads once the
+					// session context is done.
+					t.Skip("franz-go: the test requires a fix in the library")
 
-				var (
-					cluster, clusterAddr     = testkafka.CreateCluster(t, partitionID+1, topicName)
-					consumer                 = consumerFunc(func(context.Context, iter.Seq[*kgo.Record]) error { return nil })
-					listOffsetsRequestsCount = atomic.NewInt64(0)
-					contextCancelled         = atomic.NewBool(false)
-				)
+					ctx := t.Context()
 
-				// Mock Kafka to always fail the ListOffsets request.
-				cluster.ControlKey(int16(kmsg.ListOffsets), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
-					cluster.KeepControl()
+					var vnet kfake.VirtualNetwork
 
-					listOffsetsRequestsCount.Inc()
+					cluster, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, testkafka.WithVirtualNetwork(&vnet))
+					consumer := consumerFunc(func(context.Context, iter.Seq[*kgo.Record]) error { return nil })
 
-					// If context has been cancelled, we want to make sure we return an error
-					// that will allow the client to detect the cancellation faster.
-					if contextCancelled.Load() {
-						return nil, context.Canceled, true
-					}
+					listOffsetsRequestsCount := atomic.NewInt64(0)
+					readerCtx, cancelReaderCtx := context.WithCancel(ctx)
 
-					// Return a proper Kafka error response instead of a raw error
-					// to ensure franz-go will retry this error
-					req := kreq.(*kmsg.ListOffsetsRequest)
-					res := req.ResponseKind().(*kmsg.ListOffsetsResponse)
-					res.Default()
-					res.Topics = []kmsg.ListOffsetsResponseTopic{
-						{Topic: topicName, Partitions: []kmsg.ListOffsetsResponseTopicPartition{{ErrorCode: kerr.NotLeaderForPartition.Code}}},
-					}
-					return res, nil, true
-				})
+					// Mock Kafka to always fail the ListOffsets request.
+					cluster.ControlKey(int16(kmsg.ListOffsets), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+						cluster.KeepControl()
 
-				// Create and start the reader.
-				readerOpts := append([]readerTestCfgOpt{
-					withTargetAndMaxConsumerLagAtStartup(time.Second, time.Second),
-				}, concurrencyVariant...)
-				reader := createReader(t, clusterAddr, topicName, partitionID, consumer, readerOpts...)
+						listOffsetsRequestsCount.Inc()
 
-				readerCtx, cancelReaderCtx := context.WithCancel(ctx)
-				require.NoError(t, reader.StartAsync(readerCtx))
-				t.Cleanup(func() {
-					// Interrupting startup should fail the service.
-					// A context cancellation error shouldn't be swallowed and interpreted as "startup went ok"
-					assert.ErrorIs(t, services.StopAndAwaitTerminated(ctx, reader), context.Canceled)
-				})
+						// Return a proper Kafka error response instead of a raw error to ensure franz-go will retry this error
+						req := kreq.(*kmsg.ListOffsetsRequest)
+						res := req.ResponseKind().(*kmsg.ListOffsetsResponse)
+						res.Default()
+						res.Topics = []kmsg.ListOffsetsResponseTopic{
+							{Topic: topicName, Partitions: []kmsg.ListOffsetsResponseTopicPartition{{ErrorCode: kerr.NotLeaderForPartition.Code}}},
+						}
+						return res, nil, true
+					})
 
-				// Wait until the Kafka cluster received at least 2 ListOffsets requests.
-				// This ensures the reader is actively trying to fetch offsets and retrying.
-				test.Poll(t, 5*time.Second, true, func() interface{} {
-					return listOffsetsRequestsCount.Load() > 1
-				})
+					// Create and start the reader.
+					readerOpts := append([]readerTestCfgOpt{
+						withTargetAndMaxConsumerLagAtStartup(time.Second, time.Second),
+						withVirtualNetwork(&vnet),
+					}, concurrencyVariant...)
+					reader := createReader(t, clusterAddr, topicName, partitionID, consumer, readerOpts...)
 
-				// Cancelling the context should cause the service to switch to a terminal state.
-				assert.Equal(t, services.Starting, reader.State())
+					require.NoError(t, reader.StartAsync(readerCtx))
+					t.Cleanup(func() {
+						// Interrupting startup should fail the service.
+						// A context cancellation error shouldn't be swallowed and interpreted as "startup went ok"
+						// Use context.Background make sure the tests observes the startup's cancellation.
+						assert.ErrorIs(t, services.StopAndAwaitTerminated(context.Background(), reader), context.Canceled)
+					})
 
-				// Mark that context is being cancelled so subsequent requests fail faster
-				contextCancelled.Store(true)
-				cancelReaderCtx()
+					// Wait until the Kafka cluster received at least 2 ListOffsets requests.
+					// This ensures the reader is actively trying to fetch offsets and retrying.
+					test.Poll(t, 5*time.Second, true, func() interface{} {
+						return listOffsetsRequestsCount.Load() > 1
+					})
 
-				// franz-go has internal retries that can last up to 10s
-				test.Poll(t, 15*time.Second, services.Failed, func() interface{} {
-					return reader.State()
+					assert.Equal(t, services.Starting, reader.State())
+
+					// Cancelling the context should cause the service to switch to a terminal state.
+					// Mark that context is being cancelled so subsequent requests fail faster.
+					cancelReaderCtx()
+
+					// franz-go has internal retries that can last up to 10s
+					test.Poll(t, 15*time.Second, services.Failed, func() interface{} {
+						return reader.State()
+					})
 				})
 			})
 		}
 	})
 
 	t.Run("should not wait indefinitely if context is cancelled while fetching records", func(t *testing.T) {
-		t.Parallel()
-
 		for concurrencyName, concurrencyVariant := range concurrencyVariants {
-			concurrencyVariant := concurrencyVariant
-
 			t.Run(concurrencyName, func(t *testing.T) {
-				t.Parallel()
+				synctest.Test(t, func(t *testing.T) {
+					ctx := t.Context()
 
-				var (
-					cluster, clusterAddr = testkafka.CreateCluster(t, partitionID+1, topicName)
-					consumer             = consumerFunc(func(context.Context, iter.Seq[*kgo.Record]) error { return nil })
-					fetchRequestsCount   = atomic.NewInt64(0)
-				)
+					var vnet kfake.VirtualNetwork
 
-				// Mock Kafka to always fail the Fetch request.
-				cluster.ControlKey(int16(kmsg.Fetch), func(kmsg.Request) (kmsg.Response, error, bool) {
-					cluster.KeepControl()
+					cluster, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, testkafka.WithVirtualNetwork(&vnet))
+					consumer := consumerFunc(func(context.Context, iter.Seq[*kgo.Record]) error { return nil })
+					fetchRequestsCount := atomic.NewInt64(0)
 
-					fetchRequestsCount.Inc()
-					return nil, errors.New("mocked error"), true
-				})
+					// Mock Kafka to always fail the Fetch request.
+					cluster.ControlKey(int16(kmsg.Fetch), func(kmsg.Request) (kmsg.Response, error, bool) {
+						cluster.KeepControl()
 
-				// Produce some records.
-				writeClient := newKafkaProduceClient(t, clusterAddr)
-				produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-1"))
-				produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-2"))
-				t.Log("produced 2 records")
+						fetchRequestsCount.Inc()
+						return nil, errors.New("mocked error"), true
+					})
 
-				// Create and start the reader.
-				readerOpts := append([]readerTestCfgOpt{
-					withTargetAndMaxConsumerLagAtStartup(time.Second, time.Second),
-				}, concurrencyVariant...)
-				reader := createReader(t, clusterAddr, topicName, partitionID, consumer, readerOpts...)
+					// Produce some records.
+					writeClient := newKafkaProduceClient(t, clusterAddr, withWriteVirtualNetwork(&vnet))
+					produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-1"))
+					produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-2"))
+					t.Log("produced 2 records")
 
-				readerCtx, cancelReaderCtx := context.WithCancel(ctx)
-				require.NoError(t, reader.StartAsync(readerCtx))
-				t.Cleanup(func() {
-					// Interrupting startup should fail the service.
-					// A context cancellation error shouldn't be swallowed and interpreted as "startup went ok"
-					assert.ErrorIs(t, services.StopAndAwaitTerminated(ctx, reader), context.Canceled)
-				})
+					// Create and start the reader.
+					readerOpts := append([]readerTestCfgOpt{
+						withTargetAndMaxConsumerLagAtStartup(time.Second, time.Second),
+						withVirtualNetwork(&vnet),
+					}, concurrencyVariant...)
+					reader := createReader(t, clusterAddr, topicName, partitionID, consumer, readerOpts...)
 
-				// Wait until the Kafka cluster received at least 1 Fetch request.
-				test.Poll(t, 5*time.Second, true, func() interface{} {
-					return fetchRequestsCount.Load() > 0
-				})
+					readerCtx, cancelReaderCtx := context.WithCancel(ctx)
+					require.NoError(t, reader.StartAsync(readerCtx))
+					t.Cleanup(func() {
+						// Interrupting startup should fail the service.
+						// A context cancellation error shouldn't be swallowed and interpreted as "startup went ok"
+						// Use context.Background make sure the tests observes the startup's cancellation.
+						assert.ErrorIs(t, services.StopAndAwaitTerminated(context.Background(), reader), context.Canceled)
+					})
 
-				// Cancelling the context should cause the service to switch to a terminal state.
-				assert.Equal(t, services.Starting, reader.State())
-				cancelReaderCtx()
+					// Wait until the Kafka cluster received at least 1 Fetch request.
+					test.Poll(t, 5*time.Second, true, func() interface{} {
+						return fetchRequestsCount.Load() > 0
+					})
 
-				test.Poll(t, 5*time.Second, services.Failed, func() interface{} {
-					return reader.State()
+					// Cancelling the context should cause the service to switch to a terminal state.
+					assert.Equal(t, services.Starting, reader.State())
+
+					cancelReaderCtx()
+
+					test.Poll(t, 5*time.Second, services.Failed, func() interface{} {
+						return reader.State()
+					})
 				})
 			})
 		}
 	})
 
 	t.Run("should not wait indefinitely if there are no records to consume from Kafka but partition start offset is > 0 (e.g. all previous records have been deleted by Kafka retention)", func(t *testing.T) {
-		t.Parallel()
-
 		for _, consumeFromPosition := range consumeFromPositionOptions {
-			consumeFromPosition := consumeFromPosition
-
 			t.Run(fmt.Sprintf("consume from position: %s", consumeFromPosition), func(t *testing.T) {
-				t.Parallel()
-
 				for _, fileEnforced := range []bool{false, true} {
-					fileEnforced := fileEnforced
 					t.Run(fmt.Sprintf("file_enforced_%v", fileEnforced), func(t *testing.T) {
-						t.Parallel()
-
 						for concurrencyName, concurrencyVariant := range concurrencyVariants {
-							concurrencyVariant := concurrencyVariant
-
 							t.Run(concurrencyName, func(t *testing.T) {
-								t.Parallel()
+								synctest.Test(t, func(t *testing.T) {
+									ctx := t.Context()
 
-								ctx, cancel := context.WithCancel(context.Background())
-								t.Cleanup(cancel)
+									var vnet kfake.VirtualNetwork
 
-								consumer := consumerFunc(func(context.Context, iter.Seq[*kgo.Record]) error { return nil })
+									consumer := consumerFunc(func(context.Context, iter.Seq[*kgo.Record]) error { return nil })
 
-								cluster, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName)
-								cluster.ControlKey(int16(kmsg.Fetch), func(kmsg.Request) (kmsg.Response, error, bool) {
-									cluster.KeepControl()
+									cluster, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, testkafka.WithVirtualNetwork(&vnet))
+									cluster.ControlKey(int16(kmsg.Fetch), func(kmsg.Request) (kmsg.Response, error, bool) {
+										cluster.KeepControl()
 
-									// Throttle the Fetch request.
-									select {
-									case <-ctx.Done():
-									case <-time.After(time.Second):
-									}
+										// Throttle the Fetch request.
+										select {
+										case <-ctx.Done():
+										case <-time.After(time.Second):
+										}
 
-									return nil, nil, false
+										return nil, nil, false
+									})
+
+									// Produce some records.
+									writeClient := newKafkaProduceClient(t, clusterAddr, withWriteVirtualNetwork(&vnet))
+									produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-1"))
+									produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-2"))
+									t.Log("produced 2 records")
+
+									// Fetch the partition end offset, which is the offset of the next record that will be produced.
+									adminClient := kadm.NewClient(writeClient)
+									endOffsets, err := adminClient.ListEndOffsets(ctx, topicName)
+									require.NoError(t, err)
+									endOffset, exists := endOffsets.Lookup(topicName, partitionID)
+									require.True(t, exists)
+									require.NoError(t, endOffset.Err)
+									t.Logf("fetched partition end offset: %d", endOffset.Offset)
+
+									// Issue a request to delete produced records so far. What Kafka does under the hood is to advance
+									// the partition start offset to the specified offset.
+									advancePartitionStartTo := kadm.Offsets{}
+									advancePartitionStartTo.Add(kadm.Offset{Topic: topicName, Partition: partitionID, At: endOffset.Offset})
+									_, err = adminClient.DeleteRecords(ctx, advancePartitionStartTo)
+									require.NoError(t, err)
+									t.Logf("advanced partition start offset to: %d", endOffset.Offset)
+
+									// Create and start the reader. We expect the reader to immediately switch to Running state.
+									reg := prometheus.NewPedanticRegistry()
+									readerOpts := append([]readerTestCfgOpt{
+										withFileBasedOffsetEnforcement(fileEnforced),
+										withConsumeFromPositionAtStartup(consumeFromPosition),
+										withConsumeFromTimestampAtStartup(time.Now().UnixMilli()), // For the test where position=timestamp.
+										withTargetAndMaxConsumerLagAtStartup(time.Second, time.Second),
+										withRegistry(reg),
+										withVirtualNetwork(&vnet),
+									}, concurrencyVariant...)
+
+									reader := createReader(t, clusterAddr, topicName, partitionID, consumer, readerOpts...)
+
+									require.NoError(t, services.StartAndAwaitRunning(ctx, reader))
+									t.Cleanup(func() {
+										require.NoError(t, services.StopAndAwaitTerminated(context.Background(), reader))
+									})
+
+									// We expect no record has been consumed.
+									require.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
+										# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
+										# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
+										cortex_ingest_storage_reader_last_consumed_offset{partition="1"} -1
+
+										# HELP cortex_ingest_storage_reader_last_committed_offset The last consumed offset successfully committed by the partition reader. Set to -1 if not offset has been committed yet.
+										# TYPE cortex_ingest_storage_reader_last_committed_offset gauge
+										cortex_ingest_storage_reader_last_committed_offset{partition="1"} -1
+
+										# HELP cortex_ingest_storage_reader_buffered_fetch_records_total Total number of records buffered within the client ready to be consumed
+										# TYPE cortex_ingest_storage_reader_buffered_fetch_records_total gauge
+										cortex_ingest_storage_reader_buffered_fetch_records_total{component="partition-reader"} 0
+									`), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_last_committed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total"))
 								})
-
-								// Produce some records.
-								writeClient := newKafkaProduceClient(t, clusterAddr)
-								produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-1"))
-								produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-2"))
-								t.Log("produced 2 records")
-
-								// Fetch the partition end offset, which is the offset of the next record that will be produced.
-								adminClient := kadm.NewClient(writeClient)
-								endOffsets, err := adminClient.ListEndOffsets(ctx, topicName)
-								require.NoError(t, err)
-								endOffset, exists := endOffsets.Lookup(topicName, partitionID)
-								require.True(t, exists)
-								require.NoError(t, endOffset.Err)
-								t.Logf("fetched partition end offset: %d", endOffset.Offset)
-
-								// Issue a request to delete produced records so far. What Kafka does under the hood is to advance
-								// the partition start offset to the specified offset.
-								advancePartitionStartTo := kadm.Offsets{}
-								advancePartitionStartTo.Add(kadm.Offset{Topic: topicName, Partition: partitionID, At: endOffset.Offset})
-								_, err = adminClient.DeleteRecords(ctx, advancePartitionStartTo)
-								require.NoError(t, err)
-								t.Logf("advanced partition start offset to: %d", endOffset.Offset)
-
-								// Create and start the reader. We expect the reader to immediately switch to Running state.
-								reg := prometheus.NewPedanticRegistry()
-								readerOpts := append([]readerTestCfgOpt{
-									withFileBasedOffsetEnforcement(fileEnforced),
-									withConsumeFromPositionAtStartup(consumeFromPosition),
-									withConsumeFromTimestampAtStartup(time.Now().UnixMilli()), // For the test where position=timestamp.
-									withTargetAndMaxConsumerLagAtStartup(time.Second, time.Second),
-									withRegistry(reg),
-								}, concurrencyVariant...)
-
-								reader := createReader(t, clusterAddr, topicName, partitionID, consumer, readerOpts...)
-
-								require.NoError(t, services.StartAndAwaitRunning(ctx, reader))
-								t.Cleanup(func() {
-									require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
-								})
-
-								// We expect no record has been consumed.
-								require.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
-									# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
-									# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
-									cortex_ingest_storage_reader_last_consumed_offset{partition="1"} -1
-
-									# HELP cortex_ingest_storage_reader_last_committed_offset The last consumed offset successfully committed by the partition reader. Set to -1 if not offset has been committed yet.
-									# TYPE cortex_ingest_storage_reader_last_committed_offset gauge
-									cortex_ingest_storage_reader_last_committed_offset{partition="1"} -1
-
-									# HELP cortex_ingest_storage_reader_buffered_fetch_records_total Total number of records buffered within the client ready to be consumed
-									# TYPE cortex_ingest_storage_reader_buffered_fetch_records_total gauge
-									cortex_ingest_storage_reader_buffered_fetch_records_total{component="partition-reader"} 0
-								`), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_last_committed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total"))
 							})
 						}
 					})
@@ -1899,20 +1885,17 @@ func TestSingleClusterPartitionReader_ConsumeAtStartup(t *testing.T) {
 	})
 
 	t.Run("should read target lag and then consume more records after switching to 0 ongoing concurrency if position=start, startup_fetch_concurrency=2, ongoing_fetch_concurrency=0", func(t *testing.T) {
-		t.Parallel()
-
 		for _, fileEnforced := range []bool{false, true} {
-			fileEnforced := fileEnforced
 			t.Run(fmt.Sprintf("file_enforced_%v", fileEnforced), func(t *testing.T) {
-				t.Parallel()
+				ctx := t.Context()
 
-				var (
-					cluster, clusterAddr = testkafka.CreateCluster(t, partitionID+1, topicName)
-					fetchRequestsCount   = atomic.NewInt64(0)
-					fetchShouldFail      = atomic.NewBool(true)
-					consumedRecordsMx    sync.Mutex
-					consumedRecords      []string
-				)
+				var vnet kfake.VirtualNetwork
+
+				cluster, clusterAddr := testkafka.CreateCluster(t, partitionID+1, topicName, testkafka.WithVirtualNetwork(&vnet))
+				fetchRequestsCount := atomic.NewInt64(0)
+				fetchShouldFail := atomic.NewBool(true)
+				var consumedRecordsMx sync.Mutex
+				var consumedRecords []string
 
 				consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
 					consumedRecordsMx.Lock()
@@ -1936,7 +1919,7 @@ func TestSingleClusterPartitionReader_ConsumeAtStartup(t *testing.T) {
 				})
 
 				// Produce some records.
-				writeClient := newKafkaProduceClient(t, clusterAddr)
+				writeClient := newKafkaProduceClient(t, clusterAddr, withWriteVirtualNetwork(&vnet))
 				produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-1"))
 				produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-2"))
 				t.Log("produced 2 records")
@@ -1950,11 +1933,12 @@ func TestSingleClusterPartitionReader_ConsumeAtStartup(t *testing.T) {
 					withTargetAndMaxConsumerLagAtStartup(time.Second, 2*time.Second),
 					withRegistry(reg),
 					withLogger(log.NewLogfmtLogger(logs)),
+					withVirtualNetwork(&vnet),
 					withFetchConcurrency(2))
 
 				require.NoError(t, reader.StartAsync(ctx))
 				t.Cleanup(func() {
-					require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
+					require.NoError(t, services.StopAndAwaitTerminated(context.Background(), reader))
 				})
 
 				// Wait until the Kafka cluster received few Fetch requests.
@@ -1987,14 +1971,14 @@ func TestSingleClusterPartitionReader_ConsumeAtStartup(t *testing.T) {
 				// We expect the last consumed offset to be tracked in a metric, and there are no buffered records reported.
 				test.Poll(t, time.Second, nil, func() interface{} {
 					return promtest.GatherAndCompare(reg, strings.NewReader(`
-				# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
-				# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
-				cortex_ingest_storage_reader_last_consumed_offset{partition="1"} 1
+						# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
+						# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
+						cortex_ingest_storage_reader_last_consumed_offset{partition="1"} 1
 
-				# HELP cortex_ingest_storage_reader_buffered_fetch_records_total Total number of records buffered within the client ready to be consumed
-				# TYPE cortex_ingest_storage_reader_buffered_fetch_records_total gauge
-				cortex_ingest_storage_reader_buffered_fetch_records_total{component="partition-reader"} 0
-			`), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total")
+						# HELP cortex_ingest_storage_reader_buffered_fetch_records_total Total number of records buffered within the client ready to be consumed
+						# TYPE cortex_ingest_storage_reader_buffered_fetch_records_total gauge
+						cortex_ingest_storage_reader_buffered_fetch_records_total{component="partition-reader"} 0
+					`), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total")
 				})
 
 				produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-3"))
@@ -2011,14 +1995,14 @@ func TestSingleClusterPartitionReader_ConsumeAtStartup(t *testing.T) {
 				// We expect the last consumed offset to be tracked in a metric, and there are no buffered records reported.
 				test.Poll(t, time.Second, nil, func() interface{} {
 					return promtest.GatherAndCompare(reg, strings.NewReader(`
-				# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
-				# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
-				cortex_ingest_storage_reader_last_consumed_offset{partition="1"} 3
+						# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
+						# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
+						cortex_ingest_storage_reader_last_consumed_offset{partition="1"} 3
 
-				# HELP cortex_ingest_storage_reader_buffered_fetch_records_total Total number of records buffered within the client ready to be consumed
-				# TYPE cortex_ingest_storage_reader_buffered_fetch_records_total gauge
-				cortex_ingest_storage_reader_buffered_fetch_records_total{component="partition-reader"} 0
-			`), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total")
+						# HELP cortex_ingest_storage_reader_buffered_fetch_records_total Total number of records buffered within the client ready to be consumed
+						# TYPE cortex_ingest_storage_reader_buffered_fetch_records_total gauge
+						cortex_ingest_storage_reader_buffered_fetch_records_total{component="partition-reader"} 0
+					`), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total")
 				})
 			})
 		}
@@ -2070,167 +2054,170 @@ func TestSingleClusterPartitionReader_ShouldNotBufferRecordsInTheKafkaClientWhen
 				concurrencyVariant := tt.concurrencyVariant
 
 				t.Run(concurrencyName, func(t *testing.T) {
-					t.Parallel()
+					synctest.Test(t, func(t *testing.T) {
+						var vnet kfake.VirtualNetwork
 
-					var (
-						ctx               = context.Background()
-						_, clusterAddr    = testkafka.CreateCluster(t, partitionID+1, topicName)
-						consumedRecordsMx sync.Mutex
-						consumedRecords   []string
-						blocked           = atomic.NewBool(false)
-					)
+						var (
+							ctx               = context.Background()
+							_, clusterAddr    = testkafka.CreateCluster(t, partitionID+1, topicName, testkafka.WithVirtualNetwork(&vnet))
+							consumedRecordsMx sync.Mutex
+							consumedRecords   []string
+							blocked           = atomic.NewBool(false)
+						)
 
-					consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
-						if blocked.Load() {
-							blockedTicker := time.NewTicker(100 * time.Millisecond)
-							defer blockedTicker.Stop()
+						consumer := consumerFunc(func(_ context.Context, records iter.Seq[*kgo.Record]) error {
+							if blocked.Load() {
+								blockedTicker := time.NewTicker(100 * time.Millisecond)
+								defer blockedTicker.Stop()
 
-							timeoutTimer := time.NewTimer(3 * time.Second)
-							defer timeoutTimer.Stop()
+								timeoutTimer := time.NewTimer(3 * time.Second)
+								defer timeoutTimer.Stop()
 
-						outer:
-							for {
-								select {
-								case <-blockedTicker.C:
-									if !blocked.Load() {
-										break outer
+							outer:
+								for {
+									select {
+									case <-blockedTicker.C:
+										if !blocked.Load() {
+											break outer
+										}
+									case <-timeoutTimer.C:
+										// This is basically a test failure as we never finish the test in time.
+										t.Log("failed to finish unblocking the consumer in time")
+										return nil
 									}
-								case <-timeoutTimer.C:
-									// This is basically a test failure as we never finish the test in time.
-									t.Log("failed to finish unblocking the consumer in time")
-									return nil
 								}
 							}
-						}
 
-						consumedRecordsMx.Lock()
-						defer consumedRecordsMx.Unlock()
-						for r := range records {
-							consumedRecords = append(consumedRecords, string(r.Value))
-						}
-						return nil
-					})
+							consumedRecordsMx.Lock()
+							defer consumedRecordsMx.Unlock()
+							for r := range records {
+								consumedRecords = append(consumedRecords, string(r.Value))
+							}
+							return nil
+						})
 
-					// Produce some records.
-					writeClient := newKafkaProduceClient(t, clusterAddr)
-					produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-1"))
-					produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-2"))
-					t.Log("produced 2 records")
+						// Produce some records.
+						writeClient := newKafkaProduceClient(t, clusterAddr, withWriteVirtualNetwork(&vnet))
+						produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-1"))
+						produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-2"))
+						t.Log("produced 2 records")
 
-					// Create and start the reader.
-					reg := prometheus.NewPedanticRegistry()
-					logs := &concurrency.SyncBuffer{}
+						// Create and start the reader.
+						reg := prometheus.NewPedanticRegistry()
+						logs := &concurrency.SyncBuffer{}
 
-					readerOpts := append([]readerTestCfgOpt{
-						withFileBasedOffsetEnforcement(fileEnforced),
-						withConsumeFromPositionAtStartup(consumeFromStart),
-						withTargetAndMaxConsumerLagAtStartup(time.Second, 2*time.Second),
-						withRegistry(reg),
-						withLogger(log.NewLogfmtLogger(logs)),
-						withMaxBufferedBytes(maxBufferedBytes),
-					}, concurrencyVariant...)
+						readerOpts := append([]readerTestCfgOpt{
+							withFileBasedOffsetEnforcement(fileEnforced),
+							withConsumeFromPositionAtStartup(consumeFromStart),
+							withTargetAndMaxConsumerLagAtStartup(time.Second, 2*time.Second),
+							withRegistry(reg),
+							withLogger(log.NewLogfmtLogger(logs)),
+							withMaxBufferedBytes(maxBufferedBytes),
+							withVirtualNetwork(&vnet),
+						}, concurrencyVariant...)
 
-					reader := createReader(t, clusterAddr, topicName, partitionID, consumer, readerOpts...)
-					require.NoError(t, reader.StartAsync(ctx))
-					t.Cleanup(func() {
-						require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
-					})
+						reader := createReader(t, clusterAddr, topicName, partitionID, consumer, readerOpts...)
+						require.NoError(t, reader.StartAsync(ctx))
+						t.Cleanup(func() {
+							require.NoError(t, services.StopAndAwaitTerminated(ctx, reader))
+						})
 
-					// We expect the reader to catch up, and then switch to Running state.
-					test.Poll(t, 5*time.Second, services.Running, func() interface{} {
-						return reader.State()
-					})
+						// We expect the reader to catch up, and then switch to Running state.
+						test.Poll(t, 5*time.Second, services.Running, func() interface{} {
+							return reader.State()
+						})
 
-					// We expect the reader to have switched to running because target consumer lag has been honored.
-					assert.Contains(t, logs.String(), "partition reader consumed partition and current lag is lower than configured target consumer lag")
+						// We expect the reader to have switched to running because target consumer lag has been honored.
+						assert.Contains(t, logs.String(), "partition reader consumed partition and current lag is lower than configured target consumer lag")
 
-					// We expect the reader to have consumed the partition from start.
-					test.Poll(t, time.Second, []string{"record-1", "record-2"}, func() interface{} {
-						consumedRecordsMx.Lock()
-						defer consumedRecordsMx.Unlock()
-						return slices.Clone(consumedRecords)
-					})
+						// We expect the reader to have consumed the partition from start.
+						test.Poll(t, time.Second, []string{"record-1", "record-2"}, func() interface{} {
+							consumedRecordsMx.Lock()
+							defer consumedRecordsMx.Unlock()
+							return slices.Clone(consumedRecords)
+						})
 
-					// Wait some time to give some time for the Kafka client to eventually read and buffer records.
-					// We don't expect it, but to make sure it's not happening we have to give it some time.
-					time.Sleep(time.Second)
+						// Wait some time to give some time for the Kafka client to eventually read and buffer records.
+						// We don't expect it, but to make sure it's not happening we have to give it some time.
+						time.Sleep(time.Second)
 
-					// We expect the last consumed offset to be tracked in a metric, and there are no buffered records reported.
-					test.Poll(t, time.Second, nil, func() interface{} {
-						return promtest.GatherAndCompare(reg, strings.NewReader(`
-				# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
-				# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
-				cortex_ingest_storage_reader_last_consumed_offset{partition="1"} 1
+						// We expect the last consumed offset to be tracked in a metric, and there are no buffered records reported.
+						test.Poll(t, time.Second, nil, func() interface{} {
+							return promtest.GatherAndCompare(reg, strings.NewReader(`
+					# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
+					# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
+					cortex_ingest_storage_reader_last_consumed_offset{partition="1"} 1
 
-				# HELP cortex_ingest_storage_reader_buffered_fetch_records_total Total number of records buffered within the client ready to be consumed
-				# TYPE cortex_ingest_storage_reader_buffered_fetch_records_total gauge
-				cortex_ingest_storage_reader_buffered_fetch_records_total{component="partition-reader"} 0
+					# HELP cortex_ingest_storage_reader_buffered_fetch_records_total Total number of records buffered within the client ready to be consumed
+					# TYPE cortex_ingest_storage_reader_buffered_fetch_records_total gauge
+					cortex_ingest_storage_reader_buffered_fetch_records_total{component="partition-reader"} 0
 
-        		# HELP cortex_ingest_storage_reader_buffered_fetched_records The number of records fetched from Kafka by both concurrent fetchers and the Kafka client but not yet processed.
-        		# TYPE cortex_ingest_storage_reader_buffered_fetched_records gauge
-        		cortex_ingest_storage_reader_buffered_fetched_records 0
-			`), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total", "cortex_ingest_storage_reader_buffered_fetched_records")
-					})
+	        		# HELP cortex_ingest_storage_reader_buffered_fetched_records The number of records fetched from Kafka by both concurrent fetchers and the Kafka client but not yet processed.
+	        		# TYPE cortex_ingest_storage_reader_buffered_fetched_records gauge
+	        		cortex_ingest_storage_reader_buffered_fetched_records 0
+				`), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total", "cortex_ingest_storage_reader_buffered_fetched_records")
+						})
 
-					// Now, we want to assert that when the reader does have records buffered the metrics correctly reflect the current state.
-					// First, make the consumer block on the next consumption.
-					blocked.Store(true)
+						// Now, we want to assert that when the reader does have records buffered the metrics correctly reflect the current state.
+						// First, make the consumer block on the next consumption.
+						blocked.Store(true)
 
-					// Now, produce more records after the reader has started.
-					produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-3"))
-					produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-4"))
-					t.Log("produced 2 records")
+						// Now, produce more records after the reader has started.
+						produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-3"))
+						produceRecord(ctx, t, writeClient, topicName, partitionID, []byte("record-4"))
+						t.Log("produced 2 records")
 
-					// Now, we expect to have some records buffered.
-					test.Poll(t, time.Second, nil, func() interface{} {
-						return promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
-				# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
-				# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
-				cortex_ingest_storage_reader_last_consumed_offset{partition="1"} 1
+						// Now, we expect to have some records buffered.
+						test.Poll(t, time.Second, nil, func() interface{} {
+							return promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
+					# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
+					# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
+					cortex_ingest_storage_reader_last_consumed_offset{partition="1"} 1
 
-				# HELP cortex_ingest_storage_reader_buffered_fetch_records_total Total number of records buffered within the client ready to be consumed
-				# TYPE cortex_ingest_storage_reader_buffered_fetch_records_total gauge
-				cortex_ingest_storage_reader_buffered_fetch_records_total{component="partition-reader"} %d
+					# HELP cortex_ingest_storage_reader_buffered_fetch_records_total Total number of records buffered within the client ready to be consumed
+					# TYPE cortex_ingest_storage_reader_buffered_fetch_records_total gauge
+					cortex_ingest_storage_reader_buffered_fetch_records_total{component="partition-reader"} %d
 
-        		# HELP cortex_ingest_storage_reader_buffered_fetched_records The number of records fetched from Kafka by both concurrent fetchers and the Kafka client but not yet processed.
-        		# TYPE cortex_ingest_storage_reader_buffered_fetched_records gauge
-        		cortex_ingest_storage_reader_buffered_fetched_records %d
+	        		# HELP cortex_ingest_storage_reader_buffered_fetched_records The number of records fetched from Kafka by both concurrent fetchers and the Kafka client but not yet processed.
+	        		# TYPE cortex_ingest_storage_reader_buffered_fetched_records gauge
+	        		cortex_ingest_storage_reader_buffered_fetched_records %d
 
-        		# HELP cortex_ingest_storage_reader_buffered_fetched_bytes The number of bytes fetched or requested from Kafka by both concurrent fetchers and the Kafka client but not yet processed. The value depends on -ingest-storage.kafka.use-compressed-bytes-as-fetch-max-bytes.
-        		# TYPE cortex_ingest_storage_reader_buffered_fetched_bytes gauge
-        		cortex_ingest_storage_reader_buffered_fetched_bytes %d
-			`, tt.expectedBufferedRecordsFromClient, tt.expectedBufferedRecords, tt.expectedBufferedBytes)), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total", "cortex_ingest_storage_reader_buffered_fetched_records", "cortex_ingest_storage_reader_buffered_fetched_bytes")
-					})
+	        		# HELP cortex_ingest_storage_reader_buffered_fetched_bytes The number of bytes fetched or requested from Kafka by both concurrent fetchers and the Kafka client but not yet processed. The value depends on -ingest-storage.kafka.use-compressed-bytes-as-fetch-max-bytes.
+	        		# TYPE cortex_ingest_storage_reader_buffered_fetched_bytes gauge
+	        		cortex_ingest_storage_reader_buffered_fetched_bytes %d
+				`, tt.expectedBufferedRecordsFromClient, tt.expectedBufferedRecords, tt.expectedBufferedBytes)), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total", "cortex_ingest_storage_reader_buffered_fetched_records", "cortex_ingest_storage_reader_buffered_fetched_bytes")
+						})
 
-					// With that assertion done, we can unblock records consumption.
-					blocked.Store(false)
+						// With that assertion done, we can unblock records consumption.
+						blocked.Store(false)
 
-					// We expect the reader to consume subsequent records too.
-					test.Poll(t, time.Second, []string{"record-1", "record-2", "record-3", "record-4"}, func() interface{} {
-						consumedRecordsMx.Lock()
-						defer consumedRecordsMx.Unlock()
-						return slices.Clone(consumedRecords)
-					})
+						// We expect the reader to consume subsequent records too.
+						test.Poll(t, time.Second, []string{"record-1", "record-2", "record-3", "record-4"}, func() interface{} {
+							consumedRecordsMx.Lock()
+							defer consumedRecordsMx.Unlock()
+							return slices.Clone(consumedRecords)
+						})
 
-					// Wait some time to give some time for the Kafka client to eventually read and buffer records.
-					// We don't expect it, but to make sure it's not happening we have to give it some time.
-					time.Sleep(time.Second)
+						// Wait some time to give some time for the Kafka client to eventually read and buffer records.
+						// We don't expect it, but to make sure it's not happening we have to give it some time.
+						time.Sleep(time.Second)
 
-					// We expect the last consumed offset to be tracked in a metric, and there are no buffered records reported.
-					test.Poll(t, time.Second, nil, func() interface{} {
-						return promtest.GatherAndCompare(reg, strings.NewReader(`
-				# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
-				# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
-				cortex_ingest_storage_reader_last_consumed_offset{partition="1"} 3
+						// We expect the last consumed offset to be tracked in a metric, and there are no buffered records reported.
+						test.Poll(t, time.Second, nil, func() interface{} {
+							return promtest.GatherAndCompare(reg, strings.NewReader(`
+					# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
+					# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
+					cortex_ingest_storage_reader_last_consumed_offset{partition="1"} 3
 
-				# HELP cortex_ingest_storage_reader_buffered_fetch_records_total Total number of records buffered within the client ready to be consumed
-				# TYPE cortex_ingest_storage_reader_buffered_fetch_records_total gauge
-				cortex_ingest_storage_reader_buffered_fetch_records_total{component="partition-reader"} 0
+					# HELP cortex_ingest_storage_reader_buffered_fetch_records_total Total number of records buffered within the client ready to be consumed
+					# TYPE cortex_ingest_storage_reader_buffered_fetch_records_total gauge
+					cortex_ingest_storage_reader_buffered_fetch_records_total{component="partition-reader"} 0
 
-        		# HELP cortex_ingest_storage_reader_buffered_fetched_records The number of records fetched from Kafka by both concurrent fetchers and the Kafka client but not yet processed.
-        		# TYPE cortex_ingest_storage_reader_buffered_fetched_records gauge
-        		cortex_ingest_storage_reader_buffered_fetched_records 0
-			`), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total", "cortex_ingest_storage_reader_buffered_fetched_records")
+	        		# HELP cortex_ingest_storage_reader_buffered_fetched_records The number of records fetched from Kafka by both concurrent fetchers and the Kafka client but not yet processed.
+	        		# TYPE cortex_ingest_storage_reader_buffered_fetched_records gauge
+	        		cortex_ingest_storage_reader_buffered_fetched_records 0
+				`), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total", "cortex_ingest_storage_reader_buffered_fetched_records")
+						})
 					})
 				})
 			}
@@ -2901,8 +2888,6 @@ func TestSingleClusterPartitionReader_getStartOffset_RetentionPeriodFallback(t *
 }
 
 func TestPartitionCommitter(t *testing.T) {
-	t.Parallel()
-
 	const (
 		topicName     = "test-topic"
 		consumerGroup = "test-group"
@@ -2910,85 +2895,89 @@ func TestPartitionCommitter(t *testing.T) {
 	)
 
 	t.Run("should keep trying to commit offset if the last commit failed, even if the offset has not been incremented", func(t *testing.T) {
-		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			var vnet kfake.VirtualNetwork
 
-		cluster, clusterAddr := testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, partitionID+1, topicName)
+			cluster, clusterAddr := testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, partitionID+1, topicName, testkafka.WithVirtualNetwork(&vnet))
 
-		// Mock the cluster to control OffsetCommit request.
-		commitRequestsCount := atomic.NewInt64(0)
-		commitRequestsShouldFail := atomic.NewBool(true)
+			// Mock the cluster to control OffsetCommit request.
+			commitRequestsCount := atomic.NewInt64(0)
+			commitRequestsShouldFail := atomic.NewBool(true)
 
-		cluster.ControlKey(kmsg.OffsetCommit.Int16(), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
-			cluster.KeepControl()
+			cluster.ControlKey(kmsg.OffsetCommit.Int16(), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+				cluster.KeepControl()
+				commitRequestsCount.Inc()
 
-			res := kreq.ResponseKind().(*kmsg.OffsetCommitResponse)
-			res.Default()
+				res := kreq.ResponseKind().(*kmsg.OffsetCommitResponse)
+				res.Default()
 
-			if commitRequestsShouldFail.Load() {
-				res.Topics = []kmsg.OffsetCommitResponseTopic{
-					{Topic: topicName, TopicID: cluster.TopicInfo(topicName).TopicID, Partitions: []kmsg.OffsetCommitResponseTopicPartition{{Partition: partitionID, ErrorCode: kerr.InvalidCommitOffsetSize.Code}}},
+				if commitRequestsShouldFail.Load() {
+					res.Topics = []kmsg.OffsetCommitResponseTopic{
+						{Topic: topicName, TopicID: cluster.TopicInfo(topicName).TopicID, Partitions: []kmsg.OffsetCommitResponseTopicPartition{{Partition: partitionID, ErrorCode: kerr.InvalidCommitOffsetSize.Code}}},
+					}
+				} else {
+					res.Topics = []kmsg.OffsetCommitResponseTopic{
+						{Topic: topicName, TopicID: cluster.TopicInfo(topicName).TopicID, Partitions: []kmsg.OffsetCommitResponseTopicPartition{{Partition: partitionID}}},
+					}
 				}
-			} else {
-				res.Topics = []kmsg.OffsetCommitResponseTopic{
-					{Topic: topicName, TopicID: cluster.TopicInfo(topicName).TopicID, Partitions: []kmsg.OffsetCommitResponseTopicPartition{{Partition: partitionID}}},
-				}
-			}
 
-			return res, nil, true
+				return res, nil, true
+			})
+
+			logger := mimirtest.NewTestingLogger(t)
+			cfg := createTestKafkaConfig(clusterAddr, topicName)
+			cfg.Dialer = vnet.DialContext
+			client, err := kgo.NewClient(commonKafkaClientOptions(cfg, nil, logger)...)
+			require.NoError(t, err)
+			t.Cleanup(client.Close)
+
+			adm := kadm.NewClient(client)
+			reg := prometheus.NewPedanticRegistry()
+			offsetFile := newOffsetFile(filepath.Join(t.TempDir(), "offset.json"), partitionID, log.NewNopLogger())
+
+			committer := newPartitionCommitter(cfg, adm, partitionID, consumerGroup, &NoOpPreCommitNotifier{}, offsetFile, logger, reg)
+			require.NoError(t, services.StartAndAwaitRunning(t.Context(), committer))
+			t.Cleanup(func() {
+				require.NoError(t, services.StopAndAwaitTerminated(context.Background(), committer))
+			})
+
+			committer.enqueueOffset(123)
+
+			// Since we mocked the Kafka cluster to fail the OffsetCommit requests, we wait until the
+			// first failure is tracked by the partition committer.
+			require.Eventually(t, func() bool {
+				return promtest.ToFloat64(committer.commitFailuresTotal) > 0
+			}, 5*time.Second, 10*time.Millisecond)
+
+			// At least 1 commit failed. Now we unblock it.
+			commitRequestsShouldFail.Store(false)
+
+			// Now we expect the commit to succeed, once the committer will trigger the commit the next interval.
+			test.Poll(t, 10*cfg.ConsumerGroupOffsetCommitInterval, nil, func() interface{} {
+				return promtest.GatherAndCompare(reg, strings.NewReader(`
+					# HELP cortex_ingest_storage_reader_last_committed_offset The last consumed offset successfully committed by the partition reader. Set to -1 if not offset has been committed yet.
+					# TYPE cortex_ingest_storage_reader_last_committed_offset gauge
+					cortex_ingest_storage_reader_last_committed_offset{partition="1"} 123
+
+					# HELP cortex_ingest_storage_reader_offset_commit_failures_total Total number of failed requests to commit the last consumed offset.
+					# TYPE cortex_ingest_storage_reader_offset_commit_failures_total counter
+					cortex_ingest_storage_reader_offset_commit_failures_total{partition="1"} 1
+
+					# HELP cortex_ingest_storage_reader_offset_commit_requests_total Total number of requests issued to commit the last consumed offset (includes both successful and failed requests).
+					# TYPE cortex_ingest_storage_reader_offset_commit_requests_total counter
+					cortex_ingest_storage_reader_offset_commit_requests_total{partition="1"} 2
+				`),
+					"cortex_ingest_storage_reader_offset_commit_requests_total",
+					"cortex_ingest_storage_reader_offset_commit_failures_total",
+					"cortex_ingest_storage_reader_last_committed_offset")
+			})
+
+			// Since we haven't enqueued any other offset and the last enqueued one has been successfully committed,
+			// we expect the committer to not issue any other request in the future.
+			expectedRequestsCount := commitRequestsCount.Load()
+			time.Sleep(3 * cfg.ConsumerGroupOffsetCommitInterval)
+			assert.Equal(t, expectedRequestsCount, commitRequestsCount.Load())
 		})
-
-		logger := mimirtest.NewTestingLogger(t)
-		cfg := createTestKafkaConfig(clusterAddr, topicName)
-		client, err := kgo.NewClient(commonKafkaClientOptions(cfg, nil, logger)...)
-		require.NoError(t, err)
-		t.Cleanup(client.Close)
-
-		adm := kadm.NewClient(client)
-		reg := prometheus.NewPedanticRegistry()
-		offsetFile := newOffsetFile(filepath.Join(t.TempDir(), "offset.json"), partitionID, log.NewNopLogger())
-
-		committer := newPartitionCommitter(cfg, adm, partitionID, consumerGroup, &NoOpPreCommitNotifier{}, offsetFile, logger, reg)
-		require.NoError(t, services.StartAndAwaitRunning(context.Background(), committer))
-		t.Cleanup(func() {
-			require.NoError(t, services.StopAndAwaitTerminated(context.Background(), committer))
-		})
-
-		committer.enqueueOffset(123)
-
-		// Since we mocked the Kafka cluster to fail the OffsetCommit requests, we wait until the
-		// first failure is tracked by the partition committer.
-		require.Eventually(t, func() bool {
-			return promtest.ToFloat64(committer.commitFailuresTotal) > 0
-		}, 5*time.Second, 10*time.Millisecond)
-
-		// At least 1 commit failed. Now we unblock it.
-		commitRequestsShouldFail.Store(false)
-
-		// Now we expect the commit to succeed, once the committer will trigger the commit the next interval.
-		test.Poll(t, 10*cfg.ConsumerGroupOffsetCommitInterval, nil, func() interface{} {
-			return promtest.GatherAndCompare(reg, strings.NewReader(`
-				# HELP cortex_ingest_storage_reader_last_committed_offset The last consumed offset successfully committed by the partition reader. Set to -1 if not offset has been committed yet.
-				# TYPE cortex_ingest_storage_reader_last_committed_offset gauge
-				cortex_ingest_storage_reader_last_committed_offset{partition="1"} 123
-
-				# HELP cortex_ingest_storage_reader_offset_commit_failures_total Total number of failed requests to commit the last consumed offset.
-				# TYPE cortex_ingest_storage_reader_offset_commit_failures_total counter
-				cortex_ingest_storage_reader_offset_commit_failures_total{partition="1"} 1
-
-				# HELP cortex_ingest_storage_reader_offset_commit_requests_total Total number of requests issued to commit the last consumed offset (includes both successful and failed requests).
-				# TYPE cortex_ingest_storage_reader_offset_commit_requests_total counter
-				cortex_ingest_storage_reader_offset_commit_requests_total{partition="1"} 2
-			`),
-				"cortex_ingest_storage_reader_offset_commit_requests_total",
-				"cortex_ingest_storage_reader_offset_commit_failures_total",
-				"cortex_ingest_storage_reader_last_committed_offset")
-		})
-
-		// Since we haven't enqueued any other offset and the last enqueued one has been successfully committed,
-		// we expect the committer to not issue any other request in the future.
-		expectedRequestsCount := commitRequestsCount.Load()
-		time.Sleep(3 * cfg.ConsumerGroupOffsetCommitInterval)
-		assert.Equal(t, expectedRequestsCount, commitRequestsCount.Load())
 	})
 }
 
@@ -3250,6 +3239,12 @@ func withWriteTimeout(timeout time.Duration) writerTestCfgOpt {
 	}
 }
 
+func withWriteVirtualNetwork(vnet *kfake.VirtualNetwork) writerTestCfgOpt {
+	return func(cfg *KafkaConfig) {
+		cfg.Dialer = vnet.DialContext
+	}
+}
+
 func newKafkaProduceClient(t *testing.T, addrs string, opts ...writerTestCfgOpt) *kgo.Client {
 	// Configure it close to the writer client we use in the real producers, but
 	// do not configure the linger to keep tests running fast.
@@ -3413,6 +3408,12 @@ func withReplayFromDurationWhenFileOffsetMissing(period time.Duration) readerTes
 func withOffsetFilePath(path string) readerTestCfgOpt {
 	return func(cfg *readerTestCfg) {
 		cfg.offsetFilePath = path
+	}
+}
+
+func withVirtualNetwork(vnet *kfake.VirtualNetwork) readerTestCfgOpt {
+	return func(cfg *readerTestCfg) {
+		cfg.kafka.Dialer = vnet.DialContext
 	}
 }
 

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -1664,13 +1664,6 @@ func TestSingleClusterPartitionReader_ConsumeAtStartup(t *testing.T) {
 		for concurrencyName, concurrencyVariant := range concurrencyVariants {
 			t.Run(concurrencyName, func(t *testing.T) {
 				synctest.Test(t, func(t *testing.T) {
-					// Today this flakes: on some interleavings, when the reader shuts down it closes the franz-go
-					// client, and the client's Close->stopSession blocks forever because franz-go busy-re-queues the
-					// unresolved offset loads instead of draining them. So the service never reaches Failed and
-					// synctest's clock freezes. In franz-go the Client should not re-queue offset loads once the
-					// session context is done.
-					t.Skip("franz-go: the test requires a fix in the library")
-
 					ctx := t.Context()
 
 					var vnet kfake.VirtualNetwork

--- a/pkg/storage/ingest/reader_test.go
+++ b/pkg/storage/ingest/reader_test.go
@@ -2137,18 +2137,18 @@ func TestSingleClusterPartitionReader_ShouldNotBufferRecordsInTheKafkaClientWhen
 						// We expect the last consumed offset to be tracked in a metric, and there are no buffered records reported.
 						test.Poll(t, time.Second, nil, func() interface{} {
 							return promtest.GatherAndCompare(reg, strings.NewReader(`
-					# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
-					# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
-					cortex_ingest_storage_reader_last_consumed_offset{partition="1"} 1
+								# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
+								# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
+								cortex_ingest_storage_reader_last_consumed_offset{partition="1"} 1
 
-					# HELP cortex_ingest_storage_reader_buffered_fetch_records_total Total number of records buffered within the client ready to be consumed
-					# TYPE cortex_ingest_storage_reader_buffered_fetch_records_total gauge
-					cortex_ingest_storage_reader_buffered_fetch_records_total{component="partition-reader"} 0
+								# HELP cortex_ingest_storage_reader_buffered_fetch_records_total Total number of records buffered within the client ready to be consumed
+								# TYPE cortex_ingest_storage_reader_buffered_fetch_records_total gauge
+								cortex_ingest_storage_reader_buffered_fetch_records_total{component="partition-reader"} 0
 
-	        		# HELP cortex_ingest_storage_reader_buffered_fetched_records The number of records fetched from Kafka by both concurrent fetchers and the Kafka client but not yet processed.
-	        		# TYPE cortex_ingest_storage_reader_buffered_fetched_records gauge
-	        		cortex_ingest_storage_reader_buffered_fetched_records 0
-				`), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total", "cortex_ingest_storage_reader_buffered_fetched_records")
+								# HELP cortex_ingest_storage_reader_buffered_fetched_records The number of records fetched from Kafka by both concurrent fetchers and the Kafka client but not yet processed.
+								# TYPE cortex_ingest_storage_reader_buffered_fetched_records gauge
+								cortex_ingest_storage_reader_buffered_fetched_records 0
+							`), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total", "cortex_ingest_storage_reader_buffered_fetched_records")
 						})
 
 						// Now, we want to assert that when the reader does have records buffered the metrics correctly reflect the current state.
@@ -2163,22 +2163,22 @@ func TestSingleClusterPartitionReader_ShouldNotBufferRecordsInTheKafkaClientWhen
 						// Now, we expect to have some records buffered.
 						test.Poll(t, time.Second, nil, func() interface{} {
 							return promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
-					# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
-					# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
-					cortex_ingest_storage_reader_last_consumed_offset{partition="1"} 1
+								# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
+								# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
+								cortex_ingest_storage_reader_last_consumed_offset{partition="1"} 1
 
-					# HELP cortex_ingest_storage_reader_buffered_fetch_records_total Total number of records buffered within the client ready to be consumed
-					# TYPE cortex_ingest_storage_reader_buffered_fetch_records_total gauge
-					cortex_ingest_storage_reader_buffered_fetch_records_total{component="partition-reader"} %d
+								# HELP cortex_ingest_storage_reader_buffered_fetch_records_total Total number of records buffered within the client ready to be consumed
+								# TYPE cortex_ingest_storage_reader_buffered_fetch_records_total gauge
+								cortex_ingest_storage_reader_buffered_fetch_records_total{component="partition-reader"} %d
 
-	        		# HELP cortex_ingest_storage_reader_buffered_fetched_records The number of records fetched from Kafka by both concurrent fetchers and the Kafka client but not yet processed.
-	        		# TYPE cortex_ingest_storage_reader_buffered_fetched_records gauge
-	        		cortex_ingest_storage_reader_buffered_fetched_records %d
+								# HELP cortex_ingest_storage_reader_buffered_fetched_records The number of records fetched from Kafka by both concurrent fetchers and the Kafka client but not yet processed.
+								# TYPE cortex_ingest_storage_reader_buffered_fetched_records gauge
+								cortex_ingest_storage_reader_buffered_fetched_records %d
 
-	        		# HELP cortex_ingest_storage_reader_buffered_fetched_bytes The number of bytes fetched or requested from Kafka by both concurrent fetchers and the Kafka client but not yet processed. The value depends on -ingest-storage.kafka.use-compressed-bytes-as-fetch-max-bytes.
-	        		# TYPE cortex_ingest_storage_reader_buffered_fetched_bytes gauge
-	        		cortex_ingest_storage_reader_buffered_fetched_bytes %d
-				`, tt.expectedBufferedRecordsFromClient, tt.expectedBufferedRecords, tt.expectedBufferedBytes)), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total", "cortex_ingest_storage_reader_buffered_fetched_records", "cortex_ingest_storage_reader_buffered_fetched_bytes")
+								# HELP cortex_ingest_storage_reader_buffered_fetched_bytes The number of bytes fetched or requested from Kafka by both concurrent fetchers and the Kafka client but not yet processed. The value depends on -ingest-storage.kafka.use-compressed-bytes-as-fetch-max-bytes.
+								# TYPE cortex_ingest_storage_reader_buffered_fetched_bytes gauge
+								cortex_ingest_storage_reader_buffered_fetched_bytes %d
+							`, tt.expectedBufferedRecordsFromClient, tt.expectedBufferedRecords, tt.expectedBufferedBytes)), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total", "cortex_ingest_storage_reader_buffered_fetched_records", "cortex_ingest_storage_reader_buffered_fetched_bytes")
 						})
 
 						// With that assertion done, we can unblock records consumption.
@@ -2198,18 +2198,18 @@ func TestSingleClusterPartitionReader_ShouldNotBufferRecordsInTheKafkaClientWhen
 						// We expect the last consumed offset to be tracked in a metric, and there are no buffered records reported.
 						test.Poll(t, time.Second, nil, func() interface{} {
 							return promtest.GatherAndCompare(reg, strings.NewReader(`
-					# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
-					# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
-					cortex_ingest_storage_reader_last_consumed_offset{partition="1"} 3
+								# HELP cortex_ingest_storage_reader_last_consumed_offset The last offset successfully consumed by the partition reader. Set to -1 if not offset has been consumed yet.
+								# TYPE cortex_ingest_storage_reader_last_consumed_offset gauge
+								cortex_ingest_storage_reader_last_consumed_offset{partition="1"} 3
 
-					# HELP cortex_ingest_storage_reader_buffered_fetch_records_total Total number of records buffered within the client ready to be consumed
-					# TYPE cortex_ingest_storage_reader_buffered_fetch_records_total gauge
-					cortex_ingest_storage_reader_buffered_fetch_records_total{component="partition-reader"} 0
+								# HELP cortex_ingest_storage_reader_buffered_fetch_records_total Total number of records buffered within the client ready to be consumed
+								# TYPE cortex_ingest_storage_reader_buffered_fetch_records_total gauge
+								cortex_ingest_storage_reader_buffered_fetch_records_total{component="partition-reader"} 0
 
-	        		# HELP cortex_ingest_storage_reader_buffered_fetched_records The number of records fetched from Kafka by both concurrent fetchers and the Kafka client but not yet processed.
-	        		# TYPE cortex_ingest_storage_reader_buffered_fetched_records gauge
-	        		cortex_ingest_storage_reader_buffered_fetched_records 0
-				`), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total", "cortex_ingest_storage_reader_buffered_fetched_records")
+								# HELP cortex_ingest_storage_reader_buffered_fetched_records The number of records fetched from Kafka by both concurrent fetchers and the Kafka client but not yet processed.
+								# TYPE cortex_ingest_storage_reader_buffered_fetched_records gauge
+								cortex_ingest_storage_reader_buffered_fetched_records 0
+							`), "cortex_ingest_storage_reader_last_consumed_offset", "cortex_ingest_storage_reader_buffered_fetch_records_total", "cortex_ingest_storage_reader_buffered_fetched_records")
 						})
 					})
 				})

--- a/pkg/storage/ingest/writer_client_test.go
+++ b/pkg/storage/ingest/writer_client_test.go
@@ -165,6 +165,8 @@ func TestKafkaProducer_ProduceSync_ShouldTrackBufferedProduceBytes(t *testing.T)
 }
 
 func testKafkaProducer_ProduceSync_ShouldTrackBufferedProduceBytes(t *testing.T, backend string) {
+	t.Parallel()
+
 	synctest.Test(t, func(t *testing.T) {
 		const (
 			numPartitions = 1
@@ -386,6 +388,8 @@ func testKafkaProducer_ProduceSync_ShouldReturnOneResultPerRecordOnContextCancel
 	)
 
 	t.Run("context is already done before producing", func(t *testing.T) {
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			var vnet kfake.VirtualNetwork
 			_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName, testkafka.WithVirtualNetwork(&vnet))
@@ -413,6 +417,8 @@ func testKafkaProducer_ProduceSync_ShouldReturnOneResultPerRecordOnContextCancel
 	})
 
 	t.Run("context is already done before producing with a non-Canceled cause", func(t *testing.T) {
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			var vnet kfake.VirtualNetwork
 			_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName, testkafka.WithVirtualNetwork(&vnet))
@@ -441,6 +447,8 @@ func testKafkaProducer_ProduceSync_ShouldReturnOneResultPerRecordOnContextCancel
 	})
 
 	t.Run("context is canceled while waiting for produce results", func(t *testing.T) {
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			var vnet kfake.VirtualNetwork
 			cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName, testkafka.WithVirtualNetwork(&vnet))
@@ -519,8 +527,8 @@ func testKafkaProducer_ProduceSync_ShouldReturnOneResultPerRecordOnContextCancel
 }
 
 func TestKafkaProducer_ProduceSync_LatencyShouldBeDrivenByKafkaProduceLatency(t *testing.T) {
-	// Not parallel: this test measures wall-clock produce latency, so contention
-	// with other tests would make it flaky.
+	// Under testing/synctest the latency is measured on the bubble's virtual clock, so it's isolated
+	// from other tests and safe to run in parallel (testKafkaProducer_... calls t.Parallel()).
 	runForEachKafkaBackend(t, testKafkaProducer_ProduceSync_LatencyShouldBeDrivenByKafkaProduceLatency)
 }
 
@@ -550,6 +558,8 @@ func testKafkaProducer_ProduceSync_LatencyShouldBeDrivenByKafkaProduceLatency(t 
 		// in-flight slot, which adds latency on top of the backend latency.
 		produceLatency = 1 * time.Second
 	)
+
+	t.Parallel()
 
 	synctest.Test(t, func(t *testing.T) {
 		ctx := t.Context()

--- a/pkg/storage/ingest/writer_client_test.go
+++ b/pkg/storage/ingest/writer_client_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/go-kit/log"
@@ -18,6 +19,7 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kfake"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
 	"go.uber.org/atomic"
@@ -163,64 +165,67 @@ func TestKafkaProducer_ProduceSync_ShouldTrackBufferedProduceBytes(t *testing.T)
 }
 
 func testKafkaProducer_ProduceSync_ShouldTrackBufferedProduceBytes(t *testing.T, backend string) {
-	const (
-		numPartitions = 1
-		topicName     = "test"
-	)
+	synctest.Test(t, func(t *testing.T) {
+		const (
+			numPartitions = 1
+			topicName     = "test"
+		)
 
-	cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
+		var vnet kfake.VirtualNetwork
+		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName, testkafka.WithVirtualNetwork(&vnet))
 
-	// Configure Kafka to block on Produce requests until the test unblocks it.
-	unblockProduceRequests := make(chan struct{})
-	cluster.ControlKey(int16(kmsg.Produce), func(_ kmsg.Request) (kmsg.Response, error, bool) {
-		<-unblockProduceRequests
-		return nil, nil, false
+		// Configure Kafka to block on Produce requests until the test unblocks it.
+		unblockProduceRequests := make(chan struct{})
+		cluster.ControlKey(int16(kmsg.Produce), func(_ kmsg.Request) (kmsg.Response, error, bool) {
+			<-unblockProduceRequests
+			return nil, nil, false
+		})
+
+		ctx := t.Context()
+		reg := prometheus.NewPedanticRegistry()
+		producer := createTestKafkaProducerForBackend(t, backend, clusterAddr, topicName, reg, withWriteVirtualNetwork(&vnet))
+		client := producer.client
+
+		wg := sync.WaitGroup{}
+
+		// At the beginning, the buffered produced bytes metric should be 0.
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			assert.InDelta(collect, 0, getSummaryQuantileValue(collect, reg, "cortex_ingest_storage_writer_buffered_produce_bytes_distribution", 1), 0.0001)
+		}, time.Second, 100*time.Millisecond)
+
+		// Produce a 1st record.
+		wg.Add(1)
+		client.Produce(ctx, &kgo.Record{Topic: topicName, Key: []byte("test"), Value: []byte("message 1")}, func(_ *kgo.Record, err error) {
+			defer wg.Done()
+			require.NoError(t, err)
+		})
+
+		// Get the expected record size directly from Kafka client.
+		expectedRecordSize := client.BufferedProduceBytes()
+		require.Greater(t, expectedRecordSize, int64(0))
+		t.Logf("expected record size bytes: %d", expectedRecordSize)
+
+		// At this point, the buffered produced bytes metric should have tracked 1 record.
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			assert.InDelta(collect, expectedRecordSize, getSummaryQuantileValue(collect, reg, "cortex_ingest_storage_writer_buffered_produce_bytes_distribution", 1), 0.0001)
+		}, time.Second, 100*time.Millisecond)
+
+		// Produce a 2nd record, while the 1st is still in-flight (because in this test Produce requests are blocked on Kafka side).
+		wg.Add(1)
+		client.Produce(ctx, &kgo.Record{Topic: topicName, Key: []byte("test"), Value: []byte("message 1")}, func(_ *kgo.Record, err error) {
+			defer wg.Done()
+			require.NoError(t, err)
+		})
+
+		// At this point, the buffered produced bytes metric should have tracked 2 records.
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			assert.InDelta(collect, 2*expectedRecordSize, getSummaryQuantileValue(collect, reg, "cortex_ingest_storage_writer_buffered_produce_bytes_distribution", 1), 0.0001)
+		}, time.Second, 100*time.Millisecond)
+
+		// Release Produce requests and wait until done.
+		close(unblockProduceRequests)
+		wg.Wait()
 	})
-
-	ctx := context.Background()
-	reg := prometheus.NewPedanticRegistry()
-	producer := createTestKafkaProducerForBackend(t, backend, clusterAddr, topicName, reg, nil)
-	client := producer.client
-
-	wg := sync.WaitGroup{}
-
-	// At the beginning, the buffered produced bytes metric should be 0.
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assert.InDelta(collect, 0, getSummaryQuantileValue(collect, reg, "cortex_ingest_storage_writer_buffered_produce_bytes_distribution", 1), 0.0001)
-	}, time.Second, 100*time.Millisecond)
-
-	// Produce a 1st record.
-	wg.Add(1)
-	client.Produce(ctx, &kgo.Record{Topic: topicName, Key: []byte("test"), Value: []byte("message 1")}, func(_ *kgo.Record, err error) {
-		defer wg.Done()
-		require.NoError(t, err)
-	})
-
-	// Get the expected record size directly from Kafka client.
-	expectedRecordSize := client.BufferedProduceBytes()
-	require.Greater(t, expectedRecordSize, int64(0))
-	t.Logf("expected record size bytes: %d", expectedRecordSize)
-
-	// At this point, the buffered produced bytes metric should have tracked 1 record.
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assert.InDelta(collect, expectedRecordSize, getSummaryQuantileValue(collect, reg, "cortex_ingest_storage_writer_buffered_produce_bytes_distribution", 1), 0.0001)
-	}, time.Second, 100*time.Millisecond)
-
-	// Produce a 2nd record, while the 1st is still in-flight (because in this test Produce requests are blocked on Kafka side).
-	wg.Add(1)
-	client.Produce(ctx, &kgo.Record{Topic: topicName, Key: []byte("test"), Value: []byte("message 1")}, func(_ *kgo.Record, err error) {
-		defer wg.Done()
-		require.NoError(t, err)
-	})
-
-	// At this point, the buffered produced bytes metric should have tracked 2 records.
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assert.InDelta(collect, 2*expectedRecordSize, getSummaryQuantileValue(collect, reg, "cortex_ingest_storage_writer_buffered_produce_bytes_distribution", 1), 0.0001)
-	}, time.Second, 100*time.Millisecond)
-
-	// Release Produce requests and wait until done.
-	close(unblockProduceRequests)
-	wg.Wait()
 }
 
 func TestKafkaProducer_ProduceSync_ShouldCircuitBreakIfContextIsDone(t *testing.T) {
@@ -381,125 +386,135 @@ func testKafkaProducer_ProduceSync_ShouldReturnOneResultPerRecordOnContextCancel
 	)
 
 	t.Run("context is already done before producing", func(t *testing.T) {
-		_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
+		synctest.Test(t, func(t *testing.T) {
+			var vnet kfake.VirtualNetwork
+			_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName, testkafka.WithVirtualNetwork(&vnet))
 
-		reg := prometheus.NewPedanticRegistry()
-		producer := createTestKafkaProducerForBackend(t, backend, clusterAddr, topicName, reg, nil)
+			reg := prometheus.NewPedanticRegistry()
+			producer := createTestKafkaProducerForBackend(t, backend, clusterAddr, topicName, reg, withWriteVirtualNetwork(&vnet))
 
-		// Cancel the context before producing.
-		cancelCtx, cancel := context.WithCancel(context.Background())
-		cancel()
+			// Cancel the context before producing.
+			cancelCtx, cancel := context.WithCancel(t.Context())
+			cancel()
 
-		records := []*kgo.Record{
-			{Topic: topicName, Key: []byte("key-1"), Value: []byte("message 1")},
-			{Topic: topicName, Key: []byte("key-2"), Value: []byte("message 2")},
-		}
-		res := producer.ProduceSync(cancelCtx, records)
+			records := []*kgo.Record{
+				{Topic: topicName, Key: []byte("key-1"), Value: []byte("message 1")},
+				{Topic: topicName, Key: []byte("key-2"), Value: []byte("message 2")},
+			}
+			res := producer.ProduceSync(cancelCtx, records)
 
-		// We expect one result per input record, each with its Record set and the cancellation error.
-		require.Len(t, res, len(records))
-		for i, r := range res {
-			assert.Same(t, records[i], r.Record)
-			assert.ErrorIs(t, r.Err, context.Canceled)
-		}
+			// We expect one result per input record, each with its Record set and the cancellation error.
+			require.Len(t, res, len(records))
+			for i, r := range res {
+				assert.Same(t, records[i], r.Record)
+				assert.ErrorIs(t, r.Err, context.Canceled)
+			}
+		})
 	})
 
 	t.Run("context is already done before producing with a non-Canceled cause", func(t *testing.T) {
-		_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
+		synctest.Test(t, func(t *testing.T) {
+			var vnet kfake.VirtualNetwork
+			_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName, testkafka.WithVirtualNetwork(&vnet))
 
-		reg := prometheus.NewPedanticRegistry()
-		producer := createTestKafkaProducerForBackend(t, backend, clusterAddr, topicName, reg, nil)
+			reg := prometheus.NewPedanticRegistry()
+			producer := createTestKafkaProducerForBackend(t, backend, clusterAddr, topicName, reg, withWriteVirtualNetwork(&vnet))
 
-		// Cancel the context before producing, with a custom cause that wraps something other than context.Canceled.
-		customCause := errors.New("custom cancellation cause")
-		cancelCtx, cancel := context.WithCancelCause(context.Background())
-		cancel(customCause)
+			// Cancel the context before producing, with a custom cause that wraps something other than context.Canceled.
+			customCause := errors.New("custom cancellation cause")
+			cancelCtx, cancel := context.WithCancelCause(t.Context())
+			cancel(customCause)
 
-		records := []*kgo.Record{
-			{Topic: topicName, Key: []byte("key-1"), Value: []byte("message 1")},
-			{Topic: topicName, Key: []byte("key-2"), Value: []byte("message 2")},
-		}
-		res := producer.ProduceSync(cancelCtx, records)
+			records := []*kgo.Record{
+				{Topic: topicName, Key: []byte("key-1"), Value: []byte("message 1")},
+				{Topic: topicName, Key: []byte("key-2"), Value: []byte("message 2")},
+			}
+			res := producer.ProduceSync(cancelCtx, records)
 
-		// We expect one result per input record, each with its Record set and the custom cause as the underlying error.
-		require.Len(t, res, len(records))
-		for i, r := range res {
-			assert.Same(t, records[i], r.Record)
-			assert.ErrorIs(t, r.Err, customCause)
-		}
+			// We expect one result per input record, each with its Record set and the custom cause as the underlying error.
+			require.Len(t, res, len(records))
+			for i, r := range res {
+				assert.Same(t, records[i], r.Record)
+				assert.ErrorIs(t, r.Err, customCause)
+			}
+		})
 	})
 
 	t.Run("context is canceled while waiting for produce results", func(t *testing.T) {
-		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
+		synctest.Test(t, func(t *testing.T) {
+			var vnet kfake.VirtualNetwork
+			cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName, testkafka.WithVirtualNetwork(&vnet))
 
-		// Block Produce requests until the test unblocks them, so we have time to cancel the context
-		// after records have been buffered.
-		unblockProduceRequests := make(chan struct{})
-		t.Cleanup(func() {
-			// Make sure goroutines blocked on the Kafka cluster are released even if the test fails early.
-			select {
-			case <-unblockProduceRequests:
-			default:
-				close(unblockProduceRequests)
+			// Block Produce requests until the test unblocks them, so we have time to cancel the context
+			// after records have been buffered.
+			unblockProduceRequests := make(chan struct{})
+			t.Cleanup(func() {
+				// Make sure goroutines blocked on the Kafka cluster are released even if the test fails early.
+				select {
+				case <-unblockProduceRequests:
+				default:
+					close(unblockProduceRequests)
+				}
+			})
+			cluster.ControlKey(int16(kmsg.Produce), func(_ kmsg.Request) (kmsg.Response, error, bool) {
+				<-unblockProduceRequests
+				return nil, nil, false
+			})
+
+			reg := prometheus.NewPedanticRegistry()
+			producer := createTestKafkaProducerForBackend(t, backend, clusterAddr, topicName, reg, withWriteVirtualNetwork(&vnet))
+
+			ctx, cancel := context.WithCancel(t.Context())
+			t.Cleanup(cancel)
+
+			records := []*kgo.Record{
+				{Topic: topicName, Key: []byte("key-1"), Value: []byte("message 1")},
+				{Topic: topicName, Key: []byte("key-2"), Value: []byte("message 2")},
 			}
+
+			// Snapshot the input partitions so the assertions below don't read the live records,
+			// which the Kafka client may concurrently mutate after Produce() has been called.
+			expectedPartitions := make([]int32, len(records))
+			for i, r := range records {
+				expectedPartitions[i] = r.Partition
+			}
+
+			// Run ProduceSync in a goroutine and cancel the context once records are buffered in the Kafka client.
+			resCh := make(chan kgo.ProduceResults, 1)
+			go func() {
+				resCh <- producer.ProduceSync(ctx, records)
+			}()
+
+			// Once the producer goroutine is durably blocked (records buffered, waiting on the blocked
+			// Produce request), all records are buffered in the Kafka client.
+			synctest.Wait()
+			require.Equal(t, int64(len(records)), producer.BufferedProduceRecords())
+
+			cancel()
+
+			var res kgo.ProduceResults
+			select {
+			case res = <-resCh:
+			case <-time.After(5 * time.Second):
+				t.Fatal("ProduceSync did not return after context cancellation")
+			}
+
+			// We expect one result per input record, each with a non-nil Record carrying the input
+			// partition and the cancellation error. We don't assert pointer equality here: once
+			// records have been handed to the Kafka client, it may concurrently mutate them, so
+			// ProduceSync exposes synthetic records to avoid racing with the client.
+			require.Len(t, res, len(records))
+			for i, r := range res {
+				require.NotNil(t, r.Record)
+				assert.Equal(t, expectedPartitions[i], r.Record.Partition)
+				assert.ErrorIs(t, r.Err, context.Canceled)
+			}
+
+			// Unblock the in-flight produce so cleanup is fast: the Warpstream client's
+			// Close() waits for in-flight flushes, which would otherwise block until the
+			// per-flush WriteTimeout elapses.
+			close(unblockProduceRequests)
 		})
-		cluster.ControlKey(int16(kmsg.Produce), func(_ kmsg.Request) (kmsg.Response, error, bool) {
-			<-unblockProduceRequests
-			return nil, nil, false
-		})
-
-		reg := prometheus.NewPedanticRegistry()
-		producer := createTestKafkaProducerForBackend(t, backend, clusterAddr, topicName, reg, nil)
-
-		ctx, cancel := context.WithCancel(context.Background())
-		t.Cleanup(cancel)
-
-		records := []*kgo.Record{
-			{Topic: topicName, Key: []byte("key-1"), Value: []byte("message 1")},
-			{Topic: topicName, Key: []byte("key-2"), Value: []byte("message 2")},
-		}
-
-		// Snapshot the input partitions so the assertions below don't read the live records,
-		// which the Kafka client may concurrently mutate after Produce() has been called.
-		expectedPartitions := make([]int32, len(records))
-		for i, r := range records {
-			expectedPartitions[i] = r.Partition
-		}
-
-		// Run ProduceSync in a goroutine and cancel the context once records are buffered in the Kafka client.
-		resCh := make(chan kgo.ProduceResults, 1)
-		go func() {
-			resCh <- producer.ProduceSync(ctx, records)
-		}()
-
-		require.Eventually(t, func() bool {
-			return producer.BufferedProduceRecords() == int64(len(records))
-		}, 5*time.Second, 10*time.Millisecond)
-
-		cancel()
-
-		var res kgo.ProduceResults
-		select {
-		case res = <-resCh:
-		case <-time.After(5 * time.Second):
-			t.Fatal("ProduceSync did not return after context cancellation")
-		}
-
-		// We expect one result per input record, each with a non-nil Record carrying the input
-		// partition and the cancellation error. We don't assert pointer equality here: once
-		// records have been handed to the Kafka client, it may concurrently mutate them, so
-		// ProduceSync exposes synthetic records to avoid racing with the client.
-		require.Len(t, res, len(records))
-		for i, r := range res {
-			require.NotNil(t, r.Record)
-			assert.Equal(t, expectedPartitions[i], r.Record.Partition)
-			assert.ErrorIs(t, r.Err, context.Canceled)
-		}
-
-		// Unblock the in-flight produce so cleanup is fast: the Warpstream client's
-		// Close() waits for in-flight flushes, which would otherwise block until the
-		// per-flush WriteTimeout elapses.
-		close(unblockProduceRequests)
 	})
 }
 
@@ -536,96 +551,97 @@ func testKafkaProducer_ProduceSync_LatencyShouldBeDrivenByKafkaProduceLatency(t 
 		produceLatency = 1 * time.Second
 	)
 
-	// Set a max execution time for this test.
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	t.Cleanup(cancel)
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
 
-	cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
+		var vnet kfake.VirtualNetwork
+		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName, testkafka.WithVirtualNetwork(&vnet))
 
-	// Simulate high latency on Produce requests.
-	cluster.ControlKey(int16(kmsg.Produce), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
-		req := kreq.(*kmsg.ProduceRequest)
+		// Simulate high latency on Produce requests.
+		cluster.ControlKey(int16(kmsg.Produce), func(kreq kmsg.Request) (kmsg.Response, error, bool) {
+			req := kreq.(*kmsg.ProduceRequest)
 
-		numRecords, err := getProduceRequestRecordsCount(req)
-		require.NoError(t, err)
-		highestTimestamp, err := getProduceRequestHighestTimestamp(req)
-		require.NoError(t, err)
+			numRecords, err := getProduceRequestRecordsCount(req)
+			require.NoError(t, err)
+			highestTimestamp, err := getProduceRequestHighestTimestamp(req)
+			require.NoError(t, err)
 
-		// The fake Kafka server we use in unit tests have a single thread control loop. This means that when we
-		// add latency to a request, other requests pipelined on the same connections are not evaluated until
-		// the previous requests are processed.
-		//
-		// In this test we want to simulate the case each Produce takes X time to execute since when it was written
-		// on the wire. We don't have the timestamp when it was sent on the network, so we use the highest record timestamp
-		// as an approximation.
-		simulatedLatency := max(0, produceLatency-time.Since(highestTimestamp))
-		t.Log(time.Now().String(), "Produce - num records:", numRecords, "highestTimestamp:", highestTimestamp.String(), "simulatedLatency:", simulatedLatency)
+			// The fake Kafka server we use in unit tests have a single thread control loop. This means that when we
+			// add latency to a request, other requests pipelined on the same connections are not evaluated until
+			// the previous requests are processed.
+			//
+			// In this test we want to simulate the case each Produce takes X time to execute since when it was written
+			// on the wire. We don't have the timestamp when it was sent on the network, so we use the highest record timestamp
+			// as an approximation.
+			simulatedLatency := max(0, produceLatency-time.Since(highestTimestamp))
+			t.Log(time.Now().String(), "Produce - num records:", numRecords, "highestTimestamp:", highestTimestamp.String(), "simulatedLatency:", simulatedLatency)
 
-		cluster.KeepControl()
-		cluster.SleepControl(func() {
-			select {
-			case <-ctx.Done():
-			case <-time.After(simulatedLatency):
-			}
-		})
-
-		return nil, nil, false
-	})
-
-	reg := prometheus.NewPedanticRegistry()
-	producer := createTestKafkaProducerForBackend(t, backend, clusterAddr, topicName, reg, nil)
-
-	// Generate a random payload to reduce its compression ratio.
-	recordPayload, err := generateRandomBytes(produceRecordSizeBytes)
-	require.NoError(t, err)
-
-	// Produce records at fixed interval.
-	produceLatencySecondsSum := atomic.NewFloat64(0)
-	producerWg := sync.WaitGroup{}
-	producerWg.Add(1)
-
-	go func() {
-		recordsAcked := atomic.NewInt32(0)
-
-		for recordID := 0; recordID < int(produceRecordsTotal); recordID++ {
-			producer.client.Produce(ctx, &kgo.Record{
-				Topic:     topicName,
-				Key:       []byte(tenantID),
-				Value:     recordPayload,
-				Partition: int32(recordID % numPartitions), // Round robin across partitions.
-				Timestamp: time.Now(),
-			}, func(record *kgo.Record, err error) {
-				// Keep track of the latency.
-				produceLatencySecondsSum.Add(time.Since(record.Timestamp).Seconds())
-
-				// We're done once we've got the ACK for all records we produced.
-				if recordsAcked.Inc() >= int32(produceRecordsTotal) {
-					producerWg.Done()
+			cluster.KeepControl()
+			cluster.SleepControl(func() {
+				select {
+				case <-ctx.Done():
+				case <-time.After(simulatedLatency):
 				}
 			})
 
-			// Throttle.
-			select {
-			case <-ctx.Done():
-				// The test timed out. Let's unblock the main test goroutine.
-				producerWg.Done()
-				return
+			return nil, nil, false
+		})
 
-			case <-time.After(produceRecordsInterval):
+		reg := prometheus.NewPedanticRegistry()
+		producer := createTestKafkaProducerForBackend(t, backend, clusterAddr, topicName, reg, withWriteVirtualNetwork(&vnet))
+
+		// Generate a random payload to reduce its compression ratio.
+		recordPayload, err := generateRandomBytes(produceRecordSizeBytes)
+		require.NoError(t, err)
+
+		// Produce records at fixed interval.
+		produceLatencySecondsSum := atomic.NewFloat64(0)
+		producerWg := sync.WaitGroup{}
+		producerWg.Add(1)
+
+		go func() {
+			recordsAcked := atomic.NewInt32(0)
+
+			for recordID := 0; recordID < int(produceRecordsTotal); recordID++ {
+				producer.client.Produce(ctx, &kgo.Record{
+					Topic:     topicName,
+					Key:       []byte(tenantID),
+					Value:     recordPayload,
+					Partition: int32(recordID % numPartitions), // Round robin across partitions.
+					Timestamp: time.Now(),
+				}, func(record *kgo.Record, err error) {
+					// Keep track of the latency.
+					produceLatencySecondsSum.Add(time.Since(record.Timestamp).Seconds())
+
+					// We're done once we've got the ACK for all records we produced.
+					if recordsAcked.Inc() >= int32(produceRecordsTotal) {
+						producerWg.Done()
+					}
+				})
+
+				// Throttle.
+				select {
+				case <-ctx.Done():
+					// The test timed out. Let's unblock the main test goroutine.
+					producerWg.Done()
+					return
+
+				case <-time.After(produceRecordsInterval):
+				}
 			}
-		}
-	}()
+		}()
 
-	// Wait until all records have been produced.
-	producerWg.Wait()
+		// Wait until all records have been produced.
+		producerWg.Wait()
 
-	// Ensure the test didn't timed out.
-	require.NoError(t, ctx.Err())
+		// Ensure the test didn't timed out.
+		require.NoError(t, ctx.Err())
 
-	// We expect the average produce latency to be close to the simulated Kafka produce latency.
-	averageProduceLatencySeconds := produceLatencySecondsSum.Load() / float64(produceRecordsTotal)
-	t.Logf("average produce latency seconds: %.2f", averageProduceLatencySeconds)
-	require.InDelta(t, produceLatency.Seconds(), averageProduceLatencySeconds, 0.5)
+		// We expect the average produce latency to be close to the simulated Kafka produce latency.
+		averageProduceLatencySeconds := produceLatencySecondsSum.Load() / float64(produceRecordsTotal)
+		t.Logf("average produce latency seconds: %.2f", averageProduceLatencySeconds)
+		require.InDelta(t, produceLatency.Seconds(), averageProduceLatencySeconds, 0.5)
+	})
 }
 
 // createTestKafkaProducerForBackend builds a *KafkaProducer for the given backend

--- a/pkg/storage/ingest/writer_test.go
+++ b/pkg/storage/ingest/writer_test.go
@@ -72,6 +72,8 @@ func testWriter_WriteSync(t *testing.T, backend string) {
 	}
 
 	t.Run("should block until data has been committed to storage (WriteRequest stored in a single record)", func(t *testing.T) {
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			ctx := t.Context()
 
@@ -156,6 +158,8 @@ func testWriter_WriteSync(t *testing.T, backend string) {
 	})
 
 	t.Run("should block until data has been committed to storage (WriteRequest stored in multiple records)", func(t *testing.T) {
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			ctx := t.Context()
 
@@ -252,6 +256,8 @@ func testWriter_WriteSync(t *testing.T, backend string) {
 	})
 
 	t.Run("should write to the requested partition", func(t *testing.T) {
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			ctx := t.Context()
 
@@ -303,6 +309,8 @@ func testWriter_WriteSync(t *testing.T, backend string) {
 	})
 
 	t.Run("should interrupt the WriteSync() on context cancelled but other concurrent requests should not fail", func(t *testing.T) {
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			ctx := t.Context()
 
@@ -388,6 +396,8 @@ func testWriter_WriteSync(t *testing.T, backend string) {
 			t.Skipf("Warpstream client doesn't support a max in-flight Produce requests limit by design")
 		}
 
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			ctx := t.Context()
 
@@ -455,6 +465,8 @@ func testWriter_WriteSync(t *testing.T, backend string) {
 	})
 
 	t.Run("should return error on non existing partition", func(t *testing.T) {
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			ctx := t.Context()
 
@@ -484,6 +496,8 @@ func testWriter_WriteSync(t *testing.T, backend string) {
 	})
 
 	t.Run("should return an error and stop retrying sending a record once the write timeout expires", func(t *testing.T) {
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			ctx := t.Context()
 
@@ -535,6 +549,8 @@ func testWriter_WriteSync(t *testing.T, backend string) {
 		if backend != KafkaBackendKafka {
 			t.Skipf("franz-go client specific behaviour")
 		}
+
+		t.Parallel()
 
 		synctest.Test(t, func(t *testing.T) {
 			ctx := t.Context()
@@ -605,6 +621,8 @@ func testWriter_WriteSync(t *testing.T, backend string) {
 	})
 
 	t.Run("should return error if the WriteRequest contains a timeseries which is larger than the maximum allowed record data size", func(t *testing.T) {
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			ctx := t.Context()
 
@@ -699,6 +717,8 @@ func testWriter_WriteSync(t *testing.T, backend string) {
 	})
 
 	t.Run("should not block the WriteSync() because Kafka buffer is full", func(t *testing.T) {
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			ctx := t.Context()
 
@@ -851,6 +871,8 @@ func testWriter_WriteSync(t *testing.T, backend string) {
 	})
 
 	t.Run("should not panic if WriteSync() is called after the writer has been stopped", func(t *testing.T) {
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			ctx := t.Context()
 
@@ -889,6 +911,8 @@ func testWriter_MultiWriteSync(t *testing.T, backend string) {
 	)
 
 	t.Run("should write records to multiple partitions", func(t *testing.T) {
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			ctx := t.Context()
 
@@ -982,6 +1006,8 @@ func testWriter_MultiWriteSync(t *testing.T, backend string) {
 	})
 
 	t.Run("should skip empty requests", func(t *testing.T) {
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			ctx := t.Context()
 
@@ -1059,6 +1085,8 @@ func testWriter_MultiWriteSync(t *testing.T, backend string) {
 	})
 
 	t.Run("should return nil when all partition requests are empty", func(t *testing.T) {
+		t.Parallel()
+
 		synctest.Test(t, func(t *testing.T) {
 			ctx := t.Context()
 

--- a/pkg/storage/ingest/writer_test.go
+++ b/pkg/storage/ingest/writer_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/grafana/dskit/flagext"
@@ -22,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kfake"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
 	"github.com/twmb/franz-go/plugin/kprom"
@@ -52,212 +54,53 @@ func testWriter_WriteSync(t *testing.T, backend string) {
 	)
 
 	var (
-		ctx         = context.Background()
 		multiSeries = []mimirpb.PreallocTimeseries{mockPreallocTimeseries("series_1"), mockPreallocTimeseries("series_2")}
 		series1     = []mimirpb.PreallocTimeseries{mockPreallocTimeseries("series_1")}
 		series2     = []mimirpb.PreallocTimeseries{mockPreallocTimeseries("series_2")}
 		series3     = []mimirpb.PreallocTimeseries{mockPreallocTimeseries("series_3")}
 	)
 
+	newKafkaClient := func(t *testing.T, clusterAddr string, vnet *kfake.VirtualNetwork, topic string, partition int32) *kgo.Client {
+		c, err := kgo.NewClient(
+			kgo.SeedBrokers(clusterAddr),
+			kgo.Dialer(vnet.DialContext),
+			kgo.ConsumePartitions(map[string]map[int32]kgo.Offset{topic: {partition: kgo.NewOffset().AtStart()}}),
+		)
+		require.NoError(t, err)
+		t.Cleanup(c.Close)
+		return c
+	}
+
 	t.Run("should block until data has been committed to storage (WriteRequest stored in a single record)", func(t *testing.T) {
-		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
 
-		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
-		cfg := createTestKafkaConfigForBackend(backend, clusterAddr, topicName)
-		writer, reg := createTestWriter(t, cfg)
+			var vnet kfake.VirtualNetwork
+			cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName, testkafka.WithVirtualNetwork(&vnet))
+			cfg := createTestKafkaConfigForBackend(backend, clusterAddr, topicName)
+			cfg.Dialer = vnet.DialContext
+			writer, reg := createTestWriter(t, cfg)
 
-		produceRequestProcessed := atomic.NewBool(false)
+			produceRequestProcessed := atomic.NewBool(false)
 
-		cluster.ControlKey(int16(kmsg.Produce), func(kmsg.Request) (kmsg.Response, error, bool) {
-			// Add a delay, so that if WriteSync() will not wait then the test will fail.
-			time.Sleep(time.Second)
-			produceRequestProcessed.Store(true)
+			cluster.ControlKey(int16(kmsg.Produce), func(kmsg.Request) (kmsg.Response, error, bool) {
+				// Add a delay, so that if WriteSync() will not wait then the test will fail.
+				time.Sleep(time.Second)
+				produceRequestProcessed.Store(true)
 
-			return nil, nil, false
-		})
+				return nil, nil, false
+			})
 
-		req := &mimirpb.WriteRequest{Timeseries: multiSeries, Metadata: nil, Source: mimirpb.API}
-		inputSize := req.Size()
-		err := writer.WriteSync(ctx, topicName, partitionID, tenantID, req)
-		require.NoError(t, err)
-
-		// Ensure it was processed before returning.
-		assert.True(t, produceRequestProcessed.Load())
-
-		// Read back from Kafka.
-		consumer, err := kgo.NewClient(kgo.SeedBrokers(clusterAddr), kgo.ConsumePartitions(map[string]map[int32]kgo.Offset{topicName: {int32(partitionID): kgo.NewOffset().AtStart()}}))
-		require.NoError(t, err)
-		t.Cleanup(consumer.Close)
-
-		fetchCtx, cancel := context.WithTimeout(ctx, time.Second)
-		t.Cleanup(cancel)
-
-		fetches := consumer.PollFetches(fetchCtx)
-		require.NoError(t, fetches.Err())
-		require.Len(t, fetches.Records(), 1)
-		assert.Equal(t, []byte(tenantID), fetches.Records()[0].Key)
-
-		received := deserializeRecord(t, fetches.Records()[0])
-		require.Len(t, received.Timeseries, len(multiSeries))
-
-		for idx, expected := range multiSeries {
-			assert.Equal(t, expected.Labels, received.Timeseries[idx].Labels)
-			assert.Equal(t, expected.Samples, received.Timeseries[idx].Samples)
-		}
-
-		// Check metrics.
-		assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
-			# HELP cortex_ingest_storage_writer_input_bytes_total Total number of bytes in write requests before conversion to the Kafka record format.
-			# TYPE cortex_ingest_storage_writer_input_bytes_total counter
-			cortex_ingest_storage_writer_input_bytes_total %d
-
-			# HELP cortex_ingest_storage_writer_sent_bytes_total Total number of bytes produced to the Kafka backend.
-			# TYPE cortex_ingest_storage_writer_sent_bytes_total counter
-			cortex_ingest_storage_writer_sent_bytes_total %d
-
-			# HELP cortex_ingest_storage_writer_records_per_write_request The number of records a single per-partition write request has been split into.
-			# TYPE cortex_ingest_storage_writer_records_per_write_request histogram
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="1"} 1
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="2"} 1
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="4"} 1
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="8"} 1
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="16"} 1
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="32"} 1
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="64"} 1
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="128"} 1
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="+Inf"} 1
-			cortex_ingest_storage_writer_records_per_write_request_sum 1
-			cortex_ingest_storage_writer_records_per_write_request_count 1
-
-			# HELP cortex_ingest_storage_writer_produce_records_enqueued_total Total number of Kafka records enqueued to be sent to the Kafka backend (includes records that fail to be successfully sent to the Kafka backend).
-			# TYPE cortex_ingest_storage_writer_produce_records_enqueued_total counter
-			cortex_ingest_storage_writer_produce_records_enqueued_total 1
-		`, inputSize, len(fetches.Records()[0].Value))),
-			"cortex_ingest_storage_writer_input_bytes_total",
-			"cortex_ingest_storage_writer_sent_bytes_total",
-			"cortex_ingest_storage_writer_records_per_write_request",
-			"cortex_ingest_storage_writer_produce_records_enqueued_total"))
-
-		assertHistogramSampleCount(t, reg, "cortex_ingest_storage_writer_serialize_duration_seconds", 1)
-	})
-
-	t.Run("should block until data has been committed to storage (WriteRequest stored in multiple records)", func(t *testing.T) {
-		t.Parallel()
-
-		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
-
-		// Customize the max record size to force splitting the WriteRequest into two records.
-		expectedReq := &mimirpb.WriteRequest{Timeseries: multiSeries, Metadata: nil, Source: mimirpb.API}
-		cfg := createTestKafkaConfigForBackend(backend, clusterAddr, topicName)
-		cfg.ProducerMaxRecordSizeBytes = int(float64(expectedReq.Size()) * 0.8)
-
-		writer, reg := createTestWriter(t, cfg)
-
-		produceRequestProcessed := atomic.NewBool(false)
-		cluster.ControlKey(int16(kmsg.Produce), func(kmsg.Request) (kmsg.Response, error, bool) {
-			// Add a delay, so that if WriteSync() will not wait then the test will fail.
-			time.Sleep(time.Second)
-			produceRequestProcessed.Store(true)
-
-			return nil, nil, false
-		})
-
-		err := writer.WriteSync(ctx, topicName, partitionID, tenantID, expectedReq)
-		require.NoError(t, err)
-
-		// Ensure it was processed before returning.
-		assert.True(t, produceRequestProcessed.Load())
-
-		// Read back from Kafka.
-		consumer, err := kgo.NewClient(kgo.SeedBrokers(clusterAddr), kgo.ConsumePartitions(map[string]map[int32]kgo.Offset{topicName: {int32(partitionID): kgo.NewOffset().AtStart()}}))
-		require.NoError(t, err)
-		t.Cleanup(consumer.Close)
-
-		fetchCtx, cancel := context.WithTimeout(ctx, time.Second)
-		t.Cleanup(cancel)
-
-		// Wait until we received 2 records. The timeout on fetchCtx guarantees it will not wait indefinitely.
-		var records []*kgo.Record
-
-		for len(records) < 2 {
-			fetches := consumer.PollFetches(fetchCtx)
-			require.NoError(t, fetches.Err())
-
-			records = append(records, fetches.Records()...)
-		}
-
-		require.Len(t, records, 2)
-		assert.Equal(t, []byte(tenantID), records[0].Key)
-		assert.Equal(t, []byte(tenantID), records[1].Key)
-
-		actualReq1 := deserializeRecord(t, records[0])
-		actualReq2 := deserializeRecord(t, records[1])
-
-		mergedTimeseries := append(actualReq1.Timeseries, actualReq2.Timeseries...)
-		assert.Equal(t, expectedReq.Timeseries, mergedTimeseries)
-		assert.Equal(t, expectedReq.Source, actualReq1.Source)
-
-		// Check metrics.
-		expectedSentBytes := len(records[0].Value) + len(records[1].Value)
-
-		assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
-			# HELP cortex_ingest_storage_writer_input_bytes_total Total number of bytes in write requests before conversion to the Kafka record format.
-			# TYPE cortex_ingest_storage_writer_input_bytes_total counter
-			cortex_ingest_storage_writer_input_bytes_total %d
-
-			# HELP cortex_ingest_storage_writer_sent_bytes_total Total number of bytes produced to the Kafka backend.
-			# TYPE cortex_ingest_storage_writer_sent_bytes_total counter
-			cortex_ingest_storage_writer_sent_bytes_total %d
-
-			# HELP cortex_ingest_storage_writer_records_per_write_request The number of records a single per-partition write request has been split into.
-			# TYPE cortex_ingest_storage_writer_records_per_write_request histogram
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="1"} 0
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="2"} 1
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="4"} 1
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="8"} 1
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="16"} 1
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="32"} 1
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="64"} 1
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="128"} 1
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="+Inf"} 1
-			cortex_ingest_storage_writer_records_per_write_request_sum 2
-			cortex_ingest_storage_writer_records_per_write_request_count 1
-
-			# HELP cortex_ingest_storage_writer_produce_records_enqueued_total Total number of Kafka records enqueued to be sent to the Kafka backend (includes records that fail to be successfully sent to the Kafka backend).
-			# TYPE cortex_ingest_storage_writer_produce_records_enqueued_total counter
-			cortex_ingest_storage_writer_produce_records_enqueued_total 2
-		`, expectedReq.Size(), expectedSentBytes)),
-			"cortex_ingest_storage_writer_input_bytes_total",
-			"cortex_ingest_storage_writer_sent_bytes_total",
-			"cortex_ingest_storage_writer_records_per_write_request",
-			"cortex_ingest_storage_writer_produce_records_enqueued_total"))
-
-		assertHistogramSampleCount(t, reg, "cortex_ingest_storage_writer_serialize_duration_seconds", 1)
-	})
-
-	t.Run("should write to the requested partition", func(t *testing.T) {
-		t.Parallel()
-
-		seriesPerPartition := map[int32][]mimirpb.PreallocTimeseries{
-			0: series1,
-			1: series2,
-		}
-
-		_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
-		config := createTestKafkaConfigForBackend(backend, clusterAddr, topicName)
-		writer, reg := createTestWriter(t, config)
-
-		// Write to partitions.
-		for partitionID, series := range seriesPerPartition {
-			err := writer.WriteSync(ctx, topicName, partitionID, tenantID, &mimirpb.WriteRequest{Timeseries: series, Metadata: nil, Source: mimirpb.API})
+			req := &mimirpb.WriteRequest{Timeseries: multiSeries, Metadata: nil, Source: mimirpb.API}
+			inputSize := req.Size()
+			err := writer.WriteSync(ctx, topicName, partitionID, tenantID, req)
 			require.NoError(t, err)
-		}
 
-		// Read back from Kafka.
-		for partitionID, expectedSeries := range seriesPerPartition {
-			consumer, err := kgo.NewClient(kgo.SeedBrokers(clusterAddr), kgo.ConsumePartitions(map[string]map[int32]kgo.Offset{topicName: {partitionID: kgo.NewOffset().AtStart()}}))
-			require.NoError(t, err)
-			t.Cleanup(consumer.Close)
+			// Ensure it was processed before returning.
+			assert.True(t, produceRequestProcessed.Load())
+
+			// Read back from Kafka.
+			consumer := newKafkaClient(t, clusterAddr, &vnet, topicName, int32(partitionID))
 
 			fetchCtx, cancel := context.WithTimeout(ctx, time.Second)
 			t.Cleanup(cancel)
@@ -268,497 +111,701 @@ func testWriter_WriteSync(t *testing.T, backend string) {
 			assert.Equal(t, []byte(tenantID), fetches.Records()[0].Key)
 
 			received := deserializeRecord(t, fetches.Records()[0])
-			require.Len(t, received.Timeseries, len(expectedSeries))
+			require.Len(t, received.Timeseries, len(multiSeries))
 
-			for idx, expected := range expectedSeries {
+			for idx, expected := range multiSeries {
 				assert.Equal(t, expected.Labels, received.Timeseries[idx].Labels)
 				assert.Equal(t, expected.Samples, received.Timeseries[idx].Samples)
 			}
-		}
 
-		// Check metrics.
-		assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
-			# HELP cortex_ingest_storage_writer_produce_records_enqueued_total Total number of Kafka records enqueued to be sent to the Kafka backend (includes records that fail to be successfully sent to the Kafka backend).
-			# TYPE cortex_ingest_storage_writer_produce_records_enqueued_total counter
-			cortex_ingest_storage_writer_produce_records_enqueued_total 2
-		`), "cortex_ingest_storage_writer_produce_records_enqueued_total"))
+			// Check metrics.
+			assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
+				# HELP cortex_ingest_storage_writer_input_bytes_total Total number of bytes in write requests before conversion to the Kafka record format.
+				# TYPE cortex_ingest_storage_writer_input_bytes_total counter
+				cortex_ingest_storage_writer_input_bytes_total %d
+
+				# HELP cortex_ingest_storage_writer_sent_bytes_total Total number of bytes produced to the Kafka backend.
+				# TYPE cortex_ingest_storage_writer_sent_bytes_total counter
+				cortex_ingest_storage_writer_sent_bytes_total %d
+
+				# HELP cortex_ingest_storage_writer_records_per_write_request The number of records a single per-partition write request has been split into.
+				# TYPE cortex_ingest_storage_writer_records_per_write_request histogram
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="1"} 1
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="2"} 1
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="4"} 1
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="8"} 1
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="16"} 1
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="32"} 1
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="64"} 1
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="128"} 1
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="+Inf"} 1
+				cortex_ingest_storage_writer_records_per_write_request_sum 1
+				cortex_ingest_storage_writer_records_per_write_request_count 1
+
+				# HELP cortex_ingest_storage_writer_produce_records_enqueued_total Total number of Kafka records enqueued to be sent to the Kafka backend (includes records that fail to be successfully sent to the Kafka backend).
+				# TYPE cortex_ingest_storage_writer_produce_records_enqueued_total counter
+				cortex_ingest_storage_writer_produce_records_enqueued_total 1
+			`, inputSize, len(fetches.Records()[0].Value))),
+				"cortex_ingest_storage_writer_input_bytes_total",
+				"cortex_ingest_storage_writer_sent_bytes_total",
+				"cortex_ingest_storage_writer_records_per_write_request",
+				"cortex_ingest_storage_writer_produce_records_enqueued_total"))
+
+			assertHistogramSampleCount(t, reg, "cortex_ingest_storage_writer_serialize_duration_seconds", 1)
+		})
+	})
+
+	t.Run("should block until data has been committed to storage (WriteRequest stored in multiple records)", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
+
+			var vnet kfake.VirtualNetwork
+			cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName, testkafka.WithVirtualNetwork(&vnet))
+
+			// Customize the max record size to force splitting the WriteRequest into two records.
+			expectedReq := &mimirpb.WriteRequest{Timeseries: multiSeries, Metadata: nil, Source: mimirpb.API}
+			cfg := createTestKafkaConfigForBackend(backend, clusterAddr, topicName)
+			cfg.Dialer = vnet.DialContext
+			cfg.ProducerMaxRecordSizeBytes = int(float64(expectedReq.Size()) * 0.8)
+
+			writer, reg := createTestWriter(t, cfg)
+
+			produceRequestProcessed := atomic.NewBool(false)
+			cluster.ControlKey(int16(kmsg.Produce), func(kmsg.Request) (kmsg.Response, error, bool) {
+				// Add a delay, so that if WriteSync() will not wait then the test will fail.
+				time.Sleep(time.Second)
+				produceRequestProcessed.Store(true)
+
+				return nil, nil, false
+			})
+
+			err := writer.WriteSync(ctx, topicName, partitionID, tenantID, expectedReq)
+			require.NoError(t, err)
+
+			// Ensure it was processed before returning.
+			assert.True(t, produceRequestProcessed.Load())
+
+			// Read back from Kafka.
+			consumer := newKafkaClient(t, clusterAddr, &vnet, topicName, int32(partitionID))
+
+			fetchCtx, cancel := context.WithTimeout(ctx, time.Second)
+			t.Cleanup(cancel)
+
+			// Wait until we received 2 records. The timeout on fetchCtx guarantees it will not wait indefinitely.
+			var records []*kgo.Record
+
+			for len(records) < 2 {
+				fetches := consumer.PollFetches(fetchCtx)
+				require.NoError(t, fetches.Err())
+
+				records = append(records, fetches.Records()...)
+			}
+
+			require.Len(t, records, 2)
+			assert.Equal(t, []byte(tenantID), records[0].Key)
+			assert.Equal(t, []byte(tenantID), records[1].Key)
+
+			actualReq1 := deserializeRecord(t, records[0])
+			actualReq2 := deserializeRecord(t, records[1])
+
+			mergedTimeseries := append(actualReq1.Timeseries, actualReq2.Timeseries...)
+			assert.Equal(t, expectedReq.Timeseries, mergedTimeseries)
+			assert.Equal(t, expectedReq.Source, actualReq1.Source)
+
+			// Check metrics.
+			expectedSentBytes := len(records[0].Value) + len(records[1].Value)
+
+			assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
+				# HELP cortex_ingest_storage_writer_input_bytes_total Total number of bytes in write requests before conversion to the Kafka record format.
+				# TYPE cortex_ingest_storage_writer_input_bytes_total counter
+				cortex_ingest_storage_writer_input_bytes_total %d
+
+				# HELP cortex_ingest_storage_writer_sent_bytes_total Total number of bytes produced to the Kafka backend.
+				# TYPE cortex_ingest_storage_writer_sent_bytes_total counter
+				cortex_ingest_storage_writer_sent_bytes_total %d
+
+				# HELP cortex_ingest_storage_writer_records_per_write_request The number of records a single per-partition write request has been split into.
+				# TYPE cortex_ingest_storage_writer_records_per_write_request histogram
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="1"} 0
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="2"} 1
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="4"} 1
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="8"} 1
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="16"} 1
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="32"} 1
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="64"} 1
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="128"} 1
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="+Inf"} 1
+				cortex_ingest_storage_writer_records_per_write_request_sum 2
+				cortex_ingest_storage_writer_records_per_write_request_count 1
+
+				# HELP cortex_ingest_storage_writer_produce_records_enqueued_total Total number of Kafka records enqueued to be sent to the Kafka backend (includes records that fail to be successfully sent to the Kafka backend).
+				# TYPE cortex_ingest_storage_writer_produce_records_enqueued_total counter
+				cortex_ingest_storage_writer_produce_records_enqueued_total 2
+			`, expectedReq.Size(), expectedSentBytes)),
+				"cortex_ingest_storage_writer_input_bytes_total",
+				"cortex_ingest_storage_writer_sent_bytes_total",
+				"cortex_ingest_storage_writer_records_per_write_request",
+				"cortex_ingest_storage_writer_produce_records_enqueued_total"))
+
+			assertHistogramSampleCount(t, reg, "cortex_ingest_storage_writer_serialize_duration_seconds", 1)
+		})
+	})
+
+	t.Run("should write to the requested partition", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
+
+			seriesPerPartition := map[int32][]mimirpb.PreallocTimeseries{
+				0: series1,
+				1: series2,
+			}
+
+			var vnet kfake.VirtualNetwork
+			_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName, testkafka.WithVirtualNetwork(&vnet))
+			config := createTestKafkaConfigForBackend(backend, clusterAddr, topicName)
+			config.Dialer = vnet.DialContext
+			writer, reg := createTestWriter(t, config)
+
+			// Write to partitions.
+			for partitionID, series := range seriesPerPartition {
+				err := writer.WriteSync(ctx, topicName, partitionID, tenantID, &mimirpb.WriteRequest{Timeseries: series, Metadata: nil, Source: mimirpb.API})
+				require.NoError(t, err)
+			}
+
+			// Read back from Kafka.
+			for partitionID, expectedSeries := range seriesPerPartition {
+				consumer := newKafkaClient(t, clusterAddr, &vnet, topicName, partitionID)
+
+				fetchCtx, cancel := context.WithTimeout(ctx, time.Second)
+				t.Cleanup(cancel)
+
+				fetches := consumer.PollFetches(fetchCtx)
+				require.NoError(t, fetches.Err())
+				require.Len(t, fetches.Records(), 1)
+				assert.Equal(t, []byte(tenantID), fetches.Records()[0].Key)
+
+				received := deserializeRecord(t, fetches.Records()[0])
+				require.Len(t, received.Timeseries, len(expectedSeries))
+
+				for idx, expected := range expectedSeries {
+					assert.Equal(t, expected.Labels, received.Timeseries[idx].Labels)
+					assert.Equal(t, expected.Samples, received.Timeseries[idx].Samples)
+				}
+			}
+
+			// Check metrics.
+			assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
+				# HELP cortex_ingest_storage_writer_produce_records_enqueued_total Total number of Kafka records enqueued to be sent to the Kafka backend (includes records that fail to be successfully sent to the Kafka backend).
+				# TYPE cortex_ingest_storage_writer_produce_records_enqueued_total counter
+				cortex_ingest_storage_writer_produce_records_enqueued_total 2
+			`), "cortex_ingest_storage_writer_produce_records_enqueued_total"))
+		})
 	})
 
 	t.Run("should interrupt the WriteSync() on context cancelled but other concurrent requests should not fail", func(t *testing.T) {
-		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
 
-		var (
-			firstRequest         = atomic.NewBool(true)
-			firstRequestReceived = make(chan struct{})
+			var (
+				firstRequest         = atomic.NewBool(true)
+				firstRequestReceived = make(chan struct{})
 
-			receivedBatchesLengthMx sync.Mutex
-			receivedBatchesLength   []int
-		)
+				receivedBatchesLengthMx sync.Mutex
+				receivedBatchesLength   []int
+			)
 
-		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
-		writer, _ := createTestWriter(t, createTestKafkaConfigForBackend(backend, clusterAddr, topicName))
+			var vnet kfake.VirtualNetwork
+			cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName, testkafka.WithVirtualNetwork(&vnet))
+			cfg := createTestKafkaConfigForBackend(backend, clusterAddr, topicName)
+			cfg.Dialer = vnet.DialContext
+			writer, _ := createTestWriter(t, cfg)
 
-		// Get the underlying Kafka client used by the writer.
-		cluster.ControlKey(int16(kmsg.Produce), func(request kmsg.Request) (kmsg.Response, error, bool) {
-			numRecords, err := getProduceRequestRecordsCount(request.(*kmsg.ProduceRequest))
-			require.NoError(t, err)
+			// Get the underlying Kafka client used by the writer.
+			cluster.ControlKey(int16(kmsg.Produce), func(request kmsg.Request) (kmsg.Response, error, bool) {
+				numRecords, err := getProduceRequestRecordsCount(request.(*kmsg.ProduceRequest))
+				require.NoError(t, err)
 
-			receivedBatchesLengthMx.Lock()
-			receivedBatchesLength = append(receivedBatchesLength, numRecords)
-			receivedBatchesLengthMx.Unlock()
+				receivedBatchesLengthMx.Lock()
+				receivedBatchesLength = append(receivedBatchesLength, numRecords)
+				receivedBatchesLengthMx.Unlock()
 
-			if firstRequest.CompareAndSwap(true, false) {
-				close(firstRequestReceived)
+				if firstRequest.CompareAndSwap(true, false) {
+					close(firstRequestReceived)
 
-				// Introduce a delay on the 1st Produce, keeping it in-flight long
-				// enough for the test to observe the other records buffering behind it.
-				time.Sleep(3 * time.Second)
-			}
+					// Introduce a delay on the 1st Produce, keeping it in-flight long
+					// enough for the test to observe the other records buffering behind it.
+					time.Sleep(3 * time.Second)
+				}
 
-			return nil, nil, false
-		})
+				return nil, nil, false
+			})
 
-		wg := sync.WaitGroup{}
+			wg := sync.WaitGroup{}
 
-		// Write the first record, which is expected to be sent immediately.
-		runAsync(&wg, func() {
-			assert.NoError(t, writer.WriteSync(ctx, topicName, partitionID, tenantID, &mimirpb.WriteRequest{Timeseries: series1, Metadata: nil, Source: mimirpb.API}))
-		})
+			// Write the first record, which is expected to be sent immediately.
+			runAsync(&wg, func() {
+				assert.NoError(t, writer.WriteSync(ctx, topicName, partitionID, tenantID, &mimirpb.WriteRequest{Timeseries: series1, Metadata: nil, Source: mimirpb.API}))
+			})
 
-		// Once the 1st Produce request is received by the server but still processing (there's a sleep),
-		// issue two more requests. One with a short context timeout (expected to expire before the next Produce
-		// request will be sent) and one with no timeout.
+			// Once the 1st Produce request is received by the server but still processing (there's a sleep),
+			// issue two more requests. One with a short context timeout (expected to expire before the next Produce
+			// request will be sent) and one with no timeout.
 
-		runAsyncAfter(&wg, firstRequestReceived, func() {
-			secondRequestCtx, cancelSecondRequest := context.WithTimeout(ctx, 10*time.Millisecond)
-			t.Cleanup(cancelSecondRequest)
+			runAsyncAfter(&wg, firstRequestReceived, func() {
+				secondRequestCtx, cancelSecondRequest := context.WithTimeout(ctx, 10*time.Millisecond)
+				t.Cleanup(cancelSecondRequest)
 
-			assert.ErrorIs(t, writer.WriteSync(secondRequestCtx, topicName, partitionID, tenantID, &mimirpb.WriteRequest{Timeseries: series2, Metadata: nil, Source: mimirpb.API}), context.DeadlineExceeded)
-		})
+				assert.ErrorIs(t, writer.WriteSync(secondRequestCtx, topicName, partitionID, tenantID, &mimirpb.WriteRequest{Timeseries: series2, Metadata: nil, Source: mimirpb.API}), context.DeadlineExceeded)
+			})
 
-		runAsyncAfter(&wg, firstRequestReceived, func() {
-			// Wait until the 2nd request has been buffered, because we want this request to be buffered after it.
-			// The nil check guards against the writer being torn down (which swaps the client to nil) if the
-			// surrounding test fails and runs its cleanup while this goroutine is still polling.
+			runAsyncAfter(&wg, firstRequestReceived, func() {
+				// Wait until the 2nd request has been buffered, because we want this request to be buffered after it.
+				// The nil check guards against the writer being torn down (which swaps the client to nil) if the
+				// surrounding test fails and runs its cleanup while this goroutine is still polling.
+				require.Eventually(t, func() bool {
+					client := writer.client.Load()
+					return client != nil && client.BufferedProduceRecords() == 2
+				}, 2*time.Second, 10*time.Millisecond)
+
+				assert.NoError(t, writer.WriteSync(ctx, topicName, partitionID, tenantID, &mimirpb.WriteRequest{Timeseries: series3, Metadata: nil, Source: mimirpb.API}))
+			})
+
+			// Wait until all 3 requests have been buffered.
 			require.Eventually(t, func() bool {
 				client := writer.client.Load()
-				return client != nil && client.BufferedProduceRecords() == 2
+				return client != nil && client.BufferedProduceRecords() == 3
 			}, 2*time.Second, 10*time.Millisecond)
 
-			assert.NoError(t, writer.WriteSync(ctx, topicName, partitionID, tenantID, &mimirpb.WriteRequest{Timeseries: series3, Metadata: nil, Source: mimirpb.API}))
+			wg.Wait()
+
+			// Cancelling the context doesn't actually prevent that data from being sent to the wire.
+			require.Equal(t, []int{1, 2}, receivedBatchesLength)
 		})
-
-		// Wait until all 3 requests have been buffered.
-		require.Eventually(t, func() bool {
-			client := writer.client.Load()
-			return client != nil && client.BufferedProduceRecords() == 3
-		}, 2*time.Second, 10*time.Millisecond)
-
-		wg.Wait()
-
-		// Cancelling the context doesn't actually prevent that data from being sent to the wire.
-		require.Equal(t, []int{1, 2}, receivedBatchesLength)
 	})
 
 	t.Run("should batch multiple subsequent records together while sending the previous batches to Kafka once max in-flight Produce requests limit has been reached", func(t *testing.T) {
-		t.Parallel()
-
 		if backend == KafkaBackendWarpstream {
 			t.Skipf("Warpstream client doesn't support a max in-flight Produce requests limit by design")
 		}
 
-		var (
-			firstRequest         = atomic.NewBool(true)
-			firstRequestReceived = make(chan struct{})
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
 
-			receivedBatchesLengthMx sync.Mutex
-			receivedBatchesLength   []int
-		)
+			var (
+				firstRequest         = atomic.NewBool(true)
+				firstRequestReceived = make(chan struct{})
 
-		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
+				receivedBatchesLengthMx sync.Mutex
+				receivedBatchesLength   []int
+			)
 
-		// Allow only 1 in-flight Produce request in this test, to easily reproduce the scenario.
-		cfg := createTestKafkaConfigForBackend(backend, clusterAddr, topicName)
-		cfg.MaxInflightProduceRequests = 1
-		writer, _ := createTestWriter(t, cfg)
+			var vnet kfake.VirtualNetwork
+			cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName, testkafka.WithVirtualNetwork(&vnet))
 
-		cluster.ControlKey(int16(kmsg.Produce), func(request kmsg.Request) (kmsg.Response, error, bool) {
-			if firstRequest.CompareAndSwap(true, false) {
-				// The produce request has been received by Kafka, so we can fire the next requests.
-				close(firstRequestReceived)
+			// Allow only 1 in-flight Produce request in this test, to easily reproduce the scenario.
+			cfg := createTestKafkaConfigForBackend(backend, clusterAddr, topicName)
+			cfg.Dialer = vnet.DialContext
+			cfg.MaxInflightProduceRequests = 1
+			writer, _ := createTestWriter(t, cfg)
 
-				// Inject a slowdown on the 1st Produce request received by Kafka to let next produce
-				// records to buffer in the batch on the client side.
-				time.Sleep(time.Second)
-			}
+			cluster.ControlKey(int16(kmsg.Produce), func(request kmsg.Request) (kmsg.Response, error, bool) {
+				if firstRequest.CompareAndSwap(true, false) {
+					// The produce request has been received by Kafka, so we can fire the next requests.
+					close(firstRequestReceived)
 
-			numRecords, err := getProduceRequestRecordsCount(request.(*kmsg.ProduceRequest))
-			assert.NoError(t, err)
+					// Inject a slowdown on the 1st Produce request received by Kafka to let next produce
+					// records to buffer in the batch on the client side.
+					time.Sleep(time.Second)
+				}
 
-			receivedBatchesLengthMx.Lock()
-			receivedBatchesLength = append(receivedBatchesLength, numRecords)
-			receivedBatchesLengthMx.Unlock()
+				numRecords, err := getProduceRequestRecordsCount(request.(*kmsg.ProduceRequest))
+				assert.NoError(t, err)
 
-			return nil, nil, false
+				receivedBatchesLengthMx.Lock()
+				receivedBatchesLength = append(receivedBatchesLength, numRecords)
+				receivedBatchesLengthMx.Unlock()
+
+				return nil, nil, false
+			})
+
+			wg := sync.WaitGroup{}
+
+			runAsync(&wg, func() {
+				assert.NoError(t, writer.WriteSync(ctx, topicName, partitionID, tenantID, &mimirpb.WriteRequest{Timeseries: series1, Metadata: nil, Source: mimirpb.API}))
+			})
+
+			runAsyncAfter(&wg, firstRequestReceived, func() {
+				assert.NoError(t, writer.WriteSync(ctx, topicName, partitionID, tenantID, &mimirpb.WriteRequest{Timeseries: series2, Metadata: nil, Source: mimirpb.API}))
+			})
+
+			runAsyncAfter(&wg, firstRequestReceived, func() {
+				// Ensure the 3rd call to Write() is issued slightly after the 2nd one,
+				// otherwise records may be batched just because of concurrent append to it
+				// and not because it's waiting for the 1st call to complete.
+				time.Sleep(100 * time.Millisecond)
+
+				assert.NoError(t, writer.WriteSync(ctx, topicName, partitionID, tenantID, &mimirpb.WriteRequest{Timeseries: series3, Metadata: nil, Source: mimirpb.API}))
+			})
+
+			wg.Wait()
+
+			// We expect that the next 2 records have been appended to the next batch.
+			require.Equal(t, []int{1, 2}, receivedBatchesLength)
 		})
-
-		wg := sync.WaitGroup{}
-
-		runAsync(&wg, func() {
-			assert.NoError(t, writer.WriteSync(ctx, topicName, partitionID, tenantID, &mimirpb.WriteRequest{Timeseries: series1, Metadata: nil, Source: mimirpb.API}))
-		})
-
-		runAsyncAfter(&wg, firstRequestReceived, func() {
-			assert.NoError(t, writer.WriteSync(ctx, topicName, partitionID, tenantID, &mimirpb.WriteRequest{Timeseries: series2, Metadata: nil, Source: mimirpb.API}))
-		})
-
-		runAsyncAfter(&wg, firstRequestReceived, func() {
-			// Ensure the 3rd call to Write() is issued slightly after the 2nd one,
-			// otherwise records may be batched just because of concurrent append to it
-			// and not because it's waiting for the 1st call to complete.
-			time.Sleep(100 * time.Millisecond)
-
-			assert.NoError(t, writer.WriteSync(ctx, topicName, partitionID, tenantID, &mimirpb.WriteRequest{Timeseries: series3, Metadata: nil, Source: mimirpb.API}))
-		})
-
-		wg.Wait()
-
-		// We expect that the next 2 records have been appended to the next batch.
-		require.Equal(t, []int{1, 2}, receivedBatchesLength)
 	})
 
 	t.Run("should return error on non existing partition", func(t *testing.T) {
-		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
 
-		_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
-		writer, reg := createTestWriter(t, createTestKafkaConfigForBackend(backend, clusterAddr, topicName))
+			var vnet kfake.VirtualNetwork
+			_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName, testkafka.WithVirtualNetwork(&vnet))
+			cfg := createTestKafkaConfigForBackend(backend, clusterAddr, topicName)
+			cfg.Dialer = vnet.DialContext
+			writer, reg := createTestWriter(t, cfg)
 
-		// Write to a non-existing partition.
-		err := writer.WriteSync(ctx, topicName, 100, tenantID, &mimirpb.WriteRequest{Timeseries: multiSeries, Metadata: nil, Source: mimirpb.API})
-		require.Error(t, err)
+			// Write to a non-existing partition.
+			err := writer.WriteSync(ctx, topicName, 100, tenantID, &mimirpb.WriteRequest{Timeseries: multiSeries, Metadata: nil, Source: mimirpb.API})
+			require.Error(t, err)
 
-		// Check metrics.
-		assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
-			# HELP cortex_ingest_storage_writer_produce_records_enqueued_total Total number of Kafka records enqueued to be sent to the Kafka backend (includes records that fail to be successfully sent to the Kafka backend).
-			# TYPE cortex_ingest_storage_writer_produce_records_enqueued_total counter
-			cortex_ingest_storage_writer_produce_records_enqueued_total 1
+			// Check metrics.
+			assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
+				# HELP cortex_ingest_storage_writer_produce_records_enqueued_total Total number of Kafka records enqueued to be sent to the Kafka backend (includes records that fail to be successfully sent to the Kafka backend).
+				# TYPE cortex_ingest_storage_writer_produce_records_enqueued_total counter
+				cortex_ingest_storage_writer_produce_records_enqueued_total 1
 
-			# HELP cortex_ingest_storage_writer_produce_records_failed_total Total number of Kafka records that failed to be sent to the Kafka backend.
-			# TYPE cortex_ingest_storage_writer_produce_records_failed_total counter
-			cortex_ingest_storage_writer_produce_records_failed_total{reason="other"} 1
-		`),
-			"cortex_ingest_storage_writer_produce_records_enqueued_total",
-			"cortex_ingest_storage_writer_produce_records_failed_total"))
+				# HELP cortex_ingest_storage_writer_produce_records_failed_total Total number of Kafka records that failed to be sent to the Kafka backend.
+				# TYPE cortex_ingest_storage_writer_produce_records_failed_total counter
+				cortex_ingest_storage_writer_produce_records_failed_total{reason="other"} 1
+			`),
+				"cortex_ingest_storage_writer_produce_records_enqueued_total",
+				"cortex_ingest_storage_writer_produce_records_failed_total"))
+		})
 	})
 
 	t.Run("should return an error and stop retrying sending a record once the write timeout expires", func(t *testing.T) {
-		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
 
-		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
-		kafkaCfg := createTestKafkaConfigForBackend(backend, clusterAddr, topicName)
-		writer, reg := createTestWriter(t, kafkaCfg)
+			var vnet kfake.VirtualNetwork
+			cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName, testkafka.WithVirtualNetwork(&vnet))
+			kafkaCfg := createTestKafkaConfigForBackend(backend, clusterAddr, topicName)
+			kafkaCfg.Dialer = vnet.DialContext
+			writer, reg := createTestWriter(t, kafkaCfg)
 
-		cluster.ControlKey(int16(kmsg.Produce), func(kmsg.Request) (kmsg.Response, error, bool) {
-			// Keep failing every request. Sleep per attempt so the retry loop
-			// has something meaningful to elapse against.
-			cluster.KeepControl()
-			time.Sleep(kafkaCfg.WriteTimeout / 4)
-			return nil, errors.New("mock error"), true
+			cluster.ControlKey(int16(kmsg.Produce), func(kmsg.Request) (kmsg.Response, error, bool) {
+				// Keep failing every request. Sleep per attempt so the retry loop
+				// has something meaningful to elapse against.
+				cluster.KeepControl()
+				time.Sleep(kafkaCfg.WriteTimeout / 4)
+				return nil, errors.New("mock error"), true
+			})
+
+			startTime := time.Now()
+			require.ErrorIs(t, writer.WriteSync(ctx, topicName, partitionID, tenantID, &mimirpb.WriteRequest{Timeseries: series1, Metadata: nil, Source: mimirpb.API}), kgo.ErrRecordTimeout)
+			elapsedTime := time.Since(startTime)
+
+			// Upper bound applies to both backends: WriteSync must give up within
+			// a few WriteTimeouts. The lower bound only applies to the kafka
+			// backend because the warpstream client's Hedger gives up as soon
+			// as MaxHedgeAgents is exhausted across the candidate pool — which,
+			// against this single-broker kfake cluster, is after one attempt.
+			require.Less(t, elapsedTime, kafkaCfg.WriteTimeout*3)
+			if backend == KafkaBackendKafka {
+				require.Greater(t, elapsedTime, kafkaCfg.WriteTimeout/2)
+			}
+
+			// Check metrics.
+			assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
+				# HELP cortex_ingest_storage_writer_produce_records_enqueued_total Total number of Kafka records enqueued to be sent to the Kafka backend (includes records that fail to be successfully sent to the Kafka backend).
+				# TYPE cortex_ingest_storage_writer_produce_records_enqueued_total counter
+				cortex_ingest_storage_writer_produce_records_enqueued_total 1
+
+				# HELP cortex_ingest_storage_writer_produce_records_failed_total Total number of Kafka records that failed to be sent to the Kafka backend.
+				# TYPE cortex_ingest_storage_writer_produce_records_failed_total counter
+				cortex_ingest_storage_writer_produce_records_failed_total{reason="timeout"} 1
+			`),
+				"cortex_ingest_storage_writer_produce_records_enqueued_total",
+				"cortex_ingest_storage_writer_produce_records_failed_total"))
 		})
-
-		startTime := time.Now()
-		require.ErrorIs(t, writer.WriteSync(ctx, topicName, partitionID, tenantID, &mimirpb.WriteRequest{Timeseries: series1, Metadata: nil, Source: mimirpb.API}), kgo.ErrRecordTimeout)
-		elapsedTime := time.Since(startTime)
-
-		// Upper bound applies to both backends: WriteSync must give up within
-		// a few WriteTimeouts. The lower bound only applies to the kafka
-		// backend because the warpstream client's Hedger gives up as soon
-		// as MaxHedgeAgents is exhausted across the candidate pool — which,
-		// against this single-broker kfake cluster, is after one attempt.
-		require.Less(t, elapsedTime, kafkaCfg.WriteTimeout*3)
-		if backend == KafkaBackendKafka {
-			require.Greater(t, elapsedTime, kafkaCfg.WriteTimeout/2)
-		}
-
-		// Check metrics.
-		assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
-			# HELP cortex_ingest_storage_writer_produce_records_enqueued_total Total number of Kafka records enqueued to be sent to the Kafka backend (includes records that fail to be successfully sent to the Kafka backend).
-			# TYPE cortex_ingest_storage_writer_produce_records_enqueued_total counter
-			cortex_ingest_storage_writer_produce_records_enqueued_total 1
-
-			# HELP cortex_ingest_storage_writer_produce_records_failed_total Total number of Kafka records that failed to be sent to the Kafka backend.
-			# TYPE cortex_ingest_storage_writer_produce_records_failed_total counter
-			cortex_ingest_storage_writer_produce_records_failed_total{reason="timeout"} 1
-		`),
-			"cortex_ingest_storage_writer_produce_records_enqueued_total",
-			"cortex_ingest_storage_writer_produce_records_failed_total"))
 	})
 
 	// This test documents how the franz-go Kafka client works (cascading failures). It's not what we ideally want, but it's how it works.
 	t.Run("should fail all buffered records and close the connection on timeout while waiting for Produce response (franz-go client)", func(t *testing.T) {
-		t.Parallel()
 		if backend != KafkaBackendKafka {
 			t.Skipf("franz-go client specific behaviour")
 		}
 
-		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
-		kafkaCfg := createTestKafkaConfigForBackend(backend, clusterAddr, topicName)
-		writer, _ := createTestWriter(t, kafkaCfg)
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
 
-		var (
-			firstRequest         = atomic.NewBool(true)
-			firstRequestReceived = make(chan struct{})
-			wg                   = sync.WaitGroup{}
-		)
+			var vnet kfake.VirtualNetwork
+			cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName, testkafka.WithVirtualNetwork(&vnet))
+			kafkaCfg := createTestKafkaConfigForBackend(backend, clusterAddr, topicName)
+			kafkaCfg.Dialer = vnet.DialContext
+			writer, _ := createTestWriter(t, kafkaCfg)
 
-		wg.Add(1)
-		cluster.ControlKey(int16(kmsg.Produce), func(kmsg.Request) (kmsg.Response, error, bool) {
-			// Ensure the test waits for this too, since the client request will fail earlier
-			// (if we don't wait, the test will end before this function and then goleak will
-			// report a goroutine leak).
-			defer wg.Done()
+			var (
+				firstRequest         = atomic.NewBool(true)
+				firstRequestReceived = make(chan struct{})
+				wg                   = sync.WaitGroup{}
+			)
 
-			if firstRequest.CompareAndSwap(true, false) {
-				// The produce request has been received by Kafka, so we can fire the next request.
-				close(firstRequestReceived)
+			wg.Add(1)
+			cluster.ControlKey(int16(kmsg.Produce), func(kmsg.Request) (kmsg.Response, error, bool) {
+				// Ensure the test waits for this too, since the client request will fail earlier
+				// (if we don't wait, the test will end before this function and then goleak will
+				// report a goroutine leak).
+				defer wg.Done()
 
-				// Inject a slowdown on the 1st Produce request received by Kafka.
-				// NOTE: the slowdown is 1s longer than the client timeout.
-				time.Sleep(kafkaCfg.WriteTimeout + writerRequestTimeoutOverhead + time.Second)
-			}
+				if firstRequest.CompareAndSwap(true, false) {
+					// The produce request has been received by Kafka, so we can fire the next request.
+					close(firstRequestReceived)
 
-			return nil, nil, false
+					// Inject a slowdown on the 1st Produce request received by Kafka.
+					// NOTE: the slowdown is 1s longer than the client timeout.
+					time.Sleep(kafkaCfg.WriteTimeout + writerRequestTimeoutOverhead + time.Second)
+				}
+
+				return nil, nil, false
+			})
+
+			// The 1st request is expected to fail because Kafka will take longer than the configured timeout.
+			runAsync(&wg, func() {
+				startTime := time.Now()
+				assert.ErrorIs(t, writer.WriteSync(ctx, topicName, partitionID, tenantID, &mimirpb.WriteRequest{Timeseries: series1, Metadata: nil, Source: mimirpb.API}), kgo.ErrRecordTimeout)
+				elapsedTime := time.Since(startTime)
+
+				// It should take nearly the client's write timeout.
+				expectedElapsedTime := kafkaCfg.WriteTimeout + writerRequestTimeoutOverhead
+				assert.InDelta(t, expectedElapsedTime, elapsedTime, float64(time.Second))
+			})
+
+			// The 2nd request is fired while the 1st is still executing, but will fail anyway because the previous
+			// failure causes all subsequent buffered records to fail too.
+			runAsync(&wg, func() {
+				<-firstRequestReceived
+
+				// Wait 500ms less than the client timeout.
+				delay := 500 * time.Millisecond
+				time.Sleep(kafkaCfg.WriteTimeout + writerRequestTimeoutOverhead - delay)
+
+				startTime := time.Now()
+				assert.ErrorIs(t, writer.WriteSync(ctx, topicName, partitionID, tenantID, &mimirpb.WriteRequest{Timeseries: series2, Metadata: nil, Source: mimirpb.API}), kgo.ErrRecordTimeout)
+				elapsedTime := time.Since(startTime)
+
+				// We expect to fail once the previous request fails, so it should take nearly the client's write timeout
+				// minus the artificial delay introduced above.
+				tolerance := time.Second
+				assert.Less(t, elapsedTime, delay+tolerance)
+			})
+
+			wg.Wait()
 		})
-
-		// The 1st request is expected to fail because Kafka will take longer than the configured timeout.
-		runAsync(&wg, func() {
-			startTime := time.Now()
-			assert.ErrorIs(t, writer.WriteSync(ctx, topicName, partitionID, tenantID, &mimirpb.WriteRequest{Timeseries: series1, Metadata: nil, Source: mimirpb.API}), kgo.ErrRecordTimeout)
-			elapsedTime := time.Since(startTime)
-
-			// It should take nearly the client's write timeout.
-			expectedElapsedTime := kafkaCfg.WriteTimeout + writerRequestTimeoutOverhead
-			assert.InDelta(t, expectedElapsedTime, elapsedTime, float64(time.Second))
-		})
-
-		// The 2nd request is fired while the 1st is still executing, but will fail anyway because the previous
-		// failure causes all subsequent buffered records to fail too.
-		runAsync(&wg, func() {
-			<-firstRequestReceived
-
-			// Wait 500ms less than the client timeout.
-			delay := 500 * time.Millisecond
-			time.Sleep(kafkaCfg.WriteTimeout + writerRequestTimeoutOverhead - delay)
-
-			startTime := time.Now()
-			assert.ErrorIs(t, writer.WriteSync(ctx, topicName, partitionID, tenantID, &mimirpb.WriteRequest{Timeseries: series2, Metadata: nil, Source: mimirpb.API}), kgo.ErrRecordTimeout)
-			elapsedTime := time.Since(startTime)
-
-			// We expect to fail once the previous request fails, so it should take nearly the client's write timeout
-			// minus the artificial delay introduced above.
-			tolerance := time.Second
-			assert.Less(t, elapsedTime, delay+tolerance)
-		})
-
-		wg.Wait()
 	})
 
 	t.Run("should return error if the WriteRequest contains a timeseries which is larger than the maximum allowed record data size", func(t *testing.T) {
-		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
 
-		req := &mimirpb.WriteRequest{
-			Timeseries: []mimirpb.PreallocTimeseries{
-				mockPreallocTimeseries(strings.Repeat("x", producerBatchMaxBytes)), // Huge, will fail to be written.
-				mockPreallocTimeseries("series_1"),                                 // Small, will be successfully written.
-			},
-			Metadata: nil,
-			Source:   mimirpb.API,
-		}
+			req := &mimirpb.WriteRequest{
+				Timeseries: []mimirpb.PreallocTimeseries{
+					mockPreallocTimeseries(strings.Repeat("x", producerBatchMaxBytes)), // Huge, will fail to be written.
+					mockPreallocTimeseries("series_1"),                                 // Small, will be successfully written.
+				},
+				Metadata: nil,
+				Source:   mimirpb.API,
+			}
 
-		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
-		writer, reg := createTestWriter(t, createTestKafkaConfigForBackend(backend, clusterAddr, topicName))
+			var vnet kfake.VirtualNetwork
+			cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName, testkafka.WithVirtualNetwork(&vnet))
+			cfg := createTestKafkaConfigForBackend(backend, clusterAddr, topicName)
+			cfg.Dialer = vnet.DialContext
+			writer, reg := createTestWriter(t, cfg)
 
-		produceRequestProcessed := atomic.NewBool(false)
+			produceRequestProcessed := atomic.NewBool(false)
 
-		cluster.ControlKey(int16(kmsg.Produce), func(kmsg.Request) (kmsg.Response, error, bool) {
-			// Add a delay, so that if WriteSync() will not wait then the test will fail.
-			time.Sleep(time.Second)
-			produceRequestProcessed.Store(true)
+			cluster.ControlKey(int16(kmsg.Produce), func(kmsg.Request) (kmsg.Response, error, bool) {
+				// Add a delay, so that if WriteSync() will not wait then the test will fail.
+				time.Sleep(time.Second)
+				produceRequestProcessed.Store(true)
 
-			return nil, nil, false
+				return nil, nil, false
+			})
+
+			err := writer.WriteSync(ctx, topicName, partitionID, tenantID, req)
+			require.Equal(t, ErrWriteRequestDataItemTooLarge, err)
+
+			// Ensure it was processed before returning.
+			assert.True(t, produceRequestProcessed.Load())
+
+			// Read back from Kafka.
+			consumer := newKafkaClient(t, clusterAddr, &vnet, topicName, int32(partitionID))
+
+			fetchCtx, cancel := context.WithTimeout(ctx, time.Second)
+			t.Cleanup(cancel)
+
+			fetches := consumer.PollFetches(fetchCtx)
+			require.NoError(t, fetches.Err())
+			require.Len(t, fetches.Records(), 1)
+			assert.Equal(t, []byte(tenantID), fetches.Records()[0].Key)
+
+			received := deserializeRecord(t, fetches.Records()[0])
+
+			// We expect that the small time series has been ingested, while the huge one has been discarded.
+			require.Len(t, received.Timeseries, 1)
+			assert.Equal(t, mockPreallocTimeseries("series_1"), received.Timeseries[0])
+
+			// Check metrics. Since one record failed (too large), we don't track input/sent bytes
+			// to keep cortex_ingest_storage_writer_sent_bytes_total and cortex_ingest_storage_writer_input_bytes_total
+			// consistent with each other (both are only tracked on full success).
+			assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
+				# HELP cortex_ingest_storage_writer_input_bytes_total Total number of bytes in write requests before conversion to the Kafka record format.
+				# TYPE cortex_ingest_storage_writer_input_bytes_total counter
+				cortex_ingest_storage_writer_input_bytes_total 0
+
+				# HELP cortex_ingest_storage_writer_sent_bytes_total Total number of bytes produced to the Kafka backend.
+				# TYPE cortex_ingest_storage_writer_sent_bytes_total counter
+				cortex_ingest_storage_writer_sent_bytes_total 0
+
+				# HELP cortex_ingest_storage_writer_records_per_write_request The number of records a single per-partition write request has been split into.
+				# TYPE cortex_ingest_storage_writer_records_per_write_request histogram
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="1"} 0
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="2"} 1
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="4"} 1
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="8"} 1
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="16"} 1
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="32"} 1
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="64"} 1
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="128"} 1
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="+Inf"} 1
+				cortex_ingest_storage_writer_records_per_write_request_sum 2
+				cortex_ingest_storage_writer_records_per_write_request_count 1
+
+				# HELP cortex_ingest_storage_writer_produce_records_enqueued_total Total number of Kafka records enqueued to be sent to the Kafka backend (includes records that fail to be successfully sent to the Kafka backend).
+				# TYPE cortex_ingest_storage_writer_produce_records_enqueued_total counter
+				cortex_ingest_storage_writer_produce_records_enqueued_total 2
+
+				# HELP cortex_ingest_storage_writer_produce_records_failed_total Total number of Kafka records that failed to be sent to the Kafka backend.
+				# TYPE cortex_ingest_storage_writer_produce_records_failed_total counter
+				cortex_ingest_storage_writer_produce_records_failed_total{reason="record-too-large"} 1
+			`),
+				"cortex_ingest_storage_writer_input_bytes_total",
+				"cortex_ingest_storage_writer_sent_bytes_total",
+				"cortex_ingest_storage_writer_records_per_write_request",
+				"cortex_ingest_storage_writer_produce_records_enqueued_total",
+				"cortex_ingest_storage_writer_produce_records_failed_total"))
 		})
-
-		err := writer.WriteSync(ctx, topicName, partitionID, tenantID, req)
-		require.Equal(t, ErrWriteRequestDataItemTooLarge, err)
-
-		// Ensure it was processed before returning.
-		assert.True(t, produceRequestProcessed.Load())
-
-		// Read back from Kafka.
-		consumer, err := kgo.NewClient(kgo.SeedBrokers(clusterAddr), kgo.ConsumePartitions(map[string]map[int32]kgo.Offset{topicName: {int32(partitionID): kgo.NewOffset().AtStart()}}))
-		require.NoError(t, err)
-		t.Cleanup(consumer.Close)
-
-		fetchCtx, cancel := context.WithTimeout(ctx, time.Second)
-		t.Cleanup(cancel)
-
-		fetches := consumer.PollFetches(fetchCtx)
-		require.NoError(t, fetches.Err())
-		require.Len(t, fetches.Records(), 1)
-		assert.Equal(t, []byte(tenantID), fetches.Records()[0].Key)
-
-		received := deserializeRecord(t, fetches.Records()[0])
-
-		// We expect that the small time series has been ingested, while the huge one has been discarded.
-		require.Len(t, received.Timeseries, 1)
-		assert.Equal(t, mockPreallocTimeseries("series_1"), received.Timeseries[0])
-
-		// Check metrics. Since one record failed (too large), we don't track input/sent bytes
-		// to keep cortex_ingest_storage_writer_sent_bytes_total and cortex_ingest_storage_writer_input_bytes_total
-		// consistent with each other (both are only tracked on full success).
-		assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
-			# HELP cortex_ingest_storage_writer_input_bytes_total Total number of bytes in write requests before conversion to the Kafka record format.
-			# TYPE cortex_ingest_storage_writer_input_bytes_total counter
-			cortex_ingest_storage_writer_input_bytes_total 0
-
-			# HELP cortex_ingest_storage_writer_sent_bytes_total Total number of bytes produced to the Kafka backend.
-			# TYPE cortex_ingest_storage_writer_sent_bytes_total counter
-			cortex_ingest_storage_writer_sent_bytes_total 0
-
-			# HELP cortex_ingest_storage_writer_records_per_write_request The number of records a single per-partition write request has been split into.
-			# TYPE cortex_ingest_storage_writer_records_per_write_request histogram
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="1"} 0
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="2"} 1
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="4"} 1
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="8"} 1
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="16"} 1
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="32"} 1
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="64"} 1
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="128"} 1
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="+Inf"} 1
-			cortex_ingest_storage_writer_records_per_write_request_sum 2
-			cortex_ingest_storage_writer_records_per_write_request_count 1
-
-			# HELP cortex_ingest_storage_writer_produce_records_enqueued_total Total number of Kafka records enqueued to be sent to the Kafka backend (includes records that fail to be successfully sent to the Kafka backend).
-			# TYPE cortex_ingest_storage_writer_produce_records_enqueued_total counter
-			cortex_ingest_storage_writer_produce_records_enqueued_total 2
-
-			# HELP cortex_ingest_storage_writer_produce_records_failed_total Total number of Kafka records that failed to be sent to the Kafka backend.
-			# TYPE cortex_ingest_storage_writer_produce_records_failed_total counter
-			cortex_ingest_storage_writer_produce_records_failed_total{reason="record-too-large"} 1
-		`),
-			"cortex_ingest_storage_writer_input_bytes_total",
-			"cortex_ingest_storage_writer_sent_bytes_total",
-			"cortex_ingest_storage_writer_records_per_write_request",
-			"cortex_ingest_storage_writer_produce_records_enqueued_total",
-			"cortex_ingest_storage_writer_produce_records_failed_total"))
 	})
 
 	t.Run("should not block the WriteSync() because Kafka buffer is full", func(t *testing.T) {
-		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
 
-		createWriteRequest := func() *mimirpb.WriteRequest {
-			return &mimirpb.WriteRequest{Timeseries: series1, Metadata: nil, Source: mimirpb.API}
-		}
+			createWriteRequest := func() *mimirpb.WriteRequest {
+				return &mimirpb.WriteRequest{Timeseries: series1, Metadata: nil, Source: mimirpb.API}
+			}
 
-		// Estimate the size of each record written in this test.
-		writeReq := createWriteRequest()
-		serializer := RecordSerializerFromVersion(2)
-		writeReqRecords, _, err := serializer.ToRecords(topicName, partitionID, tenantID, writeReq, maxProducerRecordDataBytesLimit)
-		require.NoError(t, err)
-		require.Len(t, writeReqRecords, 1)
-		estimatedRecordSize := len(writeReqRecords[0].Value)
-		t.Logf("estimated record size: %d bytes", estimatedRecordSize)
-
-		var (
-			unblockProduceRequestsOnce = sync.Once{}
-			unblockProduceRequests     = make(chan struct{})
-			recordsReceived            = atomic.NewInt64(0)
-			goroutines                 = sync.WaitGroup{}
-
-			writeErrsMx sync.Mutex
-			writeErrs   []error
-		)
-
-		cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
-
-		cfg := createTestKafkaConfigForBackend(backend, clusterAddr, topicName)
-		cfg.ProducerMaxBufferedBytes = int64((estimatedRecordSize * 4) - 1) // Configure the test so that we expect 3 produced records.
-
-		// Pre-condition checks.
-		assert.GreaterOrEqual(t, numPartitions, 10)
-
-		doUnblockProduceRequests := func() {
-			unblockProduceRequestsOnce.Do(func() {
-				t.Log("releasing produce requests")
-				close(unblockProduceRequests)
-			})
-		}
-
-		// Ensure produce requests are released in case of premature test termination.
-		t.Cleanup(doUnblockProduceRequests)
-
-		// Configure Kafka to block Produce requests until the test unblocks it.
-		cluster.ControlKey(int16(kmsg.Produce), func(request kmsg.Request) (kmsg.Response, error, bool) {
-			goroutines.Add(1)
-			defer goroutines.Done()
-
-			numRecords, err := getProduceRequestRecordsCount(request.(*kmsg.ProduceRequest))
+			// Estimate the size of each record written in this test.
+			writeReq := createWriteRequest()
+			serializer := RecordSerializerFromVersion(2)
+			writeReqRecords, _, err := serializer.ToRecords(topicName, partitionID, tenantID, writeReq, maxProducerRecordDataBytesLimit)
 			require.NoError(t, err)
-			recordsReceived.Add(int64(numRecords))
+			require.Len(t, writeReqRecords, 1)
+			estimatedRecordSize := len(writeReqRecords[0].Value)
+			t.Logf("estimated record size: %d bytes", estimatedRecordSize)
 
-			// Block produce requests.
-			<-unblockProduceRequests
+			var (
+				unblockProduceRequestsOnce = sync.Once{}
+				unblockProduceRequests     = make(chan struct{})
+				recordsReceived            = atomic.NewInt64(0)
+				goroutines                 = sync.WaitGroup{}
 
-			return nil, nil, false
-		})
+				writeErrsMx sync.Mutex
+				writeErrs   []error
+			)
 
-		writer, reg := createTestWriter(t, cfg)
+			var vnet kfake.VirtualNetwork
+			cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName, testkafka.WithVirtualNetwork(&vnet))
 
-		// Write few records, each in a different partition, so that we ensure the buffer is global and not per partition.
-		for i := int32(0); i < 10; i++ {
-			partition := i
+			cfg := createTestKafkaConfigForBackend(backend, clusterAddr, topicName)
+			cfg.Dialer = vnet.DialContext
+			cfg.ProducerMaxBufferedBytes = int64((estimatedRecordSize * 4) - 1) // Configure the test so that we expect 3 produced records.
 
-			runAsync(&goroutines, func() {
-				err := writer.WriteSync(ctx, topicName, partition, tenantID, createWriteRequest())
-				t.Logf("WriteSync() returned with error: %v", err)
+			// Pre-condition checks.
+			assert.GreaterOrEqual(t, numPartitions, 10)
 
-				// Keep track of the returned error (if any).
-				writeErrsMx.Lock()
-				writeErrs = append(writeErrs, err)
-				writeErrsMx.Unlock()
+			doUnblockProduceRequests := func() {
+				unblockProduceRequestsOnce.Do(func() {
+					t.Log("releasing produce requests")
+					close(unblockProduceRequests)
+				})
+			}
+
+			// Ensure produce requests are released in case of premature test termination.
+			t.Cleanup(doUnblockProduceRequests)
+
+			// Configure Kafka to block Produce requests until the test unblocks it.
+			cluster.ControlKey(int16(kmsg.Produce), func(request kmsg.Request) (kmsg.Response, error, bool) {
+				goroutines.Add(1)
+				defer goroutines.Done()
+
+				numRecords, err := getProduceRequestRecordsCount(request.(*kmsg.ProduceRequest))
+				require.NoError(t, err)
+				recordsReceived.Add(int64(numRecords))
+
+				// Block produce requests.
+				<-unblockProduceRequests
+
+				return nil, nil, false
 			})
-		}
 
-		// We expect all WriteSync() requests to fail, either because the write timeout expired or
-		// because the buffer is full.
-		require.Eventually(t, func() bool {
-			writeErrsMx.Lock()
-			defer writeErrsMx.Unlock()
-			return len(writeErrs) == 10
-		}, cfg.WriteTimeout+writerRequestTimeoutOverhead+time.Second, 100*time.Millisecond)
+			writer, reg := createTestWriter(t, cfg)
 
-		// Assert on the actual errors returned by WriteSync().
-		actualErrRecordTimeoutCount := 0
-		actualErrMaxBufferedCount := 0
+			// Write few records, each in a different partition, so that we ensure the buffer is global and not per partition.
+			for i := int32(0); i < 10; i++ {
+				partition := i
 
-		for _, writeErr := range writeErrs {
-			if errors.Is(writeErr, kgo.ErrRecordTimeout) {
-				actualErrRecordTimeoutCount++
+				runAsync(&goroutines, func() {
+					err := writer.WriteSync(ctx, topicName, partition, tenantID, createWriteRequest())
+					t.Logf("WriteSync() returned with error: %v", err)
+
+					// Keep track of the returned error (if any).
+					writeErrsMx.Lock()
+					writeErrs = append(writeErrs, err)
+					writeErrsMx.Unlock()
+				})
 			}
-			if errors.Is(writeErr, kgo.ErrMaxBuffered) {
-				actualErrMaxBufferedCount++
+
+			// We expect all WriteSync() requests to fail, either because the write timeout expired or
+			// because the buffer is full.
+			require.Eventually(t, func() bool {
+				writeErrsMx.Lock()
+				defer writeErrsMx.Unlock()
+				return len(writeErrs) == 10
+			}, cfg.WriteTimeout+writerRequestTimeoutOverhead+time.Second, 100*time.Millisecond)
+
+			// Assert on the actual errors returned by WriteSync().
+			actualErrRecordTimeoutCount := 0
+			actualErrMaxBufferedCount := 0
+
+			for _, writeErr := range writeErrs {
+				if errors.Is(writeErr, kgo.ErrRecordTimeout) {
+					actualErrRecordTimeoutCount++
+				}
+				if errors.Is(writeErr, kgo.ErrMaxBuffered) {
+					actualErrMaxBufferedCount++
+				}
 			}
-		}
 
-		assert.Equal(t, 3, actualErrRecordTimeoutCount)
-		assert.Equal(t, 7, actualErrMaxBufferedCount)
+			assert.Equal(t, 3, actualErrRecordTimeoutCount)
+			assert.Equal(t, 7, actualErrMaxBufferedCount)
 
-		// We expect that only max buffered records have been sent to Kafka.
-		assert.Equal(t, 3, int(recordsReceived.Load()))
+			// We expect that only max buffered records have been sent to Kafka.
+			assert.Equal(t, 3, int(recordsReceived.Load()))
 
-		// Check metrics.
-		assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
+			// Check metrics.
+			assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
 			# HELP cortex_ingest_storage_writer_produce_records_enqueued_total Total number of Kafka records enqueued to be sent to the Kafka backend (includes records that fail to be successfully sent to the Kafka backend).
 			# TYPE cortex_ingest_storage_writer_produce_records_enqueued_total counter
 			cortex_ingest_storage_writer_produce_records_enqueued_total 10
@@ -768,27 +815,27 @@ func testWriter_WriteSync(t *testing.T, backend string) {
 			cortex_ingest_storage_writer_produce_records_failed_total{reason="buffer-full"} 7
 			cortex_ingest_storage_writer_produce_records_failed_total{reason="timeout"} 3
 		`),
-			"cortex_ingest_storage_writer_produce_records_enqueued_total",
-			"cortex_ingest_storage_writer_produce_records_failed_total"))
+				"cortex_ingest_storage_writer_produce_records_enqueued_total",
+				"cortex_ingest_storage_writer_produce_records_failed_total"))
 
-		// Unblock produce requests and wait until all goroutines are done.
-		doUnblockProduceRequests()
-		goroutines.Wait()
+			// Unblock produce requests and wait until all goroutines are done.
+			doUnblockProduceRequests()
+			goroutines.Wait()
 
-		// Now that produce requests have been unblocked, try to produce again. We expect all
-		// produce to succeed.
-		for i := int32(0); i < 3; i++ {
-			partition := i
+			// Now that produce requests have been unblocked, try to produce again. We expect all
+			// produce to succeed.
+			for i := int32(0); i < 3; i++ {
+				partition := i
 
-			runAsync(&goroutines, func() {
-				require.NoError(t, writer.WriteSync(ctx, topicName, partition, tenantID, createWriteRequest()))
-			})
-		}
+				runAsync(&goroutines, func() {
+					require.NoError(t, writer.WriteSync(ctx, topicName, partition, tenantID, createWriteRequest()))
+				})
+			}
 
-		goroutines.Wait()
+			goroutines.Wait()
 
-		// Check metrics.
-		assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
+			// Check metrics.
+			assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
 			# HELP cortex_ingest_storage_writer_produce_records_enqueued_total Total number of Kafka records enqueued to be sent to the Kafka backend (includes records that fail to be successfully sent to the Kafka backend).
 			# TYPE cortex_ingest_storage_writer_produce_records_enqueued_total counter
 			cortex_ingest_storage_writer_produce_records_enqueued_total 13
@@ -798,23 +845,29 @@ func testWriter_WriteSync(t *testing.T, backend string) {
 			cortex_ingest_storage_writer_produce_records_failed_total{reason="buffer-full"} 7
 			cortex_ingest_storage_writer_produce_records_failed_total{reason="timeout"} 3
 		`),
-			"cortex_ingest_storage_writer_produce_records_enqueued_total",
-			"cortex_ingest_storage_writer_produce_records_failed_total"))
+				"cortex_ingest_storage_writer_produce_records_enqueued_total",
+				"cortex_ingest_storage_writer_produce_records_failed_total"))
+		})
 	})
 
 	t.Run("should not panic if WriteSync() is called after the writer has been stopped", func(t *testing.T) {
-		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
 
-		_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
-		writer, _ := createTestWriter(t, createTestKafkaConfigForBackend(backend, clusterAddr, topicName))
+			var vnet kfake.VirtualNetwork
+			_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName, testkafka.WithVirtualNetwork(&vnet))
+			cfg := createTestKafkaConfigForBackend(backend, clusterAddr, topicName)
+			cfg.Dialer = vnet.DialContext
+			writer, _ := createTestWriter(t, cfg)
 
-		err := writer.WriteSync(ctx, topicName, partitionID, tenantID, &mimirpb.WriteRequest{Timeseries: multiSeries, Metadata: nil, Source: mimirpb.API})
-		require.NoError(t, err)
+			err := writer.WriteSync(ctx, topicName, partitionID, tenantID, &mimirpb.WriteRequest{Timeseries: multiSeries, Metadata: nil, Source: mimirpb.API})
+			require.NoError(t, err)
 
-		require.NoError(t, services.StopAndAwaitTerminated(ctx, writer))
+			require.NoError(t, services.StopAndAwaitTerminated(ctx, writer))
 
-		err = writer.WriteSync(ctx, topicName, partitionID, tenantID, &mimirpb.WriteRequest{Timeseries: multiSeries, Metadata: nil, Source: mimirpb.API})
-		require.ErrorIs(t, err, ErrWriterNotRunning)
+			err = writer.WriteSync(ctx, topicName, partitionID, tenantID, &mimirpb.WriteRequest{Timeseries: multiSeries, Metadata: nil, Source: mimirpb.API})
+			require.ErrorIs(t, err, ErrWriterNotRunning)
+		})
 	})
 }
 
@@ -830,40 +883,133 @@ func testWriter_MultiWriteSync(t *testing.T, backend string) {
 	)
 
 	var (
-		ctx     = context.Background()
 		series1 = []mimirpb.PreallocTimeseries{mockPreallocTimeseries("series_1")}
 		series2 = []mimirpb.PreallocTimeseries{mockPreallocTimeseries("series_2")}
 		series3 = []mimirpb.PreallocTimeseries{mockPreallocTimeseries("series_3")}
 	)
 
 	t.Run("should write records to multiple partitions", func(t *testing.T) {
-		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
 
-		_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
-		cfg := createTestKafkaConfigForBackend(backend, clusterAddr, topicName)
-		cfg.ProducerRecordVersion = 1
-		writer, reg := createTestWriter(t, cfg)
+			var vnet kfake.VirtualNetwork
+			_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName, testkafka.WithVirtualNetwork(&vnet))
+			cfg := createTestKafkaConfigForBackend(backend, clusterAddr, topicName)
+			cfg.Dialer = vnet.DialContext
+			cfg.ProducerRecordVersion = 1
+			writer, reg := createTestWriter(t, cfg)
 
-		req1 := &mimirpb.WriteRequest{Timeseries: series1, Source: mimirpb.API}
-		req2 := &mimirpb.WriteRequest{Timeseries: series2, Source: mimirpb.API}
-		req3 := &mimirpb.WriteRequest{Timeseries: series3, Source: mimirpb.API}
-		totalInputSize := req1.Size() + req2.Size() + req3.Size()
+			req1 := &mimirpb.WriteRequest{Timeseries: series1, Source: mimirpb.API}
+			req2 := &mimirpb.WriteRequest{Timeseries: series2, Source: mimirpb.API}
+			req3 := &mimirpb.WriteRequest{Timeseries: series3, Source: mimirpb.API}
+			totalInputSize := req1.Size() + req2.Size() + req3.Size()
 
-		partitionRequests := []PartitionWriteRequest{
-			{PartitionID: 0, WriteRequest: req1},
-			{PartitionID: 1, WriteRequest: req2},
-			{PartitionID: 2, WriteRequest: req3},
-		}
+			partitionRequests := []PartitionWriteRequest{
+				{PartitionID: 0, WriteRequest: req1},
+				{PartitionID: 1, WriteRequest: req2},
+				{PartitionID: 2, WriteRequest: req3},
+			}
 
-		err := writer.MultiWriteSync(ctx, topicName, tenantID, partitionRequests)
-		require.NoError(t, err)
+			err := writer.MultiWriteSync(ctx, topicName, tenantID, partitionRequests)
+			require.NoError(t, err)
 
-		// Read back from each partition and verify.
-		var totalSentBytes int
-		for _, pr := range partitionRequests {
-			consumer, err := kgo.NewClient(kgo.SeedBrokers(clusterAddr), kgo.ConsumePartitions(map[string]map[int32]kgo.Offset{
-				topicName: {pr.PartitionID: kgo.NewOffset().AtStart()},
-			}))
+			// Read back from each partition and verify.
+			var totalSentBytes int
+			for _, pr := range partitionRequests {
+				consumer, err := kgo.NewClient(
+					kgo.SeedBrokers(clusterAddr),
+					kgo.Dialer(vnet.DialContext),
+					kgo.ConsumePartitions(map[string]map[int32]kgo.Offset{
+						topicName: {pr.PartitionID: kgo.NewOffset().AtStart()},
+					}))
+				require.NoError(t, err)
+				t.Cleanup(consumer.Close)
+
+				fetchCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+				t.Cleanup(cancel)
+
+				fetches := consumer.PollFetches(fetchCtx)
+				require.NoError(t, fetches.Err())
+				require.Len(t, fetches.Records(), 1)
+				assert.Equal(t, pr.PartitionID, fetches.Records()[0].Partition)
+				totalSentBytes += len(fetches.Records()[0].Value)
+
+				received := mimirpb.WriteRequest{}
+				require.NoError(t, received.Unmarshal(fetches.Records()[0].Value))
+				require.Len(t, received.Timeseries, len(pr.WriteRequest.Timeseries))
+
+				for idx, expected := range pr.WriteRequest.Timeseries {
+					assert.Equal(t, expected.Labels, received.Timeseries[idx].Labels)
+					assert.Equal(t, expected.Samples, received.Timeseries[idx].Samples)
+				}
+			}
+
+			// Check metrics.
+			assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
+				# HELP cortex_ingest_storage_writer_input_bytes_total Total number of bytes in write requests before conversion to the Kafka record format.
+				# TYPE cortex_ingest_storage_writer_input_bytes_total counter
+				cortex_ingest_storage_writer_input_bytes_total %d
+
+				# HELP cortex_ingest_storage_writer_sent_bytes_total Total number of bytes produced to the Kafka backend.
+				# TYPE cortex_ingest_storage_writer_sent_bytes_total counter
+				cortex_ingest_storage_writer_sent_bytes_total %d
+
+				# HELP cortex_ingest_storage_writer_records_per_write_request The number of records a single per-partition write request has been split into.
+				# TYPE cortex_ingest_storage_writer_records_per_write_request histogram
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="1"} 3
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="2"} 3
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="4"} 3
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="8"} 3
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="16"} 3
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="32"} 3
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="64"} 3
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="128"} 3
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="+Inf"} 3
+				cortex_ingest_storage_writer_records_per_write_request_sum 3
+				cortex_ingest_storage_writer_records_per_write_request_count 3
+
+				# HELP cortex_ingest_storage_writer_produce_records_enqueued_total Total number of Kafka records enqueued to be sent to the Kafka backend (includes records that fail to be successfully sent to the Kafka backend).
+				# TYPE cortex_ingest_storage_writer_produce_records_enqueued_total counter
+				cortex_ingest_storage_writer_produce_records_enqueued_total 3
+			`, totalInputSize, totalSentBytes)),
+				"cortex_ingest_storage_writer_input_bytes_total",
+				"cortex_ingest_storage_writer_sent_bytes_total",
+				"cortex_ingest_storage_writer_records_per_write_request",
+				"cortex_ingest_storage_writer_produce_records_enqueued_total"))
+
+			assertHistogramSampleCount(t, reg, "cortex_ingest_storage_writer_serialize_duration_seconds", 1)
+		})
+	})
+
+	t.Run("should skip empty requests", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
+
+			var vnet kfake.VirtualNetwork
+			_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName, testkafka.WithVirtualNetwork(&vnet))
+			cfg := createTestKafkaConfigForBackend(backend, clusterAddr, topicName)
+			cfg.Dialer = vnet.DialContext
+			cfg.ProducerRecordVersion = 1
+			writer, reg := createTestWriter(t, cfg)
+
+			nonEmptyReq := &mimirpb.WriteRequest{Timeseries: series1, Source: mimirpb.API}
+			inputSize := nonEmptyReq.Size()
+
+			partitionRequests := []PartitionWriteRequest{
+				{PartitionID: 0, WriteRequest: &mimirpb.WriteRequest{}},
+				{PartitionID: 1, WriteRequest: nonEmptyReq},
+			}
+
+			err := writer.MultiWriteSync(ctx, topicName, tenantID, partitionRequests)
+			require.NoError(t, err)
+
+			// Only partition 1 should have records.
+			consumer, err := kgo.NewClient(
+				kgo.SeedBrokers(clusterAddr),
+				kgo.Dialer(vnet.DialContext),
+				kgo.ConsumePartitions(map[string]map[int32]kgo.Offset{
+					topicName: {1: kgo.NewOffset().AtStart()},
+				}))
 			require.NoError(t, err)
 			t.Cleanup(consumer.Close)
 
@@ -873,140 +1019,64 @@ func testWriter_MultiWriteSync(t *testing.T, backend string) {
 			fetches := consumer.PollFetches(fetchCtx)
 			require.NoError(t, fetches.Err())
 			require.Len(t, fetches.Records(), 1)
-			assert.Equal(t, pr.PartitionID, fetches.Records()[0].Partition)
-			totalSentBytes += len(fetches.Records()[0].Value)
+			assert.Equal(t, int32(1), fetches.Records()[0].Partition)
 
-			received := mimirpb.WriteRequest{}
-			require.NoError(t, received.Unmarshal(fetches.Records()[0].Value))
-			require.Len(t, received.Timeseries, len(pr.WriteRequest.Timeseries))
+			// Check metrics: only the non-empty partition should be tracked.
+			assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
+				# HELP cortex_ingest_storage_writer_input_bytes_total Total number of bytes in write requests before conversion to the Kafka record format.
+				# TYPE cortex_ingest_storage_writer_input_bytes_total counter
+				cortex_ingest_storage_writer_input_bytes_total %d
 
-			for idx, expected := range pr.WriteRequest.Timeseries {
-				assert.Equal(t, expected.Labels, received.Timeseries[idx].Labels)
-				assert.Equal(t, expected.Samples, received.Timeseries[idx].Samples)
-			}
-		}
+				# HELP cortex_ingest_storage_writer_sent_bytes_total Total number of bytes produced to the Kafka backend.
+				# TYPE cortex_ingest_storage_writer_sent_bytes_total counter
+				cortex_ingest_storage_writer_sent_bytes_total %d
 
-		// Check metrics.
-		assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
-			# HELP cortex_ingest_storage_writer_input_bytes_total Total number of bytes in write requests before conversion to the Kafka record format.
-			# TYPE cortex_ingest_storage_writer_input_bytes_total counter
-			cortex_ingest_storage_writer_input_bytes_total %d
+				# HELP cortex_ingest_storage_writer_records_per_write_request The number of records a single per-partition write request has been split into.
+				# TYPE cortex_ingest_storage_writer_records_per_write_request histogram
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="1"} 1
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="2"} 1
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="4"} 1
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="8"} 1
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="16"} 1
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="32"} 1
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="64"} 1
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="128"} 1
+				cortex_ingest_storage_writer_records_per_write_request_bucket{le="+Inf"} 1
+				cortex_ingest_storage_writer_records_per_write_request_sum 1
+				cortex_ingest_storage_writer_records_per_write_request_count 1
 
-			# HELP cortex_ingest_storage_writer_sent_bytes_total Total number of bytes produced to the Kafka backend.
-			# TYPE cortex_ingest_storage_writer_sent_bytes_total counter
-			cortex_ingest_storage_writer_sent_bytes_total %d
+				# HELP cortex_ingest_storage_writer_produce_records_enqueued_total Total number of Kafka records enqueued to be sent to the Kafka backend (includes records that fail to be successfully sent to the Kafka backend).
+				# TYPE cortex_ingest_storage_writer_produce_records_enqueued_total counter
+				cortex_ingest_storage_writer_produce_records_enqueued_total 1
+			`, inputSize, len(fetches.Records()[0].Value))),
+				"cortex_ingest_storage_writer_input_bytes_total",
+				"cortex_ingest_storage_writer_sent_bytes_total",
+				"cortex_ingest_storage_writer_records_per_write_request",
+				"cortex_ingest_storage_writer_produce_records_enqueued_total"))
 
-			# HELP cortex_ingest_storage_writer_records_per_write_request The number of records a single per-partition write request has been split into.
-			# TYPE cortex_ingest_storage_writer_records_per_write_request histogram
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="1"} 3
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="2"} 3
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="4"} 3
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="8"} 3
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="16"} 3
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="32"} 3
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="64"} 3
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="128"} 3
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="+Inf"} 3
-			cortex_ingest_storage_writer_records_per_write_request_sum 3
-			cortex_ingest_storage_writer_records_per_write_request_count 3
-
-			# HELP cortex_ingest_storage_writer_produce_records_enqueued_total Total number of Kafka records enqueued to be sent to the Kafka backend (includes records that fail to be successfully sent to the Kafka backend).
-			# TYPE cortex_ingest_storage_writer_produce_records_enqueued_total counter
-			cortex_ingest_storage_writer_produce_records_enqueued_total 3
-		`, totalInputSize, totalSentBytes)),
-			"cortex_ingest_storage_writer_input_bytes_total",
-			"cortex_ingest_storage_writer_sent_bytes_total",
-			"cortex_ingest_storage_writer_records_per_write_request",
-			"cortex_ingest_storage_writer_produce_records_enqueued_total"))
-
-		assertHistogramSampleCount(t, reg, "cortex_ingest_storage_writer_serialize_duration_seconds", 1)
-	})
-
-	t.Run("should skip empty requests", func(t *testing.T) {
-		t.Parallel()
-
-		_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
-		cfg := createTestKafkaConfigForBackend(backend, clusterAddr, topicName)
-		cfg.ProducerRecordVersion = 1
-		writer, reg := createTestWriter(t, cfg)
-
-		nonEmptyReq := &mimirpb.WriteRequest{Timeseries: series1, Source: mimirpb.API}
-		inputSize := nonEmptyReq.Size()
-
-		partitionRequests := []PartitionWriteRequest{
-			{PartitionID: 0, WriteRequest: &mimirpb.WriteRequest{}},
-			{PartitionID: 1, WriteRequest: nonEmptyReq},
-		}
-
-		err := writer.MultiWriteSync(ctx, topicName, tenantID, partitionRequests)
-		require.NoError(t, err)
-
-		// Only partition 1 should have records.
-		consumer, err := kgo.NewClient(kgo.SeedBrokers(clusterAddr), kgo.ConsumePartitions(map[string]map[int32]kgo.Offset{
-			topicName: {1: kgo.NewOffset().AtStart()},
-		}))
-		require.NoError(t, err)
-		t.Cleanup(consumer.Close)
-
-		fetchCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-		t.Cleanup(cancel)
-
-		fetches := consumer.PollFetches(fetchCtx)
-		require.NoError(t, fetches.Err())
-		require.Len(t, fetches.Records(), 1)
-		assert.Equal(t, int32(1), fetches.Records()[0].Partition)
-
-		// Check metrics: only the non-empty partition should be tracked.
-		assert.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(fmt.Sprintf(`
-			# HELP cortex_ingest_storage_writer_input_bytes_total Total number of bytes in write requests before conversion to the Kafka record format.
-			# TYPE cortex_ingest_storage_writer_input_bytes_total counter
-			cortex_ingest_storage_writer_input_bytes_total %d
-
-			# HELP cortex_ingest_storage_writer_sent_bytes_total Total number of bytes produced to the Kafka backend.
-			# TYPE cortex_ingest_storage_writer_sent_bytes_total counter
-			cortex_ingest_storage_writer_sent_bytes_total %d
-
-			# HELP cortex_ingest_storage_writer_records_per_write_request The number of records a single per-partition write request has been split into.
-			# TYPE cortex_ingest_storage_writer_records_per_write_request histogram
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="1"} 1
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="2"} 1
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="4"} 1
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="8"} 1
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="16"} 1
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="32"} 1
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="64"} 1
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="128"} 1
-			cortex_ingest_storage_writer_records_per_write_request_bucket{le="+Inf"} 1
-			cortex_ingest_storage_writer_records_per_write_request_sum 1
-			cortex_ingest_storage_writer_records_per_write_request_count 1
-
-			# HELP cortex_ingest_storage_writer_produce_records_enqueued_total Total number of Kafka records enqueued to be sent to the Kafka backend (includes records that fail to be successfully sent to the Kafka backend).
-			# TYPE cortex_ingest_storage_writer_produce_records_enqueued_total counter
-			cortex_ingest_storage_writer_produce_records_enqueued_total 1
-		`, inputSize, len(fetches.Records()[0].Value))),
-			"cortex_ingest_storage_writer_input_bytes_total",
-			"cortex_ingest_storage_writer_sent_bytes_total",
-			"cortex_ingest_storage_writer_records_per_write_request",
-			"cortex_ingest_storage_writer_produce_records_enqueued_total"))
-
-		assertHistogramSampleCount(t, reg, "cortex_ingest_storage_writer_serialize_duration_seconds", 1)
+			assertHistogramSampleCount(t, reg, "cortex_ingest_storage_writer_serialize_duration_seconds", 1)
+		})
 	})
 
 	t.Run("should return nil when all partition requests are empty", func(t *testing.T) {
-		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			ctx := t.Context()
 
-		_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
-		cfg := createTestKafkaConfigForBackend(backend, clusterAddr, topicName)
-		cfg.ProducerRecordVersion = 1
-		writer, _ := createTestWriter(t, cfg)
+			var vnet kfake.VirtualNetwork
+			_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName, testkafka.WithVirtualNetwork(&vnet))
+			cfg := createTestKafkaConfigForBackend(backend, clusterAddr, topicName)
+			cfg.Dialer = vnet.DialContext
+			cfg.ProducerRecordVersion = 1
+			writer, _ := createTestWriter(t, cfg)
 
-		partitionRequests := []PartitionWriteRequest{
-			{PartitionID: 0, WriteRequest: &mimirpb.WriteRequest{}},
-			{PartitionID: 1, WriteRequest: &mimirpb.WriteRequest{}},
-		}
+			partitionRequests := []PartitionWriteRequest{
+				{PartitionID: 0, WriteRequest: &mimirpb.WriteRequest{}},
+				{PartitionID: 1, WriteRequest: &mimirpb.WriteRequest{}},
+			}
 
-		err := writer.MultiWriteSync(ctx, topicName, tenantID, partitionRequests)
-		require.NoError(t, err)
+			err := writer.MultiWriteSync(ctx, topicName, tenantID, partitionRequests)
+			require.NoError(t, err)
+		})
 	})
 }
 
@@ -1040,13 +1110,11 @@ func testWriter_WriteSync_HighConcurrencyOnKafkaClientBufferFull(t *testing.T, b
 		return &mimirpb.WriteRequest{Timeseries: series, Metadata: nil, Source: mimirpb.API}
 	}
 
-	// If the test is successful (no WriteSync() request is in a deadlock state) then we expect the test
-	// to complete shortly after the estimated test duration.
-	ctx, cancel := context.WithTimeoutCause(context.Background(), 2*testDuration, errors.New("test did not complete within the expected time"))
-	t.Cleanup(cancel)
+	var vnet kfake.VirtualNetwork
 
-	cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
+	cluster, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName, testkafka.WithVirtualNetwork(&vnet))
 	cfg := createTestKafkaConfigForBackend(backend, clusterAddr, topicName)
+	cfg.Dialer = vnet.DialContext
 	cfg.ProducerMaxBufferedBytes = 10000
 	cfg.WriteTimeout = testDuration * 10 // We want the Kafka client to block in case of any issue.
 
@@ -1057,27 +1125,29 @@ func testWriter_WriteSync_HighConcurrencyOnKafkaClientBufferFull(t *testing.T, b
 		return nil, nil, false
 	})
 
+	ctx := t.Context()
+
 	writer, _ := createTestWriter(t, cfg)
 
 	// Start N workers that will concurrently write to the same partition.
-	for i := 0; i < numWorkers; i++ {
+	for range numWorkers {
 		runAsync(&workers, func() {
 			for {
 				select {
 				case <-done:
 					return
-
 				default:
-					if err := writer.WriteSync(ctx, topicName, partitionID, tenantID, createRandomWriteRequest()); err == nil {
-						writeSuccessCount.Inc()
-					} else {
-						assert.ErrorIs(t, err, kgo.ErrMaxBuffered)
-						writeFailureCount.Inc()
+				}
 
-						// Stop a worker as soon as a non-expected error occurred.
-						if !errors.Is(err, kgo.ErrMaxBuffered) {
-							return
-						}
+				if err := writer.WriteSync(ctx, topicName, partitionID, tenantID, createRandomWriteRequest()); err == nil {
+					writeSuccessCount.Inc()
+				} else {
+					assert.ErrorIs(t, err, kgo.ErrMaxBuffered)
+					writeFailureCount.Inc()
+
+					// Stop a worker as soon as a non-expected error occurred.
+					if !errors.Is(err, kgo.ErrMaxBuffered) {
+						return
 					}
 				}
 			}
@@ -1091,12 +1161,9 @@ func testWriter_WriteSync_HighConcurrencyOnKafkaClientBufferFull(t *testing.T, b
 	close(done)
 	workers.Wait()
 
-	t.Logf("writes succeeded: %d", writeSuccessCount.Load())
-	t.Logf("writes failed:    %d", writeFailureCount.Load())
-
 	// We expect some requests to have failed.
-	require.NotZero(t, writeSuccessCount.Load())
-	require.NotZero(t, writeFailureCount.Load())
+	require.NotZero(t, writeSuccessCount.Load(), "writes succeeded: %d", writeSuccessCount.Load())
+	require.NotZero(t, writeFailureCount.Load(), "writes failed:    %d", writeFailureCount.Load())
 
 	// We expect the buffered bytes to get down to 0 once all write requests completed.
 	require.Zero(t, writer.client.Load().bufferedBytes.Load())

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/atomic_maybe_work.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/atomic_maybe_work.go
@@ -61,6 +61,18 @@ func (l *workLoop) maybeFinish(again bool) bool {
 	return again
 }
 
+// hardFinish forces the loop back to unstarted, discarding any pending
+// continue-work bump that a concurrent maybeBegin may have set. Unlike
+// maybeFinish, it does not observe or preserve that bump, so work a racing
+// pusher enqueued can be stranded with no worker running.
+//
+// This is safe only where the strand is moot or compensated. Most callers
+// hardFinish because their session or client context just died, so any
+// stranded work is being torn down anyway. The one transient caller is
+// loopFetch hitting noConsumerSession: it compensates by reloading the
+// session after hardFinish and re-triggering if a new one appeared (the
+// race the comment there walks through). A new transient caller must do
+// the same.
 func (l *workLoop) hardFinish() {
 	l.state.Store(stateUnstarted)
 }

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/broker.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/broker.go
@@ -36,6 +36,17 @@ var ctxPinReq = func() *string { v := "pin_req"; return &v }()
 
 type forceOpenReq struct{ kmsg.Request }
 
+// reauthDrainReq is an internal sentinel pushed through the broker's request
+// ring by a connection's handleResps worker as it exits with a sasl
+// reauthentication pending. It runs handleReauthDrain on the broker worker
+// goroutine: reauthenticate now that no reads are in flight, then replay the
+// requests that parked while the pipeline drained. The embedded kmsg.Request
+// is nil and never used; handleReq dispatches on the type before touching it.
+type reauthDrainReq struct {
+	kmsg.Request
+	cxn *brokerCxn
+}
+
 type promisedReq struct {
 	ctx     context.Context
 	req     kmsg.Request
@@ -137,10 +148,12 @@ type broker struct {
 	addr string // net.JoinHostPort(meta.Host, meta.Port)
 	meta BrokerMetadata
 
-	// versions tracks the first load of an ApiVersions. We store this
-	// after the first connect, which helps speed things up on future
-	// reconnects (across any of the three broker connections) because we
-	// will never look up API versions for this broker again.
+	// versions tracks the broker's last loaded ApiVersions. Every new
+	// connection re-issues ApiVersions and re-stores the result (see
+	// brokerCxn.init), but the stored value serves request version
+	// resolution across all five broker connections and client-level
+	// capability checks (supportsKeyVersion, supportsFeature) without
+	// opening a connection.
 	versions atomic.Value // *brokerVersions
 
 	// The cxn fields each manage a single tcp connection to one broker.
@@ -254,14 +267,20 @@ func (b *broker) stopForever() {
 
 	b.reqs.die() // no more pushing
 
+	// Snapshot the connections under reapMu but die outside of it: die
+	// runs the user's OnBrokerDisconnect hook, and a hook must not run
+	// under reapMu (a hook that waits on anything that itself needs
+	// reapMu, e.g. a concurrent request's loadConnection, would
+	// deadlock). b.dead is already set above and loadConnection re-checks
+	// it under reapMu before storing, so no new connection can be stored
+	// after this snapshot.
 	b.reapMu.Lock()
-	defer b.reapMu.Unlock()
+	cxns := []*brokerCxn{b.cxnNormal, b.cxnProduce, b.cxnFetch, b.cxnGroup, b.cxnSlow}
+	b.reapMu.Unlock()
 
-	b.cxnNormal.die()
-	b.cxnProduce.die()
-	b.cxnFetch.die()
-	b.cxnGroup.die()
-	b.cxnSlow.die()
+	for _, cxn := range cxns {
+		cxn.die()
+	}
 }
 
 // do issues a request to the broker, eventually calling the response
@@ -315,6 +334,11 @@ start:
 
 func (b *broker) handleReq(pr promisedReq) {
 	req := pr.req
+	if r, ok := req.(*reauthDrainReq); ok {
+		b.handleReauthDrain(r.cxn)
+		pr.promise(nil, nil) // internal sentinel; the promise is a no-op
+		return
+	}
 	var cxn *brokerCxn
 	var retriedOnNewConnection bool
 start:
@@ -411,17 +435,61 @@ start:
 	}
 	req.SetVersion(ourMax)
 
-	if !cxn.expiry.IsZero() && time.Now().After(cxn.expiry) {
-		// If we are after the reauth time, try to reauth. We
-		// can only have an expiry if we went the authenticate
-		// flow, so we know we are authenticating again.
+	if !cxn.expiry.IsZero() && time.Now().After(cxn.expiry) && !cxn.hasDiscard {
+		// If we are after the reauth time, reauthenticate, for KIP-368.
+		// We can only have an expiry if we went the authenticate flow,
+		// so we know we are authenticating again.
 		//
+		// Reauthenticating reads the handshake and authenticate
+		// responses on this goroutine, so it requires that nothing
+		// else can be reading the connection:
+		//
+		//   * If any response is in flight (resps is non-empty -- an
+		//     element stays in the ring while handleResps processes
+		//     it), handleResps is reading this connection and our read
+		//     would race it byte-by-byte, interleaving the two
+		//     responses' bytes between the two readers. We park this
+		//     request (and every following request for this connection)
+		//     so the pipeline drains -- under sustained pipelining the
+		//     pipeline never goes empty on its own, so we must stop
+		//     feeding it. Our expiry is deliberately pessimistic (2-5%
+		//     early, 1s floor; see doSasl), so the in-flight responses
+		//     are on a still-valid session and the drain (bounded by
+		//     their read timeouts) fits the margin. handleResps pushes
+		//     a reauthDrainReq as it exits; handleReauthDrain then
+		//     reauthenticates and replays the parked requests in
+		//     order. Only this connection parks: the broker worker
+		//     keeps serving its other connections. The Java client
+		//     similarly holds the channel's queued send while
+		//     reauthenticating, and it too only begins with no write
+		//     in progress.
+		//
+		//     Ordering of the pending store vs the empty check below
+		//     matters: we store before checking, and handleResps reads
+		//     the flag after its final dropPeek. empty() and dropPeek
+		//     both take the ring mutex, so if we observe a non-empty
+		//     ring, our store happens-before the drain's flag read and
+		//     a parked request can never miss its drain signal.
+		//
+		//   * acks=0 produce connections run a discard goroutine that
+		//     owns all reads forever (hasDiscard, checked above), so
+		//     in-place reauth is never possible: loadConnection
+		//     recreates expired discard connections instead, and a
+		//     fresh connection authenticates in init. We can still get
+		//     here if the connection's lifetime is shorter than our
+		//     pessimism (the fresh connection is already "expired");
+		//     issuing the request on the just-authenticated connection
+		//     is correct, and the next request picks up a new one.
+		cxn.reauthPending.Store(true)
+		if cxn.anyParked() || !cxn.resps.empty() {
+			cxn.park(pr)
+			return
+		}
+		cxn.reauthPending.Store(false)
 		// Some implementations (AWS) occasionally fail for
 		// unclear reasons (principals change, somehow). If
 		// we receive SASL_AUTHENTICATION_FAILED, we retry
 		// once on a new connection. See #249.
-		//
-		// For KIP-368.
 		cxn.cl.cfg.logger.Log(LogLevelDebug, "sasl expiry limit reached, reauthenticating", "broker", logID(cxn.b.meta.NodeID))
 		if err := cxn.sasl(); err != nil {
 			cxn.die()
@@ -449,6 +517,20 @@ start:
 	}
 
 	if _, isForceOpen := req.(*forceOpenReq); isForceOpen {
+		// The connection is already fully open: loadConnection ran init
+		// (dial, ApiVersions, SASL). On an acks=0 produce connection the
+		// discard goroutine owns all reads (hasDiscard), so issuing a
+		// response-expecting request here would start a second reader
+		// (handleResps, via waitResp below) that races the discard read on
+		// the same socket -- the two io.ReadFulls split one byte stream,
+		// the same concurrent-reader hazard the expiry arm and
+		// loadConnection already avoid for reauthentication. The connection
+		// is warm; report success without probing it (init already proved
+		// the connection works end to end).
+		if cxn.hasDiscard {
+			pr.promise(nil, nil)
+			return
+		}
 		// We issue ApiVersions with v0; we could try to bound the
 		// version by going to the start above, but it really does
 		// not matter much.
@@ -576,12 +658,19 @@ func (b *broker) loadConnection(ctx context.Context, req kmsg.Request) (*brokerC
 		pcxn = &b.cxnSlow
 	}
 
-	// Do not reuse a connection that has been idle for longer than idle timeout.
-	// Kill it instead.
-	if *pcxn != nil && !(*pcxn).dead.Load() && (*pcxn).isIdleTimeout(b.cl.cfg.connIdleTimeout) {
-		// die() in a goroutine to avoid blocking
-		go (*pcxn).die()
-		reuse = false
+	// Do not reuse a connection that has been idle for longer than idle
+	// timeout; kill it instead. Same for an acks=0 produce connection
+	// whose sasl session expired: the discard goroutine owns all reads on
+	// it, so in-place reauthentication (which reads handshake responses)
+	// is impossible -- a fresh connection authenticates in init.
+	if *pcxn != nil && !(*pcxn).dead.Load() {
+		cxn := *pcxn
+		expired := cxn.hasDiscard && !cxn.expiry.IsZero() && time.Now().After(cxn.expiry)
+		if cxn.isIdleTimeout(b.cl.cfg.connIdleTimeout) || expired {
+			// die() in a goroutine to avoid blocking
+			go cxn.die()
+			reuse = false
+		}
 	}
 
 	if reuse && *pcxn != nil && !(*pcxn).dead.Load() {
@@ -589,9 +678,13 @@ func (b *broker) loadConnection(ctx context.Context, req kmsg.Request) (*brokerC
 	}
 
 	var tries int
-	start := time.Now()
 doConnect:
 	tries++
+	// start, conn, and err are declared per attempt so that each attempt's
+	// deferred OnBrokerConnect hook reports that attempt's connection,
+	// error, and duration (a backward goto over := re-executes the
+	// declaration; prior attempts' defers keep their own variables).
+	start := time.Now()
 	conn, err := b.connect(ctx)
 	defer func() {
 		since := time.Since(start)
@@ -617,12 +710,10 @@ doConnect:
 		// EventHubs does not handle v4 and resets the connection. We
 		// retry twice. On the first and second attempt, we try our max
 		// version possible (as should be allowed). On the third try,
-		// we downgrade to v0.
-		if er := (*errApiVersionsReset)(nil); errors.As(err, &er) {
-			if tries < 3 {
-				tries++
-				goto doConnect
-			}
+		// we downgrade to v0 (see requestAPIVersions).
+		if er := (*errApiVersionsReset)(nil); errors.As(err, &er) && tries < 3 {
+			cxn.closeConn()
+			goto doConnect
 		}
 		b.cl.cfg.logger.Log(LogLevelDebug, "connection initialization failed", "addr", b.addr, "broker", logID(b.meta.NodeID), "err", err)
 		cxn.closeConn()
@@ -637,24 +728,28 @@ doConnect:
 	}
 
 	b.reapMu.Lock()
-	defer b.reapMu.Unlock()
 
 	// If stopForever ran while we were connecting, the broker is
-	// dead and we must not store the connection. stopForever kills
-	// cxnProduce/etc under reapMu, but if the connection was nil at
-	// that time (we were mid-connect), stopForever's die() was a
-	// no-op. Without this check, the connection escapes destruction
+	// dead and we must not store the connection. stopForever reads
+	// cxnProduce/etc under reapMu before killing them, but if the
+	// connection was nil at that time (we were mid-connect), it was
+	// not seen. Without this check, the connection escapes destruction
 	// and a produce request succeeds on a connection that will never
 	// be reused, which -- combined with other connections from other
 	// broker objects for the same nodeID -- breaks the single-
 	// connection-per-broker ordering guarantee that Kafka requires
 	// for idempotent produce.
+	//
+	// closeConn runs the user's OnBrokerDisconnect hook, so it runs
+	// after the unlock (see stopForever for why).
 	if b.dead.Load() {
+		b.reapMu.Unlock()
 		cxn.closeConn()
 		return nil, errChosenBrokerDead
 	}
 
 	*pcxn = cxn
+	b.reapMu.Unlock()
 	return cxn, nil
 }
 
@@ -698,16 +793,20 @@ func (cl *Client) reapConnections(idleTimeout time.Duration) (total int) {
 }
 
 func (b *broker) reapConnections(idleTimeout time.Duration) (total int) {
+	// Snapshot under reapMu, evaluate and die outside: die runs the
+	// user's OnBrokerDisconnect hook, which must not run under reapMu
+	// (see stopForever).
 	b.reapMu.Lock()
-	defer b.reapMu.Unlock()
-
-	for _, cxn := range []*brokerCxn{
+	cxns := []*brokerCxn{
 		b.cxnNormal,
 		b.cxnProduce,
 		b.cxnFetch,
 		b.cxnGroup,
 		b.cxnSlow,
-	} {
+	}
+	b.reapMu.Unlock()
+
+	for _, cxn := range cxns {
 		if cxn == nil || cxn.dead.Load() {
 			continue
 		}
@@ -777,8 +876,75 @@ type brokerCxn struct {
 	resps ring[promisedResp]
 	// dead is an atomic so that a backed up resps cannot block cxn death.
 	dead atomic.Bool
-	// closed in cloneConn; allows throttle waiting to quit
+	// closed in closeConn; allows throttle waiting to quit
 	deadCh chan struct{}
+	// hasDiscard is set during init (before the connection is shared) if
+	// this is an acks=0 produce connection running the discard goroutine.
+	// The discard goroutine owns all reads on the connection, so sasl
+	// reauthentication can never happen in place; see handleReq and
+	// loadConnection.
+	hasDiscard bool
+
+	// reauthPending is set by the broker worker when the sasl expiry has
+	// passed but responses are still in flight (handleResps owns reads,
+	// so reauthenticating would race it). While pending, requests for
+	// this connection park instead of being written, so the pipeline
+	// drains; handleResps pushes a reauthDrainReq as it exits to
+	// reauthenticate and replay them. See handleReq's expiry arm for the
+	// store/load ordering argument.
+	reauthPending atomic.Bool
+
+	// parkMu guards parked/parkFailed. parked holds requests, in arrival
+	// order, that are waiting for a pending reauthentication; order
+	// matters for idempotent produce, whose sequence numbers were
+	// assigned at request build. die fails everything parked (and marks
+	// parkFailed) so a dead connection cannot strand requests.
+	parkMu     xsync.Mutex
+	parked     []promisedReq
+	parkFailed bool
+}
+
+// park holds a request destined for this connection while a sasl
+// reauthentication is pending; handleReauthDrain replays parked requests in
+// order once the pipeline drains. If the connection already died (die fails
+// everything parked), the request fails immediately with the same retryable
+// error that ring-queued requests receive on broker death.
+func (cxn *brokerCxn) park(pr promisedReq) {
+	cxn.parkMu.Lock()
+	if cxn.parkFailed {
+		cxn.parkMu.Unlock()
+		pr.promise(nil, errChosenBrokerDead)
+		return
+	}
+	cxn.parked = append(cxn.parked, pr)
+	n := len(cxn.parked)
+	cxn.parkMu.Unlock()
+	cxn.cl.cfg.logger.Log(LogLevelDebug, "sasl expiry limit reached but responses are in flight, parking request until the pipeline drains", "broker", logID(cxn.b.meta.NodeID), "parked_reqs", n)
+}
+
+func (cxn *brokerCxn) anyParked() bool {
+	cxn.parkMu.Lock()
+	defer cxn.parkMu.Unlock()
+	return len(cxn.parked) > 0
+}
+
+func (cxn *brokerCxn) takeParked() []promisedReq {
+	cxn.parkMu.Lock()
+	defer cxn.parkMu.Unlock()
+	parked := cxn.parked
+	cxn.parked = nil
+	return parked
+}
+
+func (cxn *brokerCxn) failParked() {
+	cxn.parkMu.Lock()
+	parked := cxn.parked
+	cxn.parked = nil
+	cxn.parkFailed = true
+	cxn.parkMu.Unlock()
+	for _, pr := range parked {
+		pr.promise(nil, errChosenBrokerDead)
+	}
 }
 
 func (cxn *brokerCxn) init(isProduceCxn bool, tries int) error {
@@ -811,6 +977,7 @@ func (cxn *brokerCxn) init(isProduceCxn bool, tries int) error {
 	}
 
 	if isProduceCxn && cxn.cl.cfg.acks.val == 0 {
+		cxn.hasDiscard = true
 		go cxn.discard() // see docs on discard for why we do this
 	}
 	return nil
@@ -882,9 +1049,19 @@ start:
 			cxn.cl.cfg.logger.Log(LogLevelDebug, "broker does not know our ApiVersions version, downgrading to version 0 and retrying", "broker", logID(cxn.b.meta.NodeID))
 			goto start
 		case len(resp.ApiKeys) == 1 && resp.ApiKeys[0].ApiKey == 18:
-			maxVersion = resp.ApiKeys[0].MaxVersion
-			cxn.cl.cfg.logger.Log(LogLevelDebug, fmt.Sprintf("broker does not know our ApiVersions version but replied version %[1]d, downgrading to version %[1]d and retrying", maxVersion), "broker", logID(cxn.b.meta.NodeID))
-			goto start
+			// KIP-511: the broker replies with the version we should
+			// retry with. Only accept a strictly lower, non-negative
+			// version: a real broker advertises less than what it
+			// just rejected, and accepting anything else would let a
+			// buggy/hostile broker keep us in this downgrade loop
+			// forever (the init path runs on no request context, so
+			// only client close would stop it).
+			if v := resp.ApiKeys[0].MaxVersion; v >= 0 && v < maxVersion {
+				maxVersion = v
+				cxn.cl.cfg.logger.Log(LogLevelDebug, fmt.Sprintf("broker does not know our ApiVersions version but replied version %[1]d, downgrading to version %[1]d and retrying", maxVersion), "broker", logID(cxn.b.meta.NodeID))
+				goto start
+			}
+			return fmt.Errorf("broker replied with UNSUPPORTED_VERSION to our v%d ApiVersions request but advertised non-downgrade version %d", maxVersion, resp.ApiKeys[0].MaxVersion)
 		default:
 			// Should not hit this case, but we hope the broker replied with all keys
 		}
@@ -1066,6 +1243,16 @@ func (cxn *brokerCxn) doSasl(authenticate bool) error {
 	}
 
 	if lifetimeMillis > 0 {
+		// A hostile/buggy broker can reply with a lifetime so large
+		// that converting it to a time.Duration overflows, wrapping
+		// the expiry into the past and forcing a reauth before every
+		// request. Anything beyond a year never matters for a real
+		// connection; clamp.
+		const maxLifetimeMillis = 365 * 24 * int64(time.Hour/time.Millisecond)
+		if lifetimeMillis > maxLifetimeMillis {
+			lifetimeMillis = maxLifetimeMillis
+		}
+
 		// Lifetime is problematic. We need to be a bit pessimistic.
 		//
 		// We want a lowerbound: we use 1s (arbitrary), but if 1.1x our
@@ -1104,6 +1291,14 @@ func (cxn *brokerCxn) doSasl(authenticate bool) error {
 			"lifetime_pessimism", time.Duration(usePessimismMillis)*time.Millisecond,
 			"reauthenticate_in", cxn.expiry.Sub(now),
 		)
+	} else {
+		// No (or zero) lifetime means the broker does not require
+		// reauthentication, KIP-368. If a previous authenticate on
+		// this connection set an expiry (reauth was enabled then, e.g.
+		// before a dynamic broker config change), clear it: keeping
+		// the old, already-passed expiry would re-run the full sasl
+		// flow before every subsequent request on this connection.
+		cxn.expiry = time.Time{}
 	}
 	return nil
 }
@@ -1395,9 +1590,11 @@ func (cxn *brokerCxn) readResponse(
 	return buf[4:], nil
 }
 
-// closeConn is the one place we close broker connections. This is always done
-// in either die, which is called when handleResps returns, or if init fails,
-// which means we did not succeed enough to start handleResps.
+// closeConn is the one place we close broker connections. It is reached via
+// die (callable from anywhere once the connection is live: read/write errors,
+// reaping, broker stoppage) or directly when the connection was never shared:
+// init failure, the ApiVersions-reset retry, and loadConnection's dead-broker
+// arm.
 func (cxn *brokerCxn) closeConn() {
 	cxn.cl.cfg.hooks.each(func(h Hook) {
 		if h, ok := h.(HookBrokerDisconnect); ok {
@@ -1409,13 +1606,15 @@ func (cxn *brokerCxn) closeConn() {
 }
 
 // die kills a broker connection (which could be dead already) and replies to
-// all requests awaiting responses appropriately.
+// all requests awaiting responses appropriately, including requests parked
+// for a pending reauthentication.
 func (cxn *brokerCxn) die() {
 	if cxn == nil || cxn.dead.Swap(true) {
 		return
 	}
 	cxn.closeConn()
 	cxn.resps.die()
+	cxn.failParked()
 }
 
 // waitResp, called serially by a broker's handleReqs, manages handling a
@@ -1540,7 +1739,7 @@ func (cxn *brokerCxn) discard() {
 				}
 				nread2, err = cxn.conn.Read(discard)
 				nread += nread2
-				size -= int32(nread2) // nread2 max is 128
+				size -= int32(nread2) // nread2 max is len(discardBuf), 256
 			}
 		}()
 
@@ -1580,6 +1779,60 @@ start:
 	pr, more, dead = cxn.resps.dropPeek()
 	if more {
 		goto start
+	}
+
+	// The ring is empty and this worker is exiting: no read is in flight
+	// and none can start (only the broker worker pushes responses, and it
+	// parks requests for this connection while a reauth is pending). If a
+	// reauth is pending, signal the broker worker to perform it and
+	// replay the parked requests. If the broker is stopping, the failed
+	// push is fine: stopForever dies every connection, and die fails
+	// everything parked.
+	if cxn.reauthPending.Load() {
+		cxn.b.do(cxn.cl.ctx, &reauthDrainReq{cxn: cxn}, func(kmsg.Response, error) {})
+	}
+}
+
+// handleReauthDrain runs on the broker worker goroutine when a connection
+// with a pending reauthentication has drained its in-flight responses (its
+// handleResps worker pushed this sentinel as it exited). No reads can be in
+// flight: handleResps exited, only this goroutine starts another (by writing
+// a request), and every request for this connection since the expiry passed
+// was parked. Reauthenticate and replay the parked requests in their
+// original order -- order matters for idempotent produce, whose sequence
+// numbers were assigned at request build.
+func (b *broker) handleReauthDrain(cxn *brokerCxn) {
+	// A sentinel can be spurious: the quiet-connection reauth arm stores
+	// the pending flag and clears it just after, and a concurrently
+	// exiting handleResps can observe the transient true. That alone is
+	// a harmless no-op below -- but if the broker also hands out
+	// immediately-expiring lifetimes, a request queued behind this
+	// sentinel's push may have re-parked by now with a NEW response in
+	// flight (the inline arm's own request), so "drained" no longer
+	// holds. If anything is in flight, touch nothing: that response's
+	// handleResps exit re-signals (the parker stored the pending flag
+	// before observing the non-empty ring, so the exit cannot miss it)
+	// and the re-signal finds the connection actually quiet.
+	if !cxn.resps.empty() {
+		return
+	}
+
+	// Take the parked requests before a possible die below: a failed
+	// reauth must not fail them, it replays them through the normal path,
+	// which builds a fresh connection with a fresh authentication -- the
+	// same recovery the in-place reauth arm provides via its
+	// retry-on-new-connection. (If the connection died earlier, die
+	// already failed everything parked and this take returns nil.)
+	parked := cxn.takeParked()
+	if cxn.reauthPending.Swap(false) && !cxn.dead.Load() {
+		cxn.cl.cfg.logger.Log(LogLevelDebug, "sasl expiry limit reached and responses have drained, reauthenticating", "broker", logID(cxn.b.meta.NodeID), "parked_reqs", len(parked))
+		if err := cxn.sasl(); err != nil {
+			cxn.cl.cfg.logger.Log(LogLevelDebug, "sasl reauth failed, killing connection; any parked requests retry on a new connection", "broker", logID(cxn.b.meta.NodeID), "err", err)
+			cxn.die()
+		}
+	}
+	for _, pr := range parked {
+		b.handleReq(pr)
 	}
 }
 
@@ -1629,6 +1882,14 @@ func (cxn *brokerCxn) handleResp(pr promisedResp) {
 	if readErr == nil {
 		if throttleResponse, ok := pr.resp.(kmsg.ThrottleResponse); ok {
 			millis, throttlesAfterResp := throttleResponse.Throttle()
+			// A throttle is honored in full with NO upper cap (KIP-219),
+			// matching Java's NetworkClient. millis <= 0 is ignored; a
+			// positive value - even a hostile near-MaxInt32 (~24.8 days) -
+			// delays the next write on this connection (writeRequest), which
+			// selects on the request ctx and client Close, so the wait is
+			// always interruptible and holds no lock. Capping it would break
+			// the quota mechanism; an absurd throttle is equivalent to a slow
+			// broker, which is always possible. Do not add a cap.
 			if millis > 0 {
 				if pr.resp.Key() == 0 {
 					cxn.b.cl.metrics.observeTime(&cxn.b.cl.metrics.pThrottle, int64(millis))

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/client.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/client.go
@@ -371,7 +371,7 @@ func (cl *Client) OptValues(opt any) []any {
 		return []any{cfg.recordTimeout}
 	case namefn(TransactionalID):
 		if cfg.txnID != nil {
-			return []any{cfg.txnID, true}
+			return []any{*cfg.txnID, true}
 		}
 		return []any{"", false}
 	case namefn(TransactionTimeout):
@@ -461,6 +461,14 @@ func (cl *Client) OptValues(opt any) []any {
 		return []any{true}
 	case namefn(SessionTimeout):
 		return []any{cfg.sessionTimeout}
+	case namefn(ShareGroup):
+		return []any{cfg.shareGroup}
+	case namefn(ShareAckCallback):
+		return []any{cfg.shareAckCallback}
+	case namefn(ShareMaxRecords):
+		return []any{cfg.shareMaxRecords}
+	case namefn(ShareMaxRecordsStrict):
+		return []any{cfg.shareMaxRecordsStrict}
 
 	default:
 		return nil
@@ -680,7 +688,7 @@ func (cl *Client) Ping(ctx context.Context) error {
 //
 // For admin requests, this deletes the topic from the cached metadata map for
 // sharded requests. Metadata for sharded admin requests is only cached for
-// MetadataMinAge anyway, but the map is not cleaned up one the metadata
+// MetadataMinAge anyway, but the map is not cleaned up once the metadata
 // expires. This function ensures the map is purged.
 func (cl *Client) PurgeTopicsFromClient(topics ...string) {
 	if len(topics) == 0 {
@@ -934,7 +942,21 @@ func (cl *Client) supportsOffsetForLeaderEpoch() bool {
 // v1 introduces support for regex and requires the client to generate
 // the member ID, and fully stabilizes KIP-848.
 func (cl *Client) supportsKIP848v1() bool {
-	return cl.supportsKeyVersion(int16(kmsg.ConsumerGroupHeartbeat), 1)
+	if !cl.supportsKeyVersion(int16(kmsg.ConsumerGroupHeartbeat), 1) {
+		return false
+	}
+	// The 848 manage loop runs v1 semantics (client-generated member ID,
+	// regex subscriptions). If the user's MaxVersions caps the heartbeat
+	// below v1, the wire request would be v0 while we behave as v1: v0
+	// has no SubscribedTopicRegex field at all, so a regex consumer's
+	// join would carry no subscription and silently consume nothing.
+	// Only opt in if the cap allows v1, mirroring supportsKIP890p2.
+	if mv := cl.cfg.maxVersions; mv != nil {
+		if v, ok := mv.LookupMaxKeyVersion(int16(kmsg.ConsumerGroupHeartbeat)); !ok || v < 1 {
+			return false
+		}
+	}
+	return true
 }
 
 // Called after the first metric observed, which is always after a response.
@@ -963,7 +985,28 @@ func (cl *Client) supportsKeyVersion(key, version int16) bool {
 }
 
 func (cl *Client) supportsKIP890p2() bool {
-	return cl.supportsFeature("transaction.version", 2)
+	if !cl.supportsFeature("transaction.version", 2) {
+		return false
+	}
+	// The KIP-890 part 2 paths change what goes on the wire: produce v12+
+	// skips AddPartitionsToTxn, TxnOffsetCommit v5+ skips AddOffsetsToTxn,
+	// and EndTxn v5+ bumps the producer epoch. A user MaxVersions cap
+	// below any of those keeps the OLD wire versions while skipping the
+	// explicit add requests, and the broker then rejects the produces
+	// with INVALID_TXN_STATE because the partitions were never added to
+	// the transaction. Only opt in if the cap allows the new versions.
+	if mv := cl.cfg.maxVersions; mv != nil {
+		if v, ok := mv.LookupMaxKeyVersion(int16(kmsg.Produce)); !ok || v < 12 {
+			return false
+		}
+		if v, ok := mv.LookupMaxKeyVersion(int16(kmsg.EndTxn)); !ok || v < 5 {
+			return false
+		}
+		if v, ok := mv.LookupMaxKeyVersion(int16(kmsg.TxnOffsetCommit)); !ok || v < 5 {
+			return false
+		}
+	}
+	return true
 }
 
 // Same as above. A cluster returns a max version for a feature only once the
@@ -987,32 +1030,42 @@ func (cl *Client) supportsFeature(name string, version int16) bool {
 }
 
 // fetchBrokerMetadata issues a metadata request solely for broker information.
+//
+// Concurrent callers collapse onto one in-flight request. The request itself
+// runs on the client context: if it ran on the initiating caller's context,
+// that caller canceling would fail every collapsed waiter with the canceled
+// error even though their own contexts are live (the same reasoning as
+// doLoadCoordinators). Each caller's context governs only its own wait; an
+// abandoned fetch still completes and updates broker state, which is fine.
 func (cl *Client) fetchBrokerMetadata(ctx context.Context) error {
 	cl.fetchingBrokersMu.Lock()
 	wait := cl.fetchingBrokers
-	if wait != nil {
-		cl.fetchingBrokersMu.Unlock()
-		<-wait.done
-		return wait.err
+	if wait == nil {
+		wait = &struct {
+			done chan struct{}
+			err  error
+		}{done: make(chan struct{})}
+		cl.fetchingBrokers = wait
+		go func() {
+			defer func() {
+				cl.fetchingBrokersMu.Lock()
+				defer cl.fetchingBrokersMu.Unlock()
+				cl.fetchingBrokers = nil
+				close(wait.done)
+			}()
+			req := kmsg.NewPtrMetadataRequest()
+			req.Topics = []kmsg.MetadataRequestTopic{}
+			_, _, wait.err = cl.fetchMetadata(cl.ctx, req, true, nil)
+		}()
 	}
-	wait = &struct {
-		done chan struct{}
-		err  error
-	}{done: make(chan struct{})}
-	cl.fetchingBrokers = wait
 	cl.fetchingBrokersMu.Unlock()
 
-	defer func() {
-		cl.fetchingBrokersMu.Lock()
-		defer cl.fetchingBrokersMu.Unlock()
-		cl.fetchingBrokers = nil
-		close(wait.done)
-	}()
-
-	req := kmsg.NewPtrMetadataRequest()
-	req.Topics = []kmsg.MetadataRequestTopic{}
-	_, _, wait.err = cl.fetchMetadata(ctx, req, true, nil)
-	return wait.err
+	select {
+	case <-wait.done:
+		return wait.err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func (cl *Client) fetchMetadataByName(ctx context.Context, all bool, topics []string, results map[string]cachedMetaTopic) (*broker, *kmsg.MetadataResponse, error) {
@@ -1119,8 +1172,18 @@ func (cl *Client) updateMetadataBrokers(resp *kmsg.MetadataResponse) {
 }
 
 // updateBrokers is called with the broker portion of every metadata response.
-// All metadata responses contain all known live brokers, so we can always
-// use the response.
+// All metadata responses contain all known live brokers, so the response list
+// is authoritative and we diff-merge it: brokers absent from it are stopped.
+//
+// An EMPTY list therefore wipes all discovered brokers and falls back to
+// seeds. This is intentional and long-standing: if a broker ever answers
+// metadata with no brokers, falling back to the seeds is safer than being
+// left with none, and it re-covers every seed should the cluster have somehow
+// split. KIP-1102's rebootstrap rides the same path, calling updateBrokers(nil)
+// explicitly. A buggy broker sending a transient subset only kills those
+// connections (in-flight requests fail with retriable errChosenBrokerDead) and
+// the next good response heals. Do not special-case the empty list back into a
+// no-op.
 func (cl *Client) updateBrokers(brokers []kmsg.MetadataResponseBroker) {
 	sort.Slice(brokers, func(i, j int) bool { return brokers[i].NodeID < brokers[j].NodeID })
 	newBrokers := make([]*broker, 0, len(brokers))
@@ -1270,22 +1333,27 @@ func (cl *Client) close(ctx context.Context) (rerr error) {
 	wg.Wait()
 	sessCloseCancel()
 
+	// Tell the metrics loop to send its final Terminating=true push and
+	// give it 1s to do so. This must happen BEFORE we cancel the client
+	// context: the entire request path (shardedRequest's cancel watchdog,
+	// Broker.request's select, and the broker connection write/read
+	// loops) aborts requests once cl.ctx is dead, so a terminating push
+	// started after cancelation could never be delivered. The metrics
+	// loop cancels metrics.ctx when it exits; clients with metrics
+	// disabled, unsupported, or never observed pass through instantly.
+	cl.metrics.quit()
+	after := time.NewTimer(time.Second)
+	select {
+	case <-cl.metrics.ctx.Done():
+		after.Stop()
+	case <-after.C:
+		cl.metrics.ctxCancel()
+	}
+
 	// Now we kill the client context and all brokers, ensuring all
 	// requests fail. This will finish all producer callbacks and
 	// stop the metadata loop and metrics loop.
 	cl.ctxCancel()
-
-	// Before killing brokers, give metrics 1s to push any final
-	// terminating message. The client context cancelation awakens
-	// the push-period-wait loop.
-	after := time.NewTimer(time.Second)
-	select {
-	case <-cl.metrics.ctx.Done():
-	case <-after.C:
-		cl.metrics.ctxCancel()
-	case <-ctx.Done():
-		cl.metrics.ctxCancel()
-	}
 
 	cl.brokersMu.Lock()
 	cl.stopBrokers = true
@@ -1356,6 +1424,8 @@ func (cl *Client) close(ctx context.Context) (rerr error) {
 //	ListGroups
 //	DeleteRecords
 //	OffsetForLeaderEpoch
+//	AddPartitionsToTxn
+//	WriteTxnMarkers
 //	DescribeConfigs
 //	AlterConfigs
 //	AlterReplicaLogDirs
@@ -1664,7 +1734,7 @@ type ResponseShard struct {
 	// unknown (node ID -1) metadata if the request could not be issued.
 	//
 	// Requests can fail to even be issued if an appropriate broker cannot
-	// be loaded of if the client cannot understand the request.
+	// be loaded or if the client cannot understand the request.
 	Meta BrokerMetadata
 
 	// Req is the request that was issued to this broker.
@@ -1690,9 +1760,9 @@ type ResponseShard struct {
 //
 // If, in the process of splitting a request, some topics or partitions are
 // found to not exist, or Kafka replies that a request should go to a broker
-// that does not exist, all those non-existent pieces are grouped into one
-// request to the first seed broker. This will show up as a seed broker node ID
-// (min int32) and the response will likely contain purely errors.
+// that does not exist, all those non-existent pieces are not issued; they are
+// returned as error shards with an unknown broker metadata (node ID -1) and
+// the error that prevented the piece from being mapped to a broker.
 //
 // The response shards are ordered by broker metadata.
 func (cl *Client) RequestSharded(ctx context.Context, req kmsg.Request) []ResponseShard {
@@ -1834,20 +1904,23 @@ func findBroker(candidates []*broker, node int32) *broker {
 // that error.
 func (cl *Client) brokerOrErr(ctx context.Context, id int32, err error) (*broker, error) {
 	if id < 0 {
+		// Negative IDs are seed brokers (unknownSeedID), exposed to
+		// users via SeedBrokers(). Any other negative ID (-1 unknown
+		// controller / coordinator sentinels) never exists, and
+		// metadata responses cannot introduce negative IDs, so we
+		// look up seeds directly and never try a metadata load.
+		if b := findBroker(cl.loadSeeds(), id); b != nil {
+			return b, nil
+		}
 		return nil, err
 	}
 
 	tryLoad := ctx != nil
 	tries := 0
 start:
-	var broker *broker
-	if id < 0 {
-		broker = findBroker(cl.loadSeeds(), id)
-	} else {
-		cl.brokersMu.RLock()
-		broker = findBroker(cl.brokers, id)
-		cl.brokersMu.RUnlock()
-	}
+	cl.brokersMu.RLock()
+	broker := findBroker(cl.brokers, id)
+	cl.brokersMu.RUnlock()
 
 	if broker == nil {
 		if tryLoad {
@@ -1946,13 +2019,13 @@ func (cl *Client) loadCoordinators(ctx context.Context, typ int8, keys ...string
 	}
 }
 
-// doLoadCoordinators uses the caller context to cancel loading metadata
-// (brokerOrErr), but we use the client context to actually issue the request.
-// There should be only one direct call to doLoadCoordinators, just above in
-// loadCoordinator. It is possible for two requests to be loading the same
-// coordinator (in fact, that's the point of this function -- collapse these
-// requests). We do not want the first request canceling it's context to cause
-// errors for the second request.
+// doLoadCoordinators issues the FindCoordinator request - and any broker
+// metadata load needed to resolve the response - on the client context. It is
+// possible for two requests to be loading the same coordinator (in fact,
+// that's the point of this function -- collapse these requests). We do not
+// want the first request canceling its context to cause errors for the
+// second request. The caller context only cancels the caller's wait, via
+// loadCoordinators above.
 //
 // It is ok to leave FindCoordinator running even if the caller quits. Worst
 // case, we just cache things for some time in the future; yay.
@@ -2297,8 +2370,18 @@ func (cl *Client) handleCoordinatorReq(ctx context.Context, req kmsg.Request) Re
 	case *kmsg.OffsetDeleteRequest:
 		return cl.handleCoordinatorReqSimple(ctx, coordinatorTypeGroup, t.Group, req)
 
-	// ConsumerGroupHeartbeat cannot be retried at all
+	// ConsumerGroupHeartbeat carries reconciliation state and cannot be
+	// blindly retried; the 848 heartbeat loop owns retries with full
+	// state knowledge. The exception is leaving (MemberEpoch -1, or -2
+	// for static members): a leave carries no reconcilable state and is
+	// idempotent, and the coordinator moving is precisely when leaves
+	// are issued against a stale cached coordinator - firing it once
+	// would lose the leave to a single NOT_COORDINATOR and ghost the
+	// member until the session timeout.
 	case *kmsg.ConsumerGroupHeartbeatRequest:
+		if t.MemberEpoch < 0 {
+			return cl.handleCoordinatorReqSimple(ctx, coordinatorTypeGroup, t.Group, req)
+		}
 		br, err := cl.loadCoordinator(ctx, coordinatorTypeGroup, t.Group)
 		var resp kmsg.Response
 		if err == nil {
@@ -2310,10 +2393,14 @@ func (cl *Client) handleCoordinatorReq(ctx context.Context, req kmsg.Request) Re
 	// SHARE //
 	///////////
 
-	// ShareGroupHeartbeat cannot be retried (like ConsumerGroupHeartbeat).
-	// Like ConsumerGroupHeartbeat, share membership is managed by the
-	// GROUP coordinator, not the share-state coordinator.
+	// ShareGroupHeartbeat cannot be retried (like ConsumerGroupHeartbeat),
+	// except for the leave, which is retried for the same reason as
+	// above. Share membership is managed by the GROUP coordinator, not
+	// the share-state coordinator.
 	case *kmsg.ShareGroupHeartbeatRequest:
+		if t.MemberEpoch < 0 {
+			return cl.handleCoordinatorReqSimple(ctx, coordinatorTypeGroup, t.GroupID, req)
+		}
 		br, err := cl.loadCoordinator(ctx, coordinatorTypeGroup, t.GroupID)
 		var resp kmsg.Response
 		if err == nil {
@@ -2387,6 +2474,8 @@ func (cl *Client) handleReqWithCoordinator(
 		case *kmsg.SyncGroupResponse:
 			code = t.ErrorCode
 		case *kmsg.ConsumerGroupHeartbeatResponse:
+			code = t.ErrorCode
+		case *kmsg.ShareGroupHeartbeatResponse:
 			code = t.ErrorCode
 		}
 
@@ -2742,13 +2831,18 @@ func (cl *Client) handleShardedReq(ctx context.Context, req kmsg.Request) ([]Res
 			start:
 				tries++
 
-				br := cl.broker()
+				var br *broker
 				var err error
 				if !myIssue.any {
 					br, err = cl.brokerOrErr(ctx, myIssue.broker, errUnknownBroker)
-				} else if avoidBroker != -1 {
-					for i := 0; i < 3 && br.meta.NodeID == avoidBroker; i++ {
-						br = cl.broker()
+				} else {
+					// Only consume an any-broker rotation slot for
+					// shards that actually go to any broker.
+					br = cl.broker()
+					if avoidBroker != -1 {
+						for i := 0; i < 3 && br.meta.NodeID == avoidBroker; i++ {
+							br = cl.broker()
+						}
 					}
 				}
 				if err != nil {
@@ -3063,6 +3157,12 @@ func (cl *Client) storeCachedMeta(meta *kmsg.MetadataResponse, all bool, results
 			t:    topic,
 			ps:   make(map[int32]kmsg.MetadataResponseTopicPartition),
 			when: when,
+		}
+		// A recreated topic comes back under a new ID. Delete the old
+		// ID's mapping when overwriting the entry, else byID accumulates
+		// stale IDs forever and resolves IDs that no longer exist.
+		if old, ok := cl.metaCache.topics[topicName]; ok && old.id != topic.TopicID && old.id != zeroID {
+			delete(cl.metaCache.byID, old.id)
 		}
 		cl.metaCache.topics[topicName] = t
 		for _, partition := range topic.Partitions {
@@ -4234,15 +4334,26 @@ func (cl *addPartitionsToTxnSharder) shard(ctx context.Context, kreq kmsg.Reques
 
 	var issues []issueShard
 	for id, req := range brokerReqs {
-		if len(req.Transactions) <= 1 || len(req.Transactions) == 1 && !req.Transactions[0].VerifyOnly {
+		if len(req.Transactions) == 1 && !req.Transactions[0].VerifyOnly {
+			// Clients must use v3 and below; v4+ requires CLUSTER_ACTION
+			// authorization because it is the broker-to-broker side of
+			// KIP-890.
 			issues = append(issues, issueShard{
 				req:    req,
 				pin:    &pinReq{pinMax: true, max: 3},
 				broker: id,
 			})
 		} else {
+			// Batched transactions and VerifyOnly only exist in v4+:
+			// the v3 body has no Transactions array and no VerifyOnly
+			// field, so serializing this request any lower silently
+			// drops everything that matters - VerifyOnly in particular
+			// would turn a verification into a real partition add. Pin
+			// min 4 so brokers that cannot express the request fail
+			// loudly with errBrokerTooOld instead.
 			issues = append(issues, issueShard{
 				req:    req,
+				pin:    &pinReq{pinMin: true, min: 4},
 				broker: id,
 			})
 		}
@@ -4347,10 +4458,11 @@ func (cl *writeTxnMarkersSharder) shard(ctx context.Context, kreq kmsg.Request, 
 	}
 
 	type pidEpochCommit struct {
-		pid        int64
-		epoch      int16
-		commit     bool
-		txnVersion int8
+		pid              int64
+		epoch            int16
+		commit           bool
+		coordinatorEpoch int32
+		txnVersion       int8
 	}
 
 	brokerReqs := make(map[int32]map[pidEpochCommit]map[string][]int32)
@@ -4388,6 +4500,7 @@ func (cl *writeTxnMarkersSharder) shard(ctx context.Context, kreq kmsg.Request, 
 			marker.ProducerID,
 			marker.ProducerEpoch,
 			marker.Committed,
+			marker.CoordinatorEpoch,
 			marker.TransactionVersion,
 		}
 		for _, topic := range marker.Topics {
@@ -4424,6 +4537,7 @@ func (cl *writeTxnMarkersSharder) shard(ctx context.Context, kreq kmsg.Request, 
 			rm.ProducerID = pec.pid
 			rm.ProducerEpoch = pec.epoch
 			rm.Committed = pec.commit
+			rm.CoordinatorEpoch = pec.coordinatorEpoch
 			rm.TransactionVersion = pec.txnVersion
 			for topic, parts := range topics {
 				rt := kmsg.NewWriteTxnMarkersRequestMarkerTopic()
@@ -4446,6 +4560,7 @@ func (cl *writeTxnMarkersSharder) shard(ctx context.Context, kreq kmsg.Request, 
 			rm.ProducerID = pec.pid
 			rm.ProducerEpoch = pec.epoch
 			rm.Committed = pec.commit
+			rm.CoordinatorEpoch = pec.coordinatorEpoch
 			rm.TransactionVersion = pec.txnVersion
 			for topic, parts := range topics {
 				rt := kmsg.NewWriteTxnMarkersRequestMarkerTopic()

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/compression.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/compression.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
+	"math"
 	"runtime"
 	"slices"
 	"sync"
@@ -16,6 +17,24 @@ import (
 )
 
 var byteBuffers = sync.Pool{New: func() any { return bytes.NewBuffer(make([]byte, 8<<10)) }}
+
+// maxDecompressedSize caps how much one batch may decompress to. Fetch
+// limits bound only the COMPRESSED bytes on the wire; nothing in the
+// protocol bounds the decompressed size, and the whole batch is
+// materialized contiguously while decompressing. Without a cap, a few-KB
+// malicious or corrupt batch can demand tens of GiB: zstd frames declare a
+// content size that is honored up to the decoder's configured limit (the
+// library default is 64 GiB), gzip expands up to ~1032x, lz4 up to ~255x,
+// and snappy headers claim up to 4 GiB. No legitimate batch can exceed
+// math.MaxInt32 decompressed: every known producer serializes a batch's
+// records into an int32-indexed buffer before compressing (this client's
+// own appendTo, Java's MemoryRecordsBuilder over a ByteBuffer, librdkafka),
+// so a batch claiming more is corrupt or hostile and is rejected like any
+// other corrupt batch: a loud, repeated fetch error with no offset advance.
+// A var only so tests can shrink it.
+var maxDecompressedSize = int64(math.MaxInt32)
+
+var errDecompressedTooLarge = errors.New("decompressed data exceeds the maximum allowed decompressed batch size (corrupt or malicious batch)")
 
 // CompressionCodecType is a bitfield specifying a Kafka-defined compression
 // codec. Per spec, only four compression codecs are supported. However, if
@@ -35,8 +54,9 @@ const (
 	// CodecZstd is a compression codec signifying zstd compression.
 	CodecZstd
 
-	// CodecError is returned from compressing or decompressing if an error
-	// occurred.
+	// CodecError is returned as the used-codec from Compress if an error
+	// occurred while compressing (Decompress reports errors via its error
+	// return instead).
 	CodecError = -1
 )
 
@@ -176,7 +196,7 @@ out:
 		case CodecGzip:
 			level := gzip.DefaultCompression
 			if codec.level != 0 {
-				if _, err := gzip.NewWriterLevel(nil, codec.level); err != nil {
+				if _, err := gzip.NewWriterLevel(nil, codec.level); err == nil {
 					level = codec.level
 				}
 			}
@@ -322,6 +342,7 @@ func DefaultDecompressor(pools ...Pool) Decompressor {
 				zstdDec, _ := zstd.NewReader(nil,
 					zstd.WithDecoderLowmem(true),
 					zstd.WithDecoderConcurrency(1),
+					zstd.WithDecoderMaxMemory(uint64(maxDecompressedSize)),
 				)
 				r := &zstdDecoder{zstdDec}
 				runtime.SetFinalizer(r, func(r *zstdDecoder) {
@@ -352,7 +373,12 @@ func (d *decompressor) Decompress(src []byte, codecType CompressionCodecType) ([
 	d.pools.each(func(p Pool) bool {
 		if pdecompressBytes, ok := p.(PoolDecompressBytes); ok {
 			s := pdecompressBytes.GetDecompressBytes(src, codecType)
-			out = bytes.NewBuffer(s)
+			// Only the slice's capacity is used: decompressed data
+			// must start at index 0, while a buffer initialized with
+			// len(s) > 0 (a pool returning make([]byte, sizeGuess))
+			// would have the copy/append based codecs write AFTER the
+			// existing length, prefixing the output with stale bytes.
+			out = bytes.NewBuffer(s[:0])
 			rfn = out.Bytes
 			userPooled = true
 			return true
@@ -382,13 +408,30 @@ func (d *decompressor) Decompress(src []byte, codecType CompressionCodecType) ([
 		if err := ungz.Reset(bytes.NewReader(src)); err != nil {
 			return nil, err
 		}
-		if _, err := io.Copy(out, ungz); err != nil {
+		if n, err := io.Copy(out, io.LimitReader(ungz, maxDecompressedSize+1)); err != nil {
 			return nil, err
+		} else if n > maxDecompressedSize {
+			return nil, errDecompressedTooLarge
 		}
 		return rfn(), nil
 	case CodecSnappy:
 		if len(src) > 16 && bytes.HasPrefix(src, xerialPfx) {
-			return xerialDecode(src)
+			// Decode into the pooled destination when one exists;
+			// this path previously ignored the pool's Get entirely
+			// (fresh allocation every batch, and the Get'd slice was
+			// orphaned: never used, never put back).
+			var xdst []byte
+			if userPooled {
+				xdst = out.Bytes()
+			}
+			return xerialDecode(xdst, src)
+		}
+		// The decoded length is read from the header and allocated up
+		// front; check the claim before decoding.
+		if l, err := s2.DecodedLen(src); err != nil {
+			return nil, err
+		} else if int64(l) > maxDecompressedSize {
+			return nil, errDecompressedTooLarge
 		}
 		decoded, err := s2.Decode(out.Bytes(), src)
 		if err != nil {
@@ -402,8 +445,10 @@ func (d *decompressor) Decompress(src []byte, codecType CompressionCodecType) ([
 		unlz4 := d.unlz4Pool.Get().(*lz4.Reader)
 		defer d.unlz4Pool.Put(unlz4)
 		unlz4.Reset(bytes.NewReader(src))
-		if _, err := io.Copy(out, unlz4); err != nil {
+		if n, err := io.Copy(out, io.LimitReader(unlz4, maxDecompressedSize+1)); err != nil {
 			return nil, err
+		} else if n > maxDecompressedSize {
+			return nil, errDecompressedTooLarge
 		}
 		return rfn(), nil
 	case CodecZstd:
@@ -426,13 +471,15 @@ var xerialPfx = []byte{130, 83, 78, 65, 80, 80, 89, 0}
 
 var errMalformedXerial = errors.New("malformed xerial framing")
 
-func xerialDecode(src []byte) ([]byte, error) {
+// xerialDecode appends the decoded chunks to dst (commonly a len-0 pooled
+// slice, or nil) and returns the result.
+func xerialDecode(dst, src []byte) ([]byte, error) {
 	// bytes 0-8: xerial header
 	// bytes 8-16: xerial version
 	// everything after: uint32 chunk size, snappy chunk
 	// we come into this function knowing src is at least 16
 	src = src[16:]
-	var dst, chunk []byte
+	var chunk []byte
 	var err error
 	for len(src) > 0 {
 		if len(src) < 4 {
@@ -442,6 +489,13 @@ func xerialDecode(src []byte) ([]byte, error) {
 		src = src[4:]
 		if size < 0 || len(src) < int(size) {
 			return nil, errMalformedXerial
+		}
+		// Chunks accumulate; bound the cumulative claimed output before
+		// decoding each chunk.
+		if l, err := s2.DecodedLen(src[:size]); err != nil {
+			return nil, err
+		} else if int64(l) > maxDecompressedSize-int64(len(dst)) {
+			return nil, errDecompressedTooLarge
 		}
 		if chunk, err = s2.Decode(chunk[:cap(chunk)], src[:size]); err != nil {
 			return nil, err

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/config.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/config.go
@@ -286,6 +286,18 @@ func (cfg *cfg) validate() error {
 
 	i64lt := func(l, r int64) (bool, string) { return l < r, "less" }
 	i64gt := func(l, r int64) (bool, string) { return l > r, "larger" }
+
+	// Several Durations are serialized to int32-millisecond wire fields
+	// (JoinGroup SessionTimeoutMs / RebalanceTimeoutMs, ProduceRequest
+	// TimeoutMs, InitProducerId TransactionTimeoutMs). A Duration whose
+	// millisecond value exceeds an int32 silently overflows that field when
+	// cast - e.g. a 30 day session timeout wraps to a negative wire value,
+	// and a ~50 day one wraps to a small positive value the broker quietly
+	// accepts as a completely different timeout. Java cannot hit this because
+	// its equivalent configs are int32-millisecond typed at the source; kgo
+	// takes a Duration, so the bound must be enforced here. The wire field's
+	// capacity is the only principled cap.
+	const maxWireTimeout = time.Duration(math.MaxInt32) * time.Millisecond
 	for _, limit := range []struct {
 		name    string
 		v       int64
@@ -343,6 +355,11 @@ func (cfg *cfg) validate() error {
 		{name: "max buffered bytes", v: cfg.maxBufferedBytes, allowed: 0, badcmp: i64lt},
 		{name: "linger", v: int64(cfg.linger), allowed: int64(time.Minute), badcmp: i64gt, durs: true},
 		{name: "produce timeout", v: int64(cfg.produceTimeout), allowed: int64(100 * time.Millisecond), badcmp: i64lt, durs: true},
+		{name: "produce timeout", v: int64(cfg.produceTimeout), allowed: int64(maxWireTimeout), badcmp: i64gt, durs: true},
+
+		// The transaction timeout is serialized to an int32-millisecond wire
+		// field and is otherwise unvalidated; bound it so it cannot overflow.
+		{name: "transaction timeout", v: int64(cfg.txnTimeout), allowed: int64(maxWireTimeout), badcmp: i64gt, durs: true},
 		{name: "record timeout", v: int64(cfg.recordTimeout), allowed: int64(time.Second), badcmp: func(l, r int64) (bool, string) {
 			if l == 0 {
 				return false, "" // we print nothing when things are good
@@ -360,10 +377,12 @@ func (cfg *cfg) validate() error {
 		{name: "consumer protocol length", v: int64(len(cfg.protocol)), allowed: 1, badcmp: i64lt},
 
 		{name: "session timeout", v: int64(cfg.sessionTimeout), allowed: int64(100 * time.Millisecond), badcmp: i64lt, durs: true},
+		{name: "session timeout", v: int64(cfg.sessionTimeout), allowed: int64(maxWireTimeout), badcmp: i64gt, durs: true},
 		{name: "rebalance timeout", v: int64(cfg.rebalanceTimeout), allowed: int64(100 * time.Millisecond), badcmp: i64lt, durs: true},
+		{name: "rebalance timeout", v: int64(cfg.rebalanceTimeout), allowed: int64(maxWireTimeout), badcmp: i64gt, durs: true},
 		{name: "autocommit interval", v: int64(cfg.autocommitInterval), allowed: int64(100 * time.Millisecond), badcmp: i64lt, durs: true},
 
-		{v: int64(cfg.heartbeatInterval), allowed: int64(cfg.rebalanceTimeout) * int64(time.Millisecond), badcmp: i64gt, durs: true, fmt: "heartbeat interval %v is erroneously larger than the session timeout %v"},
+		{v: int64(cfg.heartbeatInterval), allowed: int64(cfg.sessionTimeout), badcmp: i64gt, durs: true, fmt: "heartbeat interval %v is erroneously larger than the session timeout %v"},
 	} {
 		bad, cmp := limit.badcmp(limit.v, limit.allowed)
 		if bad {
@@ -441,6 +460,40 @@ func (cfg *cfg) validate() error {
 		}
 	} else if len(cfg.excludeTopics) > 0 {
 		return errors.New("invalid use of ConsumeExcludeTopics when not using ConsumeRegex")
+	}
+
+	// A topic literally named "" cannot exist; consuming it would spin on
+	// UNKNOWN_TOPIC metadata forever with no surfaced error. In regex mode the
+	// ConsumeTopics values are patterns ("" is a valid match-all regex), so we
+	// only reject empty names when not consuming via regex.
+	if !cfg.regex {
+		for topic := range cfg.topics {
+			if topic == "" {
+				return errors.New("invalid empty topic name in ConsumeTopics")
+			}
+		}
+	}
+	for topic, partitions := range cfg.partitions {
+		if topic == "" {
+			return errors.New("invalid empty topic name in ConsumePartitions")
+		}
+		for p := range partitions {
+			if p < 0 {
+				return fmt.Errorf("invalid negative partition %d for topic %q in ConsumePartitions", p, topic)
+			}
+		}
+	}
+
+	// These options take a value; if explicitly set to "" it is a mistake (an
+	// empty transactional or instance ID is not valid). Both are *string so an
+	// explicit "" is distinguishable from unset (nil). ConsumerGroup and
+	// ShareGroup are plain strings, indistinguishable from unset, so they are
+	// not checked here.
+	if cfg.txnID != nil && *cfg.txnID == "" {
+		return errors.New("invalid empty TransactionalID")
+	}
+	if cfg.instanceID != nil && *cfg.instanceID == "" {
+		return errors.New("invalid empty InstanceID")
 	}
 
 	if cfg.topics != nil && cfg.partitions != nil {
@@ -686,6 +739,12 @@ func WithLogger(l Logger) Opt {
 // WithContext sets the client to use a custom context.
 //
 // By default, the client uses context.Background.
+//
+// Canceling this context stops the client's background goroutines and fails
+// in-flight requests with ErrClientClosed, but it does not replace Close:
+// records still buffered for producing are reliably failed only by Close, and
+// a group leave is sent only by Close. Always call Close for a clean shutdown;
+// canceling this context first (to interrupt blocking calls) is fine.
 func WithContext(ctx context.Context) Opt {
 	return clientOpt{func(cfg *cfg) { cfg.ctx = ctx }}
 }
@@ -813,7 +872,7 @@ func MinVersions(versions *kversion.Versions) Opt {
 
 // RetryBackoffFn sets the backoff strategy for how long to backoff for a given
 // amount of retries, overriding the default jittery exponential backoff that
-// ranges from 250ms min to 2.5s max.
+// ranges from 250ms min to 5s max.
 //
 // This (roughly) corresponds to Kafka's retry.backoff.ms setting and
 // retry.backoff.max.ms (which is being introduced with KIP-500).
@@ -1296,16 +1355,18 @@ func RecordRetries(n int) ProducerOpt {
 }
 
 // UnknownTopicRetries sets the number of times a record can fail with
-// UNKNOWN_TOPIC_OR_PARTITION, overriding the default 4.
+// UNKNOWN_TOPIC_OR_PARTITION or UNKNOWN_TOPIC_ID, overriding the default 4.
 //
 // This is a separate limit from RecordRetries because unknown topic or
 // partition errors should only happen if the topic does not exist. It is
 // pointless for the client to continue producing to a topic that does not
 // exist, and if we repeatedly see that the topic does not exist across
 // multiple metadata queries (which are going to different brokers), then we
-// may as well stop trying and fail the records.
+// may as well stop trying and fail the records. The count is reset whenever
+// a produce to the partition succeeds; errors other than the two unknown
+// topic errors leave it unchanged.
 //
-// If this is -1, the client never fails records with this error.
+// If this is -1, the client never fails records with these errors.
 func UnknownTopicRetries(n int) ProducerOpt {
 	return producerOpt{func(cfg *cfg) { cfg.maxUnknownFailures = int64(n) }}
 }
@@ -1409,9 +1470,9 @@ func TransactionalID(id string) ProducerOpt {
 // default 40s. It is a good idea to keep this less than a group's session
 // timeout, so that a group member will always be alive for the duration of a
 // transaction even if connectivity dies. This helps prevent a transaction
-// finishing after a rebalance, which is problematic pre-Kafka 2.5. If you
-// are on Kafka 2.5+, then you can use the RequireStableFetchOffsets option
-// when assigning the group, and you can set this to whatever you would like.
+// finishing after a rebalance, which is problematic pre-Kafka 2.5. On Kafka
+// 2.5+, the client always requires stable fetch offsets (KIP-447), so you
+// can set this to whatever you would like.
 //
 // Transaction timeouts begin when the first record is produced within a
 // transaction, not when a transaction begins.
@@ -1877,9 +1938,9 @@ func Balancers(balancers ...GroupBalancer) GroupOpt {
 // If you are using a [GroupTransactSession] for EOS, wish to lower this, and are
 // talking to a Kafka cluster pre 2.5, consider lowering the
 // TransactionTimeout. If you do not, you risk a transaction finishing after a
-// group has rebalanced, which could lead to duplicate processing. If you are
-// talking to a Kafka 2.5+ cluster, you can safely use the
-// RequireStableFetchOffsets group option and prevent any problems.
+// group has rebalanced, which could lead to duplicate processing. On a Kafka
+// 2.5+ cluster there is no problem: the client always requires stable fetch
+// offsets (KIP-447).
 //
 // This option corresponds to Kafka's session.timeout.ms setting and must be
 // within the broker's group.min.session.timeout.ms and
@@ -2002,6 +2063,13 @@ func AdjustFetchOffsetsFn(adjustOffsetsBeforeAssign func(context.Context, map[st
 // This function can be called at any time you are polling or processing
 // records. If you want to ensure this function is called serially with
 // processing, consider the BlockRebalanceOnPoll option.
+//
+// Do not call Close or LeaveGroup synchronously from within this callback
+// (nor from OnPartitionsRevoked or OnPartitionsLost): leaving the group
+// waits for the group management loop to finish, and the loop is waiting
+// for your callback to return - a permanent deadlock. To leave from within
+// a callback, use LeaveGroupContext with a nil context (it triggers the
+// leave without waiting), or call LeaveGroup from a separate goroutine.
 func OnPartitionsAssigned(onAssigned func(context.Context, *Client, map[string][]int32)) GroupOpt {
 	return groupOpt{func(cfg *cfg) { cfg.onAssigned = onAssigned }}
 }
@@ -2034,6 +2102,9 @@ func OnPartitionsAssigned(onAssigned func(context.Context, *Client, map[string][
 //
 // This function is called if a "fatal" group error is encountered and you have
 // not set [OnPartitionsLost]. See OnPartitionsLost for more details.
+//
+// Do not call Close or LeaveGroup synchronously from within this callback;
+// see the warning on [OnPartitionsAssigned].
 func OnPartitionsRevoked(onRevoked func(context.Context, *Client, map[string][]int32)) GroupOpt {
 	return groupOpt{func(cfg *cfg) { cfg.onRevoked = onRevoked }}
 }
@@ -2053,6 +2124,9 @@ func OnPartitionsRevoked(onRevoked func(context.Context, *Client, map[string][]i
 // This function can be called at any time you are polling or processing
 // records. If you want to ensure this function is called serially with
 // processing, consider the BlockRebalanceOnPoll option.
+//
+// Do not call Close or LeaveGroup synchronously from within this callback;
+// see the warning on [OnPartitionsAssigned].
 func OnPartitionsLost(onLost func(context.Context, *Client, map[string][]int32)) GroupOpt {
 	return groupOpt{func(cfg *cfg) { cfg.onLost = onLost }}
 }

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/consumer.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/consumer.go
@@ -263,7 +263,16 @@ func (c *consumer) unaddPoller() {
 	}
 	c.pollWaitMu.Lock()
 	defer c.pollWaitMu.Unlock()
-	c.pollWaitState--
+	// AllowRebalance zeroes the poller count outright. If the user calls it
+	// while another goroutine's poll is still in flight (a contract
+	// violation: AllowRebalance means "all pollers are done"), that poll's
+	// release lands here after the mask and must not decrement: the low 32
+	// bits would underflow and borrow into the rebalance count, permanently
+	// blocking both polls and rebalances. A poller whose accounting was
+	// force-cleared simply no-ops its release.
+	if c.pollWaitState&math.MaxUint32 > 0 {
+		c.pollWaitState--
+	}
 	c.pollWaitC.Broadcast()
 }
 
@@ -401,7 +410,7 @@ func (c *consumer) addFakeReadyForDraining(topic string, partition int32, err er
 }
 
 // NewErrFetch returns a fake fetch containing a single empty topic with a
-// single zero partition with the given error.
+// single partition of -1 with the given error.
 func NewErrFetch(err error) Fetches {
 	return []Fetch{{
 		Topics: []FetchTopic{{
@@ -420,7 +429,7 @@ func NewErrFetch(err error) Fetches {
 // equivalent to calling PollRecords(ctx, 0).
 //
 // If the client is closed, a fake fetch will be injected that has no topic, a
-// partition of 0, and a partition error of ErrClientClosed. If the context is
+// partition of -1, and a partition error of ErrClientClosed. If the context is
 // canceled, a fake fetch will be injected with ctx.Err. These injected errors
 // can be used to break out of a poll loop.
 //
@@ -816,7 +825,12 @@ func (c *consumer) purgeTopics(topics []string) {
 			delete(c.g.using, topic)
 			delete(c.g.reSeen, topic)
 		}
-		c.g.rejoin("rejoin from PurgeFetchTopics")
+		// Our subscription shrank; reconcile per protocol. This MUST NOT
+		// feed rejoinCh in 848 mode (signalSubscriptionChange forces a
+		// heartbeat instead): a rejoinCh bounce there runs the session-end
+		// revoke's nowAssigned read-modify-write concurrently with live
+		// heartbeats, losing a heartbeat's nowAssigned store.
+		c.g.signalSubscriptionChange("topics purged from consuming")
 	} else {
 		c.assignPartitions(purgeAssignments, assignPurgeMatching, c.d.tps, fmt.Sprintf("purge of %v requested", topics))
 		for _, topic := range topics {
@@ -838,7 +852,7 @@ func (c *consumer) purgeTopics(topics []string) {
 // entire topic is purged.
 func (cl *Client) AddConsumeTopics(topics ...string) {
 	c := &cl.consumer
-	if len(topics) == 0 || c.g == nil && c.d == nil || cl.cfg.regex {
+	if len(topics) == 0 || !c.consuming() || cl.cfg.regex {
 		return
 	}
 
@@ -863,7 +877,7 @@ func (cl *Client) AddConsumeTopics(topics ...string) {
 // GetConsumeTopics retrieves a list of current topics being consumed.
 func (cl *Client) GetConsumeTopics() []string {
 	c := &cl.consumer
-	if c.g == nil && c.d == nil {
+	if !c.consuming() {
 		return nil
 	}
 	var m map[string]*topicPartitions
@@ -1045,10 +1059,9 @@ func (f fmtAssignment) String() string {
 // assignPartitions, called under the consumer's mu, is used to set new cursors
 // or add to the existing cursors.
 //
-// We do not need to pass tps when we are bumping the session or when we are
-// invalidating all. All other cases, we want the tps -- the logic below does
-// not fully differentiate needing to start a new session vs. just reusing the
-// old (third if case below)
+// We do not need to pass tps when we are invalidating all. All other cases,
+// we want the tps: guarding the session may create a new session needing it,
+// and stopping the session needs it for the restart.
 func (c *consumer) assignPartitions(assignments map[string]map[int32]Offset, how assignHow, tps *topicsPartitions, why string) {
 	if c.mu.TryLock() {
 		c.mu.Unlock()
@@ -1115,6 +1128,23 @@ func (c *consumer) assignPartitions(assignments map[string]map[int32]Offset, how
 								offset:            assignPart.at,
 								lastConsumedEpoch: assignPart.epoch,
 							})
+							// This partition can have a pending list or epoch
+							// load: an OffsetOutOfRange reload, or an epoch
+							// validation from a leader move. The cursor is then
+							// unusable and the load's completion is its only
+							// re-enabler -- and that completion would also
+							// overwrite the offset we just set with the load's
+							// now-stale result. A transact session resetting to
+							// committed offsets after an abort would be undone:
+							// consumption would resume at the pre-abort position,
+							// never re-consuming the aborted records. The set
+							// offset is the new truth: drop the load and
+							// re-enable the cursor ourselves. Safe here because
+							// the session is stopped (no source can use the
+							// cursor until the new session starts).
+							if loadOffsets.removeLoad(usedCursor.topic, usedCursor.partition) {
+								usedCursor.allowUsable()
+							}
 						}
 					}
 				}
@@ -1140,8 +1170,12 @@ func (c *consumer) assignPartitions(assignments map[string]map[int32]Offset, how
 		case assignInvalidateAll:
 			loadOffsets = listOrEpochLoads{}
 		case assignSetMatching:
-			// We had not yet loaded this partition, so there is
-			// nothing to set, and we keep everything.
+			// Loads for partitions that were being consumed were
+			// handled in the cursor walk above (offset set directly,
+			// pending load dropped). Anything remaining is a load for
+			// a partition that never finished loading; SetOffsets
+			// documents those are skipped, so we keep their loads
+			// untouched.
 		case assignInvalidateMatching:
 			loadOffsets.keepFilter(func(t string, p int32) bool {
 				if assignTopic, ok := assignments[t]; ok {
@@ -1466,7 +1500,7 @@ func (l *listOrEpochLoads) addLoad(t string, p int32, loadType listOrEpochLoadTy
 	ps[p] = load
 }
 
-func (l *listOrEpochLoads) removeLoad(t string, p int32) {
+func (l *listOrEpochLoads) removeLoad(t string, p int32) (removed bool) {
 	for _, m := range []offsetLoadMap{
 		l.List,
 		l.Epoch,
@@ -1478,11 +1512,16 @@ func (l *listOrEpochLoads) removeLoad(t string, p int32) {
 		if ps == nil {
 			continue
 		}
+		if _, exists := ps[p]; !exists {
+			continue
+		}
 		delete(ps, p)
+		removed = true
 		if len(ps) == 0 {
 			delete(m, t)
 		}
 	}
+	return removed
 }
 
 func (l listOrEpochLoads) each(fn func(string, int32)) {
@@ -1944,6 +1983,19 @@ func (s *consumerSession) listOrEpoch(waiting listOrEpochLoads, immediate bool, 
 		}
 	}
 
+	// If the session is dying, park: the loads were stored in waiting above,
+	// and stopSession returns waiting loads to the caller for the next
+	// session. Without this check, a dying session whose metadata is fresh
+	// busy-loops until metadataMinAge elapses: wait is false above, so we
+	// would issue requests on the dead context, every one fails instantly,
+	// the reload timer below is canceled by the same dead context, and its
+	// loadWithSession re-enters this function - burning CPU and holding the
+	// session-stop (every revoke, leave, close, or seek) for the full
+	// metadataMinAge.
+	if s.ctx.Err() != nil {
+		return
+	}
+
 	s.listOrEpochMu.Lock()
 	loading := s.listOrEpochLoadsWaiting
 	s.listOrEpochLoadsLoading.mergeFrom(loading)
@@ -2402,8 +2454,23 @@ func (cl *Client) listOffsetsForBrokerLoad(ctx context.Context, broker *broker, 
 					offset = start
 				}
 			}
+			// Every arm above yields a non-negative offset from a
+			// well-behaved broker: by-time listings exist only for
+			// afterMilli, whose -1 is replaced by the end listing,
+			// and the start/end/exact arms bound within the
+			// responses. A negative offset here means the broker
+			// violated the protocol; clamping to 0 (the old
+			// behavior) would silently re-consume the partition
+			// from the start. Surface the misbehavior and retry
+			// the load instead.
 			if offset < 0 {
-				offset = 0 // sanity
+				loaded.add(loadedOffset{
+					topic:     topic,
+					partition: partition,
+					err:       errNegativeListedOffset,
+					request:   loadPart,
+				})
+				continue
 			}
 
 			loaded.add(loadedOffset{
@@ -2429,10 +2496,14 @@ func (*Client) loadEpochsForBrokerLoad(ctx context.Context, broker *broker, load
 		return
 	}
 
-	// If the version is < 2, we are speaking to an old broker. We should
-	// not have an old version, but we could have spoken to a new broker
-	// first then an old broker in the middle of a broker roll. For now, we
-	// will just loop retrying until the broker is upgraded.
+	// If the negotiated version is < 2, we are speaking to an old broker:
+	// possible mid-roll when metadata (with leader epochs) came from an
+	// upgraded broker while the partition leader is not yet upgraded. The
+	// request then goes out without CurrentLeaderEpoch fencing, and a v0
+	// response carries no LeaderEpoch (kmsg defaults it to -1). Validation
+	// still compares EndOffset and completes, just unfenced and without
+	// epoch information - a degraded but correct fallback for a window
+	// that only exists rolling from pre-KIP-320 brokers.
 
 	topics := tps.load()
 	resp := kresp.(*kmsg.OffsetForLeaderEpochResponse)
@@ -2476,7 +2547,27 @@ func (*Client) loadEpochsForBrokerLoad(ctx context.Context, broker *broker, load
 			// validating.
 			offset := loadPart.at
 			var err error
-			if rPartition.EndOffset < offset {
+			switch {
+			case rPartition.EndOffset < 0:
+				// KIP-320 UNDEFINED_EPOCH_OFFSET: a conformant broker
+				// answers endOffset -1 (and leaderEpoch -1) when its
+				// leader-epoch cache holds no record of the requested
+				// epoch - an empty or freshly-truncated cache, an unclean
+				// election to a replica with no epoch history, or an epoch
+				// newer than anything in the log. This is NOT data loss; the
+				// broker simply cannot tell us a truncation point. The old
+				// `EndOffset < offset` arm treated the -1 sentinel as
+				// "truncated to offset -1", surfacing a spurious ErrDataLoss
+				// and pinning the cursor at -1. Instead carry the sentinel
+				// through so the next fetch hits OFFSET_OUT_OF_RANGE and
+				// resets via the configured ConsumeResetOffset (or, under
+				// NoResetOffset, surfaces OOOR rather than a bogus data-loss
+				// error) - the same reset path the cursor already took,
+				// minus the false alarm. Matches the Java client, which
+				// resets per policy on this sentinel rather than comparing
+				// -1 against the validating position.
+				offset = rPartition.EndOffset
+			case rPartition.EndOffset < offset:
 				err = &ErrDataLoss{topic, partition, offset, loadPart.epoch, rPartition.EndOffset, rPartition.LeaderEpoch}
 				offset = rPartition.EndOffset
 			}

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/consumer_group.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/consumer_group.go
@@ -153,10 +153,17 @@ type groupConsumer struct {
 	// done, and then starts its own.
 	commitDone chan struct{}
 
-	// blockAuto is set and cleared in CommitOffsets{,Sync} to block
-	// autocommitting if autocommitting is active. This ensures that an
-	// autocommit does not cancel the user's manual commit.
-	blockAuto bool
+	// blockAuto counts outstanding CommitOffsets{,Sync} commits and
+	// blocks autocommitting while any are in flight. This ensures that
+	// an autocommit does not trample a user's manual commit: the
+	// autocommit snapshot is taken when the commit is enqueued, but the
+	// request is issued only after all prior commits complete, so a
+	// snapshot taken while a higher manual commit is in flight would be
+	// committed after it and rewind the broker's offset. This must be a
+	// count, not a bool: with two overlapping async commits, the first
+	// completion would otherwise re-enable autocommit while the second
+	// is still in flight, reopening exactly that window.
+	blockAuto int
 
 	// We set this once to manage the group lifecycle once.
 	// If we detect we should run in 848 mode, we set is848 true.
@@ -237,6 +244,12 @@ func (cl *Client) LeaveGroup() {
 // group. If you have configured the group with an InstanceID, this
 // does not leave the group.
 //
+// For next-gen (KIP-848) consumer groups, the leave is a final
+// heartbeat with MemberEpoch -1; with an InstanceID configured the
+// epoch is -2 instead, a temporary "static" departure where the
+// member's partitions stay reserved until the session timeout or
+// until a replacement with the same InstanceID rejoins.
+//
 // For share groups: this drains any pending acks, releases records that
 // were acquired but never finalized, closes each per-broker share
 // session, and sends the final ShareGroupHeartbeat with MemberEpoch=-1
@@ -250,6 +263,13 @@ func (cl *Client) LeaveGroup() {
 // failed with an internal "consumer left" error).
 //
 // LeaveGroupContext is a no-op for direct (non-group) consumers.
+//
+// Do not call this function with a non-nil context synchronously from
+// within an OnPartitions callback: the leave waits for the group
+// management loop to finish, and the loop is waiting for your callback to
+// return. With the client's own context (LeaveGroup), that is a permanent
+// deadlock. A nil context is safe anywhere: it triggers the leave and
+// returns immediately.
 func (cl *Client) LeaveGroupContext(ctx context.Context) error {
 	c := &cl.consumer
 	if c.g == nil && c.s == nil {
@@ -465,7 +485,7 @@ func (g *groupConsumer) manageFailWait(consecutiveErrors int, err error) (ctxCan
 		g.resetExternal()
 	}
 
-	// Unblock bolling now that we have called onLost and
+	// Unblock polling now that we have called onLost and
 	// re-assigned.
 	g.c.unaddRebalance()
 
@@ -917,7 +937,14 @@ func (s *assignRevokeSession) prerevoke(g *groupConsumer, lost map[string][]int3
 		// mid-heartbeat or already gone), the regular heartbeat
 		// timer acks within one interval, which is no worse than
 		// what the session bounce this replaced provided.
-		if is848 && len(lost) > 0 {
+		//
+		// We force even when nothing was lost: a session (re)entry
+		// with only added partitions also owes the server an ack -
+		// the next full heartbeat's Topics is what reports the new
+		// assignment as owned. The Java client likewise heartbeats
+		// the moment reconciliation completes rather than waiting
+		// out the interval.
+		if is848 {
 			select {
 			case g.heartbeatForceCh <- func(error) {}:
 			default:
@@ -1122,6 +1149,7 @@ func (g *groupConsumer) heartbeat(initialHb time.Duration, fetchErrCh <-chan err
 	for {
 		var err error
 		var force func(error)
+		var fetchErr bool
 		heartbeat = false
 		select {
 		case <-cooperativeFastCheck:
@@ -1137,6 +1165,7 @@ func (g *groupConsumer) heartbeat(initialHb time.Duration, fetchErrCh <-chan err
 			err = kerr.RebalanceInProgress
 		case err = <-fetchErrCh:
 			fetchErrCh = nil
+			fetchErr = true
 		case <-revoked:
 			revoked = nil
 			didRevoke = true
@@ -1193,7 +1222,22 @@ func (g *groupConsumer) heartbeat(initialHb time.Duration, fetchErrCh <-chan err
 		// If cfg.retries consecutive failures occur without any
 		// success, the error propagates to manage848 which
 		// rebuilds the session.
-		if is848 && (isRetryableBrokerErr(err) || isAnyDialErr(err) || g.cl.maybeDeleteStaleCoordinator(g.cfg.group, coordinatorTypeGroup, err)) {
+		//
+		// This arm must only see errors from the heartbeat itself,
+		// never from fetchErrCh, even though both feed the same err
+		// variable. Walkthrough of what would go wrong: the
+		// coordinator moves, OffsetFetch exhausts its internal
+		// retries, fetchOffsets returns the retryable error here, we
+		// "retry" by heartbeating in place, the next heartbeat
+		// succeeds and resets the counter - and the session lives on
+		// with partitions that were never handed to assignPartitions
+		// (that only happens after a successful fetch). The fetch
+		// goroutine is already gone and nothing inside a live session
+		// re-runs it, so those partitions silently never consume.
+		// Only re-entering setupAssignedAndHeartbeat re-fetches (via
+		// g.fetching), so a fetch error must propagate to manage848,
+		// whose transient arm restarts the session.
+		if is848 && !fetchErr && (isRetryableBrokerErr(err) || isAnyDialErr(err) || g.cl.maybeDeleteStaleCoordinator(g.cfg.group, coordinatorTypeGroup, err)) {
 			if int64(hbBrokerRetries) < g.cfg.retries {
 				hbBrokerRetries++
 				backoff := g.cfg.retryBackoff(hbBrokerRetries)
@@ -1280,9 +1324,23 @@ func (g *groupConsumer) heartbeat(initialHb time.Duration, fetchErrCh <-chan err
 // If neither of the cases above are true (this member is not a leader, and the
 // join group metadata has not changed), then Kafka will not actually trigger a
 // rebalance and will instead reply to the member with its current assignment.
+//
+// For next-gen (KIP-848) consumer groups, assignment is entirely server
+// driven and there is no client-side join to redo: this instead forces an
+// immediate full heartbeat (best effort), which re-syncs the subscription
+// and assignment with the broker.
 func (cl *Client) ForceRebalance() {
 	if g := cl.consumer.g; g != nil {
-		g.rejoin("from ForceRebalance")
+		// Classic rejoins; 848 forces a heartbeat (848 must never feed
+		// rejoinCh - see signalSubscriptionChange). Routing every
+		// rejoinCh feeder through the one helper is what keeps "nothing
+		// feeds rejoinCh in 848 mode" true: every remaining session-end
+		// path stops heartbeating (or has a dead context) before revoke
+		// runs, so revoke's nowAssigned read-modify-write never races a
+		// live heartbeat's store.
+		g.mu.Lock()
+		g.signalSubscriptionChange("from ForceRebalance")
+		g.mu.Unlock()
 	}
 }
 
@@ -1294,6 +1352,36 @@ func (g *groupConsumer) rejoin(why string) {
 	case g.rejoinCh <- why:
 	default:
 	}
+}
+
+// signalSubscriptionChange tells the manage loop that our local set of
+// subscribed topics changed (AddConsumeTopics growth, PurgeConsumeTopics
+// shrink) and a reconcile is owed. The caller must hold g.mu (we read
+// g.is848).
+//
+// Classic and 848 reconcile differently, and routing every caller through
+// here is what keeps the difference from being re-derived (and forgotten)
+// at each site:
+//
+//   - Classic: bounce the heartbeat session via rejoinCh so the member
+//     re-joins and the group re-balances with the new subscription.
+//   - 848: the server reconciles through heartbeats, so feeding rejoinCh
+//     would only bounce the session pointlessly - AND that bounce runs the
+//     session-end revoke concurrently with live heartbeats, the one
+//     interleaving where a completing heartbeat's nowAssigned store is lost
+//     to revoke's read-modify-write. Instead force an immediate heartbeat
+//     (best effort, must not block; see the walkthrough in prerevoke): the
+//     next request rebuilds the subscription from live state, and if the
+//     force is missed the heartbeat timer sends within one interval.
+func (g *groupConsumer) signalSubscriptionChange(why string) {
+	if g.is848 {
+		select {
+		case g.heartbeatForceCh <- func(error) {}:
+		default:
+		}
+		return
+	}
+	g.rejoin(why)
 }
 
 // Joins and then syncs, issuing the two slow requests in goroutines to allow
@@ -1617,6 +1705,13 @@ func (g *groupExternal) eachTopic(fn func(string)) {
 }
 
 func (g *groupExternal) updateLatest(meta map[string]*metadataTopic) {
+	// These are topics the leader balances but does not itself consume, so
+	// there is no kept-partition floor like the leader's own topics have
+	// (metadata.go). We rewrite the cached count and trigger a rejoin on
+	// ANY change, INCLUDING a one-response stale shrink - that is one churn
+	// cycle (revoke + re-assign) that self-heals on the next refresh. This
+	// is the same stale-snapshot exposure Java's leader carries; it is
+	// intentional, not a bug to silence with a shrink filter.
 	g.cloned(func(tps map[string]int32) {
 		var rejoin bool
 		for t, ps := range tps {
@@ -1790,6 +1885,16 @@ func (g *groupConsumer) fetchOffsets(ctx context.Context, added map[string][]int
 	// Groups format, and resp.Topics is a copy that may lose TopicID.
 	var staleRetries int
 	var unknownTopicIDRetries int
+	var omittedRetries int
+	// injected tracks partitions whose non-retryable error we have already
+	// surfaced via a fake fetch. It is declared BEFORE the start label so it
+	// survives the goto-start retries below. addFakeReadyForDraining is not
+	// idempotent: a non-conformant broker that omits a requested partition
+	// (driving the omitted retry) or returns a non-retryable partition error
+	// ordered ahead of an UNSTABLE_OFFSET_COMMIT partition (driving the
+	// retryable goto-start) would otherwise re-run the injection arm every
+	// pass and emit a duplicate fake fetch for the same partition each retry.
+	var injected mtmps
 start:
 	member, gen := g.memberGen.load()
 	req := kmsg.NewPtrOffsetFetchRequest()
@@ -1803,6 +1908,23 @@ start:
 	groupTopics := g.tps.load()
 	pinV9 := false
 	for topic, partitions := range added {
+		// Skip partitions we have already surfaced a non-retryable error
+		// for and dropped (injected, below). On the first pass injected is
+		// nil and nothing is filtered; on a goto-start retry (driven by an
+		// UNSTABLE_OFFSET_COMMIT or UNKNOWN_TOPIC_ID partition) this avoids
+		// re-fetching partitions we will never re-add to the assignment.
+		if inj := injected[topic]; inj != nil {
+			kept := partitions[:0:0] // fresh backing array; do not mutate added
+			for _, p := range partitions {
+				if _, ok := inj[p]; !ok {
+					kept = append(kept, p)
+				}
+			}
+			partitions = kept
+		}
+		if len(partitions) == 0 {
+			continue
+		}
 		reqTopic := kmsg.NewOffsetFetchRequestGroupTopic()
 		reqTopic.Topic = topic
 		reqTopic.TopicID = groupTopics.loadTopic(topic).id
@@ -1918,7 +2040,18 @@ start:
 				// Some partition errors are retryable:
 				//
 				// - UnstableOffsetCommit (KIP-447): a pending
-				//   transaction should be committing soon.
+				//   transaction should be committing soon. This
+				//   1s retry is deliberately UNBOUNDED and has no
+				//   counter - the block is protocol-mandated:
+				//   require_stable hides pending txnal offsets
+				//   until the commit marker lands, so a bound
+				//   would convert a mandated wait into a spurious
+				//   error. The worst legal wait is the blocking
+				//   producer's transaction timeout; an adversarial
+				//   producer extending its txn extends the block
+				//   server-side, exactly as it does for Java. Only
+				//   session teardown (ctx below) interrupts it.
+				//   Do not add a retry cap.
 				//
 				// - UnknownTopicID: the broker has not yet
 				//   propagated the topic ID for a newly created
@@ -1961,6 +2094,15 @@ start:
 				// Instead we surface the error to the user via a
 				// fake fetch and drop the partition from this
 				// assignment; the rest of the session proceeds.
+				//
+				// Surface each partition's error exactly once across
+				// the goto-start retries: injected persists (declared
+				// before the start label), so a partition already
+				// surfaced on an earlier pass is skipped here rather
+				// than re-injected.
+				if _, ok := injected[topic][rPartition.Partition]; ok {
+					continue
+				}
 				g.cfg.logger.Log(LogLevelError, "fetch offsets failed for partition; injecting error and continuing with remaining partitions",
 					"group", g.cfg.group,
 					"topic", topic,
@@ -1968,6 +2110,7 @@ start:
 					"err", err,
 				)
 				g.c.addFakeReadyForDraining(topic, rPartition.Partition, err, "fetch offsets returned a non-retryable partition error")
+				injected.add(topic, rPartition.Partition)
 				continue
 			}
 			offset := Offset{
@@ -1977,7 +2120,12 @@ start:
 			if resp.Version >= 5 && kip320 { // KIP-320
 				offset.epoch = rPartition.LeaderEpoch
 			}
-			if rPartition.Offset == -1 {
+			// The coordinator's "no committed offset" sentinel is -1.
+			// We treat ANY negative offset as no-commit, matching the
+			// Java client's `offset >= 0` test: a buggy broker's -5
+			// must not flow into partition assignment as a literal
+			// negative offset.
+			if rPartition.Offset < 0 {
 				offset = g.cfg.startOffset
 			}
 			topicOffsets[rPartition.Partition] = offset
@@ -2011,6 +2159,64 @@ start:
 			if _, ok := requested[partition]; !ok {
 				delete(topicOffsets, partition)
 				g.cfg.logger.Log(LogLevelWarn, "broker returned partition in OffsetFetch response that we did not request, skipping", "group", g.cfg.group, "topic", fetchedTopic, "partition", partition)
+			}
+		}
+	}
+
+	// The dual of the validation above: every partition we requested must
+	// be present in the response. The group coordinator answers every
+	// requested partition (filling -1 for those with no commit), so an
+	// omission is a buggy/hostile broker - as is a duplicated topic entry,
+	// which overwrites and discards the earlier entry's partitions in the
+	// response loop above. A partition silently absent from `offsets` is
+	// never assigned a cursor, and a successful return here clears
+	// g.fetching: nothing inside a live session ever re-fetches it, so for
+	// cooperative and 848 sessions (whose unchanged assignment diffs to an
+	// empty "added" on the next session) the partition would silently
+	// never consume. Retry a few times in case the omission is transient,
+	// then surface a loud error fetch and drop the partition from this
+	// assignment, exactly like the non-retryable partition error path
+	// above.
+	var omitted mtmps
+	for topic, partitions := range added {
+		if !groupTopics.hasTopic(topic) {
+			continue // already warned and skipped above
+		}
+		topicOffsets := offsets[topic]
+		for _, partition := range partitions {
+			if injected != nil {
+				if _, ok := injected[topic][partition]; ok {
+					continue // deliberately dropped, not omitted
+				}
+			}
+			if _, ok := topicOffsets[partition]; !ok {
+				omitted.add(topic, partition)
+			}
+		}
+	}
+	if len(omitted) > 0 {
+		if omittedRetries < 3 {
+			omittedRetries++
+			g.cfg.logger.Log(LogLevelError, "fetch offsets response omitted requested partitions, waiting 1s and retrying",
+				"group", g.cfg.group,
+				"omitted", omitted,
+				"attempt", omittedRetries,
+			)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(time.Second):
+				goto start
+			}
+		}
+		for topic, partitions := range omitted {
+			for partition := range partitions {
+				g.cfg.logger.Log(LogLevelError, "fetch offsets response repeatedly omitted a requested partition; injecting error and continuing with remaining partitions",
+					"group", g.cfg.group,
+					"topic", topic,
+					"partition", partition,
+				)
+				g.c.addFakeReadyForDraining(topic, partition, errOffsetFetchOmitted, "fetch offsets response omitted the partition")
 			}
 		}
 	}
@@ -2158,23 +2364,9 @@ func (g *groupConsumer) findNewAssignments() {
 	}
 
 	if numNewTopics > 0 {
-		// 848 needs no rejoin here: mkreq rebuilds the subscription
-		// from live state on every heartbeat and the keepalive check
-		// sends a full request when it changes, so the next heartbeat
-		// already carries our new interests. Bouncing the session
-		// would only delay that, since rebuilding re-arms the
-		// heartbeat timer at a full interval. Instead, force an
-		// immediate heartbeat (best effort, must not block; see the
-		// walkthrough in prerevoke); if the force is missed, the
-		// timer sends within one interval.
-		if g.is848 {
-			select {
-			case g.heartbeatForceCh <- func(error) {}:
-			default:
-			}
-		} else {
-			g.rejoin("rejoining because there are more topics to consume, our interests have changed")
-		}
+		// Our subscription grew; reconcile per protocol (848 forces a
+		// heartbeat, classic rejoins). See signalSubscriptionChange.
+		g.signalSubscriptionChange("rejoining because there are more topics to consume, our interests have changed")
 	} else if g.leader.Load() {
 		if len(toChange) > 0 {
 			g.rejoin("rejoining because we are the leader and noticed some topics have new partitions")
@@ -2227,6 +2419,18 @@ func (g *groupConsumer) updateUncommitted(fetches Fetches) {
 	// We set the head offset if autocommitting is disabled (because we
 	// only use head / committed in that case), or if we are greedily
 	// autocommitting (so that the latest head is available to autocommit).
+	//
+	// Under DEFAULT autocommit (neither disabled nor greedy) we set only
+	// dirty here, and undirtyUncommitted promotes dirty->head at the START
+	// of the next poll. This one-poll lag is INTENTIONAL and is what makes
+	// default autocommit at-least-once: defaultRevoke commits head, so a
+	// revoke between poll N and N+1 commits none of poll N's records and
+	// the new owner re-reads them. Committing dirty at revoke instead would
+	// mark records consumed while the app may still be mid-processing them -
+	// a loss window. Do not "fix" the duplicate re-read by committing dirty
+	// on revoke; users wanting eager semantics use AutoCommitGreedy or their
+	// own OnPartitionsRevoked -> CommitUncommittedOffsets (user decision
+	// 2026-04-24).
 	setHead := g.cfg.autocommitDisable || g.cfg.autocommitGreedy
 
 	g.mu.Lock()
@@ -2538,7 +2742,7 @@ func (g *groupConsumer) loopCommit() {
 		// offsets.
 		g.noCommitDuringJoinAndSync.RLock()
 		g.mu.Lock()
-		if !g.blockAuto {
+		if g.blockAuto == 0 {
 			uncommitted := g.getUncommittedLocked(true, false)
 			if len(uncommitted) == 0 {
 				g.cfg.logger.Log(LogLevelDebug, "skipping autocommit due to no offsets to commit", "group", g.cfg.group)
@@ -2940,10 +3144,11 @@ func (cl *Client) commitOffsets(ctx context.Context, offsets map[string]map[int3
 	return rerr
 }
 
-// CommitOffsetsSync cancels any active CommitOffsets, begins a commit that
-// cannot be canceled, and waits for that commit to complete. This function
-// will not return until the commit is done and the onDone callback is
-// complete.
+// CommitOffsetsSync waits for any active CommitOffsets to complete, begins a
+// commit that cannot be canceled by other commits or by rebalancing, and
+// waits for that commit to complete. The commit is canceled only if the
+// passed context is canceled. This function will not return until the commit
+// is done and the onDone callback is complete.
 //
 // The purpose of this function is for use in OnPartitionsRevoked or committing
 // before leaving a group, because you do not want to have a commit issued in
@@ -3046,12 +3251,12 @@ func (g *groupConsumer) commitOffsetsSync(
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
-	g.blockAuto = true
+	g.blockAuto++
 	unblockAuto := func(cl *Client, req *kmsg.OffsetCommitRequest, resp *kmsg.OffsetCommitResponse, err error) {
 		unblockCommits(cl, req, resp, err)
 		g.mu.Lock()
 		defer g.mu.Unlock()
-		g.blockAuto = false
+		g.blockAuto--
 	}
 
 	g.commit(ctx, uncommitted, unblockAuto)
@@ -3075,12 +3280,14 @@ func (g *groupConsumer) commitOffsetsSync(
 // It is invalid to use this function to commit offsets for a transaction.
 //
 // Note that this function ensures absolute ordering of commit requests by
-// canceling prior requests and ensuring they are done before executing a new
-// one. This means, for absolute control, you can use this function to
-// periodically commit async and then issue a final sync commit before quitting
-// (this is the behavior of autocommiting and using the default revoke). This
-// differs from the Java async commit, which does not retry requests to avoid
-// trampling on future commits.
+// waiting for any prior in-flight commit to complete before issuing a new
+// one. Prior commits are never canceled: canceling kills the connection,
+// and the broker could then process a replacement commit issued on a new
+// connection before the original. This means, for absolute control, you can
+// use this function to periodically commit async and then issue a final sync
+// commit before quitting (this is the behavior of autocommiting and using
+// the default revoke). This differs from the Java async commit, which does
+// not retry requests to avoid trampling on future commits.
 //
 // It is highly recommended to check the response's partition's error codes if
 // the response is non-nil. While unlikely, individual partitions can error.
@@ -3127,12 +3334,12 @@ func (cl *Client) CommitOffsets(
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
-	g.blockAuto = true
+	g.blockAuto++
 	unblockAuto := func(cl *Client, req *kmsg.OffsetCommitRequest, resp *kmsg.OffsetCommitResponse, err error) {
 		unblockJoinSync(cl, req, resp, err)
 		g.mu.Lock()
 		defer g.mu.Unlock()
-		g.blockAuto = false
+		g.blockAuto--
 	}
 
 	g.commit(ctx, uncommitted, unblockAuto)
@@ -3222,16 +3429,6 @@ func (g *groupConsumer) commit(
 	req.MemberID = memberID
 	req.InstanceID = g.cfg.instanceID
 	is848 := g.is848 // g.mu is held, per the function comment above
-
-	if ctx.Done() != nil {
-		go func() {
-			select {
-			case <-ctx.Done():
-				commitCancel()
-			case <-commitCtx.Done():
-			}
-		}()
-	}
 
 	go func() {
 		defer close(commitDone) // allow future commits to continue when we are done
@@ -3440,8 +3637,18 @@ func (g *groupConsumer) commit(
 		for _, d := range dropped {
 			var rt *kmsg.OffsetCommitResponseTopic
 			for i := range resp.Topics {
-				if resp.Topics[i].Topic == d.name && resp.Topics[i].TopicID == d.id {
-					rt = &resp.Topics[i]
+				// v10+ responses carry only the TopicID (Topic is
+				// v0-v9 on the wire, so kept topics arrive with an
+				// empty name); v9 and below carry only the name (and
+				// pinV9 above guarantees an id-less topic never goes
+				// out v10+, so a zero d.id implies a v9 response).
+				// Match whichever side the wire carried; requiring
+				// both duplicated the topic on v10 and the length
+				// mismatch then made updateCommitted skip the whole
+				// response.
+				t := &resp.Topics[i]
+				if d.id != ([16]byte{}) && t.TopicID == d.id || t.Topic != "" && t.Topic == d.name {
+					rt = t
 					break
 				}
 			}

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/consumer_group_848.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/consumer_group_848.go
@@ -38,6 +38,27 @@ func (g *groupConsumer) should848() bool {
 	return true
 }
 
+// manage848 drives the KIP-848 heartbeat session: it restarts the session on
+// transient errors and re-fetches outstanding partitions via g.fetching.
+//
+// Constraints any change to coordinator/leader-churn recovery (here, in
+// heartbeat, and in fetchOffsets) must preserve — established by the
+// rebalance-churn audit:
+//
+//  1. Heartbeat-originated transport and coordinator errors retry in place
+//     (the stale-connection cycle 90bcc2bb fixed is real). Fetch errors do
+//     NOT take that arm — they propagate here so the session restarts and
+//     re-fetches; do not collapse the two error sources back together.
+//  2. Session restart is the designed heal for fetch failures: the g.fetching
+//     carryover exists precisely so a torn-down session re-fetches. Route
+//     fixes through it rather than inventing a second retry inside fetchOffsets.
+//  3. Member-identity resets are the minimum the error implies: a fresh UUID
+//     for UnknownMemberID, the SAME UUID for epoch problems (FENCED and STALE
+//     both keep it). Anything stronger strands server-side state for a full
+//     session timeout.
+//  4. Leaves (MemberEpoch -1/-2) are idempotent and stateless — safe to retry
+//     anywhere. The CGHB no-retry rule applies only to reconciliation-carrying
+//     heartbeats, never to leaves.
 func (g *groupConsumer) manage848() {
 	var serverAssignor string
 	switch g.cfg.balancers[0].(type) {
@@ -91,19 +112,28 @@ outer:
 
 		// Even if Kafka replies that the API is available, if we use it
 		// and the broker is not configured to support it, we receive
-		// UnsupportedVersion. On the first loop
+		// UnsupportedVersion. Until a join attempt settles the question
+		// (any other kerr, or success, means the API is really served),
+		// an UnsupportedVersion error falls back to classic group
+		// management.
 		if !known848Support {
 			if err != nil {
 				var ke *kerr.Error
 				if errors.As(err, &ke) {
 					if ke.Code == kerr.UnsupportedVersion.Code {
 						// It's okay to update is848 here. This is used while leaving
-						// and while heartbeating. We have not yet entered heartbeating,
-						// and if the user is concurrently leaving, the lack of a memberID
-						// means both 848 and old group mgmt leaves return early.
+						// and while heartbeating. We have not yet entered heartbeating.
 						g.mu.Lock()
 						g.is848 = false
 						g.mu.Unlock()
+						// We pre-stored a self-generated member id (v1 semantics)
+						// that the server never admitted - the join just failed.
+						// Clear it so a concurrent leave returns early (there is
+						// no member to remove; both the 848 and classic leave
+						// paths check for an empty member id) and so the classic
+						// join below starts with an empty member id rather than
+						// burning an UNKNOWN_MEMBER_ID round trip on our UUID.
+						g.memberGen.store("", -1)
 						g.cfg.logger.Log(LogLevelInfo, "falling back to standard consumer group management due to lack of broker support", "group", g.cfg.group)
 						fallbackToClassic = true
 						go g.manage()
@@ -231,7 +261,12 @@ outer:
 				sleep := g.cfg.heartbeatInterval
 				if err == nil {
 					err = errCodeMessage(resp.ErrorCode, resp.ErrorMessage)
-					sleep = time.Duration(resp.HeartbeatIntervalMillis) * time.Millisecond
+					// A zero or negative server interval (buggy or
+					// hostile broker) would hot-loop heartbeats at
+					// round-trip pace; keep the configured cadence.
+					if hb := time.Duration(resp.HeartbeatIntervalMillis) * time.Millisecond; hb > 0 {
+						sleep = hb
+					}
 				}
 				if err != nil {
 					// Reset last-sent state so the next attempt
@@ -268,21 +303,27 @@ outer:
 				isAnyDialErr(err),
 				g.cl.maybeDeleteStaleCoordinator(g.cfg.group, coordinatorTypeGroup, err):
 				consecutiveTransientRestarts++
-				if int64(consecutiveTransientRestarts) >= g.cfg.retries && int64(consecutiveTransientRestarts)%g.cfg.retries == 0 {
+				if shouldNotify848Restart(int64(consecutiveTransientRestarts), g.cfg.retries) {
 					g.c.addFakeReadyForDraining("", 0, &ErrGroupSession{
 						Err: fmt.Errorf("consumer group %s heartbeat has been failing for %d consecutive attempts, still retrying: %w", g.cfg.group, consecutiveTransientRestarts, err),
 					}, "consumer group heartbeat persistently failing")
 				}
 				err = nil
+				// Continue directly: we nil err only to keep the
+				// session loop going, not because anything
+				// succeeded. Falling into the err == nil reset
+				// below would zero the counter we just
+				// incremented, capping it at 1 forever and making
+				// the every-cfg.retries notification above
+				// unreachable. The reset is for the other arms,
+				// whose nil means a processed response.
+				continue
 
-			case errors.Is(err, kerr.UnknownMemberID),
-				errors.Is(err, kerr.StaleMemberEpoch):
-				// UnknownMemberID: server forgot us.
-				// StaleMemberEpoch: our epoch drifted (e.g. a
-				// heartbeat response was lost). Either way, the
-				// fix is identical: abandon the assignment and
-				// re-initialJoin with a fresh member id so the
-				// server hands us back a current epoch.
+			case errors.Is(err, kerr.UnknownMemberID):
+				// The server forgot us (session expired during an
+				// outage, or we were administratively removed).
+				// Abandon the assignment and re-initialJoin with a
+				// fresh member id.
 				member, gen := g.memberGen.load()
 				g.cfg.logger.Log(LogLevelInfo, "consumer group heartbeat error, abandoning assignment and rejoining with new member id",
 					"group", g.cfg.group,
@@ -294,7 +335,17 @@ outer:
 				g.memberGen.store(newStringUUID(), 0)
 				continue outer
 
+			// StaleMemberEpoch means our epoch drifted from the
+			// server's; it reaches us via OffsetFetch (the heartbeat
+			// itself fences with FencedMemberEpoch), so the server
+			// still has this member. We must KEEP our member id:
+			// rejoining at epoch 0 with the same id is the protocol's
+			// lost-response recovery - the server re-admits the member
+			// in place and re-delivers its assignment. Rejoining with
+			// a fresh id would strand the old member server-side,
+			// parking its partitions until the session timeout.
 			case errors.Is(err, kerr.FencedMemberEpoch),
+				errors.Is(err, kerr.StaleMemberEpoch),
 				errors.Is(err, kerr.GroupMaxSizeReached),
 				errors.Is(err, kerr.UnsupportedAssignor):
 				lvl := LogLevelInfo
@@ -332,8 +383,9 @@ outer:
 		}
 
 		// The errors we have to handle are:
-		// * UnknownMemberID: abandon partitions, rejoin
-		// * FencedMemberEpoch: abandon partitions, rejoin
+		// * UnknownMemberID: abandon partitions, rejoin w/ new member id
+		// * FencedMemberEpoch / StaleMemberEpoch: abandon partitions,
+		//   rejoin with the SAME member id
 		// * UnreleasedInstanceID: fatal error, do not rejoin
 		// * General error: fatal error, do not rejoin
 		//
@@ -351,6 +403,25 @@ outer:
 			return
 		}
 	}
+}
+
+// shouldNotify848Restart reports whether a transient-restart count warrants
+// surfacing the "heartbeat persistently failing" notification - the only
+// user-visible signal that an 848 group is unreachable: once we have
+// restarted at least `retries` times, on every `retries`-th restart.
+//
+// retries <= 0 means the user disabled retries (RequestRetries(0)). That also
+// disables in-session heartbeat retries - heartbeat() propagates the first
+// transient error immediately rather than retrying in place - so every
+// transient error is its own restart and each one warrants the notification.
+// We must therefore notify on every restart, NOT divide restarts by zero
+// (an integer divide-by-zero panic that would crash the manage goroutine on
+// the first transient heartbeat error).
+func shouldNotify848Restart(restarts, retries int64) bool {
+	if retries < 1 {
+		return true
+	}
+	return restarts >= retries && restarts%retries == 0
 }
 
 func (g *groupConsumer) leave848(ctx context.Context) {
@@ -375,7 +446,16 @@ func (g *groupConsumer) leave848(ctx context.Context) {
 		g.leaveErr = err
 		return
 	}
-	g.leaveErr = errCodeMessage(resp.ErrorCode, resp.ErrorMessage)
+	err = errCodeMessage(resp.ErrorCode, resp.ErrorMessage)
+	// The leave rides the coordinator retry wrapper: if a prior attempt
+	// succeeded but its response was lost (the connection died), the
+	// retry finds the member already gone. Same if the session expired
+	// before we could leave. Either way the member is out of the group,
+	// which is the goal state of leaving, not an error.
+	if errors.Is(err, kerr.UnknownMemberID) {
+		err = nil
+	}
+	g.leaveErr = err
 }
 
 type g848 struct {
@@ -402,6 +482,23 @@ type g848 struct {
 	prerevoking atomic.Bool
 }
 
+// sanitizePartitions returns the broker-provided partitions sorted, with
+// duplicates and negatives dropped. A duplicated partition is not just
+// redundant: it survives into nowAssigned, makes the assignment compare as
+// changed, and diffAssigned then re-"adds" the partition we already own -
+// re-fetching its committed offset and rewinding the live cursor into
+// duplicate consumption. Negative numbers can only come from a buggy or
+// hostile broker and would otherwise flow into the offset-load machinery.
+func sanitizePartitions(ps []int32) []int32 {
+	ps = slices.Clone(ps)
+	slices.Sort(ps)
+	ps = slices.Compact(ps)
+	for len(ps) > 0 && ps[0] < 0 {
+		ps = ps[1:]
+	}
+	return ps
+}
+
 // v1+ requires the end user to generate their own MemberID, with the
 // recommendation being v4 uuid base64 encoded so it can be put in URLs. We
 // roughly do that (no version nor variant bits). crypto/rand does not fail
@@ -424,6 +521,19 @@ func (g *g848) initialJoin() (time.Duration, error) {
 	g.g.memberGen.storeGeneration(0)
 	g.lastSubscribedTopics = nil
 	g.lastTopics = nil
+	// A (re)join must carry an EMPTY owned-partitions list: the broker
+	// rejects any epoch-0 heartbeat whose Topics is non-empty (or null)
+	// with INVALID_REQUEST, "TopicPartitions must be empty when
+	// (re-)joining." unresolvedAssigned holds the OLD member's
+	// server-side assignment, and mkreq folds it into Topics - so
+	// carrying it across a member reset would poison every join, and
+	// permanently: the only other thing that clears unresolvedAssigned
+	// is a successful assignment-carrying response, which a rejected
+	// join never produces. Dropping it loses nothing - the join
+	// response always re-delivers the member's full assignment. The
+	// Java client likewise clears its unresolved-IDs cache on every
+	// transition to joining.
+	g.unresolvedAssigned = nil
 	g.prerevoking.Store(false)
 	// Drain any stale rejoin signal, mirroring joinAndSync. Nothing
 	// else on the 848 path consumes the channel across a member reset:
@@ -454,10 +564,30 @@ func (g *g848) initialJoin() (time.Duration, error) {
 		"now_assigned", nowAssigned,
 	)
 
-	return time.Duration(resp.HeartbeatIntervalMillis) * time.Millisecond, nil
+	// As in the heartbeat closure: never adopt a zero/negative server
+	// interval, it would hot-loop the heartbeat timer.
+	if hb := time.Duration(resp.HeartbeatIntervalMillis) * time.Millisecond; hb > 0 {
+		return hb, nil
+	}
+	return g.g.cfg.heartbeatInterval, nil
 }
 
 func (g *g848) handleResp(req *kmsg.ConsumerGroupHeartbeatRequest, resp *kmsg.ConsumerGroupHeartbeatResponse) map[string][]int32 {
+	// A success response can only legitimately carry a negative member
+	// epoch as the echo of a leave (-1, or -2 static), which this loop
+	// never sends; the broker rejects requests below -2 outright. If a
+	// buggy or hostile broker hands us a negative epoch here and we
+	// store it, our next heartbeat would BE a leave: the member silently
+	// exits the group while fetches continue. Ignore the response
+	// entirely, like the Java client does.
+	if resp.MemberEpoch < 0 {
+		g.g.cfg.logger.Log(LogLevelWarn, "ignoring consumer group heartbeat response with an invalid negative member epoch",
+			"group", g.g.cfg.group,
+			"epoch", resp.MemberEpoch,
+		)
+		return nil
+	}
+
 	id2t := g.g.cl.id2tMap()
 	newAssigned := make(map[string][]int32)
 
@@ -481,16 +611,16 @@ func (g *g848) handleResp(req *kmsg.ConsumerGroupHeartbeatRequest, resp *kmsg.Co
 		// Fresh assignment from server - replace unresolved state.
 		g.unresolvedAssigned = nil
 		for _, t := range resp.Assignment.Topics {
+			ps := sanitizePartitions(t.Partitions)
 			name := id2t[t.TopicID]
 			if name == "" {
 				if g.unresolvedAssigned == nil {
 					g.unresolvedAssigned = make(map[topicID][]int32)
 				}
-				g.unresolvedAssigned[topicID(t.TopicID)] = slices.Clone(t.Partitions)
+				g.unresolvedAssigned[topicID(t.TopicID)] = ps
 				continue
 			}
-			slices.Sort(t.Partitions)
-			newAssigned[name] = t.Partitions
+			newAssigned[name] = ps
 		}
 	}
 
@@ -501,7 +631,6 @@ func (g *g848) handleResp(req *kmsg.ConsumerGroupHeartbeatRequest, resp *kmsg.Co
 	// simpler and only costs one heartbeat interval (~5s).
 	for id, ps := range g.unresolvedAssigned {
 		if name := id2t[[16]byte(id)]; name != "" {
-			slices.Sort(ps)
 			newAssigned[name] = ps
 			delete(g.unresolvedAssigned, id)
 		}
@@ -602,8 +731,17 @@ func (g *g848) mkreq() *kmsg.ConsumerGroupHeartbeatRequest {
 		// the already-resolved topic names from g.tps (which
 		// filterMetadataAllTopics populates with excludes applied).
 		// New topics are picked up on the next metadata refresh.
+		//
+		// Skip internal topics: classic regex consuming never uses them
+		// (findNewAssignments skips isInternal), and the broker honors
+		// explicit name subscriptions to internal topics, so emulating
+		// the regex with names would otherwise consume e.g.
+		// __consumer_offsets whenever the regex matches it.
 		subscribedTopics := make([]string, 0, len(tps))
-		for t := range tps {
+		for t, tp := range tps {
+			if tp.load().isInternal {
+				continue
+			}
 			subscribedTopics = append(subscribedTopics, t)
 		}
 		slices.Sort(subscribedTopics)

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/consumer_share.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/consumer_share.go
@@ -43,6 +43,15 @@ type (
 		// names. Owned by the manage goroutine.
 		unresolvedAssigns map[topicID][]int32
 
+		// Whether the last assignPartitions pass skipped an assigned
+		// partition our metadata does not know yet (the broker assigned
+		// newly added partitions before our metadata refreshed). We ack
+		// the member epoch regardless, so the broker never re-sends the
+		// assignment; while true, handleHeartbeatResp re-returns the
+		// current assignment so we retry once metadata catches up. Owned
+		// by the manage goroutine.
+		pendingAssigns bool
+
 		lastSentSubscribedTopics []string
 		lastSentRack             bool
 
@@ -80,7 +89,7 @@ type (
 		mu       xsync.Mutex
 		cond     *sync.Cond
 		dying    bool // single-shot leave guard + incWorker gate
-		workers  int  // active goroutines (manage + source loops)
+		workers  int  // active goroutines (manage + source loops + in-flight cursor migrations)
 		left     chan struct{}
 		leaveErr error
 
@@ -96,6 +105,13 @@ type (
 		// sources concurrent with user acking.
 		source atomic.Pointer[source]
 
+		// unknownIDFails counts consecutive UnknownTopicID fetch
+		// errors, mirroring cursor.unknownIDFails: the error is
+		// transient on a just-created topic while brokers sync, so we
+		// strip it for a few fetches, but persistent means the topic
+		// was recreated and we surface it forever (stall loudly).
+		unknownIDFails atomic.Int32
+
 		cursorsIdx int
 
 		// assigned is true when the cursor's partition is currently
@@ -109,6 +125,19 @@ type (
 		// dance from classic is unnecessary here and orchestrating
 		// a similar flow actually makes the code worse.
 		assigned atomic.Bool
+
+		// moving is true while a leader-move (applyMoves) is queued and
+		// in flight for this cursor. createShareReq skips a moving cursor
+		// (it then falls into the forget set, dropping it from the old
+		// broker's session like the classic strip), so the old source does
+		// not keep re-fetching the partition - getting NOT_LEADER and
+		// re-queuing the move - until the async migration lands. This is
+		// the share analog of the classic cursor going unusable for the
+		// duration of a move (source.go use() + strip, never re-enabled
+		// until the move replaces the cursor). applyMoves sets it before
+		// spawning the migration; applyMovesBlocking clears it and
+		// re-signals the cursor's source once the move has run.
+		moving atomic.Bool
 
 		ackMu       xsync.Mutex
 		pendingAcks []*shareAckState // user acks (r.Ack, finalizePreviousPoll, batchAckRecords)
@@ -145,6 +174,7 @@ type (
 		topicID   [16]byte
 		partition int32
 		leaderID  int32
+		cursor    *shareCursor // cursor to re-enable (clear moving) after the migration runs; see shareCursor.moving
 	}
 
 	// shareAckRange is a contiguous offset range with a fixed ack
@@ -620,7 +650,15 @@ func (sc *shareConsumer) leave(ctx context.Context) {
 		sc.leaveErr = err
 		return
 	}
-	sc.leaveErr = errCodeMessage(resp.ErrorCode, resp.ErrorMessage)
+	err = errCodeMessage(resp.ErrorCode, resp.ErrorMessage)
+	// As with the 848 leave: the leave is retried, so a retry can find
+	// the member already gone (prior attempt's response lost, or the
+	// session expired first). The member being out of the group is the
+	// goal state of leaving, not an error.
+	if errors.Is(err, kerr.UnknownMemberID) {
+		err = nil
+	}
+	sc.leaveErr = err
 }
 
 // closeShareSession releases any buffered records on this source,
@@ -1087,14 +1125,17 @@ func (sc *shareConsumer) handleHeartbeatResp(resp *kmsg.ShareGroupHeartbeatRespo
 	sc.memberGen.storeGeneration(resp.MemberEpoch)
 
 	if resp.Assignment == nil {
-		if len(sc.unresolvedAssigns) == 0 {
+		if len(sc.unresolvedAssigns) == 0 && !sc.pendingAssigns {
 			return nil
 		}
-		// No assignment: try to resolve prior un-resolvable
-		// topics. If we can, that updates our current assignment
-		// and we return the new update.
+		// No assignment: try to resolve prior un-resolvable topics,
+		// and if a prior assignPartitions could not activate some
+		// partitions (pendingAssigns), re-return the current
+		// assignment so activation is retried: the broker considers
+		// the assignment delivered (we acked the epoch) and will not
+		// re-send it on its own.
 		resolved := sc.resolveUnresolvedTopicIDs()
-		if len(resolved) == 0 {
+		if len(resolved) == 0 && !sc.pendingAssigns {
 			return nil
 		}
 		current := sc.nowAssigned.read()
@@ -1179,7 +1220,7 @@ func (sc *shareConsumer) assignPartitions(assignments map[string][]int32) {
 			if slices.Contains(newPs, p) { // linear, *usually* fast...
 				continue
 			}
-			if int(p) >= len(td.partitions) {
+			if p < 0 || int(p) >= len(td.partitions) {
 				continue
 			}
 			cursor := td.partitions[p].shareCursor
@@ -1188,26 +1229,52 @@ func (sc *shareConsumer) assignPartitions(assignments map[string][]int32) {
 		}
 	}
 
-	// Add what is new.
+	// Add what is new. We skip based on the cursor's own activation
+	// state, not on what nowAssigned previously contained: a partition
+	// can be in nowAssigned but never activated (skipped below because
+	// our metadata did not know it yet), and it must be re-attempted on
+	// a later pass.
 	var needsMetaUpdate bool
+	sc.pendingAssigns = false
 	for t, newPs := range assignments {
-		oldPs := old[t]
 		tp, ok := tps[t]
 		if !ok {
+			// Not subscribed (e.g. purged): the broker revokes once
+			// our next heartbeat updates SubscribedTopicNames. We
+			// deliberately do not set pendingAssigns: the topic will
+			// never appear in tps, and the broker is guaranteed to
+			// send a new assignment in response to the subscription
+			// change.
 			needsMetaUpdate = true
-			continue // if we don't know the tps data, we can't assign it; force a meta refresh
+			continue
 		}
 		td := tp.load()
 		for _, p := range newPs {
-			if slices.Contains(oldPs, p) {
-				continue // already was assigned, no-op
+			if p < 0 {
+				// A sane broker never assigns a negative partition;
+				// guard a buggy/hostile one. Unlike the too-large
+				// case below, a negative index can never become
+				// valid, so do not set pendingAssigns for it.
+				sc.cfg.logger.Log(LogLevelWarn, "share assignment contains a negative partition, ignoring it",
+					"topic", t,
+					"partition", p,
+				)
+				continue
 			}
 			if int(p) >= len(td.partitions) {
+				// Assigned a partition our metadata does not know
+				// yet (partitions were just added and the
+				// coordinator is ahead of our metadata). We cannot
+				// activate it now; retry after the metadata
+				// refresh below.
+				sc.pendingAssigns = true
 				needsMetaUpdate = true
 				continue
 			}
 			cursor := td.partitions[p].shareCursor
-			cursor.assigned.Store(true)
+			if cursor.assigned.Swap(true) {
+				continue // already active from a prior pass
+			}
 			sourcesToWake[cursor.source.Load()] = struct{}{}
 		}
 	}
@@ -1229,7 +1296,37 @@ func (sc *shareConsumer) applyMoves(moves []shareMove, endpoints []BrokerMetadat
 	if len(moves) == 0 {
 		return
 	}
-	go sc.cl.blockingMetadataFn(func() {
+	// Mark each migrating cursor unusable BEFORE spawning, on this (the
+	// fetch) goroutine, so the very next createShareReq already skips it.
+	// Setting it inside the spawned goroutine would race the next fetch,
+	// which could rebuild a request that re-fetches the partition (getting
+	// NOT_LEADER again) before the goroutine runs. applyMovesBlocking clears
+	// the flag once the migration has run. See shareCursor.moving.
+	for i := range moves {
+		moves[i].cursor.moving.Store(true)
+	}
+	go sc.applyMovesBlocking(moves, endpoints)
+}
+
+// applyMovesBlocking performs the cursor migration on the metadata loop.
+// It registers as a share-consumer worker (incWorker/decWorker) so leave's
+// barrier waits for an in-flight migration before it drains and closes the
+// per-source sessions: the move runs via blockingMetadataFn and can relocate
+// a cursor (or create a brand-new source) concurrently with leave. Without
+// the worker registration, a CurrentLeader-hint move racing LeaveGroup/Close
+// can land a cursor on a source whose closeShareSession already drained (or
+// on a source created after leave snapshotted the source list), stranding
+// that cursor's pending acks: sc.pendingAcks never returns to 0 (FlushAcks
+// hangs) and the held records release only via the broker's acquisition-lock
+// timeout. If the consumer is already dying, incWorker returns false and the
+// move is skipped; the cursor stays on its current source, which the leave's
+// closeShareSession drains.
+func (sc *shareConsumer) applyMovesBlocking(moves []shareMove, endpoints []BrokerMetadata) {
+	if !sc.incWorker() {
+		return
+	}
+	defer sc.decWorker()
+	sc.cl.blockingMetadataFn(func() {
 		// Seed any brokers from the response's NodeEndpoints that we
 		// do not yet know about. Same merge-without-remove invariant
 		// as kip951move.ensureBrokers.
@@ -1289,7 +1386,7 @@ func (sc *shareConsumer) applyMoves(moves []shareMove, endpoints []BrokerMetadat
 				continue
 			}
 			td := tp.load()
-			if int(m.partition) >= len(td.partitions) {
+			if m.partition < 0 || int(m.partition) >= len(td.partitions) {
 				continue
 			}
 			cursor := td.partitions[m.partition].shareCursor
@@ -1308,6 +1405,22 @@ func (sc *shareConsumer) applyMoves(moves []shareMove, endpoints []BrokerMetadat
 				"total_hints", len(moves),
 				"applied", moved,
 			)
+		}
+
+		// Re-enable each cursor for fetching now that its move has run, and
+		// re-signal its (current) source. addShareCursor above woke the new
+		// source's loop while moving was still set, so that loop may have
+		// skipped this cursor and exited via maybeFinish before we got here;
+		// maybeShareConsume re-fetches it. Cursors whose move was skipped
+		// (topic unresolved, out of range, already on the leader) are
+		// re-enabled on their current source so they retry. This clear runs
+		// before decWorker, so it cannot race leave's barrier; the dying
+		// bail and the cl.ctx escape skip it, but those are shutdown paths
+		// where closeShareSession drains the cursor regardless of moving.
+		for i := range moves {
+			c := moves[i].cursor
+			c.moving.Store(false)
+			c.source.Load().maybeShareConsume()
 		}
 	})
 }
@@ -1740,6 +1853,7 @@ func (s *source) shareAck(predrained []cursorAckDrain) {
 						topicID:   rt.TopicID,
 						partition: rp.Partition,
 						leaderID:  rp.CurrentLeader.LeaderID,
+						cursor:    drained.cursor,
 					})
 				}
 				if isShareAckRetryable(partErr) {
@@ -2331,12 +2445,18 @@ func (s *source) shareFetch(doneFetch chan<- bool) (fetched bool) {
 	}
 
 	var didBackoff bool
-	backoff := func() {
+	backoff := func(why any) {
 		// Release fetch slot before sleeping so other sources
 		// can fetch during our backoff.
 		doneFetch <- false
 		alreadySentToDoneFetch = true
 		didBackoff = true
+
+		// Like the classic source backoff: a fetch failure is the
+		// only signal we get when a broker dies (no response means no
+		// CurrentLeader hint), so opportunistically refresh metadata
+		// to migrate our cursors to the new leader.
+		s.cl.triggerUpdateMetadata(false, fmt.Sprintf("opportunistic load during share source backoff: %v", why))
 		s.consecutiveFailures++
 		after := time.NewTimer(sc.cfg.retryBackoff(s.consecutiveFailures))
 		defer after.Stop()
@@ -2353,7 +2473,7 @@ func (s *source) shareFetch(doneFetch chan<- bool) (fetched bool) {
 
 	if err != nil {
 		s.resetShareSession()
-		backoff()
+		backoff(err)
 		sc.enqueueAckErrors(piggybackAcks, err, nAcks)
 		return fetched
 	}
@@ -2363,7 +2483,13 @@ func (s *source) shareFetch(doneFetch chan<- bool) (fetched bool) {
 	res := s.handleShareReqResp(req, resp, usable, piggybackAcks, sentPiggyback)
 
 	if res.discardErr != nil {
+		// Top-level errors are not necessarily transient (e.g. group
+		// auth revoked mid-run answers GROUP_AUTHORIZATION_FAILED
+		// top-level on every fetch); without a backoff this loops at
+		// round-trip pace. Transport errors and all-errors-stripped
+		// responses already back off; treat top-level errors the same.
 		sc.enqueueAckErrors(piggybackAcks, res.discardErr, nAcks)
+		backoff(res.discardErr)
 		return fetched
 	}
 
@@ -2383,7 +2509,7 @@ func (s *source) shareFetch(doneFetch chan<- bool) (fetched bool) {
 		s.hook(&res.fetch, true, false)
 		sc.c.addSourceReadyForDraining(s)
 	} else if res.allErrsStripped {
-		backoff()
+		backoff("empty share fetch response due to all partitions having retryable errors")
 	}
 	return fetched
 }
@@ -2467,6 +2593,7 @@ func (s *source) handleShareReqResp(req *kmsg.ShareFetchRequest, resp *kmsg.Shar
 		ackRequeued        int64
 		partitionsWithErrs int
 		seen               = make(map[tidp]struct{}, len(usable)+len(piggybackAcks))
+		updateWhy          multiUpdateWhy
 	)
 
 	for i := range resp.Topics {
@@ -2532,16 +2659,48 @@ func (s *source) handleShareReqResp(req *kmsg.ShareFetchRequest, resp *kmsg.Shar
 						topicID:   rt.TopicID,
 						partition: rp.Partition,
 						leaderID:  rp.CurrentLeader.LeaderID,
+						cursor:    cursor,
 					})
 					continue
 				}
+				// No leader hint: classify like the classic fetch
+				// path (source.go handleReqResp). Retriable errors
+				// are stripped and heal via the metadata update
+				// triggered below (the broker only fills
+				// CurrentLeader for NotLeader/FencedLeaderEpoch and
+				// only when it knows the new leader, so hint-less
+				// errors are common: leaderless windows, storage
+				// errors, topic ID propagation). Non-retriable
+				// errors surface: share sessions give the user no
+				// other signal.
 				partErr := kerr.ErrorForCode(rp.ErrorCode)
-				partitions = append(partitions, FetchPartition{
-					Partition: rp.Partition,
-					Err:       partErr,
-				})
+				updateWhy.add(topicName, rp.Partition, partErr)
+				keep := true
+				switch {
+				case errors.Is(partErr, kerr.UnknownTopicID):
+					// Transient on just-created topics while
+					// brokers sync; persistent means recreation.
+					// Strip a few, then surface forever, exactly
+					// like the classic cursor's grace counter.
+					if fails := cursor.unknownIDFails.Add(1); fails > 5 {
+						cursor.unknownIDFails.Add(-1)
+					} else if !sc.cfg.keepRetryableFetchErrors {
+						keep = false
+					}
+				default:
+					if kerr.IsRetriable(partErr) && !sc.cfg.keepRetryableFetchErrors {
+						keep = false
+					}
+				}
+				if keep {
+					partitions = append(partitions, FetchPartition{
+						Partition: rp.Partition,
+						Err:       partErr,
+					})
+				}
 				continue
 			}
+			cursor.unknownIDFails.Store(0)
 
 			if len(rp.Records) == 0 && len(rp.AcquiredRecords) == 0 {
 				continue
@@ -2591,6 +2750,22 @@ func (s *source) handleShareReqResp(req *kmsg.ShareFetchRequest, resp *kmsg.Shar
 				"partition", tp.p,
 			)
 			ackResults = append(ackResults, ShareAckResult{topic, tp.p, errBrokerOmittedAckPartition})
+		}
+	}
+
+	// Like the classic fetch path: per-partition errors trigger an
+	// immediate metadata update so the cursor can migrate (this is the
+	// only heal when the response carries no CurrentLeader hint), except
+	// pure unknown-topic reasons, which likely mean the topic does not
+	// exist yet and reloading is wasteful - those ride the debounced
+	// trigger. Hinted moves are handled via applyMoves and do not land
+	// in updateWhy.
+	if updateWhy != nil {
+		why := updateWhy.reason(fmt.Sprintf("share fetch had inner topic errors from broker %d", s.nodeID))
+		if updateWhy.isOnly(kerr.UnknownTopicOrPartition) || updateWhy.isOnly(kerr.UnknownTopicID) {
+			s.cl.triggerUpdateMetadata(false, why)
+		} else {
+			s.cl.triggerUpdateMetadataNow(why)
 		}
 	}
 
@@ -2837,7 +3012,13 @@ func (s *source) createShareReq(skipAckDrain bool) (
 	for range s.share.cursors {
 		c := s.share.cursors[ci]
 		ci = (ci + 1) % nShareCursors
-		if !c.assigned.Load() || paused.has(c.topic, c.partition) {
+		// Skip a cursor whose leader move is in flight (moving): leaving it
+		// in the want-set would re-fetch the partition on the old leader,
+		// getting NOT_LEADER and re-queuing the move until the migration
+		// lands. Skipping drops it into the forget set below, releasing it
+		// from the old broker's session (the share analog of the classic
+		// strip). applyMovesBlocking re-enables it once the move has run.
+		if !c.assigned.Load() || c.moving.Load() || paused.has(c.topic, c.partition) {
 			continue
 		}
 		wantSet[tidp{c.topicID, c.partition}] = struct{}{}

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/errors.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/errors.go
@@ -13,13 +13,13 @@ import (
 )
 
 // IsRetryableBrokerErr returns whether the client considers an error from a
-// broker retrayble. This returns true specifically if the client thinks it can
+// broker retryable. This returns true specifically if the client thinks it can
 // retry whatever it was just trying to do with a broker. It returns false in
 // all other cases.
 //
-// This can used external to the library to help filter errors if use kgo
-// hooks: errors may be sent to hooks before the client retries whatever it was
-// just attempting.
+// This can be used external to the library to help filter errors when using
+// kgo hooks: errors may be sent to hooks before the client retries whatever it
+// was just attempting.
 func IsRetryableBrokerErr(err error) bool {
 	return isRetryableBrokerErr(err)
 }
@@ -97,11 +97,6 @@ func isRetryableBrokerErr(err error) bool {
 	// We could have chosen a broker, and then a concurrent metadata update
 	// could have removed it.
 	if errors.Is(err, errChosenBrokerDead) {
-		return true
-	}
-	// A broker kept giving us short sasl lifetimes, so we killed the
-	// connection ourselves. We can retry on a new connection.
-	if errors.Is(err, errSaslReauthLoop) {
 		return true
 	}
 	// We really should not get correlation mismatch, but if we do, we can
@@ -199,11 +194,6 @@ var (
 	// while a request was in-flight.
 	errChosenBrokerDead = errors.New("the broker connection has died and the request will be retried on a new connection")
 
-	// If a broker repeatedly gives us tiny sasl lifetimes, we fail a
-	// request after a few tries to forcefully kill the connection and
-	// restart a new connection ourselves.
-	errSaslReauthLoop = errors.New("the broker is repeatedly giving us sasl lifetimes that are too short to write a request")
-
 	// A temporary error returned when Kafka replies with a different
 	// correlation ID than we were expecting for the request the client
 	// issued.
@@ -237,6 +227,18 @@ var (
 	errMissingMetadataPartition = errors.New("metadata update is missing a partition that we were previously using")
 
 	errNoCommittedOffset = errors.New("partition has no prior committed offset")
+
+	// Returned when a ListOffsets success response carries a negative
+	// offset, which no legitimate listing produces. Non-retryable so the
+	// broker misbehavior surfaces in polls; the load is still retried.
+	errNegativeListedOffset = errors.New("broker replied to a ListOffsets request with an invalid negative offset")
+
+	// Injected as a fake errored fetch when an OffsetFetch response
+	// repeatedly omits a partition we requested; the group coordinator
+	// answers every requested partition, so an omission is a broker bug
+	// that would otherwise leave the partition silently unconsumed for
+	// the rest of the group session.
+	errOffsetFetchOmitted = errors.New("broker repeatedly omitted a requested partition from an OffsetFetch response")
 
 	// Returned by the 848 heartbeat closure when it detects an assignment
 	// change. The heartbeat loop treats this like RebalanceInProgress but

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/group_balancer.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/group_balancer.go
@@ -205,6 +205,28 @@ func ParseConsumerSyncAssignment(assignment []byte) (map[string][]int32, error) 
 //
 // If any metadata parsing fails, this returns an error.
 func NewConsumerBalancer(balance ConsumerBalancerBalance, members []kmsg.JoinGroupResponseMember) (*ConsumerBalancer, error) {
+	// A buggy or hostile broker can list the same member ID twice in one
+	// JoinGroup response. Balancers key plans by member ID, so a duplicate
+	// either merges (range, roundrobin) or, worse, overwrites: the sticky
+	// engine balances the duplicates as two members and then loses one
+	// side's partitions when keying its returned plan -- partitions
+	// assigned to nobody. Keep the first occurrence.
+	seen := make(map[string]struct{}, len(members))
+	for _, member := range members {
+		seen[member.MemberID] = struct{}{}
+	}
+	if len(seen) != len(members) {
+		dedup := make([]kmsg.JoinGroupResponseMember, 0, len(seen))
+		clear(seen)
+		for _, member := range members {
+			if _, exists := seen[member.MemberID]; !exists {
+				seen[member.MemberID] = struct{}{}
+				dedup = append(dedup, member)
+			}
+		}
+		members = dedup
+	}
+
 	b := &ConsumerBalancer{
 		b:         balance,
 		members:   members,
@@ -225,12 +247,13 @@ func NewConsumerBalancer(balance ConsumerBalancerBalance, members []kmsg.JoinGro
 			// claiming higher and higher version support and not
 			// actually supporting them. Sarama has a similarish
 			// workaround. See #493.
-			if bytes.HasPrefix(memberMeta, []byte{0, 1}) {
-				memberMeta[0] = 0
-				memberMeta[1] = 0
-				if err = meta.ReadFrom(memberMeta); err != nil {
-					return nil, fmt.Errorf("unable to read member metadata: %v", err)
-				}
+			if !bytes.HasPrefix(memberMeta, []byte{0, 1}) {
+				return nil, fmt.Errorf("unable to read member metadata: %v", err)
+			}
+			memberMeta[0] = 0
+			memberMeta[1] = 0
+			if err = meta.ReadFrom(memberMeta); err != nil {
+				return nil, fmt.Errorf("unable to read member metadata: %v", err)
 			}
 		}
 		for _, topic := range meta.Topics {
@@ -493,6 +516,13 @@ func (g *groupConsumer) balanceGroup(proto string, members []kmsg.JoinGroupRespo
 		}
 	} else {
 		into = memberBalancer.Balance(topicPartitionCount)
+	}
+
+	// A custom balancer that fails is documented to SetError and return
+	// nil; if it returns nil without setting an error, fail loudly rather
+	// than dereferencing the nil interface below.
+	if into == nil {
+		return nil, fmt.Errorf("balancer %s returned a nil plan with no error", proto)
 	}
 
 	if p, ok := into.(*BalancePlan); ok {
@@ -767,13 +797,13 @@ func (*rangeBalancer) Balance(b *ConsumerBalancer, topics map[string]int32) Into
 // StickyBalancer returns a group balancer that ensures minimal partition
 // movement on group changes while also ensuring optimal balancing.
 //
-// Suppose there are three members M0, M1, and M2, and two topics t0 and t1
-// each with three partitions p0, p1, and p2. If the initial balance plan looks
-// like
+// Suppose there are three members M0, M1, and M2, and three topics t0, t1,
+// and t2 each with three partitions p0, p1, and p2. If the initial balance
+// plan looks like
 //
 //	M0: [t0p0, t0p1, t0p2]
 //	M1: [t1p0, t1p1, t1p2]
-//	M2: [t2p0, t2p2, t2p2]
+//	M2: [t2p0, t2p1, t2p2]
 //
 // If M2 disappears, both roundrobin and range would have mostly destructive
 // reassignments.
@@ -972,6 +1002,37 @@ func (p *BalancePlan) AdjustCooperative(b *ConsumerBalancer) {
 	tmap := make(map[string]struct{}) // reusable topic existence map
 	pmap := make(map[int32]struct{})  // reusable partitions existence map
 
+	// KIP-792 / KAFKA-12983: an OwnedPartitions claim only proves current
+	// ownership when no other member claims the same partition at a
+	// strictly higher generation. A member that missed rebalances can
+	// rejoin still claiming a partition that has since been assigned to
+	// (and is actively consumed by) another member. The balance plan may
+	// deliberately move the partition back to that stale claimant (sticky
+	// re-sticking); if the claimant's own stale claim then masks the move
+	// as "already owned", we skip the revoke round and two members consume
+	// the partition until the current owner's next sync. We track the
+	// highest claimed generation per partition and ignore strictly lower
+	// claims when computing what was added. Same-generation claims all
+	// count: each claimant keeps what the plan gave it and revokes the
+	// rest at its own sync, which creates no new overlap. The revoked side
+	// below stays unfiltered on purpose -- any claimant might still be
+	// consuming, and revoking more is always safe.
+	maxClaim := make(map[string]map[int32]int32, 8)
+	b.EachMember(func(_ *kmsg.JoinGroupResponseMember, meta *kmsg.ConsumerMemberMetadata) {
+		for _, otopic := range meta.OwnedPartitions {
+			claimT := maxClaim[otopic.Topic]
+			if claimT == nil {
+				claimT = make(map[int32]int32, 20)
+				maxClaim[otopic.Topic] = claimT
+			}
+			for _, opartition := range otopic.Partitions {
+				if gen, ok := claimT[opartition]; !ok || meta.Generation > gen {
+					claimT[opartition] = meta.Generation
+				}
+			}
+		}
+	})
+
 	plan := p.plan
 
 	// First, on all members, we find what was added and what was removed
@@ -997,12 +1058,17 @@ func (p *BalancePlan) AdjustCooperative(b *ConsumerBalancer) {
 				continue
 			}
 			// calculate what was added by creating a planned existence map,
-			// then removing what was owned, and anything that remains is new,
+			// then removing what was owned, and anything that remains is new.
+			// A claim beaten by a strictly higher-generation claim elsewhere
+			// is stale and does not count as owned: the planned partition is
+			// then a real transfer that must wait for the owner's revoke.
 			for _, ppartition := range ppartitions {
 				pmap[ppartition] = struct{}{}
 			}
 			for _, opartition := range otopic.Partitions {
-				delete(pmap, opartition)
+				if meta.Generation >= maxClaim[topic][opartition] {
+					delete(pmap, opartition)
+				}
 			}
 			if len(pmap) > 0 {
 				allAddedT := addT(topic)

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/hooks.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/hooks.go
@@ -42,7 +42,7 @@ type HookNewClient interface {
 	OnNewClient(*Client)
 }
 
-// HookClientClosed is called in Close or CloseAfterRebalance after a client
+// HookClientClosed is called in Close or CloseAllowingRebalance after a client
 // has been closed. This hook can be used to perform final cleanup work.
 type HookClientClosed interface {
 	// OnClientClosed is passed the client that has been closed, after
@@ -176,7 +176,7 @@ type HookBrokerE2E interface {
 type HookBrokerThrottle interface {
 	// OnBrokerThrottle is passed the broker metadata, the imposed
 	// throttling interval, and whether the throttle was applied before
-	// Kafka responded to them request or after.
+	// Kafka responded to the request or after.
 	//
 	// For Kafka < 2.0, the throttle is applied before issuing a response.
 	// For Kafka >= 2.0, the throttle is applied after issuing a response.
@@ -380,8 +380,8 @@ type HookFetchRecordBuffered interface {
 
 // HookFetchRecordUnbuffered is called when a fetched record is unbuffered.
 //
-// A record can be internally discarded after being in some scenarios without
-// being polled, such as when the internal assignment changes.
+// A record can be internally discarded in some scenarios without being
+// polled, such as when the internal assignment changes.
 //
 // As an example, if using HookFetchRecordBuffered for a gauge of how many
 // record bytes are buffered ready to be polled, this hook can be used to

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/internal/sticky/graph.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/internal/sticky/graph.go
@@ -42,9 +42,10 @@ func (b *balancer) newGraph(
 	for memberNum := range b.plan {
 		out := outBufs[:0:len(topicPotentials)]
 		outBufs = outBufs[len(topicPotentials):]
-		// In the worst case, if every node is linked to each other,
-		// each node will have nparts edges. We preallocate the worst
-		// case. It is common for the graph to be highly connected.
+		// Out edges are per topic, not per partition: in the worst
+		// case a member subscribes to every topic, so we preallocate
+		// one topic slot per member. The partition edges themselves
+		// are enumerated from topicInfos during findSteal.
 		g.out[memberNum] = out
 	}
 	for topicNum, potentials := range topicPotentials {

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/internal/sticky/sticky.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/internal/sticky/sticky.go
@@ -17,7 +17,8 @@ import (
 // bug. The second version introduced generations with the default generation
 // from the first generation's consumers defaulting to -1.
 
-// We can support up to 65533 members; two slots are reserved.
+// We can support up to 65533 members; the unassignedPart sentinel and one
+// spare slot are reserved.
 // We can support up to 2,147,483,647 partitions.
 // I expect a server to fall over before reaching either of these numbers.
 
@@ -246,7 +247,10 @@ func (b *balancer) partNumByTopic(topic string, partition int32) (int32, bool) {
 		return 0, false
 	}
 	topicInfo := b.topicInfos[topicNum]
-	if partition >= topicInfo.partitions {
+	// Claimed partitions are arbitrary input from other group members; a
+	// negative partition would index our flat partition state at a
+	// negative offset (or alias into the preceding topic's range).
+	if partition < 0 || partition >= topicInfo.partitions {
 		return 0, false
 	}
 	return topicInfo.partNum + partition, true
@@ -671,22 +675,36 @@ func (b *balancer) tryRestickyStales(
 			}
 		}
 		if !canTake {
-			return
+			continue
 		}
 
-		// The part cannot be unassigned here; a stale member
-		// would just have it. The part also cannot be deleted;
-		// if it is, there are no potential consumers and the
-		// logic above continues before getting here. The part
-		// must be on a different owner (cannot be lastOwner),
-		// otherwise it would not be a lastOwner in the stales
-		// map; it would just be the current owner.
+		// The part cannot be deleted; if it is, there are no
+		// potential consumers and canTake is false above. The part
+		// CAN be unassigned: the member that won the claim (the
+		// higher generation) may have dropped its subscription to
+		// the topic, in which case our caller un-mapped the
+		// partition from the winner's plan and left it unassigned.
+		// We give the partition straight back to the stale member.
 		currentOwner := partitionConsumers[staleNum].memberNum
+		if currentOwner == unassignedPart {
+			b.plan[lastOwnerNum].add(staleNum)
+			partitionConsumers[staleNum] = partitionConsumer{lastOwnerNum, lastOwnerNum}
+			continue
+		}
 		lastOwnerPartitions := &b.plan[lastOwnerNum]
 		currentOwnerPartitions := &b.plan[currentOwner]
 		if len(*lastOwnerPartitions)+1 < len(*currentOwnerPartitions) {
 			currentOwnerPartitions.remove(staleNum)
 			lastOwnerPartitions.add(staleNum)
+			// partitionConsumers seeds the steal graph's edge
+			// ownership (cxns) on the complex path. If we move the
+			// partition in the plan but not here, a later steal of
+			// this partition resolves to the old owner and remove()
+			// runs against a plan that does not contain the
+			// partition -- which swap-removes an unrelated
+			// partition: the final plan then has this partition on
+			// two members and the wrongly removed one on none.
+			partitionConsumers[staleNum] = partitionConsumer{lastOwnerNum, lastOwnerNum}
 		}
 	}
 }

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/logger.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/logger.go
@@ -125,16 +125,14 @@ func (w *wrappedLogger) Log(level LogLevel, msg string, keyvals ...any) {
 	w.inner.Log(level, msg, keyvals...)
 }
 
-// LoggerFn returns an anonymous function that can be used in other packages
-// that support their own anonymous logger functions.
+// The following is a small helper you can copy into your own code to bridge a
+// kgo.Logger to packages that accept an anonymous logger function of the form
+// func(int8, string, ...any) - notably the sister 'sr' and 'kfake' packages,
+// which are initialized with a 'LogFn' option. It is intentionally not
+// exported (it would force a dependency edge); copy it where you need it:
 //
-// Notably, this was added so that you can easily use a kgo.Logger in the
-// sister 'sr' and 'kfake' packages. Both clients can be initialized with a
-// 'LogFn' option. This function makes it easy to use the same kgo.Logger
-// across the other packages.
-//
-// func LoggerFn(l Logger) func(int8, string, ...any) {
+// func loggerFn(l kgo.Logger) func(int8, string, ...any) {
 // 	return func(lvl int8, msg string, keyvals ...any) {
-// 		l.Log(LogLevel(lvl), msg, keyvals...)
+// 		l.Log(kgo.LogLevel(lvl), msg, keyvals...)
 // 	}
 // }

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/metadata.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/metadata.go
@@ -835,8 +835,11 @@ func (cl *Client) mergeTopicPartitions(
 	//
 	// 2) a topic was deleted and recreated with fewer partitions
 	//
-	// Both of these scenarios should be rare to non-existent, and we do
-	// nothing if we encounter them.
+	// Case 1 is temporary and heals on a later refresh; case 2 is
+	// permanent. Below, we keep the missing partition around either way.
+	// For producers we bump its load error, which fails buffered records
+	// only once the unknown fail limit trips (so case 1 does not fail
+	// records); consumers keep consuming through the existing cursor.
 
 	// Migrating topicPartitions is a little tricky because we have to
 	// worry about underlying pointers that may currently be loaded.
@@ -851,9 +854,11 @@ func (cl *Client) mergeTopicPartitions(
 			// consuming, the partition is part of a group or part
 			// of what was loaded for direct consuming.
 			//
-			// We only clear a partition if it is purged from the
-			// client (which can happen automatically for consumers
-			// if the user opted into ConsumeRecreatedTopics).
+			// We only clear a partition if the topic is purged from
+			// the client, either manually via PurgeTopicsFromClient
+			// or automatically for regex consumers when the topic
+			// has been missing from metadata for longer than
+			// ConsiderMissingTopicDeletedAfter.
 			dup := *oldTP
 			newTP := &dup
 			newTP.loadErr = errMissingMetadataPartition

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/metrics_714.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/metrics_714.go
@@ -29,6 +29,8 @@ func (cl *Client) pushMetrics() {
 	select {
 	case <-cl.ctx.Done():
 		return
+	case <-m.quitting:
+		return
 	case <-m.firstObserve:
 	}
 
@@ -58,12 +60,30 @@ func (cl *Client) pushMetrics() {
 			case <-cl.ctx.Done():
 				after.Stop()
 				return
+			case <-m.quitting:
+				after.Stop()
+				return
 			case <-after.C:
 			}
 			continue
 		}
 
 		clientInstanceID = gresp.ClientInstanceID
+
+		// A broker must advertise a positive push interval; a <=0 value is
+		// invalid. We substitute Kafka's documented default rather than honor
+		// it, matching the Java client's validateIntervalMs. Without this, the
+		// no-requested-metrics arm below times on the raw interval (no floor,
+		// unlike the push loop's max(..., time.Second)), so a broker returning
+		// an empty RequestedMetrics list with a non-positive interval would
+		// re-issue GetTelemetrySubscriptions at round-trip pace forever.
+		if v := validatePushIntervalMillis(gresp.PushIntervalMillis); v != gresp.PushIntervalMillis {
+			cl.cfg.logger.Log(LogLevelWarn, "broker advertised a non-positive telemetry push interval, substituting the default",
+				"advertised", gresp.PushIntervalMillis,
+				"substituted", v,
+			)
+			gresp.PushIntervalMillis = v
+		}
 
 		// If there are no requested metrics, we wait the push interval
 		// and re-get.
@@ -74,6 +94,10 @@ func (cl *Client) pushMetrics() {
 			select {
 			case <-cl.ctx.Done():
 				terminating = true
+				after.Stop()
+			case <-m.quitting:
+				terminating = true
+				after.Stop()
 			case <-after.C:
 			}
 			continue
@@ -120,12 +144,24 @@ func (cl *Client) pushMetrics() {
 			}
 
 			// Wait until our push interval; if the client is quitting,
-			// we immediately send a push with Terminating=true.
+			// we immediately send a push with Terminating=true. The
+			// quitting signal fires during Close BEFORE the client
+			// context is canceled - once cl.ctx is dead, the request
+			// path aborts everything and the push could not be
+			// delivered. This assigns the outer terminating so that
+			// after the terminating push is handled, both loops exit
+			// and our deferred ctxCancel releases Close's bounded
+			// wait; a shadowing variable here would re-enter the loop
+			// and send a second terminating push (which brokers
+			// reject).
 			after := time.NewTimer(wait)
-			var terminating bool
 			select {
 			case <-cl.ctx.Done():
 				terminating = true
+				after.Stop()
+			case <-m.quitting:
+				terminating = true
+				after.Stop()
 			case <-after.C:
 			}
 
@@ -197,6 +233,22 @@ func (cl *Client) pushMetrics() {
 			}
 		}
 	}
+}
+
+// defaultPushIntervalMillis is Kafka's documented telemetry push interval
+// default (5m), substituted when a broker advertises a non-positive interval
+// (Java's ClientTelemetryReporter.DEFAULT_PUSH_INTERVAL_MS).
+const defaultPushIntervalMillis = 5 * 60 * 1000
+
+// validatePushIntervalMillis returns the broker-advertised telemetry push
+// interval, substituting the default for a non-positive (invalid) value so the
+// re-get / push loops always pace on a sane interval. Mirrors the Java client's
+// ClientTelemetryUtils.validateIntervalMs.
+func validatePushIntervalMillis(advertised int32) int32 {
+	if advertised <= 0 {
+		return defaultPushIntervalMillis
+	}
+	return advertised
 }
 
 func buildNameFilter(requested []string) func(string) bool {
@@ -289,16 +341,17 @@ type (
 
 	// metricRate is a count per second and a total.
 	metricRate struct {
-		count   atomic.Int64 // Sum of events this period; rate == float64(count/time) at rollup
+		count   atomic.Int64 // Events this period; rate == count/elapsed-seconds at rollup.
 		tot     atomic.Int64 // Total events over all time.
 		lastTot int64        // Updated when encoding; the last value for tot in case broker requests DELTA.
 	}
 
-	// metricTime reports average latency, max latency, and total latency.
-	// The unit is in milliseconds.
+	// metricTime reports average latency and max latency. The unit is in
+	// milliseconds.
 	metricTime struct {
-		sum atomic.Int64 // With separate aggDur field, avg = sum/aggDur at rollup.
-		max atomic.Int64 // Max latency seen during this window.
+		sum   atomic.Int64 // Sum of all observations this period; avg = sum/count at rollup.
+		count atomic.Int64 // Number of observations this period; the avg denominator.
+		max   atomic.Int64 // Max latency seen during this window.
 	}
 
 	// We skip:
@@ -331,6 +384,12 @@ type (
 
 		firstObserve chan struct{}
 
+		// quitting is closed by Close before the client context is
+		// canceled, asking pushMetrics to send its final terminating
+		// push while requests can still complete.
+		quitting       chan struct{}
+		closedQuitting atomic.Bool
+
 		ctx       context.Context
 		ctxCancel func()
 	}
@@ -340,7 +399,16 @@ func (m *metrics) init(cl *Client) {
 	m.cl = cl
 	m.initNano = time.Now().UnixNano()
 	m.firstObserve = make(chan struct{})
+	m.quitting = make(chan struct{})
 	m.ctx, m.ctxCancel = context.WithCancel(context.Background()) // for graceful shutdown
+}
+
+// quit asks pushMetrics to send its final terminating push and exit; it is
+// safe to call multiple times (Close can run more than once).
+func (m *metrics) quit() {
+	if !m.closedQuitting.Swap(true) {
+		close(m.quitting)
+	}
 }
 
 func safeDiv[T ~int64 | ~float64](num, denom T) T {
@@ -357,13 +425,17 @@ func (t *metricRate) observe() {
 	t.tot.Add(1)
 }
 
-func (t *metricRate) rollNums() (rate float64, tot, lastTot int64) {
+func (t *metricRate) rollNums(aggDur time.Duration) (rate float64, tot, lastTot int64) {
 	count := t.count.Swap(0)
 	lastTot = t.lastTot
 	tot = t.tot.Load()
 	t.lastTot = tot
 
-	rate = safeDiv(float64(count), float64(tot-lastTot))
+	// A rate is events-per-second over the aggregation window, matching
+	// Kafka's Rate stat (value / elapsed-time). The previous divisor was
+	// tot-lastTot, which equals count by construction (observe increments
+	// both count and tot), so the rate was a constant ~1.0.
+	rate = safeDiv(float64(count), aggDur.Seconds())
 	return rate, tot, lastTot
 }
 
@@ -371,6 +443,7 @@ func (t *metricRate) rollNums() (rate float64, tot, lastTot int64) {
 // triggerFirstObserve is always called.
 func (t *metricTime) observe(millis int64) {
 	t.sum.Add(millis)
+	t.count.Add(1)
 	for {
 		max := t.max.Load()
 		if millis < max {
@@ -382,10 +455,14 @@ func (t *metricTime) observe(millis int64) {
 	}
 }
 
-func (t *metricTime) rollNums(aggDur time.Duration) (avg float64, max int64) {
+func (t *metricTime) rollNums() (avg float64, max int64) {
 	sum := t.sum.Swap(0)
+	count := t.count.Swap(0)
 	max = t.max.Swap(0)
-	avg = safeDiv(float64(sum), float64(aggDur.Milliseconds()))
+	// An avg is the mean observation, matching Kafka's Avg stat
+	// (total / count). The previous divisor was the aggregation window
+	// duration in millis, which is not the number of observations.
+	avg = safeDiv(float64(sum), float64(count))
 	return avg, max
 }
 
@@ -512,6 +589,7 @@ func (m *metrics) appendTo(b []byte, useDeltaSums bool, maxBytes int32, allowedN
 						timeNano:   nowNano,
 					},
 					aggregationTemporality: otelTempDelta,
+					isMonotonic:            true,
 				},
 			})
 		} else {
@@ -525,6 +603,7 @@ func (m *metrics) appendTo(b []byte, useDeltaSums bool, maxBytes int32, allowedN
 						timeNano:   nowNano,
 					},
 					aggregationTemporality: otelTempCumulative,
+					isMonotonic:            true,
 				},
 			})
 		}
@@ -548,18 +627,18 @@ func (m *metrics) appendTo(b []byte, useDeltaSums bool, maxBytes int32, allowedN
 	} {
 		switch t := s.v.(type) {
 		case *metricRate:
-			rate, tot, lastTot := t.rollNums()
+			rate, tot, lastTot := t.rollNums(aggDur)
 			appendGauge(s.name+".rate", 0, rate, nil)
 			appendSum(s.name+".total", tot, lastTot, nil)
 
 		case *metricTime:
-			avg, max := t.rollNums(aggDur)
+			avg, max := t.rollNums()
 			appendGauge(s.name+".avg", 0, avg, nil)
 			appendGauge(s.name+".max", max, 0, nil)
 
 		case *map[int32]*metricTime:
 			for broker, m := range *t {
-				avg, max := m.rollNums(aggDur)
+				avg, max := m.rollNums()
 				attrs := map[string]any{"node_id": broker}
 				appendGauge(s.name+".avg", 0, avg, attrs)
 				appendGauge(s.name+".max", max, 0, attrs)
@@ -897,18 +976,13 @@ func (d *otelNumDataPoint) appendTo(b []byte) []byte {
 }
 
 func appendOtelAttributesTo(b []byte, fieldNumber int, attrs map[string]any) []byte {
-outer:
 	for key, value := range attrs {
-		b = appendProtoTag(b, fieldNumber, protoTypeLength)
-
-		kvBytes := []byte{}
-		// Field 1: key (string)
-		kvBytes = appendProtoTag(kvBytes, 1, protoTypeLength)
-		kvBytes = appendProtoString(kvBytes, key)
-
-		// Field 2: value (AnyValue)
-		kvBytes = appendProtoTag(kvBytes, 2, protoTypeLength)
-
+		// We must determine that the value is serializable BEFORE we
+		// write anything to b: an unsupported type continues the loop,
+		// and if we had already appended the field tag we would leave a
+		// dangling tag with no length+payload, corrupting the whole
+		// protobuf (the documented Attrs contract is to silently skip
+		// unsupported types).
 		var anyValueBytes []byte
 		switch t := value.(type) {
 		case *string, string:
@@ -973,9 +1047,18 @@ outer:
 			anyValueBytes = binary.AppendUvarint(anyValueBytes, uint64(len(t)))
 			anyValueBytes = append(anyValueBytes, t...)
 		default:
-			continue outer
+			continue
 		}
 
+		b = appendProtoTag(b, fieldNumber, protoTypeLength)
+
+		kvBytes := []byte{}
+		// Field 1: key (string)
+		kvBytes = appendProtoTag(kvBytes, 1, protoTypeLength)
+		kvBytes = appendProtoString(kvBytes, key)
+
+		// Field 2: value (AnyValue)
+		kvBytes = appendProtoTag(kvBytes, 2, protoTypeLength)
 		kvBytes = binary.AppendUvarint(kvBytes, uint64(len(anyValueBytes)))
 		kvBytes = append(kvBytes, anyValueBytes...)
 

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/partitioner.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/partitioner.go
@@ -15,8 +15,8 @@ import (
 // from producing through partitioning, so you can set fields in the record
 // struct before producing to aid in partitioning with a custom partitioner.
 type Partitioner interface {
-	// forTopic returns a partitioner for an individual topic. It is
-	// guaranteed that only one record will use the an individual topic's
+	// ForTopic returns a partitioner for an individual topic. It is
+	// guaranteed that only one record will use an individual topic's
 	// topicPartitioner at a time, meaning partitioning within a topic does
 	// not require locks.
 	ForTopic(string) TopicPartitioner
@@ -229,7 +229,7 @@ func (p *leastBackupTopicPartitioner) PartitionByBackup(_ *Record, n int, backup
 				leastBackup = backup
 				p.onPart = pick
 				npicked = 1
-			} else {
+			} else if backup == leastBackup {
 				npicked++ // reservoir sampling with k = 1
 				if p.rng.Intn(npicked) == 0 {
 					p.onPart = pick
@@ -245,11 +245,11 @@ func (p *leastBackupTopicPartitioner) PartitionByBackup(_ *Record, n int, backup
 ///////////////////
 
 // UniformBytesPartitioner is a redux of the StickyPartitioner, proposed in
-// KIP-794 and release with the Java client in Kafka 3.3. This partitioner
+// KIP-794 and released with the Java client in Kafka 3.3. This partitioner
 // returns the same partition until 'bytes' is hit. At that point, a
 // re-partitioning happens. If adaptive is false, this chooses a new random
-// partition, otherwise this chooses a broker based on the inverse of the
-// backlog currently buffered for that broker. If keys is true, this uses
+// partition, otherwise this chooses a partition based on the inverse of the
+// backlog currently buffered for that partition. If keys is true, this uses
 // standard hashing based on record key for records with non-nil keys. hasher
 // is optional; if nil, the default hasher murmur2 (Kafka's default).
 //
@@ -355,8 +355,8 @@ func (p *uniformBytesTopicPartitioner) PartitionByBackup(r *Record, n int, backu
 	} else {
 		p.calc = p.calc[:0]
 
-		// For adaptive, the logic is that we pick by broker according
-		// to the inverse of the queue size. Presumably this means
+		// For adaptive, the logic is that we pick a partition according
+		// to the inverse of its queue size. Presumably this means
 		// bytes, but we use records for simplicity.
 		//
 		// We calculate 1/recs for all brokers and choose the first one
@@ -382,14 +382,28 @@ func (p *uniformBytesTopicPartitioner) PartitionByBackup(r *Record, n int, backu
 		}
 		r := p.rng.Float64()
 		pick := r * t
+		// The loop below selects nothing in two cases: floating rounding
+		// can leave pick just above 0 after subtracting every weight (the
+		// guarded case the original code handled), and we may have entered
+		// this re-pick with a stale p.onPart that is not the -1 byte-reset
+		// sentinel but rather a previously-pinned index that is now >= n
+		// because the writable partition count shrank under us (e.g. a
+		// leader election dropped partitions from writablePartitions). In
+		// both cases p.onPart is unchanged by the loop, so we must fall
+		// back to a valid index rather than return the stale value, which
+		// the caller would reject as an out-of-range partitioning choice
+		// (failing the record). The non-adaptive branch above re-picks
+		// unconditionally via Intn(n) and so has never had this hole.
+		picked := false
 		for _, c := range p.calc {
 			pick -= c.f
 			if pick <= 0 {
 				p.onPart = c.n
+				picked = true
 				break
 			}
 		}
-		if p.onPart == -1 {
+		if !picked {
 			p.onPart = p.calc[len(p.calc)-1].n
 		}
 	}
@@ -475,7 +489,7 @@ type PartitionerHasher func([]byte, int) int
 // KafkaHasher returns a PartitionerHasher using hashFn that mirrors how Kafka
 // partitions after hashing data. In Kafka, after hashing into a uint32, the
 // hash is converted to an int32 and the high bit is stripped. Kafka by default
-// uses murmur2 hashing, and the StickyKeyPartiitoner uses this by default.
+// uses murmur2 hashing, and the StickyKeyPartitioner uses this by default.
 // Using this KafkaHasher function is only necessary if you want to change the
 // underlying hashing algorithm.
 func KafkaHasher(hashFn func([]byte) uint32) PartitionerHasher {
@@ -497,8 +511,25 @@ func KafkaHasher(hashFn func([]byte) uint32) PartitionerHasher {
 // In particular, using this function with a crc32.ChecksumIEEE hasher makes
 // this partitioner match librdkafka's consistent partitioner, or the
 // zendesk/ruby-kafka partitioner.
+//
+// Note that the arithmetic depends on Go's int width: on 32-bit platforms,
+// hashes with the high bit set choose a different partition than on 64-bit
+// platforms (only the 64-bit behavior matches librdkafka). This is
+// deliberately left alone: the function exists to preserve a historical
+// placement, and changing either platform's placement would remap keys for
+// deployments relying on it.
 func SaramaHasher(hashFn func([]byte) uint32) PartitionerHasher {
 	return func(key []byte, n int) int {
+		// The int conversion makes this arithmetic int-width
+		// dependent: on 64-bit platforms int(uint32) is always
+		// non-negative (the negation below is dead and the result
+		// matches librdkafka's unsigned modulo), while on 32-bit
+		// platforms a hash with the high bit set wraps negative and
+		// is negated, choosing a different partition. This stays
+		// as-is deliberately: this function's entire purpose is
+		// preserving a historical placement (see the doc above), and
+		// existing deployments on either width depend on the
+		// placement they have been writing with.
 		p := int(hashFn(key)) % n
 		if p < 0 {
 			p = -p

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/pools.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/pools.go
@@ -11,7 +11,7 @@ import (
 
 ////////////////////////////////////////////////////////////////
 // NOTE:                                                      //
-// NOTE: Make sure new hooks are checked in implementsAnyPool //
+// NOTE: Make sure new pools are checked in implementsAnyPool //
 // NOTE:                                                      //
 ////////////////////////////////////////////////////////////////
 
@@ -42,7 +42,9 @@ func (ps pools) each(fn func(Pool) bool) {
 type PoolDecompressBytes interface {
 	// GetDecompressBytes returns a slice to decompress into. This
 	// interface is given the compressed data and the codec that will be
-	// used for decompressing.
+	// used for decompressing. Only the returned slice's capacity is used;
+	// data is written starting at index 0 regardless of the slice's
+	// length.
 	//
 	// For many decompression algorithms, it is not possible to accurately
 	// know the size that data will be once decompressed. You can guess a
@@ -143,6 +145,13 @@ func (r *Record) Recycle() {
 		return
 	}
 
+	ps.release()
+}
+
+// release zeroes and puts the pooled slices back. Called by a batch's last
+// Recycle, or directly by the fetch processor when a batch kept no records
+// (so no Recycle will ever run).
+func (ps *recordPools) release() {
 	// Reset the length of slices to max to ensure we zero things and so
 	// that users can avoid this resetting.
 	ps.decompressBytes = ps.decompressBytes[:cap(ps.decompressBytes)]
@@ -192,6 +201,10 @@ func implementsAnyPool(p Pool) bool {
 	return false
 }
 
+// ensureLen returns s reset to exactly length n, growing it if needed. n
+// must be >= 0: a negative n panics on the s[:n] slice expression. Callers
+// pass a record count read off the wire, which is rejected for < 0 before
+// reaching here (see processRecordBatch's negative-count guard).
 func ensureLen[S ~[]E, E any](s S, n int) S {
 	s = s[:cap(s)]
 	if len(s) >= n {

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/producer.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/producer.go
@@ -59,9 +59,27 @@ type producer struct {
 
 	batchPromises ring[batchPromise] // we never call die() on it
 
+	// onBatchPromiseBroadcast, if non-nil, is invoked from finishPromises
+	// immediately before the per-batch p.c.Broadcast() fires, with moreQueued
+	// reporting whether further promise elements are still queued in the ring
+	// (i.e. the broadcast is firing mid-drain rather than at ring exit). It
+	// exists purely so tests can observe the broadcast deterministically at
+	// its source instead of racing a woken goroutine; it is always nil in
+	// production.
+	onBatchPromiseBroadcast func(moreQueued bool)
+
 	txnMu   xsync.Mutex
 	inTxn   bool
 	tx890p2 atomic.Bool
+
+	// producedInTxn is set when a record is buffered within the current
+	// transaction and reset by BeginTransaction. EndTransaction consults
+	// it under KIP-890 part 2, where produce requests implicitly add
+	// partitions broker-side before the data append: a transaction whose
+	// every produce FAILED still needs an EndTxn abort even though no
+	// partition was marked addedToTxn client-side (marking happens only
+	// on produce success).
+	producedInTxn atomic.Bool
 }
 
 // BufferedProduceRecords returns the number of records currently buffered for
@@ -87,6 +105,7 @@ func (cl *Client) BufferedProduceBytes() int64 {
 
 // EnsureProduceConnectionIsOpen attempts to open a produce connection to all
 // specified brokers, or all brokers if `brokers` is empty or contains -1.
+// Broker IDs less than -1 are ignored.
 //
 // This can be used in an attempt to reduce the latency when producing if your
 // application produces infrequently: you can force open a produce connection a
@@ -127,7 +146,7 @@ func (cl *Client) EnsureProduceConnectionIsOpen(ctx context.Context, brokers ...
 		}
 		cl.brokersMu.RUnlock()
 	} else {
-		for _, b := range brokers {
+		for _, b := range keep {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
@@ -211,6 +230,20 @@ func (p *producer) purgeTopics(topics []string) {
 	p.topicsMu.Lock()
 	defer p.topicsMu.Unlock()
 
+	// We sweep unknown-topic waiters AND store the cleaned topics map
+	// while unknownTopicsMu is held. The store must not happen after the
+	// mu is released: partitionsForTopicProduce re-checks the topic's
+	// presence in p.topics under this mu before (re)creating an
+	// unknown-topic waiter, so holding the mu across both steps means a
+	// concurrent produce either sees the topic still present - and its
+	// just-added waiter is then swept by us - or sees it gone and
+	// re-registers the topic properly. If we instead released the mu
+	// between the sweep and the store (old behavior), a produce could
+	// land in that window: it saw the topic in p.topics, re-created a
+	// waiter, and we then removed the topic from the map - orphaning the
+	// waiter, which no metadata update would ever notify (the request set
+	// is built from p.topics), silently hanging the record forever. This
+	// mirrors storePartitionsUpdate's store-before-unlock requirement.
 	p.unknownTopicsMu.Lock()
 	for _, topic := range topics {
 		if unknown, exists := p.unknownTopics[topic]; exists {
@@ -222,17 +255,20 @@ func (p *producer) purgeTopics(topics []string) {
 			})
 		}
 	}
-	p.unknownTopicsMu.Unlock()
-
 	toStore := p.topics.clone()
-	defer p.topics.storeData(toStore)
-
+	var purged []*topicPartitionsData
 	for _, topic := range topics {
 		d := toStore.loadTopic(topic)
 		if d == nil {
 			continue
 		}
 		delete(toStore, topic)
+		purged = append(purged, d)
+	}
+	p.topics.storeData(toStore)
+	p.unknownTopicsMu.Unlock()
+
+	for _, d := range purged {
 		for _, p := range d.partitions {
 			r := p.records
 
@@ -296,7 +332,7 @@ func (rs ProduceResults) FirstErr() error {
 	return nil
 }
 
-// First the first record and error in the produce results.
+// First returns the first record and error in the produce results.
 //
 // This function is useful if you only passed one record to ProduceSync.
 func (rs ProduceResults) First() (*Record, error) {
@@ -476,16 +512,26 @@ func (cl *Client) TryProduce(
 // Kafka replies. For a synchronous produce, see ProduceSync. Records are
 // produced in order per partition if the record is produced successfully.
 // Successfully produced records will have their attributes, offset, and
-// partition set before the promise is called. All promises are called serially
-// (and should be relatively fast). If a record's timestamp is unset, this
-// sets the timestamp to time.Now.
+// partition set before the promise is called. All promises are called
+// serially, so they should be relatively fast and must not block: a promise
+// that blocks on the client itself -- for example, a blocking Produce while
+// the client is at its max-buffered limits, or a Flush -- waits on progress
+// that only later promises can deliver and can deadlock the client. To
+// produce from within a promise, spawn a goroutine (as
+// AbortingFirstErrPromise does for aborting): a goroutine'd produce that
+// blocks simply waits for the promise worker to make space. A direct
+// TryProduce inside a promise is safe only while promise delivery is keeping
+// up; if the record fails before buffering while the client is saturated
+// with an extreme backlog of failing records, delivering that failure blocks
+// the promise worker on itself. If a record's timestamp is unset, this sets
+// the timestamp to time.Now.
 //
 // If the topic field is empty, the client will use the DefaultProduceTopic; if
 // that is also empty, the record is failed immediately. If the record is too
 // large to fit in a batch on its own in a produce request, the record will be
-// failed with immediately kerr.MessageTooLarge.
+// failed immediately with kerr.MessageTooLarge.
 //
-// If the client is configured to automatically flush the client currently has
+// If the client is configured to automatically flush and the client currently has
 // the configured maximum amount of records buffered, Produce will block. The
 // context can be used to cancel waiting while records flush to make space. In
 // contrast, if manual flushing is configured, the record will be failed
@@ -625,6 +671,18 @@ func (cl *Client) produce(
 			}()
 			<-wait // we wait for the goroutine to exit, then unlock again (since the goroutine leaves the mutex locked)
 			p.mu.Unlock()
+			// The goroutine above decremented p.blocked, but this is the
+			// cancel path: the record is failed, not buffered, so there is
+			// no compensating bufferedRecords++ (the success path below
+			// has one, keeping the sum unchanged). The bufferedRecords +
+			// blocked sum that Flush waits on therefore just dropped, and
+			// the only broadcast on this path - the one that woke the
+			// goroutine above - fired BEFORE its decrement, so a Flush that
+			// re-checked its predicate in between observed the stale
+			// pre-decrement sum and went back to waiting. Broadcast now,
+			// after the decrement is visible, so a Flush whose sum reached
+			// zero is woken; without this it can hang forever.
+			p.c.Broadcast()
 			p.promiseRecordBeforeBuf(promisedRec{ctx, promise, r}, err)
 		}
 
@@ -645,6 +703,16 @@ func (cl *Client) produce(
 	p.bufferedBytes += userSize
 	p.mu.Unlock()
 
+	// Set at buffer time, before any produce reaches the broker, so this can
+	// over-set: a record counted here may still be failed locally (client
+	// close, unknown-topic timeout) before it is ever sent. The only
+	// consequence is an unnecessary EndTxn abort, which is always legal under
+	// KIP-890p2 -- an empty abort succeeds, bumps the epoch, and has nothing to
+	// commit. See the producedInTxn field doc and EndTransaction.
+	if cl.cfg.txnID != nil && !p.producedInTxn.Load() {
+		p.producedInTxn.Store(true)
+	}
+
 	cl.loadPartsAndPartition(promisedRec{ctx, promise, r})
 }
 
@@ -658,8 +726,18 @@ type batchPromise struct {
 	err        error
 }
 
+// promiseBatch finishes a batch of records. This never parks on the ring's
+// maxLen: every caller either carries records already admitted under the
+// max-buffered accounting (sink responses, fail/purge paths) or holds a
+// client lock (purgeTopics and failBufferedRecords under topicsMu and
+// unknownTopicsMu, storePartitionsUpdate under unknownTopicsMu, recBuf
+// failure paths under recBuf.mu). A parked lock-holder can deadlock: the
+// promise worker is the only goroutine that frees ring space, and a user
+// promise may re-enter the client (TryProduce) and need the very lock the
+// parked pusher holds, so the worker would wait on the lock while the lock
+// holder waits on the worker.
 func (p *producer) promiseBatch(b batchPromise) {
-	if first, _ := p.batchPromises.push(b); first {
+	if first, _ := p.batchPromises.pushForce(b); first {
 		go p.finishPromises(b)
 	}
 }
@@ -668,38 +746,82 @@ func (p *producer) promiseRecord(pr promisedRec, err error) {
 	p.promiseBatch(batchPromise{recs: []promisedRec{pr}, err: err})
 }
 
+// promiseRecordBeforeBuf finishes a record that failed before it was ever
+// buffered (and before it counted toward bufferedRecords). Only this entry
+// applies the ring's maxLen backpressure: pre-buffer failures are the one
+// promise source not bounded by the max-buffered admission, so a spin loop
+// of failing produces - blocking Produce or TryProduce alike - could
+// otherwise grow the ring without bound (#1194). Parking here is the
+// deliberate trade: every accepted record costs memory until its promise
+// runs and the promise is the only completion channel, so a caller outpacing
+// the promise worker must be blocked, not absorbed. The one caller that can
+// never park is the promise worker itself (a promise calling TryProduce with
+// a record that fails pre-buffer); produce-from-promise is documented to
+// spawn a goroutine, whose park is safe: the worker keeps draining and the
+// goroutine proceeds when space frees.
 func (p *producer) promiseRecordBeforeBuf(pr promisedRec, err error) {
-	p.promiseBatch(batchPromise{recs: []promisedRec{pr}, beforeBuf: true, err: err})
+	b := batchPromise{recs: []promisedRec{pr}, beforeBuf: true, err: err}
+	if first, _ := p.batchPromises.push(b); first {
+		go p.finishPromises(b)
+	}
 }
 
 func (p *producer) finishPromises(b batchPromise) {
 	cl := p.cl
 	var more bool
 	var broadcast bool
-	defer func() {
-		if broadcast {
-			p.c.Broadcast()
-		}
-	}()
 start:
 	for i, pr := range b.recs {
 		pr.LeaderEpoch = -1
-		if b.baseOffset == -1 {
-			// if the base offset is invalid/unknown (-1), all record offsets should
-			// be treated as unknown
+		if b.err != nil {
+			// Failed records carry unknown-sentinels, not the
+			// batchPromise zero values: without this, a failed
+			// record's offset was its index within the failed
+			// batch and its producer id/epoch were 0 -
+			// plausible-looking garbage.
 			pr.Offset = -1
+			pr.ProducerID = -1
+			pr.ProducerEpoch = -1
 		} else {
-			pr.Offset = b.baseOffset + int64(i)
+			if b.baseOffset == -1 {
+				// if the base offset is invalid/unknown (-1), all record offsets should
+				// be treated as unknown
+				pr.Offset = -1
+			} else {
+				pr.Offset = b.baseOffset + int64(i)
+			}
+			pr.ProducerID = b.pid
+			pr.ProducerEpoch = b.epoch
+			pr.Attrs = b.attrs
 		}
-		pr.ProducerID = b.pid
-		pr.ProducerEpoch = b.epoch
-		pr.Attrs = b.attrs
 		recBroadcast := cl.finishRecordPromise(pr, b.err, b.beforeBuf)
 		broadcast = broadcast || recBroadcast
 	}
 	clear(b.recs) // drop references so the pooled slice does not retain them
 	if cap(b.recs) > 4 {
 		cl.prsPool.put(b.recs)
+	}
+
+	// We broadcast per batch, not per record (waking blocked producers on
+	// every record forces tiny one-record batches; see ead18d3c) - but
+	// also not once per ring drain: while pre-buffer failure promises keep
+	// arriving from other goroutines, this loop never observes an empty
+	// ring and never exits, and a deferred-to-exit broadcast would starve
+	// a Flush whose condition (bufferedRecords == 0) became true mid-drain
+	// and blocked Produce calls whose space opened.
+	if broadcast {
+		if p.onBatchPromiseBroadcast != nil {
+			// The current (just-processed) element is still in the ring
+			// here, since dropPeek runs below; l > 1 thus means more
+			// elements are queued behind it and the broadcast is firing
+			// mid-drain rather than at ring exit.
+			p.batchPromises.mu.Lock()
+			moreQueued := p.batchPromises.l > 1
+			p.batchPromises.mu.Unlock()
+			p.onBatchPromiseBroadcast(moreQueued)
+		}
+		p.c.Broadcast()
+		broadcast = false
 	}
 
 	b, more, _ = p.batchPromises.dropPeek()
@@ -858,7 +980,7 @@ type producerID struct {
 
 var errReloadProducerID = errors.New("producer id needs reloading")
 
-// initProducerID initializes the client's producer ID for idempotent
+// producerID returns, loading if necessary, the client's producer ID for idempotent
 // producing only (no transactions, which are more special). After the first
 // load, this clears all buffered unknown topics.
 func (cl *Client) producerID(ctxFn func() context.Context) (int64, int16, error) {
@@ -1009,7 +1131,21 @@ func (cl *Client) doInitProducerID(ctxFn func() context.Context, lastID int64, l
 		if err != nil {
 			return err
 		}
-		return nil // resp.ErrorCode handled below
+		// We return ConcurrentTransactions so that our wrapping
+		// doWithConcurrentTransactions retries in place: the
+		// coordinator replies with it while still completing (or
+		// fence-aborting) a previous transaction for this
+		// transactional ID. Notably, taking over a crashed
+		// incarnation's ongoing transaction ALWAYS receives it at
+		// least once: the broker internally aborts the old
+		// transaction and tells us to retry. Surfacing the error
+		// instead would bubble a routine, transient condition up as a
+		// BeginTransaction failure. All other response error codes
+		// are classified below.
+		if err := kerr.ErrorForCode(resp.ErrorCode); errors.Is(err, kerr.ConcurrentTransactions) {
+			return err
+		}
+		return nil
 	})
 	if err != nil {
 		if errors.Is(err, errUnknownRequestKey) || errors.Is(err, errBrokerTooOld) {
@@ -1058,47 +1194,68 @@ func (cl *Client) partitionsForTopicProduce(pr promisedRec) (*topicPartitions, *
 	p := &cl.producer
 	topic := pr.Topic
 
-	topics := p.topics.load()
-	parts, exists := topics[topic]
-	if exists {
+	for {
+		topics := p.topics.load()
+		parts, exists := topics[topic]
+		if exists {
+			if v := parts.load(); len(v.partitions) > 0 {
+				return parts, v
+			}
+		}
+
+		if !exists { // topic did not exist: check again under mu and potentially create it
+			p.topicsMu.Lock()
+			if _, exists = p.topics.load()[topic]; !exists {
+				// Before we store the new topic, we lock unknown
+				// topics to prevent a concurrent metadata update
+				// seeing our new topic before we are waiting from the
+				// addUnknownTopicRecord fn. Otherwise, we would wait
+				// and never be re-notified.
+				p.unknownTopicsMu.Lock()
+				p.topics.storeTopics([]string{topic})
+				cl.addUnknownTopicRecord(pr)
+				cl.triggerUpdateMetadataNow("forced load because we are producing to a topic for the first time")
+				p.unknownTopicsMu.Unlock()
+				p.topicsMu.Unlock()
+				return nil, nil
+			}
+			p.topicsMu.Unlock()
+		}
+
+		// Here, the topic existed, but maybe has not loaded partitions
+		// yet. We have to lock unknown topics first to ensure ordering
+		// just in case a load has not happened.
+		p.unknownTopicsMu.Lock()
+
+		// Re-resolve the topic now that we hold the mu. Both sides of
+		// the entry's lifecycle change only under unknownTopicsMu:
+		// storePartitionsUpdate stores loaded partitions before
+		// releasing it, and purgeTopics stores the topic's removal
+		// from p.topics before releasing it. Without the re-check we
+		// could add a waiter for a topic a concurrent purge already
+		// swept: the purge then removes the topic from p.topics, no
+		// metadata update ever requests it (the request set is built
+		// from p.topics), and the waiter - and its records - silently
+		// hang forever. Re-resolving from the current map (not the
+		// `parts` pointer loaded above) also covers a purge+recreate
+		// swapping the topicPartitions object in between.
+		parts, exists = p.topics.load()[topic]
+		if !exists {
+			// Purged between our load and the lock; retry from the
+			// top, which re-creates the topic properly.
+			p.unknownTopicsMu.Unlock()
+			continue
+		}
 		if v := parts.load(); len(v.partitions) > 0 {
+			p.unknownTopicsMu.Unlock()
 			return parts, v
 		}
+		cl.addUnknownTopicRecord(pr)
+		cl.triggerUpdateMetadata(false, "reload trigger due to produce topic still not known")
+		p.unknownTopicsMu.Unlock()
+
+		return nil, nil // our record is buffered waiting for metadata update; nothing to return
 	}
-
-	if !exists { // topic did not exist: check again under mu and potentially create it
-		p.topicsMu.Lock()
-		defer p.topicsMu.Unlock()
-
-		if parts, exists = p.topics.load()[topic]; !exists { // update parts for below
-			// Before we store the new topic, we lock unknown
-			// topics to prevent a concurrent metadata update
-			// seeing our new topic before we are waiting from the
-			// addUnknownTopicRecord fn. Otherwise, we would wait
-			// and never be re-notified.
-			p.unknownTopicsMu.Lock()
-			defer p.unknownTopicsMu.Unlock()
-
-			p.topics.storeTopics([]string{topic})
-			cl.addUnknownTopicRecord(pr)
-			cl.triggerUpdateMetadataNow("forced load because we are producing to a topic for the first time")
-			return nil, nil
-		}
-	}
-
-	// Here, the topic existed, but maybe has not loaded partitions yet. We
-	// have to lock unknown topics first to ensure ordering just in case a
-	// load has not happened.
-	p.unknownTopicsMu.Lock()
-	defer p.unknownTopicsMu.Unlock()
-
-	if v := parts.load(); len(v.partitions) > 0 {
-		return parts, v
-	}
-	cl.addUnknownTopicRecord(pr)
-	cl.triggerUpdateMetadata(false, "reload trigger due to produce topic still not known")
-
-	return nil, nil // our record is buffered waiting for metadata update; nothing to return
 }
 
 // addUnknownTopicRecord adds a record to a topic whose partitions are
@@ -1119,7 +1276,11 @@ func (cl *Client) addUnknownTopicRecord(pr promisedRec) {
 	}
 }
 
-// waitUnknownTopic waits for a notification
+// waitUnknownTopic waits for the topic to be resolved by a metadata update
+// (the wait channel is closed, or receives retryable load errors that count
+// toward the retry limits), or for the record/produce contexts, the client,
+// the record timeout, or an abort (the fatal channel) to end the wait and
+// fail all buffered records.
 func (cl *Client) waitUnknownTopic(
 	pctx context.Context, // context passed to Produce
 	rctx context.Context, // context on the record itself
@@ -1166,7 +1327,11 @@ func (cl *Client) waitUnknownTopic(
 		case err = <-unknown.fatal:
 		case retryableErr, ok := <-unknown.wait:
 			if !ok {
-				cl.cfg.logger.Log(LogLevelInfo, "done waiting for metadata for new topic", "topic", topic)
+				// The channel is closed when the topic's partitions
+				// load, but also when the topic is purged or all
+				// buffered records are failed; whoever closed it
+				// already handled the buffered records.
+				cl.cfg.logger.Log(LogLevelInfo, "done waiting on metadata for new topic", "topic", topic)
 				return // metadata was successful!
 			}
 			cl.cfg.logger.Log(LogLevelInfo, "new topic metadata wait failed, retrying wait", "topic", topic, "err", retryableErr)
@@ -1226,7 +1391,7 @@ func (cl *Client) unlingerDueToMaxRecsBuffered() {
 // If the context finishes (Done), this returns the context's error.
 //
 // This function is safe to call multiple times concurrently, and safe to call
-// concurrent with Flush.
+// concurrent with AbortBufferedRecords.
 func (cl *Client) Flush(ctx context.Context) error {
 	p := &cl.producer
 

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/record_and_fetch.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/record_and_fetch.go
@@ -655,17 +655,28 @@ func (fs Fetches) EachTopic(fn func(FetchTopic)) {
 		return
 	}
 
+	// A topic's partitions are led by different brokers, so the same topic
+	// is spread across multiple Fetch entries (one per broker response); we
+	// must carry the TopicID across them rather than zeroing it. The broker
+	// returns the same ID in every fetch response for the topic, so the
+	// first non-zero copy is authoritative. Without this, EachTopic returns
+	// a zero TopicID whenever more than one broker replied -- i.e. nearly
+	// always in a real cluster, yet never in a single-broker test.
 	topics := make(map[string][]FetchPartition)
+	ids := make(map[string][16]byte)
 	for _, fetch := range fs {
 		for _, topic := range fetch.Topics {
 			topics[topic.Topic] = append(topics[topic.Topic], topic.Partitions...)
+			if topic.TopicID != ([16]byte{}) {
+				ids[topic.Topic] = topic.TopicID
+			}
 		}
 	}
 
 	for topic, partitions := range topics {
 		fn(FetchTopic{
 			topic,
-			[16]byte{},
+			ids[topic],
 			partitions,
 		})
 	}

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/record_formatter.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/record_formatter.go
@@ -84,7 +84,7 @@ func (f *RecordFormatter) AppendPartitionRecord(b []byte, p *FetchPartition, r *
 //	%D    share group delivery count (0 if not from a share group)
 //	%A    share group acquisition deadline (timestamp, 0 if not from a share group)
 //
-// For AppendPartitionRecord, the formatter also undersands the following three
+// For AppendPartitionRecord, the formatter also understands the following three
 // formatting options:
 //
 //	%[    partition log start offset
@@ -238,9 +238,7 @@ func NewRecordFormatter(layout string) (*RecordFormatter, error) {
 	var f RecordFormatter
 
 	var literal []byte // non-formatted raw text to output
-	var i int
 	for len(layout) > 0 {
-		i++
 		c, size := utf8.DecodeRuneInString(layout)
 		rawc := layout[:size]
 		layout = layout[size:]
@@ -777,7 +775,7 @@ func parseUnpack(layout string) (func([]byte, []byte) []byte, error) {
 		islittle := little
 		fns = append(fns, func(dst, src []byte) ([]byte, int) {
 			if len(src) < need {
-				return append(dst, fmt.Sprintf("%%!%%s(have %d bytes, need %d)", len(src), need)...), len(src)
+				return append(dst, fmt.Sprintf("%%!(have %d bytes, need %d)", len(src), need)...), len(src)
 			}
 
 			var ul, ub uint64
@@ -1226,7 +1224,11 @@ func (r *RecordReader) parseReadLayout(layout string) error {
 
 		switch escaped {
 		default:
-			return fmt.Errorf("unknown percent escape sequence %q", layout[:1])
+			// escaped is the verb byte; layout has already advanced past
+			// it (and past any '{'), so it can be empty here - slicing
+			// layout[:1] would panic for an unknown verb at the end of
+			// the layout (e.g. "%q").
+			return fmt.Errorf("unknown percent escape sequence %q", string(escaped))
 
 		case 'T', 'K', 'V', 'H':
 			var dst *uint64
@@ -1391,7 +1393,7 @@ func (r *RecordReader) parseReadLayout(layout string) error {
 				inner(b, r)
 				return nil
 			}}
-			bit.set(bit)
+			bits.set(bit)
 			if bits.has(bitSize) {
 				if re != nil {
 					return errors.New("cannot specify exact size and regular expression")
@@ -1480,6 +1482,13 @@ func (r *RecordReader) parseReadLayout(layout string) error {
 		} else {
 			reads = append(reads, fn)
 		}
+	}
+	// A layout consisting solely of noread verbs (fixed sizes/numbers like
+	// "%p{3}") never consumes input, so next() never reaches an EOF, never
+	// sets r.done, and ReadRecord returns identical records forever. Reject
+	// it at construction rather than looping at read time.
+	if len(reads) == 0 {
+		return errors.New("RecordReader: layout reads nothing from the input")
 	}
 	r.fns = make([]readParse, 0, len(noreads)+len(reads))
 	r.fns = append(r.fns, noreads...)
@@ -1767,6 +1776,20 @@ func (r *RecordReader) next(rec *Record) error {
 			continue
 		}
 
+		// If the input EOF'd before a fixed-size read accumulated its full
+		// byte count, r.buf is short. This happens on the fall-through
+		// above: a zero-byte read surfaces as plain io.EOF (readSize only
+		// reports io.EOF when it read nothing; a partial read is already
+		// io.ErrUnexpectedEOF), and if that read is the last fn after an
+		// earlier real read it is not the clean record boundary, so it
+		// reaches here with an empty buffer. The fixed-width number parsers
+		// index r.buf at constant offsets (binary.*.Uint64 etc.) and panic
+		// on a short slice, so surface the truncation as the unexpected EOF
+		// that ReadRecord's doc already promises for a mid-record EOF.
+		if fn.read.size > 0 && len(r.buf) < fn.read.size {
+			return io.ErrUnexpectedEOF
+		}
+
 		if err := fn.parse(r.buf, rec); err != nil {
 			return err
 		}
@@ -1837,10 +1860,34 @@ func (r *RecordReader) readRe(re *regexp.Regexp) error {
 }
 
 func (r *RecordReader) readSize(n int) error {
-	r.buf = append(r.buf, make([]byte, n)...)
-	n, err := io.ReadFull(r.r, r.buf)
-	r.buf = r.buf[:n]
-	return err
+	if n < 0 {
+		// A size verb (%T/%K/%V) reads its value from the input as a
+		// uint64; converting to int can wrap negative for values above
+		// math.MaxInt64. Reject rather than panicking in make below.
+		return fmt.Errorf("invalid negative read size %d", n)
+	}
+	// Read in bounded chunks rather than pre-allocating n bytes up front:
+	// a hostile or corrupt size verb can claim a huge length that would
+	// OOM the process before io.ReadFull notices the input is short. The
+	// caller resets r.buf to empty before invoking us, so we accumulate
+	// from index 0.
+	const chunk = 64 << 10
+	for len(r.buf) < n {
+		start := len(r.buf)
+		r.buf = append(r.buf, make([]byte, min(n-start, chunk))...)
+		nn, err := io.ReadFull(r.r, r.buf[start:])
+		r.buf = r.buf[:start+nn]
+		if err != nil {
+			// io.ReadFull reports EOF only when it read zero bytes of
+			// this chunk; if we have already accumulated bytes for this
+			// field the value is truncated, which is an unexpected EOF.
+			if err == io.EOF && len(r.buf) > 0 {
+				err = io.ErrUnexpectedEOF
+			}
+			return err
+		}
+	}
+	return nil
 }
 
 func (r *RecordReader) readExact(d []byte) error {
@@ -2263,7 +2310,10 @@ func parseLayoutSlash(layout string) (byte, int, error) {
 			return 0, 0, errors.New("invalid non-terminated hex escape sequence at end of delim string")
 		}
 		hex := layout[1:3]
-		n, err := strconv.ParseInt(hex, 16, 8)
+		// A \xNN escape names the byte with hex value NN, i.e. the full
+		// [0, 255] range. ParseInt with bitSize 8 caps at 0x7f and
+		// rejected 0x80-0xff; ParseUint with bitSize 8 accepts [0, 255].
+		n, err := strconv.ParseUint(hex, 16, 8)
 		if err != nil {
 			return 0, 0, fmt.Errorf("unable to parse hex escape sequence %q: %v", hex, err)
 		}

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/ring.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/ring.go
@@ -65,13 +65,43 @@ func (r *ring[T]) die() {
 	}
 }
 
+// empty returns whether the ring currently holds no elements. Because an
+// element being processed stays in the ring until dropPeek removes it,
+// empty also means no worker goroutine is mid-element.
+func (r *ring[T]) empty() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.l == 0
+}
+
 func (r *ring[T]) push(elem T) (first, dead bool) {
+	return r.doPush(elem, true)
+}
+
+// pushForce pushes even when the ring is at maxLen. The maxLen wait can only
+// be used by pushers that do not deadlock against the ring's worker: the
+// worker is the only goroutine that signals space (dropPeek), and a push
+// made while holding a client lock (purge/fail paths, storePartitionsUpdate,
+// recBuf failure paths) would park holding a lock the worker can need
+// through a user promise re-entering the client - the worker then waits on
+// the lock while the lock holder waits on the worker. Those internal pushers
+// force. Forcing does not unbound the ring: every record an internal push
+// carries was already admitted under the max-buffered-records accounting, so
+// forced volume is capped by that admission; only produce-entry failure
+// pushes (the unbounded source) take the blocking push.
+func (r *ring[T]) pushForce(elem T) (first, dead bool) {
+	return r.doPush(elem, false)
+}
+
+func (r *ring[T]) doPush(elem T, wait bool) (first, dead bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	// If a max length is set, block until there's space.
-	for r.maxLen > 0 && r.l >= r.maxLen && !r.dead {
-		r.cond.Wait()
+	if wait {
+		for r.maxLen > 0 && r.l >= r.maxLen && !r.dead {
+			r.cond.Wait()
+		}
 	}
 
 	if r.dead {

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/sink.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/sink.go
@@ -31,9 +31,9 @@ type sink struct {
 
 	drainState workLoop
 
-	// seqRespsMu, guarded by seqRespsMu, contains responses that must
-	// be handled sequentially. These responses are handled asynchronously,
-	// but sequentially.
+	// seqResps contains responses that must be handled sequentially: the
+	// ring preserves issue order, and its single transient worker handles
+	// responses asynchronously but in that order.
 	seqResps ring[*seqResp] // we never call die() on it
 
 	backoffMu   xsync.Mutex // guards the following
@@ -461,10 +461,14 @@ func (s *sink) produce(sem <-chan struct{}) bool {
 	// records for a new transaction. Any records in the request are
 	// from the current transaction at epoch N, which is correct.
 	//
-	// This undo is safe: resetBatchDrainIdx + decInflight rewind
-	// each recBuf to its pre-drain state, the existing defer releases
-	// the semaphore (produced is still false), and returning true
-	// retries produce() with the correct epoch.
+	// This undo is safe: undoStagedBatches rewinds each recBuf to its
+	// pre-drain state -- drain index, inflight, and (for any partition
+	// this createReq newly added to the transaction) the addedToTxn flag,
+	// so the next drain re-issues its AddPartitionsToTxn instead of
+	// producing to a partition the broker never learned is in the txn (see
+	// undoStagedBatches). The existing defer releases the semaphore
+	// (produced is still false), and returning true retries produce() with
+	// the correct epoch.
 	//
 	// We use a raw atomic load rather than producerID() to avoid
 	// side effects (blocking on idMu, triggering InitProducerID
@@ -491,10 +495,7 @@ func (s *sink) produce(sem <-chan struct{}) bool {
 	// unchanged, so we bail and the next drain pulls the reloaded
 	// (id, epoch) with seq=0 consistently.
 	if cur := s.cl.producer.id.Load().(*producerID); cur.id != id || cur.epoch != epoch || cur.err != nil {
-		req.batches.sliced().eachOwnerLocked(func(b *recBatch) {
-			b.owner.resetBatchDrainIdx()
-			b.decInflight()
-		})
+		req.undoStagedBatches(txnReq)
 		return true
 	}
 
@@ -510,18 +511,30 @@ func (s *sink) produce(sem <-chan struct{}) bool {
 		batchesStripped, err := s.doTxnReq(req, txnReq)
 		if err != nil {
 			switch {
-			case errors.Is(err, kerr.TransactionAbortable):
-				// If we get TransactionAbortable, we continue into producing.
-				// The produce will fail with the same error, and this is the
-				// only way to notify the user to abort the txn.
 			case isRetryableBrokerErr(err) || isDialNonTimeoutErr(err):
 				s.cl.bumpRepeatedLoadErr(err)
 				s.cl.cfg.logger.Log(LogLevelWarn, "unable to AddPartitionsToTxn due to retryable broker err, bumping client's buffered record load errors by 1 and retrying", "err", err)
 				s.cl.triggerUpdateMetadata(false, "attempting to refresh broker list due to failed AddPartitionsToTxn requests")
 				return moreToDrain || len(req.batches.bs) > 0 // nothing stripped if request-issuing error
 			default:
-				// Note that err can be InvalidProducerEpoch, which is
-				// potentially recoverable in EndTransaction.
+				// This includes TransactionAbortable. We used to
+				// continue into producing on TransactionAbortable so
+				// the produce failure would carry the error to the
+				// user, but doTxnReq's error path has already
+				// requeued every batch in the request (reset drain
+				// indexes, decremented inflight, and un-marked
+				// addedToTxn for the partitions whose add actually
+				// failed): producing those batches anyway would
+				// decrement inflight a second time (wrapping the
+				// counter and permanently wedging the recBuf's
+				// drain gate) and could re-drain batches that are
+				// already in flight. Failing the producer ID delivers
+				// the same error to all buffered records on the next
+				// drain, and TransactionAbortable remains recoverable
+				// via EndTransaction.
+				//
+				// Note that err can also be InvalidProducerEpoch,
+				// which is potentially recoverable in EndTransaction.
 				//
 				// We do not fail all buffered records here,
 				// because that can lead to undesirable behavior
@@ -574,9 +587,10 @@ func (s *sink) doSequenced(
 
 	// We can NOT use any record context. If we do, we force the request to
 	// fail while also force the batch to be unfailable (due to no
-	// response). If and only if the user has disabled idempotency, we
-	// allow the user to cancel the request via some random record with a
-	// canceling context.
+	// response). Only if the user has disabled idempotency or opted into
+	// AllowIdempotentProduceCancellation do we allow canceling the request
+	// via some random record with a canceling context (createReq only
+	// sets firstCancelingCtx under those options).
 	ctx := req.firstCancelingCtx
 	if ctx == nil {
 		ctx = s.cl.ctx
@@ -618,14 +632,20 @@ func (s *sink) doTxnReq(
 	req *produceRequest,
 	txnReq *kmsg.AddPartitionsToTxnRequest,
 ) (stripped bool, err error) {
-	// If we return an unretryable error, then we have to reset everything
-	// to not be in the transaction and begin draining at the start.
+	// If we return an unretryable error, every batch in this request must
+	// be requeued and any partition this request newly added to the
+	// transaction must be un-marked, since we will not issue the produce
+	// request. undoStagedBatches scopes the un-marking to txnReq so a
+	// partition added by an EARLIER AddPartitionsToTxn of this transaction
+	// (a broker-acked fact, deliberately absent here) keeps its membership;
+	// clearing it would make EndTransaction's anyAdded walk skip EndTxn and
+	// strand the broker-side transaction until its timeout abort.
 	//
 	// These batches must be the first in their recBuf, because we would
 	// not be trying to add them to a partition if they were not.
 	defer func() {
 		if err != nil {
-			req.batches.eachOwnerLocked(seqRecBatch.removeFromTxn)
+			req.undoStagedBatches(txnReq)
 		}
 	}()
 	// We do NOT let record context cancelations fail this request: doing
@@ -633,11 +653,65 @@ func (s *sink) doTxnReq(
 	// similar to the warning we give in the txn.go file, but the
 	// difference there is the user knows explicitly at the function call
 	// that canceling the context will opt them into invalid state.
+	//
+	// Note that the concurrent-transactions wrapper is defensive only:
+	// AddPartitionsToTxn is pinned at most v3 (no top-level error code)
+	// and a per-partition CONCURRENT_TRANSACTIONS is retriable, so it is
+	// stripped in issueTxnReq and healed by requeue+backoff rather than
+	// ever surfacing to the wrapper.
 	err = s.cl.doWithConcurrentTransactions(s.cl.ctx, fmt.Sprintf("AddPartitionsToTxn-sink%d", s.nodeID), func() error {
 		stripped, err = s.issueTxnReq(req, txnReq)
 		return err
 	})
 	return stripped, err
+}
+
+// txnReqContains returns whether the AddPartitionsToTxn request contains the
+// topic and partition. Partitions already in the transaction from an earlier
+// request are deliberately absent (see txnReqBuilder.add); failure handling
+// and response processing must not touch their addedToTxn state.
+func txnReqContains(txnReq *kmsg.AddPartitionsToTxnRequest, topic string, partition int32) bool {
+	for i := range txnReq.Topics {
+		t := &txnReq.Topics[i]
+		if t.Topic != topic {
+			continue
+		}
+		for _, p := range t.Partitions {
+			if p == partition {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// undoStagedBatches rewinds every batch that createReq staged into this request
+// back to its pre-drain state, for the early-return arms that decide not to
+// issue the request after staging it: the producer-ID/epoch recheck in
+// produce() and doTxnReq's failure defer. It resets each recBuf's drain index
+// and decrements inflight, and -- for the partitions THIS request newly added
+// to the transaction -- clears addedToTxn so the next drain re-issues their
+// AddPartitionsToTxn.
+//
+// txnReq holds exactly the partitions createReq newly added: txnReqBuilder.add
+// only records a partition whose addedToTxn flipped false->true, so partitions
+// added to the transaction by an EARLIER request are deliberately absent and
+// keep their broker-acked membership. Leaving a newly-added partition's
+// addedToTxn set after rewinding would suppress its AddPartitionsToTxn on the
+// next drain (txnReqBuilder.add skips already-added partitions); the broker
+// then rejects the produce to that unverified partition with INVALID_TXN_STATE
+// (or, on a non-verifying broker, the records hang in a transaction the
+// coordinator never learned the partition belongs to). txnReq is nil for
+// non-transactional and pv12+ (KIP-890p2) producers, which never stage
+// addedToTxn in createReq, so the clear is correctly skipped for them.
+func (p *produceRequest) undoStagedBatches(txnReq *kmsg.AddPartitionsToTxnRequest) {
+	p.batches.eachOwnerLocked(func(batch seqRecBatch) {
+		if txnReq != nil && txnReqContains(txnReq, batch.owner.topic, batch.owner.partition) {
+			batch.owner.addedToTxn.Store(false)
+		}
+		batch.owner.resetBatchDrainIdx()
+		batch.decInflight()
+	})
 }
 
 // Removing a batch from the transaction means we will not be issuing it
@@ -665,7 +739,24 @@ func (s *sink) issueTxnReq(
 			continue
 		}
 		for _, partition := range topic.Partitions {
-			if err := kerr.ErrorForCode(partition.ErrorCode); err != nil && err != kerr.TransactionAbortable { // see below for txn abortable
+			// TransactionAbortable partitions are deliberately NOT
+			// handled as errors here: the batch stays in the request,
+			// the subsequent produce fails with the same abortable
+			// error, and the record promises carry it to the user (who
+			// then aborts; recovery happens via EndTransaction).
+			if err := kerr.ErrorForCode(partition.ErrorCode); err != nil && err != kerr.TransactionAbortable {
+				// An errored partition that we did not ask to add must
+				// not strip a batch nor fail the producer ID: it could
+				// name a partition added by an earlier request of this
+				// transaction (deliberately absent from this txnReq),
+				// and un-marking that would break EndTransaction's
+				// anyAdded accounting -- see doTxnReq's deferred
+				// failure handling.
+				if !txnReqContains(txnReq, topic.Topic, partition.Partition) {
+					s.cl.cfg.logger.Log(LogLevelError, "broker replied with errored partition in AddPartitionsToTxnResponse that was not in the request", "topic", topic.Topic, "partition", partition.Partition)
+					continue
+				}
+
 				// OperationNotAttempted is set for all partitions that are authorized
 				// if any partition is unauthorized _or_ does not exist. We simply remove
 				// unattempted partitions and treat them as retryable.
@@ -821,11 +912,18 @@ func (s *sink) handleReqResp(br *broker, req *produceRequest, resp kmsg.Response
 		rt := &kresp.Topics[i]
 		topic := rt.Topic
 		tid := rt.TopicID
+		// For topics (and partitions below) that we did not produce to,
+		// we deliberately do NOT touch req.metrics: metrics entries only
+		// exist for batches that were actually appended to the request,
+		// so a genuinely invented entry has nothing to remove -- and a
+		// DUPLICATED reply entry lands here too (the first occurrence
+		// empties req.batches), where deleting would erase the metrics
+		// of a batch the first occurrence legitimately processed and
+		// silently skip its OnProduceBatchWritten hook.
 		if req.version >= 13 {
 			var ok bool
 			if topic, ok = req.batches.id2t[rt.TopicID]; !ok {
-				s.cl.cfg.logger.Log(LogLevelError, "broker erroneously replied with topic id in produce request that we did not produce to", "broker", logID(s.nodeID), "topic", topic, "topic_id", strtid(rt.TopicID))
-				delete(req.metrics, topic)
+				s.cl.cfg.logger.Log(LogLevelError, "broker erroneously replied with topic id in produce request that we did not produce to", "broker", logID(s.nodeID), "topic_id", strtid(rt.TopicID))
 				continue
 			}
 		} else {
@@ -834,7 +932,6 @@ func (s *sink) handleReqResp(br *broker, req *produceRequest, resp kmsg.Response
 		partitions, ok := req.batches.bs[topic]
 		if !ok {
 			s.cl.cfg.logger.Log(LogLevelError, "broker erroneously replied with topic in produce request that we did not produce to", "broker", logID(s.nodeID), "topic", topic)
-			delete(req.metrics, topic)
 			continue
 		}
 
@@ -849,8 +946,7 @@ func (s *sink) handleReqResp(br *broker, req *produceRequest, resp kmsg.Response
 			batch, ok := partitions[partition]
 			if !ok {
 				s.cl.cfg.logger.Log(LogLevelError, "broker erroneously replied with partition in produce request that we did not produce to", "broker", logID(s.nodeID), "topic", rt.Topic, "partition", partition)
-				delete(tmetrics, partition)
-				continue // should not hit this
+				continue // should not hit this; see the topic-level comment above for why tmetrics is left alone
 			}
 			delete(partitions, partition)
 
@@ -1420,7 +1516,13 @@ type recBuf struct {
 	// this recBuf. Every time this hits zero, if the batchDrainIdx is not
 	// at the end, we clear inflightOnSink and trigger the *current* sink
 	// to drain.
-	inflight uint8
+	//
+	// This is bounded by the sink's inflight sem: 1 or 4 when idempotent,
+	// or the user's MaxProduceRequestsInflightPerBroker (no upper bound)
+	// when idempotency is disabled -- which is why this is an int32 and
+	// not a small type that a large user value could wrap, breaking the
+	// != 0 drain gates here and in createReq.
+	inflight int32
 
 	lastAckedOffset int64 // last ProduceResponse's BaseOffset + how many records we produced
 
@@ -1507,6 +1609,27 @@ func (recBuf *recBuf) bufferRecord(pr promisedRec, abortOnNewBatch bool) bool {
 	if recBuf.purged {
 		recBuf.cl.producer.promiseRecord(pr, errPurged)
 		return true
+	}
+
+	// If the client is closing, fail the record rather than buffering it
+	// into a recBuf whose sink drain loop has already exited. close() cancels
+	// cl.ctx and then sweeps every recBuf exactly once via
+	// failBufferedRecords; a record buffered after that sweep would never be
+	// failed - its promise would never fire, BufferedProduceRecords would
+	// never return to zero, and a later Flush would hang - contradicting the
+	// documented ErrClientClosed contract ("for producing, records are failed
+	// with this error"). Checking cl.ctx under recBuf.mu (held here and by
+	// failAllRecords) is race-free given the close ordering (ctxCancel then
+	// sweep): we either observe the cancel and fail here, or we buffer before
+	// the sweep and the sweep fails us. The unknown-topic sibling path already
+	// honors this via waitUnknownTopic's cl.ctx.Done arm; this is the missing
+	// guard on the known-topic sibling. We select on Done rather than calling
+	// Err to keep this per-record hot path free of the context's per-call mutex.
+	select {
+	case <-recBuf.cl.ctx.Done():
+		recBuf.cl.producer.promiseRecord(pr, ErrClientClosed)
+		return true
+	default:
 	}
 
 	var (
@@ -1604,9 +1727,11 @@ func (recBuf *recBuf) unlingerAndManuallyDrain() {
 // load errors during metadata updates.
 //
 // Partition load errors are generally temporary (leader/listener/replica not
-// available), and this try bump is not expected to do much. If for some reason
-// a partition errors for a long time and we are not idempotent, this function
-// drops all buffered records.
+// available, or a metadata response from an out of date broker that is
+// missing a partition we know about), and this try bump is not expected to do
+// much. Records are failed only once a bound trips: the record timeout or
+// retry limit, or for unknown-partition style errors (including a metadata
+// response missing the partition), the unknown fail limit.
 func (recBuf *recBuf) bumpRepeatedLoadErr(err error) {
 	recBuf.mu.Lock()
 	defer recBuf.mu.Unlock()
@@ -1624,10 +1749,10 @@ func (recBuf *recBuf) bumpRepeatedLoadErr(err error) {
 		canFail        = !recBuf.cl.idempotent() || recBuf.cl.cfg.allowIdempotentProduceCancellation || (batch0.canFailFromLoadErrs && !batch0.unsureIfProduced) // we can only fail if we are not idempotent, cancellation is allowed, or if we have no outstanding requests
 		batch0Fail     = batch0.maybeFailErr(&recBuf.cl.cfg) != nil                                                                                              // timeout, retries, or aborting
 		netErr         = isRetryableBrokerErr(err) || isDialNonTimeoutErr(err)                                                                                   // we can fail if this is *not* a network error
-		retryableKerr  = kerr.IsRetriable(err)                                                                                                                   // we fail if this is not a retryable kerr,
-		isUnknownLimit = recBuf.checkUnknownFailLimit(err)                                                                                                       // or if it is, but it is UnknownTopicOrPartition and we are at our limit
+		retryableErr   = kerr.IsRetriable(err) || errors.Is(err, errMissingMetadataPartition)                                                                    // we fail if this is not a retryable error (missing-metadata-partition retries like unknown topic),
+		isUnknownLimit = recBuf.checkUnknownFailLimit(err)                                                                                                       // or if it is, but it is an unknown topic error and we are at our limit
 
-		willFail = canFail && (batch0Fail || !netErr && (!retryableKerr || retryableKerr && isUnknownLimit))
+		willFail = canFail && (batch0Fail || !netErr && (!retryableErr || retryableErr && isUnknownLimit))
 	)
 	batch0.isFailingFromLoadErr = willFail
 	batch0.mu.Unlock()
@@ -1640,7 +1765,7 @@ func (recBuf *recBuf) bumpRepeatedLoadErr(err error) {
 		"can_fail", canFail,
 		"batch0_should_fail", batch0Fail,
 		"is_network_err", netErr,
-		"is_retryable_kerr", retryableKerr,
+		"is_retryable_err", retryableErr,
 		"is_unknown_limit", isUnknownLimit,
 		"will_fail", willFail,
 	)
@@ -1650,13 +1775,20 @@ func (recBuf *recBuf) bumpRepeatedLoadErr(err error) {
 	}
 }
 
-// Called locked, if err is an unknown error, bumps our limit, otherwise resets
-// it. This returns if we have reached or exceeded the limit.
+// Called locked. A successful produce (nil err) resets the count; an unknown
+// topic error bumps it; any other error leaves it unchanged -- resetting only
+// on success is what keeps interleaved errors (e.g. an alternating
+// NOT_LEADER_FOR_PARTITION) from holding the count below the limit forever.
+// Three errors count: UNKNOWN_TOPIC_OR_PARTITION, UNKNOWN_TOPIC_ID (a deleted-
+// and-recreated topic returns it until the user purges and re-adds, since
+// produce v13+ keys topics by ID), and the metadata-side
+// errMissingMetadataPartition twin. Returns whether we have exceeded the limit.
 func (recBuf *recBuf) checkUnknownFailLimit(err error) bool {
-	if errors.Is(err, kerr.UnknownTopicOrPartition) {
-		recBuf.unknownFailures++
-	} else {
+	switch {
+	case err == nil:
 		recBuf.unknownFailures = 0
+	case errors.Is(err, kerr.UnknownTopicOrPartition) || errors.Is(err, kerr.UnknownTopicID) || errors.Is(err, errMissingMetadataPartition):
+		recBuf.unknownFailures++
 	}
 	return recBuf.cl.cfg.maxUnknownFailures >= 0 && recBuf.unknownFailures > recBuf.cl.cfg.maxUnknownFailures
 }
@@ -1918,7 +2050,7 @@ type produceRequest struct {
 	timeout int32
 	batches seqRecBatches
 
-	firstCancelingCtx context.Context // of all batches added, the first one with a record that has a canceling context; only used with disableIdempotency
+	firstCancelingCtx context.Context // of all batches added, the first one with a record that has a canceling context; only used with disableIdempotency or allowIdempotentProduceCancellation
 
 	producerID    int64
 	producerEpoch int16

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/source.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/source.go
@@ -29,7 +29,7 @@ type readerFrom interface {
 // another fetch in the background.
 type source struct {
 	cl     *Client // our owning client, for cfg, metadata triggering, context, etc.
-	nodeID int32   // the node ID of the broker this sink belongs to
+	nodeID int32   // the node ID of the broker this source belongs to
 
 	// Tracks how many _failed_ fetch requests we have in a row (unable to
 	// receive a response). Any response, even responses with an ErrorCode
@@ -117,7 +117,17 @@ func (s *source) removeCursor(rm *cursor) {
 
 // cursor is where we are consuming from for an individual partition.
 type cursor struct {
-	topic     string
+	topic string
+	// topicID is written once at cursor creation and is deliberately
+	// never re-adopted if a delete+recreate hands back a new ID for the
+	// same name: a recreated topic stalls loudly (UNKNOWN_TOPIC_ID, see
+	// the UnknownTopicID arm below) and the user must purge+re-add. This
+	// is the principled alternative to librdkafka/Java's adopt-and-gamble;
+	// issue #908 records why auto-adoption was backed out (PR #391/#377:
+	// OffsetForLeaderEpoch has no TopicID field, so an adopted ID cannot
+	// be validated against truncation). The metadata merge copies this
+	// pointer over rather than swapping the ID; do not "fix" the stall
+	// into an adopt without solving #908.
 	topicID   [16]byte
 	partition int32
 
@@ -297,7 +307,25 @@ func (p *cursorOffsetPreferred) move() {
 	c.source.cl.sinksAndSourcesMu.Unlock()
 
 	if !exists {
+		// The preferred replica is a broker we have not yet learned from
+		// metadata - e.g. a freshly added replica that the broker we
+		// fetched from already knows about, before our periodic refresh
+		// caught up. We force a metadata update so the source comes to
+		// exist for a future move, but we must ALSO re-enable the cursor
+		// on its current (leader) source. The caller (source.fetch) deletes
+		// this cursor from the request's used offsets right after we return,
+		// so neither the fetch's used-offset finishing nor a later buffered
+		// poll will re-enable it: leaving it unusable here would strand the
+		// partition. The leader is unchanged, so no cursor
+		// migration re-enables it, and a metadata refresh that merely
+		// learns the new broker never touches cursor usability - the
+		// partition would silently never be consumed again until an
+		// unrelated session restart (rebalance, assign, leader change).
+		//
+		// Re-enabling on the current source keeps us consuming from the
+		// leader until a later fetch's preferred replica can be honored.
 		c.source.cl.triggerUpdateMetadataNow("cursor moving to a different broker that is not yet known")
+		c.allowUsable()
 		return
 	}
 
@@ -1011,13 +1039,21 @@ func (s *source) fetch(consumerSession *consumerSession, doneFetch chan<- bool) 
 		return fetched
 
 	default:
-		// Any other top-level error is unexpected: current brokers
-		// only emit session-related codes here. Rather than bumping
-		// the session epoch against a failed request, reset defensively
-		// so the next request re-establishes state the broker agrees
-		// with.
-		s.cl.cfg.logger.Log(LogLevelWarn, "fetch response has unexpected top-level error, resetting session", "broker", logID(s.nodeID), "err", err)
-		s.session.reset()
+		// Any other top-level error is unexpected: current brokers only
+		// emit session-related codes here, and every one of those arms
+		// above self-heals in a single round-trip (a reset re-establishes
+		// the session at epoch 0, which the broker then accepts). An
+		// unexpected code has no such bounded heal: a non-conformant or
+		// future broker that returns one persistently would spin this
+		// fetch at round-trip pace, re-logging on every iteration, because
+		// nothing here paces the loop. Back off rather than bumping the
+		// session epoch against a failed request; backoff also resets the
+		// session defensively so the next request re-establishes state the
+		// broker agrees with. This mirrors the transport-error and
+		// all-partitions-stripped paths, and the share fetch loop's
+		// top-level-error arm.
+		s.cl.cfg.logger.Log(LogLevelWarn, "fetch response has unexpected top-level error, resetting session and backing off", "broker", logID(s.nodeID), "err", err)
+		backoff(err)
 		return fetched
 	}
 
@@ -1096,6 +1132,15 @@ func (s *source) handleReqResp(br *broker, req *fetchRequest, resp *kmsg.FetchRe
 		numErrsStripped  int
 		kip320           = s.cl.supportsOffsetForLeaderEpoch()
 		kmove            kip951move
+		// seen guards against a broker returning the same partition (or the
+		// same topic) more than once in a single fetch response. Each
+		// requested partition maps to one stable *cursorOffsetNext for the
+		// life of the request; processing one twice would double-advance its
+		// offset / double-append its records, or enqueue two move()s for one
+		// cursor (the #1167 concurrent-source hazard). We must not dedup by
+		// deleting from req.usedOffsets - that map re-enables the cursor
+		// after the response - so we track seen pointers separately.
+		seen map[*cursorOffsetNext]struct{}
 	)
 	defer kmove.maybeBeginMove(s.cl)
 
@@ -1145,6 +1190,18 @@ func (s *source) handleReqResp(br *broker, req *fetchRequest, resp *kmsg.FetchRe
 				)
 				continue
 			}
+			if _, dup := seen[partOffset]; dup {
+				s.cl.cfg.logger.Log(LogLevelWarn, "broker returned a duplicate partition in a fetch response, ignoring the duplicate",
+					"broker", logID(s.nodeID),
+					"topic", topic,
+					"partition", partition,
+				)
+				continue
+			}
+			if seen == nil {
+				seen = make(map[*cursorOffsetNext]struct{}, req.numOffsets)
+			}
+			seen[partOffset] = struct{}{}
 			c := partOffset.from
 
 			// If we are fetching from the replica already, Kafka replies with a -1
@@ -1496,7 +1553,13 @@ func ProcessFetchPartition(o ProcessFetchPartitionOpts, rp *kmsg.FetchResponseTo
 		offset := int64(binary.BigEndian.Uint64(in))
 		length = int32(binary.BigEndian.Uint32(in[8:]))
 		length += 12 // for the int64 offset we skipped and int32 length field itself
-		if len(in) < int(length) {
+		// length is read as a signed int32: a high-bit-set length field (or a
+		// near-MaxInt32 one, which overflows negative once we add 12) is
+		// negative and would slip past the truncation check below, panicking
+		// check()'s in[:length] with a negative bound. Treat a negative length
+		// as an untrustworthy/truncated batch and stop, matching the negative
+		// guards already in parseReadSize and the xerial decoder.
+		if length < 0 || len(in) < int(length) {
 			break
 		}
 
@@ -1593,6 +1656,25 @@ func buildAborter(rp *kmsg.FetchResponseTopicPartition) aborter {
 	for _, abort := range rp.AbortedTransactions {
 		a[abort.ProducerID] = append(a[abort.ProducerID], abort.FirstOffset)
 	}
+	// shouldAbortBatch and trackAbortedPID below both treat a[pid][0] as the
+	// smallest remaining aborted first offset for that producer: a batch is
+	// aborted once its FirstOffset reaches a[pid][0], and each abort marker
+	// pops a[pid][0]. The broker is NOT required to return a producer's aborted
+	// transactions sorted by first offset, though. Apache Kafka happens to (its
+	// transaction index is appended in last-offset order, which for one
+	// producer's strictly sequential transactions coincides with first-offset
+	// order), but Redpanda concatenates its newest in-memory aborted ranges
+	// (highest offsets) ahead of older on-disk snapshot ranges, so one
+	// producer's entries can arrive highest-first-offset first. With a[pid][0]
+	// not the smallest, a lower aborted transaction slips past the
+	// `FirstOffset < pidAborts[0]` guard and its records are surfaced to the
+	// application as committed - a read_committed violation. Sort each
+	// producer's first offsets ascending to restore the invariant the rest of
+	// the filtering relies on (the Java client makes the same guarantee with a
+	// first-offset-ordered priority queue).
+	for pid := range a {
+		slices.Sort(a[pid])
+	}
 	return a
 }
 
@@ -1613,7 +1695,16 @@ func (a aborter) shouldAbortBatch(b *kmsg.RecordBatch) bool {
 }
 
 func (a aborter) trackAbortedPID(producerID int64) {
-	remaining := a[producerID][1:]
+	pidAborts := a[producerID]
+	if len(pidAborts) == 0 {
+		// Already exhausted for this PID. A well-formed response pops once
+		// per aborted transaction (one abort marker each), so this is only
+		// reachable from a buggy/hostile broker; reslicing a[producerID][1:]
+		// on the nil/empty slice would panic. Java removes the PID from a Set
+		// here, which is idempotent - mirror that.
+		return
+	}
+	remaining := pidAborts[1:]
 	if len(remaining) == 0 {
 		delete(a, producerID)
 	} else {
@@ -1691,6 +1782,24 @@ func (o *ProcessFetchPartitionOpts) processRecordBatch(
 	uncompressedBytes := len(rawRecords)
 
 	numRecords := int(batch.NumRecords)
+	// NumRecords is decoded straight off the wire and is therefore
+	// attacker/bug controlled. A negative count would panic the slice
+	// sizing below (ensureLen does s[:n], which panics for n<0); reject it
+	// as a corrupt batch, matching the Java client's InvalidRecordException
+	// guard (DefaultRecordBatch: "Found invalid record count"). A count
+	// larger than the available record bytes is likewise impossible for a
+	// well-formed batch - every record needs at least one byte - so clamp
+	// the up-front allocation to the byte count to keep a bogus huge count
+	// from driving a massive allocation. The true decodable count is
+	// recomputed by readRawRecordsInto, and the truncation defer below
+	// leaves the offset unadvanced whenever it disagrees with numRecords.
+	if numRecords < 0 {
+		fp.Err = fmt.Errorf("invalid record batch: negative record count %d", numRecords)
+		return 0, 0
+	}
+	if numRecords > len(rawRecords) {
+		numRecords = len(rawRecords)
+	}
 	var krecords []kmsg.Record
 	var krecordsPool PoolKRecords
 	pools(o.Pools).each(func(p Pool) bool {
@@ -1746,8 +1855,10 @@ func (o *ProcessFetchPartitionOpts) processRecordBatch(
 	}
 
 	recordCtx := poolsCtx
+	var slabbed bool
 	if o.shareAckSlab != nil && len(rrecords) > 0 {
 		if slab := o.shareAckSlab(numRecords, &rrecords[0]); slab != nil {
+			slabbed = true
 			parent := poolsCtx
 			if parent == nil {
 				parent = context.Background()
@@ -1757,11 +1868,36 @@ func (o *ProcessFetchPartitionOpts) processRecordBatch(
 	}
 	var nkept int
 	defer func() {
-		if p != nil && nkept > 0 {
-			p.n.Add(int64(nkept))
+		if p == nil {
+			return
 		}
+		if nkept > 0 {
+			p.n.Add(int64(nkept))
+			return
+		}
+		// No record from this batch was kept: an aborted transaction's
+		// data batch, a control/marker batch, or a batch wholly below
+		// the requested offset. Nothing will ever call Recycle, so the
+		// recordPools put-back would never run and abort-heavy
+		// read_committed workloads would leak every pool Get. Release
+		// the pooled slices now, zeroing the written-then-discarded
+		// records like Recycle would have. Skip when a share-ack slab
+		// was created: the slab indexes rrecords by pointer, and putting
+		// the slice back would let the pool hand out memory the slab
+		// still references.
+		if slabbed {
+			return
+		}
+		clear(p.recs)
+		p.release()
 	}()
 
+	// A control batch ends at most one aborted transaction for its producer,
+	// so we pop the aborter at most once per batch. A well-formed control
+	// batch holds a single marker record; a buggy/hostile broker can pack many
+	// (and Java inspects only a control batch's first record), so without this
+	// guard a second abort marker would pop an already-empty aborter slice.
+	abortMarkerHandled := false
 	for i := range krecords {
 		record := &rrecords[i]
 		recordToRecord(
@@ -1777,12 +1913,13 @@ func (o *ProcessFetchPartitionOpts) processRecordBatch(
 			nkept++
 		}
 
-		if abortBatch && record.Attrs.IsControl() {
+		if abortBatch && !abortMarkerHandled && record.Attrs.IsControl() {
 			// A control record has a key and a value where the key
 			// is int16 version and int16 type. Aborted records
 			// have a type of 0.
 			if key := record.Key; len(key) >= 4 && key[2] == 0 && key[3] == 0 {
 				aborter.trackAbortedPID(batch.ProducerID)
+				abortMarkerHandled = true
 			}
 		}
 	}
@@ -1818,7 +1955,10 @@ out:
 	for len(rawInner) > 17 { // magic at byte 17
 		length := int32(binary.BigEndian.Uint32(rawInner[8:]))
 		length += 12 // offset and length fields
-		if len(rawInner) < int(length) {
+		// A negative length (high-bit-set length field, signed int32) would
+		// slip past the truncation check and panic rawInner[:length]; treat it
+		// as a truncated message set. See the record-batch loop's guard.
+		if length < 0 || len(rawInner) < int(length) {
 			break
 		}
 
@@ -1931,7 +2071,10 @@ func (o *ProcessFetchPartitionOpts) processV0OuterMessage(
 	for len(rawInner) > 17 { // magic at byte 17
 		length := int32(binary.BigEndian.Uint32(rawInner[8:]))
 		length += 12 // offset and length fields
-		if len(rawInner) < int(length) {
+		// A negative length (high-bit-set length field, signed int32) would
+		// slip past the truncation check and panic rawInner[:length]; treat it
+		// as a truncated message set. See the record-batch loop's guard.
+		if length < 0 || len(rawInner) < int(length) {
 			break // truncated batch
 		}
 		var m kmsg.MessageV0
@@ -2730,7 +2873,7 @@ func (s *source) removeShareCursor(c *shareCursor) {
 		s.share.cursorsStart = 0
 	}
 	s.share.mu.Unlock()
-	// We don't ned to wake the source to send this is a forgotten
+	// We don't need to wake the source to send this as a forgotten
 	// partition, but it doesn't hurt.
 	s.maybeShareConsume()
 }

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/topics_and_partitions.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/topics_and_partitions.go
@@ -685,6 +685,32 @@ func (old *topicPartition) migrateCursorTo( //nolint:revive // old/new naming ma
 
 func (tp *topicPartition) migrateShareCursorTo(cl *Client, new *topicPartition) {
 	c := tp.shareCursor
+	new.shareCursor = c
+
+	// Relocating the cursor between sources races the share consumer's
+	// leave. leave waits for every share worker to exit (sc.workers == 0),
+	// then drains each source's cursors via closeShareSession, iterating a
+	// snapshot of the source list taken after that barrier. A relocation that
+	// removes the cursor from its old source before that source is drained,
+	// and lands it on an already-drained source (or on one created after the
+	// snapshot), leaves the cursor's pending acks on a source nothing will
+	// drain: sc.pendingAcks never returns to 0 (FlushAcks hangs) and the held
+	// records release only via the broker's acquisition-lock timeout.
+	//
+	// Register the migration as a share worker so leave's barrier waits for an
+	// in-flight migration before it snapshots and drains. This mirrors
+	// applyMovesBlocking, the CurrentLeader-hint sibling that already does
+	// this; the metadata-merge path (this function) was the only share-cursor
+	// relocation not covered by the barrier. If the consumer is already dying,
+	// incWorker returns false: skip the swap and leave the cursor on its
+	// current source, which closeShareSession then drains. new.shareCursor is
+	// assigned above either way, so the stored partition data is always valid.
+	sc := cl.consumer.s
+	if !sc.incWorker() {
+		return
+	}
+	defer sc.decWorker()
+
 	cl.sinksAndSourcesMu.Lock()
 	sns := cl.sinksAndSources[new.leader]
 	cl.sinksAndSourcesMu.Unlock()
@@ -693,7 +719,6 @@ func (tp *topicPartition) migrateShareCursorTo(cl *Client, new *topicPartition) 
 	}
 	c.source.Store(sns.source)
 	sns.source.addShareCursor(c)
-	new.shareCursor = c
 }
 
 type kip951move struct {
@@ -911,8 +936,27 @@ func (k *kip951move) doMove(cl *Client) {
 	// same (this allows easier injection of failures in local testing).  A
 	// higher epoch can come from a concurrent metadata update that
 	// actually performed the move first.
-	modifyP := func(d *topicPartitionsData, partition int32, td topicPartitionData) (old, new *topicPartition, modified bool) {
+	//
+	// The hint was staged from a produce/fetch response and we are applied
+	// asynchronously: between staging and now, the user can purge the
+	// topic and re-add it (a produce or AddConsumeTopics recreates the
+	// topic with zero partitions until metadata loads), so the partition
+	// index can be out of range, and even in range the object at this
+	// index can belong to the new topic incarnation rather than the one
+	// whose response produced the hint. The owns check pins object
+	// identity: the records/cursor pointer is preserved across legitimate
+	// metadata updates and prior moves (the migrate functions copy it into
+	// the new topicPartition), so a mismatch can only mean purge+re-add -
+	// skip, and let the live incarnation resolve its own leader via
+	// metadata.
+	modifyP := func(d *topicPartitionsData, partition int32, td topicPartitionData, owns func(*topicPartition) bool) (old, new *topicPartition, modified bool) {
+		if int(partition) < 0 || int(partition) >= len(d.partitions) {
+			return nil, nil, false
+		}
 		old = d.partitions[partition]
+		if !owns(old) {
+			return nil, nil, false
+		}
 		if old.leaderEpoch > td.leaderEpoch {
 			return nil, nil, false
 		}
@@ -963,7 +1007,7 @@ func (k *kip951move) doMove(cl *Client) {
 			if !ok {
 				continue // perhaps concurrently purged
 			}
-			old, new, modified := modifyP(lr.r, recBuf.partition, td)
+			old, new, modified := modifyP(lr.r, recBuf.partition, td, func(tp *topicPartition) bool { return tp.records == recBuf })
 			if modified {
 				cl.cfg.logger.Log(LogLevelInfo, "moving producing partition due to kip-951 not_leader_for_partition",
 					"topic", recBuf.topic,
@@ -994,7 +1038,7 @@ func (k *kip951move) doMove(cl *Client) {
 			if !ok {
 				continue // perhaps concurrently purged
 			}
-			old, new, modified := modifyP(lr.r, cursor.partition, td)
+			old, new, modified := modifyP(lr.r, cursor.partition, td, func(tp *topicPartition) bool { return tp.cursor == cursor })
 			if modified {
 				cl.cfg.logger.Log(LogLevelInfo, "moving consuming partition due to kip-951 not_leader_for_partition",
 					"topic", cursor.topic,

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/txn.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/txn.go
@@ -27,10 +27,6 @@ const (
 // GroupTransactSession abstracts away the proper way to begin and end a
 // transaction when consuming in a group, modifying records, and producing
 // (EOS).
-//
-// If you are running Kafka 2.5+, it is strongly recommended that you also use
-// RequireStableFetchOffsets. See that config option's documentation for more
-// details.
 type GroupTransactSession struct {
 	cl *Client
 
@@ -65,9 +61,9 @@ type GroupTransactSession struct {
 // proper rebalance timeout, this single request will not fail and the commit
 // will succeed properly.
 //
-// If this client detects you are talking to a pre-2.5 cluster, OR if you have
-// not enabled RequireStableFetchOffsets, the client will sleep for 200ms after
-// a successful commit to allow Kafka's txn markers to propagate. This is not
+// If this client detects you are talking to a pre-2.5 cluster (one too old
+// for KIP-447 stable fetch offsets), the client sleeps for 500ms after a
+// successful commit to allow Kafka's txn markers to propagate. This is not
 // foolproof in the event of some extremely unlikely communication patterns and
 // **potentially** could allow duplicates. See this repo's transaction's doc
 // for more details.
@@ -436,10 +432,11 @@ func (s *GroupTransactSession) End(ctx context.Context, commit TransactionEndTry
 	// We have a few potential retryable errors from EndTransaction.
 	// OperationNotAttempted will be returned at most once.
 	//
-	// UnknownServerError should not be returned, but some brokers do:
-	// technically this is fatal, but there is no downside to retrying
-	// (even retrying a commit) and seeing if we are successful or if we
-	// get a better error.
+	// UnknownServerError should not be returned, but some brokers do
+	// (e.g. Redpanda in certain versions). It leaves the commit/abort
+	// unconfirmed: the broker may or may not have completed it. We
+	// retry as an abort (see the arm below) rather than reporting a
+	// commit we cannot confirm.
 	var tries int
 retry:
 	endTxnErr := s.cl.EndTransaction(ctx, TransactionEndTry(willTryCommit))
@@ -457,13 +454,20 @@ retry:
 			goto retry
 
 		case errors.Is(endTxnErr, kerr.UnknownServerError):
-			s.cl.cfg.logger.Log(LogLevelInfo, "end transaction with commit unknown server error; retrying")
-			after := time.NewTimer(s.cl.cfg.retryBackoff(tries))
-			select {
-			case <-after.C: // context canceled; we will see when we retry
-			case <-s.cl.ctx.Done():
-				after.Stop()
-			}
+			// We must downgrade to an abort exactly like the two arms
+			// above. EndTransaction already consumed inTxn on the
+			// erroring call, so re-calling it returns nil at its !inTxn
+			// guard without issuing another EndTxn: we cannot actually
+			// re-commit. If willTryCommit stayed true, that manufactured
+			// nil would fall into the "willTryCommit && endTxnErr == nil"
+			// success tail below and report a committed transaction,
+			// advancing the consumer offsets to postcommit even though the
+			// broker's UNKNOWN_SERVER_ERROR may have aborted it: a silent
+			// EOS data loss. Retrying as an abort reports not-committed and
+			// rewinds to the last committed offsets, so the caller
+			// reprocesses (at-least-once).
+			s.cl.cfg.logger.Log(LogLevelInfo, "end transaction returned an unknown server error; the commit is unconfirmed, retrying as abort to avoid reporting a false commit")
+			willTryCommit = false
 			goto retry
 		}
 	}
@@ -525,6 +529,7 @@ func (cl *Client) BeginTransaction() error {
 	}
 
 	cl.producer.inTxn = true
+	cl.producer.producedInTxn.Store(false)
 	if !cl.producer.tx890p2.Load() && cl.supportsKIP890p2() {
 		cl.producer.tx890p2.Store(true)
 	}
@@ -588,7 +593,7 @@ func (cl *Client) EndAndBeginTransaction(
 	return cl.EndTransaction(ctx, commit)
 }
 
-// AbortBufferedRecords fails all unflushed records with ErrAborted and waits
+// AbortBufferedRecords fails all unflushed records with ErrAborting and waits
 // for there to be no buffered records.
 //
 // This accepts a context to quit the wait early, but quitting the wait may
@@ -625,7 +630,7 @@ func (cl *Client) AbortBufferedRecords(ctx context.Context) error {
 	return cl.Flush(ctx)
 }
 
-// UnsafeAbortBufferedRecords fails all unflushed records with ErrAborted and
+// UnsafeAbortBufferedRecords fails all unflushed records with ErrAborting and
 // waits for there to be no buffered records. This function does NOT wait for
 // any inflight produce requests to finish, meaning topics in the client may be
 // in an invalid state and producing to an invalid-state topic may cause the
@@ -664,8 +669,9 @@ func (cl *Client) UnsafeAbortBufferedRecords() {
 // It may be possible for the client to recover in a new transaction via
 // BeginTransaction if an error is returned from this function:
 //
-//   - Before Kafka 4.0, InvalidProducerIDMapping and InvalidProducerEpoch
-//     are recoverable
+//   - When transactions are not running under KIP-890 part 2 (the cluster's
+//     transaction.version feature is below 2), InvalidProducerIDMapping and
+//     InvalidProducerEpoch are recoverable
 //   - UnknownProducerID is recoverable for Kafka 2.5+
 //   - TransactionAbortable is always recoverable (after aborting)
 //
@@ -692,12 +698,18 @@ func (cl *Client) EndTransaction(ctx context.Context, commit TransactionEndTry) 
 	// issues AddOffsetsToTxn, which internally adds a __consumer_offsets
 	// partition to the transaction. Thus, if we added offsets, then we
 	// also produced.
-	var anyAdded bool
-	if g := cl.consumer.g; g != nil {
+	var (
+		anyAdded         bool
+		addedSwapped     []*recBuf // every addedToTxn we consume, restored if the commit is not attempted
+		offsetsWereAdded bool
+	)
+	g := cl.consumer.g
+	if g != nil {
 		// We do not lock because we expect commitTransactionOffsets to
 		// be called *before* ending a transaction.
 		if g.offsetsAddedToTxn {
 			g.offsetsAddedToTxn = false
+			offsetsWereAdded = true
 			anyAdded = true
 		}
 	} else {
@@ -708,7 +720,10 @@ func (cl *Client) EndTransaction(ctx context.Context, commit TransactionEndTry) 
 	// addedToTxn to false outside of any mutex.
 	for _, parts := range cl.producer.topics.load() {
 		for _, part := range parts.load().partitions {
-			anyAdded = part.records.addedToTxn.Swap(false) || anyAdded
+			if part.records.addedToTxn.Swap(false) {
+				addedSwapped = append(addedSwapped, part.records)
+				anyAdded = true
+			}
 		}
 	}
 
@@ -717,13 +732,52 @@ func (cl *Client) EndTransaction(ctx context.Context, commit TransactionEndTry) 
 	// Note that anyAdded is true if the producer ID was failed, meaning we will
 	// get to the potential recovery logic below if necessary.
 	if !anyAdded {
-		cl.cfg.logger.Log(LogLevelDebug, "no records were produced during the commit; thus no transaction was began; ending without doing anything")
-		return nil
+		// Under KIP-890 part 2, produce requests implicitly add their
+		// partition to the transaction on the broker BEFORE the data
+		// append; the registration is durable even if the append then
+		// fails, and we mark a partition added client-side only on a
+		// SUCCESSFUL produce response. If produces were attempted but
+		// none succeeded, the broker can have an ongoing transaction
+		// with registered partitions that only the transaction timeout
+		// would clear, and the next transaction's produces (same
+		// epoch, since no EndTxn bumped it) would silently join that
+		// ongoing transaction. Aborting is always legal under 890p2
+		// (aborting an empty transaction succeeds and bumps the
+		// epoch), so abort regardless of what the caller asked: with
+		// zero successful produces and no committed offsets, there is
+		// nothing to commit anyway.
+		if !cl.producer.tx890p2.Load() || !cl.producer.producedInTxn.Load() {
+			cl.cfg.logger.Log(LogLevelDebug, "no records were produced during the commit; thus no transaction was began; ending without doing anything")
+			return nil
+		}
+		cl.cfg.logger.Log(LogLevelInfo, "no produce succeeded in this transaction but produces were attempted; issuing an abort to clear any server-side partition registrations",
+			"transactional_id", *cl.cfg.txnID,
+		)
+		commit = TryAbort
 	}
 
 	id, epoch, err := cl.producerID(ctx2fn(ctx))
 	if err != nil {
 		if commit {
+			// We are NOT attempting the commit: restore everything this
+			// call consumed (inTxn, addedToTxn, offsetsAddedToTxn). We
+			// document that the caller should retry with TryAbort, and
+			// that retry must still see the transaction state to issue
+			// the EndTxn abort; consuming the state here would turn the
+			// retry into a silent no-op that leaves the broker-side
+			// transaction ongoing (stalling read_committed consumers on
+			// the LSO) until the transaction timeout aborts it.
+			// producingTxn deliberately stays false: produces between
+			// the failed commit and the abort retry fail fast with
+			// errNotInTransaction rather than buffering against a
+			// failed producer ID.
+			for _, rb := range addedSwapped {
+				rb.addedToTxn.Store(true)
+			}
+			if offsetsWereAdded {
+				g.offsetsAddedToTxn = true
+			}
+			cl.producer.inTxn = true
 			return kerr.OperationNotAttempted
 		}
 
@@ -847,11 +901,37 @@ func (cl *Client) maybeRecoverProducerID(ctx context.Context) (necessary, did bo
 		return true, false, err
 	}
 
+	if ke.Retriable {
+		// The stored failure is a retriable broker code, e.g.
+		// COORDINATOR_LOAD_IN_PROGRESS or NOT_COORDINATOR that
+		// outlived its internal retries, or CONCURRENT_TRANSACTIONS
+		// that outlived doWithConcurrentTransactions. These are
+		// transient load failures, not a fatal producer state: flag
+		// the ID for reload exactly like the transport-level failures
+		// above, rather than reporting "fatal, unrecoverable" for a
+		// condition that clears on its own.
+		cl.producer.id.Store(&producerID{
+			id:    id,
+			epoch: epoch,
+			err:   errReloadProducerID,
+		})
+		return true, true, nil
+	}
+
 	var recoverable bool
-	if cl.supportsKeyVersion(int16(kmsg.EndTxn), 5) {
-		// As of KIP-890 / Kafka 4.0, InvalidProducerIDMapping and
+	if cl.producer.tx890p2.Load() {
+		// Under KIP-890 part 2 (transaction.version=2 in effect for
+		// this client's transactions), InvalidProducerIDMapping and
 		// InvalidProducerEpoch are NOT recoverable. Only
 		// UnknownProducerID and TransactionAbortable are.
+		//
+		// We gate on the mode our transactions actually ran in, NOT
+		// on broker-advertised EndTxn versions: a 4.0+ broker
+		// advertises EndTxn v5 even while the cluster's
+		// transaction.version is still 0 or 1, and under those the
+		// cluster still operates the pre-890p2 semantics where the
+		// KIP-360/KIP-588 re-init below is the designed recovery
+		// (e.g. after a transaction-timeout abort bumped our epoch).
 		recoverable = errors.Is(ke, kerr.UnknownProducerID) || errors.Is(ke, kerr.TransactionAbortable)
 	} else {
 		kip360 := cl.producer.idVersion >= 3 && (errors.Is(ke, kerr.UnknownProducerID) || errors.Is(ke, kerr.InvalidProducerIDMapping))
@@ -876,6 +956,31 @@ func (cl *Client) maybeRecoverProducerID(ctx context.Context) (necessary, did bo
 // If a transaction is begun too quickly after finishing an old transaction,
 // Kafka may still be finalizing its commit / abort and will return a
 // concurrent transactions error. We handle that by retrying for a bit.
+//
+// Constraints any change to EOS-under-coordinator-churn (here and in
+// maybeRecoverProducerID / EndTransaction) must preserve — established by the
+// txn-churn audit:
+//
+//  1. This wrapper / coordinator-retry division stays: the coordinator
+//     wrapper retries only coordinator-move codes; CONCURRENT_TRANSACTIONS
+//     loops belong to callers, ctx-bounded, because CT can legitimately last
+//     as long as a marker drain. Route CT recovery through this loop, not a
+//     second one.
+//  2. anyAdded gating stays for TV1 — EndTxn on an EMPTY TV1 transaction is
+//     INVALID_TXN_STATE. The TV2 forced-abort-when-every-produce-failed path
+//     must stay TV2-only and attempted-only; idle Begin/End cycles stay
+//     wireless.
+//  3. Producer-fenced means dead: no fix may add recovery for PRODUCER_FENCED
+//     from coordinator paths. Only the timeout-abort IPE-on-produce path is
+//     recoverable, and only under TV1 semantics.
+//
+// Two design-sized items remain deliberately NOT taken (would need their own
+// round; until then docs + AbortingFirstErrPromise carry them): (a)
+// commit-after-failed-produce — kgo commits whatever succeeded if the caller
+// asks, unlike Java's abortable-state block, so changing it means tracking
+// per-txn batch failures and changing End's contract; (b) TV2 feature
+// downgrade mid-session (transaction.version 2=>1 while a client lives) —
+// Java's per-EndTxn re-check is the reference shape if it ever bites.
 func (cl *Client) doWithConcurrentTransactions(ctx context.Context, name string, fn func() error) error {
 	start := time.Now()
 	tries := 0
@@ -885,20 +990,21 @@ start:
 	err := fn()
 	if errors.Is(err, kerr.ConcurrentTransactions) {
 		// The longer we are stalled, the more we enforce a minimum
-		// backoff.
+		// backoff. Checks are ordered longest first; switch takes the
+		// first true case.
 		since := time.Since(start)
 		switch {
-		case since > time.Second:
-			if backoff < 200*time.Millisecond {
-				backoff = 200 * time.Millisecond
+		case since > 5*time.Second:
+			if backoff < time.Second {
+				backoff = time.Second
 			}
 		case since > 5*time.Second/2:
 			if backoff < 500*time.Millisecond {
 				backoff = 500 * time.Millisecond
 			}
-		case since > 5*time.Second:
-			if backoff < time.Second {
-				backoff = time.Second
+		case since > time.Second:
+			if backoff < 200*time.Millisecond {
+				backoff = 200 * time.Millisecond
 			}
 		}
 
@@ -1069,31 +1175,12 @@ func (g *groupConsumer) commitTxn(ctx context.Context, tx890p2 bool, req *kmsg.T
 	}
 
 	priorDone := g.commitDone
-
-	// Unlike the non-txn consumer, we use the group context for
-	// transaction offset committing. We want to quit when the group is
-	// left, and we are not committing when leaving. We rely on proper
-	// usage of the GroupTransactSession API to issue commits, so there is
-	// no reason not to use the group context here.
-	commitCtx, commitCancel := context.WithCancel(g.ctx) // enable ours to be canceled and waited for
 	commitDone := make(chan struct{})
-
 	g.commitDone = commitDone
-
-	if ctx.Done() != nil {
-		go func() {
-			select {
-			case <-ctx.Done():
-				commitCancel()
-			case <-commitCtx.Done():
-			}
-		}()
-	}
 
 	go func() {
 		defer close(commitDone) // allow future commits to continue when we are done
-		defer commitCancel()
-		if priorDone != nil { // wait for any prior request to finish
+		if priorDone != nil {   // wait for any prior request to finish
 			// Same as commit(): we must NOT cancel the prior commit
 			// because canceling kills the TCP connection, and our
 			// subsequent request on a new connection can be processed
@@ -1108,7 +1195,14 @@ func (g *groupConsumer) commitTxn(ctx context.Context, tx890p2 bool, req *kmsg.T
 		g.cl.cfg.logger.Log(LogLevelDebug, "issuing txn offset commit", "uncommitted", req)
 
 		start := time.Now()
-		ctx := ctx // capture a local ctx variable; do not use the shared one that is concurrently read above
+		// The request rides the caller's context (the End context),
+		// not the group context: a transactional offset commit must
+		// not be canceled by group teardown midway, because canceling
+		// an in-flight request kills the connection and a replacement
+		// commit on a new connection can be reordered behind the
+		// canceled one by the broker. End documents that canceling
+		// ITS context risks an invalid state.
+		ctx := ctx
 		if !tx890p2 {
 			ctx = context.WithValue(ctx, ctxPinReq, &pinReq{pinMax: true, max: 4}) // v5 is only supported with KIP-890 part 2
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1307,7 +1307,7 @@ github.com/tklauser/go-sysconf
 # github.com/tklauser/numcpus v0.11.0
 ## explicit; go 1.24.0
 github.com/tklauser/numcpus
-# github.com/twmb/franz-go v1.21.3
+# github.com/twmb/franz-go v1.21.4
 ## explicit; go 1.25.0
 github.com/twmb/franz-go/pkg/kbin
 github.com/twmb/franz-go/pkg/kerr


### PR DESCRIPTION
#### What this PR does

Following https://github.com/grafana/mimir/pull/15792

This PR updates test in `pkg/storage/ingest` to `synctest`. The focus here are slow tests, that rely heavily on synchronisation via the use of polling and sleep.

In my local testing so far, this cuts significant amount of time (120s -vs- 30s).

An additional, yet very valuable, part is that the use of `synctest` **reviled** places, where our tests masked an actual buggy behaviour in franz-go's internals. I.e. an edge case, that was masked by the use of sleep, making the tests flaky. The actual bug was already fixed in `kgo@1.21.4` (in https://github.com/twmb/franz-go/pull/1348)