### PR TITLE
Compartments: move Kafka address to _config and add blocks-storage bucket helpers

### DIFF
--- a/operations/mimir-tests/test-compartments-config-validation.jsonnet
+++ b/operations/mimir-tests/test-compartments-config-validation.jsonnet
@@ -132,7 +132,7 @@ assert isError(err9, '-distributor.write-compartment-id=1') && isError(err9, 'do
 local err10 = validate(
   { gf: overrideContainerArgs(
     distributor { metadata+: { name: 'distributor' } },
-    ['-ingest-storage.kafka.address=' + env.compartments_ingest_storage_kafka_address],
+    ['-ingest-storage.kafka.address=' + env._config.compartments_ingest_storage_kafka_address],
   ) },
   ['gf'],
 );

--- a/operations/mimir/compartments-common.libsonnet
+++ b/operations/mimir/compartments-common.libsonnet
@@ -21,8 +21,7 @@ local jsonpath = import 'github.com/jsonnet-libs/xtd/jsonpath.libsonnet';
 
     // Blocks-storage bucket per read compartment. Must contain the '<read-compartment-id>' placeholder,
     // which the querier replaces with each read compartment index to read that compartment's bucket (each
-    // read compartment's store-gateways and compactors own a dedicated bucket). Defaults to the
-    // non-compartment bucket name with a per-compartment suffix.
+    // read compartment's store-gateways and compactors own a dedicated bucket).
     compartments_blocks_storage_bucket_name: '%s-rc-<read-compartment-id>' % $._config.blocks_storage_bucket_name,
   },
 

--- a/operations/mimir/compartments-common.libsonnet
+++ b/operations/mimir/compartments-common.libsonnet
@@ -12,6 +12,18 @@ local jsonpath = import 'github.com/jsonnet-libs/xtd/jsonpath.libsonnet';
     // Kafka topic produced/consumed per read compartment. Must contain the '<read-compartment-id>'
     // placeholder, which Mimir replaces with the read compartment index at runtime.
     compartments_ingest_storage_kafka_topic: 'ingest-rc-<read-compartment-id>',
+
+    // Kafka cluster address template for compartment components. Carries the '<write-compartment-id>'
+    // placeholder, which Mimir replaces with the write compartment index at runtime (distributors target
+    // their own cluster; ingesters consume from every write compartment's cluster). Mimir's jsonnet does
+    // not deploy Kafka, so this is a fictitious address mirroring the non-compartment default.
+    compartments_ingest_storage_kafka_address: 'kafka-wc-<write-compartment-id>.%(namespace)s.svc.%(cluster_domain)s:9092' % $._config,
+
+    // Blocks-storage bucket per read compartment. Must contain the '<read-compartment-id>' placeholder,
+    // which the querier replaces with each read compartment index to read that compartment's bucket (each
+    // read compartment's store-gateways and compactors own a dedicated bucket). Defaults to the
+    // non-compartment bucket name with a per-compartment suffix.
+    compartments_blocks_storage_bucket_name: '%s-rc-<read-compartment-id>' % $._config.blocks_storage_bucket_name,
   },
 
   assert $._config.compartments_read_count >= 1 : 'compartments_read_count must be >= 1',
@@ -20,11 +32,19 @@ local jsonpath = import 'github.com/jsonnet-libs/xtd/jsonpath.libsonnet';
   assert !$._config.compartments_enabled || $._config.ruler_remote_evaluation_enabled
          : 'compartments require ruler remote rule evaluation (ruler_remote_evaluation_enabled)',
 
