### PR TITLE
compartments: split Router into Router and TopicRouter

### DIFF
--- a/integration/compartments_test.go
+++ b/integration/compartments_test.go
@@ -114,7 +114,7 @@ func TestIngesterQuerying_ShouldSupportCompartments(t *testing.T) {
 
 	// Pick, per read compartment, one distinct metric name to produce through each write compartment.
 	// All names of a compartment route to that compartment regardless of which distributor produces them.
-	router := compartments.NewRouter(numReadCompartments, "mimir-ingest-rc-<read-compartment-id>")
+	router := compartments.NewRouter(numReadCompartments)
 	namesByCompartment := metricNamesPerCompartment(router, numReadCompartments, numWriteCompartments)
 
 	pushClients := make([]*e2emimir.Client, numWriteCompartments)

--- a/pkg/compartments/router.go
+++ b/pkg/compartments/router.go
@@ -11,42 +11,28 @@ import (
 	"github.com/grafana/mimir/pkg/mimirpb"
 )
 
-// Router assigns a tenant's metric to a read compartment, and the corresponding Kafka topic, based
-// on a hash of the user ID and metric name.
+// Router assigns a tenant's metric to a read compartment, based on a hash of the user ID and metric name.
 type Router struct {
-	topics []string
+	numCompartments int
 
 	// allReadCompartmentIDs holds every read compartment ID.
 	allReadCompartmentIDs []int
 }
 
-// NewRouter creates a Router. kafkaTopicTemplate is the Kafka topic name containing the
-// ReadCompartmentIDPlaceholder, which is replaced with each read compartment ID to derive
-// that compartment's topic.
-func NewRouter(numReadCompartments int, kafkaTopicTemplate string) *Router {
-	var (
-		topics                = make([]string, numReadCompartments)
-		allReadCompartmentIDs = make([]int, numReadCompartments)
-	)
-
-	for id := range topics {
-		topics[id] = ReplaceReadCompartment(kafkaTopicTemplate, id)
+// NewRouter creates a Router for the given number of read compartments.
+func NewRouter(numReadCompartments int) *Router {
+	allReadCompartmentIDs := make([]int, numReadCompartments)
+	for id := range allReadCompartmentIDs {
 		allReadCompartmentIDs[id] = id
 	}
-
-	return &Router{topics: topics, allReadCompartmentIDs: allReadCompartmentIDs}
+	return &Router{numCompartments: numReadCompartments, allReadCompartmentIDs: allReadCompartmentIDs}
 }
 
 // CompartmentForMetric returns the read compartment ID for the given tenant's metric name. The
 // metricName is only hashed and never retained, so it is safe to pass an unsafe (pooled) string.
 func (r *Router) CompartmentForMetric(userID, metricName string) int {
 	hash := mimirpb.ShardByMetricName(userID, metricName)
-	return int(hash % uint32(len(r.topics)))
-}
-
-// TopicForMetric returns the Kafka topic for the given tenant's metric name.
-func (r *Router) TopicForMetric(userID, metricName string) string {
-	return r.topics[r.CompartmentForMetric(userID, metricName)]
+	return int(hash % uint32(r.numCompartments))
 }
 
 // CompartmentsForMatchers returns the read compartments that may hold series matching the given matchers
@@ -105,16 +91,40 @@ func (r *Router) CompartmentsForMatchers(userID string, matchers []*labels.Match
 
 // NumCompartments returns the number of read compartments.
 func (r *Router) NumCompartments() int {
-	return len(r.topics)
+	return r.numCompartments
+}
+
+// TopicRouter extends Router with the Kafka topic of each read compartment, for callers on the
+// ingestion path that need to produce to a compartment's topic.
+type TopicRouter struct {
+	*Router
+
+	topics []string
+}
+
+// NewTopicRouter creates a TopicRouter. kafkaTopicTemplate is the Kafka topic name containing the
+// ReadCompartmentIDPlaceholder, which is replaced with each read compartment ID to derive that
+// compartment's topic.
+func NewTopicRouter(numReadCompartments int, kafkaTopicTemplate string) *TopicRouter {
+	topics := make([]string, numReadCompartments)
+	for id := range topics {
+		topics[id] = ReplaceReadCompartment(kafkaTopicTemplate, id)
+	}
+	return &TopicRouter{Router: NewRouter(numReadCompartments), topics: topics}
+}
+
+// TopicForMetric returns the Kafka topic for the given tenant's metric name.
+func (r *TopicRouter) TopicForMetric(userID, metricName string) string {
+	return r.topics[r.CompartmentForMetric(userID, metricName)]
 }
 
 // TopicForCompartment returns the Kafka topic for the given read compartment ID.
-func (r *Router) TopicForCompartment(compartmentID int) string {
+func (r *TopicRouter) TopicForCompartment(compartmentID int) string {
 	return r.topics[compartmentID]
 }
 
 // Topics returns the Kafka topic of every read compartment.
-func (r *Router) Topics() []string {
+func (r *TopicRouter) Topics() []string {
 	return slices.Clone(r.topics)
 }
 

--- a/pkg/compartments/router_test.go
+++ b/pkg/compartments/router_test.go
@@ -14,11 +14,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newTestRouter(numCompartments int) *Router {
-	return NewRouter(numCompartments, "mimir-rc-<read-compartment-id>")
+func newTestRouter(numCompartments int) *TopicRouter {
+	return NewTopicRouter(numCompartments, "mimir-rc-<read-compartment-id>")
 }
 
-func TestRouter_TopicForCompartment(t *testing.T) {
+func TestTopicRouter_TopicForCompartment(t *testing.T) {
 	r := newTestRouter(3)
 	require.Equal(t, 3, r.NumCompartments())
 	assert.Equal(t, "mimir-rc-0", r.TopicForCompartment(0))
@@ -26,7 +26,7 @@ func TestRouter_TopicForCompartment(t *testing.T) {
 	assert.Equal(t, "mimir-rc-2", r.TopicForCompartment(2))
 }
 
-func TestRouter_Topics(t *testing.T) {
+func TestTopicRouter_Topics(t *testing.T) {
 	r := newTestRouter(3)
 	assert.Equal(t, []string{"mimir-rc-0", "mimir-rc-1", "mimir-rc-2"}, r.Topics())
 
@@ -149,5 +149,28 @@ func TestRouter_TopicForMetric(t *testing.T) {
 			seen[r.CompartmentForMetric("user-1", fmt.Sprintf("metric_%d", i))] = struct{}{}
 		}
 		assert.Len(t, seen, numCompartments)
+	})
+}
+
+func TestNewRouter(t *testing.T) {
+	const numCompartments = 4
+	r := NewRouter(numCompartments)
+	withTopics := NewTopicRouter(numCompartments, "mimir-rc-<read-compartment-id>")
+
+	assert.Equal(t, numCompartments, r.NumCompartments())
+
+	t.Run("routes identically to a topic-aware router", func(t *testing.T) {
+		for i := 0; i < 1000; i++ {
+			name := "metric_" + strconv.Itoa(i)
+			assert.Equal(t, withTopics.CompartmentForMetric("user-1", name), r.CompartmentForMetric("user-1", name))
+		}
+	})
+
+	t.Run("CompartmentsForMatchers narrows and fans out", func(t *testing.T) {
+		exact := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, model.MetricNameLabel, "the_metric")}
+		assert.Equal(t, []int{r.CompartmentForMetric("user-1", "the_metric")}, r.CompartmentsForMatchers("user-1", exact))
+
+		none := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "job", "test")}
+		assert.ElementsMatch(t, []int{0, 1, 2, 3}, r.CompartmentsForMatchers("user-1", none))
 	})
 }

--- a/pkg/distributor/compartments.go
+++ b/pkg/distributor/compartments.go
@@ -33,7 +33,7 @@ func (ct *compartmentTokens) writeRequestIndexes(tokenIndexes []int) []int {
 //
 // It returns the grouped tokens and the index at which metadata starts in the combined series+metadata
 // index space (i.e. len(req.Timeseries)).
-func getCompartmentTokensForWriteRequest(router *compartments.Router, userID string, req *mimirpb.WriteRequest) ([]compartmentTokens, int) {
+func getCompartmentTokensForWriteRequest(router *compartments.TopicRouter, userID string, req *mimirpb.WriteRequest) ([]compartmentTokens, int) {
 	initialMetadataIndex := len(req.Timeseries)
 
 	numCompartments := router.NumCompartments()

--- a/pkg/distributor/compartments_test.go
+++ b/pkg/distributor/compartments_test.go
@@ -39,8 +39,8 @@ func TestCompartmentTokens_WriteRequestIndexes(t *testing.T) {
 func TestGetCompartmentTokensForWriteRequest(t *testing.T) {
 	userID := "user-1"
 
-	newTestCompartmentRouter := func(numCompartments int) *compartments.Router {
-		return compartments.NewRouter(numCompartments, "comp-<read-compartment-id>")
+	newTestCompartmentRouter := func(numCompartments int) *compartments.TopicRouter {
+		return compartments.NewTopicRouter(numCompartments, "comp-<read-compartment-id>")
 	}
 
 	req := &mimirpb.WriteRequest{

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -233,7 +233,7 @@ type Distributor struct {
 	partitionInstanceRings *ingest.PartitionInstanceRings
 
 	// compartmentRouter shards series to read compartments. Nil when compartments are disabled.
-	compartmentRouter *compartments.Router
+	compartmentRouter *compartments.TopicRouter
 
 	// usageTrackerClient is the client that should be used to track per-tenant series and
 	// enforce max series limit in the distributor. This field is nil if usage-tracker
@@ -831,7 +831,7 @@ func New(cfg Config, clientConfig ingester_client.Config, limits *validation.Ove
 			// Resolve the writer's Kafka address and credentials for this distributor's write compartment.
 			writerKafkaCfg = writerKafkaCfg.WriteCompartmentConfig(cfg.WriteCompartmentID)
 
-			d.compartmentRouter = compartments.NewRouter(cfg.Compartments.Read.NumCompartments, cfg.IngestStorageConfig.KafkaConfig.Topic)
+			d.compartmentRouter = compartments.NewTopicRouter(cfg.Compartments.Read.NumCompartments, cfg.IngestStorageConfig.KafkaConfig.Topic)
 
 			d.queryIngesterCompartmentsHit = promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 				Name: "cortex_querier_compartments_hit_per_query",

--- a/pkg/distributor/distributor_compartments_test.go
+++ b/pkg/distributor/distributor_compartments_test.go
@@ -281,6 +281,6 @@ func prepareCompartmentsTestDistributor(t *testing.T, numCompartments int) (*Dis
 	return distributors[0], kafkaCluster, compartmentTopics
 }
 
-func compartmentsTestRouter(numCompartments int) *compartments.Router {
-	return compartments.NewRouter(numCompartments, compartmentsTestTopicFormat)
+func compartmentsTestRouter(numCompartments int) *compartments.TopicRouter {
+	return compartments.NewTopicRouter(numCompartments, compartmentsTestTopicFormat)
 }

--- a/pkg/distributor/query_compartments_test.go
+++ b/pkg/distributor/query_compartments_test.go
@@ -412,7 +412,7 @@ func prepareCompartmentsQueryTestDistributor(t *testing.T, tenantID string, numC
 
 // metricNamesByCompartment returns, indexed by compartment, a metric name that the router assigns to that
 // compartment for the given tenant.
-func metricNamesByCompartment(t *testing.T, router *compartments.Router, tenantID string, numCompartments int) []string {
+func metricNamesByCompartment(t *testing.T, router *compartments.TopicRouter, tenantID string, numCompartments int) []string {
 	t.Helper()
 
 	metricForCompartment := make([]string, numCompartments)


### PR DESCRIPTION
#### What this PR does

This is a preliminary refactoring extracted from #15856 to make that PR easier to review.

It splits the compartments `Router` into two types:

- `Router` keeps only the read-compartment routing logic (which compartment a metric belongs to, and the set of compartments a query touches).
- `TopicRouter` embeds `Router` and adds the per-compartment Kafka topic mapping needed on the ingestion path.

The write path (distributor) uses `TopicRouter`, while callers that only need compartment routing can depend on the smaller `Router`. Behavior is unchanged.

#### Which issue(s) this PR fixes or relates to

Preliminary refactoring for #15856.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - not needed; compartments are experimental, disabled by default, and intentionally undocumented externally until the architecture works end to end (`changelog-not-needed`).
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
