### PR TITLE
Helm: support revisionHistoryLimit on StatefulSet components

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -33,6 +33,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [CHANGE] Querier: Reduce the default concurrency of queriers, `querier.max_concurrent`, to 8. #15984
 * [BUGFIX] Fix bug in `ScaledObject` templates when using `kedaAutoscaling.fallback` #15793
 * [ENHANCEMENT] Add support for `revisionHistoryLimit` on StatefulSet-based components: `alertmanager`, `ingester`, `store_gateway`, `compactor`, and the `chunks-cache`, `index-cache`, `metadata-cache`, and `results-cache` memcached StatefulSets. Previously `revisionHistoryLimit` was only honored on Deployment-based components. #PR
+* [ENHANCEMENT] Add support for `revisionHistoryLimit` on StatefulSet-based components: `alertmanager`, `ingester`, `store_gateway`, `compactor`, and the `chunks-cache`, `index-cache`, `metadata-cache`, and `results-cache` memcached StatefulSets. Previously `revisionHistoryLimit` was only honored on Deployment-based components. #15950
 * [BUGFIX]: Fix bug in `ScaledObject` templates when using `kedaAutoscaling.fallback` #15793
 
 ## 6.1.0

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -32,6 +32,8 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 * [CHANGE] Querier: Reduce the default concurrency of queriers, `querier.max_concurrent`, to 8. #15984
 * [BUGFIX] Fix bug in `ScaledObject` templates when using `kedaAutoscaling.fallback` #15793
+* [ENHANCEMENT] Add support for `revisionHistoryLimit` on StatefulSet-based components: `alertmanager`, `ingester`, `store_gateway`, `compactor`, and the `chunks-cache`, `index-cache`, `metadata-cache`, and `results-cache` memcached StatefulSets. Previously `revisionHistoryLimit` was only honored on Deployment-based components. #PR
+* [BUGFIX]: Fix bug in `ScaledObject` templates when using `kedaAutoscaling.fallback` #15793
 
 ## 6.1.0
 

--- a/operations/helm/charts/mimir-distributed/ci/offline/test-revisionhistorylimit-values.yaml
+++ b/operations/helm/charts/mimir-distributed/ci/offline/test-revisionhistorylimit-values.yaml
@@ -24,3 +24,31 @@ ruler_query_scheduler:
 
 ruler:
   revisionHistoryLimit: 3
+
+alertmanager:
+  revisionHistoryLimit: 3
+
+ingester:
+  revisionHistoryLimit: 3
+
+store_gateway:
+  revisionHistoryLimit: 3
+
+compactor:
+  revisionHistoryLimit: 3
+
+chunks-cache:
+  enabled: true
+  revisionHistoryLimit: 3
+
+index-cache:
+  enabled: true
+  revisionHistoryLimit: 3
+
+metadata-cache:
+  enabled: true
+  revisionHistoryLimit: 3
+
+results-cache:
+  enabled: true
+  revisionHistoryLimit: 3

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -31,6 +31,9 @@ spec:
     whenDeleted: {{ .Values.alertmanager.persistentVolume.whenDeleted }}
     whenScaled: {{ .Values.alertmanager.persistentVolume.whenScaled }}
   {{- end }}
+  {{- with .Values.alertmanager.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "mimir.selectorLabels" $args | nindent 6 }}

--- a/operations/helm/charts/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -16,6 +16,9 @@ spec:
     whenScaled: {{ .Values.compactor.persistentVolume.whenScaled }}
   {{- end }}
   replicas: {{ .Values.compactor.replicas }}
+  {{- with .Values.compactor.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "mimir.selectorLabels" (dict "ctx" . "component" "compactor" "memberlist" true) | nindent 6 }}

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -36,6 +36,9 @@ spec:
     whenDeleted: {{ .Values.ingester.persistentVolume.whenDeleted }}
     whenScaled: {{ .Values.ingester.persistentVolume.whenScaled }}
   {{- end }}
+  {{- with .Values.ingester.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "mimir.selectorLabels" $args | nindent 6 }}

--- a/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-statefulset.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-statefulset.tpl
@@ -17,6 +17,9 @@ spec:
   podManagementPolicy: {{ .podManagementPolicy }}
   minReadySeconds: {{ .minReadySeconds }}
   replicas: {{ .replicas }}
+  {{- with .revisionHistoryLimit }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "mimir.selectorLabels" (dict "ctx" $.ctx "component" $.component) | nindent 6 }}

--- a/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -36,6 +36,9 @@ spec:
     whenDeleted: {{ .Values.store_gateway.persistentVolume.whenDeleted }}
     whenScaled: {{ .Values.store_gateway.persistentVolume.whenScaled }}
   {{- end }}
