### PR TITLE
querier: refactor NewBlocksStoreQueryableFromConfig and take bucket ID in NewMetadataCachingBucket

### DIFF
--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -235,7 +235,12 @@ func NewBlocksStoreQueryableFromConfig(querierCfg Config, gatewayCfg storegatewa
 		ringKey   = storegateway.RingKey
 	)
 
-	finder, err := newBlocksStoreQueryableFinder(bucketCfg, storageCfg, limits, logger, storeReg)
+	// The cache bucket ID should be "blocks" but we pass an empty string to not cause a massive cache
+	// invalidation when rolling out the Mimir version introducing the bucket ID; this is fine as far as
+	// every other caching bucket uses its own unique ID.
+	cacheBucketID := ""
+
+	finder, err := newBlocksStoreQueryableFinder(cacheBucketID, bucketCfg, storageCfg, limits, logger, storeReg)
 	if err != nil {
 		return nil, err
 	}
@@ -256,16 +261,11 @@ func NewBlocksStoreQueryableFromConfig(querierCfg Config, gatewayCfg storegatewa
 }
 
 // newBlocksStoreQueryableFinder creates a BucketIndexBlocksFinder over the given bucket config.
-func newBlocksStoreQueryableFinder(bucketCfg bucket.Config, storageCfg mimir_tsdb.BlocksStorageConfig, limits BlocksStoreLimits, logger log.Logger, reg prometheus.Registerer) (BlocksFinder, error) {
+func newBlocksStoreQueryableFinder(cacheBucketID string, bucketCfg bucket.Config, storageCfg mimir_tsdb.BlocksStorageConfig, limits BlocksStoreLimits, logger log.Logger, reg prometheus.Registerer) (BlocksFinder, error) {
 	bucketClient, err := bucket.NewClient(context.Background(), bucketCfg, "querier", logger, reg)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create bucket client")
 	}
-
-	// The cache bucket ID should be "blocks" but we pass an empty string to not cause a massive cache
-	// invalidation when rolling out the Mimir version introducing the bucket ID; this is fine as far as
-	// every other caching bucket uses its own unique ID.
-	cacheBucketID := ""
 
 	cachingBucket, err := mimir_tsdb.NewMetadataCachingBucket(
 		cacheBucketID,

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -200,12 +200,22 @@ func NewBlocksStoreQueryable(
 }
 
 func NewBlocksStoreQueryableFromConfig(querierCfg Config, gatewayCfg storegateway.Config, storageCfg mimir_tsdb.BlocksStorageConfig, limits BlocksStoreLimits, logger log.Logger, reg prometheus.Registerer) (*BlocksStoreQueryable, error) {
-	var stores BlocksStoreSet
-
-	finder, err := newBlocksStoreQueryableFinder(storageCfg.Bucket, storageCfg, limits, logger, reg)
-	if err != nil {
-		return nil, err
+	var dynamicReplication storegateway.DynamicReplication = storegateway.NewNopDynamicReplication(gatewayCfg.ShardingRing.ReplicationFactor)
+	if gatewayCfg.DynamicReplication.Enabled {
+		dynamicReplication = storegateway.NewMaxTimeDynamicReplication(
+			gatewayCfg,
+			// Keep syncing blocks to store-gateways for a grace period (3 times the sync interval) to
+			// ensure they are not unloaded while they are still being queried.
+			mimir_tsdb.NewBlockDiscoveryDelayMultiplier*storageCfg.BucketStore.SyncInterval,
+		)
 	}
+
+	consistency := NewBlocksConsistency(
+		// Exclude blocks which have been recently uploaded, in order to give enough time to store-gateways
+		// to discover and load them (3 times the sync interval).
+		mimir_tsdb.NewBlockDiscoveryDelayMultiplier*storageCfg.BucketStore.SyncInterval,
+		reg,
+	)
 
 	storesRingCfg := gatewayCfg.ShardingRing.ToRingConfig()
 	storesRingBackend, err := kv.NewClient(
@@ -218,36 +228,31 @@ func NewBlocksStoreQueryableFromConfig(querierCfg Config, gatewayCfg storegatewa
 		return nil, errors.Wrap(err, "failed to create store-gateway ring backend")
 	}
 
-	storesRing, err := ring.NewWithStoreClientAndStrategy(storesRingCfg, storegateway.RingNameForClient, storegateway.RingKey, storesRingBackend, ring.NewIgnoreUnhealthyInstancesReplicationStrategy(), prometheus.WrapRegistererWithPrefix("cortex_", reg), logger)
+	var (
+		storeReg  = reg
+		bucketCfg = storageCfg.Bucket
+		ringName  = storegateway.RingNameForClient
+		ringKey   = storegateway.RingKey
+	)
+
+	finder, err := newBlocksStoreQueryableFinder(bucketCfg, storageCfg, limits, logger, storeReg)
+	if err != nil {
+		return nil, err
+	}
+
+	storesRing, err := ring.NewWithStoreClientAndStrategy(storesRingCfg, ringName, ringKey, storesRingBackend, ring.NewIgnoreUnhealthyInstancesReplicationStrategy(), prometheus.WrapRegistererWithPrefix("cortex_", storeReg), logger)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create store-gateway ring client")
 	}
 
-	var dynamicReplication storegateway.DynamicReplication = storegateway.NewNopDynamicReplication(gatewayCfg.ShardingRing.ReplicationFactor)
-	if gatewayCfg.DynamicReplication.Enabled {
-		dynamicReplication = storegateway.NewMaxTimeDynamicReplication(
-			gatewayCfg,
-			// Keep syncing blocks to store-gateways for a grace period (3 times the sync interval) to
-			// ensure they are not unloaded while they are still being queried.
-			mimir_tsdb.NewBlockDiscoveryDelayMultiplier*storageCfg.BucketStore.SyncInterval,
-		)
-	}
-
-	stores, err = newBlocksStoreReplicationSet(storesRing, randomLoadBalancing, dynamicReplication, querierCfg.PreferAvailabilityZones, limits, querierCfg.StoreGatewayClient, logger, reg)
+	storeSet, err := newBlocksStoreReplicationSet(storesRing, randomLoadBalancing, dynamicReplication, querierCfg.PreferAvailabilityZones, limits, querierCfg.StoreGatewayClient, logger, storeReg)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create store set")
 	}
 
-	consistency := NewBlocksConsistency(
-		// Exclude blocks which have been recently uploaded, in order to give enough time to store-gateways
-		// to discover and load them (3 times the sync interval).
-		mimir_tsdb.NewBlockDiscoveryDelayMultiplier*storageCfg.BucketStore.SyncInterval,
-		reg,
-	)
-
 	streamingBufferSize := querierCfg.StreamingChunksPerStoreGatewaySeriesBufferSize
 
-	return NewBlocksStoreQueryable(stores, dynamicReplication, finder, consistency, limits, querierCfg.QueryStoreAfter, streamingBufferSize, logger, reg)
+	return NewBlocksStoreQueryable(storeSet, dynamicReplication, finder, consistency, limits, querierCfg.QueryStoreAfter, streamingBufferSize, logger, reg)
 }
 
 // newBlocksStoreQueryableFinder creates a BucketIndexBlocksFinder over the given bucket config.
@@ -257,7 +262,13 @@ func newBlocksStoreQueryableFinder(bucketCfg bucket.Config, storageCfg mimir_tsd
 		return nil, errors.Wrap(err, "failed to create bucket client")
 	}
 
+	// The cache bucket ID should be "blocks" but we pass an empty string to not cause a massive cache
+	// invalidation when rolling out the Mimir version introducing the bucket ID; this is fine as far as
+	// every other caching bucket uses its own unique ID.
+	cacheBucketID := ""
+
 	cachingBucket, err := mimir_tsdb.NewMetadataCachingBucket(
+		cacheBucketID,
 		storageCfg.BucketStore.MetadataCache,
 		bucketClient,
 		logger,

--- a/pkg/storage/tsdb/caching_config.go
+++ b/pkg/storage/tsdb/caching_config.go
@@ -157,8 +157,10 @@ func configureMetadataCaching(
 	return cachingBucketCfg
 }
 
-// NewMetadataCachingBucket creates a caching bucket for metadata and indexes of the bucket store and its tenant TSDBs.
+// NewMetadataCachingBucket creates a caching bucket for metadata and indexes of the bucket store and
+// its tenant TSDBs. The bucketID prefixes every cache key.
 func NewMetadataCachingBucket(
+	bucketID string,
 	metadataCfg MetadataCacheConfig,
 	bkt objstore.Bucket,
 	logger log.Logger,
@@ -176,11 +178,7 @@ func NewMetadataCachingBucket(
 	cachingBucketCfg := bucketcache.NewCachingBucketConfig()
 	cachingBucketCfg = configureMetadataCaching(metadataCache, metadataCfg, cachingBucketCfg)
 
-	// NOTE: the bucket ID should be "blocks" but we're passing an empty string to not cause
-	// a massive cache invalidation when rolling out a new Mimir version introducing the bucket
-	// ID. This is still fine, as far as all other caching bucket implementations specify their
-	// own unique ID.
-	return bucketcache.NewCachingBucket("", bkt, cachingBucketCfg, logger, reg)
+	return bucketcache.NewCachingBucket(bucketID, bkt, cachingBucketCfg, logger, reg)
 }
 
 func NewChunksCacheClient(


### PR DESCRIPTION
#### What this PR does

Preliminary, behavior-preserving refactor extracted from #15856 (compartments-aware blocks-storage query path) to keep that PR's diff focused on the compartments logic.

- `NewMetadataCachingBucket` now takes the cache bucket ID as input instead of hardcoding the empty string, so the caller controls the cache key prefix.
- In `NewBlocksStoreQueryableFromConfig` the store-gateway ring KV backend is now built before the finder, and the bucket config, ring name, ring key and registerer are hoisted into local variables. This is the shape the compartments PR needs to vary them per read compartment.
- The local store set variable is renamed `stores` → `storeSet`.

No functional change: without compartments everything resolves to the same values as before (the cache bucket ID stays empty to avoid invalidating existing caches).

#### Which issue(s) this PR fixes or relates to

Preliminary to #15856.

#### Checklist

- [ ] Tests updated. - not needed; behavior-preserving refactor covered by existing tests.
- [ ] Documentation added. - not needed.
- [x] `CHANGELOG.md` updated - not needed, no user-visible change (`changelog-not-needed`).
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features. - not needed.
