### PR TITLE
WIP: Jsonnet: align compartments defaults across Mimir components

### DIFF
--- a/operations/mimir-tests/test-compartments-config-validation.jsonnet
+++ b/operations/mimir-tests/test-compartments-config-validation.jsonnet
@@ -37,6 +37,13 @@ local removeContainerArg(resource, flag) =
     } } },
   };
 
+local addSidecar(resource) =
+  resource {
+    spec+: { template+: { spec+: {
+      containers+: [{ name: 'sidecar' }],
+    } } },
+  };
+
 local isError(err, needle) = err != null && std.length(std.findSubstr(needle, err)) > 0;
 
 // Synthetic root carrying validateMimirCompartmentsConfig and the resource fields under test. Built
@@ -201,5 +208,26 @@ assert isError(err16, '-blocks-storage.gcs.bucket-name=blocks-bucket-rc-0') && i
 local err17 = validate({ gf: globalWithBucket('blocks-bucket-rc-<read-compartment-id>') }, ['gf']);
 assert err17 == null :
        'case 17: expected no error for a parametrised blocks-storage bucket on a global deployment, got: %s' % err17;
+
+// 18. Mimir workload containers must carry the compartments enabled flag.
+local err18 = validate(
+  { dist: removeContainerArg(distributor, '-compartments.enabled') },
+  ['dist'],
+);
+assert isError(err18, 'missing "-compartments.enabled=true"') :
+       'case 18: expected missing compartments.enabled error, got: %s' % err18;
+
+// 19. Mimir workload containers must use the configured compartment counts.
+local err19 = validate(
+  { dist: overrideContainerArgs(distributor, ['-compartments.read.num-compartments=3']) },
+  ['dist'],
+);
+assert isError(err19, '-compartments.read.num-compartments=3') && isError(err19, 'compartments require "-compartments.read.num-compartments=2"') :
+       'case 19: expected compartments.read.num-compartments mismatch error, got: %s' % err19;
+
+// 20. Sidecars without a Mimir target are outside the common compartments config contract.
+local err20 = validate({ dist: addSidecar(distributor) }, ['dist']);
+assert err20 == null :
+       'case 20: expected a non-Mimir sidecar to be ignored, got: %s' % err20;
 
 {}

--- a/operations/mimir-tests/test-compartments-generated.yaml
+++ b/operations/mimir-tests/test-compartments-generated.yaml
@@ -306,6 +306,19 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
+    name: overrides-exporter
+  name: overrides-exporter
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: overrides-exporter
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
     name: querier-zone-a
   name: querier-zone-a
   namespace: default
@@ -1249,6 +1262,21 @@ spec:
     targetPort: 9150
   selector:
     name: memcached-zone-b-rc-1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: overrides-exporter
+  name: overrides-exporter
+  namespace: default
+spec:
+  ports:
+  - name: overrides-exporter-http-metrics
+    port: 8080
+    targetPort: 8080
+  selector:
+    name: overrides-exporter
 ---
 apiVersion: v1
 kind: Service
@@ -2355,10 +2383,13 @@ spec:
             topologyKey: kubernetes.io/hostname
       containers:
       - args:
+        - -compartments.enabled=true
+        - -compartments.read.num-compartments=2
+        - -compartments.write.num-compartments=2
         - -ingest-storage.enabled=true
-        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
-        - -ingest-storage.kafka.topic=ingest
+        - -ingest-storage.kafka.topic=ingest-rc-<read-compartment-id>
         - -memberlist.abort-if-fast-join-fails=false
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
@@ -2448,10 +2479,13 @@ spec:
             topologyKey: kubernetes.io/hostname
       containers:
       - args:
+        - -compartments.enabled=true
+        - -compartments.read.num-compartments=2
+        - -compartments.write.num-compartments=2
         - -ingest-storage.enabled=true
