### PR TITLE
querier: return store-gateway query stats from queryWithConsistencyCheck

### DIFF
--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -394,7 +394,7 @@ func (q *blocksStoreQuerier) LabelNames(ctx context.Context, hints *storage.Labe
 		return queriedBlocks, nil
 	}
 
-	if err := q.queryWithConsistencyCheck(ctx, spanLog, minT, maxT, tenantID, nil, queryF); err != nil {
+	if err := q.queryWithConsistencyCheckAndObserve(ctx, spanLog, minT, maxT, tenantID, nil, queryF); err != nil {
 		return nil, nil, err
 	}
 
@@ -438,7 +438,7 @@ func (q *blocksStoreQuerier) LabelValues(ctx context.Context, name string, hints
 		return queriedBlocks, nil
 	}
 
-	if err := q.queryWithConsistencyCheck(ctx, spanLog, minT, maxT, tenantID, nil, queryF); err != nil {
+	if err := q.queryWithConsistencyCheckAndObserve(ctx, spanLog, minT, maxT, tenantID, nil, queryF); err != nil {
 		return nil, nil, err
 	}
 
@@ -497,7 +497,7 @@ func (q *blocksStoreQuerier) selectSorted(ctx context.Context, sp *storage.Selec
 		return queriedBlocks, nil
 	}
 
-	err = q.queryWithConsistencyCheck(ctx, spanLog, minT, maxT, tenantID, shard, queryF)
+	err = q.queryWithConsistencyCheckAndObserve(ctx, spanLog, minT, maxT, tenantID, shard, queryF)
 	if err != nil {
 		return storage.ErrSeriesSet(err)
 	}
@@ -554,15 +554,22 @@ func (q *blocksStoreQuerier) startBuffering(streamReaders []*storeGatewayStreamR
 
 type queryFunc func(clients map[BlocksStoreClient][]ulid.ULID, minT, maxT int64, indexMeta *bucketindex.Metadata) ([]ulid.ULID, error)
 
+// storeGatewayQueryStats holds the per-query store-gateway histogram values. queryWithConsistencyCheck
+// returns it (rather than observing the histograms itself) so the caller observes them once per query.
+type storeGatewayQueryStats struct {
+	storesHit int  // number of distinct store-gateway instances queried
+	refetches int  // number of retries due to missing blocks
+	queried   bool // whether the block store was actually queried (true only on the success path)
+}
+
 func (q *blocksStoreQuerier) queryWithConsistencyCheck(
 	ctx context.Context, spanLog *spanlogger.SpanLogger, minT, maxT int64, tenantID string, shard *sharding.ShardSelector, queryF queryFunc,
-) (returnErr error) {
+) (stats storeGatewayQueryStats, returnErr error) {
 	now := time.Now()
 
 	if !ShouldQueryBlockStore(q.queryStoreAfter, now, minT) {
-		q.metrics.storesHit.Observe(0)
 		spanLog.DebugLog("msg", "not querying block store; query time range begins after the query-store-after limit")
-		return nil
+		return storeGatewayQueryStats{}, nil
 	}
 
 	maxT = clampMaxTime(spanLog, maxT, now.UnixMilli(), -q.queryStoreAfter, "query store after")
@@ -570,13 +577,12 @@ func (q *blocksStoreQuerier) queryWithConsistencyCheck(
 	// Find the list of blocks we need to query given the time range.
 	knownBlocks, indexMeta, err := q.finder.GetBlocks(ctx, tenantID, minT, maxT)
 	if err != nil {
-		return err
+		return storeGatewayQueryStats{}, err
 	}
 
 	if len(knownBlocks) == 0 {
-		q.metrics.storesHit.Observe(0)
 		spanLog.DebugLog("msg", "no blocks found")
-		return nil
+		return storeGatewayQueryStats{}, nil
 	}
 
 	q.metrics.blocksFound.Add(float64(len(knownBlocks)))
@@ -627,7 +633,7 @@ func (q *blocksStoreQuerier) queryWithConsistencyCheck(
 				break
 			}
 
-			return err
+			return storeGatewayQueryStats{}, err
 		}
 		spanLog.DebugLog("msg", "found store-gateway instances to query", "num instances", len(clients), "attempt", attempt)
 
@@ -635,7 +641,7 @@ func (q *blocksStoreQuerier) queryWithConsistencyCheck(
 		// are only meant to cover missing blocks.
 		queriedBlocks, err := queryF(clients, minT, maxT, indexMeta)
 		if err != nil {
-			return err
+			return storeGatewayQueryStats{}, err
 		}
 		spanLog.DebugLog("msg", "received series from all store-gateways", "queried blocks", strings.Join(convertULIDsToString(queriedBlocks), " "))
 
@@ -652,10 +658,7 @@ func (q *blocksStoreQuerier) queryWithConsistencyCheck(
 		// The next attempt should just query the missing blocks.
 		remainingBlocks = consistencyTracker.Check(queriedBlocks)
 		if len(remainingBlocks) == 0 {
-			q.metrics.storesHit.Observe(float64(len(touchedStores)))
-			q.metrics.refetches.Observe(float64(attempt - 1))
-
-			return nil
+			return storeGatewayQueryStats{storesHit: len(touchedStores), refetches: attempt - 1, queried: true}, nil
 		}
 
 		spanLog.DebugLog("msg", "couldn't query all blocks", "attempt", attempt, "missing blocks", strings.Join(convertULIDsToString(remainingBlocks.GetULIDs()), " "))
@@ -664,7 +667,23 @@ func (q *blocksStoreQuerier) queryWithConsistencyCheck(
 	// We've not been able to query all expected blocks after all retries.
 	err = newStoreConsistencyCheckFailedError(remainingBlocks.GetULIDs())
 	level.Warn(util_log.WithContext(ctx, spanLog)).Log("msg", "failed consistency check after all attempts", "err", err)
-	return err
+	return storeGatewayQueryStats{}, err
+}
+
+// queryWithConsistencyCheckAndObserve runs queryWithConsistencyCheck and, on success, observes the
+// per-query store-gateway histograms from the returned stats.
+func (q *blocksStoreQuerier) queryWithConsistencyCheckAndObserve(ctx context.Context, spanLog *spanlogger.SpanLogger, minT, maxT int64, tenantID string, shard *sharding.ShardSelector, queryF queryFunc) error {
+	stats, err := q.queryWithConsistencyCheck(ctx, spanLog, minT, maxT, tenantID, shard, queryF)
+	if err != nil {
+		return err
+	}
+
+	q.metrics.storesHit.Observe(float64(stats.storesHit))
+	if stats.queried {
+		// refetches is only meaningful (and was historically only observed) when the block store was queried.
+		q.metrics.refetches.Observe(float64(stats.refetches))
+	}
+	return nil
 }
 
 type storeConsistencyCheckFailedErr struct {

--- a/pkg/querier/blocks_store_queryable_search.go
+++ b/pkg/querier/blocks_store_queryable_search.go
@@ -93,7 +93,7 @@ func (q *blocksStoreQuerier) SearchLabelNames(
 		return queriedBlocks, nil
 	}
 
-	if err := q.queryWithConsistencyCheck(ctx, spanLog, minT, maxT, tenantID, nil, queryF); err != nil {
+	if err := q.queryWithConsistencyCheckAndObserve(ctx, spanLog, minT, maxT, tenantID, nil, queryF); err != nil {
 		closeSearchResultSets(resSources)
 		return storage.ErrSearchResultSet(err)
 	}
@@ -145,7 +145,7 @@ func (q *blocksStoreQuerier) SearchLabelValues(
 		return queriedBlocks, nil
 	}
 
-	if err := q.queryWithConsistencyCheck(ctx, spanLog, minT, maxT, tenantID, nil, queryF); err != nil {
+	if err := q.queryWithConsistencyCheckAndObserve(ctx, spanLog, minT, maxT, tenantID, nil, queryF); err != nil {
 		closeSearchResultSets(resSources)
 		return storage.ErrSearchResultSet(err)
 	}


### PR DESCRIPTION
#### What this PR does

Preliminary, no-op refactoring extracted from #15856 to make that PR smaller to review.

It changes `queryWithConsistencyCheck` to return a `storeGatewayQueryStats` value instead of observing the per-query store-gateway histograms (`storesHit`, `refetches`) itself, and moves the observation into a new `queryWithConsistencyCheckAndObserve` wrapper that every caller now goes through.

From a metrics tracking perspective this is intentionally identical: both histograms are observed under exactly the same conditions and with the same values as before. Pulling the observation out of `queryWithConsistencyCheck` is what #15856 needs so it can sum the stats across the per-compartment block-query pipelines and observe the per-query totals once — without that change also having to move the metrics out of the hot path.

#### Which issue(s) this PR fixes or relates to

Preliminary to #15856.

#### Checklist

- [x] Tests updated. (no test changes needed — existing metrics assertions are unchanged and still pass)
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - not needed, internal no-op refactoring with no user-visible change (`changelog-not-needed`).
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
