### PR TITLE
block-builder-scheduler: multi-cluster support for replaying offsets at startup

### DIFF
--- a/pkg/blockbuilder/scheduler/offset_scanner.go
+++ b/pkg/blockbuilder/scheduler/offset_scanner.go
@@ -23,7 +23,8 @@ type offsetTime struct {
 // offsetScanner computes an initial set of <offset, time> pairs for each
 // partition, used to seed the scheduler at startup.
 type offsetScanner struct {
-	store   offsetStore
+	// stores are indexed by clusterID.
+	stores  []offsetStore
 	endTime time.Time
 	// probeTimes are the timestamps to query Kafka offsets at, in descending
 	// order so the scan stops once it reaches the partition's resume offset.
@@ -31,20 +32,41 @@ type offsetScanner struct {
 	recordTimeDelta prometheus.Observer
 }
 
-func newOffsetScanner(offs offsetStore, endTime time.Time, jobSize, maxScanAge time.Duration, recordTimeDelta prometheus.Observer) *offsetScanner {
+func newOffsetScanner(stores []offsetStore, endTime time.Time, jobSize, maxScanAge time.Duration, recordTimeDelta prometheus.Observer) *offsetScanner {
 	minScanTime := endTime.Add(-maxScanAge)
 	return &offsetScanner{
-		store:           offs,
+		stores:          stores,
 		endTime:         endTime,
 		probeTimes:      scanProbeTimes(endTime, jobSize, minScanTime),
 		recordTimeDelta: recordTimeDelta,
 	}
 }
 
-// probeInitialOffsets computes an initial set of <offset, time> pairs that exist between this
-// partition's resume and end offsets. These pairs can be used to seed a bunch of
-// end offset observations to start the scheduler.
-func (s *offsetScanner) probeInitialOffsets(ctx context.Context, po partitionOffsets, logger log.Logger) ([]*offsetTime, error) {
+// probeInitialPartitionOffsets probes every cluster of a partition and returns their offsets,
+// indexed by clusterID. These offsets can be used to seed the scheduler's per-cluster end
+// offset tracking at startup. clusterOffsets is indexed by clusterID; a nil entry means the
+// partition has no offsets on that cluster and is skipped, leaving a nil slot in the result.
+func (s *offsetScanner) probeInitialPartitionOffsets(ctx context.Context, clusterOffsets []*partitionOffsets, logger log.Logger) ([][]*offsetTime, error) {
+	perCluster := make([][]*offsetTime, len(clusterOffsets))
+	for clusterID, po := range clusterOffsets {
+		if po == nil {
+			continue
+		}
+		offsets, err := s.probeSingleClusterOffsets(ctx, clusterID, *po, logger)
+		if err != nil {
+			return nil, err
+		}
+		perCluster[clusterID] = offsets
+	}
+	return perCluster, nil
+}
+
+// probeSingleClusterOffsets computes an initial set of offsets that exist between this
+// partition's resume and end offsets on a single cluster. These offsets can be used to
+// seed the scheduler's per-cluster end offset tracking at startup.
+func (s *offsetScanner) probeSingleClusterOffsets(ctx context.Context, clusterID int, po partitionOffsets, logger log.Logger) ([]*offsetTime, error) {
+	store := s.stores[clusterID]
+
 	if po.resume >= po.end || po.start >= po.end {
 		// No new data to consume. Return the single end offset so it is initially registered.
 		return []*offsetTime{{offset: po.end, time: s.endTime}}, nil
@@ -58,7 +80,7 @@ func (s *offsetScanner) probeInitialOffsets(ctx context.Context, po partitionOff
 	// given a timestamp, so we iteratively call that API for each probe time
 	// until we reach the resume offset.
 	for _, pb := range s.probeTimes {
-		offset, t, isEndOffset, err := s.store.offsetAfterTime(ctx, po.topic, po.partition, pb)
+		offset, t, isEndOffset, err := store.offsetAfterTime(ctx, po.topic, po.partition, pb)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/blockbuilder/scheduler/offset_scanner_test.go
+++ b/pkg/blockbuilder/scheduler/offset_scanner_test.go
@@ -4,6 +4,7 @@ package scheduler
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -19,7 +20,7 @@ import (
 	"github.com/grafana/mimir/pkg/util/testkafka"
 )
 
-func TestInitialOffsetProbing(t *testing.T) {
+func TestProbeSingleClusterOffsets(t *testing.T) {
 	ctx := context.Background()
 
 	tests := map[string]struct {
@@ -46,6 +47,23 @@ func TestInitialOffsetProbing(t *testing.T) {
 			endTime:        time.Date(2025, 3, 1, 10, 0, 0, 600*1000000, time.UTC),
 			minScanTime:    time.Date(2025, 2, 20, 10, 0, 0, 600*1000000, time.UTC),
 			expectedRanges: []*offsetTime{{offset: 2000, time: time.Date(2025, 3, 1, 10, 0, 0, 600*1000000, time.UTC)}},
+		},
+		"record at or after end time is registered instead of the end offset": {
+			// A record whose timestamp is at or after endTime means the first probe finds a
+			// real record rather than falling back to the end offset, so the end offset (2001)
+			// is never registered; the last sample is the real record at 2000. Best-effort:
+			// the current bucket ends slightly behind the true end offset.
+			offsets: []*offsetTime{
+				{offset: 2000, time: time.Date(2025, 3, 1, 10, 0, 0, 700*1000000, time.UTC)},
+			},
+			resume:      2000,
+			end:         2001,
+			jobSize:     200 * time.Millisecond,
+			endTime:     time.Date(2025, 3, 1, 10, 0, 0, 600*1000000, time.UTC),
+			minScanTime: time.Date(2025, 2, 20, 10, 0, 0, 600*1000000, time.UTC),
+			expectedRanges: []*offsetTime{
+				{offset: 2000, time: time.Date(2025, 3, 1, 10, 0, 0, 700*1000000, time.UTC)},
+			},
 		},
 		"old data with single unconsumed record": {
 			offsets: []*offsetTime{
@@ -232,12 +250,73 @@ func TestInitialOffsetProbing(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			f := &mockOffsetFinder{offsets: tt.offsets, end: tt.end, distinctTimes: make(map[time.Time]struct{})}
-			scanner := newOffsetScanner(f, tt.endTime, tt.jobSize, tt.endTime.Sub(tt.minScanTime), promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}))
-			j, err := scanner.probeInitialOffsets(ctx, partitionOffsets{topic: "topic", partition: 0, start: tt.start, resume: tt.resume, end: tt.end}, test.NewTestingLogger(t))
+			scanner := newOffsetScanner([]offsetStore{f}, tt.endTime, tt.jobSize, tt.endTime.Sub(tt.minScanTime), promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}))
+			j, err := scanner.probeSingleClusterOffsets(ctx, 0, partitionOffsets{topic: "topic", partition: 0, start: tt.start, resume: tt.resume, end: tt.end}, test.NewTestingLogger(t))
 			assert.NoError(t, err)
 			assert.EqualValues(t, tt.expectedRanges, j, tt.msg)
 		})
 	}
+}
+
+func TestProbeInitialPartitionOffsets(t *testing.T) {
+	ctx := context.Background()
+	endTime := time.Date(2025, 3, 1, 13, 0, 0, 0, time.UTC)
+	at := func(h, m int) time.Time { return time.Date(2025, 3, 1, h, m, 0, 0, time.UTC) }
+	newScanner := func(stores []offsetStore) *offsetScanner {
+		return newOffsetScanner(stores, endTime, time.Hour, 13*time.Hour, promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}))
+	}
+	clusterOffsets := []*partitionOffsets{
+		{topic: "topic", partition: 0, resume: 100, end: 250},
+		{topic: "topic", partition: 0, resume: 1000, end: 1150},
+		{topic: "topic", partition: 0, resume: 5000, end: 5150},
+	}
+	// probed is what probeSingleClusterOffsets yields for a store holding a single record at
+	// 10:07: the record itself, then the end-offset seed stamped at endTime.
+	probed := func(recordOffset, endOffset int64) []*offsetTime {
+		return []*offsetTime{{offset: recordOffset, time: at(10, 7)}, {offset: endOffset, time: endTime}}
+	}
+
+	t.Run("returns each cluster's offsets indexed by clusterID", func(t *testing.T) {
+		stores := []offsetStore{
+			&mockOffsetFinder{offsets: []*offsetTime{{offset: 100, time: at(10, 7)}}, end: 250, distinctTimes: make(map[time.Time]struct{})},
+			&mockOffsetFinder{offsets: []*offsetTime{{offset: 1000, time: at(10, 7)}}, end: 1150, distinctTimes: make(map[time.Time]struct{})},
+			&mockOffsetFinder{offsets: []*offsetTime{{offset: 5000, time: at(10, 7)}}, end: 5150, distinctTimes: make(map[time.Time]struct{})},
+		}
+
+		perCluster, err := newScanner(stores).probeInitialPartitionOffsets(ctx, clusterOffsets, test.NewTestingLogger(t))
+		require.NoError(t, err)
+		assert.Equal(t, [][]*offsetTime{probed(100, 250), probed(1000, 1150), probed(5000, 5150)}, perCluster)
+	})
+
+	t.Run("skips a nil entry and leaves a nil slot for it", func(t *testing.T) {
+		stores := []offsetStore{
+			&mockOffsetFinder{offsets: []*offsetTime{{offset: 100, time: at(10, 7)}}, end: 250, distinctTimes: make(map[time.Time]struct{})},
+			&mockOffsetFinder{distinctTimes: make(map[time.Time]struct{})},
+			&mockOffsetFinder{offsets: []*offsetTime{{offset: 5000, time: at(10, 7)}}, end: 5150, distinctTimes: make(map[time.Time]struct{})},
+		}
+		clusterOffsets := []*partitionOffsets{
+			{topic: "topic", partition: 0, resume: 100, end: 250},
+			nil,
+			{topic: "topic", partition: 0, resume: 5000, end: 5150},
+		}
+
+		perCluster, err := newScanner(stores).probeInitialPartitionOffsets(ctx, clusterOffsets, test.NewTestingLogger(t))
+		require.NoError(t, err)
+		// The nil entry leaves a nil slot without shifting cluster 2's offsets down to slot 1.
+		assert.Equal(t, [][]*offsetTime{probed(100, 250), nil, probed(5000, 5150)}, perCluster)
+	})
+
+	t.Run("propagates a probe error", func(t *testing.T) {
+		wantErr := errors.New("boom")
+		stores := []offsetStore{
+			&mockOffsetFinder{err: wantErr, distinctTimes: make(map[time.Time]struct{})},
+			&mockOffsetFinder{distinctTimes: make(map[time.Time]struct{})},
+			&mockOffsetFinder{distinctTimes: make(map[time.Time]struct{})},
+		}
+
+		_, err := newScanner(stores).probeInitialPartitionOffsets(ctx, clusterOffsets, test.NewTestingLogger(t))
+		require.ErrorIs(t, err, wantErr)
+	})
 }
 
 func TestScanProbeTimes(t *testing.T) {
@@ -365,9 +444,13 @@ type mockOffsetFinder struct {
 	offsets       []*offsetTime
 	end           int64
 	distinctTimes map[time.Time]struct{}
+	err           error
 }
 
 func (o *mockOffsetFinder) offsetAfterTime(_ context.Context, _ string, _ int32, t time.Time) (int64, time.Time, bool, error) {
+	if o.err != nil {
+		return 0, time.Time{}, false, o.err
+	}
 	o.distinctTimes[t] = struct{}{}
 	// scan the offsets slice and return the lowest offset whose time is after t.
 	mint := time.Time{}

--- a/pkg/blockbuilder/scheduler/partition_state.go
+++ b/pkg/blockbuilder/scheduler/partition_state.go
@@ -136,6 +136,20 @@ func (s *partitionState) updateTime(ts time.Time, jobSize time.Duration) (*sched
 // than one already replayed folds into the current bucket rather than reopening an earlier
 // one.
 func (s *partitionState) replayOffsetsAtStartup(perCluster [][]*offsetTime, jobSize time.Duration, logger log.Logger) {
+	// Special casing for the single cluster path. We don't need to worry about aligning the offsets by time between
+	// clusters for better job alignment, so we can replay the offsets and their recorded time.
+	if len(perCluster) == 1 {
+		for _, offset := range perCluster[0] {
+			s.updateEndOffset(0, offset.offset)
+			if job, err := s.updateTime(offset.time, jobSize); err != nil {
+				level.Warn(logger).Log("msg", "failed to update partition time", "partition", s.partition, "err", err)
+			} else if job != nil {
+				s.addPendingJob(job)
+			}
+		}
+		return
+	}
+
 	// Start the boundary walk at the earliest offset's timestamp across clusters.
 	var firstTime time.Time
 	for _, offsets := range perCluster {

--- a/pkg/blockbuilder/scheduler/partition_state.go
+++ b/pkg/blockbuilder/scheduler/partition_state.go
@@ -127,6 +127,66 @@ func (s *partitionState) updateTime(ts time.Time, jobSize time.Duration) (*sched
 	return nil, nil
 }
 
+// replayOffsetsAtStartup replays each cluster's probed offsets into the partition, cutting a
+// job at every jobSize boundary. perCluster[i] must hold cluster i's offsets in ascending order.
+//
+// Within a cluster, offsets are replayed in input order. Their timestamps decide
+// which job bucket each one lands in, but timestamps are not guaranteed to be monotonic, so
+// the walk only ever moves forward through boundaries: an offset whose timestamp is earlier
+// than one already replayed folds into the current bucket rather than reopening an earlier
+// one.
+func (s *partitionState) replayOffsetsAtStartup(perCluster [][]*offsetTime, jobSize time.Duration, logger log.Logger) {
+	// Start the boundary walk at the earliest offset's timestamp across clusters.
+	var firstTime time.Time
+	for _, offsets := range perCluster {
+		if len(offsets) > 0 && (firstTime.IsZero() || offsets[0].time.Before(firstTime)) {
+			firstTime = offsets[0].time
+		}
+	}
+	if firstTime.IsZero() {
+		return // No offsets to replay.
+	}
+
+	cursors := make([]int, len(perCluster))
+	for boundary := firstTime.Truncate(jobSize); ; {
+		// Advancing to the next boundary each iteration closes the bucket we just filled, but
+		// updateTime only returns a job when that bucket actually had data (an empty bucket, or
+		// the first call that just seeds the starting bucket, returns nil).
+		if job, err := s.updateTime(boundary, jobSize); err != nil {
+			level.Warn(logger).Log("msg", "failed to update partition time", "partition", s.partition, "err", err)
+		} else if job != nil {
+			s.addPendingJob(job)
+		}
+
+		next := boundary.Add(jobSize)
+		remaining := false
+		for clusterID := range perCluster {
+			offsets := perCluster[clusterID]
+			cursor := cursors[clusterID]
+			for cursor < len(offsets) && offsets[cursor].time.Before(next) {
+				s.updateEndOffset(clusterID, offsets[cursor].offset)
+				cursor++
+			}
+			cursors[clusterID] = cursor
+			// End offsets are exclusive, so this bucket ends at the first offset at or after the
+			// next boundary. That offset is also real data belonging to a later bucket, so we record
+			// it as the end but don't increment the cursor so we can consume it when it lands in its
+			// proper bucket.
+			if cursor < len(offsets) {
+				s.updateEndOffset(clusterID, offsets[cursor].offset)
+				remaining = true
+			}
+		}
+
+		if !remaining {
+			// Leave the final (current) bucket open; it'll
+			// cut later once live updates roll it over.
+			return
+		}
+		boundary = next
+	}
+}
+
 // offsetsSummary returns a per-cluster offset summary for debugging.
 func (s *partitionState) offsetsSummary(includePlanned bool) string {
 	var b strings.Builder

--- a/pkg/blockbuilder/scheduler/partition_state_test.go
+++ b/pkg/blockbuilder/scheduler/partition_state_test.go
@@ -671,3 +671,280 @@ func TestNewSingleClusterOffsets(t *testing.T) {
 	// An end offset that moves backwards is a logical error and panics.
 	require.Panics(t, func() { o.updateEndOffset(150) })
 }
+
+func TestReplayOffsetsAtStartup(t *testing.T) {
+	at := func(h, m int) time.Time { return time.Date(2025, 3, 1, h, m, 0, 0, time.UTC) }
+
+	// openBucket is the [startOffset, endOffset) a cluster carries in the bucket left
+	// open at the end of the replay, i.e. what live operation will cut next.
+	type openBucket struct {
+		startOffset int64
+		endOffset   int64
+	}
+
+	tests := map[string]struct {
+		numClusters  int
+		perCluster   [][]*offsetTime
+		expectedJobs []map[int32]schedulerpb.OffsetRange
+		// expectedJobBucket is the bucket boundary the replay leaves open; zero means untouched.
+		expectedJobBucket time.Time
+		// expectedOpen is the open bucket per cluster, indexed by clusterID.
+		expectedOpen []openBucket
+	}{
+		"cuts a shared bucket with per-cluster ranges and leaves the current bucket open": {
+			// Both clusters have data in the 10:00 and 11:00 windows (independent, interleaved
+			// offset spaces); the 13:00 end-offset seed is the exclusive end of the 11:00 window.
+			// Both completed windows are cut together per cluster, and the current 13:00 bucket
+			// is empty (starts at the seed) and left open.
+			numClusters: 2,
+			perCluster: [][]*offsetTime{
+				{
+					{offset: 100, time: at(10, 7)},
+					{offset: 200, time: at(11, 7)},
+					{offset: 250, time: at(13, 0)},
+				},
+				{
+					{offset: 1000, time: at(10, 7)},
+					{offset: 1100, time: at(11, 7)},
+					{offset: 1150, time: at(13, 0)},
+				},
+			},
+			expectedJobs: []map[int32]schedulerpb.OffsetRange{
+				{0: {StartOffset: 100, EndOffset: 200}, 1: {StartOffset: 1000, EndOffset: 1100}},
+				{0: {StartOffset: 200, EndOffset: 250}, 1: {StartOffset: 1100, EndOffset: 1150}},
+			},
+			expectedJobBucket: at(13, 0),
+			expectedOpen:      []openBucket{{250, 250}, {1150, 1150}},
+		},
+		"does not emit a job for an empty bucket between two populated buckets": {
+			// The cluster has data in the 10:00 and 12:00 windows but none in 11:00. The empty
+			// 11:00 window cuts a zero-width range (no job). The 13:00 offset ends the 12:00 window
+			// and opens the current 13:00 bucket, which has no end yet (start == end) and is left open.
+			numClusters: 1,
+			perCluster: [][]*offsetTime{{
+				{offset: 100, time: at(10, 7)},
+				{offset: 150, time: at(10, 40)},
+				{offset: 200, time: at(12, 7)},
+				{offset: 250, time: at(12, 40)},
+				{offset: 300, time: at(13, 0)},
+			}},
+			expectedJobs: []map[int32]schedulerpb.OffsetRange{
+				{0: {StartOffset: 100, EndOffset: 200}},
+				{0: {StartOffset: 200, EndOffset: 300}},
+			},
+			expectedJobBucket: at(13, 0),
+			expectedOpen:      []openBucket{{300, 300}},
+		},
+		"carries the end across several empty buckets to the current one": {
+			// Each cluster's only offset after the 10:00 window is far ahead at 13:00, so it's the
+			// exclusive end of the 10:00 window and of the empty 11:00 and 12:00 windows. One
+			// shared job is cut, yet the walk still advances through those empty windows to 13:00,
+			// where the offsets are consumed and the current bucket left open.
+			numClusters: 2,
+			perCluster: [][]*offsetTime{
+				{
+					{offset: 100, time: at(10, 0)},
+					{offset: 400, time: at(13, 0)},
+				},
+				{
+					{offset: 1000, time: at(10, 0)},
+					{offset: 1400, time: at(13, 0)},
+				},
+			},
+			expectedJobs: []map[int32]schedulerpb.OffsetRange{
+				{0: {StartOffset: 100, EndOffset: 400}, 1: {StartOffset: 1000, EndOffset: 1400}},
+			},
+			expectedJobBucket: at(13, 0),
+			expectedOpen:      []openBucket{{400, 400}, {1400, 1400}},
+		},
+		"applies offsets in offset order even when their times are not monotonic": {
+			// Each cluster has an offset whose timestamp is earlier than the offset before it,
+			// but because the replay only ever looks ahead, that offset folds into the window the
+			// walk is already in rather than reopening an earlier one. Bucketing is independent per
+			// cluster: cluster 0's out-of-order offset (10:30) folds into its 11:00 window, while
+			// cluster 1's (11:30) folds into its 12:00 window, so cluster 1 has no data in 11:00.
+			numClusters: 2,
+			perCluster: [][]*offsetTime{
+				{
+					{offset: 100, time: at(10, 7)},
+					{offset: 200, time: at(11, 7)},
+					{offset: 300, time: at(10, 30)},
+					{offset: 400, time: at(12, 7)},
+					{offset: 500, time: at(13, 0)},
+				},
+				{
+					{offset: 1000, time: at(10, 7)},
+					{offset: 1100, time: at(12, 7)},
+					{offset: 1200, time: at(11, 30)},
+					{offset: 1300, time: at(13, 0)},
+				},
+			},
+			expectedJobs: []map[int32]schedulerpb.OffsetRange{
+				{0: {StartOffset: 100, EndOffset: 200}, 1: {StartOffset: 1000, EndOffset: 1100}},
+				{0: {StartOffset: 200, EndOffset: 400}},
+				{0: {StartOffset: 400, EndOffset: 500}, 1: {StartOffset: 1100, EndOffset: 1300}},
+			},
+			expectedJobBucket: at(13, 0),
+			expectedOpen:      []openBucket{{500, 500}, {1300, 1300}},
+		},
+		"cuts each cluster in the bucket where its data lands when clusters are staggered": {
+			// Cluster 0 has data in the 10:00 and 11:00 windows, cluster 1 in the 11:00 and
+			// 12:00 windows. Each window's job carries only the clusters with data in it, so the
+			// shared 11:00 window bundles both while 10:00 and 12:00 are single-cluster.
+			numClusters: 2,
+			perCluster: [][]*offsetTime{
+				{
+					{offset: 100, time: at(10, 7)},
+					{offset: 200, time: at(11, 7)},
+					{offset: 250, time: at(13, 0)},
+				},
+				{
+					{offset: 1000, time: at(11, 7)},
+					{offset: 1100, time: at(12, 7)},
+					{offset: 1150, time: at(13, 0)},
+				},
+			},
+			expectedJobs: []map[int32]schedulerpb.OffsetRange{
+				{0: {StartOffset: 100, EndOffset: 200}},
+				{0: {StartOffset: 200, EndOffset: 250}, 1: {StartOffset: 1000, EndOffset: 1100}},
+				{1: {StartOffset: 1100, EndOffset: 1150}},
+			},
+			expectedJobBucket: at(13, 0),
+			expectedOpen:      []openBucket{{250, 250}, {1150, 1150}},
+		},
+		"cuts a shared bucket across three clusters": {
+			// All three clusters have data in the 10:00 and 11:00 windows; the 13:00 seeds end
+			// the 11:00 window. Both completed windows are cut as single jobs carrying all three
+			// clusters' ranges.
+			numClusters: 3,
+			perCluster: [][]*offsetTime{
+				{
+					{offset: 100, time: at(10, 7)},
+					{offset: 200, time: at(11, 7)},
+					{offset: 250, time: at(13, 0)},
+				},
+				{
+					{offset: 1000, time: at(10, 7)},
+					{offset: 1100, time: at(11, 7)},
+					{offset: 1150, time: at(13, 0)},
+				},
+				{
+					{offset: 5000, time: at(10, 7)},
+					{offset: 5100, time: at(11, 7)},
+					{offset: 5150, time: at(13, 0)},
+				},
+			},
+			expectedJobs: []map[int32]schedulerpb.OffsetRange{
+				{
+					0: {StartOffset: 100, EndOffset: 200},
+					1: {StartOffset: 1000, EndOffset: 1100},
+					2: {StartOffset: 5000, EndOffset: 5100},
+				},
+				{
+					0: {StartOffset: 200, EndOffset: 250},
+					1: {StartOffset: 1100, EndOffset: 1150},
+					2: {StartOffset: 5100, EndOffset: 5150},
+				},
+			},
+			expectedJobBucket: at(13, 0),
+			expectedOpen:      []openBucket{{250, 250}, {1150, 1150}, {5150, 5150}},
+		},
+		"cuts three staggered clusters each in the bucket where its data lands": {
+			// Cluster 2 has data only in the 10:00 window, cluster 0 in 10:00 and 11:00, cluster
+			// 1 in 11:00 and 12:00. Each window's job bundles whichever clusters have data in it.
+			numClusters: 3,
+			perCluster: [][]*offsetTime{
+				{
+					{offset: 100, time: at(10, 7)},
+					{offset: 200, time: at(11, 7)},
+					{offset: 250, time: at(13, 0)},
+				},
+				{
+					{offset: 1000, time: at(11, 7)},
+					{offset: 1100, time: at(12, 7)},
+					{offset: 1150, time: at(13, 0)},
+				},
+				{
+					{offset: 5000, time: at(10, 7)},
+					{offset: 5100, time: at(10, 40)},
+					{offset: 5150, time: at(13, 0)},
+				},
+			},
+			expectedJobs: []map[int32]schedulerpb.OffsetRange{
+				{0: {StartOffset: 100, EndOffset: 200}, 2: {StartOffset: 5000, EndOffset: 5150}},
+				{0: {StartOffset: 200, EndOffset: 250}, 1: {StartOffset: 1000, EndOffset: 1100}},
+				{1: {StartOffset: 1100, EndOffset: 1150}},
+			},
+			expectedJobBucket: at(13, 0),
+			expectedOpen:      []openBucket{{250, 250}, {1150, 1150}, {5150, 5150}},
+		},
+		"leaves the in-progress bucket open with its data": {
+			// endTime falls inside the 12:00 window (the latest offsets are at 12:45), so that
+			// window is still in progress: with no offset at or after 13:00 to close it, each
+			// cluster's data stays in the open bucket for live operation to cut later rather than
+			// being emitted now.
+			numClusters: 2,
+			perCluster: [][]*offsetTime{
+				{
+					{offset: 100, time: at(10, 7)},
+					{offset: 200, time: at(12, 7)},
+					{offset: 300, time: at(12, 45)},
+				},
+				{
+					{offset: 1000, time: at(10, 7)},
+					{offset: 1100, time: at(12, 7)},
+					{offset: 1150, time: at(12, 45)},
+				},
+			},
+			expectedJobs: []map[int32]schedulerpb.OffsetRange{
+				{0: {StartOffset: 100, EndOffset: 200}, 1: {StartOffset: 1000, EndOffset: 1100}},
+			},
+			expectedJobBucket: at(12, 0),
+			expectedOpen:      []openBucket{{200, 300}, {1100, 1150}},
+		},
+		"emits no job for a single end-offset seed": {
+			// A partition with no new data since last consume yields a single end-offset seed
+			// at endTime; the replay records it as the open bucket's end without cutting a job.
+			numClusters: 1,
+			perCluster: [][]*offsetTime{{
+				{offset: 250, time: at(13, 0)},
+			}},
+			expectedJobBucket: at(13, 0),
+			expectedOpen:      []openBucket{{250, 250}},
+		},
+		"no offsets leaves partition state untouched": {
+			numClusters:  2,
+			perCluster:   [][]*offsetTime{nil, nil},
+			expectedOpen: []openBucket{{offsetEmpty, offsetEmpty}, {offsetEmpty, offsetEmpty}},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ps := newTestPartitionStateWithClusters(t, "topic", 0, tc.numClusters, true)
+
+			ps.replayOffsetsAtStartup(tc.perCluster, time.Hour, test.NewTestingLogger(t))
+
+			jobs := pendingJobSpecs(ps)
+			require.Len(t, jobs, len(tc.expectedJobs))
+			for i, want := range tc.expectedJobs {
+				assert.Equal(t, want, jobs[i].OffsetRanges)
+			}
+
+			assert.Equal(t, tc.expectedJobBucket, ps.jobBucket, "open job bucket")
+			require.Len(t, tc.expectedOpen, tc.numClusters)
+			for clusterID, want := range tc.expectedOpen {
+				assert.Equal(t, want.startOffset, ps.offsets[clusterID].startOffset, "cluster %d open start offset", clusterID)
+				assert.Equal(t, want.endOffset, ps.offsets[clusterID].endOffset, "cluster %d open end offset", clusterID)
+			}
+		})
+	}
+}
+
+func pendingJobSpecs(ps *partitionState) []*schedulerpb.JobSpec {
+	var jobs []*schedulerpb.JobSpec
+	for e := ps.pendingJobs.Front(); e != nil; e = e.Next() {
+		jobs = append(jobs, e.Value.(*schedulerpb.JobSpec))
+	}
+	return jobs
+}

--- a/pkg/blockbuilder/scheduler/partition_state_test.go
+++ b/pkg/blockbuilder/scheduler/partition_state_test.go
@@ -735,6 +735,34 @@ func TestReplayOffsetsAtStartup(t *testing.T) {
 			expectedJobBucket: at(13, 0),
 			expectedOpen:      []openBucket{{300, 300}},
 		},
+		"does not emit jobs for buckets that are empty across all clusters": {
+			// Both clusters have data in the 10:00 and 13:00 windows but none in 11:00 or 12:00.
+			// The empty windows cut zero-width ranges for both clusters (no jobs). The 14:00 offsets
+			// end the 13:00 window and open the current 14:00 bucket, which is left open.
+			numClusters: 2,
+			perCluster: [][]*offsetTime{
+				{
+					{offset: 100, time: at(10, 7)},
+					{offset: 150, time: at(10, 40)},
+					{offset: 200, time: at(13, 7)},
+					{offset: 250, time: at(13, 40)},
+					{offset: 300, time: at(14, 0)},
+				},
+				{
+					{offset: 1000, time: at(10, 7)},
+					{offset: 1150, time: at(10, 40)},
+					{offset: 1200, time: at(13, 7)},
+					{offset: 1250, time: at(13, 40)},
+					{offset: 1300, time: at(14, 0)},
+				},
+			},
+			expectedJobs: []map[int32]schedulerpb.OffsetRange{
+				{0: {StartOffset: 100, EndOffset: 200}, 1: {StartOffset: 1000, EndOffset: 1200}},
+				{0: {StartOffset: 200, EndOffset: 300}, 1: {StartOffset: 1200, EndOffset: 1300}},
+			},
+			expectedJobBucket: at(14, 0),
+			expectedOpen:      []openBucket{{300, 300}, {1300, 1300}},
+		},
 		"carries the end across several empty buckets to the current one": {
 			// Each cluster's only offset after the 10:00 window is far ahead at 13:00, so it's the
 			// exclusive end of the 10:00 window and of the empty 11:00 and 12:00 windows. One

--- a/pkg/blockbuilder/scheduler/scheduler.go
+++ b/pkg/blockbuilder/scheduler/scheduler.go
@@ -188,7 +188,7 @@ func (s *BlockBuilderScheduler) completeObservationMode(ctx context.Context) {
 		return
 	}
 
-	scanner := newOffsetScanner(newOffsetFinder(s.adminClient), time.Now(), s.cfg.JobSize, s.cfg.MaxScanAge, s.metrics.probeRecordTimeDelta)
+	scanner := newOffsetScanner([]offsetStore{newOffsetFinder(s.adminClient)}, time.Now(), s.cfg.JobSize, s.cfg.MaxScanAge, s.metrics.probeRecordTimeDelta)
 	s.populateInitialJobs(ctx, consumeOffs, scanner)
 	s.observations = nil
 	s.observationComplete = true
@@ -317,27 +317,18 @@ func (s *BlockBuilderScheduler) populateInitialJobs(ctx context.Context, consume
 	// those two offsets and seeding the schedule by calling updateEndOffset and
 	// updateTime for each of them- just like we do during normal operation.
 
-	for _, off := range consumeOffs {
-		o, err := scanner.probeInitialOffsets(ctx, off, s.logger)
+	// A partition currently maps to a single cluster, so each entry is reconstructed as
+	// a one-cluster partition (its offsets sit at clusterID 0). Once consumptionOffsets
+	// returns per-cluster offsets, they can be grouped by partition and passed together.
+	for i := range consumeOffs {
+		off := &consumeOffs[i]
+		ps := s.getPartitionState(off.topic, off.partition)
+		perCluster, err := scanner.probeInitialPartitionOffsets(ctx, []*partitionOffsets{off}, s.logger)
 		if err != nil {
 			level.Warn(s.logger).Log("msg", "failed to probe initial offsets", "partition", off.partition, "err", err)
 			continue
 		}
-		if len(o) == 0 {
-			// No new data to consume, so skip.
-			continue
-		}
-
-		ps := s.getPartitionState(off.topic, off.partition)
-
-		for _, io := range o {
-			ps.updateEndOffset(0, io.offset)
-			if job, err := ps.updateTime(io.time, s.cfg.JobSize); err != nil {
-				level.Warn(s.logger).Log("msg", "failed to update partition time", "partition", ps.partition, "err", err)
-			} else if job != nil {
-				ps.addPendingJob(job)
-			}
-		}
+		ps.replayOffsetsAtStartup(perCluster, s.cfg.JobSize, s.logger)
 	}
 }
 

--- a/pkg/blockbuilder/scheduler/scheduler_test.go
+++ b/pkg/blockbuilder/scheduler/scheduler_test.go
@@ -758,7 +758,7 @@ func TestPopulateInitialJobs_ProbeTimesReused(t *testing.T) {
 	}
 
 	endTime := time.Date(2025, 3, 1, 11, 0, 0, 0, time.UTC)
-	scanner := newOffsetScanner(finder, endTime, sched.cfg.JobSize, sched.cfg.MaxScanAge, sched.metrics.probeRecordTimeDelta)
+	scanner := newOffsetScanner([]offsetStore{finder}, endTime, sched.cfg.JobSize, sched.cfg.MaxScanAge, sched.metrics.probeRecordTimeDelta)
 	sched.populateInitialJobs(context.Background(), consumeOffs, scanner)
 	require.Len(t, finder.distinctTimes, 4, "four partitions will each be probed at the same times, so the probe times should be shared across partitions")
 }
@@ -1214,7 +1214,7 @@ func TestStartupToRegularModeJobProduction(t *testing.T) {
 			}
 
 			// Call populateInitialJobs to set up initial state
-			scanner := newOffsetScanner(finder, tt.initialTime, sched.cfg.JobSize, sched.cfg.MaxScanAge, sched.metrics.probeRecordTimeDelta)
+			scanner := newOffsetScanner([]offsetStore{finder}, tt.initialTime, sched.cfg.JobSize, sched.cfg.MaxScanAge, sched.metrics.probeRecordTimeDelta)
 			sched.populateInitialJobs(context.Background(), consumeOffs, scanner)
 
 			collectedJobs := []*schedulerpb.JobSpec{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
At startup the block-builder-scheduler reconstructs its in-progress and pending jobs by probing Kafka offsets. With write compartments a single job bundles an offset range per cluster, all aligned to the same job boundaries, so the reconstruction has to line offsets up across clusters.

This takes a different approach from the implementation draft e2e PR (#15774), which probed every cluster together on a shared time grid and merged them in one interleaved pass. That coupling forced several fragile cleanup steps — deduplicating unchanged offsets while walking, re-sorting by time, dropping sightings that moved a cluster backwards because offsets and record times aren't co-monotonic, and separately seeding clusters that were never observed.

Here each cluster is probed independently, returning that cluster's offsets sorted ascending by offset. The per-cluster results are then replayed together by walking job boundaries: within each boundary window we advance every cluster's offsets and cut a job at the boundary. The result is considerably easier to reason about: probing and merging are cleanly separated, and the merge is a single forward walk.

The tradeoff is that the walk replays some of the boundary/job-cutting behaviour `updateTime` already implements. That duplication is hard to avoid whatever implementation we use, as aligning jobs across clusters at startup means reasoning about the same boundaries the live path uses

The logic has been implemented in `partitionState`, since that's where the job boundary logic for the live path lives. 

In the single, non-compartment case the behaviour is effectively unchanged. We no longer feed record time into updateTime(), but each offset still ends up in the boundary window its record time falls in since we call updateTime() at the job boundary times.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
