### PR TITLE
querier: fix store-gateway streams cancelled during multi-compartment query fan-out

### DIFF
--- a/integration/compartments_test.go
+++ b/integration/compartments_test.go
@@ -4,6 +4,7 @@ package integration
 
 import (
 	"fmt"
+	"net/http"
 	"strconv"
 	"testing"
 	"time"
@@ -169,6 +170,292 @@ func TestIngesterQuerying_ShouldSupportCompartments(t *testing.T) {
 	}
 }
 
+// TestStoreGatewayQuerying_ShouldSupportCompartments runs the compartments architecture end to end with
+// two read and two write compartments, and verifies queries served from the store-gateway (blocks) work
+// across it: series shipped to each read compartment's bucket are queried back through the compartment's
+// own store-gateway, and a query is fanned out only to the read compartments it targets.
+func TestStoreGatewayQuerying_ShouldSupportCompartments(t *testing.T) {
+	const (
+		numWriteCompartments = 2
+		numReadCompartments  = 2
+	)
+
+	s, err := e2e.NewScenario(networkName)
+	require.NoError(t, err)
+	defer s.Close()
+
+	baseFlags := mergeFlags(
+		BlocksStorageFlags(),
+		BlocksStorageS3Flags(),
+		IngestStorageFlags(e2edb.KafkaAuthNone),
+		CompartmentsFlags(numWriteCompartments, numReadCompartments),
+		map[string]string{
+			// Blocks are created only by the explicit flush below, so keep the head block range well above
+			// the test duration to avoid auto head-compaction splitting series across blocks (the idle
+			// timeout already defaults to 1h).
+			"-blocks-storage.tsdb.block-ranges-period": "1h",
+			// Process the flush-triggered compaction and ship the resulting block quickly.
+			"-blocks-storage.tsdb.head-compaction-interval": "1s",
+			"-blocks-storage.tsdb.ship-interval":            "1s",
+			// Sync shipped blocks into the store-gateway quickly.
+			"-blocks-storage.bucket-store.sync-interval": "1s",
+			// Force every query onto the store-gateway (never the ingester), so a result provably comes from blocks.
+			"-querier.query-ingesters-within": "1ms",
+			// Disable query sharding so each query is a single querier invocation, keeping the fan-out assertions crisp.
+			"-query-frontend.query-sharding-total-shards": "0",
+		},
+	)
+
+	// Start dependencies: Consul, MinIO, and one Kafka cluster per write compartment.
+	consul := e2edb.NewConsul()
+
+	// Each read compartment owns a dedicated blocks-storage bucket; create one per read compartment.
+	blocksBucketNameTemplate, compartmentBuckets := compartmentBlocksBucketNames(baseFlags["-blocks-storage.s3.bucket-name"], numReadCompartments)
+	minio := e2edb.NewMinio(9000, compartmentBuckets...)
+	require.NoError(t, s.StartAndWaitReady(consul, minio))
+
+	kafkas := make([]e2e.Service, numWriteCompartments)
+	for wc := range kafkas {
+		kafkas[wc] = e2edb.NewKafka(e2edb.WithKafkaName(fmt.Sprintf("kafka-wc-%d", wc)))
+	}
+	require.NoError(t, s.StartAndWaitReady(kafkas...))
+
+	// Start the query-scheduler and wire the query-frontend and querier to it.
+	queryScheduler := e2emimir.NewQueryScheduler("query-scheduler", baseFlags)
+	require.NoError(t, s.StartAndWaitReady(queryScheduler))
+	baseFlags = mergeFlags(baseFlags, map[string]string{
+		"-query-frontend.scheduler-address": queryScheduler.NetworkGRPCEndpoint(),
+		"-querier.scheduler-address":        queryScheduler.NetworkGRPCEndpoint(),
+	})
+
+	// One distributor per write compartment, each producing to its own Kafka cluster.
+	distributors := make([]*e2emimir.MimirService, numWriteCompartments)
+	for wc := range distributors {
+		distributors[wc] = e2emimir.NewDistributor(fmt.Sprintf("distributor-wc-%d", wc), consul.NetworkHTTPEndpoint(), mergeFlags(baseFlags, map[string]string{
+			"-distributor.write-compartment-id": strconv.Itoa(wc),
+		}))
+	}
+
+	// One ingester (partition 0) per read compartment, shipping its blocks to its own bucket.
+	ingesters := make([]*e2emimir.MimirService, numReadCompartments)
+	for rc := range ingesters {
+		ingesters[rc] = e2emimir.NewIngester(fmt.Sprintf("ingester-rc-%d-0", rc), consul.NetworkHTTPEndpoint(), mergeFlags(baseFlags, map[string]string{
+			"-ingester.read-compartment-id":  strconv.Itoa(rc),
+			"-blocks-storage.s3.bucket-name": compartmentBuckets[rc],
+		}))
+	}
+
+	// One compactor per read compartment, writing its bucket's index (which the querier's blocks finder needs).
+	compactors := make([]*e2emimir.MimirService, numReadCompartments)
+	for rc := range compactors {
+		compactors[rc] = e2emimir.NewCompactor(fmt.Sprintf("compactor-rc-%d", rc), consul.NetworkHTTPEndpoint(), mergeFlags(baseFlags, map[string]string{
+			"-compactor.read-compartment-id": strconv.Itoa(rc),
+			"-blocks-storage.s3.bucket-name": compartmentBuckets[rc],
+		}))
+	}
+
+	// One store-gateway per read compartment, reading its own bucket and registering into its own ring.
+	storeGateways := make([]*e2emimir.MimirService, numReadCompartments)
+	for rc := range storeGateways {
+		storeGateways[rc] = e2emimir.NewStoreGateway(fmt.Sprintf("store-gateway-rc-%d", rc), consul.NetworkHTTPEndpoint(), mergeFlags(baseFlags, map[string]string{
+			"-store-gateway.read-compartment-id": strconv.Itoa(rc),
+			"-blocks-storage.s3.bucket-name":     compartmentBuckets[rc],
+		}))
+	}
+
+	queryFrontend := e2emimir.NewQueryFrontend("query-frontend", consul.NetworkHTTPEndpoint(), baseFlags)
+	querier := e2emimir.NewQuerier("querier", consul.NetworkHTTPEndpoint(), mergeFlags(baseFlags, map[string]string{
+		// The querier reads every compartment's bucket, so it gets the placeholder template and resolves each
+		// compartment's bucket internally.
+		"-blocks-storage.s3.bucket-name": blocksBucketNameTemplate,
+	}))
+
+	mimirServices := []e2e.Service{queryFrontend, querier}
+	for _, d := range distributors {
+		mimirServices = append(mimirServices, d)
+	}
+	for _, i := range ingesters {
+		mimirServices = append(mimirServices, i)
+	}
+	for _, c := range compactors {
+		mimirServices = append(mimirServices, c)
+	}
+	for _, sg := range storeGateways {
+		mimirServices = append(mimirServices, sg)
+	}
+	require.NoError(t, s.StartAndWaitReady(mimirServices...))
+
+	// The ingester instance ring is shared across compartments, so the distributor and querier should
+	// see every ingester ACTIVE in it.
+	for _, svc := range []*e2emimir.MimirService{distributors[0], querier} {
+		require.NoErrorf(t, svc.WaitSumMetricsWithOptions(e2e.Equals(numReadCompartments), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+			labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
+			labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))),
+			"service: %s", svc.Name())
+	}
+
+	// Each read compartment has its own partition ring; wait until its partition is ACTIVE, observed from
+	// the components that route to it. Every distributor produces to each read compartment's partition, so
+	// all of them (not just one) must see it ACTIVE.
+	partitionRingWatchers := append([]*e2emimir.MimirService{querier, queryFrontend}, distributors...)
+	for rc := 0; rc < numReadCompartments; rc++ {
+		ringName := fmt.Sprintf("ingester-partitions-rc-%d", rc)
+		for _, svc := range partitionRingWatchers {
+			require.NoErrorf(t, svc.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_partition_ring_partitions"}, e2e.WithLabelMatchers(
+				labels.MustNewMatcher(labels.MatchEqual, "name", ringName),
+				labels.MustNewMatcher(labels.MatchEqual, "state", "Active"))),
+				"service: %s ring: %s", svc.Name(), ringName)
+		}
+	}
+
+	// Each read compartment has its own store-gateway ring; wait until the store-gateway is ACTIVE in it,
+	// observed both from the store-gateway itself and from the querier's per-compartment client ring.
+	for rc := 0; rc < numReadCompartments; rc++ {
+		require.NoErrorf(t, storeGateways[rc].WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+			labels.MustNewMatcher(labels.MatchEqual, "name", fmt.Sprintf("store-gateway-rc-%d", rc)),
+			labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))),
+			"read compartment: %d", rc)
+		require.NoErrorf(t, querier.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+			labels.MustNewMatcher(labels.MatchEqual, "name", fmt.Sprintf("store-gateway-client-rc-%d", rc)),
+			labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))),
+			"read compartment: %d", rc)
+	}
+
+	// Wait until the query-frontend has fetched the last produced offsets from every write compartment's
+	// Kafka cluster at least once. This avoids querying before the topics exist in every cluster.
+	waitQueryFrontendToFetchOffsetsPerWriteCompartment(t, queryFrontend, numWriteCompartments)
+
+	// Pick, per read compartment, one distinct metric name to produce through each write compartment.
+	router := compartments.NewRouter(numReadCompartments)
+	namesByCompartment := metricNamesPerCompartment(router, numReadCompartments, numWriteCompartments)
+
+	pushClients := make([]*e2emimir.Client, numWriteCompartments)
+	for wc := range pushClients {
+		client, err := e2emimir.NewClient(distributors[wc].HTTPEndpoint(), "", "", "", userID)
+		require.NoError(t, err)
+		pushClients[wc] = client
+	}
+
+	now := time.Now()
+	expectedVectors := map[string]model.Vector{}
+
+	for rc := 0; rc < numReadCompartments; rc++ {
+		for wc := 0; wc < numWriteCompartments; wc++ {
+			name := namesByCompartment[rc][wc]
+			series, expectedVector, _ := generateFloatSeries(name, now)
+
+			// Retry the push: right after a topic is auto-created, its partition leader may briefly be
+			// unavailable, which fails the produce with a 500.
+			client := pushClients[wc]
+			test.Poll(t, 10*time.Second, true, func() interface{} {
+				res, err := client.Push(series)
+				return err == nil && res.StatusCode == 200
+			})
+
+			expectedVectors[name] = expectedVector
+		}
+	}
+
+	// Wait until each read compartment's ingester has consumed all its series (one produced through each
+	// write compartment's Kafka cluster), then flush its head to a block and ship it. The created-series
+	// counter is cumulative, so it's a stable gate even once the series are compacted out of the head.
+	for rc := 0; rc < numReadCompartments; rc++ {
+		require.NoErrorf(t, ingesters[rc].WaitSumMetrics(e2e.Equals(numWriteCompartments), "cortex_ingester_memory_series_created_total"),
+			"read compartment: %d", rc)
+
+		flushIngesterBlocks(t, ingesters[rc])
+
+		require.NoErrorf(t, ingesters[rc].WaitSumMetrics(e2e.GreaterOrEqual(1), "cortex_ingester_shipper_uploads_total"),
+			"read compartment: %d", rc)
+	}
+
+	// Wait until each read compartment's store-gateway has loaded its one block. Each compartment reads a
+	// different bucket, so a store-gateway only ever loads its own compartment's block.
+	for rc := 0; rc < numReadCompartments; rc++ {
+		require.NoErrorf(t, storeGateways[rc].WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_bucket_store_blocks_loaded"}, e2e.WaitMissingMetrics),
+			"read compartment: %d", rc)
+	}
+
+	queryClient, err := e2emimir.NewClient("", queryFrontend.HTTPEndpoint(), "", "", userID)
+	require.NoError(t, err)
+	// The store-gateway query path (bucket-index load, block sync, index-header build) is slower than the
+	// 5s default, especially for the single-shot fan-out assertions below which aren't retried.
+	queryClient.SetTimeout(30 * time.Second)
+
+	// Query every series back through the query-frontend. Unlike the ingester read path (which is
+	// deterministic under strong read consistency), a block becomes queryable only once the compactor has
+	// written it into the per-tenant bucket index and the querier has loaded that index, both of which are
+	// asynchronous: until then the query returns an empty result rather than an error. Poll until the exact
+	// expected series is returned.
+	for name, expectedVector := range expectedVectors {
+		test.Poll(t, 30*time.Second, expectedVector, func() interface{} {
+			res, err := queryClient.Query(name, now)
+			if err != nil || res.Type() != model.ValVector {
+				return model.Vector(nil)
+			}
+			return res.(model.Vector)
+		})
+	}
+
+	// A query matching a single metric name is scoped to exactly one read compartment, so only that
+	// compartment's store-gateway is queried.
+	for rc := 0; rc < numReadCompartments; rc++ {
+		name := namesByCompartment[rc][0]
+
+		before := make([]float64, numReadCompartments)
+		for i := range storeGateways {
+			before[i] = storeGatewaySeriesRequests(t, storeGateways[i])
+		}
+		querierSumBefore, querierCountBefore := querierStoreGatewayCompartmentsHit(t, querier)
+
+		_, err := queryClient.Query(name, now)
+		require.NoErrorf(t, err, "metric: %s", name)
+
+		// The targeted compartment's store-gateway served one more Series request...
+		require.NoErrorf(t, storeGateways[rc].WaitSumMetricsWithOptions(e2e.Greater(before[rc]), []string{"cortex_request_duration_seconds"}, e2e.WithMetricCount, e2e.WithLabelMatchers(
+			labels.MustNewMatcher(labels.MatchEqual, "route", storeGatewaySeriesRoute)), e2e.WaitMissingMetrics),
+			"read compartment: %d", rc)
+
+		// ...while every other compartment's store-gateway was not queried at all.
+		for other := range storeGateways {
+			if other == rc {
+				continue
+			}
+			require.Equalf(t, before[other], storeGatewaySeriesRequests(t, storeGateways[other]),
+				"store-gateway of read compartment %d must not be queried for a query scoped to compartment %d", other, rc)
+		}
+
+		// The querier reports exactly one read compartment queried for this query.
+		querierSumAfter, querierCountAfter := querierStoreGatewayCompartmentsHit(t, querier)
+		require.Equal(t, querierCountBefore+1, querierCountAfter)
+		require.Equal(t, querierSumBefore+1, querierSumAfter)
+	}
+
+	// A query whose __name__ matcher can't be narrowed to a single compartment (a non-enumerable regexp)
+	// is fanned out to every read compartment's store-gateway.
+	{
+		before := make([]float64, numReadCompartments)
+		for i := range storeGateways {
+			before[i] = storeGatewaySeriesRequests(t, storeGateways[i])
+		}
+		querierSumBefore, querierCountBefore := querierStoreGatewayCompartmentsHit(t, querier)
+
+		_, err := queryClient.Query(`{__name__=~"compartment_series_.*"}`, now)
+		require.NoError(t, err)
+
+		for i := range storeGateways {
+			require.NoErrorf(t, storeGateways[i].WaitSumMetricsWithOptions(e2e.Greater(before[i]), []string{"cortex_request_duration_seconds"}, e2e.WithMetricCount, e2e.WithLabelMatchers(
+				labels.MustNewMatcher(labels.MatchEqual, "route", storeGatewaySeriesRoute)), e2e.WaitMissingMetrics),
+				"read compartment: %d", i)
+		}
+
+		// The querier reports every read compartment queried for this query.
+		querierSumAfter, querierCountAfter := querierStoreGatewayCompartmentsHit(t, querier)
+		require.Equal(t, querierCountBefore+1, querierCountAfter)
+		require.Equal(t, querierSumBefore+float64(numReadCompartments), querierSumAfter)
+	}
+}
+
 // compartmentBlocksBucketNames derives, from the base blocks-storage bucket name, the placeholder template
 // the querier resolves to read every read compartment's bucket, and the resolved bucket name of each read
 // compartment (the compartment's ingester ships to it and the querier reads it).
