### PR TITLE
ingest: divide per-client Kafka budgets across write compartments

### DIFF
--- a/docs/internal/compartments/read-compartments.md
+++ b/docs/internal/compartments/read-compartments.md
@@ -31,6 +31,15 @@ flowchart LR
     K1 --> ING
 ```
 
+### Spreading consumer resources across write compartments
+
+Some read-compartment components consume from every write compartment's Kafka cluster: ingesters
+consume their partition from all of them, and block-builders read the same partition across all of
+them to build blocks. Such a component maintains a separate consumer per write compartment, and the
+resources dedicated to consumption are divided across these consumers, so the component's total
+consumption resource usage stays independent of the number of write compartments instead of growing
+with it.
+
 ## Blocks storage
 
 Each read compartment owns its blocks storage end to end:

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -577,12 +577,7 @@ func New(cfg Config, limits *validation.Overrides, ingestersRing ring.ReadRing, 
 			// write compartment's Kafka cluster. The per-cluster offset files live in the TSDB directory
 			// alongside the ingester's data, one per write compartment.
 			readCompartmentTopic := compartments.ReplaceReadCompartment(kafkaCfg.Topic, cfg.ReadCompartmentID)
-			kafkaCfgs := make([]ingest.KafkaConfig, cfg.Compartments.Write.NumCompartments)
-			for writeCompartmentID := range kafkaCfgs {
-				clusterCfg := kafkaCfg.WriteCompartmentConfig(writeCompartmentID)
-				clusterCfg.Topic = readCompartmentTopic
-				kafkaCfgs[writeCompartmentID] = clusterCfg
-			}
+			kafkaCfgs := ingest.WriteCompartmentConfigs(kafkaCfg, cfg.Compartments.Write.NumCompartments, readCompartmentTopic)
 			offsetFilePath := filepath.Join(cfg.BlocksStorageConfig.TSDB.Dir, "kafka-offset-wc-"+compartments.WriteCompartmentIDPlaceholder+".json")
 
 			i.ingestReader, err = ingest.NewMultiClusterPartitionReader(kafkaCfgs, i.ingestPartitionID, cfg.IngesterRing.InstanceID, offsetFilePath, profilingIngester, log.With(logger, "component", "ingest_reader"), registerer)

--- a/pkg/storage/ingest/config.go
+++ b/pkg/storage/ingest/config.go
@@ -429,6 +429,36 @@ func (cfg *KafkaConfig) WriteCompartmentConfig(writeCompartmentID int) KafkaConf
 	return c
 }
 
+// WriteCompartmentConfigs returns one KafkaConfig per write compartment, each targeting
+// that compartment's Kafka cluster and the given read compartment's topic. Because a
+// separate Kafka client is created per compartment, the per-client resource budgets are divided across the compartments so
+// that fanning out keeps peak resource usage independent of the compartment count.
+func WriteCompartmentConfigs(base KafkaConfig, numCompartments int, topic string) []KafkaConfig {
+	fetchConcurrencyMax := divideBudget(base.FetchConcurrencyMax, numCompartments)
+	maxBufferedBytes := divideBudget(base.MaxBufferedBytes, numCompartments)
+	ingestionConcurrencyMax := divideBudget(base.IngestionConcurrencyMax, numCompartments)
+	out := make([]KafkaConfig, numCompartments)
+	for i := range out {
+		c := base.WriteCompartmentConfig(i)
+		c.Topic = topic
+		c.FetchConcurrencyMax = fetchConcurrencyMax
+		c.MaxBufferedBytes = maxBufferedBytes
+		c.IngestionConcurrencyMax = ingestionConcurrencyMax
+		out[i] = c
+	}
+	return out
+}
+
+// divideBudget splits a per-client resource budget across numCompartments clients.
+// A non-positive budget (commonly 0, meaning disabled or unlimited) is left untouched. A
+// positive budget is floored at 1 so it never collapses to 0.
+func divideBudget(budget, numCompartments int) int {
+	if budget <= 0 || numCompartments <= 1 {
+		return budget
+	}
+	return max(1, budget/numCompartments)
+}
+
 // MigrationConfig holds the configuration used to migrate Mimir to ingest storage. This config shouldn't be
 // set for any other reason.
 type MigrationConfig struct {

--- a/pkg/storage/ingest/config_test.go
+++ b/pkg/storage/ingest/config_test.go
@@ -546,6 +546,93 @@ func TestKafkaConfig_WriteCompartmentConfig(t *testing.T) {
 	}
 }
 
+func TestWriteCompartmentConfigs(t *testing.T) {
+	newBase := func() KafkaConfig {
+		base := KafkaConfig{}
+		flagext.DefaultValues(&base)
+		base.Address = flagext.StringSliceCSV{"kafka-wc-<write-compartment-id>:9092"}
+		base.Topic = "ingest-rc-<read-compartment-id>"
+		base.SASL.Username = "user-wc-<write-compartment-id>"
+		base.SASL.Password = flagext.SecretWithValue("pass-wc-<write-compartment-id>")
+		base.FetchConcurrencyMax = 12
+		base.MaxBufferedBytes = 1_000_000_000
+		base.IngestionConcurrencyMax = 8
+		return base
+	}
+
+	t.Run("resolves each cluster, applies the topic, and divides per-client budgets", func(t *testing.T) {
+		const numCompartments = 4
+		cfgs := WriteCompartmentConfigs(newBase(), numCompartments, "ingest-rc-2")
+		require.Len(t, cfgs, numCompartments)
+
+		for wc, cfg := range cfgs {
+			assert.Equal(t, flagext.StringSliceCSV{fmt.Sprintf("kafka-wc-%d:9092", wc)}, cfg.Address)
+			assert.Equal(t, fmt.Sprintf("user-wc-%d", wc), cfg.SASL.Username)
+			assert.Equal(t, fmt.Sprintf("pass-wc-%d", wc), cfg.SASL.Password.String())
+			// The topic is resolved for the given read compartment.
+			assert.Equal(t, "ingest-rc-2", cfg.Topic)
+			// The per-client budgets are the global value split across compartments, so peak
+			// resource usage stays independent of the compartment count.
+			assert.Equal(t, 12/numCompartments, cfg.FetchConcurrencyMax)
+			assert.Equal(t, 1_000_000_000/numCompartments, cfg.MaxBufferedBytes)
+			assert.Equal(t, 8/numCompartments, cfg.IngestionConcurrencyMax)
+		}
+	})
+
+	t.Run("a single compartment keeps the full budget", func(t *testing.T) {
+		cfgs := WriteCompartmentConfigs(newBase(), 1, "ingest-rc-0")
+		require.Len(t, cfgs, 1)
+		assert.Equal(t, 12, cfgs[0].FetchConcurrencyMax)
+		assert.Equal(t, 1_000_000_000, cfgs[0].MaxBufferedBytes)
+		assert.Equal(t, 8, cfgs[0].IngestionConcurrencyMax)
+	})
+
+	t.Run("a positive budget never collapses to zero", func(t *testing.T) {
+		base := newBase()
+		base.FetchConcurrencyMax = 3
+		cfgs := WriteCompartmentConfigs(base, 8, "ingest-rc-0")
+		require.Len(t, cfgs, 8)
+		for _, cfg := range cfgs {
+			assert.Equal(t, 1, cfg.FetchConcurrencyMax)
+		}
+	})
+
+	t.Run("a disabled budget stays disabled", func(t *testing.T) {
+		base := newBase()
+		base.FetchConcurrencyMax = 0
+		base.MaxBufferedBytes = 0
+		base.IngestionConcurrencyMax = 0
+		cfgs := WriteCompartmentConfigs(base, 4, "ingest-rc-0")
+		require.Len(t, cfgs, 4)
+		for _, cfg := range cfgs {
+			assert.Zero(t, cfg.FetchConcurrencyMax)
+			assert.Zero(t, cfg.MaxBufferedBytes)
+			assert.Zero(t, cfg.IngestionConcurrencyMax)
+		}
+	})
+}
+
+func TestDivideBudget(t *testing.T) {
+	tests := map[string]struct {
+		budget          int
+		numCompartments int
+		expected        int
+	}{
+		"divides evenly":                          {budget: 12, numCompartments: 4, expected: 3},
+		"floors to integer division":              {budget: 10, numCompartments: 3, expected: 3},
+		"single compartment keeps full budget":    {budget: 12, numCompartments: 1, expected: 12},
+		"zero compartments keep full budget":      {budget: 12, numCompartments: 0, expected: 12},
+		"positive budget never collapses to zero": {budget: 3, numCompartments: 8, expected: 1},
+		"disabled budget stays disabled":          {budget: 0, numCompartments: 4, expected: 0},
+		"negative budget left untouched":          {budget: -1, numCompartments: 4, expected: -1},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, divideBudget(tc.budget, tc.numCompartments))
+		})
+	}
+}
+
 func TestKafkaConfig_ToWarpstreamClientOptions(t *testing.T) {
 	baseConfig := func() KafkaConfig {
 		return KafkaConfig{


### PR DESCRIPTION
When compartments are enabled, an ingester opens a separate Kafka client per write compartment. The per-client resource budgets (fetch concurrency, buffered fetch bytes, ingestion concurrency) were each applied in full to every client, so peak resource usage scaled with the number of write compartments instead of staying constant.

`WriteCompartmentConfigs` returns one config per write compartment, and dividing those budgets across the compartments so peak usage stays independent of how many compartments are configured. The ingester's multi-cluster reader builds its per-compartment configs through it; the helper lives in the ingest package so block-builder and block-builder-scheduler can reuse it as they gain compartment support.

Divided — each is a per-client concurrency cap or memory pool on the consume path, so N clients would otherwise use up to N times the configured value:

- `fetch_concurrency_max` — concurrent fetch requests per client.
- `max_buffered_bytes` — buffered fetch bytes per client.
- `ingestion_concurrency_max` —  per-tenant cap on parallel storage-push shards. I'm unsure about dividing this. The default is 8; with 10 compartments the per-compartment cap becomes 1, so every tenant gets exactly 1 shard per compartment regardless of size.

Deliberately not divided:

- `ingestion_concurrency_batch_size`, `ingestion_concurrency_queue_capacity`, `ingestion_concurrency_target_flushes_per_shard` — these are per-shard sizes and tuning ratios, not pools. We already cap the number of shards with `ingestion_concurrency_max`, so these don't need to be scale down.
- Producer-side budgets (`producer_max_buffered_bytes`, `producer_max_record_size_bytes`) — the components that fan out are consumers; the only producer (distributor) is single-compartment and doesn't fan out.
