### PR TITLE
Jsonnet: validate the blocks-storage bucket name in validateMimirCompartmentsConfig

### DIFF
--- a/operations/mimir-tests/test-compartments-config-validation.jsonnet
+++ b/operations/mimir-tests/test-compartments-config-validation.jsonnet
@@ -139,4 +139,58 @@ local err10 = validate(
 assert isError(err10, '-distributor.write-compartment-id=0') && isError(err10, 'does not belong to a write compartment') :
        'case 10: expected global-resource compartment-id error, got: %s' % err10;
 
+// 11. validateBlocksBucket: read compartment pointed at another compartment's bucket.
+local err11 = validate(
+  { ing: overrideContainerArgs(ingester, ['-blocks-storage.gcs.bucket-name=blocks-bucket-rc-0']) },
+  ['ing'],
+);
+assert isError(err11, '-blocks-storage.gcs.bucket-name=blocks-bucket-rc-0') && isError(err11, 'uses its own blocks-storage bucket') :
+       'case 11: expected blocks-storage bucket mismatch error, got: %s' % err11;
+
+// 12. validateBlocksBucket: read compartment pointed at the shared non-compartment bucket.
+local err12 = validate(
+  { ing: overrideContainerArgs(ingester, ['-blocks-storage.gcs.bucket-name=blocks-bucket']) },
+  ['ing'],
+);
+assert isError(err12, '-blocks-storage.gcs.bucket-name=blocks-bucket') && isError(err12, 'uses its own blocks-storage bucket') :
+       'case 12: expected blocks-storage shared-bucket error, got: %s' % err12;
+
+// 13. validateBlocksBucket: read compartment keeping the parametrised placeholder is accepted.
+local err13 = validate(
+  { ing: overrideContainerArgs(ingester, ['-blocks-storage.gcs.bucket-name=blocks-bucket-rc-<read-compartment-id>']) },
+  ['ing'],
+);
+assert err13 == null :
+       'case 13: expected no error for a parametrised blocks-storage bucket, got: %s' % err13;
+
+// 14. validateBlocksBucket: read compartment with its own concrete bucket is accepted.
+local err14 = validate(
+  { ing: overrideContainerArgs(ingester, ['-blocks-storage.gcs.bucket-name=blocks-bucket-rc-1']) },
+  ['ing'],
+);
+assert err14 == null :
+       'case 14: expected no error for the matching per-compartment bucket, got: %s' % err14;
+
+// A global deployment (no compartment marker) built from the distributor: the Kafka address is reset to the
+// placeholder and the write-compartment-id flag removed, so only the blocks-storage bucket is under test.
+local globalWithBucket(bucket) =
+  overrideContainerArgs(
+    removeContainerArg(distributor { metadata+: { name: 'querier' } }, '-distributor.write-compartment-id'),
+    [
+      '-ingest-storage.kafka.address=' + env._config.compartments_ingest_storage_kafka_address,
+      '-blocks-storage.gcs.bucket-name=' + bucket,
+    ],
+  );
+
+// 15. validateBlocksBucket: global deployment with a concrete per-compartment bucket must be rejected,
+// because one bucket can't serve every read compartment.
+local err15 = validate({ gf: globalWithBucket('blocks-bucket-rc-0') }, ['gf']);
+assert isError(err15, '-blocks-storage.gcs.bucket-name=blocks-bucket-rc-0') && isError(err15, 'only a read compartment owns a dedicated blocks-storage bucket') :
+       'case 15: expected global-deployment blocks-storage bucket error, got: %s' % err15;
+
+// 16. validateBlocksBucket: global deployment keeping the parametrised placeholder is accepted.
+local err16 = validate({ gf: globalWithBucket('blocks-bucket-rc-<read-compartment-id>') }, ['gf']);
+assert err16 == null :
+       'case 16: expected no error for a parametrised blocks-storage bucket on a global deployment, got: %s' % err16;
+
 {}

--- a/operations/mimir/compartments-common.libsonnet
+++ b/operations/mimir/compartments-common.libsonnet
@@ -83,6 +83,7 @@ local jsonpath = import 'github.com/jsonnet-libs/xtd/jsonpath.libsonnet';
     local root = $;
     local addressFlag = '-ingest-storage.kafka.address';
     local topicFlag = '-ingest-storage.kafka.topic';
+    local blocksBucketFlag = '-' + root.mimirBlocksStorageBucketNameFlag;
     local writeIdSuffix = '.write-compartment-id';
     local readIdSuffix = '.read-compartment-id';
     local writePlaceholder = '<write-compartment-id>';
@@ -143,7 +144,7 @@ local jsonpath = import 'github.com/jsonnet-libs/xtd/jsonpath.libsonnet';
           local eq = std.findSubstr('=', arg)[0];
           { flag: std.substr(arg, 0, eq), value: std.substr(arg, eq + 1, std.length(arg) - eq - 1) };
 
-    local validateAddress(name, compartment, container) =
+    local validateKafkaAddress(name, compartment, container) =
       local value = flagValue(container, addressFlag);
       if value == null then
         null
@@ -162,7 +163,7 @@ local jsonpath = import 'github.com/jsonnet-libs/xtd/jsonpath.libsonnet';
       else
         null;
 
-    local validateTopic(name, compartment, container) =
+    local validateKafkaTopic(name, compartment, container) =
       local value = flagValue(container, topicFlag);
       if value == null then
         null
@@ -180,6 +181,23 @@ local jsonpath = import 'github.com/jsonnet-libs/xtd/jsonpath.libsonnet';
           'The Deployment or StatefulSet "%s" sets "%s=%s", but a global deployment queries every read compartment\'s topic, so the topic must contain the "%s" placeholder.' % [name, topicFlag, value, readPlaceholder]
       else
         null;
+
+    // The blocks-storage bucket is per read compartment. A read compartment must point at its own bucket
+    // (name contains "-rc-<id>") or keep the "<read-compartment-id>" placeholder; any other deployment that
+    // sets a blocks bucket must keep the placeholder, since one concrete bucket can't serve every compartment.
+    local validateBlocksBucket(name, compartment, container) =
+      local value = flagValue(container, blocksBucketFlag);
+      if value == null then
+        null
+      else if std.length(std.findSubstr(readPlaceholder, value)) > 0 then
+        null
+      else if compartment.kind == 'read' then
+        if !containsIdToken(value, '-rc-%d' % compartment.id) then
+          'The Deployment or StatefulSet "%s" sets "%s=%s", but read compartment %d uses its own blocks-storage bucket (the bucket name must contain "-rc-%d" or the "%s" placeholder).' % [name, blocksBucketFlag, value, compartment.id, compartment.id, readPlaceholder]
+        else
+          null
+      else
+        'The Deployment or StatefulSet "%s" sets "%s=%s", but only a read compartment owns a dedicated blocks-storage bucket, so a bucket name here must contain the "%s" placeholder to address every read compartment.' % [name, blocksBucketFlag, value, readPlaceholder];
 
     // A "<kind>-compartment-id" flag must appear only on a matching compartment, and its value must
     // equal the id encoded in the resource name.
@@ -203,7 +221,7 @@ local jsonpath = import 'github.com/jsonnet-libs/xtd/jsonpath.libsonnet';
     local validateContainer(name, compartment, container) =
       std.foldl(
         function(firstError, validator) if firstError != null then firstError else validator(name, compartment, container),
-        [validateAddress, validateTopic, validateWriteCompartmentId, validateReadCompartmentId],
+        [validateKafkaAddress, validateKafkaTopic, validateBlocksBucket, validateWriteCompartmentId, validateReadCompartmentId],
         null
       );
 


### PR DESCRIPTION
#### What this PR does

Extend `validateMimirCompartmentsConfig` to also validate the per-compartment blocks-storage bucket name, so a misconfigured compartment bucket fails the jsonnet build instead of silently corrupting data at runtime (e.g. a read compartment pointing at another compartment's bucket, or at the shared non-compartment bucket).

A read compartment must use its own bucket (name contains `-rc-<id>`) or keep the `<read-compartment-id>` placeholder; any other deployment that sets a blocks bucket must keep the placeholder, since one concrete bucket can't serve every read compartment.

Also renames `validateAddress`/`validateTopic` to `validateKafkaAddress`/`validateKafkaTopic` for clarity now that a third resource type is validated.

#### Which issue(s) this PR fixes or relates to

N/A — part of the experimental compartments architecture work.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - not needed (`changelog-not-needed` label added); internal jsonnet validation for the experimental compartments architecture.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.