### PR TITLE
querier: reduce default max concurrency to 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [CHANGE] Continuous-test: Change default values for `tests.write-read-series-test.num-series` and `tests.write-read-series-test.max-query-age` to match the values being set in jsonnet. #15705
 * [CHANGE] Update Docker image bases from Debian 12 to Debian 13 (`gcr.io/distroless/static-debian13`; race images use `base-nossl-debian13`). #15629
 * [CHANGE] Querier: Query planning metrics previously emitted with a `component="querier"` label are now emitted with a `engine="querier"` label instead, mirroring the similar metrics emitted by the query-frontend and other querier metrics. #15787
+* [CHANGE] Querier: Reduce the default concurrency of queriers, `-querier.max-concurrent`, to 8. #15984
 * [CHANGE] Query-frontend: the number of query shards is now always rounded up to the next power of two, both for the configured `-query-frontend.query-sharding-total-shards` and for the per-query computed value. #15807
 * [CHANGE] Compactor: `-compactor.split-and-merge-shards` and `-compactor.ooo-split-and-merge-shards` are now rounded up to the next power of two, so compactor and query shards always mesh (one is a divisor or multiple of the other). #15807
 * [FEATURE] Ingester: Shared tenant-fair compute worker pool. Replaces the previous per-request fanout (which could let a heavy tenant occupy all CPU) with a fixed pool of workers backed by a round-robin per-tenant queue. The label-values-cardinality endpoint is the first consumer. New experimental flags: `-ingester.compute-workers` (default 0 = GOMAXPROCS) and `-ingester.label-values-count-chunk-size` (default 32). #15493
@@ -109,6 +110,7 @@
 * [CHANGE] Query-frontend: Increase memory requested and limit to 2GiB and 4GiB respectively. #15688
 * [CHANGE] Continuous-test: Don't explicitly set `tests.write-read-series-test.num-series` and `tests.write-read-series-test.max-query-age` to their default values. #15705
 * [CHANGE] Request 50Mi of ephemeral storage for the distributor, ingester, querier, query-frontend, query-scheduler, ruler-querier, ruler-query-frontend, ruler-query-scheduler, store-gateway, compactor, compactor-scheduler and continuous-test containers. Configure with the new `ephemeral_storage_request_size` option (set it to `null` to disable). #15916
+* [CHANGE] Querier: Reduce the default concurrency of queriers, `-querier.max-concurrent`, to 8. #15984
 * [FEATURE] Compactor: add support for deploying the experimental compactor-scheduler. Enable with `compactor_scheduler_enabled: true`. #15850
 * [FEATURE] Compactor: add experimental compactor autoscaling, enabled with `autoscaling_compactor_enabled: true`. When the compactor-scheduler is enabled, compactors are autoscaled based on the estimated time to drain the scheduler queue instead of CPU utilization. #15850
 * [ENHANCEMENT] Updated rollout-operator jsonnet library to v0.38.0. #15328, #15626

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -2518,7 +2518,7 @@
           "required": false,
           "desc": "The number of workers running in each querier process. This setting limits the maximum number of concurrent queries in each querier. The minimum value is four; lower values are ignored and set to the minimum",
           "fieldValue": null,
-          "fieldDefaultValue": 20,
+          "fieldDefaultValue": 8,
           "fieldFlag": "querier.max-concurrent",
           "fieldType": "int"
         },

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2300,7 +2300,7 @@ Usage of ./cmd/mimir/mimir:
   -querier.lookback-delta duration
     	Time since the last sample after which a time series is considered stale and ignored by expression evaluations. This config option should be set on query-frontend too when query sharding is enabled. (default 5m0s)
   -querier.max-concurrent int
-    	The number of workers running in each querier process. This setting limits the maximum number of concurrent queries in each querier. The minimum value is four; lower values are ignored and set to the minimum (default 20)
+    	The number of workers running in each querier process. This setting limits the maximum number of concurrent queries in each querier. The minimum value is four; lower values are ignored and set to the minimum (default 8)
   -querier.max-concurrent-remote-read-queries int
     	Maximum number of remote read queries that can be executed concurrently. 0 or negative values mean unlimited concurrency. (default 2)
   -querier.max-estimated-fetched-chunks-per-query-multiplier float

