### PR TITLE
ingester: fix flaky TSDB head compaction startup-replay tests

### DIFF
--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -203,8 +203,9 @@ type Config struct {
 	IngestStorageConfig ingest.Config       `yaml:"-"`
 	Compartments        compartments.Config `yaml:"-"`
 
-	// This config can be overridden in tests.
+	// These configs can be overridden in tests.
 	limitMetricsUpdatePeriod time.Duration `yaml:"-"`
+	minCompactionLoopDelay   time.Duration `yaml:"-"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
@@ -238,6 +239,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 
 	// Hardcoded config (can only be overridden in tests).
 	cfg.limitMetricsUpdatePeriod = time.Second * 15
+	cfg.minCompactionLoopDelay = defaultMinCompactionLoopDelay
 }
 
 func (cfg *Config) Validate(compartmentsCfg compartments.Config) error {

--- a/pkg/ingester/ingester_compaction.go
+++ b/pkg/ingester/ingester_compaction.go
@@ -23,11 +23,12 @@ import (
 	"github.com/grafana/mimir/pkg/util"
 )
 
-// minCompactionLoopDelay is the minimum delay enforced between TSDB head
-// compaction iterations, so the loop cannot run continuously and starve
-// other ingester work when a single iteration approaches or exceeds the
-// configured compaction interval.
-const minCompactionLoopDelay = 10 * time.Second
+// defaultMinCompactionLoopDelay is the default minimum delay enforced between
+// TSDB head compaction iterations, so the loop cannot run continuously and
+// starve other ingester work when a single iteration approaches or exceeds the
+// configured compaction interval. It can be overridden in tests via
+// Config.minCompactionLoopDelay.
+const defaultMinCompactionLoopDelay = 10 * time.Second
 
 func (i *Ingester) shipBlocksLoop(ctx context.Context) error {
 	// We add a slight jitter to make sure that if the head compaction interval and ship interval are set to the same
@@ -173,7 +174,7 @@ func (i *Ingester) compactionServiceRunning(ctx context.Context) error {
 			// so the compaction loop can't run continuously when iterations are slow and
 			// starve other ingester work (e.g. ingestion offset commits).
 			iterationDuration := time.Since(iterationStart)
-			if extraDelay := compactionLoopExtraDelay(iterationDuration, standardInterval, minCompactionLoopDelay); extraDelay > 0 {
+			if extraDelay := compactionLoopExtraDelay(iterationDuration, standardInterval, i.cfg.minCompactionLoopDelay); extraDelay > 0 {
 				level.Warn(i.logger).Log(
 					"msg", "enforcing minimum delay between TSDB head compaction iterations because the previous iteration approached or exceeded the configured interval",
 					"iteration_duration", iterationDuration,

--- a/pkg/ingester/ingester_compartments_test.go
+++ b/pkg/ingester/ingester_compartments_test.go
@@ -131,6 +131,12 @@ func TestIngester_Compartments_ShouldConsumeReadCompartmentTopicAtStartup(t *tes
 	cfg.BlocksStorageConfig.TSDB.HeadCompactionIntervalWhileStarting = headCompactionIntervalWhileStarting
 	cfg.BlocksStorageConfig.TSDB.HeadCompactionIntervalJitterEnabled = false
 
+	// Disable the minimum delay between compaction iterations, otherwise it would dominate the small
+	// headCompactionIntervalWhileStarting used above and the compaction loop would run only once during
+	// startup, before the replayed series is appended to the head. The default 10s delay is only
+	// meaningful with production-sized intervals.
+	cfg.minCompactionLoopDelay = 0
+
 	// Create the ingester, consuming the read compartment's topic from one Kafka cluster per write compartment.
 	overrides := validation.NewOverrides(defaultLimitsTestConfig(), nil)
 	ingester, kafkaClusters, watcher := createTestCompartmentsIngester(t, &cfg, overrides, reg, util_test.NewTestingLogger(t))

--- a/pkg/ingester/ingester_ingest_storage_test.go
+++ b/pkg/ingester/ingester_ingest_storage_test.go
@@ -192,6 +192,12 @@ func TestIngester_ShouldReplayPartitionAtStartupAndThenJoinTheRings(t *testing.T
 	cfg.BlocksStorageConfig.TSDB.HeadCompactionIntervalWhileStarting = headCompactionIntervalWhileStarting
 	cfg.BlocksStorageConfig.TSDB.HeadCompactionIntervalJitterEnabled = false
 
+	// Disable the minimum delay between compaction iterations, otherwise it would dominate the small
+	// headCompactionIntervalWhileStarting used above and the compaction loop would run only once during
+	// startup, before the replayed series is appended to the head. The default 10s delay is only
+	// meaningful with production-sized intervals.
+	cfg.minCompactionLoopDelay = 0
+
 	// Create the ingester.
 	overrides := validation.NewOverrides(defaultLimitsTestConfig(), nil)
 	ingester, kafkaCluster, watcher := createTestIngesterWithIngestStorage(t, &cfg, overrides, nil, reg, util_test.NewTestingLogger(t))


### PR DESCRIPTION
#### What this PR does

`TestIngester_ShouldReplayPartitionAtStartupAndThenJoinTheRings` and `TestIngester_Compartments_ShouldConsumeReadCompartmentTopicAtStartup` are flaky (~10% locally, [observed in CI](https://github.com/grafana/mimir/actions/runs/28524351704/job/84556766594?pr=15834)). Both assert that TSDB head compaction runs while the ingester replays its partition at startup.

The root cause is the 10s minimum delay between compaction iterations added in #15061: it dominates the 100ms `HeadCompactionIntervalWhileStarting` the tests configure (`100ms - iterationDuration` is always `< 10s`), so during startup the compaction loop compacts only once — and that single iteration usually runs before the replayed series has been appended to the head. `compactionsTriggered` therefore never increments and the assertions time out.

The floor only interferes with such tiny intervals; production uses a 30s starting interval and is unaffected. This PR makes the minimum delay overridable in tests (defaulting to the existing 10s) and disables it in the two affected tests, so head compaction ticks at the configured 100ms interval during startup — restoring the behaviour these assertions were written against.

Verified by running each test 60× with `-race`: 60/60 pass (previously ~3/30 failed).

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - not needed (test-only fix; internal test-override field).
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.