### PR TITLE
Compartments: scope store-gateway and compactor metadata cache keys per read compartment

### DIFF
--- a/pkg/compactor/batch_caching_meta_fetcher.go
+++ b/pkg/compactor/batch_caching_meta_fetcher.go
@@ -27,12 +27,13 @@ import (
 // batchCachingMetaFetcher fetches block metadata from a cache with GetMulti
 // before possibly falling back to object storage.
 type batchCachingMetaFetcher struct {
-	userBkt     objstore.BucketReader
-	cache       cache.Cache
-	logger      log.Logger
-	tenant      string
-	concurrency int
-	contentTTL  time.Duration
+	userBkt       objstore.BucketReader
+	cache         cache.Cache
+	logger        log.Logger
+	tenant        string
+	concurrency   int
+	contentTTL    time.Duration
+	cacheBucketID string
 }
 
 func newBatchCachingMetaFetcher(
@@ -42,20 +43,21 @@ func newBatchCachingMetaFetcher(
 	tenant string,
 	concurrency int,
 	contentTTL time.Duration,
+	cacheBucketID string,
 ) *batchCachingMetaFetcher {
 	return &batchCachingMetaFetcher{
-		userBkt:     userBkt,
-		cache:       cache,
-		logger:      logger,
-		tenant:      tenant,
-		concurrency: concurrency,
-		contentTTL:  contentTTL,
+		userBkt:       userBkt,
+		cache:         cache,
+		logger:        logger,
+		tenant:        tenant,
+		concurrency:   concurrency,
+		contentTTL:    contentTTL,
+		cacheBucketID: cacheBucketID,
 	}
 }
 
 func (f *batchCachingMetaFetcher) metaCacheKey(blockID ulid.ULID) string {
-	// hardcoded "" bucketID to match caching bucket
-	return bucketcache.ContentKey("", path.Join(f.tenant, blockID.String(), block.MetaFilename))
+	return bucketcache.ContentKey(f.cacheBucketID, path.Join(f.tenant, blockID.String(), block.MetaFilename))
 }
 
 // fetchCompactableMetasFromListing discovers blockIDs through an object storage listing,

--- a/pkg/compactor/batch_caching_meta_fetcher_test.go
+++ b/pkg/compactor/batch_caching_meta_fetcher_test.go
@@ -224,7 +224,7 @@ func TestBatchCachingMetaFetcher_FetchCompactableMetasFromListing(t *testing.T) 
 		c := cache.NewMockCache()
 		metrics := block.NewFetcherMetrics(prometheus.NewPedanticRegistry(), nil)
 
-		fetcher := newBatchCachingMetaFetcher(errBkt, c, log.NewNopLogger(), tenant, 2, 24*time.Hour)
+		fetcher := newBatchCachingMetaFetcher(errBkt, c, log.NewNopLogger(), tenant, 2, 24*time.Hour, "")
 		_, err := fetcher.fetchCompactableMetasFromListing(ctx, 0, nil, metrics)
 
 		require.Error(t, err)
@@ -240,7 +240,7 @@ func TestBatchCachingMetaFetcher_FetchCompactableMetasFromListing(t *testing.T) 
 			Injector: bucket.InjectErrorOn(bucket.OpGet, path.Join(block1Meta.ULID.String(), block.MetaFilename), errors.New("injected get error")),
 		}
 		metrics := block.NewFetcherMetrics(prometheus.NewPedanticRegistry(), nil)
-		fetcher := newBatchCachingMetaFetcher(errBkt, nil, log.NewNopLogger(), tenant, 2, 24*time.Hour)
+		fetcher := newBatchCachingMetaFetcher(errBkt, nil, log.NewNopLogger(), tenant, 2, 24*time.Hour, "")
 
 		_, err := fetcher.fetchCompactableMetasFromListing(ctx, 0, nil, metrics)
 		require.Error(t, err)
@@ -262,7 +262,7 @@ func TestBatchCachingMetaFetcher_FetchCompactableMetasFromListing(t *testing.T) 
 	t.Run("nil cache falls back to storage", func(t *testing.T) {
 		bkt := objstore.NewInMemBucket()
 		metrics := block.NewFetcherMetrics(prometheus.NewPedanticRegistry(), nil)
-		fetcher := newBatchCachingMetaFetcher(bkt, nil, log.NewNopLogger(), tenant, 2, 24*time.Hour)
+		fetcher := newBatchCachingMetaFetcher(bkt, nil, log.NewNopLogger(), tenant, 2, 24*time.Hour, "")
 
 		uploadBlockMeta(t, bkt, block1Meta)
 
@@ -357,7 +357,7 @@ func TestBatchCachingMetaFetcher_FetchMetasFromIDs(t *testing.T) {
 
 	t.Run("nil cache falls back to storage", func(t *testing.T) {
 		bkt := objstore.NewInMemBucket()
-		fetcher := newBatchCachingMetaFetcher(bkt, nil, log.NewNopLogger(), tenant, 2, 24*time.Hour)
+		fetcher := newBatchCachingMetaFetcher(bkt, nil, log.NewNopLogger(), tenant, 2, 24*time.Hour, "")
 
 		uploadBlockMeta(t, bkt, block1Meta)
 
@@ -374,7 +374,7 @@ func newTestFetcher(t *testing.T, tenant string) (*batchCachingMetaFetcher, *obj
 	bkt := objstore.NewInMemBucket()
 	c := cache.NewMockCache()
 	metrics := block.NewFetcherMetrics(prometheus.NewPedanticRegistry(), nil)
-	return newBatchCachingMetaFetcher(bkt, c, log.NewNopLogger(), tenant, 2, 24*time.Hour), bkt, c, metrics
+	return newBatchCachingMetaFetcher(bkt, c, log.NewNopLogger(), tenant, 2, 24*time.Hour, ""), bkt, c, metrics
 }
 
 // createBlockMeta creates a block.Meta with a ULID derived from minTime

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -542,6 +542,15 @@ func newMultitenantCompactor(
 	return c, nil
 }
 
+// cacheBucketID returns the metadata-cache bucket ID used to scope the cache keys.
+func (c *MultitenantCompactor) cacheBucketID() string {
+	// The logic must match the store-gateway's one.
+	if !c.compactorCfg.Compartments.Enabled {
+		return ""
+	}
+	return compartments.WithReadCompartmentSuffix("blocks", c.compactorCfg.ReadCompartmentID)
+}
+
 // Start the compactor.
 func (c *MultitenantCompactor) starting(ctx context.Context) error {
 	var err error

--- a/pkg/compactor/executor.go
+++ b/pkg/compactor/executor.go
@@ -592,7 +592,7 @@ func (e *schedulerExecutor) executeCompactionJob(ctx context.Context, c *Multite
 	filters := []block.MetadataFilter{
 		NewLabelRemoverFilter(compactionIgnoredLabels),
 	}
-	fetcher := newBatchCachingMetaFetcher(userBucket, e.metadataCache, userLogger, userID, c.compactorCfg.MetaSyncConcurrency, e.cfg.MetadataCacheConfig.MetafileContentTTL)
+	fetcher := newBatchCachingMetaFetcher(userBucket, e.metadataCache, userLogger, userID, c.compactorCfg.MetaSyncConcurrency, e.cfg.MetadataCacheConfig.MetafileContentTTL, c.cacheBucketID())
 	metaMap, err := fetcher.fetchMetasFromIDs(ctx, blockIDs, filters)
 	if err != nil {
 		// Abandon the job if a block metadata was not found or corrupt
@@ -682,7 +682,7 @@ func (e *schedulerExecutor) executePlanningJob(ctx context.Context, c *Multitena
 
 	// The BatchCachingMetaFetcher handles marker filtering on its own
 	deduplicateBlocksFilter := NewShardAwareDeduplicateFilter()
-	fetcher := newBatchCachingMetaFetcher(userBucket, e.metadataCache, userLogger, tenant, c.compactorCfg.MetaSyncConcurrency, e.cfg.MetadataCacheConfig.MetafileContentTTL)
+	fetcher := newBatchCachingMetaFetcher(userBucket, e.metadataCache, userLogger, tenant, c.compactorCfg.MetaSyncConcurrency, e.cfg.MetadataCacheConfig.MetafileContentTTL, c.cacheBucketID())
 
 	level.Info(userLogger).Log("msg", "start sync of metas")
 	metas, err := fetcher.fetchCompactableMetasFromListing(ctx, maxLookback, []block.MetadataFilter{

--- a/pkg/storage/tsdb/caching_config.go
+++ b/pkg/storage/tsdb/caching_config.go
@@ -208,13 +208,15 @@ func NewIndexHeaderCacheClient(
 }
 
 // NewStoreCachingBucket creates a single caching bucket that handles metadata, index-header, and chunks caching.
-// Cache clients may be passed as nil to disable the corresponding bucket cache.
+// Cache clients may be passed as nil to disable the corresponding bucket cache. cacheBucketID prefixes
+// every cache key.
 //
 //   - Index-header config matches isBlockIndexFile to cache GetRange calls.
 //   - Chunks config matches isTSDBChunkFile to cache GetRange calls.
 //   - Metadata caching is shared with across index-header and chunks caching buckets if enabled,
 //     otherwise each cache handles its own metadata storage.
 func NewStoreCachingBucket(
+	cacheBucketID string,
 	cfg BlocksStorageConfig,
 	metadataCache cache.Cache,
 	indexHeaderCache cache.Cache,
@@ -225,12 +227,13 @@ func NewStoreCachingBucket(
 ) (objstore.Bucket, error) {
 	cachingBucketCfg := bucketcache.NewCachingBucketConfig()
 	return newStoreCachingBucket(
-		cachingBucketCfg, cfg, metadataCache, indexHeaderCache, chunksCache, bkt, logger, reg,
+		cachingBucketCfg, cacheBucketID, cfg, metadataCache, indexHeaderCache, chunksCache, bkt, logger, reg,
 	)
 }
 
 func newStoreCachingBucket(
 	cachingBucketCfg *bucketcache.CachingBucketConfig,
+	cacheBucketID string,
 	cfg BlocksStorageConfig,
 	metadataCache cache.Cache,
 	indexHeaderCache cache.Cache,
@@ -336,11 +339,7 @@ func newStoreCachingBucket(
 		return bkt, nil
 	}
 
-	// NOTE: the bucket ID should be "blocks" but we're passing an empty string to not cause
-	// a massive cache invalidation when rolling out a new Mimir version introducing the bucket
-	// ID. This is still fine, as far as all other caching bucket implementations specify their
-	// own unique ID.
-	return bucketcache.NewCachingBucket("", bkt, cachingBucketCfg, logger, reg)
+	return bucketcache.NewCachingBucket(cacheBucketID, bkt, cachingBucketCfg, logger, reg)
 }
 
 var chunksMatcher = regexp.MustCompile(`^.*/chunks/\d+$`)

--- a/pkg/storage/tsdb/caching_config_test.go
+++ b/pkg/storage/tsdb/caching_config_test.go
@@ -125,7 +125,7 @@ func Test_NewStoreCachingBucket(t *testing.T) {
 		bucketCacheCfg := bucketcache.NewCachingBucketConfig()
 
 		cacheBkt, err := newStoreCachingBucket(
-			bucketCacheCfg, BlocksStorageConfig{}, nil, nil, nil, bkt, ll, reg,
+			bucketCacheCfg, "", BlocksStorageConfig{}, nil, nil, nil, bkt, ll, reg,
 		)
 		require.NoError(t, err)
 		require.IsNotType(t, &bucketcache.CachingBucket{}, cacheBkt)
@@ -139,7 +139,7 @@ func Test_NewStoreCachingBucket(t *testing.T) {
 		metadata, indexHeader, chunks := cache.NewMockCache(), cache.NewMockCache(), cache.NewMockCache()
 
 		cacheBkt, err := newStoreCachingBucket(
-			bucketCacheCfg, BlocksStorageConfig{}, metadata, indexHeader, chunks, bkt, ll, reg,
+			bucketCacheCfg, "", BlocksStorageConfig{}, metadata, indexHeader, chunks, bkt, ll, reg,
 		)
 		require.NoError(t, err)
 		require.IsType(t, &bucketcache.CachingBucket{}, cacheBkt)
@@ -160,7 +160,7 @@ func Test_NewStoreCachingBucket(t *testing.T) {
 		indexHeader, chunks := cache.NewMockCache(), cache.NewMockCache()
 
 		cacheBkt, err := newStoreCachingBucket(
-			bucketCacheCfg, BlocksStorageConfig{}, metadata, indexHeader, chunks, bkt, ll, reg,
+			bucketCacheCfg, "", BlocksStorageConfig{}, metadata, indexHeader, chunks, bkt, ll, reg,
 		)
 		require.NoError(t, err)
 		require.IsType(t, &bucketcache.CachingBucket{}, cacheBkt)
@@ -181,7 +181,7 @@ func Test_NewStoreCachingBucket(t *testing.T) {
 		metadata, chunks := cache.NewMockCache(), cache.NewMockCache()
 
 		cacheBkt, err := newStoreCachingBucket(
-			bucketCacheCfg, BlocksStorageConfig{}, metadata, indexHeader, chunks, bkt, ll, reg,
+			bucketCacheCfg, "", BlocksStorageConfig{}, metadata, indexHeader, chunks, bkt, ll, reg,
 		)
 		require.NoError(t, err)
 		require.IsType(t, &bucketcache.CachingBucket{}, cacheBkt)
@@ -202,7 +202,7 @@ func Test_NewStoreCachingBucket(t *testing.T) {
 		metadata, indexHeader := cache.NewMockCache(), cache.NewMockCache()
 
 		cacheBkt, err := newStoreCachingBucket(
-			bucketCacheCfg, BlocksStorageConfig{}, metadata, indexHeader, chunks, bkt, ll, reg,
+			bucketCacheCfg, "", BlocksStorageConfig{}, metadata, indexHeader, chunks, bkt, ll, reg,
 		)
 		require.NoError(t, err)
 		require.IsType(t, &bucketcache.CachingBucket{}, cacheBkt)

--- a/pkg/storegateway/bucket_stores.go
+++ b/pkg/storegateway/bucket_stores.go
@@ -93,8 +93,8 @@ type BucketStores struct {
 	blocksLoadedSizeBytes *prometheus.Desc
 }
 
-// NewBucketStores makes a new BucketStores. After starting the returned BucketStores
-func NewBucketStores(cfg tsdb.BlocksStorageConfig, shardingStrategy ShardingStrategy, bucketClient objstore.Bucket, allowedTenants *util.AllowList, limits *validation.Overrides, logger log.Logger, reg prometheus.Registerer) (*BucketStores, error) {
+// NewBucketStores makes a new BucketStores.
+func NewBucketStores(cfg tsdb.BlocksStorageConfig, cacheBucketID string, shardingStrategy ShardingStrategy, bucketClient objstore.Bucket, allowedTenants *util.AllowList, limits *validation.Overrides, logger log.Logger, reg prometheus.Registerer) (*BucketStores, error) {
 	var err error
 
 	// Init index cache.
@@ -120,7 +120,7 @@ func NewBucketStores(cfg tsdb.BlocksStorageConfig, shardingStrategy ShardingStra
 
 	// Configure caching bucket to cover configured metadata, index-header, and chunks caching.
 	// Bucket caches for index-header and chunks share the metadata cache for object attributes.
-	cachingBucket, err := tsdb.NewStoreCachingBucket(cfg, metadataCache, indexHeaderCacheClient, chunksCacheClient, bucketClient, logger, reg)
+	cachingBucket, err := tsdb.NewStoreCachingBucket(cacheBucketID, cfg, metadataCache, indexHeaderCacheClient, chunksCacheClient, bucketClient, logger, reg)
 	if err != nil {
 		return nil, errors.Wrapf(err, "create caching bucket")
 	}

--- a/pkg/storegateway/bucket_stores_test.go
+++ b/pkg/storegateway/bucket_stores_test.go
@@ -77,7 +77,7 @@ func TestNewBucketStores_PartitionerConfig(t *testing.T) {
 		bucket, err := filesystem.NewBucketClient(filesystem.Config{Directory: storageDir})
 		require.NoError(t, err)
 
-		stores, err := NewBucketStores(cfg, newNoShardingStrategy(), bucket, nil, defaultLimitsOverrides(t), log.NewNopLogger(), nil)
+		stores, err := NewBucketStores(cfg, "", newNoShardingStrategy(), bucket, nil, defaultLimitsOverrides(t), log.NewNopLogger(), nil)
 		require.NoError(t, err)
 
 		require.IsType(t, &gapBasedPartitioner{}, stores.partitioners.chunks)
@@ -110,7 +110,7 @@ func TestBucketStores_InitialSync(t *testing.T) {
 
 	var allowedTenants *util.AllowList
 	reg := prometheus.NewPedanticRegistry()
-	stores, err := NewBucketStores(cfg, newNoShardingStrategy(), bucket, allowedTenants, defaultLimitsOverrides(t), log.NewLogfmtLogger(os.Stdout), reg)
+	stores, err := NewBucketStores(cfg, "", newNoShardingStrategy(), bucket, allowedTenants, defaultLimitsOverrides(t), log.NewLogfmtLogger(os.Stdout), reg)
 	require.NoError(t, err)
 
 	// Query series before the initial sync.
@@ -194,7 +194,7 @@ func TestBucketStores_InitialSyncShouldRetryOnFailure(t *testing.T) {
 
 	var allowedTenants *util.AllowList
 	reg := prometheus.NewPedanticRegistry()
-	stores, err := NewBucketStores(cfg, newNoShardingStrategy(), bucket, allowedTenants, defaultLimitsOverrides(t), log.NewNopLogger(), reg)
+	stores, err := NewBucketStores(cfg, "", newNoShardingStrategy(), bucket, allowedTenants, defaultLimitsOverrides(t), log.NewNopLogger(), reg)
 	require.NoError(t, err)
 
 	// Initial sync should succeed even if a transient error occurs.
@@ -257,7 +257,7 @@ func TestBucketStores_SyncBlocks(t *testing.T) {
 
 	var allowedTenants *util.AllowList
 	reg := prometheus.NewPedanticRegistry()
-	stores, err := NewBucketStores(cfg, newNoShardingStrategy(), bucket, allowedTenants, defaultLimitsOverrides(t), log.NewNopLogger(), reg)
+	stores, err := NewBucketStores(cfg, "", newNoShardingStrategy(), bucket, allowedTenants, defaultLimitsOverrides(t), log.NewNopLogger(), reg)
 	require.NoError(t, err)
 
 	// Run an initial sync to discover 1 block.
@@ -358,7 +358,7 @@ func TestBucketStores_ownedUsers(t *testing.T) {
 			bucketClient := &bucket.ClientMock{}
 			bucketClient.MockIter("", allUsers, nil)
 
-			stores, err := NewBucketStores(cfg, testData.shardingStrategy, bucketClient, testData.allowedTenants, defaultLimitsOverrides(t), log.NewNopLogger(), nil)
+			stores, err := NewBucketStores(cfg, "", testData.shardingStrategy, bucketClient, testData.allowedTenants, defaultLimitsOverrides(t), log.NewNopLogger(), nil)
 			require.NoError(t, err)
 
 			// Sync user stores and count the number of times the callback is called.
@@ -422,7 +422,7 @@ func TestBucketStores_ChunksAndSeriesLimiterFactoriesInitializedByEnforcedLimits
 
 			var allowedTenants *util.AllowList
 			reg := prometheus.NewPedanticRegistry()
-			stores, err := NewBucketStores(cfg, newNoShardingStrategy(), bucket, allowedTenants, overrides, log.NewNopLogger(), reg)
+			stores, err := NewBucketStores(cfg, "", newNoShardingStrategy(), bucket, allowedTenants, overrides, log.NewNopLogger(), reg)
 			require.NoError(t, err)
 			require.NoError(t, services.StartAndAwaitRunning(context.Background(), stores))
 			t.Cleanup(func() {
@@ -479,7 +479,7 @@ func testBucketStoresSeriesShouldCorrectlyQuerySeriesSpanningMultipleChunks(t *t
 
 	var allowedTenants *util.AllowList
 	reg := prometheus.NewPedanticRegistry()
-	stores, err := NewBucketStores(cfg, newNoShardingStrategy(), bucket, allowedTenants, defaultLimitsOverrides(t), log.NewNopLogger(), reg)
+	stores, err := NewBucketStores(cfg, "", newNoShardingStrategy(), bucket, allowedTenants, defaultLimitsOverrides(t), log.NewNopLogger(), reg)
 	require.NoError(t, err)
 
 	createBucketIndex(t, bucket, userID)
@@ -588,7 +588,7 @@ func TestBucketStore_Series_ShouldQueryBlockWithOutOfOrderChunks(t *testing.T) {
 
 	var allowedTenants *util.AllowList
 	reg := prometheus.NewPedanticRegistry()
-	stores, err := NewBucketStores(cfg, newNoShardingStrategy(), bkt, allowedTenants, defaultLimitsOverrides(t), log.NewNopLogger(), reg)
+	stores, err := NewBucketStores(cfg, "", newNoShardingStrategy(), bkt, allowedTenants, defaultLimitsOverrides(t), log.NewNopLogger(), reg)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(ctx, stores))
 	t.Cleanup(func() {
@@ -755,7 +755,7 @@ func TestBucketStores_deleteLocalFilesForExcludedTenants(t *testing.T) {
 
 	var allowedTenants *util.AllowList
 	reg := prometheus.NewPedanticRegistry()
-	stores, err := NewBucketStores(cfg, &sharding, bucket, allowedTenants, defaultLimitsOverrides(t), log.NewNopLogger(), reg)
+	stores, err := NewBucketStores(cfg, "", &sharding, bucket, allowedTenants, defaultLimitsOverrides(t), log.NewNopLogger(), reg)
 	require.NoError(t, err)
 
 	// Perform sync.
@@ -889,7 +889,7 @@ func indexHeaderCachingBucket(
 	blocksStorageCfg := prepareStorageConfig(tb)
 
 	return mimir_tsdb.NewStoreCachingBucket(
-		blocksStorageCfg, nil, indexHeaderCache, nil, bkt, logger, reg,
+		"", blocksStorageCfg, nil, indexHeaderCache, nil, bkt, logger, reg,
 	)
 }
 

--- a/pkg/storegateway/gateway.go
+++ b/pkg/storegateway/gateway.go
@@ -231,7 +231,18 @@ func newStoreGateway(gatewayCfg Config, storageCfg mimir_tsdb.BlocksStorageConfi
 		level.Info(logger).Log("msg", "store-gateway using disabled users", "disabled", gatewayCfg.DisabledTenants)
 	}
 
-	g.stores, err = NewBucketStores(storageCfg, shardingStrategy, bucketClient, allowedTenants, limits, logger, prometheus.WrapRegistererWith(prometheus.Labels{"component": "store-gateway"}, reg))
+	// cacheBucketID prefixes the caching-bucket keys. The bucket ID should be "blocks" but we pass an empty
+	// string to not cause a massive cache invalidation when rolling out a new Mimir version introducing the
+	// bucket ID. This is still fine, as far as all other caching bucket implementations specify their own
+	// unique ID. With compartments enabled the store-gateways of different read compartments read different
+	// buckets at identical object paths through a shared cache, so each is scoped to its read compartment or
+	// they collide.
+	cacheBucketID := ""
+	if gatewayCfg.Compartments.Enabled {
+		cacheBucketID = compartments.WithReadCompartmentSuffix("blocks", gatewayCfg.ReadCompartmentID)
+	}
+
+	g.stores, err = NewBucketStores(storageCfg, cacheBucketID, shardingStrategy, bucketClient, allowedTenants, limits, logger, prometheus.WrapRegistererWith(prometheus.Labels{"component": "store-gateway"}, reg))
 	if err != nil {
 		return nil, errors.Wrap(err, "create bucket stores")
 	}


### PR DESCRIPTION
#### What this PR does

Preliminary, behavior-preserving change extracted from #15856 (compartments-aware blocks-storage query path) to keep that PR's diff focused on the compartments query logic.

With compartments enabled, the store-gateways of different read compartments read different buckets at identical object paths but they _can_ share a metadata cache backend. The store caching bucket used an empty cache bucket ID, so one compartment's store-gateway could read another's cached bucket index and load the wrong blocks. This scopes the cache keys per read compartment to isolate them.

- `compartments.ReadCompartmentCacheID` derives the per-compartment cache bucket ID (`blocks-rc-<id>`), mirroring the existing ring key/name helpers.
- The store caching bucket (`NewStoreCachingBucket` / `NewBucketStores`) and the compactor's batch meta fetcher now take the cache bucket ID as input. The store-gateway and compactor set it from their read compartment ID when compartments are enabled, and leave it empty otherwise.

With compartments disabled the cache keys are unchanged (the ID stays empty to avoid invalidating existing caches). The compactor wasn't affected by the collision itself — its meta cache is keyed by the globally-unique block ULID — but it is scoped the same way so a read compartment's compactor and store-gateway share their cache entries.

#### Which issue(s) this PR fixes or relates to

Preliminary to #15856.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - not needed; compartments are experimental, disabled by default, and intentionally undocumented externally until the architecture works end to end (`changelog-not-needed`).
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features - deferred until compartments are complete end to end.
