### PR TITLE
querier: extract newBlocksStoreQueryableFinder

### DIFF
--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -33,7 +33,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/util/annotations"
-	"github.com/thanos-io/objstore"
 	"golang.org/x/sync/errgroup"
 	grpc_metadata "google.golang.org/grpc/metadata"
 
@@ -201,39 +200,12 @@ func NewBlocksStoreQueryable(
 }
 
 func NewBlocksStoreQueryableFromConfig(querierCfg Config, gatewayCfg storegateway.Config, storageCfg mimir_tsdb.BlocksStorageConfig, limits BlocksStoreLimits, logger log.Logger, reg prometheus.Registerer) (*BlocksStoreQueryable, error) {
-	var (
-		stores       BlocksStoreSet
-		bucketClient objstore.Bucket
-	)
+	var stores BlocksStoreSet
 
-	bucketClient, err := bucket.NewClient(context.Background(), storageCfg.Bucket, "querier", logger, reg)
+	finder, err := newBlocksStoreQueryableFinder(storageCfg.Bucket, storageCfg, limits, logger, reg)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create bucket client")
+		return nil, err
 	}
-
-	querierReg := prometheus.WrapRegistererWith(prometheus.Labels{"component": "querier"}, reg)
-	cachingBucket, err := mimir_tsdb.NewMetadataCachingBucket(
-		storageCfg.BucketStore.MetadataCache,
-		bucketClient,
-		logger,
-		querierReg,
-	)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create caching bucket")
-	}
-	bucketClient = cachingBucket
-
-	// Create the blocks finder.
-	finder := NewBucketIndexBlocksFinder(BucketIndexBlocksFinderConfig{
-		IndexLoader: bucketindex.LoaderConfig{
-			CheckInterval:         time.Minute,
-			UpdateOnStaleInterval: storageCfg.BucketStore.SyncInterval,
-			UpdateOnErrorInterval: storageCfg.BucketStore.BucketIndex.UpdateOnErrorInterval,
-			IdleTimeout:           storageCfg.BucketStore.BucketIndex.IdleTimeout,
-		},
-		MaxStalePeriod:           storageCfg.BucketStore.BucketIndex.MaxStalePeriod,
-		IgnoreDeletionMarksDelay: storageCfg.BucketStore.IgnoreDeletionMarksWhileQueryingDelay,
-	}, bucketClient, limits, logger, reg)
 
 	storesRingCfg := gatewayCfg.ShardingRing.ToRingConfig()
 	storesRingBackend, err := kv.NewClient(
@@ -276,6 +248,35 @@ func NewBlocksStoreQueryableFromConfig(querierCfg Config, gatewayCfg storegatewa
 	streamingBufferSize := querierCfg.StreamingChunksPerStoreGatewaySeriesBufferSize
 
 	return NewBlocksStoreQueryable(stores, dynamicReplication, finder, consistency, limits, querierCfg.QueryStoreAfter, streamingBufferSize, logger, reg)
+}
+
+// newBlocksStoreQueryableFinder creates a BucketIndexBlocksFinder over the given bucket config.
+func newBlocksStoreQueryableFinder(bucketCfg bucket.Config, storageCfg mimir_tsdb.BlocksStorageConfig, limits BlocksStoreLimits, logger log.Logger, reg prometheus.Registerer) (BlocksFinder, error) {
+	bucketClient, err := bucket.NewClient(context.Background(), bucketCfg, "querier", logger, reg)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create bucket client")
+	}
+
+	cachingBucket, err := mimir_tsdb.NewMetadataCachingBucket(
+		storageCfg.BucketStore.MetadataCache,
+		bucketClient,
+		logger,
+		prometheus.WrapRegistererWith(prometheus.Labels{"component": "querier"}, reg),
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create caching bucket")
+	}
+
+	return NewBucketIndexBlocksFinder(BucketIndexBlocksFinderConfig{
+		IndexLoader: bucketindex.LoaderConfig{
+			CheckInterval:         time.Minute,
+			UpdateOnStaleInterval: storageCfg.BucketStore.SyncInterval,
+			UpdateOnErrorInterval: storageCfg.BucketStore.BucketIndex.UpdateOnErrorInterval,
+			IdleTimeout:           storageCfg.BucketStore.BucketIndex.IdleTimeout,
+		},
+		MaxStalePeriod:           storageCfg.BucketStore.BucketIndex.MaxStalePeriod,
+		IgnoreDeletionMarksDelay: storageCfg.BucketStore.IgnoreDeletionMarksWhileQueryingDelay,
+	}, cachingBucket, limits, logger, reg), nil
 }
 
 func (q *BlocksStoreQueryable) starting(ctx context.Context) error {


### PR DESCRIPTION
#### What this PR does

Extracts the bucket-index blocks finder setup (bucket client, metadata caching bucket, finder) out of `NewBlocksStoreQueryableFromConfig` into a dedicated `newBlocksStoreQueryableFinder` function, taking the bucket config as input.

This is a pure refactoring with no behavioral change. It's pulled out ahead of #15856 (making the querier blocks-storage path compartment-aware), where the finder needs to be created per read compartment over each compartment's own bucket. Landing it separately keeps that PR's diff focused on the compartments logic.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated - not needed; no behavioral change.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - not needed (`changelog-not-needed`).
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
