### PR TITLE
Jsonnet: add per-compartment memcached

### DIFF
--- a/operations/mimir-tests/test-compartments-generated.yaml
+++ b/operations/mimir-tests/test-compartments-generated.yaml
@@ -124,53 +124,157 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: memcached
-  name: memcached
+    name: memcached-frontend-zone-a
+  name: memcached-frontend-zone-a
   namespace: default
 spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-      name: memcached
+      name: memcached-frontend-zone-a
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: memcached-frontend
-  name: memcached-frontend
+    name: memcached-frontend-zone-b
+  name: memcached-frontend-zone-b
   namespace: default
 spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-      name: memcached-frontend
+      name: memcached-frontend-zone-b
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: memcached-index-queries
-  name: memcached-index-queries
+    name: memcached-index-queries-zone-a-rc-0
+  name: memcached-index-queries-zone-a-rc-0
   namespace: default
 spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-      name: memcached-index-queries
+      name: memcached-index-queries-zone-a-rc-0
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: memcached-metadata
-  name: memcached-metadata
+    name: memcached-index-queries-zone-a-rc-1
+  name: memcached-index-queries-zone-a-rc-1
   namespace: default
 spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-      name: memcached-metadata
+      name: memcached-index-queries-zone-a-rc-1
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: memcached-index-queries-zone-b-rc-0
+  name: memcached-index-queries-zone-b-rc-0
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: memcached-index-queries-zone-b-rc-0
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: memcached-index-queries-zone-b-rc-1
+  name: memcached-index-queries-zone-b-rc-1
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: memcached-index-queries-zone-b-rc-1
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: memcached-metadata-zone-a
+  name: memcached-metadata-zone-a
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: memcached-metadata-zone-a
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: memcached-metadata-zone-b
+  name: memcached-metadata-zone-b
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: memcached-metadata-zone-b
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: memcached-zone-a-rc-0
+  name: memcached-zone-a-rc-0
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: memcached-zone-a-rc-0
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: memcached-zone-a-rc-1
+  name: memcached-zone-a-rc-1
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: memcached-zone-a-rc-1
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: memcached-zone-b-rc-0
+  name: memcached-zone-b-rc-0
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: memcached-zone-b-rc-0
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: memcached-zone-b-rc-1
+  name: memcached-zone-b-rc-1
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: memcached-zone-b-rc-1
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -742,8 +846,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    name: memcached
-  name: memcached
+    name: memcached-frontend-zone-a
+  name: memcached-frontend-zone-a
   namespace: default
 spec:
   clusterIP: None
@@ -755,14 +859,14 @@ spec:
     port: 9150
     targetPort: 9150
   selector:
-    name: memcached
+    name: memcached-frontend-zone-a
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    name: memcached-frontend
-  name: memcached-frontend
+    name: memcached-frontend-zone-b
+  name: memcached-frontend-zone-b
   namespace: default
 spec:
   clusterIP: None
@@ -774,14 +878,14 @@ spec:
     port: 9150
     targetPort: 9150
   selector:
-    name: memcached-frontend
+    name: memcached-frontend-zone-b
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    name: memcached-index-queries
-  name: memcached-index-queries
+    name: memcached-index-queries-zone-a-rc-0
+  name: memcached-index-queries-zone-a-rc-0
   namespace: default
 spec:
   clusterIP: None
@@ -793,14 +897,14 @@ spec:
     port: 9150
     targetPort: 9150
   selector:
-    name: memcached-index-queries
+    name: memcached-index-queries-zone-a-rc-0
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    name: memcached-metadata
-  name: memcached-metadata
+    name: memcached-index-queries-zone-a-rc-1
+  name: memcached-index-queries-zone-a-rc-1
   namespace: default
 spec:
   clusterIP: None
@@ -812,7 +916,178 @@ spec:
     port: 9150
     targetPort: 9150
   selector:
-    name: memcached-metadata
+    name: memcached-index-queries-zone-a-rc-1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: memcached-index-queries-zone-b-rc-0
+  name: memcached-index-queries-zone-b-rc-0
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: memcached-client
+    port: 11211
+    targetPort: 11211
+  - name: exporter-http-metrics
+    port: 9150
+    targetPort: 9150
+  selector:
+    name: memcached-index-queries-zone-b-rc-0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: memcached-index-queries-zone-b-rc-1
+  name: memcached-index-queries-zone-b-rc-1
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: memcached-client
+    port: 11211
+    targetPort: 11211
+  - name: exporter-http-metrics
+    port: 9150
+    targetPort: 9150
+  selector:
+    name: memcached-index-queries-zone-b-rc-1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: memcached-metadata-multi-zone
+  name: memcached-metadata-multi-zone
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: memcached-client
+    port: 11211
+    protocol: TCP
+    targetPort: 11211
+  selector:
+    cache-group: metadata
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: memcached-metadata-zone-a
+  name: memcached-metadata-zone-a
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: memcached-client
+    port: 11211
+    targetPort: 11211
+  - name: exporter-http-metrics
+    port: 9150
+    targetPort: 9150
+  selector:
+    cache-group: metadata
+    name: memcached-metadata-zone-a
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: memcached-metadata-zone-b
+  name: memcached-metadata-zone-b
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: memcached-client
+    port: 11211
+    targetPort: 11211
+  - name: exporter-http-metrics
+    port: 9150
+    targetPort: 9150
+  selector:
+    cache-group: metadata
+    name: memcached-metadata-zone-b
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: memcached-zone-a-rc-0
+  name: memcached-zone-a-rc-0
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: memcached-client
+    port: 11211
+    targetPort: 11211
+  - name: exporter-http-metrics
+    port: 9150
+    targetPort: 9150
+  selector:
+    name: memcached-zone-a-rc-0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: memcached-zone-a-rc-1
+  name: memcached-zone-a-rc-1
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: memcached-client
+    port: 11211
+    targetPort: 11211
+  - name: exporter-http-metrics
+    port: 9150
+    targetPort: 9150
+  selector:
+    name: memcached-zone-a-rc-1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: memcached-zone-b-rc-0
+  name: memcached-zone-b-rc-0
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: memcached-client
+    port: 11211
+    targetPort: 11211
+  - name: exporter-http-metrics
+    port: 9150
+    targetPort: 9150
+  selector:
+    name: memcached-zone-b-rc-0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: memcached-zone-b-rc-1
+  name: memcached-zone-b-rc-1
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: memcached-client
+    port: 11211
+    targetPort: 11211
+  - name: exporter-http-metrics
+    port: 9150
+    targetPort: 9150
+  selector:
+    name: memcached-zone-b-rc-1
 ---
 apiVersion: v1
 kind: Service
@@ -2560,7 +2835,7 @@ spec:
         - -compactor.ring.wait-stability-min-duration=1m
         - -compactor.scheduler-client.enabled=true
         - -compactor.scheduler-client.metadata-cache.backend=memcached
-        - -compactor.scheduler-client.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
+        - -compactor.scheduler-client.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata-zone-a.default.svc.cluster.local.:11211
         - -compactor.scheduler-client.metadata-cache.memcached.max-async-concurrency=50
         - -compactor.scheduler-client.metadata-cache.memcached.max-item-size=1048576
         - -compactor.scheduler-client.scheduler-endpoint=dns:///compactor-scheduler-rc-0.default.svc.cluster.local.:9095
@@ -2682,7 +2957,7 @@ spec:
         - -compactor.ring.wait-stability-min-duration=1m
         - -compactor.scheduler-client.enabled=true
         - -compactor.scheduler-client.metadata-cache.backend=memcached
-        - -compactor.scheduler-client.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
+        - -compactor.scheduler-client.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata-zone-a.default.svc.cluster.local.:11211
         - -compactor.scheduler-client.metadata-cache.memcached.max-async-concurrency=50
         - -compactor.scheduler-client.metadata-cache.memcached.max-item-size=1048576
         - -compactor.scheduler-client.scheduler-endpoint=dns:///compactor-scheduler-rc-1.default.svc.cluster.local.:9095
@@ -3643,86 +3918,34 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: memcached
+  name: memcached-frontend-zone-a
   namespace: default
 spec:
   minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
-      name: memcached
-  serviceName: memcached
+      name: memcached-frontend-zone-a
+  serviceName: memcached-frontend-zone-a
   template:
     metadata:
       labels:
-        name: memcached
+        name: memcached-frontend-zone-a
     spec:
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2a
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchLabels:
-                name: memcached
-            topologyKey: kubernetes.io/hostname
-      containers:
-      - args:
-        - -m 6144
-        - -I 1m
-        - -c 16384
-        - -v
-        image: memcached:1.6.34-alpine
-        imagePullPolicy: IfNotPresent
-        name: memcached
-        ports:
-        - containerPort: 11211
-          name: client
-        resources:
-          limits:
-            memory: 9Gi
-          requests:
-            cpu: 500m
-            memory: 6552Mi
-      - args:
-        - --memcached.address=localhost:11211
-        - --web.listen-address=0.0.0.0:9150
-        image: prom/memcached-exporter:v0.15.3
-        imagePullPolicy: IfNotPresent
-        name: exporter
-        ports:
-        - containerPort: 9150
-          name: http-metrics
-        resources:
-          limits:
-            memory: 250Mi
-          requests:
-            cpu: "0.05"
-            memory: 50Mi
-  updateStrategy:
-    type: RollingUpdate
----
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: memcached-frontend
-  namespace: default
-spec:
-  minReadySeconds: 60
-  replicas: 3
-  selector:
-    matchLabels:
-      name: memcached-frontend
-  serviceName: memcached-frontend
-  template:
-    metadata:
-      labels:
-        name: memcached-frontend
-    spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: memcached-frontend
+                name: memcached-frontend-zone-a
             topologyKey: kubernetes.io/hostname
       containers:
       - args:
@@ -3757,32 +3980,118 @@ spec:
           requests:
             cpu: "0.05"
             memory: 50Mi
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
   updateStrategy:
     type: RollingUpdate
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: memcached-index-queries
+  name: memcached-frontend-zone-b
   namespace: default
 spec:
   minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
-      name: memcached-index-queries
-  serviceName: memcached-index-queries
+      name: memcached-frontend-zone-b
+  serviceName: memcached-frontend-zone-b
   template:
     metadata:
       labels:
-        name: memcached-index-queries
+        name: memcached-frontend-zone-b
     spec:
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2b
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchLabels:
-                name: memcached-index-queries
+                name: memcached-frontend-zone-b
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -m 1024
+        - -I 25m
+        - -c 16384
+        - -v
+        image: memcached:1.6.34-alpine
+        imagePullPolicy: IfNotPresent
+        name: memcached
+        ports:
+        - containerPort: 11211
+          name: client
+        resources:
+          limits:
+            memory: 1536Mi
+          requests:
+            cpu: 500m
+            memory: 1176Mi
+      - args:
+        - --memcached.address=localhost:11211
+        - --web.listen-address=0.0.0.0:9150
+        image: prom/memcached-exporter:v0.15.3
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9150
+          name: http-metrics
+        resources:
+          limits:
+            memory: 250Mi
+          requests:
+            cpu: "0.05"
+            memory: 50Mi
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
+  updateStrategy:
+    type: RollingUpdate
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: memcached-index-queries-zone-a-rc-0
+  namespace: default
+spec:
+  minReadySeconds: 60
+  replicas: 3
+  selector:
+    matchLabels:
+      name: memcached-index-queries-zone-a-rc-0
+  serviceName: memcached-index-queries-zone-a-rc-0
+  template:
+    metadata:
+      labels:
+        name: memcached-index-queries-zone-a-rc-0
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2a
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: memcached-index-queries-zone-a-rc-0
             topologyKey: kubernetes.io/hostname
       containers:
       - args:
@@ -3817,32 +4126,265 @@ spec:
           requests:
             cpu: "0.05"
             memory: 50Mi
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
   updateStrategy:
     type: RollingUpdate
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: memcached-metadata
+  name: memcached-index-queries-zone-a-rc-1
   namespace: default
 spec:
   minReadySeconds: 60
   replicas: 3
   selector:
     matchLabels:
-      name: memcached-metadata
-  serviceName: memcached-metadata
+      name: memcached-index-queries-zone-a-rc-1
+  serviceName: memcached-index-queries-zone-a-rc-1
   template:
     metadata:
       labels:
-        name: memcached-metadata
+        name: memcached-index-queries-zone-a-rc-1
     spec:
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2a
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchLabels:
-                name: memcached-metadata
+                name: memcached-index-queries-zone-a-rc-1
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -m 1024
+        - -I 5m
+        - -c 16384
+        - -v
+        image: memcached:1.6.34-alpine
+        imagePullPolicy: IfNotPresent
+        name: memcached
+        ports:
+        - containerPort: 11211
+          name: client
+        resources:
+          limits:
+            memory: 1536Mi
+          requests:
+            cpu: 500m
+            memory: 1176Mi
+      - args:
+        - --memcached.address=localhost:11211
+        - --web.listen-address=0.0.0.0:9150
+        image: prom/memcached-exporter:v0.15.3
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9150
+          name: http-metrics
+        resources:
+          limits:
+            memory: 250Mi
+          requests:
+            cpu: "0.05"
+            memory: 50Mi
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
+  updateStrategy:
+    type: RollingUpdate
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: memcached-index-queries-zone-b-rc-0
+  namespace: default
+spec:
+  minReadySeconds: 60
+  replicas: 3
+  selector:
+    matchLabels:
+      name: memcached-index-queries-zone-b-rc-0
+  serviceName: memcached-index-queries-zone-b-rc-0
+  template:
+    metadata:
+      labels:
+        name: memcached-index-queries-zone-b-rc-0
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2b
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: memcached-index-queries-zone-b-rc-0
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -m 1024
+        - -I 5m
+        - -c 16384
+        - -v
+        image: memcached:1.6.34-alpine
+        imagePullPolicy: IfNotPresent
+        name: memcached
+        ports:
+        - containerPort: 11211
+          name: client
+        resources:
+          limits:
+            memory: 1536Mi
+          requests:
+            cpu: 500m
+            memory: 1176Mi
+      - args:
+        - --memcached.address=localhost:11211
+        - --web.listen-address=0.0.0.0:9150
+        image: prom/memcached-exporter:v0.15.3
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9150
+          name: http-metrics
+        resources:
+          limits:
+            memory: 250Mi
+          requests:
+            cpu: "0.05"
+            memory: 50Mi
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
+  updateStrategy:
+    type: RollingUpdate
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: memcached-index-queries-zone-b-rc-1
+  namespace: default
+spec:
+  minReadySeconds: 60
+  replicas: 3
+  selector:
+    matchLabels:
+      name: memcached-index-queries-zone-b-rc-1
+  serviceName: memcached-index-queries-zone-b-rc-1
+  template:
+    metadata:
+      labels:
+        name: memcached-index-queries-zone-b-rc-1
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2b
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: memcached-index-queries-zone-b-rc-1
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -m 1024
+        - -I 5m
+        - -c 16384
+        - -v
+        image: memcached:1.6.34-alpine
+        imagePullPolicy: IfNotPresent
+        name: memcached
+        ports:
+        - containerPort: 11211
+          name: client
+        resources:
+          limits:
+            memory: 1536Mi
+          requests:
+            cpu: 500m
+            memory: 1176Mi
+      - args:
+        - --memcached.address=localhost:11211
+        - --web.listen-address=0.0.0.0:9150
+        image: prom/memcached-exporter:v0.15.3
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9150
+          name: http-metrics
+        resources:
+          limits:
+            memory: 250Mi
+          requests:
+            cpu: "0.05"
+            memory: 50Mi
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
+  updateStrategy:
+    type: RollingUpdate
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: memcached-metadata-zone-a
+  namespace: default
+spec:
+  minReadySeconds: 60
+  replicas: 3
+  selector:
+    matchLabels:
+      name: memcached-metadata-zone-a
+  serviceName: memcached-metadata-zone-a
+  template:
+    metadata:
+      labels:
+        cache-group: metadata
+        name: memcached-metadata-zone-a
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2a
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: memcached-metadata-zone-a
             topologyKey: kubernetes.io/hostname
       containers:
       - args:
@@ -3877,6 +4419,377 @@ spec:
           requests:
             cpu: "0.05"
             memory: 50Mi
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
+  updateStrategy:
+    type: RollingUpdate
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: memcached-metadata-zone-b
+  namespace: default
+spec:
+  minReadySeconds: 60
+  replicas: 3
+  selector:
+    matchLabels:
+      name: memcached-metadata-zone-b
+  serviceName: memcached-metadata-zone-b
+  template:
+    metadata:
+      labels:
+        cache-group: metadata
+        name: memcached-metadata-zone-b
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2b
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: memcached-metadata-zone-b
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -m 512
+        - -I 1m
+        - -c 16384
+        - -v
+        image: memcached:1.6.34-alpine
+        imagePullPolicy: IfNotPresent
+        name: memcached
+        ports:
+        - containerPort: 11211
+          name: client
+        resources:
+          limits:
+            memory: 768Mi
+          requests:
+            cpu: 500m
+            memory: 638Mi
+      - args:
+        - --memcached.address=localhost:11211
+        - --web.listen-address=0.0.0.0:9150
+        image: prom/memcached-exporter:v0.15.3
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9150
+          name: http-metrics
+        resources:
+          limits:
+            memory: 250Mi
+          requests:
+            cpu: "0.05"
+            memory: 50Mi
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
+  updateStrategy:
+    type: RollingUpdate
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: memcached-zone-a-rc-0
+  namespace: default
+spec:
+  minReadySeconds: 60
+  replicas: 3
+  selector:
+    matchLabels:
+      name: memcached-zone-a-rc-0
+  serviceName: memcached-zone-a-rc-0
+  template:
+    metadata:
+      labels:
+        name: memcached-zone-a-rc-0
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2a
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: memcached-zone-a-rc-0
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -m 6144
+        - -I 1m
+        - -c 16384
+        - -v
+        image: memcached:1.6.34-alpine
+        imagePullPolicy: IfNotPresent
+        name: memcached
+        ports:
+        - containerPort: 11211
+          name: client
+        resources:
+          limits:
+            memory: 9Gi
+          requests:
+            cpu: 500m
+            memory: 6552Mi
+      - args:
+        - --memcached.address=localhost:11211
+        - --web.listen-address=0.0.0.0:9150
+        image: prom/memcached-exporter:v0.15.3
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9150
+          name: http-metrics
+        resources:
+          limits:
+            memory: 250Mi
+          requests:
+            cpu: "0.05"
+            memory: 50Mi
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
+  updateStrategy:
+    type: RollingUpdate
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: memcached-zone-a-rc-1
+  namespace: default
+spec:
+  minReadySeconds: 60
+  replicas: 3
+  selector:
+    matchLabels:
+      name: memcached-zone-a-rc-1
+  serviceName: memcached-zone-a-rc-1
+  template:
+    metadata:
+      labels:
+        name: memcached-zone-a-rc-1
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2a
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: memcached-zone-a-rc-1
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -m 6144
+        - -I 1m
+        - -c 16384
+        - -v
+        image: memcached:1.6.34-alpine
+        imagePullPolicy: IfNotPresent
+        name: memcached
+        ports:
+        - containerPort: 11211
+          name: client
+        resources:
+          limits:
+            memory: 9Gi
+          requests:
+            cpu: 500m
+            memory: 6552Mi
+      - args:
+        - --memcached.address=localhost:11211
+        - --web.listen-address=0.0.0.0:9150
+        image: prom/memcached-exporter:v0.15.3
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9150
+          name: http-metrics
+        resources:
+          limits:
+            memory: 250Mi
+          requests:
+            cpu: "0.05"
+            memory: 50Mi
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
+  updateStrategy:
+    type: RollingUpdate
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: memcached-zone-b-rc-0
+  namespace: default
+spec:
+  minReadySeconds: 60
+  replicas: 3
+  selector:
+    matchLabels:
+      name: memcached-zone-b-rc-0
+  serviceName: memcached-zone-b-rc-0
+  template:
+    metadata:
+      labels:
+        name: memcached-zone-b-rc-0
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2b
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: memcached-zone-b-rc-0
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -m 6144
+        - -I 1m
+        - -c 16384
+        - -v
+        image: memcached:1.6.34-alpine
+        imagePullPolicy: IfNotPresent
+        name: memcached
+        ports:
+        - containerPort: 11211
+          name: client
+        resources:
+          limits:
+            memory: 9Gi
+          requests:
+            cpu: 500m
+            memory: 6552Mi
+      - args:
+        - --memcached.address=localhost:11211
+        - --web.listen-address=0.0.0.0:9150
+        image: prom/memcached-exporter:v0.15.3
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9150
+          name: http-metrics
+        resources:
+          limits:
+            memory: 250Mi
+          requests:
+            cpu: "0.05"
+            memory: 50Mi
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
+  updateStrategy:
+    type: RollingUpdate
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: memcached-zone-b-rc-1
+  namespace: default
+spec:
+  minReadySeconds: 60
+  replicas: 3
+  selector:
+    matchLabels:
+      name: memcached-zone-b-rc-1
+  serviceName: memcached-zone-b-rc-1
+  template:
+    metadata:
+      labels:
+        name: memcached-zone-b-rc-1
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2b
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: memcached-zone-b-rc-1
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -m 6144
+        - -I 1m
+        - -c 16384
+        - -v
+        image: memcached:1.6.34-alpine
+        imagePullPolicy: IfNotPresent
+        name: memcached
+        ports:
+        - containerPort: 11211
+          name: client
+        resources:
+          limits:
+            memory: 9Gi
+          requests:
+            cpu: 500m
+            memory: 6552Mi
+      - args:
+        - --memcached.address=localhost:11211
+        - --web.listen-address=0.0.0.0:9150
+        image: prom/memcached-exporter:v0.15.3
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9150
+          name: http-metrics
+        resources:
+          limits:
+            memory: 250Mi
+          requests:
+            cpu: "0.05"
+            memory: 50Mi
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
   updateStrategy:
     type: RollingUpdate
 ---
@@ -3929,14 +4842,14 @@ spec:
       containers:
       - args:
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
-        - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached-zone-a-rc-0.default.svc.cluster.local.:11211
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-idle-connections=150
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-item-size=1048576
         - -blocks-storage.bucket-store.chunks-cache.memcached.timeout=750ms
         - -blocks-storage.bucket-store.index-cache.backend=memcached
-        - -blocks-storage.bucket-store.index-cache.memcached.addresses=dnssrvnoa+memcached-index-queries.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.index-cache.memcached.addresses=dnssrvnoa+memcached-index-queries-zone-a-rc-0.default.svc.cluster.local.:11211
         - -blocks-storage.bucket-store.index-cache.memcached.max-async-concurrency=50
         - -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.index-cache.memcached.max-idle-connections=150
@@ -4087,14 +5000,14 @@ spec:
       containers:
       - args:
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
-        - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached-zone-a-rc-1.default.svc.cluster.local.:11211
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-idle-connections=150
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-item-size=1048576
         - -blocks-storage.bucket-store.chunks-cache.memcached.timeout=750ms
         - -blocks-storage.bucket-store.index-cache.backend=memcached
-        - -blocks-storage.bucket-store.index-cache.memcached.addresses=dnssrvnoa+memcached-index-queries.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.index-cache.memcached.addresses=dnssrvnoa+memcached-index-queries-zone-a-rc-1.default.svc.cluster.local.:11211
         - -blocks-storage.bucket-store.index-cache.memcached.max-async-concurrency=50
         - -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.index-cache.memcached.max-idle-connections=150
@@ -4247,14 +5160,14 @@ spec:
       containers:
       - args:
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
-        - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached-zone-b-rc-0.default.svc.cluster.local.:11211
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-idle-connections=150
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-item-size=1048576
         - -blocks-storage.bucket-store.chunks-cache.memcached.timeout=750ms
         - -blocks-storage.bucket-store.index-cache.backend=memcached
-        - -blocks-storage.bucket-store.index-cache.memcached.addresses=dnssrvnoa+memcached-index-queries.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.index-cache.memcached.addresses=dnssrvnoa+memcached-index-queries-zone-b-rc-0.default.svc.cluster.local.:11211
         - -blocks-storage.bucket-store.index-cache.memcached.max-async-concurrency=50
         - -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.index-cache.memcached.max-idle-connections=150
@@ -4409,14 +5322,14 @@ spec:
       containers:
       - args:
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
-        - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached-zone-b-rc-1.default.svc.cluster.local.:11211
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-idle-connections=150
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-item-size=1048576
         - -blocks-storage.bucket-store.chunks-cache.memcached.timeout=750ms
         - -blocks-storage.bucket-store.index-cache.backend=memcached
-        - -blocks-storage.bucket-store.index-cache.memcached.addresses=dnssrvnoa+memcached-index-queries.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.index-cache.memcached.addresses=dnssrvnoa+memcached-index-queries-zone-b-rc-1.default.svc.cluster.local.:11211
         - -blocks-storage.bucket-store.index-cache.memcached.max-async-concurrency=50
         - -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.index-cache.memcached.max-idle-connections=150
@@ -4571,14 +5484,14 @@ spec:
       containers:
       - args:
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
-        - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached-zone-a-rc-0.default.svc.cluster.local.:11211
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-idle-connections=150
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-item-size=1048576
         - -blocks-storage.bucket-store.chunks-cache.memcached.timeout=750ms
         - -blocks-storage.bucket-store.index-cache.backend=memcached
-        - -blocks-storage.bucket-store.index-cache.memcached.addresses=dnssrvnoa+memcached-index-queries.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.index-cache.memcached.addresses=dnssrvnoa+memcached-index-queries-zone-a-rc-0.default.svc.cluster.local.:11211
         - -blocks-storage.bucket-store.index-cache.memcached.max-async-concurrency=50
         - -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.index-cache.memcached.max-idle-connections=150
@@ -4731,14 +5644,14 @@ spec:
       containers:
       - args:
         - -blocks-storage.bucket-store.chunks-cache.backend=memcached
-        - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached-zone-a-rc-1.default.svc.cluster.local.:11211
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-idle-connections=150
         - -blocks-storage.bucket-store.chunks-cache.memcached.max-item-size=1048576
         - -blocks-storage.bucket-store.chunks-cache.memcached.timeout=750ms
         - -blocks-storage.bucket-store.index-cache.backend=memcached
-        - -blocks-storage.bucket-store.index-cache.memcached.addresses=dnssrvnoa+memcached-index-queries.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.index-cache.memcached.addresses=dnssrvnoa+memcached-index-queries-zone-a-rc-1.default.svc.cluster.local.:11211
         - -blocks-storage.bucket-store.index-cache.memcached.max-async-concurrency=50
         - -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.index-cache.memcached.max-idle-connections=150

--- a/operations/mimir-tests/test-compartments-generated.yaml
+++ b/operations/mimir-tests/test-compartments-generated.yaml
@@ -124,6 +124,32 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
+    name: memberlist-bridge-zone-a
+  name: memberlist-bridge-zone-a
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: memberlist-bridge-zone-a
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: memberlist-bridge-zone-b
+  name: memberlist-bridge-zone-b
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: memberlist-bridge-zone-b
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
     name: memcached-frontend-zone-a
   name: memcached-frontend-zone-a
   namespace: default
@@ -280,40 +306,79 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: querier
-  name: querier
+    name: querier-zone-a
+  name: querier-zone-a
   namespace: default
 spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-      name: querier
+      name: querier-zone-a
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: query-frontend
-  name: query-frontend
+    name: querier-zone-b
+  name: querier-zone-b
   namespace: default
 spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-      name: query-frontend
+      name: querier-zone-b
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: query-scheduler
-  name: query-scheduler
+    name: query-frontend-zone-a
+  name: query-frontend-zone-a
   namespace: default
 spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-      name: query-scheduler
+      name: query-frontend-zone-a
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: query-frontend-zone-b
+  name: query-frontend-zone-b
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: query-frontend-zone-b
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: query-scheduler-zone-a
+  name: query-scheduler-zone-a
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: query-scheduler-zone-a
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: query-scheduler-zone-b
+  name: query-scheduler-zone-b
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: query-scheduler-zone-b
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -332,53 +397,105 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ruler
-  name: ruler
+    name: ruler-querier-zone-a
+  name: ruler-querier-zone-a
   namespace: default
 spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-      name: ruler
+      name: ruler-querier-zone-a
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ruler-querier
-  name: ruler-querier
+    name: ruler-querier-zone-b
+  name: ruler-querier-zone-b
   namespace: default
 spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-      name: ruler-querier
+      name: ruler-querier-zone-b
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ruler-query-frontend
-  name: ruler-query-frontend
+    name: ruler-query-frontend-zone-a
+  name: ruler-query-frontend-zone-a
   namespace: default
 spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-      name: ruler-query-frontend
+      name: ruler-query-frontend-zone-a
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    name: ruler-query-scheduler
-  name: ruler-query-scheduler
+    name: ruler-query-frontend-zone-b
+  name: ruler-query-frontend-zone-b
   namespace: default
 spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-      name: ruler-query-scheduler
+      name: ruler-query-frontend-zone-b
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: ruler-query-scheduler-zone-a
+  name: ruler-query-scheduler-zone-a
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: ruler-query-scheduler-zone-a
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: ruler-query-scheduler-zone-b
+  name: ruler-query-scheduler-zone-b
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: ruler-query-scheduler-zone-b
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: ruler-zone-a
+  name: ruler-zone-a
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: ruler-zone-a
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: ruler-zone-b
+  name: ruler-zone-b
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: ruler-zone-b
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -846,6 +963,50 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    name: memberlist-bridge-zone-a
+  name: memberlist-bridge-zone-a
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: memberlist-bridge-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: memberlist-bridge-grpc
+    port: 9095
+    targetPort: 9095
+  - name: memberlist-bridge-gossip-ring
+    port: 7946
+    targetPort: 7946
+  selector:
+    name: memberlist-bridge-zone-a
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: memberlist-bridge-zone-b
+  name: memberlist-bridge-zone-b
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: memberlist-bridge-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: memberlist-bridge-grpc
+    port: 9095
+    targetPort: 9095
+  - name: memberlist-bridge-gossip-ring
+    port: 7946
+    targetPort: 7946
+  selector:
+    name: memberlist-bridge-zone-b
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
     name: memcached-frontend-zone-a
   name: memcached-frontend-zone-a
   namespace: default
@@ -1093,8 +1254,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    name: querier
-  name: querier
+    name: querier-zone-a
+  name: querier-zone-a
   namespace: default
 spec:
   ports:
@@ -1108,14 +1269,35 @@ spec:
     port: 7946
     targetPort: 7946
   selector:
-    name: querier
+    name: querier-zone-a
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    name: query-frontend
-  name: query-frontend
+    name: querier-zone-b
+  name: querier-zone-b
+  namespace: default
+spec:
+  ports:
+  - name: querier-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: querier-grpc
+    port: 9095
+    targetPort: 9095
+  - name: querier-gossip-ring
+    port: 7946
+    targetPort: 7946
+  selector:
+    name: querier-zone-b
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: query-frontend-zone-a
+  name: query-frontend-zone-a
   namespace: default
 spec:
   ports:
@@ -1125,15 +1307,39 @@ spec:
   - name: query-frontend-grpc
     port: 9095
     targetPort: 9095
+  - name: query-frontend-gossip-ring
+    port: 7946
+    targetPort: 7946
   selector:
-    name: query-frontend
+    name: query-frontend-zone-a
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    name: query-scheduler
-  name: query-scheduler
+    name: query-frontend-zone-b
+  name: query-frontend-zone-b
+  namespace: default
+spec:
+  ports:
+  - name: query-frontend-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: query-frontend-grpc
+    port: 9095
+    targetPort: 9095
+  - name: query-frontend-gossip-ring
+    port: 7946
+    targetPort: 7946
+  selector:
+    name: query-frontend-zone-b
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: query-scheduler-zone-a
+  name: query-scheduler-zone-a
   namespace: default
 spec:
   ports:
@@ -1143,18 +1349,20 @@ spec:
   - name: query-scheduler-grpc
     port: 9095
     targetPort: 9095
+  - name: query-scheduler-gossip-ring
+    port: 7946
+    targetPort: 7946
   selector:
-    name: query-scheduler
+    name: query-scheduler-zone-a
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    name: query-scheduler
-  name: query-scheduler-discovery
+    name: query-scheduler-zone-b
+  name: query-scheduler-zone-b
   namespace: default
 spec:
-  clusterIP: None
   ports:
   - name: query-scheduler-http-metrics
     port: 8080
@@ -1162,9 +1370,11 @@ spec:
   - name: query-scheduler-grpc
     port: 9095
     targetPort: 9095
-  publishNotReadyAddresses: true
+  - name: query-scheduler-gossip-ring
+    port: 7946
+    targetPort: 7946
   selector:
-    name: query-scheduler
+    name: query-scheduler-zone-b
 ---
 apiVersion: v1
 kind: Service
@@ -1184,26 +1394,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    name: ruler
-  name: ruler
-  namespace: default
-spec:
-  ports:
-  - name: ruler-http-metrics
-    port: 8080
-    targetPort: 8080
-  - name: ruler-grpc
-    port: 9095
-    targetPort: 9095
-  selector:
-    name: ruler
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    name: ruler-querier
-  name: ruler-querier
+    name: ruler-querier-zone-a
+  name: ruler-querier-zone-a
   namespace: default
 spec:
   ports:
@@ -1217,14 +1409,35 @@ spec:
     port: 7946
     targetPort: 7946
   selector:
-    name: ruler-querier
+    name: ruler-querier-zone-a
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    name: ruler-query-frontend
-  name: ruler-query-frontend
+    name: ruler-querier-zone-b
+  name: ruler-querier-zone-b
+  namespace: default
+spec:
+  ports:
+  - name: ruler-querier-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: ruler-querier-grpc
+    port: 9095
+    targetPort: 9095
+  - name: ruler-querier-gossip-ring
+    port: 7946
+    targetPort: 7946
+  selector:
+    name: ruler-querier-zone-b
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: ruler-query-frontend-zone-a
+  name: ruler-query-frontend-zone-a
   namespace: default
 spec:
   ports:
@@ -1234,15 +1447,18 @@ spec:
   - name: ruler-query-frontend-grpc
     port: 9095
     targetPort: 9095
+  - name: ruler-query-frontend-gossip-ring
+    port: 7946
+    targetPort: 7946
   selector:
-    name: ruler-query-frontend
+    name: ruler-query-frontend-zone-a
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    name: ruler-query-frontend
-  name: ruler-query-frontend-headless
+    name: ruler-query-frontend-zone-a
+  name: ruler-query-frontend-zone-a-headless
   namespace: default
 spec:
   clusterIP: None
@@ -1253,46 +1469,132 @@ spec:
   - name: ruler-query-frontend-grpc
     port: 9095
     targetPort: 9095
+  - name: ruler-query-frontend-gossip-ring
+    port: 7946
+    targetPort: 7946
   selector:
-    name: ruler-query-frontend
+    name: ruler-query-frontend-zone-a
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    name: ruler-query-scheduler
-  name: ruler-query-scheduler
+    name: ruler-query-frontend-zone-b
+  name: ruler-query-frontend-zone-b
   namespace: default
 spec:
   ports:
-  - name: ruler-query-scheduler-http-metrics
+  - name: ruler-query-frontend-http-metrics
     port: 8080
     targetPort: 8080
-  - name: ruler-query-scheduler-grpc
+  - name: ruler-query-frontend-grpc
     port: 9095
     targetPort: 9095
+  - name: ruler-query-frontend-gossip-ring
+    port: 7946
+    targetPort: 7946
   selector:
-    name: ruler-query-scheduler
+    name: ruler-query-frontend-zone-b
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    name: ruler-query-scheduler
-  name: ruler-query-scheduler-discovery
+    name: ruler-query-frontend-zone-b
+  name: ruler-query-frontend-zone-b-headless
   namespace: default
 spec:
   clusterIP: None
   ports:
+  - name: ruler-query-frontend-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: ruler-query-frontend-grpc
+    port: 9095
+    targetPort: 9095
+  - name: ruler-query-frontend-gossip-ring
+    port: 7946
+    targetPort: 7946
+  selector:
+    name: ruler-query-frontend-zone-b
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: ruler-query-scheduler-zone-a
+  name: ruler-query-scheduler-zone-a
+  namespace: default
+spec:
+  ports:
   - name: ruler-query-scheduler-http-metrics
     port: 8080
     targetPort: 8080
   - name: ruler-query-scheduler-grpc
     port: 9095
     targetPort: 9095
-  publishNotReadyAddresses: true
+  - name: ruler-query-scheduler-gossip-ring
+    port: 7946
+    targetPort: 7946
   selector:
-    name: ruler-query-scheduler
+    name: ruler-query-scheduler-zone-a
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: ruler-query-scheduler-zone-b
+  name: ruler-query-scheduler-zone-b
+  namespace: default
+spec:
+  ports:
+  - name: ruler-query-scheduler-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: ruler-query-scheduler-grpc
+    port: 9095
+    targetPort: 9095
+  - name: ruler-query-scheduler-gossip-ring
+    port: 7946
+    targetPort: 7946
+  selector:
+    name: ruler-query-scheduler-zone-b
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: ruler-zone-a
+  name: ruler-zone-a
+  namespace: default
+spec:
+  ports:
+  - name: ruler-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: ruler-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: ruler-zone-a
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: ruler-zone-b
+  name: ruler-zone-b
+  namespace: default
+spec:
+  ports:
+  - name: ruler-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: ruler-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: ruler-zone-b
 ---
 apiVersion: v1
 kind: Service
@@ -1515,8 +1817,15 @@ spec:
         - -ingester.ring.store=memberlist
         - -ingester.ring.zone-awareness-enabled=true
         - -mem-ballast-size-bytes=1073741824
+        - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.abort-if-fast-join-fails-min-nodes=2
         - -memberlist.bind-port=7946
-        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -memberlist.join=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.rejoin-interval=300s
+        - -memberlist.rejoin-seed-nodes=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946
+        - -memberlist.zone-aware-routing.enabled=true
+        - -memberlist.zone-aware-routing.instance-availability-zone=zone-a
+        - -memberlist.zone-aware-routing.role=member
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-concurrent-streams=1000
         - -server.grpc.keepalive.max-connection-age=60s
@@ -1652,8 +1961,15 @@ spec:
         - -ingester.ring.store=memberlist
         - -ingester.ring.zone-awareness-enabled=true
         - -mem-ballast-size-bytes=1073741824
+        - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.abort-if-fast-join-fails-min-nodes=2
         - -memberlist.bind-port=7946
-        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -memberlist.join=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.rejoin-interval=300s
+        - -memberlist.rejoin-seed-nodes=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946
+        - -memberlist.zone-aware-routing.enabled=true
+        - -memberlist.zone-aware-routing.instance-availability-zone=zone-a
+        - -memberlist.zone-aware-routing.role=member
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-concurrent-streams=1000
         - -server.grpc.keepalive.max-connection-age=60s
@@ -1789,8 +2105,15 @@ spec:
         - -ingester.ring.store=memberlist
         - -ingester.ring.zone-awareness-enabled=true
         - -mem-ballast-size-bytes=1073741824
+        - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.abort-if-fast-join-fails-min-nodes=2
         - -memberlist.bind-port=7946
-        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -memberlist.join=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.rejoin-interval=300s
+        - -memberlist.rejoin-seed-nodes=dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.zone-aware-routing.enabled=true
+        - -memberlist.zone-aware-routing.instance-availability-zone=zone-b
+        - -memberlist.zone-aware-routing.role=member
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-concurrent-streams=1000
         - -server.grpc.keepalive.max-connection-age=60s
@@ -1926,8 +2249,15 @@ spec:
         - -ingester.ring.store=memberlist
         - -ingester.ring.zone-awareness-enabled=true
         - -mem-ballast-size-bytes=1073741824
+        - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.abort-if-fast-join-fails-min-nodes=2
         - -memberlist.bind-port=7946
-        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -memberlist.join=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.rejoin-interval=300s
+        - -memberlist.rejoin-seed-nodes=dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.zone-aware-routing.enabled=true
+        - -memberlist.zone-aware-routing.instance-availability-zone=zone-b
+        - -memberlist.zone-aware-routing.role=member
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-concurrent-streams=1000
         - -server.grpc.keepalive.max-connection-age=60s
@@ -1989,15 +2319,201 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: querier
+  name: memberlist-bridge-zone-a
   namespace: default
 spec:
-  minReadySeconds: 10
-  replicas: 6
+  minReadySeconds: 300
+  replicas: 3
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      name: querier
+      name: memberlist-bridge-zone-a
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: memberlist-bridge-zone-a
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2a
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: memberlist-bridge-zone-a
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -ingest-storage.enabled=true
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.topic=ingest
+        - -memberlist.abort-if-fast-join-fails=false
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.max-concurrent-writes=15
+        - -memberlist.rejoin-interval=60s
+        - -memberlist.rejoin-seed-nodes=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.zone-aware-routing.enabled=true
+        - -memberlist.zone-aware-routing.instance-availability-zone=zone-a
+        - -memberlist.zone-aware-routing.role=bridge
+        - -query-scheduler.ring.prefix=
+        - -query-scheduler.ring.store=memberlist
+        - -server.http-listen-port=8080
+        - -target=memberlist-kv
+        - -usage-stats.installation-mode=jsonnet
+        image: grafana/mimir:3.1.2
+        imagePullPolicy: IfNotPresent
+        name: memberlist-bridge
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 2Gi
+          requests:
+            cpu: "0.25"
+            memory: 1Gi
+      priorityClassName: high-nonpreempting
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: memberlist-bridge-zone-a
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: memberlist-bridge-zone-b
+  namespace: default
+spec:
+  minReadySeconds: 300
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: memberlist-bridge-zone-b
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: memberlist-bridge-zone-b
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2b
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: memberlist-bridge-zone-b
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -ingest-storage.enabled=true
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.topic=ingest
+        - -memberlist.abort-if-fast-join-fails=false
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.max-concurrent-writes=15
+        - -memberlist.rejoin-interval=60s
+        - -memberlist.rejoin-seed-nodes=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.zone-aware-routing.enabled=true
+        - -memberlist.zone-aware-routing.instance-availability-zone=zone-b
+        - -memberlist.zone-aware-routing.role=bridge
+        - -query-scheduler.ring.prefix=
+        - -query-scheduler.ring.store=memberlist
+        - -server.http-listen-port=8080
+        - -target=memberlist-kv
+        - -usage-stats.installation-mode=jsonnet
+        image: grafana/mimir:3.1.2
+        imagePullPolicy: IfNotPresent
+        name: memberlist-bridge
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 2Gi
+          requests:
+            cpu: "0.25"
+            memory: 1Gi
+      priorityClassName: high-nonpreempting
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: memberlist-bridge-zone-b
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: querier-zone-a
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: querier-zone-a
   strategy:
     rollingUpdate:
       maxSurge: 15%
@@ -2006,12 +2522,21 @@ spec:
     metadata:
       labels:
         gossip_ring_member: "true"
-        name: querier
+        name: querier-zone-a
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2a
       containers:
       - args:
         - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata-zone-a.default.svc.cluster.local.:11211
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
         - -blocks-storage.bucket-store.sync-dir=/data/tsdb
@@ -2035,13 +2560,24 @@ spec:
         - -ingester.ring.store=memberlist
         - -ingester.ring.zone-awareness-enabled=true
         - -mem-ballast-size-bytes=268435456
+        - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.abort-if-fast-join-fails-min-nodes=2
         - -memberlist.bind-port=7946
-        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -memberlist.join=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.rejoin-interval=300s
+        - -memberlist.rejoin-seed-nodes=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946
+        - -memberlist.zone-aware-routing.enabled=true
+        - -memberlist.zone-aware-routing.instance-availability-zone=zone-a
+        - -memberlist.zone-aware-routing.role=member
         - -querier.frontend-client.grpc-max-send-msg-size=104857600
         - -querier.max-concurrent=8
         - -querier.max-partial-query-length=768h
-        - -querier.scheduler-address=query-scheduler-discovery.default.svc.cluster.local.:9095
+        - -querier.prefer-availability-zones=zone-a,zone-a-backup
+        - -querier.ring.prefix=querier-zone-a/
         - -querier.store-gateway-client.grpc-max-recv-msg-size=209715200
+        - -query-scheduler.ring.prefix=query-scheduler-zone-a/
+        - -query-scheduler.ring.store=memberlist
+        - -query-scheduler.service-discovery-mode=ring
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
@@ -2084,10 +2620,15 @@ spec:
         - mountPath: /etc/mimir
           name: overrides
       terminationGracePeriodSeconds: 180
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:
-            name: querier
+            name: querier-zone-a
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway
@@ -2099,7 +2640,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: query-frontend
+  name: querier-zone-b
   namespace: default
 spec:
   minReadySeconds: 10
@@ -2107,7 +2648,7 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      name: query-frontend
+      name: querier-zone-b
   strategy:
     rollingUpdate:
       maxSurge: 15%
@@ -2115,8 +2656,153 @@ spec:
   template:
     metadata:
       labels:
-        name: query-frontend
+        gossip_ring_member: "true"
+        name: querier-zone-b
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2b
+      containers:
+      - args:
+        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
+        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata-zone-b.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
+        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
+        - -blocks-storage.bucket-store.sync-interval=15m
+        - -blocks-storage.gcs.bucket-name=blocks-bucket-rc-<read-compartment-id>
+        - -common.storage.backend=gcs
+        - -compartments.enabled=true
+        - -compartments.read.num-compartments=2
+        - -compartments.write.num-compartments=2
+        - -distributor.health-check-ingesters=true
+        - -distributor.ingestion-tenant-shard-size=3
+        - -ingest-storage.enabled=true
+        - -ingest-storage.ingestion-partition-tenant-shard-size=1
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.topic=ingest-rc-<read-compartment-id>
+        - -ingester.partition-ring.prefix=
+        - -ingester.ring.heartbeat-timeout=10m
+        - -ingester.ring.prefix=partition-ingesters/
+        - -ingester.ring.replication-factor=3
+        - -ingester.ring.store=memberlist
+        - -ingester.ring.zone-awareness-enabled=true
+        - -mem-ballast-size-bytes=268435456
+        - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.abort-if-fast-join-fails-min-nodes=2
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.rejoin-interval=300s
+        - -memberlist.rejoin-seed-nodes=dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.zone-aware-routing.enabled=true
+        - -memberlist.zone-aware-routing.instance-availability-zone=zone-b
+        - -memberlist.zone-aware-routing.role=member
+        - -querier.frontend-client.grpc-max-send-msg-size=104857600
+        - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
+        - -querier.prefer-availability-zones=zone-b,zone-b-backup
+        - -querier.ring.prefix=querier-zone-b/
+        - -querier.store-gateway-client.grpc-max-recv-msg-size=209715200
+        - -query-scheduler.ring.prefix=query-scheduler-zone-b/
+        - -query-scheduler.ring.store=memberlist
+        - -query-scheduler.service-discovery-mode=ring
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -store-gateway.sharding-ring.heartbeat-timeout=10m
+        - -store-gateway.sharding-ring.prefix=multi-zone/
+        - -store-gateway.sharding-ring.replication-factor=3
+        - -store-gateway.sharding-ring.store=memberlist
+        - -store-gateway.sharding-ring.zone-awareness-enabled=true
+        - -store-gateway.tenant-shard-size=3
+        - -target=querier
+        - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOMAXPROCS
+          value: "5"
+        image: grafana/mimir:3.1.2
+        imagePullPolicy: IfNotPresent
+        name: querier
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "1"
+            ephemeral-storage: 50Mi
+            memory: 12Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      terminationGracePeriodSeconds: 180
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: querier-zone-b
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: query-frontend-zone-a
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: query-frontend-zone-a
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: query-frontend-zone-a
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2a
       containers:
       - args:
         - -compartments.enabled=true