-        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
-        - -ingest-storage.kafka.topic=ingest
+        - -ingest-storage.kafka.topic=ingest-rc-<read-compartment-id>
         - -memberlist.abort-if-fast-join-fails=false
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+memberlist-bridge-zone-a.default.svc.cluster.local.:7946,dns+memberlist-bridge-zone-b.default.svc.cluster.local.:7946
@@ -2501,6 +2535,76 @@ spec:
         maxSkew: 1
         topologyKey: kubernetes.io/hostname
         whenUnsatisfiable: ScheduleAnyway
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    name: overrides-exporter
+  name: overrides-exporter
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: overrides-exporter
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        name: overrides-exporter
+    spec:
+      containers:
+      - args:
+        - -compactor.blocks-retention-period=0
+        - -compartments.enabled=true
+        - -compartments.read.num-compartments=2
+        - -compartments.write.num-compartments=2
+        - -distributor.ingestion-burst-size=200000
+        - -distributor.ingestion-rate-limit=10000
+        - -ingest-storage.enabled=true
+        - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
+        - -ingest-storage.kafka.topic=ingest-rc-<read-compartment-id>
+        - -ingester.max-global-metadata-per-metric=10
+        - -ingester.max-global-metadata-per-user=30000
+        - -ingester.max-global-series-per-user=150000
+        - -overrides-exporter.enabled-metrics=ingestion_burst_size,ingestion_rate,max_fetched_chunk_bytes_per_query,max_fetched_chunks_per_query,max_fetched_series_per_query,max_global_exemplars_per_user,max_global_series_per_metric,max_global_series_per_user,ruler_max_rule_groups_per_tenant,ruler_max_rules_per_rule_group
+        - -querier.max-partial-query-length=768h
+        - -ruler.max-rule-groups-per-tenant=85
+        - -ruler.max-rules-per-rule-group=20
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.http-listen-port=8080
+        - -store-gateway.tenant-shard-size=3
+        - -target=overrides-exporter
+        image: grafana/mimir:3.1.2
+        imagePullPolicy: IfNotPresent
+        name: overrides-exporter
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: http-metrics
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: "0.5"
+            memory: 0.5Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -3043,10 +3147,13 @@ spec:
             topologyKey: kubernetes.io/hostname
       containers:
       - args:
+        - -compartments.enabled=true
+        - -compartments.read.num-compartments=2
+        - -compartments.write.num-compartments=2
         - -ingest-storage.enabled=true
-        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
-        - -ingest-storage.kafka.topic=ingest
+        - -ingest-storage.kafka.topic=ingest-rc-<read-compartment-id>
         - -memberlist.abort-if-fast-join-fails=true
         - -memberlist.abort-if-fast-join-fails-min-nodes=2
         - -memberlist.bind-port=7946
@@ -3142,10 +3249,13 @@ spec:
             topologyKey: kubernetes.io/hostname
       containers:
       - args:
+        - -compartments.enabled=true
+        - -compartments.read.num-compartments=2
+        - -compartments.write.num-compartments=2
         - -ingest-storage.enabled=true
-        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
-        - -ingest-storage.kafka.topic=ingest
+        - -ingest-storage.kafka.topic=ingest-rc-<read-compartment-id>
         - -memberlist.abort-if-fast-join-fails=true
         - -memberlist.abort-if-fast-join-fails-min-nodes=2
         - -memberlist.bind-port=7946
@@ -3799,10 +3909,13 @@ spec:
             topologyKey: kubernetes.io/hostname
       containers:
       - args:
+        - -compartments.enabled=true
+        - -compartments.read.num-compartments=2
+        - -compartments.write.num-compartments=2
         - -ingest-storage.enabled=true
-        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
-        - -ingest-storage.kafka.topic=ingest
+        - -ingest-storage.kafka.topic=ingest-rc-<read-compartment-id>
         - -memberlist.abort-if-fast-join-fails=true
         - -memberlist.abort-if-fast-join-fails-min-nodes=2
         - -memberlist.bind-port=7946
@@ -3898,10 +4011,13 @@ spec:
             topologyKey: kubernetes.io/hostname
       containers:
       - args:
+        - -compartments.enabled=true
+        - -compartments.read.num-compartments=2
+        - -compartments.write.num-compartments=2
         - -ingest-storage.enabled=true
-        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
-        - -ingest-storage.kafka.topic=ingest
+        - -ingest-storage.kafka.topic=ingest-rc-<read-compartment-id>
         - -memberlist.abort-if-fast-join-fails=true
         - -memberlist.abort-if-fast-join-fails-min-nodes=2
         - -memberlist.bind-port=7946
@@ -4267,10 +4383,13 @@ spec:
         - -alertmanager.storage.path=/data
         - -alertmanager.web.external-url=http://test/alertmanager
         - -common.storage.backend=gcs
