### PR TITLE
MQE: ensure slice mangling is enabled for all tests by default, and fix race in unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -349,6 +349,8 @@ lint: check-makefiles check-merge-conflicts
 
 	./tools/find-unpooled-slice-creation.sh
 
+	./tools/check-mangling-returned-slices-enabled.sh
+
 	# Configured via .golangci.yml (which sets build-tags matching GO_TAGS).
 	$(LINT_GO_ENV) golangci-lint run
 

--- a/pkg/streamingpromql/benchmarks/init_test.go
+++ b/pkg/streamingpromql/benchmarks/init_test.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package benchmarks_test
+
+import (
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func init() {
+	types.EnableManglingReturnedSlices = true
+}

--- a/pkg/streamingpromql/caching/init_test.go
+++ b/pkg/streamingpromql/caching/init_test.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package caching_test
+
+import (
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func init() {
+	types.EnableManglingReturnedSlices = true
+}

--- a/pkg/streamingpromql/comparisons/init_test.go
+++ b/pkg/streamingpromql/comparisons/init_test.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package comparisons
+
+import (
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func init() {
+	types.EnableManglingReturnedSlices = true
+}

--- a/pkg/streamingpromql/compat/init_test.go
+++ b/pkg/streamingpromql/compat/init_test.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package compat_test
+
+import (
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func init() {
+	types.EnableManglingReturnedSlices = true
+}

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -66,8 +66,6 @@ const (
 )
 
 func init() {
-	types.EnableManglingReturnedSlices = true
-
 	// Set a tracer provider with in memory span exporter so we can check the spans later.
 	otel.SetTracerProvider(
 		tracesdk.NewTracerProvider(

--- a/pkg/streamingpromql/floats/init_test.go
+++ b/pkg/streamingpromql/floats/init_test.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package floats_test
+
+import (
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func init() {
+	types.EnableManglingReturnedSlices = true
+}

--- a/pkg/streamingpromql/fuzz/init_test.go
+++ b/pkg/streamingpromql/fuzz/init_test.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package fuzz
+
+import (
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func init() {
+	types.EnableManglingReturnedSlices = true
+}

--- a/pkg/streamingpromql/init_test.go
+++ b/pkg/streamingpromql/init_test.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package streamingpromql
+
+import (
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func init() {
+	types.EnableManglingReturnedSlices = true
+}

--- a/pkg/streamingpromql/operators/aggregations/init_test.go
+++ b/pkg/streamingpromql/operators/aggregations/init_test.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package aggregations_test
+
+import (
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func init() {
+	types.EnableManglingReturnedSlices = true
+}

--- a/pkg/streamingpromql/operators/aggregations/topkbottomk/init_test.go
+++ b/pkg/streamingpromql/operators/aggregations/topkbottomk/init_test.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package topkbottomk_test
+
+import (
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func init() {
+	types.EnableManglingReturnedSlices = true
+}

--- a/pkg/streamingpromql/operators/binops/init_test.go
+++ b/pkg/streamingpromql/operators/binops/init_test.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package binops_test
+
+import (
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func init() {
+	types.EnableManglingReturnedSlices = true
+}

--- a/pkg/streamingpromql/operators/functions/histogram_function.go
+++ b/pkg/streamingpromql/operators/functions/histogram_function.go
@@ -148,8 +148,7 @@ var pointBucketPool = types.NewLimitingBucketedPool(
 
 func mangleBuckets(b promql.Buckets) promql.Buckets {
 	for i := range b {
-		b[i].UpperBound = 12345678
-		b[i].Count = 12345678
+		b[i] = mangleBucket(b[i])
 	}
 	return b
 }
@@ -163,9 +162,15 @@ var bucketSliceBucketedPool = types.NewLimitingBucketedPool(
 	limiter.BucketSlices,
 	uint64(unsafe.Sizeof(promql.Bucket{})),
 	true,
-	nil,
+	mangleBucket,
 	nil,
 )
+
+func mangleBucket(b promql.Bucket) promql.Bucket {
+	b.UpperBound = 12345678
+	b.Count = 12345678
+	return b
+}
 
 func NewHistogramQuantileFunction(
 	phArg types.ScalarOperator,
@@ -480,8 +485,8 @@ func (g *histogramGrouper) saveNativeHistogramsToGroup(hPoints []promql.HPoint, 
 // called once the group's output series have all been computed.
 func (g *histogramGrouper) releaseGroup(group *bucketGroup) {
 	group.lastInputSeriesIdx = 0
-	for _, b := range group.pointBuckets {
-		bucketSliceBucketedPool.Put(&b, g.memoryConsumptionTracker)
+	for i := range group.pointBuckets {
+		bucketSliceBucketedPool.Put(&group.pointBuckets[i], g.memoryConsumptionTracker)
 	}
 	pointBucketPool.Put(&group.pointBuckets, g.memoryConsumptionTracker)
 	if group.nativeHistograms != nil {

--- a/pkg/streamingpromql/operators/functions/init_test.go
+++ b/pkg/streamingpromql/operators/functions/init_test.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package functions_test
+
+import (
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func init() {
+	types.EnableManglingReturnedSlices = true
+}

--- a/pkg/streamingpromql/operators/init_test.go
+++ b/pkg/streamingpromql/operators/init_test.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package operators_test
+
+import (
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func init() {
+	types.EnableManglingReturnedSlices = true
+}

--- a/pkg/streamingpromql/operators/selectors/init_test.go
+++ b/pkg/streamingpromql/operators/selectors/init_test.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package selectors_test
+
+import (
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func init() {
+	types.EnableManglingReturnedSlices = true
+}

--- a/pkg/streamingpromql/optimize/ast/init_test.go
+++ b/pkg/streamingpromql/optimize/ast/init_test.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package ast_test
+
+import (
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func init() {
+	types.EnableManglingReturnedSlices = true
+}

--- a/pkg/streamingpromql/optimize/ast/sharding/init_test.go
+++ b/pkg/streamingpromql/optimize/ast/sharding/init_test.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package sharding_test
+
+import (
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func init() {
+	types.EnableManglingReturnedSlices = true
+}

--- a/pkg/streamingpromql/optimize/ast/subqueryspinoff/init_test.go
+++ b/pkg/streamingpromql/optimize/ast/subqueryspinoff/init_test.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package subqueryspinoff_test
+
+import (
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func init() {
+	types.EnableManglingReturnedSlices = true
+}

--- a/pkg/streamingpromql/optimize/init_test.go
+++ b/pkg/streamingpromql/optimize/init_test.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package optimize_test
+
+import (
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func init() {
+	types.EnableManglingReturnedSlices = true
+}

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/init_test.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/init_test.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package commonsubexpressionelimination_test
+
+import (
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func init() {
+	types.EnableManglingReturnedSlices = true
+}

--- a/pkg/streamingpromql/optimize/plan/eliminate_deduplicate_and_merge_test.go
+++ b/pkg/streamingpromql/optimize/plan/eliminate_deduplicate_and_merge_test.go
@@ -1246,11 +1246,6 @@ func TestEliminateDeduplicateAndMergeOptimizationWithDelayedNameRemovalDisabled(
 }
 
 func runTestCasesWithDelayedNameRemovalDisabled(t *testing.T, globPattern string) {
-	types.EnableManglingReturnedSlices = true
-	t.Cleanup(func() {
-		types.EnableManglingReturnedSlices = false
-	})
-
 	testdataFS := os.DirFS("../../testdata")
 	testFiles, err := fs.Glob(testdataFS, globPattern)
 	require.NoError(t, err)

--- a/pkg/streamingpromql/optimize/plan/init_test.go
+++ b/pkg/streamingpromql/optimize/plan/init_test.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package plan_test
+
+import (
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func init() {
+	types.EnableManglingReturnedSlices = true
+}

--- a/pkg/streamingpromql/optimize/plan/multiaggregation/init_test.go
+++ b/pkg/streamingpromql/optimize/plan/multiaggregation/init_test.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package multiaggregation_test
+
+import (
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func init() {
+	types.EnableManglingReturnedSlices = true
+}

--- a/pkg/streamingpromql/optimize/plan/rangevectorsplitting/cache/init_test.go
+++ b/pkg/streamingpromql/optimize/plan/rangevectorsplitting/cache/init_test.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package cache_test
+
+import (
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func init() {
+	types.EnableManglingReturnedSlices = true
+}

--- a/pkg/streamingpromql/optimize/plan/rangevectorsplitting/init_test.go
+++ b/pkg/streamingpromql/optimize/plan/rangevectorsplitting/init_test.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package rangevectorsplitting_test
+
+import (
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func init() {
+	types.EnableManglingReturnedSlices = true
+}

--- a/pkg/streamingpromql/optimize/plan/remoteexec/init_test.go
+++ b/pkg/streamingpromql/optimize/plan/remoteexec/init_test.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package remoteexec_test
+
+import (
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func init() {
+	types.EnableManglingReturnedSlices = true
+}

--- a/pkg/streamingpromql/optimize/plan/splitandcache/init_test.go
+++ b/pkg/streamingpromql/optimize/plan/splitandcache/init_test.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package splitandcache_test
+
+import (
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func init() {
+	types.EnableManglingReturnedSlices = true
+}

--- a/pkg/streamingpromql/optimize/plan/splitandcache/split_operator_test.go
+++ b/pkg/streamingpromql/optimize/plan/splitandcache/split_operator_test.go
@@ -21,10 +21,6 @@ import (
 	"github.com/grafana/mimir/pkg/util/limiter"
 )
 
-func init() {
-	types.EnableManglingReturnedSlices = true
-}
-
 func TestSplitOperator(t *testing.T) {
 	firstRangeTimeRange := types.NewRangeQueryTimeRange(timestamp.Time(1), timestamp.Time(3), time.Millisecond)
 	secondRangeTimeRange := types.NewRangeQueryTimeRange(timestamp.Time(4), timestamp.Time(6), time.Millisecond)

--- a/pkg/streamingpromql/planning/analysis/init_test.go
+++ b/pkg/streamingpromql/planning/analysis/init_test.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package analysis_test
+
+import (
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func init() {
+	types.EnableManglingReturnedSlices = true
+}

--- a/pkg/streamingpromql/planning/core/init_test.go
+++ b/pkg/streamingpromql/planning/core/init_test.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package core_test
+
+import (
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func init() {
+	types.EnableManglingReturnedSlices = true
+}

--- a/pkg/streamingpromql/planning/init_test.go
+++ b/pkg/streamingpromql/planning/init_test.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package planning_test
+
+import (
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func init() {
+	types.EnableManglingReturnedSlices = true
+}

--- a/pkg/streamingpromql/planning/metrics/init_test.go
+++ b/pkg/streamingpromql/planning/metrics/init_test.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package planningmetrics_test
+
+import (
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func init() {
+	types.EnableManglingReturnedSlices = true
+}

--- a/pkg/streamingpromql/requestoptions/init_test.go
+++ b/pkg/streamingpromql/requestoptions/init_test.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package requestoptions_test
+
+import (
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func init() {
+	types.EnableManglingReturnedSlices = true
+}

--- a/pkg/streamingpromql/sliceutil/init_test.go
+++ b/pkg/streamingpromql/sliceutil/init_test.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package sliceutil_test
+
+import (
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func init() {
+	types.EnableManglingReturnedSlices = true
+}

--- a/pkg/streamingpromql/testutils/init_test.go
+++ b/pkg/streamingpromql/testutils/init_test.go
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package testutils_test
+
+import (
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func init() {
+	types.EnableManglingReturnedSlices = true
+}

--- a/pkg/streamingpromql/types/init_test.go
+++ b/pkg/streamingpromql/types/init_test.go
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package types
+
+func init() {
+	EnableManglingReturnedSlices = true
+}

--- a/tools/check-mangling-returned-slices-enabled.sh
+++ b/tools/check-mangling-returned-slices-enabled.sh
@@ -24,6 +24,61 @@ ROOT="pkg/streamingpromql"
 
 cd "$PROJECT_DIR"
 
+main() {
+  FAILURES=()
+
+  # Find every directory including and beneath the root that contains test files.
+  while IFS= read -r dir; do
+    file="$dir/init_test.go"
+
+    if [ ! -f "$file" ]; then
+      FAILURES+=("$dir (missing init_test.go)")
+      continue
+    fi
+
+    # Read the declared package name. Go enforces that it matches the directory's
+    # package, so we only need it to regenerate the expected content.
+    pkg=$(awk '$1 == "package" { print $2; exit }' "$file")
+
+    if diff <(expected_with_import "$pkg") "$file" >/dev/null 2>&1; then
+      continue
+    fi
+
+    if diff <(expected_without_import "$pkg") "$file" >/dev/null 2>&1; then
+      continue
+    fi
+
+    FAILURES+=("$dir (init_test.go does not match the required content)")
+  done < <(find "$ROOT" -name '*_test.go' -exec dirname {} \; | sort -u)
+
+  if [ ${#FAILURES[@]} -ne 0 ]; then
+    echo "The following test packages do not enable types.EnableManglingReturnedSlices in an init function:"
+    echo
+    for failure in "${FAILURES[@]}"; do
+      echo "  $failure"
+    done
+    echo
+    echo "Each test directory must contain an init_test.go with exactly this content (using the package's own name):"
+    echo
+    echo "  // SPDX-License-Identifier: AGPL-3.0-only"
+    echo
+    echo "  package <package>"
+    echo
+    echo "  import ("
+    echo "  	\"github.com/grafana/mimir/pkg/streamingpromql/types\""
+    echo "  )"
+    echo
+    echo "  func init() {"
+    echo "  	types.EnableManglingReturnedSlices = true"
+    echo "  }"
+    echo
+    echo "This helps detect use-after-return bugs by mangling slices returned to the pool."
+    exit 1
+  fi
+
+  echo "All test packages including and beneath $ROOT enable types.EnableManglingReturnedSlices in an init function."
+}
+
 # Prints the init_test.go contents expected for a package that imports the
 # types package. $1 is the package name.
 expected_with_import() {
@@ -56,55 +111,4 @@ func init() {
 EOF
 }
 
-FAILURES=()
-
-# Find every directory including and beneath the root that contains test files.
-while IFS= read -r dir; do
-  file="$dir/init_test.go"
-
-  if [ ! -f "$file" ]; then
-    FAILURES+=("$dir (missing init_test.go)")
-    continue
-  fi
-
-  # Read the declared package name. Go enforces that it matches the directory's
-  # package, so we only need it to regenerate the expected content.
-  pkg=$(awk '$1 == "package" { print $2; exit }' "$file")
-
-  if diff <(expected_with_import "$pkg") "$file" >/dev/null 2>&1; then
-    continue
-  fi
-
-  if diff <(expected_without_import "$pkg") "$file" >/dev/null 2>&1; then
-    continue
-  fi
-
-  FAILURES+=("$dir (init_test.go does not match the required content)")
-done < <(find "$ROOT" -name '*_test.go' -exec dirname {} \; | sort -u)
-
-if [ ${#FAILURES[@]} -ne 0 ]; then
-  echo "The following test packages do not enable types.EnableManglingReturnedSlices in an init function:"
-  echo
-  for failure in "${FAILURES[@]}"; do
-    echo "  $failure"
-  done
-  echo
-  echo "Each test directory must contain an init_test.go with exactly this content (using the package's own name):"
-  echo
-  echo "  // SPDX-License-Identifier: AGPL-3.0-only"
-  echo
-  echo "  package <package>"
-  echo
-  echo "  import ("
-  echo "  	\"github.com/grafana/mimir/pkg/streamingpromql/types\""
-  echo "  )"
-  echo
-  echo "  func init() {"
-  echo "  	types.EnableManglingReturnedSlices = true"
-  echo "  }"
-  echo
-  echo "This helps detect use-after-return bugs by mangling slices returned to the pool."
-  exit 1
-fi
-
-echo "All test packages including and beneath $ROOT enable types.EnableManglingReturnedSlices in an init function."
+main

--- a/tools/check-mangling-returned-slices-enabled.sh
+++ b/tools/check-mangling-returned-slices-enabled.sh
@@ -1,0 +1,77 @@
+#! /usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# This script checks that every test package including and beneath
+# pkg/streamingpromql enables types.EnableManglingReturnedSlices in an init
+# function. Mangling slices returned to the pool helps detect use-after-return
+# bugs, so we want it enabled whenever the engine's tests run.
+#
+# A single directory can contain test files split across an internal test
+# package ("xxx") and an external test package ("xxx_test"). Both are compiled
+# into the same test binary, so the init function can live in either package.
+# This script therefore checks all *_test.go files in a directory together and
+# passes the directory if any of them enables mangling in an init function.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(realpath "$(dirname "${0}")")
+PROJECT_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
+ROOT="pkg/streamingpromql"
+
+cd "$PROJECT_DIR"
+
+# Returns success if any of the given test files sets EnableManglingReturnedSlices
+# to true inside an init function.
+has_init_enabling_mangling() {
+  awk '
+    # Enter an init function. Brace tracking below detects when we leave it,
+    # allowing multiple init functions per file.
+    /^func[ \t]+init\(\)[ \t]*{/ { in_init = 1 }
+
+    in_init {
+      if (index($0, "EnableManglingReturnedSlices") && $0 ~ /=[ \t]*true/) {
+        found = 1
+      }
+
+      opens = gsub(/{/, "{")
+      closes = gsub(/}/, "}")
+      depth += opens - closes
+
+      if (depth <= 0) {
+        in_init = 0
+      }
+    }
+
+    END { exit(found ? 0 : 1) }
+  ' "$@"
+}
+
+FAILURES=()
+
+# Find every directory including and beneath the root that contains test files.
+while IFS= read -r dir; do
+  # shellcheck disable=SC2046
+  # Word splitting is intended here: pass each test file as a separate argument.
+  if ! has_init_enabling_mangling $(find "$dir" -maxdepth 1 -name '*_test.go'); then
+    FAILURES+=("$dir")
+  fi
+done < <(find "$ROOT" -name '*_test.go' -exec dirname {} \; | sort -u)
+
+if [ ${#FAILURES[@]} -ne 0 ]; then
+  echo "The following test packages do not set types.EnableManglingReturnedSlices to true in an init function:"
+  echo
+  for dir in "${FAILURES[@]}"; do
+    echo "  $dir"
+  done
+  echo
+  echo "Add an init function to one of the package's test files (either the 'xxx' or 'xxx_test' package):"
+  echo
+  echo "  func init() {"
+  echo "  	types.EnableManglingReturnedSlices = true"
+  echo "  }"
+  echo
+  echo "This helps detect use-after-return bugs by mangling slices returned to the pool."
+  exit 1
+fi
+
+echo "All test packages including and beneath $ROOT enable types.EnableManglingReturnedSlices in an init function."

--- a/tools/check-mangling-returned-slices-enabled.sh
+++ b/tools/check-mangling-returned-slices-enabled.sh
@@ -6,11 +6,15 @@
 # function. Mangling slices returned to the pool helps detect use-after-return
 # bugs, so we want it enabled whenever the engine's tests run.
 #
-# A single directory can contain test files split across an internal test
-# package ("xxx") and an external test package ("xxx_test"). Both are compiled
-# into the same test binary, so the init function can live in either package.
-# This script therefore checks all *_test.go files in a directory together and
-# passes the directory if any of them enables mangling in an init function.
+# Rather than trying to parse Go, we require each test directory to contain an
+# init_test.go file whose contents exactly match one of two canonical
+# templates. The package name is the only part allowed to vary, so we read it
+# from the file and regenerate the expected content to compare against:
+#
+#   - most packages import the types package and set
+#     types.EnableManglingReturnedSlices; and
+#   - the types package itself refers to EnableManglingReturnedSlices directly,
+#     as it cannot import itself.
 
 set -euo pipefail
 
@@ -20,51 +24,80 @@ ROOT="pkg/streamingpromql"
 
 cd "$PROJECT_DIR"
 
-# Returns success if any of the given test files sets EnableManglingReturnedSlices
-# to true inside an init function.
-has_init_enabling_mangling() {
-  awk '
-    # Enter an init function. Brace tracking below detects when we leave it,
-    # allowing multiple init functions per file.
-    /^func[ \t]+init\(\)[ \t]*{/ { in_init = 1 }
+# Prints the init_test.go contents expected for a package that imports the
+# types package. $1 is the package name.
+expected_with_import() {
+  cat <<EOF
+// SPDX-License-Identifier: AGPL-3.0-only
 
-    in_init {
-      if (index($0, "EnableManglingReturnedSlices") && $0 ~ /=[ \t]*true/) {
-        found = 1
-      }
+package $1
 
-      opens = gsub(/{/, "{")
-      closes = gsub(/}/, "}")
-      depth += opens - closes
+import (
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
 
-      if (depth <= 0) {
-        in_init = 0
-      }
-    }
+func init() {
+	types.EnableManglingReturnedSlices = true
+}
+EOF
+}
 
-    END { exit(found ? 0 : 1) }
-  ' "$@"
+# Prints the init_test.go contents expected for the types package itself, which
+# refers to EnableManglingReturnedSlices directly. $1 is the package name.
+expected_without_import() {
+  cat <<EOF
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package $1
+
+func init() {
+	EnableManglingReturnedSlices = true
+}
+EOF
 }
 
 FAILURES=()
 
 # Find every directory including and beneath the root that contains test files.
 while IFS= read -r dir; do
-  # shellcheck disable=SC2046
-  # Word splitting is intended here: pass each test file as a separate argument.
-  if ! has_init_enabling_mangling $(find "$dir" -maxdepth 1 -name '*_test.go'); then
-    FAILURES+=("$dir")
+  file="$dir/init_test.go"
+
+  if [ ! -f "$file" ]; then
+    FAILURES+=("$dir (missing init_test.go)")
+    continue
   fi
+
+  # Read the declared package name. Go enforces that it matches the directory's
+  # package, so we only need it to regenerate the expected content.
+  pkg=$(awk '$1 == "package" { print $2; exit }' "$file")
+
+  if diff <(expected_with_import "$pkg") "$file" >/dev/null 2>&1; then
+    continue
+  fi
+
+  if diff <(expected_without_import "$pkg") "$file" >/dev/null 2>&1; then
+    continue
+  fi
+
+  FAILURES+=("$dir (init_test.go does not match the required content)")
 done < <(find "$ROOT" -name '*_test.go' -exec dirname {} \; | sort -u)
 
 if [ ${#FAILURES[@]} -ne 0 ]; then
-  echo "The following test packages do not set types.EnableManglingReturnedSlices to true in an init function:"
+  echo "The following test packages do not enable types.EnableManglingReturnedSlices in an init function:"
   echo
-  for dir in "${FAILURES[@]}"; do
-    echo "  $dir"
+  for failure in "${FAILURES[@]}"; do
+    echo "  $failure"
   done
   echo
-  echo "Add an init function to one of the package's test files (either the 'xxx' or 'xxx_test' package):"
+  echo "Each test directory must contain an init_test.go with exactly this content (using the package's own name):"
+  echo
+  echo "  // SPDX-License-Identifier: AGPL-3.0-only"
+  echo
+  echo "  package <package>"
+  echo
+  echo "  import ("
+  echo "  	\"github.com/grafana/mimir/pkg/streamingpromql/types\""
+  echo "  )"
   echo
   echo "  func init() {"
   echo "  	types.EnableManglingReturnedSlices = true"


### PR DESCRIPTION
#### What this PR does

This PR enables slice mangling for tests in all MQE packages by default, and adds a script to enforce this. This would help catch issues like https://github.com/grafana/mimir/pull/15999 as part of unit testing.

This uncovered a race that only affects unit tests: `histogramGrouper.releaseGroup` could modify a `promql.Buckets` slice that had already been returned to `bucketSliceBucketedPool`, because `group.pointBuckets[i]` was not cleared before mangling of the `[]promql.Buckets` slice occured when returning `group.pointBuckets` to `pointBucketPool`.

This does not affect production query correctness, as both pools had `clearOnGet` set, and so queries running in parallel could not access or modify data from one another.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
