### PR TITLE
block-builder-scheduler: add multi-cluster support to `partitionState` 

### DIFF
--- a/pkg/blockbuilder/scheduler/jobs_test.go
+++ b/pkg/blockbuilder/scheduler/jobs_test.go
@@ -23,7 +23,7 @@ type testSpec struct {
 }
 
 func TestAssign(t *testing.T) {
-	s := newJobQueue(988*time.Hour, noOpJobCreationPolicy[testSpec]{}, 2, newSchedulerMetrics(prometheus.NewPedanticRegistry()), test.NewTestingLogger(t))
+	s := newJobQueue(988*time.Hour, noOpJobCreationPolicy[testSpec]{}, 2, newSchedulerMetrics(prometheus.NewPedanticRegistry(), false, 1), test.NewTestingLogger(t))
 	require.NotNil(t, s)
 
 	j0, j0spec, err := s.assign("w0")
@@ -54,7 +54,7 @@ func TestAssign(t *testing.T) {
 }
 
 func TestAssignComplete(t *testing.T) {
-	s := newJobQueue(988*time.Hour, noOpJobCreationPolicy[testSpec]{}, 2, newSchedulerMetrics(prometheus.NewPedanticRegistry()), test.NewTestingLogger(t))
+	s := newJobQueue(988*time.Hour, noOpJobCreationPolicy[testSpec]{}, 2, newSchedulerMetrics(prometheus.NewPedanticRegistry(), false, 1), test.NewTestingLogger(t))
 	require.NotNil(t, s)
 
 	{
@@ -100,7 +100,7 @@ func TestAssignComplete(t *testing.T) {
 }
 
 func TestLease(t *testing.T) {
-	s := newJobQueue(988*time.Hour, noOpJobCreationPolicy[testSpec]{}, 2, newSchedulerMetrics(prometheus.NewPedanticRegistry()), test.NewTestingLogger(t))
+	s := newJobQueue(988*time.Hour, noOpJobCreationPolicy[testSpec]{}, 2, newSchedulerMetrics(prometheus.NewPedanticRegistry(), false, 1), test.NewTestingLogger(t))
 	require.NotNil(t, s)
 
 	e := s.add("job1", testSpec{topic: "hello", commitRecTs: time.Now()})
@@ -143,7 +143,7 @@ func TestLease(t *testing.T) {
 
 func TestPersistentFailure(t *testing.T) {
 	reg := prometheus.NewPedanticRegistry()
-	s := newJobQueue(988*time.Hour, noOpJobCreationPolicy[testSpec]{}, 2, newSchedulerMetrics(reg), test.NewTestingLogger(t))
+	s := newJobQueue(988*time.Hour, noOpJobCreationPolicy[testSpec]{}, 2, newSchedulerMetrics(reg, false, 1), test.NewTestingLogger(t))
 	require.NotNil(t, s)
 
 	require.NoError(t, s.add("job1", testSpec{topic: "hello", commitRecTs: time.Now()}))
@@ -178,7 +178,7 @@ func TestPersistentFailure(t *testing.T) {
 // TestImportJob tests the importJob method - the method that is called to learn
 // about jobs in-flight from a previous scheduler instance.
 func TestImportJob(t *testing.T) {
-	s := newJobQueue(988*time.Hour, noOpJobCreationPolicy[testSpec]{}, 2, newSchedulerMetrics(prometheus.NewPedanticRegistry()), test.NewTestingLogger(t))
+	s := newJobQueue(988*time.Hour, noOpJobCreationPolicy[testSpec]{}, 2, newSchedulerMetrics(prometheus.NewPedanticRegistry(), false, 1), test.NewTestingLogger(t))
 	require.NotNil(t, s)
 
 	spec := testSpec{commitRecTs: time.Now().Add(-1 * time.Hour)}
@@ -198,7 +198,7 @@ func TestImportJob(t *testing.T) {
 
 func TestJobCreationPolicies(t *testing.T) {
 	t.Run("noOpJobCreationPolicy", func(t *testing.T) {
-		s := newJobQueue(988*time.Hour, noOpJobCreationPolicy[testSpec]{}, 2, newSchedulerMetrics(prometheus.NewPedanticRegistry()), test.NewTestingLogger(t))
+		s := newJobQueue(988*time.Hour, noOpJobCreationPolicy[testSpec]{}, 2, newSchedulerMetrics(prometheus.NewPedanticRegistry(), false, 1), test.NewTestingLogger(t))
 		require.NotNil(t, s)
 
 		// noOp policy should always allow job creation
@@ -212,7 +212,7 @@ func TestJobCreationPolicies(t *testing.T) {
 	})
 
 	t.Run("allowNone", func(t *testing.T) {
-		s := newJobQueue(988*time.Hour, noOpJobCreationPolicy[testSpec]{}, 2, newSchedulerMetrics(prometheus.NewPedanticRegistry()), test.NewTestingLogger(t))
+		s := newJobQueue(988*time.Hour, noOpJobCreationPolicy[testSpec]{}, 2, newSchedulerMetrics(prometheus.NewPedanticRegistry(), false, 1), test.NewTestingLogger(t))
 		require.NotNil(t, s)
 		s.creationPolicy = allowNoneJobCreationPolicy[testSpec]{}
 

--- a/pkg/blockbuilder/scheduler/metrics.go
+++ b/pkg/blockbuilder/scheduler/metrics.go
@@ -3,27 +3,28 @@
 package scheduler
 
 import (
+	"strconv"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 type schedulerMetrics struct {
-	updateScheduleDuration   prometheus.Histogram
-	probeRecordTimeDelta     prometheus.Histogram
-	partitionStartOffset     *prometheus.GaugeVec
-	partitionCommittedOffset *prometheus.GaugeVec
-	partitionPlannedOffset   *prometheus.GaugeVec
-	partitionEndOffset       *prometheus.GaugeVec
-	flushFailed              prometheus.Counter
-	fetchOffsetsFailed       prometheus.Counter
-	outstandingJobs          prometheus.Gauge
-	assignedJobs             prometheus.Gauge
-	pendingJobs              *prometheus.GaugeVec
-	persistentJobFailures    prometheus.Counter
-	jobGapDetected           *prometheus.CounterVec
+	updateScheduleDuration prometheus.Histogram
+	probeRecordTimeDelta   prometheus.Histogram
+	flushFailed            prometheus.Counter
+	fetchOffsetsFailed     prometheus.Counter
+	outstandingJobs        prometheus.Gauge
+	assignedJobs           prometheus.Gauge
+	pendingJobs            *prometheus.GaugeVec
+	persistentJobFailures  prometheus.Counter
+	jobGapDetected         *prometheus.CounterVec
+
+	// perClusterMetrics holds one set of partition offset gauges per cluster, indexed by cluster ID.
+	perClusterMetrics []singleClusterMetrics
 }
 
-func newSchedulerMetrics(reg prometheus.Registerer) schedulerMetrics {
+func newSchedulerMetrics(reg prometheus.Registerer, compartmentsEnabled bool, numClusters int) schedulerMetrics {
 	scm := schedulerMetrics{
 		updateScheduleDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 			Name: "cortex_blockbuilder_scheduler_schedule_update_seconds",
@@ -37,22 +38,6 @@ func newSchedulerMetrics(reg prometheus.Registerer) schedulerMetrics {
 
 			NativeHistogramBucketFactor: 1.1,
 		}),
-		partitionStartOffset: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
-			Name: "cortex_blockbuilder_scheduler_partition_start_offset",
-			Help: "The observed start offset of each partition.",
-		}, []string{"partition"}),
-		partitionEndOffset: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
-			Name: "cortex_blockbuilder_scheduler_partition_end_offset",
-			Help: "The observed end offset of each partition.",
-		}, []string{"partition"}),
-		partitionCommittedOffset: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
-			Name: "cortex_blockbuilder_scheduler_partition_committed_offset",
-			Help: "The observed committed offset of each partition.",
-		}, []string{"partition"}),
-		partitionPlannedOffset: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
-			Name: "cortex_blockbuilder_scheduler_partition_planned_offset",
-			Help: "The planned offset of each partition.",
-		}, []string{"partition"}),
 		flushFailed: promauto.With(reg).NewCounter(prometheus.CounterOpts{
 			Name: "cortex_blockbuilder_scheduler_flush_failed_total",
 			Help: "The total number of Kafka flushes that failed.",
@@ -87,5 +72,51 @@ func newSchedulerMetrics(reg prometheus.Registerer) schedulerMetrics {
 	scm.jobGapDetected.WithLabelValues(offsetNamePlanned)
 	scm.jobGapDetected.WithLabelValues(offsetNameCommitted)
 
+	scm.perClusterMetrics = newClusterMetrics(reg, compartmentsEnabled, numClusters)
+
 	return scm
+}
+
+// singleClusterMetrics holds the observed offset gauges for a single cluster.
+type singleClusterMetrics struct {
+	startOffset     *prometheus.GaugeVec
+	endOffset       *prometheus.GaugeVec
+	committedOffset *prometheus.GaugeVec
+	plannedOffset   *prometheus.GaugeVec
+}
+
+// newClusterMetrics builds one set of partition offset gauges per cluster, indexed
+// by cluster ID. With compartments enabled each cluster's gauges carry a constant
+// write_compartment label; with compartments disabled there is a single unlabeled set.
+func newClusterMetrics(reg prometheus.Registerer, compartmentsEnabled bool, numClusters int) []singleClusterMetrics {
+	metrics := make([]singleClusterMetrics, numClusters)
+	for clusterID := range metrics {
+		clusterReg := reg
+		if compartmentsEnabled {
+			clusterReg = prometheus.WrapRegistererWith(prometheus.Labels{"write_compartment": strconv.Itoa(clusterID)}, reg)
+		}
+		metrics[clusterID] = newSingleClusterMetrics(clusterReg)
+	}
+	return metrics
+}
+
+func newSingleClusterMetrics(reg prometheus.Registerer) singleClusterMetrics {
+	return singleClusterMetrics{
+		startOffset: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "cortex_blockbuilder_scheduler_partition_start_offset",
+			Help: "The observed start offset of each partition.",
+		}, []string{"partition"}),
+		endOffset: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "cortex_blockbuilder_scheduler_partition_end_offset",
+			Help: "The observed end offset of each partition.",
+		}, []string{"partition"}),
+		committedOffset: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "cortex_blockbuilder_scheduler_partition_committed_offset",
+			Help: "The observed committed offset of each partition.",
+		}, []string{"partition"}),
+		plannedOffset: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "cortex_blockbuilder_scheduler_partition_planned_offset",
+			Help: "The planned offset of each partition.",
+		}, []string{"partition"}),
+	}
 }

--- a/pkg/blockbuilder/scheduler/metrics_test.go
+++ b/pkg/blockbuilder/scheduler/metrics_test.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package scheduler
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	promtest "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClusterMetrics_PerCluster(t *testing.T) {
+	t.Run("compartments disabled omits the write_compartment label", func(t *testing.T) {
+		reg := prometheus.NewPedanticRegistry()
+		metrics := newClusterMetrics(reg, false, 1)
+		require.Len(t, metrics, 1)
+
+		metrics[0].startOffset.WithLabelValues("1").Set(42)
+
+		require.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
+			# HELP cortex_blockbuilder_scheduler_partition_start_offset The observed start offset of each partition.
+			# TYPE cortex_blockbuilder_scheduler_partition_start_offset gauge
+			cortex_blockbuilder_scheduler_partition_start_offset{partition="1"} 42
+		`), "cortex_blockbuilder_scheduler_partition_start_offset"))
+	})
+
+	t.Run("compartments enabled labels each cluster with its write_compartment", func(t *testing.T) {
+		reg := prometheus.NewPedanticRegistry()
+		metrics := newClusterMetrics(reg, true, 2)
+		require.Len(t, metrics, 2)
+
+		metrics[0].startOffset.WithLabelValues("1").Set(42)
+		metrics[1].startOffset.WithLabelValues("1").Set(99)
+
+		require.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(`
+			# HELP cortex_blockbuilder_scheduler_partition_start_offset The observed start offset of each partition.
+			# TYPE cortex_blockbuilder_scheduler_partition_start_offset gauge
+			cortex_blockbuilder_scheduler_partition_start_offset{partition="1",write_compartment="0"} 42
+			cortex_blockbuilder_scheduler_partition_start_offset{partition="1",write_compartment="1"} 99
+		`), "cortex_blockbuilder_scheduler_partition_start_offset"))
+	})
+}

--- a/pkg/blockbuilder/scheduler/partition_state.go
+++ b/pkg/blockbuilder/scheduler/partition_state.go
@@ -5,6 +5,7 @@ package scheduler
 import (
 	"container/list"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go-kit/log"
@@ -17,9 +18,12 @@ type partitionState struct {
 	topic     string
 	partition int32
 
+	compartmentsEnabled bool
+
 	jobBucket time.Time
 
-	offsets singleClusterOffsets
+	// offsets is indexed by cluster ID.
+	offsets []singleClusterOffsets
 
 	// pendingJobs are jobs that are waiting to be enqueued. The job creation policy is what allows them to advance to the plannedJobs list.
 	pendingJobs *list.List
@@ -41,21 +45,30 @@ const (
 	bucketAfter  = 1
 )
 
-func newPartitionState(topic string, partition int32, metrics *schedulerMetrics, logger log.Logger) *partitionState {
-	return &partitionState{
-		topic:          topic,
-		partition:      partition,
-		offsets:        newSingleClusterOffsets(metrics, logger),
-		pendingJobs:    list.New(),
-		plannedJobs:    list.New(),
-		plannedJobsMap: make(map[string]*jobState),
+func newPartitionState(topic string, partition int32, numClusters int, compartmentsEnabled bool, metrics *schedulerMetrics, logger log.Logger) *partitionState {
+	ps := &partitionState{
+		topic:               topic,
+		partition:           partition,
+		compartmentsEnabled: compartmentsEnabled,
+		offsets:             make([]singleClusterOffsets, numClusters),
+		pendingJobs:         list.New(),
+		plannedJobs:         list.New(),
+		plannedJobsMap:      make(map[string]*jobState),
 	}
+	for clusterID := range ps.offsets {
+		clusterLogger := log.With(logger, "partition", partition)
+		if compartmentsEnabled {
+			clusterLogger = log.With(clusterLogger, "write_compartment", clusterID)
+		}
+		ps.offsets[clusterID] = newSingleClusterOffsets(metrics, clusterLogger)
+	}
+	return ps
 }
 
-// updateEndOffset records the latest observed end offset for the partition. It
+// updateEndOffset records the latest observed end offset for the partition/cluster. It
 // is expected to be called with monotonically increasing end offsets.
-func (s *partitionState) updateEndOffset(end int64) {
-	s.offsets.updateEndOffset(end)
+func (s *partitionState) updateEndOffset(clusterID int, end int64) {
+	s.offsets[clusterID].updateEndOffset(end)
 }
 
 // updateTime advances the partition's time bucket to the bucket containing ts
@@ -74,34 +87,65 @@ func (s *partitionState) updateTime(ts time.Time, jobSize time.Duration) (*sched
 	case bucketBefore:
 		// New bucket is before our current one. This should only happen if our
 		// Kafka's end offsets aren't monotonically increasing.
-		return nil, fmt.Errorf("time went backwards: %s < %s (%d, %d)", newJobBucket, s.jobBucket, s.offsets.startOffset, s.offsets.endOffset)
+		return nil, fmt.Errorf("time went backwards: %s < %s (offsets: %s)", newJobBucket, s.jobBucket, s.offsetsSummary(false))
+
 	case bucketSame:
 		// Observation is in the currently tracked bucket. No action needed.
-	case bucketAfter:
-		// We've entered a new job bucket. Emit a job for the current
-		// bucket if it has data and start a new one.
 
-		var job *schedulerpb.JobSpec
-		if s.offsets.startOffset != offsetEmpty && s.offsets.startOffset < s.offsets.endOffset {
-			job = &schedulerpb.JobSpec{
-				Topic:       s.topic,
-				Partition:   s.partition,
-				StartOffset: s.offsets.startOffset,
-				EndOffset:   s.offsets.endOffset,
+	case bucketAfter:
+		// We've entered a new job bucket. Emit one job bundling every cluster that has new
+		// data in [startOffset, endOffset), then start the next bucket.
+		ranges := make(map[int32]schedulerpb.OffsetRange, len(s.offsets))
+		for clusterID := range s.offsets {
+			// Skip a cluster we've never sampled: we don't know its start offset yet, and we
+			// don't want to emit a job from offset 0.
+			if s.offsets[clusterID].startOffset == offsetEmpty {
+				continue
 			}
+			if s.offsets[clusterID].endOffset > s.offsets[clusterID].startOffset {
+				ranges[int32(clusterID)] = schedulerpb.OffsetRange{
+					StartOffset: s.offsets[clusterID].startOffset,
+					EndOffset:   s.offsets[clusterID].endOffset,
+				}
+			}
+			s.offsets[clusterID].startOffset = s.offsets[clusterID].endOffset
 		}
-		s.offsets.startOffset = s.offsets.endOffset
 		s.jobBucket = newJobBucket
-		return job, nil
+		if len(ranges) == 0 {
+			return nil, nil
+		}
+		if !s.compartmentsEnabled {
+			r := ranges[0]
+			return &schedulerpb.JobSpec{Topic: s.topic, Partition: s.partition, StartOffset: r.StartOffset, EndOffset: r.EndOffset}, nil
+		}
+		return &schedulerpb.JobSpec{Topic: s.topic, Partition: s.partition, OffsetRanges: ranges}, nil
 	}
 
 	return nil, nil
 }
 
-func (s *partitionState) initCommit(commit int64) {
-	s.offsets.committed.set(commit)
+// offsetsSummary returns a per-cluster offset summary for debugging.
+func (s *partitionState) offsetsSummary(includePlanned bool) string {
+	var b strings.Builder
+	for clusterID := range s.offsets {
+		if clusterID > 0 {
+			b.WriteByte(' ')
+		}
+		if s.compartmentsEnabled {
+			fmt.Fprintf(&b, "%d:", clusterID)
+		}
+		fmt.Fprintf(&b, "[%d,%d)", s.offsets[clusterID].startOffset, s.offsets[clusterID].endOffset)
+		if includePlanned {
+			fmt.Fprintf(&b, " planned=%d", s.offsets[clusterID].planned.offset())
+		}
+	}
+	return b.String()
+}
+
+func (s *partitionState) initCommit(clusterID int, commit int64) {
+	s.offsets[clusterID].committed.set(commit)
 	// Initially, the planned offset is the committed offset.
-	s.offsets.planned.set(commit)
+	s.offsets[clusterID].planned.set(commit)
 }
 
 func (s *partitionState) addPendingJob(job *schedulerpb.JobSpec) {
@@ -109,17 +153,20 @@ func (s *partitionState) addPendingJob(job *schedulerpb.JobSpec) {
 }
 
 func (s *partitionState) addPlannedJob(id string, spec schedulerpb.JobSpec) {
-	if s.offsets.planned.beyondSpec(spec) {
+	for clusterID, offsetRange := range spec.Ranges() {
 		// This shouldn't happen. All callers of addPlannedJob must do so in
-		// increasing offset order.
-		panic(fmt.Sprintf("given spec %d [%d, %d) is behind the current planned offset %d",
-			spec.Partition, spec.StartOffset, spec.EndOffset, s.offsets.planned.offset()))
+		// increasing offset order (for all clusters).
+		if s.offsets[clusterID].planned.beyondOffsetRange(offsetRange) {
+			panic(fmt.Sprintf("planned job %q for partition %d is behind the current planned offset: job=%v current=%s", id, s.partition, spec.Ranges(), s.offsetsSummary(true)))
+		}
 	}
 
 	js := &jobState{jobID: id, spec: spec, complete: false}
 	s.plannedJobs.PushBack(js)
 	s.plannedJobsMap[js.jobID] = js
-	s.offsets.planned.advance(id, spec)
+	for clusterID, offsetRange := range spec.Ranges() {
+		s.offsets[clusterID].planned.advance(id, offsetRange)
+	}
 }
 
 func (s *partitionState) completeJob(jobID string) error {
@@ -141,37 +188,62 @@ func (s *partitionState) completeJob(jobID string) error {
 		}
 		s.plannedJobs.Remove(elem)
 		delete(s.plannedJobsMap, js.jobID)
-		s.offsets.committed.advance(js.jobID, js.spec)
+		for clusterID, offsetRange := range js.spec.Ranges() {
+			s.offsets[clusterID].committed.advance(js.jobID, offsetRange)
+		}
 	}
 	return nil
 }
 
-func (s *partitionState) committedOffset() int64 {
-	return s.offsets.committed.offset()
+func (s *partitionState) committedOffset(clusterID int) int64 {
+	return s.offsets[clusterID].committed.offset()
 }
 
-func (s *partitionState) committedEmpty() bool {
-	return s.offsets.committed.empty()
+func (s *partitionState) committedEmpty(clusterID int) bool {
+	return s.offsets[clusterID].committed.empty()
 }
 
+// committedBeyondSpec reports whether every cluster range in spec is already at or
+// under that cluster's committed offset (i.e. the whole job is already consumed).
 func (s *partitionState) committedBeyondSpec(spec schedulerpb.JobSpec) bool {
-	return s.offsets.committed.beyondSpec(spec)
+	for clusterID, offsetRange := range spec.Ranges() {
+		if !s.offsets[clusterID].committed.beyondOffsetRange(offsetRange) {
+			return false
+		}
+	}
+	return true
 }
 
-func (s *partitionState) plannedOffset() int64 {
-	return s.offsets.planned.offset()
+func (s *partitionState) plannedOffset(clusterID int) int64 {
+	return s.offsets[clusterID].planned.offset()
 }
 
-func (s *partitionState) plannedEmpty() bool {
-	return s.offsets.planned.empty()
+func (s *partitionState) plannedEmpty(clusterID int) bool {
+	return s.offsets[clusterID].planned.empty()
 }
 
+// plannedBeyondSpec reports whether every cluster range in spec is already at or
+// under that cluster's planned offset (i.e. the whole job has already been planned).
 func (s *partitionState) plannedBeyondSpec(spec schedulerpb.JobSpec) bool {
-	return s.offsets.planned.beyondSpec(spec)
+	for clusterID, offsetRange := range spec.Ranges() {
+		if !s.offsets[clusterID].planned.beyondOffsetRange(offsetRange) {
+			return false
+		}
+	}
+	return true
 }
 
+// plannedValidNextSpec reports whether spec is the contiguous next job for
+// every cluster, i.e. each cluster entry's start offset equals that cluster's
+// planned offset (or that cluster's planned offset is still empty). A gap in any
+// cluster makes it false.
 func (s *partitionState) plannedValidNextSpec(spec schedulerpb.JobSpec) bool {
-	return s.offsets.planned.validNextSpec(spec)
+	for clusterID, offsetRange := range spec.Ranges() {
+		if !s.offsets[clusterID].planned.validNextOffsetRange(offsetRange) {
+			return false
+		}
+	}
+	return true
 }
 
 // singleClusterOffsets tracks the offsets for a single Kafka cluster.
@@ -233,26 +305,26 @@ const (
 	offsetNameCommitted = "committed"
 )
 
-// advance moves the offset forward by the given job spec. Advancements are
+// advance moves the offset forward by a single cluster's range. Advancements are
 // expected to be monotonically increasing and contiguous. Advance will not
 // allow backwards movement. If a gap is detected, a warning is logged and a
 // metric is incremented.
-func (o *advancingOffset) advance(jobID string, spec schedulerpb.JobSpec) {
-	if o.beyondSpec(spec) {
+func (o *advancingOffset) advance(jobID string, offsetRange schedulerpb.OffsetRange) {
+	if o.beyondOffsetRange(offsetRange) {
 		// Frequent, and expected.
 		level.Debug(o.logger).Log("msg", "ignoring historical job", "offset_name", o.name, "job_id", jobID,
-			"partition", spec.Partition, "start_offset", spec.StartOffset, "end_offset", spec.EndOffset, "committed", o.off)
+			"start_offset", offsetRange.StartOffset, "end_offset", offsetRange.EndOffset, "current_offset", o.off)
 		return
 	}
 
-	if !o.validNextSpec(spec) {
+	if !o.validNextOffsetRange(offsetRange) {
 		// Gap detected.
 		level.Warn(o.logger).Log("msg", "gap detected in offset advancement", "offset_name", o.name, "job_id", jobID,
-			"partition", spec.Partition, "start_offset", spec.StartOffset, "end_offset", spec.EndOffset, "committed", o.off)
+			"start_offset", offsetRange.StartOffset, "end_offset", offsetRange.EndOffset, "current_offset", o.off)
 		o.metrics.jobGapDetected.WithLabelValues(o.name).Inc()
 	}
 
-	o.off = spec.EndOffset
+	o.off = offsetRange.EndOffset
 }
 
 func (o *advancingOffset) offset() int64 {
@@ -268,14 +340,15 @@ func (o *advancingOffset) empty() bool {
 	return o.off == offsetEmpty
 }
 
-// validNextSpec returns true if the given job spec is valid to be added to the
-// offset. It is valid if the start offset is the same as the current offset.
-// We also allow transitioning out of an empty offset without calling it a gap.
-func (o *advancingOffset) validNextSpec(spec schedulerpb.JobSpec) bool {
-	return o.off == spec.StartOffset || o.empty()
+// validNextOffsetRange returns true if a single cluster's range is valid to be
+// added to the offset. It is valid if the start offset is the same as the
+// current offset. We also allow transitioning out of an empty offset without
+// calling it a gap.
+func (o *advancingOffset) validNextOffsetRange(offsetRange schedulerpb.OffsetRange) bool {
+	return o.off == offsetRange.StartOffset || o.empty()
 }
 
-// beyondSpec returns true if the offset is beyond the given job spec.
-func (o *advancingOffset) beyondSpec(spec schedulerpb.JobSpec) bool {
-	return !o.empty() && spec.EndOffset <= o.off
+// beyondOffsetRange returns true if the offset is beyond a single cluster's range.
+func (o *advancingOffset) beyondOffsetRange(offsetRange schedulerpb.OffsetRange) bool {
+	return !o.empty() && offsetRange.EndOffset <= o.off
 }

--- a/pkg/blockbuilder/scheduler/partition_state.go
+++ b/pkg/blockbuilder/scheduler/partition_state.go
@@ -46,6 +46,9 @@ const (
 )
 
 func newPartitionState(topic string, partition int32, numClusters int, compartmentsEnabled bool, metrics *schedulerMetrics, logger log.Logger) *partitionState {
+	if !compartmentsEnabled && numClusters != 1 {
+		panic(fmt.Sprintf("compartments disabled but numClusters=%d (expected 1)", numClusters))
+	}
 	ps := &partitionState{
 		topic:               topic,
 		partition:           partition,
@@ -102,7 +105,7 @@ func (s *partitionState) updateTime(ts time.Time, jobSize time.Duration) (*sched
 			if s.offsets[clusterID].startOffset == offsetEmpty {
 				continue
 			}
-			if s.offsets[clusterID].endOffset > s.offsets[clusterID].startOffset {
+			if s.offsets[clusterID].startOffset < s.offsets[clusterID].endOffset {
 				ranges[int32(clusterID)] = schedulerpb.OffsetRange{
 					StartOffset: s.offsets[clusterID].startOffset,
 					EndOffset:   s.offsets[clusterID].endOffset,

--- a/pkg/blockbuilder/scheduler/partition_state_test.go
+++ b/pkg/blockbuilder/scheduler/partition_state_test.go
@@ -3,6 +3,7 @@
 package scheduler
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -15,8 +16,12 @@ import (
 )
 
 func newTestPartitionState(t *testing.T, topic string, partition int32) *partitionState {
-	m := newSchedulerMetrics(prometheus.NewPedanticRegistry())
-	return newPartitionState(topic, partition, &m, test.NewTestingLogger(t))
+	return newTestPartitionStateWithClusters(t, topic, partition, 1, false)
+}
+
+func newTestPartitionStateWithClusters(t *testing.T, topic string, partition int32, numClusters int, compartmentsEnabled bool) *partitionState {
+	m := newSchedulerMetrics(prometheus.NewPedanticRegistry(), compartmentsEnabled, numClusters)
+	return newPartitionState(topic, partition, numClusters, compartmentsEnabled, &m, test.NewTestingLogger(t))
 }
 
 func TestPartitionState(t *testing.T) {
@@ -28,11 +33,11 @@ func TestPartitionState(t *testing.T) {
 	var job *schedulerpb.JobSpec
 	var err error
 
-	pt.updateEndOffset(100)
+	pt.updateEndOffset(0, 100)
 	job, err = pt.updateTime(time.Date(2025, 3, 1, 10, 1, 10, 0, time.UTC), sz)
 	require.Nil(t, job)
 	require.Nil(t, err)
-	pt.updateEndOffset(200)
+	pt.updateEndOffset(0, 200)
 	job, err = pt.updateTime(time.Date(2025, 3, 1, 11, 1, 10, 0, time.UTC), sz)
 	require.Equal(t, &schedulerpb.JobSpec{
 		Topic:       "topic",
@@ -42,20 +47,20 @@ func TestPartitionState(t *testing.T) {
 	}, job)
 	require.Nil(t, err)
 
-	pt.updateEndOffset(201)
+	pt.updateEndOffset(0, 201)
 	job, err = pt.updateTime(time.Date(2025, 3, 1, 11, 1, 10, 0, time.UTC), sz)
 	require.Nil(t, job)
 	require.NoError(t, err)
-	pt.updateEndOffset(202)
+	pt.updateEndOffset(0, 202)
 	job, err = pt.updateTime(time.Date(2025, 3, 1, 11, 2, 10, 0, time.UTC), sz)
 	require.NoError(t, err)
 	require.Nil(t, job)
-	pt.updateEndOffset(203)
+	pt.updateEndOffset(0, 203)
 	job, err = pt.updateTime(time.Date(2025, 3, 1, 11, 3, 10, 0, time.UTC), sz)
 	require.Nil(t, job)
 	require.Nil(t, err)
 
-	pt.updateEndOffset(300)
+	pt.updateEndOffset(0, 300)
 	job, err = pt.updateTime(z.Add(2*time.Hour), sz)
 	require.Equal(t, &schedulerpb.JobSpec{
 		Topic:       "topic",
@@ -66,10 +71,11 @@ func TestPartitionState(t *testing.T) {
 	require.NoError(t, err)
 
 	// And, if the time goes backwards, we return an error.
-	pt.updateEndOffset(300)
+	pt.updateEndOffset(0, 300)
 	job, err = pt.updateTime(z.Add(-2*time.Hour), sz)
 	require.Nil(t, job)
 	require.ErrorContains(t, err, "time went backwards")
+	require.ErrorContains(t, err, "[300,300)", "error should include the offsets for diagnostics")
 }
 
 func TestPartitionState_TerminallyDormantPartition(t *testing.T) {
@@ -79,7 +85,7 @@ func TestPartitionState_TerminallyDormantPartition(t *testing.T) {
 
 	for i := 0; i < 1000; i++ {
 		z = z.Add(7 * time.Minute)
-		pt.updateEndOffset(0)
+		pt.updateEndOffset(0, 0)
 		j, err := pt.updateTime(z, sz)
 		assert.Nil(t, j)
 		assert.NoError(t, err)
@@ -93,26 +99,26 @@ func TestPartitionState_PartitionBecomesInactive(t *testing.T) {
 	// A bunch of data observed:
 	var j *schedulerpb.JobSpec
 	var err error
-	pt.updateEndOffset(10)
+	pt.updateEndOffset(0, 10)
 	j, err = pt.updateTime(time.Date(2025, 3, 1, 10, 1, 10, 0, time.UTC), sz)
 	assert.Nil(t, j)
 	assert.NoError(t, err)
-	pt.updateEndOffset(11)
+	pt.updateEndOffset(0, 11)
 	j, err = pt.updateTime(time.Date(2025, 3, 1, 10, 1, 11, 0, time.UTC), sz)
 	assert.Nil(t, j)
 	assert.NoError(t, err)
-	pt.updateEndOffset(12)
+	pt.updateEndOffset(0, 12)
 	j, err = pt.updateTime(time.Date(2025, 3, 1, 10, 1, 12, 0, time.UTC), sz)
 	assert.Nil(t, j)
 	assert.NoError(t, err)
 	// data ceases. continue to get observations in the same bucket.
-	pt.updateEndOffset(12)
+	pt.updateEndOffset(0, 12)
 	j, err = pt.updateTime(time.Date(2025, 3, 1, 10, 1, 13, 0, time.UTC), sz)
 	assert.Nil(t, j)
 	assert.NoError(t, err)
 
 	// as we cross into the next bucket, there's still no new data.
-	pt.updateEndOffset(12)
+	pt.updateEndOffset(0, 12)
 	j, err = pt.updateTime(time.Date(2025, 3, 1, 11, 1, 0, 0, time.UTC), sz)
 	assert.Equal(t, &schedulerpb.JobSpec{
 		Topic:       "topic",
@@ -122,17 +128,17 @@ func TestPartitionState_PartitionBecomesInactive(t *testing.T) {
 	}, j)
 	assert.NoError(t, err)
 	// and we keep getting the same offset.
-	pt.updateEndOffset(12)
+	pt.updateEndOffset(0, 12)
 	j, err = pt.updateTime(time.Date(2025, 3, 1, 11, 2, 0, 0, time.UTC), sz)
 	assert.Nil(t, j)
 	assert.NoError(t, err)
-	pt.updateEndOffset(12)
+	pt.updateEndOffset(0, 12)
 	j, err = pt.updateTime(time.Date(2025, 3, 1, 11, 3, 0, 0, time.UTC), sz)
 	assert.Nil(t, j)
 	assert.NoError(t, err)
 
 	// And in the next job bucket, still no new data.
-	pt.updateEndOffset(12)
+	pt.updateEndOffset(0, 12)
 	j, err = pt.updateTime(time.Date(2025, 3, 1, 12, 1, 0, 0, time.UTC), sz)
 	assert.Nil(t, j)
 	assert.NoError(t, err)
@@ -144,15 +150,15 @@ func TestPartitionState_MultipleOffsetsBeforeTimeUpdate(t *testing.T) {
 	ts := time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC)
 
 	// Seed the start offset and the current bucket.
-	ps.updateEndOffset(100)
+	ps.updateEndOffset(0, 100)
 	job, err := ps.updateTime(ts, jobSize)
 	require.NoError(t, err)
 	require.Nil(t, job)
 
 	// Several observations within the same bucket, with no time update between them.
-	ps.updateEndOffset(150)
-	ps.updateEndOffset(175)
-	ps.updateEndOffset(200)
+	ps.updateEndOffset(0, 150)
+	ps.updateEndOffset(0, 175)
+	ps.updateEndOffset(0, 200)
 
 	// Crossing into the next bucket emits a single job spanning the seeded start
 	// offset to the latest observed offset.
@@ -180,11 +186,289 @@ func TestPartitionState_TimeAdvancesBeforeAnyOffset(t *testing.T) {
 	}
 }
 
+func TestPartitionState_CompartmentsEmitOffsetRanges(t *testing.T) {
+	pt := newTestPartitionStateWithClusters(t, "topic", 0, 3, true)
+	sz := time.Hour
+	base := time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC)
+
+	// Seed the first bucket. Clusters 0 and 1 observe data; cluster 2 is never sampled.
+	pt.updateEndOffset(0, 100)
+	pt.updateEndOffset(1, 500)
+	job, err := pt.updateTime(base, sz)
+	require.NoError(t, err)
+	require.Nil(t, job)
+
+	// More data in the same bucket for both sampled clusters.
+	pt.updateEndOffset(0, 150)
+	pt.updateEndOffset(1, 600)
+
+	// Crossing into the next bucket emits a single compartment-encoded job. It carries
+	// one range per cluster with new data and no top-level offsets; the unsampled
+	// cluster 2 is omitted.
+	job, err = pt.updateTime(base.Add(sz), sz)
+	require.NoError(t, err)
+	require.NotNil(t, job)
+	require.Equal(t, "topic", job.Topic)
+	require.Equal(t, int32(0), job.Partition)
+	require.Zero(t, job.StartOffset)
+	require.Zero(t, job.EndOffset)
+	require.Equal(t, map[int32]schedulerpb.OffsetRange{
+		0: {StartOffset: 100, EndOffset: 150},
+		1: {StartOffset: 500, EndOffset: 600},
+	}, job.OffsetRanges)
+
+	// Only cluster 0 advances in the next bucket. The emitted job continues from each
+	// cluster's previous end offset and drops the cluster that saw no new data.
+	pt.updateEndOffset(0, 175)
+	job, err = pt.updateTime(base.Add(2*sz), sz)
+	require.NoError(t, err)
+	require.Equal(t, map[int32]schedulerpb.OffsetRange{
+		0: {StartOffset: 150, EndOffset: 175},
+	}, job.OffsetRanges)
+
+	// The previously unsampled cluster 2 starts receiving data. Its first range begins at
+	// the seeded start offset (not zero), cluster 0 keeps advancing, and cluster 1 is
+	// dropped as it saw no new data.
+	pt.updateEndOffset(2, 900)
+	pt.updateEndOffset(2, 950)
+	pt.updateEndOffset(0, 200)
+	job, err = pt.updateTime(base.Add(3*sz), sz)
+	require.NoError(t, err)
+	require.Equal(t, map[int32]schedulerpb.OffsetRange{
+		0: {StartOffset: 175, EndOffset: 200},
+		2: {StartOffset: 900, EndOffset: 950},
+	}, job.OffsetRanges)
+
+	// In compartment mode, diagnostics prefix each range with its cluster ID and list
+	// every cluster.
+	_, err = pt.updateTime(base.Add(-sz), sz)
+	require.EqualError(t, err, "time went backwards: 2025-03-01 09:00:00 +0000 UTC < 2025-03-01 13:00:00 +0000 UTC (offsets: 0:[200,200) 1:[600,600) 2:[950,950))")
+}
+
+func TestPartitionState_CompartmentsTrackOffsetsPerCluster(t *testing.T) {
+	pt := newTestPartitionStateWithClusters(t, "topic", 1, 3, true)
+
+	pt.initCommit(0, 100)
+	pt.initCommit(1, 500)
+	pt.initCommit(2, 700)
+	require.Equal(t, int64(100), pt.committedOffset(0))
+	require.Equal(t, int64(500), pt.committedOffset(1))
+	require.Equal(t, int64(700), pt.committedOffset(2))
+	require.Equal(t, int64(100), pt.plannedOffset(0))
+	require.Equal(t, int64(500), pt.plannedOffset(1))
+	require.Equal(t, int64(700), pt.plannedOffset(2))
+
+	// A job that spans clusters 0 and 2 only, skipping cluster 1.
+	spec := schedulerpb.JobSpec{
+		Topic:     "topic",
+		Partition: 1,
+		OffsetRanges: map[int32]schedulerpb.OffsetRange{
+			0: {StartOffset: 100, EndOffset: 200},
+			2: {StartOffset: 700, EndOffset: 900},
+		},
+	}
+
+	pt.addPlannedJob("job1", spec)
+	// Planning advances the planned offset of the job's clusters, leaves committed untouched,
+	// and does not affect cluster 1, which the job omits.
+	require.Equal(t, int64(200), pt.plannedOffset(0))
+	require.Equal(t, int64(500), pt.plannedOffset(1))
+	require.Equal(t, int64(900), pt.plannedOffset(2))
+	require.Equal(t, int64(100), pt.committedOffset(0))
+	require.Equal(t, int64(500), pt.committedOffset(1))
+	require.Equal(t, int64(700), pt.committedOffset(2))
+
+	require.NoError(t, pt.completeJob("job1"))
+	// Completion advances committed for the job's clusters only; cluster 1 stays put.
+	require.Equal(t, int64(200), pt.committedOffset(0))
+	require.Equal(t, int64(500), pt.committedOffset(1))
+	require.Equal(t, int64(900), pt.committedOffset(2))
+}
+
+func TestPartitionState_CompartmentsBeyondSpecRequiresAllClusters(t *testing.T) {
+	pt := newTestPartitionStateWithClusters(t, "topic", 1, 3, true)
+	pt.initCommit(0, 200)
+	pt.initCommit(1, 900)
+	// Cluster 2 has a committed offset but never appears in the specs below. committedBeyondSpec
+	// only considers the clusters the job covers, so cluster 2 must not affect the result.
+	pt.initCommit(2, 500)
+
+	// A job wholly at or under the committed offsets of the clusters it covers is beyond the commit.
+	require.True(t, pt.committedBeyondSpec(schedulerpb.JobSpec{
+		OffsetRanges: map[int32]schedulerpb.OffsetRange{
+			0: {StartOffset: 100, EndOffset: 200},
+			1: {StartOffset: 800, EndOffset: 900},
+		},
+	}))
+
+	// Cluster 1 ends past its committed offset (1000 > 900), so it is not yet consumed and the
+	// whole job is not beyond, even though cluster 0 is.
+	require.False(t, pt.committedBeyondSpec(schedulerpb.JobSpec{
+		OffsetRanges: map[int32]schedulerpb.OffsetRange{
+			0: {StartOffset: 100, EndOffset: 200},
+			1: {StartOffset: 900, EndOffset: 1000},
+		},
+	}))
+}
+
+func TestPartitionState_CompartmentsPlannedBeyondSpec(t *testing.T) {
+	pt := newTestPartitionStateWithClusters(t, "topic", 1, 3, true)
+	pt.initCommit(0, 100)
+	pt.initCommit(1, 500)
+	pt.initCommit(2, 700)
+
+	// Plan a job to advance the planned offsets of clusters 0 and 1 past their committed
+	// offsets. Cluster 2 is left untouched.
+	pt.addPlannedJob("seed", schedulerpb.JobSpec{
+		OffsetRanges: map[int32]schedulerpb.OffsetRange{
+			0: {StartOffset: 100, EndOffset: 200},
+			1: {StartOffset: 500, EndOffset: 900},
+		},
+	})
+
+	// A job wholly at or under both clusters' planned offsets is beyond the planned offset,
+	// even though it is not beyond the (lower) committed offset.
+	spec := schedulerpb.JobSpec{
+		OffsetRanges: map[int32]schedulerpb.OffsetRange{
+			0: {StartOffset: 100, EndOffset: 200},
+			1: {StartOffset: 800, EndOffset: 900},
+		},
+	}
+	require.True(t, pt.plannedBeyondSpec(spec))
+	require.False(t, pt.committedBeyondSpec(spec))
+
+	// Cluster 1 ends past its planned offset (1000 > 900), so it is not yet planned and the
+	// whole job is not beyond, even though cluster 0 is.
+	require.False(t, pt.plannedBeyondSpec(schedulerpb.JobSpec{
+		OffsetRanges: map[int32]schedulerpb.OffsetRange{
+			0: {StartOffset: 100, EndOffset: 200},
+			1: {StartOffset: 900, EndOffset: 1000},
+		},
+	}))
+}
+
+func TestPartitionState_CompartmentsAddPlannedJobPanicsWhenAnyClusterBehind(t *testing.T) {
+	pt := newTestPartitionStateWithClusters(t, "topic", 1, 2, true)
+	pt.initCommit(0, 100)
+	pt.initCommit(1, 500)
+
+	pt.addPlannedJob("job1", schedulerpb.JobSpec{
+		OffsetRanges: map[int32]schedulerpb.OffsetRange{
+			0: {StartOffset: 100, EndOffset: 200},
+			1: {StartOffset: 500, EndOffset: 600},
+		},
+	})
+
+	// A job that is a valid next step for cluster 0 but whose cluster 1 range is already
+	// planned must panic: the guard rejects a job behind the planned offset in any single
+	// cluster, even when the others would advance cleanly.
+	require.Panics(t, func() {
+		pt.addPlannedJob("job2", schedulerpb.JobSpec{
+			OffsetRanges: map[int32]schedulerpb.OffsetRange{
+				0: {StartOffset: 200, EndOffset: 300},
+				1: {StartOffset: 500, EndOffset: 600},
+			},
+		})
+	})
+}
+
+func TestPartitionState_CompartmentsNoInducedGaps(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+	m := newSchedulerMetrics(reg, true, 2)
+	pt := newPartitionState("topic", 0, 2, true, &m, test.NewTestingLogger(t))
+	sz := time.Hour
+	base := time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC)
+
+	jobNum := 0
+	// crossBucket advances into the given bucket and plans+completes any emitted job,
+	// mirroring the scheduler's normal flow.
+	crossBucket := func(bucket time.Time) {
+		job, err := pt.updateTime(bucket, sz)
+		require.NoError(t, err)
+		if job == nil {
+			return
+		}
+		jobNum++
+		id := fmt.Sprintf("job-%d", jobNum)
+		pt.addPlannedJob(id, *job)
+		require.NoError(t, pt.completeJob(id))
+	}
+
+	// Seed the first bucket for both clusters.
+	pt.updateEndOffset(0, 100)
+	pt.updateEndOffset(1, 500)
+	crossBucket(base)
+
+	// Both clusters advance.
+	pt.updateEndOffset(0, 150)
+	pt.updateEndOffset(1, 600)
+	crossBucket(base.Add(sz))
+
+	// Only cluster 0 advances; cluster 1 drops out of the job.
+	pt.updateEndOffset(0, 175)
+	crossBucket(base.Add(2 * sz))
+
+	// Only cluster 1 advances, reappearing after being absent.
+	pt.updateEndOffset(1, 700)
+	crossBucket(base.Add(3 * sz))
+
+	// Both advance again.
+	pt.updateEndOffset(0, 200)
+	pt.updateEndOffset(1, 800)
+	crossBucket(base.Add(4 * sz))
+
+	// Clusters advanced at different rates and dropped out of some jobs entirely, but an absent
+	// cluster's offset doesn't move, so each cluster's next range always resumes exactly where
+	// its previous one ended. No cluster ever sees a gap.
+	requireGaps(t, reg, 0, 0)
+	require.Equal(t, int64(200), pt.committedOffset(0))
+	require.Equal(t, int64(800), pt.committedOffset(1))
+}
+
+func TestPartitionState_CompartmentsDetectPerClusterGap(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+	m := newSchedulerMetrics(reg, true, 3)
+	pt := newPartitionState("topic", 0, 3, true, &m, test.NewTestingLogger(t))
+	pt.initCommit(0, 100)
+	pt.initCommit(1, 500)
+	pt.initCommit(2, 900)
+
+	// Contiguous next job for clusters 0 and 1, omitting cluster 2: valid, no gap.
+	contiguous := schedulerpb.JobSpec{OffsetRanges: map[int32]schedulerpb.OffsetRange{
+		0: {StartOffset: 100, EndOffset: 150},
+		1: {StartOffset: 500, EndOffset: 550},
+	}}
+	require.True(t, pt.plannedValidNextSpec(contiguous))
+	pt.addPlannedJob("job1", contiguous)
+	requireGaps(t, reg, 0, 0, "a contiguous multi-cluster job should not register a gap")
+
+	// Cluster 1's range jumps ahead of its planned offset (550 -> 600): a gap in that
+	// cluster only. Cluster 0 stays contiguous.
+	gapped := schedulerpb.JobSpec{OffsetRanges: map[int32]schedulerpb.OffsetRange{
+		0: {StartOffset: 150, EndOffset: 200},
+		1: {StartOffset: 600, EndOffset: 650},
+	}}
+	require.False(t, pt.plannedValidNextSpec(gapped))
+	pt.addPlannedJob("job2", gapped)
+	requireGaps(t, reg, 1, 0, "a gap in a single cluster's range should register one planned gap")
+
+	// A single job can gap in more than one cluster at once: cluster 1 jumps again
+	// (650 -> 700) and cluster 2 appears for the first time above its planned offset
+	// (900 -> 1000). Each gapped range is counted, so the planned gap total rises by two.
+	multiGap := schedulerpb.JobSpec{OffsetRanges: map[int32]schedulerpb.OffsetRange{
+		1: {StartOffset: 700, EndOffset: 750},
+		2: {StartOffset: 1000, EndOffset: 1050},
+	}}
+	require.False(t, pt.plannedValidNextSpec(multiGap))
+	pt.addPlannedJob("job3", multiGap)
+	requireGaps(t, reg, 3, 0, "gaps in two clusters within one job should register two planned gaps")
+}
+
 func TestPartitionState_ParallelJobs(t *testing.T) {
 	t.Run("planned job order required", func(t *testing.T) {
 		sched, _ := mustScheduler(t, 4)
 		ps := sched.getPartitionState("ingest", 1)
-		ps.initCommit(100)
+		ps.initCommit(0, 100)
 
 		// It is a logical error to add a job to the planned list out of order. The safe completion logic requires it.
 
@@ -214,7 +498,7 @@ func TestPartitionState_ParallelJobs(t *testing.T) {
 	t.Run("complete_single_job_at_front", func(t *testing.T) {
 		sched, _ := mustScheduler(t, 4)
 		ps := sched.getPartitionState("ingest", 1)
-		ps.initCommit(100)
+		ps.initCommit(0, 100)
 
 		jobSpec := schedulerpb.JobSpec{
 			Topic:       "ingest",
@@ -225,7 +509,7 @@ func TestPartitionState_ParallelJobs(t *testing.T) {
 		ps.addPlannedJob("job1", jobSpec)
 		require.Equal(t, 1, ps.plannedJobs.Len())
 		require.Len(t, ps.plannedJobsMap, 1)
-		require.Equal(t, int64(100), ps.offsets.committed.offset())
+		require.Equal(t, int64(100), ps.offsets[0].committed.offset())
 
 		err := ps.completeJob("job1")
 		require.NoError(t, err)
@@ -233,13 +517,13 @@ func TestPartitionState_ParallelJobs(t *testing.T) {
 		// Verify job was completed and garbage collected
 		require.Equal(t, 0, ps.plannedJobs.Len())
 		require.Len(t, ps.plannedJobsMap, 0)
-		require.Equal(t, int64(200), ps.offsets.committed.offset())
+		require.Equal(t, int64(200), ps.offsets[0].committed.offset())
 	})
 
 	t.Run("complete_nonexistent_job", func(t *testing.T) {
 		sched, _ := mustScheduler(t, 4)
 		ps := sched.getPartitionState("ingest", 1)
-		ps.initCommit(100)
+		ps.initCommit(0, 100)
 		// Try to complete a job that doesn't exist
 		err := ps.completeJob("nonexistent_job")
 		require.Error(t, err)
@@ -250,7 +534,7 @@ func TestPartitionState_ParallelJobs(t *testing.T) {
 	t.Run("complete_multiple_jobs_in_order", func(t *testing.T) {
 		sched, _ := mustScheduler(t, 4)
 		ps := sched.getPartitionState("ingest", 1)
-		ps.initCommit(100)
+		ps.initCommit(0, 100)
 
 		// Add multiple planned jobs
 		ps.addPlannedJob("job1", schedulerpb.JobSpec{
@@ -275,35 +559,35 @@ func TestPartitionState_ParallelJobs(t *testing.T) {
 		// Verify initial state
 		require.Equal(t, 3, ps.plannedJobs.Len())
 		require.Len(t, ps.plannedJobsMap, 3)
-		require.Equal(t, int64(100), ps.offsets.committed.offset())
+		require.Equal(t, int64(100), ps.offsets[0].committed.offset())
 
 		// Complete first job - should be garbage collected
 		err := ps.completeJob("job1")
 		require.NoError(t, err)
 		require.Equal(t, 2, ps.plannedJobs.Len())
 		require.Len(t, ps.plannedJobsMap, 2)
-		require.Equal(t, int64(200), ps.offsets.committed.offset())
+		require.Equal(t, int64(200), ps.offsets[0].committed.offset())
 
 		// Complete second job - should be garbage collected
 		err = ps.completeJob("job2")
 		require.NoError(t, err)
 		require.Equal(t, 1, ps.plannedJobs.Len())
 		require.Len(t, ps.plannedJobsMap, 1)
-		require.Equal(t, int64(300), ps.offsets.committed.offset())
+		require.Equal(t, int64(300), ps.offsets[0].committed.offset())
 
 		// Complete third job - should be garbage collected
 		err = ps.completeJob("job3")
 		require.NoError(t, err)
 		require.Equal(t, 0, ps.plannedJobs.Len())
 		require.Len(t, ps.plannedJobsMap, 0)
-		require.Equal(t, int64(400), ps.offsets.committed.offset())
+		require.Equal(t, int64(400), ps.offsets[0].committed.offset())
 	})
 
 	// Test 4: Complete jobs out of order (only front jobs get garbage collected)
 	t.Run("complete_jobs_out_of_order", func(t *testing.T) {
 		sched, _ := mustScheduler(t, 4)
 		ps := sched.getPartitionState("ingest", 1)
-		ps.initCommit(100)
+		ps.initCommit(0, 100)
 
 		// Add multiple planned jobs
 		ps.addPlannedJob("job1", schedulerpb.JobSpec{
@@ -332,14 +616,14 @@ func TestPartitionState_ParallelJobs(t *testing.T) {
 		// Job2 should be marked complete but not garbage collected yet
 		require.Equal(t, 3, ps.plannedJobs.Len(), "expecting no garbage collection yet")
 		require.Len(t, ps.plannedJobsMap, 3, "expecting no garbage collection yet")
-		require.Equal(t, int64(100), ps.offsets.committed.offset(), "should be no advancement yet")
+		require.Equal(t, int64(100), ps.offsets[0].committed.offset(), "should be no advancement yet")
 
 		// Complete job1 - should garbage collect both job1 and job2
 		err = ps.completeJob("job1")
 		require.NoError(t, err)
 		require.Equal(t, 1, ps.plannedJobs.Len(), "expecting garbage collection of job1 and job2")
 		require.Len(t, ps.plannedJobsMap, 1, "expecting garbage collection of job1 and job2")
-		require.Equal(t, int64(300), ps.offsets.committed.offset(), "should be advanced commit to the end of job3")
+		require.Equal(t, int64(300), ps.offsets[0].committed.offset(), "should be advanced commit to the end of job3")
 		require.Equal(t, "job3", ps.plannedJobs.Front().Value.(*jobState).jobID, "expecting job3 to be the remaining planned job")
 	})
 
@@ -347,7 +631,7 @@ func TestPartitionState_ParallelJobs(t *testing.T) {
 	t.Run("complete_job_empty_partition", func(t *testing.T) {
 		sched, _ := mustScheduler(t, 4)
 		ps := sched.getPartitionState("ingest", 1)
-		ps.initCommit(100)
+		ps.initCommit(0, 100)
 
 		// Try to complete a job when no jobs exist
 		err := ps.completeJob("any_job")
@@ -357,12 +641,12 @@ func TestPartitionState_ParallelJobs(t *testing.T) {
 		// Verify state remains unchanged
 		require.Equal(t, 0, ps.plannedJobs.Len())
 		require.Len(t, ps.plannedJobsMap, 0)
-		require.Equal(t, int64(100), ps.offsets.committed.offset())
+		require.Equal(t, int64(100), ps.offsets[0].committed.offset())
 	})
 }
 
 func TestNewSingleClusterOffsets(t *testing.T) {
-	m := newSchedulerMetrics(prometheus.NewPedanticRegistry())
+	m := newSchedulerMetrics(prometheus.NewPedanticRegistry(), false, 1)
 	o := newSingleClusterOffsets(&m, test.NewTestingLogger(t))
 
 	// Before observing any end offset, both offsets are empty.

--- a/pkg/blockbuilder/scheduler/scheduler.go
+++ b/pkg/blockbuilder/scheduler/scheduler.go
@@ -40,11 +40,19 @@ type BlockBuilderScheduler struct {
 	mu                  sync.Mutex
 	observations        obsMap
 	observationComplete bool
-	partState           map[int32]*partitionState
+
+	partState map[int32]*partitionState
 
 	// for synchronizing tests.
 	onScheduleUpdated func()
 }
+
+// Compartment support is not wired up yet; the scheduler runs a single cluster per
+// partition. These will be replaced by config once compartments are enabled.
+const (
+	compartmentsEnabled = false
+	numClusters         = 1
+)
 
 func New(
 	cfg Config,
@@ -56,7 +64,7 @@ func New(
 		cfg:      cfg,
 		logger:   logger,
 		register: reg,
-		metrics:  newSchedulerMetrics(reg),
+		metrics:  newSchedulerMetrics(reg, compartmentsEnabled, numClusters),
 
 		observations: make(obsMap),
 		partState:    make(map[int32]*partitionState),
@@ -112,7 +120,7 @@ func (s *BlockBuilderScheduler) running(ctx context.Context) error {
 	s.mu.Lock()
 	c.Each(func(o kadm.Offset) {
 		ps := s.getPartitionState(o.Topic, o.Partition)
-		ps.initCommit(o.At)
+		ps.initCommit(0, o.At)
 	})
 	s.mu.Unlock()
 
@@ -209,13 +217,13 @@ func (s *BlockBuilderScheduler) updateSchedule(ctx context.Context) {
 
 	endOffsets.Each(func(o kadm.ListedOffset) {
 		partStr := fmt.Sprint(o.Partition)
-		s.metrics.partitionEndOffset.WithLabelValues(partStr).Set(float64(o.Offset))
+		s.metrics.perClusterMetrics[0].endOffset.WithLabelValues(partStr).Set(float64(o.Offset))
 
 		s.mu.Lock()
 		defer s.mu.Unlock()
 
 		ps := s.getPartitionState(o.Topic, o.Partition)
-		ps.updateEndOffset(o.Offset)
+		ps.updateEndOffset(0, o.Offset)
 		job, err := ps.updateTime(now, s.cfg.JobSize)
 
 		if err != nil {
@@ -277,7 +285,7 @@ func (s *BlockBuilderScheduler) enqueuePendingJobs() {
 			// older than our committed offset.
 			if ps.committedBeyondSpec(*spec) {
 				level.Info(s.logger).Log("msg", "ignoring pending job as it's behind the committed offset (expected at startup)",
-					"partition", partition, "start", spec.StartOffset, "end", spec.EndOffset, "committed", ps.committedOffset())
+					"partition", partition, "start", spec.StartOffset, "end", spec.EndOffset, "committed", ps.committedOffset(0))
 				ps.pendingJobs.Remove(e)
 				continue
 			}
@@ -325,7 +333,7 @@ func (s *BlockBuilderScheduler) populateInitialJobs(ctx context.Context, consume
 		ps := s.getPartitionState(off.topic, off.partition)
 
 		for _, io := range o {
-			ps.updateEndOffset(io.offset)
+			ps.updateEndOffset(0, io.offset)
 			if job, err := ps.updateTime(io.time, s.cfg.JobSize); err != nil {
 				level.Warn(s.logger).Log("msg", "failed to update partition time", "partition", ps.partition, "err", err)
 			} else if job != nil {
@@ -340,7 +348,7 @@ func (s *BlockBuilderScheduler) getPartitionState(topic string, partition int32)
 		return ps
 	}
 
-	ps := newPartitionState(topic, partition, &s.metrics, s.logger)
+	ps := newPartitionState(topic, partition, numClusters, compartmentsEnabled, &s.metrics, s.logger)
 	s.partState[partition] = ps
 	return ps
 }
@@ -393,9 +401,9 @@ func (s *BlockBuilderScheduler) consumptionOffsets(ctx context.Context, topic st
 
 			var resumeOffset int64
 
-			if !ps.plannedEmpty() {
-				planned := ps.plannedOffset()
-				s.metrics.partitionPlannedOffset.WithLabelValues(partStr).Set(float64(planned))
+			if !ps.plannedEmpty(0) {
+				planned := ps.plannedOffset(0)
+				s.metrics.perClusterMetrics[0].plannedOffset.WithLabelValues(partStr).Set(float64(planned))
 				resumeOffset = planned
 			} else {
 				// Nothing planned offset for this partition. Resume from fallback offset instead.
@@ -418,8 +426,8 @@ func (s *BlockBuilderScheduler) consumptionOffsets(ctx context.Context, topic st
 			level.Debug(s.logger).Log("msg", "consumptionOffsets", "topic", t, "partition", partition,
 				"start", startOffset.At, "end", end.Offset, "consumeOffset", resumeOffset)
 
-			s.metrics.partitionStartOffset.WithLabelValues(partStr).Set(float64(startOffset.At))
-			s.metrics.partitionEndOffset.WithLabelValues(partStr).Set(float64(end.Offset))
+			s.metrics.perClusterMetrics[0].startOffset.WithLabelValues(partStr).Set(float64(startOffset.At))
+			s.metrics.perClusterMetrics[0].endOffset.WithLabelValues(partStr).Set(float64(end.Offset))
 
 			offs = append(offs, partitionOffsets{
 				topic:     t,
@@ -488,11 +496,11 @@ func (s *BlockBuilderScheduler) snapOffsets() (kadm.Offsets, kadm.Offsets) {
 	defer s.mu.Unlock()
 
 	for _, ps := range s.partState {
-		if !ps.committedEmpty() {
-			cp.AddOffset(ps.topic, ps.partition, ps.committedOffset(), 0)
+		if !ps.committedEmpty(0) {
+			cp.AddOffset(ps.topic, ps.partition, ps.committedOffset(0), 0)
 		}
-		if !ps.plannedEmpty() {
-			pp.AddOffset(ps.topic, ps.partition, ps.plannedOffset(), 0)
+		if !ps.plannedEmpty(0) {
+			pp.AddOffset(ps.topic, ps.partition, ps.plannedOffset(0), 0)
 		}
 	}
 
@@ -505,10 +513,10 @@ func (s *BlockBuilderScheduler) flushOffsetsToKafka(ctx context.Context) error {
 	committed, planned := s.snapOffsets()
 
 	committed.Each(func(o kadm.Offset) {
-		s.metrics.partitionCommittedOffset.WithLabelValues(fmt.Sprint(o.Partition)).Set(float64(o.At))
+		s.metrics.perClusterMetrics[0].committedOffset.WithLabelValues(fmt.Sprint(o.Partition)).Set(float64(o.At))
 	})
 	planned.Each(func(o kadm.Offset) {
-		s.metrics.partitionPlannedOffset.WithLabelValues(fmt.Sprint(o.Partition)).Set(float64(o.At))
+		s.metrics.perClusterMetrics[0].plannedOffset.WithLabelValues(fmt.Sprint(o.Partition)).Set(float64(o.At))
 	})
 
 	err := s.adminClient.CommitAllOffsets(ctx, s.cfg.ConsumerGroup, committed)
@@ -577,7 +585,7 @@ func (s *BlockBuilderScheduler) assignJob(workerID string) (jobKey, schedulerpb.
 			level.Info(s.logger).Log("msg", "removing job as it's behind the committed offset (expected at startup)",
 				"job_id", k.id, "epoch", k.epoch, "partition", spec.Partition,
 				"start_offset", spec.StartOffset, "end_offset", spec.EndOffset,
-				"committed", ps.committedOffset())
+				"committed", ps.committedOffset(0))
 			s.jobs.removeJob(k)
 			continue
 		}
@@ -728,7 +736,7 @@ func (s *BlockBuilderScheduler) finalizeObservations() {
 				contiguous = false
 				level.Warn(s.logger).Log("msg", "startup: skipping job due to detected offset gap",
 					"partition", partition, "job_id", obs.key.id, "start_offset", obs.spec.StartOffset,
-					"end_offset", obs.spec.EndOffset, "latest_planned_offset", ps.plannedOffset())
+					"end_offset", obs.spec.EndOffset, "latest_planned_offset", ps.plannedOffset(0))
 				continue
 			}
 

--- a/pkg/blockbuilder/scheduler/scheduler_test.go
+++ b/pkg/blockbuilder/scheduler/scheduler_test.go
@@ -194,9 +194,9 @@ func TestServiceStopsCleanlyDuringStartupObservation(t *testing.T) {
 func TestStartup(t *testing.T) {
 	sched, _ := mustScheduler(t, 4)
 	// (a new scheduler starts in observation mode.)
-	sched.getPartitionState("ingest", 64).initCommit(1000)
-	sched.getPartitionState("ingest", 65).initCommit(256)
-	sched.getPartitionState("ingest", 66).initCommit(57)
+	sched.getPartitionState("ingest", 64).initCommit(0, 1000)
+	sched.getPartitionState("ingest", 65).initCommit(0, 256)
+	sched.getPartitionState("ingest", 66).initCommit(0, 57)
 
 	{
 		_, _, err := sched.assignJob("w0")
@@ -347,9 +347,9 @@ func TestAssignJobSkipsObsoleteOffsets(t *testing.T) {
 	require.Equal(t, 3, sched.jobs.count())
 
 	p1 := sched.getPartitionState("ingest", 1)
-	p1.initCommit(256)
+	p1.initCommit(0, 256)
 	p2 := sched.getPartitionState("ingest", 2)
-	p2.initCommit(500)
+	p2.initCommit(0, 500)
 
 	// Advancing offsets doesn't actually remove any jobs.
 	require.Equal(t, 3, sched.jobs.count())
@@ -388,7 +388,7 @@ func TestAssignJobSkipsObsoleteOffsets_PriorScheduler(t *testing.T) {
 
 	// Simulate a completion of a job that was created by a prior scheduler.
 	p1 := sched.getPartitionState("ingest", 1)
-	p1.initCommit(5000)
+	p1.initCommit(0, 5000)
 	// Advancing offsets doesn't actually remove any jobs.
 	require.Equal(t, 1, sched.jobs.count())
 
@@ -413,15 +413,15 @@ func TestObservations(t *testing.T) {
 	sched, _ := mustScheduler(t, 10)
 	// Initially we're in observation mode. We have Kafka's commit offsets, but no client jobs.
 
-	sched.getPartitionState("ingest", 1).initCommit(5000)
-	sched.getPartitionState("ingest", 2).initCommit(800)
-	sched.getPartitionState("ingest", 3).initCommit(974)
-	sched.getPartitionState("ingest", 4).initCommit(500)
-	sched.getPartitionState("ingest", 5).initCommit(12000)
+	sched.getPartitionState("ingest", 1).initCommit(0, 5000)
+	sched.getPartitionState("ingest", 2).initCommit(0, 800)
+	sched.getPartitionState("ingest", 3).initCommit(0, 974)
+	sched.getPartitionState("ingest", 4).initCommit(0, 500)
+	sched.getPartitionState("ingest", 5).initCommit(0, 12000)
 	sched.getPartitionState("ingest", 6) // no commit for 6
 	sched.getPartitionState("ingest", 7) // no commit for 7
-	sched.getPartitionState("ingest", 8).initCommit(1000)
-	sched.getPartitionState("ingest", 9).initCommit(1000)
+	sched.getPartitionState("ingest", 8).initCommit(0, 1000)
+	sched.getPartitionState("ingest", 9).initCommit(0, 1000)
 
 	{
 		nq := newJobQueue(988*time.Hour, noOpJobCreationPolicy[schedulerpb.JobSpec]{}, 2, sched.metrics, test.NewTestingLogger(t))
@@ -583,13 +583,13 @@ func TestObservations(t *testing.T) {
 func (s *BlockBuilderScheduler) requireOffset(t *testing.T, topic string, partition int32, expected int64, msgAndArgs ...any) {
 	t.Helper()
 	ps := s.getPartitionState(topic, partition)
-	require.Equal(t, expected, ps.offsets.committed.offset(), msgAndArgs...)
+	require.Equal(t, expected, ps.offsets[0].committed.offset(), msgAndArgs...)
 }
 
 func TestOffsetMovement(t *testing.T) {
 	sched, _ := mustScheduler(t, 4)
 	ps := sched.getPartitionState("ingest", 1)
-	ps.initCommit(5000)
+	ps.initCommit(0, 5000)
 	sched.completeObservationMode(context.Background())
 
 	spec := schedulerpb.JobSpec{
@@ -613,18 +613,14 @@ func TestOffsetMovement(t *testing.T) {
 	sched.requireOffset(t, "ingest", 1, 6000, "re-completing the same job shouldn't change the commit")
 
 	p1 := sched.getPartitionState("ingest", 1)
-	p1.offsets.committed.advance("ancient_job", schedulerpb.JobSpec{
-		Topic:       "ingest",
-		Partition:   1,
+	p1.offsets[0].committed.advance("ancient_job", schedulerpb.OffsetRange{
 		StartOffset: 1000,
 		EndOffset:   2000,
 	})
 	sched.requireOffset(t, "ingest", 1, 6000, "committed offsets cannot rewind")
 
 	p2 := sched.getPartitionState("ingest", 2)
-	p2.offsets.committed.advance("ancient_job2", schedulerpb.JobSpec{
-		Topic:       "ingest",
-		Partition:   2,
+	p2.offsets[0].committed.advance("ancient_job2", schedulerpb.OffsetRange{
 		StartOffset: 6000,
 		EndOffset:   6222,
 	})
@@ -660,19 +656,19 @@ func TestKafkaFlush(t *testing.T) {
 	// (No commit yet for p0.)
 
 	p1 := sched.getPartitionState("ingest", 1)
-	p1.initCommit(2000)
+	p1.initCommit(0, 2000)
 	flushAndRequireOffsets("ingest", map[int32]int64{
 		1: 2000,
 	})
 
 	p4 := sched.getPartitionState("ingest", 4)
-	p4.initCommit(65535)
+	p4.initCommit(0, 65535)
 	flushAndRequireOffsets("ingest", map[int32]int64{
 		1: 2000,
 		4: 65535,
 	})
 
-	p1.initCommit(4000)
+	p1.initCommit(0, 4000)
 	flushAndRequireOffsets("ingest", map[int32]int64{
 		1: 4000,
 		4: 65535,
@@ -950,7 +946,7 @@ func TestBlockBuilderScheduler_EnqueuePendingJobs_CommitRace(t *testing.T) {
 
 	part := int32(1)
 	pt := sched.getPartitionState("ingest", part)
-	pt.initCommit(20)
+	pt.initCommit(0, 20)
 	pt.addPendingJob(&schedulerpb.JobSpec{
 		Topic:       "ingest",
 		Partition:   part,
@@ -981,7 +977,7 @@ func TestBlockBuilderScheduler_EnqueuePendingJobs_StartupRace(t *testing.T) {
 	})
 
 	// But the job we imported from the existing workers now being completed may be (10, 20):
-	pt.initCommit(20)
+	pt.initCommit(0, 20)
 
 	assert.Equal(t, 1, pt.pendingJobs.Len())
 	assert.Equal(t, 0, sched.jobs.count())
@@ -1006,11 +1002,11 @@ func TestBlockBuilderScheduler_EnqueuePendingJobs_GapDetection(t *testing.T) {
 
 	assert.Equal(t, 3, pt.pendingJobs.Len())
 	assert.Equal(t, 0, sched.jobs.count())
-	assert.True(t, pt.offsets.planned.empty())
+	assert.True(t, pt.offsets[0].planned.empty())
 	sched.enqueuePendingJobs()
 	assert.Equal(t, 0, pt.pendingJobs.Len())
 	assert.Equal(t, 3, sched.jobs.count())
-	assert.Equal(t, int64(50), pt.offsets.planned.offset())
+	assert.Equal(t, int64(50), pt.offsets[0].planned.offset())
 
 	requireGaps(t, reg, 0, 0)
 
@@ -1019,11 +1015,11 @@ func TestBlockBuilderScheduler_EnqueuePendingJobs_GapDetection(t *testing.T) {
 
 	assert.Equal(t, 1, pt.pendingJobs.Len())
 	assert.Equal(t, 3, sched.jobs.count())
-	assert.Equal(t, int64(50), pt.offsets.planned.offset())
+	assert.Equal(t, int64(50), pt.offsets[0].planned.offset())
 	sched.enqueuePendingJobs()
 	assert.Equal(t, 0, pt.pendingJobs.Len())
 	assert.Equal(t, 4, sched.jobs.count(), "a gap should not interfere with job queueing")
-	assert.Equal(t, int64(70), pt.offsets.planned.offset())
+	assert.Equal(t, int64(70), pt.offsets[0].planned.offset())
 
 	requireGaps(t, reg, 1, 0)
 
@@ -1035,11 +1031,11 @@ func TestBlockBuilderScheduler_EnqueuePendingJobs_GapDetection(t *testing.T) {
 
 	assert.Equal(t, 3, pt.pendingJobs.Len())
 	assert.Equal(t, 4, sched.jobs.count())
-	assert.Equal(t, int64(70), pt.offsets.planned.offset())
+	assert.Equal(t, int64(70), pt.offsets[0].planned.offset())
 	sched.enqueuePendingJobs()
 	assert.Equal(t, 0, pt.pendingJobs.Len())
 	assert.Equal(t, 7, sched.jobs.count(), "a gap should not interfere with job queueing")
-	assert.Equal(t, int64(120), pt.offsets.planned.offset())
+	assert.Equal(t, int64(120), pt.offsets[0].planned.offset())
 
 	requireGaps(t, reg, 2, 0)
 
@@ -1072,36 +1068,32 @@ func TestBlockBuilderScheduler_NoCommit_NoGap(t *testing.T) {
 	requireGaps(t, reg, 0, 0)
 
 	pp := sched.getPartitionState("ingest", part)
-	require.True(t, pp.offsets.planned.empty())
-	require.True(t, pp.offsets.committed.empty())
+	require.True(t, pp.offsets[0].planned.empty())
+	require.True(t, pp.offsets[0].committed.empty())
 
 	k := jobKey{"myjob5", 5}
-	spec := schedulerpb.JobSpec{
-		Topic:       "ingest",
-		Partition:   part,
+	spec := schedulerpb.OffsetRange{
 		StartOffset: 10,
 		EndOffset:   20,
 	}
 
-	pp.offsets.planned.advance(k.id, spec)
+	pp.offsets[0].planned.advance(k.id, spec)
 	requireGaps(t, reg, 0, 0, "advancing an empty planned offset should not register a gap")
 
-	pp.offsets.committed.advance(k.id, spec)
+	pp.offsets[0].committed.advance(k.id, spec)
 	requireGaps(t, reg, 0, 0, "advancing an empty committed offset should not register a gap")
 
 	// Now create a gap:
 	k2 := jobKey{"myjob7", 23}
-	spec2 := schedulerpb.JobSpec{
-		Topic:       "ingest",
-		Partition:   part,
+	spec2 := schedulerpb.OffsetRange{
 		StartOffset: 40,
 		EndOffset:   50,
 	}
 
-	pp.offsets.planned.advance(k2.id, spec2)
+	pp.offsets[0].planned.advance(k2.id, spec2)
 	requireGaps(t, reg, 1, 0, "a gap after a non-empty planned offset should register a gap")
 
-	pp.offsets.committed.advance(k2.id, spec2)
+	pp.offsets[0].committed.advance(k2.id, spec2)
 	requireGaps(t, reg, 1, 1, "a gap after a non-empty committed offset should register a gap")
 }
 
@@ -1231,7 +1223,7 @@ func TestStartupToRegularModeJobProduction(t *testing.T) {
 			ps := sched.getPartitionState("topic", 0)
 
 			for _, obs := range tt.futureObservations {
-				ps.updateEndOffset(obs.offset)
+				ps.updateEndOffset(0, obs.offset)
 				job, err := ps.updateTime(obs.timestamp, sched.cfg.JobSize)
 				require.NoError(t, err)
 				if job != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

partitionState now holds a slice of per-cluster offsets indexed by cluster ID instead of a single set, and its offset accessors take a cluster index. The advancing-offset helpers operate on a schedulerpb.OffsetRange rather than a whole JobSpec.

This is the groundwork for per-compartment block builders. The scheduler still drives a single cluster, hardcoding cluster 0 at every call site, so behavior is unchanged.

- Despite most of the code referring to `clusters`, metrics and logs have `write_compartment` as a label. This follows the pattern for other components e.g. https://github.com/grafana/mimir/blob/15a5a7fe2225d8a33fdec5e353f13e1dd94bb7f2/pkg/storage/ingest/multi_cluster_reader.go#L74-L75
- `cortex_blockbuilder_scheduler_partition_*` metrics have been extracted to be per-compartment, since they track offsets for a partition, and each cluster can have a different offset for the same partition

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
