### PR TITLE
gitattributes: add CHANGELOG.md merge=union

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 **/*.pb.go linguist-generated=true
 vendor/**/* linguist-generated=true
+CHANGELOG.md merge=union


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR should automatically resolve merge conflicts for `CHANGELOG.md` when backporting ([example](https://github.com/grafana/mimir/pull/15978#issuecomment-4901797986)), reducing the amount of manual work.

`merge=union` will keep both changes. This sometimes might result in weird additions but for the CHANGELOG file specifically, I think will work fine.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
