### PR TITLE
fix(kafkatool): make --kafka-address optional for file-only commands (#15917)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@
 * [ENHANCEMENT] Mimirtool: `partition-ring` subcommands now accept an optional `--partition-ring.key` flag to select the KV store key of the partition ring to operate on. It defaults to `ingester-partitions`. #15719
 * [ENHANCEMENT] Makefile: `build-mixin` and `mixin-screenshots` can now be configured to use native histograms for latency panels in dashboards. #15269
 * [ENHANCEMENT] kafkatool: Add a README. #15898
+* [ENHANCEMENT] kafkatool: `--kafka-address` is now optional. Commands that only operate on a local dump file (`dump print`, `dump analyse`, `dump find-duplicates`) no longer require it; commands that contact Kafka still require it and fail with a clear error if it is missing. #15917
 
 ### Query-tee
 

--- a/tools/kafkatool/README.md
+++ b/tools/kafkatool/README.md
@@ -4,7 +4,7 @@ A command-line tool to inspect and manage the Kafka cluster backing Mimir's [ing
 
 Build it with `go build .` in this directory.
 
-Every command needs `--kafka-address` (e.g. `localhost:9092`). For authenticated clusters, also pass `--kafka-sasl-username` and `--kafka-sasl-password`. Run any command with `--help` to see its flags.
+Every command needs `--kafka-address` (e.g. `localhost:9092`) — except `dump print`, `dump analyse`, and `dump find-duplicates`, which only read a local dump file and therefore don't contact Kafka. For authenticated clusters, also pass `--kafka-sasl-username` and `--kafka-sasl-password`. Run any command with `--help` to see its flags.
 
 ## Examples
 
@@ -28,10 +28,10 @@ Dump a partition's raw records to a file. Useful for offline analysis:
 ./kafkatool --kafka-address localhost:9092 dump export --file ./dump.json --topic ingest --partition 0 --offset 0 --export-max-records 100000
 ```
 
-Analyze a dump file (these subcommands never contact the broker, `--kafka-address` is just a placeholder):
+Analyze a dump file (these subcommands never contact the broker, so `--kafka-address` is not required):
 
 ```bash
-./kafkatool --kafka-address localhost:9092 dump --file ./dump.json analyse
-./kafkatool --kafka-address localhost:9092 dump --file ./dump.json print --format json
-./kafkatool --kafka-address localhost:9092 dump --file ./dump.json find-duplicates
+./kafkatool dump --file ./dump.json analyse
+./kafkatool dump --file ./dump.json print --format json
+./kafkatool dump --file ./dump.json find-duplicates
 ```

--- a/tools/kafkatool/main.go
+++ b/tools/kafkatool/main.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/alecthomas/kingpin/v2"
@@ -22,13 +23,23 @@ func main() {
 	)
 
 	app := kingpin.New("kafkatool", "A command-line tool to manage Kafka.")
-	app.Flag("kafka-address", "Kafka broker address.").Required().StringVar(&kafkaAddress)
+	app.Flag("kafka-address", "Kafka broker address. Required by commands that contact Kafka; not needed for 'dump print', 'dump analyse', and 'dump find-duplicates' (which only read a local dump file).").StringVar(&kafkaAddress)
 	app.Flag("kafka-client-id", "Kafka client ID.").StringVar(&kafkaClientID)
 	app.Flag("kafka-sasl-username", "SASL username. SASL plain authentication is enabled when both username and password are set.").StringVar(&kafkaSASLUsername)
 	app.Flag("kafka-sasl-password", "SASL password. SASL plain authentication is enabled when both username and password are set.").StringVar(&kafkaSASLPassword)
 
-	// Create the Kafka client before any command is executed.
+	// Create the Kafka client before any command is executed, but only when an
+	// address is provided. Commands that operate on a local dump file only
+	// (dump print/analyse/find-duplicates) never contact Kafka and should not
+	// be forced to pass --kafka-address.
 	app.Action(func(_ *kingpin.ParseContext) error {
+		if kafkaAddress == "" {
+			// No Kafka address: leave the client nil. Commands that need a
+			// client will fail with a clear error when they call
+			// getKafkaClient(); file-only commands proceed normally.
+			return nil
+		}
+
 		var err error
 		var auth sasl.Mechanism
 
@@ -56,6 +67,10 @@ func main() {
 
 	// Function passed to commands to get Kafka client.
 	getKafkaClient := func() *kgo.Client {
+		if kafkaClient == nil {
+			fmt.Fprintln(os.Stderr, "error: --kafka-address is required for this command (it was not provided)")
+			os.Exit(1)
+		}
 		return kafkaClient
 	}
 


### PR DESCRIPTION
## Summary
- Make `--kafka-address` optional (`StringVar` instead of `Required().StringVar`).
- In `app.Action()`, skip Kafka client creation when no address is provided.
- Guard `getKafkaClient` callers with nil checks.

Closes #15917