@@ -2128,16 +2814,28 @@ spec:
         - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
         - -ingest-storage.kafka.topic=ingest-rc-<read-compartment-id>
         - -ingester.partition-ring.prefix=
+        - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.abort-if-fast-join-fails-min-nodes=2
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.rejoin-interval=300s
+        - -memberlist.rejoin-seed-nodes=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946
+        - -memberlist.zone-aware-routing.enabled=true
+        - -memberlist.zone-aware-routing.instance-availability-zone=zone-a
+        - -memberlist.zone-aware-routing.role=member
+        - -querier.ring.prefix=querier-zone-a/
         - -query-frontend.cache-results=true
         - -query-frontend.max-cache-freshness=10m
         - -query-frontend.max-queriers-per-tenant=10
         - -query-frontend.max-total-query-length=12000h
         - -query-frontend.query-sharding-target-series-per-shard=2500
         - -query-frontend.results-cache.backend=memcached
-        - -query-frontend.results-cache.memcached.addresses=dnssrvnoa+memcached-frontend.default.svc.cluster.local.:11211
+        - -query-frontend.results-cache.memcached.addresses=dnssrvnoa+memcached-frontend-zone-a.default.svc.cluster.local.:11211
         - -query-frontend.results-cache.memcached.max-item-size=26214400
         - -query-frontend.results-cache.memcached.timeout=500ms
-        - -query-frontend.scheduler-address=query-scheduler-discovery.default.svc.cluster.local.:9095
+        - -query-scheduler.ring.prefix=query-scheduler-zone-a/
+        - -query-scheduler.ring.store=memberlist
+        - -query-scheduler.service-discovery-mode=ring
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.max-connection-age=30s
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -2154,6 +2852,8 @@ spec:
           name: http-metrics
         - containerPort: 9095
           name: grpc
+        - containerPort: 7946
+          name: gossip-ring
         readinessProbe:
           httpGet:
             path: /ready
@@ -2171,10 +2871,15 @@ spec:
         - mountPath: /etc/mimir
           name: overrides
       terminationGracePeriodSeconds: 390
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:
-            name: query-frontend
+            name: query-frontend-zone-a
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway
@@ -2186,7 +2891,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: query-scheduler
+  name: query-frontend-zone-b
   namespace: default
 spec:
   minReadySeconds: 10
@@ -2194,7 +2899,123 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      name: query-scheduler
+      name: query-frontend-zone-b
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: query-frontend-zone-b
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2b
+      containers:
+      - args:
+        - -compartments.enabled=true
+        - -compartments.read.num-compartments=2
+        - -compartments.write.num-compartments=2
+        - -ingest-storage.enabled=true
+        - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
+        - -ingest-storage.kafka.topic=ingest-rc-<read-compartment-id>
+        - -ingester.partition-ring.prefix=
+        - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.abort-if-fast-join-fails-min-nodes=2
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.rejoin-interval=300s
+        - -memberlist.rejoin-seed-nodes=dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.zone-aware-routing.enabled=true
+        - -memberlist.zone-aware-routing.instance-availability-zone=zone-b
+        - -memberlist.zone-aware-routing.role=member
+        - -querier.ring.prefix=querier-zone-b/
+        - -query-frontend.cache-results=true
+        - -query-frontend.max-cache-freshness=10m
+        - -query-frontend.max-queriers-per-tenant=10
+        - -query-frontend.max-total-query-length=12000h
+        - -query-frontend.query-sharding-target-series-per-shard=2500
+        - -query-frontend.results-cache.backend=memcached
+        - -query-frontend.results-cache.memcached.addresses=dnssrvnoa+memcached-frontend-zone-b.default.svc.cluster.local.:11211
+        - -query-frontend.results-cache.memcached.max-item-size=26214400
+        - -query-frontend.results-cache.memcached.timeout=500ms
+        - -query-scheduler.ring.prefix=query-scheduler-zone-b/
+        - -query-scheduler.ring.store=memberlist
+        - -query-scheduler.service-discovery-mode=ring
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.max-connection-age=30s
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -shutdown-delay=90s
+        - -target=query-frontend
+        - -usage-stats.installation-mode=jsonnet
+        image: grafana/mimir:3.1.2
+        imagePullPolicy: IfNotPresent
+        name: query-frontend
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 4Gi
+          requests:
+            cpu: "2"
+            ephemeral-storage: 50Mi
+            memory: 2Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      terminationGracePeriodSeconds: 390
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: query-frontend-zone-b
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: query-scheduler-zone-a
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: query-scheduler-zone-a
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -2202,14 +3023,23 @@ spec:
   template:
     metadata:
       labels:
-        name: query-scheduler
+        gossip_ring_member: "true"
+        name: query-scheduler-zone-a
     spec:
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2a
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchLabels:
-                name: query-scheduler
+                name: query-scheduler-zone-a
             topologyKey: kubernetes.io/hostname
       containers:
       - args:
@@ -2217,8 +3047,20 @@ spec:
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
         - -ingest-storage.kafka.topic=ingest
+        - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.abort-if-fast-join-fails-min-nodes=2
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.rejoin-interval=300s
+        - -memberlist.rejoin-seed-nodes=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946
+        - -memberlist.zone-aware-routing.enabled=true
+        - -memberlist.zone-aware-routing.instance-availability-zone=zone-a
+        - -memberlist.zone-aware-routing.role=member
         - -query-frontend.max-queriers-per-tenant=10
         - -query-scheduler.max-outstanding-requests-per-tenant=100
+        - -query-scheduler.ring.prefix=query-scheduler-zone-a/
+        - -query-scheduler.ring.store=memberlist
+        - -query-scheduler.service-discovery-mode=ring
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
         - -server.http-listen-port=8080
@@ -2232,6 +3074,8 @@ spec:
           name: http-metrics
         - containerPort: 9095
           name: grpc
+        - containerPort: 7946
+          name: gossip-ring
         readinessProbe:
           httpGet:
             path: /ready
@@ -2249,6 +3093,110 @@ spec:
         - mountPath: /etc/mimir
           name: overrides
       terminationGracePeriodSeconds: 180
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: query-scheduler-zone-b
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: query-scheduler-zone-b
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: query-scheduler-zone-b
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2b
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: query-scheduler-zone-b
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -ingest-storage.enabled=true
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.topic=ingest
+        - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.abort-if-fast-join-fails-min-nodes=2
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.rejoin-interval=300s
+        - -memberlist.rejoin-seed-nodes=dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.zone-aware-routing.enabled=true
+        - -memberlist.zone-aware-routing.instance-availability-zone=zone-b
+        - -memberlist.zone-aware-routing.role=member
+        - -query-frontend.max-queriers-per-tenant=10
+        - -query-scheduler.max-outstanding-requests-per-tenant=100
+        - -query-scheduler.ring.prefix=query-scheduler-zone-b/
+        - -query-scheduler.ring.store=memberlist
+        - -query-scheduler.service-discovery-mode=ring
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -target=query-scheduler
+        - -usage-stats.installation-mode=jsonnet
+        image: grafana/mimir:3.1.2
+        imagePullPolicy: IfNotPresent
+        name: query-scheduler
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 2Gi
+          requests:
+            cpu: "2"
+            ephemeral-storage: 50Mi
+            memory: 1Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      terminationGracePeriodSeconds: 180
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
       volumes:
       - configMap:
           name: overrides
@@ -2307,7 +3255,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ruler
+  name: ruler-querier-zone-a
   namespace: default
 spec:
   minReadySeconds: 10
@@ -2315,7 +3263,713 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      name: ruler
+      name: ruler-querier-zone-a
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: ruler-querier-zone-a
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2a
+      containers:
+      - args:
+        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
+        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata-zone-a.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
+        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
+        - -blocks-storage.bucket-store.sync-interval=15m
+        - -blocks-storage.gcs.bucket-name=blocks-bucket-rc-<read-compartment-id>
+        - -common.storage.backend=gcs
+        - -compartments.enabled=true
+        - -compartments.read.num-compartments=2
+        - -compartments.write.num-compartments=2
+        - -distributor.health-check-ingesters=true
+        - -distributor.ingestion-tenant-shard-size=3
+        - -ingest-storage.enabled=true
+        - -ingest-storage.ingestion-partition-tenant-shard-size=1
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.topic=ingest-rc-<read-compartment-id>
+        - -ingester.partition-ring.prefix=
+        - -ingester.ring.heartbeat-timeout=10m
+        - -ingester.ring.prefix=partition-ingesters/
+        - -ingester.ring.replication-factor=3
+        - -ingester.ring.store=memberlist
+        - -ingester.ring.zone-awareness-enabled=true
+        - -mem-ballast-size-bytes=268435456
+        - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.abort-if-fast-join-fails-min-nodes=2
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.rejoin-interval=300s
+        - -memberlist.rejoin-seed-nodes=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946
+        - -memberlist.zone-aware-routing.enabled=true
+        - -memberlist.zone-aware-routing.instance-availability-zone=zone-a
+        - -memberlist.zone-aware-routing.role=member
+        - -querier.frontend-client.grpc-max-send-msg-size=104857600
+        - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
+        - -querier.prefer-availability-zones=zone-a,zone-a-backup
+        - -querier.ring.prefix=ruler-querier-zone-a/
+        - -querier.store-gateway-client.grpc-max-recv-msg-size=209715200
+        - -query-scheduler.ring.prefix=ruler-query-scheduler-zone-a/
+        - -query-scheduler.ring.store=memberlist
+        - -query-scheduler.service-discovery-mode=ring
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -store-gateway.sharding-ring.heartbeat-timeout=10m
+        - -store-gateway.sharding-ring.prefix=multi-zone/
+        - -store-gateway.sharding-ring.replication-factor=3
+        - -store-gateway.sharding-ring.store=memberlist
+        - -store-gateway.sharding-ring.zone-awareness-enabled=true
+        - -store-gateway.tenant-shard-size=3
+        - -target=querier
+        - -usage-stats.installation-mode=jsonnet
+        env: []
+        image: grafana/mimir:3.1.2
+        imagePullPolicy: IfNotPresent
+        name: ruler-querier
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "1"
+            ephemeral-storage: 50Mi
+            memory: 12Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      terminationGracePeriodSeconds: 180
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler-querier-zone-a
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ruler-querier-zone-b
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: ruler-querier-zone-b
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: ruler-querier-zone-b
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2b
+      containers:
+      - args:
+        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
+        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata-zone-b.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
+        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
+        - -blocks-storage.bucket-store.sync-interval=15m
+        - -blocks-storage.gcs.bucket-name=blocks-bucket-rc-<read-compartment-id>
+        - -common.storage.backend=gcs
+        - -compartments.enabled=true
+        - -compartments.read.num-compartments=2
+        - -compartments.write.num-compartments=2
+        - -distributor.health-check-ingesters=true
+        - -distributor.ingestion-tenant-shard-size=3
+        - -ingest-storage.enabled=true
+        - -ingest-storage.ingestion-partition-tenant-shard-size=1
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.topic=ingest-rc-<read-compartment-id>
+        - -ingester.partition-ring.prefix=
+        - -ingester.ring.heartbeat-timeout=10m
+        - -ingester.ring.prefix=partition-ingesters/
+        - -ingester.ring.replication-factor=3
+        - -ingester.ring.store=memberlist
+        - -ingester.ring.zone-awareness-enabled=true
+        - -mem-ballast-size-bytes=268435456
+        - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.abort-if-fast-join-fails-min-nodes=2
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.rejoin-interval=300s
+        - -memberlist.rejoin-seed-nodes=dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.zone-aware-routing.enabled=true
+        - -memberlist.zone-aware-routing.instance-availability-zone=zone-b
+        - -memberlist.zone-aware-routing.role=member
+        - -querier.frontend-client.grpc-max-send-msg-size=104857600
+        - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
+        - -querier.prefer-availability-zones=zone-b,zone-b-backup
+        - -querier.ring.prefix=ruler-querier-zone-b/
+        - -querier.store-gateway-client.grpc-max-recv-msg-size=209715200
+        - -query-scheduler.ring.prefix=ruler-query-scheduler-zone-b/
+        - -query-scheduler.ring.store=memberlist
+        - -query-scheduler.service-discovery-mode=ring
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -store-gateway.sharding-ring.heartbeat-timeout=10m
+        - -store-gateway.sharding-ring.prefix=multi-zone/
+        - -store-gateway.sharding-ring.replication-factor=3
+        - -store-gateway.sharding-ring.store=memberlist
+        - -store-gateway.sharding-ring.zone-awareness-enabled=true
+        - -store-gateway.tenant-shard-size=3
+        - -target=querier
+        - -usage-stats.installation-mode=jsonnet
+        env: []
+        image: grafana/mimir:3.1.2
+        imagePullPolicy: IfNotPresent
+        name: ruler-querier
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "1"
+            ephemeral-storage: 50Mi
+            memory: 12Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      terminationGracePeriodSeconds: 180
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler-querier-zone-b
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ruler-query-frontend-zone-a
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: ruler-query-frontend-zone-a
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: ruler-query-frontend-zone-a
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2a
+      containers:
+      - args:
+        - -compartments.enabled=true
+        - -compartments.read.num-compartments=2
+        - -compartments.write.num-compartments=2
+        - -ingest-storage.enabled=true
+        - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
+        - -ingest-storage.kafka.topic=ingest-rc-<read-compartment-id>
+        - -ingester.partition-ring.prefix=
+        - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.abort-if-fast-join-fails-min-nodes=2
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.rejoin-interval=300s
+        - -memberlist.rejoin-seed-nodes=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946
+        - -memberlist.zone-aware-routing.enabled=true
+        - -memberlist.zone-aware-routing.instance-availability-zone=zone-a
+        - -memberlist.zone-aware-routing.role=member
+        - -querier.ring.prefix=ruler-querier-zone-a/
+        - -query-frontend.cache-results=false
+        - -query-frontend.max-cache-freshness=10m
+        - -query-frontend.max-queriers-per-tenant=10
+        - -query-frontend.max-total-query-length=12000h
+        - -query-frontend.query-sharding-target-series-per-shard=2500
+        - -query-frontend.results-cache.backend=memcached
+        - -query-frontend.results-cache.memcached.addresses=dnssrvnoa+memcached-frontend-zone-a.default.svc.cluster.local.:11211
+        - -query-frontend.results-cache.memcached.max-item-size=26214400
+        - -query-frontend.results-cache.memcached.timeout=500ms
+        - -query-scheduler.ring.prefix=ruler-query-scheduler-zone-a/
+        - -query-scheduler.ring.store=memberlist
+        - -query-scheduler.service-discovery-mode=ring
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc-max-concurrent-streams=300
+        - -server.grpc-max-recv-msg-size-bytes=104857600
+        - -server.grpc-max-send-msg-size-bytes=104857600
+        - -server.grpc.keepalive.max-connection-age=30s
+        - -server.grpc.keepalive.max-connection-age-grace=5m
+        - -server.grpc.keepalive.max-connection-idle=1m
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -shutdown-delay=90s
+        - -target=query-frontend
+        - -usage-stats.installation-mode=jsonnet
+        image: grafana/mimir:3.1.2
+        imagePullPolicy: IfNotPresent
+        name: ruler-query-frontend
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 4Gi
+          requests:
+            cpu: "2"
+            ephemeral-storage: 50Mi
+            memory: 2Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      terminationGracePeriodSeconds: 390
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler-query-frontend-zone-a
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ruler-query-frontend-zone-b
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: ruler-query-frontend-zone-b
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: ruler-query-frontend-zone-b
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2b
+      containers:
+      - args:
+        - -compartments.enabled=true
+        - -compartments.read.num-compartments=2
+        - -compartments.write.num-compartments=2
+        - -ingest-storage.enabled=true
+        - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
+        - -ingest-storage.kafka.topic=ingest-rc-<read-compartment-id>
+        - -ingester.partition-ring.prefix=
+        - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.abort-if-fast-join-fails-min-nodes=2
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.rejoin-interval=300s
+        - -memberlist.rejoin-seed-nodes=dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.zone-aware-routing.enabled=true
+        - -memberlist.zone-aware-routing.instance-availability-zone=zone-b
+        - -memberlist.zone-aware-routing.role=member
+        - -querier.ring.prefix=ruler-querier-zone-b/
+        - -query-frontend.cache-results=false
+        - -query-frontend.max-cache-freshness=10m
+        - -query-frontend.max-queriers-per-tenant=10
+        - -query-frontend.max-total-query-length=12000h
+        - -query-frontend.query-sharding-target-series-per-shard=2500
+        - -query-frontend.results-cache.backend=memcached
+        - -query-frontend.results-cache.memcached.addresses=dnssrvnoa+memcached-frontend-zone-b.default.svc.cluster.local.:11211
+        - -query-frontend.results-cache.memcached.max-item-size=26214400
+        - -query-frontend.results-cache.memcached.timeout=500ms
+        - -query-scheduler.ring.prefix=ruler-query-scheduler-zone-b/
+        - -query-scheduler.ring.store=memberlist
+        - -query-scheduler.service-discovery-mode=ring
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc-max-concurrent-streams=300
+        - -server.grpc-max-recv-msg-size-bytes=104857600
+        - -server.grpc-max-send-msg-size-bytes=104857600
+        - -server.grpc.keepalive.max-connection-age=30s
+        - -server.grpc.keepalive.max-connection-age-grace=5m
+        - -server.grpc.keepalive.max-connection-idle=1m
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -shutdown-delay=90s
+        - -target=query-frontend
+        - -usage-stats.installation-mode=jsonnet
+        image: grafana/mimir:3.1.2
+        imagePullPolicy: IfNotPresent
+        name: ruler-query-frontend
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 4Gi
+          requests:
+            cpu: "2"
+            ephemeral-storage: 50Mi
+            memory: 2Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      terminationGracePeriodSeconds: 390
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: ruler-query-frontend-zone-b
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ruler-query-scheduler-zone-a
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: ruler-query-scheduler-zone-a
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: ruler-query-scheduler-zone-a
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2a
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: ruler-query-scheduler-zone-a
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -ingest-storage.enabled=true
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.topic=ingest
+        - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.abort-if-fast-join-fails-min-nodes=2
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.rejoin-interval=300s
+        - -memberlist.rejoin-seed-nodes=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946
+        - -memberlist.zone-aware-routing.enabled=true
+        - -memberlist.zone-aware-routing.instance-availability-zone=zone-a
+        - -memberlist.zone-aware-routing.role=member
+        - -query-frontend.max-queriers-per-tenant=10
+        - -query-scheduler.max-outstanding-requests-per-tenant=100
+        - -query-scheduler.ring.prefix=ruler-query-scheduler-zone-a/
+        - -query-scheduler.ring.store=memberlist
+        - -query-scheduler.service-discovery-mode=ring
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -target=query-scheduler
+        - -usage-stats.installation-mode=jsonnet
+        image: grafana/mimir:3.1.2
+        imagePullPolicy: IfNotPresent
+        name: ruler-query-scheduler
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 2Gi
+          requests:
+            cpu: "2"
+            ephemeral-storage: 50Mi
+            memory: 1Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      terminationGracePeriodSeconds: 180
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ruler-query-scheduler-zone-b
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: ruler-query-scheduler-zone-b
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: ruler-query-scheduler-zone-b
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2b
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: ruler-query-scheduler-zone-b
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -ingest-storage.enabled=true
+        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.topic=ingest
+        - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.abort-if-fast-join-fails-min-nodes=2
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.rejoin-interval=300s
+        - -memberlist.rejoin-seed-nodes=dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.zone-aware-routing.enabled=true
+        - -memberlist.zone-aware-routing.instance-availability-zone=zone-b
+        - -memberlist.zone-aware-routing.role=member
+        - -query-frontend.max-queriers-per-tenant=10
+        - -query-scheduler.max-outstanding-requests-per-tenant=100
+        - -query-scheduler.ring.prefix=ruler-query-scheduler-zone-b/
+        - -query-scheduler.ring.store=memberlist
+        - -query-scheduler.service-discovery-mode=ring
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -target=query-scheduler
+        - -usage-stats.installation-mode=jsonnet
+        image: grafana/mimir:3.1.2
+        imagePullPolicy: IfNotPresent
+        name: ruler-query-scheduler
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 2Gi
+          requests:
+            cpu: "2"
+            ephemeral-storage: 50Mi
+            memory: 1Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      terminationGracePeriodSeconds: 180
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ruler-zone-a
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: ruler-zone-a
   strategy:
     rollingUpdate:
       maxSurge: 50%
