### PR TITLE
Jsonnet: add per-compartment compactor and compactor-scheduler

### DIFF
--- a/operations/mimir-tests/test-compartments-generated.yaml
+++ b/operations/mimir-tests/test-compartments-generated.yaml
@@ -20,14 +20,53 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: compactor
-  name: compactor
+    name: compactor-rc-0
+  name: compactor-rc-0
   namespace: default
 spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-      name: compactor
+      name: compactor-rc-0
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: compactor-rc-1
+  name: compactor-rc-1
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: compactor-rc-1
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: compactor-scheduler-rc-0
+  name: compactor-scheduler-rc-0
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: compactor-scheduler-rc-0
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: compactor-scheduler-rc-1
+  name: compactor-scheduler-rc-1
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: compactor-scheduler-rc-1
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -463,8 +502,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    name: compactor
-  name: compactor
+    name: compactor-rc-0
+  name: compactor-rc-0
   namespace: default
 spec:
   clusterIP: None
@@ -479,7 +518,69 @@ spec:
     port: 7946
     targetPort: 7946
   selector:
-    name: compactor
+    name: compactor-rc-0
+    rollout-group: compactor-rc-0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: compactor-rc-1
+  name: compactor-rc-1
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: compactor-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: compactor-grpc
+    port: 9095
+    targetPort: 9095
+  - name: compactor-gossip-ring
+    port: 7946
+    targetPort: 7946
+  selector:
+    name: compactor-rc-1
+    rollout-group: compactor-rc-1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: compactor-scheduler-rc-0
+  name: compactor-scheduler-rc-0
+  namespace: default
+spec:
+  ports:
+  - name: compactor-scheduler-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: compactor-scheduler-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: compactor-scheduler-rc-0
+    statefulset.kubernetes.io/pod-name: compactor-scheduler-rc-0-0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: compactor-scheduler-rc-1
+  name: compactor-scheduler-rc-1
+  namespace: default
+spec:
+  ports:
+  - name: compactor-scheduler-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: compactor-scheduler-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: compactor-scheduler-rc-1
+    statefulset.kubernetes.io/pod-name: compactor-scheduler-rc-1-0
 ---
 apiVersion: v1
 kind: Service
@@ -2343,26 +2444,33 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
+  annotations:
+    rollout-max-unavailable: "1"
   labels:
-    name: compactor
-  name: compactor
+    name: compactor-rc-0
+    rollout-group: compactor-rc-0
+  name: compactor-rc-0
   namespace: default
 spec:
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
   podManagementPolicy: Parallel
-  replicas: 1
   selector:
     matchLabels:
-      name: compactor
-  serviceName: compactor
+      name: compactor-rc-0
+      rollout-group: compactor-rc-0
+  serviceName: compactor-rc-0
   template:
     metadata:
       labels:
         gossip_ring_member: "true"
-        name: compactor
+        name: compactor-rc-0
+        rollout-group: compactor-rc-0
     spec:
       containers:
       - args:
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.gcs.bucket-name=blocks-bucket-rc-0
         - -common.storage.backend=gcs
         - -compactor.block-ranges=2h,12h,24h
         - -compactor.blocks-retention-period=0
@@ -2375,18 +2483,28 @@ spec:
         - -compactor.first-level-compaction-wait-period=25m
         - -compactor.max-closing-blocks-concurrency=2
         - -compactor.max-opening-blocks-concurrency=4
+        - -compactor.read-compartment-id=0
         - -compactor.ring.heartbeat-period=1m
         - -compactor.ring.heartbeat-timeout=4m
         - -compactor.ring.prefix=
         - -compactor.ring.store=memberlist
         - -compactor.ring.wait-stability-min-duration=1m
+        - -compactor.scheduler-client.enabled=true
+        - -compactor.scheduler-client.metadata-cache.backend=memcached
+        - -compactor.scheduler-client.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
+        - -compactor.scheduler-client.metadata-cache.memcached.max-async-concurrency=50
+        - -compactor.scheduler-client.metadata-cache.memcached.max-item-size=1048576
+        - -compactor.scheduler-client.scheduler-endpoint=dns:///compactor-scheduler-rc-0.default.svc.cluster.local.:9095
         - -compactor.split-and-merge-shards=0
         - -compactor.split-groups=1
         - -compactor.symbols-flushers-concurrency=4
+        - -compartments.enabled=true
+        - -compartments.read.num-compartments=2
+        - -compartments.write.num-compartments=2
         - -ingest-storage.enabled=true
-        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
-        - -ingest-storage.kafka.topic=ingest
+        - -ingest-storage.kafka.topic=ingest-rc-0
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -2430,7 +2548,7 @@ spec:
           name: overrides
         name: overrides
   updateStrategy:
-    type: RollingUpdate
+    type: OnDelete
   volumeClaimTemplates:
   - apiVersion: v1
     kind: PersistentVolumeClaim
@@ -2442,6 +2560,299 @@ spec:
       resources:
         requests:
           storage: 250Gi