--- a/cmd/mimir/help.txt.tmpl
+++ b/cmd/mimir/help.txt.tmpl
@@ -592,7 +592,7 @@ Usage of ./cmd/mimir/mimir:
   -querier.label-values-max-cardinality-label-names-per-request int
     	Maximum number of label names allowed to be queried in a single /api/v1/cardinality/label_values API call. (default 100)
   -querier.max-concurrent int
-    	The number of workers running in each querier process. This setting limits the maximum number of concurrent queries in each querier. The minimum value is four; lower values are ignored and set to the minimum (default 20)
+    	The number of workers running in each querier process. This setting limits the maximum number of concurrent queries in each querier. The minimum value is four; lower values are ignored and set to the minimum (default 8)
   -querier.max-fetched-chunk-bytes-per-query int
     	The maximum size of all chunks in bytes that a query can fetch from ingesters and store-gateways. This limit is enforced in the querier and ruler. 0 to disable.
   -querier.max-fetched-chunks-per-query int

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -1980,7 +1980,7 @@ store_gateway_client:
 # maximum number of concurrent queries in each querier. The minimum value is
 # four; lower values are ignored and set to the minimum
 # CLI flag: -querier.max-concurrent
-[max_concurrent: <int> | default = 20]
+[max_concurrent: <int> | default = 8]
 
 # The timeout for a query. This config option should be set on query-frontend
 # too when query sharding is enabled. This also applies to queries evaluated by

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -30,7 +30,8 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
-* [BUGFIX]: Fix bug in `ScaledObject` templates when using `kedaAutoscaling.fallback` #15793
+* [CHANGE] Querier: Reduce the default concurrency of queriers, `querier.max_concurrent`, to 8. #15984
+* [BUGFIX] Fix bug in `ScaledObject` templates when using `kedaAutoscaling.fallback` #15793
 
 ## 6.1.0
 

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -281,10 +281,7 @@ mimir:
       - dns+{{ include "mimir.fullname" . }}-gossip-ring.{{ .Release.Namespace }}.svc.{{ .Values.global.clusterDomain }}:{{ include "mimir.memberlistBindPort" . }}
 
     querier:
-      # With query sharding we run more but smaller queries. We must strike a balance
-      # which allows us to process more sharded queries in parallel when requested, but not overload
-      # queriers during non-sharded queries.
-      max_concurrent: 16
+      max_concurrent: 8
 
     query_scheduler:
       # Increase from default of 100 to account for queries created by query sharding

--- a/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/classic-architecture-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -96,7 +96,7 @@ data:
       join_members:
       - dns+classic-architecture-values-mimir-gossip-ring.citestns.svc.cluster.local.:7946
     querier:
-      max_concurrent: 16
+      max_concurrent: 8
     query_scheduler:
       max_outstanding_requests_per_tenant: 800
     ruler:

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -96,7 +96,7 @@ data:
       join_members:
       - dns+gateway-nginx-values-mimir-gossip-ring.citestns.svc.cluster.local.:7946
     querier:
-      max_concurrent: 16
+      max_concurrent: 8
     query_scheduler:
       max_outstanding_requests_per_tenant: 800
     ruler:

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -96,7 +96,7 @@ data:
       join_members:
       - dns+keda-autoscaling-global-values-mimir-gossip-ring.citestns.svc.cluster.local.:7946
     querier:
-      max_concurrent: 16
+      max_concurrent: 8
     query_scheduler:
       max_outstanding_requests_per_tenant: 800
     ruler:

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -96,7 +96,7 @@ data:
       join_members:
       - dns+keda-autoscaling-metamonitoring-values-mimir-gossip-ring.citestns.svc.cluster.local.:7946
     querier:
-      max_concurrent: 16
+      max_concurrent: 8
     query_scheduler:
       max_outstanding_requests_per_tenant: 800
     ruler:

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -96,7 +96,7 @@ data:
       join_members:
       - dns+keda-autoscaling-values-mimir-gossip-ring.citestns.svc.cluster.local.:7946
     querier:
-      max_concurrent: 16
+      max_concurrent: 8
     query_scheduler:
       max_outstanding_requests_per_tenant: 800
     ruler:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -110,7 +110,7 @@ data:
       join_members:
       - dns+large-values-mimir-gossip-ring.citestns.svc.cluster.local.:7946
     querier:
-      max_concurrent: 16
+      max_concurrent: 8
     query_scheduler:
       max_outstanding_requests_per_tenant: 800
     ruler:

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -95,7 +95,7 @@ data:
       join_members:
       - dns+metamonitoring-values-mimir-gossip-ring.citestns.svc.cluster.local.:7946
     querier:
-      max_concurrent: 16
+      max_concurrent: 8
     query_scheduler:
       max_outstanding_requests_per_tenant: 800
     ruler:

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -82,7 +82,7 @@ data:
       join_members:
       - dns+openshift-values-mimir-gossip-ring.citestns.svc.cluster.local.:7946
     querier:
-      max_concurrent: 16
+      max_concurrent: 8
     query_scheduler:
       max_outstanding_requests_per_tenant: 800
     ruler:

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -82,7 +82,7 @@ data:
       join_members:
       - dns+scheduler-name-values-mimir-gossip-ring.citestns.svc.cluster.local.:7946
     querier:
-      max_concurrent: 16
+      max_concurrent: 8
     query_scheduler:
       max_outstanding_requests_per_tenant: 800
     ruler:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -110,7 +110,7 @@ data:
       join_members:
       - dns+small-values-mimir-gossip-ring.citestns.svc.cluster.local.:7946
     querier:
-      max_concurrent: 16
+      max_concurrent: 8
     query_scheduler:
       max_outstanding_requests_per_tenant: 800
     ruler:

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -96,7 +96,7 @@ data:
       join_members:
       - dns+test-extra-args-values-mimir-gossip-ring.citestns.svc.cluster.local.:7946
     querier:
-      max_concurrent: 16
+      max_concurrent: 8
     query_scheduler:
       max_outstanding_requests_per_tenant: 800
     ruler:

--- a/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/test-extra-objects-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -96,7 +96,7 @@ data:
       join_members:
       - dns+test-extra-objects-values-mimir-gossip-ring.citestns.svc.cluster.local.:7946
     querier:
-      max_concurrent: 16
+      max_concurrent: 8
     query_scheduler:
       max_outstanding_requests_per_tenant: 800
     ruler:

--- a/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/test-gomaxprocs-override-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -96,7 +96,7 @@ data:
       join_members:
       - dns+test-gomaxprocs-override-values-mimir-gossip-ring.citestns.svc.cluster.local.:7946
     querier:
-      max_concurrent: 16
+      max_concurrent: 8
     query_scheduler:
       max_outstanding_requests_per_tenant: 800
     ruler:

--- a/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/test-ingest-storage-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -98,7 +98,7 @@ data:
       join_members:
       - dns+test-ingest-storage-values-mimir-gossip-ring.citestns.svc.cluster.local.:7946
     querier:
-      max_concurrent: 16
+      max_concurrent: 8
     query_scheduler:
       max_outstanding_requests_per_tenant: 800
     ruler:

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -96,7 +96,7 @@ data:
       join_members:
       - dns+test-ingress-values-mimir-gossip-ring.citestns.svc.cluster.local.:7946
     querier:
-      max_concurrent: 16
+      max_concurrent: 8
     query_scheduler:
       max_outstanding_requests_per_tenant: 800
     ruler:

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -82,7 +82,7 @@ data:
       join_members:
       - dns+test-oss-component-image-values-mimir-gossip-ring.citestns.svc.cluster.local.:7946
     querier:
