### PR TITLE
Jsonnet: add per-compartment store-gateway

### DIFF
--- a/operations/mimir-tests/test-compartments-generated.yaml
+++ b/operations/mimir-tests/test-compartments-generated.yaml
@@ -3949,6 +3949,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -store-gateway.read-compartment-id=0
+        - -store-gateway.sharding-ring.auto-forget-enabled=false
         - -store-gateway.sharding-ring.heartbeat-period=1m
         - -store-gateway.sharding-ring.heartbeat-timeout=10m
         - -store-gateway.sharding-ring.instance-availability-zone=zone-a
@@ -4105,6 +4106,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -store-gateway.read-compartment-id=1
+        - -store-gateway.sharding-ring.auto-forget-enabled=false
         - -store-gateway.sharding-ring.heartbeat-period=1m
         - -store-gateway.sharding-ring.heartbeat-timeout=10m
         - -store-gateway.sharding-ring.instance-availability-zone=zone-a
@@ -4263,6 +4265,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -store-gateway.read-compartment-id=0
+        - -store-gateway.sharding-ring.auto-forget-enabled=false
         - -store-gateway.sharding-ring.heartbeat-period=1m
         - -store-gateway.sharding-ring.heartbeat-timeout=10m
         - -store-gateway.sharding-ring.instance-availability-zone=zone-b
@@ -4423,6 +4426,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -store-gateway.read-compartment-id=1
+        - -store-gateway.sharding-ring.auto-forget-enabled=false
         - -store-gateway.sharding-ring.heartbeat-period=1m
         - -store-gateway.sharding-ring.heartbeat-timeout=10m
         - -store-gateway.sharding-ring.instance-availability-zone=zone-b
@@ -4583,6 +4587,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -store-gateway.read-compartment-id=0
+        - -store-gateway.sharding-ring.auto-forget-enabled=false
         - -store-gateway.sharding-ring.heartbeat-period=1m
         - -store-gateway.sharding-ring.heartbeat-timeout=10m
         - -store-gateway.sharding-ring.instance-availability-zone=zone-c
@@ -4741,6 +4746,7 @@ spec:
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
         - -store-gateway.read-compartment-id=1
+        - -store-gateway.sharding-ring.auto-forget-enabled=false
         - -store-gateway.sharding-ring.heartbeat-period=1m
         - -store-gateway.sharding-ring.heartbeat-timeout=10m
         - -store-gateway.sharding-ring.instance-availability-zone=zone-c

--- a/operations/mimir-tests/test-compartments-generated.yaml
+++ b/operations/mimir-tests/test-compartments-generated.yaml
@@ -1023,24 +1023,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    name: store-gateway-multi-zone
-  name: store-gateway-multi-zone
-  namespace: default
-spec:
-  ports:
-  - name: store-gateway-http-metrics
-    port: 80
-    protocol: TCP
-    targetPort: 80
-  selector:
-    rollout-group: store-gateway
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    name: store-gateway-zone-a
-  name: store-gateway-zone-a
+    name: store-gateway-zone-a-rc-0
+  name: store-gateway-zone-a-rc-0
   namespace: default
 spec:
   clusterIP: None
@@ -1055,15 +1039,16 @@ spec:
     port: 7946
     targetPort: 7946
   selector:
-    name: store-gateway-zone-a
-    rollout-group: store-gateway
+    mimir-rc: "0"
+    name: store-gateway-zone-a-rc-0
+    rollout-group: store-gateway-rc-0
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    name: store-gateway-zone-b
-  name: store-gateway-zone-b
+    name: store-gateway-zone-a-rc-1
+  name: store-gateway-zone-a-rc-1
   namespace: default
 spec:
   clusterIP: None
@@ -1078,15 +1063,16 @@ spec:
     port: 7946
     targetPort: 7946
   selector:
-    name: store-gateway-zone-b
-    rollout-group: store-gateway
+    mimir-rc: "1"
+    name: store-gateway-zone-a-rc-1
+    rollout-group: store-gateway-rc-1
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    name: store-gateway-zone-c
-  name: store-gateway-zone-c
+    name: store-gateway-zone-b-rc-0
+  name: store-gateway-zone-b-rc-0
   namespace: default
 spec:
   clusterIP: None
@@ -1101,8 +1087,81 @@ spec:
     port: 7946
     targetPort: 7946
   selector:
-    name: store-gateway-zone-c
-    rollout-group: store-gateway
+    mimir-rc: "0"
+    name: store-gateway-zone-b-rc-0
+    rollout-group: store-gateway-rc-0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: store-gateway-zone-b-rc-1
+  name: store-gateway-zone-b-rc-1
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: store-gateway-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: store-gateway-grpc
+    port: 9095
+    targetPort: 9095
+  - name: store-gateway-gossip-ring
+    port: 7946
+    targetPort: 7946
+  selector:
+    mimir-rc: "1"
+    name: store-gateway-zone-b-rc-1
+    rollout-group: store-gateway-rc-1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: store-gateway-zone-c-rc-0
+  name: store-gateway-zone-c-rc-0
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: store-gateway-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: store-gateway-grpc
+    port: 9095
+    targetPort: 9095
+  - name: store-gateway-gossip-ring
+    port: 7946
+    targetPort: 7946
+  selector:
+    mimir-rc: "0"
+    name: store-gateway-zone-c-rc-0
+    rollout-group: store-gateway-rc-0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: store-gateway-zone-c-rc-1
+  name: store-gateway-zone-c-rc-1
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: store-gateway-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: store-gateway-grpc
+    port: 9095
+    targetPort: 9095
+  - name: store-gateway-gossip-ring
+    port: 7946
+    targetPort: 7946
+  selector:
+    mimir-rc: "1"
+    name: store-gateway-zone-c-rc-1
+    rollout-group: store-gateway-rc-1
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -3807,25 +3866,33 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations:
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "80"
     rollout-max-unavailable: "50"
   labels:
-    rollout-group: store-gateway
-  name: store-gateway-zone-a
+    grafana.com/min-time-between-zones-downscale: 15m
+    grafana.com/prepare-downscale: "true"
+    mimir-rc: "0"
+    name: store-gateway-zone-a-rc-0
+    rollout-group: store-gateway-rc-0
+  name: store-gateway-zone-a-rc-0
   namespace: default
 spec:
+  persistentVolumeClaimRetentionPolicy:
+    whenScaled: Delete
   podManagementPolicy: Parallel
-  replicas: 1
   selector:
     matchLabels:
-      name: store-gateway-zone-a
-      rollout-group: store-gateway
-  serviceName: store-gateway-zone-a
+      name: store-gateway-zone-a-rc-0
+      rollout-group: store-gateway-rc-0
+  serviceName: store-gateway-zone-a-rc-0
   template:
     metadata:
       labels:
         gossip_ring_member: "true"
-        name: store-gateway-zone-a
-        rollout-group: store-gateway
+        mimir-rc: "0"
+        name: store-gateway-zone-a-rc-0
+        rollout-group: store-gateway-rc-0
     spec:
       affinity:
         podAntiAffinity:
@@ -3835,11 +3902,11 @@ spec:
               - key: rollout-group
                 operator: In
                 values:
-                - store-gateway
+                - store-gateway-rc-0
               - key: name
                 operator: NotIn
                 values:
-                - store-gateway-zone-a
+                - store-gateway-zone-a-rc-0
             topologyKey: kubernetes.io/hostname
       containers:
       - args:
@@ -3865,12 +3932,15 @@ spec:
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
         - -blocks-storage.bucket-store.sync-dir=/data/tsdb
         - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.gcs.bucket-name=blocks-bucket-rc-0
         - -common.storage.backend=gcs
+        - -compartments.enabled=true
+        - -compartments.read.num-compartments=2
+        - -compartments.write.num-compartments=2
         - -ingest-storage.enabled=true
-        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
-        - -ingest-storage.kafka.topic=ingest
+        - -ingest-storage.kafka.topic=ingest-rc-0
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -3878,6 +3948,7 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -store-gateway.read-compartment-id=0
         - -store-gateway.sharding-ring.heartbeat-period=1m
         - -store-gateway.sharding-ring.heartbeat-timeout=10m
         - -store-gateway.sharding-ring.instance-availability-zone=zone-a
@@ -3951,25 +4022,33 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations:
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "80"
     rollout-max-unavailable: "50"
   labels:
-    rollout-group: store-gateway
-  name: store-gateway-zone-b
+    grafana.com/min-time-between-zones-downscale: 15m
+    grafana.com/prepare-downscale: "true"
+    mimir-rc: "1"
+    name: store-gateway-zone-a-rc-1
+    rollout-group: store-gateway-rc-1
+  name: store-gateway-zone-a-rc-1
   namespace: default
 spec:
+  persistentVolumeClaimRetentionPolicy:
+    whenScaled: Delete
   podManagementPolicy: Parallel
-  replicas: 1
   selector:
     matchLabels:
-      name: store-gateway-zone-b
-      rollout-group: store-gateway
-  serviceName: store-gateway-zone-b
+      name: store-gateway-zone-a-rc-1
+      rollout-group: store-gateway-rc-1
+  serviceName: store-gateway-zone-a-rc-1
   template:
     metadata:
       labels:
         gossip_ring_member: "true"
-        name: store-gateway-zone-b
-        rollout-group: store-gateway
+        mimir-rc: "1"
+        name: store-gateway-zone-a-rc-1
+        rollout-group: store-gateway-rc-1
     spec:
       affinity:
         podAntiAffinity:
@@ -3979,11 +4058,11 @@ spec:
               - key: rollout-group
                 operator: In
                 values:
-                - store-gateway
+                - store-gateway-rc-1
               - key: name
                 operator: NotIn
                 values:
-                - store-gateway-zone-b
+                - store-gateway-zone-a-rc-1
             topologyKey: kubernetes.io/hostname
       containers:
       - args:
@@ -4009,12 +4088,15 @@ spec:
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
         - -blocks-storage.bucket-store.sync-dir=/data/tsdb
         - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.gcs.bucket-name=blocks-bucket-rc-1
         - -common.storage.backend=gcs
+        - -compartments.enabled=true
+        - -compartments.read.num-compartments=2
+        - -compartments.write.num-compartments=2
         - -ingest-storage.enabled=true
