### PR TITLE
mixin: Don't alert on no rule groups for small environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@
 * [ENHANCEMENT] Alerts: Widen the `MimirBlockBuilderPersistentJobFailure` lookback window to 20m to prevent the alert from flapping. #15332
 * [ENHANCEMENT] Alerts: Add a native histogram variant of the `MimirRequestLatency` alert, distinguished by the `histogram` label (`classic` or `native`). #15413
 * [ENHANCEMENT] Alerts: Add a "for" period to `MimirBucketIndexNotUpdated` to avoid false-positives when a compactor restarted near the end of the previous update cycle. #15935
+* [ENHANCEMENT] Alerts: Only alert `MimirRulerInstanceHasNoRuleGroups` when other ruler instances have at least 10 rule groups assigned to avoid noise in low traffic environments. #15987
 * [ENHANCEMENT] Dashboards: Add "Rejected queries rate" panel to the Tenants dashboard showing the per-tenant rate of queries rejected by the query-frontend, split by reason. #14979
 * [ENHANCEMENT] Dashboards: Add 100th percentile to query expression percentiles graph. #15421
 * [ENHANCEMENT] Dashboards: Add the experimental streaming search API endpoints to the "Overview" per-endpoint query breakdown, and include the ingester `SearchLabelNames`/`SearchLabelValues` gRPC routes in the ingester panels of the "Reads", "Queries", and "Remote ruler reads" dashboards. #15571

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -261,9 +261,9 @@ spec:
             expr: |
               # Alert on ruler instances in microservices mode that have no rule groups assigned,
               min by(cluster, namespace, pod) (cortex_ruler_managers_total{pod=~"(.*mimir-)?ruler.*"}) == 0
-              # but only if other ruler instances of the same cell do have rule groups assigned
+              # but only if other ruler instances of the same cell do have at least 10 rule groups assigned
               and on (cluster, namespace)
-              (max by(cluster, namespace) (cortex_ruler_managers_total) > 0)
+              (max by(cluster, namespace) (cortex_ruler_managers_total) > 10)
               # and there are more than two instances overall
               and on (cluster, namespace)
               (count by (cluster, namespace) (cortex_ruler_managers_total) > 2)

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -249,9 +249,9 @@ groups:
           expr: |
             # Alert on ruler instances in microservices mode that have no rule groups assigned,
             min by(cluster, namespace, instance) (cortex_ruler_managers_total{instance=~".*ruler.*"}) == 0
-            # but only if other ruler instances of the same cell do have rule groups assigned
+            # but only if other ruler instances of the same cell do have at least 10 rule groups assigned
             and on (cluster, namespace)
-            (max by(cluster, namespace) (cortex_ruler_managers_total) > 0)
+            (max by(cluster, namespace) (cortex_ruler_managers_total) > 10)
             # and there are more than two instances overall
             and on (cluster, namespace)
             (count by (cluster, namespace) (cortex_ruler_managers_total) > 2)

--- a/operations/mimir-mixin-compiled-gem/alerts.yaml
+++ b/operations/mimir-mixin-compiled-gem/alerts.yaml
@@ -249,9 +249,9 @@ groups:
           expr: |
             # Alert on ruler instances in microservices mode that have no rule groups assigned,
             min by(cluster, namespace, pod) (cortex_ruler_managers_total{pod=~"(.*mimir-)?ruler.*"}) == 0
-            # but only if other ruler instances of the same cell do have rule groups assigned
+            # but only if other ruler instances of the same cell do have at least 10 rule groups assigned
             and on (cluster, namespace)
-            (max by(cluster, namespace) (cortex_ruler_managers_total) > 0)
+            (max by(cluster, namespace) (cortex_ruler_managers_total) > 10)
             # and there are more than two instances overall
             and on (cluster, namespace)
             (count by (cluster, namespace) (cortex_ruler_managers_total) > 2)

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -249,9 +249,9 @@ groups:
           expr: |
             # Alert on ruler instances in microservices mode that have no rule groups assigned,
             min by(cluster, namespace, pod) (cortex_ruler_managers_total{pod=~"(.*mimir-)?ruler.*"}) == 0
-            # but only if other ruler instances of the same cell do have rule groups assigned
+            # but only if other ruler instances of the same cell do have at least 10 rule groups assigned
             and on (cluster, namespace)
-            (max by(cluster, namespace) (cortex_ruler_managers_total) > 0)
+            (max by(cluster, namespace) (cortex_ruler_managers_total) > 10)
             # and there are more than two instances overall
             and on (cluster, namespace)
             (count by (cluster, namespace) (cortex_ruler_managers_total) > 2)

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -376,15 +376,15 @@ local utils = import 'mixin-utils/utils.libsonnet';
           },
         },
         {
-          // Alert if a ruler instance has no rule groups assigned while other instances in the same cell do.
+          // Alert if a ruler instance has no rule groups assigned while other instances in the same cell have a non-trivial number.
           alert: $.alertName('RulerInstanceHasNoRuleGroups'),
           'for': '1h',
           expr: |||
             # Alert on ruler instances in microservices mode that have no rule groups assigned,
             min by(%(alert_aggregation_labels)s, %(per_instance_label)s) (cortex_ruler_managers_total{%(per_instance_label)s=~"%(rulerInstanceName)s"}) == 0
-            # but only if other ruler instances of the same cell do have rule groups assigned
+            # but only if other ruler instances of the same cell do have at least 10 rule groups assigned
             and on (%(alert_aggregation_labels)s)
-            (max by(%(alert_aggregation_labels)s) (cortex_ruler_managers_total) > 0)
+            (max by(%(alert_aggregation_labels)s) (cortex_ruler_managers_total) > 10)
             # and there are more than two instances overall
             and on (%(alert_aggregation_labels)s)
             (count by (%(alert_aggregation_labels)s) (cortex_ruler_managers_total) > 2)


### PR DESCRIPTION
#### What this PR does

Change `MimirRulerInstanceHasNoRuleGroups` to only warn when other ruler instances have at least 10 rule groups (instead of any positive number) so that we aren't warning for no reason in small environments.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