+      storageClassName: standard
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    rollout-max-unavailable: "1"
+  labels:
+    name: compactor-rc-1
+    rollout-group: compactor-rc-1
+  name: compactor-rc-1
+  namespace: default
+spec:
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      name: compactor-rc-1
+      rollout-group: compactor-rc-1
+  serviceName: compactor-rc-1
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: compactor-rc-1
+        rollout-group: compactor-rc-1
+    spec:
+      containers:
+      - args:
+        - -blocks-storage.gcs.bucket-name=blocks-bucket-rc-1
+        - -common.storage.backend=gcs
+        - -compactor.block-ranges=2h,12h,24h
+        - -compactor.blocks-retention-period=0
+        - -compactor.cleanup-interval=15m
+        - -compactor.compaction-concurrency=1
+        - -compactor.compaction-interval=30m
+        - -compactor.compactor-tenant-shard-size=1
+        - -compactor.data-dir=/data
+        - -compactor.deletion-delay=2h
+        - -compactor.first-level-compaction-wait-period=25m
+        - -compactor.max-closing-blocks-concurrency=2
+        - -compactor.max-opening-blocks-concurrency=4
+        - -compactor.read-compartment-id=1
+        - -compactor.ring.heartbeat-period=1m
+        - -compactor.ring.heartbeat-timeout=4m
+        - -compactor.ring.prefix=
+        - -compactor.ring.store=memberlist
+        - -compactor.ring.wait-stability-min-duration=1m
+        - -compactor.scheduler-client.enabled=true
+        - -compactor.scheduler-client.metadata-cache.backend=memcached
+        - -compactor.scheduler-client.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
+        - -compactor.scheduler-client.metadata-cache.memcached.max-async-concurrency=50
+        - -compactor.scheduler-client.metadata-cache.memcached.max-item-size=1048576
+        - -compactor.scheduler-client.scheduler-endpoint=dns:///compactor-scheduler-rc-1.default.svc.cluster.local.:9095
+        - -compactor.split-and-merge-shards=0
+        - -compactor.split-groups=1
+        - -compactor.symbols-flushers-concurrency=4
+        - -compartments.enabled=true
+        - -compartments.read.num-compartments=2
+        - -compartments.write.num-compartments=2
+        - -ingest-storage.enabled=true
+        - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.topic=ingest-rc-1
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -target=compactor
+        - -usage-stats.installation-mode=jsonnet
+        image: grafana/mimir:3.1.2
+        imagePullPolicy: IfNotPresent
+        name: compactor
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 6Gi
+          requests:
+            cpu: 1
+            memory: 6Gi
+        volumeMounts:
+        - mountPath: /data
+          name: compactor-data
+        - mountPath: /etc/mimir
+          name: overrides
+      securityContext:
+        runAsUser: 0
+      terminationGracePeriodSeconds: 900
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+  updateStrategy:
+    type: OnDelete
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: compactor-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 250Gi
+      storageClassName: standard
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    mimir-rc: "0"
+    name: compactor-scheduler-rc-0
+  name: compactor-scheduler-rc-0
+  namespace: default
+spec:
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      name: compactor-scheduler-rc-0
+  serviceName: compactor-scheduler-rc-0
+  template:
+    metadata:
+      labels:
+        mimir-rc: "0"
+        name: compactor-scheduler-rc-0
+    spec:
+      containers:
+      - args:
+        - -blocks-storage.gcs.bucket-name=blocks-bucket-rc-0
+        - -common.storage.backend=gcs
+        - -compactor-scheduler.bbolt.dir=/data
+        - -compactor-scheduler.persistence-type=bbolt
+        - -compactor-scheduler.planning-interval=30m
+        - -ingest-storage.enabled=true
+        - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.topic=ingest-rc-0
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -target=compactor-scheduler
+        image: grafana/mimir:3.1.2
+        imagePullPolicy: IfNotPresent
+        name: compactor-scheduler
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 500m
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /data
+          name: compactor-scheduler-data
+        - mountPath: /etc/mimir
+          name: overrides
+      securityContext:
+        runAsUser: 0
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: compactor-scheduler-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi
+      storageClassName: standard
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    mimir-rc: "1"
+    name: compactor-scheduler-rc-1
+  name: compactor-scheduler-rc-1
+  namespace: default
+spec:
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      name: compactor-scheduler-rc-1
+  serviceName: compactor-scheduler-rc-1
+  template:
+    metadata:
+      labels:
+        mimir-rc: "1"
+        name: compactor-scheduler-rc-1
+    spec:
+      containers:
+      - args:
+        - -blocks-storage.gcs.bucket-name=blocks-bucket-rc-1
+        - -common.storage.backend=gcs
+        - -compactor-scheduler.bbolt.dir=/data
+        - -compactor-scheduler.persistence-type=bbolt
+        - -compactor-scheduler.planning-interval=30m
+        - -ingest-storage.enabled=true
+        - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.topic=ingest-rc-1
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -target=compactor-scheduler
+        image: grafana/mimir:3.1.2
+        imagePullPolicy: IfNotPresent
+        name: compactor-scheduler
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 500m
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /data
+          name: compactor-scheduler-data
+        - mountPath: /etc/mimir
+          name: overrides
+      securityContext:
+        runAsUser: 0
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: compactor-scheduler-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi
       storageClassName: standard
 ---
 apiVersion: apps/v1
