### PR TITLE
Fix compactor worker ID logged in scheduler mode

### DIFF
--- a/pkg/compactor/executor.go
+++ b/pkg/compactor/executor.go
@@ -262,7 +262,7 @@ func parseLaneRequests(configuredLanes flagext.StringSliceCSV) ([][]*compactorsc
 }
 
 func (e *schedulerExecutor) run(ctx context.Context, c *MultitenantCompactor) error {
-	baseWorkerID := fmt.Sprintf("compactor-%s", c.ringLifecycler.GetInstanceID())
+	baseWorkerID := c.ringLifecycler.GetInstanceID()
 	level.Info(e.logger).Log("msg", "compactor running in scheduler mode", "scheduler_endpoint", e.cfg.SchedulerEndpoint, "worker_id", baseWorkerID)
 
 	// Scheduler mode compactors work on jobs for arbitrary tenants, so unlike standalone mode they


### PR DESCRIPTION
#### What this PR does

Fixes a silly mistake where a redundant `compactor-` was logged in the `workerID` creating strings like `compactor-compactor-10`. This string isn't functional and is used for logging in the compactor and compactor scheduler.

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
