### PR TITLE
[release-3.0] ci: Create, attach artifacts, and publish releases automatically

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -30,8 +30,14 @@ jobs:
       - name: Get build image from Makefile
         id: build_image_step
         run: echo "build_image=$(make print-build-image)" >> "$GITHUB_OUTPUT"
+      - name: Get supported OS/arch for dist builds
+        id: dist_matrix_step
+        run: |
+          matrix=$(make print-supported-os-arch | jq -Rc 'split("\t") | {os: .[0], arch: .[1]}' | jq -sc '{include: .}')
+          echo "dist_matrix=$matrix" >> "$GITHUB_OUTPUT"
     outputs:
       build_image: ${{ steps.build_image_step.outputs.build_image }}
+      dist_matrix: ${{ steps.dist_matrix_step.outputs.dist_matrix }}
       # Determine if we will deploy (aka push) the image to the registry.
       is_deploy: ${{ (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/r')) && github.event_name == 'push' && github.repository == 'grafana/mimir' }}
 
@@ -292,6 +298,69 @@ jobs:
           artifact_name: docker-image-copyblocks
           target: "./tools/copyblocks/.uptodate"
 
+  build-dist:
+    runs-on: ubuntu-latest
+    name: build-dist (${{ matrix.os }}, ${{ matrix.arch }})
+    needs:
+      - prepare
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prepare.outputs.dist_matrix) }}
+    container:
+      image: ${{ needs.prepare.outputs.build_image }} # zizmor: ignore[unpinned-images] The image output produced by the prepare step is pinned
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - name: Run Git Config
+        run: git config --global --add safe.directory '*'
+      - name: Build
+        run: make BUILD_IN_CONTAINER=false dist GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }}
+      # Upload Linux binaries for build-packages always. The rest, for releases only.
+      - name: Upload dist artifacts
+        if: matrix.os == 'linux' || startsWith(github.ref, 'refs/tags/mimir-')
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: dist-${{ matrix.os }}-${{ matrix.arch }}
+          path: dist/
+          retention-days: 1
+
+  # Build the DEB/RPM packages that get attached to the GitHub release.
+  build-packages:
+    # Runs on ubuntu-latest (not inside the build container) because nfpm.sh needs
+    # Docker to run the jsonnet, envsubst, and nfpm helper containers.
+    runs-on: ubuntu-latest
+    needs:
+      - build-dist
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Download linux dist artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: dist-linux-*
+          path: dist
+          merge-multiple: true
+      # make packages runs nfpm against the downloaded binaries in dist/, validating that the
+      # DEB/RPM packages can be built on every push and PR (not just when cutting a release).
+      - name: Build DEB/RPM packages
+        run: make packages
+      # Only the release job consumes these, so they're only uploaded for release tags.
+      - name: Upload packages artifacts
+        if: startsWith(github.ref, 'refs/tags/mimir-')
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: packages
+          path: |
+            dist/*.deb
+            dist/*.rpm
+            dist/*.deb-sha-256
+            dist/*.rpm-sha-256
+          retention-days: 1
+
   # This job does not do anything - it exists to simplify the "needs" condition of the "deploy" job,
   # and to make it easier to configure the required passing checks in branch protection rules in GitHub,
   # as we have to specify each required passing job there. This job won't be considered successful unless
@@ -304,6 +373,8 @@ jobs:
       - build-query-tee-image
       - build-mimirtool-image
       - build-copyblocks-image
+      - build-dist
+      - build-packages
     steps:
       - run: echo "All dependencies succeeded!"
 
@@ -470,3 +541,48 @@ jobs:
       - name: Push Docker Images
         run: |
           ./.github/workflows/scripts/push-images.sh /tmp/images us-docker.pkg.dev/grafanalabs-global/dockerhub-mimir-prod-mirror/ $(make image-tag)
+
+  # Create, populate and publish the GitHub release for a Mimir release tag.
+  release:
+    needs:
+      - deploy
+      - build-dist
+      - build-packages
+    if: startsWith(github.ref, 'refs/tags/mimir-') && github.event_name == 'push' && github.repository == 'grafana/mimir'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+          # Fetch the full history and all tags so that the release notes script
+          # can compute contributor stats and locate the previous release tag.
+          fetch-depth: 0
+      - name: Download dist artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: dist-*
+          path: dist
+          merge-multiple: true
+      - name: Download packages artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: packages
+          path: dist
+      - name: Create the draft GitHub release
+        id: draft
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: echo "release=$(./tools/release/create-draft-release.sh --artifacts-dir dist)" >> "$GITHUB_OUTPUT"
+      - name: Publish the GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE: ${{ steps.draft.outputs.release }}
+        run: |
+          gh release edit "$(jq -r .tag <<< "$RELEASE")" \
+            --draft=false \
+            --latest="$(jq -r .latest <<< "$RELEASE")"

--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,18 @@ print-build-image:
 print-build-image-build-args:
 	@printf '%s\n' revision=$(GIT_REVISION) goproxyValue=$(GOPROXY_VALUE)
 
+# Supported operating systems and architectures for dist builds.
+DIST_OSES ?= linux darwin windows freebsd
+DIST_ARCHES ?= amd64 arm64
+
+.PHONY: print-supported-os-arch
+print-supported-os-arch: ## Print supported OS/arch combinations for dist.
+	@for os in $(DIST_OSES); do \
+		for arch in $(DIST_ARCHES); do \
+			printf '%s\t%s\n' "$$os" "$$arch"; \
+		done; \
+	done
+
 # We don't want find to scan inside a bunch of directories, to accelerate the
 # 'make: Entering directory '/go/src/github.com/grafana/mimir' phase.
 DONT_FIND := -name vendor -prune -o -name .git -prune -o -name .cache -prune -o -name .pkg -prune -o -name packaging -prune -o -name mimir-mixin-tools -prune -o -name trafficdump -prune -o
@@ -532,8 +544,17 @@ dist: ## Generates binaries for a Mimir release.
 	@mkdir -p ./dist
 	@# Build binaries for various architectures and operating systems. Only
 	@# mimirtool supports Windows for now.
-	@for os in linux darwin windows freebsd; do \
-		for arch in amd64 arm64; do \
+	@# When GOOS and/or GOARCH are passed on the command line, only matching
+	@# targets are built.
+	@set -e; \
+	for os in $(DIST_OSES); do \
+		if [ -n "$(filter command line,$(origin GOOS))" ] && [ "$$os" != "$(GOOS)" ]; then \
+			continue; \
+		fi; \
+		for arch in $(DIST_ARCHES); do \
+			if [ -n "$(filter command line,$(origin GOARCH))" ] && [ "$$arch" != "$(GOARCH)" ]; then \
+				continue; \
+			fi; \
 			suffix="" ; \
 			if [ "$$os" = "windows" ]; then \
 				suffix=".exe" ; \
@@ -758,7 +779,8 @@ integration-tests-race: cmd/mimir/$(UPTODATE_RACE)
 # Those vars are needed for packages target
 export VERSION
 
-packages: dist
+.PHONY: packages
+packages:
 	@packaging/nfpm/nfpm.sh
 
 # Build both arm64 and amd64 images, so that we can test deb/rpm packages for both architectures.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -96,17 +96,12 @@ If something is not clear, you can get back to this document to learn more about
     ./tools/release/tag-release.sh
     ```
   - [ ] Wait until the CI pipeline succeeds
-  - [ ] [Create a pre-release on GitHub](https://github.com/grafana/mimir/blob/main/RELEASE.md#creating-release-on-github)
-    ```bash
-    git checkout release-<version>
-    ./tools/release/create-draft-release.sh
-    ```
+    - [ ] Review the GitHub pre-release published by CI
   - [ ] [Merge the release branch release-<version> into main](https://github.com/grafana/mimir/blob/main/RELEASE.md#merging-release-branch-into-main)
     ```bash
     ./tools/release/create-pr-to-merge-release-branch-to-main.sh
     ```
     This prepares a PR into `main` branch. On approval, **use** the `merge-approved-pr-branch-to-main.sh` script, following the [instruction](https://github.com/grafana/mimir/blob/main/RELEASE.md#merging-release-branch-into-main) on how to merge the PR with "Merge commit" (i.e. we DO NOT "Squash and merge" this one).
-  - [ ] Publish the Github pre-release draft after getting review from at least one maintainer
   - [ ] Announce the release candidate on social media such as on Mimir community slack using your own Twitter, Mastodon or LinkedIn account
 - [ ] Vendor the release commit of Mimir into Grafana Enterprise Metrics (GEM)
   - _This is addressed by Grafana Labs_
@@ -132,11 +127,7 @@ If something is not clear, you can get back to this document to learn more about
     ./tools/release/tag-release.sh
     ```
   - [ ] Wait until the CI pipeline succeeds
-  - [ ] [Create a release on GitHub](https://github.com/grafana/mimir/blob/main/RELEASE.md#creating-release-on-github)
-    ```bash
-    git checkout release-<version>
-    ./tools/release/create-draft-release.sh
-    ```
+  - [ ] Review the GitHub release published by CI
   - [ ] [Merge the release branch release-<version> into main](https://github.com/grafana/mimir/blob/main/RELEASE.md#merging-release-branch-into-main)
     ```bash
     ./tools/release/create-pr-to-merge-release-branch-to-main.sh
@@ -229,39 +220,28 @@ To publish a release candidate:
 1. Do not change the release branch directly; make a PR to the release-X.Y branch with VERSION and any CHANGELOG changes.
    1. Ensure the `VERSION` file has the `-rc.X` suffix (`X` starting from `0`).
 1. After merging your PR to the release branch, run `./tools/release/tag-release.sh` to tag the new release from the release branch (see [How to tag a release](#how-to-tag-a-release)).
-1. Wait until the CI pipeline succeeds (once a tag is created, the release process through GitHub Actions will be triggered for this tag).
-1. Merge the release branch `release-x.y` into `main` (see [Merging release branch into main](#merging-release-branch-into-main))
-1. Create a pre-release on GitHub. See [Creating release on GitHub](#creating-release-on-github).
+1. Wait until the CI pipeline succeeds. Once a tag is created, CI builds the release artifacts and [creates and publishes the GitHub pre-release](#creating-release-on-github).
+1. Review the GitHub pre-release published by CI.
+1. Merge the release branch `release-x.y` into `main` (see [Merging release branch into main](#merging-release-branch-into-main)).
 
 ### Creating release on GitHub
 
-**How to create the release using the script:**
+When you [push the release tag](#how-to-tag-a-release), the [`test-build-deploy.yml`](https://github.com/grafana/mimir/actions/workflows/test-build-deploy.yml) workflow:
 
-```bash
-git checkout release-<version>
+1. Builds the release binaries (`make dist`, in the standardized build container) and the DEB/RPM packages (`make packages`).
+1. Runs [`./tools/release/create-draft-release.sh`](tools/release/create-draft-release.sh), which:
+   - Generates the release description with [`./tools/release/create-draft-release-notes.sh`](tools/release/create-draft-release-notes.sh), which contains:
+     - The CHANGELOG section for the version being released.
+     - For major and minor releases (including their release candidates), the content of the release notes document [written previously](#write-release-notes-document).
+   - Creates a draft GitHub release titled `Mimir <VERSION>` and attaches the binaries and packages to it.
+1. Publishes the release, which makes it immutable. Release candidates are published as pre-releases; stable releases are published as the final release and, when they are the newest stable release, marked as "latest".
 
-# Ensure you are authenticated and there is not a stale token in the GITHUB_TOKEN environment variable
-gh auth login
+Publishing the release makes it immutable, so make sure everything the release description needs is committed to the release branch **before** [tagging the release](#how-to-tag-a-release):
 
-# Then run the following script and follow the instructions:
-./tools/release/create-draft-release.sh
-```
+- For major and minor releases, the release notes document must be present at `docs/sources/mimir/release-notes/` on the release branch (not just on `main`). If it is missing, the `release` job fails instead of publishing an incomplete release.
+- The CHANGELOG must contain the section for the version being released.
 
-**How to create the release manually:**
-
-1. Go to https://github.com/grafana/mimir/releases/new to start a new release on GitHub (or click "Draft a new release" at https://github.com/grafana/mimir/releases page.)
-1. Select your new tag, use `Mimir <VERSION>` as Release Title. Check that "Previous tag" next to "Generate release notes" button shows previous Mimir release.
-   Click "Generate release notes" button. This will pre-fill the changelog for the release.
-   You can delete all of it, but keep "New Contributors" section and "Full Changelog" link for later.
-1. Release description consists of:
-   - "This release contains XX contributions from YY authors. Thank you!" at the beginning.
-     You can find the numbers by running `./tools/release/check-changelog.sh LAST-RELEASE-TAG...NEW-RELEASE-TAG`.
-     As an example, running the script with `mimir-2.0.0...mimir-2.1.0` argument reports `Found 417 PRs from 47 authors.`.
-   - After contributor stats, please include content of the release notes document [created previously](#write-release-notes-document).
-   - After release notes, please copy-paste content of CHANGELOG.md file since the previous release.
-   - After CHANGELOG, please include "New Contributors" section and "Full Changelog" link at the end.
-     Both were created previously by "Generate release notes" button in GitHub UI.
-1. Build binaries with `make BUILD_IN_CONTAINER=true dist` and attach them to the release (building in container ensures standardized toolchain).
+Follow the `release` job and, if it fails, fix the issue and re-run. You can preview the release details (title, pre-release/latest flags, artifacts, and description) without creating anything by running `./tools/release/create-draft-release.sh --dry-run` from the release tag.
 
 ### Publish a stable release
 
@@ -288,11 +268,9 @@ To publish a stable release:
    1. Review all updated screenshots and ensure no sensitive data is disclosed
    1. Open a PR
 1. After merging your PR to the release branch, run `./tools/release/tag-release.sh` to tag the new release from the release branch (see [How to tag a release](#how-to-tag-a-release)).
-1. Wait until the CI pipeline succeeds (once a tag is created, the release process through GitHub Actions will be triggered for this tag)
-1. Create a release on GitHub.
-   1. See [Creating release on GitHub](#creating-release-on-github) again.
-   1. Copy the release notes from pre-release version, with up-to-date CHANGELOG (if there were any changes in release candidates).
-   1. Don't forget the binaries, you'll need to build them again for this version.
+1. Wait until the CI pipeline succeeds. Once a tag is created, CI builds the release artifacts and [creates and publishes the GitHub release](#creating-release-on-github).
+   1. The description is generated from the release notes and/or CHANGELOG, so make sure they are up-to-date. Note though that it's possible to amend the description afterwards.
+1. Review the GitHub release published by CI.
 1. Merge the release branch `release-x.y` into `main` (see [Merging release branch into main](#merging-release-branch-into-main))
 1. Check the `README.md` file for any broken links.
 1. Open a PR to **add** the new version to the backward compatibility integration test (`integration/backward_compatibility_test.go`)

--- a/packaging/nfpm/nfpm.sh
+++ b/packaging/nfpm/nfpm.sh
@@ -26,7 +26,7 @@ for name in metaconvert mimir mimirtool query-tee ; do
             # Generate NFPM configuration using jsonnet
             docker run --rm \
               -v "$(pwd)/packaging/nfpm/nfpm.jsonnet:/nfpm/nfpm.jsonnet" \
-              -it 'bitnamilegacy/jsonnet:0.21.0-debian-12-r6' \
+              -i 'bitnamilegacy/jsonnet:0.21.0-debian-12-r6' \
               -V "name=${name}" -V "arch=${arch}" -V "packager=${packager}" "/nfpm/nfpm.jsonnet" > "${config_path}"
 
             # Generate package dependencies using envsubst
@@ -39,7 +39,7 @@ for name in metaconvert mimir mimirtool query-tee ; do
                     -v "$(pwd)/packaging/nfpm/${name}:/work" \
                     -v "$(pwd)/${pkg_dependencies_path}:/processed" \
                     -e "OS_ENV_DIR=${os_env_dir}" \
-                    -it 'bhgedigital/envsubst' \
+                    -i 'bhgedigital/envsubst' \
                     sh -c "envsubst '\${OS_ENV_DIR}' < /work/${dependency} > /processed/${dependency}"
               done
             fi
@@ -48,7 +48,7 @@ for name in metaconvert mimir mimirtool query-tee ; do
               -v  "$(pwd):/work:delegated,z" \
               -w /work \
               -e "VERSION=${VERSION}" \
-              -it goreleaser/nfpm:v2.22.2 \
+              -i goreleaser/nfpm:v2.22.2 \
               package \
               --config ${config_path} \
               --packager ${packager} \

--- a/tools/release/create-draft-release-notes.sh
+++ b/tools/release/create-draft-release-notes.sh
@@ -11,7 +11,8 @@ check_required_setup
 find_last_release
 find_prev_release
 
-CHANGELOG_PATH="${CURR_DIR}/../../CHANGELOG.md"
+REPO_ROOT="${CURR_DIR}/../.."
+CHANGELOG_PATH="${REPO_ROOT}/CHANGELOG.md"
 
 #
 # Contributors
@@ -32,16 +33,26 @@ fi
 # Release notes
 #
 
-# We don't publish release notes for patch versions.
-PREV_RELEASE_MINOR_VERSION=$(echo -n "${PREV_RELEASE_VERSION}" | grep -Eo '^[0-9]+\.[0-9]+')
-LAST_RELEASE_MINOR_VERSION=$(echo -n "${LAST_RELEASE_VERSION}" | grep -Eo '^[0-9]+\.[0-9]+')
+# We only publish release notes for major and minor releases (including their release
+# candidates), which are the ones whose patch version is 0. Patch releases only get a CHANGELOG.
+RELEASE_PATCH=$(echo -n "${LAST_RELEASE_VERSION}" | $SED -E 's/^[0-9]+\.[0-9]+\.([0-9]+).*/\1/')
+RELEASE_MINOR=$(echo -n "${LAST_RELEASE_VERSION}" | grep -Eo '^[0-9]+\.[0-9]+')
 