@@ -2465,6 +2876,8 @@ metadata:
   name: ingester-zone-a-rc-0
   namespace: default
 spec:
+  persistentVolumeClaimRetentionPolicy:
+    whenScaled: Delete
   podManagementPolicy: Parallel
   selector:
     matchLabels:
@@ -2512,7 +2925,7 @@ spec:
             topologyKey: kubernetes.io/hostname
       containers:
       - args:
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.gcs.bucket-name=blocks-bucket-rc-0
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
@@ -2645,6 +3058,8 @@ metadata:
   name: ingester-zone-a-rc-1
   namespace: default
 spec:
+  persistentVolumeClaimRetentionPolicy:
+    whenScaled: Delete
   podManagementPolicy: Parallel
   selector:
     matchLabels:
@@ -2692,7 +3107,7 @@ spec:
             topologyKey: kubernetes.io/hostname
       containers:
       - args:
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.gcs.bucket-name=blocks-bucket-rc-1
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
@@ -2821,6 +3236,8 @@ metadata:
   name: ingester-zone-b-rc-0
   namespace: default
 spec:
+  persistentVolumeClaimRetentionPolicy:
+    whenScaled: Delete
   podManagementPolicy: Parallel
   selector:
     matchLabels:
@@ -2868,7 +3285,7 @@ spec:
             topologyKey: kubernetes.io/hostname
       containers:
       - args:
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.gcs.bucket-name=blocks-bucket-rc-0
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
@@ -2991,6 +3408,8 @@ metadata:
   name: ingester-zone-b-rc-1
   namespace: default
 spec:
+  persistentVolumeClaimRetentionPolicy:
+    whenScaled: Delete
   podManagementPolicy: Parallel
   selector:
     matchLabels:
@@ -3038,7 +3457,7 @@ spec:
             topologyKey: kubernetes.io/hostname
       containers:
       - args:
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.gcs.bucket-name=blocks-bucket-rc-1
         - -blocks-storage.tsdb.block-ranges-period=2h
         - -blocks-storage.tsdb.dir=/data/tsdb
         - -blocks-storage.tsdb.head-compaction-interval=15m
