### PR TITLE
compactor scheduler: code changes to prepare for documentation

### DIFF
--- a/operations/mimir/compactor-scheduler.libsonnet
+++ b/operations/mimir/compactor-scheduler.libsonnet
@@ -97,10 +97,20 @@
     'compactor.scheduler-client.scheduler-endpoint': 'dns:///compactor-scheduler.%(namespace)s.svc.%(cluster_domain)s:9095' % $._config,
   } + (
     if !$._config.compactor_scheduler_metadata_caching_enabled then {} else
+      local metadataCachePrefix = 'blocks-storage.bucket-store.metadata-cache.';
+      // The metadata cache configuration used by workers only requires a subset of the flags exposed by
+      // blocks-storage.bucket-store.metadata-cache.
+      // Note that metafile_max_size_bytes is intentionally excluded since the memcached client configuration
+      // includes a max size already.
+      local isSupportedFlag(k) =
+        k == metadataCachePrefix + 'backend' ||
+        k == metadataCachePrefix + 'metafile-content-ttl' ||
+        std.startsWith(k, metadataCachePrefix + 'memcached.');
       local merged = $.blocks_metadata_caching_config + $.blocks_metadata_zone_a_caching_config;
       {
         [std.strReplace(k, 'blocks-storage.bucket-store', 'compactor.scheduler-client')]: merged[k]
         for k in std.objectFields(merged)
+        if isSupportedFlag(k)
       }
   ),
 

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -143,7 +143,7 @@ type Config struct {
 	SparseIndexHeadersConfig       indexheader.Config `yaml:"-"`
 
 	// Configuration for interacting with a compaction job scheduler
-	SchedulerClientConfig SchedulerClientConfig `yaml:"scheduler_client" category:"experimental" doc:"hidden"`
+	SchedulerClientConfig SchedulerClientConfig `yaml:"scheduler_client" doc:"hidden"`
 
 	// ReadCompartmentID is the read compartment this compactor serves.
 	ReadCompartmentID int `yaml:"read_compartment_id" category:"experimental" doc:"hidden"`

--- a/pkg/compactor/executor.go
+++ b/pkg/compactor/executor.go
@@ -94,18 +94,18 @@ var (
 )
 
 type SchedulerClientConfig struct {
-	Enabled                       bool                    `yaml:"enabled" category:"experimental"`
-	SchedulerEndpoint             string                  `yaml:"scheduler_endpoint" category:"experimental"`
-	GRPCClientConfig              grpcclient.Config       `yaml:"grpc_client_config" category:"experimental"`
-	LeasingMinBackoff             time.Duration           `yaml:"leasing_min_backoff" category:"experimental"`
-	LeasingMaxBackoff             time.Duration           `yaml:"leasing_max_backoff" category:"experimental"`
-	UpdateInterval                time.Duration           `yaml:"update_interval" category:"experimental"`
-	UpdateMinBackoff              time.Duration           `yaml:"update_min_backoff" category:"experimental"`
-	UpdateMaxBackoff              time.Duration           `yaml:"update_max_backoff" category:"experimental"`
-	CompactionDirCleanupInterval  time.Duration           `yaml:"compaction_dir_cleanup_interval" category:"experimental"`
-	MetadataCacheConfig           MetadataCacheConfig     `yaml:"metadata_cache"` 
-	TerminatingFinalStatusTimeout time.Duration           `yaml:"terminating_final_status_timeout" category:"experimental"`
-	Lanes                         flagext.StringSliceCSV  `yaml:"lanes" category:"experimental"`
+	Enabled                       bool                   `yaml:"enabled" category:"experimental"`
+	SchedulerEndpoint             string                 `yaml:"scheduler_endpoint" category:"experimental"`
+	GRPCClientConfig              grpcclient.Config      `yaml:"grpc_client_config" category:"experimental"`
+	LeasingMinBackoff             time.Duration          `yaml:"leasing_min_backoff" category:"experimental"`
+	LeasingMaxBackoff             time.Duration          `yaml:"leasing_max_backoff" category:"experimental"`
+	UpdateInterval                time.Duration          `yaml:"update_interval" category:"experimental"`
+	UpdateMinBackoff              time.Duration          `yaml:"update_min_backoff" category:"experimental"`
+	UpdateMaxBackoff              time.Duration          `yaml:"update_max_backoff" category:"experimental"`
+	CompactionDirCleanupInterval  time.Duration          `yaml:"compaction_dir_cleanup_interval" category:"experimental"`
+	MetadataCacheConfig           MetadataCacheConfig    `yaml:"metadata_cache"`
+	TerminatingFinalStatusTimeout time.Duration          `yaml:"terminating_final_status_timeout" category:"experimental"`
+	Lanes                         flagext.StringSliceCSV `yaml:"lanes" category:"experimental"`
 }
 
 func (cfg *SchedulerClientConfig) RegisterFlags(f *flag.FlagSet) {

--- a/pkg/compactor/executor.go
+++ b/pkg/compactor/executor.go
@@ -35,7 +35,6 @@ import (
 
 	"github.com/grafana/mimir/pkg/compactor/scheduler/compactorschedulerpb"
 	"github.com/grafana/mimir/pkg/storage/bucket"
-	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
 	"github.com/grafana/mimir/pkg/storage/tsdb/block"
 	"github.com/grafana/mimir/pkg/util"
 	util_log "github.com/grafana/mimir/pkg/util/log"
@@ -95,18 +94,18 @@ var (
 )
 
 type SchedulerClientConfig struct {
-	Enabled                       bool                           `yaml:"enabled" category:"experimental"`
-	SchedulerEndpoint             string                         `yaml:"scheduler_endpoint" category:"experimental"`
-	GRPCClientConfig              grpcclient.Config              `yaml:"grpc_client_config" category:"experimental"`
-	LeasingMinBackoff             time.Duration                  `yaml:"leasing_min_backoff" category:"experimental"`
-	LeasingMaxBackoff             time.Duration                  `yaml:"leasing_max_backoff" category:"experimental"`
-	UpdateInterval                time.Duration                  `yaml:"update_interval" category:"experimental"`
-	UpdateMinBackoff              time.Duration                  `yaml:"update_min_backoff" category:"experimental"`
-	UpdateMaxBackoff              time.Duration                  `yaml:"update_max_backoff" category:"experimental"`
-	CompactionDirCleanupInterval  time.Duration                  `yaml:"compaction_dir_cleanup_interval" category:"experimental"`
-	MetadataCacheConfig           mimir_tsdb.MetadataCacheConfig `yaml:"metadata_cache" category:"experimental"`
-	TerminatingFinalStatusTimeout time.Duration                  `yaml:"terminating_final_status_timeout" category:"experimental"`
-	Lanes                         flagext.StringSliceCSV         `yaml:"lanes" category:"experimental"`
+	Enabled                       bool                    `yaml:"enabled" category:"experimental"`
+	SchedulerEndpoint             string                  `yaml:"scheduler_endpoint" category:"experimental"`
+	GRPCClientConfig              grpcclient.Config       `yaml:"grpc_client_config" category:"experimental"`
+	LeasingMinBackoff             time.Duration           `yaml:"leasing_min_backoff" category:"experimental"`
+	LeasingMaxBackoff             time.Duration           `yaml:"leasing_max_backoff" category:"experimental"`
+	UpdateInterval                time.Duration           `yaml:"update_interval" category:"experimental"`
+	UpdateMinBackoff              time.Duration           `yaml:"update_min_backoff" category:"experimental"`
+	UpdateMaxBackoff              time.Duration           `yaml:"update_max_backoff" category:"experimental"`
+	CompactionDirCleanupInterval  time.Duration           `yaml:"compaction_dir_cleanup_interval" category:"experimental"`
+	MetadataCacheConfig           MetadataCacheConfig     `yaml:"metadata_cache"` 
+	TerminatingFinalStatusTimeout time.Duration           `yaml:"terminating_final_status_timeout" category:"experimental"`
+	Lanes                         flagext.StringSliceCSV  `yaml:"lanes" category:"experimental"`
 }
 
 func (cfg *SchedulerClientConfig) RegisterFlags(f *flag.FlagSet) {
@@ -155,6 +154,26 @@ func (cfg *SchedulerClientConfig) Validate() error {
 		return errInvalidSchedulerTerminatingFinalStatusTimeout
 	}
 	return nil
+}
+
+var supportedMetadataCacheBackends = []string{cache.BackendMemcached}
+
+// MetadataCacheConfig configures the cache that compactor workers use for block metadata.
+// Similar to MetadataCacheConfig from pkg/storage/tsdb/config.go, but contains only the subset of flags used.
+type MetadataCacheConfig struct {
+	cache.BackendConfig `yaml:",inline"`
+
+	MetafileContentTTL time.Duration `yaml:"metafile_content_ttl" category:"experimental"`
+}
+
+func (cfg *MetadataCacheConfig) RegisterFlagsWithPrefix(f *flag.FlagSet, prefix string) {
+	f.StringVar(&cfg.Backend, prefix+"backend", "", fmt.Sprintf("Backend for metadata cache, if not empty. Supported values: %s.", strings.Join(supportedMetadataCacheBackends, ", ")))
+	cfg.Memcached.RegisterFlagsWithPrefix(prefix+"memcached.", f)
+	f.DurationVar(&cfg.MetafileContentTTL, prefix+"metafile-content-ttl", 24*time.Hour, "How long to cache block metadata content.")
+}
+
+func (cfg *MetadataCacheConfig) Validate() error {
+	return cfg.BackendConfig.Validate()
 }
 
 const (

--- a/pkg/compactor/scheduler/lane_policy.go
+++ b/pkg/compactor/scheduler/lane_policy.go
@@ -33,19 +33,19 @@ type lanePolicy interface {
 }
 
 type LanePolicyConfig struct {
-	policy string
+	Policy string `yaml:"policy" category:"experimental"`
 }
 
 func (cfg *LanePolicyConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
-	f.StringVar(&cfg.policy, prefix+".policy", "simple", "The lane policy the compactor scheduler should use. Valid values: "+fmt.Sprintf("(%s)", lanePolicySimple))
+	f.StringVar(&cfg.Policy, prefix+".policy", "simple", "The lane policy the compactor scheduler should use. Valid values: "+fmt.Sprintf("(%s)", lanePolicySimple))
 }
 
 func newLanePolicy(cfg LanePolicyConfig) (lanePolicy, error) {
-	switch cfg.policy {
+	switch cfg.Policy {
 	case "simple":
 		return newSimpleLanePolicy(), nil
 	default:
-		return nil, fmt.Errorf("unrecognized lane policy: %s", cfg.policy)
+		return nil, fmt.Errorf("unrecognized lane policy: %s", cfg.Policy)
 	}
 }
 

--- a/pkg/compactor/scheduler/scheduler.go
+++ b/pkg/compactor/scheduler/scheduler.go
@@ -47,17 +47,17 @@ type Config struct {
 	MaintenanceIntervalsBeforeLeaseExpiration   int              `yaml:"maintenance_intervals_before_lease_expiration" category:"experimental"`
 	MaintenanceIntervalsBeforeColdStartPlanning int              `yaml:"maintenance_intervals_before_cold_start_planning" category:"experimental"`
 	TenantDiscoveryInterval                     time.Duration    `yaml:"tenant_discovery_interval" category:"experimental"`
-	TenantDiscoveryBackoff                      backoff.Config   `yaml:"tenant_discovery_backoff" category:"experimental"`
+	TenantDiscoveryBackoff                      backoff.Config   `yaml:"tenant_discovery_backoff"`
 	PersistenceType                             string           `yaml:"persistence_type" category:"experimental"`
 	RepeatedFailureReportThreshold              int              `yaml:"repeated_failure_report_threshold" category:"experimental"`
-	Bbolt                                       BboltConfig      `yaml:"bbolt" category:"experimental"`
-	LanePolicy                                  LanePolicyConfig `yaml:"lane_policy" category:"experimental"`
+	Bbolt                                       BboltConfig      `yaml:"bbolt"`
+	LanePolicy                                  LanePolicyConfig `yaml:"lane_policy"`
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.MaxLeases, "compactor-scheduler.max-leases", 3, "The maximum number of times a job can be retried before it is removed. 0 for no limit.")
 	f.DurationVar(&cfg.LeaseDuration, "compactor-scheduler.lease-duration", 10*time.Minute, "The duration of time without contact until the scheduler is able to lease a work item to another worker.")
-	f.DurationVar(&cfg.PlanningInterval, "compactor-scheduler.planning-interval", 1*time.Hour, "The duration of time between when plan jobs are submitted aligned by UTC. Note that -compactor.first-level-compaction-wait-period is accounted for during alignment of this interval.")
+	f.DurationVar(&cfg.PlanningInterval, "compactor-scheduler.planning-interval", 30*time.Minute, "The duration of time between when plan jobs are submitted aligned by UTC. Note that -compactor.first-level-compaction-wait-period is accounted for during alignment of this interval.")
 	f.DurationVar(&cfg.MaintenanceInterval, "compactor-scheduler.maintenance-interval", 2*time.Minute, "The duration of time between when maintenance tasks are performed on job trackers. This includes lease expiration and plan job submission checks.")
 	f.IntVar(&cfg.MaintenanceIntervalsBeforeLeaseExpiration, "compactor-scheduler.maintenance-intervals-before-lease-expiration", 3, "The number of maintenance intervals before lease expiration is enforced. Nonpositive values are all treated as zero.")
 	f.IntVar(&cfg.MaintenanceIntervalsBeforeColdStartPlanning, "compactor-scheduler.maintenance-intervals-before-cold-start-planning", 5, "The number of maintenance intervals before planning occurs when starting from no recovered state. Nonpositive values are all treated as zero.")


### PR DESCRIPTION
#### What this PR does

I was originally going to make a PR to remove `doc:"hidden"` from the compactor scheduler fields, but doing that exposed a number of issues that needed to be cleaned up in the code. These are the changes to fix those issues without including the actual documentation change.

- Mirroring all of `blocks-storage.bucket-store.metadata-cache.*` leads to documenting configuration that is never used. This replaces that by using a subset instead.
- Removes `category:"experimental"` from fields that are structs. `category` only applies to fields that are flags, so setting this on a struct does nothing.
- Expose `Policy` on the lane configuration so that it can be set through YAML.
- Changes the default planning interval to 30m. This is the default through jsonnet already. I did not modify the jsonnet to remove the now matching override (that can be done later).

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