+  {{- with .Values.store_gateway.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "mimir.selectorLabels" $args | nindent 6 }}

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -915,6 +915,7 @@ ingester:
   # Otherwise each zone starts `ceil(replicas / number_of_zones)` number of pods.
   #   E.g. if 'replicas' is set to 4 and there are 3 zones, then 4/3=1.33 and after rounding up it means 2 pods per zone are started.
   replicas: 3
+  revisionHistoryLimit: null
 
   statefulSet:
     enabled: true
@@ -2121,6 +2122,7 @@ store_gateway:
   # Otherwise each zone starts `ceil(replicas / number_of_zones)` number of pods.
   #   E.g. if 'replicas' is set to 4 and there are 3 zones, then 4/3=1.33 and after rounding up it means 2 pods per zone are started.
   replicas: 1
+  revisionHistoryLimit: null
 
   service:
     annotations: {}
@@ -2387,6 +2389,7 @@ compactor:
     # tag: 3.0.0
 
   replicas: 1
+  revisionHistoryLimit: null
 
   service:
     annotations: {}
@@ -2587,6 +2590,9 @@ chunks-cache:
   # -- Total number of chunks-cache replicas
   replicas: 1
 
+  # -- Number of old ReplicaSets to retain to allow rollback (if not set, the default Kubernetes value is set to 10)
+  revisionHistoryLimit: null
+
   # -- Port of the chunks-cache service
   port: 11211
 
@@ -2691,6 +2697,9 @@ index-cache:
 
   # -- Total number of index-cache replicas
   replicas: 1
+
+  # -- Number of old ReplicaSets to retain to allow rollback (if not set, the default Kubernetes value is set to 10)
+  revisionHistoryLimit: null
 
   # -- Port of the index-cache service
   port: 11211
@@ -2797,6 +2806,9 @@ metadata-cache:
   # -- Total number of metadata-cache replicas
   replicas: 1
 
+  # -- Number of old ReplicaSets to retain to allow rollback (if not set, the default Kubernetes value is set to 10)
+  revisionHistoryLimit: null
+
   # -- Port of the metadata-cache service
   port: 11211
 
@@ -2901,6 +2913,9 @@ results-cache:
 
   # -- Total number of results-cache replicas
   replicas: 1
+
+  # -- Number of old ReplicaSets to retain to allow rollback (if not set, the default Kubernetes value is set to 10)
+  revisionHistoryLimit: null
 
   # -- Port of the results-cache service
   port: 11211

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -15,6 +15,7 @@ metadata:
   namespace: "citestns"
 spec:
   replicas: 1
+  revisionHistoryLimit: 3
   selector:
     matchLabels:
       app.kubernetes.io/name: mimir

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-pdb.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/chunks-cache/chunks-cache-pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: test-revisionhistorylimit-values-mimir-chunks-cache
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-revisionhistorylimit-values
+    app.kubernetes.io/component: chunks-cache
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-revisionhistorylimit-values
+      app.kubernetes.io/component: chunks-cache
+  maxUnavailable: 1

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
@@ -1,0 +1,98 @@
+---
+# Source: mimir-distributed/templates/chunks-cache/chunks-cache-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-revisionhistorylimit-values-mimir-chunks-cache
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-revisionhistorylimit-values
+    app.kubernetes.io/component: memcached
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  podManagementPolicy: Parallel
+  minReadySeconds: 60
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-revisionhistorylimit-values
+      app.kubernetes.io/component: chunks-cache
+  updateStrategy:
+    type: RollingUpdate
+  serviceName: test-revisionhistorylimit-values-mimir-chunks-cache
+
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-revisionhistorylimit-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: chunks-cache
+      annotations:
+
+    spec:
+      serviceAccountName: test-revisionhistorylimit-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      
+      terminationGracePeriodSeconds: 30
+      volumes:
+      containers:
+        - name: memcached
+          image: memcached:1.6.39-alpine
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              memory: 9830Mi
+            requests:
+              cpu: 500m
+              memory: 9830Mi
+          ports:
+            - containerPort: 11211
+              name: client
+          args:
+            - -m 8192
+            - --extended=modern
+            - -I 1m
+            - -c 16384
+            - -v
+            - -u 11211
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+        - name: exporter
+          image: prom/memcached-exporter:v0.15.3
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9150
+              name: http-metrics
+          args:
+            - "--memcached.address=localhost:11211"
+            - "--web.listen-address=0.0.0.0:9150"
+          resources:
+            limits:
+              memory: 250Mi
+            requests:
+              cpu: 50m
+              memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-svc-headless.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/chunks-cache/chunks-cache-svc-headless.yaml
@@ -1,0 +1,31 @@
+---
+# Source: mimir-distributed/templates/chunks-cache/chunks-cache-svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-revisionhistorylimit-values-mimir-chunks-cache
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-revisionhistorylimit-values
+    app.kubernetes.io/component: chunks-cache
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: memcached-client
+      port: 11211
+      targetPort: 11211
+    
+    - name: http-metrics
+      port: 9150
+      targetPort: 9150
+    
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-revisionhistorylimit-values
+    app.kubernetes.io/component: chunks-cache
+

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -16,6 +16,7 @@ metadata:
 spec:
   podManagementPolicy: OrderedReady
   replicas: 1
