### PR TITLE
compartments: consolidate read compartment ring helpers into WithReadCompartmentSuffix

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -435,7 +435,7 @@ func (a *API) RegisterIngesterPartitionRings(compartmentsEnabled bool, partition
 	a.RegisterRoute("/ingester/partition-ring", index, false, true, "GET")
 
 	for compartmentID, partitionRing := range partitionRings.All() {
-		key := compartments.ReadCompartmentRingKey(compartmentID, ringKey)
+		key := compartments.WithReadCompartmentSuffix(ringKey, compartmentID)
 		handler := ring.NewPartitionRingPageHandler(partitionRing, ring.NewPartitionRingEditor(key, kvClient))
 		a.RegisterRoute(fmt.Sprintf("/ingester/partition-ring/compartment-%d", compartmentID), handler, false, true, "GET", "POST")
 	}

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -565,8 +565,8 @@ func (c *MultitenantCompactor) starting(ctx context.Context) error {
 	// registers into its read compartment's own ring.
 	name, key := ringName, ringKey
 	if c.compactorCfg.Compartments.Enabled {
-		name = compartments.ReadCompartmentRingName(c.compactorCfg.ReadCompartmentID, ringName)
-		key = compartments.ReadCompartmentRingKey(c.compactorCfg.ReadCompartmentID, ringKey)
+		name = compartments.WithReadCompartmentSuffix(ringName, c.compactorCfg.ReadCompartmentID)
+		key = compartments.WithReadCompartmentSuffix(ringKey, c.compactorCfg.ReadCompartmentID)
 	}
 	c.ring, c.ringLifecycler, err = newRingAndLifecycler(c.compactorCfg.ShardingRing, name, key, c.logger, c.registerer)
 	if err != nil {

--- a/pkg/compactor/compactor_compartments_test.go
+++ b/pkg/compactor/compactor_compartments_test.go
@@ -59,7 +59,7 @@ func TestMultitenantCompactor_Compartments_RegistersInReadCompartmentRing(t *tes
 
 	// The instance is registered under the read compartment's ring key.
 	test.Poll(t, 5*time.Second, 1, func() interface{} {
-		return countInstances(compartments.ReadCompartmentRingKey(readCompartmentID, ringKey))
+		return countInstances(compartments.WithReadCompartmentSuffix(ringKey, readCompartmentID))
 	})
 
 	// Nothing is registered under the non-compartment key.

--- a/pkg/compartments/config.go
+++ b/pkg/compartments/config.go
@@ -84,21 +84,8 @@ func ReplaceWriteCompartment(s string, writeCompartmentID int) string {
 	return strings.ReplaceAll(s, WriteCompartmentIDPlaceholder, strconv.Itoa(writeCompartmentID))
 }
 
-// readCompartmentRingSuffix builds the "-rc-<id>" suffix appended to a ring key or name to
-// scope it to a single read compartment. A suffix is used for consistency with how the read
-// compartment ID is appended elsewhere (e.g. Kubernetes resource names, offset filenames).
-func readCompartmentRingSuffix(compartmentID int) string {
-	return "-rc-" + strconv.Itoa(compartmentID)
-}
-
-// ReadCompartmentRingKey returns the KVStore key for the partition ring of the given read
-// compartment, derived from the non-compartment ring key.
-func ReadCompartmentRingKey(compartmentID int, ringKey string) string {
-	return ringKey + readCompartmentRingSuffix(compartmentID)
-}
-
-// ReadCompartmentRingName returns the ring name for the given read compartment, derived from the
-// non-compartment ring name.
-func ReadCompartmentRingName(compartmentID int, ringName string) string {
-	return ringName + readCompartmentRingSuffix(compartmentID)
+// WithReadCompartmentSuffix returns name with the "-rc-<id>" suffix that scopes it to a single read
+// compartment.
+func WithReadCompartmentSuffix(name string, compartmentID int) string {
+	return name + "-rc-" + strconv.Itoa(compartmentID)
 }

--- a/pkg/compartments/config_test.go
+++ b/pkg/compartments/config_test.go
@@ -64,9 +64,8 @@ func TestReplaceWriteCompartment(t *testing.T) {
 	assert.Equal(t, "kafka:9092", ReplaceWriteCompartment("kafka:9092", 1))
 }
 
-func TestReadCompartmentRingKeyAndName(t *testing.T) {
-	assert.Equal(t, "ingester-partitions-rc-0", ReadCompartmentRingKey(0, "ingester-partitions"))
-	assert.Equal(t, "ingester-partitions-rc-3", ReadCompartmentRingKey(3, "ingester-partitions"))
-	assert.Equal(t, "partition-ring-rc-0", ReadCompartmentRingName(0, "partition-ring"))
-	assert.Equal(t, "partition-ring-rc-2", ReadCompartmentRingName(2, "partition-ring"))
+func TestWithReadCompartmentSuffix(t *testing.T) {
+	assert.Equal(t, "ingester-partitions-rc-0", WithReadCompartmentSuffix("ingester-partitions", 0))
+	assert.Equal(t, "ingester-partitions-rc-3", WithReadCompartmentSuffix("ingester-partitions", 3))
+	assert.Equal(t, "blocks-rc-2", WithReadCompartmentSuffix("blocks", 2))
 }

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -6526,7 +6526,7 @@ func prepare(t testing.TB, cfg prepConfig) ([]*Distributor, []*mockIngester, []*
 		if compartmentsEnabled {
 			// Seed each read compartment's own partition ring.
 			for c := 0; c < cfg.numCompartments; c++ {
-				key := compartments.ReadCompartmentRingKey(c, ingester.PartitionRingKey)
+				key := compartments.WithReadCompartmentSuffix(ingester.PartitionRingKey, c)
 				activePartitions := cfg.compartmentActivePartitions[c]
 				require.NoError(t, partitionsStore.CAS(ctx, key, func(_ interface{}) (interface{}, bool, error) {
 					return prepareCompartmentPartitionRing(activePartitions, ingesters), true, nil

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -607,8 +607,8 @@ func New(cfg Config, limits *validation.Overrides, ingestersRing ring.ReadRing, 
 		// validated by Config.Validate.
 		partitionRingName, partitionRingKey := PartitionRingName, PartitionRingKey
 		if cfg.Compartments.Enabled {
-			partitionRingName = compartments.ReadCompartmentRingName(cfg.ReadCompartmentID, PartitionRingName)
-			partitionRingKey = compartments.ReadCompartmentRingKey(cfg.ReadCompartmentID, PartitionRingKey)
+			partitionRingName = compartments.WithReadCompartmentSuffix(PartitionRingName, cfg.ReadCompartmentID)
+			partitionRingKey = compartments.WithReadCompartmentSuffix(PartitionRingKey, cfg.ReadCompartmentID)
 		}
 
 		i.ingestPartitionLifecycler = ring.NewPartitionInstanceLifecycler(

--- a/pkg/ingester/ingester_compartments_test.go
+++ b/pkg/ingester/ingester_compartments_test.go
@@ -75,7 +75,7 @@ func TestIngester_Compartments_RegistersPartitionInReadCompartmentRing(t *testin
 	}
 
 	// The partition is registered under the read compartment's ring key.
-	compartmentKey := compartments.ReadCompartmentRingKey(readCompartmentID, PartitionRingKey)
+	compartmentKey := compartments.WithReadCompartmentSuffix(PartitionRingKey, readCompartmentID)
 	test.Poll(t, 5*time.Second, 1, func() interface{} {
 		return countPartitions(compartmentKey)
 	})
@@ -206,7 +206,7 @@ func TestIngester_Compartments_ShouldConsumeReadCompartmentTopicAtStartup(t *tes
 	}))
 
 	// Add the partition and owner in the read compartment's partition ring, to simulate an ingester restart.
-	require.NoError(t, cfg.IngesterPartitionRing.KVStore.Mock.CAS(context.Background(), compartments.ReadCompartmentRingKey(readCompartmentID, PartitionRingKey), func(in interface{}) (out interface{}, retry bool, err error) {
+	require.NoError(t, cfg.IngesterPartitionRing.KVStore.Mock.CAS(context.Background(), compartments.WithReadCompartmentSuffix(PartitionRingKey, readCompartmentID), func(in interface{}) (out interface{}, retry bool, err error) {
 		desc := ring.GetOrCreatePartitionRingDesc(in)
 		desc.AddPartition(partitionID, ring.PartitionActive, time.Now())
 		desc.AddOrUpdateOwner(cfg.IngesterRing.InstanceID, ring.OwnerDeleted, partitionID, time.Now())
@@ -496,8 +496,8 @@ func createTestCompartmentsIngester(t *testing.T, ingesterCfg *Config, overrides
 
 	// Create and start the partition ring watcher on the ingester's read compartment ring.
 	prw := ring.NewPartitionRingWatcher(
-		compartments.ReadCompartmentRingName(ingesterCfg.ReadCompartmentID, PartitionRingName),
-		compartments.ReadCompartmentRingKey(ingesterCfg.ReadCompartmentID, PartitionRingKey),
+		compartments.WithReadCompartmentSuffix(PartitionRingName, ingesterCfg.ReadCompartmentID),
+		compartments.WithReadCompartmentSuffix(PartitionRingKey, ingesterCfg.ReadCompartmentID),
 		kv, log.NewNopLogger(), nil)
 	require.NoError(t, services.StartAndAwaitRunning(ctx, prw))
 	t.Cleanup(func() {

--- a/pkg/storage/ingest/partition_instance_rings_test.go
+++ b/pkg/storage/ingest/partition_instance_rings_test.go
@@ -23,8 +23,8 @@ func TestPartitionInstanceRings(t *testing.T) {
 	t.Cleanup(func() { _ = closer.Close() })
 
 	// Each read compartment has a single partition owned by a distinct ingester.
-	writePartitionAndOwner(t, kvClient, compartments.ReadCompartmentRingKey(0, testRingKey), 0, "ingester-c0")
-	writePartitionAndOwner(t, kvClient, compartments.ReadCompartmentRingKey(1, testRingKey), 0, "ingester-c1")
+	writePartitionAndOwner(t, kvClient, compartments.WithReadCompartmentSuffix(testRingKey, 0), 0, "ingester-c0")
+	writePartitionAndOwner(t, kvClient, compartments.WithReadCompartmentSuffix(testRingKey, 1), 0, "ingester-c1")
 
 	watcher, err := NewPartitionRingWatchers(true, 2, testRingName, testRingKey, kvClient, log.NewNopLogger(), nil)
 	require.NoError(t, err)

--- a/pkg/storage/ingest/partition_ring_watchers.go
+++ b/pkg/storage/ingest/partition_ring_watchers.go
@@ -17,7 +17,7 @@ import (
 
 // PartitionRingWatchers watches the ingester partition ring(s) and exposes them through a single
 // reference. When compartments are disabled it holds one watcher for the legacy partition ring; when
-// enabled it holds one watcher per read compartment, each keyed via compartments.ReadCompartmentRingKey.
+// enabled it holds one watcher per read compartment, each keyed via compartments.WithReadCompartmentSuffix.
 //
 // The distributor holds the whole component because it writes across all read compartments. An
 // ingester does not: it only needs the watcher for its own read compartment, obtained via Watcher.
@@ -47,8 +47,8 @@ func NewPartitionRingWatchers(compartmentsEnabled bool, numCompartments int, rin
 		}
 		watchers = make([]*ring.PartitionRingWatcher, numCompartments)
 		for c := range watchers {
-			name := compartments.ReadCompartmentRingName(c, ringName)
-			key := compartments.ReadCompartmentRingKey(c, ringKey)
+			name := compartments.WithReadCompartmentSuffix(ringName, c)
+			key := compartments.WithReadCompartmentSuffix(ringKey, c)
 
 			watchers[c] = ring.NewPartitionRingWatcher(name, key, kvClient, logger, reg)
 		}

--- a/pkg/storage/ingest/partition_ring_watchers_test.go
+++ b/pkg/storage/ingest/partition_ring_watchers_test.go
@@ -45,9 +45,9 @@ func TestPartitionRingWatchers_Enabled(t *testing.T) {
 	t.Cleanup(func() { _ = closer.Close() })
 
 	// Each read compartment has its own key with a distinct number of partitions.
-	writePartitions(t, kvClient, compartments.ReadCompartmentRingKey(0, testRingKey), 0)
-	writePartitions(t, kvClient, compartments.ReadCompartmentRingKey(1, testRingKey), 0, 1)
-	writePartitions(t, kvClient, compartments.ReadCompartmentRingKey(2, testRingKey), 0, 1, 2)
+	writePartitions(t, kvClient, compartments.WithReadCompartmentSuffix(testRingKey, 0), 0)
+	writePartitions(t, kvClient, compartments.WithReadCompartmentSuffix(testRingKey, 1), 0, 1)
+	writePartitions(t, kvClient, compartments.WithReadCompartmentSuffix(testRingKey, 2), 0, 1, 2)
 
 	w, err := NewPartitionRingWatchers(true, 3, testRingName, testRingKey, kvClient, log.NewNopLogger(), nil)
 	require.NoError(t, err)

--- a/pkg/storegateway/gateway.go
+++ b/pkg/storegateway/gateway.go
@@ -187,8 +187,8 @@ func newStoreGateway(gatewayCfg Config, storageCfg mimir_tsdb.BlocksStorageConfi
 	// With compartments enabled the store-gateway registers into its read compartment's own ring.
 	ringName, ringKey := RingNameForServer, RingKey
 	if gatewayCfg.Compartments.Enabled {
-		ringName = compartments.ReadCompartmentRingName(gatewayCfg.ReadCompartmentID, RingNameForServer)
-		ringKey = compartments.ReadCompartmentRingKey(gatewayCfg.ReadCompartmentID, RingKey)
+		ringName = compartments.WithReadCompartmentSuffix(RingNameForServer, gatewayCfg.ReadCompartmentID)
+		ringKey = compartments.WithReadCompartmentSuffix(RingKey, gatewayCfg.ReadCompartmentID)
 	}
 
 	// Define lifecycler delegates in reverse order (last to be called defined first because they're

--- a/pkg/storegateway/gateway_compartments_test.go
+++ b/pkg/storegateway/gateway_compartments_test.go
@@ -52,7 +52,7 @@ func TestStoreGateway_Compartments_RegistersInReadCompartmentRing(t *testing.T) 
 	}
 
 	// The instance is registered under the read compartment's ring key.
-	assert.Equal(t, 1, countInstances(compartments.ReadCompartmentRingKey(readCompartmentID, RingKey)))
+	assert.Equal(t, 1, countInstances(compartments.WithReadCompartmentSuffix(RingKey, readCompartmentID)))
 
 	// Nothing is registered under the non-compartment key.
 	assert.Zero(t, countInstances(RingKey))


### PR DESCRIPTION
#### What this PR does

Preliminary refactor extracted from #15856 to keep that PR focused on the querier blocks-storage changes.

`pkg/compartments/config.go` had three near-identical helpers — `readCompartmentRingSuffix`, `ReadCompartmentRingKey` and `ReadCompartmentRingName` — that only differed in name. They are consolidated into a single `WithReadCompartmentSuffix(name, compartmentID)` helper that appends the `-rc-<id>` suffix, which reads naturally at every call site (ring key, ring name, and the upcoming bucket name). Call sites are updated accordingly.

No behavior change.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added. - not needed; compartments are experimental, disabled by default, and intentionally undocumented externally.
- [ ] `CHANGELOG.md` updated - not needed; compartments are experimental and disabled by default (`changelog-not-needed`).
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features - deferred until compartments are complete end to end.