@@ -2324,12 +3978,21 @@ spec:
     metadata:
       labels:
         gossip_ring_member: "true"
-        name: ruler
+        name: ruler-zone-a
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2a
       containers:
       - args:
         - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata-zone-a.default.svc.cluster.local.:11211
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
         - -blocks-storage.bucket-store.sync-dir=/data/tsdb
@@ -2353,11 +4016,18 @@ spec:
         - -ingester.ring.store=memberlist
         - -ingester.ring.zone-awareness-enabled=true
         - -mem-ballast-size-bytes=1073741824
+        - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.abort-if-fast-join-fails-min-nodes=2
         - -memberlist.bind-port=7946
-        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -memberlist.join=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.rejoin-interval=300s
+        - -memberlist.rejoin-seed-nodes=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946
+        - -memberlist.zone-aware-routing.enabled=true
+        - -memberlist.zone-aware-routing.instance-availability-zone=zone-a
+        - -memberlist.zone-aware-routing.role=member
         - -querier.max-partial-query-length=768h
         - -ruler-storage.cache.backend=memcached
-        - -ruler-storage.cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
+        - -ruler-storage.cache.memcached.addresses=dnssrvnoa+memcached-metadata-multi-zone.default.svc.cluster.local.:11211
         - -ruler-storage.cache.memcached.max-async-concurrency=50
         - -ruler-storage.cache.memcached.max-item-size=1048576
         - -ruler-storage.cache.memcached.timeout=500ms
@@ -2365,7 +4035,7 @@ spec:
         - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local./alertmanager
         - -ruler.max-rule-groups-per-tenant=85
         - -ruler.max-rules-per-rule-group=20
-        - -ruler.query-frontend.address=dns:///ruler-query-frontend-headless.default.svc.cluster.local.:9095
+        - -ruler.query-frontend.address=dns:///ruler-query-frontend-zone-a-headless.default.svc.cluster.local.:9095
         - -ruler.query-frontend.grpc-client-config.grpc-max-recv-msg-size=104857600
         - -ruler.ring.store=memberlist
         - -ruler.rule-path=/rules
@@ -2407,10 +4077,15 @@ spec:
         - mountPath: /etc/mimir
           name: overrides
       terminationGracePeriodSeconds: 600
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:
-            name: ruler
+            name: ruler-zone-a
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway
@@ -2422,60 +4097,85 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ruler-querier
+  name: ruler-zone-b
   namespace: default
 spec:
   minReadySeconds: 10
-  replicas: 6
+  replicas: 2
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      name: ruler-querier
+      name: ruler-zone-b
   strategy:
     rollingUpdate:
-      maxSurge: 15%
+      maxSurge: 50%
       maxUnavailable: 0
   template:
     metadata:
       labels:
         gossip_ring_member: "true"
-        name: ruler-querier
+        name: ruler-zone-b
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2b
       containers:
       - args:
         - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata-zone-b.default.svc.cluster.local.:11211
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
         - -blocks-storage.bucket-store.sync-dir=/data/tsdb
         - -blocks-storage.bucket-store.sync-interval=15m
-        - -blocks-storage.gcs.bucket-name=blocks-bucket-rc-<read-compartment-id>
+        - -blocks-storage.gcs.bucket-name=blocks-bucket
         - -common.storage.backend=gcs
-        - -compartments.enabled=true
-        - -compartments.read.num-compartments=2
-        - -compartments.write.num-compartments=2
         - -distributor.health-check-ingesters=true
         - -distributor.ingestion-tenant-shard-size=3
+        - -distributor.remote-timeout=10s
         - -ingest-storage.enabled=true
         - -ingest-storage.ingestion-partition-tenant-shard-size=1
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
-        - -ingest-storage.kafka.topic=ingest-rc-<read-compartment-id>
+        - -ingest-storage.kafka.producer-max-buffered-bytes=1073741824
+        - -ingest-storage.kafka.producer-record-version=2
+        - -ingest-storage.kafka.topic=ingest
         - -ingester.partition-ring.prefix=
         - -ingester.ring.heartbeat-timeout=10m
         - -ingester.ring.prefix=partition-ingesters/
         - -ingester.ring.replication-factor=3
         - -ingester.ring.store=memberlist
         - -ingester.ring.zone-awareness-enabled=true
-        - -mem-ballast-size-bytes=268435456
+        - -mem-ballast-size-bytes=1073741824
+        - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.abort-if-fast-join-fails-min-nodes=2
         - -memberlist.bind-port=7946
-        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
-        - -querier.frontend-client.grpc-max-send-msg-size=104857600
-        - -querier.max-concurrent=8
+        - -memberlist.join=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.rejoin-interval=300s
+        - -memberlist.rejoin-seed-nodes=dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.zone-aware-routing.enabled=true
+        - -memberlist.zone-aware-routing.instance-availability-zone=zone-b
+        - -memberlist.zone-aware-routing.role=member
         - -querier.max-partial-query-length=768h
-        - -querier.ring.prefix=ruler-querier/
-        - -querier.scheduler-address=ruler-query-scheduler-discovery.default.svc.cluster.local.:9095
-        - -querier.store-gateway-client.grpc-max-recv-msg-size=209715200
+        - -ruler-storage.cache.backend=memcached
+        - -ruler-storage.cache.memcached.addresses=dnssrvnoa+memcached-metadata-multi-zone.default.svc.cluster.local.:11211
+        - -ruler-storage.cache.memcached.max-async-concurrency=50
+        - -ruler-storage.cache.memcached.max-item-size=1048576
+        - -ruler-storage.cache.memcached.timeout=500ms
+        - -ruler-storage.gcs.bucket-name=rules-bucket
+        - -ruler.alertmanager-url=http://alertmanager.default.svc.cluster.local./alertmanager
+        - -ruler.max-rule-groups-per-tenant=85
+        - -ruler.max-rules-per-rule-group=20
+        - -ruler.query-frontend.address=dns:///ruler-query-frontend-zone-b-headless.default.svc.cluster.local.:9095
+        - -ruler.query-frontend.grpc-client-config.grpc-max-recv-msg-size=104857600
+        - -ruler.ring.store=memberlist
+        - -ruler.rule-path=/rules
+        - -ruler.tenant-shard-size=2
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
@@ -2486,19 +4186,16 @@ spec:
         - -store-gateway.sharding-ring.store=memberlist
         - -store-gateway.sharding-ring.zone-awareness-enabled=true
         - -store-gateway.tenant-shard-size=3
-        - -target=querier
+        - -target=ruler
         - -usage-stats.installation-mode=jsonnet
-        env: []
         image: grafana/mimir:3.1.2
         imagePullPolicy: IfNotPresent
-        name: ruler-querier
+        name: ruler
         ports:
         - containerPort: 8080
           name: http-metrics
         - containerPort: 9095
           name: grpc
-        - containerPort: 7946
-          name: gossip-ring
         readinessProbe:
           httpGet:
             path: /ready
@@ -2507,186 +4204,27 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            memory: 24Gi
+            cpu: "16"
+            memory: 16Gi
           requests:
             cpu: "1"
-            ephemeral-storage: 50Mi
-            memory: 12Gi
+            memory: 6Gi
         volumeMounts:
         - mountPath: /etc/mimir
           name: overrides
-      terminationGracePeriodSeconds: 180
+      terminationGracePeriodSeconds: 600
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
       topologySpreadConstraints:
       - labelSelector:
           matchLabels:
-            name: ruler-querier
+            name: ruler-zone-b
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway
-      volumes:
-      - configMap:
-          name: overrides
-        name: overrides
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: ruler-query-frontend
-  namespace: default
-spec:
-  minReadySeconds: 10
-  replicas: 2
-  revisionHistoryLimit: 10
-  selector:
-    matchLabels:
-      name: ruler-query-frontend
-  strategy:
-    rollingUpdate:
-      maxSurge: 15%
-      maxUnavailable: 0
-  template:
-    metadata:
-      labels:
-        name: ruler-query-frontend
-    spec:
-      containers:
-      - args:
-        - -compartments.enabled=true
-        - -compartments.read.num-compartments=2
-        - -compartments.write.num-compartments=2
-        - -ingest-storage.enabled=true
-        - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
-        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
-        - -ingest-storage.kafka.last-produced-offset-poll-interval=500ms
-        - -ingest-storage.kafka.topic=ingest-rc-<read-compartment-id>
-        - -ingester.partition-ring.prefix=
-        - -querier.ring.prefix=ruler-querier/
-        - -query-frontend.cache-results=false
-        - -query-frontend.max-cache-freshness=10m
-        - -query-frontend.max-queriers-per-tenant=10
-        - -query-frontend.max-total-query-length=12000h
-        - -query-frontend.query-sharding-target-series-per-shard=2500
-        - -query-frontend.results-cache.backend=memcached
-        - -query-frontend.results-cache.memcached.addresses=dnssrvnoa+memcached-frontend.default.svc.cluster.local.:11211
-        - -query-frontend.results-cache.memcached.max-item-size=26214400
-        - -query-frontend.results-cache.memcached.timeout=500ms
-        - -query-frontend.scheduler-address=ruler-query-scheduler-discovery.default.svc.cluster.local.:9095
-        - -runtime-config.file=/etc/mimir/overrides.yaml
-        - -server.grpc-max-concurrent-streams=300
-        - -server.grpc-max-recv-msg-size-bytes=104857600
-        - -server.grpc-max-send-msg-size-bytes=104857600
-        - -server.grpc.keepalive.max-connection-age=30s
-        - -server.grpc.keepalive.max-connection-age-grace=5m
-        - -server.grpc.keepalive.max-connection-idle=1m
-        - -server.grpc.keepalive.min-time-between-pings=10s
-        - -server.grpc.keepalive.ping-without-stream-allowed=true
-        - -server.http-listen-port=8080
-        - -shutdown-delay=90s
-        - -target=query-frontend
-        - -usage-stats.installation-mode=jsonnet
-        image: grafana/mimir:3.1.2
-        imagePullPolicy: IfNotPresent
-        name: ruler-query-frontend
-        ports:
-        - containerPort: 8080
-          name: http-metrics
-        - containerPort: 9095
-          name: grpc
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 8080
-          initialDelaySeconds: 15
-          timeoutSeconds: 1
-        resources:
-          limits:
-            memory: 4Gi
-          requests:
-            cpu: "2"
-            ephemeral-storage: 50Mi
-            memory: 2Gi
-        volumeMounts:
-        - mountPath: /etc/mimir
-          name: overrides
-      terminationGracePeriodSeconds: 390
-      topologySpreadConstraints:
-      - labelSelector:
-          matchLabels:
-            name: ruler-query-frontend
-        maxSkew: 1
-        topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: ScheduleAnyway
-      volumes:
-      - configMap:
-          name: overrides
-        name: overrides
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: ruler-query-scheduler
-  namespace: default
-spec:
-  minReadySeconds: 10
-  replicas: 2
-  revisionHistoryLimit: 10
-  selector:
-    matchLabels:
-      name: ruler-query-scheduler
-  strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
-  template:
-    metadata:
-      labels:
-        name: ruler-query-scheduler
-    spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                name: ruler-query-scheduler
-            topologyKey: kubernetes.io/hostname
-      containers:
-      - args:
-        - -ingest-storage.enabled=true
-        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
-        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
-        - -ingest-storage.kafka.topic=ingest
-        - -query-frontend.max-queriers-per-tenant=10
-        - -query-scheduler.max-outstanding-requests-per-tenant=100
-        - -server.grpc.keepalive.min-time-between-pings=10s
-        - -server.grpc.keepalive.ping-without-stream-allowed=true
-        - -server.http-listen-port=8080
-        - -target=query-scheduler
-        - -usage-stats.installation-mode=jsonnet
-        image: grafana/mimir:3.1.2
-        imagePullPolicy: IfNotPresent
-        name: ruler-query-scheduler
-        ports:
-        - containerPort: 8080
-          name: http-metrics
-        - containerPort: 9095
-          name: grpc
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 8080
-          initialDelaySeconds: 15
-          timeoutSeconds: 1
-        resources:
-          limits:
-            memory: 2Gi
-          requests:
-            cpu: "2"
-            ephemeral-storage: 50Mi
-            memory: 1Gi
-        volumeMounts:
-        - mountPath: /etc/mimir
-          name: overrides
-      terminationGracePeriodSeconds: 180
       volumes:
       - configMap:
           name: overrides
