### PR TITLE
jsonnet: include commonConfig in continuous-test arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@
 * [ENHANCEMENT] Updated rollout-operator jsonnet library to v0.38.0. #15328, #15626
 * [ENHANCEMENT] Make range vector splitting configurable per query path. #15706
 * [ENHANCEMENT] Add `newMimirtoolBlocksJob` and subcommand-specific helpers to run `mimirtool blocks` as Kubernetes Jobs. #15757
+* [BUGFIX] Continuous-test: Include `._config.commonConfig` in arguments passed to continuous-test. #15988
 
 
 ### Documentation

--- a/operations/mimir/continuous-test.libsonnet
+++ b/operations/mimir/continuous-test.libsonnet
@@ -12,12 +12,14 @@ local k = import 'ksonnet-util/kausal.libsonnet';
   local containerPort = k.core.v1.containerPort,
   local deployment = k.apps.v1.deployment,
 
-  continuous_test_args:: {
-    target: 'continuous-test',
-    'tests.write-endpoint': $._config.continuous_test_write_endpoint,
-    'tests.read-endpoint': $._config.continuous_test_read_endpoint,
-    'tests.tenant-id': $._config.continuous_test_tenant_id,
-  },
+  continuous_test_args::
+    $._config.commonConfig
+    {
+      target: 'continuous-test',
+      'tests.write-endpoint': $._config.continuous_test_write_endpoint,
+      'tests.read-endpoint': $._config.continuous_test_read_endpoint,
+      'tests.tenant-id': $._config.continuous_test_tenant_id,
+    },
 
   continuous_test_node_affinity_matchers:: [],
 


### PR DESCRIPTION
Fixes an oversight from when we made continuous-test a module.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