+        - -compartments.enabled=true
+        - -compartments.read.num-compartments=2
+        - -compartments.write.num-compartments=2
         - -ingest-storage.enabled=true
-        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
-        - -ingest-storage.kafka.topic=ingest
+        - -ingest-storage.kafka.topic=ingest-rc-<read-compartment-id>
         - -memberlist.abort-if-fast-join-fails=true
         - -memberlist.abort-if-fast-join-fails-min-nodes=2
         - -memberlist.bind-port=7946

--- a/operations/mimir-tests/test-compartments-generated.yaml
+++ b/operations/mimir-tests/test-compartments-generated.yaml
@@ -2550,7 +2550,7 @@ spec:
         - -distributor.ingestion-tenant-shard-size=3
         - -ingest-storage.enabled=true
         - -ingest-storage.ingestion-partition-tenant-shard-size=1
-        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
         - -ingest-storage.kafka.topic=ingest-rc-<read-compartment-id>
         - -ingester.partition-ring.prefix=
@@ -2685,7 +2685,7 @@ spec:
         - -distributor.ingestion-tenant-shard-size=3
         - -ingest-storage.enabled=true
         - -ingest-storage.ingestion-partition-tenant-shard-size=1
-        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
         - -ingest-storage.kafka.topic=ingest-rc-<read-compartment-id>
         - -ingester.partition-ring.prefix=
@@ -3300,7 +3300,7 @@ spec:
         - -distributor.ingestion-tenant-shard-size=3
         - -ingest-storage.enabled=true
         - -ingest-storage.ingestion-partition-tenant-shard-size=1
-        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
         - -ingest-storage.kafka.topic=ingest-rc-<read-compartment-id>
         - -ingester.partition-ring.prefix=
@@ -3433,7 +3433,7 @@ spec:
         - -distributor.ingestion-tenant-shard-size=3
         - -ingest-storage.enabled=true
         - -ingest-storage.ingestion-partition-tenant-shard-size=1
-        - -ingest-storage.kafka.address=kafka.default.svc.cluster.local.:9092
+        - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
         - -ingest-storage.kafka.topic=ingest-rc-<read-compartment-id>
         - -ingester.partition-ring.prefix=
@@ -4626,6 +4626,9 @@ spec:
         - -compactor-scheduler.bbolt.dir=/data
         - -compactor-scheduler.persistence-type=bbolt
         - -compactor-scheduler.planning-interval=30m
+        - -compartments.enabled=true
+        - -compartments.read.num-compartments=2
+        - -compartments.write.num-compartments=2
         - -ingest-storage.enabled=true
         - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000
@@ -4713,6 +4716,9 @@ spec:
         - -compactor-scheduler.bbolt.dir=/data
         - -compactor-scheduler.persistence-type=bbolt
         - -compactor-scheduler.planning-interval=30m
+        - -compartments.enabled=true
+        - -compartments.read.num-compartments=2
+        - -compartments.write.num-compartments=2
         - -ingest-storage.enabled=true
         - -ingest-storage.kafka.address=kafka-wc-<write-compartment-id>.default.svc.cluster.local.:9092
         - -ingest-storage.kafka.auto-create-topic-default-partitions=1000

--- a/operations/mimir-tests/test-compartments.jsonnet
+++ b/operations/mimir-tests/test-compartments.jsonnet
@@ -40,6 +40,9 @@ local env = (import 'test-ingest-storage-autoscaling-one-trigger.jsonnet') {
     autoscaling_store_gateway_min_replicas_per_compartment_zone: 1,
     autoscaling_store_gateway_max_replicas_per_compartment_zone: 3,
     enable_pvc_auto_deletion_for_store_gateways: true,
+
+    // Exercise the global overrides-exporter workload.
+    overrides_exporter_enabled: true,
   },
 };
 
@@ -48,7 +51,21 @@ local rulerDistributorAddress(zone) =
 
 local rulerBlocksBucket(args) = args[env.mimirBlocksStorageBucketNameFlag];
 
+local all(values) = std.foldl(function(acc, value) acc && value, values, true);
 local any(values) = std.foldl(function(acc, value) acc || value, values, false);
