### PR TITLE
perf: GCS & S3 latency benchmark

### DIFF
--- a/pkg/storage/bucket/gcs/gcs_bench_test.go
+++ b/pkg/storage/bucket/gcs/gcs_bench_test.go
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// To run against a real GCS bucket, set GCS_BENCH_BUCKET
+// and populate benchBlocks in a git-ignored file Go file in this package.
+//
+//	GCS_BENCH_BUCKET=<your-gcs-bucket> \
+//	  go test ./pkg/storage/bucket/gcs/ \
+//	  -test.v -test.run='^$' -test.bench='^\QBenchmarkGetRangeGCS\E$' -test.benchtime=1x
+//
+// Auth uses the standard GCP credential chain.
+package gcs
+
+import (
+	"context"
+	"io"
+	"math/rand"
+	"net"
+	"net/http"
+	"os"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+	thanosgcs "github.com/thanos-io/objstore/providers/gcs"
+	"go.uber.org/atomic"
+)
+
+// indexFile describes one TSDB block index object in GCS.
+type indexFile struct {
+	path      string
+	sizeBytes int64
+}
+
+// benchBlocks is populated by bench_blocks_test.go (not committed).
+// If empty, the benchmark skips. See bench_blocks_test.go.example for the format.
+var benchBlocks []indexFile
+
+const (
+	readSize = 1 << 20 // 1 MiB
+
+	totalCalls  = 10_000 // ~150 seconds run time
+	concurrency = 32
+
+	// maxConnsPerHost caps the number of TCP connections to GCS. 0 = unlimited,
+	// letting Go's HTTP/2 transport open connections as needed when GCS's
+	// SETTINGS_MAX_CONCURRENT_STREAMS limit is reached or a GOAWAY is received.
+	// Restricting this concentrates GOAWAY reconnect latency onto fewer connections.
+	// 0 is the default on thanosgcs.DefaultConfig.HTTPConfig.
+	maxConnsPerHost = 0
+)
+
+// countingTransport counts new TCP connections via a wrapped DialContext.
+type countingTransport struct {
+	base     http.RoundTripper
+	newConns atomic.Int64
+}
+
+func (c *countingTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	return c.base.RoundTrip(r)
+}
+
+// benchCall is a pre-computed (file, offset) pair for one GetRange call.
+type benchCall struct {
+	file indexFile
+	off  int64
+}
+
+// benchResult holds the measurements from one GetRange call.
+type benchResult struct {
+	header time.Duration
+}
+
+// BenchmarkGetRangeGCS measures random 1 MiB GetRange header latency against real GCS
+// index files. It makes totalCalls requests across concurrency goroutines and reports:
+//   - hdr latency:    time until GetRange returns (server response, any retry backoff)
+//   - new_tcp_conns:  TCP connections opened during the run
+//
+// Skips unless GCS_BENCH_BUCKET is set and benchBlocks is populated.
+func BenchmarkGetRangeGCS(b *testing.B) {
+	bucket := os.Getenv("GCS_BENCH_BUCKET")
+	if bucket == "" {
+		b.Skip("set GCS_BENCH_BUCKET to run against a real GCS bucket")
+	}
+	if len(benchBlocks) == 0 {
+		b.Skip("benchBlocks is empty — populate bench_blocks_test.go")
+	}
+
+	ctx := context.Background()
+
+	ct := &countingTransport{}
+	httpCfg := thanosgcs.DefaultConfig.HTTPConfig
+	httpCfg.MaxConnsPerHost = maxConnsPerHost
+
+	bucketCfg := thanosgcs.Config{
+		Bucket:     bucket,
+		MaxRetries: 20,
+		HTTPConfig: httpCfg,
+	}
+	bkt, err := thanosgcs.NewBucketWithConfig(ctx, log.NewNopLogger(), bucketCfg, "bench",
+		func(rt http.RoundTripper) http.RoundTripper {
+			// Wrap DialContext on the base transport to count new TCP connections.
+			// This fires once per TCP handshake, not per HTTP request or stream.
+			if t, ok := rt.(*http.Transport); ok {
+				orig := t.DialContext
+				t.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+					ct.newConns.Add(1)
+					return orig(ctx, network, addr)
+				}
+			}
+			ct.base = rt
+			return ct
+		},
+	)
+	require.NoError(b, err)
+	b.Cleanup(func() { _ = bkt.Close() })
+
+	// Pre-compute all calls with a fixed seed so results are reproducible.
+	rng := rand.New(rand.NewSource(42))
+	calls := make([]benchCall, totalCalls)
+	for i := range calls {
+		f := benchBlocks[rng.Intn(len(benchBlocks))]
+		calls[i] = benchCall{f, rng.Int63n(f.sizeBytes - readSize)}
+	}
+
+	// drainCh receives response bodies from measurement goroutines immediately after
+	// header time is stamped. Background drainers consume them so HTTP/2 streams are
+	// released and the connection remains available for new streams.
+	//
+	// Buffer is bounded to concurrency so measurement goroutines block when all
+	// drainers are busy, keeping simultaneous open HTTP/2 streams bounded to
+	// ~2×concurrency. An unbounded buffer lets measurement goroutines race ahead,
+	// accumulating thousands of open streams and creating artificial GCS load.
+	drainCh := make(chan io.ReadCloser, concurrency)
+	var drainWg sync.WaitGroup
+	for range concurrency {
+		drainWg.Add(1)
+		go func() {
+			defer drainWg.Done()
+			for rc := range drainCh {
+				_, _ = io.Copy(io.Discard, rc)
+				_ = rc.Close()
+			}
+		}()
+	}
+
+	results := make([]benchResult, totalCalls)
+	work := make(chan int, totalCalls)
+	for i := range calls {
+		work <- i
+	}
+	close(work)
+
+	b.ResetTimer()
+
+	var wg sync.WaitGroup
+	for range concurrency {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range work {
+				c := calls[i]
+
+				start := time.Now()
+				rc, err := bkt.GetRange(ctx, c.file.path, c.off, readSize)
+				header := time.Since(start)
+				if err != nil {
+					b.Errorf("GetRange call %d: %v", i, err)
+					continue
+				}
+				drainCh <- rc
+
+				results[i] = benchResult{header: header}
+			}
+		}()
+	}
+	wg.Wait()
+	close(drainCh)
+	drainWg.Wait()
+
+	b.StopTimer()
+
+	headerSamples := make([]time.Duration, totalCalls)
+	for i, r := range results {
+		headerSamples[i] = r.header
+	}
+
+	reportDurationPercentiles(b, "hdr", headerSamples)
+	b.ReportMetric(float64(ct.newConns.Load()), "new_tcp_conns")
+}
+
+func reportDurationPercentiles(b *testing.B, prefix string, samples []time.Duration) {
+	b.Helper()
+	if len(samples) == 0 {
+		return
+	}
+	slices.Sort(samples)
+	ms := func(p float64) float64 {
+		return samples[int(float64(len(samples)-1)*p)].Seconds() * 1000
+	}
+	b.ReportMetric(ms(0.50), prefix+"_p50_ms")
+	b.ReportMetric(ms(0.90), prefix+"_p90_ms")
+	b.ReportMetric(ms(0.99), prefix+"_p99_ms")
+	b.ReportMetric(ms(0.999), prefix+"_p999_ms")
+	b.ReportMetric(samples[len(samples)-1].Seconds()*1000, prefix+"_max_ms")
+}