-        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
-        - -ingest-storage.kafka.topic=ingest
+        - -ingest-storage.kafka.topic=ingest-rc-1
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -4022,6 +4104,165 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -store-gateway.read-compartment-id=1
+        - -store-gateway.sharding-ring.heartbeat-period=1m
+        - -store-gateway.sharding-ring.heartbeat-timeout=10m
+        - -store-gateway.sharding-ring.instance-availability-zone=zone-a
+        - -store-gateway.sharding-ring.prefix=multi-zone/
+        - -store-gateway.sharding-ring.replication-factor=3
+        - -store-gateway.sharding-ring.store=memberlist
+        - -store-gateway.sharding-ring.tokens-file-path=/data/tokens
+        - -store-gateway.sharding-ring.unregister-on-shutdown=false
+        - -store-gateway.sharding-ring.wait-stability-min-duration=1m
+        - -store-gateway.sharding-ring.zone-awareness-enabled=true
+        - -store-gateway.tenant-shard-size=3
+        - -target=store-gateway
+        - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: A
+          value: all-store-gateways
+        - name: GOMAXPROCS
+          value: "5"
+        - name: GOMEMLIMIT
+          value: "12884901888"
+        image: grafana/mimir:3.1.2
+        imagePullPolicy: IfNotPresent
+        name: store-gateway
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 18Gi
+          requests:
+            cpu: "1"
+            memory: 12Gi
+        volumeMounts:
+        - mountPath: /data
+          name: store-gateway-data
+        - mountPath: /etc/mimir
+          name: overrides
+      securityContext:
+        runAsUser: 0
+      terminationGracePeriodSeconds: 120
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+  updateStrategy:
+    type: OnDelete
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: store-gateway-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 50Gi
+      storageClassName: standard
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/rollout-downscale-leader: store-gateway-zone-a-rc-0
+    grafana.com/rollout-upscale-only-when-leader-ready: "true"
+    rollout-max-unavailable: "50"
+  labels:
+    grafana.com/min-time-between-zones-downscale: 15m
+    grafana.com/prepare-downscale: "true"
+    mimir-rc: "0"
+    name: store-gateway-zone-b-rc-0
+    rollout-group: store-gateway-rc-0
+  name: store-gateway-zone-b-rc-0
+  namespace: default
+spec:
+  persistentVolumeClaimRetentionPolicy:
+    whenScaled: Delete
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      name: store-gateway-zone-b-rc-0
+      rollout-group: store-gateway-rc-0
+  serviceName: store-gateway-zone-b-rc-0
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        mimir-rc: "0"
+        name: store-gateway-zone-b-rc-0
+        rollout-group: store-gateway-rc-0
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: rollout-group
+                operator: In
+                values:
+                - store-gateway-rc-0
+              - key: name
+                operator: NotIn
+                values:
+                - store-gateway-zone-b-rc-0
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -blocks-storage.bucket-store.chunks-cache.backend=memcached
+        - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-concurrency=100
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-idle-connections=150
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-item-size=1048576
+        - -blocks-storage.bucket-store.chunks-cache.memcached.timeout=750ms
+        - -blocks-storage.bucket-store.index-cache.backend=memcached
+        - -blocks-storage.bucket-store.index-cache.memcached.addresses=dnssrvnoa+memcached-index-queries.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.index-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-concurrency=100
+        - -blocks-storage.bucket-store.index-cache.memcached.max-idle-connections=150
+        - -blocks-storage.bucket-store.index-cache.memcached.max-item-size=5242880
+        - -blocks-storage.bucket-store.index-cache.memcached.timeout=750ms
+        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
+        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-concurrency=100
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-idle-connections=150
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
+        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
+        - -blocks-storage.bucket-store.sync-interval=15m
+        - -blocks-storage.gcs.bucket-name=blocks-bucket-rc-0
+        - -common.storage.backend=gcs
+        - -compartments.enabled=true
+        - -compartments.read.num-compartments=2
+        - -compartments.write.num-compartments=2
+        - -ingest-storage.enabled=true
+        - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.topic=ingest-rc-0
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc-max-send-msg-size-bytes=209715200
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -store-gateway.read-compartment-id=0
         - -store-gateway.sharding-ring.heartbeat-period=1m
         - -store-gateway.sharding-ring.heartbeat-timeout=10m
         - -store-gateway.sharding-ring.instance-availability-zone=zone-b
@@ -4097,25 +4338,35 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations:
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/rollout-downscale-leader: store-gateway-zone-a-rc-1
+    grafana.com/rollout-upscale-only-when-leader-ready: "true"
     rollout-max-unavailable: "50"
   labels:
-    rollout-group: store-gateway
-  name: store-gateway-zone-c
+    grafana.com/min-time-between-zones-downscale: 15m
+    grafana.com/prepare-downscale: "true"
+    mimir-rc: "1"
+    name: store-gateway-zone-b-rc-1
+    rollout-group: store-gateway-rc-1
+  name: store-gateway-zone-b-rc-1
   namespace: default
 spec:
+  persistentVolumeClaimRetentionPolicy:
+    whenScaled: Delete
   podManagementPolicy: Parallel
-  replicas: 1
   selector:
     matchLabels:
-      name: store-gateway-zone-c
-      rollout-group: store-gateway
-  serviceName: store-gateway-zone-c
+      name: store-gateway-zone-b-rc-1
+      rollout-group: store-gateway-rc-1
+  serviceName: store-gateway-zone-b-rc-1
   template:
     metadata:
       labels:
         gossip_ring_member: "true"
-        name: store-gateway-zone-c
-        rollout-group: store-gateway
+        mimir-rc: "1"
+        name: store-gateway-zone-b-rc-1
+        rollout-group: store-gateway-rc-1
     spec:
       affinity:
         podAntiAffinity:
@@ -4125,11 +4376,11 @@ spec:
               - key: rollout-group
                 operator: In
                 values:
-                - store-gateway
+                - store-gateway-rc-1
               - key: name
                 operator: NotIn
                 values:
-                - store-gateway-zone-c
+                - store-gateway-zone-b-rc-1
             topologyKey: kubernetes.io/hostname
       containers:
       - args:
@@ -4155,12 +4406,15 @@ spec:
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
         - -blocks-storage.bucket-store.sync-dir=/data/tsdb
         - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.gcs.bucket-name=blocks-bucket-rc-1
         - -common.storage.backend=gcs
+        - -compartments.enabled=true
+        - -compartments.read.num-compartments=2
+        - -compartments.write.num-compartments=2
         - -ingest-storage.enabled=true
