### PR TITLE
Use known offsets across all callers to fetchPostings

### DIFF
--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1712,7 +1712,7 @@ func labelValuesFromPostings(
 		keysOffsets[i] = labelPostingOffset{labels.Label{Name: labelName, Value: value.LabelValue}, value.Off}
 	}
 
-	fetchedPostings, err := indexr.fetchPostingsWithKnownOffsets(ctx, keysOffsets, stats)
+	fetchedPostings, err := indexr.FetchPostingsIndexV2(ctx, keysOffsets, stats)
 	if err != nil {
 		return nil, errors.Wrap(err, "get postings")
 	}

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1703,15 +1703,16 @@ func labelValuesFromSeries(ctx context.Context, labelName string, seriesPerBatch
 	return vals, nil
 }
 
-func labelValuesFromPostings(ctx context.Context, labelName string, indexr *bucketIndexReader, allValues []streamindex.PostingListOffset, p []storage.SeriesRef, stats *safeQueryStats) ([]string, error) {
-	keys := make([]labels.Label, len(allValues))
-	offsets := make([]index.Range, len(allValues))
+func labelValuesFromPostings(
+	ctx context.Context, labelName string, indexr *bucketIndexReader,
+	allValues []streamindex.PostingListOffset, p []storage.SeriesRef, stats *safeQueryStats,
+) ([]string, error) {
+	keysOffsets := make([]labelPostingOffset, len(allValues))
 	for i, value := range allValues {
-		keys[i] = labels.Label{Name: labelName, Value: value.LabelValue}
-		offsets[i] = value.Off
+		keysOffsets[i] = labelPostingOffset{labels.Label{Name: labelName, Value: value.LabelValue}, value.Off}
 	}
 
-	fetchedPostings, err := indexr.fetchPostingsWithKnownOffsets(ctx, keys, offsets, stats)
+	fetchedPostings, err := indexr.fetchPostingsWithKnownOffsets(ctx, keysOffsets, stats)
 	if err != nil {
 		return nil, errors.Wrap(err, "get postings")
 	}

--- a/pkg/storegateway/bucket.go
+++ b/pkg/storegateway/bucket.go
@@ -1705,11 +1705,13 @@ func labelValuesFromSeries(ctx context.Context, labelName string, seriesPerBatch
 
 func labelValuesFromPostings(ctx context.Context, labelName string, indexr *bucketIndexReader, allValues []streamindex.PostingListOffset, p []storage.SeriesRef, stats *safeQueryStats) ([]string, error) {
 	keys := make([]labels.Label, len(allValues))
+	offsets := make([]index.Range, len(allValues))
 	for i, value := range allValues {
 		keys[i] = labels.Label{Name: labelName, Value: value.LabelValue}
+		offsets[i] = value.Off
 	}
 
-	fetchedPostings, err := indexr.FetchPostings(ctx, keys, stats)
+	fetchedPostings, err := indexr.fetchPostingsWithKnownOffsets(ctx, keys, offsets, stats)
 	if err != nil {
 		return nil, errors.Wrap(err, "get postings")
 	}

--- a/pkg/storegateway/bucket_index_postings.go
+++ b/pkg/storegateway/bucket_index_postings.go
@@ -211,7 +211,8 @@ type postingGroup struct {
 	isSubtract bool
 	matcher    *labels.Matcher
 	keys       []labels.Label
-	offsets    []index.Range
+	// offsets must match 1:1 with keys
+	offsets []index.Range
 
 	// totalSize is the size in bytes of all the posting lists for keys.
 	totalSize int64

--- a/pkg/storegateway/bucket_index_postings.go
+++ b/pkg/storegateway/bucket_index_postings.go
@@ -86,6 +86,7 @@ func newLazySubtractingPostingGroup(m *labels.Matcher) rawPostingGroup {
 func (g rawPostingGroup) toPostingGroup(ctx context.Context, r indexheader.Reader) (postingGroup, error) {
 	var (
 		keys      []labels.Label
+		offsets   []index.Range
 		totalSize int64
 	)
 	if g.isLazy {
@@ -98,13 +99,15 @@ func (g rawPostingGroup) toPostingGroup(ctx context.Context, r indexheader.Reade
 			return postingGroup{}, err
 		}
 		keys = make([]labels.Label, len(vals))
+		offsets = make([]index.Range, len(vals))
 		for i := range vals {
 			keys[i] = labels.Label{Name: g.labelName, Value: vals[i].LabelValue}
+			offsets[i] = vals[i].Off
 			totalSize += vals[i].Off.End - vals[i].Off.Start
 		}
 	} else {
 		var err error
-		keys, totalSize, err = g.filterNonExistingKeys(ctx, r)
+		keys, offsets, totalSize, err = g.filterNonExistingKeys(ctx, r)
 		if err != nil {
 			return postingGroup{}, errors.Wrap(err, "filter posting keys")
 		}
@@ -114,17 +117,21 @@ func (g rawPostingGroup) toPostingGroup(ctx context.Context, r indexheader.Reade
 		isSubtract: g.isSubtract,
 		matcher:    g.matcher,
 		keys:       keys,
+		offsets:    offsets,
 		totalSize:  totalSize,
 	}, nil
 }
 
 // filterNonExistingKeys uses the indexheader.Reader to filter out any label values that do not exist in this index.
 // modifies the underlying keys slice of the group. Do not use the rawPostingGroup after calling toPostingGroup.
-func (g rawPostingGroup) filterNonExistingKeys(ctx context.Context, r indexheader.Reader) ([]labels.Label, int64, error) {
+func (g rawPostingGroup) filterNonExistingKeys(ctx context.Context, r indexheader.Reader) ([]labels.Label, []index.Range, int64, error) {
 	var (
 		writeIdx  int
 		totalSize int64
+		offsets   []index.Range
 	)
+
+	offsets = make([]index.Range, len(g.keys))
 	for _, l := range g.keys {
 		offset, err := r.PostingsOffset(ctx, l.Name, l.Value)
 		if errors.Is(err, indexheader.NotFoundRangeErr) {
@@ -133,13 +140,14 @@ func (g rawPostingGroup) filterNonExistingKeys(ctx context.Context, r indexheade
 			// Continue so we overwrite it next time there's an existing value.
 			continue
 		} else if err != nil {
-			return nil, 0, err
+			return nil, nil, 0, err
 		}
 		g.keys[writeIdx] = l
+		offsets[writeIdx] = offset
 		writeIdx++
 		totalSize += offset.End - offset.Start
 	}
-	return g.keys[:writeIdx], totalSize, nil
+	return g.keys[:writeIdx], offsets[:writeIdx], totalSize, nil
 }
 
 func toRawPostingGroup(m *labels.Matcher) rawPostingGroup {
@@ -203,6 +211,7 @@ type postingGroup struct {
 	isSubtract bool
 	matcher    *labels.Matcher
 	keys       []labels.Label
+	offsets    []index.Range
 
 	// totalSize is the size in bytes of all the posting lists for keys.
 	totalSize int64

--- a/pkg/storegateway/bucket_index_reader.go
+++ b/pkg/storegateway/bucket_index_reader.go
@@ -205,13 +205,15 @@ func (r *bucketIndexReader) expandedPostings(ctx context.Context, ms []*labels.M
 	postingGroups, omittedPostingGroups := r.postingsStrategy.selectPostings(postingGroups)
 	logSelectedPostingGroups(ctx, r.block.logger, r.block.meta.ULID, postingGroups, omittedPostingGroups)
 
-	fetchedPostings, err := r.fetchPostings(ctx, extractLabels(postingGroups), extractOffsets(postingGroups), stats)
+	keysOffsets := extractKeysOffsets(postingGroups)
+
+	fetchedPostings, err := r.fetchPostings(ctx, keysOffsets, stats)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "get postings")
 	}
 
 	// The order of the fetched postings is the same as the order of the requested keys.
-	// This is guaranteed by extractLabels.
+	// This is guaranteed by extractKeysOffsets.
 	postingIndex := 0
 
 	var groupAdds, groupRemovals []index.Postings
@@ -291,30 +293,19 @@ func extractLabelMatchers(groups []postingGroup) []*labels.Matcher {
 	return m
 }
 
-// extractOffsets returns the offsets of the posting groups in the order that they are found in each posting group.
-func extractOffsets(groups []postingGroup) []index.Range {
-	numOffsets := 0
-	for _, pg := range groups {
-		numOffsets += len(pg.offsets)
-	}
-	offsets := make([]index.Range, 0, numOffsets)
-	for _, pg := range groups {
-		offsets = append(offsets, pg.offsets...)
-	}
-	return offsets
-}
-
-// extractLabels returns the keys of the posting groups in the order that they are found in each posting group.
-func extractLabels(groups []postingGroup) []labels.Label {
+// extractKeysOffsets returns the keys and offsets of the posting groups in the order that they are found in each posting group.
+func extractKeysOffsets(groups []postingGroup) []labelPostingOffset {
 	numKeys := 0
 	for _, pg := range groups {
 		numKeys += len(pg.keys)
 	}
-	keys := make([]labels.Label, 0, numKeys)
+	keysOffsets := make([]labelPostingOffset, 0, numKeys)
 	for _, pg := range groups {
-		keys = append(keys, pg.keys...)
+		for ix, k := range pg.keys {
+			keysOffsets = append(keysOffsets, labelPostingOffset{k, pg.offsets[ix]})
+		}
 	}
-	return keys
+	return keysOffsets
 }
 
 func extractLabelValues(offsets []streamindex.PostingListOffset) []string {
@@ -423,28 +414,25 @@ func toPostingGroups(ctx context.Context, ms []*labels.Matcher, indexhdr indexhe
 	return postingGroups, nil
 }
 
-// fetchPostingsWithKnownOffsets is like FetchPostings, but uses the caller-provided
-// byte offsets (e.g. from IndexHeaderReader.LabelValuesOffsets) instead of
-// resolving each key's offset with a separate PostingsOffset call.
-// offsets, if non-nil, must be aligned 1:1 with keys and hold the non-empty byte range of each key's
-// posting list, so they can be reused instead of resolving them again via PostingsOffset;
-// a length mismatch between keys and offsets will result in an error.
-func (r *bucketIndexReader) fetchPostingsWithKnownOffsets(ctx context.Context, keys []labels.Label, offsets []index.Range, stats *safeQueryStats) ([]index.Postings, error) {
-	return r.fetchAndPadPostings(ctx, keys, offsets, stats)
+type labelPostingOffset struct {
+	labels.Label
+	off index.Range
 }
 
-// FetchPostings fills postings requested by posting groups.
-// It returns one postings for each key, in the same order.
-// If postings for given key is not fetched, entry at given index will be an ErrPostings
-func (r *bucketIndexReader) FetchPostings(ctx context.Context, keys []labels.Label, stats *safeQueryStats) (returnPostings []index.Postings, returnErr error) {
-	return r.fetchAndPadPostings(ctx, keys, nil, stats)
-}
-
-func (r *bucketIndexReader) fetchAndPadPostings(ctx context.Context, keys []labels.Label, knownOffsets []index.Range, stats *safeQueryStats) ([]index.Postings, error) {
-	ps, err := r.fetchPostings(ctx, keys, knownOffsets, stats)
+// fetchPostingsWithKnownOffsets fills postings using the caller-provided offset for each key.
+// It returns one postings list per key, in the same order as keysOffsets.
+// If a key's offset is the zero-value index.Range, the index header is consulted to resolve it.
+// If the block has no posting list for a key, its entry is an empty postings list (index.EmptyPostings).
+// If a key's postings were never fetched, its entry is an ErrPostings.
+func (r *bucketIndexReader) fetchPostingsWithKnownOffsets(ctx context.Context, keysOffsets []labelPostingOffset, stats *safeQueryStats) ([]index.Postings, error) {
+	ps, err := r.fetchPostings(ctx, keysOffsets, stats)
 	if err != nil {
 		return nil, err
 	}
+	return r.padPostings(ctx, keysOffsets, ps)
+}
+
+func (r *bucketIndexReader) padPostings(ctx context.Context, keysOffsets []labelPostingOffset, ps []index.Postings) ([]index.Postings, error) {
 	// As of version two all series entries are 16 byte padded. All references
 	// we get have to account for that to get the correct offset.
 	version, err := r.block.indexHeaderReader.IndexVersion(ctx)
@@ -452,7 +440,7 @@ func (r *bucketIndexReader) fetchAndPadPostings(ctx context.Context, keys []labe
 		return nil, errors.Wrap(err, "get index version")
 	}
 	for i := range ps {
-		ps[i] = checkNilPosting(keys[i], ps[i])
+		ps[i] = checkNilPosting(keysOffsets[i].Label, ps[i])
 		if version >= 2 {
 			ps[i] = paddedPostings{ps[i]}
 		}
@@ -460,10 +448,10 @@ func (r *bucketIndexReader) fetchAndPadPostings(ctx context.Context, keys []labe
 	return ps, nil
 }
 
-// fetchPostings is the version-unaware private implementation of FetchPostings.
+// fetchPostings is the version-unaware private implementation of fetchPostingsWithKnownOffsets.
 // callers of this method may need to add padding to the results.
 // If postings for given key is not fetched, entry at given index will be nil.
-func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Label, knownOffsets []index.Range, stats *safeQueryStats) (output []index.Postings, returnErr error) {
+func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Label, keysOffsets []labelPostingOffset, stats *safeQueryStats) (output []index.Postings, returnErr error) {
 	ctx, span := tracer.Start(ctx, "fetchPostings()")
 	defer func() {
 		span.SetAttributes(
@@ -475,24 +463,24 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 		}
 		span.End()
 	}()
-	// If knownOffsets length does not match the number of keys, we shouldn't trust it.
-	if knownOffsets != nil && len(knownOffsets) != len(keys) {
-		return nil, fmt.Errorf("knownOffsets length %d must match keys length %d", len(knownOffsets), len(keys))
-	}
 	timer := prometheus.NewTimer(r.block.metrics.postingsFetchDuration)
 	defer timer.ObserveDuration()
 
 	var ptrs []postingPtr
 
-	output = make([]index.Postings, len(keys))
+	output = make([]index.Postings, len(keysOffsets))
 
+	keys := make([]labels.Label, len(keysOffsets))
+	for i := range keysOffsets {
+		keys[i] = keysOffsets[i].Label
+	}
 	// Fetch postings from the cache with a single call.
 	fromCache := r.block.indexCache.FetchMultiPostings(ctx, r.block.userID, r.block.meta.ULID, keys)
 
 	// Iterate over all groups and fetch posting from cache.
 	// If we have a miss, mark key to be fetched in `ptrs` slice.
 	// Overlaps are well handled by partitioner, so we don't need to deduplicate keys.
-	for ix, key := range keys {
+	for ix, ko := range keysOffsets {
 		// Get postings for the given key from cache first.
 		if b, _ := fromCache.Next(); b != nil {
 			stats.update(func(stats *queryStats) {
@@ -503,9 +491,9 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 			l, cachedLabelsKey, pendingMatchers, err := r.decodePostings(b, stats)
 			if len(pendingMatchers) > 0 {
 				return nil, fmt.Errorf("not expecting matchers on non-expanded postings for %s=%s in block %s, but got %s",
-					key.Name, key.Value, r.block.meta.ULID, util.MatchersStringer(pendingMatchers))
+					ko.Name, ko.Value, r.block.meta.ULID, util.MatchersStringer(pendingMatchers))
 			}
-			if err == nil && cachedLabelsKey == encodeLabelForPostingsCache(key) {
+			if err == nil && cachedLabelsKey == encodeLabelForPostingsCache(ko.Label) {
 				output[ix] = l
 				continue
 			}
@@ -513,7 +501,7 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 			level.Warn(r.block.logger).Log(
 				"msg", "can't decode cached postings",
 				"err", err,
-				"key", fmt.Sprintf("%+v", key),
+				"key", fmt.Sprintf("%+v", ko.Label),
 				"labels_key", cachedLabelsKey,
 				"block", r.block.meta.ULID,
 				"bytes_len", len(b),
@@ -523,11 +511,12 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 
 		// Cache miss; save pointer for actual posting in index stored in object store.
 		var ptr index.Range
-		if knownOffsets != nil {
-			ptr = knownOffsets[ix]
+		// A zero-value offset is invalid; if for some reason we receive one, fall back to fetching
+		if (ko.off != index.Range{}) {
+			ptr = keysOffsets[ix].off
 		} else {
 			var err error
-			ptr, err = r.block.indexHeaderReader.PostingsOffset(ctx, key.Name, key.Value)
+			ptr, err = r.block.indexHeaderReader.PostingsOffset(ctx, ko.Name, ko.Value)
 			if errors.Is(err, indexheader.NotFoundRangeErr) {
 				// This block does not have any posting for given key.
 				output[ix] = index.EmptyPostings()

--- a/pkg/storegateway/bucket_index_reader.go
+++ b/pkg/storegateway/bucket_index_reader.go
@@ -419,12 +419,12 @@ type labelPostingOffset struct {
 	off index.Range
 }
 
-// fetchPostingsWithKnownOffsets fills postings using the caller-provided offset for each key.
+// FetchPostingsIndexV2 fills postings using the caller-provided offset for each key.
 // It returns one postings list per key, in the same order as keysOffsets.
 // If a key's offset is the zero-value index.Range, the index header is consulted to resolve it.
 // If the block has no posting list for a key, its entry is an empty postings list (index.EmptyPostings).
 // If a key's postings were never fetched, its entry is an ErrPostings.
-func (r *bucketIndexReader) fetchPostingsWithKnownOffsets(ctx context.Context, keysOffsets []labelPostingOffset, stats *safeQueryStats) ([]index.Postings, error) {
+func (r *bucketIndexReader) FetchPostingsIndexV2(ctx context.Context, keysOffsets []labelPostingOffset, stats *safeQueryStats) ([]index.Postings, error) {
 	ps, err := r.fetchPostings(ctx, keysOffsets, stats)
 	if err != nil {
 		return nil, err
@@ -448,14 +448,14 @@ func (r *bucketIndexReader) padPostings(ctx context.Context, keysOffsets []label
 	return ps, nil
 }
 
-// fetchPostings is the version-unaware private implementation of fetchPostingsWithKnownOffsets.
+// fetchPostings is the version-unaware private implementation of FetchPostingsIndexV2.
 // callers of this method may need to add padding to the results.
 // If postings for given key is not fetched, entry at given index will be nil.
-func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Label, keysOffsets []labelPostingOffset, stats *safeQueryStats) (output []index.Postings, returnErr error) {
+func (r *bucketIndexReader) fetchPostings(ctx context.Context, keysOffsets []labelPostingOffset, stats *safeQueryStats) (output []index.Postings, returnErr error) {
 	ctx, span := tracer.Start(ctx, "fetchPostings()")
 	defer func() {
 		span.SetAttributes(
-			attribute.Int("keys", len(keys)),
+			attribute.Int("keys", len(keysOffsets)),
 			attribute.Stringer("block_id", r.block.meta.ULID),
 		)
 		if returnErr != nil {

--- a/pkg/storegateway/bucket_index_reader.go
+++ b/pkg/storegateway/bucket_index_reader.go
@@ -205,7 +205,7 @@ func (r *bucketIndexReader) expandedPostings(ctx context.Context, ms []*labels.M
 	postingGroups, omittedPostingGroups := r.postingsStrategy.selectPostings(postingGroups)
 	logSelectedPostingGroups(ctx, r.block.logger, r.block.meta.ULID, postingGroups, omittedPostingGroups)
 
-	fetchedPostings, err := r.fetchPostings(ctx, extractLabels(postingGroups), stats)
+	fetchedPostings, err := r.fetchPostings(ctx, extractLabels(postingGroups), extractOffsets(postingGroups), stats)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "get postings")
 	}
@@ -289,6 +289,19 @@ func extractLabelMatchers(groups []postingGroup) []*labels.Matcher {
 		m[i] = groups[i].matcher
 	}
 	return m
+}
+
+// extractOffsets returns the offsets of the posting groups in the order that they are found in each posting group.
+func extractOffsets(groups []postingGroup) []index.Range {
+	numOffsets := 0
+	for _, pg := range groups {
+		numOffsets += len(pg.offsets)
+	}
+	offsets := make([]index.Range, 0, numOffsets)
+	for _, pg := range groups {
+		offsets = append(offsets, pg.offsets...)
+	}
+	return offsets
 }
 
 // extractLabels returns the keys of the posting groups in the order that they are found in each posting group.
@@ -382,7 +395,21 @@ func toPostingGroups(ctx context.Context, ms []*labels.Matcher, indexhdr indexhe
 	// We only need special All postings if there are no other adds. If there are, we can skip fetching
 	// special All postings completely.
 	if allRequested && !hasAdds {
-		postingGroups = append(postingGroups, postingGroup{isSubtract: false, keys: []labels.Label{allPostingsKey}})
+		// Resolve the offset of the all postings list now, so it can be carried in the posting group
+		// alongside the offsets of the other groups and reused later in fetchPostings without an
+		// additional PostingsOffset lookup.
+		allPostingsOffset, err := indexhdr.PostingsOffset(ctx, allPostingsKey.Name, allPostingsKey.Value)
+		if errors.Is(err, indexheader.NotFoundRangeErr) {
+			// There is no all postings list, so there are no series to subtract from. Shortcut to an empty set.
+			return nil, nil
+		} else if err != nil {
+			return nil, errors.Wrap(err, "get all postings offset")
+		}
+		postingGroups = append(postingGroups, postingGroup{
+			isSubtract: false,
+			keys:       []labels.Label{allPostingsKey},
+			offsets:    []index.Range{allPostingsOffset},
+		})
 	}
 
 	// If hasAdds is false, then there were no posting lists for any labels that we will intersect.
@@ -396,15 +423,28 @@ func toPostingGroups(ctx context.Context, ms []*labels.Matcher, indexhdr indexhe
 	return postingGroups, nil
 }
 
+// fetchPostingsWithKnownOffsets is like FetchPostings, but uses the caller-provided
+// byte offsets (e.g. from IndexHeaderReader.LabelValuesOffsets) instead of
+// resolving each key's offset with a separate PostingsOffset call.
+// offsets, if non-nil, must be aligned 1:1 with keys and hold the non-empty byte range of each key's
+// posting list, so they can be reused instead of resolving them again via PostingsOffset;
+// a length mismatch between keys and offsets will result in an error.
+func (r *bucketIndexReader) fetchPostingsWithKnownOffsets(ctx context.Context, keys []labels.Label, offsets []index.Range, stats *safeQueryStats) ([]index.Postings, error) {
+	return r.fetchAndPadPostings(ctx, keys, offsets, stats)
+}
+
 // FetchPostings fills postings requested by posting groups.
 // It returns one postings for each key, in the same order.
 // If postings for given key is not fetched, entry at given index will be an ErrPostings
 func (r *bucketIndexReader) FetchPostings(ctx context.Context, keys []labels.Label, stats *safeQueryStats) (returnPostings []index.Postings, returnErr error) {
-	ps, err := r.fetchPostings(ctx, keys, stats)
+	return r.fetchAndPadPostings(ctx, keys, nil, stats)
+}
+
+func (r *bucketIndexReader) fetchAndPadPostings(ctx context.Context, keys []labels.Label, knownOffsets []index.Range, stats *safeQueryStats) ([]index.Postings, error) {
+	ps, err := r.fetchPostings(ctx, keys, knownOffsets, stats)
 	if err != nil {
 		return nil, err
 	}
-
 	// As of version two all series entries are 16 byte padded. All references
 	// we get have to account for that to get the correct offset.
 	version, err := r.block.indexHeaderReader.IndexVersion(ctx)
@@ -423,7 +463,7 @@ func (r *bucketIndexReader) FetchPostings(ctx context.Context, keys []labels.Lab
 // fetchPostings is the version-unaware private implementation of FetchPostings.
 // callers of this method may need to add padding to the results.
 // If postings for given key is not fetched, entry at given index will be nil.
-func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Label, stats *safeQueryStats) (output []index.Postings, returnErr error) {
+func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Label, knownOffsets []index.Range, stats *safeQueryStats) (output []index.Postings, returnErr error) {
 	ctx, span := tracer.Start(ctx, "fetchPostings()")
 	defer func() {
 		span.SetAttributes(
@@ -435,6 +475,10 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 		}
 		span.End()
 	}()
+	// If knownOffsets length does not match the number of keys, we shouldn't trust it.
+	if knownOffsets != nil && len(knownOffsets) != len(keys) {
+		return nil, fmt.Errorf("knownOffsets length %d must match keys length %d", len(knownOffsets), len(keys))
+	}
 	timer := prometheus.NewTimer(r.block.metrics.postingsFetchDuration)
 	defer timer.ObserveDuration()
 
@@ -478,15 +522,20 @@ func (r *bucketIndexReader) fetchPostings(ctx context.Context, keys []labels.Lab
 		}
 
 		// Cache miss; save pointer for actual posting in index stored in object store.
-		ptr, err := r.block.indexHeaderReader.PostingsOffset(ctx, key.Name, key.Value)
-		if errors.Is(err, indexheader.NotFoundRangeErr) {
-			// This block does not have any posting for given key.
-			output[ix] = index.EmptyPostings()
-			continue
-		}
-
-		if err != nil {
-			return nil, errors.Wrap(err, "index header PostingsOffset")
+		var ptr index.Range
+		if knownOffsets != nil {
+			ptr = knownOffsets[ix]
+		} else {
+			var err error
+			ptr, err = r.block.indexHeaderReader.PostingsOffset(ctx, key.Name, key.Value)
+			if errors.Is(err, indexheader.NotFoundRangeErr) {
+				// This block does not have any posting for given key.
+				output[ix] = index.EmptyPostings()
+				continue
+			}
+			if err != nil {
+				return nil, errors.Wrap(err, "index header PostingsOffset")
+			}
 		}
 
 		stats.update(func(stats *queryStats) {

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -1103,7 +1103,7 @@ func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 	})
 }
 
-func TestBucketIndexReader_FetchPostingsWithKnownOffsets(t *testing.T) {
+func TestBucketIndexReader_fetchPostingsWithKnownOffsets(t *testing.T) {
 	const (
 		series    = 50000
 		labelName = "n"
@@ -1121,20 +1121,12 @@ func TestBucketIndexReader_FetchPostingsWithKnownOffsets(t *testing.T) {
 		return offsets
 	}
 
-	rangesFromOffsets := func(offsets []streamindex.PostingListOffset) []index.Range {
-		ranges := make([]index.Range, len(offsets))
+	keysOffsets := func(name string, offsets []streamindex.PostingListOffset) []labelPostingOffset {
+		keysOffsets := make([]labelPostingOffset, len(offsets))
 		for i, o := range offsets {
-			ranges[i] = o.Off
+			keysOffsets[i] = labelPostingOffset{labels.Label{Name: name, Value: o.LabelValue}, o.Off}
 		}
-		return ranges
-	}
-
-	keysFromOffsets := func(name string, offsets []streamindex.PostingListOffset) []labels.Label {
-		keys := make([]labels.Label, len(offsets))
-		for i, o := range offsets {
-			keys[i] = labels.Label{Name: name, Value: o.LabelValue}
-		}
-		return keys
+		return keysOffsets
 	}
 
 	expectedRefs := func(b *bucketBlock, name, value string) []storage.SeriesRef {
@@ -1154,10 +1146,10 @@ func TestBucketIndexReader_FetchPostingsWithKnownOffsets(t *testing.T) {
 	t.Run("returns correct postings for every value using knownOffsets", func(t *testing.T) {
 		b := newTestBucketBlock()
 		offsets := offsetsForLabel(b, labelName, "")
-		keys := keysFromOffsets(labelName, offsets)
+		kos := keysOffsets(labelName, offsets)
 
-		// With known offsets supplied, FetchPostingsWithKnownOffsets must take the non-nil path and
-		// never resolve an offset with PostingsOffset.
+		// With known offsets supplied,
+		// fetchPostingsWithKnownOffsets must use the supplied offsets and never resolve an offset with PostingsOffset.
 		iir := &interceptedIndexReader{
 			Reader: b.indexHeaderReader,
 			onPostingsOffsetCalled: func(name, value string) error {
@@ -1165,47 +1157,36 @@ func TestBucketIndexReader_FetchPostingsWithKnownOffsets(t *testing.T) {
 			},
 		}
 		b.indexHeaderReader = iir
-		ps, err := b.indexReader(selectAllStrategy{}).fetchPostingsWithKnownOffsets(ctx, keys, rangesFromOffsets(offsets), newSafeQueryStats())
+		ps, err := b.indexReader(selectAllStrategy{}).fetchPostingsWithKnownOffsets(ctx, kos, newSafeQueryStats())
 		require.NoError(t, err)
-		require.Len(t, ps, len(keys))
+		require.Len(t, ps, len(kos))
 
-		// reset index header reader so we can properly expand postings to assert correctness against
+		// reset index header reader so we can properly expand postings in expectedRefs to assert correctness against
 		b.indexHeaderReader = iir.Reader
 
-		for i, key := range keys {
-			assert.Equal(t, expectedRefs(b, key.Name, key.Value), expandPostings(ps[i]), "postings for %s=%s", key.Name, key.Value)
+		for i, ko := range kos {
+			assert.Equal(t, expectedRefs(b, ko.Name, ko.Value), expandPostings(ps[i]), "postings for %s=%s", ko.Name, ko.Value)
 		}
-	})
-
-	t.Run("returns error for mismatched key and offset lengths", func(t *testing.T) {
-		b := newTestBucketBlock()
-		offsets := offsetsForLabel(b, labelName, "")
-		offsetsForPrefix := offsetsForLabel(b, labelName, "1")
-		keys := keysFromOffsets(labelName, offsets)
-
-		ps, err := b.indexReader(selectAllStrategy{}).fetchPostingsWithKnownOffsets(ctx, keys, rangesFromOffsets(offsetsForPrefix), newSafeQueryStats())
-		require.Error(t, err)
-		require.Nil(t, ps)
 	})
 
 	t.Run("returns postings for values matching the prefix", func(t *testing.T) {
 		b := newTestBucketBlock()
 		prefix := "1"
 		offsets := offsetsForLabel(b, labelName, prefix)
-		keys := keysFromOffsets(labelName, offsets)
+		kos := keysOffsets(labelName, offsets)
 
-		ps, err := b.indexReader(selectAllStrategy{}).fetchPostingsWithKnownOffsets(ctx, keys, rangesFromOffsets(offsets), newSafeQueryStats())
+		ps, err := b.indexReader(selectAllStrategy{}).fetchPostingsWithKnownOffsets(ctx, kos, newSafeQueryStats())
 		require.NoError(t, err)
-		require.Len(t, ps, len(keys))
-		for i, key := range keys {
-			require.True(t, strings.HasPrefix(key.Value, prefix), "LabelValuesOffsets returned a value not matching the prefix: %s", key.Value)
-			assert.Equal(t, expectedRefs(b, key.Name, key.Value), expandPostings(ps[i]), "postings for %s=%s", key.Name, key.Value)
+		require.Len(t, ps, len(kos))
+		for i, ko := range kos {
+			require.True(t, strings.HasPrefix(ko.Value, prefix), "LabelValuesOffsets returned a value not matching the prefix: %s", ko.Value)
+			assert.Equal(t, expectedRefs(b, ko.Name, ko.Value), expandPostings(ps[i]), "postings for %s=%s", ko.Name, ko.Value)
 		}
 	})
 
 	t.Run("no keys returns no postings", func(t *testing.T) {
 		b := newTestBucketBlock()
-		ps, err := b.indexReader(selectAllStrategy{}).fetchPostingsWithKnownOffsets(ctx, nil, nil, newSafeQueryStats())
+		ps, err := b.indexReader(selectAllStrategy{}).fetchPostingsWithKnownOffsets(ctx, nil, newSafeQueryStats())
 		require.NoError(t, err)
 		require.Empty(t, ps)
 	})
@@ -1214,27 +1195,38 @@ func TestBucketIndexReader_FetchPostingsWithKnownOffsets(t *testing.T) {
 		b := newTestBucketBlock()
 		b.indexCache = newInMemoryIndexCache(t)
 		offsets := offsetsForLabel(b, labelName, "")
-		keys := keysFromOffsets(labelName, offsets)
+		kos := keysOffsets(labelName, offsets)
 
 		// First call misses cache, does the fetch
-		first, err := b.indexReader(selectAllStrategy{}).fetchPostingsWithKnownOffsets(ctx, keys, rangesFromOffsets(offsets), newSafeQueryStats())
+		first, err := b.indexReader(selectAllStrategy{}).fetchPostingsWithKnownOffsets(ctx, kos, newSafeQueryStats())
 		require.NoError(t, err)
-		require.Len(t, first, len(keys))
+		require.Len(t, first, len(kos))
 
-		// The second call passes no known offsets, but should still hit the cache when resolving postings offsets to postings
+		for ix := range kos {
+			kos[ix].off = index.Range{}
+		}
+
+		b.indexHeaderReader = &interceptedIndexReader{
+			Reader: b.indexHeaderReader,
+			onPostingsOffsetCalled: func(name, value string) error {
+				return fmt.Errorf("didn't expect a PostingsOffset(%q, %q) call when offsets are known", name, value)
+			},
+		}
+
+		// The second call passes empty known offsets,
+		// but should still hit the cache (and therefore not execute any PostingOffset calls) when resolving postings offsets to postings
 		secondCallStats := newSafeQueryStats()
-		second, err := b.indexReader(selectAllStrategy{}).fetchPostingsWithKnownOffsets(ctx, keys, nil, secondCallStats)
+		second, err := b.indexReader(selectAllStrategy{}).fetchPostingsWithKnownOffsets(ctx, kos, secondCallStats)
 		require.NoError(t, err)
-		require.Len(t, second, len(keys))
+		require.Len(t, second, len(kos))
 
-		for i, key := range keys {
-			assert.Equal(t, expandPostings(first[i]), expandPostings(second[i]), "postings for %s=%s", key.Name, key.Value)
+		for i, ko := range kos {
+			assert.Equal(t, expandPostings(first[i]), expandPostings(second[i]), "postings for %s=%s", ko.Name, ko.Value)
 		}
 
 		// All postings were served from the cache, so nothing should have been fetched from the bucket.
 		assert.Zero(t, secondCallStats.export().postingsFetchCount)
 	})
-
 }
 
 func newInMemoryIndexCache(t testing.TB) indexcache.IndexCache {

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -1103,7 +1103,7 @@ func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 	})
 }
 
-func TestBucketIndexReader_fetchPostingsWithKnownOffsets(t *testing.T) {
+func TestBucketIndexReader_FetchPostingsIndexV2(t *testing.T) {
 	const (
 		series    = 50000
 		labelName = "n"
@@ -1149,7 +1149,7 @@ func TestBucketIndexReader_fetchPostingsWithKnownOffsets(t *testing.T) {
 		kos := keysOffsets(labelName, offsets)
 
 		// With known offsets supplied,
-		// fetchPostingsWithKnownOffsets must use the supplied offsets and never resolve an offset with PostingsOffset.
+		// FetchPostingsIndexV2 must use the supplied offsets and never resolve an offset with PostingsOffset.
 		iir := &interceptedIndexReader{
 			Reader: b.indexHeaderReader,
 			onPostingsOffsetCalled: func(name, value string) error {
@@ -1157,7 +1157,7 @@ func TestBucketIndexReader_fetchPostingsWithKnownOffsets(t *testing.T) {
 			},
 		}
 		b.indexHeaderReader = iir
-		ps, err := b.indexReader(selectAllStrategy{}).fetchPostingsWithKnownOffsets(ctx, kos, newSafeQueryStats())
+		ps, err := b.indexReader(selectAllStrategy{}).FetchPostingsIndexV2(ctx, kos, newSafeQueryStats())
 		require.NoError(t, err)
 		require.Len(t, ps, len(kos))
 
@@ -1175,7 +1175,7 @@ func TestBucketIndexReader_fetchPostingsWithKnownOffsets(t *testing.T) {
 		offsets := offsetsForLabel(b, labelName, prefix)
 		kos := keysOffsets(labelName, offsets)
 
-		ps, err := b.indexReader(selectAllStrategy{}).fetchPostingsWithKnownOffsets(ctx, kos, newSafeQueryStats())
+		ps, err := b.indexReader(selectAllStrategy{}).FetchPostingsIndexV2(ctx, kos, newSafeQueryStats())
 		require.NoError(t, err)
 		require.Len(t, ps, len(kos))
 		for i, ko := range kos {
@@ -1186,7 +1186,7 @@ func TestBucketIndexReader_fetchPostingsWithKnownOffsets(t *testing.T) {
 
 	t.Run("no keys returns no postings", func(t *testing.T) {
 		b := newTestBucketBlock()
-		ps, err := b.indexReader(selectAllStrategy{}).fetchPostingsWithKnownOffsets(ctx, nil, newSafeQueryStats())
+		ps, err := b.indexReader(selectAllStrategy{}).FetchPostingsIndexV2(ctx, nil, newSafeQueryStats())
 		require.NoError(t, err)
 		require.Empty(t, ps)
 	})
@@ -1198,7 +1198,7 @@ func TestBucketIndexReader_fetchPostingsWithKnownOffsets(t *testing.T) {
 		kos := keysOffsets(labelName, offsets)
 
 		// First call misses cache, does the fetch
-		first, err := b.indexReader(selectAllStrategy{}).fetchPostingsWithKnownOffsets(ctx, kos, newSafeQueryStats())
+		first, err := b.indexReader(selectAllStrategy{}).FetchPostingsIndexV2(ctx, kos, newSafeQueryStats())
 		require.NoError(t, err)
 		require.Len(t, first, len(kos))
 
@@ -1216,7 +1216,7 @@ func TestBucketIndexReader_fetchPostingsWithKnownOffsets(t *testing.T) {
 		// The second call passes empty known offsets,
 		// but should still hit the cache (and therefore not execute any PostingOffset calls) when resolving postings offsets to postings
 		secondCallStats := newSafeQueryStats()
-		second, err := b.indexReader(selectAllStrategy{}).fetchPostingsWithKnownOffsets(ctx, kos, secondCallStats)
+		second, err := b.indexReader(selectAllStrategy{}).FetchPostingsIndexV2(ctx, kos, secondCallStats)
 		require.NoError(t, err)
 		require.Len(t, second, len(kos))
 

--- a/pkg/storegateway/bucket_test.go
+++ b/pkg/storegateway/bucket_test.go
@@ -1103,6 +1103,140 @@ func TestBucketIndexReader_ExpandedPostings(t *testing.T) {
 	})
 }
 
+func TestBucketIndexReader_FetchPostingsWithKnownOffsets(t *testing.T) {
+	const (
+		series    = 50000
+		labelName = "n"
+	)
+
+	ctx := context.Background()
+	tb := test.NewTB(t)
+	testBlock := fixtures.SetupTestBlock(tb, fixtures.AppendTestSeries(series))
+	newTestBucketBlock := testBlockToBucketBlock(tb, testBlock)
+
+	offsetsForLabel := func(b *bucketBlock, name, prefix string) []streamindex.PostingListOffset {
+		offsets, err := b.indexHeaderReader.LabelValuesOffsets(ctx, name, prefix, nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, offsets)
+		return offsets
+	}
+
+	rangesFromOffsets := func(offsets []streamindex.PostingListOffset) []index.Range {
+		ranges := make([]index.Range, len(offsets))
+		for i, o := range offsets {
+			ranges[i] = o.Off
+		}
+		return ranges
+	}
+
+	keysFromOffsets := func(name string, offsets []streamindex.PostingListOffset) []labels.Label {
+		keys := make([]labels.Label, len(offsets))
+		for i, o := range offsets {
+			keys[i] = labels.Label{Name: name, Value: o.LabelValue}
+		}
+		return keys
+	}
+
+	expectedRefs := func(b *bucketBlock, name, value string) []storage.SeriesRef {
+		matcher := labels.MustNewMatcher(labels.MatchEqual, name, value)
+		refs, _, err := b.indexReader(selectAllStrategy{}).ExpandedPostings(ctx, []*labels.Matcher{matcher}, newSafeQueryStats())
+		require.NoError(t, err)
+		require.NotEmpty(t, refs, "test setup: expected some series for %s=%s", name, value)
+		return refs
+	}
+
+	expandPostings := func(p index.Postings) []storage.SeriesRef {
+		refs, err := index.ExpandPostings(p)
+		require.NoError(t, err)
+		return refs
+	}
+
+	t.Run("returns correct postings for every value using knownOffsets", func(t *testing.T) {
+		b := newTestBucketBlock()
+		offsets := offsetsForLabel(b, labelName, "")
+		keys := keysFromOffsets(labelName, offsets)
+
+		// With known offsets supplied, FetchPostingsWithKnownOffsets must take the non-nil path and
+		// never resolve an offset with PostingsOffset.
+		iir := &interceptedIndexReader{
+			Reader: b.indexHeaderReader,
+			onPostingsOffsetCalled: func(name, value string) error {
+				return fmt.Errorf("didn't expect a PostingsOffset(%q, %q) call when offsets are known", name, value)
+			},
+		}
+		b.indexHeaderReader = iir
+		ps, err := b.indexReader(selectAllStrategy{}).fetchPostingsWithKnownOffsets(ctx, keys, rangesFromOffsets(offsets), newSafeQueryStats())
+		require.NoError(t, err)
+		require.Len(t, ps, len(keys))
+
+		// reset index header reader so we can properly expand postings to assert correctness against
+		b.indexHeaderReader = iir.Reader
+
+		for i, key := range keys {
+			assert.Equal(t, expectedRefs(b, key.Name, key.Value), expandPostings(ps[i]), "postings for %s=%s", key.Name, key.Value)
+		}
+	})
+
+	t.Run("returns error for mismatched key and offset lengths", func(t *testing.T) {
+		b := newTestBucketBlock()
+		offsets := offsetsForLabel(b, labelName, "")
+		offsetsForPrefix := offsetsForLabel(b, labelName, "1")
+		keys := keysFromOffsets(labelName, offsets)
+
+		ps, err := b.indexReader(selectAllStrategy{}).fetchPostingsWithKnownOffsets(ctx, keys, rangesFromOffsets(offsetsForPrefix), newSafeQueryStats())
+		require.Error(t, err)
+		require.Nil(t, ps)
+	})
+
+	t.Run("returns postings for values matching the prefix", func(t *testing.T) {
+		b := newTestBucketBlock()
+		prefix := "1"
+		offsets := offsetsForLabel(b, labelName, prefix)
+		keys := keysFromOffsets(labelName, offsets)
+
+		ps, err := b.indexReader(selectAllStrategy{}).fetchPostingsWithKnownOffsets(ctx, keys, rangesFromOffsets(offsets), newSafeQueryStats())
+		require.NoError(t, err)
+		require.Len(t, ps, len(keys))
+		for i, key := range keys {
+			require.True(t, strings.HasPrefix(key.Value, prefix), "LabelValuesOffsets returned a value not matching the prefix: %s", key.Value)
+			assert.Equal(t, expectedRefs(b, key.Name, key.Value), expandPostings(ps[i]), "postings for %s=%s", key.Name, key.Value)
+		}
+	})
+
+	t.Run("no keys returns no postings", func(t *testing.T) {
+		b := newTestBucketBlock()
+		ps, err := b.indexReader(selectAllStrategy{}).fetchPostingsWithKnownOffsets(ctx, nil, nil, newSafeQueryStats())
+		require.NoError(t, err)
+		require.Empty(t, ps)
+	})
+
+	t.Run("postings are served from the cache", func(t *testing.T) {
+		b := newTestBucketBlock()
+		b.indexCache = newInMemoryIndexCache(t)
+		offsets := offsetsForLabel(b, labelName, "")
+		keys := keysFromOffsets(labelName, offsets)
+
+		// First call misses cache, does the fetch
+		first, err := b.indexReader(selectAllStrategy{}).fetchPostingsWithKnownOffsets(ctx, keys, rangesFromOffsets(offsets), newSafeQueryStats())
+		require.NoError(t, err)
+		require.Len(t, first, len(keys))
+
+		// The second call passes no known offsets, but should still hit the cache when resolving postings offsets to postings
+		secondCallStats := newSafeQueryStats()
+		second, err := b.indexReader(selectAllStrategy{}).fetchPostingsWithKnownOffsets(ctx, keys, nil, secondCallStats)
+		require.NoError(t, err)
+		require.Len(t, second, len(keys))
+
+		for i, key := range keys {
+			assert.Equal(t, expandPostings(first[i]), expandPostings(second[i]), "postings for %s=%s", key.Name, key.Value)
+		}
+
+		// All postings were served from the cache, so nothing should have been fetched from the bucket.
+		assert.Zero(t, secondCallStats.export().postingsFetchCount)
+	})
+
+}
+
 func newInMemoryIndexCache(t testing.TB) indexcache.IndexCache {
 	cache, err := indexcache.NewInMemoryIndexCacheWithConfig(
 		indexcache.InMemoryIndexCacheConfig{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Before, when we called `labelValuesFromPostings`, we immediately issued a `fetchPostings`. This is cheap for disk-based index header readers, but for the bucket-based reader, it costs bucket ops to fetch offsets (and their postings) which we'd already fetched while expanding postings in `blockLabelValues`. Similarly, when expanding postings, we fetch postings offsets for all posting groups, and then fetch them again in `fetchPostings`.

This PR introduces a new type, `labelPostingOffset`, which is used to pass posting offsets for specific labels down to `fetchPostings` and avoid duplicate index header reads. If a `labelPostingOffset` has a zero-value offset, the index header _will_ be read for that key to check for a valid offset.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