--- a/pkg/storage/bucket/s3/s3_bench_test.go
+++ b/pkg/storage/bucket/s3/s3_bench_test.go
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// To run against a real S3 bucket, set S3_BENCH_BUCKET and S3_BENCH_REGION, and
+// and populate benchBlocks in a git-ignored file Go file in this package.
+//
+//		AWS_PROFILE=<your-profile> S3_BENCH_BUCKET=<your-s3-bucket> S3_BENCH_REGION=<region> \
+//		  go test ./pkg/storage/bucket/s3/
+//	   	  -test.v -test.run='^$' -test.bench='^\QBenchmarkGetRangeS3\E$' -test.benchtime=1x
+//
+// Auth uses the standard AWS credential chain (env vars, ~/.aws/credentials, IAM role).
+package s3
+
+import (
+	"context"
+	"io"
+	"math/rand"
+	"net"
+	"net/http"
+	"os"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+	thanoss3 "github.com/thanos-io/objstore/providers/s3"
+	"go.uber.org/atomic"
+)
+
+type indexFile struct {
+	path      string
+	sizeBytes int64
+}
+
+// benchBlocks is populated by bench_blocks_test.go (not committed).
+// If empty, the benchmark skips. See bench_blocks_test.go.example for the format.
+var benchBlocks []indexFile
+
+const (
+	readSize    = 1 << 20 // 1 MiB
+	totalCalls  = 10_000  // ~150 seconds run time
+	concurrency = 32
+
+	// maxConnsPerHost caps the number of TCP connections to S3. 0 = unlimited.
+	// 0 is the default on thanosgcs.DefaultConfig.HTTPConfig.
+	maxConnsPerHost = 0
+)
+
+// countingTransport counts new TCP connections via a wrapped DialContext.
+type countingTransport struct {
+	base     http.RoundTripper
+	newConns atomic.Int64
+}
+
+func (c *countingTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	return c.base.RoundTrip(r)
+}
+
+type benchCall struct {
+	file indexFile
+	off  int64
+}
+
+type benchResult struct {
+	header time.Duration
+}
+
+// BenchmarkGetRangeS3 measures random 1 MiB GetRange header latency against real S3
+// index files. It makes totalCalls requests across concurrency goroutines and reports:
+//   - hdr latency:   time until GetRange returns (server response, any retry backoff)
+//   - new_tcp_conns: TCP connections opened during the run
+//
+// Skips unless S3_BENCH_BUCKET is set and benchBlocks is non-empty.
+func BenchmarkGetRangeS3(b *testing.B) {
+	bucket := os.Getenv("S3_BENCH_BUCKET")
+	if bucket == "" {
+		b.Skip("set S3_BENCH_BUCKET to run against a real S3 bucket")
+	}
+	if len(benchBlocks) == 0 {
+		b.Skip("benchBlocks is empty — fill in block paths in bench_blocks_test.go")
+	}
+
+	ctx := context.Background()
+
+	region := os.Getenv("S3_BENCH_REGION")
+	if region == "" {
+		region = "us-east-1"
+	}
+	// Thanos's S3 provider (minio-go underneath) always requires an explicit endpoint.
+	endpoint := os.Getenv("S3_BENCH_ENDPOINT")
+	if endpoint == "" {
+		endpoint = "s3." + region + ".amazonaws.com"
+	}
+
+	ct := &countingTransport{}
+	httpCfg := thanoss3.DefaultConfig.HTTPConfig
+	httpCfg.MaxConnsPerHost = maxConnsPerHost
+
+	bucketCfg := thanoss3.Config{
+		Bucket:     bucket,
+		Endpoint:   endpoint,
+		Region:     region,
+		AWSSDKAuth: true, // standard AWS credential chain
+		HTTPConfig: httpCfg,
+	}
+	bkt, err := thanoss3.NewBucketWithConfig(log.NewNopLogger(), bucketCfg, "bench",
+		func(rt http.RoundTripper) http.RoundTripper {
+			// Wrap DialContext on the base transport to count new TCP connections.
+			// This fires once per TCP handshake, not per HTTP request or stream.
+			if t, ok := rt.(*http.Transport); ok {
+				orig := t.DialContext
+				t.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+					ct.newConns.Add(1)
+					return orig(ctx, network, addr)
+				}
+			}
+			ct.base = rt
+			return ct
+		},
+	)
+	require.NoError(b, err)
+	b.Cleanup(func() { _ = bkt.Close() })
+
+	rng := rand.New(rand.NewSource(42))
+	calls := make([]benchCall, totalCalls)
+	for i := range calls {
+		f := benchBlocks[rng.Intn(len(benchBlocks))]
+		calls[i] = benchCall{f, rng.Int63n(f.sizeBytes - readSize)}
+	}
+
+	// drainCh receives response bodies from measurement goroutines immediately after
+	// header time is stamped. Background drainers consume them so connections are
+	// returned to the idle pool and subsequent requests don't dial.
+	//
+	// Buffer is bounded to concurrency so measurement goroutines block when all
+	// drainers are busy, keeping simultaneous open connections bounded to
+	// ~2×concurrency. An unbounded buffer lets measurement goroutines race ahead,
+	// accumulating open connections and creating artificial S3 load.
+	drainCh := make(chan io.ReadCloser, concurrency)
+	var drainWg sync.WaitGroup
+	for range concurrency {
+		drainWg.Add(1)
+		go func() {
+			defer drainWg.Done()
+			for rc := range drainCh {
+				_, _ = io.Copy(io.Discard, rc)
+				_ = rc.Close()
+			}
+		}()
+	}
+
+	results := make([]benchResult, totalCalls)
+	work := make(chan int, totalCalls)
+	for i := range calls {
+		work <- i
+	}
+	close(work)
+
+	b.ResetTimer()
+
+	var wg sync.WaitGroup
+	for range concurrency {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range work {
+				c := calls[i]
+
+				start := time.Now()
+				rc, err := bkt.GetRange(ctx, c.file.path, c.off, readSize)
+				header := time.Since(start)
+				if err != nil {
+					b.Errorf("GetRange call %d: %v", i, err)
+					continue
+				}
+				drainCh <- rc
+
+				results[i] = benchResult{header: header}
+			}
+		}()
+	}
+	wg.Wait()
+	close(drainCh)
+	drainWg.Wait()
+
+	b.StopTimer()
+
+	headerSamples := make([]time.Duration, totalCalls)
+	for i, r := range results {
+		headerSamples[i] = r.header
+	}
+
+	reportDurationPercentiles(b, "hdr", headerSamples)
+	b.ReportMetric(float64(ct.newConns.Load()), "new_tcp_conns")
+}
+
+func reportDurationPercentiles(b *testing.B, prefix string, samples []time.Duration) {
+	b.Helper()
+	if len(samples) == 0 {
+		return
+	}
+	slices.Sort(samples)
+	ms := func(p float64) float64 {
+		return samples[int(float64(len(samples)-1)*p)].Seconds() * 1000
+	}
+	b.ReportMetric(ms(0.50), prefix+"_p50_ms")
+	b.ReportMetric(ms(0.90), prefix+"_p90_ms")
+	b.ReportMetric(ms(0.99), prefix+"_p99_ms")
+	b.ReportMetric(ms(0.999), prefix+"_p999_ms")
+	b.ReportMetric(samples[len(samples)-1].Seconds()*1000, prefix+"_max_ms")
+}