+
+local hasCommonArgs(args) = all([
+  std.objectHas(args, flag) && args[flag] == env.mimirCompartmentsCommonArgs[flag]
+  for flag in std.objectFields(env.mimirCompartmentsCommonArgs)
+]);
+
+local globalComponentArgs = {
+  alertmanager: env.alertmanager_args,
+  query_scheduler: env.query_scheduler_args,
+  ruler_query_scheduler: env.ruler_query_scheduler_args,
+  overrides_exporter: env.overrides_exporter_args,
+  memberlist_bridge: env.memberlist_bridge_args,
+};
 
 local resourceContainers(resource) =
   if resource == null ||
@@ -101,6 +118,10 @@ local dataPathCoexistenceResources = {
   compactor: dataPathCoexistenceEnv.compactor_statefulset,
   compactor_scheduler: dataPathCoexistenceEnv.compactor_scheduler_statefulset,
 };
+
+local missingCommonArgs = [name for name in std.objectFields(globalComponentArgs) if !hasCommonArgs(globalComponentArgs[name])];
+assert std.length(missingCommonArgs) == 0 :
+       'expected global Mimir component args to inherit compartments defaults; missing on: %s' % std.join(', ', missingCommonArgs);
 
 local missingCoexistenceResources = [name for name in std.objectFields(dataPathCoexistenceResources) if std.length(resourceContainers(dataPathCoexistenceResources[name])) == 0];
 assert std.length(missingCoexistenceResources) == 0 :

--- a/operations/mimir-tests/test-compartments.jsonnet
+++ b/operations/mimir-tests/test-compartments.jsonnet
@@ -48,6 +48,31 @@ local rulerDistributorAddress(zone) =
 
 local rulerBlocksBucket(args) = args[env.mimirBlocksStorageBucketNameFlag];
 
+local any(values) = std.foldl(function(acc, value) acc || value, values, false);
+
+local resourceContainers(resource) =
+  if resource == null ||
+     !std.objectHas(resource, 'spec') ||
+     !std.objectHas(resource.spec, 'template') ||
+     !std.objectHas(resource.spec.template, 'spec') ||
+     !std.objectHas(resource.spec.template.spec, 'containers') then
+    []
+  else
+    resource.spec.template.spec.containers;
+
+local rootFlagNames = [
+  '-compartments.enabled',
+  '-compartments.read.num-compartments',
+  '-compartments.write.num-compartments',
+];
+
+local hasAnyRootFlag(resource) = any([
+  std.isString(arg) && any([std.startsWith(arg, flag + '=') for flag in rootFlagNames])
+  for container in resourceContainers(resource)
+  if std.objectHas(container, 'args')
+  for arg in container.args
+]);
+
 local coexistenceEnv = env {
   _config+:: {
     no_compartments_distributor_enabled: true,
@@ -59,6 +84,31 @@ local routedCoexistenceEnv = coexistenceEnv {
     compartments_distributor_routing_enabled: true,
   },
 };
+
+local dataPathCoexistenceEnv = env {
+  _config+:: {
+    no_compartments_distributor_enabled: true,
+    no_compartments_ingester_enabled: true,
+    no_compartments_store_gateway_enabled: true,
+    no_compartments_compactor_enabled: true,
+  },
+};
+
+local dataPathCoexistenceResources = {
+  distributor: dataPathCoexistenceEnv.distributor_zone_a_deployment,
+  ingester: dataPathCoexistenceEnv.ingester_zone_a_statefulset,
+  store_gateway: dataPathCoexistenceEnv.store_gateway_zone_a_statefulset,
+  compactor: dataPathCoexistenceEnv.compactor_statefulset,
+  compactor_scheduler: dataPathCoexistenceEnv.compactor_scheduler_statefulset,
+};
+
+local missingCoexistenceResources = [name for name in std.objectFields(dataPathCoexistenceResources) if std.length(resourceContainers(dataPathCoexistenceResources[name])) == 0];
+assert std.length(missingCoexistenceResources) == 0 :
+       'expected legacy no-compartments coexistence resources to render; missing: %s' % std.join(', ', missingCoexistenceResources);
+
+local coexistenceResourcesWithRootFlags = [name for name in std.objectFields(dataPathCoexistenceResources) if hasAnyRootFlag(dataPathCoexistenceResources[name])];
+assert std.length(coexistenceResourcesWithRootFlags) == 0 :
+       'expected legacy no-compartments coexistence resources to omit compartments root flags; found on: %s' % std.join(', ', coexistenceResourcesWithRootFlags);
 
 assert env._config.compartments_distributor_routing_enabled :
        'expected compartments-only deployments to route to compartment distributors';

--- a/operations/mimir/compartments-alertmanager.libsonnet
+++ b/operations/mimir/compartments-alertmanager.libsonnet
@@ -1,0 +1,11 @@
+{
+  local isEnabled = $._config.compartments_enabled,
+
+  alertmanager_args+:: if !isEnabled then {} else $.mimirCompartmentsCommonArgs,
+
+  // Config validation.
+  local alertmanagerCompartmentConfigError = if !isEnabled then null else $.validateMimirCompartmentsConfig([
+    'alertmanager_statefulset',
+  ]),
+  assert alertmanagerCompartmentConfigError == null : alertmanagerCompartmentConfigError,
+}

--- a/operations/mimir/compartments-common.libsonnet
+++ b/operations/mimir/compartments-common.libsonnet
@@ -54,6 +54,7 @@ local jsonpath = import 'github.com/jsonnet-libs/xtd/jsonpath.libsonnet';
     'compartments.enabled': true,
     'compartments.read.num-compartments': $._config.compartments_read_count,
     'compartments.write.num-compartments': $._config.compartments_write_count,
+    'ingest-storage.kafka.address': $._config.compartments_ingest_storage_kafka_address,
     'ingest-storage.kafka.topic': $._config.compartments_ingest_storage_kafka_topic,
   },
 

