### PR TITLE
usage-tracker: bound snapshot and event loading at startup

### DIFF
--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -2397,6 +2397,24 @@ How to **investigate**:
 - Check whether the expected snapshot files exist in the bucket — they may have been deleted or never uploaded.
 - Check for network issues between the usage-tracker and the object storage backend.
 
+### MimirUsageTrackerSnapshotLoadFailedAtStartup
+
+This alert fires when the usage-tracker failed to load the snapshot and events within the snapshot interval during startup, and therefore started with partial state.
+
+How it **works**:
+
+- At startup, the usage-tracker loads the last snapshot and replays events to reconstruct the tracked usage data.
+- This must complete within the snapshot interval (half of `-usage-tracker.idle-timeout`), because any data older than the idle timeout is considered stale and removed on the first cleanup anyway.
+- If loading doesn't complete in time, the usage-tracker starts with partial state instead of blocking startup, sets the metric `cortex_usage_tracker_snapshot_load_failed_at_startup` to 1, and resets it to 0 after 10 minutes.
+- Starting with partial state means some series may be temporarily undercounted until the state is rebuilt from the events stream. This should be investigated.
+
+How to **investigate**:
+
+- Check the usage-tracker logs for the `"snapshot and events loading timed out at startup, starting with partial state"` warning message.
+- Check whether snapshot download from object storage was slow: look for `"downloaded snapshot file"` log messages and their `file_download_time`, and check for network or object storage latency issues.
+- Check whether event replay was slow: look for `"finished loading events"` log messages and the number of events replayed.
+- If the partition repeatedly fails to start in time, you can temporarily set `-usage-tracker.skip-snapshot-loading-at-startup=true` to skip snapshot loading and rebuild state from the events stream only.
+
 ## Errors catalog
 
 Mimir has some codified error IDs that you might see in HTTP responses or logs.

--- a/operations/mimir-mixin/alerts/usage-tracker.libsonnet
+++ b/operations/mimir-mixin/alerts/usage-tracker.libsonnet
@@ -33,6 +33,20 @@
             message: '%(product)s usage-tracker %(alert_instance_variable)s in %(alert_aggregation_variables)s is failing to download snapshots from object storage.' % $._config,
           },
         },
+        {
+          alert: $.alertName('UsageTrackerSnapshotLoadFailedAtStartup'),
+          // The metric is set to 1 on failure and reset to 0 after 10 minutes, so keep 'for' well within that window.
+          'for': '5m',
+          expr: |||
+            max by(%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_usage_tracker_snapshot_load_failed_at_startup) > 0
+          ||| % $._config,
+          labels: {
+            severity: 'warning',
+          },
+          annotations: {
+            message: '%(product)s usage-tracker %(alert_instance_variable)s in %(alert_aggregation_variables)s failed to load the snapshot and events within the snapshot interval at startup and started with partial state.' % $._config,
+          },
+        },
       ],
     },
   ],

