### PR TITLE
block-builder-scheduler: final refactoring ahead of multi-cluster support

### DIFF
--- a/pkg/blockbuilder/scheduler/offset_scanner.go
+++ b/pkg/blockbuilder/scheduler/offset_scanner.go
@@ -25,6 +25,7 @@ type offsetTime struct {
 type offsetScanner struct {
 	// stores are indexed by clusterID.
 	stores  []offsetStore
+	topic   string
 	endTime time.Time
 	// probeTimes are the timestamps to query Kafka offsets at, in descending
 	// order so the scan stops once it reaches the partition's resume offset.
@@ -32,10 +33,11 @@ type offsetScanner struct {
 	recordTimeDelta prometheus.Observer
 }
 
-func newOffsetScanner(stores []offsetStore, endTime time.Time, jobSize, maxScanAge time.Duration, recordTimeDelta prometheus.Observer) *offsetScanner {
+func newOffsetScanner(stores []offsetStore, topic string, endTime time.Time, jobSize, maxScanAge time.Duration, recordTimeDelta prometheus.Observer) *offsetScanner {
 	minScanTime := endTime.Add(-maxScanAge)
 	return &offsetScanner{
 		stores:          stores,
+		topic:           topic,
 		endTime:         endTime,
 		probeTimes:      scanProbeTimes(endTime, jobSize, minScanTime),
 		recordTimeDelta: recordTimeDelta,
@@ -80,12 +82,12 @@ func (s *offsetScanner) probeSingleClusterOffsets(ctx context.Context, clusterID
 	// given a timestamp, so we iteratively call that API for each probe time
 	// until we reach the resume offset.
 	for _, pb := range s.probeTimes {
-		offset, t, isEndOffset, err := store.offsetAfterTime(ctx, po.topic, po.partition, pb)
+		offset, t, isEndOffset, err := store.offsetAfterTime(ctx, s.topic, po.partition, pb)
 		if err != nil {
 			return nil, err
 		}
 		level.Debug(logger).Log("msg", "found next boundary offset", "ts", pb,
-			"topic", po.topic, "partition", po.partition, "offset", offset, "isEndOffset", isEndOffset)
+			"topic", s.topic, "partition", po.partition, "offset", offset, "isEndOffset", isEndOffset)
 
 		// Don't want to probe for offsets before the resume offset.
 		offset = max(offset, po.resume)

--- a/pkg/blockbuilder/scheduler/offset_scanner_test.go
+++ b/pkg/blockbuilder/scheduler/offset_scanner_test.go
@@ -250,8 +250,8 @@ func TestProbeSingleClusterOffsets(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			f := &mockOffsetFinder{offsets: tt.offsets, end: tt.end, distinctTimes: make(map[time.Time]struct{})}
-			scanner := newOffsetScanner([]offsetStore{f}, tt.endTime, tt.jobSize, tt.endTime.Sub(tt.minScanTime), promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}))
-			j, err := scanner.probeSingleClusterOffsets(ctx, 0, partitionOffsets{topic: "topic", partition: 0, start: tt.start, resume: tt.resume, end: tt.end}, test.NewTestingLogger(t))
+			scanner := newOffsetScanner([]offsetStore{f}, "topic", tt.endTime, tt.jobSize, tt.endTime.Sub(tt.minScanTime), promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}))
+			j, err := scanner.probeSingleClusterOffsets(ctx, 0, partitionOffsets{partition: 0, start: tt.start, resume: tt.resume, end: tt.end}, test.NewTestingLogger(t))
 			assert.NoError(t, err)
 			assert.EqualValues(t, tt.expectedRanges, j, tt.msg)
 		})
@@ -263,12 +263,12 @@ func TestProbeInitialPartitionOffsets(t *testing.T) {
 	endTime := time.Date(2025, 3, 1, 13, 0, 0, 0, time.UTC)
 	at := func(h, m int) time.Time { return time.Date(2025, 3, 1, h, m, 0, 0, time.UTC) }
 	newScanner := func(stores []offsetStore) *offsetScanner {
-		return newOffsetScanner(stores, endTime, time.Hour, 13*time.Hour, promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}))
+		return newOffsetScanner(stores, "topic", endTime, time.Hour, 13*time.Hour, promauto.With(nil).NewHistogram(prometheus.HistogramOpts{}))
 	}
 	clusterOffsets := []*partitionOffsets{
-		{topic: "topic", partition: 0, resume: 100, end: 250},
-		{topic: "topic", partition: 0, resume: 1000, end: 1150},
-		{topic: "topic", partition: 0, resume: 5000, end: 5150},
+		{partition: 0, resume: 100, end: 250},
+		{partition: 0, resume: 1000, end: 1150},
+		{partition: 0, resume: 5000, end: 5150},
 	}
 	// probed is what probeSingleClusterOffsets yields for a store holding a single record at
 	// 10:07: the record itself, then the end-offset seed stamped at endTime.
@@ -295,9 +295,9 @@ func TestProbeInitialPartitionOffsets(t *testing.T) {
 			&mockOffsetFinder{offsets: []*offsetTime{{offset: 5000, time: at(10, 7)}}, end: 5150, distinctTimes: make(map[time.Time]struct{})},
 		}
 		clusterOffsets := []*partitionOffsets{
-			{topic: "topic", partition: 0, resume: 100, end: 250},
+			{partition: 0, resume: 100, end: 250},
 			nil,
-			{topic: "topic", partition: 0, resume: 5000, end: 5150},
+			{partition: 0, resume: 5000, end: 5150},
 		}
 
 		perCluster, err := newScanner(stores).probeInitialPartitionOffsets(ctx, clusterOffsets, test.NewTestingLogger(t))