--- a/operations/mimir/compartments-common.libsonnet
+++ b/operations/mimir/compartments-common.libsonnet
@@ -82,10 +82,16 @@ local jsonpath = import 'github.com/jsonnet-libs/xtd/jsonpath.libsonnet';
   blocks_chunks_zone_b_caching_configs:: $.mimirCompartmentsCreateIf(true, $._config.compartments_read_count, function(c) {}),
   blocks_chunks_zone_c_caching_configs:: $.mimirCompartmentsCreateIf(true, $._config.compartments_read_count, function(c) {}),
 
-  // Validates that per-compartment Deployments/StatefulSets configuration options are correctly
-  // parameterised for the compartment they belong to.
+  // Validates that Deployments/StatefulSets have the common compartments flags and that their
+  // configuration options are correctly parameterised for the compartment they belong to.
   validateMimirCompartmentsConfig(resourceNames)::
     local root = $;
+    local targetFlag = '-target';
+    local requiredCommonFlags = [
+      { flag: '-compartments.enabled', value: std.toString(root.mimirCompartmentsCommonArgs['compartments.enabled']) },
+      { flag: '-compartments.read.num-compartments', value: std.toString(root.mimirCompartmentsCommonArgs['compartments.read.num-compartments']) },
+      { flag: '-compartments.write.num-compartments', value: std.toString(root.mimirCompartmentsCommonArgs['compartments.write.num-compartments']) },
+    ];
     local addressFlag = '-ingest-storage.kafka.address';
     local topicFlag = '-ingest-storage.kafka.topic';
     local blocksBucketFlag = '-' + root.mimirBlocksStorageBucketNameFlag;
@@ -223,12 +229,36 @@ local jsonpath = import 'github.com/jsonnet-libs/xtd/jsonpath.libsonnet';
     local validateReadCompartmentId(name, compartment, container) =
       validateCompartmentId(name, compartment, container, readIdSuffix, 'read');
 
-    local validateContainer(name, compartment, container) =
+    local validateCommonFlag(name, container, expected) =
+      local value = flagValue(container, expected.flag);
+      if value == null then
+        'The Deployment or StatefulSet "%s" is missing "%s=%s" on the Mimir container with "%s=%s".' % [name, expected.flag, expected.value, targetFlag, flagValue(container, targetFlag)]
+      else if value != expected.value then
+        'The Deployment or StatefulSet "%s" sets "%s=%s", but compartments require "%s=%s" on every Mimir container.' % [name, expected.flag, value, expected.flag, expected.value]
+      else
+        null;
+
+    local validateCommonFlags(name, container) =
       std.foldl(
+        function(firstError, expected) if firstError != null then firstError else validateCommonFlag(name, container, expected),
+        requiredCommonFlags,
+        null
+      );
+
+    local isMimirContainer(container) = flagValue(container, targetFlag) != null;
+
+    local validateContainer(name, compartment, container) =
+      local parameterisationError = std.foldl(
         function(firstError, validator) if firstError != null then firstError else validator(name, compartment, container),
         [validateKafkaAddress, validateKafkaTopic, validateBlocksBucket, validateWriteCompartmentId, validateReadCompartmentId],
         null
       );