-        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
-        - -ingest-storage.kafka.topic=ingest
+        - -ingest-storage.kafka.topic=ingest-rc-1
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
@@ -4168,6 +4422,325 @@ spec:
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
+        - -store-gateway.read-compartment-id=1
+        - -store-gateway.sharding-ring.heartbeat-period=1m
+        - -store-gateway.sharding-ring.heartbeat-timeout=10m
+        - -store-gateway.sharding-ring.instance-availability-zone=zone-b
+        - -store-gateway.sharding-ring.prefix=multi-zone/
+        - -store-gateway.sharding-ring.replication-factor=3
+        - -store-gateway.sharding-ring.store=memberlist
+        - -store-gateway.sharding-ring.tokens-file-path=/data/tokens
+        - -store-gateway.sharding-ring.unregister-on-shutdown=false
+        - -store-gateway.sharding-ring.wait-stability-min-duration=1m
+        - -store-gateway.sharding-ring.zone-awareness-enabled=true
+        - -store-gateway.tenant-shard-size=3
+        - -target=store-gateway
+        - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: A
+          value: zone-b
+        - name: GOGC
+          value: "1000"
+        - name: GOMAXPROCS
+          value: "5"
+        - name: GOMEMLIMIT
+          value: "12884901888"
+        image: grafana/mimir:3.1.2
+        imagePullPolicy: IfNotPresent
+        name: store-gateway
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 18Gi
+          requests:
+            cpu: "1"
+            memory: 12Gi
+        volumeMounts:
+        - mountPath: /data
+          name: store-gateway-data
+        - mountPath: /etc/mimir
+          name: overrides
+      securityContext:
+        runAsUser: 0
+      terminationGracePeriodSeconds: 120
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+  updateStrategy:
+    type: OnDelete
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: store-gateway-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 50Gi
+      storageClassName: standard
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/rollout-downscale-leader: store-gateway-zone-b-rc-0
+    grafana.com/rollout-upscale-only-when-leader-ready: "true"
+    rollout-max-unavailable: "50"
+  labels:
+    grafana.com/min-time-between-zones-downscale: 15m
+    grafana.com/prepare-downscale: "true"
+    mimir-rc: "0"
+    name: store-gateway-zone-c-rc-0
+    rollout-group: store-gateway-rc-0
+  name: store-gateway-zone-c-rc-0
+  namespace: default
+spec:
+  persistentVolumeClaimRetentionPolicy:
+    whenScaled: Delete
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      name: store-gateway-zone-c-rc-0
+      rollout-group: store-gateway-rc-0
+  serviceName: store-gateway-zone-c-rc-0
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        mimir-rc: "0"
+        name: store-gateway-zone-c-rc-0
+        rollout-group: store-gateway-rc-0
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: rollout-group
+                operator: In
+                values:
+                - store-gateway-rc-0
+              - key: name
+                operator: NotIn
+                values:
+                - store-gateway-zone-c-rc-0
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -blocks-storage.bucket-store.chunks-cache.backend=memcached
+        - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-concurrency=100
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-idle-connections=150
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-item-size=1048576
+        - -blocks-storage.bucket-store.chunks-cache.memcached.timeout=750ms
+        - -blocks-storage.bucket-store.index-cache.backend=memcached
+        - -blocks-storage.bucket-store.index-cache.memcached.addresses=dnssrvnoa+memcached-index-queries.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.index-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-concurrency=100
+        - -blocks-storage.bucket-store.index-cache.memcached.max-idle-connections=150
+        - -blocks-storage.bucket-store.index-cache.memcached.max-item-size=5242880
+        - -blocks-storage.bucket-store.index-cache.memcached.timeout=750ms
+        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
+        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-concurrency=100
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-idle-connections=150
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
+        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
+        - -blocks-storage.bucket-store.sync-interval=15m
+        - -blocks-storage.gcs.bucket-name=blocks-bucket-rc-0
+        - -common.storage.backend=gcs
+        - -compartments.enabled=true
+        - -compartments.read.num-compartments=2
+        - -compartments.write.num-compartments=2
+        - -ingest-storage.enabled=true
+        - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.topic=ingest-rc-0
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc-max-send-msg-size-bytes=209715200
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -store-gateway.read-compartment-id=0
+        - -store-gateway.sharding-ring.heartbeat-period=1m
+        - -store-gateway.sharding-ring.heartbeat-timeout=10m
+        - -store-gateway.sharding-ring.instance-availability-zone=zone-c
+        - -store-gateway.sharding-ring.prefix=multi-zone/
+        - -store-gateway.sharding-ring.replication-factor=3
+        - -store-gateway.sharding-ring.store=memberlist
+        - -store-gateway.sharding-ring.tokens-file-path=/data/tokens
+        - -store-gateway.sharding-ring.unregister-on-shutdown=false
+        - -store-gateway.sharding-ring.wait-stability-min-duration=1m
+        - -store-gateway.sharding-ring.zone-awareness-enabled=true
+        - -store-gateway.tenant-shard-size=3
+        - -target=store-gateway
+        - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: A
+          value: all-store-gateways
+        - name: GOMAXPROCS
+          value: "5"
+        - name: GOMEMLIMIT
+          value: "12884901888"
+        image: grafana/mimir:3.1.2
+        imagePullPolicy: IfNotPresent
+        name: store-gateway
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 18Gi
+          requests:
+            cpu: "1"
+            memory: 12Gi
+        volumeMounts:
+        - mountPath: /data
+          name: store-gateway-data
+        - mountPath: /etc/mimir
+          name: overrides
+      securityContext:
+        runAsUser: 0
+      terminationGracePeriodSeconds: 120
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+  updateStrategy:
+    type: OnDelete
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: store-gateway-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 50Gi
+      storageClassName: standard
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "80"
+    grafana.com/rollout-downscale-leader: store-gateway-zone-b-rc-1
+    grafana.com/rollout-upscale-only-when-leader-ready: "true"
+    rollout-max-unavailable: "50"
+  labels:
+    grafana.com/min-time-between-zones-downscale: 15m
+    grafana.com/prepare-downscale: "true"
+    mimir-rc: "1"
+    name: store-gateway-zone-c-rc-1
+    rollout-group: store-gateway-rc-1
+  name: store-gateway-zone-c-rc-1
+  namespace: default
+spec:
+  persistentVolumeClaimRetentionPolicy:
+    whenScaled: Delete
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      name: store-gateway-zone-c-rc-1
+      rollout-group: store-gateway-rc-1
+  serviceName: store-gateway-zone-c-rc-1
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        mimir-rc: "1"
+        name: store-gateway-zone-c-rc-1
+        rollout-group: store-gateway-rc-1
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: rollout-group
+                operator: In
+                values:
+                - store-gateway-rc-1
+              - key: name
+                operator: NotIn
+                values:
+                - store-gateway-zone-c-rc-1
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -blocks-storage.bucket-store.chunks-cache.backend=memcached
+        - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-concurrency=100
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-idle-connections=150
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-item-size=1048576
+        - -blocks-storage.bucket-store.chunks-cache.memcached.timeout=750ms
+        - -blocks-storage.bucket-store.index-cache.backend=memcached
+        - -blocks-storage.bucket-store.index-cache.memcached.addresses=dnssrvnoa+memcached-index-queries.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.index-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-concurrency=100
+        - -blocks-storage.bucket-store.index-cache.memcached.max-idle-connections=150
+        - -blocks-storage.bucket-store.index-cache.memcached.max-item-size=5242880
+        - -blocks-storage.bucket-store.index-cache.memcached.timeout=750ms
+        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
+        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-concurrency=100
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-idle-connections=150
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
+        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
+        - -blocks-storage.bucket-store.sync-interval=15m
+        - -blocks-storage.gcs.bucket-name=blocks-bucket-rc-1
+        - -common.storage.backend=gcs
+        - -compartments.enabled=true
+        - -compartments.read.num-compartments=2
+        - -compartments.write.num-compartments=2
+        - -ingest-storage.enabled=true
+        - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.topic=ingest-rc-1
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc-max-send-msg-size-bytes=209715200
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -store-gateway.read-compartment-id=1
         - -store-gateway.sharding-ring.heartbeat-period=1m
         - -store-gateway.sharding-ring.heartbeat-timeout=10m
         - -store-gateway.sharding-ring.instance-availability-zone=zone-c
@@ -4849,6 +5422,88 @@ spec:
     name: cortex_ingester_zone_a_rc_1_replicas_hpa_default_0
     type: prometheus
 ---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: store-gateway-zone-a-rc-0
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 600
+            type: Pods
+            value: 1
+          stabilizationWindowSeconds: 3600
+        scaleUp:
+          policies:
+          - periodSeconds: 600
+            type: Percent
+            value: 50
+          stabilizationWindowSeconds: 1800
+  maxReplicaCount: 3
+  minReplicaCount: 1
+  pollingInterval: 10
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: store-gateway-zone-a-rc-0
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: mimir_store_gateway_zone_a_rc_0_replicas_hpa_default
+      query: (1 - (min(kubelet_volume_stats_available_bytes{namespace="default", persistentvolumeclaim=~"store-gateway-data-store-gateway-zone-.*-rc-0-.*"}/kubelet_volume_stats_capacity_bytes{namespace="default",
+        persistentvolumeclaim=~"store-gateway-data-store-gateway-zone-.*-rc-0-.*"})))
+        * 100
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "77"
+    metricType: Value
+    name: mimir_store_gateway_zone_a_rc_0_replicas_hpa_default
+    type: prometheus
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: store-gateway-zone-a-rc-1
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 600
+            type: Pods
+            value: 1
+          stabilizationWindowSeconds: 3600
+        scaleUp:
+          policies:
+          - periodSeconds: 600
+            type: Percent
+            value: 50
+          stabilizationWindowSeconds: 1800
+  maxReplicaCount: 3
+  minReplicaCount: 1
+  pollingInterval: 10
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: store-gateway-zone-a-rc-1
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: mimir_store_gateway_zone_a_rc_1_replicas_hpa_default
+      query: (1 - (min(kubelet_volume_stats_available_bytes{namespace="default", persistentvolumeclaim=~"store-gateway-data-store-gateway-zone-.*-rc-1-.*"}/kubelet_volume_stats_capacity_bytes{namespace="default",
+        persistentvolumeclaim=~"store-gateway-data-store-gateway-zone-.*-rc-1-.*"})))
+        * 100
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "77"
+    metricType: Value
+    name: mimir_store_gateway_zone_a_rc_1_replicas_hpa_default
+    type: prometheus
+---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -4988,11 +5643,24 @@ apiVersion: rollout-operator.grafana.com/v1
 kind: ZoneAwarePodDisruptionBudget
 metadata:
   labels:
-    name: store-gateway-rollout
-  name: store-gateway-rollout
+    name: store-gateway-rollout-rc-0
+  name: store-gateway-rollout-rc-0
   namespace: default
 spec:
   maxUnavailable: 50
   selector:
     matchLabels:
-      rollout-group: store-gateway
+      rollout-group: store-gateway-rc-0
+---
+apiVersion: rollout-operator.grafana.com/v1
+kind: ZoneAwarePodDisruptionBudget
+metadata:
+  labels:
+    name: store-gateway-rollout-rc-1
+  name: store-gateway-rollout-rc-1
+  namespace: default
+spec:
+  maxUnavailable: 50
+  selector:
+    matchLabels:
+      rollout-group: store-gateway-rc-1

--- a/operations/mimir-tests/test-compartments.jsonnet
+++ b/operations/mimir-tests/test-compartments.jsonnet
@@ -26,5 +26,15 @@
     cortex_compactor_concurrent_rollout_enabled: true,
     enable_pvc_auto_deletion_for_compactors: true,
     enable_pvc_auto_deletion_for_ingesters: true,
+
+    // Exercise the per-compartment store-gateways (zones a/b/c, no backup zones).
+    multi_zone_store_gateway_enabled: true,
+    multi_zone_store_gateway_replicas: 3,
+    autoscaling_store_gateway_enabled: true,
+    autoscaling_store_gateway_min_replicas_per_zone: 1,
+    autoscaling_store_gateway_max_replicas_per_zone: 6,
+    autoscaling_store_gateway_min_replicas_per_compartment_zone: 1,
+    autoscaling_store_gateway_max_replicas_per_compartment_zone: 3,
+    enable_pvc_auto_deletion_for_store_gateways: true,
   },
 }

--- a/operations/mimir/compartments-store-gateway.libsonnet
+++ b/operations/mimir/compartments-store-gateway.libsonnet
@@ -67,6 +67,9 @@
     // gossip-ring membership label is added by memberlist.libsonnet.
     statefulSet.mixin.spec.template.metadata.withLabelsMixin({ name: name, 'mimir-rc': compartmentIdxStr, 'rollout-group': rolloutGroup }) +
     statefulSet.mixin.spec.selector.withMatchLabels({ name: name, 'rollout-group': rolloutGroup }) +
+    // Backup zones default to 0 replicas; when autoscaled the rollout-operator scales them to follow their
+    // leader (they run on spot nodes). Mirrors the non-compartment backup store-gateways.
+    (if zone == 'a-backup' || zone == 'b-backup' then statefulSet.mixin.spec.withReplicas(0) else {}) +
     (if multiAZ then statefulSet.spec.template.spec.withTolerationsMixin($.newMimirMultiZoneToleration()) else {}) +
     // Replace the base cross-zone anti-affinity (baked with the non-compartment name): keep different zones of
     // the same compartment off the same node, while allowing same-zone replicas to share one.

--- a/operations/mimir/compartments-store-gateway.libsonnet
+++ b/operations/mimir/compartments-store-gateway.libsonnet
@@ -2,18 +2,12 @@
   _config+:: {
     compartments_store_gateway_enabled: $._config.compartments_enabled,
     no_compartments_store_gateway_enabled: !self.compartments_store_gateway_enabled,
-
-    // Per-compartment, per-zone autoscaling bounds (zones b/c follow the zone-a leader).
-    autoscaling_store_gateway_min_replicas_per_compartment_zone: 3,
-    autoscaling_store_gateway_max_replicas_per_compartment_zone: 10,
   },
 
   assert !$._config.compartments_store_gateway_enabled || $._config.compartments_compactor_enabled
          : 'compartments_store_gateway_enabled requires compartments_compactor_enabled (per-compartment blocks buckets)',
   assert !$._config.compartments_store_gateway_enabled || $._config.multi_zone_store_gateway_enabled
          : 'compartments_store_gateway_enabled requires multi_zone_store_gateway_enabled',