@@ -3869,6 +4288,168 @@ metadata:
   namespace: default
 spec:
   labelSelector: name=ingester-zone-a-rc-1
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: compactor-rc-0
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 1800
+            type: Percent
+            value: 50
+          selectPolicy: Max
+          stabilizationWindowSeconds: 3600
+        scaleUp:
+          policies:
+          - periodSeconds: 600
+            type: Percent
+            value: 100
+          selectPolicy: Max
+          stabilizationWindowSeconds: 300
+  maxReplicaCount: 10
+  minReplicaCount: 1
+  pollingInterval: 10
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: compactor-rc-0
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_compactor_rc_0_drain_scheduler_hpa_default
+      query: |+
+        max_over_time(
+          (
+            (
+              # Compaction jobs: outstanding bytes * seconds/byte per compaction type
+              sum(
+                (
+                  sum by (compaction_type) (cortex_compactor_scheduler_incomplete_compaction_jobs_bytes{namespace="default", compaction_type=~"split|merge", pod=~"compactor-scheduler-rc-0-.*"})
+                  * (
+                    sum by (compaction_type) (histogram_sum(rate(cortex_compactor_job_duration_seconds{namespace="default", job_type="compaction", compaction_type=~"split|merge", pod=~"compactor-rc-0-.*"}[3h] @ end())))
+                    / sum by (compaction_type) (histogram_sum(rate(cortex_compactor_compaction_job_bytes{namespace="default", compaction_type=~"split|merge", pod=~"compactor-rc-0-.*"}[3h] @ end())))
+                    and sum by (compaction_type) (histogram_count(increase(cortex_compactor_job_duration_seconds{namespace="default", job_type="compaction", compaction_type=~"split|merge", pod=~"compactor-rc-0-.*"}[3h] @ end()))) >= 12
+                  )
+                )
+                or
+                sum by (compaction_type) (cortex_compactor_scheduler_incomplete_compaction_jobs_bytes{namespace="default", compaction_type=~"split|merge", pod=~"compactor-scheduler-rc-0-.*"}) * 1e-07
+              )
+              +
+              # Plan jobs: pending jobs * seconds/job.
+              sum(cortex_compactor_scheduler_pending_jobs{namespace="default", job_type="plan", pod=~"compactor-scheduler-rc-0-.*"})
+              * (
+                histogram_avg(sum(rate(cortex_compactor_job_duration_seconds{namespace="default", job_type="plan", pod=~"compactor-rc-0-.*"}[3h] @ end())))
+                and on() (sum(histogram_count(increase(cortex_compactor_job_duration_seconds{namespace="default", job_type="plan", pod=~"compactor-rc-0-.*"}[3h] @ end()))) >= 12)
+                or on() vector(1)
+              )
+            )
+            / 3600
+          )[1h:5m]
+        )
+        # A [1;2] multiplier, based on the time since we last saw an empty queue.
+        # We increment 0.1 every 3600 seconds of continuous pending jobs.
+        * (
+          clamp_max(
+            1 + 0.1 * floor(
+              (time() - max(max_over_time(cortex_compactor_scheduler_pending_jobs_last_empty_timestamp_seconds{namespace="default", pod=~"compactor-scheduler-rc-0-.*"}[36000s]) > 0)) / 3600
+            ),
+            2
+          )
+          or on() vector(2)
+        )
+
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "1"
+    metricType: AverageValue
+    name: cortex_compactor_rc_0_drain_scheduler_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: compactor-rc-1
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 1800
+            type: Percent
+            value: 50
+          selectPolicy: Max
+          stabilizationWindowSeconds: 3600
+        scaleUp:
+          policies:
+          - periodSeconds: 600
+            type: Percent
+            value: 100
+          selectPolicy: Max
+          stabilizationWindowSeconds: 300
+  maxReplicaCount: 10
+  minReplicaCount: 1
+  pollingInterval: 10
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: compactor-rc-1
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_compactor_rc_1_drain_scheduler_hpa_default
+      query: |+
+        max_over_time(
+          (
+            (
+              # Compaction jobs: outstanding bytes * seconds/byte per compaction type
+              sum(
+                (
+                  sum by (compaction_type) (cortex_compactor_scheduler_incomplete_compaction_jobs_bytes{namespace="default", compaction_type=~"split|merge", pod=~"compactor-scheduler-rc-1-.*"})
+                  * (
+                    sum by (compaction_type) (histogram_sum(rate(cortex_compactor_job_duration_seconds{namespace="default", job_type="compaction", compaction_type=~"split|merge", pod=~"compactor-rc-1-.*"}[3h] @ end())))
+                    / sum by (compaction_type) (histogram_sum(rate(cortex_compactor_compaction_job_bytes{namespace="default", compaction_type=~"split|merge", pod=~"compactor-rc-1-.*"}[3h] @ end())))
+                    and sum by (compaction_type) (histogram_count(increase(cortex_compactor_job_duration_seconds{namespace="default", job_type="compaction", compaction_type=~"split|merge", pod=~"compactor-rc-1-.*"}[3h] @ end()))) >= 12
+                  )
+                )
+                or
+                sum by (compaction_type) (cortex_compactor_scheduler_incomplete_compaction_jobs_bytes{namespace="default", compaction_type=~"split|merge", pod=~"compactor-scheduler-rc-1-.*"}) * 1e-07
+              )
+              +
+              # Plan jobs: pending jobs * seconds/job.
+              sum(cortex_compactor_scheduler_pending_jobs{namespace="default", job_type="plan", pod=~"compactor-scheduler-rc-1-.*"})
+              * (
+                histogram_avg(sum(rate(cortex_compactor_job_duration_seconds{namespace="default", job_type="plan", pod=~"compactor-rc-1-.*"}[3h] @ end())))
+                and on() (sum(histogram_count(increase(cortex_compactor_job_duration_seconds{namespace="default", job_type="plan", pod=~"compactor-rc-1-.*"}[3h] @ end()))) >= 12)
+                or on() vector(1)
+              )
+            )
+            / 3600
+          )[1h:5m]
+        )
+        # A [1;2] multiplier, based on the time since we last saw an empty queue.
+        # We increment 0.1 every 3600 seconds of continuous pending jobs.
+        * (
+          clamp_max(
+            1 + 0.1 * floor(
+              (time() - max(max_over_time(cortex_compactor_scheduler_pending_jobs_last_empty_timestamp_seconds{namespace="default", pod=~"compactor-scheduler-rc-1-.*"}[36000s]) > 0)) / 3600
+            ),
+            2
+          )
+          or on() vector(2)
+        )
+
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "1"
+    metricType: AverageValue
+    name: cortex_compactor_rc_1_drain_scheduler_hpa_default
+    type: prometheus
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject

--- a/operations/mimir-tests/test-compartments.jsonnet
+++ b/operations/mimir-tests/test-compartments.jsonnet
@@ -18,5 +18,13 @@
     compartments_enabled: true,
     compartments_read_count: 2,
     compartments_write_count: 2,
+
+    compactor_scheduler_enabled: true,
+    autoscaling_compactor_enabled: true,
+    autoscaling_compactor_min_replicas: 2,
+    autoscaling_compactor_max_replicas: 30,
+    cortex_compactor_concurrent_rollout_enabled: true,
+    enable_pvc_auto_deletion_for_compactors: true,
+    enable_pvc_auto_deletion_for_ingesters: true,
   },
 }

--- a/operations/mimir/compactor.libsonnet
+++ b/operations/mimir/compactor.libsonnet
@@ -102,19 +102,21 @@
     $.util.readinessProbe +
     $.tracing_env_mixin,
 
