### PR TITLE
block-builder-scheduler: add compartments support

### DIFF
--- a/development/mimir-compartments/config/mimir.yaml
+++ b/development/mimir-compartments/config/mimir.yaml
@@ -60,7 +60,7 @@ blocks_storage:
   tsdb:
     dir: /data
     # Each read compartment's block-builder builds and ships that compartment's blocks, so ingester block
-    # shipping is disabled (ship_interval: 0s). Cut blocks frequently for a fast feedback loop in development.
+    # shipping is disabled (ship_interval: 0s).
     block_ranges_period: ["2m"]
     retention_period: 20m
     ship_interval: 0s

--- a/development/mimir-compartments/config/mimir.yaml
+++ b/development/mimir-compartments/config/mimir.yaml
@@ -12,13 +12,11 @@ common:
 ingest_storage:
   enabled:       true
   kafka:
-    # Default Kafka cluster, used by components that don't override the address (e.g. block-builder).
-    # Distributors override this with their own write compartment's cluster, and ingesters override it
-    # with a template addressing every write compartment's cluster.
+    # ingest_storage is enabled globally, so every component validates the Kafka address and topic even if
+    # it never connects (compactor, store-gateway, querier, ruler, alertmanager). These defaults satisfy
+    # that validation; the components that actually consume/produce (distributors, ingesters, query-frontend,
+    # block-builders and schedulers) override them via CLI flags to target their own write/read compartment.
     address: kafka-wc-0:9092
-    # Default to read compartment 0's topic. Components that aren't compartment-aware yet (e.g.
-    # block-builder) use this concrete topic. Distributors and ingesters override it via CLI flag with
-    # the read-compartment-templated topic (mimir-ingest-rc-<read-compartment-id>).
     topic:   mimir-ingest-rc-0
     last_produced_offset_poll_interval: 500ms
     fetch_concurrency_max: 15
@@ -46,7 +44,8 @@ ingester:
 
 block_builder:
   scheduler_config:
-    address: block-builder-scheduler-0:9095
+    # Each per-read-compartment block-builder sets its scheduler address (block-builder-scheduler-rc-<id>)
+    # via CLI flag, so no default address is set here.
     update_interval: 5s
     max_update_age: 30m
 
@@ -60,12 +59,11 @@ blocks_storage:
     bucket_name:       mimir-blocks
   tsdb:
     dir: /data
-    # The block-builder isn't compartment-aware yet and is disabled, so ingesters ship their own blocks to
-    # their read compartment's bucket (each ingester overrides -blocks-storage.s3.bucket-name). Cut and
-    # ship blocks frequently for a fast feedback loop in development.
+    # Each read compartment's block-builder builds and ships that compartment's blocks, so ingester block
+    # shipping is disabled (ship_interval: 0s). Cut blocks frequently for a fast feedback loop in development.
     block_ranges_period: ["2m"]
     retention_period: 20m
-    ship_interval: 10s
+    ship_interval: 0s
     head_postings_for_matchers_cache_force: true
     block_postings_for_matchers_cache_force: true
 