@@ -2723,8 +4261,12 @@ spec:
         - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
         - -ingest-storage.kafka.topic=ingest
+        - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.abort-if-fast-join-fails-min-nodes=2
         - -memberlist.bind-port=7946
-        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -memberlist.join=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.rejoin-interval=300s
+        - -memberlist.rejoin-seed-nodes=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
@@ -2849,8 +4391,15 @@ spec:
         - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
         - -ingest-storage.kafka.topic=ingest-rc-0
+        - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.abort-if-fast-join-fails-min-nodes=2
         - -memberlist.bind-port=7946
-        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -memberlist.join=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.rejoin-interval=300s
+        - -memberlist.rejoin-seed-nodes=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946
+        - -memberlist.zone-aware-routing.enabled=true
+        - -memberlist.zone-aware-routing.instance-availability-zone=zone-a
+        - -memberlist.zone-aware-routing.role=member
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
@@ -2971,8 +4520,15 @@ spec:
         - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
         - -ingest-storage.kafka.topic=ingest-rc-1
+        - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.abort-if-fast-join-fails-min-nodes=2
         - -memberlist.bind-port=7946
-        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -memberlist.join=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.rejoin-interval=300s
+        - -memberlist.rejoin-seed-nodes=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946
+        - -memberlist.zone-aware-routing.enabled=true
+        - -memberlist.zone-aware-routing.instance-availability-zone=zone-a
+        - -memberlist.zone-aware-routing.role=member
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc.keepalive.min-time-between-pings=10s
         - -server.grpc.keepalive.ping-without-stream-allowed=true
@@ -3311,8 +4867,14 @@ spec:
         - -ingester.ring.unregister-on-shutdown=true
         - -ingester.ring.zone-awareness-enabled=true
         - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.abort-if-fast-join-fails-min-nodes=2
         - -memberlist.bind-port=7946
-        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -memberlist.join=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.rejoin-interval=300s
+        - -memberlist.rejoin-seed-nodes=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946
+        - -memberlist.zone-aware-routing.enabled=true
+        - -memberlist.zone-aware-routing.instance-availability-zone=zone-a
+        - -memberlist.zone-aware-routing.role=member
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-concurrent-streams=500
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -3494,8 +5056,14 @@ spec:
         - -ingester.ring.unregister-on-shutdown=true
         - -ingester.ring.zone-awareness-enabled=true
         - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.abort-if-fast-join-fails-min-nodes=2
         - -memberlist.bind-port=7946
-        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -memberlist.join=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.rejoin-interval=300s
+        - -memberlist.rejoin-seed-nodes=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946
+        - -memberlist.zone-aware-routing.enabled=true
+        - -memberlist.zone-aware-routing.instance-availability-zone=zone-a
+        - -memberlist.zone-aware-routing.role=member
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-concurrent-streams=500
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -3673,8 +5241,14 @@ spec:
         - -ingester.ring.unregister-on-shutdown=true
         - -ingester.ring.zone-awareness-enabled=true
         - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.abort-if-fast-join-fails-min-nodes=2
         - -memberlist.bind-port=7946
-        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -memberlist.join=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.rejoin-interval=300s
+        - -memberlist.rejoin-seed-nodes=dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.zone-aware-routing.enabled=true
+        - -memberlist.zone-aware-routing.instance-availability-zone=zone-b
+        - -memberlist.zone-aware-routing.role=member
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-concurrent-streams=500
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -3846,8 +5420,14 @@ spec:
         - -ingester.ring.unregister-on-shutdown=true
         - -ingester.ring.zone-awareness-enabled=true
         - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.abort-if-fast-join-fails-min-nodes=2
         - -memberlist.bind-port=7946
-        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -memberlist.join=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.rejoin-interval=300s
+        - -memberlist.rejoin-seed-nodes=dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.zone-aware-routing.enabled=true
+        - -memberlist.zone-aware-routing.instance-availability-zone=zone-b
+        - -memberlist.zone-aware-routing.role=member
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-concurrent-streams=500
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -4826,6 +6406,14 @@ spec:
         rollout-group: store-gateway-rc-0
     spec:
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2a
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -4856,7 +6444,7 @@ spec:
         - -blocks-storage.bucket-store.index-cache.memcached.max-item-size=5242880
         - -blocks-storage.bucket-store.index-cache.memcached.timeout=750ms
         - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata-zone-a.default.svc.cluster.local.:11211
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-idle-connections=150
@@ -4872,8 +6460,15 @@ spec:
         - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
         - -ingest-storage.kafka.topic=ingest-rc-0
+        - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.abort-if-fast-join-fails-min-nodes=2
         - -memberlist.bind-port=7946
-        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -memberlist.join=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.rejoin-interval=300s
+        - -memberlist.rejoin-seed-nodes=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946
+        - -memberlist.zone-aware-routing.enabled=true
+        - -memberlist.zone-aware-routing.instance-availability-zone=zone-a
+        - -memberlist.zone-aware-routing.role=member
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-send-msg-size-bytes=209715200
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -4932,6 +6527,11 @@ spec:
       securityContext:
         runAsUser: 0
       terminationGracePeriodSeconds: 120
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
       volumes:
       - configMap:
           name: overrides
@@ -4984,6 +6584,14 @@ spec:
         rollout-group: store-gateway-rc-1
     spec:
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2a
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -5014,7 +6622,7 @@ spec:
         - -blocks-storage.bucket-store.index-cache.memcached.max-item-size=5242880
         - -blocks-storage.bucket-store.index-cache.memcached.timeout=750ms
         - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata-zone-a.default.svc.cluster.local.:11211
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-idle-connections=150
@@ -5030,8 +6638,15 @@ spec:
         - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
         - -ingest-storage.kafka.topic=ingest-rc-1
+        - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.abort-if-fast-join-fails-min-nodes=2
         - -memberlist.bind-port=7946
-        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -memberlist.join=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.rejoin-interval=300s
+        - -memberlist.rejoin-seed-nodes=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946
+        - -memberlist.zone-aware-routing.enabled=true
+        - -memberlist.zone-aware-routing.instance-availability-zone=zone-a
+        - -memberlist.zone-aware-routing.role=member
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-send-msg-size-bytes=209715200
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -5090,6 +6705,11 @@ spec:
       securityContext:
         runAsUser: 0
       terminationGracePeriodSeconds: 120
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
       volumes:
       - configMap:
           name: overrides
@@ -5144,6 +6764,14 @@ spec:
         rollout-group: store-gateway-rc-0
     spec:
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2b
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -5174,7 +6802,7 @@ spec:
         - -blocks-storage.bucket-store.index-cache.memcached.max-item-size=5242880
         - -blocks-storage.bucket-store.index-cache.memcached.timeout=750ms
         - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata-zone-b.default.svc.cluster.local.:11211
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-idle-connections=150
@@ -5190,8 +6818,15 @@ spec:
         - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
         - -ingest-storage.kafka.topic=ingest-rc-0
+        - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.abort-if-fast-join-fails-min-nodes=2
         - -memberlist.bind-port=7946
-        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -memberlist.join=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.rejoin-interval=300s
+        - -memberlist.rejoin-seed-nodes=dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.zone-aware-routing.enabled=true
+        - -memberlist.zone-aware-routing.instance-availability-zone=zone-b
+        - -memberlist.zone-aware-routing.role=member
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-send-msg-size-bytes=209715200
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -5252,6 +6887,11 @@ spec:
       securityContext:
         runAsUser: 0
       terminationGracePeriodSeconds: 120
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
       volumes:
       - configMap:
           name: overrides
@@ -5306,6 +6946,14 @@ spec:
         rollout-group: store-gateway-rc-1
     spec:
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - us-east-2b
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
@@ -5336,7 +6984,7 @@ spec:
         - -blocks-storage.bucket-store.index-cache.memcached.max-item-size=5242880
         - -blocks-storage.bucket-store.index-cache.memcached.timeout=750ms
         - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata-zone-b.default.svc.cluster.local.:11211
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-idle-connections=150
@@ -5352,8 +7000,15 @@ spec:
         - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
         - -ingest-storage.kafka.topic=ingest-rc-1
+        - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.abort-if-fast-join-fails-min-nodes=2
         - -memberlist.bind-port=7946
-        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -memberlist.join=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.rejoin-interval=300s
+        - -memberlist.rejoin-seed-nodes=dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.zone-aware-routing.enabled=true
+        - -memberlist.zone-aware-routing.instance-availability-zone=zone-b
+        - -memberlist.zone-aware-routing.role=member
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-send-msg-size-bytes=209715200
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -5414,6 +7069,11 @@ spec:
       securityContext:
         runAsUser: 0
       terminationGracePeriodSeconds: 120
+      tolerations:
+      - effect: NoSchedule
+        key: topology
+        operator: Equal
+        value: secondary-az
       volumes:
       - configMap:
           name: overrides
@@ -5498,7 +7158,7 @@ spec:
         - -blocks-storage.bucket-store.index-cache.memcached.max-item-size=5242880
         - -blocks-storage.bucket-store.index-cache.memcached.timeout=750ms
         - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata-zone-a.default.svc.cluster.local.:11211
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-idle-connections=150
@@ -5514,8 +7174,15 @@ spec:
         - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
         - -ingest-storage.kafka.topic=ingest-rc-0
+        - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.abort-if-fast-join-fails-min-nodes=2
         - -memberlist.bind-port=7946
-        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -memberlist.join=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.rejoin-interval=300s
+        - -memberlist.rejoin-seed-nodes=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946
+        - -memberlist.zone-aware-routing.enabled=true
+        - -memberlist.zone-aware-routing.instance-availability-zone=zone-a
+        - -memberlist.zone-aware-routing.role=member
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-send-msg-size-bytes=209715200
         - -server.grpc.keepalive.min-time-between-pings=10s
@@ -5658,7 +7325,7 @@ spec:
         - -blocks-storage.bucket-store.index-cache.memcached.max-item-size=5242880
         - -blocks-storage.bucket-store.index-cache.memcached.timeout=750ms
         - -blocks-storage.bucket-store.metadata-cache.backend=memcached
-        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata-zone-a.default.svc.cluster.local.:11211
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-concurrency=100
         - -blocks-storage.bucket-store.metadata-cache.memcached.max-idle-connections=150
@@ -5674,8 +7341,15 @@ spec:
         - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
         - -ingest-storage.kafka.topic=ingest-rc-1
+        - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.abort-if-fast-join-fails-min-nodes=2
         - -memberlist.bind-port=7946
-        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -memberlist.join=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
+        - -memberlist.rejoin-interval=300s
+        - -memberlist.rejoin-seed-nodes=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946
+        - -memberlist.zone-aware-routing.enabled=true
+        - -memberlist.zone-aware-routing.instance-availability-zone=zone-a
+        - -memberlist.zone-aware-routing.role=member
         - -runtime-config.file=/etc/mimir/overrides.yaml
         - -server.grpc-max-send-msg-size-bytes=209715200
         - -server.grpc.keepalive.min-time-between-pings=10s

--- a/operations/mimir-tests/test-compartments.jsonnet
+++ b/operations/mimir-tests/test-compartments.jsonnet
@@ -1,13 +1,22 @@
-// Renders Mimir with the experimental compartments architecture enabled.
+// Renders Mimir with the experimental compartments architecture enabled, deployed multi-AZ across all
+// components (write and read path). This matches the production topology (e.g. mimir-dev-26): the
+// per-compartment memcached caches are zonal (memcached-zone-<zone>-rc-<id>) and each per-compartment
+// store-gateway zone routes to its zonal cache, exercising the 2-AZ zone-c->zone-a fallback.
 // Based on test-ingest-storage-autoscaling-one-trigger.jsonnet.
 (import 'test-ingest-storage-autoscaling-one-trigger.jsonnet') {
   _config+:: {
     multi_zone_availability_zones: ['us-east-2a', 'us-east-2b'],
     ingest_storage_ingester_zones: 2,
 
-    // Multi-AZ write path.
-    multi_zone_ingester_multi_az_enabled: true,
+    // Multi-AZ write and read path: distributors, ingesters, queriers, query-frontends, query-schedulers,
+    // rulers, store-gateways and memcached all become zonal/AZ-pinned (multi_zone_read_path_multi_az_enabled
+    // also drives the ingester multi-AZ deployment that the compartments ingester requires).
     multi_zone_write_path_enabled: true,
+    multi_zone_read_path_enabled: true,
+    multi_zone_read_path_multi_az_enabled: true,
+    multi_zone_memberlist_bridge_enabled: true,
+    memberlist_zone_aware_routing_enabled: true,
+    query_scheduler_service_discovery_mode: 'ring',
 
     // Exercise the per-compartment distributor scaled objects.
     autoscaling_distributor_enabled: true,
@@ -36,10 +45,5 @@
     autoscaling_store_gateway_min_replicas_per_compartment_zone: 1,
     autoscaling_store_gateway_max_replicas_per_compartment_zone: 3,
     enable_pvc_auto_deletion_for_store_gateways: true,
-
-    // Exercise the per-compartment memcached (chunks + index-queries) multi-AZ path, including the
-    // store-gateway per-compartment caching-config wiring and the 2-AZ zone-c->zone-a fallback.
-    multi_zone_memcached_enabled: true,
-    multi_zone_memcached_routing_enabled: true,
   },
 }

--- a/operations/mimir-tests/test-compartments.jsonnet
+++ b/operations/mimir-tests/test-compartments.jsonnet
@@ -36,5 +36,10 @@
     autoscaling_store_gateway_min_replicas_per_compartment_zone: 1,
     autoscaling_store_gateway_max_replicas_per_compartment_zone: 3,
     enable_pvc_auto_deletion_for_store_gateways: true,
+
+    // Exercise the per-compartment memcached (chunks + index-queries) multi-AZ path, including the
+    // store-gateway per-compartment caching-config wiring and the 2-AZ zone-c->zone-a fallback.
+    multi_zone_memcached_enabled: true,
+    multi_zone_memcached_routing_enabled: true,
   },
 }

