### PR TITLE
Add offset ranges to jobspec proto in preparation for compartments support

### DIFF
--- a/pkg/blockbuilder/scheduler/jobs.go
+++ b/pkg/blockbuilder/scheduler/jobs.go
@@ -7,11 +7,14 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"slices"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/grafana/mimir/pkg/blockbuilder/schedulerpb"
 )
 
 var (
@@ -338,3 +341,29 @@ func (p noOpJobCreationPolicy[T]) canCreateJob(_ jobKey, _ *T, _ iter.Seq[*T]) e
 }
 
 var _ jobCreationPolicy[any] = (*noOpJobCreationPolicy[any])(nil)
+
+// jobIDForSpec builds a stable ID for a job based on its start offsets.
+// In compartments mode, each cluster's start offset is included in the returned ID.
+func jobIDForSpec(compartmentsEnabled bool, spec *schedulerpb.JobSpec) string {
+	if !compartmentsEnabled {
+		// Non-compartment case (cluster ID not included).
+		return fmt.Sprintf("%s/%d/%d", spec.Topic, spec.Partition, spec.StartOffset)
+	}
+
+	// In compartments mode, sort by cluster ID so the ID is deterministic.
+	clusters := make([]int32, 0, len(spec.OffsetRanges))
+	for clusterID := range spec.OffsetRanges {
+		clusters = append(clusters, clusterID)
+	}
+	slices.Sort(clusters)
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%s/%d/", spec.Topic, spec.Partition)
+	for i, cluster := range clusters {
+		if i > 0 {
+			sb.WriteByte('-')
+		}
+		fmt.Fprintf(&sb, "%d:%d", cluster, spec.OffsetRanges[cluster].StartOffset)
+	}
+	return sb.String()
+}

--- a/pkg/blockbuilder/scheduler/jobs.go
+++ b/pkg/blockbuilder/scheduler/jobs.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+
 	"github.com/grafana/mimir/pkg/blockbuilder/schedulerpb"
 )
 

--- a/pkg/blockbuilder/scheduler/jobs_test.go
+++ b/pkg/blockbuilder/scheduler/jobs_test.go
@@ -13,6 +13,7 @@ import (
 	promtest "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/mimir/pkg/blockbuilder/schedulerpb"
 	"github.com/grafana/mimir/pkg/util/test"
 )
 
@@ -224,6 +225,39 @@ func TestJobCreationPolicies(t *testing.T) {
 		_, ok2 := s.jobs["job2"]
 		require.False(t, ok2, "job2 should not be created")
 	})
+}
+
+func TestJobIDForSpec(t *testing.T) {
+	tests := map[string]struct {
+		compartmentsEnabled bool
+		spec                *schedulerpb.JobSpec
+		expected            string
+	}{
+		"non-compartment mode uses the single start offset": {
+			compartmentsEnabled: false,
+			spec:                &schedulerpb.JobSpec{Topic: "ingest", Partition: 3, StartOffset: 42},
+			expected:            "ingest/3/42",
+		},
+		"compartment mode includes each cluster's start offset sorted by cluster ID": {
+			compartmentsEnabled: true,
+			spec: &schedulerpb.JobSpec{
+				Topic:     "ingest",
+				Partition: 3,
+				OffsetRanges: map[int32]schedulerpb.OffsetRange{
+					2: {StartOffset: 20, EndOffset: 30},
+					0: {StartOffset: 5, EndOffset: 9},
+					1: {StartOffset: 10, EndOffset: 15},
+				},
+			},
+			expected: "ingest/3/0:5-1:10-2:20",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.expected, jobIDForSpec(tc.compartmentsEnabled, tc.spec))
+		})
+	}
 }
 
 // allowNoneJobCreationPolicy is a job creation policy that never allows job creation.

--- a/pkg/blockbuilder/scheduler/scheduler.go
+++ b/pkg/blockbuilder/scheduler/scheduler.go
@@ -280,7 +280,6 @@ func (s *BlockBuilderScheduler) enqueuePendingJobs() {
 				continue
 			}
 
