### PR TITLE
Add experimental `cortex_query_scheduler_max_queue_length ` metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 * [FEATURE] MQE: Add `cortex_querier_inflight_query_max_age_seconds` metric reporting the age of the oldest in-flight query memory consumption tracker. #15300
 * [FEATURE] MQE: Add experimental support for splitting and caching `present_over_time` over range vectors in instant queries. #15386
 * [FEATURE] Query-scheduler: Add experimental `cortex_query_scheduler_inflight_max_age_seconds` metric reporting how long the oldest inflight request has been waiting since it was enqueued. Reports 0 when no requests are inflight. Enabled by default; can be disabled with `-query-scheduler.inflight-max-age-metric-enabled=false`. #15419
-* [FEATURE] Query-scheduler: Add experimental `cortex_query_scheduler_queue_length_peak` metric reporting the per-tenant peak queue length observed since the last scrape. Enable with `-query-scheduler.max-queue-length-metric-enabled=true`. #TODO
+* [FEATURE] Query-scheduler: Add experimental `cortex_query_scheduler_queue_length_peak` metric reporting the per-tenant peak queue length observed since the last scrape. Enable with `-query-scheduler.max-queue-length-metric-enabled=true`. #15906
 * [FEATURE] MQE: Add support for experimental PromQL functions `min_of` and `max_of`. #15597
 * [FEATURE] MQE: Add support for the experimental PromQL function `histogram_quantiles`, which computes multiple quantiles from classic or native histograms in a single call. #15710
 * [FEATURE] MQE: Add support for the native histogram trim operators `</` (trim upper) and `>/` (trim lower), including query sharding support. #15708 #15711

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [FEATURE] MQE: Add `cortex_querier_inflight_query_max_age_seconds` metric reporting the age of the oldest in-flight query memory consumption tracker. #15300
 * [FEATURE] MQE: Add experimental support for splitting and caching `present_over_time` over range vectors in instant queries. #15386
 * [FEATURE] Query-scheduler: Add experimental `cortex_query_scheduler_inflight_max_age_seconds` metric reporting how long the oldest inflight request has been waiting since it was enqueued. Reports 0 when no requests are inflight. Enabled by default; can be disabled with `-query-scheduler.inflight-max-age-metric-enabled=false`. #15419
+* [FEATURE] Query-scheduler: Add experimental `cortex_query_scheduler_queue_length_peak` metric reporting the per-tenant peak queue length observed since the last scrape. Enable with `-query-scheduler.max-queue-length-metric-enabled=true`. #TODO
 * [FEATURE] MQE: Add support for experimental PromQL functions `min_of` and `max_of`. #15597
 * [FEATURE] MQE: Add support for the experimental PromQL function `histogram_quantiles`, which computes multiple quantiles from classic or native histograms in a single call. #15710
 * [FEATURE] MQE: Add support for the native histogram trim operators `</` (trim upper) and `>/` (trim lower), including query sharding support. #15708 #15711

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 * [FEATURE] MQE: Add `cortex_querier_inflight_query_max_age_seconds` metric reporting the age of the oldest in-flight query memory consumption tracker. #15300
 * [FEATURE] MQE: Add experimental support for splitting and caching `present_over_time` over range vectors in instant queries. #15386
 * [FEATURE] Query-scheduler: Add experimental `cortex_query_scheduler_inflight_max_age_seconds` metric reporting how long the oldest inflight request has been waiting since it was enqueued. Reports 0 when no requests are inflight. Enabled by default; can be disabled with `-query-scheduler.inflight-max-age-metric-enabled=false`. #15419
-* [FEATURE] Query-scheduler: Add experimental `cortex_query_scheduler_queue_length_peak` metric reporting the per-tenant peak queue length observed since the last scrape. Enable with `-query-scheduler.max-queue-length-metric-enabled=true`. #15906
+* [FEATURE] Query-scheduler: Add experimental `cortex_query_scheduler_max_queue_length` metric reporting the per-tenant peak queue length observed since the last scrape. Enable with `-query-scheduler.max-queue-length-metric-enabled=true`. #15906
 * [FEATURE] MQE: Add support for experimental PromQL functions `min_of` and `max_of`. #15597
 * [FEATURE] MQE: Add support for the experimental PromQL function `histogram_quantiles`, which computes multiple quantiles from classic or native histograms in a single call. #15710
 * [FEATURE] MQE: Add support for the native histogram trim operators `</` (trim upper) and `>/` (trim lower), including query sharding support. #15708 #15711

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -20126,7 +20126,7 @@
           "kind": "field",
           "name": "max_queue_length_metric_enabled",
           "required": false,