+  // Switches a compactor StatefulSet to rollout-operator-coordinated concurrent rollouts: OnDelete updates
+  // plus a rollout-group keyed on the StatefulSet name.
+  newCompactorConcurrentRolloutMixin(name, max_unavailable)::
+    statefulSet.mixin.spec.selector.withMatchLabels({ name: name, 'rollout-group': name }) +
+    statefulSet.mixin.spec.updateStrategy.withType('OnDelete') +
+    statefulSet.mixin.metadata.withLabelsMixin({ 'rollout-group': name }) +
+    statefulSet.mixin.metadata.withAnnotationsMixin({ 'rollout-max-unavailable': std.toString(max_unavailable) }) +
+    statefulSet.mixin.spec.template.metadata.withLabelsMixin({ 'rollout-group': name }),
+
   newCompactorStatefulSet(name, container, nodeAffinityMatchers=[], concurrent_rollout_enabled=false, max_unavailable=1)::
     $.newMimirStatefulSet(name, 1, container, compactor_data_pvc) +
     $.newMimirNodeAffinityMatchers(nodeAffinityMatchers) +
     statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(900) +
     $.mimirVolumeMounts +
-    (
-      if !concurrent_rollout_enabled then {} else
-        statefulSet.mixin.spec.selector.withMatchLabels({ name: 'compactor', 'rollout-group': 'compactor' }) +
-        statefulSet.mixin.spec.updateStrategy.withType('OnDelete') +
-        statefulSet.mixin.metadata.withLabelsMixin({ 'rollout-group': 'compactor' }) +
-        statefulSet.mixin.metadata.withAnnotationsMixin({ 'rollout-max-unavailable': std.toString(max_unavailable) }) +
-        statefulSet.mixin.spec.template.metadata.withLabelsMixin({ 'rollout-group': 'compactor' })
-    ),
+    (if !concurrent_rollout_enabled then {} else $.newCompactorConcurrentRolloutMixin(name, max_unavailable)),
 
   compactor_statefulset:
     $.newCompactorStatefulSet(

--- a/operations/mimir/compartments-common.libsonnet
+++ b/operations/mimir/compartments-common.libsonnet
@@ -38,6 +38,10 @@ local jsonpath = import 'github.com/jsonnet-libs/xtd/jsonpath.libsonnet';
   // '<read-compartment-id>' placeholder in compartments_blocks_storage_bucket_name.
   mimirBlocksStorageCompartmentBucketName(compartmentID):: std.strReplace($._config.compartments_blocks_storage_bucket_name, '<read-compartment-id>', std.toString(compartmentID)),
 
+  // Concrete Kafka topic for the given read compartment, resolving the '<read-compartment-id>' placeholder
+  // in compartments_ingest_storage_kafka_topic.
+  mimirIngestStorageCompartmentKafkaTopic(compartmentID):: std.strReplace($._config.compartments_ingest_storage_kafka_topic, '<read-compartment-id>', std.toString(compartmentID)),
+
   // The blocks-storage bucket-name CLI flag for the configured storage backend.
   mimirBlocksStorageBucketNameFlag::
     if $._config.storage_backend == 'gcs' then 'blocks-storage.gcs.bucket-name'

--- a/operations/mimir/compartments-compactor-scheduler.libsonnet
+++ b/operations/mimir/compartments-compactor-scheduler.libsonnet
@@ -1,0 +1,65 @@
+{
+  local statefulSet = $.apps.v1.statefulSet,
+
+  assert !$._config.compartments_compactor_enabled || $._config.compactor_scheduler_enabled
+         : 'compartments_compactor_enabled requires compactor_scheduler_enabled',
+
+  local isEnabled = $._config.compartments_compactor_enabled,
+  local numCompartments = $._config.compartments_read_count,
+  local isNoCompartmentsEnabled = $._config.no_compartments_compactor_enabled,
+
+  compactorSchedulerCompartmentEndpoint(compartmentIdx)::
+    'dns:///compactor-scheduler-rc-%d.%s.svc.%s:9095' % [compartmentIdx, $._config.namespace, $._config.cluster_domain],
+
+  // Per-compartment compactors lease from their own compactor-scheduler, so overwrite the single-scheduler
+  // endpoint they inherit (via compactor_args) with the per-compartment one.
+  compactor_compartments_args+:: $.mimirCompartmentsOverrides(super.compactor_compartments_args, function(compartmentIdx) {
+    'compactor.scheduler-client.scheduler-endpoint': $.compactorSchedulerCompartmentEndpoint(compartmentIdx),
+  }),
+
+  // Args.
+  compactor_scheduler_compartments_args:: $.mimirCompartmentsCreateIf(isEnabled, numCompartments, function(compartmentIdx)
+    $.compactor_scheduler_args {
+      [$.mimirBlocksStorageBucketNameFlag]: $.mimirBlocksStorageCompartmentBucketName(compartmentIdx),
+
+      // The scheduler doesn't consume Kafka, but it inherits the ingest-storage args from the common config,
+      // so set them to this read compartment's values for consistency (and so the compartments config
+      // validation passes).
+      'ingest-storage.kafka.address': $._config.compartments_ingest_storage_kafka_address,
+      'ingest-storage.kafka.topic': $.mimirIngestStorageCompartmentKafkaTopic(compartmentIdx),
+    }),
+
+  // Containers.
+  newCompactorSchedulerCompartmentContainer(compartmentIdx)::
+    $.newCompactorSchedulerContainer('compactor-scheduler', $.compactor_scheduler_compartments_args['compartment_%d' % compartmentIdx], $.compactor_scheduler_env_map),
+
+  compactor_scheduler_containers:: $.mimirCompartmentsCreateIf(isEnabled, numCompartments, function(compartment) $.newCompactorSchedulerCompartmentContainer(compartment)),
+
+  // StatefulSets, Services and PDBs.
+  newCompactorSchedulerCompartmentStatefulSet(compartmentIdx)::
+    local name = 'compactor-scheduler-rc-%d' % compartmentIdx;
+    $.newCompactorSchedulerStatefulSet(name, $.compactor_scheduler_containers['compartment_%d' % compartmentIdx]) +
+    statefulSet.mixin.metadata.withLabelsMixin({ 'mimir-rc': std.toString(compartmentIdx) }) +
+    statefulSet.mixin.spec.template.metadata.withLabelsMixin({ 'mimir-rc': std.toString(compartmentIdx) }),
+
+  compactor_scheduler_statefulsets: $.mimirCompartmentsCreateIf(isEnabled, numCompartments, function(compartment) $.newCompactorSchedulerCompartmentStatefulSet(compartment)),
+  compactor_scheduler_services: $.mimirCompartmentsCreateIf(isEnabled, numCompartments, function(compartment) $.newCompactorSchedulerService('compactor-scheduler-rc-%d' % compartment, $.compactor_scheduler_statefulsets['compartment_%d' % compartment])),
+  compactor_scheduler_pdbs: $.mimirCompartmentsCreateIf(isEnabled, numCompartments, function(compartment) $.newMimirPdb('compactor-scheduler-rc-%d' % compartment)),
+
+  // Per-compartment compactors are ephemeral workers when the scheduler is enabled (the scheduler re-leases
+  // jobs from compactors that go away), so delete their data volumes on scale-down and deletion. Mirrors the
+  // singular compactor in compactor-scheduler.libsonnet.
+  local schedulerWorkerPvcRetention = if !$._config.compactor_scheduler_enabled then {} else
+    statefulSet.spec.persistentVolumeClaimRetentionPolicy.withWhenScaled('Delete') +
+    statefulSet.spec.persistentVolumeClaimRetentionPolicy.withWhenDeleted('Delete'),
+  compactor_statefulsets+: $.mimirCompartmentsOverrides(super.compactor_statefulsets, schedulerWorkerPvcRetention),
+
+  // Null out the non-compartments compactor-scheduler when retired.
+  compactor_scheduler_statefulset: if isEnabled && !isNoCompartmentsEnabled then null else super.compactor_scheduler_statefulset,
+  compactor_scheduler_service: if isEnabled && !isNoCompartmentsEnabled then null else super.compactor_scheduler_service,
+  compactor_scheduler_pdb: if isEnabled && !isNoCompartmentsEnabled then null else super.compactor_scheduler_pdb,
+
+  // Config validation.
+  local schedulerCompartmentConfigError = $.validateMimirCompartmentsConfig(['compactor_scheduler_statefulsets']),
+  assert schedulerCompartmentConfigError == null : schedulerCompartmentConfigError,
+}

--- a/operations/mimir/compartments-compactor.libsonnet
+++ b/operations/mimir/compartments-compactor.libsonnet
@@ -1,0 +1,100 @@
+{
+  _config+:: {
+    compartments_compactor_enabled: $._config.compartments_enabled,
+    no_compartments_compactor_enabled: !self.compartments_compactor_enabled,
+
+    // Per-compartment compactor autoscaling bounds (per read compartment).
+    autoscaling_compactor_min_replicas_per_compartment: 1,
+    autoscaling_compactor_max_replicas_per_compartment: 10,
+  },
+
+  assert !$._config.compartments_compactor_enabled || $._config.compactor_scheduler_enabled
+         : 'compartments_compactor_enabled requires compactor_scheduler_enabled',
+  assert !$._config.compartments_compactor_enabled || $._config.autoscaling_compactor_enabled
+         : 'compartments_compactor_enabled requires autoscaling_compactor_enabled',
+  assert !$._config.compartments_compactor_enabled || $._config.cortex_compactor_concurrent_rollout_enabled
+         : 'compartments_compactor_enabled requires cortex_compactor_concurrent_rollout_enabled',
+
+  local container = $.core.v1.container,
+
+  local isEnabled = $._config.compartments_compactor_enabled,
+  local numCompartments = $._config.compartments_read_count,
+  local isNoCompartmentsEnabled = $._config.no_compartments_compactor_enabled,
+
+  local compartmentBlocksBucketArg(compartmentIdx) = {
+    [$.mimirBlocksStorageBucketNameFlag]: $.mimirBlocksStorageCompartmentBucketName(compartmentIdx),
+  },
+
+  // Args.
+  compactor_compartments_args:: $.mimirCompartmentsCreateIf(isEnabled, numCompartments, function(compartmentIdx)
+    $.compactor_args + compartmentBlocksBucketArg(compartmentIdx) {
+      'compartments.enabled': true,
+      'compartments.read.num-compartments': $._config.compartments_read_count,
+      'compartments.write.num-compartments': $._config.compartments_write_count,
+      'compactor.read-compartment-id': compartmentIdx,
+
+      // The compactor doesn't consume Kafka, but it inherits the ingest-storage args from the common config,
+      // so set them to this read compartment's values for consistency (and so the compartments config
+      // validation passes).
+      'ingest-storage.kafka.address': $._config.compartments_ingest_storage_kafka_address,
+      'ingest-storage.kafka.topic': $.mimirIngestStorageCompartmentKafkaTopic(compartmentIdx),
+    }),
+
+  // Containers.
+  newCompactorCompartmentContainer(compartmentIdx)::
+    $.compactor_container +
+    container.withArgs($.util.mapToFlags($.compactor_compartments_args['compartment_%d' % compartmentIdx])),
+
+  local compartmentCompactorMaxUnavailable = std.max(std.floor($._config.autoscaling_compactor_min_replicas_per_compartment / 2), 1),
+
+  newCompactorCompartmentStatefulSet(compartmentIdx)::
+    $.newCompactorStatefulSet(
+      'compactor-rc-%d' % compartmentIdx,
+      $.newCompactorCompartmentContainer(compartmentIdx),
+      $.compactor_node_affinity_matchers,
+      true,
+      compartmentCompactorMaxUnavailable,
+    ) +
+    // The per-compartment ScaledObject owns the replica count.
+    $.removeReplicasFromSpec,
+
+  // StatefulSets, Services and PDBs.
+  compactor_statefulsets: $.mimirCompartmentsCreateIf(isEnabled, numCompartments, function(compartment) $.newCompactorCompartmentStatefulSet(compartment)),
+  compactor_services: $.mimirCompartmentsCreateIf(isEnabled, numCompartments, function(compartment)
+    $.util.serviceFor($.compactor_statefulsets['compartment_%d' % compartment], $._config.service_ignored_labels) +
+    $.core.v1.service.mixin.spec.withClusterIp('None')),
+  compactor_pdbs: $.mimirCompartmentsCreateIf(isEnabled, numCompartments, function(compartment) $.newMimirPdb('compactor-rc-%d' % compartment)),
+
+  // Scaled objects.
+  compactor_scaled_objects: $.mimirCompartmentsCreateIf(isEnabled, numCompartments, function(compartment)
+    $.newCompactorSchedulerDrainScaledObject(
+      'compactor-rc-%d' % compartment,
+      'pod=~"compactor-scheduler-rc-%d-.*"' % compartment,
+      'pod=~"compactor-rc-%d-.*"' % compartment,
+      $._config.autoscaling_compactor_min_replicas_per_compartment,
+      $._config.autoscaling_compactor_max_replicas_per_compartment,
+    )),
+
+  // Null out the non-compartments compactor resources.
+  compactor_statefulset: if !isNoCompartmentsEnabled then null else super.compactor_statefulset,
+  compactor_service: if !isNoCompartmentsEnabled then null else super.compactor_service,
+  compactor_pdb: if !isNoCompartmentsEnabled then null else super.compactor_pdb,
+
+  compactor_scaled_object:
+    // When the non-compartments compactor also runs (e.g. during a migration), scope its drain autoscaler to
+    // exclude the per-compartment pods.
+    if isEnabled && isNoCompartmentsEnabled && $._config.compactor_scheduler_enabled then
+      $.newCompactorSchedulerDrainScaledObject(
+        'compactor',
+        'pod!~"compactor-scheduler-rc-.*"',
+        'pod!~"compactor-rc-.*"',
+        $._config.autoscaling_compactor_min_replicas,
+        $._config.autoscaling_compactor_max_replicas,
+      )
+    else if !isNoCompartmentsEnabled then null
+    else super.compactor_scaled_object,
+
+  // Config validation.
+  local compactorCompartmentConfigError = $.validateMimirCompartmentsConfig(['compactor_statefulsets']),
+  assert compactorCompartmentConfigError == null : compactorCompartmentConfigError,
+}

--- a/operations/mimir/compartments-ingester.libsonnet
+++ b/operations/mimir/compartments-ingester.libsonnet
@@ -98,7 +98,10 @@
       // '<read-compartment-id>' placeholder to the compartment id. The address keeps the write-compartment
       // placeholder because the ingester consumes from every write compartment's Kafka cluster.
       'ingest-storage.kafka.address': $._config.compartments_ingest_storage_kafka_address,
-      'ingest-storage.kafka.topic': std.strReplace($._config.compartments_ingest_storage_kafka_topic, '<read-compartment-id>', std.toString(compartmentIdx)),
+      'ingest-storage.kafka.topic': $.mimirIngestStorageCompartmentKafkaTopic(compartmentIdx),
+
+      // Each read compartment's ingesters upload blocks to that compartment's bucket.
+      [$.mimirBlocksStorageBucketNameFlag]: $.mimirBlocksStorageCompartmentBucketName(compartmentIdx),
     },
 
   ingester_zone_a_compartments_args:: $.mimirCompartmentsCreateIf(isEnabled && isZoneAEnabled, numCompartments, function(compartment) $.ingester_zone_a_args + perCompartmentIngesterArgs(compartment)),