-if [ "${PREV_RELEASE_MINOR_VERSION}" != "${LAST_RELEASE_MINOR_VERSION}" ]; then
-  # Title
-  printf "# Grafana Mimir version %s release notes\n\n" "${LAST_RELEASE_VERSION}"
+if [ "${RELEASE_PATCH}" = "0" ]; then
+  RELEASE_NOTES_DOC="${REPO_ROOT}/docs/sources/mimir/release-notes/v${RELEASE_MINOR}.md"
 
-  # Add a place holder for the release notes.
-  printf "**TODO: add release notes here**\n\n"
+  if [ ! -f "${RELEASE_NOTES_DOC}" ]; then
+    echo "Expected release notes document '${RELEASE_NOTES_DOC}' for release ${LAST_RELEASE_VERSION}, but it was not found." > /dev/stderr
+    echo "The release notes document must be committed to the release branch before tagging the release." > /dev/stderr
+    exit 1
+  fi
+
+  FIRST_HEADING_LINE=$(grep -n -m1 '^# ' "${RELEASE_NOTES_DOC}" | cut -d: -f1)
+  tail -n +"${FIRST_HEADING_LINE}" "${RELEASE_NOTES_DOC}" | # Remove everything before the first heading (the YAML front matter)
+    $SED -E '/^<!--.*-->$/d' | # Remove HTML comments (e.g. vale directives)
+    $SED -E '/^\{\{[<%].*[%>]\}\}$/d' | # Remove Hugo shortcodes, keeping inner content
+    $SED "s|<MIMIR_VERSION>|v${RELEASE_MINOR}.x|g" # Replace the docs version placeholder that the website resolves at publish time
+  printf "\n"
 fi
 
 #

