### PR TITLE
mimir-mixin: add extra time buffer to MimirBucketIndexNotUpdated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
 * [ENHANCEMENT] Alerts: Make `MimirInconsistentRuntimeConfig` alert less flaky when performing multiple configuration changes in a row in a large Kubernetes cluster. #15257
 * [ENHANCEMENT] Alerts: Widen the `MimirBlockBuilderPersistentJobFailure` lookback window to 20m to prevent the alert from flapping. #15332
 * [ENHANCEMENT] Alerts: Add a native histogram variant of the `MimirRequestLatency` alert, distinguished by the `histogram` label (`classic` or `native`). #15413
+* [ENHANCEMENT] Alerts: Add a "for" period to `MimirBucketIndexNotUpdated` to avoid false-positives when a compactor restarted near the end of the previous update cycle. #15935
 * [ENHANCEMENT] Dashboards: Add "Rejected queries rate" panel to the Tenants dashboard showing the per-tenant rate of queries rejected by the query-frontend, split by reason. #14979
 * [ENHANCEMENT] Dashboards: Add 100th percentile to query expression percentiles graph. #15421
 * [ENHANCEMENT] Dashboards: Add the experimental streaming search API endpoints to the "Overview" per-endpoint query breakdown, and include the ingester `SearchLabelNames`/`SearchLabelValues` gRPC routes in the ingester panels of the "Reads", "Queries", and "Remote ruler reads" dashboards. #15571

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -1140,6 +1140,7 @@ spec:
               runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirbucketindexnotupdated
             expr: |
               min by(cluster, namespace, user) (time() - (max_over_time(cortex_bucket_index_last_successful_update_timestamp_seconds[15m]))) > 2100
+            for: 2m
             labels:
               severity: critical
           - alert: MimirHighVolumeLevel1BlocksQueried

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -1114,6 +1114,7 @@ groups:
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirbucketindexnotupdated
           expr: |
             min by(cluster, namespace, user) (time() - (max_over_time(cortex_bucket_index_last_successful_update_timestamp_seconds[15m]))) > 2100
+          for: 2m
           labels:
             severity: critical
         - alert: MimirHighVolumeLevel1BlocksQueried

--- a/operations/mimir-mixin-compiled-gem/alerts.yaml
+++ b/operations/mimir-mixin-compiled-gem/alerts.yaml
@@ -1128,6 +1128,7 @@ groups:
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirbucketindexnotupdated
           expr: |
             min by(cluster, namespace, user) (time() - (max_over_time(cortex_bucket_index_last_successful_update_timestamp_seconds[15m]))) > 2100
+          for: 2m
           labels:
             severity: critical
         - alert: MimirHighVolumeLevel1BlocksQueried

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -1128,6 +1128,7 @@ groups:
             runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirbucketindexnotupdated
           expr: |
             min by(cluster, namespace, user) (time() - (max_over_time(cortex_bucket_index_last_successful_update_timestamp_seconds[15m]))) > 2100
+          for: 2m
           labels:
             severity: critical
         - alert: MimirHighVolumeLevel1BlocksQueried

--- a/operations/mimir-mixin/alerts/blocks.libsonnet
+++ b/operations/mimir-mixin/alerts/blocks.libsonnet
@@ -241,6 +241,7 @@
           ||| % $._config {
             rate_interval: $.rateInterval('15m'),
           },
+          'for': '2m',  // Extra buffer to allow the compactor that was restarted close to the end of previous update cycle to discover the tenant and udpate their bucket.
           labels: {
             severity: 'critical',
           },


### PR DESCRIPTION
#### What this PR does

Following older experience https://github.com/grafana/mimir/pull/7879

The PR updates `MimirBucketIndexNotUpdated` alert, adding an extra `for` time buffer before the alerts fires.

Today, we see the alert occasionally flaps in large multi-tenant cells, when a compactor was restarted (e.g. its kubernetes pod was evicted from its node). After the new pod is scheduled to a new node, there is a chance for an alert to fire before the compactor finishes the initial update of its bucket-indices. Here is an illustration of a similar situation, where the page triggered but no actions required from the on-call:

<img width="1459" height="666" alt="Screenshot 2026-07-02 at 10 43 26" src="https://github.com/user-attachments/assets/8c3b33d7-04e7-4aa6-98e0-82c917955e3a" />

This PR should improve the behaviour without reducing the observability.