-          "desc": "Enable the cortex_query_scheduler_queue_length_peak metric, which reports the per-tenant peak queue length observed since the last scrape. Disabling it skips per-tenant peak tracking on enqueue and dequeue.",
+          "desc": "Enable the cortex_query_scheduler_max_queue_length metric, which reports the per-tenant peak queue length observed since the last scrape. Disabling it skips per-tenant peak tracking on enqueue and dequeue.",
           "fieldValue": null,
           "fieldDefaultValue": false,
           "fieldFlag": "query-scheduler.max-queue-length-metric-enabled",

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -20123,6 +20123,17 @@
           "fieldCategory": "experimental"
         },
         {
+          "kind": "field",
+          "name": "max_queue_length_metric_enabled",
+          "required": false,
+          "desc": "Enable the cortex_query_scheduler_queue_length_peak metric, which reports the per-tenant peak queue length observed since the last scrape. Disabling it skips per-tenant peak tracking on enqueue and dequeue.",
+          "fieldValue": null,
+          "fieldDefaultValue": false,
+          "fieldFlag": "query-scheduler.max-queue-length-metric-enabled",
+          "fieldType": "boolean",
+          "fieldCategory": "experimental"
+        },
+        {
           "kind": "block",
           "name": "grpc_client_config",
           "required": false,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2817,6 +2817,8 @@ Usage of ./cmd/mimir/mimir:
     	[experimental] Enable the cortex_query_scheduler_inflight_max_age_seconds metric, which reports the age of the oldest inflight request. Disabling it skips the per-tick scan over inflight requests. (default true)
   -query-scheduler.max-outstanding-requests-per-tenant int
     	Maximum number of outstanding requests per tenant per query-scheduler. In-flight requests above this limit will fail with HTTP response status code 429. (default 100)
+  -query-scheduler.max-queue-length-metric-enabled
+    	[experimental] Enable the cortex_query_scheduler_queue_length_peak metric, which reports the per-tenant peak queue length observed since the last scrape. Disabling it skips per-tenant peak tracking on enqueue and dequeue.
   -query-scheduler.max-used-instances int
     	The maximum number of query-scheduler instances to use, regardless how many replicas are running. This option can be set only when -query-scheduler.service-discovery-mode is set to 'ring'. 0 to use all available query-scheduler instances.
   -query-scheduler.querier-forget-delay duration

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2818,7 +2818,7 @@ Usage of ./cmd/mimir/mimir:
   -query-scheduler.max-outstanding-requests-per-tenant int
     	Maximum number of outstanding requests per tenant per query-scheduler. In-flight requests above this limit will fail with HTTP response status code 429. (default 100)
   -query-scheduler.max-queue-length-metric-enabled
-    	[experimental] Enable the cortex_query_scheduler_queue_length_peak metric, which reports the per-tenant peak queue length observed since the last scrape. Disabling it skips per-tenant peak tracking on enqueue and dequeue.
+    	[experimental] Enable the cortex_query_scheduler_max_queue_length metric, which reports the per-tenant peak queue length observed since the last scrape. Disabling it skips per-tenant peak tracking on enqueue and dequeue.
   -query-scheduler.max-used-instances int
     	The maximum number of query-scheduler instances to use, regardless how many replicas are running. This option can be set only when -query-scheduler.service-discovery-mode is set to 'ring'. 0 to use all available query-scheduler instances.
   -query-scheduler.querier-forget-delay duration

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -242,6 +242,7 @@ The following features are currently experimental:
 - Query-scheduler
   - `-query-scheduler.querier-forget-delay`
   - `-query-scheduler.inflight-max-age-metric-enabled`
+  - `-query-scheduler.max-queue-length-metric-enabled`
 - Store-gateway
   - Eagerly loading some blocks on startup even when lazy loading is enabled `-blocks-storage.bucket-store.index-header.eager-loading-startup-enabled`
   - Allow more than the default of 3 store-gateways to own recent blocks `-store-gateway.dynamic-replication`

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -2377,6 +2377,12 @@ The `query_scheduler` block configures the query-scheduler.
 # CLI flag: -query-scheduler.inflight-max-age-metric-enabled
 [inflight_max_age_metric_enabled: <boolean> | default = true]
 
+# (experimental) Enable the cortex_query_scheduler_queue_length_peak metric,
+# which reports the per-tenant peak queue length observed since the last scrape.
+# Disabling it skips per-tenant peak tracking on enqueue and dequeue.
+# CLI flag: -query-scheduler.max-queue-length-metric-enabled
+[max_queue_length_metric_enabled: <boolean> | default = false]
+
 # This configures the gRPC client used to report errors back to the
 # query-frontend.
 # The CLI flags prefix for this block configuration is:

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -2377,7 +2377,7 @@ The `query_scheduler` block configures the query-scheduler.
 # CLI flag: -query-scheduler.inflight-max-age-metric-enabled
 [inflight_max_age_metric_enabled: <boolean> | default = true]
 
-# (experimental) Enable the cortex_query_scheduler_queue_length_peak metric,
+# (experimental) Enable the cortex_query_scheduler_max_queue_length metric,
 # which reports the per-tenant peak queue length observed since the last scrape.
 # Disabling it skips per-tenant peak tracking on enqueue and dequeue.
 # CLI flag: -query-scheduler.max-queue-length-metric-enabled

--- a/pkg/queue/max_queue_length.go
+++ b/pkg/queue/max_queue_length.go
@@ -33,7 +33,7 @@ type tenantQueueDepth struct {
 func NewMaxQueueLengthGauge() *MaxQueueLengthGauge {
 	return &MaxQueueLengthGauge{
 		desc: prometheus.NewDesc(
-			"cortex_query_scheduler_queue_length_peak",
+			"cortex_query_scheduler_max_queue_length",
 			"Maximum number of queries observed in a tenant's queue since the last metric collection (reset on each scrape). Captures the true peak queue depth between scrapes.",
 			[]string{"user"},
 			nil,

--- a/pkg/queue/max_queue_length.go
+++ b/pkg/queue/max_queue_length.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package queue
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// MaxQueueLengthGauge is a prometheus.Collector that reports, per tenant, the
+// maximum number of queued items observed since the last collection (scrape).
+//
+// The instantaneous cortex_query_scheduler_queue_length gauge only reflects the
+// queue depth at scrape time, so short bursts between scrapes are invisible.
+// MaxQueueLengthGauge tracks the running peak as items are enqueued and emits it
+// on Collect, then resets each tenant's tracked maximum to its current depth so
+// the next scrape window starts from the standing queue depth rather than zero.
+type MaxQueueLengthGauge struct {
+	desc *prometheus.Desc
+
+	mtx     sync.Mutex
+	tenants map[string]*tenantQueueDepth
+}
+
+type tenantQueueDepth struct {
+	current int
+	max     int
+}
+
+// NewMaxQueueLengthGauge returns a MaxQueueLengthGauge. The caller is
+// responsible for registering it with a prometheus.Registerer.
+func NewMaxQueueLengthGauge() *MaxQueueLengthGauge {
+	return &MaxQueueLengthGauge{
+		desc: prometheus.NewDesc(
+			"cortex_query_scheduler_queue_length_peak",
+			"Maximum number of queries observed in a tenant's queue since the last metric collection (reset on each scrape). Captures the true peak queue depth between scrapes.",
+			[]string{"user"},
+			nil,
+		),
+		tenants: map[string]*tenantQueueDepth{},
+	}
+}
+
+// inc records the enqueue of one item for tenantID, updating the running peak.
+func (g *MaxQueueLengthGauge) inc(tenantID string) {
+	g.mtx.Lock()
+	defer g.mtx.Unlock()
+
+	d := g.tenants[tenantID]
+	if d == nil {
+		d = &tenantQueueDepth{}
+		g.tenants[tenantID] = d
+	}
+	d.current++
+	if d.current > d.max {
+		d.max = d.current
+	}
+}
+
+// dec records the dequeue of one item for tenantID.
+func (g *MaxQueueLengthGauge) dec(tenantID string) {
+	g.mtx.Lock()
+	defer g.mtx.Unlock()
+
+	d := g.tenants[tenantID]
+	if d == nil {
+		return
+	}
+	if d.current > 0 {
+		d.current--
+	}
+}
+
+// DeleteTenant drops all tracked state for tenantID. It is called when a tenant
+// becomes inactive so the map does not grow unbounded.
+func (g *MaxQueueLengthGauge) DeleteTenant(tenantID string) {
+	g.mtx.Lock()
+	defer g.mtx.Unlock()
+
+	delete(g.tenants, tenantID)
+}
+
+func (g *MaxQueueLengthGauge) Describe(ch chan<- *prometheus.Desc) {
+	ch <- g.desc
+}
+
+// Collect emits the peak queue depth observed for each tenant since the last
+// collection, then resets each tenant's tracked maximum to its current depth.
+//
+// The tracked peaks are snapshotted (and reset) under a short lock, then emitted
+// to ch afterwards: sending to ch can block until prometheus drains the metric
+// channel, and inc/dec share this lock on the query dispatcher hot path, so the
+// lock must not be held across the channel sends.
+func (g *MaxQueueLengthGauge) Collect(ch chan<- prometheus.Metric) {
+	type tenantPeak struct {
+		tenantID string
+		max      int
+	}
+
+	g.mtx.Lock()
+	peaks := make([]tenantPeak, 0, len(g.tenants))
+	for tenantID, d := range g.tenants {
+		peaks = append(peaks, tenantPeak{tenantID: tenantID, max: d.max})
+		d.max = d.current
+	}
+	g.mtx.Unlock()
+
+	for _, p := range peaks {
+		ch <- prometheus.MustNewConstMetric(g.desc, prometheus.GaugeValue, float64(p.max), p.tenantID)
+	}
+}

--- a/pkg/queue/max_queue_length_test.go
+++ b/pkg/queue/max_queue_length_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const maxQueueLengthMetricName = "cortex_query_scheduler_queue_length_peak"
+const maxQueueLengthMetricName = "cortex_query_scheduler_max_queue_length"
 
 func gatherMaxQueueLength(t *testing.T, reg *prometheus.Registry, expected string) {
 	t.Helper()
@@ -19,8 +19,8 @@ func gatherMaxQueueLength(t *testing.T, reg *prometheus.Registry, expected strin
 }
 
 func expectedMaxQueueLength(series string) string {
-	return "# HELP cortex_query_scheduler_queue_length_peak Maximum number of queries observed in a tenant's queue since the last metric collection (reset on each scrape). Captures the true peak queue depth between scrapes.\n" +
-		"# TYPE cortex_query_scheduler_queue_length_peak gauge\n" +
+	return "# HELP cortex_query_scheduler_max_queue_length Maximum number of queries observed in a tenant's queue since the last metric collection (reset on each scrape). Captures the true peak queue depth between scrapes.\n" +
+		"# TYPE cortex_query_scheduler_max_queue_length gauge\n" +
 		series
 }
 
@@ -33,7 +33,7 @@ func TestMaxQueueLengthGauge_TracksPeak(t *testing.T) {
 	g.inc("a")
 	g.inc("a")
 
-	gatherMaxQueueLength(t, reg, expectedMaxQueueLength(`cortex_query_scheduler_queue_length_peak{user="a"} 3`+"\n"))
+	gatherMaxQueueLength(t, reg, expectedMaxQueueLength(`cortex_query_scheduler_max_queue_length{user="a"} 3`+"\n"))
 }
 
 func TestMaxQueueLengthGauge_PeakIsIntraWindowMaxNotEndValue(t *testing.T) {
@@ -50,7 +50,7 @@ func TestMaxQueueLengthGauge_PeakIsIntraWindowMaxNotEndValue(t *testing.T) {
 	g.inc("a") // 2
 
 	// The reported value is the intra-window peak (3), not the depth at scrape time (2).
-	gatherMaxQueueLength(t, reg, expectedMaxQueueLength(`cortex_query_scheduler_queue_length_peak{user="a"} 3`+"\n"))
+	gatherMaxQueueLength(t, reg, expectedMaxQueueLength(`cortex_query_scheduler_max_queue_length{user="a"} 3`+"\n"))
 }
 
 func TestMaxQueueLengthGauge_ResetsToStandingDepth(t *testing.T) {
@@ -63,17 +63,17 @@ func TestMaxQueueLengthGauge_ResetsToStandingDepth(t *testing.T) {
 	g.inc("a") // current=3, max=3
 
 	// First scrape reports the peak and reseeds max to the standing depth (3).
-	gatherMaxQueueLength(t, reg, expectedMaxQueueLength(`cortex_query_scheduler_queue_length_peak{user="a"} 3`+"\n"))
+	gatherMaxQueueLength(t, reg, expectedMaxQueueLength(`cortex_query_scheduler_max_queue_length{user="a"} 3`+"\n"))
 
 	// Queue drains with no new enqueues in this window.
 	g.dec("a")
 	g.dec("a") // current=1, max still 3
 
 	// The window began at standing depth 3, so the peak for it is still 3 (not under-reported as 1).
-	gatherMaxQueueLength(t, reg, expectedMaxQueueLength(`cortex_query_scheduler_queue_length_peak{user="a"} 3`+"\n"))
+	gatherMaxQueueLength(t, reg, expectedMaxQueueLength(`cortex_query_scheduler_max_queue_length{user="a"} 3`+"\n"))
 
 	// With no further activity, the next window reflects the new standing depth (1).
-	gatherMaxQueueLength(t, reg, expectedMaxQueueLength(`cortex_query_scheduler_queue_length_peak{user="a"} 1`+"\n"))
+	gatherMaxQueueLength(t, reg, expectedMaxQueueLength(`cortex_query_scheduler_max_queue_length{user="a"} 1`+"\n"))
 }
 
 func TestMaxQueueLengthGauge_DecNeverGoesNegative(t *testing.T) {
@@ -87,9 +87,9 @@ func TestMaxQueueLengthGauge_DecNeverGoesNegative(t *testing.T) {
 	g.dec("a") // 0
 	g.dec("a") // still 0
 
-	gatherMaxQueueLength(t, reg, expectedMaxQueueLength(`cortex_query_scheduler_queue_length_peak{user="a"} 1`+"\n"))
+	gatherMaxQueueLength(t, reg, expectedMaxQueueLength(`cortex_query_scheduler_max_queue_length{user="a"} 1`+"\n"))
 	// Standing depth is 0 after the reset.
-	gatherMaxQueueLength(t, reg, expectedMaxQueueLength(`cortex_query_scheduler_queue_length_peak{user="a"} 0`+"\n"))
+	gatherMaxQueueLength(t, reg, expectedMaxQueueLength(`cortex_query_scheduler_max_queue_length{user="a"} 0`+"\n"))
 }
 
 func TestMaxQueueLengthGauge_PerTenantAndDelete(t *testing.T) {
@@ -102,10 +102,10 @@ func TestMaxQueueLengthGauge_PerTenantAndDelete(t *testing.T) {
 	g.inc("b")
 
 	gatherMaxQueueLength(t, reg, expectedMaxQueueLength(
-		`cortex_query_scheduler_queue_length_peak{user="a"} 2`+"\n"+
-			`cortex_query_scheduler_queue_length_peak{user="b"} 1`+"\n"))
+		`cortex_query_scheduler_max_queue_length{user="a"} 2`+"\n"+
+			`cortex_query_scheduler_max_queue_length{user="b"} 1`+"\n"))
 
 	g.DeleteTenant("a")
 
-	gatherMaxQueueLength(t, reg, expectedMaxQueueLength(`cortex_query_scheduler_queue_length_peak{user="b"} 1`+"\n"))
+	gatherMaxQueueLength(t, reg, expectedMaxQueueLength(`cortex_query_scheduler_max_queue_length{user="b"} 1`+"\n"))
 }

--- a/pkg/queue/max_queue_length_test.go
+++ b/pkg/queue/max_queue_length_test.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package queue
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+const maxQueueLengthMetricName = "cortex_query_scheduler_queue_length_peak"
+
+func gatherMaxQueueLength(t *testing.T, reg *prometheus.Registry, expected string) {
+	t.Helper()
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expected), maxQueueLengthMetricName))
+}
+
+func expectedMaxQueueLength(series string) string {
+	return "# HELP cortex_query_scheduler_queue_length_peak Maximum number of queries observed in a tenant's queue since the last metric collection (reset on each scrape). Captures the true peak queue depth between scrapes.\n" +
+		"# TYPE cortex_query_scheduler_queue_length_peak gauge\n" +
+		series
+}
+
+func TestMaxQueueLengthGauge_TracksPeak(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+	g := NewMaxQueueLengthGauge()
+	reg.MustRegister(g)
+
+	g.inc("a")
+	g.inc("a")
+	g.inc("a")
+
+	gatherMaxQueueLength(t, reg, expectedMaxQueueLength(`cortex_query_scheduler_queue_length_peak{user="a"} 3`+"\n"))
+}
+
+func TestMaxQueueLengthGauge_PeakIsIntraWindowMaxNotEndValue(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+	g := NewMaxQueueLengthGauge()
+	reg.MustRegister(g)
+
+	// Within a single scrape window: rise to 3, drain to 1, rise to 2.
+	g.inc("a") // 1
+	g.inc("a") // 2
+	g.inc("a") // 3 (peak)
+	g.dec("a") // 2
+	g.dec("a") // 1
+	g.inc("a") // 2
+
+	// The reported value is the intra-window peak (3), not the depth at scrape time (2).
+	gatherMaxQueueLength(t, reg, expectedMaxQueueLength(`cortex_query_scheduler_queue_length_peak{user="a"} 3`+"\n"))
+}
+
+func TestMaxQueueLengthGauge_ResetsToStandingDepth(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+	g := NewMaxQueueLengthGauge()
+	reg.MustRegister(g)
+
+	g.inc("a")
+	g.inc("a")
+	g.inc("a") // current=3, max=3
+
+	// First scrape reports the peak and reseeds max to the standing depth (3).
+	gatherMaxQueueLength(t, reg, expectedMaxQueueLength(`cortex_query_scheduler_queue_length_peak{user="a"} 3`+"\n"))
+
+	// Queue drains with no new enqueues in this window.
+	g.dec("a")
+	g.dec("a") // current=1, max still 3
+
+	// The window began at standing depth 3, so the peak for it is still 3 (not under-reported as 1).
+	gatherMaxQueueLength(t, reg, expectedMaxQueueLength(`cortex_query_scheduler_queue_length_peak{user="a"} 3`+"\n"))
+
+	// With no further activity, the next window reflects the new standing depth (1).
+	gatherMaxQueueLength(t, reg, expectedMaxQueueLength(`cortex_query_scheduler_queue_length_peak{user="a"} 1`+"\n"))
+}
+
+func TestMaxQueueLengthGauge_DecNeverGoesNegative(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+	g := NewMaxQueueLengthGauge()
+	reg.MustRegister(g)
+
+	// dec on an unknown / already-empty tenant must be a no-op, not a negative depth.
+	g.dec("a")
+	g.inc("a") // 1
+	g.dec("a") // 0
+	g.dec("a") // still 0
+
+	gatherMaxQueueLength(t, reg, expectedMaxQueueLength(`cortex_query_scheduler_queue_length_peak{user="a"} 1`+"\n"))
+	// Standing depth is 0 after the reset.
+	gatherMaxQueueLength(t, reg, expectedMaxQueueLength(`cortex_query_scheduler_queue_length_peak{user="a"} 0`+"\n"))
+}
+
+func TestMaxQueueLengthGauge_PerTenantAndDelete(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+	g := NewMaxQueueLengthGauge()
+	reg.MustRegister(g)
+
+	g.inc("a")
+	g.inc("a")
+	g.inc("b")
+
+	gatherMaxQueueLength(t, reg, expectedMaxQueueLength(
+		`cortex_query_scheduler_queue_length_peak{user="a"} 2`+"\n"+
+			`cortex_query_scheduler_queue_length_peak{user="b"} 1`+"\n"))
+
+	g.DeleteTenant("a")
+
+	gatherMaxQueueLength(t, reg, expectedMaxQueueLength(`cortex_query_scheduler_queue_length_peak{user="b"} 1`+"\n"))
+}

--- a/pkg/queue/multi_queuing_algorithm_tree_queue_benchmark_test.go
+++ b/pkg/queue/multi_queuing_algorithm_tree_queue_benchmark_test.go
@@ -421,6 +421,7 @@ func TestMultiDimensionalQueueAlgorithmSlowConsumerEffects(t *testing.T) {
 					promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
 					promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 					promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
+					nil,
 				)
 				require.NoError(t, err)
 

--- a/pkg/queue/multi_queuing_algorithm_tree_queue_benchmark_test.go
+++ b/pkg/queue/multi_queuing_algorithm_tree_queue_benchmark_test.go
@@ -419,9 +419,9 @@ func TestMultiDimensionalQueueAlgorithmSlowConsumerEffects(t *testing.T) {
 					maxOutStandingPerTenant,
 					consumerForgetDelay,
 					promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
+					nil,
 					promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 					promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
-					nil,
 				)
 				require.NoError(t, err)
 

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -66,6 +66,7 @@ type Queue struct {
 	queueLength       *prometheus.GaugeVec   // per user
 	discardedRequests *prometheus.CounterVec // per user
 	enqueueDuration   prometheus.Histogram
+	maxQueueLength    *MaxQueueLengthGauge // per user; nil when the metric is disabled
 
 	stopRequested chan struct{} // Written to by stop() to wake up dispatcherLoop() in response to a stop request.
 	stopCompleted chan struct{} // Closed by dispatcherLoop() after a stop is requested and the dispatcher has stopped.
@@ -163,6 +164,7 @@ func New(
 	queueLength *prometheus.GaugeVec,
 	discardedRequests *prometheus.CounterVec,
 	enqueueDuration prometheus.Histogram,
+	maxQueueLength *MaxQueueLengthGauge,
 ) (*Queue, error) {
 	q := &Queue{
 		// settings
@@ -175,6 +177,7 @@ func New(
 		queueLength:              queueLength,
 		discardedRequests:        discardedRequests,
 		enqueueDuration:          enqueueDuration,
+		maxQueueLength:           maxQueueLength,
 
 		// channels must not be buffered so that we can detect when dispatcherLoop() has finished.
 		stopRequested: make(chan struct{}),
@@ -332,6 +335,9 @@ func (q *Queue) enqueueItemInternal(r itemToEnqueue) error {
 	}
 
 	q.queueLength.WithLabelValues(r.tenantID).Inc()
+	if q.maxQueueLength != nil {
+		q.maxQueueLength.inc(r.tenantID)
+	}
 	return nil
 }
 
@@ -368,6 +374,9 @@ func (q *Queue) trySendNextItemForConsumer(dequeueReq *ConsumerWorkerDequeueRequ
 	sent := dequeueReq.sendResponse(response)
 	if sent {
 		q.queueLength.WithLabelValues(tenant.tenantID).Dec()
+		if q.maxQueueLength != nil {
+			q.maxQueueLength.dec(tenant.tenantID)
+		}
 	} else {
 		// should never error; any item previously in the queue already passed validation
 		err := q.queueBroker.enqueueItemFront(dequeued, tenant.maxConsumers)

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -162,9 +162,9 @@ func New(
 	maxOutstandingPerTenant int,
 	forgetDelay time.Duration,
 	queueLength *prometheus.GaugeVec,
+	maxQueueLength *MaxQueueLengthGauge,
 	discardedRequests *prometheus.CounterVec,
 	enqueueDuration prometheus.Histogram,
-	maxQueueLength *MaxQueueLengthGauge,
 ) (*Queue, error) {
 	q := &Queue{
 		// settings

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -175,9 +175,9 @@ func New(
 		// metrics for reporting
 		connectedConsumerWorkers: atomic.NewInt64(0),
 		queueLength:              queueLength,
+		maxQueueLength:           maxQueueLength,
 		discardedRequests:        discardedRequests,
 		enqueueDuration:          enqueueDuration,
-		maxQueueLength:           maxQueueLength,
 
 		// channels must not be buffered so that we can detect when dispatcherLoop() has finished.
 		stopRequested: make(chan struct{}),

--- a/pkg/queue/queue_test.go
+++ b/pkg/queue/queue_test.go
@@ -134,6 +134,7 @@ func BenchmarkConcurrentQueueOperations(b *testing.B) {
 								promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
 								promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 								promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
+								nil,
 							)
 							require.NoError(b, err)
 
@@ -403,6 +404,7 @@ func TestDispatchToWaitingDequeueRequestForUnregisteredConsumerWorker(t *testing
 		promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
 		promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 		promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -519,6 +521,7 @@ func TestQueue_RegisterAndUnregisterConsumerWorkerConnections(t *testing.T) {
 		promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
 		promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 		promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -604,6 +607,7 @@ func TestQueue_GetNextRequestForConsumer_ShouldGetRequestAfterReshardingBecauseC
 		promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
 		promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 		promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -676,6 +680,7 @@ func TestQueue_GetNextRequestForConsumer_ReshardNotifiedCorrectlyForMultipleCons
 		promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
 		promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 		promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -764,6 +769,7 @@ func TestQueue_GetNextRequestForConsumer_ShouldReturnAfterContextCancelled(t *te
 		promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
 		promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 		promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -819,6 +825,7 @@ func TestQueue_GetNextRequestForConsumer_ShouldReturnImmediatelyIfConsumerIsAlre
 		promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
 		promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 		promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -849,6 +856,7 @@ func TestQueue_tryDispatchRequestToConsumer_ShouldReEnqueueAfterFailedSendToCons
 		promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
 		promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 		promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -914,6 +922,7 @@ func TestQueue_ShutdownWithPendingRequests_ShouldDrainRequests(t *testing.T) {
 		promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
 		promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 		promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
+		nil,
 	)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(ctx, queue))

--- a/pkg/queue/queue_test.go
+++ b/pkg/queue/queue_test.go
@@ -132,9 +132,9 @@ func BenchmarkConcurrentQueueOperations(b *testing.B) {
 								maxOutstandingRequestsPerTenant,
 								forgetConsumerDelay,
 								promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
+								nil,
 								promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 								promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
-								nil,
 							)
 							require.NoError(b, err)
 
@@ -402,9 +402,9 @@ func TestDispatchToWaitingDequeueRequestForUnregisteredConsumerWorker(t *testing
 		2,
 		forgetDelay,
 		promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
+		nil,
 		promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 		promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
-		nil,
 	)
 	require.NoError(t, err)
 
@@ -519,9 +519,9 @@ func TestQueue_RegisterAndUnregisterConsumerWorkerConnections(t *testing.T) {
 		1,
 		forgetDelay,
 		promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
+		nil,
 		promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 		promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
-		nil,
 	)
 	require.NoError(t, err)
 
@@ -605,9 +605,9 @@ func TestQueue_GetNextRequestForConsumer_ShouldGetRequestAfterReshardingBecauseC
 		1,
 		forgetDelay,
 		promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
+		nil,
 		promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 		promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
-		nil,
 	)
 	require.NoError(t, err)
 
@@ -678,9 +678,9 @@ func TestQueue_GetNextRequestForConsumer_ReshardNotifiedCorrectlyForMultipleCons
 		1,
 		forgetDelay,
 		promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
+		nil,
 		promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 		promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
-		nil,
 	)
 	require.NoError(t, err)
 
@@ -767,9 +767,9 @@ func TestQueue_GetNextRequestForConsumer_ShouldReturnAfterContextCancelled(t *te
 		1,
 		forgetDelay,
 		promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
+		nil,
 		promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 		promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
-		nil,
 	)
 	require.NoError(t, err)
 
@@ -823,9 +823,9 @@ func TestQueue_GetNextRequestForConsumer_ShouldReturnImmediatelyIfConsumerIsAlre
 		1,
 		forgetDelay,
 		promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
+		nil,
 		promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 		promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
-		nil,
 	)
 	require.NoError(t, err)
 
@@ -854,9 +854,9 @@ func TestQueue_tryDispatchRequestToConsumer_ShouldReEnqueueAfterFailedSendToCons
 		1,
 		forgetDelay,
 		promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
+		nil,
 		promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 		promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
-		nil,
 	)
 	require.NoError(t, err)
 
@@ -920,9 +920,9 @@ func TestQueue_ShutdownWithPendingRequests_ShouldDrainRequests(t *testing.T) {
 		1,
 		0,
 		promauto.With(nil).NewGaugeVec(prometheus.GaugeOpts{}, []string{"user"}),
+		nil,
 		promauto.With(nil).NewCounterVec(prometheus.CounterOpts{}, []string{"user"}),
 		promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}),
-		nil,
 	)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(ctx, queue))

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -118,7 +118,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.IntVar(&cfg.MaxOutstandingPerTenant, "query-scheduler.max-outstanding-requests-per-tenant", 100, "Maximum number of outstanding requests per tenant per query-scheduler. In-flight requests above this limit will fail with HTTP response status code 429.")
 	f.DurationVar(&cfg.QuerierForgetDelay, "query-scheduler.querier-forget-delay", 0, "If a querier disconnects without sending notification about graceful shutdown, the query-scheduler will keep the querier in the tenant's shard until the forget delay has passed. This feature is useful to reduce the blast radius when shuffle-sharding is enabled.")
 	f.BoolVar(&cfg.InflightMaxAgeMetricEnabled, "query-scheduler.inflight-max-age-metric-enabled", true, "Enable the cortex_query_scheduler_inflight_max_age_seconds metric, which reports the age of the oldest inflight request. Disabling it skips the per-tick scan over inflight requests.")
-	f.BoolVar(&cfg.MaxQueueLengthMetricEnabled, "query-scheduler.max-queue-length-metric-enabled", false, "Enable the cortex_query_scheduler_queue_length_peak metric, which reports the per-tenant peak queue length observed since the last scrape. Disabling it skips per-tenant peak tracking on enqueue and dequeue.")
+	f.BoolVar(&cfg.MaxQueueLengthMetricEnabled, "query-scheduler.max-queue-length-metric-enabled", false, "Enable the cortex_query_scheduler_max_queue_length metric, which reports the per-tenant peak queue length observed since the last scrape. Disabling it skips per-tenant peak tracking on enqueue and dequeue.")
 
 	cfg.GRPCClientConfig.CustomCompressors = []string{s2.Name}
 	cfg.GRPCClientConfig.RegisterFlagsWithPrefix("query-scheduler.grpc-client-config", f)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -192,10 +192,10 @@ func NewScheduler(cfg Config, limits Limits, log log.Logger, registerer promethe
 		limits,
 		s.log,
 		s.queueLength,
+		s.maxQueueLength,
 		s.discardedRequests,
 		enqueueDuration,
 		querierInflightRequestsMetric,
-		s.maxQueueLength,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -84,6 +84,7 @@ type Scheduler struct {
 
 	// Metrics.
 	queueLength              *prometheus.GaugeVec
+	maxQueueLength           *queue.MaxQueueLengthGauge
 	discardedRequests        *prometheus.CounterVec
 	cancelledRequests        *prometheus.CounterVec
 	connectedQuerierClients  prometheus.GaugeFunc
@@ -107,6 +108,7 @@ type Config struct {
 	MaxOutstandingPerTenant     int           `yaml:"max_outstanding_requests_per_tenant"`
 	QuerierForgetDelay          time.Duration `yaml:"querier_forget_delay" category:"experimental"`
 	InflightMaxAgeMetricEnabled bool          `yaml:"inflight_max_age_metric_enabled" category:"experimental"`
+	MaxQueueLengthMetricEnabled bool          `yaml:"max_queue_length_metric_enabled" category:"experimental"`
 
 	GRPCClientConfig grpcclient.Config         `yaml:"grpc_client_config" doc:"description=This configures the gRPC client used to report errors back to the query-frontend."`
 	ServiceDiscovery schedulerdiscovery.Config `yaml:",inline"`
@@ -116,6 +118,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.IntVar(&cfg.MaxOutstandingPerTenant, "query-scheduler.max-outstanding-requests-per-tenant", 100, "Maximum number of outstanding requests per tenant per query-scheduler. In-flight requests above this limit will fail with HTTP response status code 429.")
 	f.DurationVar(&cfg.QuerierForgetDelay, "query-scheduler.querier-forget-delay", 0, "If a querier disconnects without sending notification about graceful shutdown, the query-scheduler will keep the querier in the tenant's shard until the forget delay has passed. This feature is useful to reduce the blast radius when shuffle-sharding is enabled.")
 	f.BoolVar(&cfg.InflightMaxAgeMetricEnabled, "query-scheduler.inflight-max-age-metric-enabled", true, "Enable the cortex_query_scheduler_inflight_max_age_seconds metric, which reports the age of the oldest inflight request. Disabling it skips the per-tick scan over inflight requests.")
+	f.BoolVar(&cfg.MaxQueueLengthMetricEnabled, "query-scheduler.max-queue-length-metric-enabled", false, "Enable the cortex_query_scheduler_queue_length_peak metric, which reports the per-tenant peak queue length observed since the last scrape. Disabling it skips per-tenant peak tracking on enqueue and dequeue.")
 
 	cfg.GRPCClientConfig.CustomCompressors = []string{s2.Name}
 	cfg.GRPCClientConfig.RegisterFlagsWithPrefix("query-scheduler.grpc-client-config", f)
@@ -145,6 +148,14 @@ func NewScheduler(cfg Config, limits Limits, log log.Logger, registerer promethe
 		Name: "cortex_query_scheduler_queue_length",
 		Help: "Number of queries in the queue.",
 	}, []string{"user"})
+
+	if cfg.MaxQueueLengthMetricEnabled {
+		s.maxQueueLength = queue.NewMaxQueueLengthGauge()
+		// registerer is nil in some tests; mirror promauto.With(nil) by skipping registration.
+		if registerer != nil {
+			registerer.MustRegister(s.maxQueueLength)
+		}
+	}
 
 	s.cancelledRequests = promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
 		Name: "cortex_query_scheduler_cancelled_requests_total",
@@ -184,6 +195,7 @@ func NewScheduler(cfg Config, limits Limits, log log.Logger, registerer promethe
 		s.discardedRequests,
 		enqueueDuration,
 		querierInflightRequestsMetric,
+		s.maxQueueLength,
 	)
 	if err != nil {
 		return nil, err
@@ -738,6 +750,9 @@ func (s *Scheduler) stopping(_ error) error {
 
 func (s *Scheduler) cleanupMetricsForInactiveUser(user string) {
 	s.queueLength.DeleteLabelValues(user)
+	if s.maxQueueLength != nil {
+		s.maxQueueLength.DeleteTenant(user)
+	}
 	s.discardedRequests.DeleteLabelValues(user)
 	s.cancelledRequests.DeleteLabelValues(user)
 }

--- a/pkg/scheduler/scheduler_queue.go
+++ b/pkg/scheduler/scheduler_queue.go
@@ -47,9 +47,9 @@ func newSchedulerQueue(
 		cfg.MaxOutstandingPerTenant,
 		cfg.QuerierForgetDelay,
 		queueLength,
+		maxQueueLength,
 		discardedRequests,
 		enqueueDuration,
-		maxQueueLength,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/scheduler/scheduler_queue.go
+++ b/pkg/scheduler/scheduler_queue.go
@@ -40,6 +40,7 @@ func newSchedulerQueue(
 	discardedRequests *prometheus.CounterVec,
 	enqueueDuration prometheus.Histogram,
 	querierInflightRequestsMetric *prometheus.SummaryVec,
+	maxQueueLength *queue.MaxQueueLengthGauge,
 ) (*schedulerQueue, error) {
 	q, err := queue.New(
 		logger,
@@ -48,6 +49,7 @@ func newSchedulerQueue(
 		queueLength,
 		discardedRequests,
 		enqueueDuration,
+		maxQueueLength,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/scheduler/scheduler_queue.go
+++ b/pkg/scheduler/scheduler_queue.go
@@ -37,10 +37,10 @@ func newSchedulerQueue(
 	limits Limits,
 	logger log.Logger,
 	queueLength *prometheus.GaugeVec,
+	maxQueueLength *queue.MaxQueueLengthGauge,
 	discardedRequests *prometheus.CounterVec,
 	enqueueDuration prometheus.Histogram,
 	querierInflightRequestsMetric *prometheus.SummaryVec,
-	maxQueueLength *queue.MaxQueueLengthGauge,
 ) (*schedulerQueue, error) {
 	q, err := queue.New(
 		logger,

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -80,10 +80,13 @@ func TestMain(m *testing.M) {
 	util_test.VerifyNoLeakTestMain(m)
 }
 
-func setupScheduler(t *testing.T, reg prometheus.Registerer) (*Scheduler, schedulerpb.SchedulerForFrontendClient, schedulerpb.SchedulerForQuerierClient) {
+func setupScheduler(t *testing.T, reg prometheus.Registerer, opts ...func(*Config)) (*Scheduler, schedulerpb.SchedulerForFrontendClient, schedulerpb.SchedulerForQuerierClient) {
 	cfg := Config{}
 	flagext.DefaultValues(&cfg)
 	cfg.MaxOutstandingPerTenant = testMaxOutstandingPerTenant
+	for _, opt := range opts {
+		opt(&cfg)
+	}
 
 	s, err := NewScheduler(cfg, &limits{queriers: 2}, log.NewNopLogger(), reg)
 	require.NoError(t, err)
@@ -747,6 +750,69 @@ func TestSchedulerQueueMetrics(t *testing.T) {
 		# TYPE cortex_query_scheduler_queue_length gauge
 		cortex_query_scheduler_queue_length{user="another"} 1
 	`), "cortex_query_scheduler_queue_length"))
+}
+
+func TestSchedulerMaxQueueLengthMetric(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+
+	scheduler, frontendClient, _ := setupScheduler(t, reg, func(c *Config) {
+		c.MaxQueueLengthMetricEnabled = true
+	})
+
+	t.Cleanup(func() {
+		drainScheduler(t, scheduler)
+		require.NoError(t, services.StopAndAwaitTerminated(context.Background(), scheduler))
+	})
+
+	require.NotNil(t, scheduler.maxQueueLength, "metric should be constructed when enabled")
+
+	frontendLoop := initFrontendLoop(t, frontendClient, "frontend-12345")
+	frontendToScheduler(t, frontendLoop, &schedulerpb.FrontendToScheduler{
+		Type:    schedulerpb.ENQUEUE,
+		QueryID: 1,
+		UserID:  "test",
+		Payload: &schedulerpb.FrontendToScheduler_HttpRequest{HttpRequest: &httpgrpc.HTTPRequest{Method: "GET", Url: "/hello"}},
+	})
+	frontendToScheduler(t, frontendLoop, &schedulerpb.FrontendToScheduler{
+		Type:    schedulerpb.ENQUEUE,
+		QueryID: 1,
+		UserID:  "another",
+		Payload: &schedulerpb.FrontendToScheduler_HttpRequest{HttpRequest: &httpgrpc.HTTPRequest{Method: "GET", Url: "/hello"}},
+	})
+
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+		# HELP cortex_query_scheduler_queue_length_peak Maximum number of queries observed in a tenant's queue since the last metric collection (reset on each scrape). Captures the true peak queue depth between scrapes.
+		# TYPE cortex_query_scheduler_queue_length_peak gauge
+		cortex_query_scheduler_queue_length_peak{user="another"} 1
+		cortex_query_scheduler_queue_length_peak{user="test"} 1
+	`), "cortex_query_scheduler_queue_length_peak"))
+
+	scheduler.cleanupMetricsForInactiveUser("test")
+
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+		# HELP cortex_query_scheduler_queue_length_peak Maximum number of queries observed in a tenant's queue since the last metric collection (reset on each scrape). Captures the true peak queue depth between scrapes.
+		# TYPE cortex_query_scheduler_queue_length_peak gauge
+		cortex_query_scheduler_queue_length_peak{user="another"} 1
+	`), "cortex_query_scheduler_queue_length_peak"))
+}
+
+func TestSchedulerMaxQueueLengthMetricDisabled(t *testing.T) {
+	cfg := Config{}
+	flagext.DefaultValues(&cfg)
+	cfg.MaxOutstandingPerTenant = testMaxOutstandingPerTenant
+	cfg.MaxQueueLengthMetricEnabled = false
+
+	reg := prometheus.NewPedanticRegistry()
+	s, err := NewScheduler(cfg, &limits{queriers: 2}, log.NewNopLogger(), reg)
+	require.NoError(t, err)
+
+	require.NoError(t, services.StartAndAwaitRunning(context.Background(), s))
+	t.Cleanup(func() {
+		require.NoError(t, services.StopAndAwaitTerminated(context.Background(), s))
+	})
+
+	require.Nil(t, s.maxQueueLength, "tracker must not be constructed when the metric is disabled")
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(""), "cortex_query_scheduler_queue_length_peak"))
 }
 
 func TestSchedulerQuerierMetrics(t *testing.T) {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -781,19 +781,19 @@ func TestSchedulerMaxQueueLengthMetric(t *testing.T) {
 	})
 
 	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
-		# HELP cortex_query_scheduler_queue_length_peak Maximum number of queries observed in a tenant's queue since the last metric collection (reset on each scrape). Captures the true peak queue depth between scrapes.
-		# TYPE cortex_query_scheduler_queue_length_peak gauge
-		cortex_query_scheduler_queue_length_peak{user="another"} 1
-		cortex_query_scheduler_queue_length_peak{user="test"} 1
-	`), "cortex_query_scheduler_queue_length_peak"))
+		# HELP cortex_query_scheduler_max_queue_length Maximum number of queries observed in a tenant's queue since the last metric collection (reset on each scrape). Captures the true peak queue depth between scrapes.
+		# TYPE cortex_query_scheduler_max_queue_length gauge
+		cortex_query_scheduler_max_queue_length{user="another"} 1
+		cortex_query_scheduler_max_queue_length{user="test"} 1
+	`), "cortex_query_scheduler_max_queue_length"))
 
 	scheduler.cleanupMetricsForInactiveUser("test")
 
 	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
-		# HELP cortex_query_scheduler_queue_length_peak Maximum number of queries observed in a tenant's queue since the last metric collection (reset on each scrape). Captures the true peak queue depth between scrapes.
-		# TYPE cortex_query_scheduler_queue_length_peak gauge
-		cortex_query_scheduler_queue_length_peak{user="another"} 1
-	`), "cortex_query_scheduler_queue_length_peak"))
+		# HELP cortex_query_scheduler_max_queue_length Maximum number of queries observed in a tenant's queue since the last metric collection (reset on each scrape). Captures the true peak queue depth between scrapes.
+		# TYPE cortex_query_scheduler_max_queue_length gauge
+		cortex_query_scheduler_max_queue_length{user="another"} 1
+	`), "cortex_query_scheduler_max_queue_length"))
 }
 
 func TestSchedulerMaxQueueLengthMetricDisabled(t *testing.T) {
@@ -812,7 +812,7 @@ func TestSchedulerMaxQueueLengthMetricDisabled(t *testing.T) {
 	})
 
 	require.Nil(t, s.maxQueueLength, "tracker must not be constructed when the metric is disabled")
-	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(""), "cortex_query_scheduler_queue_length_peak"))
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(""), "cortex_query_scheduler_max_queue_length"))
 }
 
 func TestSchedulerQuerierMetrics(t *testing.T) {


### PR DESCRIPTION
#### What this PR does

Whilst investigating query-scheduler queue activity per tenant, it was evident that the existing `cortex_query_scheduler_queue_length` guage is not ideal. 

Being a guage over a queue which fluctuates quickly and often, the value obtained at scrape is not useful for tracking the high water marks in the queue.

This PR introduces a new metric which tracks the peak queue size per tenant within each scrape interval. The metric is reset after each scrape. 

This metric can be used to monitor the peak number of queries queued per tenant.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