-  // Kafka cluster address template for compartment components. Carries the '<write-compartment-id>'
-  // placeholder, which Mimir replaces with the write compartment index at runtime (distributors target
-  // their own cluster; ingesters consume from every write compartment's cluster). Mimir's jsonnet does
-  // not deploy Kafka, so this is a fictitious address mirroring the non-compartment default.
-  compartments_ingest_storage_kafka_address:: 'kafka-wc-<write-compartment-id>.%(namespace)s.svc.%(cluster_domain)s:9092' % $._config,
+  assert !$._config.compartments_enabled || std.length(std.findSubstr('<read-compartment-id>', $._config.compartments_blocks_storage_bucket_name)) > 0
+         : 'compartments_blocks_storage_bucket_name must contain the "<read-compartment-id>" placeholder',
+
+  // Concrete blocks-storage bucket name for the given read compartment, resolving the
+  // '<read-compartment-id>' placeholder in compartments_blocks_storage_bucket_name.
+  mimirBlocksStorageCompartmentBucketName(compartmentID):: std.strReplace($._config.compartments_blocks_storage_bucket_name, '<read-compartment-id>', std.toString(compartmentID)),
+
+  // The blocks-storage bucket-name CLI flag for the configured storage backend.
+  mimirBlocksStorageBucketNameFlag::
+    if $._config.storage_backend == 'gcs' then 'blocks-storage.gcs.bucket-name'
+    else if $._config.storage_backend == 's3' then 'blocks-storage.s3.bucket-name'
+    else if $._config.storage_backend == 'azure' then 'blocks-storage.azure.container-name'
+    else error 'compartments do not support the "%s" storage backend' % $._config.storage_backend,
 
   // Common CLI args shared by every compartment-aware Mimir component.
   mimirCompartmentsCommonArgs:: {

--- a/operations/mimir/compartments-distributor.libsonnet
+++ b/operations/mimir/compartments-distributor.libsonnet
@@ -96,7 +96,7 @@
       // The distributor targets its own write compartment's Kafka cluster, so its address resolves the
       // '<write-compartment-id>' placeholder to the compartment id. The topic keeps the read-compartment
       // placeholder because the distributor produces to every read compartment's topic.
-      'ingest-storage.kafka.address': std.strReplace($.compartments_ingest_storage_kafka_address, '<write-compartment-id>', std.toString(compartmentIdx)),
+      'ingest-storage.kafka.address': std.strReplace($._config.compartments_ingest_storage_kafka_address, '<write-compartment-id>', std.toString(compartmentIdx)),
     },
 
   distributor_zone_a_compartments_args:: $.mimirCompartmentsCreateIf(isEnabled && isZoneAEnabled, numCompartments, function(compartment) $.distributor_zone_a_args + perCompartmentDistributorArgs(compartment)),

--- a/operations/mimir/compartments-ingester.libsonnet
+++ b/operations/mimir/compartments-ingester.libsonnet
@@ -97,7 +97,7 @@
       // The ingester consumes its own read compartment's topic, so its topic resolves the
       // '<read-compartment-id>' placeholder to the compartment id. The address keeps the write-compartment
       // placeholder because the ingester consumes from every write compartment's Kafka cluster.
-      'ingest-storage.kafka.address': $.compartments_ingest_storage_kafka_address,
+      'ingest-storage.kafka.address': $._config.compartments_ingest_storage_kafka_address,
       'ingest-storage.kafka.topic': std.strReplace($._config.compartments_ingest_storage_kafka_topic, '<read-compartment-id>', std.toString(compartmentIdx)),
     },
 

--- a/operations/mimir/compartments-query-frontend.libsonnet
+++ b/operations/mimir/compartments-query-frontend.libsonnet
@@ -4,7 +4,7 @@
     // The query-frontend monitors the last produced offset of every read-compartment topic in every write
     // compartment's Kafka cluster (to enforce strong read consistency), so its address must target every
     // cluster via the '<write-compartment-id>' placeholder.
-    'ingest-storage.kafka.address': $.compartments_ingest_storage_kafka_address,
+    'ingest-storage.kafka.address': $._config.compartments_ingest_storage_kafka_address,
   },
 
   query_frontend_args+:: perCompartmentQueryFrontendArgs,


### PR DESCRIPTION
#### What this PR does

Preliminary, behavior-preserving jsonnet refactor that carves out shared plumbing ahead of [#15856](https://github.com/grafana/mimir/pull/15856) (making the querier blocks-storage path compartment-aware), so that PR stays focused on the actual behavior change.

It does three things in `operations/mimir/compartments-common.libsonnet`:

- Moves `compartments_ingest_storage_kafka_address` from a top-level hidden field into `$._config`, next to the other compartment storage settings, and updates its callers (distributor, ingester, query-frontend, config-validation test).
- Adds a sibling `compartments_blocks_storage_bucket_name` config carrying the `<read-compartment-id>` placeholder (defaults to the non-compartment bucket name with a per-compartment suffix), validated at config time.
- Introduces two helpers: `mimirBlocksStorageCompartmentBucketName` resolves the placeholder for a given read compartment, and `mimirBlocksStorageBucketNameFlag` returns the blocks-storage bucket-name CLI flag for the configured storage backend.

The generated manifests are unchanged. The helpers are wired into the querier in #15856.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated. (existing jsonnet config-validation test follows the field move)
- [ ] Documentation added. (not needed; internal compartments plumbing)
- [ ] `CHANGELOG.md` updated - not needed; compartments are experimental, disabled by default, and intentionally undocumented externally (`changelog-not-needed`).
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features - not needed.