--- a/operations/mimir/memberlist.libsonnet
+++ b/operations/mimir/memberlist.libsonnet
@@ -105,6 +105,7 @@
 
   alertmanager_statefulset: overrideSuperIfExists('alertmanager_statefulset', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
   compactor_statefulset: overrideSuperIfExists('compactor_statefulset', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
+  compactor_statefulsets+: overrideSuperCompartmentsIfExists('compactor_statefulsets', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
   distributor_deployment: overrideSuperIfExists('distributor_deployment', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
   distributor_zone_a_deployment: overrideSuperIfExists('distributor_zone_a_deployment', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
   distributor_zone_b_deployment: overrideSuperIfExists('distributor_zone_b_deployment', if !$._config.memberlist_ring_enabled then {} else gossipLabel),

--- a/operations/mimir/mimir.libsonnet
+++ b/operations/mimir/mimir.libsonnet
@@ -54,9 +54,6 @@
 (import 'ingester-automated-downscale-v2.libsonnet') +
 (import 'store-gateway-autoscaling.libsonnet') +
 
-// Automatic cleanup of unused PVCs after scaling down
-(import 'pvc-auto-deletion.libsonnet') +
-
 // Deletion protection for specific Mimir components.
 (import 'deletion-protection.libsonnet') +
 
@@ -72,6 +69,12 @@
 (import 'compartments-ingester.libsonnet') +
 (import 'compartments-querier.libsonnet') +
 (import 'compartments-query-frontend.libsonnet') +
+(import 'compartments-compactor.libsonnet') +
+(import 'compartments-compactor-scheduler.libsonnet') +
+
+// Automatic cleanup of unused PVCs after scaling down. Keep it after compartments so it can patch the
+// per-compartment StatefulSet maps.
+(import 'pvc-auto-deletion.libsonnet') +
 
 // Add memberlist support. Keep it at the end because it overrides all Mimir components.
 (import 'memberlist.libsonnet') +

--- a/operations/mimir/pvc-auto-deletion.libsonnet
+++ b/operations/mimir/pvc-auto-deletion.libsonnet
@@ -31,12 +31,21 @@ local statefulset = k.apps.v1.statefulSet;
   store_gateway_zone_b_backup_statefulset: overrideSuperIfExists('store_gateway_zone_b_backup_statefulset', store_gateway_pvc_auto_deletion),
 
   compactor_statefulset: overrideSuperIfExists('compactor_statefulset', compactor_pvc_auto_deletion),
+  compactor_statefulsets+: overrideSuperCompartmentsIfExists('compactor_statefulsets', compactor_pvc_auto_deletion),
 
   ingester_statefulset: overrideSuperIfExists('ingester_statefulset', ingester_pvc_auto_deletion),
   ingester_zone_a_statefulset: overrideSuperIfExists('ingester_zone_a_statefulset', ingester_pvc_auto_deletion),
   ingester_zone_b_statefulset: overrideSuperIfExists('ingester_zone_b_statefulset', ingester_pvc_auto_deletion),
   ingester_zone_c_statefulset: overrideSuperIfExists('ingester_zone_c_statefulset', ingester_pvc_auto_deletion),
+  ingester_zone_a_statefulsets+: overrideSuperCompartmentsIfExists('ingester_zone_a_statefulsets', ingester_pvc_auto_deletion),
+  ingester_zone_b_statefulsets+: overrideSuperCompartmentsIfExists('ingester_zone_b_statefulsets', ingester_pvc_auto_deletion),
+  ingester_zone_c_statefulsets+: overrideSuperCompartmentsIfExists('ingester_zone_c_statefulsets', ingester_pvc_auto_deletion),
 
   local overrideSuperIfExists(name, override) = if !( name in super) || super[name] == null || super[name] == {} then null else
     super[name] + override,
+
+  // Like overrideSuperIfExists, but merges the override into each entry of a per-compartment workload map.
+  local overrideSuperCompartmentsIfExists(name, override) =
+    if !( name in super) || !std.isObject(super[name]) then {}
+    else { [compartment]+: override for compartment in std.objectFields(super[name]) },
 }


### PR DESCRIPTION
#### What this PR does

Upstreams the per-compartment compactor and compactor-scheduler deployment jsonnet from Grafana Labs, so the experimental compartments architecture can compact each read compartment's blocks in isolation. Each compartment's compactors lease jobs from their own compactor-scheduler and compact that compartment's `-rc-<id>` blocks bucket (into which the compartment's ingesters upload).

This follows the earlier compartments jsonnet (#15752) and the base compactor-scheduler + compactor autoscaling (#15850).

#### Which issue(s) this PR fixes or relates to

N/A — experimental compartments architecture.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.