### PR TITLE
MQE: reduce not-equals matchers already excluded by positive regex

### DIFF
--- a/pkg/streamingpromql/optimize/ast/reduce_matchers.go
+++ b/pkg/streamingpromql/optimize/ast/reduce_matchers.go
@@ -254,36 +254,51 @@ func filterRegexMatchers(mf map[labels.MatchType][]*labels.Matcher, regexType la
 }
 
 // filterNotEqualsMatchers returns a subset of not-equals matchers which should actually reduce the result set size.
-// This subset is determined by comparing each not-equals matchers against equals and not-regex matchers.
+// This subset is determined by comparing each not-equals matchers against equals, regex, and not-regex matchers.
 // A not-equals matcher is dropped on any of these conditions:
 //   - there are any not-regex matchers which would also remove the not-equals matcher value from the result set
+//   - there are any regex matchers which would also remove the not-equals matcher value from the result set
 //   - any equals matcher for a value that is matched by the not-equals matcher
 //
 // Examples:
 //   - for the matcher set {foo!="bar", foo="b"}, foo!="bar" does match the value "b", so foo!="bar" is dropped.
 //   - for the matcher set {foo!="bar", foo="bar"}, foo!="bar" does not match the value "bar", so foo!="bar" is not dropped.
 //   - for the matcher set {foo!="bar", foo!~".*bar.*"}, foo!~".*bar.*" will exclude more values from the result set than foo!="bar", so foo!="bar" is dropped.
+//   - for the matcher set {foo!="bar", foo=~".*baz.*"}, foo=~".*baz.*" will already exclude the "bar" value.
 func filterNotEqualsMatchers(mf map[labels.MatchType][]*labels.Matcher) []*labels.Matcher {
 	outMatchers := make([]*labels.Matcher, 0, len(mf[labels.MatchNotEqual]))
-	// If the value of a not-equals matcher is matched by the inverse of any not-regex matcher,
-	// that not-equals matcher can be dropped, because it will select a subset of the regex.
-	// Using the example of x!="a" and x!~"a.*",
-	// x!~"a.*" will exclude more values than x!="a".
+
 	for _, m := range mf[labels.MatchNotEqual] {
-		noRegexMatchesValue := true
+		// If the value of a not-equals matcher is matched by the inverse of any not-regex matcher,
+		// that not-equals matcher can be dropped, because it will select a subset of the regex.
+		// Using the example of x!="a" and x!~"a.*",
+		// x!~"a.*" will exclude more values than x!="a".
+		notRegexExcludesValue := false
 		for _, nr := range mf[labels.MatchNotRegexp] {
 			if inv, err := nr.Inverse(); err == nil {
 				if inv.Matches(m.Value) {
-					noRegexMatchesValue = false
+					notRegexExcludesValue = true
 					break
 				}
 			}
 		}
+
+		// If the value of a not-equals matcher is not matched by a positive regex matcher,
+		// that not-equals matcher can be dropped because it will already be excluded by the
+		// regex.
+		positiveRegexExcludesValue := false
+		for _, r := range mf[labels.MatchRegexp] {
+			if !r.Matches(m.Value) {
+				positiveRegexExcludesValue = true
+				break
+			}
+		}
+
 		// If the value of any equals matcher is matched by the not-equals matcher, only keep the equals matcher,
 		// because the not-equals will not "subtract" anything from the final set.
 		matchesNoEquals := !matcherMatchesAnyValues(m, mf[labels.MatchEqual])
 
-		if noRegexMatchesValue && matchesNoEquals {
+		if !notRegexExcludesValue && !positiveRegexExcludesValue && matchesNoEquals {
 			outMatchers = append(outMatchers, m)
 		}
 	}

--- a/pkg/streamingpromql/optimize/ast/reduce_matchers_test.go
+++ b/pkg/streamingpromql/optimize/ast/reduce_matchers_test.go
@@ -89,6 +89,21 @@ func TestReduceMatchers_Apply_Vectors(t *testing.T) {
 			inputQuery:    `test_series{foo!="bar",foo="baz"}`,
 			expectedQuery: `test_series{foo="baz"}`,
 		},
+		{
+			name:          "not equals empty string matcher should be removed if a positive regex matcher already excludes its value",
+			inputQuery:    `test_series{foo!="",foo=~".+baz.+"}`,
+			expectedQuery: `test_series{foo=~".+baz.+"}`,
+		},
+		{
+			name:          "not equals matcher should be removed if a positive regex matcher already excludes its value",
+			inputQuery:    `test_series{foo!="host99", foo=~"(?i:(host1|host2|host3|host4|host5))"}`,
+			expectedQuery: `test_series{foo=~"(?i:(host1|host2|host3|host4|host5))"}`,
+		},
+		{
+			name:          "not equals matcher should not be removed if a positive regex matcher doesn't exclude its value",
+			inputQuery:    `test_series{foo!="bad",foo=~"b.+"}`,
+			expectedQuery: `test_series{foo!="bad",foo=~"b.+"}`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/streamingpromql/testdata/ours/reduce_matchers.test
+++ b/pkg/streamingpromql/testdata/ours/reduce_matchers.test
@@ -152,6 +152,15 @@ eval instant at 0m series{system!="http_requests", system!~".*bananas.*"}
   series{system="cpu_usage", instance="web-1", job="webserver"} 0.9
   series{system="cache_requests", backend="memcached"} 33
 
+# not-equals matcher and overlapping positive regex matcher
+eval instant at 0m series{system!="", system=~".+requests"}
+  series{system="http_requests", method="GET", status="200", handler="/api"} 10
+  series{system="http_requests", method="POST", status="200", handler="/api"} 20
+  series{system="http_requests", method="GET", status="404", handler="/api"} 30
+  series{system="http_requests", method="GET", status="500", handler="/api"} 40
+  series{system="http_requests", method="GET", status="504", handler="/api"} 50
+  series{system="cache_requests", backend="memcached"} 33
+
 # not-equals matcher and overlapping equals matcher
 eval instant at 0m series{system!="", system="http_requests"}
   series{system="http_requests", method="GET", status="200", handler="/api"} 10
@@ -203,3 +212,4 @@ eval instant at 0m series{system=~".*", method=~".*"}
   series{system="http_requests", method="GET", status="504", handler="/api"} 50
   series{system="cpu_usage", instance="web-1", job="webserver"} 0.9
   series{system="cache_requests", backend="memcached"} 33
+


### PR DESCRIPTION
Remove not-equals matchers when the value they are excluding is already excluded by a positive regular expression.

Fixes #13634

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
