### PR TITLE
CI: trial GitHub Actions parallel steps in lint-jsonnet job

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -133,18 +133,22 @@ jobs:
         run: |
           mkdir -p /go/src/github.com/grafana/mimir
           ln -s $GITHUB_WORKSPACE/* /go/src/github.com/grafana/mimir
-      - name: Check Mixin
-        run: make BUILD_IN_CONTAINER=false check-mixin
-      - name: Check Mixin Tests
-        run: make BUILD_IN_CONTAINER=false check-mixin-tests
-      - name: Check Mixin with Mimirtool rules check
-        run: make BUILD_IN_CONTAINER=false check-mixin-mimirtool-rules
-      - name: Check Jsonnet Manifests
-        run: make BUILD_IN_CONTAINER=false check-jsonnet-manifests
-      - name: Check Jsonnet Getting Started
-        run: make BUILD_IN_CONTAINER=false check-jsonnet-getting-started
-      - name: Check Jsonnet Tests
-        run: make BUILD_IN_CONTAINER=false check-jsonnet-tests
+      # The three groups below don't touch each other's files, so they run concurrently.
+      # Within each group the checks stay sequential because they mutate shared paths:
+      # the mixin checks all write to operations/mimir-mixin(-compiled*), and the two
+      # jsonnet checks both diff operations/mimir-tests.
+      - parallel:
+          - name: Check Mixin
+            run: |
+              make BUILD_IN_CONTAINER=false check-mixin
+              make BUILD_IN_CONTAINER=false check-mixin-tests
+              make BUILD_IN_CONTAINER=false check-mixin-mimirtool-rules
+          - name: Check Jsonnet Manifests and Tests
+            run: |
+              make BUILD_IN_CONTAINER=false check-jsonnet-manifests
+              make BUILD_IN_CONTAINER=false check-jsonnet-tests
+          - name: Check Jsonnet Getting Started
+            run: make BUILD_IN_CONTAINER=false check-jsonnet-getting-started
 
   lint-helm:
     runs-on: ubuntu-latest


### PR DESCRIPTION
#### What this PR does

Trials the new GitHub Actions step-level parallelism ([shipped 2026-06-25](https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/)) on the `lint-jsonnet` job, as a low-risk canary before considering the same for the bigger `lint` job.

The six checks are grouped into three parallel lanes rather than fully parallelized, because some of them mutate shared paths and would race if run concurrently:

- `check-mixin`, `check-mixin-tests` and `check-mixin-mimirtool-rules` all write under `operations/mimir-mixin*`: `build-mixin` (run by both `check-mixin` and `check-mixin-mimirtool-rules`) empties and regenerates the compiled output dirs, and the mixin tests temporarily copy a file into the mixin source dir that would trip `check-mixin`'s untracked-files check.
- `check-jsonnet-manifests` and `check-jsonnet-tests` both diff `operations/mimir-tests`, and the latter deletes/rebuilds the generated YAML there.
- `check-jsonnet-getting-started` is self-contained and runs in its own lane.

Things this trial should answer:

1. Do the new `parallel:`/`background:` keywords work inside `container:` jobs? (Public adopters so far only use them on plain runners.)
2. How much wall-clock time does the job actually save, given the checks contend for the same 4-core runner?

This is a draft to observe the CI run; if it works and saves meaningful time, the `lint` job is the next candidate.

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)