-  assert !$._config.compartments_store_gateway_enabled || $._config.autoscaling_store_gateway_enabled
-         : 'compartments_store_gateway_enabled requires autoscaling_store_gateway_enabled',
 
   local statefulSet = $.apps.v1.statefulSet,
   local podDisruptionBudget = $.policy.v1.podDisruptionBudget,
@@ -23,11 +17,15 @@
   local isNoCompartmentsEnabled = $._config.no_compartments_store_gateway_enabled,
   local numCompartments = $._config.compartments_read_count,
 
+  // Primary zones (a/b/c) plus the optional multi-AZ backup zones (a-backup/b-backup), used for the RF-4
+  // topology [a, a-backup, b, b-backup] (zone-c disabled). Backups follow their primary zone, mirroring the
+  // non-compartment multi-zone-store-gateway / store-gateway-autoscaling libs.
   local isZoneAEnabled = $._config.multi_zone_store_gateway_enabled,
   local isZoneBEnabled = $._config.multi_zone_store_gateway_enabled,
   local isZoneCEnabled = $._config.multi_zone_store_gateway_zone_c_enabled,
   local isZoneABackupEnabled = $._config.multi_zone_store_gateway_zone_a_backup_enabled,
   local isZoneBBackupEnabled = $._config.multi_zone_store_gateway_zone_b_backup_enabled,
+  // Whether each zone runs multi-AZ, used to apply the multi-zone toleration and gate the zonal-address validation.
   local isZoneAMultiAZ = $._config.multi_zone_store_gateway_zone_a_multi_az_enabled && std.length($._config.multi_zone_availability_zones) >= 1,
   local isZoneBMultiAZ = $._config.multi_zone_store_gateway_zone_b_multi_az_enabled && std.length($._config.multi_zone_availability_zones) >= 2,
   local isZoneCMultiAZ = $._config.multi_zone_store_gateway_zone_c_multi_az_enabled && std.length($._config.multi_zone_availability_zones) >= 3,
@@ -56,40 +54,6 @@
   store_gateway_zone_a_backup_compartments_args:: $.mimirCompartmentsCreateIf(isEnabled && isZoneABackupEnabled, numCompartments, function(c) $.store_gateway_zone_a_backup_args + perCompartmentStoreGatewayArgs(c)),
   store_gateway_zone_b_backup_compartments_args:: $.mimirCompartmentsCreateIf(isEnabled && isZoneBBackupEnabled, numCompartments, function(c) $.store_gateway_zone_b_backup_args + perCompartmentStoreGatewayArgs(c)),
 
-  // Prepare-downscale labels/annotations, so the rollout-operator calls the shutdown endpoint before scaling down.
-  local prepareDownscaleLabelsAnnotations =
-    statefulSet.mixin.metadata.withLabelsMixin({
-      'grafana.com/prepare-downscale': 'true',
-      'grafana.com/min-time-between-zones-downscale': $._config.store_gateway_automated_downscale_min_time_between_zones,
-    }) +
-    statefulSet.mixin.metadata.withAnnotationsMixin({
-      'grafana.com/prepare-downscale-http-path': 'store-gateway/prepare-shutdown',
-      'grafana.com/prepare-downscale-http-port': '80',
-    }),
-
-  // Zone-a is the autoscaled leader; zone-b follows its compartment's zone-a, zone-c follows its compartment's
-  // zone-b. Backup zones follow their primary zone (a-backup→a, b-backup→b), matching
-  // store-gateway-autoscaling.libsonnet: backups run on spot nodes and follow the standard-node leader so none
-  // follows a (potentially missing) spot zone.
-  local storeGatewayCompartmentDownscaleMixin(zone, compartmentIdx) =
-    if zone == 'b' then statefulSet.mixin.metadata.withAnnotationsMixin({
-      'grafana.com/rollout-downscale-leader': 'store-gateway-zone-a-rc-%d' % compartmentIdx,
-      'grafana.com/rollout-upscale-only-when-leader-ready': 'true',
-    })
-    else if zone == 'c' then statefulSet.mixin.metadata.withAnnotationsMixin({
-      'grafana.com/rollout-downscale-leader': 'store-gateway-zone-b-rc-%d' % compartmentIdx,
-      'grafana.com/rollout-upscale-only-when-leader-ready': 'true',
-    })
-    else if zone == 'a-backup' then statefulSet.mixin.metadata.withAnnotationsMixin({
-      'grafana.com/rollout-downscale-leader': 'store-gateway-zone-a-rc-%d' % compartmentIdx,
-      'grafana.com/rollout-upscale-only-when-leader-ready': 'true',
-    })
-    else if zone == 'b-backup' then statefulSet.mixin.metadata.withAnnotationsMixin({
-      'grafana.com/rollout-downscale-leader': 'store-gateway-zone-b-rc-%d' % compartmentIdx,
-      'grafana.com/rollout-upscale-only-when-leader-ready': 'true',
-    })
-    else {},
-
   newStoreGatewayCompartmentStatefulSet(zone, compartmentIdx, container, nodeAffinityMatchers=[], multiAZ=false)::
     local name = 'store-gateway-zone-%s-rc-%d' % [zone, compartmentIdx];
     local compartmentIdxStr = std.toString(compartmentIdx);
@@ -103,10 +67,6 @@
     // gossip-ring membership label is added by memberlist.libsonnet.
     statefulSet.mixin.spec.template.metadata.withLabelsMixin({ name: name, 'mimir-rc': compartmentIdxStr, 'rollout-group': rolloutGroup }) +
     statefulSet.mixin.spec.selector.withMatchLabels({ name: name, 'rollout-group': rolloutGroup }) +
-    // Replicas are owned by the autoscaler.
-    $.removeReplicasFromSpec +
-    prepareDownscaleLabelsAnnotations +
-    storeGatewayCompartmentDownscaleMixin(zone, compartmentIdx) +
     (if multiAZ then statefulSet.spec.template.spec.withTolerationsMixin($.newMimirMultiZoneToleration()) else {}) +
     // Replace the base cross-zone anti-affinity (baked with the non-compartment name): keep different zones of
     // the same compartment off the same node, while allowing same-zone replicas to share one.
@@ -128,7 +88,8 @@
   store_gateway_zone_a_backup_containers:: $.mimirCompartmentsCreateIf(isEnabled && isZoneABackupEnabled, numCompartments, function(c) $.newStoreGatewayZoneContainer('a-backup', $.store_gateway_zone_a_backup_compartments_args['compartment_%d' % c], $.store_gateway_zone_a_backup_env_map)),
   store_gateway_zone_b_backup_containers:: $.mimirCompartmentsCreateIf(isEnabled && isZoneBBackupEnabled, numCompartments, function(c) $.newStoreGatewayZoneContainer('b-backup', $.store_gateway_zone_b_backup_compartments_args['compartment_%d' % c], $.store_gateway_zone_b_backup_env_map)),
 
-  // StatefulSets.
+  // StatefulSets. The per-compartment autoscaling (ScaledObjects, prepare-downscale, removeReplicasFromSpec) is
+  // layered on top in store-gateway-autoscaling.libsonnet, mirroring the non-compartment store-gateway.
   store_gateway_zone_a_statefulsets: $.mimirCompartmentsCreateIf(isEnabled && isZoneAEnabled, numCompartments, function(c) $.newStoreGatewayCompartmentStatefulSet('a', c, $.store_gateway_zone_a_containers['compartment_%d' % c], $.store_gateway_zone_a_node_affinity_matchers, isZoneAMultiAZ)),
   store_gateway_zone_b_statefulsets: $.mimirCompartmentsCreateIf(isEnabled && isZoneBEnabled, numCompartments, function(c) $.newStoreGatewayCompartmentStatefulSet('b', c, $.store_gateway_zone_b_containers['compartment_%d' % c], $.store_gateway_zone_b_node_affinity_matchers, isZoneBMultiAZ)),
   store_gateway_zone_c_statefulsets: $.mimirCompartmentsCreateIf(isEnabled && isZoneCEnabled, numCompartments, function(c) $.newStoreGatewayCompartmentStatefulSet('c', c, $.store_gateway_zone_c_containers['compartment_%d' % c], $.store_gateway_zone_c_node_affinity_matchers, isZoneCMultiAZ)),
@@ -158,16 +119,6 @@
 
   store_gateway_rollout_pdbs: $.mimirCompartmentsCreateIf(isEnabled, numCompartments, function(c) newStoreGatewayRolloutCompartmentPdb(c)),
 
-  // Scaled objects.
-  store_gateway_zone_a_scaled_objects: $.mimirCompartmentsCreateIf(isEnabled && isZoneAEnabled, numCompartments, function(c)
-    $.newLeaderStoreGatewayScaledObject(
-      'store-gateway-zone-a-rc-%d' % c,
-      $._config.autoscaling_store_gateway_min_replicas_per_compartment_zone,
-      $._config.autoscaling_store_gateway_max_replicas_per_compartment_zone,
-      $._config.autoscaling_store_gateway_disk_usage_threshold,
-      'store-gateway-data-store-gateway-zone-.*-rc-%d-.*' % c,
-    )),
-
   // Null out the non-compartments store-gateway resources.
   store_gateway_zone_a_statefulset: if !isNoCompartmentsEnabled && isZoneAEnabled then null else super.store_gateway_zone_a_statefulset,
   store_gateway_zone_b_statefulset: if !isNoCompartmentsEnabled && isZoneBEnabled then null else super.store_gateway_zone_b_statefulset,
@@ -183,27 +134,6 @@
 
   store_gateway_multi_zone_service: if !isNoCompartmentsEnabled then null else super.store_gateway_multi_zone_service,
   store_gateway_rollout_pdb: if !isNoCompartmentsEnabled then null else super.store_gateway_rollout_pdb,