+  revisionHistoryLimit: 3
   selector:
     matchLabels:
       app.kubernetes.io/name: mimir

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/index-cache/index-cache-pdb.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/index-cache/index-cache-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/index-cache/index-cache-pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: test-revisionhistorylimit-values-mimir-index-cache
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-revisionhistorylimit-values
+    app.kubernetes.io/component: index-cache
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-revisionhistorylimit-values
+      app.kubernetes.io/component: index-cache
+  maxUnavailable: 1

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
@@ -1,0 +1,98 @@
+---
+# Source: mimir-distributed/templates/index-cache/index-cache-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-revisionhistorylimit-values-mimir-index-cache
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-revisionhistorylimit-values
+    app.kubernetes.io/component: memcached
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  podManagementPolicy: Parallel
+  minReadySeconds: 60
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-revisionhistorylimit-values
+      app.kubernetes.io/component: index-cache
+  updateStrategy:
+    type: RollingUpdate
+  serviceName: test-revisionhistorylimit-values-mimir-index-cache
+
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-revisionhistorylimit-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: index-cache
+      annotations:
+
+    spec:
+      serviceAccountName: test-revisionhistorylimit-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      
+      terminationGracePeriodSeconds: 30
+      volumes:
+      containers:
+        - name: memcached
+          image: memcached:1.6.39-alpine
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              memory: 2458Mi
+            requests:
+              cpu: 500m
+              memory: 2458Mi
+          ports:
+            - containerPort: 11211
+              name: client
+          args:
+            - -m 2048
+            - --extended=modern
+            - -I 5m
+            - -c 16384
+            - -v
+            - -u 11211
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+        - name: exporter
+          image: prom/memcached-exporter:v0.15.3
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9150
+              name: http-metrics
+          args:
+            - "--memcached.address=localhost:11211"
+            - "--web.listen-address=0.0.0.0:9150"
+          resources:
+            limits:
+              memory: 250Mi
+            requests:
+              cpu: 50m
+              memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/index-cache/index-cache-svc-headless.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/index-cache/index-cache-svc-headless.yaml
@@ -1,0 +1,31 @@
+---
+# Source: mimir-distributed/templates/index-cache/index-cache-svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-revisionhistorylimit-values-mimir-index-cache
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-revisionhistorylimit-values
+    app.kubernetes.io/component: index-cache
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: memcached-client
+      port: 11211
+      targetPort: 11211
+    
+    - name: http-metrics
+      port: 9150
+      targetPort: 9150
+    
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-revisionhistorylimit-values
+    app.kubernetes.io/component: index-cache
+

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -23,6 +23,7 @@ metadata:
 spec:
   podManagementPolicy: Parallel
   replicas: 1
+  revisionHistoryLimit: 3
   selector:
     matchLabels:
       app.kubernetes.io/name: mimir
@@ -163,6 +164,7 @@ metadata:
 spec:
   podManagementPolicy: Parallel
   replicas: 1
+  revisionHistoryLimit: 3
   selector:
     matchLabels:
       app.kubernetes.io/name: mimir
@@ -303,6 +305,7 @@ metadata:
 spec:
   podManagementPolicy: Parallel
   replicas: 1
