### PR TITLE
block-builder-scheduler: multi-cluster support for ordering observations for import 

### DIFF
--- a/pkg/blockbuilder/scheduler/observation_ordering.go
+++ b/pkg/blockbuilder/scheduler/observation_ordering.go
@@ -5,6 +5,7 @@ package scheduler
 import (
 	"cmp"
 	"errors"
+	"fmt"
 	"slices"
 )
 
@@ -111,6 +112,12 @@ func emitCandidate(candidate *observation, observationsByCluster [][]clusterObse
 		// The same *observation pointer is shared across all cluster lists.
 		for i := next; ; i++ {
 			if entries[i].obs == candidate {
+				if entries[next].startOffset != entries[i].startOffset {
+					// This should not happen as canEmit() guarantees entries[next] and the
+					// candidate share the same start offset, but a bug here could be subtle.
+					panic(fmt.Sprintf("observation ordering invariant violated: expected job %q and job %q to share a start offset, got %d and %d",
+						entries[next].obs.key.id, candidate.key.id, entries[next].startOffset, entries[i].startOffset))
+				}
 				entries[next], entries[i] = entries[i], entries[next]
 				break
 			}

--- a/pkg/blockbuilder/scheduler/observation_ordering.go
+++ b/pkg/blockbuilder/scheduler/observation_ordering.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package scheduler
+
+import (
+	"cmp"
+	"errors"
+	"slices"
+)
+
+// orderObservationsForImport returns observations ordered so that, within each
+// cluster, jobs appear in ascending start-offset order, and a job spanning multiple
+// clusters appears only after every job that precedes it in any of its clusters;
+// equal start offsets impose no ordering. Specs are sparse (a job lists only the
+// clusters that had new data) and consecutive jobs can cover disjoint cluster sets,
+// so there's no single offset to sort by.
+//
+// A cycle should be impossible, but if it is detected errObservationOffsetCycle is returned.
+func orderObservationsForImport(observations []*observation, numClusters int) ([]*observation, error) {
+	if numClusters <= 1 {
+		slices.SortFunc(observations, func(a, b *observation) int {
+			return cmp.Compare(a.spec.Ranges()[0].StartOffset, b.spec.Ranges()[0].StartOffset)
+		})
+		return observations, nil
+	}
+
+	observationsByCluster := groupByClusterID(observations, numClusters)
+	// nextUnemittedByCluster[clusterID] indexes the next unemitted entry in observationsByCluster[clusterID].
+	nextUnemittedByCluster := make([]int, numClusters)
+
+	ordered := make([]*observation, 0, len(observations))
+	for len(ordered) < len(observations) {
+		emittedThisPass := false
+		for clusterID := 0; clusterID < numClusters; clusterID++ {
+			entries := observationsByCluster[clusterID]
+			next := nextUnemittedByCluster[clusterID]
+
+			if next >= len(entries) {
+				continue
+			}
+
+			// Entries tied with the front are equally valid candidates; the front
+			// itself can be blocked by another cluster while a tied sibling is not.
+			frontOffset := entries[next].startOffset
+			for i := next; i < len(entries) && entries[i].startOffset == frontOffset; i++ {
+				candidate := entries[i].obs
+				if !canEmit(candidate, observationsByCluster, nextUnemittedByCluster) {
+					continue
+				}
+
+				ordered = append(ordered, candidate)
+				emitCandidate(candidate, observationsByCluster, nextUnemittedByCluster)
+				emittedThisPass = true
+				break
+			}
+		}
+
+		if !emittedThisPass {
+			return nil, errObservationOffsetCycle
+		}
+	}
+	return ordered, nil
+}
+
+var errObservationOffsetCycle = errors.New("observation offsets form a cycle across clusters")
+
+type clusterObservation struct {
+	obs *observation
+	// startOffset is the cluster's start offset for the observation.
+	startOffset int64
+}
+
+// groupByClusterID groups observations into one list per cluster (indexed
+// by ID), each sorted ascending by that cluster's start offset.
+func groupByClusterID(observations []*observation, numClusters int) [][]clusterObservation {
+	observationsByCluster := make([][]clusterObservation, numClusters)
+	for _, obs := range observations {
+		for clusterID, clusterRange := range obs.spec.Ranges() {
+			observationsByCluster[clusterID] = append(observationsByCluster[clusterID],
+				clusterObservation{obs: obs, startOffset: clusterRange.StartOffset})
+		}
+	}
+	for clusterID := range observationsByCluster {
+		slices.SortFunc(observationsByCluster[clusterID], func(a, b clusterObservation) int {
+			return cmp.Compare(a.startOffset, b.startOffset)
+		})
+	}
+	return observationsByCluster
+}
+
+// canEmit reports whether no cluster the candidate belongs to has an unemitted entry
+// with a smaller start offset, i.e. all of the candidate's predecessors are emitted.
+func canEmit(candidate *observation, observationsByCluster [][]clusterObservation, nextUnemittedByCluster []int) bool {
+	for clusterID, clusterRange := range candidate.spec.Ranges() {
+		entries := observationsByCluster[clusterID]
+		next := nextUnemittedByCluster[clusterID]
+		if next >= len(entries) || entries[next].startOffset < clusterRange.StartOffset {
+			return false
+		}
+	}
+	return true
+}
+
+// emitCandidate advances the cursor of every cluster the candidate belongs to,
+// first swapping the candidate into the front slot (it ties with the front but may
+// not be it) so cursors keep pointing at unemitted entries.
+func emitCandidate(candidate *observation, observationsByCluster [][]clusterObservation, nextUnemittedByCluster []int) {
+	for clusterID := range candidate.spec.Ranges() {
+		entries := observationsByCluster[clusterID]
+		next := nextUnemittedByCluster[clusterID]
+		// The same *observation pointer is shared across all cluster lists.
+		for i := next; ; i++ {
+			if entries[i].obs == candidate {
+				entries[next], entries[i] = entries[i], entries[next]
+				break
+			}
+		}
+		nextUnemittedByCluster[clusterID]++
+	}
+}

--- a/pkg/blockbuilder/scheduler/observation_ordering_test.go
+++ b/pkg/blockbuilder/scheduler/observation_ordering_test.go
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package scheduler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/blockbuilder/schedulerpb"
+)
+
+func TestOrderObservationsForImport(t *testing.T) {
+	// clusterRangeArg pairs a cluster ID with its offset range for building JobSpecs.
+	type clusterRangeArg struct {
+		cluster     int32
+		offsetRange schedulerpb.OffsetRange
+	}
+	offsetRange := func(cluster int32, start, end int64) clusterRangeArg {
+		return clusterRangeArg{cluster: cluster, offsetRange: schedulerpb.OffsetRange{StartOffset: start, EndOffset: end}}
+	}
+	obs := func(id string, ranges ...clusterRangeArg) *observation {
+		m := make(map[int32]schedulerpb.OffsetRange, len(ranges))
+		for _, r := range ranges {
+			m[r.cluster] = r.offsetRange
+		}
+		return &observation{key: jobKey{id: id}, spec: schedulerpb.JobSpec{Topic: "t", Partition: 0, OffsetRanges: m}}
+	}
+	// legacyObs builds a non-compartment spec, with StartOffset/EndOffset set and no
+	// OffsetRanges, so ordering goes through the JobSpec.Ranges() fallback used in production.
+	legacyObs := func(id string, start, end int64) *observation {
+		return &observation{key: jobKey{id: id}, spec: schedulerpb.JobSpec{Topic: "t", Partition: 0, StartOffset: start, EndOffset: end}}
+	}
+	ids := func(observations []*observation) []string {
+		out := make([]string, len(observations))
+		for i, o := range observations {
+			out[i] = o.key.id
+		}
+		return out
+	}
+
+	type testCase struct {
+		name         string
+		observations []*observation
+		numClusters  int
+		want         []string
+		unordered    bool
+		wantErr      error
+	}
+
+	tests := [...]testCase{
+		{
+			name: "single cluster sorts by start offset",
+			observations: []*observation{
+				obs("c", offsetRange(0, 20, 30)),
+				obs("a", offsetRange(0, 0, 10)),
+				obs("b", offsetRange(0, 10, 20)),
+			},
+			numClusters: 1,
+			want:        []string{"a", "b", "c"},
+		},
+		{
+			// J2 only continues cluster 1; J1 spans both with a high cluster 0 start, so a
+			// single representative offset would mis-order them. J1 must come first.
+			name: "multi-cluster sparse, predecessor before successor",
+			observations: []*observation{
+				obs("J2", offsetRange(1, 50, 120)),
+				obs("J1", offsetRange(0, 1000, 1100), offsetRange(1, 0, 50)),
+			},
+			numClusters: 2,
+			want:        []string{"J1", "J2"},
+		},
+		{
+			name: "disjoint cluster sets all emitted",
+			observations: []*observation{
+				obs("b", offsetRange(1, 0, 5)),
+				obs("a", offsetRange(0, 0, 10)),
+			},
+			numClusters: 2,
+			want:        []string{"a", "b"},
+		},
+		{
+			// Cluster 0 ties X and Y; cluster 1 strictly orders Y before X. The tie
+			// must not count as a precedence constraint, else the valid order [Y,X]
+			// is misreported as a cycle.
+			name: "tie in one cluster resolved by strict order in another",
+			observations: []*observation{
+				obs("X", offsetRange(0, 10, 20), offsetRange(1, 20, 30)),
+				obs("Y", offsetRange(0, 10, 20), offsetRange(1, 10, 20)),
+			},
+			numClusters: 2,
+			want:        []string{"Y", "X"},
+		},
+		{
+			// Y ties with X in cluster 0 but is never at the front of any other
+			// cluster; it must still be considered for emission while X waits on Z.
+			name: "tied job behind a blocked front is still emittable",
+			observations: []*observation{
+				obs("X", offsetRange(0, 10, 20), offsetRange(1, 20, 30)),
+				obs("Y", offsetRange(0, 10, 20)),
+				obs("Z", offsetRange(1, 10, 20)),
+			},
+			numClusters: 2,
+			want:        []string{"Y", "Z", "X"},
+		},
+		{
+			// Cluster 0 orders J1 before J2; cluster 1 orders J2 before J1.
+			name: "offset cycle returns error",
+			observations: []*observation{
+				obs("J1", offsetRange(0, 0, 10), offsetRange(1, 20, 30)),
+				obs("J2", offsetRange(0, 20, 30), offsetRange(1, 0, 10)),
+			},
+			numClusters: 2,
+			wantErr:     errObservationOffsetCycle,
+		},
+		{
+			// cluster 0: J1<J3<J4<J5, cluster 1: J1<J2<J3<J5. Those constraints pin a
+			// single valid order across several merge passes, regardless of input order.
+			name: "multi-cluster forced chain across sparse specs",
+			observations: []*observation{
+				obs("J4", offsetRange(0, 20, 30)),
+				obs("J1", offsetRange(0, 0, 10), offsetRange(1, 0, 10)),
+				obs("J5", offsetRange(0, 30, 40), offsetRange(1, 30, 40)),
+				obs("J2", offsetRange(1, 10, 20)),
+				obs("J3", offsetRange(0, 10, 20), offsetRange(1, 20, 30)),
+			},
+			numClusters: 2,
+			want:        []string{"J1", "J2", "J3", "J4", "J5"},
+		},
+		{
+			// Three clusters (A=0, B=1, C=2), each link forced through a different shared
+			// cluster: A<AB in cluster A, AB<BC in cluster B, BC<C in cluster C.
+			name: "forced chain across three clusters via distinct shared clusters",
+			observations: []*observation{
+				obs("C", offsetRange(2, 10, 20)),
+				obs("AB", offsetRange(0, 10, 20), offsetRange(1, 0, 10)),
+				obs("A", offsetRange(0, 0, 10)),
+				obs("BC", offsetRange(1, 10, 20), offsetRange(2, 0, 10)),
+			},
+			numClusters: 3,
+			want:        []string{"A", "AB", "BC", "C"},
+		},
+		{
+			// Clusters 0-2 hold the A/B/C chain; clusters 3-4 hold a separate D/E chain
+			// sharing no cluster with the first group. The merge walks clusters in order
+			// each pass, so the order is deterministic: C trails D and E because it only
+			// becomes cluster 2's front after BC, on a later pass.
+			name: "disjoint cluster groups all emitted",
+			observations: []*observation{
+				obs("BC", offsetRange(1, 10, 20), offsetRange(2, 0, 10)),
+				obs("E", offsetRange(4, 10, 20)),
+				obs("A", offsetRange(0, 0, 10)),
+				obs("D", offsetRange(3, 0, 10), offsetRange(4, 0, 10)),
+				obs("C", offsetRange(2, 10, 20)),
+				obs("AB", offsetRange(0, 10, 20), offsetRange(1, 0, 10)),
+			},
+			numClusters: 5,
+			want:        []string{"A", "AB", "BC", "D", "E", "C"},
+		},
+		{
+			// Identical specs with distinct names must all be emitted; their relative
+			// order is unspecified. Exercises the identity-based swap in emitCandidate
+			// with look-alikes.
+			name: "duplicate specs with different names all emitted",
+			observations: []*observation{
+				obs("dupA", offsetRange(0, 0, 10), offsetRange(1, 0, 10)),
+				obs("dupB", offsetRange(0, 0, 10), offsetRange(1, 0, 10)),
+			},
+			numClusters: 2,
+			want:        []string{"dupA", "dupB"},
+			unordered:   true,
+		},
+		{
+			// Non-compartment specs (StartOffset/EndOffset, no OffsetRanges) sort via the
+			// JobSpec.Ranges() fallback, matching the live single-cluster recovery path.
+			name: "legacy specs sort by start offset via ranges fallback",
+			observations: []*observation{
+				legacyObs("c", 20, 30),
+				legacyObs("a", 0, 10),
+				legacyObs("b", 10, 20),
+			},
+			numClusters: 1,
+			want:        []string{"a", "b", "c"},
+		},
+		{
+			// Compartments configured, but every job only touched cluster 0, so the
+			// other cluster's list is empty and the result is a plain offset sort.
+			name: "multiple clusters configured, all jobs in cluster 0",
+			observations: []*observation{
+				obs("c", offsetRange(0, 20, 30)),
+				obs("a", offsetRange(0, 0, 10)),
+				obs("b", offsetRange(0, 10, 20)),
+			},
+			numClusters: 2,
+			want:        []string{"a", "b", "c"},
+		},
+		{
+			name:         "no observations",
+			observations: nil,
+			numClusters:  2,
+			want:         []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := orderObservationsForImport(tt.observations, tt.numClusters)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			if tt.unordered {
+				require.ElementsMatch(t, tt.want, ids(got))
+			} else {
+				require.Equal(t, tt.want, ids(got))
+			}
+		})
+	}
+}