@@ -224,4 +511,35 @@ func waitQueryFrontendToFetchOffsetsPerWriteCompartment(t *testing.T, queryFront
 		}
 		return true
 	})
+}
+
+// storeGatewaySeriesRoute is the gRPC route label of the store-gateway Series endpoint.
+const storeGatewaySeriesRoute = "/gatewaypb.StoreGateway/Series"
+
+// flushIngesterBlocks triggers force-compaction of the ingester's TSDB head into a block and its shipping.
+// It runs asynchronously because the default 1s HTTP timeout is too short for a synchronous flush.
+func flushIngesterBlocks(t *testing.T, ingester *e2emimir.MimirService) {
+	res, err := e2e.DoGet("http://" + ingester.HTTPEndpoint() + "/ingester/flush")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNoContent, res.StatusCode)
+}
+
+// storeGatewaySeriesRequests returns the number of Series requests the store-gateway has served so far.
+func storeGatewaySeriesRequests(t *testing.T, storeGateway *e2emimir.MimirService) float64 {
+	sums, err := storeGateway.SumMetrics([]string{"cortex_request_duration_seconds"}, e2e.WithMetricCount, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "route", storeGatewaySeriesRoute)), e2e.SkipMissingMetrics)
+	require.NoError(t, err)
+	return sums[0]
+}
+
+// querierStoreGatewayCompartmentsHit returns the running sum and count of the querier's
+// cortex_querier_compartments_hit_per_query histogram for the store-gateway path: sum is the total number
+// of read compartments queried across all queries, count is the number of queries.
+func querierStoreGatewayCompartmentsHit(t *testing.T, querier *e2emimir.MimirService) (sum, count float64) {
+	matcher := e2e.WithLabelMatchers(labels.MustNewMatcher(labels.MatchEqual, "storage", "store-gateway"))
+	sums, err := querier.SumMetrics([]string{"cortex_querier_compartments_hit_per_query"}, matcher, e2e.SkipMissingMetrics)
+	require.NoError(t, err)
+	counts, err := querier.SumMetrics([]string{"cortex_querier_compartments_hit_per_query"}, e2e.WithMetricCount, matcher, e2e.SkipMissingMetrics)
+	require.NoError(t, err)
+	return sums[0], counts[0]
 }

