### PR TITLE
Fix issue where changelog check is skipped for any PR with a `backport rXXX` label

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -22,8 +22,7 @@ jobs:
         run: |
           LABELS=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')
 
-          # "grep -w" to check for the whole words
-          if echo "$LABELS" | grep -w -qE "(changelog-not-needed|dependency-update|vendored-mimir-prometheus-update|helm-weekly-release|backport)"; then
+          if echo "$LABELS" | grep -qE '^(changelog-not-needed|dependency-update|vendored-mimir-prometheus-update|helm-weekly-release|backport)$'; then
             echo "skip=true" >> $GITHUB_OUTPUT
             echo "PR has a label that skips changelog check, skipping changelog check"
           else


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue where the changelog check is skipped for PRs with a `backport rXXX` label attached.

The check should only be skipped if the `backport` label (used to identify PRs that apply a backported change to a release branch) is applied to a PR. If a `backport rXXX` label (used to request a backport to `rXXX`) is applied, the changelog check should still run.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