--- a/pkg/blockbuilder/scheduler/scheduler.go
+++ b/pkg/blockbuilder/scheduler/scheduler.go
@@ -3,12 +3,10 @@
 package scheduler
 
 import (
-	"cmp"
 	"context"
 	"errors"
 	"fmt"
 	"iter"
-	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -704,17 +702,25 @@ func (s *BlockBuilderScheduler) finalizeObservations() {
 			continue
 		}
 
-		// Sort observations by start offset
-		slices.SortFunc(observations, func(a, b *observation) int {
-			return cmp.Compare(a.spec.StartOffset, b.spec.StartOffset)
-		})
+		// Track the highest epoch across all observations so setEpoch resumes
+		// assigning epochs above every recovered job's epoch. Done before the
+		// skip check below so a partition we choose not to recover still advances
+		// the counter past its jobs.
+		for _, obs := range observations {
+			maxEpoch = max(maxEpoch, obs.key.epoch)
+		}
+
+		ordered, err := orderObservationsForImport(observations, len(ps.offsets))
+		if err != nil {
+			level.Error(s.logger).Log("msg", "startup: skipping partition recovery",
+				"partition", partition, "observations", len(observations), "err", err)
+			continue
+		}
 
 		// Find the highest contiguous coverage by processing jobs in order.
 		// Stop importing jobs if we find a gap. The last continuous job defines
 		// our latest planned offset which will be where we resume job planning.
-		for _, obs := range observations {
-			maxEpoch = max(maxEpoch, obs.key.epoch)
-
+		for _, obs := range ordered {
 			if !contiguous {
 				// We found a gap earlier. Skip and warn.
 				level.Warn(s.logger).Log("msg", "startup: skipping job import due to offset gap",


### PR DESCRIPTION
Extracted from https://github.com/grafana/mimir/pull/15774 (per-compartment block-builders) for focused review: the observation ordering used during scheduler startup recovery.

With per-compartment block-building, an observed job's spec is sparse (it lists only the clusters that had new data), so recovery can no longer sort observations by a single offset — a job spanning multiple clusters must be ordered after every job that precedes it in any of its clusters. `orderObservationsForImport` merges the per-cluster offset-sorted observations to produce that order, falling back to the existing single-offset sort while compartments stay disabled (the only live configuration today).

This also fixes a gap from the draft PR: ties are now handled correctly. For example, Job X `(C1: 100, C2: 100)` and Job Y `(C1: 100, C2: 200)` tie on C1's start offset, but C2 requires X before Y. Previously, depending on non-deterministic map iteration order this could be misreported as a cycle — discarding X, an otherwise fully recoverable job, along with everything else in the partition. Now ties are treated as unordered, so X is always ordered before Y.

The multi-cluster ordering path is not executed yet, currently the scheduler only passes jobs for a single cluster.