-      max_concurrent: 16
+      max_concurrent: 8
     query_scheduler:
       max_outstanding_requests_per_tenant: 800
     ruler:

--- a/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/test-oss-emptydir-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -96,7 +96,7 @@ data:
       join_members:
       - dns+test-oss-emptydir-values-mimir-gossip-ring.citestns.svc.cluster.local.:7946
     querier:
-      max_concurrent: 16
+      max_concurrent: 8
     query_scheduler:
       max_outstanding_requests_per_tenant: 800
     ruler:

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -98,7 +98,7 @@ data:
       join_members:
       - dns+test-oss-logical-multizone-values-mimir-gossip-ring.citestns.svc.cluster.local.:7946
     querier:
-      max_concurrent: 16
+      max_concurrent: 8
     query_scheduler:
       max_outstanding_requests_per_tenant: 800
     ruler:

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -98,7 +98,7 @@ data:
       join_members:
       - dns+test-oss-multizone-values-mimir-gossip-ring.citestns.svc.cluster.local.:7946
     querier:
-      max_concurrent: 16
+      max_concurrent: 8
     query_scheduler:
       max_outstanding_requests_per_tenant: 800
     ruler:

--- a/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/test-oss-pvc-name-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -96,7 +96,7 @@ data:
       join_members:
       - dns+test-oss-pvc-name-values-mimir-gossip-ring.citestns.svc.cluster.local.:7946
     querier:
-      max_concurrent: 16
+      max_concurrent: 8
     query_scheduler:
       max_outstanding_requests_per_tenant: 800
     ruler:

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -96,7 +96,7 @@ data:
       join_members:
       - dns+test-oss-topology-spread-constraints-values-mimir-gossip-ring.citestns.svc.cluster.local.:7946
     querier:
-      max_concurrent: 16
+      max_concurrent: 8
     query_scheduler:
       max_outstanding_requests_per_tenant: 800
     ruler:

--- a/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/test-oss-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -123,7 +123,7 @@ data:
       join_members:
       - dns+test-oss-values-mimir-gossip-ring.citestns.svc.cluster.local.:7946
     querier:
-      max_concurrent: 16
+      max_concurrent: 8
     query_scheduler:
       max_outstanding_requests_per_tenant: 800
     ruler:

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -96,7 +96,7 @@ data:
       join_members:
       - dns+test-requests-and-limits-values-mimir-gossip-ring.citestns.svc.cluster.local.:7946
     querier:
-      max_concurrent: 16
+      max_concurrent: 8
     query_scheduler:
       max_outstanding_requests_per_tenant: 800
     ruler:

--- a/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/test-revisionhistorylimit-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -96,7 +96,7 @@ data:
       join_members:
       - dns+test-revisionhistorylimit-values-mimir-gossip-ring.citestns.svc.cluster.local.:7946
     querier:
-      max_concurrent: 16
+      max_concurrent: 8
     query_scheduler:
       max_outstanding_requests_per_tenant: 800
     ruler:

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -96,7 +96,7 @@ data:
       join_members:
       - dns+test-ruler-dedicated-query-path-values-mimir-gossip-ring.citestns.svc.cluster.local.:7946
     querier:
-      max_concurrent: 16
+      max_concurrent: 8
     query_scheduler:
       max_outstanding_requests_per_tenant: 800
     ruler:

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/mimir-config.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/mimir-config.yaml
@@ -96,7 +96,7 @@ data:
       join_members:
       - dns+test-vault-agent-values-mimir-gossip-ring.citestns.svc.cluster.local.:7946
     querier:
-      max_concurrent: 16
+      max_concurrent: 8
     query_scheduler:
       max_outstanding_requests_per_tenant: 800
     ruler:

--- a/operations/mimir-tests/test-helm-parity-generated.yaml
+++ b/operations/mimir-tests/test-helm-parity-generated.yaml
@@ -713,7 +713,7 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -querier.frontend-client.grpc-max-send-msg-size=419430400
-        - -querier.max-concurrent=16
+        - -querier.max-concurrent=8
         - -querier.scheduler-address=query-scheduler-discovery.default.svc.cluster.local.:9095
         - -querier.store-gateway-client.grpc-max-recv-msg-size=209715200
         - -runtime-config.file=/etc/mimir/overrides.yaml

--- a/operations/mimir-tests/test-query-sharding-generated.yaml
+++ b/operations/mimir-tests/test-query-sharding-generated.yaml
@@ -612,7 +612,7 @@ spec:
         - -memberlist.bind-port=7946
         - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
         - -querier.frontend-client.grpc-max-send-msg-size=419430400
-        - -querier.max-concurrent=16
+        - -querier.max-concurrent=8
         - -querier.max-partial-query-length=768h
         - -querier.scheduler-address=query-scheduler-discovery.default.svc.cluster.local.:9095
         - -querier.store-gateway-client.grpc-max-recv-msg-size=209715200

--- a/operations/mimir/mimir-flags-defaults.json
+++ b/operations/mimir/mimir-flags-defaults.json
@@ -167,7 +167,7 @@
   "querier.query-engine": "mimir",
   "querier.enable-query-engine-fallback": true,
   "querier.max-concurrent-remote-read-queries": 2,
-  "querier.max-concurrent": 20,
+  "querier.max-concurrent": 8,
   "querier.timeout": 120000000000,
   "querier.max-samples": 50000000,
   "querier.default-evaluation-interval": 60000000000,

--- a/operations/mimir/query-sharding.libsonnet
+++ b/operations/mimir/query-sharding.libsonnet
@@ -5,15 +5,6 @@
     // Raise the msg size for the GRPC messages query-frontend <-> querier by this factor when query sharding is enabled
     query_sharding_msg_size_factor: 4,
 
-    // The expectation is that if sharding is enabled, we would run more but smaller
-    // queries on the queriers. However this can't be extended too far because several
-    // queries (including instant queries) can't be sharded. Therefore, we must strike a balance
-    // which allows us to process more sharded queries in parallel when requested, but not overload
-    // queriers during normal queries.
-    //
-    // NOTE: we're intentionally not overriding ruler_querier_max_concurrency because it inherits querier_max_concurrency by default
-    querier_max_concurrency: if !$._config.query_sharding_enabled then super.querier_max_concurrency else 16,
-
     overrides+: if $._config.query_sharding_enabled then {
       // Target 6M active series.
       big_user+:: {

--- a/pkg/querier/engine/config.go
+++ b/pkg/querier/engine/config.go
@@ -46,7 +46,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 		return help + "This config option should be set on query-frontend too when query sharding is enabled."
 	}
 
-	f.IntVar(&cfg.MaxConcurrent, "querier.max-concurrent", 20, "The number of workers running in each querier process. This setting limits the maximum number of concurrent queries in each querier. The minimum value is four; lower values are ignored and set to the minimum")
+	f.IntVar(&cfg.MaxConcurrent, "querier.max-concurrent", 8, "The number of workers running in each querier process. This setting limits the maximum number of concurrent queries in each querier. The minimum value is four; lower values are ignored and set to the minimum")
 	f.DurationVar(&cfg.Timeout, "querier.timeout", 2*time.Minute, sharedWithQueryFrontend("The timeout for a query.")+" This also applies to queries evaluated by the ruler (internally or remotely).")
 	f.IntVar(&cfg.MaxSamples, "querier.max-samples", 50e6, sharedWithQueryFrontend("Maximum number of samples a single query can load into memory."))
 	f.DurationVar(&cfg.DefaultEvaluationInterval, "querier.default-evaluation-interval", time.Minute, sharedWithQueryFrontend("The default evaluation interval or step size for subqueries."))


### PR DESCRIPTION
#### What this PR does

Reduce the maximum concurrency of requests run in a single querier from 20 (CLI default) or 16 (jsonnet and helm). This aligns it better with the maximum amount of memory a single query can use in MQE (4GB).

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [X] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