+  revisionHistoryLimit: 3
   selector:
     matchLabels:
       app.kubernetes.io/name: mimir

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-pdb.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/metadata-cache/metadata-cache-pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: test-revisionhistorylimit-values-mimir-metadata-cache
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-revisionhistorylimit-values
+    app.kubernetes.io/component: metadata-cache
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-revisionhistorylimit-values
+      app.kubernetes.io/component: metadata-cache
+  maxUnavailable: 1

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
@@ -1,0 +1,98 @@
+---
+# Source: mimir-distributed/templates/metadata-cache/metadata-cache-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-revisionhistorylimit-values-mimir-metadata-cache
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-revisionhistorylimit-values
+    app.kubernetes.io/component: memcached
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  podManagementPolicy: Parallel
+  minReadySeconds: 60
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-revisionhistorylimit-values
+      app.kubernetes.io/component: metadata-cache
+  updateStrategy:
+    type: RollingUpdate
+  serviceName: test-revisionhistorylimit-values-mimir-metadata-cache
+
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-revisionhistorylimit-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: metadata-cache
+      annotations:
+
+    spec:
+      serviceAccountName: test-revisionhistorylimit-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      
+      terminationGracePeriodSeconds: 30
+      volumes:
+      containers:
+        - name: memcached
+          image: memcached:1.6.39-alpine
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              memory: 614Mi
+            requests:
+              cpu: 500m
+              memory: 614Mi
+          ports:
+            - containerPort: 11211
+              name: client
+          args:
+            - -m 512
+            - --extended=modern
+            - -I 1m
+            - -c 16384
+            - -v
+            - -u 11211
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+        - name: exporter
+          image: prom/memcached-exporter:v0.15.3
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9150
+              name: http-metrics
+          args:
+            - "--memcached.address=localhost:11211"
+            - "--web.listen-address=0.0.0.0:9150"
+          resources:
+            limits:
+              memory: 250Mi
+            requests:
+              cpu: 50m
+              memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-svc-headless.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/metadata-cache/metadata-cache-svc-headless.yaml
@@ -1,0 +1,31 @@
+---
+# Source: mimir-distributed/templates/metadata-cache/metadata-cache-svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-revisionhistorylimit-values-mimir-metadata-cache
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-revisionhistorylimit-values
+    app.kubernetes.io/component: metadata-cache
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: memcached-client
+      port: 11211
+      targetPort: 11211
+    
+    - name: http-metrics
+      port: 9150
+      targetPort: 9150
+    
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-revisionhistorylimit-values
+    app.kubernetes.io/component: metadata-cache
+

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -30,6 +30,26 @@ data:
     blocks_storage:
       backend: s3
       bucket_store:
+        chunks_cache:
+          backend: memcached
+          memcached:
+            addresses: dnssrvnoa+test-revisionhistorylimit-values-mimir-chunks-cache.citestns.svc.cluster.local.:11211
+            max_idle_connections: 150
+            max_item_size: 1048576
+            timeout: 750ms
+        index_cache:
+          backend: memcached
+          memcached:
+            addresses: dnssrvnoa+test-revisionhistorylimit-values-mimir-index-cache.citestns.svc.cluster.local.:11211
+            max_idle_connections: 150
+            max_item_size: 5242880
+            timeout: 750ms
+        metadata_cache:
+          backend: memcached
+          memcached:
+            addresses: dnssrvnoa+test-revisionhistorylimit-values-mimir-metadata-cache.citestns.svc.cluster.local.:11211
+            max_idle_connections: 150
+            max_item_size: 1048576
         sync_dir: /data/tsdb-sync
       s3:
         access_key_id: grafana-mimir
@@ -59,7 +79,15 @@ data:
         heartbeat_period: 1m
         heartbeat_timeout: 4m
     frontend:
+      cache_results: true
       parallelize_shardable_queries: true
+      query_sharding_target_series_per_shard: 2500
+      results_cache:
+        backend: memcached
+        memcached:
+          addresses: dnssrvnoa+test-revisionhistorylimit-values-mimir-results-cache.citestns.svc.cluster.local.:11211
+          max_item_size: 26214400
+          timeout: 500ms
       scheduler_address: test-revisionhistorylimit-values-mimir-query-scheduler-headless.citestns.svc:9095
     frontend_worker:
       grpc_client_config:
@@ -105,6 +133,12 @@ data:
       rule_path: /data
     ruler_storage:
       backend: s3