+      if parameterisationError != null then
+        parameterisationError
+      else if isMimirContainer(container) then
+        validateCommonFlags(name, container)
+      else
+        null;
 
     local validateResource(resource) =
       if resource == null then

--- a/operations/mimir/compartments-compactor-scheduler.libsonnet
+++ b/operations/mimir/compartments-compactor-scheduler.libsonnet
@@ -23,9 +23,7 @@
       [$.mimirBlocksStorageBucketNameFlag]: $.mimirBlocksStorageCompartmentBucketName(compartmentIdx),
 
       // The scheduler doesn't consume Kafka, but it inherits the ingest-storage args from the common config,
-      // so set them to this read compartment's values for consistency (and so the compartments config
-      // validation passes).
-      'ingest-storage.kafka.address': $._config.compartments_ingest_storage_kafka_address,
+      // so set the topic to this read compartment's value for consistency.
       'ingest-storage.kafka.topic': $.mimirIngestStorageCompartmentKafkaTopic(compartmentIdx),
     }),
 

--- a/operations/mimir/compartments-compactor-scheduler.libsonnet
+++ b/operations/mimir/compartments-compactor-scheduler.libsonnet
@@ -19,7 +19,7 @@
 
   // Args.
   compactor_scheduler_compartments_args:: $.mimirCompartmentsCreateIf(isEnabled, numCompartments, function(compartmentIdx)
-    $.compactor_scheduler_args {
+    $.compactor_scheduler_args + $.mimirCompartmentsCommonArgs {
       [$.mimirBlocksStorageBucketNameFlag]: $.mimirBlocksStorageCompartmentBucketName(compartmentIdx),
 
       // The scheduler doesn't consume Kafka, but it inherits the ingest-storage args from the common config,

--- a/operations/mimir/compartments-compactor.libsonnet
+++ b/operations/mimir/compartments-compactor.libsonnet
@@ -27,16 +27,11 @@
 
   // Args.
   compactor_compartments_args:: $.mimirCompartmentsCreateIf(isEnabled, numCompartments, function(compartmentIdx)
-    $.compactor_args + compartmentBlocksBucketArg(compartmentIdx) {
-      'compartments.enabled': true,
-      'compartments.read.num-compartments': $._config.compartments_read_count,
-      'compartments.write.num-compartments': $._config.compartments_write_count,
+    $.compactor_args + $.mimirCompartmentsCommonArgs + compartmentBlocksBucketArg(compartmentIdx) {
       'compactor.read-compartment-id': compartmentIdx,
 
       // The compactor doesn't consume Kafka, but it inherits the ingest-storage args from the common config,
-      // so set them to this read compartment's values for consistency (and so the compartments config
-      // validation passes).
-      'ingest-storage.kafka.address': $._config.compartments_ingest_storage_kafka_address,
+      // so set the topic to this read compartment's value for consistency.
       'ingest-storage.kafka.topic': $.mimirIngestStorageCompartmentKafkaTopic(compartmentIdx),
     }),
 

--- a/operations/mimir/compartments-memberlist-bridge.libsonnet
+++ b/operations/mimir/compartments-memberlist-bridge.libsonnet
@@ -1,0 +1,13 @@
+{
+  local isEnabled = $._config.compartments_enabled,
+
+  memberlist_bridge_args+:: if !isEnabled then {} else $.mimirCompartmentsCommonArgs,
+
+  // Config validation.
+  local memberlistBridgeCompartmentConfigError = if !isEnabled then null else $.validateMimirCompartmentsConfig([
+    'memberlist_bridge_zone_a_deployment',
+    'memberlist_bridge_zone_b_deployment',
+    'memberlist_bridge_zone_c_deployment',
+  ]),
+  assert memberlistBridgeCompartmentConfigError == null : memberlistBridgeCompartmentConfigError,
+}

--- a/operations/mimir/compartments-overrides-exporter.libsonnet
+++ b/operations/mimir/compartments-overrides-exporter.libsonnet
@@ -1,0 +1,11 @@
+{
+  local isEnabled = $._config.compartments_enabled,
+
+  overrides_exporter_args+:: if !isEnabled then {} else $.mimirCompartmentsCommonArgs,
+
+  // Config validation.
+  local overridesExporterCompartmentConfigError = if !isEnabled then null else $.validateMimirCompartmentsConfig([
+    'overrides_exporter_deployment',
+  ]),
+  assert overridesExporterCompartmentConfigError == null : overridesExporterCompartmentConfigError,
+}

--- a/operations/mimir/compartments-querier.libsonnet
+++ b/operations/mimir/compartments-querier.libsonnet
@@ -1,10 +1,6 @@
 {
   // Make queriers compartment-aware.
   local perCompartmentQuerierArgs = if !$._config.compartments_ingester_enabled then {} else $.mimirCompartmentsCommonArgs {
-    // Queriers inherit this otherwise unused setting through commonConfig. Keep it consistent with
-    // compartments so shared config validation can verify the rendered workload.
-    'ingest-storage.kafka.address': $._config.compartments_ingest_storage_kafka_address,
-
     // The querier reads each read compartment's dedicated blocks bucket, resolving the
     // '<read-compartment-id>' placeholder per compartment. This overrides the single bucket name set by
     // blocksStorageConfig, and is required: with compartments enabled the querier fails to start unless

--- a/operations/mimir/compartments-querier.libsonnet
+++ b/operations/mimir/compartments-querier.libsonnet
@@ -1,6 +1,10 @@
 {
   // Make queriers compartment-aware.
   local perCompartmentQuerierArgs = if !$._config.compartments_ingester_enabled then {} else $.mimirCompartmentsCommonArgs {
+    // Queriers inherit this otherwise unused setting through commonConfig. Keep it consistent with
+    // compartments so shared config validation can verify the rendered workload.
+    'ingest-storage.kafka.address': $._config.compartments_ingest_storage_kafka_address,
+
     // The querier reads each read compartment's dedicated blocks bucket, resolving the
     // '<read-compartment-id>' placeholder per compartment. This overrides the single bucket name set by
     // blocksStorageConfig, and is required: with compartments enabled the querier fails to start unless
@@ -12,4 +16,17 @@
   querier_zone_a_args+:: perCompartmentQuerierArgs,
   querier_zone_b_args+:: perCompartmentQuerierArgs,
   querier_zone_c_args+:: perCompartmentQuerierArgs,
+
+  // Config validation.
+  local querierCompartmentConfigError = if !$._config.compartments_ingester_enabled then null else $.validateMimirCompartmentsConfig([
+    'querier_deployment',
+    'querier_zone_a_deployment',
+    'querier_zone_b_deployment',
+    'querier_zone_c_deployment',
+    'ruler_querier_deployment',
+    'ruler_querier_zone_a_deployment',
+    'ruler_querier_zone_b_deployment',
+    'ruler_querier_zone_c_deployment',
+  ]),
+  assert querierCompartmentConfigError == null : querierCompartmentConfigError,
 }

--- a/operations/mimir/compartments-query-frontend.libsonnet
+++ b/operations/mimir/compartments-query-frontend.libsonnet
@@ -12,6 +12,13 @@
   // Config validation.
   local queryFrontendCompartmentConfigError = if !$._config.compartments_ingester_enabled then null else $.validateMimirCompartmentsConfig([
     'query_frontend_deployment',
+    'query_frontend_zone_a_deployment',
+    'query_frontend_zone_b_deployment',
+    'query_frontend_zone_c_deployment',
+    'ruler_query_frontend_deployment',
+    'ruler_query_frontend_zone_a_deployment',
+    'ruler_query_frontend_zone_b_deployment',
+    'ruler_query_frontend_zone_c_deployment',
   ]),
   assert queryFrontendCompartmentConfigError == null : queryFrontendCompartmentConfigError,
 }

--- a/operations/mimir/compartments-query-scheduler.libsonnet
+++ b/operations/mimir/compartments-query-scheduler.libsonnet
@@ -1,0 +1,19 @@
+{
+  local isEnabled = $._config.compartments_enabled,
+
+  // Ruler and zonal query-scheduler args are derived from this field and pick up the mixin via late binding.
+  query_scheduler_args+:: if !isEnabled then {} else $.mimirCompartmentsCommonArgs,
+
+  // Config validation.
+  local querySchedulerCompartmentConfigError = if !isEnabled then null else $.validateMimirCompartmentsConfig([
+    'query_scheduler_deployment',
+    'query_scheduler_zone_a_deployment',
+    'query_scheduler_zone_b_deployment',
+    'query_scheduler_zone_c_deployment',
+    'ruler_query_scheduler_deployment',
+    'ruler_query_scheduler_zone_a_deployment',
+    'ruler_query_scheduler_zone_b_deployment',
+    'ruler_query_scheduler_zone_c_deployment',
+  ]),
+  assert querySchedulerCompartmentConfigError == null : querySchedulerCompartmentConfigError,
+}

--- a/operations/mimir/compartments-store-gateway.libsonnet
+++ b/operations/mimir/compartments-store-gateway.libsonnet
@@ -35,18 +35,13 @@
   local isZoneBBackupMultiAZ = $._config.multi_zone_store_gateway_zone_b_backup_multi_az_enabled && std.length($._config.multi_zone_availability_zones) >= 2,
 
   // Args.
-  local perCompartmentStoreGatewayArgs(compartmentIdx) = {
+  local perCompartmentStoreGatewayArgs(compartmentIdx) = $.mimirCompartmentsCommonArgs {
     [$.mimirBlocksStorageBucketNameFlag]: $.mimirBlocksStorageCompartmentBucketName(compartmentIdx),
 
-    'compartments.enabled': true,
-    'compartments.read.num-compartments': $._config.compartments_read_count,
-    'compartments.write.num-compartments': $._config.compartments_write_count,
     'store-gateway.read-compartment-id': compartmentIdx,
 
     // The store-gateway doesn't consume Kafka, but it inherits the ingest-storage args from the common config,
-    // so set them to this read compartment's values for consistency (and so the compartments config
-    // validation passes).
-    'ingest-storage.kafka.address': $._config.compartments_ingest_storage_kafka_address,
+    // so set the topic to this read compartment's value for consistency.
     'ingest-storage.kafka.topic': $.mimirIngestStorageCompartmentKafkaTopic(compartmentIdx),
   },
 

--- a/operations/mimir/mimir.libsonnet
+++ b/operations/mimir/mimir.libsonnet
@@ -69,9 +69,12 @@
 (import 'compartments-ingester.libsonnet') +
 (import 'compartments-querier.libsonnet') +
 (import 'compartments-query-frontend.libsonnet') +
+(import 'compartments-alertmanager.libsonnet') +
+(import 'compartments-query-scheduler.libsonnet') +
 (import 'compartments-compactor.libsonnet') +
 (import 'compartments-compactor-scheduler.libsonnet') +
 (import 'compartments-store-gateway.libsonnet') +
+(import 'compartments-overrides-exporter.libsonnet') +
 (import 'compartments-memcached.libsonnet') +
 
 // Store-gateway autoscaling. Keep it after multi-zone-store-gateway (it patches those StatefulSets) and after
@@ -84,4 +87,5 @@
 
 // Add memberlist support. Keep it at the end because it overrides all Mimir components.
 (import 'memberlist.libsonnet') +
-(import 'multi-zone-memberlist-bridge.libsonnet')
+(import 'multi-zone-memberlist-bridge.libsonnet') +
+(import 'compartments-memberlist-bridge.libsonnet')


### PR DESCRIPTION
#### What this PR does

Apply the shared compartments defaults to alertmanager, query schedulers, overrides-exporter, and the memberlist bridge when compartments are enabled. These targets already inherit ingest-storage settings through `commonConfig`; their rendered configuration now uses the same enabled and count flags and parameterized Kafka defaults as the compartment data path.

Reuse the shared defaults for per-compartment compactors, compactor schedulers, and store gateways instead of duplicating their root flags and Kafka address.

Strengthen `validateMimirCompartmentsConfig()` to reject missing or mismatched root flags on Mimir containers while ignoring sidecars. Validate global, zonal, and ruler querier and query-frontend variants, and verify that legacy data-path resources continue to omit compartment flags during coexistence.

#### Which issue(s) this PR fixes or relates to

Follow-up to #16017.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If a changelog entry is not needed, add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.