--- a/development/mimir-compartments/docker-compose.jsonnet
+++ b/development/mimir-compartments/docker-compose.jsonnet
@@ -8,10 +8,8 @@ std.manifestYamlDoc({
     self.querier +
     self.store_gateways +
     self.compactors +
-    // The block-builder is not compartment-aware yet (it would build only read compartment 0's blocks), so
-    // it is disabled and ingesters ship their own blocks per compartment instead.
-    // self.block_builder +
-    // self.block_builder_scheduler +
+    self.block_builder +
+    self.block_builder_scheduler +
     self.rulers(1) +
     self.alertmanagers(1) +
     self.usage_trackers +
@@ -80,9 +78,8 @@ std.manifestYamlDoc({
         // redirections by the "sh -c" command.
         "-ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092'",
         "-ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>'",
-        // The block-builder is disabled, so each ingester ships its own blocks to its read compartment's
-        // dedicated bucket (mimir-blocks-rc-<id>), where the compartment's store-gateways serve them.
-        '-blocks-storage.s3.bucket-name=mimir-blocks-rc-%d' % compartment,
+        // Each read compartment's block-builder ships that compartment's blocks (ingester shipping is
+        // disabled in mimir.yaml), so ingesters don't need a per-compartment blocks bucket here.
       ],
       extraVolumes: ['.data-ingester-%s-rc-%d-%d:/data:delegated' % [zones[zoneIdx], compartment, partition]],
     })
@@ -190,25 +187,34 @@ std.manifestYamlDoc({
     for id in std.range(1, count)
   },
 
-  // The block-builder isn't compartment-aware yet: it consumes read compartment 0's topic and uploads
-  // to that compartment's dedicated bucket, so read compartment 0 is a full end-to-end slice whose
-  // blocks are compacted and served by its own compactor and store-gateways. The other compartments'
-  // compactors and store-gateways run against (empty) buckets until the block-builder is compartmentalised.
   block_builder:: {
-    'block-builder-0': mimirService({
-      name: 'block-builder-0',
+    ['block-builder-rc-%d' % compartment]: mimirService({
+      name: 'block-builder-rc-%d' % compartment,
       target: 'block-builder',
-      publishedHttpPort: 8009,
-      extraArguments: ['-blocks-storage.s3.bucket-name=mimir-blocks-rc-0'],
-    }),
+      publishedHttpPort: 8070 + compartment,
+      jaegerApp: 'block-builder-rc-%d' % compartment,
+      extraArguments: [
+        "-ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092'",
+        '-ingest-storage.kafka.topic=mimir-ingest-rc-%d' % compartment,
+        '-blocks-storage.s3.bucket-name=mimir-blocks-rc-%d' % compartment,
+        '-block-builder.scheduler.address=block-builder-scheduler-rc-%d:9095' % compartment,
+      ],
+    })
+    for compartment in std.range(0, numCompartments - 1)
   },
 
   block_builder_scheduler:: {
-    'block-builder-scheduler-0': mimirService({
-      name: 'block-builder-scheduler-0',
+    ['block-builder-scheduler-rc-%d' % compartment]: mimirService({
+      name: 'block-builder-scheduler-rc-%d' % compartment,
       target: 'block-builder-scheduler',
-      publishedHttpPort: 8010,
-    }),
+      publishedHttpPort: 8075 + compartment,
+      jaegerApp: 'block-builder-scheduler-rc-%d' % compartment,
+      extraArguments: [
+        "-ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092'",
+        '-ingest-storage.kafka.topic=mimir-ingest-rc-%d' % compartment,
+      ],
+    })
+    for compartment in std.range(0, numCompartments - 1)
   },
 
   usage_trackers:: {
@@ -336,7 +342,7 @@ std.manifestYamlDoc({
         test: 'kafka-broker-api-versions --bootstrap-server localhost:9092 || exit 1',
         start_period: '1s',
         interval: '1s',
-        timeout: '1s',
+        timeout: '2s',
         retries: '30',
       },
     }

--- a/development/mimir-compartments/docker-compose.jsonnet
+++ b/development/mimir-compartments/docker-compose.jsonnet
@@ -78,8 +78,11 @@ std.manifestYamlDoc({
         // redirections by the "sh -c" command.
         "-ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092'",
         "-ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>'",
-        // Each read compartment's block-builder ships that compartment's blocks (ingester shipping is
-        // disabled in mimir.yaml), so ingesters don't need a per-compartment blocks bucket here.
+        // Each read compartment's block-builder ships that compartment's blocks, so ingester block
+        // shipping is disabled (mimir.yaml sets ship_interval: 0s). The ingester still needs a blocks
+        // bucket that exists for the startup object-storage sanity check, so point it at its own read
+        // compartment's bucket.
+        '-blocks-storage.s3.bucket-name=mimir-blocks-rc-%d' % compartment,
       ],
       extraVolumes: ['.data-ingester-%s-rc-%d-%d:/data:delegated' % [zones[zoneIdx], compartment, partition]],
     })
@@ -163,7 +166,9 @@ std.manifestYamlDoc({
     for zoneIdx in std.range(0, std.length(zones) - 1)
   },
 
-  // The ruler evaluates rules via remote rule evaluation, so it needs no per-compartment bucket configuration.
+  // The ruler evaluates rules via remote rule evaluation, so it never reads or writes blocks. It's not
+  // compartment-bound either, but the startup object-storage sanity check still requires a blocks bucket
+  // that exists, so point it at read compartment 0's bucket (the choice is arbitrary and unused).
   rulers(count):: if count <= 0 then {} else {
     ['ruler-%d' % id]: mimirService({
       name: 'ruler-' + id,
@@ -171,7 +176,10 @@ std.manifestYamlDoc({
       publishedHttpPort: 8030 + id,
       jaegerApp: 'ruler-%d' % id,
       // The ruler writes rule results through distributors, which own write-compartment routing.
-      extraArguments: ['-ruler.distributor.address=dns:///distributor:9095'],
+      extraArguments: [
+        '-ruler.distributor.address=dns:///distributor:9095',
+        '-blocks-storage.s3.bucket-name=mimir-blocks-rc-0',
+      ],
     })
     for id in std.range(1, count)
   },
@@ -285,9 +293,10 @@ std.manifestYamlDoc({
   minio:: {
     // One blocks bucket per read compartment (mimir-blocks-rc-<id>): the per-compartment store-gateways,
     // compactors and block-builder write/serve their own bucket, and the querier read every
-    // compartment's bucket by resolving the <read-compartment-id> placeholder.
-    local buckets = ['mimir-blocks'] +
-                    ['mimir-blocks-rc-%d' % compartment for compartment in std.range(0, numCompartments - 1)] +
+    // compartment's bucket by resolving the <read-compartment-id> placeholder. Components that don't own
+    // a compartment bucket (ingester, ruler) point at a real per-compartment bucket for the startup
+    // sanity check.
+    local buckets = ['mimir-blocks-rc-%d' % compartment for compartment in std.range(0, numCompartments - 1)] +
                     ['mimir-ruler', 'mimir-alertmanager', 'usage-tracker-snapshots'],
     minio: {
       image: 'minio/minio:RELEASE.2025-05-24T17-08-30Z',

--- a/development/mimir-compartments/docker-compose.yml
+++ b/development/mimir-compartments/docker-compose.yml
@@ -24,6 +24,106 @@
     "volumes":
       - "./config:/mimir/config"
       - "./activity:/activity"
+  "block-builder-rc-0":
+    "build":
+      "context": "."
+      "dockerfile": "dev.dockerfile"
+    "command":
+      - "sh"
+      - "-c"
+      - "exec ./mimir -config.file=./config/mimir.yaml -target=block-builder -activity-tracker.filepath=/activity/block-builder-rc-0 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic=mimir-ingest-rc-0 -blocks-storage.s3.bucket-name=mimir-blocks-rc-0 -block-builder.scheduler.address=block-builder-scheduler-rc-0:9095"
+    "depends_on":
+      "kafka-wc-0":
+        "condition": "service_healthy"
+      "kafka-wc-1":
+        "condition": "service_healthy"
+      "minio":
+        "condition": "service_started"
+    "environment":
+      - "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://tempo:4318/v1/traces"
+    "hostname": "block-builder-rc-0"
+    "image": "mimir"
+    "ports":
+      - "8070:8080"
+      - "11070:11070"
+    "volumes":
+      - "./config:/mimir/config"
+      - "./activity:/activity"
+  "block-builder-rc-1":
+    "build":
+      "context": "."
+      "dockerfile": "dev.dockerfile"
+    "command":
+      - "sh"
+      - "-c"
+      - "exec ./mimir -config.file=./config/mimir.yaml -target=block-builder -activity-tracker.filepath=/activity/block-builder-rc-1 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic=mimir-ingest-rc-1 -blocks-storage.s3.bucket-name=mimir-blocks-rc-1 -block-builder.scheduler.address=block-builder-scheduler-rc-1:9095"
+    "depends_on":
+      "kafka-wc-0":
+        "condition": "service_healthy"
+      "kafka-wc-1":
+        "condition": "service_healthy"
+      "minio":
+        "condition": "service_started"
+    "environment":
+      - "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://tempo:4318/v1/traces"
+    "hostname": "block-builder-rc-1"
+    "image": "mimir"
+    "ports":
+      - "8071:8080"
+      - "11071:11071"
+    "volumes":
+      - "./config:/mimir/config"
+      - "./activity:/activity"
+  "block-builder-scheduler-rc-0":
+    "build":
+      "context": "."
+      "dockerfile": "dev.dockerfile"
+    "command":
+      - "sh"
+      - "-c"
+      - "exec ./mimir -config.file=./config/mimir.yaml -target=block-builder-scheduler -activity-tracker.filepath=/activity/block-builder-scheduler-rc-0 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic=mimir-ingest-rc-0"
+    "depends_on":
+      "kafka-wc-0":
+        "condition": "service_healthy"
+      "kafka-wc-1":
+        "condition": "service_healthy"
+      "minio":
+        "condition": "service_started"
+    "environment":
+      - "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://tempo:4318/v1/traces"
+    "hostname": "block-builder-scheduler-rc-0"
+    "image": "mimir"
+    "ports":
+      - "8075:8080"
+      - "11075:11075"
+    "volumes":
+      - "./config:/mimir/config"
+      - "./activity:/activity"
+  "block-builder-scheduler-rc-1":
+    "build":
+      "context": "."
+      "dockerfile": "dev.dockerfile"
+    "command":
+      - "sh"
+      - "-c"
+      - "exec ./mimir -config.file=./config/mimir.yaml -target=block-builder-scheduler -activity-tracker.filepath=/activity/block-builder-scheduler-rc-1 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic=mimir-ingest-rc-1"
+    "depends_on":
+      "kafka-wc-0":
+        "condition": "service_healthy"
+      "kafka-wc-1":
+        "condition": "service_healthy"
+      "minio":
+        "condition": "service_started"
+    "environment":
+      - "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://tempo:4318/v1/traces"
+    "hostname": "block-builder-scheduler-rc-1"
+    "image": "mimir"
+    "ports":
+      - "8076:8080"
+      - "11076:11076"
+    "volumes":
+      - "./config:/mimir/config"
+      - "./activity:/activity"
   "compactor-rc-0":
     "build":
       "context": "."
@@ -163,7 +263,7 @@
     "command":
       - "sh"
       - "-c"
-      - "exec ./mimir -config.file=./config/mimir.yaml -target=ingester -activity-tracker.filepath=/activity/ingester-zone-a-rc-0-0 -ingester.ring.instance-availability-zone=zone-a -ingester.read-compartment-id=0 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>' -blocks-storage.s3.bucket-name=mimir-blocks-rc-0"
+      - "exec ./mimir -config.file=./config/mimir.yaml -target=ingester -activity-tracker.filepath=/activity/ingester-zone-a-rc-0-0 -ingester.ring.instance-availability-zone=zone-a -ingester.read-compartment-id=0 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>'"
     "depends_on":
       "kafka-wc-0":
         "condition": "service_healthy"
@@ -189,7 +289,7 @@
     "command":
       - "sh"
       - "-c"
-      - "exec ./mimir -config.file=./config/mimir.yaml -target=ingester -activity-tracker.filepath=/activity/ingester-zone-a-rc-0-1 -ingester.ring.instance-availability-zone=zone-a -ingester.read-compartment-id=0 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>' -blocks-storage.s3.bucket-name=mimir-blocks-rc-0"
+      - "exec ./mimir -config.file=./config/mimir.yaml -target=ingester -activity-tracker.filepath=/activity/ingester-zone-a-rc-0-1 -ingester.ring.instance-availability-zone=zone-a -ingester.read-compartment-id=0 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>'"
     "depends_on":
       "kafka-wc-0":
         "condition": "service_healthy"
@@ -215,7 +315,7 @@
     "command":
       - "sh"
       - "-c"
-      - "exec ./mimir -config.file=./config/mimir.yaml -target=ingester -activity-tracker.filepath=/activity/ingester-zone-a-rc-1-0 -ingester.ring.instance-availability-zone=zone-a -ingester.read-compartment-id=1 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>' -blocks-storage.s3.bucket-name=mimir-blocks-rc-1"
+      - "exec ./mimir -config.file=./config/mimir.yaml -target=ingester -activity-tracker.filepath=/activity/ingester-zone-a-rc-1-0 -ingester.ring.instance-availability-zone=zone-a -ingester.read-compartment-id=1 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>'"
     "depends_on":
       "kafka-wc-0":
         "condition": "service_healthy"
@@ -241,7 +341,7 @@
     "command":
       - "sh"
       - "-c"
-      - "exec ./mimir -config.file=./config/mimir.yaml -target=ingester -activity-tracker.filepath=/activity/ingester-zone-a-rc-1-1 -ingester.ring.instance-availability-zone=zone-a -ingester.read-compartment-id=1 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>' -blocks-storage.s3.bucket-name=mimir-blocks-rc-1"
+      - "exec ./mimir -config.file=./config/mimir.yaml -target=ingester -activity-tracker.filepath=/activity/ingester-zone-a-rc-1-1 -ingester.ring.instance-availability-zone=zone-a -ingester.read-compartment-id=1 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>'"
     "depends_on":
       "kafka-wc-0":
         "condition": "service_healthy"
@@ -267,7 +367,7 @@
     "command":
       - "sh"
       - "-c"
-      - "exec ./mimir -config.file=./config/mimir.yaml -target=ingester -activity-tracker.filepath=/activity/ingester-zone-b-rc-0-0 -ingester.ring.instance-availability-zone=zone-b -ingester.read-compartment-id=0 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>' -blocks-storage.s3.bucket-name=mimir-blocks-rc-0"
+      - "exec ./mimir -config.file=./config/mimir.yaml -target=ingester -activity-tracker.filepath=/activity/ingester-zone-b-rc-0-0 -ingester.ring.instance-availability-zone=zone-b -ingester.read-compartment-id=0 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>'"
     "depends_on":
       "kafka-wc-0":
         "condition": "service_healthy"
@@ -293,7 +393,7 @@
     "command":
       - "sh"
       - "-c"
-      - "exec ./mimir -config.file=./config/mimir.yaml -target=ingester -activity-tracker.filepath=/activity/ingester-zone-b-rc-0-1 -ingester.ring.instance-availability-zone=zone-b -ingester.read-compartment-id=0 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>' -blocks-storage.s3.bucket-name=mimir-blocks-rc-0"
+      - "exec ./mimir -config.file=./config/mimir.yaml -target=ingester -activity-tracker.filepath=/activity/ingester-zone-b-rc-0-1 -ingester.ring.instance-availability-zone=zone-b -ingester.read-compartment-id=0 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>'"
     "depends_on":
       "kafka-wc-0":
         "condition": "service_healthy"
@@ -319,7 +419,7 @@
     "command":
       - "sh"
       - "-c"
-      - "exec ./mimir -config.file=./config/mimir.yaml -target=ingester -activity-tracker.filepath=/activity/ingester-zone-b-rc-1-0 -ingester.ring.instance-availability-zone=zone-b -ingester.read-compartment-id=1 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>' -blocks-storage.s3.bucket-name=mimir-blocks-rc-1"
+      - "exec ./mimir -config.file=./config/mimir.yaml -target=ingester -activity-tracker.filepath=/activity/ingester-zone-b-rc-1-0 -ingester.ring.instance-availability-zone=zone-b -ingester.read-compartment-id=1 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>'"
     "depends_on":
       "kafka-wc-0":
         "condition": "service_healthy"
@@ -345,7 +445,7 @@
     "command":
       - "sh"
       - "-c"
-      - "exec ./mimir -config.file=./config/mimir.yaml -target=ingester -activity-tracker.filepath=/activity/ingester-zone-b-rc-1-1 -ingester.ring.instance-availability-zone=zone-b -ingester.read-compartment-id=1 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>' -blocks-storage.s3.bucket-name=mimir-blocks-rc-1"
+      - "exec ./mimir -config.file=./config/mimir.yaml -target=ingester -activity-tracker.filepath=/activity/ingester-zone-b-rc-1-1 -ingester.ring.instance-availability-zone=zone-b -ingester.read-compartment-id=1 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>'"
     "depends_on":
       "kafka-wc-0":
         "condition": "service_healthy"
@@ -386,7 +486,7 @@
       "retries": "30"
       "start_period": "1s"
       "test": "kafka-broker-api-versions --bootstrap-server localhost:9092 || exit 1"
-      "timeout": "1s"
+      "timeout": "2s"
     "hostname": "kafka-wc-0"
     "image": "confluentinc/cp-kafka:latest"
     "ports":
@@ -413,7 +513,7 @@
       "retries": "30"
       "start_period": "1s"
       "test": "kafka-broker-api-versions --bootstrap-server localhost:9092 || exit 1"
-      "timeout": "1s"
+      "timeout": "2s"
     "hostname": "kafka-wc-1"
     "image": "confluentinc/cp-kafka:latest"
     "ports":

--- a/development/mimir-compartments/docker-compose.yml
+++ b/development/mimir-compartments/docker-compose.yml
@@ -263,7 +263,7 @@
     "command":
       - "sh"
       - "-c"
-      - "exec ./mimir -config.file=./config/mimir.yaml -target=ingester -activity-tracker.filepath=/activity/ingester-zone-a-rc-0-0 -ingester.ring.instance-availability-zone=zone-a -ingester.read-compartment-id=0 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>'"
+      - "exec ./mimir -config.file=./config/mimir.yaml -target=ingester -activity-tracker.filepath=/activity/ingester-zone-a-rc-0-0 -ingester.ring.instance-availability-zone=zone-a -ingester.read-compartment-id=0 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>' -blocks-storage.s3.bucket-name=mimir-blocks-rc-0"
     "depends_on":
       "kafka-wc-0":
         "condition": "service_healthy"
@@ -289,7 +289,7 @@
     "command":
       - "sh"
       - "-c"
-      - "exec ./mimir -config.file=./config/mimir.yaml -target=ingester -activity-tracker.filepath=/activity/ingester-zone-a-rc-0-1 -ingester.ring.instance-availability-zone=zone-a -ingester.read-compartment-id=0 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>'"
+      - "exec ./mimir -config.file=./config/mimir.yaml -target=ingester -activity-tracker.filepath=/activity/ingester-zone-a-rc-0-1 -ingester.ring.instance-availability-zone=zone-a -ingester.read-compartment-id=0 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>' -blocks-storage.s3.bucket-name=mimir-blocks-rc-0"
     "depends_on":
       "kafka-wc-0":
         "condition": "service_healthy"
@@ -315,7 +315,7 @@
     "command":
       - "sh"
       - "-c"
-      - "exec ./mimir -config.file=./config/mimir.yaml -target=ingester -activity-tracker.filepath=/activity/ingester-zone-a-rc-1-0 -ingester.ring.instance-availability-zone=zone-a -ingester.read-compartment-id=1 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>'"
+      - "exec ./mimir -config.file=./config/mimir.yaml -target=ingester -activity-tracker.filepath=/activity/ingester-zone-a-rc-1-0 -ingester.ring.instance-availability-zone=zone-a -ingester.read-compartment-id=1 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>' -blocks-storage.s3.bucket-name=mimir-blocks-rc-1"
     "depends_on":
       "kafka-wc-0":
         "condition": "service_healthy"
@@ -341,7 +341,7 @@
     "command":
       - "sh"
       - "-c"
-      - "exec ./mimir -config.file=./config/mimir.yaml -target=ingester -activity-tracker.filepath=/activity/ingester-zone-a-rc-1-1 -ingester.ring.instance-availability-zone=zone-a -ingester.read-compartment-id=1 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>'"
+      - "exec ./mimir -config.file=./config/mimir.yaml -target=ingester -activity-tracker.filepath=/activity/ingester-zone-a-rc-1-1 -ingester.ring.instance-availability-zone=zone-a -ingester.read-compartment-id=1 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>' -blocks-storage.s3.bucket-name=mimir-blocks-rc-1"
     "depends_on":
       "kafka-wc-0":
         "condition": "service_healthy"
@@ -367,7 +367,7 @@
     "command":
       - "sh"
       - "-c"
-      - "exec ./mimir -config.file=./config/mimir.yaml -target=ingester -activity-tracker.filepath=/activity/ingester-zone-b-rc-0-0 -ingester.ring.instance-availability-zone=zone-b -ingester.read-compartment-id=0 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>'"
+      - "exec ./mimir -config.file=./config/mimir.yaml -target=ingester -activity-tracker.filepath=/activity/ingester-zone-b-rc-0-0 -ingester.ring.instance-availability-zone=zone-b -ingester.read-compartment-id=0 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>' -blocks-storage.s3.bucket-name=mimir-blocks-rc-0"
     "depends_on":
       "kafka-wc-0":
         "condition": "service_healthy"
@@ -393,7 +393,7 @@
     "command":
       - "sh"
       - "-c"
-      - "exec ./mimir -config.file=./config/mimir.yaml -target=ingester -activity-tracker.filepath=/activity/ingester-zone-b-rc-0-1 -ingester.ring.instance-availability-zone=zone-b -ingester.read-compartment-id=0 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>'"
+      - "exec ./mimir -config.file=./config/mimir.yaml -target=ingester -activity-tracker.filepath=/activity/ingester-zone-b-rc-0-1 -ingester.ring.instance-availability-zone=zone-b -ingester.read-compartment-id=0 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>' -blocks-storage.s3.bucket-name=mimir-blocks-rc-0"
     "depends_on":
       "kafka-wc-0":
         "condition": "service_healthy"
@@ -419,7 +419,7 @@
     "command":
       - "sh"
       - "-c"
-      - "exec ./mimir -config.file=./config/mimir.yaml -target=ingester -activity-tracker.filepath=/activity/ingester-zone-b-rc-1-0 -ingester.ring.instance-availability-zone=zone-b -ingester.read-compartment-id=1 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>'"
+      - "exec ./mimir -config.file=./config/mimir.yaml -target=ingester -activity-tracker.filepath=/activity/ingester-zone-b-rc-1-0 -ingester.ring.instance-availability-zone=zone-b -ingester.read-compartment-id=1 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>' -blocks-storage.s3.bucket-name=mimir-blocks-rc-1"
     "depends_on":
       "kafka-wc-0":
         "condition": "service_healthy"
@@ -445,7 +445,7 @@
     "command":
       - "sh"
       - "-c"
-      - "exec ./mimir -config.file=./config/mimir.yaml -target=ingester -activity-tracker.filepath=/activity/ingester-zone-b-rc-1-1 -ingester.ring.instance-availability-zone=zone-b -ingester.read-compartment-id=1 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>'"
+      - "exec ./mimir -config.file=./config/mimir.yaml -target=ingester -activity-tracker.filepath=/activity/ingester-zone-b-rc-1-1 -ingester.ring.instance-availability-zone=zone-b -ingester.read-compartment-id=1 -ingest-storage.kafka.address='kafka-wc-<write-compartment-id>:9092' -ingest-storage.kafka.topic='mimir-ingest-rc-<read-compartment-id>' -blocks-storage.s3.bucket-name=mimir-blocks-rc-1"
     "depends_on":
       "kafka-wc-0":
         "condition": "service_healthy"
@@ -524,7 +524,7 @@
     "entrypoint":
       - "sh"
       - "-c"
-      - "mkdir -p /data/mimir-blocks /data/mimir-blocks-rc-0 /data/mimir-blocks-rc-1 /data/mimir-ruler /data/mimir-alertmanager /data/usage-tracker-snapshots && exec minio server --console-address :9001 /data"
+      - "mkdir -p /data/mimir-blocks-rc-0 /data/mimir-blocks-rc-1 /data/mimir-ruler /data/mimir-alertmanager /data/usage-tracker-snapshots && exec minio server --console-address :9001 /data"
     "environment":
       - "MINIO_ROOT_USER=mimir"
       - "MINIO_ROOT_PASSWORD=supersecret"
@@ -650,7 +650,7 @@
     "command":
       - "sh"
       - "-c"
-      - "exec ./mimir -config.file=./config/mimir.yaml -target=ruler -activity-tracker.filepath=/activity/ruler-1 -ruler.distributor.address=dns:///distributor:9095"
+      - "exec ./mimir -config.file=./config/mimir.yaml -target=ruler -activity-tracker.filepath=/activity/ruler-1 -ruler.distributor.address=dns:///distributor:9095 -blocks-storage.s3.bucket-name=mimir-blocks-rc-0"
     "depends_on":
       "kafka-wc-0":
         "condition": "service_healthy"

--- a/pkg/blockbuilder/scheduler/config.go
+++ b/pkg/blockbuilder/scheduler/config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/grafana/mimir/pkg/compartments"
 	"github.com/grafana/mimir/pkg/storage/ingest"
 )
 
@@ -23,7 +24,8 @@ type Config struct {
 	JobFailuresAllowed  int           `yaml:"job_failures_allowed" category:"advanced"`
 
 	// Config parameters defined outside the block-builder-scheduler config and are injected dynamically.
-	Kafka ingest.KafkaConfig `yaml:"-"`
+	Kafka        ingest.KafkaConfig  `yaml:"-"`
+	Compartments compartments.Config `yaml:"-"`
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
@@ -74,4 +76,11 @@ func (cfg *Config) Validate() error {
 		return fmt.Errorf("job failures allowed (%d) must be non-negative", cfg.JobFailuresAllowed)
 	}
 	return nil
+}
+
+func (cfg *Config) NumClusters() int {
+	if !cfg.Compartments.Enabled {
+		return 1
+	}
+	return cfg.Compartments.Write.NumCompartments
 }

--- a/pkg/blockbuilder/scheduler/partition_state.go
+++ b/pkg/blockbuilder/scheduler/partition_state.go
@@ -283,15 +283,47 @@ func (s *partitionState) committedEmpty(clusterID int) bool {
 	return s.offsets[clusterID].committed.empty()
 }
 
-// committedBeyondSpec reports whether every cluster range in spec is already at or
-// under that cluster's committed offset (i.e. the whole job is already consumed).
-func (s *partitionState) committedBeyondSpec(spec schedulerpb.JobSpec) bool {
+// specBeyond classifies a job spec's per-cluster ranges against one offset kind
+// (committed or planned).
+type specBeyond int
+
+const (
+	// beyondNone means no cluster's offset is at or past its range end.
+	beyondNone specBeyond = iota
+	// beyondSome means some clusters' offsets are at or past their range ends, others' are not.
+	// Only expressible with more than one cluster in the spec.
+	beyondSome
+	// beyondAll means every cluster's offset is at or past its range end.
+	beyondAll
+)
+
+// classifyBeyondSpec classifies spec's cluster ranges against the offsets selected by
+// offsetFor. A cluster whose offset is still empty is never beyond its range.
+func classifyBeyondSpec(spec schedulerpb.JobSpec, offsetFor func(clusterID int32) *advancingOffset) specBeyond {
+	beyond, needed := false, false
 	for clusterID, offsetRange := range spec.Ranges() {
-		if !s.offsets[clusterID].committed.beyondOffsetRange(offsetRange) {
-			return false
+		if offsetFor(clusterID).beyondOffsetRange(offsetRange) {
+			beyond = true
+		} else {
+			needed = true
 		}
 	}
-	return true
+	switch {
+	case beyond && needed:
+		return beyondSome
+	case beyond:
+		return beyondAll
+	default:
+		return beyondNone
+	}
+}
+
+// committedBeyondSpec classifies spec's cluster ranges against each cluster's committed
+// offset (beyondAll means the whole job is already consumed).
+func (s *partitionState) committedBeyondSpec(spec schedulerpb.JobSpec) specBeyond {
+	return classifyBeyondSpec(spec, func(clusterID int32) *advancingOffset {
+		return s.offsets[clusterID].committed
+	})
 }
 
 func (s *partitionState) plannedOffset(clusterID int) int64 {
@@ -302,15 +334,12 @@ func (s *partitionState) plannedEmpty(clusterID int) bool {
 	return s.offsets[clusterID].planned.empty()
 }
 
-// plannedBeyondSpec reports whether every cluster range in spec is already at or
-// under that cluster's planned offset (i.e. the whole job has already been planned).
-func (s *partitionState) plannedBeyondSpec(spec schedulerpb.JobSpec) bool {
-	for clusterID, offsetRange := range spec.Ranges() {
-		if !s.offsets[clusterID].planned.beyondOffsetRange(offsetRange) {
-			return false
-		}
-	}
-	return true
+// plannedBeyondSpec classifies spec's cluster ranges against each cluster's planned
+// offset (beyondAll means the whole job has already been planned).
+func (s *partitionState) plannedBeyondSpec(spec schedulerpb.JobSpec) specBeyond {
+	return classifyBeyondSpec(spec, func(clusterID int32) *advancingOffset {
+		return s.offsets[clusterID].planned
+	})
 }
 
 // plannedValidNextSpec reports whether spec is the contiguous next job for

--- a/pkg/blockbuilder/scheduler/partition_state.go
+++ b/pkg/blockbuilder/scheduler/partition_state.go
@@ -268,6 +268,10 @@ func (s *partitionState) completeJob(jobID string) error {
 		}
 		s.plannedJobs.Remove(elem)
 		delete(s.plannedJobsMap, js.jobID)
+		// Advance every cluster of the job together, never partially, while the caller holds the
+		// scheduler lock. This keeps the committed offset from landing partway through a job's
+		// ranges (a beyondSome state), which assignJob/updateJob/enqueuePendingJobs reject as a
+		// fatal invariant break.
 		for clusterID, offsetRange := range js.spec.Ranges() {
 			s.offsets[clusterID].committed.advance(js.jobID, offsetRange)
 		}

--- a/pkg/blockbuilder/scheduler/partition_state.go
+++ b/pkg/blockbuilder/scheduler/partition_state.go
@@ -304,18 +304,18 @@ const (
 // classifyBeyondSpec classifies spec's cluster ranges against the offsets selected by
 // offsetFor. A cluster whose offset is still empty is never beyond its range.
 func classifyBeyondSpec(spec schedulerpb.JobSpec, offsetFor func(clusterID int32) *advancingOffset) specBeyond {
-	beyond, needed := false, false
+	hasBeyond, hasNotBeyond := false, false
 	for clusterID, offsetRange := range spec.Ranges() {
 		if offsetFor(clusterID).beyondOffsetRange(offsetRange) {
-			beyond = true
+			hasBeyond = true
 		} else {
-			needed = true
+			hasNotBeyond = true
 		}
 	}
 	switch {
-	case beyond && needed:
+	case hasBeyond && hasNotBeyond:
 		return beyondSome
-	case beyond:
+	case hasBeyond:
 		return beyondAll
 	default:
 		return beyondNone

--- a/pkg/blockbuilder/scheduler/partition_state_test.go
+++ b/pkg/blockbuilder/scheduler/partition_state_test.go
@@ -285,28 +285,52 @@ func TestPartitionState_CompartmentsTrackOffsetsPerCluster(t *testing.T) {
 	require.Equal(t, int64(900), pt.committedOffset(2))
 }
 
-func TestPartitionState_CompartmentsBeyondSpecRequiresAllClusters(t *testing.T) {
-	pt := newTestPartitionStateWithClusters(t, "topic", 1, 3, true)
+func TestPartitionState_CompartmentsCommittedBeyondSpec(t *testing.T) {
+	pt := newTestPartitionStateWithClusters(t, "topic", 1, 4, true)
 	pt.initCommit(0, 200)
 	pt.initCommit(1, 900)
 	// Cluster 2 has a committed offset but never appears in the specs below. committedBeyondSpec
 	// only considers the clusters the job covers, so cluster 2 must not affect the result.
 	pt.initCommit(2, 500)
+	// (Cluster 3 has no committed offset.)
 
 	// A job wholly at or under the committed offsets of the clusters it covers is beyond the commit.
-	require.True(t, pt.committedBeyondSpec(schedulerpb.JobSpec{
+	require.Equal(t, beyondAll, pt.committedBeyondSpec(schedulerpb.JobSpec{
 		OffsetRanges: map[int32]schedulerpb.OffsetRange{
 			0: {StartOffset: 100, EndOffset: 200},
 			1: {StartOffset: 800, EndOffset: 900},
 		},
 	}))
 
-	// Cluster 1 ends past its committed offset (1000 > 900), so it is not yet consumed and the
-	// whole job is not beyond, even though cluster 0 is.
-	require.False(t, pt.committedBeyondSpec(schedulerpb.JobSpec{
+	// Cluster 1 ends past its committed offset (1000 > 900) while cluster 0 is already
+	// consumed: a mixed, partially-stale job.
+	require.Equal(t, beyondSome, pt.committedBeyondSpec(schedulerpb.JobSpec{
 		OffsetRanges: map[int32]schedulerpb.OffsetRange{
 			0: {StartOffset: 100, EndOffset: 200},
 			1: {StartOffset: 900, EndOffset: 1000},
+		},
+	}))
+
+	// Every cluster's range ends past its committed offset: the job is fully needed.
+	require.Equal(t, beyondNone, pt.committedBeyondSpec(schedulerpb.JobSpec{
+		OffsetRanges: map[int32]schedulerpb.OffsetRange{
+			0: {StartOffset: 200, EndOffset: 300},
+			1: {StartOffset: 900, EndOffset: 1000},
+		},
+	}))
+
+	// Cluster 3's empty committed offset is never beyond its range, so a job covering only
+	// cluster 3 is fully needed, and bundling it with an already-consumed cluster 0 range
+	// yields a mixed classification.
+	require.Equal(t, beyondNone, pt.committedBeyondSpec(schedulerpb.JobSpec{
+		OffsetRanges: map[int32]schedulerpb.OffsetRange{
+			3: {StartOffset: 0, EndOffset: 50},
+		},
+	}))
+	require.Equal(t, beyondSome, pt.committedBeyondSpec(schedulerpb.JobSpec{
+		OffsetRanges: map[int32]schedulerpb.OffsetRange{
+			0: {StartOffset: 100, EndOffset: 200},
+			3: {StartOffset: 0, EndOffset: 50},
 		},
 	}))
 }
@@ -334,12 +358,12 @@ func TestPartitionState_CompartmentsPlannedBeyondSpec(t *testing.T) {
 			1: {StartOffset: 800, EndOffset: 900},
 		},
 	}
-	require.True(t, pt.plannedBeyondSpec(spec))
-	require.False(t, pt.committedBeyondSpec(spec))
+	require.Equal(t, beyondAll, pt.plannedBeyondSpec(spec))
+	require.Equal(t, beyondNone, pt.committedBeyondSpec(spec))
 
-	// Cluster 1 ends past its planned offset (1000 > 900), so it is not yet planned and the
-	// whole job is not beyond, even though cluster 0 is.
-	require.False(t, pt.plannedBeyondSpec(schedulerpb.JobSpec{
+	// Cluster 1 ends past its planned offset (1000 > 900) while cluster 0 is already planned:
+	// a mixed, partially-planned job.
+	require.Equal(t, beyondSome, pt.plannedBeyondSpec(schedulerpb.JobSpec{
 		OffsetRanges: map[int32]schedulerpb.OffsetRange{
 			0: {StartOffset: 100, EndOffset: 200},
 			1: {StartOffset: 900, EndOffset: 1000},

--- a/pkg/blockbuilder/scheduler/scheduler.go
+++ b/pkg/blockbuilder/scheduler/scheduler.go
@@ -349,8 +349,8 @@ func (s *BlockBuilderScheduler) enqueuePendingJobs() {
 				// The job discovery process happens concurrently with ongoing job
 				// completions. Now that we have the lock, ignore this job if it's
 				// older than our committed offset.
-				level.Info(s.logger).Log("msg", "ignoring pending job as it's behind the committed offset",
-					"partition (expected at startup)", partition, "job", spec.RangesString(), "offsets", ps.offsetsSummary(true, false))
+				level.Info(s.logger).Log("msg", "ignoring pending job as it's behind the committed offset (expected at startup)",
+					"partition", partition, "job", spec.RangesString(), "offsets", ps.offsetsSummary(true, false))
 				ps.pendingJobs.Remove(e)
 				continue
 			case beyondSome:

--- a/pkg/blockbuilder/scheduler/scheduler.go
+++ b/pkg/blockbuilder/scheduler/scheduler.go
@@ -266,7 +266,7 @@ func (s *BlockBuilderScheduler) updateSchedule(ctx context.Context) {
 		s.recordEndOffsets(clusterID, endOffsets, touched)
 	}
 	if len(failedClusters) > 0 && len(failedClusters) < len(s.adminClients) {
-		level.Warn(s.logger).Log("msg", "advancing schedule despite failed end offset probes", "failed_clusters", fmt.Sprint(failedClusters))
+		level.Warn(s.logger).Log("msg", "advancing schedule despite failed end offset probes", "failed_write_compartments", fmt.Sprint(failedClusters))
 	}
 
 	// Advance the time bucket of each touched partition, enqueuing any job that rolled over.
@@ -443,6 +443,9 @@ func (s *BlockBuilderScheduler) initConsumptionOffsets(ctx context.Context, fall
 			if !ok {
 				byCluster = make([]*partitionOffsets, len(s.adminClients))
 				offsetsByPartition[po.partition] = byCluster
+			}
+			if byCluster[clusterID] != nil {
+				panic(fmt.Sprintf("invariant violation: consumption offsets for partition %d already set for cluster %d", po.partition, clusterID))
 			}
 			byCluster[clusterID] = po
 		}

--- a/pkg/blockbuilder/scheduler/scheduler.go
+++ b/pkg/blockbuilder/scheduler/scheduler.go
@@ -245,9 +245,9 @@ func (s *BlockBuilderScheduler) updateSchedule(ctx context.Context) {
 	// Probe and record each cluster's end offsets in turn.
 	// A cluster whose probe fails is skipped for this tick rather than abandoning the tick:
 	// i.e. one cluster's outage does not block cutting jobs for the others. The skipped cluster
-	// keeps the end offsets from its last successful probe, the rest is cut in a later bucket once probing recovers. Offsets
-	// stay contiguous per cluster either way, so nothing is lost or consumed twice — the
-	// cluster's data is just built into blocks later.
+	// keeps the end offsets from its last successful probe, the rest is cut in a later bucket
+	// once probing recovers. Offsets stay contiguous per cluster either way, so nothing is lost
+	// or consumed twice — the cluster's data is just built into blocks later.
 	touched := make(map[int32]struct{})
 	var failedClusters []int
 	for clusterID, ac := range s.adminClients {
@@ -350,18 +350,19 @@ func (s *BlockBuilderScheduler) enqueuePendingJobs() {
 				// completions. Now that we have the lock, ignore this job if it's
 				// older than our committed offset.
 				level.Info(s.logger).Log("msg", "ignoring pending job as it's behind the committed offset",
-					"partition", partition, "job", spec.RangesString(), "offsets", ps.offsetsSummary(true, false))
+					"partition (expected at startup)", partition, "job", spec.RangesString(), "offsets", ps.offsetsSummary(true, false))
 				ps.pendingJobs.Remove(e)
 				continue
 			case beyondSome:
-				// Behind the committed offset on a subset of clusters, still needed by the rest. This
-				// should not happen: at startup, jobs in this state are dropped rather than imported, and
-				// in normal running, jobs are always created with committed <= planned <= the job's start.
-				// Planned and committed can catch up to a pending job's start but never pass it — unless a
-				// cluster's end offsets go backwards (e.g. topic recreation), a data-loss emergency.
-				// This unreachability also depends on completeJob advancing every cluster of a job
-				// together (see partition_state.go); that coupling is brittle. Handling it more gracefully
-				// (e.g. trimming the job to the clusters that still need it) may be a future improvement.
+				// Behind the committed offset on a subset of clusters, still needed by the rest.
+				// This should not happen: at startup, jobs in this state are dropped rather than
+				// imported, and in normal running mode, jobs are always created with committed <=
+				// planned <= the job's start. Planned and committed can catch up to a pending job's
+				// start but never pass it unless a cluster's end offsets go backwards (e.g. topic
+				// recreation), which is a data-loss emergency. This unreachability depends on
+				// completeJob advancing every cluster of a job together (see partition_state.go).
+				// Since nothing enforces that coupling, handling it more gracefully (e.g. trimming
+				// the job to the clusters that still need it) may be a future improvement.
 				panic(fmt.Sprintf("pending job for partition %d is partially behind the committed offset: job=%s offsets=%s",
 					partition, spec.RangesString(), ps.offsetsSummary(true, false)))
 			case beyondNone:
@@ -704,7 +705,7 @@ func (s *BlockBuilderScheduler) assignJob(workerID string) (jobKey, schedulerpb.
 		ps := s.getPartitionState(spec.Topic, spec.Partition)
 		switch ps.committedBeyondSpec(spec) {
 		case beyondAll:
-			// The whole job is behind the committed offset. Remove it (expected at startup).
+			// The whole job is behind the committed offset. Remove it.
 			level.Info(s.logger).Log("msg", "removing job as it's behind the committed offset (expected at startup)",
 				"job_id", k.id, "epoch", k.epoch, "partition", spec.Partition,
 				"job", spec.RangesString(), "offsets", ps.offsetsSummary(true, false))
@@ -712,8 +713,7 @@ func (s *BlockBuilderScheduler) assignJob(workerID string) (jobKey, schedulerpb.
 			continue
 		case beyondSome:
 			// Behind the committed offset on a subset of clusters — should not happen (see the
-			// beyondSome case in enqueuePendingJobs). Panic rather than risk dropping the ranges the
-			// lagging clusters still need; a later PR could handle it more gracefully.
+			// beyondSome case in enqueuePendingJobs).
 			panic(fmt.Sprintf("assigned job for partition %d is partially behind the committed offset: job=%s offsets=%s",
 				spec.Partition, spec.RangesString(), ps.offsetsSummary(true, false)))
 		case beyondNone:
@@ -780,8 +780,7 @@ func (s *BlockBuilderScheduler) updateJob(key jobKey, workerID string, complete 
 			return nil
 		case beyondSome:
 			// Behind the committed offset on a subset of clusters — should not happen (see the
-			// beyondSome case in enqueuePendingJobs). Panic rather than risk dropping the ranges the
-			// lagging clusters still need; a later PR could handle it more gracefully.
+			// beyondSome case in enqueuePendingJobs).
 			panic(fmt.Sprintf("in-progress job update for partition %d is partially behind the committed offset: job=%s offsets=%s",
 				j.Partition, j.RangesString(), ps.offsetsSummary(true, false)))
 		case beyondNone:

--- a/pkg/blockbuilder/scheduler/scheduler.go
+++ b/pkg/blockbuilder/scheduler/scheduler.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -28,12 +29,14 @@ import (
 type BlockBuilderScheduler struct {
 	services.Service
 
-	adminClient *kadm.Client
-	jobs        *jobQueue[schedulerpb.JobSpec]
-	cfg         Config
-	logger      log.Logger
-	register    prometheus.Registerer
-	metrics     schedulerMetrics
+	// adminClients holds one Kafka admin client per write cluster, indexed by cluster ID.
+	// When compartments are disabled there is a single client at index 0.
+	adminClients []*kadm.Client
+	jobs         *jobQueue[schedulerpb.JobSpec]
+	cfg          Config
+	logger       log.Logger
+	register     prometheus.Registerer
+	metrics      schedulerMetrics
 
 	mu                  sync.Mutex
 	observations        obsMap
@@ -45,13 +48,6 @@ type BlockBuilderScheduler struct {
 	onScheduleUpdated func()
 }
 
-// Compartment support is not wired up yet; the scheduler runs a single cluster per
-// partition. These will be replaced by config once compartments are enabled.
-const (
-	compartmentsEnabled = false
-	numClusters         = 1
-)
-
 func New(
 	cfg Config,
 	logger log.Logger,
@@ -62,7 +58,7 @@ func New(
 		cfg:      cfg,
 		logger:   logger,
 		register: reg,
-		metrics:  newSchedulerMetrics(reg, compartmentsEnabled, numClusters),
+		metrics:  newSchedulerMetrics(reg, cfg.Compartments.Enabled, cfg.NumClusters()),
 
 		observations:    make(obsMap),
 		partitionStates: make(map[int32]*partitionState),
@@ -74,16 +70,36 @@ func New(
 }
 
 func (s *BlockBuilderScheduler) starting(_ context.Context) error {
-	kc, err := ingest.NewKafkaReaderClient(
-		s.cfg.Kafka,
-		ingest.NewKafkaReaderClientMetrics(ingest.ReaderMetricsPrefix, "block-builder-scheduler", s.register),
-		s.logger,
-	)
-	if err != nil {
-		return fmt.Errorf("creating kafka reader: %w", err)
+	if !s.cfg.Compartments.Enabled {
+		kc, err := ingest.NewKafkaReaderClient(
+			s.cfg.Kafka,
+			ingest.NewKafkaReaderClientMetrics(ingest.ReaderMetricsPrefix, "block-builder-scheduler", s.register),
+			s.logger,
+		)
+		if err != nil {
+			return fmt.Errorf("creating kafka reader: %w", err)
+		}
+		s.adminClients = []*kadm.Client{kadm.NewClient(kc)}
+		return nil
 	}
 
-	s.adminClient = kadm.NewClient(kc)
+	// One Kafka client per write compartment, each targeting that compartment's cluster. The
+	// per-client reader metrics are labeled by write_compartment so they stay distinct.
+	configs := ingest.WriteCompartmentConfigs(s.cfg.Kafka, s.cfg.NumClusters(), s.cfg.Kafka.Topic)
+	clients := make([]*kadm.Client, len(configs))
+	for clusterID, kcfg := range configs {
+		reg := prometheus.WrapRegistererWith(prometheus.Labels{"write_compartment": strconv.Itoa(clusterID)}, s.register)
+		kc, err := ingest.NewKafkaReaderClient(
+			kcfg,
+			ingest.NewKafkaReaderClientMetrics(ingest.ReaderMetricsPrefix, "block-builder-scheduler", reg),
+			s.logger,
+		)
+		if err != nil {
+			return fmt.Errorf("creating kafka reader for write compartment %d: %w", clusterID, err)
+		}
+		clients[clusterID] = kadm.NewClient(kc)
+	}
+	s.adminClients = clients
 	return nil
 }
 
@@ -92,7 +108,9 @@ func (s *BlockBuilderScheduler) stopping(_ error) error {
 		level.Error(s.logger).Log("msg", "failed to flush offsets at shutdown", "err", err)
 	}
 
-	s.adminClient.Close()
+	for _, ac := range s.adminClients {
+		ac.Close()
+	}
 	return nil
 }
 
@@ -152,26 +170,28 @@ func (s *BlockBuilderScheduler) running(ctx context.Context) error {
 	}
 }
 
-// loadInitialCommittedOffsets seeds each partition's committed offset from the committed
-// offsets, so startup recovery resumes from where the previous scheduler left off.
+// loadInitialCommittedOffsets seeds each partition's committed offset from every cluster's
+// committed offsets, so startup recovery resumes from where the previous scheduler left off.
 func (s *BlockBuilderScheduler) loadInitialCommittedOffsets(ctx context.Context) error {
-	c, err := fetchCommittedOffsets(ctx, s.adminClient, s.cfg.ConsumerGroup, s.cfg.Kafka.Topic)
-	if err != nil {
-		if errors.Is(err, context.Canceled) {
-			return err
+	for clusterID, client := range s.adminClients {
+		logger := s.compartmentLogger(clusterID)
+		c, err := fetchCommittedOffsets(ctx, client, s.cfg.ConsumerGroup, s.cfg.Kafka.Topic)
+		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return err
+			}
+			level.Error(logger).Log("msg", "failed to load initial committed offsets", "err", err)
+			s.metrics.fetchOffsetsFailed.Inc()
+			return s.compartmentError(clusterID, fmt.Errorf("fetch committed offsets: %w", err))
 		}
-		err = fmt.Errorf("fetch committed offsets: %w", err)
-		level.Error(s.logger).Log("msg", "failed to load initial committed offsets", "err", err)
-		s.metrics.fetchOffsetsFailed.Inc()
-		return err
+		level.Info(logger).Log("msg", "loaded initial committed offsets", "offsets", offsetsStr(c))
+		s.mu.Lock()
+		c.Each(func(o kadm.Offset) {
+			ps := s.getPartitionState(o.Topic, o.Partition)
+			ps.initCommit(clusterID, o.At)
+		})
+		s.mu.Unlock()
 	}
-	level.Info(s.logger).Log("msg", "loaded initial committed offsets", "offsets", offsetsStr(c))
-	s.mu.Lock()
-	c.Each(func(o kadm.Offset) {
-		ps := s.getPartitionState(o.Topic, o.Partition)
-		ps.initCommit(0, o.At)
-	})
-	s.mu.Unlock()
 	return nil
 }
 
@@ -201,7 +221,12 @@ func (s *BlockBuilderScheduler) completeObservationMode(ctx context.Context) {
 		return
 	}
 
-	scanner := newOffsetScanner([]offsetStore{newOffsetFinder(s.adminClient)}, s.cfg.Kafka.Topic, time.Now(), s.cfg.JobSize, s.cfg.MaxScanAge, s.metrics.probeRecordTimeDelta)
+	stores := make([]offsetStore, len(s.adminClients))
+	for clusterID := range s.adminClients {
+		stores[clusterID] = newOffsetFinder(s.adminClients[clusterID])
+	}
+
+	scanner := newOffsetScanner(stores, s.cfg.Kafka.Topic, time.Now(), s.cfg.JobSize, s.cfg.MaxScanAge, s.metrics.probeRecordTimeDelta)
 	s.populateInitialJobs(ctx, offsetsByPartition, scanner)
 	s.observations = nil
 	s.observationComplete = true
@@ -217,18 +242,40 @@ func (s *BlockBuilderScheduler) updateSchedule(ctx context.Context) {
 
 	now := time.Now()
 
-	endOffsets, err := s.adminClient.ListEndOffsets(ctx, s.cfg.Kafka.Topic)
-	if err != nil {
-		level.Warn(s.logger).Log("msg", "failed to list end offsets", "err", err)
-		return
-	}
-	if endOffsets.Error() != nil {
-		level.Warn(s.logger).Log("msg", "failed to list end offsets", "err", endOffsets.Error())
-		return
-	}
-
+	// Probe and record each cluster's end offsets in turn. Recording every cluster before
+	// advancing partition time (below) lets a single job bundle the buckets that rolled over
+	// across all clusters.
+	//
+	// A cluster whose probe fails is skipped for this tick rather than abandoning the tick:
+	// one cluster's outage must not block cutting jobs for the others. The skipped cluster
+	// keeps the end offsets from its last successful probe, so a job cut this tick covers its
+	// data only up to there; the rest is cut in a later bucket once probing recovers. Offsets
+	// stay contiguous per cluster either way, so nothing is lost or consumed twice — the
+	// cluster's data is just built into blocks later.
+	//
+	// touched is populated only by recordEndOffsets, i.e. only from successfully probed
+	// clusters — a failed cluster contributes nothing to it. A partition therefore skips its
+	// time advance below only when no cluster reported it this tick.
 	touched := make(map[int32]struct{})
-	s.recordEndOffsets(endOffsets, touched)
+	var failedClusters []int
+	for clusterID, ac := range s.adminClients {
+		endOffsets, err := ac.ListEndOffsets(ctx, s.cfg.Kafka.Topic)
+		if err == nil {
+			err = endOffsets.Error()
+		}
+		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return
+			}
+			level.Warn(s.compartmentLogger(clusterID)).Log("msg", "failed to list end offsets", "err", err)
+			failedClusters = append(failedClusters, clusterID)
+			continue
+		}
+		s.recordEndOffsets(clusterID, endOffsets, touched)
+	}
+	if len(failedClusters) > 0 && len(failedClusters) < len(s.adminClients) {
+		level.Warn(s.logger).Log("msg", "advancing schedule despite failed end offset probes", "failed_clusters", fmt.Sprint(failedClusters))
+	}
 
 	// Advance the time bucket of each touched partition, enqueuing any job that rolled over.
 	s.mu.Lock()
@@ -249,17 +296,17 @@ func (s *BlockBuilderScheduler) updateSchedule(ctx context.Context) {
 	s.metrics.assignedJobs.Set(float64(s.jobs.assigned()))
 }
 
-// recordEndOffsets records the end offsets into each partition's state, marking every partition
-// it touched so the caller can advance them once all offsets are recorded.
-func (s *BlockBuilderScheduler) recordEndOffsets(endOffsets kadm.ListedOffsets, touched map[int32]struct{}) {
+// recordEndOffsets records one cluster's end offsets into each partition's state, marking every
+// partition it touched so the caller can advance them once all clusters are recorded.
+func (s *BlockBuilderScheduler) recordEndOffsets(clusterID int, endOffsets kadm.ListedOffsets, touched map[int32]struct{}) {
 	endOffsets.Each(func(o kadm.ListedOffset) {
-		s.metrics.perClusterMetrics[0].endOffset.WithLabelValues(fmt.Sprint(o.Partition)).Set(float64(o.Offset))
+		s.metrics.perClusterMetrics[clusterID].endOffset.WithLabelValues(fmt.Sprint(o.Partition)).Set(float64(o.Offset))
 
 		s.mu.Lock()
 		defer s.mu.Unlock()
 
 		ps := s.getPartitionState(o.Topic, o.Partition)
-		ps.updateEndOffset(0, o.Offset)
+		ps.updateEndOffset(clusterID, o.Offset)
 		touched[o.Partition] = struct{}{}
 	})
 }
@@ -305,17 +352,33 @@ func (s *BlockBuilderScheduler) enqueuePendingJobs() {
 			e := ps.pendingJobs.Front()
 			spec := e.Value.(*schedulerpb.JobSpec)
 
-			// The job discovery process happens concurrently with ongoing job
-			// completions. Now that we have the lock, ignore this job if it's
-			// older than our committed offset.
-			if ps.committedBeyondSpec(*spec) {
-				level.Info(s.logger).Log("msg", "ignoring pending job as it's behind the committed offset (expected at startup)",
+			switch ps.committedBeyondSpec(*spec) {
+			case beyondAll:
+				// The whole job is already consumed on every cluster. Ignore.
+				level.Info(s.logger).Log("msg", "ignoring pending job as it's behind the committed offset",
 					"partition", partition, "job", spec.RangesString(), "offsets", ps.offsetsSummary(true, false))
 				ps.pendingJobs.Remove(e)
 				continue
+			case beyondSome:
+				// Behind the committed offset on a subset of clusters, still needed by
+				// the rest. This should not happen as for every cluster in a pending
+				// job, committed <= planned <= the job's start. Planned and committed
+				// can catch up to a pending job's start but never pass it — unless a
+				// cluster's end offsets go backwards (e.g. topic recreation), which is
+				// a data-loss emergency.
+				// Unlike beyondAll, where the commit vouches for every range and
+				// dropping is lossless, there is no easy way out here: dropping the
+				// job would lose the fresh clusters' ranges (cuts never revisit
+				// them), but downstream logic assumes offsets cannot go backwards.
+				// Handling it gracefully (e.g. trimming the job to the clusters
+				// that still need it) may be a possible future improvement.
+				panic(fmt.Sprintf("pending job for partition %d is partially behind the committed offset: job=%s offsets=%s",
+					partition, spec.RangesString(), ps.offsetsSummary(true, false)))
+			case beyondNone:
+				// Fully needed; plan it below.
 			}
 
-			jobID := jobIDForSpec(compartmentsEnabled, spec)
+			jobID := jobIDForSpec(s.cfg.Compartments.Enabled, spec)
 			if err := s.jobs.add(jobID, *spec); err != nil {
 				if errors.Is(err, errJobCreationDisallowed) || errors.Is(err, errJobAlreadyExists) {
 					// We've hit the limit for this partition.
@@ -363,7 +426,7 @@ func (s *BlockBuilderScheduler) getPartitionState(topic string, partition int32)
 		return ps
 	}
 
-	ps := newPartitionState(topic, partition, numClusters, compartmentsEnabled, &s.metrics, s.logger)
+	ps := newPartitionState(topic, partition, s.cfg.NumClusters(), s.cfg.Compartments.Enabled, &s.metrics, s.logger)
 	s.partitionStates[partition] = ps
 	return ps
 }
@@ -373,39 +436,48 @@ type partitionOffsets struct {
 	start, resume, end int64
 }
 
-// initConsumptionOffsets probes the consumption offsets and groups them by partition. The
-// returned slice for each partition is indexed by cluster ID, currently a single cluster.
+// initConsumptionOffsets probes every cluster's consumption offsets and groups them by
+// partition. The returned slice for each partition is indexed by cluster ID; a nil entry means
+// that cluster had no offsets for the partition.
 func (s *BlockBuilderScheduler) initConsumptionOffsets(ctx context.Context, fallbackTime time.Time) (map[int32][]*partitionOffsets, error) {
-	consumeOffs, err := s.initSingleClusterConsumptionOffsets(ctx, s.cfg.Kafka.Topic, fallbackTime)
-	if err != nil {
-		return nil, err
-	}
-	offsetsByPartition := make(map[int32][]*partitionOffsets, len(consumeOffs))
-	for i := range consumeOffs {
-		po := &consumeOffs[i]
-		offsetsByPartition[po.partition] = []*partitionOffsets{po}
+	offsetsByPartition := make(map[int32][]*partitionOffsets)
+	for clusterID := range s.adminClients {
+		consumeOffs, err := s.initSingleClusterConsumptionOffsets(ctx, s.cfg.Kafka.Topic, fallbackTime, clusterID)
+		if err != nil {
+			return nil, s.compartmentError(clusterID, err)
+		}
+		for i := range consumeOffs {
+			po := &consumeOffs[i]
+			byCluster, ok := offsetsByPartition[po.partition]
+			if !ok {
+				byCluster = make([]*partitionOffsets, len(s.adminClients))
+				offsetsByPartition[po.partition] = byCluster
+			}
+			byCluster[clusterID] = po
+		}
 	}
 	return offsetsByPartition, nil
 }
 
-// initSingleClusterConsumptionOffsets returns the resumption and end offsets for each partition,
-// falling back to the fallbackTime if there is no planned offset for a partition.
-func (s *BlockBuilderScheduler) initSingleClusterConsumptionOffsets(ctx context.Context, topic string, fallbackTime time.Time) ([]partitionOffsets, error) {
-	startOffsets, err := s.adminClient.ListStartOffsets(ctx, topic)
+// initSingleClusterConsumptionOffsets returns the resumption and end offsets for each partition on the given
+// cluster, falling back to the fallbackTime if there is no planned offset for a partition.
+func (s *BlockBuilderScheduler) initSingleClusterConsumptionOffsets(ctx context.Context, topic string, fallbackTime time.Time, clusterID int) ([]partitionOffsets, error) {
+	logger := s.compartmentLogger(clusterID)
+	startOffsets, err := s.adminClients[clusterID].ListStartOffsets(ctx, topic)
 	if err != nil {
 		return nil, fmt.Errorf("list start offsets: %w", err)
 	}
 	if startOffsets.Error() != nil {
 		return nil, fmt.Errorf("list start offsets: %w", startOffsets.Error())
 	}
-	endOffsets, err := s.adminClient.ListEndOffsets(ctx, topic)
+	endOffsets, err := s.adminClients[clusterID].ListEndOffsets(ctx, topic)
 	if err != nil {
 		return nil, fmt.Errorf("list end offsets: %w", err)
 	}
 	if endOffsets.Error() != nil {
 		return nil, fmt.Errorf("list end offsets: %w", endOffsets.Error())
 	}
-	fallbackOffsets, err := s.adminClient.ListOffsetsAfterMilli(ctx, fallbackTime.UnixMilli(), topic)
+	fallbackOffsets, err := s.adminClients[clusterID].ListOffsetsAfterMilli(ctx, fallbackTime.UnixMilli(), topic)
 	if err != nil {
 		return nil, fmt.Errorf("list fallback offsets: %w", err)
 	}
@@ -430,9 +502,9 @@ func (s *BlockBuilderScheduler) initSingleClusterConsumptionOffsets(ctx context.
 
 			var resumeOffset int64
 
-			if !ps.plannedEmpty(0) {
-				planned := ps.plannedOffset(0)
-				s.metrics.perClusterMetrics[0].plannedOffset.WithLabelValues(partStr).Set(float64(planned))
+			if !ps.plannedEmpty(clusterID) {
+				planned := ps.plannedOffset(clusterID)
+				s.metrics.perClusterMetrics[clusterID].plannedOffset.WithLabelValues(partStr).Set(float64(planned))
 				resumeOffset = planned
 			} else {
 				// Nothing planned offset for this partition. Resume from fallback offset instead.
@@ -441,7 +513,7 @@ func (s *BlockBuilderScheduler) initSingleClusterConsumptionOffsets(ctx context.
 					return nil, fmt.Errorf("partition %d not found in fallback offsets for topic %s", partition, t)
 				}
 
-				level.Debug(s.logger).Log("msg", "no planned offset; falling back to max of startOffset and fallbackOffset",
+				level.Debug(logger).Log("msg", "no planned offset; falling back to max of startOffset and fallbackOffset",
 					"topic", t, "partition", partition, "startOffset", startOffset.At, "fallbackOffset", o.Offset)
 
 				resumeOffset = max(startOffset.At, o.Offset)
@@ -452,11 +524,11 @@ func (s *BlockBuilderScheduler) initSingleClusterConsumptionOffsets(ctx context.
 				return nil, fmt.Errorf("partition %d not found in end offsets for topic %s", partition, t)
 			}
 
-			level.Debug(s.logger).Log("msg", "initSingleClusterConsumptionOffsets", "topic", t, "partition", partition,
+			level.Debug(logger).Log("msg", "initSingleClusterConsumptionOffsets", "topic", t, "partition", partition,
 				"start", startOffset.At, "end", end.Offset, "consumeOffset", resumeOffset)
 
-			s.metrics.perClusterMetrics[0].startOffset.WithLabelValues(partStr).Set(float64(startOffset.At))
-			s.metrics.perClusterMetrics[0].endOffset.WithLabelValues(partStr).Set(float64(end.Offset))
+			s.metrics.perClusterMetrics[clusterID].startOffset.WithLabelValues(partStr).Set(float64(startOffset.At))
+			s.metrics.perClusterMetrics[clusterID].endOffset.WithLabelValues(partStr).Set(float64(end.Offset))
 
 			offs = append(offs, partitionOffsets{
 				partition: partition,
@@ -521,8 +593,9 @@ func fetchCommittedOffsets(ctx context.Context, adminClient *kadm.Client, consum
 	return kadm.Offsets{}, lastErr
 }
 
-// snapshotOffsets returns a snapshot of the committed and planned offsets for all partitions.
-func (s *BlockBuilderScheduler) snapshotOffsets() (kadm.Offsets, kadm.Offsets) {
+// snapshotOffsets returns a snapshot of the committed and planned offsets for the given cluster
+// across all partitions.
+func (s *BlockBuilderScheduler) snapshotOffsets(clusterID int) (kadm.Offsets, kadm.Offsets) {
 	cp := make(kadm.Offsets)
 	pp := make(kadm.Offsets)
 
@@ -530,36 +603,42 @@ func (s *BlockBuilderScheduler) snapshotOffsets() (kadm.Offsets, kadm.Offsets) {
 	defer s.mu.Unlock()
 
 	for _, ps := range s.partitionStates {
-		if !ps.committedEmpty(0) {
-			cp.AddOffset(ps.topic, ps.partition, ps.committedOffset(0), 0)
+		if !ps.committedEmpty(clusterID) {
+			cp.AddOffset(ps.topic, ps.partition, ps.committedOffset(clusterID), 0)
 		}
-		if !ps.plannedEmpty(0) {
-			pp.AddOffset(ps.topic, ps.partition, ps.plannedOffset(0), 0)
+		if !ps.plannedEmpty(clusterID) {
+			pp.AddOffset(ps.topic, ps.partition, ps.plannedOffset(clusterID), 0)
 		}
 	}
 
 	return cp, pp
 }
 
-// flushOffsetsToKafka flushes the committed offsets to Kafka and updates relevant metrics.
+// flushOffsetsToKafka flushes each cluster's committed offsets to that cluster's Kafka and
+// updates relevant metrics.
+// If a single cluster's flush errors, we continue to flush to other clusters, then return
+// all cluster flush errors.
 func (s *BlockBuilderScheduler) flushOffsetsToKafka(ctx context.Context) error {
 	// TODO: only flush if dirty.
-	committed, planned := s.snapshotOffsets()
+	var errs []error
+	for clusterID, client := range s.adminClients {
+		committed, planned := s.snapshotOffsets(clusterID)
 
-	committed.Each(func(o kadm.Offset) {
-		s.metrics.perClusterMetrics[0].committedOffset.WithLabelValues(fmt.Sprint(o.Partition)).Set(float64(o.At))
-	})
-	planned.Each(func(o kadm.Offset) {
-		s.metrics.perClusterMetrics[0].plannedOffset.WithLabelValues(fmt.Sprint(o.Partition)).Set(float64(o.At))
-	})
+		committed.Each(func(o kadm.Offset) {
+			s.metrics.perClusterMetrics[clusterID].committedOffset.WithLabelValues(fmt.Sprint(o.Partition)).Set(float64(o.At))
+		})
+		planned.Each(func(o kadm.Offset) {
+			s.metrics.perClusterMetrics[clusterID].plannedOffset.WithLabelValues(fmt.Sprint(o.Partition)).Set(float64(o.At))
+		})
 
-	err := s.adminClient.CommitAllOffsets(ctx, s.cfg.ConsumerGroup, committed)
-	if err != nil {
-		return fmt.Errorf("commit offsets: %w", err)
+		if err := client.CommitAllOffsets(ctx, s.cfg.ConsumerGroup, committed); err != nil {
+			errs = append(errs, s.compartmentError(clusterID, fmt.Errorf("commit offsets: %w", err)))
+			continue
+		}
+
+		level.Debug(s.compartmentLogger(clusterID)).Log("msg", "flushed offsets to Kafka", "offsets", offsetsStr(committed))
 	}
-
-	level.Debug(s.logger).Log("msg", "flushed offsets to Kafka", "offsets", offsetsStr(committed))
-	return nil
+	return errors.Join(errs...)
 }
 
 // offsetsStr returns a string representation of the given offsets.
@@ -579,6 +658,24 @@ func offsetsStr(offsets kadm.Offsets) string {
 		offsetsStr = "<none>"
 	}
 	return offsetsStr
+}
+
+// compartmentLogger returns a logger annotated with the write compartment ID. With compartments
+// disabled there is a single cluster, so the plain logger is returned to avoid a misleading label.
+func (s *BlockBuilderScheduler) compartmentLogger(clusterID int) log.Logger {
+	if !s.cfg.Compartments.Enabled {
+		return s.logger
+	}
+	return log.With(s.logger, "write_compartment", clusterID)
+}
+
+// compartmentError annotates err with the write compartment ID, but only when compartments are
+// enabled so that single-cluster errors aren't misleadingly attributed to a compartment.
+func (s *BlockBuilderScheduler) compartmentError(clusterID int, err error) error {
+	if !s.cfg.Compartments.Enabled {
+		return err
+	}
+	return fmt.Errorf("write compartment %d: %w", clusterID, err)
 }
 
 // AssignJob assigns and returns a job, if one is available.
@@ -614,7 +711,11 @@ func (s *BlockBuilderScheduler) assignJob(workerID string) (jobKey, schedulerpb.
 			return k, spec, err
 		}
 
-		if ps := s.getPartitionState(spec.Topic, spec.Partition); ps.committedBeyondSpec(spec) {
+		// A job is obsolete only when every cluster's range is behind its committed
+		// offset (beyondAll). We don't expect beyondSome here, but if it happens we
+		// keep processing the job rather than drop it, to avoid possibly dropping the
+		// ranges the fresh clusters still need.
+		if ps := s.getPartitionState(spec.Topic, spec.Partition); ps.committedBeyondSpec(spec) == beyondAll {
 			// Job is before the committed offset. Remove it.
 			level.Info(s.logger).Log("msg", "removing job as it's behind the committed offset (expected at startup)",
 				"job_id", k.id, "epoch", k.epoch, "partition", spec.Partition,
@@ -629,7 +730,7 @@ func (s *BlockBuilderScheduler) assignJob(workerID string) (jobKey, schedulerpb.
 
 // UpdateJob takes a job update from the client and records it, if necessary.
 func (s *BlockBuilderScheduler) UpdateJob(_ context.Context, req *schedulerpb.UpdateJobRequest) (*schedulerpb.UpdateJobResponse, error) {
-	if err := req.Spec.Validate(compartmentsEnabled, numClusters); err != nil {
+	if err := req.Spec.Validate(s.cfg.Compartments.Enabled, s.cfg.NumClusters()); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 	k := jobKey{
@@ -677,7 +778,11 @@ func (s *BlockBuilderScheduler) updateJob(key jobKey, workerID string, complete 
 	} else {
 		// It's an in-progress job whose lease we need to renew.
 
-		if ps.committedBeyondSpec(j) {
+		// Ignore only when every cluster's range is behind its committed offset
+		// (beyondAll). We don't expect beyondSome here, but if it happens we renew the
+		// lease rather than ignore it, to avoid possibly dropping the ranges the fresh
+		// clusters still need.
+		if ps.committedBeyondSpec(j) == beyondAll {
 			// Update of a completed/committed job. Ignore.
 			level.Debug(logger).Log("msg", "ignored historical job")
 			return nil
@@ -767,12 +872,30 @@ func (s *BlockBuilderScheduler) finalizeObservations() {
 				continue
 			}
 
-			if ps.plannedBeyondSpec(obs.spec) {
-				// This job is wholly before the latest planned offset. Skip.
+			switch ps.plannedBeyondSpec(obs.spec) {
+			case beyondAll:
+				// This job is wholly before the planned offset on every cluster: a
+				// historical job whose ranges were already flushed. Skip it and keep
+				// importing.
 				level.Warn(s.logger).Log("msg", "startup: skipping job before commit",
 					"partition", partition, "job_id", obs.key.id, "epoch", obs.key.epoch,
 					"job", obs.spec.RangesString())
 				continue
+			case beyondSome:
+				// Behind the planned offset on a subset of clusters. This is possible
+				// if the scheduler crashes halfway through committing offsets for a
+				// completed job: on restart, initCommit seeds committed=planned, so the
+				// job is behind the planned offsets of the clusters whose commit
+				// succeeded, but not the rest. For safety and simplicity we flag this
+				// as not contiguous and replan jobs. A future improvement could be to
+				// handle this in a more graceful manner.
+				contiguous = false
+				level.Warn(s.logger).Log("msg", "startup: skipping job partially behind planned offsets, truncating recovery",
+					"partition", partition, "job_id", obs.key.id, "epoch", obs.key.epoch,
+					"job", obs.spec.RangesString(), "offsets", ps.offsetsSummary(false, true))
+				continue
+			case beyondNone:
+				// Fully ahead of the planned frontier; validate contiguity below.
 			}
 
 			if !ps.plannedValidNextSpec(obs.spec) {

--- a/pkg/blockbuilder/scheduler/scheduler.go
+++ b/pkg/blockbuilder/scheduler/scheduler.go
@@ -242,20 +242,12 @@ func (s *BlockBuilderScheduler) updateSchedule(ctx context.Context) {
 
 	now := time.Now()
 
-	// Probe and record each cluster's end offsets in turn. Recording every cluster before
-	// advancing partition time (below) lets a single job bundle the buckets that rolled over
-	// across all clusters.
-	//
+	// Probe and record each cluster's end offsets in turn.
 	// A cluster whose probe fails is skipped for this tick rather than abandoning the tick:
-	// one cluster's outage must not block cutting jobs for the others. The skipped cluster
-	// keeps the end offsets from its last successful probe, so a job cut this tick covers its
-	// data only up to there; the rest is cut in a later bucket once probing recovers. Offsets
+	// i.e. one cluster's outage does not block cutting jobs for the others. The skipped cluster
+	// keeps the end offsets from its last successful probe, the rest is cut in a later bucket once probing recovers. Offsets
 	// stay contiguous per cluster either way, so nothing is lost or consumed twice — the
 	// cluster's data is just built into blocks later.
-	//
-	// touched is populated only by recordEndOffsets, i.e. only from successfully probed
-	// clusters — a failed cluster contributes nothing to it. A partition therefore skips its
-	// time advance below only when no cluster reported it this tick.
 	touched := make(map[int32]struct{})
 	var failedClusters []int
 	for clusterID, ac := range s.adminClients {
@@ -354,24 +346,22 @@ func (s *BlockBuilderScheduler) enqueuePendingJobs() {
 
 			switch ps.committedBeyondSpec(*spec) {
 			case beyondAll:
-				// The whole job is already consumed on every cluster. Ignore.
+				// The job discovery process happens concurrently with ongoing job
+				// completions. Now that we have the lock, ignore this job if it's
+				// older than our committed offset.
 				level.Info(s.logger).Log("msg", "ignoring pending job as it's behind the committed offset",
 					"partition", partition, "job", spec.RangesString(), "offsets", ps.offsetsSummary(true, false))
 				ps.pendingJobs.Remove(e)
 				continue
 			case beyondSome:
-				// Behind the committed offset on a subset of clusters, still needed by
-				// the rest. This should not happen as for every cluster in a pending
-				// job, committed <= planned <= the job's start. Planned and committed
-				// can catch up to a pending job's start but never pass it — unless a
-				// cluster's end offsets go backwards (e.g. topic recreation), which is
-				// a data-loss emergency.
-				// Unlike beyondAll, where the commit vouches for every range and
-				// dropping is lossless, there is no easy way out here: dropping the
-				// job would lose the fresh clusters' ranges (cuts never revisit
-				// them), but downstream logic assumes offsets cannot go backwards.
-				// Handling it gracefully (e.g. trimming the job to the clusters
-				// that still need it) may be a possible future improvement.
+				// Behind the committed offset on a subset of clusters, still needed by the rest. This
+				// should not happen: at startup, jobs in this state are dropped rather than imported, and
+				// in normal running, jobs are always created with committed <= planned <= the job's start.
+				// Planned and committed can catch up to a pending job's start but never pass it — unless a
+				// cluster's end offsets go backwards (e.g. topic recreation), a data-loss emergency.
+				// This unreachability also depends on completeJob advancing every cluster of a job
+				// together (see partition_state.go); that coupling is brittle. Handling it more gracefully
+				// (e.g. trimming the job to the clusters that still need it) may be a future improvement.
 				panic(fmt.Sprintf("pending job for partition %d is partially behind the committed offset: job=%s offsets=%s",
 					partition, spec.RangesString(), ps.offsetsSummary(true, false)))
 			case beyondNone:
@@ -711,17 +701,23 @@ func (s *BlockBuilderScheduler) assignJob(workerID string) (jobKey, schedulerpb.
 			return k, spec, err
 		}
 
-		// A job is obsolete only when every cluster's range is behind its committed
-		// offset (beyondAll). We don't expect beyondSome here, but if it happens we
-		// keep processing the job rather than drop it, to avoid possibly dropping the
-		// ranges the fresh clusters still need.
-		if ps := s.getPartitionState(spec.Topic, spec.Partition); ps.committedBeyondSpec(spec) == beyondAll {
-			// Job is before the committed offset. Remove it.
+		ps := s.getPartitionState(spec.Topic, spec.Partition)
+		switch ps.committedBeyondSpec(spec) {
+		case beyondAll:
+			// The whole job is behind the committed offset. Remove it (expected at startup).
 			level.Info(s.logger).Log("msg", "removing job as it's behind the committed offset (expected at startup)",
 				"job_id", k.id, "epoch", k.epoch, "partition", spec.Partition,
 				"job", spec.RangesString(), "offsets", ps.offsetsSummary(true, false))
 			s.jobs.removeJob(k)
 			continue
+		case beyondSome:
+			// Behind the committed offset on a subset of clusters — should not happen (see the
+			// beyondSome case in enqueuePendingJobs). Panic rather than risk dropping the ranges the
+			// lagging clusters still need; a later PR could handle it more gracefully.
+			panic(fmt.Sprintf("assigned job for partition %d is partially behind the committed offset: job=%s offsets=%s",
+				spec.Partition, spec.RangesString(), ps.offsetsSummary(true, false)))
+		case beyondNone:
+			// Fully needed; assign it below.
 		}
 
 		return k, spec, nil
@@ -777,15 +773,19 @@ func (s *BlockBuilderScheduler) updateJob(key jobKey, workerID string, complete 
 		level.Info(logger).Log("msg", "completed job")
 	} else {
 		// It's an in-progress job whose lease we need to renew.
-
-		// Ignore only when every cluster's range is behind its committed offset
-		// (beyondAll). We don't expect beyondSome here, but if it happens we renew the
-		// lease rather than ignore it, to avoid possibly dropping the ranges the fresh
-		// clusters still need.
-		if ps.committedBeyondSpec(j) == beyondAll {
+		switch ps.committedBeyondSpec(j) {
+		case beyondAll:
 			// Update of a completed/committed job. Ignore.
 			level.Debug(logger).Log("msg", "ignored historical job")
 			return nil
+		case beyondSome:
+			// Behind the committed offset on a subset of clusters — should not happen (see the
+			// beyondSome case in enqueuePendingJobs). Panic rather than risk dropping the ranges the
+			// lagging clusters still need; a later PR could handle it more gracefully.
+			panic(fmt.Sprintf("in-progress job update for partition %d is partially behind the committed offset: job=%s offsets=%s",
+				j.Partition, j.RangesString(), ps.offsetsSummary(true, false)))
+		case beyondNone:
+			// Fully needed; renew below.
 		}
 
 		if err := s.jobs.renewLease(key, workerID); err != nil {

--- a/pkg/blockbuilder/scheduler/scheduler_test.go
+++ b/pkg/blockbuilder/scheduler/scheduler_test.go
@@ -187,8 +187,7 @@ func TestService(t *testing.T) {
 
 // TestService_MultiCluster runs the scheduler through its Service interface with compartments
 // enabled, so the service builds one Kafka client per write compartment from the templated
-// address. Every cluster gets a distinct number of records per partition, so each cluster's
-// committed offsets must match exactly the counts produced to that cluster.
+// address.
 func TestService_MultiCluster(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		sched, clients := mustMultiClusterScheduler(t, 4, 3)
@@ -230,9 +229,8 @@ func TestService_MultiCluster(t *testing.T) {
 			require.NoError(t, produceResult.FirstErr())
 		}
 
-		// counts[c][p] is the number of records produced to partition p on cluster c. All
-		// non-zero cells are distinct so commits landing on the wrong cluster or partition fail
-		// the test; partition 0 gets no data and must end up with no commits.
+		// counts[c][p] is the number of records produced to partition p on cluster c;
+		// partition 0 gets no data and must end up with no commits.
 		counts := [3][4]int{
 			{0, 10, 20, 30},
 			{0, 40, 50, 60},
@@ -418,9 +416,30 @@ func TestStartup_MultiCluster(t *testing.T) {
 
 	// Some jobs that ostensibly exist, but scheduler doesn't know about. Each job's ranges
 	// resume from its clusters' committed offsets.
-	j1 := observedJob(10, multiSpec(64, offsetRange(0, 1000, 1100), offsetRange(1, 5000, 5200), offsetRange(2, 30, 90)))
-	j2 := observedJob(11, multiSpec(65, offsetRange(0, 256, 300), offsetRange(2, 88, 100)))
-	j3 := observedJob(12, multiSpec(66, offsetRange(1, 57, 100)))
+	j1 := observedJob(10, schedulerpb.JobSpec{
+		Topic:     "ingest",
+		Partition: 64,
+		OffsetRanges: map[int32]schedulerpb.OffsetRange{
+			0: {StartOffset: 1000, EndOffset: 1100},
+			1: {StartOffset: 5000, EndOffset: 5200},
+			2: {StartOffset: 30, EndOffset: 90},
+		},
+	})
+	j2 := observedJob(11, schedulerpb.JobSpec{
+		Topic:     "ingest",
+		Partition: 65,
+		OffsetRanges: map[int32]schedulerpb.OffsetRange{
+			0: {StartOffset: 256, EndOffset: 300},
+			2: {StartOffset: 88, EndOffset: 100},
+		},
+	})
+	j3 := observedJob(12, schedulerpb.JobSpec{
+		Topic:     "ingest",
+		Partition: 66,
+		OffsetRanges: map[int32]schedulerpb.OffsetRange{
+			1: {StartOffset: 57, EndOffset: 100},
+		},
+	})
 
 	// Clients will be pinging with their updates for some time.
 
@@ -473,11 +492,32 @@ func TestStartup_MultiCluster(t *testing.T) {
 func TestStartup_MultiCluster_GapOnOneCluster(t *testing.T) {
 	sched, _ := mustMultiClusterScheduler(t, 3, 3)
 
-	jobA := observedJob(10, multiSpec(64, offsetRange(0, 100, 200), offsetRange(1, 100, 200)))
+	jobA := observedJob(10, schedulerpb.JobSpec{
+		Topic:     "ingest",
+		Partition: 64,
+		OffsetRanges: map[int32]schedulerpb.OffsetRange{
+			0: {StartOffset: 100, EndOffset: 200},
+			1: {StartOffset: 100, EndOffset: 200},
+		},
+	})
 	// jobB's cluster 0 range leaves a gap (200 -> 250); its cluster 1 range is contiguous.
-	jobB := observedJob(11, multiSpec(64, offsetRange(0, 250, 300), offsetRange(1, 200, 300)))
+	jobB := observedJob(11, schedulerpb.JobSpec{
+		Topic:     "ingest",
+		Partition: 64,
+		OffsetRanges: map[int32]schedulerpb.OffsetRange{
+			0: {StartOffset: 250, EndOffset: 300},
+			1: {StartOffset: 200, EndOffset: 300},
+		},
+	})
 	// jobC continues jobB contiguously on both clusters.
-	jobC := observedJob(12, multiSpec(64, offsetRange(0, 300, 400), offsetRange(1, 300, 400)))
+	jobC := observedJob(12, schedulerpb.JobSpec{
+		Topic:     "ingest",
+		Partition: 64,
+		OffsetRanges: map[int32]schedulerpb.OffsetRange{
+			0: {StartOffset: 300, EndOffset: 400},
+			1: {StartOffset: 300, EndOffset: 400},
+		},
+	})
 
 	require.NoError(t, sched.updateJob(jobA.key, "w0", false, jobA.spec))
 	require.NoError(t, sched.updateJob(jobB.key, "w1", false, jobB.spec))
@@ -493,20 +533,13 @@ func TestStartup_MultiCluster_GapOnOneCluster(t *testing.T) {
 	require.False(t, ok, "jobC should be skipped because it's after the gap, even though it's contiguous with jobB")
 
 	ps := sched.getPartitionState("ingest", 64)
-	require.Equal(t, int64(200), ps.plannedOffset(0), "planned offsets should stop at jobA's ends")
-	require.Equal(t, int64(200), ps.plannedOffset(1), "planned offsets should stop at jobA's ends")
+	require.Equal(t, int64(200), ps.plannedOffset(0))
+	require.Equal(t, int64(200), ps.plannedOffset(1))
 	require.True(t, ps.plannedEmpty(2), "cluster 2 was in no job's ranges")
 }
 
 // TestStartup_MultiCluster_PartiallyFlushedCommit documents recovery after a crash that
-// persisted a completed job's commit on a subset of clusters. It runs the pre-crash scheduler
-// for real: a worker completes a job, advancing every cluster's in-memory commit, and the
-// per-cluster flush persists all but one cluster's offsets (flushes continue past failures). A
-// restarted scheduler against the same clusters thus loads committed offsets that are beyond
-// the re-reported job's ranges on the flushed clusters and behind them on the rest. Such a job
-// cannot be imported (it would rewind the flushed clusters), so recovery truncates there: the
-// job and all later observed jobs are skipped, and each cluster resumes from its own flushed
-// frontier.
+// persisted a completed job's commit on a subset of clusters
 func TestStartup_MultiCluster_PartiallyFlushedCommit(t *testing.T) {
 	clusters := createTestClusters(t, 3, 3)
 	ctx := t.Context()
@@ -520,7 +553,15 @@ func TestStartup_MultiCluster_PartiallyFlushedCommit(t *testing.T) {
 
 	// A worker runs jobJ to completion, advancing every cluster's in-memory commit to its
 	// range end.
-	jobJ := multiSpec(0, offsetRange(0, 100, 200), offsetRange(1, 100, 200), offsetRange(2, 50, 150))
+	jobJ := schedulerpb.JobSpec{
+		Topic:     "ingest",
+		Partition: 0,
+		OffsetRanges: map[int32]schedulerpb.OffsetRange{
+			0: {StartOffset: 100, EndOffset: 200},
+			1: {StartOffset: 100, EndOffset: 200},
+			2: {StartOffset: 50, EndOffset: 150},
+		},
+	}
 	addPendingJob(schedA, jobJ)
 	schedA.enqueuePendingJobs()
 	keyJ, specJ, err := schedA.assignJob("w0")
@@ -546,7 +587,15 @@ func TestStartup_MultiCluster_PartiallyFlushedCommit(t *testing.T) {
 	// The worker re-reports the completed jobJ during observation, along with an in-progress
 	// jobK continuing jobJ contiguously on every cluster.
 	require.NoError(t, schedB.updateJob(keyJ, "w0", true, specJ))
-	jobK := observedJob(keyJ.epoch+1, multiSpec(0, offsetRange(0, 200, 300), offsetRange(1, 200, 300), offsetRange(2, 150, 250)))
+	jobK := observedJob(keyJ.epoch+1, schedulerpb.JobSpec{
+		Topic:     "ingest",
+		Partition: 0,
+		OffsetRanges: map[int32]schedulerpb.OffsetRange{
+			0: {StartOffset: 200, EndOffset: 300},
+			1: {StartOffset: 200, EndOffset: 300},
+			2: {StartOffset: 150, EndOffset: 250},
+		},
+	})
 	require.NoError(t, schedB.updateJob(jobK.key, "w1", false, jobK.spec))
 
 	schedB.completeObservationMode(ctx)
@@ -557,17 +606,15 @@ func TestStartup_MultiCluster_PartiallyFlushedCommit(t *testing.T) {
 	require.False(t, ok, "jobK should be skipped because recovery truncated at the partially flushed jobJ")
 
 	pB := schedB.getPartitionState("ingest", 0)
-	require.Equal(t, int64(200), pB.plannedOffset(0), "flushed clusters should resume from their flushed frontier")
+	require.Equal(t, int64(200), pB.plannedOffset(0))
 	require.Equal(t, int64(100), pB.plannedOffset(1), "the unflushed cluster should resume from its stale commit, re-covering jobJ's range")
-	require.Equal(t, int64(150), pB.plannedOffset(2), "flushed clusters should resume from their flushed frontier")
+	require.Equal(t, int64(150), pB.plannedOffset(2))
 	requireOffsets(t, schedB, "ingest", 0, map[int]int64{0: 200, 1: 100, 2: 150})
 }
 
 // TestCompleteObservationMode_ResumesFromImportedPlan verifies that startup cuts pending jobs
 // from the planned frontier established by observation import: ranges recovered from workers are
-// not re-cut, only the data beyond them is. If consumption offsets were probed before
-// finalizeObservations sanitized the planned offsets, the cut job would overlap the imported
-// plan and panic at enqueue (see addPlannedJob).
+// not re-cut, only the data beyond them is.
 func TestCompleteObservationMode_ResumesFromImportedPlan(t *testing.T) {
 	ctx, cancel := context.WithCancelCause(context.Background())
 	t.Cleanup(func() { cancel(errors.New("test done")) })
@@ -596,7 +643,14 @@ func TestCompleteObservationMode_ResumesFromImportedPlan(t *testing.T) {
 
 	// A worker reports an in-progress job covering all of cluster 0's records and part of
 	// cluster 1's; cluster 2 is not part of the job.
-	observed := observedJob(10, multiSpec(0, offsetRange(0, 0, 10), offsetRange(1, 0, 5)))
+	observed := observedJob(10, schedulerpb.JobSpec{
+		Topic:     "ingest",
+		Partition: 0,
+		OffsetRanges: map[int32]schedulerpb.OffsetRange{
+			0: {StartOffset: 0, EndOffset: 10},
+			1: {StartOffset: 0, EndOffset: 5},
+		},
+	})
 	require.NoError(t, sched.updateJob(observed.key, "w0", false, observed.spec))
 
 	sched.completeObservationMode(ctx)
@@ -604,33 +658,23 @@ func TestCompleteObservationMode_ResumesFromImportedPlan(t *testing.T) {
 
 	_, ok := sched.jobs.jobs[observed.key.id]
 	require.True(t, ok, "the observed job should be imported")
-	_, ok = sched.jobs.jobs["ingest/0/1:5-2:0"]
+
+	newJob, ok := sched.jobs.jobs["ingest/0/1:5-2:0"]
 	require.True(t, ok, "the data beyond the imported plan should be planned: cluster 1 past the observed job, cluster 2 in full")
+	require.Equal(t, schedulerpb.JobSpec{
+		Topic:     "ingest",
+		Partition: 0,
+		OffsetRanges: map[int32]schedulerpb.OffsetRange{
+			1: {StartOffset: 5, EndOffset: 8},
+			2: {StartOffset: 0, EndOffset: 6},
+		},
+	}, newJob.spec, "the new job should cover only the unplanned data; cluster 0 is fully in the observed job")
 	require.Equal(t, 2, sched.jobs.count())
 
 	ps := sched.getPartitionState("ingest", 0)
-	require.Equal(t, int64(10), ps.plannedOffset(0))
+	require.Equal(t, int64(10), ps.plannedOffset(0), "cluster 0's frontier comes entirely from the imported observed job")
 	require.Equal(t, int64(8), ps.plannedOffset(1))
 	require.Equal(t, int64(6), ps.plannedOffset(2))
-}
-
-// TestCompleteObservationMode_ConsumptionOffsetsProbeFails pins the behavior when any single
-// cluster's consumption-offset probe fails while completing observation mode: the transition is
-// abandoned before observationComplete is set, and since completeObservationMode runs only once
-// per process, the scheduler stays in observation mode — refusing job assignment — until it is
-// restarted.
-func TestCompleteObservationMode_ConsumptionOffsetsProbeFails(t *testing.T) {
-	clusters := createTestClusters(t, 3, 3)
-	sched, _ := mustMultiClusterSchedulerWithClusters(t, clusters)
-
-	failListOffsets(clusters[1].cluster)
-
-	sched.completeObservationMode(t.Context())
-
-	require.False(t, sched.observationCompleteLocked(),
-		"a failed consumption-offset probe should leave the scheduler in observation mode")
-	_, _, err := sched.assignJob("w0")
-	require.ErrorContains(t, err, "observation period not complete")
 }
 
 func requireGaps(t *testing.T, reg *prometheus.Registry, planned, committed int, msgAndArgs ...any) {
@@ -760,7 +804,15 @@ func TestAssignJobSkipsObsoleteOffsets_MultiCluster(t *testing.T) {
 		sched.completeObservationMode(context.Background())
 
 		// Every cluster's committed offset reaches its range end: fully consumed.
-		s1 := multiSpec(1, offsetRange(0, 100, 200), offsetRange(1, 300, 400), offsetRange(2, 500, 600))
+		s1 := schedulerpb.JobSpec{
+			Topic:     "ingest",
+			Partition: 1,
+			OffsetRanges: map[int32]schedulerpb.OffsetRange{
+				0: {StartOffset: 100, EndOffset: 200},
+				1: {StartOffset: 300, EndOffset: 400},
+				2: {StartOffset: 500, EndOffset: 600},
+			},
+		}
 		require.NoError(t, sched.jobs.add(jobIDForSpec(true, &s1), s1))
 		initCommits(sched, "ingest", 1, map[int]int64{0: 200, 1: 400, 2: 600})
 
@@ -773,7 +825,15 @@ func TestAssignJobSkipsObsoleteOffsets_MultiCluster(t *testing.T) {
 		sched.completeObservationMode(context.Background())
 
 		// Consumed on cluster 0 only; clusters 1 and 2 still need it.
-		s2 := multiSpec(2, offsetRange(0, 100, 200), offsetRange(1, 300, 400), offsetRange(2, 500, 600))
+		s2 := schedulerpb.JobSpec{
+			Topic:     "ingest",
+			Partition: 2,
+			OffsetRanges: map[int32]schedulerpb.OffsetRange{
+				0: {StartOffset: 100, EndOffset: 200},
+				1: {StartOffset: 300, EndOffset: 400},
+				2: {StartOffset: 500, EndOffset: 600},
+			},
+		}
 		require.NoError(t, sched.jobs.add(jobIDForSpec(true, &s2), s2))
 		initCommits(sched, "ingest", 2, map[int]int64{0: 200, 1: 300, 2: 500})
 
@@ -789,7 +849,15 @@ func TestUpdateJobPanicsOnPartiallyConsumed_MultiCluster(t *testing.T) {
 	sched.completeObservationMode(context.Background())
 
 	// Consumed on cluster 0 only; clusters 1 and 2 still need it.
-	spec := multiSpec(2, offsetRange(0, 100, 200), offsetRange(1, 300, 400), offsetRange(2, 500, 600))
+	spec := schedulerpb.JobSpec{
+		Topic:     "ingest",
+		Partition: 2,
+		OffsetRanges: map[int32]schedulerpb.OffsetRange{
+			0: {StartOffset: 100, EndOffset: 200},
+			1: {StartOffset: 300, EndOffset: 400},
+			2: {StartOffset: 500, EndOffset: 600},
+		},
+	}
 	initCommits(sched, "ingest", 2, map[int]int64{0: 200, 1: 300, 2: 500})
 
 	key := jobKey{id: jobIDForSpec(true, &spec), epoch: 0}
@@ -1072,8 +1140,7 @@ func TestKafkaFlush(t *testing.T) {
 
 // TestKafkaFlush_MultiCluster verifies that each cluster's Kafka receives exactly that cluster's
 // committed offsets, and that a fresh scheduler against the same clusters recovers them with
-// each cluster's offsets landing back in that cluster's slot. Offsets are asymmetric (including
-// partitions committed on only one cluster) so cross-cluster mix-ups fail the test.
+// each cluster's offsets landing back in that cluster's slot.
 func TestKafkaFlush_MultiCluster(t *testing.T) {
 	clusters := createTestClusters(t, 3, 3)
 	sched, _ := mustMultiClusterSchedulerWithClusters(t, clusters)
@@ -1218,8 +1285,7 @@ func TestUpdateSchedule_ProbeFailure(t *testing.T) {
 }
 
 // TestUpdateSchedule_MultiCluster verifies that with compartments enabled the scheduler probes
-// every write cluster's end offsets, not just the first, so a partition's per-cluster offset
-// tracking reflects all clusters.
+// every write cluster's end offsets.
 func TestUpdateSchedule_MultiCluster(t *testing.T) {
 	ctx, cancel := context.WithCancelCause(context.Background())
 	t.Cleanup(func() { cancel(errors.New("test done")) })
@@ -1227,8 +1293,7 @@ func TestUpdateSchedule_MultiCluster(t *testing.T) {
 	sched, clients := mustMultiClusterScheduler(t, 3, 3)
 	sched.completeObservationMode(ctx)
 
-	// counts[c][p] is the number of records produced to partition p on cluster c; all distinct
-	// so end offsets recorded against the wrong cluster or partition fail the test.
+	// counts[c][p] is the number of records produced to partition p on cluster c.
 	counts := [3][3]int{
 		{3, 1, 4},
 		{5, 9, 2},
@@ -1242,9 +1307,9 @@ func TestUpdateSchedule_MultiCluster(t *testing.T) {
 
 	sched.updateSchedule(ctx)
 
-	requireEndOffsets(t, sched, "ingest", 0, map[int]int64{0: 3, 1: 5, 2: 6}, "each cluster's end offset should be probed")
-	requireEndOffsets(t, sched, "ingest", 1, map[int]int64{0: 1, 1: 9, 2: 7}, "each cluster's end offset should be probed")
-	requireEndOffsets(t, sched, "ingest", 2, map[int]int64{0: 4, 1: 2, 2: 8}, "each cluster's end offset should be probed")
+	requireEndOffsets(t, sched, "ingest", 0, map[int]int64{0: 3, 1: 5, 2: 6})
+	requireEndOffsets(t, sched, "ingest", 1, map[int]int64{0: 1, 1: 9, 2: 7})
+	requireEndOffsets(t, sched, "ingest", 2, map[int]int64{0: 4, 1: 2, 2: 8})
 }
 
 // TestUpdateSchedule_MultiCluster_OneClusterProbeFails verifies that when probing one cluster's
@@ -1259,9 +1324,7 @@ func TestUpdateSchedule_MultiCluster_OneClusterProbeFails(t *testing.T) {
 	sched, clients := mustMultiClusterSchedulerWithClusters(t, clusters)
 	sched.completeObservationMode(ctx)
 
-	// rounds[r][c][p] is the number of records produced to partition p on cluster c in round r;
-	// all cumulative counts are distinct so end offsets recorded against the wrong cluster,
-	// partition, or round fail the test.
+	// rounds[r][c][p] is the number of records produced to partition p on cluster c in round r.
 	rounds := [2][3][3]int{
 		{
 			{3, 1, 4},
@@ -1296,15 +1359,17 @@ func TestUpdateSchedule_MultiCluster_OneClusterProbeFails(t *testing.T) {
 
 	sched.updateSchedule(ctx)
 
+	// Each end below is written as round-0 count + round-1 count. Cluster 1's probe fails this
+	// tick, so it stays frozen at its round-0 count (a bare number) while clusters 0 and 2 sum both.
 	msg := "the healthy clusters 0 and 2 should record both rounds; the failing cluster 1 keeps its last successfully probed ends"
-	requireEndOffsets(t, sched, "ingest", 0, map[int]int64{0: 13, 1: 5, 2: 76}, msg)
-	requireEndOffsets(t, sched, "ingest", 1, map[int]int64{0: 21, 1: 9, 2: 87}, msg)
-	requireEndOffsets(t, sched, "ingest", 2, map[int]int64{0: 34, 1: 2, 2: 98}, msg)
+	requireEndOffsets(t, sched, "ingest", 0, map[int]int64{0: 3 + 10, 1: 5, 2: 6 + 70}, msg)
+	requireEndOffsets(t, sched, "ingest", 1, map[int]int64{0: 1 + 20, 1: 9, 2: 7 + 80}, msg)
+	requireEndOffsets(t, sched, "ingest", 2, map[int]int64{0: 4 + 30, 1: 2, 2: 8 + 90}, msg)
 
 	expectedRanges := map[int32]map[int32]schedulerpb.OffsetRange{
-		0: {0: {StartOffset: 0, EndOffset: 13}, 1: {StartOffset: 0, EndOffset: 5}, 2: {StartOffset: 0, EndOffset: 76}},
-		1: {0: {StartOffset: 0, EndOffset: 21}, 1: {StartOffset: 0, EndOffset: 9}, 2: {StartOffset: 0, EndOffset: 87}},
-		2: {0: {StartOffset: 0, EndOffset: 34}, 1: {StartOffset: 0, EndOffset: 2}, 2: {StartOffset: 0, EndOffset: 98}},
+		0: {0: {StartOffset: 0, EndOffset: 3 + 10}, 1: {StartOffset: 0, EndOffset: 5}, 2: {StartOffset: 0, EndOffset: 6 + 70}},
+		1: {0: {StartOffset: 0, EndOffset: 1 + 20}, 1: {StartOffset: 0, EndOffset: 9}, 2: {StartOffset: 0, EndOffset: 7 + 80}},
+		2: {0: {StartOffset: 0, EndOffset: 4 + 30}, 1: {StartOffset: 0, EndOffset: 2}, 2: {StartOffset: 0, EndOffset: 8 + 90}},
 	}
 	for p, expected := range expectedRanges {
 		ps := sched.getPartitionState("ingest", p)
@@ -1317,10 +1382,11 @@ func TestUpdateSchedule_MultiCluster_OneClusterProbeFails(t *testing.T) {
 	stopFailing()
 	sched.updateSchedule(ctx)
 
+	// Cluster 1's probe succeeds now, so it too sums both rounds and catches up.
 	msg = "the next successful probe should catch cluster 1 up"
-	requireEndOffsets(t, sched, "ingest", 0, map[int]int64{0: 13, 1: 45, 2: 76}, msg)
-	requireEndOffsets(t, sched, "ingest", 1, map[int]int64{0: 21, 1: 59, 2: 87}, msg)
-	requireEndOffsets(t, sched, "ingest", 2, map[int]int64{0: 34, 1: 62, 2: 98}, msg)
+	requireEndOffsets(t, sched, "ingest", 0, map[int]int64{0: 3 + 10, 1: 5 + 40, 2: 6 + 70}, msg)
+	requireEndOffsets(t, sched, "ingest", 1, map[int]int64{0: 1 + 20, 1: 9 + 50, 2: 7 + 80}, msg)
+	requireEndOffsets(t, sched, "ingest", 2, map[int]int64{0: 4 + 30, 1: 2 + 60, 2: 8 + 90}, msg)
 }
 
 // TestUpdateSchedule_MultiCluster_AllClusterProbesFail verifies that when every cluster's
@@ -1380,8 +1446,7 @@ func TestPopulateInitialJobs_MultiCluster(t *testing.T) {
 	sched.cfg.JobSize = 1 * time.Hour
 
 	recordTime := time.Date(2025, 3, 1, 10, 30, 0, 0, time.UTC)
-	// ranges[p][c] is cluster c's offset range for partition p; all bounds are distinct so
-	// ranges attributed to the wrong cluster or partition fail the test. Partition 0 has data
+	// ranges[p][c] is cluster c's offset range for partition p. Partition 0 has data
 	// on every cluster; partitions 1 and 2 on subsets only, so their jobs must bundle just the
 	// clusters that had data and leave the absent clusters out of the spec.
 	ranges := map[int32]map[int32]schedulerpb.OffsetRange{
@@ -1405,8 +1470,7 @@ func TestPopulateInitialJobs_MultiCluster(t *testing.T) {
 
 // TestInitConsumptionOffsets_PartitionOnSubsetOfClusters verifies that probing clusters with
 // uneven partition counts groups offsets by partition, with a nil entry for each cluster that
-// doesn't host the partition. Every (cluster, partition) cell gets a distinct record count so
-// offsets landing in the wrong slot fail the test.
+// doesn't host the partition.
 func TestInitConsumptionOffsets_PartitionOnSubsetOfClusters(t *testing.T) {
 	ctx, cancel := context.WithCancelCause(context.Background())
 	t.Cleanup(func() { cancel(errors.New("test done")) })
@@ -1459,8 +1523,7 @@ func TestLoadInitialCommittedOffsets(t *testing.T) {
 }
 
 // TestLoadInitialCommittedOffsets_MultiCluster verifies each cluster's committed offsets seed
-// that cluster's slot in partition state. Offsets are asymmetric so that commits applied to the
-// wrong cluster's slot fail the test.
+// that cluster's slot in partition state and foreign topics are ignored.
 func TestLoadInitialCommittedOffsets_MultiCluster(t *testing.T) {
 	sched, _ := mustMultiClusterScheduler(t, 3, 3)
 	ctx := t.Context()
@@ -1901,10 +1964,7 @@ func TestBlockBuilderScheduler_EnqueuePendingJobs_CommitRace(t *testing.T) {
 
 // TestBlockBuilderScheduler_EnqueuePendingJobs_CommitRace_MultiCluster verifies enqueue-time
 // handling of pending jobs stale relative to per-cluster progress: a job behind every cluster's
-// committed offset is dropped, while a job stale on only a subset of clusters panics. Job
-// discovery cannot produce the partially-stale state — pending jobs are cut in ascending
-// per-cluster order from the frontier that startup sanitizes — so it is surfaced as a bug
-// rather than silently planned or dropped.
+// committed offset is dropped, while a job stale on only a subset of clusters panics.
 func TestBlockBuilderScheduler_EnqueuePendingJobs_CommitRace_MultiCluster(t *testing.T) {
 	sched, _ := mustMultiClusterScheduler(t, 3, 3)
 	sched.cfg.MaxJobsPerPartition = 0
@@ -1912,7 +1972,14 @@ func TestBlockBuilderScheduler_EnqueuePendingJobs_CommitRace_MultiCluster(t *tes
 
 	// Partition 2's pending job is behind every cluster's committed offset: dropped.
 	initCommits(sched, "ingest", 2, map[int]int64{0: 20, 1: 15})
-	addPendingJob(sched, multiSpec(2, offsetRange(0, 10, 20), offsetRange(1, 5, 15)))
+	addPendingJob(sched, schedulerpb.JobSpec{
+		Topic:     "ingest",
+		Partition: 2,
+		OffsetRanges: map[int32]schedulerpb.OffsetRange{
+			0: {StartOffset: 10, EndOffset: 20},
+			1: {StartOffset: 5, EndOffset: 15},
+		},
+	})
 
 	sched.enqueuePendingJobs()
 	assert.Equal(t, 0, sched.getPartitionState("ingest", 2).pendingJobs.Len())
@@ -1920,19 +1987,16 @@ func TestBlockBuilderScheduler_EnqueuePendingJobs_CommitRace_MultiCluster(t *tes
 
 	// Partition 1's pending job is behind cluster 0's progress but still needed by cluster 1.
 	initCommits(sched, "ingest", 1, map[int]int64{0: 20, 1: 5})
-	addPendingJob(sched, multiSpec(1, offsetRange(0, 10, 20), offsetRange(1, 5, 15)))
+	addPendingJob(sched, schedulerpb.JobSpec{
+		Topic:     "ingest",
+		Partition: 1,
+		OffsetRanges: map[int32]schedulerpb.OffsetRange{
+			0: {StartOffset: 10, EndOffset: 20},
+			1: {StartOffset: 5, EndOffset: 15},
+		},
+	})
 
-	panicMsg := func() (msg string) {
-		defer func() {
-			if r := recover(); r != nil {
-				msg = fmt.Sprint(r)
-			}
-		}()
-		sched.enqueuePendingJobs()
-		return
-	}()
-	require.Contains(t, panicMsg, "partially behind the committed offset",
-		"a job stale on a subset of clusters should fail fast at the enqueue decision point, not deep in addPlannedJob")
+	require.Panics(t, sched.enqueuePendingJobs)
 }
 
 func TestBlockBuilderScheduler_EnqueuePendingJobs_StartupRace(t *testing.T) {
@@ -2046,8 +2110,24 @@ func TestBlockBuilderScheduler_EnqueuePendingJobs_GapDetection_MultiCluster(t *t
 
 	// Partition 0: every cluster's ranges are contiguous.
 	p0 := sched.getPartitionState("ingest", 0)
-	addPendingJob(sched, multiSpec(0, offsetRange(0, 0, 30), offsetRange(1, 0, 100), offsetRange(2, 0, 10)))
-	addPendingJob(sched, multiSpec(0, offsetRange(0, 30, 40), offsetRange(1, 100, 200), offsetRange(2, 10, 20)))
+	addPendingJob(sched, schedulerpb.JobSpec{
+		Topic:     "ingest",
+		Partition: 0,
+		OffsetRanges: map[int32]schedulerpb.OffsetRange{
+			0: {StartOffset: 0, EndOffset: 30},
+			1: {StartOffset: 0, EndOffset: 100},
+			2: {StartOffset: 0, EndOffset: 10},
+		},
+	})
+	addPendingJob(sched, schedulerpb.JobSpec{
+		Topic:     "ingest",
+		Partition: 0,
+		OffsetRanges: map[int32]schedulerpb.OffsetRange{
+			0: {StartOffset: 30, EndOffset: 40},
+			1: {StartOffset: 100, EndOffset: 200},
+			2: {StartOffset: 10, EndOffset: 20},
+		},
+	})
 	sched.enqueuePendingJobs()
 	require.Equal(t, 2, sched.jobs.count())
 	require.Equal(t, int64(40), p0.plannedOffset(0))
@@ -2057,8 +2137,24 @@ func TestBlockBuilderScheduler_EnqueuePendingJobs_GapDetection_MultiCluster(t *t
 
 	// Partition 1: a gap in cluster 1's ranges only; the other clusters' are contiguous.
 	p1 := sched.getPartitionState("ingest", 1)
-	addPendingJob(sched, multiSpec(1, offsetRange(0, 0, 30), offsetRange(1, 0, 100), offsetRange(2, 0, 10)))
-	addPendingJob(sched, multiSpec(1, offsetRange(0, 30, 40), offsetRange(1, 150, 200), offsetRange(2, 10, 20)))
+	addPendingJob(sched, schedulerpb.JobSpec{
+		Topic:     "ingest",
+		Partition: 1,
+		OffsetRanges: map[int32]schedulerpb.OffsetRange{
+			0: {StartOffset: 0, EndOffset: 30},
+			1: {StartOffset: 0, EndOffset: 100},
+			2: {StartOffset: 0, EndOffset: 10},
+		},
+	})
+	addPendingJob(sched, schedulerpb.JobSpec{
+		Topic:     "ingest",
+		Partition: 1,
+		OffsetRanges: map[int32]schedulerpb.OffsetRange{
+			0: {StartOffset: 30, EndOffset: 40},
+			1: {StartOffset: 150, EndOffset: 200},
+			2: {StartOffset: 10, EndOffset: 20},
+		},
+	})
 	sched.enqueuePendingJobs()
 	require.Equal(t, 4, sched.jobs.count(), "a gap should not interfere with job queueing")
 	require.Equal(t, int64(40), p1.plannedOffset(0))
@@ -2067,8 +2163,24 @@ func TestBlockBuilderScheduler_EnqueuePendingJobs_GapDetection_MultiCluster(t *t
 	requireGaps(t, reg, 1, 0, "the gap in cluster 1's ranges should be detected")
 
 	// Partition 2: gaps in all three clusters' ranges count once per cluster.
-	addPendingJob(sched, multiSpec(2, offsetRange(0, 0, 30), offsetRange(1, 0, 100), offsetRange(2, 0, 10)))
-	addPendingJob(sched, multiSpec(2, offsetRange(0, 50, 60), offsetRange(1, 150, 200), offsetRange(2, 30, 40)))
+	addPendingJob(sched, schedulerpb.JobSpec{
+		Topic:     "ingest",
+		Partition: 2,
+		OffsetRanges: map[int32]schedulerpb.OffsetRange{
+			0: {StartOffset: 0, EndOffset: 30},
+			1: {StartOffset: 0, EndOffset: 100},
+			2: {StartOffset: 0, EndOffset: 10},
+		},
+	})
+	addPendingJob(sched, schedulerpb.JobSpec{
+		Topic:     "ingest",
+		Partition: 2,
+		OffsetRanges: map[int32]schedulerpb.OffsetRange{
+			0: {StartOffset: 50, EndOffset: 60},
+			1: {StartOffset: 150, EndOffset: 200},
+			2: {StartOffset: 30, EndOffset: 40},
+		},
+	})
 	sched.enqueuePendingJobs()
 	require.Equal(t, 6, sched.jobs.count())
 	requireGaps(t, reg, 4, 0, "gaps in all clusters' ranges should each be detected")
@@ -2453,26 +2565,6 @@ func mustMultiClusterSchedulerWithClusters(t *testing.T, clusters []testCluster)
 // independent Kafka clusters, one per write compartment, along with a producer client for each.
 func mustMultiClusterScheduler(t *testing.T, partitions int32, numClusters int) (*BlockBuilderScheduler, []*kgo.Client) {
 	return mustMultiClusterSchedulerWithClusters(t, createTestClusters(t, partitions, numClusters))
-}
-
-// specRange pairs a cluster ID with an offset range for building multi-cluster job specs.
-type specRange struct {
-	cluster     int32
-	offsetRange schedulerpb.OffsetRange
-}
-
-func offsetRange(cluster int32, start, end int64) specRange {
-	return specRange{cluster: cluster, offsetRange: schedulerpb.OffsetRange{StartOffset: start, EndOffset: end}}
-}
-
-// multiSpec builds a job spec for a partition of the "ingest" topic covering the given
-// clusters' offset ranges.
-func multiSpec(partition int32, ranges ...specRange) schedulerpb.JobSpec {
-	or := make(map[int32]schedulerpb.OffsetRange, len(ranges))
-	for _, r := range ranges {
-		or[r.cluster] = r.offsetRange
-	}
-	return schedulerpb.JobSpec{Topic: "ingest", Partition: partition, OffsetRanges: or}
 }
 
 // observedJob builds a worker-reported job for observation-mode tests, deriving the job ID

--- a/pkg/blockbuilder/scheduler/scheduler_test.go
+++ b/pkg/blockbuilder/scheduler/scheduler_test.go
@@ -749,29 +749,51 @@ func TestAssignJobSkipsObsoleteOffsets_PriorScheduler(t *testing.T) {
 	)
 }
 
-// TestAssignJobSkipsObsoleteOffsets_MultiCluster verifies that a job is skipped as obsolete only
-// when every cluster's range is behind that cluster's committed offset: a job whose ranges are
-// consumed on a subset of clusters must still be assigned for the lagging clusters.
+// TestAssignJobSkipsObsoleteOffsets_MultiCluster verifies that a job whose ranges are behind the
+// committed offset on every cluster (beyondAll) is skipped as obsolete, while a job behind on only
+// a subset of clusters (beyondSome) is a fatal invariant break: it should not happen for a queued
+// job, so assignJob panics rather than risk dropping the lagging clusters' ranges.
 func TestAssignJobSkipsObsoleteOffsets_MultiCluster(t *testing.T) {
+	t.Run("fully consumed job is skipped", func(t *testing.T) {
+		sched, _ := mustMultiClusterScheduler(t, 3, 3)
+		sched.cfg.MaxJobsPerPartition = 0
+		sched.completeObservationMode(context.Background())
+
+		// Every cluster's committed offset reaches its range end: fully consumed.
+		s1 := multiSpec(1, offsetRange(0, 100, 200), offsetRange(1, 300, 400), offsetRange(2, 500, 600))
+		require.NoError(t, sched.jobs.add(jobIDForSpec(true, &s1), s1))
+		initCommits(sched, "ingest", 1, map[int]int64{0: 200, 1: 400, 2: 600})
+
+		require.Empty(t, assignAllJobs(t, sched, "w0"), "fully consumed job should be skipped")
+	})
+
+	t.Run("partially consumed job panics", func(t *testing.T) {
+		sched, _ := mustMultiClusterScheduler(t, 3, 3)
+		sched.cfg.MaxJobsPerPartition = 0
+		sched.completeObservationMode(context.Background())
+
+		// Consumed on cluster 0 only; clusters 1 and 2 still need it.
+		s2 := multiSpec(2, offsetRange(0, 100, 200), offsetRange(1, 300, 400), offsetRange(2, 500, 600))
+		require.NoError(t, sched.jobs.add(jobIDForSpec(true, &s2), s2))
+		initCommits(sched, "ingest", 2, map[int]int64{0: 200, 1: 300, 2: 500})
+
+		require.Panics(t, func() { _, _, _ = sched.assignJob("w0") })
+	})
+}
+
+// TestUpdateJobPanicsOnPartiallyConsumed_MultiCluster verifies that an in-progress job update whose
+// ranges are behind the committed offset on only a subset of clusters (beyondSome) panics, matching
+// assignJob and enqueuePendingJobs, rather than renewing a lease on a torn job.
+func TestUpdateJobPanicsOnPartiallyConsumed_MultiCluster(t *testing.T) {
 	sched, _ := mustMultiClusterScheduler(t, 3, 3)
-	sched.cfg.MaxJobsPerPartition = 0
 	sched.completeObservationMode(context.Background())
 
-	// Partition 1's job is fully consumed: every cluster's committed offset reaches its range end.
-	s1 := multiSpec(1, offsetRange(0, 100, 200), offsetRange(1, 300, 400), offsetRange(2, 500, 600))
-	// Partition 2's job is consumed on cluster 0 only; clusters 1 and 2 still need it.
-	s2 := multiSpec(2, offsetRange(0, 100, 200), offsetRange(1, 300, 400), offsetRange(2, 500, 600))
-
-	require.NoError(t, sched.jobs.add(jobIDForSpec(true, &s1), s1))
-	require.NoError(t, sched.jobs.add(jobIDForSpec(true, &s2), s2))
-
-	initCommits(sched, "ingest", 1, map[int]int64{0: 200, 1: 400, 2: 600})
+	// Consumed on cluster 0 only; clusters 1 and 2 still need it.
+	spec := multiSpec(2, offsetRange(0, 100, 200), offsetRange(1, 300, 400), offsetRange(2, 500, 600))
 	initCommits(sched, "ingest", 2, map[int]int64{0: 200, 1: 300, 2: 500})
 
-	require.ElementsMatch(t,
-		[]*schedulerpb.JobSpec{&s2}, assignAllJobs(t, sched, "w0"),
-		"partition 1's job should be skipped as fully consumed; partition 2's must be assigned for the lagging clusters",
-	)
+	key := jobKey{id: jobIDForSpec(true, &spec), epoch: 0}
+	require.Panics(t, func() { _ = sched.updateJob(key, "w0", false, spec) })
 }
 
 func TestObservations(t *testing.T) {

--- a/pkg/blockbuilder/scheduler/scheduler_test.go
+++ b/pkg/blockbuilder/scheduler/scheduler_test.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/grafana/mimir/pkg/blockbuilder/schedulerpb"
+	"github.com/grafana/mimir/pkg/compartments"
 	"github.com/grafana/mimir/pkg/storage/ingest"
 	"github.com/grafana/mimir/pkg/util/test"
 	"github.com/grafana/mimir/pkg/util/testkafka"
@@ -62,7 +63,7 @@ func mustSchedulerWithKafkaAddrAndDialer(t *testing.T, addr string, dialer diale
 
 	reg := prometheus.NewPedanticRegistry()
 	sched, err := New(cfg, test.NewTestingLogger(t), reg)
-	sched.adminClient = kadm.NewClient(cli)
+	sched.adminClients = []*kadm.Client{kadm.NewClient(cli)}
 	require.NoError(t, err)
 	return sched, cli
 }
@@ -111,7 +112,7 @@ func TestService(t *testing.T) {
 		reg := prometheus.NewPedanticRegistry()
 		sched, err := New(cfg, test.NewTestingLogger(t), reg)
 		require.NoError(t, err)
-		sched.adminClient = kadm.NewClient(cli)
+		sched.adminClients = []*kadm.Client{kadm.NewClient(cli)}
 
 		// Signal our channel any time the schedule is updated.
 		scheduleUpdated := make(chan struct{})
@@ -176,11 +177,109 @@ func TestService(t *testing.T) {
 		require.NoError(t, sched.flushOffsetsToKafka(ctx))
 
 		// And our offsets should have advanced.
-		offs, err := fetchCommittedOffsets(ctx, sched.adminClient, sched.cfg.ConsumerGroup, sched.cfg.Kafka.Topic)
+		offs, err := fetchCommittedOffsets(ctx, sched.adminClients[0], sched.cfg.ConsumerGroup, sched.cfg.Kafka.Topic)
 		require.NoError(t, err)
 		o, ok := offs.Lookup(spec.Topic, spec.Partition)
 		require.True(t, ok)
 		require.Equal(t, spec.EndOffset, o.At)
+	})
+}
+
+// TestService_MultiCluster runs the scheduler through its Service interface with compartments
+// enabled, so the service builds one Kafka client per write compartment from the templated
+// address. Every cluster gets a distinct number of records per partition, so each cluster's
+// committed offsets must match exactly the counts produced to that cluster.
+func TestService_MultiCluster(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		sched, clients := mustMultiClusterScheduler(t, 4, 3)
+
+		// Signal our channel any time the schedule is updated.
+		scheduleUpdated := make(chan struct{})
+		sched.onScheduleUpdated = func() {
+			select {
+			case scheduleUpdated <- struct{}{}:
+			default:
+			}
+		}
+
+		// Configure all timers and intervals to be muy rapido.
+		sched.cfg.SchedulingInterval = 5 * time.Millisecond
+		sched.cfg.EnqueueInterval = 5 * time.Millisecond
+		sched.cfg.StartupObserveTime = 10 * time.Millisecond
+		sched.cfg.JobLeaseExpiry = 10 * time.Millisecond
+		sched.cfg.LookbackOnNoCommit = 1 * time.Minute
+		sched.cfg.MaxScanAge = 1 * time.Hour
+		sched.cfg.JobSize = 3 * time.Millisecond
+
+		ctx := context.Background()
+		require.NoError(t, services.StartAndAwaitRunning(ctx, sched))
+
+		t.Cleanup(func() {
+			require.NoError(t, services.StopAndAwaitTerminated(context.WithoutCancel(ctx), sched))
+		})
+
+		require.Eventually(t, sched.observationCompleteLocked, 5*time.Second, 10*time.Millisecond)
+
+		produce := func(cli *kgo.Client, partition, n int32) {
+			produceResult := cli.ProduceSync(ctx, &kgo.Record{
+				Timestamp: time.Now(),
+				Value:     fmt.Appendf(nil, "value-%d-%d", partition, n),
+				Topic:     "ingest",
+				Partition: partition,
+			})
+			require.NoError(t, produceResult.FirstErr())
+		}
+
+		// counts[c][p] is the number of records produced to partition p on cluster c. All
+		// non-zero cells are distinct so commits landing on the wrong cluster or partition fail
+		// the test; partition 0 gets no data and must end up with no commits.
+		counts := [3][4]int{
+			{0, 10, 20, 30},
+			{0, 40, 50, 60},
+			{0, 70, 80, 90},
+		}
+		maxCount := 0
+		for _, byPartition := range counts {
+			maxCount = max(maxCount, slices.Max(byPartition[:]))
+		}
+		for n := range maxCount {
+			<-scheduleUpdated
+
+			for c, byPartition := range counts {
+				for p, count := range byPartition {
+					if n < count {
+						produce(clients[c], int32(p), int32(n))
+					}
+				}
+			}
+		}
+
+		// Complete jobs as they're created until every cluster's committed offsets reach that
+		// cluster's produced totals. Cross-wired clusters would commit another cluster's counts.
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			if key, spec, err := sched.assignJob("w0"); err == nil {
+				assert.NoError(c, sched.updateJob(key, "w0", true, spec))
+			}
+			assert.NoError(c, sched.flushOffsetsToKafka(ctx))
+
+			for clusterID, admin := range sched.adminClients {
+				offs, err := fetchCommittedOffsets(ctx, admin, sched.cfg.ConsumerGroup, sched.cfg.Kafka.Topic)
+				if !assert.NoError(c, err) {
+					return
+				}
+				for p, count := range counts[clusterID] {
+					o, ok := offs.Lookup("ingest", int32(p))
+					if count == 0 {
+						assert.False(c, ok, "cluster %d should have no commit for empty partition %d", clusterID, p)
+						continue
+					}
+					if !assert.True(c, ok, "cluster %d should have a commit for partition %d", clusterID, p) {
+						return
+					}
+					assert.Equal(c, int64(count), o.At, "cluster %d should commit its own totals for partition %d", clusterID, p)
+				}
+			}
+		}, 30*time.Second, 10*time.Millisecond)
 	})
 }
 
@@ -298,6 +397,242 @@ func TestStartup(t *testing.T) {
 	requireGaps(t, sched.register.(*prometheus.Registry), 0, 0)
 }
 
+// TestStartup_MultiCluster verifies the observation-mode recovery flow with compartments
+// enabled: jobs reported by workers carry per-cluster offset ranges (spanning all clusters or a
+// subset), are reconstructed when observation mode completes, and completing them advances each
+// cluster's committed offset independently.
+func TestStartup_MultiCluster(t *testing.T) {
+	sched, _ := mustMultiClusterScheduler(t, 3, 3)
+	// (a new scheduler starts in observation mode.)
+
+	// Committed offsets are asymmetric across clusters, and partitions 65 and 66 are committed
+	// on a subset of clusters only.
+	initCommits(sched, "ingest", 64, map[int]int64{0: 1000, 1: 5000, 2: 30})
+	initCommits(sched, "ingest", 65, map[int]int64{0: 256, 2: 88})
+	initCommits(sched, "ingest", 66, map[int]int64{1: 57})
+
+	{
+		_, _, err := sched.assignJob("w0")
+		require.ErrorContains(t, err, "observation period not complete")
+	}
+
+	// Some jobs that ostensibly exist, but scheduler doesn't know about. Each job's ranges
+	// resume from its clusters' committed offsets.
+	j1 := observedJob(10, multiSpec(64, offsetRange(0, 1000, 1100), offsetRange(1, 5000, 5200), offsetRange(2, 30, 90)))
+	j2 := observedJob(11, multiSpec(65, offsetRange(0, 256, 300), offsetRange(2, 88, 100)))
+	j3 := observedJob(12, multiSpec(66, offsetRange(1, 57, 100)))
+
+	// Clients will be pinging with their updates for some time.
+
+	require.NoError(t, sched.updateJob(j1.key, "w0", false, j1.spec))
+
+	require.NoError(t, sched.updateJob(j2.key, "w0", true, j2.spec))
+
+	require.NoError(t, sched.updateJob(j3.key, "w0", false, j3.spec))
+	require.NoError(t, sched.updateJob(j3.key, "w0", false, j3.spec))
+	require.NoError(t, sched.updateJob(j3.key, "w0", false, j3.spec))
+	require.NoError(t, sched.updateJob(j3.key, "w0", true, j3.spec))
+
+	// Convert the observations to actual jobs.
+	sched.completeObservationMode(context.Background())
+
+	// Now that we're out of observation mode, we should know about all the jobs.
+
+	require.NoError(t, sched.updateJob(j1.key, "w0", false, j1.spec))
+	require.NoError(t, sched.updateJob(j1.key, "w0", false, j1.spec))
+
+	require.NoError(t, sched.updateJob(j2.key, "w0", true, j2.spec))
+
+	require.NoError(t, sched.updateJob(j3.key, "w0", true, j3.spec))
+
+	_, ok := sched.jobs.jobs[j1.key.id]
+	require.True(t, ok)
+
+	// And eventually they'll all complete, advancing each cluster's committed offset to that
+	// cluster's range end, and leaving clusters outside a job's ranges untouched.
+	require.NoError(t, sched.updateJob(j1.key, "w0", true, j1.spec))
+	require.NoError(t, sched.updateJob(j2.key, "w0", true, j2.spec))
+	require.NoError(t, sched.updateJob(j3.key, "w0", true, j3.spec))
+
+	requireOffsets(t, sched, "ingest", 64, map[int]int64{0: 1100, 1: 5200, 2: 90})
+	requireOffsets(t, sched, "ingest", 65, map[int]int64{0: 300, 2: 100})
+	requireOffsets(t, sched, "ingest", 66, map[int]int64{1: 100})
+
+	{
+		_, _, err := sched.assignJob("w0")
+		require.ErrorIs(t, err, errNoJobAvailable)
+	}
+
+	requireGaps(t, sched.register.(*prometheus.Registry), 0, 0)
+}
+
+// TestStartup_MultiCluster_GapOnOneCluster documents recovery truncation: an observed job whose
+// ranges leave a gap on any single cluster stops the import there, and later observed jobs are
+// skipped even if they are themselves contiguous. The rest of the partition's progress falls
+// back to committed offsets.
+func TestStartup_MultiCluster_GapOnOneCluster(t *testing.T) {
+	sched, _ := mustMultiClusterScheduler(t, 3, 3)
+
+	jobA := observedJob(10, multiSpec(64, offsetRange(0, 100, 200), offsetRange(1, 100, 200)))
+	// jobB's cluster 0 range leaves a gap (200 -> 250); its cluster 1 range is contiguous.
+	jobB := observedJob(11, multiSpec(64, offsetRange(0, 250, 300), offsetRange(1, 200, 300)))
+	// jobC continues jobB contiguously on both clusters.
+	jobC := observedJob(12, multiSpec(64, offsetRange(0, 300, 400), offsetRange(1, 300, 400)))
+
+	require.NoError(t, sched.updateJob(jobA.key, "w0", false, jobA.spec))
+	require.NoError(t, sched.updateJob(jobB.key, "w1", false, jobB.spec))
+	require.NoError(t, sched.updateJob(jobC.key, "w2", false, jobC.spec))
+
+	sched.completeObservationMode(context.Background())
+
+	_, ok := sched.jobs.jobs[jobA.key.id]
+	require.True(t, ok, "jobA should be imported")
+	_, ok = sched.jobs.jobs[jobB.key.id]
+	require.False(t, ok, "jobB should be skipped due to its gap on cluster 0")
+	_, ok = sched.jobs.jobs[jobC.key.id]
+	require.False(t, ok, "jobC should be skipped because it's after the gap, even though it's contiguous with jobB")
+
+	ps := sched.getPartitionState("ingest", 64)
+	require.Equal(t, int64(200), ps.plannedOffset(0), "planned offsets should stop at jobA's ends")
+	require.Equal(t, int64(200), ps.plannedOffset(1), "planned offsets should stop at jobA's ends")
+	require.True(t, ps.plannedEmpty(2), "cluster 2 was in no job's ranges")
+}
+
+// TestStartup_MultiCluster_PartiallyFlushedCommit documents recovery after a crash that
+// persisted a completed job's commit on a subset of clusters. It runs the pre-crash scheduler
+// for real: a worker completes a job, advancing every cluster's in-memory commit, and the
+// per-cluster flush persists all but one cluster's offsets (flushes continue past failures). A
+// restarted scheduler against the same clusters thus loads committed offsets that are beyond
+// the re-reported job's ranges on the flushed clusters and behind them on the rest. Such a job
+// cannot be imported (it would rewind the flushed clusters), so recovery truncates there: the
+// job and all later observed jobs are skipped, and each cluster resumes from its own flushed
+// frontier.
+func TestStartup_MultiCluster_PartiallyFlushedCommit(t *testing.T) {
+	clusters := createTestClusters(t, 3, 3)
+	ctx := t.Context()
+
+	// The pre-crash scheduler starts with every cluster's commit at jobJ's start offsets, all
+	// persisted to Kafka.
+	schedA, _ := mustMultiClusterSchedulerWithClusters(t, clusters)
+	initCommits(schedA, "ingest", 0, map[int]int64{0: 100, 1: 100, 2: 50})
+	schedA.completeObservationMode(ctx)
+	require.NoError(t, schedA.flushOffsetsToKafka(ctx))
+
+	// A worker runs jobJ to completion, advancing every cluster's in-memory commit to its
+	// range end.
+	jobJ := multiSpec(0, offsetRange(0, 100, 200), offsetRange(1, 100, 200), offsetRange(2, 50, 150))
+	addPendingJob(schedA, jobJ)
+	schedA.enqueuePendingJobs()
+	keyJ, specJ, err := schedA.assignJob("w0")
+	require.NoError(t, err)
+	require.Equal(t, jobJ, specJ)
+	require.NoError(t, schedA.updateJob(keyJ, "w0", true, specJ))
+
+	// The flush persists the completed commits on clusters 0 and 2 but fails on cluster 1,
+	// whose Kafka commit stays at jobJ's start.
+	failOffsetCommits(clusters[1].cluster)
+	err = schedA.flushOffsetsToKafka(ctx)
+	require.ErrorContains(t, err, "write compartment 1")
+	requireCommittedInKafka(ctx, t, schedA, 0, map[int32]int64{0: 200})
+	requireCommittedInKafka(ctx, t, schedA, 1, map[int32]int64{0: 100})
+	requireCommittedInKafka(ctx, t, schedA, 2, map[int32]int64{0: 150})
+
+	// The scheduler "crashes": a fresh one starts against the same clusters and loads the
+	// partially flushed commits.
+	schedB, _ := mustMultiClusterSchedulerWithClusters(t, clusters)
+	require.NoError(t, schedB.loadInitialCommittedOffsets(ctx))
+	requireOffsets(t, schedB, "ingest", 0, map[int]int64{0: 200, 1: 100, 2: 150})
+
+	// The worker re-reports the completed jobJ during observation, along with an in-progress
+	// jobK continuing jobJ contiguously on every cluster.
+	require.NoError(t, schedB.updateJob(keyJ, "w0", true, specJ))
+	jobK := observedJob(keyJ.epoch+1, multiSpec(0, offsetRange(0, 200, 300), offsetRange(1, 200, 300), offsetRange(2, 150, 250)))
+	require.NoError(t, schedB.updateJob(jobK.key, "w1", false, jobK.spec))
+
+	schedB.completeObservationMode(ctx)
+
+	_, ok := schedB.jobs.jobs[keyJ.id]
+	require.False(t, ok, "jobJ should not be imported: it's behind the flushed clusters' commits")
+	_, ok = schedB.jobs.jobs[jobK.key.id]
+	require.False(t, ok, "jobK should be skipped because recovery truncated at the partially flushed jobJ")
+
+	pB := schedB.getPartitionState("ingest", 0)
+	require.Equal(t, int64(200), pB.plannedOffset(0), "flushed clusters should resume from their flushed frontier")
+	require.Equal(t, int64(100), pB.plannedOffset(1), "the unflushed cluster should resume from its stale commit, re-covering jobJ's range")
+	require.Equal(t, int64(150), pB.plannedOffset(2), "flushed clusters should resume from their flushed frontier")
+	requireOffsets(t, schedB, "ingest", 0, map[int]int64{0: 200, 1: 100, 2: 150})
+}
+
+// TestCompleteObservationMode_ResumesFromImportedPlan verifies that startup cuts pending jobs
+// from the planned frontier established by observation import: ranges recovered from workers are
+// not re-cut, only the data beyond them is. If consumption offsets were probed before
+// finalizeObservations sanitized the planned offsets, the cut job would overlap the imported
+// plan and panic at enqueue (see addPlannedJob).
+func TestCompleteObservationMode_ResumesFromImportedPlan(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { cancel(errors.New("test done")) })
+
+	sched, clients := mustMultiClusterScheduler(t, 3, 3)
+	sched.cfg.MaxJobsPerPartition = 0
+	sched.cfg.JobSize = time.Hour
+	sched.cfg.MaxScanAge = 24 * time.Hour
+	sched.cfg.LookbackOnNoCommit = 24 * time.Hour
+
+	recordTime := time.Now().Add(-2 * time.Hour)
+	produce := func(cli *kgo.Client, n int) {
+		for i := range n {
+			produceResult := cli.ProduceSync(ctx, &kgo.Record{
+				Timestamp: recordTime,
+				Value:     fmt.Appendf(nil, "value-%d", i),
+				Topic:     "ingest",
+				Partition: 0,
+			})
+			require.NoError(t, produceResult.FirstErr())
+		}
+	}
+	produce(clients[0], 10)
+	produce(clients[1], 8)
+	produce(clients[2], 6)
+
+	// A worker reports an in-progress job covering all of cluster 0's records and part of
+	// cluster 1's; cluster 2 is not part of the job.
+	observed := observedJob(10, multiSpec(0, offsetRange(0, 0, 10), offsetRange(1, 0, 5)))
+	require.NoError(t, sched.updateJob(observed.key, "w0", false, observed.spec))
+
+	sched.completeObservationMode(ctx)
+	sched.enqueuePendingJobs()
+
+	_, ok := sched.jobs.jobs[observed.key.id]
+	require.True(t, ok, "the observed job should be imported")
+	_, ok = sched.jobs.jobs["ingest/0/1:5-2:0"]
+	require.True(t, ok, "the data beyond the imported plan should be planned: cluster 1 past the observed job, cluster 2 in full")
+	require.Equal(t, 2, sched.jobs.count())
+
+	ps := sched.getPartitionState("ingest", 0)
+	require.Equal(t, int64(10), ps.plannedOffset(0))
+	require.Equal(t, int64(8), ps.plannedOffset(1))
+	require.Equal(t, int64(6), ps.plannedOffset(2))
+}
+
+// TestCompleteObservationMode_ConsumptionOffsetsProbeFails pins the behavior when any single
+// cluster's consumption-offset probe fails while completing observation mode: the transition is
+// abandoned before observationComplete is set, and since completeObservationMode runs only once
+// per process, the scheduler stays in observation mode — refusing job assignment — until it is
+// restarted.
+func TestCompleteObservationMode_ConsumptionOffsetsProbeFails(t *testing.T) {
+	clusters := createTestClusters(t, 3, 3)
+	sched, _ := mustMultiClusterSchedulerWithClusters(t, clusters)
+
+	failListOffsets(clusters[1].cluster)
+
+	sched.completeObservationMode(t.Context())
+
+	require.False(t, sched.observationCompleteLocked(),
+		"a failed consumption-offset probe should leave the scheduler in observation mode")
+	_, _, err := sched.assignJob("w0")
+	require.ErrorContains(t, err, "observation period not complete")
+}
+
 func requireGaps(t *testing.T, reg *prometheus.Registry, planned, committed int, msgAndArgs ...any) {
 	t.Helper()
 
@@ -411,6 +746,31 @@ func TestAssignJobSkipsObsoleteOffsets_PriorScheduler(t *testing.T) {
 	require.ElementsMatch(t,
 		[]*schedulerpb.JobSpec{&s1}, assignedJobs,
 		"s1 should not have been skipped",
+	)
+}
+
+// TestAssignJobSkipsObsoleteOffsets_MultiCluster verifies that a job is skipped as obsolete only
+// when every cluster's range is behind that cluster's committed offset: a job whose ranges are
+// consumed on a subset of clusters must still be assigned for the lagging clusters.
+func TestAssignJobSkipsObsoleteOffsets_MultiCluster(t *testing.T) {
+	sched, _ := mustMultiClusterScheduler(t, 3, 3)
+	sched.cfg.MaxJobsPerPartition = 0
+	sched.completeObservationMode(context.Background())
+
+	// Partition 1's job is fully consumed: every cluster's committed offset reaches its range end.
+	s1 := multiSpec(1, offsetRange(0, 100, 200), offsetRange(1, 300, 400), offsetRange(2, 500, 600))
+	// Partition 2's job is consumed on cluster 0 only; clusters 1 and 2 still need it.
+	s2 := multiSpec(2, offsetRange(0, 100, 200), offsetRange(1, 300, 400), offsetRange(2, 500, 600))
+
+	require.NoError(t, sched.jobs.add(jobIDForSpec(true, &s1), s1))
+	require.NoError(t, sched.jobs.add(jobIDForSpec(true, &s2), s2))
+
+	initCommits(sched, "ingest", 1, map[int]int64{0: 200, 1: 400, 2: 600})
+	initCommits(sched, "ingest", 2, map[int]int64{0: 200, 1: 300, 2: 500})
+
+	require.ElementsMatch(t,
+		[]*schedulerpb.JobSpec{&s2}, assignAllJobs(t, sched, "w0"),
+		"partition 1's job should be skipped as fully consumed; partition 2's must be assigned for the lagging clusters",
 	)
 }
 
@@ -544,15 +904,15 @@ func TestObservations(t *testing.T) {
 	}
 
 	verifyCommits := func() {
-		sched.requireOffset(t, "ingest", 1, 5000, "ingest/1 is in progress, so we should not move the offset")
-		sched.requireOffset(t, "ingest", 2, 1400, "ingest/2 job was complete up to 1400, so it should move the offset forward")
-		sched.requireOffset(t, "ingest", 3, 974, "ingest/3 should be unchanged - no updates")
-		sched.requireOffset(t, "ingest", 4, 900, "ingest/4 should be moved forward to account for the completed jobs")
-		sched.requireOffset(t, "ingest", 5, 12000, "ingest/5 has nothing new completed")
-		sched.requireOffset(t, "ingest", 6, 600, "ingest/6 allowed to move the commit")
-		sched.requireOffset(t, "ingest", 7, offsetEmpty, "ingest/7 has an in-progress job, but had no commit at startup")
-		sched.requireOffset(t, "ingest", 8, 1300, "ingest/8 should be committed only until the gap")
-		sched.requireOffset(t, "ingest", 9, 1300, "ingest/9 should be committed only until the gap")
+		requireOffsets(t, sched, "ingest", 1, map[int]int64{0: 5000}, "ingest/1 is in progress, so we should not move the offset")
+		requireOffsets(t, sched, "ingest", 2, map[int]int64{0: 1400}, "ingest/2 job was complete up to 1400, so it should move the offset forward")
+		requireOffsets(t, sched, "ingest", 3, map[int]int64{0: 974}, "ingest/3 should be unchanged - no updates")
+		requireOffsets(t, sched, "ingest", 4, map[int]int64{0: 900}, "ingest/4 should be moved forward to account for the completed jobs")
+		requireOffsets(t, sched, "ingest", 5, map[int]int64{0: 12000}, "ingest/5 has nothing new completed")
+		requireOffsets(t, sched, "ingest", 6, map[int]int64{0: 600}, "ingest/6 allowed to move the commit")
+		requireOffsets(t, sched, "ingest", 7, map[int]int64{}, "ingest/7 has an in-progress job, but had no commit at startup")
+		requireOffsets(t, sched, "ingest", 8, map[int]int64{0: 1300}, "ingest/8 should be committed only until the gap")
+		requireOffsets(t, sched, "ingest", 9, map[int]int64{0: 1300}, "ingest/9 should be committed only until the gap")
 	}
 
 	sendUpdates()
@@ -561,7 +921,7 @@ func TestObservations(t *testing.T) {
 	verifyCommits()
 
 	// Make sure the resumption offsets account for the gaps.
-	offs, err := sched.initSingleClusterConsumptionOffsets(context.Background(), "ingest", time.Now())
+	offs, err := sched.initSingleClusterConsumptionOffsets(context.Background(), "ingest", time.Now(), 0)
 	require.NoError(t, err)
 	require.ElementsMatch(t, []partitionOffsets{
 		{partition: 0, resume: 0},
@@ -585,12 +945,6 @@ func TestObservations(t *testing.T) {
 	verifyCommits()
 }
 
-func (s *BlockBuilderScheduler) requireOffset(t *testing.T, topic string, partition int32, expected int64, msgAndArgs ...any) {
-	t.Helper()
-	ps := s.getPartitionState(topic, partition)
-	require.Equal(t, expected, ps.offsets[0].committed.offset(), msgAndArgs...)
-}
-
 func TestOffsetMovement(t *testing.T) {
 	sched, _ := mustScheduler(t, 4)
 	ps := sched.getPartitionState("ingest", 1)
@@ -611,25 +965,25 @@ func TestOffsetMovement(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, sched.updateJob(key, "w0", false, spec))
-	sched.requireOffset(t, "ingest", 1, 5000, "ingest/1 is in progress, so we should not move the offset")
+	requireOffsets(t, sched, "ingest", 1, map[int]int64{0: 5000}, "ingest/1 is in progress, so we should not move the offset")
 	require.NoError(t, sched.updateJob(key, "w0", true, spec))
-	sched.requireOffset(t, "ingest", 1, 6000, "ingest/1 is complete, so we should advance")
+	requireOffsets(t, sched, "ingest", 1, map[int]int64{0: 6000}, "ingest/1 is complete, so we should advance")
 	require.NoError(t, sched.updateJob(key, "w0", true, spec))
-	sched.requireOffset(t, "ingest", 1, 6000, "re-completing the same job shouldn't change the commit")
+	requireOffsets(t, sched, "ingest", 1, map[int]int64{0: 6000}, "re-completing the same job shouldn't change the commit")
 
 	p1 := sched.getPartitionState("ingest", 1)
 	p1.offsets[0].committed.advance("ancient_job", schedulerpb.OffsetRange{
 		StartOffset: 1000,
 		EndOffset:   2000,
 	})
-	sched.requireOffset(t, "ingest", 1, 6000, "committed offsets cannot rewind")
+	requireOffsets(t, sched, "ingest", 1, map[int]int64{0: 6000}, "committed offsets cannot rewind")
 
 	p2 := sched.getPartitionState("ingest", 2)
 	p2.offsets[0].committed.advance("ancient_job2", schedulerpb.OffsetRange{
 		StartOffset: 6000,
 		EndOffset:   6222,
 	})
-	sched.requireOffset(t, "ingest", 2, 6222, "should create knowledge of partition 2")
+	requireOffsets(t, sched, "ingest", 2, map[int]int64{0: 6222}, "should create knowledge of partition 2")
 }
 
 func TestKafkaFlush(t *testing.T) {
@@ -640,7 +994,7 @@ func TestKafkaFlush(t *testing.T) {
 	flushAndRequireOffsets := func(topic string, offsets map[int32]int64, args ...any) {
 		require.NoError(t, sched.flushOffsetsToKafka(ctx))
 
-		offs, err := fetchCommittedOffsets(ctx, sched.adminClient, sched.cfg.ConsumerGroup, sched.cfg.Kafka.Topic)
+		offs, err := fetchCommittedOffsets(ctx, sched.adminClients[0], sched.cfg.ConsumerGroup, sched.cfg.Kafka.Topic)
 		require.NoError(t, err)
 		offcount := 0
 		offs.Each(func(o kadm.Offset) {
@@ -694,6 +1048,82 @@ func TestKafkaFlush(t *testing.T) {
 	`), "cortex_blockbuilder_scheduler_partition_planned_offset"), "should only modify planned gauge for non-empty planned offsets")
 }
 
+// TestKafkaFlush_MultiCluster verifies that each cluster's Kafka receives exactly that cluster's
+// committed offsets, and that a fresh scheduler against the same clusters recovers them with
+// each cluster's offsets landing back in that cluster's slot. Offsets are asymmetric (including
+// partitions committed on only one cluster) so cross-cluster mix-ups fail the test.
+func TestKafkaFlush_MultiCluster(t *testing.T) {
+	clusters := createTestClusters(t, 3, 3)
+	sched, _ := mustMultiClusterSchedulerWithClusters(t, clusters)
+	ctx := t.Context()
+
+	initCommits(sched, "ingest", 0, map[int]int64{0: 100, 1: 900, 2: 300})
+	initCommits(sched, "ingest", 1, map[int]int64{0: 55})
+	initCommits(sched, "ingest", 2, map[int]int64{2: 77})
+
+	require.NoError(t, sched.flushOffsetsToKafka(ctx))
+
+	requireCommittedInKafka(ctx, t, sched, 0, map[int32]int64{0: 100, 1: 55})
+	requireCommittedInKafka(ctx, t, sched, 1, map[int32]int64{0: 900})
+	requireCommittedInKafka(ctx, t, sched, 2, map[int32]int64{0: 300, 2: 77})
+
+	reg := sched.register.(*prometheus.Registry)
+	require.NoError(t, promtest.GatherAndCompare(reg, strings.NewReader(
+		`# HELP cortex_blockbuilder_scheduler_partition_committed_offset The observed committed offset of each partition.
+		# TYPE cortex_blockbuilder_scheduler_partition_committed_offset gauge
+		cortex_blockbuilder_scheduler_partition_committed_offset{partition="0",write_compartment="0"} 100
+		cortex_blockbuilder_scheduler_partition_committed_offset{partition="0",write_compartment="1"} 900
+		cortex_blockbuilder_scheduler_partition_committed_offset{partition="0",write_compartment="2"} 300
+		cortex_blockbuilder_scheduler_partition_committed_offset{partition="1",write_compartment="0"} 55
+		cortex_blockbuilder_scheduler_partition_committed_offset{partition="2",write_compartment="2"} 77
+	`), "cortex_blockbuilder_scheduler_partition_committed_offset"), "each cluster's commit gauge should carry its own offsets under its write_compartment label")
+
+	restarted, _ := mustMultiClusterSchedulerWithClusters(t, clusters)
+	require.NoError(t, restarted.loadInitialCommittedOffsets(ctx))
+
+	requireOffsets(t, restarted, "ingest", 0, map[int]int64{0: 100, 1: 900, 2: 300})
+	requireOffsets(t, restarted, "ingest", 1, map[int]int64{0: 55})
+	requireOffsets(t, restarted, "ingest", 2, map[int]int64{2: 77})
+}
+
+// TestKafkaFlush_MultiCluster_ClustersFailToCommit verifies that clusters rejecting offset
+// commits don't block the rest: the joined error identifies exactly the failing compartments,
+// and every healthy cluster's offsets are still flushed.
+func TestKafkaFlush_MultiCluster_ClustersFailToCommit(t *testing.T) {
+	clusters := createTestClusters(t, 3, 3)
+	sched, _ := mustMultiClusterSchedulerWithClusters(t, clusters)
+	ctx := t.Context()
+
+	failOffsetCommits(clusters[1].cluster)
+
+	initCommits(sched, "ingest", 0, map[int]int64{0: 100, 1: 900, 2: 300})
+	initCommits(sched, "ingest", 1, map[int]int64{0: 55})
+	initCommits(sched, "ingest", 2, map[int]int64{1: 66, 2: 77})
+
+	err := sched.flushOffsetsToKafka(ctx)
+	require.ErrorContains(t, err, "write compartment 1")
+	require.NotContains(t, err.Error(), "write compartment 0", "the healthy compartments should not be reported as failed")
+	require.NotContains(t, err.Error(), "write compartment 2", "the healthy compartments should not be reported as failed")
+
+	// The healthy clusters' offsets should be flushed despite cluster 1 failing.
+	requireCommittedInKafka(ctx, t, sched, 0, map[int32]int64{0: 100, 1: 55})
+	requireCommittedInKafka(ctx, t, sched, 2, map[int32]int64{0: 300, 2: 77})
+
+	// Cluster 2 starts failing too. The joined error names both failing compartments, and the
+	// remaining healthy cluster still flushes fresh offsets.
+	failOffsetCommits(clusters[2].cluster)
+	initCommits(sched, "ingest", 0, map[int]int64{0: 150, 1: 950, 2: 350})
+
+	err = sched.flushOffsetsToKafka(ctx)
+	require.ErrorContains(t, err, "write compartment 1")
+	require.ErrorContains(t, err, "write compartment 2")
+	require.NotContains(t, err.Error(), "write compartment 0", "the healthy compartment should not be reported as failed")
+
+	requireCommittedInKafka(ctx, t, sched, 0, map[int32]int64{0: 150, 1: 55})
+	// Cluster 2's Kafka keeps the offsets from before it started failing.
+	requireCommittedInKafka(ctx, t, sched, 2, map[int32]int64{0: 300, 2: 77})
+}
+
 func TestUpdateSchedule(t *testing.T) {
 	ctx, cancel := context.WithCancelCause(context.Background())
 	t.Cleanup(func() { cancel(errors.New("test done")) })
@@ -739,9 +1169,9 @@ func TestUpdateSchedule(t *testing.T) {
 	`), "cortex_blockbuilder_scheduler_partition_end_offset"))
 }
 
-// TestUpdateSchedule_ProbeFailure verifies that a failed end-offset probe abandons the tick,
-// leaving partition state untouched and enqueuing no jobs, and that the next successful tick
-// picks up where the failed one left off.
+// TestUpdateSchedule_ProbeFailure verifies that when the only cluster's end-offset probe fails
+// the tick records nothing and enqueues no jobs, and that the next successful tick picks up
+// where the failed one left off.
 func TestUpdateSchedule_ProbeFailure(t *testing.T) {
 	ctx, cancel := context.WithCancelCause(context.Background())
 	t.Cleanup(func() { cancel(errors.New("test done")) })
@@ -765,12 +1195,230 @@ func TestUpdateSchedule_ProbeFailure(t *testing.T) {
 	require.Equal(t, int64(3), ps.offsets[0].endOffset, "the next successful probe should record the produced records")
 }
 
+// TestUpdateSchedule_MultiCluster verifies that with compartments enabled the scheduler probes
+// every write cluster's end offsets, not just the first, so a partition's per-cluster offset
+// tracking reflects all clusters.
+func TestUpdateSchedule_MultiCluster(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { cancel(errors.New("test done")) })
+
+	sched, clients := mustMultiClusterScheduler(t, 3, 3)
+	sched.completeObservationMode(ctx)
+
+	// counts[c][p] is the number of records produced to partition p on cluster c; all distinct
+	// so end offsets recorded against the wrong cluster or partition fail the test.
+	counts := [3][3]int{
+		{3, 1, 4},
+		{5, 9, 2},
+		{6, 7, 8},
+	}
+	for c, byPartition := range counts {
+		for p, n := range byPartition {
+			produceRecords(ctx, t, clients[c], int32(p), n)
+		}
+	}
+
+	sched.updateSchedule(ctx)
+
+	requireEndOffsets(t, sched, "ingest", 0, map[int]int64{0: 3, 1: 5, 2: 6}, "each cluster's end offset should be probed")
+	requireEndOffsets(t, sched, "ingest", 1, map[int]int64{0: 1, 1: 9, 2: 7}, "each cluster's end offset should be probed")
+	requireEndOffsets(t, sched, "ingest", 2, map[int]int64{0: 4, 1: 2, 2: 8}, "each cluster's end offset should be probed")
+}
+
+// TestUpdateSchedule_MultiCluster_OneClusterProbeFails verifies that when probing one cluster's
+// end offsets fails, the tick proceeds without it: every other cluster's end offsets are still
+// recorded and partition time still advances, cutting jobs that carry the failed cluster's
+// ranges up to its last successfully probed end offset.
+func TestUpdateSchedule_MultiCluster_OneClusterProbeFails(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { cancel(errors.New("test done")) })
+
+	clusters := createTestClusters(t, 3, 3)
+	sched, clients := mustMultiClusterSchedulerWithClusters(t, clusters)
+	sched.completeObservationMode(ctx)
+
+	// rounds[r][c][p] is the number of records produced to partition p on cluster c in round r;
+	// all cumulative counts are distinct so end offsets recorded against the wrong cluster,
+	// partition, or round fail the test.
+	rounds := [2][3][3]int{
+		{
+			{3, 1, 4},
+			{5, 9, 2},
+			{6, 7, 8},
+		},
+		{
+			{10, 20, 30},
+			{40, 50, 60},
+			{70, 80, 90},
+		},
+	}
+	produceRound := func(round int) {
+		for c, byPartition := range rounds[round] {
+			for p, n := range byPartition {
+				produceRecords(ctx, t, clients[c], int32(p), n)
+			}
+		}
+	}
+
+	produceRound(0)
+	sched.updateSchedule(ctx)
+	requireEndOffsets(t, sched, "ingest", 0, map[int]int64{0: 3, 1: 5, 2: 6}, "the healthy tick should record every cluster's ends")
+
+	produceRound(1)
+	// Backdate the job buckets so the next tick rolls over and cuts a job per partition.
+	for p := range int32(3) {
+		ps := sched.getPartitionState("ingest", p)
+		ps.jobBucket = ps.jobBucket.Add(-2 * sched.cfg.JobSize)
+	}
+	stopFailing := failListOffsets(clusters[1].cluster)
+
+	sched.updateSchedule(ctx)
+
+	msg := "the healthy clusters 0 and 2 should record both rounds; the failing cluster 1 keeps its last successfully probed ends"
+	requireEndOffsets(t, sched, "ingest", 0, map[int]int64{0: 13, 1: 5, 2: 76}, msg)
+	requireEndOffsets(t, sched, "ingest", 1, map[int]int64{0: 21, 1: 9, 2: 87}, msg)
+	requireEndOffsets(t, sched, "ingest", 2, map[int]int64{0: 34, 1: 2, 2: 98}, msg)
+
+	expectedRanges := map[int32]map[int32]schedulerpb.OffsetRange{
+		0: {0: {StartOffset: 0, EndOffset: 13}, 1: {StartOffset: 0, EndOffset: 5}, 2: {StartOffset: 0, EndOffset: 76}},
+		1: {0: {StartOffset: 0, EndOffset: 21}, 1: {StartOffset: 0, EndOffset: 9}, 2: {StartOffset: 0, EndOffset: 87}},
+		2: {0: {StartOffset: 0, EndOffset: 34}, 1: {StartOffset: 0, EndOffset: 2}, 2: {StartOffset: 0, EndOffset: 98}},
+	}
+	for p, expected := range expectedRanges {
+		ps := sched.getPartitionState("ingest", p)
+		require.Equal(t, 1, ps.pendingJobs.Len(), "partition %d should still get a job cut despite cluster 1's probe failure", p)
+		spec := ps.pendingJobs.Front().Value.(*schedulerpb.JobSpec)
+		require.Equal(t, expected, spec.OffsetRanges,
+			"partition %d's job should bundle the healthy clusters' fresh ends with cluster 1's stale end", p)
+	}
+
+	stopFailing()
+	sched.updateSchedule(ctx)
+
+	msg = "the next successful probe should catch cluster 1 up"
+	requireEndOffsets(t, sched, "ingest", 0, map[int]int64{0: 13, 1: 45, 2: 76}, msg)
+	requireEndOffsets(t, sched, "ingest", 1, map[int]int64{0: 21, 1: 59, 2: 87}, msg)
+	requireEndOffsets(t, sched, "ingest", 2, map[int]int64{0: 34, 1: 62, 2: 98}, msg)
+}
+
+// TestUpdateSchedule_MultiCluster_AllClusterProbesFail verifies that when every cluster's
+// end-offset probe fails the tick advances nothing — no end offsets recorded, no partition time
+// advance, no jobs — and the next successful tick picks up where the failed one left off.
+func TestUpdateSchedule_MultiCluster_AllClusterProbesFail(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { cancel(errors.New("test done")) })
+
+	clusters := createTestClusters(t, 3, 3)
+	sched, clients := mustMultiClusterSchedulerWithClusters(t, clusters)
+	sched.completeObservationMode(ctx)
+
+	// counts[c][p] is the number of records produced to partition p on cluster c.
+	counts := [3][3]int{
+		{3, 1, 4},
+		{5, 9, 2},
+		{6, 7, 8},
+	}
+	for c, byPartition := range counts {
+		for p, n := range byPartition {
+			produceRecords(ctx, t, clients[c], int32(p), n)
+		}
+	}
+
+	stops := make([]func(), len(clusters))
+	for c, tc := range clusters {
+		stops[c] = failListOffsets(tc.cluster)
+	}
+
+	sched.updateSchedule(ctx)
+
+	for p := range int32(3) {
+		requireEndOffsets(t, sched, "ingest", p, map[int]int64{0: 0, 1: 0, 2: 0},
+			"no cluster's end offsets should be recorded when every probe fails")
+		require.Equal(t, 0, sched.getPartitionState("ingest", p).pendingJobs.Len(),
+			"no job should be cut when every probe fails")
+	}
+
+	for _, stop := range stops {
+		stop()
+	}
+	sched.updateSchedule(ctx)
+
+	msg := "the next successful tick should record every cluster's ends"
+	requireEndOffsets(t, sched, "ingest", 0, map[int]int64{0: 3, 1: 5, 2: 6}, msg)
+	requireEndOffsets(t, sched, "ingest", 1, map[int]int64{0: 1, 1: 9, 2: 7}, msg)
+	requireEndOffsets(t, sched, "ingest", 2, map[int]int64{0: 4, 1: 2, 2: 8}, msg)
+}
+
+// TestPopulateInitialJobs_MultiCluster verifies that at startup a partition's clusters are
+// probed and replayed together, producing a single job whose offset ranges bundle every cluster
+// that had new data.
+func TestPopulateInitialJobs_MultiCluster(t *testing.T) {
+	sched, _ := mustMultiClusterScheduler(t, 3, 3)
+	sched.cfg.MaxScanAge = 1 * time.Hour
+	sched.cfg.JobSize = 1 * time.Hour
+
+	recordTime := time.Date(2025, 3, 1, 10, 30, 0, 0, time.UTC)
+	// ranges[p][c] is cluster c's offset range for partition p; all bounds are distinct so
+	// ranges attributed to the wrong cluster or partition fail the test. Partition 0 has data
+	// on every cluster; partitions 1 and 2 on subsets only, so their jobs must bundle just the
+	// clusters that had data and leave the absent clusters out of the spec.
+	ranges := map[int32]map[int32]schedulerpb.OffsetRange{
+		0: {0: {StartOffset: 100, EndOffset: 200}, 1: {StartOffset: 500, EndOffset: 700}, 2: {StartOffset: 900, EndOffset: 910}},
+		1: {1: {StartOffset: 710, EndOffset: 720}, 2: {StartOffset: 920, EndOffset: 930}},
+		2: {2: {StartOffset: 940, EndOffset: 950}},
+	}
+	offsetsByPartition, stores := buildPopulateInputs(3, recordTime, ranges)
+
+	endTime := time.Date(2025, 3, 1, 11, 0, 0, 0, time.UTC)
+	scanner := newOffsetScanner(stores, "ingest", endTime, sched.cfg.JobSize, sched.cfg.MaxScanAge, sched.metrics.probeRecordTimeDelta)
+	sched.populateInitialJobs(context.Background(), offsetsByPartition, scanner)
+
+	for partition, expected := range ranges {
+		ps := sched.getPartitionState("ingest", partition)
+		require.Equal(t, 1, ps.pendingJobs.Len(), "partition %d should get one job bundling the clusters that have data", partition)
+		spec := ps.pendingJobs.Front().Value.(*schedulerpb.JobSpec)
+		require.Equal(t, expected, spec.OffsetRanges, "partition %d", partition)
+	}
+}
+
+// TestInitConsumptionOffsets_PartitionOnSubsetOfClusters verifies that probing clusters with
+// uneven partition counts groups offsets by partition, with a nil entry for each cluster that
+// doesn't host the partition. Every (cluster, partition) cell gets a distinct record count so
+// offsets landing in the wrong slot fail the test.
+func TestInitConsumptionOffsets_PartitionOnSubsetOfClusters(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { cancel(errors.New("test done")) })
+
+	clusters := createTestClustersWithPartitions(t, []int32{3, 1, 2})
+	sched, clients := mustMultiClusterSchedulerWithClusters(t, clusters)
+
+	produceRecords(ctx, t, clients[0], 0, 3)
+	produceRecords(ctx, t, clients[0], 1, 1)
+	produceRecords(ctx, t, clients[0], 2, 4)
+	produceRecords(ctx, t, clients[1], 0, 5)
+	produceRecords(ctx, t, clients[2], 0, 6)
+	produceRecords(ctx, t, clients[2], 1, 7)
+
+	offs, err := sched.initConsumptionOffsets(ctx, time.Now().Add(-time.Minute))
+	require.NoError(t, err)
+
+	// The records' timestamps predate the fallback time, so each cell resumes from its end offset.
+	po := func(partition int32, offset int64) *partitionOffsets {
+		return &partitionOffsets{partition: partition, start: 0, resume: offset, end: offset}
+	}
+	require.Equal(t, map[int32][]*partitionOffsets{
+		0: {po(0, 3), po(0, 5), po(0, 6)},
+		1: {po(1, 1), nil, po(1, 7)},
+		2: {po(2, 4), nil, nil},
+	}, offs)
+}
+
 // TestLoadInitialCommittedOffsets verifies that the consumer group's committed offsets seed
 // each partition's state, and that commits for other topics in the group don't pollute it.
 func TestLoadInitialCommittedOffsets(t *testing.T) {
 	sched, _ := mustScheduler(t, 2)
 	ctx := t.Context()
-	admin := sched.adminClient
+	admin := sched.adminClients[0]
 
 	_, err := admin.CreateTopic(ctx, 1, 1, nil, "other-topic")
 	require.NoError(t, err)
@@ -783,9 +1431,60 @@ func TestLoadInitialCommittedOffsets(t *testing.T) {
 
 	require.NoError(t, sched.loadInitialCommittedOffsets(ctx))
 
-	sched.requireOffset(t, "ingest", 0, 42, "partition 0 should be seeded from its committed offset")
-	sched.requireOffset(t, "ingest", 1, 64, "partition 1 should be seeded from its committed offset")
+	requireOffsets(t, sched, "ingest", 0, map[int]int64{0: 42}, "partition 0 should be seeded from its committed offset")
+	requireOffsets(t, sched, "ingest", 1, map[int]int64{0: 64}, "partition 1 should be seeded from its committed offset")
 	require.Len(t, sched.partitionStates, 2, "foreign topic commits should not seed partition state")
+}
+
+// TestLoadInitialCommittedOffsets_MultiCluster verifies each cluster's committed offsets seed
+// that cluster's slot in partition state. Offsets are asymmetric so that commits applied to the
+// wrong cluster's slot fail the test.
+func TestLoadInitialCommittedOffsets_MultiCluster(t *testing.T) {
+	sched, _ := mustMultiClusterScheduler(t, 3, 3)
+	ctx := t.Context()
+
+	commit := func(clusterID int, offsets map[int32]int64) {
+		offs := make(kadm.Offsets)
+		for partition, offset := range offsets {
+			offs.AddOffset("ingest", partition, offset, -1)
+		}
+		require.NoError(t, sched.adminClients[clusterID].CommitAllOffsets(ctx, sched.cfg.ConsumerGroup, offs))
+	}
+	commit(0, map[int32]int64{0: 42, 1: 64, 2: 11})
+	commit(1, map[int32]int64{0: 1000, 1: 7})
+	commit(2, map[int32]int64{0: 5, 2: 88})
+
+	_, err := sched.adminClients[1].CreateTopic(ctx, 1, 1, nil, "other-topic")
+	require.NoError(t, err)
+	foreign := make(kadm.Offsets)
+	foreign.AddOffset("other-topic", 0, 99, -1)
+	require.NoError(t, sched.adminClients[1].CommitAllOffsets(ctx, sched.cfg.ConsumerGroup, foreign))
+
+	require.NoError(t, sched.loadInitialCommittedOffsets(ctx))
+
+	requireOffsets(t, sched, "ingest", 0, map[int]int64{0: 42, 1: 1000, 2: 5})
+	requireOffsets(t, sched, "ingest", 1, map[int]int64{0: 64, 1: 7})
+	requireOffsets(t, sched, "ingest", 2, map[int]int64{0: 11, 2: 88})
+	require.Len(t, sched.partitionStates, 3, "foreign topic commits should not seed partition state")
+}
+
+// TestLoadInitialCommittedOffsets_MultiCluster_OneClusterFails verifies that startup seeding
+// fails fast when any single cluster's committed offsets can't be fetched, with the error
+// naming the failing compartment: proceeding without them would wrongly seed that cluster's
+// offset ladder.
+func TestLoadInitialCommittedOffsets_MultiCluster_OneClusterFails(t *testing.T) {
+	clusters := createTestClusters(t, 3, 3)
+	sched, _ := mustMultiClusterSchedulerWithClusters(t, clusters)
+	// fetchCommittedOffsets retries with backoff; the deadline bounds the retries so the test
+	// observes the fetch error rather than waiting out all attempts.
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	failOffsetFetches(clusters[1].cluster)
+
+	err := sched.loadInitialCommittedOffsets(ctx)
+	require.ErrorContains(t, err, "write compartment 1")
+	require.ErrorContains(t, err, "fetch committed offsets")
 }
 
 // TestFetchCommittedOffsets_IgnoresForeignTopics verifies that committed offsets for other
@@ -793,7 +1492,7 @@ func TestLoadInitialCommittedOffsets(t *testing.T) {
 func TestFetchCommittedOffsets_IgnoresForeignTopics(t *testing.T) {
 	sched, _ := mustScheduler(t, 1)
 	ctx := t.Context()
-	admin := sched.adminClient
+	admin := sched.adminClients[0]
 
 	_, err := admin.CreateTopic(ctx, 1, 1, nil, "other-topic")
 	require.NoError(t, err)
@@ -817,6 +1516,7 @@ func TestFetchCommittedOffsets_IgnoresForeignTopics(t *testing.T) {
 // rejected instead of panicking the scheduler.
 func TestUpdateJob_ValidatesSpec(t *testing.T) {
 	tests := map[string]struct {
+		numClusters  int // 0 means compartments disabled.
 		spec         *schedulerpb.JobSpec
 		expectedCode codes.Code
 	}{
@@ -829,11 +1529,33 @@ func TestUpdateJob_ValidatesSpec(t *testing.T) {
 				OffsetRanges: map[int32]schedulerpb.OffsetRange{1: {StartOffset: 5, EndOffset: 10}}},
 			expectedCode: codes.InvalidArgument,
 		},
+		"enabled accepts valid offset ranges": {
+			numClusters: 2,
+			spec: &schedulerpb.JobSpec{Topic: "ingest", Partition: 0,
+				OffsetRanges: map[int32]schedulerpb.OffsetRange{0: {StartOffset: 5, EndOffset: 10}, 1: {StartOffset: 7, EndOffset: 12}}},
+			expectedCode: codes.OK,
+		},
+		"enabled rejects an out-of-range cluster ID": {
+			numClusters: 2,
+			spec: &schedulerpb.JobSpec{Topic: "ingest", Partition: 0,
+				OffsetRanges: map[int32]schedulerpb.OffsetRange{5: {StartOffset: 5, EndOffset: 10}}},
+			expectedCode: codes.InvalidArgument,
+		},
+		"enabled rejects start/end offsets": {
+			numClusters:  2,
+			spec:         &schedulerpb.JobSpec{Topic: "ingest", Partition: 0, StartOffset: 5, EndOffset: 10},
+			expectedCode: codes.InvalidArgument,
+		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			sched, _ := mustScheduler(t, 1)
+			var sched *BlockBuilderScheduler
+			if tc.numClusters == 0 {
+				sched, _ = mustScheduler(t, 1)
+			} else {
+				sched, _ = mustMultiClusterScheduler(t, 1, tc.numClusters)
+			}
 
 			_, err := sched.UpdateJob(t.Context(), &schedulerpb.UpdateJobRequest{
 				Key:      &schedulerpb.JobKey{Id: "job/0/1", Epoch: 1},
@@ -908,6 +1630,24 @@ func TestPopulateInitialJobs_ProbeErrorIsolation(t *testing.T) {
 
 	ps1 := sched.getPartitionState("ingest", 1)
 	require.Equal(t, int64(700), ps1.offsets[0].endOffset, "the other partition should still be replayed")
+}
+
+// TestCompartmentError verifies the write compartment is only attached to errors when
+// compartments are enabled, so single-cluster errors aren't misleadingly attributed to one.
+func TestCompartmentError(t *testing.T) {
+	baseErr := errors.New("boom")
+
+	t.Run("disabled leaves the error unannotated", func(t *testing.T) {
+		sched, _ := mustScheduler(t, 1)
+		require.Equal(t, baseErr, sched.compartmentError(0, baseErr))
+	})
+
+	t.Run("enabled annotates with the write compartment", func(t *testing.T) {
+		sched, _ := mustMultiClusterScheduler(t, 1, 2)
+		err := sched.compartmentError(1, baseErr)
+		require.ErrorIs(t, err, baseErr)
+		require.Contains(t, err.Error(), "write compartment 1")
+	})
 }
 
 func TestPopulateInitialJobs_ProbeTimesReused(t *testing.T) {
@@ -1137,6 +1877,42 @@ func TestBlockBuilderScheduler_EnqueuePendingJobs_CommitRace(t *testing.T) {
 	assert.Equal(t, 0, sched.jobs.count(), "the job should have been ignored because it's behind the committed offset")
 }
 
+// TestBlockBuilderScheduler_EnqueuePendingJobs_CommitRace_MultiCluster verifies enqueue-time
+// handling of pending jobs stale relative to per-cluster progress: a job behind every cluster's
+// committed offset is dropped, while a job stale on only a subset of clusters panics. Job
+// discovery cannot produce the partially-stale state — pending jobs are cut in ascending
+// per-cluster order from the frontier that startup sanitizes — so it is surfaced as a bug
+// rather than silently planned or dropped.
+func TestBlockBuilderScheduler_EnqueuePendingJobs_CommitRace_MultiCluster(t *testing.T) {
+	sched, _ := mustMultiClusterScheduler(t, 3, 3)
+	sched.cfg.MaxJobsPerPartition = 0
+	sched.completeObservationMode(context.Background())
+
+	// Partition 2's pending job is behind every cluster's committed offset: dropped.
+	initCommits(sched, "ingest", 2, map[int]int64{0: 20, 1: 15})
+	addPendingJob(sched, multiSpec(2, offsetRange(0, 10, 20), offsetRange(1, 5, 15)))
+
+	sched.enqueuePendingJobs()
+	assert.Equal(t, 0, sched.getPartitionState("ingest", 2).pendingJobs.Len())
+	assert.Equal(t, 0, sched.jobs.count(), "the job should have been ignored because it's behind every cluster's committed offset")
+
+	// Partition 1's pending job is behind cluster 0's progress but still needed by cluster 1.
+	initCommits(sched, "ingest", 1, map[int]int64{0: 20, 1: 5})
+	addPendingJob(sched, multiSpec(1, offsetRange(0, 10, 20), offsetRange(1, 5, 15)))
+
+	panicMsg := func() (msg string) {
+		defer func() {
+			if r := recover(); r != nil {
+				msg = fmt.Sprint(r)
+			}
+		}()
+		sched.enqueuePendingJobs()
+		return
+	}()
+	require.Contains(t, panicMsg, "partially behind the committed offset",
+		"a job stale on a subset of clusters should fail fast at the enqueue decision point, not deep in addPlannedJob")
+}
+
 func TestBlockBuilderScheduler_EnqueuePendingJobs_StartupRace(t *testing.T) {
 	sched, _ := mustScheduler(t, 4)
 	sched.cfg.MaxJobsPerPartition = 0
@@ -1234,6 +2010,46 @@ func TestBlockBuilderScheduler_EnqueuePendingJobs_GapDetection(t *testing.T) {
 		expectedStart = spec.EndOffset
 		requireGaps(t, reg, 2, commitGaps, "expected %d commit gaps at job %d", commitGaps, j)
 	}
+}
+
+// TestBlockBuilderScheduler_EnqueuePendingJobs_GapDetection_MultiCluster verifies gap accounting
+// with per-cluster offset ranges: a gap in a single cluster's range is detected even when the
+// other cluster's range is contiguous, and doesn't block job queueing.
+func TestBlockBuilderScheduler_EnqueuePendingJobs_GapDetection_MultiCluster(t *testing.T) {
+	sched, _ := mustMultiClusterScheduler(t, 3, 3)
+	sched.cfg.MaxJobsPerPartition = 0
+	sched.completeObservationMode(context.Background())
+
+	reg := sched.register.(*prometheus.Registry)
+
+	// Partition 0: every cluster's ranges are contiguous.
+	p0 := sched.getPartitionState("ingest", 0)
+	addPendingJob(sched, multiSpec(0, offsetRange(0, 0, 30), offsetRange(1, 0, 100), offsetRange(2, 0, 10)))
+	addPendingJob(sched, multiSpec(0, offsetRange(0, 30, 40), offsetRange(1, 100, 200), offsetRange(2, 10, 20)))
+	sched.enqueuePendingJobs()
+	require.Equal(t, 2, sched.jobs.count())
+	require.Equal(t, int64(40), p0.plannedOffset(0))
+	require.Equal(t, int64(200), p0.plannedOffset(1))
+	require.Equal(t, int64(20), p0.plannedOffset(2))
+	requireGaps(t, reg, 0, 0)
+
+	// Partition 1: a gap in cluster 1's ranges only; the other clusters' are contiguous.
+	p1 := sched.getPartitionState("ingest", 1)
+	addPendingJob(sched, multiSpec(1, offsetRange(0, 0, 30), offsetRange(1, 0, 100), offsetRange(2, 0, 10)))
+	addPendingJob(sched, multiSpec(1, offsetRange(0, 30, 40), offsetRange(1, 150, 200), offsetRange(2, 10, 20)))
+	sched.enqueuePendingJobs()
+	require.Equal(t, 4, sched.jobs.count(), "a gap should not interfere with job queueing")
+	require.Equal(t, int64(40), p1.plannedOffset(0))
+	require.Equal(t, int64(200), p1.plannedOffset(1))
+	require.Equal(t, int64(20), p1.plannedOffset(2))
+	requireGaps(t, reg, 1, 0, "the gap in cluster 1's ranges should be detected")
+
+	// Partition 2: gaps in all three clusters' ranges count once per cluster.
+	addPendingJob(sched, multiSpec(2, offsetRange(0, 0, 30), offsetRange(1, 0, 100), offsetRange(2, 0, 10)))
+	addPendingJob(sched, multiSpec(2, offsetRange(0, 50, 60), offsetRange(1, 150, 200), offsetRange(2, 30, 40)))
+	sched.enqueuePendingJobs()
+	require.Equal(t, 6, sched.jobs.count())
+	requireGaps(t, reg, 4, 0, "gaps in all clusters' ranges should each be detected")
 }
 
 func TestBlockBuilderScheduler_NoCommit_NoGap(t *testing.T) {
@@ -1474,6 +2290,50 @@ func failListOffsets(cluster *kfake.Cluster) (stop func()) {
 	return func() { failing.Store(false) }
 }
 
+// failOffsetCommits makes the cluster reject all offset commits until stop is called.
+func failOffsetCommits(cluster *kfake.Cluster) (stop func()) {
+	failing := atomic.NewBool(true)
+	cluster.ControlKey(kmsg.OffsetCommit.Int16(), func(req kmsg.Request) (kmsg.Response, error, bool) {
+		cluster.KeepControl()
+		if !failing.Load() {
+			return nil, nil, false
+		}
+		commitR := req.(*kmsg.OffsetCommitRequest)
+		resp := req.ResponseKind().(*kmsg.OffsetCommitResponse)
+		resp.Default()
+		for _, reqTopic := range commitR.Topics {
+			respTopic := kmsg.OffsetCommitResponseTopic{Topic: reqTopic.Topic, TopicID: reqTopic.TopicID}
+			for _, reqPartition := range reqTopic.Partitions {
+				respTopic.Partitions = append(respTopic.Partitions, kmsg.OffsetCommitResponseTopicPartition{
+					Partition: reqPartition.Partition,
+					ErrorCode: kerr.GroupAuthorizationFailed.Code,
+				})
+			}
+			resp.Topics = append(resp.Topics, respTopic)
+		}
+		return resp, nil, true
+	})
+	return func() { failing.Store(false) }
+}
+
+// failOffsetFetches makes the cluster reject all offset fetches.
+func failOffsetFetches(cluster *kfake.Cluster) {
+	cluster.ControlKey(kmsg.OffsetFetch.Int16(), func(req kmsg.Request) (kmsg.Response, error, bool) {
+		cluster.KeepControl()
+		fetchR := req.(*kmsg.OffsetFetchRequest)
+		resp := req.ResponseKind().(*kmsg.OffsetFetchResponse)
+		resp.Default()
+		resp.ErrorCode = kerr.GroupAuthorizationFailed.Code
+		for _, g := range fetchR.Groups {
+			resp.Groups = append(resp.Groups, kmsg.OffsetFetchResponseGroup{
+				Group:     g.Group,
+				ErrorCode: kerr.GroupAuthorizationFailed.Code,
+			})
+		}
+		return resp, nil, true
+	})
+}
+
 // produceRecords produces n records to the given partition of the "ingest" topic.
 func produceRecords(ctx context.Context, t *testing.T, cli *kgo.Client, partition int32, n int) {
 	t.Helper()
@@ -1486,4 +2346,225 @@ func produceRecords(ctx context.Context, t *testing.T, cli *kgo.Client, partitio
 		})
 		require.NoError(t, produceResult.FirstErr())
 	}
+}
+
+// testCluster is one fake Kafka cluster and the coordinates needed to connect more clients to it.
+type testCluster struct {
+	cluster *kfake.Cluster
+	addr    string
+	dialer  dialerFunc
+}
+
+// Write compartment c's fake cluster listens at port testClusterBasePort+c on a shared in-memory
+// network, so that the compartment ID placeholder in testClusterAddressTemplate resolves to that
+// compartment's cluster. Assumes single-digit compartment IDs.
+const (
+	testClusterBasePort        = 10090
+	testClusterAddressTemplate = "localhost:1009" + compartments.WriteCompartmentIDPlaceholder
+)
+
+// createTestClusters creates n independent fake Kafka clusters, one per write compartment.
+func createTestClusters(t *testing.T, partitions int32, n int) []testCluster {
+	partitionsByCluster := make([]int32, n)
+	for c := range partitionsByCluster {
+		partitionsByCluster[c] = partitions
+	}
+	return createTestClustersWithPartitions(t, partitionsByCluster)
+}
+
+// createTestClustersWithPartitions creates one fake Kafka cluster per entry of
+// partitionsByCluster, with cluster c hosting partitionsByCluster[c] partitions.
+func createTestClustersWithPartitions(t *testing.T, partitionsByCluster []int32) []testCluster {
+	vnet := &kfake.VirtualNetwork{}
+	clusters := make([]testCluster, len(partitionsByCluster))
+	for c, partitions := range partitionsByCluster {
+		cluster, kafkaAddr := testkafka.CreateClusterWithoutCustomConsumerGroupsSupport(t, partitions, "ingest",
+			testkafka.WithVirtualNetwork(vnet), testkafka.WithPort(testClusterBasePort+c))
+		clusters[c] = testCluster{cluster: cluster, addr: kafkaAddr, dialer: vnet.DialContext}
+	}
+	return clusters
+}
+
+// mustMultiClusterSchedulerWithClusters returns a compartments-enabled scheduler backed by the
+// given Kafka clusters, along with a producer client for each. Multiple schedulers can be created
+// against the same clusters to exercise restart scenarios.
+func mustMultiClusterSchedulerWithClusters(t *testing.T, clusters []testCluster) (*BlockBuilderScheduler, []*kgo.Client) {
+	cfg := Config{
+		Kafka: ingest.KafkaConfig{
+			Address:      flagext.StringSliceCSV{testClusterAddressTemplate},
+			Dialer:       clusters[0].dialer, // All clusters share one in-memory network.
+			Topic:        "ingest",
+			FetchMaxWait: 10 * time.Millisecond,
+		},
+		ConsumerGroup:       "test-builder",
+		SchedulingInterval:  1000000 * time.Hour,
+		JobSize:             1 * time.Hour,
+		MaxJobsPerPartition: 1,
+		Compartments: compartments.Config{
+			Enabled: true,
+			Write:   compartments.WriteConfig{NumCompartments: len(clusters)},
+		},
+	}
+
+	reg := prometheus.NewPedanticRegistry()
+	sched, err := New(cfg, test.NewTestingLogger(t), reg)
+	require.NoError(t, err)
+
+	clients := make([]*kgo.Client, len(clusters))
+	admins := make([]*kadm.Client, len(clusters))
+	for c, tc := range clusters {
+		cli, err := kgo.NewClient(
+			kgo.SeedBrokers(tc.addr),
+			kgo.Dialer(tc.dialer),
+			kgo.RecordPartitioner(kgo.ManualPartitioner()),
+		)
+		require.NoError(t, err)
+		t.Cleanup(cli.Close)
+		clients[c] = cli
+		admins[c] = kadm.NewClient(cli)
+	}
+	sched.adminClients = admins
+	return sched, clients
+}
+
+// mustMultiClusterScheduler returns a compartments-enabled scheduler backed by numClusters
+// independent Kafka clusters, one per write compartment, along with a producer client for each.
+func mustMultiClusterScheduler(t *testing.T, partitions int32, numClusters int) (*BlockBuilderScheduler, []*kgo.Client) {
+	return mustMultiClusterSchedulerWithClusters(t, createTestClusters(t, partitions, numClusters))
+}
+
+// specRange pairs a cluster ID with an offset range for building multi-cluster job specs.
+type specRange struct {
+	cluster     int32
+	offsetRange schedulerpb.OffsetRange
+}
+
+func offsetRange(cluster int32, start, end int64) specRange {
+	return specRange{cluster: cluster, offsetRange: schedulerpb.OffsetRange{StartOffset: start, EndOffset: end}}
+}
+
+// multiSpec builds a job spec for a partition of the "ingest" topic covering the given
+// clusters' offset ranges.
+func multiSpec(partition int32, ranges ...specRange) schedulerpb.JobSpec {
+	or := make(map[int32]schedulerpb.OffsetRange, len(ranges))
+	for _, r := range ranges {
+		or[r.cluster] = r.offsetRange
+	}
+	return schedulerpb.JobSpec{Topic: "ingest", Partition: partition, OffsetRanges: or}
+}
+
+// observedJob builds a worker-reported job for observation-mode tests, deriving the job ID
+// from the spec the same way the planner does.
+func observedJob(epoch int64, spec schedulerpb.JobSpec) job[schedulerpb.JobSpec] {
+	return job[schedulerpb.JobSpec]{key: jobKey{id: jobIDForSpec(true, &spec), epoch: epoch}, spec: spec}
+}
+
+// initCommits seeds a partition's per-cluster committed offsets, keyed by cluster ID like
+// requireOffsets.
+func initCommits(sched *BlockBuilderScheduler, topic string, partition int32, offsets map[int]int64) {
+	ps := sched.getPartitionState(topic, partition)
+	for clusterID, offset := range offsets {
+		ps.initCommit(clusterID, offset)
+	}
+}
+
+// addPendingJob appends the spec to its partition's pending queue.
+func addPendingJob(sched *BlockBuilderScheduler, spec schedulerpb.JobSpec) {
+	sched.getPartitionState(spec.Topic, spec.Partition).addPendingJob(&spec)
+}
+
+// assignAllJobs assigns jobs to the worker until the queue is drained, returning the assigned
+// specs.
+func assignAllJobs(t *testing.T, sched *BlockBuilderScheduler, workerID string) []*schedulerpb.JobSpec {
+	t.Helper()
+	var specs []*schedulerpb.JobSpec
+	for {
+		_, spec, err := sched.assignJob(workerID)
+		if errors.Is(err, errNoJobAvailable) {
+			return specs
+		}
+		require.NoError(t, err)
+		specs = append(specs, &spec)
+	}
+}
+
+// requireOffsets asserts the partition's committed offsets equal expected. Unlike compartment
+// data in production code, which is slice-indexed, the expectations are keyed by cluster ID so
+// each expected offset names its cluster; clusters without a commit are simply absent.
+func requireOffsets(t *testing.T, sched *BlockBuilderScheduler, topic string, partition int32, expected map[int]int64, msgAndArgs ...any) {
+	t.Helper()
+	ps := sched.getPartitionState(topic, partition)
+	actual := make(map[int]int64, len(ps.offsets))
+	for clusterID := range ps.offsets {
+		if o := ps.offsets[clusterID].committed.offset(); o != offsetEmpty {
+			actual[clusterID] = o
+		}
+	}
+	require.Equal(t, expected, actual, msgAndArgs...)
+}
+
+// requireEndOffsets asserts the partition's probed end offsets equal expected, keyed by cluster
+// ID like requireOffsets. Every cluster needs an entry: unlike commits, an end offset always
+// exists, and an unprobed cluster's is 0.
+func requireEndOffsets(t *testing.T, sched *BlockBuilderScheduler, topic string, partition int32, expected map[int]int64, msgAndArgs ...any) {
+	t.Helper()
+	ps := sched.getPartitionState(topic, partition)
+	actual := make(map[int]int64, len(ps.offsets))
+	for clusterID := range ps.offsets {
+		actual[clusterID] = ps.offsets[clusterID].endOffset
+	}
+	require.Equal(t, expected, actual, msgAndArgs...)
+}
+
+// requireCommittedInKafka asserts the cluster's Kafka holds exactly the expected committed
+// offsets for the scheduler's consumer group and topic.
+func requireCommittedInKafka(ctx context.Context, t *testing.T, sched *BlockBuilderScheduler, clusterID int, expected map[int32]int64) {
+	t.Helper()
+	offs, err := fetchCommittedOffsets(ctx, sched.adminClients[clusterID], sched.cfg.ConsumerGroup, sched.cfg.Kafka.Topic)
+	require.NoError(t, err)
+	got := make(map[int32]int64)
+	offs.Each(func(o kadm.Offset) {
+		got[o.Partition] = o.At
+	})
+	require.Equal(t, expected, got, "cluster %d should hold exactly its own committed offsets", clusterID)
+}
+
+// partitionedOffsetFinder dispatches offset probes to a per-partition mock finder.
+type partitionedOffsetFinder struct {
+	byPartition map[int32]*mockOffsetFinder
+}
+
+func (f *partitionedOffsetFinder) offsetAfterTime(ctx context.Context, topic string, partition int32, t time.Time) (int64, time.Time, bool, error) {
+	finder, ok := f.byPartition[partition]
+	if !ok {
+		return 0, time.Time{}, false, fmt.Errorf("unexpected probe for partition %d", partition)
+	}
+	return finder.offsetAfterTime(ctx, topic, partition, t)
+}
+
+// buildPopulateInputs converts per-partition, per-cluster offset ranges into populateInitialJobs
+// inputs: offsets grouped by partition (nil entries for clusters without the partition) and one
+// finder per cluster reporting a single record at recordTime within each of its ranges.
+func buildPopulateInputs(numClusters int, recordTime time.Time, ranges map[int32]map[int32]schedulerpb.OffsetRange) (map[int32][]*partitionOffsets, []offsetStore) {
+	offsetsByPartition := make(map[int32][]*partitionOffsets, len(ranges))
+	finders := make([]*partitionedOffsetFinder, numClusters)
+	for c := range finders {
+		finders[c] = &partitionedOffsetFinder{byPartition: make(map[int32]*mockOffsetFinder)}
+	}
+	for partition, byCluster := range ranges {
+		slots := make([]*partitionOffsets, numClusters)
+		for clusterID, r := range byCluster {
+			slots[clusterID] = &partitionOffsets{partition: partition, start: r.StartOffset, resume: r.StartOffset, end: r.EndOffset}
+			finders[clusterID].byPartition[partition] = &mockOffsetFinder{
+				offsets: []*offsetTime{{offset: r.StartOffset, time: recordTime}},
+				end:     r.EndOffset,
+			}
+		}
+		offsetsByPartition[partition] = slots
+	}
+	stores := make([]offsetStore, numClusters)
+	for c := range finders {
+		stores[c] = finders[c]
+	}
+	return offsetsByPartition, stores
 }

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -1623,6 +1623,7 @@ func (t *Mimir) initBlockBuilder() (_ services.Service, err error) {
 
 func (t *Mimir) initBlockBuilderScheduler() (services.Service, error) {
 	t.Cfg.BlockBuilderScheduler.Kafka = t.Cfg.IngestStorage.KafkaConfig
+	t.Cfg.BlockBuilderScheduler.Compartments = t.Cfg.Compartments
 
 	s, err := blockbuilderscheduler.New(t.Cfg.BlockBuilderScheduler, util_log.Logger, t.Registerer)
 	if err != nil {

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -1614,6 +1614,7 @@ func (t *Mimir) initUsageTracker() (services.Service, error) {
 func (t *Mimir) initBlockBuilder() (_ services.Service, err error) {
 	t.Cfg.BlockBuilder.Kafka = t.Cfg.IngestStorage.KafkaConfig
 	t.Cfg.BlockBuilder.BlocksStorage = t.Cfg.BlocksStorage
+	t.Cfg.BlockBuilder.Compartments = t.Cfg.Compartments
 	t.BlockBuilder, err = blockbuilder.New(t.Cfg.BlockBuilder, util_log.Logger, t.Registerer, t.Overrides)
 	if err != nil {
 		return nil, errors.Wrap(err, "block-builder init")

--- a/pkg/util/testkafka/cluster.go
+++ b/pkg/util/testkafka/cluster.go
@@ -70,6 +70,15 @@ func WithVirtualNetwork(vnet *kfake.VirtualNetwork) Opt {
 	}
 }
 
+// WithPort makes the (single-broker) fake cluster listen on the given port instead of a random
+// one, so the caller can predict the cluster's address. Combine with WithVirtualNetwork to host
+// multiple clusters at deterministic ports on one in-memory network.
+func WithPort(port int) Opt {
+	return func() []kfake.Opt {
+		return []kfake.Opt{kfake.Ports(port)}
+	}
+}
+
 // CreateCluster returns a fake Kafka cluster for unit testing.
 func CreateCluster(t testing.TB, numPartitions int32, topicName string, opts ...Opt) (*kfake.Cluster, string) {
 	cluster, addr := CreateClusterWithoutCustomConsumerGroupsSupport(t, numPartitions, topicName, opts...)


### PR DESCRIPTION
Adding compartments support to the block builder scheduler.

This PR aims to be easy to diff against the previous, non-compartments, code. The main line additions are from tests for multi-cluster cases.
- When compartments are disabled the scheduler runs a single cluster, that path is behaviourally unchanged. 
- There are some cases where more graceful recovery strategies for partial failures are possible in the multi-cluster case. However, these require more in-depth reasoning and would make the PR harder to review, so that has been deferred.
- We could add more metrics/alerts for partial-failure cases (e.g. per-cluster offset-flush failures); these have been deferred too.

Two design principles worth calling out for review:
- Error handling aims to be similar to the single-cluster case: where it failed hard (e.g. loading committed offsets at startup), one cluster's failure still fails hard; where it warned and carried on (e.g. offset flushes), a single cluster's failure does the same, without blocking the other clusters' progress. One deviation is the periodic end-offset probe in updateSchedule: the single-cluster scheduler abandoned the whole tick on a failed probe, but failed cluster is skipped for the tick (its data is cut in a later bucket once probing recovers) while the rest advance. 
- Mixed per-cluster states that have no single-cluster equivalent: a job that is behind some clusters' committed offsets and ahead of others'. This is not something we had to handle with a single cluster only. In general, panics are added as we don't expect to reach this state. However, more graceful handling could be added later, in the same spirit as how the single-cluster scheduler already tolerates an unexpected offset discontinuity, e.g. `advancingOffset` warns and increments a gap metric rather than panicking. There is one edge case at startup which could result in mixed states, and in this case we skip importing the rest of the jobs and recreate based on offset probing.

This supersedes https://github.com/grafana/mimir/pull/15774. All comments in that PR are now outdated or addressed, aside from https://github.com/grafana/mimir/pull/15774#discussion_r3490010110 which is pre-existing behaviour from prior non-compartments code.