-  // The non-compartment zone-a autoscaler's default PVC selector ("store-gateway-.*") also matches the
-  // per-compartment "-rc-<idx>-" PVCs, so when the non-compartment store-gateways are also deployed it would
-  // size off their disks too. Exclude those PVCs so it sizes off the non-compartment store-gateways only
-  // (mirrors the "-partition" exclusion in ingester-autoscaling.libsonnet; the per-compartment autoscalers
-  // are already scoped to their own PVCs).
-  local scaleUp = $.keda.v1alpha1.scaledObject.spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleUp,
-  local inheritedStoreGatewayZoneAScaledObject = super.store_gateway_zone_a_scaled_object,
-  store_gateway_zone_a_scaled_object:
-    if !isNoCompartmentsEnabled then null
-    else if !isEnabled then inheritedStoreGatewayZoneAScaledObject
-    else $.newLeaderStoreGatewayScaledObject(
-      'store-gateway-zone-a',
-      $._config.autoscaling_store_gateway_min_replicas_per_zone,
-      $._config.autoscaling_store_gateway_max_replicas_per_zone,
-      $._config.autoscaling_store_gateway_disk_usage_threshold,
-      extra_matchers='persistentvolumeclaim!~"store-gateway-data-store-gateway-zone-.*-rc-.*"',
-      // Rebuilding via newLeaderStoreGatewayScaledObject resets the scale-up stabilization window to the OSS
-      // default; re-apply the inherited one in case it was overridden.
-    ) + scaleUp.withStabilizationWindowSeconds(
-      inheritedStoreGatewayZoneAScaledObject.spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleUp.stabilizationWindowSeconds
-    ),
 
   // Config validation.
   local storeGatewayCompartmentZoneAError = if isZoneAMultiAZ then $.validateMimirMultiZoneConfig(['store_gateway_zone_a_statefulsets']) else null,

