### PR TITLE
Introduce optional limit on active series and active native histograms request sharding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 * [ENHANCEMENT] Block-builder: Respect `-blocks-storage.tsdb.bigger-out-of-order-blocks-for-old-samples` to produce 24h blocks for out-of-order data belonging to previous days. #15892
 * [ENHANCEMENT] MQE: Ensure that intermediate results cache keys can not exceed the cache backend's key-size limit when a query federates over many tenants. #15847
 * [ENHANCEMENT] Query-frontend: add a `retries` field to the "query stats" log line reporting the number of times requests were retried while processing the query. The value is 0 when all requests succeeded on their first attempt. #15929
+* [ENHANCEMENT] Query-frontend: Add `query-frontend.cardinality-sharding-max-sharded-queries` to optionally limit sharding for `cardinality/active_series` and `cardinality/active_native_histogram_metrics` endpoints separately from `query-frontend.query-sharding-max-sharded-queries`. #15922
 * [BUGFIX] Query-frontend: Fix `cardinality_analysis_max_results` being ignored when set higher than the default of 500. #15581
 * [BUGFIX] Ingest storage: Fix `KafkaProducer.ProduceSync()` returning a single result with a nil record when the context is canceled, instead of one result per input record (with the record set) as the underlying franz-go client does. #15199
 * [BUGFIX] Ingest storage: Fix `cortex_ingest_storage_reader_receive_delay_seconds` inflation by no longer setting the Kafka record `Timestamp` on the distributor side; the Kafka client now sets it at produce time. #15572

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -6057,6 +6057,17 @@
         },
         {
           "kind": "field",
+          "name": "cardinality_sharding_max_sharded_queries",
+          "required": false,
+          "desc": "The max number of sharded queries that can be run for a cardinality (active series and active native histogram metrics) request. 0 to fall back to -query-frontend.query-sharding-max-sharded-queries.",
+          "fieldValue": null,
+          "fieldDefaultValue": 0,
+          "fieldFlag": "query-frontend.cardinality-sharding-max-sharded-queries",
+          "fieldType": "int",
+          "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
           "name": "query_ingesters_within",
           "required": false,
           "desc": "Maximum lookback beyond which queries are not sent to ingester. 0 means all queries are sent to ingester.",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2585,6 +2585,8 @@ Usage of ./cmd/mimir/mimir:
     	[deprecated] Cache statistics of processed samples on results cache. Deprecated: has no effect.
   -query-frontend.cache-unaligned-requests
     	Cache requests that are not step-aligned.
+  -query-frontend.cardinality-sharding-max-sharded-queries int
+    	[experimental] The max number of sharded queries that can be run for a cardinality (active series and active native histogram metrics) request. 0 to fall back to -query-frontend.query-sharding-max-sharded-queries.
   -query-frontend.client-cluster-validation.label string
     	[experimental] Primary cluster validation label.
   -query-frontend.enable-multiple-node-remote-execution-requests

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -234,6 +234,7 @@ The following features are currently experimental:
     Requests with invalid cluster validation labels are tracked via the `cortex_client_invalid_cluster_validation_label_requests_total` metric.
   - Support for duration expressions in PromQL, which are simple arithmetics on numbers in offset and range specification.
   - Support for configuring the maximum series limit for cardinality API requests on a per-tenant basis via `cardinality_analysis_max_results`.
+  - Separate query sharding limit for cardinality API requests (active series and active native histogram metrics): `-query-frontend.cardinality-sharding-max-sharded-queries`
   - [Mimir query engine](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/mimir-query-engine) (`-query-frontend.query-engine` and `-query-frontend.enable-query-engine-fallback`)
   - Remote execution of queries in queriers: `-query-frontend.enable-remote-execution=true` and `-query-frontend.enable-multiple-node-remote-execution-requests=true`
   - Performing query sharding within MQE: `-query-frontend.use-mimir-query-engine-for-sharding=true`

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -4591,6 +4591,12 @@ The `limits` block configures default and per-tenant limits imposed by component
 # CLI flag: -query-frontend.query-sharding-max-regexp-size-bytes
 [query_sharding_max_regexp_size_bytes: <int> | default = 4096]
 
+# (experimental) The max number of sharded queries that can be run for a
+# cardinality (active series and active native histogram metrics) request. 0 to
+# fall back to -query-frontend.query-sharding-max-sharded-queries.
+# CLI flag: -query-frontend.cardinality-sharding-max-sharded-queries
+[cardinality_sharding_max_sharded_queries: <int> | default = 0]
+
 # (advanced) Maximum lookback beyond which queries are not sent to ingester. 0
 # means all queries are sent to ingester.
 # CLI flag: -querier.query-ingesters-within

--- a/operations/mimir/mimir-flags-defaults.json
+++ b/operations/mimir/mimir-flags-defaults.json
@@ -425,6 +425,7 @@
   "query-frontend.query-sharding-total-shards": 16,
   "query-frontend.query-sharding-max-sharded-queries": 128,
   "query-frontend.query-sharding-max-regexp-size-bytes": 4096,
+  "query-frontend.cardinality-sharding-max-sharded-queries": 0,
   "querier.query-ingesters-within": 46800000000000,
   "query-frontend.max-total-query-length": 0,
   "query-frontend.results-cache-ttl": 604800000000000,

--- a/pkg/frontend/querymiddleware/limits.go
+++ b/pkg/frontend/querymiddleware/limits.go
@@ -71,6 +71,11 @@ type Limits interface {
 	// than this limit, the query will not be sharded. 0 to disable limit.
 	QueryShardingMaxRegexpSizeBytes(userID string) int
 
+	// CardinalityShardingMaxShardedQueries returns the max number of sharded queries that can
+	// be run for a cardinality (active series and active native histogram metrics) request.
+	// 0 to fall back to QueryShardingMaxShardedQueries.
+	CardinalityShardingMaxShardedQueries(userID string) int
+
 	// CompactorSplitAndMergeShards returns the number of shards to use when splitting blocks
 	// This method is copied from compactor.ConfigProvider.
 	CompactorSplitAndMergeShards(userID string) int

--- a/pkg/frontend/querymiddleware/limits_test.go
+++ b/pkg/frontend/querymiddleware/limits_test.go
@@ -705,6 +705,10 @@ func (m multiTenantMockLimits) QueryShardingMaxShardedQueries(userID string) int
 	return m.byTenant[userID].maxShardedQueries
 }
 
+func (m multiTenantMockLimits) CardinalityShardingMaxShardedQueries(userID string) int {
+	return m.byTenant[userID].cardinalityMaxShardedQueries
+}
+
 func (m multiTenantMockLimits) QueryShardingMaxRegexpSizeBytes(userID string) int {
 	return m.byTenant[userID].maxRegexpSizeBytes
 }
@@ -806,6 +810,7 @@ type mockLimits struct {
 	maxCacheFreshness                     time.Duration
 	maxQueryParallelism                   int
 	maxShardedQueries                     int
+	cardinalityMaxShardedQueries          int
 	maxRegexpSizeBytes                    int
 	totalShards                           int
 	compactorShards                       int
@@ -872,6 +877,10 @@ func (m mockLimits) QueryShardingMaxShardedQueries(string) int {
 
 func (m mockLimits) QueryShardingMaxRegexpSizeBytes(string) int {
 	return m.maxRegexpSizeBytes
+}
+
+func (m mockLimits) CardinalityShardingMaxShardedQueries(string) int {
+	return m.cardinalityMaxShardedQueries
 }
 
 func (m mockLimits) CompactorSplitAndMergeShards(string) int {

--- a/pkg/frontend/querymiddleware/shard_active_series_test.go
+++ b/pkg/frontend/querymiddleware/shard_active_series_test.go
@@ -359,6 +359,84 @@ func Test_shardActiveSeriesMiddleware_RoundTrip(t *testing.T) {
 	}
 }
 
+func Test_shardBySeriesBase_cardinalityShardingMaxShardedQueries(t *testing.T) {
+	makeReq := func(shardCount int) *http.Request {
+		r := httptest.NewRequest("POST", "/active_series", strings.NewReader(`selector={__name__="metric"}`))
+		r.Header.Add("X-Scope-OrgID", "test")
+		r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+		r.Header.Add(requestoptions.TotalShardsControlHeader, strconv.Itoa(shardCount))
+		return r.WithContext(user.InjectOrgID(r.Context(), "test"))
+	}
+
+	// return an empty but valid response for any requested shard.
+	upstream := RoundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"data":[]}`))}, nil
+	})
+
+	middlewares := []struct {
+		name       string
+		middleware func(http.RoundTripper, Limits, log.Logger) http.RoundTripper
+	}{
+		{"active series", newShardActiveSeriesMiddleware},
+		{"active native histogram metrics", newShardActiveNativeHistogramMetricsMiddleware},
+	}
+
+	tests := []struct {
+		name                         string
+		maxShardedQueries            int
+		cardinalityMaxShardedQueries int
+		requestedShards              int
+		expectedErr                  string
+	}{
+		{
+			name:                         "falls back to QueryShardingMaxShardedQueries when cardinality limit is unset",
+			maxShardedQueries:            4,
+			cardinalityMaxShardedQueries: -1,
+			requestedShards:              8,
+			expectedErr:                  "shard count 8 exceeds allowed maximum (4)",
+		},
+		{
+			name:                         "cardinality limit overrides QueryShardingMaxShardedQueries when set",
+			maxShardedQueries:            128,
+			cardinalityMaxShardedQueries: 4,
+			requestedShards:              8,
+			expectedErr:                  "shard count 8 exceeds allowed maximum (4)",
+		},
+		{
+			name:                         "cardinality limit allows more shards than QueryShardingMaxShardedQueries",
+			maxShardedQueries:            4,
+			cardinalityMaxShardedQueries: 16,
+			requestedShards:              8,
+			expectedErr:                  "",
+		},
+	}
+
+	for _, mw := range middlewares {
+		for _, tt := range tests {
+			t.Run(mw.name+": "+tt.name, func(t *testing.T) {
+				s := mw.middleware(upstream, mockLimits{
+					totalShards:                  tt.requestedShards,
+					maxShardedQueries:            tt.maxShardedQueries,
+					cardinalityMaxShardedQueries: tt.cardinalityMaxShardedQueries,
+				}, log.NewNopLogger())
+
+				resp, err := s.RoundTrip(makeReq(tt.requestedShards))
+				if tt.expectedErr != "" {
+					require.Error(t, err)
+					assert.Equal(t, err.Error(), tt.expectedErr)
+					return
+				}
+
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				_, err = io.ReadAll(resp.Body)
+				assert.NoError(t, err)
+				assert.NoError(t, resp.Body.Close())
+			})
+		}
+	}
+}
+
 func Test_shardActiveSeriesMiddleware_RoundTrip_concurrent(t *testing.T) {
 	const shardCount = 4
 

--- a/pkg/frontend/querymiddleware/shard_by_series_base.go
+++ b/pkg/frontend/querymiddleware/shard_by_series_base.go
@@ -49,7 +49,11 @@ func (s *shardBySeriesBase) shardBySeriesSelector(ctx context.Context, spanLog *
 		return s.upstream.RoundTrip(r)
 	}
 
-	if maxShards := s.limits.QueryShardingMaxShardedQueries(tenantID); shardCount > maxShards {
+	maxShards := s.limits.QueryShardingMaxShardedQueries(tenantID)
+	if cardinalityMaxShards := s.limits.CardinalityShardingMaxShardedQueries(tenantID); cardinalityMaxShards > 0 {
+		maxShards = cardinalityMaxShards
+	}
+	if maxShards > 0 && shardCount > maxShards {
 		return nil, apierror.New(
 			apierror.TypeBadData,
 			fmt.Sprintf("shard count %d exceeds allowed maximum (%d)", shardCount, maxShards),

--- a/pkg/frontend/v2/remoteexec_test.go
+++ b/pkg/frontend/v2/remoteexec_test.go
@@ -2376,6 +2376,10 @@ func (m mockLimitedParallelismLimits) QueryShardingMaxShardedQueries(_ string) i
 	return 0
 }
 
+func (m mockLimitedParallelismLimits) CardinalityShardingMaxShardedQueries(_ string) int {
+	return 0
+}
+
 func (m mockLimitedParallelismLimits) CompactorSplitAndMergeShards(_ string) int {
 	return 4
 }

--- a/pkg/util/validation/limits.go
+++ b/pkg/util/validation/limits.go
@@ -221,6 +221,7 @@ type Limits struct {
 	QueryShardingTotalShards              int            `yaml:"query_sharding_total_shards" json:"query_sharding_total_shards"`
 	QueryShardingMaxShardedQueries        int            `yaml:"query_sharding_max_sharded_queries" json:"query_sharding_max_sharded_queries"`
 	QueryShardingMaxRegexpSizeBytes       int            `yaml:"query_sharding_max_regexp_size_bytes" json:"query_sharding_max_regexp_size_bytes"`
+	CardinalityShardingMaxShardedQueries  int            `yaml:"cardinality_sharding_max_sharded_queries" json:"cardinality_sharding_max_sharded_queries" category:"experimental"`
 	QueryIngestersWithin                  model.Duration `yaml:"query_ingesters_within" json:"query_ingesters_within" category:"advanced"`
 	EnableDelayedNameRemoval              bool           `yaml:"enable_delayed_name_removal" json:"enable_delayed_name_removal" category:"experimental"`
 
@@ -445,6 +446,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.QueryShardingTotalShards, "query-frontend.query-sharding-total-shards", 16, "The amount of shards to use when doing parallelisation via query sharding by tenant. 0 to disable query sharding for tenant. Values greater than 1 are rounded up to the next power of two, so the query shard count always meshes with the compactor's power-of-two shard count. This allows querier to not search the blocks which cannot possibly have the series for given query shard.")
 	f.IntVar(&l.QueryShardingMaxShardedQueries, "query-frontend.query-sharding-max-sharded-queries", 128, "The max number of sharded queries that can be run for a given received query. 0 to disable limit.")
 	f.IntVar(&l.QueryShardingMaxRegexpSizeBytes, "query-frontend.query-sharding-max-regexp-size-bytes", 4096, "Disable query sharding for any query containing a regular expression matcher longer than the configured number of bytes. 0 to disable the limit.")
+	f.IntVar(&l.CardinalityShardingMaxShardedQueries, "query-frontend.cardinality-sharding-max-sharded-queries", 0, "The max number of sharded queries that can be run for a cardinality (active series and active native histogram metrics) request. 0 to fall back to -query-frontend.query-sharding-max-sharded-queries.")
 	_ = l.QueryIngestersWithin.Set("13h")
 	f.Var(&l.QueryIngestersWithin, QueryIngestersWithinFlag, "Maximum lookback beyond which queries are not sent to ingester. 0 means all queries are sent to ingester.")
 	f.BoolVar(&l.EnableDelayedNameRemoval, EnableDelayedNameRemovalFlag, false, "Enable the experimental Prometheus feature for delayed name removal within MQE, which only works if remote execution and running sharding within MQE is enabled.")
@@ -1137,6 +1139,12 @@ func (o *Overrides) QueryShardingMaxShardedQueries(userID string) int {
 // than this limit, the query will not be sharded. 0 to disable limit.
 func (o *Overrides) QueryShardingMaxRegexpSizeBytes(userID string) int {
 	return o.getOverridesForUser(userID).QueryShardingMaxRegexpSizeBytes
+}
+
+// CardinalityShardingMaxShardedQueries returns the max number of sharded queries that can
+// be run for a cardinality (active series and active native histogram metrics) request.
+func (o *Overrides) CardinalityShardingMaxShardedQueries(userID string) int {
+	return o.getOverridesForUser(userID).CardinalityShardingMaxShardedQueries
 }
 
 // QueryIngestersWithin returns the maximum lookback beyond which queries are not sent to ingester.


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Currently, the `cardinality/active_series` and `cardinality/active_native_histogram_metrics` endpoints shard requests up to the general query sharding limit (`query_sharding_max_sharded_queries`). However, operators may want to allow more or less sharding for these endpoints without necessarily changing the limit for general querying. This PR introduces `cardinality_sharding_max_sharded_queries`, which governs sharding for only cardinality-related requests. Setting it to <0 falls back to the general query-sharding limit.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