--- a/pkg/usagetracker/partition_handler.go
+++ b/pkg/usagetracker/partition_handler.go
@@ -278,7 +278,7 @@ func (p *partitionHandler) tryLoadSnapshotAndEventsInReasonableAmountOfTime(ctx 
 // doesn't carry the cause, so callers relying on errors.Is against the cause sentinel need this
 // to make the timeout detectable. The original err is preserved in the chain for logging.
 func causeIfTimedOut(ctx context.Context, err error) error {
-	if cause := context.Cause(ctx); cause == snapshotLoadingTookLongerThanDataRangeItCovers {
+	if cause := context.Cause(ctx); errors.Is(cause, snapshotLoadingTookLongerThanDataRangeItCovers) {
 		return fmt.Errorf("%w: %w", cause, err)
 	}
 	return err

--- a/pkg/usagetracker/partition_handler.go
+++ b/pkg/usagetracker/partition_handler.go
@@ -42,6 +42,8 @@ const (
 var (
 	eventTypeSeriesCreatedBytes = []byte(eventTypeSeriesCreated)
 	eventTypeSnapshotBytes      = []byte(eventTypeSnapshot)
+
+	snapshotLoadingTookLongerThanDataRangeItCovers = errors.New("snapshot loading took longer than data range it covers")
 )
 
 type partitionHandler struct {
@@ -87,7 +89,8 @@ type partitionHandler struct {
 
 	pendingCreatedSeriesMarshaledEvents chan []byte
 
-	eventFetchFailures prometheus.Counter
+	snapshotLoadFailedAtStartup prometheus.Gauge
+	eventFetchFailures          prometheus.Counter
 
 	seriesCreatedEventsReceived        prometheus.Counter
 	seriesCreatedEventsTotalErrors     *prometheus.CounterVec
@@ -140,6 +143,10 @@ func newPartitionHandler(
 
 		pendingCreatedSeriesMarshaledEvents: make(chan []byte, cfg.CreatedSeriesEventsMaxPending),
 
+		snapshotLoadFailedAtStartup: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Name: "cortex_usage_tracker_snapshot_load_failed_at_startup",
+			Help: "Set to 1 when the partition handler failed to load the snapshot and events within the snapshot interval at startup; reset to 0 after 10 minutes.",
+		}),
 		eventFetchFailures: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "cortex_usage_tracker_event_fetch_failures_total",
 			Help: "Total number of failures while fetching events from Kafka.",
@@ -216,13 +223,19 @@ func (p *partitionHandler) start(ctx context.Context) error {
 		return errors.Wrap(err, "unable to register partition handler collector as Prometheus collector")
 	}
 
-	eventsOffset, err := p.loadLastSnapshotRecordAndGetEventsOffset(ctx)
-	if err != nil {
-		return errors.Wrap(err, "unable to load snapshot")
+	if err := p.tryLoadSnapshotAndEventsInReasonableAmountOfTime(ctx); err != nil {
+		// Set a metric on which we'll alert and ping the oncall engineer.
+		// This sometimes will cause a restart, or an empty start, both should be investigated.
+		p.snapshotLoadFailedAtStartup.Set(1)
+		time.AfterFunc(10*time.Minute, func() { p.snapshotLoadFailedAtStartup.Set(0) })
+		if !errors.Is(err, snapshotLoadingTookLongerThanDataRangeItCovers) {
+			// Something else happened, fail.
+			return errors.Wrap(err, "unable to load events in reasonable amount of time, if this prevents startup multiple times, consider setting -usage-tracker.skip-snapshot-loading-at-startup=true temporarily")
+		}
+		// We timed out loading the snapshot and events: tolerate it and start empty/partial, but make it visible.
+		level.Error(p.logger).Log("msg", "snapshot and events loading timed out at startup, starting with partial state", "err", err)
 	}
-	if err := p.loadEvents(ctx, eventsOffset); err != nil {
-		return errors.Wrap(err, "unable to load events")
-	}
+
 	// Initial limits are lower than real limits, and we've just loaded the snapshots and processed events,
 	// so update the limits to let users track more series.
 	p.store.updateLimits()
@@ -240,6 +253,35 @@ func (p *partitionHandler) start(ctx context.Context) error {
 	p.subservicesWatcher = services.NewFailureWatcher()
 	p.subservicesWatcher.WatchService(p.partitionLifecycler)
 	return nil
+}
+
+func (p *partitionHandler) tryLoadSnapshotAndEventsInReasonableAmountOfTime(ctx context.Context) error {
+	// The snapshot holds data for a range of p.cfg.IdleTimeout, and it's being taken every p.snapshotInterval(), which is half of that.
+	// It doesn't make sense to keep waiting longer than that to load the data: it's going to be stale and removed on first cleanup anyway.
+	// If this happens frequently, it should be investigated.
+	ctx, cancel := context.WithTimeoutCause(ctx, p.snapshotInterval(), snapshotLoadingTookLongerThanDataRangeItCovers)
+	defer cancel()
+
+	eventsOffset, err := p.loadLastSnapshotRecordAndGetEventsOffset(ctx)
+	if err != nil {
+		return causeIfTimedOut(ctx, errors.Wrap(err, "unable to load snapshot"))
+	}
+	if err := p.loadEvents(ctx, eventsOffset); err != nil {
+		return causeIfTimedOut(ctx, errors.Wrap(err, "unable to load events"))
+	}
+
+	return nil
+}
+
+// causeIfTimedOut wraps err with the context cancellation cause when the context was canceled
+// due to our own timeout. Downstream code returns ctx.Err() (context.DeadlineExceeded), which
+// doesn't carry the cause, so callers relying on errors.Is against the cause sentinel need this
+// to make the timeout detectable. The original err is preserved in the chain for logging.
+func causeIfTimedOut(ctx context.Context, err error) error {
+	if cause := context.Cause(ctx); cause == snapshotLoadingTookLongerThanDataRangeItCovers {
+		return fmt.Errorf("%w: %w", cause, err)
+	}
+	return err
 }
 
 func (p *partitionHandler) loadLastSnapshotRecordAndGetEventsOffset(ctx context.Context) (int64, error) {
@@ -306,7 +348,10 @@ func (p *partitionHandler) loadAllSnapshotShards(ctx context.Context, files []st
 
 	// One is being downloaded, one is buffered, one is being processed.
 	downloaded := make(chan downloadedSnapshot, 1)
-	errs := make(chan error, 1)
+	// Buffered for 2: both the downloader and the processor goroutines can send here (e.g. the
+	// downloader sends an error and then, via the deferred close(downloaded), the processor sends nil).
+	// We only read one value below, so without room for both the second sender would leak.
+	errs := make(chan error, 2)
 	go func() {
 		for snapshot := range downloaded {
 			snapshotT0 := time.Now()
@@ -752,8 +797,12 @@ func (p *partitionHandler) newEventKafkaRecord(eventTypeBytes []byte, data []byt
 	}
 }
 
+func (p *partitionHandler) snapshotInterval() time.Duration {
+	return p.cfg.IdleTimeout / 2
+}
+
 func (p *partitionHandler) publishSnapshots(ctx context.Context) {
-	delay := util.DurationWithJitter(p.cfg.IdleTimeout/2, p.cfg.SnapshotIntervalJitter)
+	delay := util.DurationWithJitter(p.snapshotInterval(), p.cfg.SnapshotIntervalJitter)
 	var firstSnapshot <-chan time.Time
 	if !p.loadedLastSnapshotTimestamp.IsZero() {
 		nextExpectedSnapshot := p.loadedLastSnapshotTimestamp.Add(delay)

--- a/pkg/usagetracker/partition_handler_test.go
+++ b/pkg/usagetracker/partition_handler_test.go
@@ -495,6 +495,65 @@ func TestPartitionHandler(t *testing.T) {
 
 		require.NoError(t, services.StopAndAwaitTerminated(ctx, ph))
 	})
+
+	t.Run("snapshot loading timeout at startup is tolerated and flagged", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		defer cancel()
+
+		h := newPartitionHandlerTestHelper(t)
+		h.limiter[tenantID] = 3
+
+		// First partitionHandler tracks some series, creates a snapshot, and shuts down.
+		startPartitionHandlerTrackTwoSeriesAndShutDown(t, h)
+
+		// New partitionHandler with a short idle timeout, so snapshotInterval() (IdleTimeout/2) becomes
+		// the deadline for loading the snapshot and events at startup.
+		ph := h.newHandler(t, func(cfg *Config) { cfg.IdleTimeout = 4 * time.Second })
+		// Bucket reads block until the context is cancelled, so the snapshot load hits the startup deadline.
+		ph.snapshotsBucket = &slowBucket{ph.snapshotsBucket, make(chan struct{})}
+
+		// Startup is tolerated (doesn't fail) even though the snapshot couldn't be loaded in time...
+		require.NoError(t, services.StartAndAwaitRunning(ctx, ph))
+		// ...and the failure is flagged so we can alert on it.
+		require.Equal(t, float64(1), testutil.ToFloat64(ph.snapshotLoadFailedAtStartup))
+
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, ph))
+	})
+
+	t.Run("non-timeout snapshot load error fails startup", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		defer cancel()
+
+		h := newPartitionHandlerTestHelper(t)
+		h.limiter[tenantID] = 3
+
+		// First partitionHandler tracks some series, creates a snapshot, and shuts down.
+		startPartitionHandlerTrackTwoSeriesAndShutDown(t, h)
+
+		// Fail fast on snapshot download with a non-context error. The default (long) idle timeout keeps
+		// the startup deadline from firing, so this is treated as a genuine failure and not tolerated.
+		ph := h.newHandler(t, func(cfg *Config) {
+			cfg.SnapshotsLoadBackoff.MinBackoff = time.Millisecond
+			cfg.SnapshotsLoadBackoff.MaxBackoff = time.Millisecond
+			cfg.SnapshotsLoadBackoff.MaxRetries = 2
+		})
+		ph.snapshotsBucket = &erroringBucket{ph.snapshotsBucket, io.ErrClosedPipe}
+		// Failed startup doesn't run the stopping function, so close the readers to avoid leaking goroutines.
+		t.Cleanup(func() {
+			ph.eventsKafkaReader.Close()
+			ph.snapshotsKafkaReader.Close()
+		})
+
+		err := services.StartAndAwaitRunning(ctx, ph)
+		require.Error(t, err)
+		require.NotErrorIs(t, err, snapshotLoadingTookLongerThanDataRangeItCovers)
+		// The failure is still flagged for alerting.
+		require.Equal(t, float64(1), testutil.ToFloat64(ph.snapshotLoadFailedAtStartup))
+	})
 }
 
 func requireTrackSeries(t *testing.T, p *partitionHandler, id string, series, rejected []uint64) {
@@ -693,4 +752,13 @@ type getCounterBucketReader struct {
 func (s *getCounterBucketReader) Get(ctx context.Context, name string) (io.ReadCloser, error) {
 	s.getCalls.Inc()
 	return s.Bucket.Get(ctx, name)
+}
+
+type erroringBucket struct {
+	objstore.Bucket
+	err error
+}
+
+func (b *erroringBucket) Get(context.Context, string) (io.ReadCloser, error) {
+	return nil, b.err
 }


### PR DESCRIPTION
#### What this PR does

At startup a partition handler loads the last snapshot and replays events to rebuild its state. This could block indefinitely (slow object storage, large event backlog), preventing the usage-tracker from becoming ready.

This bounds that loading to the snapshot interval (half of `-usage-tracker.idle-timeout`). Any data older than the idle timeout is considered stale and dropped on the first cleanup anyway, so waiting longer than the snapshot interval has no value.

On timeout the handler starts with partial state instead of blocking startup, sets a new `cortex_usage_tracker_snapshot_load_failed_at_startup` gauge, and logs a warning. A new warning-severity alert `MimirUsageTrackerSnapshotLoadFailedAtStartup` fires on that gauge, with a matching runbook entry so on-call can investigate. Any other (non-timeout) load error still fails startup as before.

It also fixes a pre-existing goroutine leak in `loadAllSnapshotShards`: on a snapshot download error both goroutines send to the `errs` channel while only one value is read, leaving the other sender blocked forever. The channel is now buffered for both senders.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated - not needed, experimental feature, `changelog-not-needed` label added.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) - no new config; behavior of the existing experimental usage-tracker only.