### PR TITLE
Fix GatherBlockHealthStats postings walk error check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
 * [BUGFIX] Memcached: Fix issue where cache-related trace spans included events emitted with an empty `name` label. #15794
 * [BUGFIX] MQE: Fix issue where LBAC is not respected by range vector splitting cache. #15802
 * [BUGFIX] Block-builder-scheduler: Fix a spurious "time went backwards" warning logged at startup when a partition has no records after the scan time. #15855
+* [BUGFIX] Compactor: Fix `GatherBlockHealthStats` postings walk error check to prevent swallowing errors. #15895
 
 ### Mixin
 

--- a/pkg/storage/tsdb/block/index.go
+++ b/pkg/storage/tsdb/block/index.go
@@ -291,7 +291,7 @@ func GatherBlockHealthStats(ctx context.Context, logger log.Logger, blockDir str
 			level.Debug(logger).Log("msg", "found out of order series", "labels", lset)
 		}
 	}
-	if p.Err() != nil {
+	if err = p.Err(); err != nil {
 		return stats, errors.Wrap(err, "walk postings")
 	}
 


### PR DESCRIPTION
#### What this PR does

Fixes an error check in `GatherBlockHealthStats`.  Currently `p.Err()` gets checked, but `err` gets wrapped, which would return a `nil` error. The provenance of this file is Thanos and this bug is also present upstream ([ref](https://github.com/thanos-io/thanos/blob/be1d6e457bdd6c1ff56b4099cdd9d0f5cfa43e2e/pkg/block/index.go#L377)). I'll open a PR for them as well.

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
