### PR TITLE
feat(helm): allow disabling hardcoded ServiceMonitor job relabeling rule

### DIFF
--- a/operations/helm/charts/mimir-distributed/templates/lib/service-monitor.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/lib/service-monitor.tpl
@@ -47,10 +47,12 @@ spec:
       scrapeTimeout: {{ . }}
       {{- end }}
       relabelings:
+        {{- if or (not (hasKey . "relabelJobLabel")) .relabelJobLabel }}
         - action: replace
           sourceLabels: [job]
           replacement: "{{ $.ctx.Release.Namespace }}/{{ $.component }}"
           targetLabel: job
+        {{- end }}
         {{- if kindIs "string" .clusterLabel }}
         - action: replace
           replacement: "{{ .clusterLabel | default (include "mimir.clusterName" $.ctx) }}"

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -3598,6 +3598,8 @@ metaMonitoring:
     scheme: http
     # -- ServiceMonitor will use these tlsConfig settings to make the health check requests
     tlsConfig: null
+    # -- Enforce default job label modification (set to false if scraping via OpenTelemetry Collector to avoid double namespaces)
+    relabelJobLabel: true
 
   # Rules for the Prometheus Operator
   prometheusRule:


### PR DESCRIPTION
#### What this PR does

This PR introduces a configuration toggle `metaMonitoring.serviceMonitor.relabelJobLabel` (defaulting to `true`) to allow operators to disable the hardcoded `job` metric relabeling rule within the Mimir ServiceMonitors.

**Context / Rationale:**
Currently, the Mimir Helm chart hardcodes a relabeling rule that forces the `job` label into a `<namespace>/<component>` schema (e.g., `mimir/ingester`). While this works seamlessly for native Prometheus configurations, it introduces structural data corruption when scraped via an OpenTelemetry Collector. 

Because OpenTelemetry adheres strictly to OTel resource semantic conventions, the forward-slash configuration causes the OTel Collector to split and duplicate the namespace during exporting/remote-write routines. This yields a doubled job label string layout (e.g., `mimir/mimir/ingester`). 

Providing this toggle allows environments leveraging an OpenTelemetry-native metrics pipeline to disable this rule cleanly while maintaining complete backward compatibility for native Prometheus configurations.

**Changes Made:**
- **`values.yaml`**: Added `metaMonitoring.serviceMonitor.relabelJobLabel: true` with a configuration comment block.
- **`templates/common/_service-monitor.tpl`**: Wrapped the hardcoded `job` replacement action in an `if` block that gracefully falls back to `true` if the value isn't explicitly configured.

**Verification Performed:**
Verified template evaluation using local `helm template` dry-runs:
1. When `relabelJobLabel` is left out or set to `true`, the standard `job` target replacement logic renders normally.
2. When `relabelJobLabel` is set to `false`, the `job` replacement rule is completely suppressed from the rendered manifests, while remaining configuration blocks (such as the `cluster` label) continue compiling properly.

#### Which issue(s) this PR fixes or relates to

Fixes #14519

#### Checklist

- [x] Tests updated. (Verified via local helm template compilation dry-runs)
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com) updated with experimental features.