-			// TODO: pass in compartments enabled flag once compartments support is added.
 			jobID := jobIDForSpec(false, spec)
 			if err := s.jobs.add(jobID, *spec); err != nil {
 				if errors.Is(err, errJobCreationDisallowed) || errors.Is(err, errJobAlreadyExists) {

--- a/pkg/blockbuilder/scheduler/scheduler.go
+++ b/pkg/blockbuilder/scheduler/scheduler.go
@@ -280,7 +280,8 @@ func (s *BlockBuilderScheduler) enqueuePendingJobs() {
 				continue
 			}
 
-			jobID := fmt.Sprintf("%s/%d/%d", s.cfg.Kafka.Topic, partition, spec.StartOffset)
+			// TODO: pass in compartments enabled flag once compartments support is added.
+			jobID := jobIDForSpec(false, spec)
 			if err := s.jobs.add(jobID, *spec); err != nil {
 				if errors.Is(err, errJobCreationDisallowed) || errors.Is(err, errJobAlreadyExists) {
 					// We've hit the limit for this partition.

--- a/pkg/blockbuilder/schedulerpb/custom.go
+++ b/pkg/blockbuilder/schedulerpb/custom.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package schedulerpb
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Ranges returns the offset ranges to consume keyed by cluster ID. In non-compartment mode,
+// cluster ID is set to zero.
+func (m JobSpec) Ranges() map[int32]OffsetRange {
+	if len(m.OffsetRanges) > 0 {
+		return m.OffsetRanges
+	}
+	return map[int32]OffsetRange{0: {StartOffset: m.StartOffset, EndOffset: m.EndOffset}}
+}
+
+func (m JobSpec) Validate(compartmentsEnabled bool, numCompartments int) error {
+	if compartmentsEnabled {
+		if m.EndOffset != 0 || m.StartOffset != 0 {
+			return errors.New("start/end_offsets should not be set when compartments is enabled")
+		}
+
+		for id := range m.OffsetRanges {
+			if int(id) >= numCompartments || id < 0 {
+				return fmt.Errorf("invalid compartment id, expecting id between [0,%d) got: %d", numCompartments, id)
+			}
+		}
+	} else {
+		if len(m.OffsetRanges) > 0 {
+			return errors.New("offset_ranges should not be set when compartments is disabled")
+		}
+	}
+	return nil
+}

--- a/pkg/blockbuilder/schedulerpb/custom.go
+++ b/pkg/blockbuilder/schedulerpb/custom.go
@@ -22,6 +22,10 @@ func (m JobSpec) Validate(compartmentsEnabled bool, numCompartments int) error {
 			return errors.New("start/end_offsets should not be set when compartments is enabled")
 		}
 
+		if len(m.OffsetRanges) < 1 {
+			return errors.New("offset_ranges should not be empty when compartments is enabled")
+		}
+
 		for id := range m.OffsetRanges {
 			if int(id) >= numCompartments || id < 0 {
 				return fmt.Errorf("invalid compartment id, expecting id between [0,%d) got: %d", numCompartments, id)

--- a/pkg/blockbuilder/schedulerpb/custom_test.go
+++ b/pkg/blockbuilder/schedulerpb/custom_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package schedulerpb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestJobSpec_Ranges(t *testing.T) {
+	tests := map[string]struct {
+		spec     JobSpec
+		expected map[int32]OffsetRange
+	}{
+		"returns the explicit offset ranges when set": {
+			spec: JobSpec{OffsetRanges: map[int32]OffsetRange{
+				0: {StartOffset: 5, EndOffset: 9},
+				1: {StartOffset: 10, EndOffset: 15},
+			}},
+			expected: map[int32]OffsetRange{
+				0: {StartOffset: 5, EndOffset: 9},
+				1: {StartOffset: 10, EndOffset: 15},
+			},
+		},
+		"derives a single cluster-zero range from start/end offsets": {
+			spec:     JobSpec{StartOffset: 42, EndOffset: 100},
+			expected: map[int32]OffsetRange{0: {StartOffset: 42, EndOffset: 100}},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.expected, tc.spec.Ranges())
+		})
+	}
+}
+
+func TestJobSpec_Validate(t *testing.T) {
+	const numCompartments = 4
+
+	tests := map[string]struct {
+		spec                JobSpec
+		compartmentsEnabled bool
+		expectedErr         string
+	}{
+		"disabled: accepts a single start/end range": {
+			spec:                JobSpec{StartOffset: 1, EndOffset: 5},
+			compartmentsEnabled: false,
+		},
+		"disabled: rejects offset ranges combined with start/end offsets": {
+			spec: JobSpec{
+				StartOffset:  1,
+				EndOffset:    5,
+				OffsetRanges: map[int32]OffsetRange{0: {StartOffset: 1, EndOffset: 5}},
+			},
+			compartmentsEnabled: false,
+			expectedErr:         "offset_ranges should not be set",
+		},
+		"enabled: accepts offset ranges with valid cluster IDs": {
+			spec: JobSpec{OffsetRanges: map[int32]OffsetRange{
+				0: {StartOffset: 1, EndOffset: 5},
+				3: {StartOffset: 2, EndOffset: 8},
+			}},
+			compartmentsEnabled: true,
+		},
+		"enabled: rejects start/end offsets": {
+			spec: JobSpec{
+				StartOffset:  1,
+				EndOffset:    5,
+				OffsetRanges: map[int32]OffsetRange{0: {StartOffset: 1, EndOffset: 5}},
+			},
+			compartmentsEnabled: true,
+			expectedErr:         "start/end_offsets should not be set",
+		},
+		"enabled: rejects a cluster ID outside the valid range": {
+			spec:                JobSpec{OffsetRanges: map[int32]OffsetRange{numCompartments: {StartOffset: 1, EndOffset: 5}}},
+			compartmentsEnabled: true,
+			expectedErr:         "invalid compartment id",
+		},
+		"enabled: rejects a negative cluster ID": {
+			spec:                JobSpec{OffsetRanges: map[int32]OffsetRange{-1: {StartOffset: 1, EndOffset: 5}}},
+			compartmentsEnabled: true,
+			expectedErr:         "invalid compartment id",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := tc.spec.Validate(tc.compartmentsEnabled, numCompartments)
+			if tc.expectedErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tc.expectedErr)
+		})
+	}
+}

--- a/pkg/blockbuilder/schedulerpb/custom_test.go
+++ b/pkg/blockbuilder/schedulerpb/custom_test.go
@@ -83,6 +83,11 @@ func TestJobSpec_Validate(t *testing.T) {
 			compartmentsEnabled: true,
 			expectedErr:         "invalid compartment id",
 		},
+		"enabled: rejects empty range": {
+			spec:                JobSpec{OffsetRanges: map[int32]OffsetRange{}},
+			compartmentsEnabled: true,
+			expectedErr:         "offset_ranges should not be empty when compartments is enabled",
+		},
 	}
 
 	for name, tc := range tests {

--- a/pkg/blockbuilder/schedulerpb/scheduler.pb.go
+++ b/pkg/blockbuilder/schedulerpb/scheduler.pb.go
@@ -8,6 +8,7 @@ import (
 	fmt "fmt"
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
+	github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -81,10 +82,18 @@ func (m *JobKey) GetEpoch() int64 {
 }
 
 type JobSpec struct {
-	Topic       string `protobuf:"bytes,1,opt,name=topic,proto3" json:"topic,omitempty"`
-	Partition   int32  `protobuf:"varint,2,opt,name=partition,proto3" json:"partition,omitempty"`
-	StartOffset int64  `protobuf:"varint,3,opt,name=start_offset,json=startOffset,proto3" json:"start_offset,omitempty"`
-	EndOffset   int64  `protobuf:"varint,4,opt,name=end_offset,json=endOffset,proto3" json:"end_offset,omitempty"`
+	Topic     string `protobuf:"bytes,1,opt,name=topic,proto3" json:"topic,omitempty"`
+	Partition int32  `protobuf:"varint,2,opt,name=partition,proto3" json:"partition,omitempty"`
+	// Non-compartment mode: the single [start_offset, end_offset) range to
+	// consume. Used when compartments are disabled.
+	StartOffset int64 `protobuf:"varint,3,opt,name=start_offset,json=startOffset,proto3" json:"start_offset,omitempty"`
+	EndOffset   int64 `protobuf:"varint,4,opt,name=end_offset,json=endOffset,proto3" json:"end_offset,omitempty"`
+	// Compartment mode: one [start_offset, end_offset) range per cluster, keyed by
+	// cluster ID. When compartments are enabled, these are consumed instead of
+	// start_offset/end_offset. Only clusters with new data to consume are
+	// included; clusters with nothing to consume are omitted.
+	// Compartments support is experimental, so this field may change without warning.
+	OffsetRanges map[int32]OffsetRange `protobuf:"bytes,5,rep,name=offset_ranges,json=offsetRanges,proto3" json:"offset_ranges" protobuf_key:"varint,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 }
 
 func (m *JobSpec) Reset()      { *m = JobSpec{} }
@@ -147,6 +156,67 @@ func (m *JobSpec) GetEndOffset() int64 {
 	return 0
 }
 
+func (m *JobSpec) GetOffsetRanges() map[int32]OffsetRange {
+	if m != nil {
+		return m.OffsetRanges
+	}
+	return nil
+}
+
+// OffsetRange is the range of offsets to consume from a single Kafka cluster's partition.
+type OffsetRange struct {
+	// start_offset is inclusive.
+	StartOffset int64 `protobuf:"varint,1,opt,name=start_offset,json=startOffset,proto3" json:"start_offset,omitempty"`
+	// end_offset is exclusive.
+	EndOffset int64 `protobuf:"varint,2,opt,name=end_offset,json=endOffset,proto3" json:"end_offset,omitempty"`
+}
+
+func (m *OffsetRange) Reset()      { *m = OffsetRange{} }
+func (*OffsetRange) ProtoMessage() {}
+func (*OffsetRange) Descriptor() ([]byte, []int) {
+	return fileDescriptor_2b3fc28395a6d9c5, []int{2}
+}
+func (m *OffsetRange) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *OffsetRange) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_OffsetRange.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *OffsetRange) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_OffsetRange.Merge(m, src)
+}
+func (m *OffsetRange) XXX_Size() int {
+	return m.Size()
+}
+func (m *OffsetRange) XXX_DiscardUnknown() {
+	xxx_messageInfo_OffsetRange.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_OffsetRange proto.InternalMessageInfo
+
+func (m *OffsetRange) GetStartOffset() int64 {
+	if m != nil {
+		return m.StartOffset
+	}
+	return 0
+}
+
+func (m *OffsetRange) GetEndOffset() int64 {
+	if m != nil {
+		return m.EndOffset
+	}
+	return 0
+}
+
 type AssignJobRequest struct {
 	WorkerId string `protobuf:"bytes,1,opt,name=worker_id,json=workerId,proto3" json:"worker_id,omitempty"`
 }
@@ -154,7 +224,7 @@ type AssignJobRequest struct {
 func (m *AssignJobRequest) Reset()      { *m = AssignJobRequest{} }
 func (*AssignJobRequest) ProtoMessage() {}
 func (*AssignJobRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_2b3fc28395a6d9c5, []int{2}
+	return fileDescriptor_2b3fc28395a6d9c5, []int{3}
 }
 func (m *AssignJobRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -198,7 +268,7 @@ type AssignJobResponse struct {
 func (m *AssignJobResponse) Reset()      { *m = AssignJobResponse{} }
 func (*AssignJobResponse) ProtoMessage() {}
 func (*AssignJobResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_2b3fc28395a6d9c5, []int{3}
+	return fileDescriptor_2b3fc28395a6d9c5, []int{4}
 }
 func (m *AssignJobResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -251,7 +321,7 @@ type UpdateJobRequest struct {
 func (m *UpdateJobRequest) Reset()      { *m = UpdateJobRequest{} }
 func (*UpdateJobRequest) ProtoMessage() {}
 func (*UpdateJobRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_2b3fc28395a6d9c5, []int{4}
+	return fileDescriptor_2b3fc28395a6d9c5, []int{5}
 }
 func (m *UpdateJobRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -314,7 +384,7 @@ type UpdateJobResponse struct {
 func (m *UpdateJobResponse) Reset()      { *m = UpdateJobResponse{} }
 func (*UpdateJobResponse) ProtoMessage() {}
 func (*UpdateJobResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_2b3fc28395a6d9c5, []int{5}
+	return fileDescriptor_2b3fc28395a6d9c5, []int{6}
 }
 func (m *UpdateJobResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -346,6 +416,8 @@ var xxx_messageInfo_UpdateJobResponse proto.InternalMessageInfo
 func init() {
 	proto.RegisterType((*JobKey)(nil), "schedulerpb.JobKey")
 	proto.RegisterType((*JobSpec)(nil), "schedulerpb.JobSpec")
+	proto.RegisterMapType((map[int32]OffsetRange)(nil), "schedulerpb.JobSpec.OffsetRangesEntry")
+	proto.RegisterType((*OffsetRange)(nil), "schedulerpb.OffsetRange")
 	proto.RegisterType((*AssignJobRequest)(nil), "schedulerpb.AssignJobRequest")
 	proto.RegisterType((*AssignJobResponse)(nil), "schedulerpb.AssignJobResponse")
 	proto.RegisterType((*UpdateJobRequest)(nil), "schedulerpb.UpdateJobRequest")
@@ -355,35 +427,40 @@ func init() {
 func init() { proto.RegisterFile("scheduler.proto", fileDescriptor_2b3fc28395a6d9c5) }
 
 var fileDescriptor_2b3fc28395a6d9c5 = []byte{
-	// 433 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x92, 0xc1, 0x6e, 0xd3, 0x40,
-	0x10, 0x86, 0xbd, 0x76, 0x5b, 0xe2, 0x31, 0x82, 0x76, 0x1b, 0xa4, 0x28, 0xd0, 0x55, 0xb1, 0x84,
-	0x94, 0x93, 0x2b, 0x05, 0x5e, 0x80, 0xdc, 0x30, 0x07, 0x24, 0x57, 0x9c, 0xab, 0xd8, 0x3b, 0x4d,
-	0xad, 0x18, 0xef, 0xe2, 0xdd, 0x08, 0xf5, 0x04, 0x8f, 0xc0, 0x03, 0xf0, 0x00, 0xdc, 0x78, 0x0d,
-	0x8e, 0x39, 0xf6, 0x48, 0x9c, 0x0b, 0xc7, 0x3c, 0x02, 0xf2, 0x3a, 0x31, 0x8e, 0x11, 0x82, 0x9b,
-	0xe7, 0x9f, 0x7f, 0x66, 0xfe, 0xfd, 0x64, 0x78, 0xa8, 0x92, 0x1b, 0xe4, 0x8b, 0x0c, 0x8b, 0x40,
-	0x16, 0x42, 0x0b, 0xea, 0x35, 0x82, 0x8c, 0x87, 0xfd, 0x99, 0x98, 0x09, 0xa3, 0x5f, 0x54, 0x5f,
-	0xb5, 0xc5, 0x0f, 0xe0, 0x28, 0x14, 0xf1, 0x6b, 0xbc, 0xa5, 0x0f, 0xc0, 0x4e, 0xf9, 0x80, 0x9c,
-	0x93, 0x91, 0x1b, 0xd9, 0x29, 0xa7, 0x7d, 0x38, 0x44, 0x29, 0x92, 0x9b, 0x81, 0x7d, 0x4e, 0x46,
-	0x4e, 0x54, 0x17, 0xfe, 0x47, 0xb8, 0x17, 0x8a, 0xf8, 0x52, 0x62, 0x52, 0x19, 0xb4, 0x90, 0x69,
-	0xb2, 0x9d, 0xa9, 0x0b, 0xfa, 0x04, 0x5c, 0x39, 0x2d, 0x74, 0xaa, 0x53, 0x91, 0x9b, 0xd1, 0xc3,
-	0xe8, 0xb7, 0x40, 0x9f, 0xc2, 0x7d, 0xa5, 0xa7, 0x85, 0xbe, 0x12, 0xd7, 0xd7, 0x0a, 0xf5, 0xc0,
-	0x31, 0xbb, 0x3d, 0xa3, 0xbd, 0x31, 0x12, 0x3d, 0x03, 0xc0, 0x9c, 0xef, 0x0c, 0x07, 0xc6, 0xe0,
-	0x62, 0xce, 0xeb, 0xb6, 0x7f, 0x01, 0xc7, 0x2f, 0x95, 0x4a, 0x67, 0x79, 0x28, 0xe2, 0x08, 0xdf,
-	0x2f, 0x50, 0x69, 0xfa, 0x18, 0xdc, 0x0f, 0xa2, 0x98, 0x63, 0x71, 0xd5, 0xbc, 0xa0, 0x57, 0x0b,
-	0xaf, 0xb8, 0xcf, 0xe1, 0xa4, 0x35, 0xa0, 0xa4, 0xc8, 0x15, 0xd2, 0x67, 0xe0, 0xcc, 0xf1, 0xd6,
-	0x78, 0xbd, 0xf1, 0x69, 0xd0, 0xe2, 0x14, 0xd4, 0x38, 0xa2, 0xaa, 0x4f, 0x47, 0x70, 0xa0, 0x24,
-	0x26, 0xe6, 0x1d, 0xde, 0xb8, 0xdf, 0xf5, 0x55, 0x18, 0x22, 0xe3, 0xf0, 0xbf, 0x10, 0x38, 0x7e,
-	0x2b, 0xf9, 0x54, 0x63, 0x2b, 0xd7, 0x7f, 0x5e, 0xd9, 0x8b, 0x6f, 0xef, 0xc7, 0x6f, 0x22, 0x38,
-	0xff, 0x8a, 0x40, 0x87, 0xd0, 0x4b, 0xc4, 0x3b, 0x99, 0xa1, 0x46, 0x83, 0xad, 0x17, 0x35, 0xb5,
-	0x7f, 0x0a, 0x27, 0xad, 0x74, 0x35, 0x84, 0xf1, 0x37, 0x02, 0x8f, 0x26, 0x99, 0x48, 0xe6, 0x93,
-	0x45, 0x9a, 0x71, 0x2c, 0x2e, 0x77, 0xab, 0x69, 0x08, 0x6e, 0xc3, 0x8c, 0x9e, 0xed, 0xdd, 0xec,
-	0xc2, 0x1f, 0xb2, 0xbf, 0xb5, 0xb7, 0xa8, 0x43, 0x70, 0x9b, 0xd3, 0x9d, 0x5d, 0x5d, 0x60, 0x9d,
-	0x5d, 0x7f, 0x24, 0x9e, 0xbc, 0x58, 0xae, 0x98, 0x75, 0xb7, 0x62, 0xd6, 0x66, 0xc5, 0xc8, 0xa7,
-	0x92, 0x91, 0xaf, 0x25, 0x23, 0xdf, 0x4b, 0x46, 0x96, 0x25, 0x23, 0x3f, 0x4a, 0x46, 0x7e, 0x96,
-	0xcc, 0xda, 0x94, 0x8c, 0x7c, 0x5e, 0x33, 0x6b, 0xb9, 0x66, 0xd6, 0xdd, 0x9a, 0x59, 0xf1, 0x91,
-	0xf9, 0xd5, 0x9f, 0xff, 0x0a, 0x00, 0x00, 0xff, 0xff, 0x3d, 0xa0, 0x63, 0x35, 0x20, 0x03, 0x00,
-	0x00,
+	// 524 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x53, 0xc1, 0x6e, 0xd3, 0x40,
+	0x10, 0xf5, 0x3a, 0x4d, 0x89, 0xc7, 0x05, 0x92, 0x6d, 0x90, 0xa2, 0x40, 0x97, 0x60, 0x09, 0x94,
+	0x93, 0x2b, 0x05, 0x0e, 0x88, 0x1b, 0x91, 0x38, 0x90, 0x1e, 0x2a, 0x5c, 0x71, 0xe0, 0x14, 0x25,
+	0xf6, 0x34, 0xb5, 0x12, 0xbc, 0x8b, 0x77, 0x03, 0xca, 0x8d, 0x4f, 0xe0, 0x03, 0xf8, 0x00, 0x2e,
+	0x88, 0xdf, 0xe8, 0x31, 0xc7, 0x9e, 0x10, 0x71, 0x2e, 0x1c, 0xfb, 0x09, 0x28, 0xeb, 0xd4, 0x75,
+	0x1c, 0x50, 0xb9, 0xed, 0xbc, 0x79, 0x33, 0xf3, 0xde, 0x4b, 0x0c, 0x77, 0xa5, 0x7f, 0x86, 0xc1,
+	0x74, 0x82, 0xb1, 0x2b, 0x62, 0xae, 0x38, 0xb5, 0x33, 0x40, 0x0c, 0x9b, 0xf5, 0x11, 0x1f, 0x71,
+	0x8d, 0x1f, 0xae, 0x5e, 0x29, 0xc5, 0x71, 0x61, 0xb7, 0xc7, 0x87, 0x47, 0x38, 0xa3, 0x77, 0xc0,
+	0x0c, 0x83, 0x06, 0x69, 0x91, 0xb6, 0xe5, 0x99, 0x61, 0x40, 0xeb, 0x50, 0x46, 0xc1, 0xfd, 0xb3,
+	0x86, 0xd9, 0x22, 0xed, 0x92, 0x97, 0x16, 0xce, 0x77, 0x13, 0x6e, 0xf5, 0xf8, 0xf0, 0x44, 0xa0,
+	0xbf, 0x62, 0x28, 0x2e, 0x42, 0x7f, 0x3d, 0x94, 0x16, 0xf4, 0x01, 0x58, 0x62, 0x10, 0xab, 0x50,
+	0x85, 0x3c, 0xd2, 0xb3, 0x65, 0xef, 0x1a, 0xa0, 0x8f, 0x60, 0x4f, 0xaa, 0x41, 0xac, 0xfa, 0xfc,
+	0xf4, 0x54, 0xa2, 0x6a, 0x94, 0xf4, 0x72, 0x5b, 0x63, 0xc7, 0x1a, 0xa2, 0x07, 0x00, 0x18, 0x05,
+	0x57, 0x84, 0x1d, 0x4d, 0xb0, 0x30, 0x0a, 0xd6, 0xed, 0x37, 0x70, 0x3b, 0x6d, 0xf5, 0xe3, 0x41,
+	0x34, 0x42, 0xd9, 0x28, 0xb7, 0x4a, 0x6d, 0xbb, 0xf3, 0xc4, 0xcd, 0x99, 0x75, 0xd7, 0x12, 0xdd,
+	0x74, 0xc6, 0xd3, 0xc4, 0x57, 0x91, 0x8a, 0x67, 0xdd, 0x9d, 0xf3, 0x9f, 0x0f, 0x0d, 0x6f, 0x8f,
+	0xe7, 0x1a, 0xcd, 0x77, 0x50, 0xdb, 0x22, 0xd2, 0x2a, 0x94, 0xc6, 0x38, 0xd3, 0xde, 0xca, 0xde,
+	0xea, 0x49, 0x5d, 0x28, 0x7f, 0x1c, 0x4c, 0xa6, 0xa8, 0x5d, 0xd9, 0x9d, 0xc6, 0xc6, 0xc5, 0xdc,
+	0x02, 0x2f, 0xa5, 0xbd, 0x30, 0x9f, 0x13, 0xe7, 0x18, 0xec, 0x5c, 0x67, 0xcb, 0x3e, 0xb9, 0xc9,
+	0xbe, 0x59, 0xb0, 0xef, 0x1c, 0x42, 0xf5, 0xa5, 0x94, 0xe1, 0x28, 0xea, 0xf1, 0xa1, 0x87, 0x1f,
+	0xa6, 0x28, 0x15, 0xbd, 0x0f, 0xd6, 0x27, 0x1e, 0x8f, 0x31, 0xee, 0x67, 0xbf, 0x60, 0x25, 0x05,
+	0x5e, 0x07, 0x4e, 0x00, 0xb5, 0xdc, 0x80, 0x14, 0x3c, 0x92, 0x48, 0x1f, 0x5f, 0x9b, 0xb3, 0x3b,
+	0xfb, 0xc5, 0xe8, 0x8e, 0x70, 0x96, 0x3a, 0x6e, 0xc3, 0x8e, 0x14, 0xe8, 0xaf, 0x0d, 0xd7, 0xff,
+	0x16, 0xb1, 0xa7, 0x19, 0xce, 0x57, 0x02, 0xd5, 0xb7, 0x22, 0x18, 0x28, 0xcc, 0xe9, 0xfa, 0xcf,
+	0x2b, 0x1b, 0xf2, 0xcd, 0x4d, 0xf9, 0x99, 0x84, 0xd2, 0x4d, 0x12, 0x68, 0x13, 0x2a, 0x3e, 0x7f,
+	0x2f, 0x26, 0xa8, 0x50, 0xff, 0x6b, 0x2a, 0x5e, 0x56, 0x3b, 0xfb, 0x50, 0xcb, 0xa9, 0x4b, 0x43,
+	0xe8, 0xfc, 0x20, 0x70, 0xaf, 0x3b, 0xe1, 0xfe, 0xb8, 0x3b, 0x0d, 0x27, 0x01, 0xc6, 0x27, 0x57,
+	0xab, 0x69, 0x0f, 0xac, 0x2c, 0x33, 0x7a, 0xb0, 0x71, 0xb3, 0x18, 0x7e, 0x93, 0xfd, 0xab, 0xbd,
+	0x8e, 0xba, 0x07, 0x56, 0x76, 0xba, 0xb0, 0xab, 0x18, 0x58, 0x61, 0xd7, 0x96, 0xe2, 0xee, 0xb3,
+	0xf9, 0x82, 0x19, 0x17, 0x0b, 0x66, 0x5c, 0x2e, 0x18, 0xf9, 0x9c, 0x30, 0xf2, 0x2d, 0x61, 0xe4,
+	0x3c, 0x61, 0x64, 0x9e, 0x30, 0xf2, 0x2b, 0x61, 0xe4, 0x77, 0xc2, 0x8c, 0xcb, 0x84, 0x91, 0x2f,
+	0x4b, 0x66, 0xcc, 0x97, 0xcc, 0xb8, 0x58, 0x32, 0x63, 0xb8, 0xab, 0x3f, 0xf5, 0xa7, 0x7f, 0x02,
+	0x00, 0x00, 0xff, 0xff, 0x59, 0xc8, 0x70, 0xea, 0x20, 0x04, 0x00, 0x00,
 }
 
 func (this *JobKey) Equal(that interface{}) bool {
@@ -436,6 +513,43 @@ func (this *JobSpec) Equal(that interface{}) bool {
 		return false
 	}
 	if this.Partition != that1.Partition {
+		return false
+	}
+	if this.StartOffset != that1.StartOffset {
+		return false
+	}
+	if this.EndOffset != that1.EndOffset {
+		return false
+	}
+	if len(this.OffsetRanges) != len(that1.OffsetRanges) {
+		return false
+	}
+	for i := range this.OffsetRanges {
+		a := this.OffsetRanges[i]
+		b := that1.OffsetRanges[i]
+		if !(&a).Equal(&b) {
+			return false
+		}
+	}
+	return true
+}
+func (this *OffsetRange) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*OffsetRange)
+	if !ok {
+		that2, ok := that.(OffsetRange)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
 		return false
 	}
 	if this.StartOffset != that1.StartOffset {
@@ -566,10 +680,34 @@ func (this *JobSpec) GoString() string {
 	if this == nil {
 		return "nil"
 	}
-	s := make([]string, 0, 8)
+	s := make([]string, 0, 9)
 	s = append(s, "&schedulerpb.JobSpec{")
 	s = append(s, "Topic: "+fmt.Sprintf("%#v", this.Topic)+",\n")
 	s = append(s, "Partition: "+fmt.Sprintf("%#v", this.Partition)+",\n")
+	s = append(s, "StartOffset: "+fmt.Sprintf("%#v", this.StartOffset)+",\n")
+	s = append(s, "EndOffset: "+fmt.Sprintf("%#v", this.EndOffset)+",\n")
+	keysForOffsetRanges := make([]int32, 0, len(this.OffsetRanges))
+	for k, _ := range this.OffsetRanges {
+		keysForOffsetRanges = append(keysForOffsetRanges, k)
+	}
+	github_com_gogo_protobuf_sortkeys.Int32s(keysForOffsetRanges)
+	mapStringForOffsetRanges := "map[int32]OffsetRange{"
+	for _, k := range keysForOffsetRanges {
+		mapStringForOffsetRanges += fmt.Sprintf("%#v: %#v,", k, this.OffsetRanges[k])
+	}
+	mapStringForOffsetRanges += "}"
+	if this.OffsetRanges != nil {
+		s = append(s, "OffsetRanges: "+mapStringForOffsetRanges+",\n")
+	}
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *OffsetRange) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 6)
+	s = append(s, "&schedulerpb.OffsetRange{")
 	s = append(s, "StartOffset: "+fmt.Sprintf("%#v", this.StartOffset)+",\n")
 	s = append(s, "EndOffset: "+fmt.Sprintf("%#v", this.EndOffset)+",\n")
 	s = append(s, "}")
@@ -806,6 +944,28 @@ func (m *JobSpec) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if len(m.OffsetRanges) > 0 {
+		for k := range m.OffsetRanges {
+			v := m.OffsetRanges[k]
+			baseI := i
+			{
+				size, err := (&v).MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintScheduler(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x12
+			i = encodeVarintScheduler(dAtA, i, uint64(k))
+			i--
+			dAtA[i] = 0x8
+			i = encodeVarintScheduler(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x2a
+		}
+	}
 	if m.EndOffset != 0 {
 		i = encodeVarintScheduler(dAtA, i, uint64(m.EndOffset))
 		i--
@@ -827,6 +987,39 @@ func (m *JobSpec) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		i = encodeVarintScheduler(dAtA, i, uint64(len(m.Topic)))
 		i--
 		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *OffsetRange) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *OffsetRange) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *OffsetRange) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.EndOffset != 0 {
+		i = encodeVarintScheduler(dAtA, i, uint64(m.EndOffset))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.StartOffset != 0 {
+		i = encodeVarintScheduler(dAtA, i, uint64(m.StartOffset))
+		i--
+		dAtA[i] = 0x8
 	}
 	return len(dAtA) - i, nil
 }
@@ -1041,6 +1234,30 @@ func (m *JobSpec) Size() (n int) {
 	if m.EndOffset != 0 {
 		n += 1 + sovScheduler(uint64(m.EndOffset))
 	}
+	if len(m.OffsetRanges) > 0 {
+		for k, v := range m.OffsetRanges {
+			_ = k
+			_ = v
+			l = v.Size()
+			mapEntrySize := 1 + sovScheduler(uint64(k)) + 1 + l + sovScheduler(uint64(l))
+			n += mapEntrySize + 1 + sovScheduler(uint64(mapEntrySize))
+		}
+	}
+	return n
+}
+
+func (m *OffsetRange) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.StartOffset != 0 {
+		n += 1 + sovScheduler(uint64(m.StartOffset))
+	}
+	if m.EndOffset != 0 {
+		n += 1 + sovScheduler(uint64(m.EndOffset))
+	}
 	return n
 }
 
@@ -1128,9 +1345,31 @@ func (this *JobSpec) String() string {
 	if this == nil {
 		return "nil"
 	}
+	keysForOffsetRanges := make([]int32, 0, len(this.OffsetRanges))
+	for k, _ := range this.OffsetRanges {
+		keysForOffsetRanges = append(keysForOffsetRanges, k)
+	}
+	github_com_gogo_protobuf_sortkeys.Int32s(keysForOffsetRanges)
+	mapStringForOffsetRanges := "map[int32]OffsetRange{"
+	for _, k := range keysForOffsetRanges {
+		mapStringForOffsetRanges += fmt.Sprintf("%v: %v,", k, this.OffsetRanges[k])
+	}
+	mapStringForOffsetRanges += "}"
 	s := strings.Join([]string{`&JobSpec{`,
 		`Topic:` + fmt.Sprintf("%v", this.Topic) + `,`,
 		`Partition:` + fmt.Sprintf("%v", this.Partition) + `,`,
+		`StartOffset:` + fmt.Sprintf("%v", this.StartOffset) + `,`,
+		`EndOffset:` + fmt.Sprintf("%v", this.EndOffset) + `,`,
+		`OffsetRanges:` + mapStringForOffsetRanges + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *OffsetRange) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&OffsetRange{`,
 		`StartOffset:` + fmt.Sprintf("%v", this.StartOffset) + `,`,
 		`EndOffset:` + fmt.Sprintf("%v", this.EndOffset) + `,`,
 		`}`,
@@ -1389,6 +1628,209 @@ func (m *JobSpec) Unmarshal(dAtA []byte) error {
 				}
 			}
 		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field EndOffset", wireType)
+			}
+			m.EndOffset = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowScheduler
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.EndOffset |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field OffsetRanges", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowScheduler
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthScheduler
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthScheduler
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.OffsetRanges == nil {
+				m.OffsetRanges = make(map[int32]OffsetRange)
+			}
+			var mapkey int32
+			mapvalue := &OffsetRange{}
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return ErrIntOverflowScheduler
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowScheduler
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						mapkey |= int32(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+				} else if fieldNum == 2 {
+					var mapmsglen int
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowScheduler
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						mapmsglen |= int(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					if mapmsglen < 0 {
+						return ErrInvalidLengthScheduler
+					}
+					postmsgIndex := iNdEx + mapmsglen
+					if postmsgIndex < 0 {
+						return ErrInvalidLengthScheduler
+					}
+					if postmsgIndex > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = &OffsetRange{}
+					if err := mapvalue.Unmarshal(dAtA[iNdEx:postmsgIndex]); err != nil {
+						return err
+					}
+					iNdEx = postmsgIndex
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := skipScheduler(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return ErrInvalidLengthScheduler
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.OffsetRanges[mapkey] = *mapvalue
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipScheduler(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthScheduler
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *OffsetRange) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowScheduler
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: OffsetRange: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: OffsetRange: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field StartOffset", wireType)
+			}
+			m.StartOffset = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowScheduler
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.StartOffset |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field EndOffset", wireType)
 			}

--- a/pkg/blockbuilder/schedulerpb/scheduler.pb.go
+++ b/pkg/blockbuilder/schedulerpb/scheduler.pb.go
@@ -93,7 +93,6 @@ type JobSpec struct {
 	// start_offset/end_offset. Only clusters with new data to consume are
 	// included; clusters with nothing to consume are omitted.
 	// There should be at least one offset range set if compartments are enabled.
-	// Compartments support is experimental, so this field may change without warning.
 	OffsetRanges map[int32]OffsetRange `protobuf:"bytes,5,rep,name=offset_ranges,json=offsetRanges,proto3" json:"offset_ranges" protobuf_key:"varint,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 }
 

--- a/pkg/blockbuilder/schedulerpb/scheduler.pb.go
+++ b/pkg/blockbuilder/schedulerpb/scheduler.pb.go
@@ -92,6 +92,7 @@ type JobSpec struct {
 	// cluster ID. When compartments are enabled, these are consumed instead of
 	// start_offset/end_offset. Only clusters with new data to consume are
 	// included; clusters with nothing to consume are omitted.
+	// There should be at least one offset range set if compartments are enabled.
 	// Compartments support is experimental, so this field may change without warning.
 	OffsetRanges map[int32]OffsetRange `protobuf:"bytes,5,rep,name=offset_ranges,json=offsetRanges,proto3" json:"offset_ranges" protobuf_key:"varint,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 }

--- a/pkg/blockbuilder/schedulerpb/scheduler.proto
+++ b/pkg/blockbuilder/schedulerpb/scheduler.proto
@@ -28,7 +28,6 @@ message JobSpec {
   // start_offset/end_offset. Only clusters with new data to consume are
   // included; clusters with nothing to consume are omitted.
   // There should be at least one offset range set if compartments are enabled.
-  // Compartments support is experimental, so this field may change without warning.
   map<int32, OffsetRange> offset_ranges = 5 [(gogoproto.nullable) = false];
 }
 

--- a/pkg/blockbuilder/schedulerpb/scheduler.proto
+++ b/pkg/blockbuilder/schedulerpb/scheduler.proto
@@ -17,8 +17,26 @@ message JobKey {
 message JobSpec {
   string topic = 1;
   int32 partition = 2;
+
+  // Non-compartment mode: the single [start_offset, end_offset) range to
+  // consume. Used when compartments are disabled.
   int64 start_offset = 3;
   int64 end_offset = 4;
+
+  // Compartment mode: one [start_offset, end_offset) range per cluster, keyed by
+  // cluster ID. When compartments are enabled, these are consumed instead of
+  // start_offset/end_offset. Only clusters with new data to consume are
+  // included; clusters with nothing to consume are omitted.
+  // Compartments support is experimental, so this field may change without warning.
+  map<int32, OffsetRange> offset_ranges = 5 [(gogoproto.nullable) = false];
+}
+
+// OffsetRange is the range of offsets to consume from a single Kafka cluster's partition.
+message OffsetRange {
+  // start_offset is inclusive.
+  int64 start_offset = 1;
+  // end_offset is exclusive.
+  int64 end_offset = 2;
 }
 
 service BlockBuilderScheduler {

--- a/pkg/blockbuilder/schedulerpb/scheduler.proto
+++ b/pkg/blockbuilder/schedulerpb/scheduler.proto
@@ -27,6 +27,7 @@ message JobSpec {
   // cluster ID. When compartments are enabled, these are consumed instead of
   // start_offset/end_offset. Only clusters with new data to consume are
   // included; clusters with nothing to consume are omitted.
+  // There should be at least one offset range set if compartments are enabled.
   // Compartments support is experimental, so this field may change without warning.
   map<int32, OffsetRange> offset_ranges = 5 [(gogoproto.nullable) = false];
 }


### PR DESCRIPTION
#### What this PR does
Split off from https://github.com/grafana/mimir/pull/15774

Add `OffsetRanges` field to `JobSpec` proto, which will be used in compartments mode, and a few helper functions, some of which are not called yet.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