--- a/operations/mimir-tests/test-compartments.jsonnet
+++ b/operations/mimir-tests/test-compartments.jsonnet
@@ -1,16 +1,11 @@
 // Renders Mimir with the experimental compartments architecture enabled, deployed multi-AZ across all
-// components (write and read path). This matches the production topology (e.g. mimir-dev-26): the
-// per-compartment memcached caches are zonal (memcached-zone-<zone>-rc-<id>) and each per-compartment
-// store-gateway zone routes to its zonal cache, exercising the 2-AZ zone-c->zone-a fallback.
-// Based on test-ingest-storage-autoscaling-one-trigger.jsonnet.
+// components (write and read path).
 (import 'test-ingest-storage-autoscaling-one-trigger.jsonnet') {
   _config+:: {
     multi_zone_availability_zones: ['us-east-2a', 'us-east-2b'],
     ingest_storage_ingester_zones: 2,
 
-    // Multi-AZ write and read path: distributors, ingesters, queriers, query-frontends, query-schedulers,
-    // rulers, store-gateways and memcached all become zonal/AZ-pinned (multi_zone_read_path_multi_az_enabled
-    // also drives the ingester multi-AZ deployment that the compartments ingester requires).
+    // Multi-AZ write and read path.
     multi_zone_write_path_enabled: true,
     multi_zone_read_path_enabled: true,
     multi_zone_read_path_multi_az_enabled: true,

--- a/operations/mimir/compartments-common.libsonnet
+++ b/operations/mimir/compartments-common.libsonnet
@@ -77,9 +77,7 @@ local jsonpath = import 'github.com/jsonnet-libs/xtd/jsonpath.libsonnet';
     for compartment in std.range(0, numCompartments - 1)
   },
 
-  // Per-compartment blocks chunks/index caching config, keyed by compartment. Empty by default;
-  // compartments-memcached.libsonnet layers the per-compartment memcached addresses on top, and
-  // compartments-store-gateway.libsonnet merges them into each per-compartment store-gateway zone's args.
+  // Base (empty) per-compartment caching config.
   blocks_chunks_zone_a_caching_configs:: $.mimirCompartmentsCreateIf(true, $._config.compartments_read_count, function(c) {}),
   blocks_chunks_zone_b_caching_configs:: $.mimirCompartmentsCreateIf(true, $._config.compartments_read_count, function(c) {}),
   blocks_chunks_zone_c_caching_configs:: $.mimirCompartmentsCreateIf(true, $._config.compartments_read_count, function(c) {}),

--- a/operations/mimir/compartments-common.libsonnet
+++ b/operations/mimir/compartments-common.libsonnet
@@ -77,6 +77,13 @@ local jsonpath = import 'github.com/jsonnet-libs/xtd/jsonpath.libsonnet';
     for compartment in std.range(0, numCompartments - 1)
   },
 
+  // Per-compartment blocks chunks/index caching config, keyed by compartment. Empty by default;
+  // compartments-memcached.libsonnet layers the per-compartment memcached addresses on top, and
+  // compartments-store-gateway.libsonnet merges them into each per-compartment store-gateway zone's args.
+  blocks_chunks_zone_a_caching_configs:: $.mimirCompartmentsCreateIf(true, $._config.compartments_read_count, function(c) {}),
+  blocks_chunks_zone_b_caching_configs:: $.mimirCompartmentsCreateIf(true, $._config.compartments_read_count, function(c) {}),
+  blocks_chunks_zone_c_caching_configs:: $.mimirCompartmentsCreateIf(true, $._config.compartments_read_count, function(c) {}),
+
   // Validates that per-compartment Deployments/StatefulSets configuration options are correctly
   // parameterised for the compartment they belong to.
   validateMimirCompartmentsConfig(resourceNames)::

--- a/operations/mimir/compartments-memcached.libsonnet
+++ b/operations/mimir/compartments-memcached.libsonnet
@@ -1,0 +1,112 @@
+{
+  _config+:: {
+    // Deploy per-compartment memcached (chunks) and memcached-index-queries. Per-zone when multi-AZ
+    // memcached is enabled, otherwise a single per-compartment instance.
+    compartments_memcached_enabled: $._config.compartments_enabled,
+    no_compartments_memcached_enabled: !self.compartments_memcached_enabled,
+
+    // Per-compartment replica counts.
+    memcached_chunks_replicas_per_compartment: $._config.memcached_chunks_replicas,
+    memcached_index_queries_replicas_per_compartment: $._config.memcached_index_queries_replicas,
+  },
+
+  assert !$._config.compartments_memcached_enabled || !$._config.multi_zone_memcached_routing_enabled || $._config.multi_zone_memcached_enabled
+         : 'compartments memcached: multi_zone_memcached_routing_enabled requires multi_zone_memcached_enabled',
+  assert !$._config.compartments_memcached_enabled || $._config.multi_zone_memcached_routing_enabled || $._config.single_zone_memcached_enabled
+         : 'compartments memcached: single-zone routing (multi_zone_memcached_routing_enabled=false) requires single_zone_memcached_enabled',
+
+  local statefulSet = $.apps.v1.statefulSet,
+
+  local isEnabled = $._config.compartments_memcached_enabled,
+  local isNoCompartmentsEnabled = $._config.no_compartments_memcached_enabled,
+  local numCompartments = $._config.compartments_read_count,
+
+  local isSingleZoneEnabled = $._config.single_zone_memcached_enabled,
+  local isMultiZoneEnabled = $._config.multi_zone_memcached_enabled,
+  local isZoneAEnabled = isMultiZoneEnabled && std.length($._config.multi_zone_availability_zones) >= 1,
+  local isZoneBEnabled = isMultiZoneEnabled && std.length($._config.multi_zone_availability_zones) >= 2,
+  local isZoneCEnabled = isMultiZoneEnabled && std.length($._config.multi_zone_availability_zones) >= 3,
+
+  local cacheChunksEnabled = $._config.cache_chunks_enabled,
+  local cacheIndexQueriesEnabled = $._config.cache_index_queries_enabled,
+
+  // Builders.
+  newMemcachedChunksCompartment(compartmentIdx, nodeAffinityMatchers=[])::
+    $.newMemcachedChunks('memcached-rc-%d' % compartmentIdx, nodeAffinityMatchers) + {
+      statefulSet+: statefulSet.mixin.spec.withReplicas($._config.memcached_chunks_replicas_per_compartment),
+    },
+
+  newMemcachedChunksCompartmentZone(zone, compartmentIdx, nodeAffinityMatchers=[])::
+    $.newMemcachedChunks('memcached-zone-%s-rc-%d' % [zone, compartmentIdx], nodeAffinityMatchers) + {
+      statefulSet+:
+        statefulSet.mixin.spec.withReplicas($._config.memcached_chunks_replicas_per_compartment) +
+        statefulSet.mixin.spec.template.spec.withTolerationsMixin($.newMimirMultiZoneToleration()),
+    },
+
+  newMemcachedIndexQueriesCompartment(compartmentIdx, nodeAffinityMatchers=[])::
+    $.newMemcachedIndexQueries('memcached-index-queries-rc-%d' % compartmentIdx, nodeAffinityMatchers) + {
+      statefulSet+: statefulSet.mixin.spec.withReplicas($._config.memcached_index_queries_replicas_per_compartment),
+    },
+
+  newMemcachedIndexQueriesCompartmentZone(zone, compartmentIdx, nodeAffinityMatchers=[])::
+    $.newMemcachedIndexQueries('memcached-index-queries-zone-%s-rc-%d' % [zone, compartmentIdx], nodeAffinityMatchers) + {
+      statefulSet+:
+        statefulSet.mixin.spec.withReplicas($._config.memcached_index_queries_replicas_per_compartment) +
+        statefulSet.mixin.spec.template.spec.withTolerationsMixin($.newMimirMultiZoneToleration()),
+    },
+
+  // Single-zone per-compartment caches.
+  memcached_chunks_compartments: $.mimirCompartmentsCreateIf(isEnabled && isSingleZoneEnabled && cacheChunksEnabled, numCompartments, function(c)
+    $.newMemcachedChunksCompartment(c, $.memcached_chunks_node_affinity_matchers)),
+  memcached_index_queries_compartments: $.mimirCompartmentsCreateIf(isEnabled && isSingleZoneEnabled && cacheIndexQueriesEnabled, numCompartments, function(c)
+    $.newMemcachedIndexQueriesCompartment(c, $.memcached_index_queries_node_affinity_matchers)),
+
+  // Multi-AZ per-compartment caches.
+  memcached_chunks_zone_a_compartments: $.mimirCompartmentsCreateIf(isEnabled && isZoneAEnabled && cacheChunksEnabled, numCompartments, function(c)
+    $.newMemcachedChunksCompartmentZone('a', c, $.memcached_chunks_zone_a_node_affinity_matchers)),
+  memcached_chunks_zone_b_compartments: $.mimirCompartmentsCreateIf(isEnabled && isZoneBEnabled && cacheChunksEnabled, numCompartments, function(c)
+    $.newMemcachedChunksCompartmentZone('b', c, $.memcached_chunks_zone_b_node_affinity_matchers)),
+  memcached_chunks_zone_c_compartments: $.mimirCompartmentsCreateIf(isEnabled && isZoneCEnabled && cacheChunksEnabled, numCompartments, function(c)
+    $.newMemcachedChunksCompartmentZone('c', c, $.memcached_chunks_zone_c_node_affinity_matchers)),
+
+  memcached_index_queries_zone_a_compartments: $.mimirCompartmentsCreateIf(isEnabled && isZoneAEnabled && cacheIndexQueriesEnabled, numCompartments, function(c)
+    $.newMemcachedIndexQueriesCompartmentZone('a', c, $.memcached_index_queries_zone_a_node_affinity_matchers)),
+  memcached_index_queries_zone_b_compartments: $.mimirCompartmentsCreateIf(isEnabled && isZoneBEnabled && cacheIndexQueriesEnabled, numCompartments, function(c)
+    $.newMemcachedIndexQueriesCompartmentZone('b', c, $.memcached_index_queries_zone_b_node_affinity_matchers)),
+  memcached_index_queries_zone_c_compartments: $.mimirCompartmentsCreateIf(isEnabled && isZoneCEnabled && cacheIndexQueriesEnabled, numCompartments, function(c)
+    $.newMemcachedIndexQueriesCompartmentZone('c', c, $.memcached_index_queries_zone_c_node_affinity_matchers)),
+
+  // Store-gateway zone-c runs in zone-a's AZ on 2-AZ cells (memcached zone-c isn't deployed there), so it
+  // uses zone-a's per-compartment cache.
+  local memcachedZone(zone) = if zone == 'c' && !isZoneCEnabled then 'a' else zone,
+
+  // Resolved caching config for a store-gateway zone: the zonal per-compartment cache when routed
+  // multi-zone, otherwise the single non-zonal one. Bundles both index-cache and chunks-cache addresses.
+  local blocksChunksCompartmentZoneCachingConfig(zone, compartmentIdx) =
+    (if !cacheIndexQueriesEnabled || !isEnabled then {} else {
+       'blocks-storage.bucket-store.index-cache.memcached.addresses':
+         if $._config.multi_zone_memcached_routing_enabled
+         then 'dnssrvnoa+memcached-index-queries-zone-%(zone)s-rc-%(idx)d.%(namespace)s.svc.%(cluster_domain)s:11211' % ($._config { zone: memcachedZone(zone), idx: compartmentIdx })
+         else 'dnssrvnoa+memcached-index-queries-rc-%(idx)d.%(namespace)s.svc.%(cluster_domain)s:11211' % ($._config { idx: compartmentIdx }),
+     }) +
+    (if !cacheChunksEnabled || !isEnabled then {} else {
+       'blocks-storage.bucket-store.chunks-cache.memcached.addresses':
+         if $._config.multi_zone_memcached_routing_enabled
+         then 'dnssrvnoa+memcached-zone-%(zone)s-rc-%(idx)d.%(namespace)s.svc.%(cluster_domain)s:11211' % ($._config { zone: memcachedZone(zone), idx: compartmentIdx })
+         else 'dnssrvnoa+memcached-rc-%(idx)d.%(namespace)s.svc.%(cluster_domain)s:11211' % ($._config { idx: compartmentIdx }),
+     }),
+
+  blocks_chunks_zone_a_caching_configs+:: $.mimirCompartmentsOverrides(super.blocks_chunks_zone_a_caching_configs, function(c) blocksChunksCompartmentZoneCachingConfig('a', c)),
+  blocks_chunks_zone_b_caching_configs+:: $.mimirCompartmentsOverrides(super.blocks_chunks_zone_b_caching_configs, function(c) blocksChunksCompartmentZoneCachingConfig('b', c)),
+  blocks_chunks_zone_c_caching_configs+:: $.mimirCompartmentsOverrides(super.blocks_chunks_zone_c_caching_configs, function(c) blocksChunksCompartmentZoneCachingConfig('c', c)),
+
+  // Null out non-compartment caches.
+  memcached_chunks: if !isNoCompartmentsEnabled then null else super.memcached_chunks,
+  memcached_index_queries: if !isNoCompartmentsEnabled then null else super.memcached_index_queries,
+  memcached_chunks_zone_a: if !isNoCompartmentsEnabled then null else super.memcached_chunks_zone_a,
+  memcached_chunks_zone_b: if !isNoCompartmentsEnabled then null else super.memcached_chunks_zone_b,
+  memcached_chunks_zone_c: if !isNoCompartmentsEnabled then null else super.memcached_chunks_zone_c,
+  memcached_index_queries_zone_a: if !isNoCompartmentsEnabled then null else super.memcached_index_queries_zone_a,
+  memcached_index_queries_zone_b: if !isNoCompartmentsEnabled then null else super.memcached_index_queries_zone_b,
+  memcached_index_queries_zone_c: if !isNoCompartmentsEnabled then null else super.memcached_index_queries_zone_c,
+}