--- a/vendor/github.com/thanos-io/objstore/exthttp/transport.go
+++ b/vendor/github.com/thanos-io/objstore/exthttp/transport.go
@@ -75,5 +75,9 @@ func DefaultTransport(config HTTPConfig) (*http.Transport, error) {
 		//
 		// Refer: https://golang.org/src/net/http/transport.go?h=roundTrip#L1843.
 		TLSClientConfig: tlsConfig,
+		// ForceAttemptHTTP2 re-enables HTTP/2 negotiation when TLSClientConfig is set.
+		// Go's transport disables HTTP/2 by default whenever TLSClientConfig is non-nil,
+		// even if the TLS config is otherwise compatible with HTTP/2.
+		ForceAttemptHTTP2: true,
 	}, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Benchmarks to reproduce extreme tail latency on GCS storage - our test GCP environments have observed up to 14 seconds for a single get-range request of 1MiB.

These benchmarks only measure the time to receive headers, but they read and close the response body to allow the goroutine to be reused in the connection pool.

**Benchmark Outputs: GCS**
Benchmarked with and without HTTP/2 force-enablement here - HTTP/2 appears to cut p99.9 in half, and pmax by 70%.

```console
goos: linux
goarch: amd64
pkg: github.com/grafana/mimir/pkg/storage/bucket/gcs
cpu: AMD Ryzen 9 PRO 6950H with Radeon Graphics
               │ benchout-http1-10k.txt │        benchout-http2-10k.txt        │
               │       hdr_max_ms       │  hdr_max_ms   vs base                │
GetRangeGCS-16             3.716k ± 94%   1.065k ± 81%  -71.32% (p=0.000 n=10)

               │ benchout-http1-10k.txt │       benchout-http2-10k.txt       │
               │       hdr_p50_ms       │ hdr_p50_ms  vs base                │
GetRangeGCS-16               118.4 ± 4%   170.6 ± 2%  +44.13% (p=0.000 n=10)

               │ benchout-http1-10k.txt │       benchout-http2-10k.txt       │
               │       hdr_p90_ms       │ hdr_p90_ms  vs base                │
GetRangeGCS-16               325.1 ± 3%   216.8 ± 9%  -33.34% (p=0.000 n=10)

               │ benchout-http1-10k.txt │       benchout-http2-10k.txt        │
               │      hdr_p999_ms       │ hdr_p999_ms  vs base                │
GetRangeGCS-16             1344.0 ± 30%   608.4 ± 17%  -54.73% (p=0.000 n=10)

               │ benchout-http1-10k.txt │       benchout-http2-10k.txt        │
               │       hdr_p99_ms       │ hdr_p99_ms   vs base                │
GetRangeGCS-16               568.3 ± 3%   361.9 ± 13%  -36.32% (p=0.000 n=10)

               │ benchout-http1-10k.txt │        benchout-http2-10k.txt         │
               │     new_tcp_conns      │ new_tcp_conns  vs base                │
GetRangeGCS-16             110.50 ± 12%      32.00 ± 0%  -71.04% (p=0.000 n=10)
```

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
