### PR TITLE
[r399] block-builder: respect blocks-storage.tsdb.bigger-out-of-order-blocks-for-old-samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * [ENHANCEMENT] Memberlist: Add `memberlist.processed-messages-queue-size` flag to set the size of the per-key internal queue for processing messages received from other nodes. Increasing this value may help to avoid dropping per-key updates when the node is processing many updates for the same key. #15536
 * [ENHANCEMENT] MQE: Respect the `Cache-Control: no-store` request header when caching intermediate results for range vector splitting. #15148
 * [ENHANCEMENET] Runtimeconfig: The HTTP client used to fetch runtime configurations from HTTP endpoints now has keep-alives disabled by default. New CLI flag `-runtime-config.http-client-disable-keep-alives` is enabled by default, an can be set to `false` in-order to re-enable keep-alives. #15695
+* [ENHANCEMENT] Block-builder: Respect `-blocks-storage.tsdb.bigger-out-of-order-blocks-for-old-samples` to produce 24h blocks for out-of-order data belonging to previous days. #15892
 * [BUGFIX] Query-frontend: Fix `cardinality_analysis_max_results` being ignored when set higher than the default of 500. #15581
 * [BUGFIX] Ingest storage: Fix `KafkaProducer.ProduceSync()` returning a single result with a nil record when the context is canceled, instead of one result per input record (with the record set) as the underlying franz-go client does. #15199
 * [BUGFIX] Ingest storage: Fix `cortex_ingest_storage_reader_receive_delay_seconds` inflation by no longer setting the Kafka record `Timestamp` on the distributor side; the Kafka client now sets it at produce time. #15572

--- a/pkg/blockbuilder/tsdb.go
+++ b/pkg/blockbuilder/tsdb.go
@@ -353,6 +353,7 @@ func (b *TSDBBuilder) newTSDB(tenant tsdbTenant) (*userTSDB, error) {
 		EnableOverlappingCompaction:          false,                                                // Always false since Mimir only uploads lvl 1 compacted blocks
 		OutOfOrderTimeWindow:                 b.limits.OutOfOrderTimeWindow(userID).Milliseconds(), // The unit must be same as our timestamps.
 		OutOfOrderCapMax:                     int64(b.cfg.BlocksStorage.TSDB.OutOfOrderCapacityMax),
+		EnableBiggerOOOBlockForOldSamples:    b.cfg.BlocksStorage.TSDB.BiggerOutOfOrderBlocksForOldSamples,
 		SecondaryHashFunction:                nil, // TODO(codesome): May needed when applying limits. Used to determine the owned series by an ingesters
 		SeriesLifecycleCallback:              udb,
 		HeadPostingsForMatchersCacheMetrics:  tsdb.NewPostingsForMatchersCacheMetrics(nil), // No need for these metrics; no one queries tsdb through block-builder

--- a/pkg/blockbuilder/tsdb_test.go
+++ b/pkg/blockbuilder/tsdb_test.go
@@ -321,6 +321,88 @@ type testHistogram struct {
 	shouldDiscard bool
 }
 
+func TestTSDBBuilder_BiggerOOOBlocksForOldSamples(t *testing.T) {
+	const (
+		partitionID = int32(0)
+		userID      = "user1"
+	)
+
+	day := 24 * time.Hour.Milliseconds()
+	blockRange := 2 * time.Hour.Milliseconds()
+
+	// "now" is day 10 at 03:00.
+	now := 10*day + 3*time.Hour.Milliseconds()
+
+	for _, tc := range []struct {
+		name           string
+		enableFlag     bool
+		expBlockRanges []int64 // expected (maxT - minT) for each block, sorted by minT
+	}{
+		{
+			name:       "disabled produces 2h blocks",
+			enableFlag: false,
+			// All 4 samples each land in their own 2h block.
+			expBlockRanges: []int64{blockRange, blockRange, blockRange, blockRange},
+		},
+		{
+			name:       "enabled produces 24h blocks for previous days",
+			enableFlag: true,
+			// Day 7 and day 8 OOO samples each get a 24h block;
+			// day 10 OOO sample (current day) and in-order sample each get a 2h block.
+			expBlockRanges: []int64{day, day, blockRange, blockRange},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			limits := map[string]*validation.Limits{
+				userID: {
+					OutOfOrderTimeWindow: model.Duration(30 * 24 * time.Hour),
+				},
+			}
+			config, overrides := blockBuilderConfig(t, "kafka:9092", validation.NewMockTenantLimits(limits))
+			config.BlocksStorage.TSDB.BiggerOutOfOrderBlocksForOldSamples = tc.enableFlag
+
+			builder := NewTSDBBuilder(
+				partitionID, config, overrides, log.NewNopLogger(),
+				newTSDBBuilderMetrics(prometheus.NewPedanticRegistry()),
+				mimir_tsdb.NewTSDBMetrics(prometheus.NewPedanticRegistry(), log.NewNopLogger()),
+			)
+
+			ctx := user.InjectOrgID(t.Context(), userID)
+
+			// Push an in-order sample at "now" first, then OOO samples on previous days.
+			for _, ts := range []int64{
+				now,                                 // in-order, day 10 03:00
+				7*day + 5*time.Hour.Milliseconds(),  // OOO, day 7
+				8*day + 11*time.Hour.Milliseconds(), // OOO, day 8
+				10*day + 1*time.Hour.Milliseconds(), // OOO, day 10 (current day)
+			} {
+				req := createWriteRequest(userID, floatSample(ts, float64(ts)), nil)
+				require.NoError(t, builder.PushToStorageAndReleaseRequest(ctx, &req))
+			}
+
+			shipperDir := t.TempDir()
+			_, err := builder.CompactAndUpload(ctx, mockUploaderFunc(t, shipperDir))
+			require.NoError(t, err)
+
+			newDB, err := tsdb.Open(shipperDir, promslog.NewNopLogger(), nil, nil, nil)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, newDB.Close()) })
+
+			blocks := newDB.Blocks()
+			slices.SortFunc(blocks, func(a, b *tsdb.Block) int {
+				return cmp.Compare(a.Meta().MinTime, b.Meta().MinTime)
+			})
+
+			require.Len(t, blocks, len(tc.expBlockRanges), "unexpected number of blocks")
+			for i, b := range blocks {
+				got := b.Meta().MaxTime - b.Meta().MinTime
+				require.Equal(t, got, tc.expBlockRanges[i],
+					"block %d: minT=%d maxT=%d range=%d", i, b.Meta().MinTime, b.Meta().MaxTime, got)
+			}
+		})
+	}
+}
+
 func TestTSDBBuilder_CompactToReduceInMemorySeries(t *testing.T) {
 	const (
 		user1       = "user1"


### PR DESCRIPTION
Backport d45b6cb9b6db1fcc115e89de6ee3dfc73aa5e6b5 from #15892

---

#### What this PR does

Relates to https://github.com/grafana/mimir/issues/9911

This PR updates the block-builder to respect `-blocks-storage.tsdb.bigger-out-of-order-blocks-for-old-samples`, similar to how ingesters do that (ref to the reasoning in the original issue).