--- a/integration/getting_started_with_gossiped_ring_test.go
+++ b/integration/getting_started_with_gossiped_ring_test.go
@@ -127,9 +127,7 @@ func runTestGettingStartedWithGossipedRing(t *testing.T, mimir1 *e2emimir.MimirS
 
 	// Flush blocks from ingesters to the store.
 	for _, instance := range []*e2emimir.MimirService{mimir1, mimir2} {
-		res, err := e2e.DoGet("http://" + instance.HTTPEndpoint() + "/ingester/flush")
-		require.NoError(t, err)
-		require.Equal(t, 204, res.StatusCode)
+		flushIngesterBlocks(t, instance)
 	}
 
 	// Given store-gateway blocks sharding is enabled with the default replication factor of 3,

--- a/pkg/querier/blocks_store_queryable.go
+++ b/pkg/querier/blocks_store_queryable.go
@@ -821,19 +821,27 @@ func (q *blocksStoreQuerier) targetCompartments(tenantID string, matchers []*lab
 
 // forEachCompartment runs fn for each targeted compartment. With a single target it runs inline (no
 // goroutine), so the compartments-disabled path is unchanged. With several, it runs them concurrently
-// and returns the first error, cancelling the in-flight siblings through the shared context.
+// and returns the first error, cancelling the in-flight siblings on error.
 func (q *blocksStoreQuerier) forEachCompartment(ctx context.Context, targets []int, fn func(ctx context.Context, c blocksStoreCompartment) error) error {
 	if len(targets) == 1 {
 		return fn(ctx, q.compartments[targets[0]])
 	}
 
-	g, gCtx := errgroup.WithContext(ctx)
+	// fn may open store-gateway streams that are read lazily after this returns, so the context passed to
+	// fn must outlive this call and only be cancelled on error, never on normal completion (mirrors the
+	// contract in fetchSeriesFromStores; errgroup.WithContext would cancel it when Wait returns).
+	ctx, cancel := context.WithCancelCause(ctx) //nolint:govet
+	g := &errgroup.Group{}
 	for _, c := range targets {
 		g.Go(func() error {
-			return fn(gCtx, q.compartments[c])
+			if err := fn(ctx, q.compartments[c]); err != nil {
+				cancel(err)
+				return err
+			}
+			return nil
 		})
 	}
-	return g.Wait()
+	return g.Wait() //nolint:govet // OK to return without cancelling ctx on success, see comment above.
 }
 
 // queryCompartmentsWithConsistencyCheck runs queryWithConsistencyCheck against each targeted compartment

--- a/pkg/querier/blocks_store_queryable_compartments_test.go
+++ b/pkg/querier/blocks_store_queryable_compartments_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -442,6 +443,79 @@ func TestBlocksStoreQuerier_Compartments_Select(t *testing.T) {
 		// The per-query store-gateway histogram is observed once for the whole fanned-out query, summed
 		// across the two compartments (one store-gateway each), not once per compartment.
 		assertStoreGatewayInstancesHit(t, reg, 1, 2)
+	})
+
+	t.Run("should keep store-gateway streams alive until their chunks are read", func(t *testing.T) {
+		// A query that fans out to more than one compartment queries them concurrently, but each
+		// store-gateway's chunks are read lazily, after Select has returned. The per-compartment queries
+		// must therefore run under a context that outlives the fan-out. The regression this guards against:
+		// giving them a context that is cancelled the moment the fan-out completes (e.g. the one from
+		// errgroup.WithContext, which cancels when Wait returns) aborts the still-open chunk streams, so
+		// reading any series' chunks fails the whole query with "query was cancelled". The store-gateway
+		// mocks below fail once their context is cancelled, like a real gRPC stream, so that regression
+		// reproduces here instead of being masked by mocks that ignore the context.
+		ctx := user.InjectOrgID(context.Background(), compartmentsTestTenant)
+		ctx = limiter.AddQueryLimiterToContext(ctx, limiter.NewQueryLimiter(0, 0, 0, 0, nil))
+		ctx = limiter.ContextWithNewUnlimitedMemoryConsumptionTracker(ctx)
+		ctx = limiter.ContextWithNewSeriesLabelsDeduplicator(ctx, limiter.NewSeriesDeduplicatorMetrics(prometheus.NewPedanticRegistry()))
+		_, ctx = stats.ContextWithEmptyStats(ctx)
+
+		block0 := ulid.MustNew(1, nil)
+		block1 := ulid.MustNew(2, nil)
+		seriesA := labels.FromStrings(model.MetricNameLabel, "metric_a")
+		seriesB := labels.FromStrings(model.MetricNameLabel, "metric_b")
+
+		// Non-testify finders: both compartments query concurrently (see stubBlocksFinder).
+		finders := []BlocksFinder{
+			&stubBlocksFinder{blocks: bucketindex.Blocks{{ID: block0}}, meta: &bucketindex.Metadata{}},
+			&stubBlocksFinder{blocks: bucketindex.Blocks{{ID: block1}}, meta: &bucketindex.Metadata{}},
+		}
+
+		stores := []BlocksStoreSet{
+			&blocksStoreSetMock{mockedResponses: []interface{}{
+				map[BlocksStoreClient][]ulid.ULID{
+					&storeGatewayClientMock{
+						remoteAddr: "1.1.1.1",
+						mockedSeriesResponses: newSeriesResponseBuilder().
+							addValue(seriesA, minT, 1).
+							addBlocks(block0).
+							build(),
+					}: {block0},
+				},
+			}},
+			&blocksStoreSetMock{mockedResponses: []interface{}{
+				map[BlocksStoreClient][]ulid.ULID{
+					&storeGatewayClientMock{
+						remoteAddr: "2.2.2.2",
+						mockedSeriesResponses: newSeriesResponseBuilder().
+							addValue(seriesB, minT, 2).
+							addBlocks(block1).
+							build(),
+					}: {block1},
+				},
+			}},
+		}
+
+		reg := prometheus.NewPedanticRegistry()
+		q := newCompartmentsTestQuerierWithFinders(finders, stores, reg, minT, maxT)
+
+		// A matcher that doesn't pin the metric name fans out to both compartments.
+		set := q.Select(ctx, true, &storage.SelectHints{Start: minT, End: maxT}, labels.MustNewMatcher(labels.MatchEqual, "job", "test"))
+		require.NoError(t, set.Err())
+
+		// Iterating reads each store-gateway stream's chunks lazily; this is where a prematurely cancelled
+		// stream fails.
+		var got []string
+		var it chunkenc.Iterator
+		for set.Next() {
+			it = set.At().Iterator(it)
+			for it.Next() != chunkenc.ValNone { //nolint:revive
+			}
+			require.NoError(t, it.Err())
+			got = append(got, set.At().Labels().String())
+		}
+		require.NoError(t, set.Err())
+		require.Equal(t, []string{seriesA.String(), seriesB.String()}, got)
 	})
 
 	t.Run("should stop on the first compartment error", func(t *testing.T) {

--- a/pkg/querier/blocks_store_queryable_test.go
+++ b/pkg/querier/blocks_store_queryable_test.go
@@ -3349,6 +3349,12 @@ func (m *storeGatewaySeriesClientMock) Recv() (*storepb.SeriesResponse, error) {
 	// Ensure some concurrency occurs.
 	time.Sleep(10 * time.Millisecond)
 
+	// Mirror a real gRPC stream, which fails once its context is cancelled. The querier reads a stream's
+	// chunks lazily, after the query returns, so cancelling the stream's context early will surface bugs.
+	if err := m.Context().Err(); err != nil {
+		return nil, err
+	}
+
 	if len(m.mockedResponses) == 0 {
 		return nil, io.EOF
 	}


### PR DESCRIPTION
#### What this PR does

While adding an integration test for querying blocks from the store-gateway under the (experimental, disabled-by-default) compartments architecture, the test surfaced a bug in the compartment-aware querier. **Fixing that bug is the focus of this PR**; the integration test is included to increase confidence.

When a query fans out to more than one read compartment, the querier reads each store-gateway's chunk streams **lazily — after the fan-out has returned**. `forEachCompartment` ran the per-compartment queries under an `errgroup.WithContext` context, which errgroup cancels as soon as `Wait()` returns. That cancelled the still-open store-gateway streams the instant the fan-out completed, so any multi-compartment query failed with `query was cancelled` when its chunks were read. Single-compartment queries — and every query when compartments are disabled — were unaffected, because they run inline with the caller's context.

The fix runs each compartment's query under a context that is cancelled only on error (preserving fail-fast), never on normal completion, so the streams outlive the fan-out. This mirrors the existing contract already documented in `fetchSeriesFromStores`.

Tests:
- A unit regression test (`TestBlocksStoreQuerier_Compartments_Select` → "should keep store-gateway streams alive until their chunks are read") reproduces the failure. The shared store-gateway stream mock now fails on a cancelled context, like a real gRPC stream, so the bug is reproduced rather than masked.
- The store-gateway integration test (`TestStoreGatewayQuerying_ShouldSupportCompartments`) that started this work.

Compartments are experimental and not enabled in any release, so no changelog entry is needed.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - not needed (experimental, disabled-by-default feature); `changelog-not-needed` label added.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