--- a/operations/mimir/compartments-memcached.libsonnet
+++ b/operations/mimir/compartments-memcached.libsonnet
@@ -1,7 +1,7 @@
 {
   _config+:: {
-    // Deploy per-compartment memcached (chunks) and memcached-index-queries. Per-zone when multi-AZ
-    // memcached is enabled, otherwise a single per-compartment instance.
+    // Deploy per-compartment memcached (chunks) and memcached-index-queries, one instance per zone
+    // (compartments require multi-AZ memcached with multi-zone routing).
     compartments_memcached_enabled: $._config.compartments_enabled,
     no_compartments_memcached_enabled: !self.compartments_memcached_enabled,
 
@@ -10,14 +10,12 @@
     memcached_index_queries_replicas_per_compartment: $._config.memcached_index_queries_replicas,
   },
 
-  // Per-compartment memcached must be deployed zonal (multi-AZ), matching the per-compartment store-gateways
-  // and ingesters that also require multi-AZ. Single-zone may additionally be enabled during migrations.
+  // Per-compartment memcached is always deployed zonal (multi-AZ) and routed multi-zone, matching the
+  // per-compartment store-gateways and ingesters that also require multi-AZ.
   assert !$._config.compartments_memcached_enabled || $._config.multi_zone_memcached_enabled
          : 'compartments_memcached_enabled requires multi_zone_memcached_enabled',
-  assert !$._config.compartments_memcached_enabled || !$._config.multi_zone_memcached_routing_enabled || $._config.multi_zone_memcached_enabled
-         : 'compartments memcached: multi_zone_memcached_routing_enabled requires multi_zone_memcached_enabled',
-  assert !$._config.compartments_memcached_enabled || $._config.multi_zone_memcached_routing_enabled || $._config.single_zone_memcached_enabled
-         : 'compartments memcached: single-zone routing (multi_zone_memcached_routing_enabled=false) requires single_zone_memcached_enabled',
+  assert !$._config.compartments_memcached_enabled || $._config.multi_zone_memcached_routing_enabled
+         : 'compartments_memcached_enabled requires multi_zone_memcached_routing_enabled',
 
   local statefulSet = $.apps.v1.statefulSet,
 
@@ -25,7 +23,6 @@
   local isNoCompartmentsEnabled = $._config.no_compartments_memcached_enabled,
   local numCompartments = $._config.compartments_read_count,
 
-  local isSingleZoneEnabled = $._config.single_zone_memcached_enabled,
   local isMultiZoneEnabled = $._config.multi_zone_memcached_enabled,
   local isZoneAEnabled = isMultiZoneEnabled && std.length($._config.multi_zone_availability_zones) >= 1,
   local isZoneBEnabled = isMultiZoneEnabled && std.length($._config.multi_zone_availability_zones) >= 2,
@@ -35,21 +32,11 @@
   local cacheIndexQueriesEnabled = $._config.cache_index_queries_enabled,
 
   // Builders.
-  newMemcachedChunksCompartment(compartmentIdx, nodeAffinityMatchers=[])::
-    $.newMemcachedChunks('memcached-rc-%d' % compartmentIdx, nodeAffinityMatchers) + {
-      statefulSet+: statefulSet.mixin.spec.withReplicas($._config.memcached_chunks_replicas_per_compartment),
-    },
-
   newMemcachedChunksCompartmentZone(zone, compartmentIdx, nodeAffinityMatchers=[])::
     $.newMemcachedChunks('memcached-zone-%s-rc-%d' % [zone, compartmentIdx], nodeAffinityMatchers) + {
       statefulSet+:
         statefulSet.mixin.spec.withReplicas($._config.memcached_chunks_replicas_per_compartment) +
         statefulSet.mixin.spec.template.spec.withTolerationsMixin($.newMimirMultiZoneToleration()),
-    },
-
-  newMemcachedIndexQueriesCompartment(compartmentIdx, nodeAffinityMatchers=[])::
-    $.newMemcachedIndexQueries('memcached-index-queries-rc-%d' % compartmentIdx, nodeAffinityMatchers) + {
-      statefulSet+: statefulSet.mixin.spec.withReplicas($._config.memcached_index_queries_replicas_per_compartment),
     },
 
   newMemcachedIndexQueriesCompartmentZone(zone, compartmentIdx, nodeAffinityMatchers=[])::
@@ -59,13 +46,7 @@
         statefulSet.mixin.spec.template.spec.withTolerationsMixin($.newMimirMultiZoneToleration()),
     },
 
-  // Single-zone per-compartment caches.
-  memcached_chunks_compartments: $.mimirCompartmentsCreateIf(isEnabled && isSingleZoneEnabled && cacheChunksEnabled, numCompartments, function(c)
-    $.newMemcachedChunksCompartment(c, $.memcached_chunks_node_affinity_matchers)),
-  memcached_index_queries_compartments: $.mimirCompartmentsCreateIf(isEnabled && isSingleZoneEnabled && cacheIndexQueriesEnabled, numCompartments, function(c)
-    $.newMemcachedIndexQueriesCompartment(c, $.memcached_index_queries_node_affinity_matchers)),
-
-  // Multi-AZ per-compartment caches.
+  // Per-compartment zonal caches.
   memcached_chunks_zone_a_compartments: $.mimirCompartmentsCreateIf(isEnabled && isZoneAEnabled && cacheChunksEnabled, numCompartments, function(c)
     $.newMemcachedChunksCompartmentZone('a', c, $.memcached_chunks_zone_a_node_affinity_matchers)),
   memcached_chunks_zone_b_compartments: $.mimirCompartmentsCreateIf(isEnabled && isZoneBEnabled && cacheChunksEnabled, numCompartments, function(c)
@@ -84,20 +65,16 @@
   // uses zone-a's per-compartment cache.
   local memcachedZone(zone) = if zone == 'c' && !isZoneCEnabled then 'a' else zone,
 
-  // Resolved caching config for a store-gateway zone: the zonal per-compartment cache when routed
-  // multi-zone, otherwise the single non-zonal one. Bundles both index-cache and chunks-cache addresses.
+  // Zonal per-compartment caching config for a store-gateway zone. Bundles both index-cache and
+  // chunks-cache addresses.
   local blocksChunksCompartmentZoneCachingConfig(zone, compartmentIdx) =
     (if !cacheIndexQueriesEnabled || !isEnabled then {} else {
        'blocks-storage.bucket-store.index-cache.memcached.addresses':
-         if $._config.multi_zone_memcached_routing_enabled
-         then 'dnssrvnoa+memcached-index-queries-zone-%(zone)s-rc-%(idx)d.%(namespace)s.svc.%(cluster_domain)s:11211' % ($._config { zone: memcachedZone(zone), idx: compartmentIdx })
-         else 'dnssrvnoa+memcached-index-queries-rc-%(idx)d.%(namespace)s.svc.%(cluster_domain)s:11211' % ($._config { idx: compartmentIdx }),
+         'dnssrvnoa+memcached-index-queries-zone-%(zone)s-rc-%(idx)d.%(namespace)s.svc.%(cluster_domain)s:11211' % ($._config { zone: memcachedZone(zone), idx: compartmentIdx }),
      }) +
     (if !cacheChunksEnabled || !isEnabled then {} else {
        'blocks-storage.bucket-store.chunks-cache.memcached.addresses':
-         if $._config.multi_zone_memcached_routing_enabled
-         then 'dnssrvnoa+memcached-zone-%(zone)s-rc-%(idx)d.%(namespace)s.svc.%(cluster_domain)s:11211' % ($._config { zone: memcachedZone(zone), idx: compartmentIdx })
-         else 'dnssrvnoa+memcached-rc-%(idx)d.%(namespace)s.svc.%(cluster_domain)s:11211' % ($._config { idx: compartmentIdx }),
+         'dnssrvnoa+memcached-zone-%(zone)s-rc-%(idx)d.%(namespace)s.svc.%(cluster_domain)s:11211' % ($._config { zone: memcachedZone(zone), idx: compartmentIdx }),
      }),
 
   blocks_chunks_zone_a_caching_configs+:: $.mimirCompartmentsOverrides(super.blocks_chunks_zone_a_caching_configs, function(c) blocksChunksCompartmentZoneCachingConfig('a', c)),

--- a/operations/mimir/compartments-memcached.libsonnet
+++ b/operations/mimir/compartments-memcached.libsonnet
@@ -10,6 +10,10 @@
     memcached_index_queries_replicas_per_compartment: $._config.memcached_index_queries_replicas,
   },
 
+  // Per-compartment memcached must be deployed zonal (multi-AZ), matching the per-compartment store-gateways
+  // and ingesters that also require multi-AZ. Single-zone may additionally be enabled during migrations.
+  assert !$._config.compartments_memcached_enabled || $._config.multi_zone_memcached_enabled
+         : 'compartments_memcached_enabled requires multi_zone_memcached_enabled',
   assert !$._config.compartments_memcached_enabled || !$._config.multi_zone_memcached_routing_enabled || $._config.multi_zone_memcached_enabled
          : 'compartments memcached: multi_zone_memcached_routing_enabled requires multi_zone_memcached_enabled',
   assert !$._config.compartments_memcached_enabled || $._config.multi_zone_memcached_routing_enabled || $._config.single_zone_memcached_enabled

--- a/operations/mimir/compartments-store-gateway.libsonnet
+++ b/operations/mimir/compartments-store-gateway.libsonnet
@@ -8,6 +8,11 @@
          : 'compartments_store_gateway_enabled requires compartments_compactor_enabled (per-compartment blocks buckets)',
   assert !$._config.compartments_store_gateway_enabled || $._config.multi_zone_store_gateway_enabled
          : 'compartments_store_gateway_enabled requires multi_zone_store_gateway_enabled',
+  // Per-compartment store-gateways must run multi-AZ so they route to the zonal per-compartment memcached
+  // (their zonal cache args are only set when multi-AZ). Otherwise they'd fall back to the single-AZ caches,
+  // which aren't deployed under multi-zone memcached.
+  assert !$._config.compartments_store_gateway_enabled || $._config.multi_zone_store_gateway_multi_az_enabled
+         : 'compartments_store_gateway_enabled requires multi_zone_store_gateway_multi_az_enabled',
 
   local statefulSet = $.apps.v1.statefulSet,
   local podDisruptionBudget = $.policy.v1.podDisruptionBudget,

--- a/operations/mimir/compartments-store-gateway.libsonnet
+++ b/operations/mimir/compartments-store-gateway.libsonnet
@@ -48,9 +48,6 @@
     'ingest-storage.kafka.topic': $.mimirIngestStorageCompartmentKafkaTopic(compartmentIdx),
   },
 
-  // Each per-compartment store-gateway zone points at its per-compartment blocks chunks/index cache
-  // (compartments-memcached.libsonnet populates blocks_chunks_zone_*_caching_configs; empty when
-  // per-compartment memcached is disabled). Backup zones reuse their primary zone's config.
   store_gateway_zone_a_compartments_args:: $.mimirCompartmentsCreateIf(isEnabled && isZoneAEnabled, numCompartments, function(c) $.store_gateway_zone_a_args + perCompartmentStoreGatewayArgs(c) + $.blocks_chunks_zone_a_caching_configs['compartment_%d' % c]),
   store_gateway_zone_b_compartments_args:: $.mimirCompartmentsCreateIf(isEnabled && isZoneBEnabled, numCompartments, function(c) $.store_gateway_zone_b_args + perCompartmentStoreGatewayArgs(c) + $.blocks_chunks_zone_b_caching_configs['compartment_%d' % c]),
   store_gateway_zone_c_compartments_args:: $.mimirCompartmentsCreateIf(isEnabled && isZoneCEnabled, numCompartments, function(c) $.store_gateway_zone_c_args + perCompartmentStoreGatewayArgs(c) + $.blocks_chunks_zone_c_caching_configs['compartment_%d' % c]),

--- a/operations/mimir/compartments-store-gateway.libsonnet
+++ b/operations/mimir/compartments-store-gateway.libsonnet
@@ -8,9 +8,6 @@
          : 'compartments_store_gateway_enabled requires compartments_compactor_enabled (per-compartment blocks buckets)',
   assert !$._config.compartments_store_gateway_enabled || $._config.multi_zone_store_gateway_enabled
          : 'compartments_store_gateway_enabled requires multi_zone_store_gateway_enabled',
-  // Per-compartment store-gateways must run multi-AZ so they route to the zonal per-compartment memcached
-  // (their zonal cache args are only set when multi-AZ). Otherwise they'd fall back to the single-AZ caches,
-  // which aren't deployed under multi-zone memcached.
   assert !$._config.compartments_store_gateway_enabled || $._config.multi_zone_store_gateway_multi_az_enabled
          : 'compartments_store_gateway_enabled requires multi_zone_store_gateway_multi_az_enabled',
 

--- a/operations/mimir/compartments-store-gateway.libsonnet
+++ b/operations/mimir/compartments-store-gateway.libsonnet
@@ -48,11 +48,14 @@
     'ingest-storage.kafka.topic': $.mimirIngestStorageCompartmentKafkaTopic(compartmentIdx),
   },
 
-  store_gateway_zone_a_compartments_args:: $.mimirCompartmentsCreateIf(isEnabled && isZoneAEnabled, numCompartments, function(c) $.store_gateway_zone_a_args + perCompartmentStoreGatewayArgs(c)),
-  store_gateway_zone_b_compartments_args:: $.mimirCompartmentsCreateIf(isEnabled && isZoneBEnabled, numCompartments, function(c) $.store_gateway_zone_b_args + perCompartmentStoreGatewayArgs(c)),
-  store_gateway_zone_c_compartments_args:: $.mimirCompartmentsCreateIf(isEnabled && isZoneCEnabled, numCompartments, function(c) $.store_gateway_zone_c_args + perCompartmentStoreGatewayArgs(c)),
-  store_gateway_zone_a_backup_compartments_args:: $.mimirCompartmentsCreateIf(isEnabled && isZoneABackupEnabled, numCompartments, function(c) $.store_gateway_zone_a_backup_args + perCompartmentStoreGatewayArgs(c)),
-  store_gateway_zone_b_backup_compartments_args:: $.mimirCompartmentsCreateIf(isEnabled && isZoneBBackupEnabled, numCompartments, function(c) $.store_gateway_zone_b_backup_args + perCompartmentStoreGatewayArgs(c)),
+  // Each per-compartment store-gateway zone points at its per-compartment blocks chunks/index cache
+  // (compartments-memcached.libsonnet populates blocks_chunks_zone_*_caching_configs; empty when
+  // per-compartment memcached is disabled). Backup zones reuse their primary zone's config.
+  store_gateway_zone_a_compartments_args:: $.mimirCompartmentsCreateIf(isEnabled && isZoneAEnabled, numCompartments, function(c) $.store_gateway_zone_a_args + perCompartmentStoreGatewayArgs(c) + $.blocks_chunks_zone_a_caching_configs['compartment_%d' % c]),
+  store_gateway_zone_b_compartments_args:: $.mimirCompartmentsCreateIf(isEnabled && isZoneBEnabled, numCompartments, function(c) $.store_gateway_zone_b_args + perCompartmentStoreGatewayArgs(c) + $.blocks_chunks_zone_b_caching_configs['compartment_%d' % c]),
+  store_gateway_zone_c_compartments_args:: $.mimirCompartmentsCreateIf(isEnabled && isZoneCEnabled, numCompartments, function(c) $.store_gateway_zone_c_args + perCompartmentStoreGatewayArgs(c) + $.blocks_chunks_zone_c_caching_configs['compartment_%d' % c]),
+  store_gateway_zone_a_backup_compartments_args:: $.mimirCompartmentsCreateIf(isEnabled && isZoneABackupEnabled, numCompartments, function(c) $.store_gateway_zone_a_backup_args + perCompartmentStoreGatewayArgs(c) + $.blocks_chunks_zone_a_caching_configs['compartment_%d' % c]),
+  store_gateway_zone_b_backup_compartments_args:: $.mimirCompartmentsCreateIf(isEnabled && isZoneBBackupEnabled, numCompartments, function(c) $.store_gateway_zone_b_backup_args + perCompartmentStoreGatewayArgs(c) + $.blocks_chunks_zone_b_caching_configs['compartment_%d' % c]),
 
   newStoreGatewayCompartmentStatefulSet(zone, compartmentIdx, container, nodeAffinityMatchers=[], multiAZ=false)::
     local name = 'store-gateway-zone-%s-rc-%d' % [zone, compartmentIdx];

--- a/operations/mimir/mimir.libsonnet
+++ b/operations/mimir/mimir.libsonnet
@@ -71,6 +71,7 @@
 (import 'compartments-compactor.libsonnet') +
 (import 'compartments-compactor-scheduler.libsonnet') +
 (import 'compartments-store-gateway.libsonnet') +
+(import 'compartments-memcached.libsonnet') +
 
 // Store-gateway autoscaling. Keep it after multi-zone-store-gateway (it patches those StatefulSets) and after
 // compartments-store-gateway so it can layer the same autoscaling onto the per-compartment StatefulSet maps.


### PR DESCRIPTION
#### What this PR does

Upstreams the per-read-compartment memcached (chunks + index-queries) jsonnet from Grafana Labs.

`compartments-memcached.libsonnet` deploys a per-compartment, per-zone chunks and index-queries cache, nulls the non-compartment chunks/index caches, and wires each per-compartment store-gateway zone at its own cache (including the 2-AZ zone-c→zone-a fallback). This mirrors the existing non-compartment `multi-zone-memcached` / `multi-zone-store-gateway` wiring.

Per-compartment memcached (and store-gateways) are supported **only** multi-AZ. The compartments ingester already requires `multi_zone_ingester_multi_az_enabled`, so rather than support a mix, the whole compartments architecture is kept consistently multi-AZ.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - not needed (experimental compartments jsonnet), `changelog-not-needed` label added.
- [ ] `about-versioning.md` updated with experimental features.