--- a/tools/release/create-draft-release.sh
+++ b/tools/release/create-draft-release.sh
@@ -1,5 +1,17 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: AGPL-3.0-only
+#
+# Creates a draft GitHub release for the release tag currently checked out.
+#
+# It prints a JSON object with the release metadata needed to publish it:
+#
+#   {"tag": "...", "title": "...", "prerelease": <bool>, "latest": <bool>}
+#
+# Usage:
+#   create-draft-release.sh [--dry-run] [--artifacts-dir DIR]
+#
+#   --dry-run            Don't create the draft release, just print the release details.
+#   --artifacts-dir DIR  Directory containing the artifacts to attach (default: ./dist).
 
 set -e
 
@@ -7,32 +19,101 @@ set -e
 CURR_DIR="$(dirname "$0")"
 . "${CURR_DIR}/common.sh"
 
+DRY_RUN=false
+ARTIFACTS_DIR="${CURR_DIR}/../../dist"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    --artifacts-dir)
+      ARTIFACTS_DIR="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" > /dev/stderr
+      exit 1
+      ;;
+  esac
+done
+
 check_required_setup
 find_last_release
+find_prev_release
 
-# Build binaries and packages.
-echo "Building binaries (this may take a while)..."
-cd "${CURR_DIR}"/../../ && make dist packages && cd -
+# Release candidates (version ending in -rc.N) are published as pre-releases and are never
+# marked as "latest".
+if [[ "${LAST_RELEASE_VERSION}" == *-rc.* ]]; then
+  PRERELEASE=true
+  LATEST=false
+else
+  PRERELEASE=false
+  # Only mark as "latest" when this is the newest stable release, so that patching an older
+  # minor doesn't steal the "latest" badge from a newer one.
+  NEWEST_STABLE_TAG=$(git tag --list 'mimir-[0-9]*' | grep -E '^mimir-[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1)
+  if [ "${NEWEST_STABLE_TAG}" = "${LAST_RELEASE_TAG}" ]; then
+    LATEST=true
+  else
+    LATEST=false
+  fi
+fi
 
-# Generate release notes draft.
-echo "Generating the draft release notes..."
-RELEASE_NOTES_FILE="./tmp-release-notes.md"
+RELEASE_TITLE="Mimir ${LAST_RELEASE_VERSION}"
+
+# Generate the release notes.
+RELEASE_NOTES_FILE="$(mktemp)"
 trap 'rm -f "${RELEASE_NOTES_FILE}"' EXIT
 "${CURR_DIR}"/create-draft-release-notes.sh > "${RELEASE_NOTES_FILE}"
 
-# Create the draft release.
-echo "Creating the draft release (uploading assets may take a while)..."
-gh release create \
-  --draft \
-  --prerelease \
-  --title "${LAST_RELEASE_VERSION}" \
-  --notes-file "${RELEASE_NOTES_FILE}" \
-  "${LAST_RELEASE_TAG}" "${CURR_DIR}"/../../dist/*
+{
+  echo "Artifacts:"
+  for artifact in "${ARTIFACTS_DIR}"/*; do
+    [ -f "${artifact}" ] || continue
+    printf '%s\t%s\tsha256:%s\n' "$(basename "${artifact}")" "$(du -h "${artifact}" | cut -f1)" "$(sha256sum "${artifact}" | cut -d' ' -f1)"
+  done
+} > /dev/stderr
 
-# Print instructions to move on.
-echo ""
-echo "The draft release has been created. To continue:"
-echo "1. Copy the release notes from the documentation and fix the links. Skip if publishing a patch release."
-echo "2. Review the draft release."
-echo "3. If this is a stable release, remove the tick from 'This is a pre-release'."
-echo "4. Publish it."
+if [ "${DRY_RUN}" = "true" ]; then
+  {
+    echo ""
+    echo "Release notes:"
+    echo "----------------------------------------"
+    cat "${RELEASE_NOTES_FILE}"
+    echo "----------------------------------------"
+
+    echo "Dry run: not creating the draft release ${LAST_RELEASE_TAG}."
+  } > /dev/stderr
+else
+  # Create the release as a draft, so the artifacts can be attached before the caller publishes
+  # it (and it becomes immutable). If a draft already exists (e.g. this is a re-run after a
+  # transient failure), update it instead so that re-runs are idempotent.
+  if gh release view "${LAST_RELEASE_TAG}" > /dev/null 2>&1; then
+    echo "Updating existing release ${LAST_RELEASE_TAG}..." > /dev/stderr
+    gh release edit "${LAST_RELEASE_TAG}" \
+      --draft \
+      --prerelease="${PRERELEASE}" \
+      --title "${RELEASE_TITLE}" \
+      --notes-file "${RELEASE_NOTES_FILE}" > /dev/stderr
+  else
+    echo "Creating the draft release ${LAST_RELEASE_TAG}..." > /dev/stderr
+    gh release create "${LAST_RELEASE_TAG}" \
+      --draft \
+      --prerelease="${PRERELEASE}" \
+      --title "${RELEASE_TITLE}" \
+      --notes-file "${RELEASE_NOTES_FILE}" > /dev/stderr
+  fi
+
+  echo "Attaching the artifacts..." > /dev/stderr
+  gh release upload "${LAST_RELEASE_TAG}" "${ARTIFACTS_DIR}"/* --clobber > /dev/stderr
+
+  echo "Draft release created: https://github.com/grafana/mimir/releases/tag/${LAST_RELEASE_TAG}" > /dev/stderr
+fi
+
+jq -nc \
+  --arg tag "${LAST_RELEASE_TAG}" \
+  --arg title "${RELEASE_TITLE}" \
+  --argjson prerelease "${PRERELEASE}" \
+  --argjson latest "${LATEST}" \
+  '{tag: $tag, title: $title, prerelease: $prerelease, latest: $latest}'


### PR DESCRIPTION
Backport 61cc9fffb4a05268353774c83833d17167048b99 from #15505

It also brings over some dependencies (`build-dist`) that weren't in release-3.0.