--- a/operations/mimir/compartments-store-gateway.libsonnet
+++ b/operations/mimir/compartments-store-gateway.libsonnet
@@ -1,0 +1,232 @@
+{
+  _config+:: {
+    compartments_store_gateway_enabled: $._config.compartments_enabled,
+    no_compartments_store_gateway_enabled: !self.compartments_store_gateway_enabled,
+
+    // Per-compartment, per-zone autoscaling bounds (zones b/c follow the zone-a leader).
+    autoscaling_store_gateway_min_replicas_per_compartment_zone: 3,
+    autoscaling_store_gateway_max_replicas_per_compartment_zone: 10,
+  },
+
+  assert !$._config.compartments_store_gateway_enabled || $._config.compartments_compactor_enabled
+         : 'compartments_store_gateway_enabled requires compartments_compactor_enabled (per-compartment blocks buckets)',
+  assert !$._config.compartments_store_gateway_enabled || $._config.multi_zone_store_gateway_enabled
+         : 'compartments_store_gateway_enabled requires multi_zone_store_gateway_enabled',
+  assert !$._config.compartments_store_gateway_enabled || $._config.autoscaling_store_gateway_enabled
+         : 'compartments_store_gateway_enabled requires autoscaling_store_gateway_enabled',
+
+  local statefulSet = $.apps.v1.statefulSet,
+  local podDisruptionBudget = $.policy.v1.podDisruptionBudget,
+  local podAntiAffinity = statefulSet.mixin.spec.template.spec.affinity.podAntiAffinity,
+
+  local isEnabled = $._config.compartments_store_gateway_enabled,
+  local isNoCompartmentsEnabled = $._config.no_compartments_store_gateway_enabled,
+  local numCompartments = $._config.compartments_read_count,
+
+  local isZoneAEnabled = $._config.multi_zone_store_gateway_enabled,
+  local isZoneBEnabled = $._config.multi_zone_store_gateway_enabled,
+  local isZoneCEnabled = $._config.multi_zone_store_gateway_zone_c_enabled,
+  local isZoneABackupEnabled = $._config.multi_zone_store_gateway_zone_a_backup_enabled,
+  local isZoneBBackupEnabled = $._config.multi_zone_store_gateway_zone_b_backup_enabled,
+  local isZoneAMultiAZ = $._config.multi_zone_store_gateway_zone_a_multi_az_enabled && std.length($._config.multi_zone_availability_zones) >= 1,
+  local isZoneBMultiAZ = $._config.multi_zone_store_gateway_zone_b_multi_az_enabled && std.length($._config.multi_zone_availability_zones) >= 2,
+  local isZoneCMultiAZ = $._config.multi_zone_store_gateway_zone_c_multi_az_enabled && std.length($._config.multi_zone_availability_zones) >= 3,
+  local isZoneABackupMultiAZ = $._config.multi_zone_store_gateway_zone_a_backup_multi_az_enabled && std.length($._config.multi_zone_availability_zones) >= 1,
+  local isZoneBBackupMultiAZ = $._config.multi_zone_store_gateway_zone_b_backup_multi_az_enabled && std.length($._config.multi_zone_availability_zones) >= 2,
+
+  // Args.
+  local perCompartmentStoreGatewayArgs(compartmentIdx) = {
+    [$.mimirBlocksStorageBucketNameFlag]: $.mimirBlocksStorageCompartmentBucketName(compartmentIdx),
+
+    'compartments.enabled': true,
+    'compartments.read.num-compartments': $._config.compartments_read_count,
+    'compartments.write.num-compartments': $._config.compartments_write_count,
+    'store-gateway.read-compartment-id': compartmentIdx,
+
+    // The store-gateway doesn't consume Kafka, but it inherits the ingest-storage args from the common config,
+    // so set them to this read compartment's values for consistency (and so the compartments config
+    // validation passes).
+    'ingest-storage.kafka.address': $._config.compartments_ingest_storage_kafka_address,
+    'ingest-storage.kafka.topic': $.mimirIngestStorageCompartmentKafkaTopic(compartmentIdx),
+  },
+
+  store_gateway_zone_a_compartments_args:: $.mimirCompartmentsCreateIf(isEnabled && isZoneAEnabled, numCompartments, function(c) $.store_gateway_zone_a_args + perCompartmentStoreGatewayArgs(c)),
+  store_gateway_zone_b_compartments_args:: $.mimirCompartmentsCreateIf(isEnabled && isZoneBEnabled, numCompartments, function(c) $.store_gateway_zone_b_args + perCompartmentStoreGatewayArgs(c)),
+  store_gateway_zone_c_compartments_args:: $.mimirCompartmentsCreateIf(isEnabled && isZoneCEnabled, numCompartments, function(c) $.store_gateway_zone_c_args + perCompartmentStoreGatewayArgs(c)),
+  store_gateway_zone_a_backup_compartments_args:: $.mimirCompartmentsCreateIf(isEnabled && isZoneABackupEnabled, numCompartments, function(c) $.store_gateway_zone_a_backup_args + perCompartmentStoreGatewayArgs(c)),
+  store_gateway_zone_b_backup_compartments_args:: $.mimirCompartmentsCreateIf(isEnabled && isZoneBBackupEnabled, numCompartments, function(c) $.store_gateway_zone_b_backup_args + perCompartmentStoreGatewayArgs(c)),
+
+  // Prepare-downscale labels/annotations, so the rollout-operator calls the shutdown endpoint before scaling down.
+  local prepareDownscaleLabelsAnnotations =
+    statefulSet.mixin.metadata.withLabelsMixin({
+      'grafana.com/prepare-downscale': 'true',
+      'grafana.com/min-time-between-zones-downscale': $._config.store_gateway_automated_downscale_min_time_between_zones,
+    }) +
+    statefulSet.mixin.metadata.withAnnotationsMixin({
+      'grafana.com/prepare-downscale-http-path': 'store-gateway/prepare-shutdown',
+      'grafana.com/prepare-downscale-http-port': '80',
+    }),
+
+  // Zone-a is the autoscaled leader; zone-b follows its compartment's zone-a, zone-c follows its compartment's
+  // zone-b. Backup zones follow their primary zone (a-backup→a, b-backup→b), matching
+  // store-gateway-autoscaling.libsonnet: backups run on spot nodes and follow the standard-node leader so none
+  // follows a (potentially missing) spot zone.
+  local storeGatewayCompartmentDownscaleMixin(zone, compartmentIdx) =
+    if zone == 'b' then statefulSet.mixin.metadata.withAnnotationsMixin({
+      'grafana.com/rollout-downscale-leader': 'store-gateway-zone-a-rc-%d' % compartmentIdx,
+      'grafana.com/rollout-upscale-only-when-leader-ready': 'true',
+    })
+    else if zone == 'c' then statefulSet.mixin.metadata.withAnnotationsMixin({
+      'grafana.com/rollout-downscale-leader': 'store-gateway-zone-b-rc-%d' % compartmentIdx,
+      'grafana.com/rollout-upscale-only-when-leader-ready': 'true',
+    })
+    else if zone == 'a-backup' then statefulSet.mixin.metadata.withAnnotationsMixin({
+      'grafana.com/rollout-downscale-leader': 'store-gateway-zone-a-rc-%d' % compartmentIdx,
+      'grafana.com/rollout-upscale-only-when-leader-ready': 'true',
+    })
+    else if zone == 'b-backup' then statefulSet.mixin.metadata.withAnnotationsMixin({
+      'grafana.com/rollout-downscale-leader': 'store-gateway-zone-b-rc-%d' % compartmentIdx,
+      'grafana.com/rollout-upscale-only-when-leader-ready': 'true',
+    })
+    else {},
+
+  newStoreGatewayCompartmentStatefulSet(zone, compartmentIdx, container, nodeAffinityMatchers=[], multiAZ=false)::
+    local name = 'store-gateway-zone-%s-rc-%d' % [zone, compartmentIdx];
+    local compartmentIdxStr = std.toString(compartmentIdx);
+    local rolloutGroup = 'store-gateway-rc-%d' % compartmentIdx;
+    $.newStoreGatewayZoneStatefulSet(zone, container, nodeAffinityMatchers, rolloutGroup) +
+    statefulSet.mixin.metadata.withName(name) +
+    statefulSet.mixin.spec.withServiceName(name) +
+    // Label identifying the read compartment.
+    statefulSet.mixin.metadata.withLabelsMixin({ name: name, 'mimir-rc': compartmentIdxStr, 'rollout-group': rolloutGroup }) +
+    // Mixin (not a replace) so the base pod labels set by newStoreGatewayZoneStatefulSet are kept; the
+    // gossip-ring membership label is added by memberlist.libsonnet.
+    statefulSet.mixin.spec.template.metadata.withLabelsMixin({ name: name, 'mimir-rc': compartmentIdxStr, 'rollout-group': rolloutGroup }) +
+    statefulSet.mixin.spec.selector.withMatchLabels({ name: name, 'rollout-group': rolloutGroup }) +
+    // Replicas are owned by the autoscaler.
+    $.removeReplicasFromSpec +
+    prepareDownscaleLabelsAnnotations +
+    storeGatewayCompartmentDownscaleMixin(zone, compartmentIdx) +
+    (if multiAZ then statefulSet.spec.template.spec.withTolerationsMixin($.newMimirMultiZoneToleration()) else {}) +
+    // Replace the base cross-zone anti-affinity (baked with the non-compartment name): keep different zones of
+    // the same compartment off the same node, while allowing same-zone replicas to share one.
+    (if $._config.store_gateway_allow_multiple_replicas_on_same_node then {} else {
+       spec+: podAntiAffinity.withRequiredDuringSchedulingIgnoredDuringExecution([
+         podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecutionType.new() +
+         podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecutionType.mixin.labelSelector.withMatchExpressions([
+           { key: 'rollout-group', operator: 'In', values: [rolloutGroup] },
+           { key: 'name', operator: 'NotIn', values: [name] },
+         ]) +
+         podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecutionType.withTopologyKey('kubernetes.io/hostname'),
+       ]).spec,
+     }),
+
+  // Containers.
+  store_gateway_zone_a_containers:: $.mimirCompartmentsCreateIf(isEnabled && isZoneAEnabled, numCompartments, function(c) $.newStoreGatewayZoneContainer('a', $.store_gateway_zone_a_compartments_args['compartment_%d' % c], $.store_gateway_zone_a_env_map)),
+  store_gateway_zone_b_containers:: $.mimirCompartmentsCreateIf(isEnabled && isZoneBEnabled, numCompartments, function(c) $.newStoreGatewayZoneContainer('b', $.store_gateway_zone_b_compartments_args['compartment_%d' % c], $.store_gateway_zone_b_env_map)),
+  store_gateway_zone_c_containers:: $.mimirCompartmentsCreateIf(isEnabled && isZoneCEnabled, numCompartments, function(c) $.newStoreGatewayZoneContainer('c', $.store_gateway_zone_c_compartments_args['compartment_%d' % c], $.store_gateway_zone_c_env_map)),
+  store_gateway_zone_a_backup_containers:: $.mimirCompartmentsCreateIf(isEnabled && isZoneABackupEnabled, numCompartments, function(c) $.newStoreGatewayZoneContainer('a-backup', $.store_gateway_zone_a_backup_compartments_args['compartment_%d' % c], $.store_gateway_zone_a_backup_env_map)),
+  store_gateway_zone_b_backup_containers:: $.mimirCompartmentsCreateIf(isEnabled && isZoneBBackupEnabled, numCompartments, function(c) $.newStoreGatewayZoneContainer('b-backup', $.store_gateway_zone_b_backup_compartments_args['compartment_%d' % c], $.store_gateway_zone_b_backup_env_map)),
+
+  // StatefulSets.
+  store_gateway_zone_a_statefulsets: $.mimirCompartmentsCreateIf(isEnabled && isZoneAEnabled, numCompartments, function(c) $.newStoreGatewayCompartmentStatefulSet('a', c, $.store_gateway_zone_a_containers['compartment_%d' % c], $.store_gateway_zone_a_node_affinity_matchers, isZoneAMultiAZ)),
+  store_gateway_zone_b_statefulsets: $.mimirCompartmentsCreateIf(isEnabled && isZoneBEnabled, numCompartments, function(c) $.newStoreGatewayCompartmentStatefulSet('b', c, $.store_gateway_zone_b_containers['compartment_%d' % c], $.store_gateway_zone_b_node_affinity_matchers, isZoneBMultiAZ)),
+  store_gateway_zone_c_statefulsets: $.mimirCompartmentsCreateIf(isEnabled && isZoneCEnabled, numCompartments, function(c) $.newStoreGatewayCompartmentStatefulSet('c', c, $.store_gateway_zone_c_containers['compartment_%d' % c], $.store_gateway_zone_c_node_affinity_matchers, isZoneCMultiAZ)),
+  store_gateway_zone_a_backup_statefulsets: $.mimirCompartmentsCreateIf(isEnabled && isZoneABackupEnabled, numCompartments, function(c) $.newStoreGatewayCompartmentStatefulSet('a-backup', c, $.store_gateway_zone_a_backup_containers['compartment_%d' % c], $.store_gateway_zone_a_backup_node_affinity_matchers, isZoneABackupMultiAZ)),
+  store_gateway_zone_b_backup_statefulsets: $.mimirCompartmentsCreateIf(isEnabled && isZoneBBackupEnabled, numCompartments, function(c) $.newStoreGatewayCompartmentStatefulSet('b-backup', c, $.store_gateway_zone_b_backup_containers['compartment_%d' % c], $.store_gateway_zone_b_backup_node_affinity_matchers, isZoneBBackupMultiAZ)),
+
+  // Services.
+  store_gateway_zone_a_services: $.mimirCompartmentsCreateIf(isEnabled && isZoneAEnabled, numCompartments, function(c) $.newStoreGatewayZoneService($.store_gateway_zone_a_statefulsets['compartment_%d' % c])),
+  store_gateway_zone_b_services: $.mimirCompartmentsCreateIf(isEnabled && isZoneBEnabled, numCompartments, function(c) $.newStoreGatewayZoneService($.store_gateway_zone_b_statefulsets['compartment_%d' % c])),
+  store_gateway_zone_c_services: $.mimirCompartmentsCreateIf(isEnabled && isZoneCEnabled, numCompartments, function(c) $.newStoreGatewayZoneService($.store_gateway_zone_c_statefulsets['compartment_%d' % c])),
+  store_gateway_zone_a_backup_services: $.mimirCompartmentsCreateIf(isEnabled && isZoneABackupEnabled, numCompartments, function(c) $.newStoreGatewayZoneService($.store_gateway_zone_a_backup_statefulsets['compartment_%d' % c])),
+  store_gateway_zone_b_backup_services: $.mimirCompartmentsCreateIf(isEnabled && isZoneBBackupEnabled, numCompartments, function(c) $.newStoreGatewayZoneService($.store_gateway_zone_b_backup_statefulsets['compartment_%d' % c])),
+
+  // PDBs.
+  local newStoreGatewayRolloutCompartmentPdb(compartmentIdx) =
+    local name = 'store-gateway-rollout-rc-%d' % compartmentIdx;
+    local rolloutGroup = 'store-gateway-rc-%d' % compartmentIdx;
+    (
+      if $._config.multi_zone_store_gateway_zpdb_enabled then
+        $.newZPDB(name, rolloutGroup, $._config.multi_zone_store_gateway_zpdb_max_unavailable)
+      else
+        podDisruptionBudget.new(name) +
+        podDisruptionBudget.mixin.spec.withMaxUnavailable(1) +
+        podDisruptionBudget.mixin.spec.selector.withMatchLabels({ 'rollout-group': rolloutGroup })
+    )
+    + podDisruptionBudget.mixin.metadata.withLabels({ name: name }),
+
+  store_gateway_rollout_pdbs: $.mimirCompartmentsCreateIf(isEnabled, numCompartments, function(c) newStoreGatewayRolloutCompartmentPdb(c)),
+
+  // Scaled objects.
+  store_gateway_zone_a_scaled_objects: $.mimirCompartmentsCreateIf(isEnabled && isZoneAEnabled, numCompartments, function(c)
+    $.newLeaderStoreGatewayScaledObject(
+      'store-gateway-zone-a-rc-%d' % c,
+      $._config.autoscaling_store_gateway_min_replicas_per_compartment_zone,
+      $._config.autoscaling_store_gateway_max_replicas_per_compartment_zone,
+      $._config.autoscaling_store_gateway_disk_usage_threshold,
+      'store-gateway-data-store-gateway-zone-.*-rc-%d-.*' % c,
+    )),
+
+  // Null out the non-compartments store-gateway resources.
+  store_gateway_zone_a_statefulset: if !isNoCompartmentsEnabled && isZoneAEnabled then null else super.store_gateway_zone_a_statefulset,
+  store_gateway_zone_b_statefulset: if !isNoCompartmentsEnabled && isZoneBEnabled then null else super.store_gateway_zone_b_statefulset,
+  store_gateway_zone_c_statefulset: if !isNoCompartmentsEnabled && isZoneCEnabled then null else super.store_gateway_zone_c_statefulset,
+  store_gateway_zone_a_backup_statefulset: if !isNoCompartmentsEnabled && isZoneABackupEnabled then null else super.store_gateway_zone_a_backup_statefulset,
+  store_gateway_zone_b_backup_statefulset: if !isNoCompartmentsEnabled && isZoneBBackupEnabled then null else super.store_gateway_zone_b_backup_statefulset,
+
+  store_gateway_zone_a_service: if !isNoCompartmentsEnabled && isZoneAEnabled then null else super.store_gateway_zone_a_service,
+  store_gateway_zone_b_service: if !isNoCompartmentsEnabled && isZoneBEnabled then null else super.store_gateway_zone_b_service,
+  store_gateway_zone_c_service: if !isNoCompartmentsEnabled && isZoneCEnabled then null else super.store_gateway_zone_c_service,
+  store_gateway_zone_a_backup_service: if !isNoCompartmentsEnabled && isZoneABackupEnabled then null else super.store_gateway_zone_a_backup_service,
+  store_gateway_zone_b_backup_service: if !isNoCompartmentsEnabled && isZoneBBackupEnabled then null else super.store_gateway_zone_b_backup_service,
+
+  store_gateway_multi_zone_service: if !isNoCompartmentsEnabled then null else super.store_gateway_multi_zone_service,
+  store_gateway_rollout_pdb: if !isNoCompartmentsEnabled then null else super.store_gateway_rollout_pdb,
+  // The non-compartment zone-a autoscaler's default PVC selector ("store-gateway-.*") also matches the
+  // per-compartment "-rc-<idx>-" PVCs, so when the non-compartment store-gateways are also deployed it would
+  // size off their disks too. Exclude those PVCs so it sizes off the non-compartment store-gateways only
+  // (mirrors the "-partition" exclusion in ingester-autoscaling.libsonnet; the per-compartment autoscalers
+  // are already scoped to their own PVCs).
+  local scaleUp = $.keda.v1alpha1.scaledObject.spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleUp,
+  local inheritedStoreGatewayZoneAScaledObject = super.store_gateway_zone_a_scaled_object,
+  store_gateway_zone_a_scaled_object:
+    if !isNoCompartmentsEnabled then null
+    else if !isEnabled then inheritedStoreGatewayZoneAScaledObject
+    else $.newLeaderStoreGatewayScaledObject(
+      'store-gateway-zone-a',
+      $._config.autoscaling_store_gateway_min_replicas_per_zone,
+      $._config.autoscaling_store_gateway_max_replicas_per_zone,
+      $._config.autoscaling_store_gateway_disk_usage_threshold,
+      extra_matchers='persistentvolumeclaim!~"store-gateway-data-store-gateway-zone-.*-rc-.*"',
+      // Rebuilding via newLeaderStoreGatewayScaledObject resets the scale-up stabilization window to the OSS
+      // default; re-apply the inherited one in case it was overridden.
+    ) + scaleUp.withStabilizationWindowSeconds(
+      inheritedStoreGatewayZoneAScaledObject.spec.advanced.horizontalPodAutoscalerConfig.behavior.scaleUp.stabilizationWindowSeconds
+    ),
+
+  // Config validation.
+  local storeGatewayCompartmentZoneAError = if isZoneAMultiAZ then $.validateMimirMultiZoneConfig(['store_gateway_zone_a_statefulsets']) else null,
+  assert storeGatewayCompartmentZoneAError == null : storeGatewayCompartmentZoneAError,
+
+  local storeGatewayCompartmentZoneBError = if isZoneBMultiAZ then $.validateMimirMultiZoneConfig(['store_gateway_zone_b_statefulsets']) else null,
+  assert storeGatewayCompartmentZoneBError == null : storeGatewayCompartmentZoneBError,
+
+  local storeGatewayCompartmentZoneCError = if isZoneCMultiAZ then $.validateMimirMultiZoneConfig(['store_gateway_zone_c_statefulsets']) else null,
+  assert storeGatewayCompartmentZoneCError == null : storeGatewayCompartmentZoneCError,
+
+  local storeGatewayCompartmentZoneABackupError = if isZoneABackupMultiAZ then $.validateMimirMultiZoneConfig(['store_gateway_zone_a_backup_statefulsets']) else null,
+  assert storeGatewayCompartmentZoneABackupError == null : storeGatewayCompartmentZoneABackupError,
+
+  local storeGatewayCompartmentZoneBBackupError = if isZoneBBackupMultiAZ then $.validateMimirMultiZoneConfig(['store_gateway_zone_b_backup_statefulsets']) else null,
+  assert storeGatewayCompartmentZoneBBackupError == null : storeGatewayCompartmentZoneBBackupError,
+
+  local storeGatewayCompartmentConfigError = $.validateMimirCompartmentsConfig([
+    'store_gateway_zone_a_statefulsets',
+    'store_gateway_zone_b_statefulsets',
+    'store_gateway_zone_c_statefulsets',
+    'store_gateway_zone_a_backup_statefulsets',
+    'store_gateway_zone_b_backup_statefulsets',
+  ]),
+  assert storeGatewayCompartmentConfigError == null : storeGatewayCompartmentConfigError,
+}