@@ -450,6 +450,9 @@ type mockOffsetFinder struct {
 func (o *mockOffsetFinder) offsetAfterTime(_ context.Context, _ string, _ int32, t time.Time) (int64, time.Time, bool, error) {
 	if o.err != nil {
 		return 0, time.Time{}, false, o.err
+	}
+	if o.distinctTimes == nil {
+		o.distinctTimes = make(map[time.Time]struct{})
 	}
 	o.distinctTimes[t] = struct{}{}
 	// scan the offsets slice and return the lowest offset whose time is after t.

--- a/pkg/blockbuilder/scheduler/partition_state.go
+++ b/pkg/blockbuilder/scheduler/partition_state.go
@@ -90,7 +90,7 @@ func (s *partitionState) updateTime(ts time.Time, jobSize time.Duration) (*sched
 	case bucketBefore:
 		// New bucket is before our current one. This should only happen if our
 		// Kafka's end offsets aren't monotonically increasing.
-		return nil, fmt.Errorf("time went backwards: %s < %s (offsets: %s)", newJobBucket, s.jobBucket, s.offsetsSummary(false))
+		return nil, fmt.Errorf("time went backwards: %s < %s (offsets: %s)", newJobBucket, s.jobBucket, s.offsetsSummary(false, false))
 
 	case bucketSame:
 		// Observation is in the currently tracked bucket. No action needed.
@@ -202,7 +202,7 @@ func (s *partitionState) replayOffsetsAtStartup(perCluster [][]*offsetTime, jobS
 }
 
 // offsetsSummary returns a per-cluster offset summary for debugging.
-func (s *partitionState) offsetsSummary(includePlanned bool) string {
+func (s *partitionState) offsetsSummary(includeCommitted, includePlanned bool) string {
 	var b strings.Builder
 	for clusterID := range s.offsets {
 		if clusterID > 0 {
@@ -212,6 +212,9 @@ func (s *partitionState) offsetsSummary(includePlanned bool) string {
 			fmt.Fprintf(&b, "%d:", clusterID)
 		}
 		fmt.Fprintf(&b, "[%d,%d)", s.offsets[clusterID].startOffset, s.offsets[clusterID].endOffset)
+		if includeCommitted {
+			fmt.Fprintf(&b, " committed=%d", s.offsets[clusterID].committed.offset())
+		}
 		if includePlanned {
 			fmt.Fprintf(&b, " planned=%d", s.offsets[clusterID].planned.offset())
 		}
@@ -234,7 +237,7 @@ func (s *partitionState) addPlannedJob(id string, spec schedulerpb.JobSpec) {
 		// This shouldn't happen. All callers of addPlannedJob must do so in
 		// increasing offset order (for all clusters).
 		if s.offsets[clusterID].planned.beyondOffsetRange(offsetRange) {
-			panic(fmt.Sprintf("planned job %q for partition %d is behind the current planned offset: job=%v current=%s", id, s.partition, spec.Ranges(), s.offsetsSummary(true)))
+			panic(fmt.Sprintf("planned job %q for partition %d is behind the current planned offset: job=%v current=%s", id, s.partition, spec.Ranges(), s.offsetsSummary(false, true)))
 		}
 	}
 

--- a/pkg/blockbuilder/scheduler/scheduler.go
+++ b/pkg/blockbuilder/scheduler/scheduler.go
@@ -39,7 +39,7 @@ type BlockBuilderScheduler struct {
 	observations        obsMap
 	observationComplete bool
 
-	partState map[int32]*partitionState
+	partitionStates map[int32]*partitionState
 
 	// for synchronizing tests.
 	onScheduleUpdated func()
@@ -64,8 +64,8 @@ func New(
 		register: reg,
 		metrics:  newSchedulerMetrics(reg, compartmentsEnabled, numClusters),
 
-		observations: make(obsMap),
-		partState:    make(map[int32]*partitionState),
+		observations:    make(obsMap),
+		partitionStates: make(map[int32]*partitionState),
 
 		onScheduleUpdated: func() {},
 	}
@@ -73,7 +73,7 @@ func New(
 	return s, nil
 }
 
-func (s *BlockBuilderScheduler) starting(ctx context.Context) error {
+func (s *BlockBuilderScheduler) starting(_ context.Context) error {
 	kc, err := ingest.NewKafkaReaderClient(
 		s.cfg.Kafka,
 		ingest.NewKafkaReaderClientMetrics(ingest.ReaderMetricsPrefix, "block-builder-scheduler", s.register),
@@ -105,22 +105,12 @@ func (s *BlockBuilderScheduler) running(ctx context.Context) error {
 
 	observeComplete := time.After(s.cfg.StartupObserveTime)
 
-	c, err := s.fetchCommittedOffsets(ctx)
-	if err != nil {
+	if err := s.loadInitialCommittedOffsets(ctx); err != nil {
 		if errors.Is(err, context.Canceled) {
 			return nil
 		}
-		level.Error(s.logger).Log("msg", "failed to fetch committed offsets", "err", err)
-		s.metrics.fetchOffsetsFailed.Inc()
-		return fmt.Errorf("fetch committed offsets: %w", err)
+		return err
 	}
-	level.Info(s.logger).Log("msg", "loaded initial committed offsets", "offsets", offsetsStr(c))
-	s.mu.Lock()
-	c.Each(func(o kadm.Offset) {
-		ps := s.getPartitionState(o.Topic, o.Partition)
-		ps.initCommit(0, o.At)
-	})
-	s.mu.Unlock()
 
 	// Wait for StartupObserveTime to pass.
 	select {
@@ -162,6 +152,29 @@ func (s *BlockBuilderScheduler) running(ctx context.Context) error {
 	}
 }
 
+// loadInitialCommittedOffsets seeds each partition's committed offset from the committed
+// offsets, so startup recovery resumes from where the previous scheduler left off.
+func (s *BlockBuilderScheduler) loadInitialCommittedOffsets(ctx context.Context) error {
+	c, err := fetchCommittedOffsets(ctx, s.adminClient, s.cfg.ConsumerGroup, s.cfg.Kafka.Topic)
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return err
+		}
+		err = fmt.Errorf("fetch committed offsets: %w", err)
+		level.Error(s.logger).Log("msg", "failed to load initial committed offsets", "err", err)
+		s.metrics.fetchOffsetsFailed.Inc()
+		return err
+	}
+	level.Info(s.logger).Log("msg", "loaded initial committed offsets", "offsets", offsetsStr(c))
+	s.mu.Lock()
+	c.Each(func(o kadm.Offset) {
+		ps := s.getPartitionState(o.Topic, o.Partition)
+		ps.initCommit(0, o.At)
+	})
+	s.mu.Unlock()
+	return nil
+}
+
 // completeObservationMode transitions the scheduler from observation mode to normal operation.
 func (s *BlockBuilderScheduler) completeObservationMode(ctx context.Context) {
 	s.mu.Lock()
@@ -182,14 +195,14 @@ func (s *BlockBuilderScheduler) completeObservationMode(ctx context.Context) {
 	s.jobs = newJobQueue(s.cfg.JobLeaseExpiry, policy, s.cfg.JobFailuresAllowed, s.metrics, s.logger)
 	s.finalizeObservations()
 
-	consumeOffs, err := s.consumptionOffsets(ctx, s.cfg.Kafka.Topic, time.Now().Add(-s.cfg.LookbackOnNoCommit))
+	offsetsByPartition, err := s.initConsumptionOffsets(ctx, time.Now().Add(-s.cfg.LookbackOnNoCommit))
 	if err != nil {
 		level.Warn(s.logger).Log("msg", "failed to get consumption offsets", "err", err)
 		return
 	}
 
-	scanner := newOffsetScanner([]offsetStore{newOffsetFinder(s.adminClient)}, time.Now(), s.cfg.JobSize, s.cfg.MaxScanAge, s.metrics.probeRecordTimeDelta)
-	s.populateInitialJobs(ctx, consumeOffs, scanner)
+	scanner := newOffsetScanner([]offsetStore{newOffsetFinder(s.adminClient)}, s.cfg.Kafka.Topic, time.Now(), s.cfg.JobSize, s.cfg.MaxScanAge, s.metrics.probeRecordTimeDelta)
+	s.populateInitialJobs(ctx, offsetsByPartition, scanner)
 	s.observations = nil
 	s.observationComplete = true
 }
@@ -203,6 +216,7 @@ func (s *BlockBuilderScheduler) updateSchedule(ctx context.Context) {
 	}()
 
 	now := time.Now()
+
 	endOffsets, err := s.adminClient.ListEndOffsets(ctx, s.cfg.Kafka.Topic)
 	if err != nil {
 		level.Warn(s.logger).Log("msg", "failed to list end offsets", "err", err)
@@ -213,28 +227,41 @@ func (s *BlockBuilderScheduler) updateSchedule(ctx context.Context) {
 		return
 	}
 
+	touched := make(map[int32]struct{})
+	s.recordEndOffsets(endOffsets, touched)
+
+	// Advance the time bucket of each touched partition, enqueuing any job that rolled over.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for partition := range touched {
+		ps := s.getPartitionState(s.cfg.Kafka.Topic, partition)
+		job, err := ps.updateTime(now, s.cfg.JobSize)
+		if err != nil {
+			level.Warn(s.logger).Log("msg", "failed to update partition time", "err", err)
+			continue
+		}
+		if job != nil {
+			ps.addPendingJob(job)
+		}
+	}
+
+	s.metrics.outstandingJobs.Set(float64(s.jobs.count()))
+	s.metrics.assignedJobs.Set(float64(s.jobs.assigned()))
+}
+
+// recordEndOffsets records the end offsets into each partition's state, marking every partition
+// it touched so the caller can advance them once all offsets are recorded.
+func (s *BlockBuilderScheduler) recordEndOffsets(endOffsets kadm.ListedOffsets, touched map[int32]struct{}) {
 	endOffsets.Each(func(o kadm.ListedOffset) {
-		partStr := fmt.Sprint(o.Partition)
-		s.metrics.perClusterMetrics[0].endOffset.WithLabelValues(partStr).Set(float64(o.Offset))
+		s.metrics.perClusterMetrics[0].endOffset.WithLabelValues(fmt.Sprint(o.Partition)).Set(float64(o.Offset))
 
 		s.mu.Lock()
 		defer s.mu.Unlock()
 
 		ps := s.getPartitionState(o.Topic, o.Partition)
 		ps.updateEndOffset(0, o.Offset)
-		job, err := ps.updateTime(now, s.cfg.JobSize)
-
-		if err != nil {
-			level.Warn(s.logger).Log("msg", "failed to update partition time", "err", err)
-			return
-		}
-		if job != nil {
-			ps.addPendingJob(job)
-		}
+		touched[o.Partition] = struct{}{}
 	})
-
-	s.metrics.outstandingJobs.Set(float64(s.jobs.count()))
-	s.metrics.assignedJobs.Set(float64(s.jobs.assigned()))
 }
 
 // enqueuePendingJobsWorker is a worker method that enqueues pending jobs at a regular interval.
@@ -257,7 +284,7 @@ func (s *BlockBuilderScheduler) enqueuePendingJobsWorker(ctx context.Context) {
 // for assignment to workers, subject to the job creation policy.
 func (s *BlockBuilderScheduler) enqueuePendingJobs() {
 	s.mu.Lock()
-	pending := make(map[int32]int, len(s.partState))
+	pending := make(map[int32]int, len(s.partitionStates))
 
 	defer func() {
 		// Unlock the scheduler before populating metrics. Unblocks the concurrent goroutines a tiny bit faster.
@@ -271,7 +298,7 @@ func (s *BlockBuilderScheduler) enqueuePendingJobs() {
 	// For each partition, attempt to enqueue jobs until we run into a rejection
 	// from the job creation policy. Pending jobs are created in order of their
 	// offsets, therefore pulling from the front achieves the same.
-	for partition, ps := range s.partState {
+	for partition, ps := range s.partitionStates {
 		pending[partition] = ps.pendingJobs.Len()
 
 		for ps.pendingJobs.Len() > 0 {
@@ -283,12 +310,12 @@ func (s *BlockBuilderScheduler) enqueuePendingJobs() {
 			// older than our committed offset.
 			if ps.committedBeyondSpec(*spec) {
 				level.Info(s.logger).Log("msg", "ignoring pending job as it's behind the committed offset (expected at startup)",
-					"partition", partition, "start", spec.StartOffset, "end", spec.EndOffset, "committed", ps.committedOffset(0))
+					"partition", partition, "job", spec.RangesString(), "offsets", ps.offsetsSummary(true, false))
 				ps.pendingJobs.Remove(e)
 				continue
 			}
 
-			jobID := jobIDForSpec(false, spec)
+			jobID := jobIDForSpec(compartmentsEnabled, spec)
 			if err := s.jobs.add(jobID, *spec); err != nil {
 				if errors.Is(err, errJobCreationDisallowed) || errors.Is(err, errJobAlreadyExists) {
 					// We've hit the limit for this partition.
@@ -306,7 +333,7 @@ func (s *BlockBuilderScheduler) enqueuePendingJobs() {
 	}
 }
 
-func (s *BlockBuilderScheduler) populateInitialJobs(ctx context.Context, consumeOffs []partitionOffsets, scanner *offsetScanner) {
+func (s *BlockBuilderScheduler) populateInitialJobs(ctx context.Context, offsetsByPartition map[int32][]*partitionOffsets, scanner *offsetScanner) {
 	// (Note that the lock is already held because we're in startup mode.)
 
 	// While during normal operation we are periodically asking about every
@@ -317,40 +344,53 @@ func (s *BlockBuilderScheduler) populateInitialJobs(ctx context.Context, consume
 	// those two offsets and seeding the schedule by calling updateEndOffset and
 	// updateTime for each of them- just like we do during normal operation.
 
-	// A partition currently maps to a single cluster, so each entry is reconstructed as
-	// a one-cluster partition (its offsets sit at clusterID 0). Once consumptionOffsets
-	// returns per-cluster offsets, they can be grouped by partition and passed together.
-	for i := range consumeOffs {
-		off := &consumeOffs[i]
-		ps := s.getPartitionState(off.topic, off.partition)
-		perCluster, err := scanner.probeInitialPartitionOffsets(ctx, []*partitionOffsets{off}, s.logger)
+	// Each partition's clusters are probed and replayed together (clusterOffsets is indexed by
+	// cluster ID; a nil entry means the partition has no offsets on that cluster) so jobs are cut
+	// at boundaries aligned across all of the partition's clusters.
+	for partition, clusterOffsets := range offsetsByPartition {
+		perCluster, err := scanner.probeInitialPartitionOffsets(ctx, clusterOffsets, s.logger)
 		if err != nil {
-			level.Warn(s.logger).Log("msg", "failed to probe initial offsets", "partition", off.partition, "err", err)
+			level.Warn(s.logger).Log("msg", "failed to probe initial offsets", "partition", partition, "err", err)
 			continue
 		}
+		ps := s.getPartitionState(s.cfg.Kafka.Topic, partition)
 		ps.replayOffsetsAtStartup(perCluster, s.cfg.JobSize, s.logger)
 	}
 }
 
 func (s *BlockBuilderScheduler) getPartitionState(topic string, partition int32) *partitionState {
-	if ps, ok := s.partState[partition]; ok {
+	if ps, ok := s.partitionStates[partition]; ok {
 		return ps
 	}
 
 	ps := newPartitionState(topic, partition, numClusters, compartmentsEnabled, &s.metrics, s.logger)
-	s.partState[partition] = ps
+	s.partitionStates[partition] = ps
 	return ps
 }
 
 type partitionOffsets struct {
-	topic              string
 	partition          int32
 	start, resume, end int64
 }
 
-// consumptionOffsets returns the resumption and end offsets for each partition, falling back to the
-// fallbackTime if there is no planned offset for a partition.
-func (s *BlockBuilderScheduler) consumptionOffsets(ctx context.Context, topic string, fallbackTime time.Time) ([]partitionOffsets, error) {
+// initConsumptionOffsets probes the consumption offsets and groups them by partition. The
+// returned slice for each partition is indexed by cluster ID, currently a single cluster.
+func (s *BlockBuilderScheduler) initConsumptionOffsets(ctx context.Context, fallbackTime time.Time) (map[int32][]*partitionOffsets, error) {
+	consumeOffs, err := s.initSingleClusterConsumptionOffsets(ctx, s.cfg.Kafka.Topic, fallbackTime)
+	if err != nil {
+		return nil, err
+	}
+	offsetsByPartition := make(map[int32][]*partitionOffsets, len(consumeOffs))
+	for i := range consumeOffs {
+		po := &consumeOffs[i]
+		offsetsByPartition[po.partition] = []*partitionOffsets{po}
+	}
+	return offsetsByPartition, nil
+}
+
+// initSingleClusterConsumptionOffsets returns the resumption and end offsets for each partition,
+// falling back to the fallbackTime if there is no planned offset for a partition.
+func (s *BlockBuilderScheduler) initSingleClusterConsumptionOffsets(ctx context.Context, topic string, fallbackTime time.Time) ([]partitionOffsets, error) {
 	startOffsets, err := s.adminClient.ListStartOffsets(ctx, topic)
 	if err != nil {
 		return nil, fmt.Errorf("list start offsets: %w", err)
@@ -412,14 +452,13 @@ func (s *BlockBuilderScheduler) consumptionOffsets(ctx context.Context, topic st
 				return nil, fmt.Errorf("partition %d not found in end offsets for topic %s", partition, t)
 			}
 
-			level.Debug(s.logger).Log("msg", "consumptionOffsets", "topic", t, "partition", partition,
+			level.Debug(s.logger).Log("msg", "initSingleClusterConsumptionOffsets", "topic", t, "partition", partition,
 				"start", startOffset.At, "end", end.Offset, "consumeOffset", resumeOffset)
 
 			s.metrics.perClusterMetrics[0].startOffset.WithLabelValues(partStr).Set(float64(startOffset.At))
 			s.metrics.perClusterMetrics[0].endOffset.WithLabelValues(partStr).Set(float64(end.Offset))
 
 			offs = append(offs, partitionOffsets{
-				topic:     t,
 				partition: partition,
 				start:     startOffset.At,
 				resume:    resumeOffset,
@@ -431,9 +470,9 @@ func (s *BlockBuilderScheduler) consumptionOffsets(ctx context.Context, topic st
 	return offs, nil
 }
 
-// fetchCommittedOffsets fetches the committed offsets for the scheduler's consumer group.
-// It returns empty offsets if the consumer group is not found.
-func (s *BlockBuilderScheduler) fetchCommittedOffsets(ctx context.Context) (kadm.Offsets, error) {
+// fetchCommittedOffsets fetches the topic's committed offsets for the given consumer group on
+// the given cluster's Kafka. It returns empty offsets if the consumer group is not found.
+func fetchCommittedOffsets(ctx context.Context, adminClient *kadm.Client, consumerGroup, topic string) (kadm.Offsets, error) {
 	boff := backoff.New(ctx, backoff.Config{
 		MinBackoff: 100 * time.Millisecond,
 		MaxBackoff: 5 * time.Second,
@@ -442,7 +481,7 @@ func (s *BlockBuilderScheduler) fetchCommittedOffsets(ctx context.Context) (kadm
 	var lastErr error
 
 	for boff.Ongoing() {
-		offs, err := s.adminClient.FetchOffsets(ctx, s.cfg.ConsumerGroup)
+		offs, err := adminClient.FetchOffsets(ctx, consumerGroup)
 		if err != nil {
 			if !errors.Is(err, kerr.GroupIDNotFound) {
 				lastErr = fmt.Errorf("fetch offsets: %w", err)
@@ -461,6 +500,12 @@ func (s *BlockBuilderScheduler) fetchCommittedOffsets(ctx context.Context) (kadm
 
 		for _, ps := range offs {
 			for _, o := range ps {
+				// A write compartment's cluster hosts every read compartment's topic. The
+				// per-read-compartment consumer group should keep commits separate, but filter
+				// by topic too so another read compartment's commits can't seed our partition state.
+				if o.Topic != topic {
+					continue
+				}
 				committed.Add(kadm.Offset{
 					Topic:       o.Topic,
 					Partition:   o.Partition,
@@ -476,15 +521,15 @@ func (s *BlockBuilderScheduler) fetchCommittedOffsets(ctx context.Context) (kadm
 	return kadm.Offsets{}, lastErr
 }
 
-// snapOffsets returns a snapshot of the committed and planned offsets for all partitions.
-func (s *BlockBuilderScheduler) snapOffsets() (kadm.Offsets, kadm.Offsets) {
+// snapshotOffsets returns a snapshot of the committed and planned offsets for all partitions.
+func (s *BlockBuilderScheduler) snapshotOffsets() (kadm.Offsets, kadm.Offsets) {
 	cp := make(kadm.Offsets)
 	pp := make(kadm.Offsets)
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	for _, ps := range s.partState {
+	for _, ps := range s.partitionStates {
 		if !ps.committedEmpty(0) {
 			cp.AddOffset(ps.topic, ps.partition, ps.committedOffset(0), 0)
 		}
@@ -499,7 +544,7 @@ func (s *BlockBuilderScheduler) snapOffsets() (kadm.Offsets, kadm.Offsets) {
 // flushOffsetsToKafka flushes the committed offsets to Kafka and updates relevant metrics.
 func (s *BlockBuilderScheduler) flushOffsetsToKafka(ctx context.Context) error {
 	// TODO: only flush if dirty.
-	committed, planned := s.snapOffsets()
+	committed, planned := s.snapshotOffsets()
 
 	committed.Each(func(o kadm.Offset) {
 		s.metrics.perClusterMetrics[0].committedOffset.WithLabelValues(fmt.Sprint(o.Partition)).Set(float64(o.At))
@@ -573,8 +618,7 @@ func (s *BlockBuilderScheduler) assignJob(workerID string) (jobKey, schedulerpb.
 			// Job is before the committed offset. Remove it.
 			level.Info(s.logger).Log("msg", "removing job as it's behind the committed offset (expected at startup)",
 				"job_id", k.id, "epoch", k.epoch, "partition", spec.Partition,
-				"start_offset", spec.StartOffset, "end_offset", spec.EndOffset,
-				"committed", ps.committedOffset(0))
+				"job", spec.RangesString(), "offsets", ps.offsetsSummary(true, false))
 			s.jobs.removeJob(k)
 			continue
 		}
@@ -585,6 +629,9 @@ func (s *BlockBuilderScheduler) assignJob(workerID string) (jobKey, schedulerpb.
 
 // UpdateJob takes a job update from the client and records it, if necessary.
 func (s *BlockBuilderScheduler) UpdateJob(_ context.Context, req *schedulerpb.UpdateJobRequest) (*schedulerpb.UpdateJobResponse, error) {
+	if err := req.Spec.Validate(compartmentsEnabled, numClusters); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
 	k := jobKey{
 		id:    req.Key.Id,
 		epoch: req.Key.Epoch,
@@ -597,7 +644,7 @@ func (s *BlockBuilderScheduler) UpdateJob(_ context.Context, req *schedulerpb.Up
 
 func (s *BlockBuilderScheduler) updateJob(key jobKey, workerID string, complete bool, j schedulerpb.JobSpec) error {
 	logger := log.With(s.logger, "job_id", key.id, "epoch", key.epoch,
-		"worker", workerID, "start_offset", j.StartOffset, "end_offset", j.EndOffset)
+		"worker", workerID, "job", j.RangesString())
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -716,7 +763,7 @@ func (s *BlockBuilderScheduler) finalizeObservations() {
 				// We found a gap earlier. Skip and warn.
 				level.Warn(s.logger).Log("msg", "startup: skipping job import due to offset gap",
 					"partition", partition, "job_id", obs.key.id, "epoch", obs.key.epoch,
-					"start_offset", obs.spec.StartOffset, "end_offset", obs.spec.EndOffset)
+					"job", obs.spec.RangesString())
 				continue
 			}
 
@@ -724,7 +771,7 @@ func (s *BlockBuilderScheduler) finalizeObservations() {
 				// This job is wholly before the latest planned offset. Skip.
 				level.Warn(s.logger).Log("msg", "startup: skipping job before commit",
 					"partition", partition, "job_id", obs.key.id, "epoch", obs.key.epoch,
-					"start_offset", obs.spec.StartOffset, "end_offset", obs.spec.EndOffset)
+					"job", obs.spec.RangesString())
 				continue
 			}
 
@@ -732,8 +779,8 @@ func (s *BlockBuilderScheduler) finalizeObservations() {
 				// Found a gap, can't continue the contiguous range
 				contiguous = false
 				level.Warn(s.logger).Log("msg", "startup: skipping job due to detected offset gap",
-					"partition", partition, "job_id", obs.key.id, "start_offset", obs.spec.StartOffset,
-					"end_offset", obs.spec.EndOffset, "latest_planned_offset", ps.plannedOffset(0))
+					"partition", partition, "job_id", obs.key.id, "job", obs.spec.RangesString(),
+					"offsets", ps.offsetsSummary(false, true))
 				continue
 			}
 

--- a/pkg/blockbuilder/scheduler/scheduler_test.go
+++ b/pkg/blockbuilder/scheduler/scheduler_test.go
@@ -22,8 +22,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kfake"
 	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
+	"go.uber.org/atomic"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/grafana/mimir/pkg/blockbuilder/schedulerpb"
 	"github.com/grafana/mimir/pkg/storage/ingest"
@@ -171,7 +176,7 @@ func TestService(t *testing.T) {
 		require.NoError(t, sched.flushOffsetsToKafka(ctx))
 
 		// And our offsets should have advanced.
-		offs, err := sched.fetchCommittedOffsets(ctx)
+		offs, err := fetchCommittedOffsets(ctx, sched.adminClient, sched.cfg.ConsumerGroup, sched.cfg.Kafka.Topic)
 		require.NoError(t, err)
 		o, ok := offs.Lookup(spec.Topic, spec.Partition)
 		require.True(t, ok)
@@ -556,19 +561,19 @@ func TestObservations(t *testing.T) {
 	verifyCommits()
 
 	// Make sure the resumption offsets account for the gaps.
-	offs, err := sched.consumptionOffsets(context.Background(), "ingest", time.Now())
+	offs, err := sched.initSingleClusterConsumptionOffsets(context.Background(), "ingest", time.Now())
 	require.NoError(t, err)
 	require.ElementsMatch(t, []partitionOffsets{
-		{topic: "ingest", partition: 0, resume: 0},
-		{topic: "ingest", partition: 1, resume: 6000},
-		{topic: "ingest", partition: 2, resume: 1600},
-		{topic: "ingest", partition: 3, resume: 974},
-		{topic: "ingest", partition: 4, resume: 900},
-		{topic: "ingest", partition: 5, resume: 13000},
-		{topic: "ingest", partition: 6, resume: 600},
-		{topic: "ingest", partition: 7, resume: 93874},
-		{topic: "ingest", partition: 8, resume: 1300},
-		{topic: "ingest", partition: 9, resume: 1300},
+		{partition: 0, resume: 0},
+		{partition: 1, resume: 6000},
+		{partition: 2, resume: 1600},
+		{partition: 3, resume: 974},
+		{partition: 4, resume: 900},
+		{partition: 5, resume: 13000},
+		{partition: 6, resume: 600},
+		{partition: 7, resume: 93874},
+		{partition: 8, resume: 1300},
+		{partition: 9, resume: 1300},
 	}, offs)
 
 	require.Len(t, sched.jobs.jobs, 4, "should be 4 in-progress jobs")
@@ -635,7 +640,7 @@ func TestKafkaFlush(t *testing.T) {
 	flushAndRequireOffsets := func(topic string, offsets map[int32]int64, args ...any) {
 		require.NoError(t, sched.flushOffsetsToKafka(ctx))
 
-		offs, err := sched.fetchCommittedOffsets(ctx)
+		offs, err := fetchCommittedOffsets(ctx, sched.adminClient, sched.cfg.ConsumerGroup, sched.cfg.Kafka.Topic)
 		require.NoError(t, err)
 		offcount := 0
 		offs.Each(func(o kadm.Offset) {
@@ -734,6 +739,177 @@ func TestUpdateSchedule(t *testing.T) {
 	`), "cortex_blockbuilder_scheduler_partition_end_offset"))
 }
 
+// TestUpdateSchedule_ProbeFailure verifies that a failed end-offset probe abandons the tick,
+// leaving partition state untouched and enqueuing no jobs, and that the next successful tick
+// picks up where the failed one left off.
+func TestUpdateSchedule_ProbeFailure(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { cancel(errors.New("test done")) })
+
+	var vnet kfake.VirtualNetwork
+	cluster, kafkaAddr := testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, 1, "ingest", testkafka.WithVirtualNetwork(&vnet))
+	sched, cli := mustSchedulerWithKafkaAddrAndDialer(t, kafkaAddr, vnet.DialContext)
+	sched.completeObservationMode(ctx)
+
+	produceRecords(ctx, t, cli, 0, 3)
+	stopFailing := failListOffsets(cluster)
+
+	sched.updateSchedule(ctx)
+
+	ps := sched.getPartitionState("ingest", 0)
+	require.Equal(t, int64(0), ps.offsets[0].endOffset, "a failed probe should leave the end offset at its startup value")
+	require.Equal(t, 0, ps.pendingJobs.Len(), "a failed probe should not enqueue jobs")
+
+	stopFailing()
+	sched.updateSchedule(ctx)
+	require.Equal(t, int64(3), ps.offsets[0].endOffset, "the next successful probe should record the produced records")
+}
+
+// TestLoadInitialCommittedOffsets verifies that the consumer group's committed offsets seed
+// each partition's state, and that commits for other topics in the group don't pollute it.
+func TestLoadInitialCommittedOffsets(t *testing.T) {
+	sched, _ := mustScheduler(t, 2)
+	ctx := t.Context()
+	admin := sched.adminClient
+
+	_, err := admin.CreateTopic(ctx, 1, 1, nil, "other-topic")
+	require.NoError(t, err)
+
+	offs := make(kadm.Offsets)
+	offs.AddOffset("ingest", 0, 42, -1)
+	offs.AddOffset("ingest", 1, 64, -1)
+	offs.AddOffset("other-topic", 0, 99, -1)
+	require.NoError(t, admin.CommitAllOffsets(ctx, sched.cfg.ConsumerGroup, offs))
+
+	require.NoError(t, sched.loadInitialCommittedOffsets(ctx))
+
+	sched.requireOffset(t, "ingest", 0, 42, "partition 0 should be seeded from its committed offset")
+	sched.requireOffset(t, "ingest", 1, 64, "partition 1 should be seeded from its committed offset")
+	require.Len(t, sched.partitionStates, 2, "foreign topic commits should not seed partition state")
+}
+
+// TestFetchCommittedOffsets_IgnoresForeignTopics verifies that committed offsets for other
+// topics in the consumer group are filtered out, so they can't seed partition state.
+func TestFetchCommittedOffsets_IgnoresForeignTopics(t *testing.T) {
+	sched, _ := mustScheduler(t, 1)
+	ctx := t.Context()
+	admin := sched.adminClient
+
+	_, err := admin.CreateTopic(ctx, 1, 1, nil, "other-topic")
+	require.NoError(t, err)
+
+	offs := make(kadm.Offsets)
+	offs.AddOffset("ingest", 0, 42, -1)
+	offs.AddOffset("other-topic", 0, 99, -1)
+	require.NoError(t, admin.CommitAllOffsets(ctx, sched.cfg.ConsumerGroup, offs))
+
+	got, err := fetchCommittedOffsets(ctx, admin, sched.cfg.ConsumerGroup, "ingest")
+	require.NoError(t, err)
+	o, ok := got.Lookup("ingest", 0)
+	require.True(t, ok)
+	require.Equal(t, int64(42), o.At)
+	_, ok = got.Lookup("other-topic", 0)
+	require.False(t, ok, "foreign topic offsets should be filtered out")
+}
+
+// TestUpdateJob_ValidatesSpec verifies that specs arriving over the UpdateJob RPC are validated
+// before use, so a malformed spec (e.g. an out-of-range cluster ID in its offset ranges) is
+// rejected instead of panicking the scheduler.
+func TestUpdateJob_ValidatesSpec(t *testing.T) {
+	tests := map[string]struct {
+		spec         *schedulerpb.JobSpec
+		expectedCode codes.Code
+	}{
+		"disabled accepts start/end offsets": {
+			spec:         &schedulerpb.JobSpec{Topic: "ingest", Partition: 0, StartOffset: 5, EndOffset: 10},
+			expectedCode: codes.OK,
+		},
+		"disabled rejects offset ranges": {
+			spec: &schedulerpb.JobSpec{Topic: "ingest", Partition: 0,
+				OffsetRanges: map[int32]schedulerpb.OffsetRange{1: {StartOffset: 5, EndOffset: 10}}},
+			expectedCode: codes.InvalidArgument,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			sched, _ := mustScheduler(t, 1)
+
+			_, err := sched.UpdateJob(t.Context(), &schedulerpb.UpdateJobRequest{
+				Key:      &schedulerpb.JobKey{Id: "job/0/1", Epoch: 1},
+				WorkerId: "w0",
+				Spec:     tc.spec,
+			})
+			if tc.expectedCode == codes.OK {
+				require.NoError(t, err)
+				return
+			}
+			require.Equal(t, tc.expectedCode, status.Code(err))
+		})
+	}
+}
+
+// TestPopulateInitialJobs_GroupedByPartition verifies the partition-grouped input contract:
+// every partition in the map is probed and replayed independently, a partition with new data
+// gets a pending job covering [resume, end), and a dormant partition (resume == end) registers
+// its end offset without producing a job.
+func TestPopulateInitialJobs_GroupedByPartition(t *testing.T) {
+	sched, _ := mustScheduler(t, 2)
+	recordTime := time.Date(2025, 3, 1, 10, 30, 0, 0, time.UTC)
+	finder := &mockOffsetFinder{offsets: []*offsetTime{{offset: 100, time: recordTime}}, end: 200}
+
+	runPopulateInitialJobs(sched, finder, map[int32][]*partitionOffsets{
+		0: {{partition: 0, start: 100, resume: 100, end: 200}},
+		1: {{partition: 1, start: 500, resume: 700, end: 700}},
+	})
+
+	ps0 := sched.getPartitionState("ingest", 0)
+	require.Equal(t, 1, ps0.pendingJobs.Len(), "the partition with new data should get one job")
+	spec := ps0.pendingJobs.Front().Value.(*schedulerpb.JobSpec)
+	require.Equal(t, int64(100), spec.StartOffset)
+	require.Equal(t, int64(200), spec.EndOffset)
+
+	ps1 := sched.getPartitionState("ingest", 1)
+	require.Equal(t, 0, ps1.pendingJobs.Len(), "the dormant partition should get no job")
+	require.Equal(t, int64(700), ps1.offsets[0].endOffset, "the dormant partition's end offset should still be registered")
+}
+
+// TestPopulateInitialJobs_NilClusterEntry verifies that a nil entry in a partition's cluster
+// slice (the partition has no offsets on that cluster) is skipped without panicking or
+// producing a job.
+func TestPopulateInitialJobs_NilClusterEntry(t *testing.T) {
+	sched, _ := mustScheduler(t, 1)
+
+	runPopulateInitialJobs(sched, &mockOffsetFinder{}, map[int32][]*partitionOffsets{
+		0: {nil},
+	})
+
+	ps := sched.getPartitionState("ingest", 0)
+	require.Equal(t, 0, ps.pendingJobs.Len())
+	require.Equal(t, int64(offsetEmpty), ps.offsets[0].endOffset, "a nil cluster entry should leave the partition's offsets untouched")
+}
+
+// TestPopulateInitialJobs_ProbeErrorIsolation verifies that a probe failure on one partition
+// only skips that partition: other partitions in the same call are still replayed.
+func TestPopulateInitialJobs_ProbeErrorIsolation(t *testing.T) {
+	sched, _ := mustScheduler(t, 2)
+	finder := &mockOffsetFinder{err: errors.New("probe failed")}
+
+	// Partition 0 has new data, so it needs a probe, which fails. Partition 1 is dormant
+	// (resume == end), which needs no probe.
+	runPopulateInitialJobs(sched, finder, map[int32][]*partitionOffsets{
+		0: {{partition: 0, start: 100, resume: 100, end: 200}},
+		1: {{partition: 1, start: 500, resume: 700, end: 700}},
+	})
+
+	ps0 := sched.getPartitionState("ingest", 0)
+	require.Equal(t, 0, ps0.pendingJobs.Len(), "the failing partition should be skipped")
+	require.Equal(t, int64(offsetEmpty), ps0.offsets[0].endOffset, "the failing partition's offsets should be untouched")
+
+	ps1 := sched.getPartitionState("ingest", 1)
+	require.Equal(t, int64(700), ps1.offsets[0].endOffset, "the other partition should still be replayed")
+}
+
 func TestPopulateInitialJobs_ProbeTimesReused(t *testing.T) {
 	// Ensure that the probe times are reused across partitions, which is a
 	// necessary condition for cached offset reuse in the offsetFinder.
@@ -750,16 +926,16 @@ func TestPopulateInitialJobs_ProbeTimesReused(t *testing.T) {
 		distinctTimes: make(map[time.Time]struct{}),
 	}
 
-	consumeOffs := []partitionOffsets{
-		{topic: "topic", partition: 0, start: 100, resume: 100, end: 1000},
-		{topic: "topic", partition: 1, start: 100, resume: 100, end: 1000},
-		{topic: "topic", partition: 2, start: 100, resume: 100, end: 1000},
-		{topic: "topic", partition: 3, start: 100, resume: 100, end: 1000},
+	offsetsByPartition := map[int32][]*partitionOffsets{
+		0: {{partition: 0, start: 100, resume: 100, end: 1000}},
+		1: {{partition: 1, start: 100, resume: 100, end: 1000}},
+		2: {{partition: 2, start: 100, resume: 100, end: 1000}},
+		3: {{partition: 3, start: 100, resume: 100, end: 1000}},
 	}
 
 	endTime := time.Date(2025, 3, 1, 11, 0, 0, 0, time.UTC)
-	scanner := newOffsetScanner([]offsetStore{finder}, endTime, sched.cfg.JobSize, sched.cfg.MaxScanAge, sched.metrics.probeRecordTimeDelta)
-	sched.populateInitialJobs(context.Background(), consumeOffs, scanner)
+	scanner := newOffsetScanner([]offsetStore{finder}, "ingest", endTime, sched.cfg.JobSize, sched.cfg.MaxScanAge, sched.metrics.probeRecordTimeDelta)
+	sched.populateInitialJobs(context.Background(), offsetsByPartition, scanner)
 	require.Len(t, finder.distinctTimes, 4, "four partitions will each be probed at the same times, so the probe times should be shared across partitions")
 }
 
@@ -1203,24 +1379,25 @@ func TestStartupToRegularModeJobProduction(t *testing.T) {
 				distinctTimes: make(map[time.Time]struct{}),
 			}
 
-			consumeOffs := []partitionOffsets{
-				{
-					topic:     "topic",
-					partition: 0,
-					start:     tt.initialStart,
-					resume:    tt.initialResume,
-					end:       tt.initialEnd,
+			offsetsByPartition := map[int32][]*partitionOffsets{
+				0: {
+					{
+						partition: 0,
+						start:     tt.initialStart,
+						resume:    tt.initialResume,
+						end:       tt.initialEnd,
+					},
 				},
 			}
 
 			// Call populateInitialJobs to set up initial state
-			scanner := newOffsetScanner([]offsetStore{finder}, tt.initialTime, sched.cfg.JobSize, sched.cfg.MaxScanAge, sched.metrics.probeRecordTimeDelta)
-			sched.populateInitialJobs(context.Background(), consumeOffs, scanner)
+			scanner := newOffsetScanner([]offsetStore{finder}, "ingest", tt.initialTime, sched.cfg.JobSize, sched.cfg.MaxScanAge, sched.metrics.probeRecordTimeDelta)
+			sched.populateInitialJobs(context.Background(), offsetsByPartition, scanner)
 
 			collectedJobs := []*schedulerpb.JobSpec{}
 
 			// Apply future end offset observations and collect jobs returned from updateTime
-			ps := sched.getPartitionState("topic", 0)
+			ps := sched.getPartitionState("ingest", 0)
 
 			for _, obs := range tt.futureObservations {
 				ps.updateEndOffset(0, obs.offset)
@@ -1257,5 +1434,56 @@ func TestStartupToRegularModeJobProduction(t *testing.T) {
 					i, current.EndOffset, next.StartOffset)
 			}
 		})
+	}
+}
+
+// runPopulateInitialJobs runs populateInitialJobs over a scanner backed by finder, with 1h
+// JobSize/MaxScanAge and buckets ending at 2025-03-01 11:00 UTC.
+func runPopulateInitialJobs(sched *BlockBuilderScheduler, finder offsetStore, offsetsByPartition map[int32][]*partitionOffsets) {
+	sched.cfg.MaxScanAge = 1 * time.Hour
+	sched.cfg.JobSize = 1 * time.Hour
+	endTime := time.Date(2025, 3, 1, 11, 0, 0, 0, time.UTC)
+	scanner := newOffsetScanner([]offsetStore{finder}, "ingest", endTime, sched.cfg.JobSize, sched.cfg.MaxScanAge, sched.metrics.probeRecordTimeDelta)
+	sched.populateInitialJobs(context.Background(), offsetsByPartition, scanner)
+}
+
+// failListOffsets makes the cluster answer ListOffsets requests with UNKNOWN_SERVER_ERROR
+// until the returned stop function is called.
+func failListOffsets(cluster *kfake.Cluster) (stop func()) {
+	failing := atomic.NewBool(true)
+	cluster.ControlKey(kmsg.ListOffsets.Int16(), func(req kmsg.Request) (kmsg.Response, error, bool) {
+		cluster.KeepControl()
+		if !failing.Load() {
+			return nil, nil, false
+		}
+		listR := req.(*kmsg.ListOffsetsRequest)
+		resp := req.ResponseKind().(*kmsg.ListOffsetsResponse)
+		resp.Default()
+		for _, reqTopic := range listR.Topics {
+			respTopic := kmsg.ListOffsetsResponseTopic{Topic: reqTopic.Topic}
+			for _, reqPartition := range reqTopic.Partitions {
+				respTopic.Partitions = append(respTopic.Partitions, kmsg.ListOffsetsResponseTopicPartition{
+					Partition: reqPartition.Partition,
+					ErrorCode: kerr.UnknownServerError.Code,
+				})
+			}
+			resp.Topics = append(resp.Topics, respTopic)
+		}
+		return resp, nil, true
+	})
+	return func() { failing.Store(false) }
+}
+
+// produceRecords produces n records to the given partition of the "ingest" topic.
+func produceRecords(ctx context.Context, t *testing.T, cli *kgo.Client, partition int32, n int) {
+	t.Helper()
+	for i := range n {
+		produceResult := cli.ProduceSync(ctx, &kgo.Record{
+			Timestamp: time.Unix(int64(i), 0),
+			Value:     []byte("value"),
+			Topic:     "ingest",
+			Partition: partition,
+		})
+		require.NoError(t, produceResult.FirstErr())
 	}
 }

--- a/pkg/blockbuilder/schedulerpb/custom.go
+++ b/pkg/blockbuilder/schedulerpb/custom.go
@@ -5,6 +5,8 @@ package schedulerpb
 import (
 	"errors"
 	"fmt"
+	"slices"
+	"strings"
 )
 
 // Ranges returns the offset ranges to consume keyed by cluster ID. In non-compartment mode,
@@ -14,6 +16,28 @@ func (m JobSpec) Ranges() map[int32]OffsetRange {
 		return m.OffsetRanges
 	}
 	return map[int32]OffsetRange{0: {StartOffset: m.StartOffset, EndOffset: m.EndOffset}}
+}
+
+// RangesString returns a compact, log-friendly rendering of the offset ranges. In non-compartment
+// mode it is "[start,end)"; in compartment mode it is "clusterID:[start,end)" per cluster, sorted
+// by cluster ID (e.g. "0:[100,200) 1:[500,700)").
+func (m JobSpec) RangesString() string {
+	if len(m.OffsetRanges) == 0 {
+		return fmt.Sprintf("[%d,%d)", m.StartOffset, m.EndOffset)
+	}
+	clusters := make([]int32, 0, len(m.OffsetRanges))
+	for clusterID := range m.OffsetRanges {
+		clusters = append(clusters, clusterID)
+	}
+	slices.Sort(clusters)
+	var b strings.Builder
+	for i, clusterID := range clusters {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprintf(&b, "%d:[%d,%d)", clusterID, m.OffsetRanges[clusterID].StartOffset, m.OffsetRanges[clusterID].EndOffset)
+	}
+	return b.String()
 }
 
 func (m JobSpec) Validate(compartmentsEnabled bool, numCompartments int) error {

--- a/pkg/blockbuilder/schedulerpb/custom_test.go
+++ b/pkg/blockbuilder/schedulerpb/custom_test.go
@@ -36,6 +36,31 @@ func TestJobSpec_Ranges(t *testing.T) {
 	}
 }
 
+func TestJobSpec_RangesString(t *testing.T) {
+	tests := map[string]struct {
+		spec     JobSpec
+		expected string
+	}{
+		"non-compartment renders a single range without a cluster prefix": {
+			spec:     JobSpec{StartOffset: 42, EndOffset: 100},
+			expected: "[42,100)",
+		},
+		"compartment renders one range per cluster, sorted by cluster ID": {
+			spec: JobSpec{OffsetRanges: map[int32]OffsetRange{
+				1: {StartOffset: 500, EndOffset: 700},
+				0: {StartOffset: 100, EndOffset: 200},
+			}},
+			expected: "0:[100,200) 1:[500,700)",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.expected, tc.spec.RangesString())
+		})
+	}
+}
+
 func TestJobSpec_Validate(t *testing.T) {
 	const numCompartments = 4
 


### PR DESCRIPTION
Part of the per-compartment block-builders work, a final refactoring before wiring up compartments support. This PR keeps the scheduler on a single Kafka cluster, so behavior is unchanged apart from the two defensive fixes called out below.

This is stacked on #15938. The follow-up will be #15774.

Notable changes:

- `updateSchedule` records end offsets into partition state via the extracted `recordEndOffsets` and only then advances partition time, so the follow-up can record every cluster's offsets before cutting a job that bundles all of them.
- `consumptionOffsets` is renamed to `initSingleClusterConsumptionOffsets` and wrapped by `initConsumptionOffsets`, which groups the probed offsets by partition into per-cluster slices (a single entry for now) — the shape `populateInitialJobs` needs to probe and replay all of a partition's clusters together.
- `partitionOffsets` loses its `topic` field. This was mostly motivated by [this part of the code](https://github.com/grafana/mimir/blob/6d65f77656c38f4b97fa32d7b2ce10f459ae31e1/pkg/blockbuilder/scheduler/scheduler.go#L354-L355), where we want all the `partitionOffsets` for the same partition to be processed at the same time and run through the same `partitionState`'s `replayOffsetsAtStartup()` method at the same time, so we need a singular topic for all offsets.
- `loadInitialCommittedOffsets` is extracted from `running()` and owns its error logging and metric; `fetchCommittedOffsets` becomes a standalone function taking the admin client.
- Defensive fix: `fetchCommittedOffsets` filters the consumer group's commits by topic. A write compartment's cluster hosts every read compartment's topic, so another read compartment's commits must not seed our partition state.
- Defensive fix: `UpdateJob` validates incoming specs and rejects malformed ones with InvalidArgument, instead of risking a panic on an out-of-range cluster ID once specs carry per-cluster ranges.
- `JobSpec.RangesString()` renders offset ranges compactly for logs, and `offsetsSummary` can now include committed offsets.
- Renames for clarity: `partState` → `partitionStates`, `snapOffsets` → `snapshotOffsets`.