+      cache:
+        backend: memcached
+        memcached:
+          addresses: dnssrvnoa+test-revisionhistorylimit-values-mimir-metadata-cache.citestns.svc.cluster.local.:11211
+          max_item_size: 1048576
+          timeout: 500ms
       s3:
         access_key_id: grafana-mimir
         bucket_name: mimir-ruler

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/results-cache/results-cache-pdb.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/results-cache/results-cache-pdb.yaml
@@ -1,0 +1,19 @@
+---
+# Source: mimir-distributed/templates/results-cache/results-cache-pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: test-revisionhistorylimit-values-mimir-results-cache
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-revisionhistorylimit-values
+    app.kubernetes.io/component: results-cache
+    app.kubernetes.io/managed-by: Helm
+  namespace: "citestns"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-revisionhistorylimit-values
+      app.kubernetes.io/component: results-cache
+  maxUnavailable: 1

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
@@ -1,0 +1,98 @@
+---
+# Source: mimir-distributed/templates/results-cache/results-cache-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-revisionhistorylimit-values-mimir-results-cache
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-revisionhistorylimit-values
+    app.kubernetes.io/component: memcached
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  podManagementPolicy: Parallel
+  minReadySeconds: 60
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mimir
+      app.kubernetes.io/instance: test-revisionhistorylimit-values
+      app.kubernetes.io/component: results-cache
+  updateStrategy:
+    type: RollingUpdate
+  serviceName: test-revisionhistorylimit-values-mimir-results-cache
+
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mimir
+        app.kubernetes.io/instance: test-revisionhistorylimit-values
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: results-cache
+      annotations:
+
+    spec:
+      serviceAccountName: test-revisionhistorylimit-values-mimir
+      securityContext:
+        fsGroup: 10001
+        runAsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      
+      terminationGracePeriodSeconds: 30
+      volumes:
+      containers:
+        - name: memcached
+          image: memcached:1.6.39-alpine
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              memory: 614Mi
+            requests:
+              cpu: 500m
+              memory: 614Mi
+          ports:
+            - containerPort: 11211
+              name: client
+          args:
+            - -m 512
+            - --extended=modern
+            - -I 25m
+            - -c 16384
+            - -v
+            - -u 11211
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+        - name: exporter
+          image: prom/memcached-exporter:v0.15.3
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9150
+              name: http-metrics
+          args:
+            - "--memcached.address=localhost:11211"
+            - "--web.listen-address=0.0.0.0:9150"
+          resources:
+            limits:
+              memory: 250Mi
+            requests:
+              cpu: 50m
+              memory: 50Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/results-cache/results-cache-svc-headless.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/results-cache/results-cache-svc-headless.yaml
@@ -1,0 +1,31 @@
+---
+# Source: mimir-distributed/templates/results-cache/results-cache-svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-revisionhistorylimit-values-mimir-results-cache
+  labels:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-revisionhistorylimit-values
+    app.kubernetes.io/component: results-cache
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
+  namespace: "citestns"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: memcached-client
+      port: 11211
+      targetPort: 11211
+    
+    - name: http-metrics
+      port: 9150
+      targetPort: 9150
+    
+  selector:
+    app.kubernetes.io/name: mimir
+    app.kubernetes.io/instance: test-revisionhistorylimit-values
+    app.kubernetes.io/component: results-cache
+

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -23,6 +23,7 @@ metadata:
 spec:
   podManagementPolicy: OrderedReady
   replicas: 1
+  revisionHistoryLimit: 3
   selector:
     matchLabels:
       app.kubernetes.io/name: mimir
@@ -164,6 +165,7 @@ metadata:
 spec:
   podManagementPolicy: OrderedReady
   replicas: 1
+  revisionHistoryLimit: 3
   selector:
     matchLabels:
       app.kubernetes.io/name: mimir
@@ -305,6 +307,7 @@ metadata:
 spec:
   podManagementPolicy: OrderedReady
   replicas: 1
+  revisionHistoryLimit: 3
   selector:
     matchLabels:
       app.kubernetes.io/name: mimir


### PR DESCRIPTION
## What this PR does

`revisionHistoryLimit` was added to the `mimir-distributed` chart in #12323, but only for **Deployment**-based components. This PR wires the same field through all **StatefulSet**-based components so they reach parity (matching the `tempo-distributed` and `loki`/`loki-distributed` charts, which already support it on their StatefulSets):

- `alertmanager`, `ingester`, `store-gateway`, `compactor`
- `chunks-cache`, `index-cache`, `metadata-cache`, `results-cache` (via the shared `mimir.memcached.statefulSet` helper)

It uses the same idiom as the Deployments:

```yaml
{{- with .Values.<component>.revisionHistoryLimit }}
revisionHistoryLimit: {{ . }}
{{- end }}
```

so the field is omitted from the manifest when unset. The default stays `null` for every component, so this is a no-op for existing installs.

## Changes

- Templates: add the `revisionHistoryLimit` block to the four StatefulSet templates and the memcached StatefulSet helper.
- `values.yaml`: add `revisionHistoryLimit: null` for `ingester`, `store_gateway`, `compactor`, and the four caches (`alertmanager` already had the key).
- `ci/offline/test-revisionhistorylimit-values.yaml`: set `revisionHistoryLimit` on all the new components. The caches are enabled here so the memcached StatefulSet path is actually exercised in the golden records — this is why the fixture's `mimir-config.yaml` and cache PDB/headless-service manifests also appear in the diff.
- Regenerated golden records via `make build-helm-tests`.
- CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)