--- a/operations/mimir/memberlist.libsonnet
+++ b/operations/mimir/memberlist.libsonnet
@@ -155,6 +155,11 @@
   store_gateway_zone_a_statefulset: overrideSuperIfExists('store_gateway_zone_a_statefulset', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
   store_gateway_zone_b_statefulset: overrideSuperIfExists('store_gateway_zone_b_statefulset', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
   store_gateway_zone_c_statefulset: overrideSuperIfExists('store_gateway_zone_c_statefulset', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
+  store_gateway_zone_a_statefulsets+: overrideSuperCompartmentsIfExists('store_gateway_zone_a_statefulsets', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
+  store_gateway_zone_b_statefulsets+: overrideSuperCompartmentsIfExists('store_gateway_zone_b_statefulsets', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
+  store_gateway_zone_c_statefulsets+: overrideSuperCompartmentsIfExists('store_gateway_zone_c_statefulsets', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
+  store_gateway_zone_a_backup_statefulsets+: overrideSuperCompartmentsIfExists('store_gateway_zone_a_backup_statefulsets', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
+  store_gateway_zone_b_backup_statefulsets+: overrideSuperCompartmentsIfExists('store_gateway_zone_b_backup_statefulsets', if !$._config.memberlist_ring_enabled then {} else gossipLabel),
 
   // Headless service (= no assigned IP, DNS returns all targets instead) pointing to gossip network members.
   gossip_ring_service:

--- a/operations/mimir/mimir.libsonnet
+++ b/operations/mimir/mimir.libsonnet
@@ -71,6 +71,7 @@
 (import 'compartments-query-frontend.libsonnet') +
 (import 'compartments-compactor.libsonnet') +
 (import 'compartments-compactor-scheduler.libsonnet') +
+(import 'compartments-store-gateway.libsonnet') +
 
 // Automatic cleanup of unused PVCs after scaling down. Keep it after compartments so it can patch the
 // per-compartment StatefulSet maps.

--- a/operations/mimir/mimir.libsonnet
+++ b/operations/mimir/mimir.libsonnet
@@ -52,7 +52,6 @@
 // Automated downscale of ingesters and store-gateways
 (import 'ingester-automated-downscale.libsonnet') +
 (import 'ingester-automated-downscale-v2.libsonnet') +
-(import 'store-gateway-autoscaling.libsonnet') +
 
 // Deletion protection for specific Mimir components.
 (import 'deletion-protection.libsonnet') +
@@ -72,6 +71,10 @@
 (import 'compartments-compactor.libsonnet') +
 (import 'compartments-compactor-scheduler.libsonnet') +
 (import 'compartments-store-gateway.libsonnet') +
+
+// Store-gateway autoscaling. Keep it after multi-zone-store-gateway (it patches those StatefulSets) and after
+// compartments-store-gateway so it can layer the same autoscaling onto the per-compartment StatefulSet maps.
+(import 'store-gateway-autoscaling.libsonnet') +
 
 // Automatic cleanup of unused PVCs after scaling down. Keep it after compartments so it can patch the
 // per-compartment StatefulSet maps.

--- a/operations/mimir/pvc-auto-deletion.libsonnet
+++ b/operations/mimir/pvc-auto-deletion.libsonnet
@@ -29,6 +29,11 @@ local statefulset = k.apps.v1.statefulSet;
   store_gateway_zone_c_statefulset: overrideSuperIfExists('store_gateway_zone_c_statefulset', store_gateway_pvc_auto_deletion),
   store_gateway_zone_a_backup_statefulset: overrideSuperIfExists('store_gateway_zone_a_backup_statefulset', store_gateway_pvc_auto_deletion),
   store_gateway_zone_b_backup_statefulset: overrideSuperIfExists('store_gateway_zone_b_backup_statefulset', store_gateway_pvc_auto_deletion),
+  store_gateway_zone_a_statefulsets+: overrideSuperCompartmentsIfExists('store_gateway_zone_a_statefulsets', store_gateway_pvc_auto_deletion),
+  store_gateway_zone_b_statefulsets+: overrideSuperCompartmentsIfExists('store_gateway_zone_b_statefulsets', store_gateway_pvc_auto_deletion),
+  store_gateway_zone_c_statefulsets+: overrideSuperCompartmentsIfExists('store_gateway_zone_c_statefulsets', store_gateway_pvc_auto_deletion),
+  store_gateway_zone_a_backup_statefulsets+: overrideSuperCompartmentsIfExists('store_gateway_zone_a_backup_statefulsets', store_gateway_pvc_auto_deletion),
+  store_gateway_zone_b_backup_statefulsets+: overrideSuperCompartmentsIfExists('store_gateway_zone_b_backup_statefulsets', store_gateway_pvc_auto_deletion),
 
   compactor_statefulset: overrideSuperIfExists('compactor_statefulset', compactor_pvc_auto_deletion),
   compactor_statefulsets+: overrideSuperCompartmentsIfExists('compactor_statefulsets', compactor_pvc_auto_deletion),

--- a/operations/mimir/store-gateway-autoscaling.libsonnet
+++ b/operations/mimir/store-gateway-autoscaling.libsonnet
@@ -23,6 +23,10 @@
     autoscaling_store_gateway_min_replicas_per_zone: error 'you must set autoscaling_store_gateway_min_replicas_per_zone in the _config',
     autoscaling_store_gateway_max_replicas_per_zone: error 'you must set autoscaling_store_gateway_max_replicas_per_zone in the _config',
 
+    // Per-compartment, per-zone autoscaling bounds.
+    autoscaling_store_gateway_min_replicas_per_compartment_zone: 3,
+    autoscaling_store_gateway_max_replicas_per_compartment_zone: 10,
+
     // Give more time if lazy-loading is disabled.
     store_gateway_automated_downscale_min_time_between_zones: if $._config.store_gateway_lazy_loading_enabled then '15m' else '60m',
   },
@@ -94,13 +98,42 @@
       'grafana.com/prepare-downscale-http-port': '80',
     }),
 
-  store_gateway_zone_a_scaled_object: if !$._config.autoscaling_store_gateway_enabled || !$._config.multi_zone_store_gateway_enabled || !$._config.store_gateway_automated_downscale_zone_a_enabled then null else
-    $.newLeaderStoreGatewayScaledObject(
+  // Downscale-leader annotations telling the rollout-operator which zone each follower tracks.
+  // compartmentIdx is null for the non-compartment store-gateways and the read compartment index
+  // for the per-compartment ones.
+  local storeGatewayDownscaleLeaderMixin(zone, compartmentIdx=null) =
+    local suffix = if compartmentIdx == null then '' else '-rc-%d' % compartmentIdx;
+    // - zone-b follows zone-a
+    // - zone-c follows zone-b
+    // - backup zones follow their primary zone (a-backup→a, b-backup→b), since they
+    //   run on spot nodes and must follow the standard-node leader (so none follows a
+    //   potentially-missing spot zone)
+    // - zone-a is the leader and gets no annotation
+    local leader =
+      if zone == 'b' || zone == 'a-backup' then 'store-gateway-zone-a' + suffix
+      else if zone == 'c' || zone == 'b-backup' then 'store-gateway-zone-b' + suffix
+      else null;
+    if leader == null then {} else statefulSet.mixin.metadata.withAnnotationsMixin({
+      'grafana.com/rollout-downscale-leader': leader,
+      'grafana.com/rollout-upscale-only-when-leader-ready': 'true',
+    }),
+
+  store_gateway_zone_a_scaled_object:
+    if $._config.compartments_store_gateway_enabled && !$._config.no_compartments_store_gateway_enabled
+    // When the per-compartment store-gateways own the read path and the non-compartment ones are removed,
+    // there's no non-compartment zone-a to autoscale.
+    then null
+    else if !$._config.autoscaling_store_gateway_enabled || !$._config.multi_zone_store_gateway_enabled || !$._config.store_gateway_automated_downscale_zone_a_enabled
+    then null
+    else $.newLeaderStoreGatewayScaledObject(
       'store-gateway-zone-a',
       $._config.autoscaling_store_gateway_min_replicas_per_zone,
       $._config.autoscaling_store_gateway_max_replicas_per_zone,
       $._config.autoscaling_store_gateway_disk_usage_threshold,
       null,
+      // In mixed mode the per-compartment store-gateways share the "store-gateway-.*" PVC prefix, so exclude
+      // their "-rc-<idx>-" PVCs to size the non-compartment autoscaler off the non-compartment disks only.
+      extra_matchers=if $._config.compartments_store_gateway_enabled then 'persistentvolumeclaim!~"store-gateway-data-store-gateway-zone-.*-rc-.*"' else '',
     ),
 
   // Store-gateway prepare-downscale configuration
@@ -115,10 +148,7 @@
     if !$._config.store_gateway_automated_downscale_zone_b_enabled || !$._config.multi_zone_store_gateway_enabled then {} else
       prepareDownscaleLabelsAnnotations +
       $.removeReplicasFromSpec +
-      statefulSet.mixin.metadata.withAnnotationsMixin({
-        'grafana.com/rollout-downscale-leader': 'store-gateway-zone-a',
-        'grafana.com/rollout-upscale-only-when-leader-ready': 'true',
-      }),
+      storeGatewayDownscaleLeaderMixin('b'),
   ),
 
   store_gateway_zone_c_statefulset: overrideSuperIfExists(
@@ -126,10 +156,7 @@
     if !$._config.store_gateway_automated_downscale_zone_c_enabled || !$._config.multi_zone_store_gateway_enabled then {} else
       prepareDownscaleLabelsAnnotations +
       $.removeReplicasFromSpec +
-      statefulSet.mixin.metadata.withAnnotationsMixin({
-        'grafana.com/rollout-downscale-leader': 'store-gateway-zone-b',
-        'grafana.com/rollout-upscale-only-when-leader-ready': 'true',
-      }),
+      storeGatewayDownscaleLeaderMixin('c'),
   ),
 
   store_gateway_zone_a_backup_statefulset: overrideSuperIfExists(
@@ -137,12 +164,7 @@
     if !$._config.store_gateway_automated_downscale_zone_a_backup_enabled || !$._config.multi_zone_store_gateway_enabled then {} else
       prepareDownscaleLabelsAnnotations +
       $.removeReplicasFromSpec +
-      statefulSet.mixin.metadata.withAnnotationsMixin({
-        // store-gateway-zone-a-backup is expected to run on spot nodes. Since spot nodes can be unavailable from time to time,
-        // we follow zone-a that is running on standard nodes and we ensure none follows zone-a-backup.
-        'grafana.com/rollout-downscale-leader': 'store-gateway-zone-a',
-        'grafana.com/rollout-upscale-only-when-leader-ready': 'true',
-      })
+      storeGatewayDownscaleLeaderMixin('a-backup')
   ),
 
   store_gateway_zone_b_backup_statefulset: overrideSuperIfExists(
@@ -150,12 +172,7 @@
     if !$._config.store_gateway_automated_downscale_zone_b_backup_enabled || !$._config.multi_zone_store_gateway_enabled then {} else
       prepareDownscaleLabelsAnnotations +
       $.removeReplicasFromSpec +
-      statefulSet.mixin.metadata.withAnnotationsMixin({
-        // store-gateway-zone-b-backup is expected to run on spot nodes. Since spot nodes can be unavailable from time to time,
-        // we follow zone-b that is running on standard nodes and we ensure none follows zone-b-backup.
-        'grafana.com/rollout-downscale-leader': 'store-gateway-zone-b',
-        'grafana.com/rollout-upscale-only-when-leader-ready': 'true',
-      }),
+      storeGatewayDownscaleLeaderMixin('b-backup'),
   ),
 
   // When prepare-downscale webhook is in use, we don't need the auto-forget feature to ensure
@@ -179,4 +196,47 @@
   store_gateway_zone_b_backup_args+:: if !$._config.store_gateway_automated_downscale_zone_b_backup_enabled || !$._config.multi_zone_store_gateway_enabled then {} else {
     'store-gateway.sharding-ring.auto-forget-enabled': false,
   },
+
+  //
+  // Per-compartment store-gateway autoscaling. Mirrors the non-compartment autoscaling above, layered on top of
+  // the per-compartment StatefulSet maps built in compartments-store-gateway.libsonnet. Gated on
+  // autoscaling_store_gateway_enabled; when disabled the per-compartment store-gateways run fixed replicas.
+  //
+
+  local compartmentsStoreGatewayAutoscalingEnabled = $._config.compartments_store_gateway_enabled && $._config.autoscaling_store_gateway_enabled,
+
+  // Applied to every per-compartment StatefulSet: the autoscaler owns the replicas and the rollout-operator
+  // drives safe downscales via the prepare-shutdown endpoint (zones follow their leader per compartment).
+  local storeGatewayCompartmentAutoscaleMixin(zone) = function(compartmentIdx)
+    $.removeReplicasFromSpec +
+    prepareDownscaleLabelsAnnotations +
+    storeGatewayDownscaleLeaderMixin(zone, compartmentIdx),
+
+  // Per-compartment store-gateways always use prepare-downscale when autoscaled (the shutdown endpoint removes
+  // them from the ring), so disable auto-forget.
+  local storeGatewayCompartmentAutoForgetArgs = if !compartmentsStoreGatewayAutoscalingEnabled then {} else {
+    'store-gateway.sharding-ring.auto-forget-enabled': false,
+  },
+
+  store_gateway_zone_a_compartments_args+:: $.mimirCompartmentsOverrides(super.store_gateway_zone_a_compartments_args, storeGatewayCompartmentAutoForgetArgs),
+  store_gateway_zone_b_compartments_args+:: $.mimirCompartmentsOverrides(super.store_gateway_zone_b_compartments_args, storeGatewayCompartmentAutoForgetArgs),
+  store_gateway_zone_c_compartments_args+:: $.mimirCompartmentsOverrides(super.store_gateway_zone_c_compartments_args, storeGatewayCompartmentAutoForgetArgs),
+  store_gateway_zone_a_backup_compartments_args+:: $.mimirCompartmentsOverrides(super.store_gateway_zone_a_backup_compartments_args, storeGatewayCompartmentAutoForgetArgs),
+  store_gateway_zone_b_backup_compartments_args+:: $.mimirCompartmentsOverrides(super.store_gateway_zone_b_backup_compartments_args, storeGatewayCompartmentAutoForgetArgs),
+
+  store_gateway_zone_a_statefulsets+: if !compartmentsStoreGatewayAutoscalingEnabled then {} else $.mimirCompartmentsOverrides(super.store_gateway_zone_a_statefulsets, storeGatewayCompartmentAutoscaleMixin('a')),
+  store_gateway_zone_b_statefulsets+: if !compartmentsStoreGatewayAutoscalingEnabled then {} else $.mimirCompartmentsOverrides(super.store_gateway_zone_b_statefulsets, storeGatewayCompartmentAutoscaleMixin('b')),
+  store_gateway_zone_c_statefulsets+: if !compartmentsStoreGatewayAutoscalingEnabled then {} else $.mimirCompartmentsOverrides(super.store_gateway_zone_c_statefulsets, storeGatewayCompartmentAutoscaleMixin('c')),
+  store_gateway_zone_a_backup_statefulsets+: if !compartmentsStoreGatewayAutoscalingEnabled then {} else $.mimirCompartmentsOverrides(super.store_gateway_zone_a_backup_statefulsets, storeGatewayCompartmentAutoscaleMixin('a-backup')),
+  store_gateway_zone_b_backup_statefulsets+: if !compartmentsStoreGatewayAutoscalingEnabled then {} else $.mimirCompartmentsOverrides(super.store_gateway_zone_b_backup_statefulsets, storeGatewayCompartmentAutoscaleMixin('b-backup')),
+
+  // Zone-a leader ScaledObject per compartment; the other zones follow it via the downscale-leader annotations.
+  store_gateway_zone_a_scaled_objects: $.mimirCompartmentsCreateIf(compartmentsStoreGatewayAutoscalingEnabled, $._config.compartments_read_count, function(c)
+    $.newLeaderStoreGatewayScaledObject(
+      'store-gateway-zone-a-rc-%d' % c,
+      $._config.autoscaling_store_gateway_min_replicas_per_compartment_zone,
+      $._config.autoscaling_store_gateway_max_replicas_per_compartment_zone,
+      $._config.autoscaling_store_gateway_disk_usage_threshold,
+      'store-gateway-data-store-gateway-zone-.*-rc-%d-.*' % c,
+    )),
 }


### PR DESCRIPTION
#### What this PR does

Adds `operations/mimir/compartments-store-gateway.libsonnet`, which deploys per-read-compartment store-gateways — the last piece of the experimental compartments deployment jsonnet still living only in `deployment_tools`. Each read compartment's store-gateways serve that compartment's own blocks bucket (produced by its per-compartment compactor) and register into their own ring.

It mirrors the non-compartment `multi-zone-store-gateway.libsonnet` + `store-gateway-autoscaling.libsonnet` (zones a/b/c plus the a-backup/b-backup multi-AZ zones, per-compartment autoscaling with the zone-a leader driving the follower zones) and follows the existing `compartments-*.libsonnet` structure. It is a no-op unless `compartments_store_gateway_enabled` (defaults to `compartments_enabled`).

Follow-up to #15889 (per-compartment compactor).

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated — not needed (experimental compartments work); `changelog-not-needed` label added.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
