### PR TITLE
Update warpstream-go with the produce record-reuse fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853
-	github.com/grafana/warpstream-go v0.0.0-20260625083726-8ebc81451c89
+	github.com/grafana/warpstream-go v0.0.0-20260708135512-e5879b5c8615
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/hashicorp/vault/api v1.23.0
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
@@ -74,7 +74,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/thanos-io/objstore v0.0.0-20260615134008-fb6fd3a5170a
 	github.com/tjhop/slog-gokit v0.2.0
-	github.com/twmb/franz-go v1.21.4
+	github.com/twmb/franz-go v1.21.5
 	github.com/twmb/franz-go/pkg/kadm v1.18.1-0.20260529212035-11b03a277c72
 	github.com/twmb/franz-go/pkg/kfake v0.0.0-20260515175617-8268a5d078c0
 	github.com/twmb/franz-go/pkg/kmsg v1.13.1

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853
-	github.com/grafana/warpstream-go v0.0.0-20260708135512-e5879b5c8615
+	github.com/grafana/warpstream-go v0.0.0-20260708155533-24eb1aa7aa2b
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/hashicorp/vault/api v1.23.0
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853
-	github.com/grafana/warpstream-go v0.0.0-20260708155533-24eb1aa7aa2b
+	github.com/grafana/warpstream-go v0.0.0-20260709145107-2e28adcc4bff
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/hashicorp/vault/api v1.23.0
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db

--- a/go.sum
+++ b/go.sum
@@ -590,8 +590,8 @@ github.com/grafana/pyroscope-go/godeltaprof v0.1.9 h1:c1Us8i6eSmkW+Ez05d3co8kasn
 github.com/grafana/pyroscope-go/godeltaprof v0.1.9/go.mod h1:2+l7K7twW49Ct4wFluZD3tZ6e0SjanjcUUBPVD/UuGU=
 github.com/grafana/regexp v0.0.0-20250905101755-5eb4f3acbf71 h1:A4D22zZV7+EeQk9TeATDDY/PG2wnzdqKcj4IZq+PcwA=
 github.com/grafana/regexp v0.0.0-20250905101755-5eb4f3acbf71/go.mod h1:+JKpmjMGhpgPL+rXZ5nsZieVzvarn86asRlBg4uNGnk=
-github.com/grafana/warpstream-go v0.0.0-20260625083726-8ebc81451c89 h1:KVQJldbpxTf5rNhp30+WqPOu4FBOt8nZq+tPaa2uKeE=
-github.com/grafana/warpstream-go v0.0.0-20260625083726-8ebc81451c89/go.mod h1:iSsYPL1NaE7fLP9GRHhN62jaUgnPf5h8agzwOWpc9FE=
+github.com/grafana/warpstream-go v0.0.0-20260708135512-e5879b5c8615 h1:YfjfuVta5OzEZswFCf2OhoRboblUsNuclvT1GevCBEM=
+github.com/grafana/warpstream-go v0.0.0-20260708135512-e5879b5c8615/go.mod h1:9iFIyD7D+F+2Hsk+P6PNMBH8E+JYxPsLGIP2p46L1s0=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=
@@ -1018,8 +1018,8 @@ github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=
 github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
-github.com/twmb/franz-go v1.21.4 h1:skglTjGHOHHKxVdUG3A563gynBDhvSWFBBHXKOOMS8M=
-github.com/twmb/franz-go v1.21.4/go.mod h1:rfoMTnVk7107fhTGxfEKIHP/e7tPe6oyij/ywzO0czk=
+github.com/twmb/franz-go v1.21.5 h1:cVYI2+JTTKSvohhy8bCOleYrS7G79ZBrLVFIJsoHm8M=
+github.com/twmb/franz-go v1.21.5/go.mod h1:rfoMTnVk7107fhTGxfEKIHP/e7tPe6oyij/ywzO0czk=
 github.com/twmb/franz-go/pkg/kadm v1.18.1-0.20260529212035-11b03a277c72 h1:Uk0p3O2EPbqosXuSA6bhRMhbu+zt42Xv1G/h59fDX4s=
 github.com/twmb/franz-go/pkg/kadm v1.18.1-0.20260529212035-11b03a277c72/go.mod h1:cw/5ILOe0iIKJ81GwmCKwP11wnbU3YlMAa++wdZQHB4=
 github.com/twmb/franz-go/pkg/kfake v0.0.0-20260515175617-8268a5d078c0 h1:YWmvjmcidrKLLgObwU1k7K9KuesdYTV33OTIS0Ltj8o=

--- a/go.sum
+++ b/go.sum
@@ -590,8 +590,8 @@ github.com/grafana/pyroscope-go/godeltaprof v0.1.9 h1:c1Us8i6eSmkW+Ez05d3co8kasn
 github.com/grafana/pyroscope-go/godeltaprof v0.1.9/go.mod h1:2+l7K7twW49Ct4wFluZD3tZ6e0SjanjcUUBPVD/UuGU=
 github.com/grafana/regexp v0.0.0-20250905101755-5eb4f3acbf71 h1:A4D22zZV7+EeQk9TeATDDY/PG2wnzdqKcj4IZq+PcwA=
 github.com/grafana/regexp v0.0.0-20250905101755-5eb4f3acbf71/go.mod h1:+JKpmjMGhpgPL+rXZ5nsZieVzvarn86asRlBg4uNGnk=
-github.com/grafana/warpstream-go v0.0.0-20260708135512-e5879b5c8615 h1:YfjfuVta5OzEZswFCf2OhoRboblUsNuclvT1GevCBEM=
-github.com/grafana/warpstream-go v0.0.0-20260708135512-e5879b5c8615/go.mod h1:9iFIyD7D+F+2Hsk+P6PNMBH8E+JYxPsLGIP2p46L1s0=
+github.com/grafana/warpstream-go v0.0.0-20260708155533-24eb1aa7aa2b h1:Ll5zW/c5LOynYBlkomDE3yRmL3hfSrS1JiHUsMT2Xg0=
+github.com/grafana/warpstream-go v0.0.0-20260708155533-24eb1aa7aa2b/go.mod h1:9iFIyD7D+F+2Hsk+P6PNMBH8E+JYxPsLGIP2p46L1s0=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=

--- a/go.sum
+++ b/go.sum
@@ -590,8 +590,8 @@ github.com/grafana/pyroscope-go/godeltaprof v0.1.9 h1:c1Us8i6eSmkW+Ez05d3co8kasn
 github.com/grafana/pyroscope-go/godeltaprof v0.1.9/go.mod h1:2+l7K7twW49Ct4wFluZD3tZ6e0SjanjcUUBPVD/UuGU=
 github.com/grafana/regexp v0.0.0-20250905101755-5eb4f3acbf71 h1:A4D22zZV7+EeQk9TeATDDY/PG2wnzdqKcj4IZq+PcwA=
 github.com/grafana/regexp v0.0.0-20250905101755-5eb4f3acbf71/go.mod h1:+JKpmjMGhpgPL+rXZ5nsZieVzvarn86asRlBg4uNGnk=
-github.com/grafana/warpstream-go v0.0.0-20260708155533-24eb1aa7aa2b h1:Ll5zW/c5LOynYBlkomDE3yRmL3hfSrS1JiHUsMT2Xg0=
-github.com/grafana/warpstream-go v0.0.0-20260708155533-24eb1aa7aa2b/go.mod h1:9iFIyD7D+F+2Hsk+P6PNMBH8E+JYxPsLGIP2p46L1s0=
+github.com/grafana/warpstream-go v0.0.0-20260709145107-2e28adcc4bff h1:mOsGwr9eKhnZ9jPjCyRVDVkrMmDncWZmBzkG54NSyUs=
+github.com/grafana/warpstream-go v0.0.0-20260709145107-2e28adcc4bff/go.mod h1:9iFIyD7D+F+2Hsk+P6PNMBH8E+JYxPsLGIP2p46L1s0=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/agent_record_buffer.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/agent_record_buffer.go
@@ -5,48 +5,36 @@ import (
 	"errors"
 	"sync"
 	"time"
-
-	"github.com/twmb/franz-go/pkg/kgo"
 )
 
 // errBufferClosed is returned to Add callers attempting to enqueue after Close.
 var errBufferClosed = errors.New("record buffer is closed")
 
-// AgentFlushFunc is invoked by AgentRecordBuffer when a batch is ready to
-// send. The function only produces the batch and returns the resulting
-// ProduceResult. A successful outcome must carry a non-nil resp; an error-only
-// (or zero) ProduceResult is treated as a failure by completion handling.
-//
-// The partitions it receives satisfy two guarantees:
-//
-//   - All belong to nodeID — the agent that owns the AgentRecordBuffer doing
-//     the flush — because the buffer bins incoming routed entries by nodeID.
-//   - At most one entry per (topic, partition). The buffer coalesces
-//     same-partition records into a single entry before the call, because the
-//     produce/hedge path keys per-partition state by (topic, partition) and
-//     rejects duplicates (see produceResultAccumulator).
-type AgentFlushFunc func(ctx context.Context, nodeID int32, partitions []routedTopicPartitionRecords) ProduceResult
+// AgentFlushFunc produces one agent's batch of wire items — all targeting
+// nodeID, at most one entry per (topic, partition) — and returns the outcome. A
+// successful outcome must carry a non-nil resp; an error-only or zero
+// ProduceResult counts as a failure.
+type AgentFlushFunc[W routedBatch[W]] func(ctx context.Context, nodeID int32, wire []W) ProduceResult
 
-// AgentRecordBuffer accumulates records targeted at one Warpstream agent and
-// flushes them as a single ProduceRequest on linger expiry, batch-size
-// overflow, or Close. It exists because Warpstream's stateless model lets a
-// single Produce request to one agent carry batches for many partitions —
-// the natural unit of batching here is "records bound for this agent",
-// independent of how many topics or partitions they span.
+// AgentBuffer accumulates items targeted at one Warpstream agent and flushes
+// them as a single ProduceRequest on linger expiry, batch-size overflow, or
+// Close. It exists because Warpstream's stateless model lets a single Produce
+// request to one agent carry batches for many partitions — the natural unit of
+// batching here is "items bound for this agent", independent of how many topics
+// or partitions they span.
 //
 // The buffer is intentionally narrow: it knows nothing about routing,
-// resolvers, hedging, or other agents. ClusterRecordBuffer owns those
-// concerns. This split keeps the per-agent contention surface small (one
-// mutex per agent) and keeps the multi-agent fan-in logic out of the hot
-// per-record path. Concurrent Adds for *different* agents never touch the
-// same mutex.
+// resolvers, hedging, or other agents. ClusterBuffer owns those concerns. This
+// split keeps the per-agent contention surface small (one mutex per agent) and
+// keeps the multi-agent fan-in logic out of the hot per-item path. Concurrent
+// Adds for *different* agents never touch the same mutex.
 //
 // Two design choices stand out:
 //
 //   - Linger bounds batching on the steady path: the typical deployment has
 //     many concurrent client processes producing to the same Warpstream
 //     cluster, and lingering lets us amortise the Produce request cost. A
-//     batch still flushes early when adding the next record would exceed the
+//     batch still flushes early when adding the next item would exceed the
 //     byte cap, so linger is an upper bound on batching delay, not a floor.
 //   - Each flush runs in its own goroutine so the buffer can immediately
 //     start accumulating the next batch. This means multiple Produce
@@ -55,31 +43,30 @@ type AgentFlushFunc func(ctx context.Context, nodeID int32, partitions []routedT
 //     stateless, ordering between requests doesn't matter for the produce
 //     contract this client exposes, and the cap that would matter (memory
 //     pressure) is enforced by the caller upstream.
-type AgentRecordBuffer struct {
+type AgentBuffer[W routedBatch[W]] struct {
 	nodeID        int32
 	linger        time.Duration
 	batchMaxBytes int32
-	flush         AgentFlushFunc
+	flush         AgentFlushFunc[W]
 	metrics       *metrics
 
-	mu                        sync.Mutex
-	nextProduceFirstTimestamp int64
-	nextProducePartitions     []promisedRoutedTopicPartitionRecords
-	nextProduceRecords        int
-	nextProduceWireBytes      int64
-	nextProduceFlushTimer     *time.Timer
-	closed                    bool
+	mu                    sync.Mutex
+	nextProduceItems      []promised[W]
+	nextProduceRecords    int
+	nextProduceWireBytes  int64
+	nextProduceFlushTimer *time.Timer
+	closed                bool
 
 	flushWG        sync.WaitGroup
 	flushCtx       context.Context
 	cancelFlushCtx context.CancelFunc
 }
 
-// NewAgentRecordBuffer returns a buffer for records destined to nodeID.
-// flush runs in a background goroutine when a batch is ready.
-func NewAgentRecordBuffer(nodeID int32, linger time.Duration, batchMaxBytes int32, flush AgentFlushFunc, m *metrics) *AgentRecordBuffer {
+// NewAgentBuffer returns a buffer for items destined to nodeID. flush runs in a
+// background goroutine when a batch is ready.
+func NewAgentBuffer[W routedBatch[W]](nodeID int32, linger time.Duration, batchMaxBytes int32, flush AgentFlushFunc[W], m *metrics) *AgentBuffer[W] {
 	ctx, cancel := context.WithCancel(context.Background())
-	return &AgentRecordBuffer{
+	return &AgentBuffer[W]{
 		nodeID:         nodeID,
 		linger:         linger,
 		batchMaxBytes:  batchMaxBytes,
@@ -90,31 +77,31 @@ func NewAgentRecordBuffer(nodeID int32, linger time.Duration, batchMaxBytes int3
 	}
 }
 
-// Add buffers partition groups for produce. Each group's done fires exactly
-// once with its terminal outcome.
-func (a *AgentRecordBuffer) Add(partitions []promisedRoutedTopicPartitionRecords) {
+// Add buffers items for produce. Each item's done fires exactly once with its
+// terminal outcome.
+func (a *AgentBuffer[W]) Add(items []promised[W]) {
 	incoming := 0
-	for _, p := range partitions {
-		incoming += len(p.records)
+	for i := range items {
+		incoming += items[i].item.recordCount()
 	}
 	if incoming == 0 {
 		return
 	}
 
-	// Split any group whose own RecordBatch would exceed batchMaxBytes into
+	// Split any item whose own RecordBatch would exceed batchMaxBytes into
 	// chunks that each fit, so no single flushed per-partition batch can be
-	// rejected MessageTooLarge. Chunks are then added one at a time below, and
-	// because each is <= batchMaxBytes the overflow check keeps nextProduceWireBytes
-	// (and therefore every per-partition batch) within the cap.
-	chunks := make([]promisedRoutedTopicPartitionRecords, 0, len(partitions))
-	for _, p := range partitions {
-		chunks = append(chunks, splitPromisedRoutedTopicPartitionRecordsByBatchMaxBytes(p, a.batchMaxBytes)...)
+	// rejected MessageTooLarge. Chunks are added one at a time below, and
+	// because each is <= batchMaxBytes the overflow check keeps
+	// nextProduceWireBytes (and therefore every per-partition batch) within the cap.
+	chunks := make([]promised[W], 0, len(items))
+	for _, p := range items {
+		chunks = append(chunks, splitPromisedRoutedBatchByBatchMaxBytes(p, a.batchMaxBytes)...)
 	}
 
 	a.mu.Lock()
 	if a.closed {
 		// Closed buffer: there is no flush to carry the outcome, so resolve
-		// every group's done synchronously with errBufferClosed.
+		// every item's done synchronously with errBufferClosed.
 		a.mu.Unlock()
 		for _, p := range chunks {
 			p.done(ProduceResult{err: errBufferClosed})
@@ -131,58 +118,24 @@ func (a *AgentRecordBuffer) Add(partitions []promisedRoutedTopicPartitionRecords
 	a.mu.Unlock()
 }
 
-// addToNextProduceLocked appends one group (already <= batchMaxBytes) to the
-// pending produce, flushing first when it wouldn't fit. Groups are never merged
+// addToNextProduceLocked appends one item (already <= batchMaxBytes) to the
+// pending produce, flushing first when it wouldn't fit. Items are never merged
 // here: same-partition entries are coalesced into one wire batch at flush time
-// (startFlushLocked), which keeps each group's done untouched. Caller must hold
+// (startFlushLocked), which keeps each item's done untouched. Caller must hold
 // a.mu.
-func (a *AgentRecordBuffer) addToNextProduceLocked(p promisedRoutedTopicPartitionRecords) {
-	addBytes, firstTS := a.computeAddCostLocked(p.records)
+func (a *AgentBuffer[W]) addToNextProduceLocked(p promised[W]) {
+	addBytes := p.item.wireBytes()
 	if a.nextProduceRecords > 0 && a.nextProduceWireBytes+addBytes > int64(a.batchMaxBytes) {
-		// Re-cost after the forced flush: the batch overhead and offsetDelta
-		// values reset, so the original addBytes no longer applies.
 		a.startFlushLocked()
-		addBytes, firstTS = a.computeAddCostLocked(p.records)
 	}
-
-	if a.nextProduceRecords == 0 {
-		// Fresh produce: anchor timestamp.
-		a.nextProduceFirstTimestamp = firstTS
-	}
-	a.nextProducePartitions = append(a.nextProducePartitions, p)
-	a.nextProduceRecords += len(p.records)
+	a.nextProduceItems = append(a.nextProduceItems, p)
+	a.nextProduceRecords += p.item.recordCount()
 	a.nextProduceWireBytes += addBytes
 }
 
-// computeAddCostLocked returns the additional wire bytes that appending records
-// to the pending produce would contribute, plus the firstTimestamp that anchors
-// the computation (the pending produce's existing anchor when non-empty, the
-// first incoming record's timestamp otherwise). Includes the
-// recordBatchHeaderBytes overhead when the pending produce is empty so the
-// caller can add the result to a zeroed counter. Caller must hold a.mu.
-func (a *AgentRecordBuffer) computeAddCostLocked(records []*kgo.Record) (int64, int64) {
-	fresh := a.nextProduceRecords == 0
-	firstTS := a.nextProduceFirstTimestamp
-	if fresh && len(records) > 0 {
-		firstTS = records[0].Timestamp.UnixMilli()
-	}
-
-	var bytes int64
-	if fresh {
-		bytes = recordBatchHeaderBytes
-	}
-	offset := int32(a.nextProduceRecords)
-	for _, rec := range records {
-		tsDelta := rec.Timestamp.UnixMilli() - firstTS
-		bytes += recordEstimateBytes(rec, offset, tsDelta)
-		offset++
-	}
-	return bytes, firstTS
-}
-
-// Close flushes the pending produce and waits for every in-flight FlushFunc
-// to report. Subsequent Adds fail with errBufferClosed. Idempotent.
-func (a *AgentRecordBuffer) Close() {
+// Close flushes the pending produce and waits for every in-flight flush to
+// report. Subsequent Adds fail with errBufferClosed. Idempotent.
+func (a *AgentBuffer[W]) Close() {
 	a.mu.Lock()
 	if a.closed {
 		a.mu.Unlock()
@@ -197,7 +150,7 @@ func (a *AgentRecordBuffer) Close() {
 }
 
 // timerFlush is invoked by the linger timer.
-func (a *AgentRecordBuffer) timerFlush() {
+func (a *AgentBuffer[W]) timerFlush() {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.startFlushLocked()
@@ -206,7 +159,7 @@ func (a *AgentRecordBuffer) timerFlush() {
 // startFlushLocked dispatches the pending produce to flush in a goroutine and
 // resets buffer state so the next produce can accumulate immediately. No-op
 // if nothing is pending. Caller must hold a.mu.
-func (a *AgentRecordBuffer) startFlushLocked() {
+func (a *AgentBuffer[W]) startFlushLocked() {
 	if a.nextProduceRecords == 0 {
 		return
 	}
@@ -217,17 +170,16 @@ func (a *AgentRecordBuffer) startFlushLocked() {
 		a.nextProduceFlushTimer.Stop()
 		a.nextProduceFlushTimer = nil
 	}
-	entries := a.nextProducePartitions
-	a.nextProducePartitions = nil
+	entries := a.nextProduceItems
+	a.nextProduceItems = nil
 	a.nextProduceRecords = 0
 	a.nextProduceWireBytes = 0
-	a.nextProduceFirstTimestamp = 0
 
-	// Merge same-partition records into one wire entry: the produce/hedge path
+	// Merge same-partition items into one wire entry: the produce/hedge path
 	// keys per-partition state by (topic, partition) and rejects duplicates
 	// (see produceResultAccumulator). Completion still fans out to every
 	// original entry's done, so the merged wire view drops done.
-	wire := mergePromisedRoutedTopicPartitionRecordsByTopicPartition(entries)
+	wire := mergePromisedRoutedBatchByTopicPartition(entries)
 
 	a.flushWG.Add(1)
 	go func() {

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/agent_record_buffer.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/agent_record_buffer.go
@@ -124,7 +124,12 @@ func (a *AgentBuffer[W]) Add(items []promised[W]) {
 // (startFlushLocked), which keeps each item's done untouched. Caller must hold
 // a.mu.
 func (a *AgentBuffer[W]) addToNextProduceLocked(p promised[W]) {
-	addBytes := p.item.wireBytes()
+	// uncompressedWireBytes() sizes each item as a standalone RecordBatch (own
+	// header, 0-based offsets). Same-partition items merge into one batch at flush,
+	// so this usually over-counts — chiefly one header per merged-in item — and
+	// tends to flush early. It is an estimate, not exact: merging re-bases offsets
+	// and timestamp deltas, which can slightly grow record-body varints.
+	addBytes := p.item.uncompressedWireBytes()
 	if a.nextProduceRecords > 0 && a.nextProduceWireBytes+addBytes > int64(a.batchMaxBytes) {
 		a.startFlushLocked()
 	}

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/client.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/client.go
@@ -167,10 +167,6 @@ func (c *WarpstreamClient) Produce(ctx context.Context, record *kgo.Record, prom
 		return
 	}
 
-	// Stamp the record's produce time at entry, before buffering, mirroring
-	// franz-go's bufferRecord.
-	ensureRecordTimestamp(record, time.Now())
-
 	routed, err := c.routeRecord(record, perRecordDone(record, func(r *kgo.Record, err error) {
 		// The buffered path counts a post-dispatch failure on any non-nil error;
 		// the pre-dispatch rejections are counted by produceRecordsRejectedTotal.
@@ -184,6 +180,10 @@ func (c *WarpstreamClient) Produce(ctx context.Context, record *kgo.Record, prom
 		promise(record, err)
 		return
 	}
+
+	// Stamp the produce time only after routing succeeds, so a failed produce
+	// leaves the caller's record unchanged. Mirrors franz-go's bufferRecord.
+	ensureRecordTimestamp(record, time.Now())
 	c.buffer.Add(ctx, []promised[routedTopicPartitionRecords]{routed})
 }
 
@@ -222,14 +222,6 @@ func (c *WarpstreamClient) ProduceSync(ctx context.Context, records []*kgo.Recor
 		return results
 	}
 
-	// Stamp each record's produce time at entry, before buffering, mirroring
-	// franz-go's bufferRecord. A single now keeps records buffered together on
-	// one produce timestamp.
-	now := time.Now()
-	for _, r := range okRecords {
-		ensureRecordTimestamp(r, now)
-	}
-
 	wg.Add(len(okRecords))
 	indexOf := make(map[*kgo.Record]int, len(okRecords))
 	for _, idx := range okIndices {
@@ -257,6 +249,14 @@ func (c *WarpstreamClient) ProduceSync(ctx context.Context, records []*kgo.Recor
 			results[i] = kgo.ProduceResult{Record: records[i], Err: err}
 		}
 		return results
+	}
+
+	// Stamp each record's produce time only after routing succeeds, so a failed
+	// produce leaves the caller's records unchanged. A single now keeps records
+	// buffered together on one produce timestamp. Mirrors franz-go's bufferRecord.
+	now := time.Now()
+	for _, r := range okRecords {
+		ensureRecordTimestamp(r, now)
 	}
 
 	c.buffer.Add(ctx, routed)

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/client.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/client.go
@@ -51,7 +51,7 @@ const produceAPIVersion int16 = 11
 //     primary/secondary mapping. Every client instance with the same pool
 //     view picks the same secondary for a given partition, which keeps
 //     hedge load predictable and analysable instead of random.
-//   - A *ClusterRecordBuffer* + per-agent *AgentRecordBuffer* implement
+//   - A *ClusterBuffer* + per-agent *AgentBuffer* implement
 //     linger-based batching keyed on the primary agent (not on partition,
 //     as franz-go does), so a single Produce request to one agent can
 //     carry batches for many partitions.
@@ -79,7 +79,7 @@ type WarpstreamClient struct {
 	demoter        *Demoter
 	directProducer *KafkaDirectProducer
 	hedger         *Hedger
-	buffer         *ClusterRecordBuffer
+	buffer         *ClusterBuffer[routedTopicPartitionRecords]
 
 	// refreshCtx is canceled by Close. It both signals the background
 	// refresh goroutine to exit and interrupts any in-flight Refresh.
@@ -143,7 +143,7 @@ func NewWarpstreamClient(logger log.Logger, reg prometheus.Registerer, opts ...O
 	// bound each flush by WriteTimeout. The Hedger is otherwise shaped
 	// like a DirectProducer (same signature as KafkaDirectProducer) so it
 	// composes directly with the buffer.
-	c.buffer = NewClusterRecordBuffer(cfg.Linger, cfg.BatchMaxBytes, c.flushBatch, m, reg)
+	c.buffer = NewClusterBuffer[routedTopicPartitionRecords](cfg.Linger, cfg.BatchMaxBytes, c.flushBatch, m, reg)
 	c.startBackgroundRefresh()
 	return c, nil
 }
@@ -151,6 +151,13 @@ func NewWarpstreamClient(logger log.Logger, reg prometheus.Registerer, opts ...O
 // Produce buffers record and invokes promise once it has been
 // acknowledged or failed. Cancelling ctx detaches the caller; the record
 // is still produced in the background.
+//
+// Record ownership: the caller must not mutate record until promise fires by
+// completion (an ack or terminal failure). After that the record is safe to
+// reuse, reset, or pool — the client has captured it and never reads it again,
+// including on any still-in-flight hedge attempt. Cancelling ctx is not a
+// completion: it detaches the caller while the background produce keeps the
+// record, so a record whose produce was cancelled must not be reused.
 func (c *WarpstreamClient) Produce(ctx context.Context, record *kgo.Record, promise func(*kgo.Record, error)) {
 	c.metrics.produceRecordsTotal.Inc()
 
@@ -159,6 +166,10 @@ func (c *WarpstreamClient) Produce(ctx context.Context, record *kgo.Record, prom
 		promise(record, errRecordTooLarge(record))
 		return
 	}
+
+	// Stamp the record's produce time at entry, before buffering, mirroring
+	// franz-go's bufferRecord.
+	ensureRecordTimestamp(record, time.Now())
 
 	routed, err := c.routeRecord(record, perRecordDone(record, func(r *kgo.Record, err error) {
 		// The buffered path counts a post-dispatch failure on any non-nil error;
@@ -173,12 +184,19 @@ func (c *WarpstreamClient) Produce(ctx context.Context, record *kgo.Record, prom
 		promise(record, err)
 		return
 	}
-	c.buffer.Add(ctx, []promisedRoutedTopicPartitionRecords{routed})
+	c.buffer.Add(ctx, []promised[routedTopicPartitionRecords]{routed})
 }
 
 // ProduceSync produces records and blocks until each has been
 // acknowledged or failed. Results are in input order; each record has its
 // own outcome. Cancelling ctx detaches the caller, not the in-flight produce.
+//
+// Record ownership: when ProduceSync returns by completion (every record acked
+// or terminally failed), the records are safe to reuse, reset, or pool — the
+// client has captured them and never reads them again, including on any
+// still-in-flight hedge attempt. A ctx cancellation is not a completion: it
+// detaches the caller while the background produce keeps the records, so records
+// whose produce was cancelled must not be reused.
 func (c *WarpstreamClient) ProduceSync(ctx context.Context, records []*kgo.Record) kgo.ProduceResults {
 	if len(records) == 0 {
 		return nil
@@ -202,6 +220,14 @@ func (c *WarpstreamClient) ProduceSync(ctx context.Context, records []*kgo.Recor
 	}
 	if len(okRecords) == 0 {
 		return results
+	}
+
+	// Stamp each record's produce time at entry, before buffering, mirroring
+	// franz-go's bufferRecord. A single now keeps records buffered together on
+	// one produce timestamp.
+	now := time.Now()
+	for _, r := range okRecords {
+		ensureRecordTimestamp(r, now)
 	}
 
 	wg.Add(len(okRecords))
@@ -238,12 +264,28 @@ func (c *WarpstreamClient) ProduceSync(ctx context.Context, records []*kgo.Recor
 	return results
 }
 
-// flushBatch is the cluster buffer's AgentFlushFunc: it bounds the
-// Hedger call to WriteTimeout and forwards everything else verbatim.
+// flushBatch is the cluster buffer's AgentFlushFunc: it encodes each partition's
+// RecordBatch once, up front, then bounds the Hedger call to WriteTimeout.
 func (c *WarpstreamClient) flushBatch(ctx context.Context, nodeID int32, partitions []routedTopicPartitionRecords) ProduceResult {
+	// Encode here — synchronously on the flush goroutine, before the Hedger runs
+	// and any completion promise can fire — so the primary and every hedge leg
+	// transmit the same immutable bytes and no leg reads a *kgo.Record afterward.
+	// This is the only records->encoded conversion point.
+	encoded := make([]routedEncodedTopicPartitionRecords, 0, len(partitions))
+	for _, p := range partitions {
+		if len(p.records) == 0 {
+			continue
+		}
+		encoded = append(encoded, routedEncodedTopicPartitionRecords{
+			encodedTopicPartitionRecords: newEncodedTopicPartitionRecords(p.topic, p.partition, p.records),
+			nodeID:                       p.nodeID,
+			nodeState:                    p.nodeState,
+		})
+	}
+
 	flushCtx, cancel := context.WithTimeout(ctx, c.cfg.WriteTimeout)
 	defer cancel()
-	return c.hedger.ProduceSync(flushCtx, nodeID, partitions)
+	return c.hedger.ProduceSync(flushCtx, nodeID, encoded)
 }
 
 // BufferedProduceBytes returns the bytes of all records awaiting ack.
@@ -308,8 +350,8 @@ func (c *WarpstreamClient) startBackgroundRefresh() {
 // routeRecords groups records by (topic, partition), stamps each group with
 // its initial destination NodeID and mints the per-group done callback.
 // Returns an error if any record's partition has no known candidate.
-func (c *WarpstreamClient) routeRecords(records []*kgo.Record, doneFor func(groupRecords []*kgo.Record) func(ProduceResult)) ([]promisedRoutedTopicPartitionRecords, error) {
-	groups := make(map[topicPartition]*promisedRoutedTopicPartitionRecords)
+func (c *WarpstreamClient) routeRecords(records []*kgo.Record, doneFor func(groupRecords []*kgo.Record) func(ProduceResult)) ([]promised[routedTopicPartitionRecords], error) {
+	groups := make(map[topicPartition]*promised[routedTopicPartitionRecords])
 	order := make([]topicPartition, 0)
 	for _, r := range records {
 		key := topicPartition{topic: r.Topic, partition: r.Partition}
@@ -319,8 +361,8 @@ func (c *WarpstreamClient) routeRecords(records []*kgo.Record, doneFor func(grou
 			if len(cands) == 0 {
 				return nil, fmt.Errorf("no agent assigned for topic %q partition %d", r.Topic, r.Partition)
 			}
-			g = &promisedRoutedTopicPartitionRecords{
-				routedTopicPartitionRecords: routedTopicPartitionRecords{
+			g = &promised[routedTopicPartitionRecords]{
+				item: routedTopicPartitionRecords{
 					topicPartitionRecords: topicPartitionRecords{
 						topic:     r.Topic,
 						partition: r.Partition,
@@ -332,12 +374,12 @@ func (c *WarpstreamClient) routeRecords(records []*kgo.Record, doneFor func(grou
 			groups[key] = g
 			order = append(order, key)
 		}
-		g.records = append(g.records, r)
+		g.item.records = append(g.item.records, r)
 	}
-	out := make([]promisedRoutedTopicPartitionRecords, 0, len(order))
+	out := make([]promised[routedTopicPartitionRecords], 0, len(order))
 	for _, key := range order {
 		g := groups[key]
-		g.done = doneFor(g.records)
+		g.done = doneFor(g.item.records)
 		out = append(out, *g)
 	}
 	return out, nil
@@ -346,13 +388,13 @@ func (c *WarpstreamClient) routeRecords(records []*kgo.Record, doneFor func(grou
 // routeRecord is the single-record specialisation of routeRecords: it
 // skips the per-partition map and avoids heap-allocating an intermediate
 // group. Returns an error if the record's partition has no known candidate.
-func (c *WarpstreamClient) routeRecord(record *kgo.Record, done func(ProduceResult)) (promisedRoutedTopicPartitionRecords, error) {
+func (c *WarpstreamClient) routeRecord(record *kgo.Record, done func(ProduceResult)) (promised[routedTopicPartitionRecords], error) {
 	cands := c.demoter.Candidates(record.Topic, record.Partition, 1)
 	if len(cands) == 0 {
-		return promisedRoutedTopicPartitionRecords{}, fmt.Errorf("no agent assigned for topic %q partition %d", record.Topic, record.Partition)
+		return promised[routedTopicPartitionRecords]{}, fmt.Errorf("no agent assigned for topic %q partition %d", record.Topic, record.Partition)
 	}
-	return promisedRoutedTopicPartitionRecords{
-		routedTopicPartitionRecords: routedTopicPartitionRecords{
+	return promised[routedTopicPartitionRecords]{
+		item: routedTopicPartitionRecords{
 			topicPartitionRecords: topicPartitionRecords{
 				topic:     record.Topic,
 				partition: record.Partition,

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/cluster_record_buffer.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/cluster_record_buffer.go
@@ -10,15 +10,14 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-// ClusterRecordBuffer is the cluster-wide entry point for buffering produce
-// records. It owns the routing and lifecycle of per-agent batches; each
-// AgentRecordBuffer owns its own state, linger timer, and flush loop.
+// ClusterBuffer is the cluster-wide entry point for buffering produce items. It
+// owns the routing and lifecycle of per-agent batches; each AgentBuffer owns its
+// own state, linger timer, and flush loop.
 //
-// The buffer is strategy-free: callers hand partition-grouped work
-// pre-stamped with a destination NodeID (via routedTopicPartitionRecords) and the
-// buffer just bins them by agent. The
-// routing decision is owned upstream, where the PartitionAssignmentStrategy
-// is consulted; the buffer's job is purely batching.
+// The buffer is strategy-free: callers hand items pre-stamped with a destination
+// nodeID and the buffer just bins them by agent. The routing decision is owned
+// upstream, where the PartitionAssignmentStrategy is consulted; the buffer's job
+// is purely batching.
 //
 // Batching per agent has two consequences that matter:
 //
@@ -33,7 +32,7 @@ import (
 // Concurrency is biased to the hot path: the agents map is guarded by a
 // sync.RWMutex so concurrent Adds to different agents take RLock and never
 // contend with each other. Creating a per-agent buffer is a one-time write
-// lock per new NodeID; subsequent Adds reuse it. bufferedBytes /
+// lock per new nodeID; subsequent Adds reuse it. bufferedBytes /
 // bufferedRecords are atomic counters that mirror franz-go's
 // BufferedProduceBytes / BufferedProduceRecords semantics — they reflect
 // "records the producer is responsible for", not "records the caller is
@@ -45,10 +44,10 @@ import (
 // intentionally the caller's responsibility — a caller that needs
 // backpressure must cap its own outstanding produces rather than rely on
 // the buffer to reject work.
-type ClusterRecordBuffer struct {
+type ClusterBuffer[W routedBatch[W]] struct {
 	linger        time.Duration
 	batchMaxBytes int32
-	flush         AgentFlushFunc
+	flush         AgentFlushFunc[W]
 	metrics       *metrics
 
 	// bufferedBytes is the total size in bytes of every record waiting
@@ -62,20 +61,20 @@ type ClusterRecordBuffer struct {
 	bufferedRecords atomic.Int64
 
 	mu           sync.RWMutex
-	agentBuffers map[int32]*AgentRecordBuffer
+	agentBuffers map[int32]*AgentBuffer[W]
 	closed       bool
 }
 
-// NewClusterRecordBuffer returns a buffer that lazily spawns one
-// AgentRecordBuffer per NodeID seen via Add, all sharing flush. It registers
-// the buffered-producer gauges on reg.
-func NewClusterRecordBuffer(linger time.Duration, batchMaxBytes int32, flush AgentFlushFunc, m *metrics, reg prometheus.Registerer) *ClusterRecordBuffer {
-	c := &ClusterRecordBuffer{
+// NewClusterBuffer returns a buffer that lazily spawns one AgentBuffer per
+// nodeID seen via Add, all sharing flush. It registers the buffered-producer
+// gauges on reg.
+func NewClusterBuffer[W routedBatch[W]](linger time.Duration, batchMaxBytes int32, flush AgentFlushFunc[W], m *metrics, reg prometheus.Registerer) *ClusterBuffer[W] {
+	c := &ClusterBuffer[W]{
 		linger:        linger,
 		batchMaxBytes: batchMaxBytes,
 		flush:         flush,
 		metrics:       m,
-		agentBuffers:  make(map[int32]*AgentRecordBuffer),
+		agentBuffers:  make(map[int32]*AgentBuffer[W]),
 	}
 
 	promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{
@@ -90,25 +89,24 @@ func NewClusterRecordBuffer(linger time.Duration, batchMaxBytes int32, flush Age
 	return c
 }
 
-// Add buffers partition-grouped work for produce. Each entry's done fires
-// exactly once with the partition's final outcome (nil on success, an
-// error on terminal failure, or ctx.Err() if ctx is canceled before the
-// producer resolves the partition). Cancelling ctx detaches the caller
-// but does not stop the in-flight produce.
-func (c *ClusterRecordBuffer) Add(ctx context.Context, partitions []promisedRoutedTopicPartitionRecords) {
-	if len(partitions) == 0 {
+// Add buffers items for produce. Each item's done fires exactly once with its
+// final outcome (nil on success, an error on terminal failure, or ctx.Err() if
+// ctx is canceled before the producer resolves the partition). Cancelling ctx
+// detaches the caller but does not stop the in-flight produce.
+func (c *ClusterBuffer[W]) Add(ctx context.Context, items []promised[W]) {
+	if len(items) == 0 {
 		return
 	}
 
-	// Wrap each partition's done with two layers:
+	// Wrap each item's done with two layers:
 	//   - a once-fire that delivers either the produce outcome or
 	//     ctx.Err() (whichever first) to the original done;
 	//   - an accounting hook that decrements the buffered counters on
 	//     actual flush completion regardless of whether ctx already fired.
-	wrapped := make([]promisedRoutedTopicPartitionRecords, len(partitions))
-	for i, p := range partitions {
-		payloadBytes := p.recordPayloadBytes()
-		recCount := int64(len(p.records))
+	wrapped := make([]promised[W], len(items))
+	for i, p := range items {
+		payloadBytes := p.item.payloadBytes()
+		recCount := int64(p.item.recordCount())
 		c.bufferedBytes.Add(payloadBytes)
 		c.bufferedRecords.Add(recCount)
 
@@ -151,60 +149,53 @@ func (c *ClusterRecordBuffer) Add(ctx context.Context, partitions []promisedRout
 	c.addToBuffers(ctx, wrapped)
 }
 
-// addToBuffers bins partition groups by destination and dispatches them to
-// the matching per-agent buffer.
-func (c *ClusterRecordBuffer) addToBuffers(ctx context.Context, partitions []promisedRoutedTopicPartitionRecords) {
-	if len(partitions) == 0 {
+// addToBuffers bins items by destination and dispatches them to the matching
+// per-agent buffer.
+func (c *ClusterBuffer[W]) addToBuffers(ctx context.Context, items []promised[W]) {
+	if len(items) == 0 {
 		return
 	}
 	if err := ctx.Err(); err != nil {
-		// Pre-canceled fast path: fail every partition without dispatching.
+		// Pre-canceled fast path: fail every item without dispatching.
 		// Distinct from a mid-flight cancel (which still buffers and lets
 		// the batch flush in the background); this matters because the
 		// caller may otherwise observe a duplicate from a "no-op" call.
-		for _, p := range partitions {
+		for _, p := range items {
 			p.done(ProduceResult{err: err})
 		}
 		return
 	}
 
-	// Stamp record timestamps here, to keep it consistent with franz-go.
-	now := time.Now()
-	for _, p := range partitions {
-		for _, r := range p.records {
-			ensureRecordTimestamp(r, now)
-		}
+	byAgent := make(map[int32][]promised[W])
+	for _, p := range items {
+		nodeID := p.item.getNodeID()
+		byAgent[nodeID] = append(byAgent[nodeID], p)
 	}
-
-	byAgent := make(map[int32][]promisedRoutedTopicPartitionRecords)
-	for _, p := range partitions {
-		byAgent[p.nodeID] = append(byAgent[p.nodeID], p)
-	}
-	for nodeID, agentPartitions := range byAgent {
-		buffer, err := c.agentRecordBufferFor(nodeID)
+	for nodeID, agentItems := range byAgent {
+		buffer, err := c.agentBufferFor(nodeID)
 		if err != nil {
-			for _, p := range agentPartitions {
+			for _, p := range agentItems {
 				p.done(ProduceResult{err: err})
 			}
 			continue
 		}
-		buffer.Add(agentPartitions)
+		buffer.Add(agentItems)
 	}
 }
 
 // BufferedBytes returns the bytes of all records awaiting ack.
-func (c *ClusterRecordBuffer) BufferedBytes() int64 {
+func (c *ClusterBuffer[W]) BufferedBytes() int64 {
 	return c.bufferedBytes.Load()
 }
 
 // BufferedRecords returns the count of records awaiting ack.
-func (c *ClusterRecordBuffer) BufferedRecords() int64 {
+func (c *ClusterBuffer[W]) BufferedRecords() int64 {
 	return c.bufferedRecords.Load()
 }
 
 // Close flushes every per-agent buffer in parallel and waits for them to
 // drain. Subsequent Adds fail with errBufferClosed. Idempotent.
-func (c *ClusterRecordBuffer) Close() {
+func (c *ClusterBuffer[W]) Close() {
 	c.mu.Lock()
 	if c.closed {
 		c.mu.Unlock()
@@ -213,7 +204,7 @@ func (c *ClusterRecordBuffer) Close() {
 	c.closed = true
 
 	// Take ownership of the map and drop it from the cluster. Subsequent
-	// Add / agentRecordBufferFor calls observe c.closed and never touch it.
+	// Add / agentBufferFor calls observe c.closed and never touch it.
 	agentBuffers := c.agentBuffers
 	c.agentBuffers = nil
 	c.mu.Unlock()
@@ -221,7 +212,7 @@ func (c *ClusterRecordBuffer) Close() {
 	var wg sync.WaitGroup
 	for _, a := range agentBuffers {
 		wg.Add(1)
-		go func(a *AgentRecordBuffer) {
+		go func(a *AgentBuffer[W]) {
 			defer wg.Done()
 			a.Close()
 		}(a)
@@ -229,9 +220,9 @@ func (c *ClusterRecordBuffer) Close() {
 	wg.Wait()
 }
 
-// agentRecordBufferFor returns the per-agent buffer for nodeID, creating it
-// on first call. Errors with errBufferClosed if the cluster is closed.
-func (c *ClusterRecordBuffer) agentRecordBufferFor(nodeID int32) (*AgentRecordBuffer, error) {
+// agentBufferFor returns the per-agent buffer for nodeID, creating it on first
+// call. Errors with errBufferClosed if the cluster is closed.
+func (c *ClusterBuffer[W]) agentBufferFor(nodeID int32) (*AgentBuffer[W], error) {
 	// Hot path: read lock for an already-known agent.
 	c.mu.RLock()
 	if c.closed {
@@ -244,7 +235,7 @@ func (c *ClusterRecordBuffer) agentRecordBufferFor(nodeID int32) (*AgentRecordBu
 		return a, nil
 	}
 
-	// Cold path: create on first record for this agent.
+	// Cold path: create on first item for this agent.
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.closed {
@@ -253,7 +244,7 @@ func (c *ClusterRecordBuffer) agentRecordBufferFor(nodeID int32) (*AgentRecordBu
 	if a, ok := c.agentBuffers[nodeID]; ok {
 		return a, nil
 	}
-	a = NewAgentRecordBuffer(nodeID, c.linger, c.batchMaxBytes, c.flush, c.metrics)
+	a = NewAgentBuffer[W](nodeID, c.linger, c.batchMaxBytes, c.flush, c.metrics)
 	c.agentBuffers[nodeID] = a
 	return a, nil
 }

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/direct_producer.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/direct_producer.go
@@ -10,17 +10,17 @@ import (
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
-// DirectProducer produces partitions to a specific Warpstream agent by its
-// Kafka NodeID. Implementations must be safe for concurrent use. The wire
-// encoding of partitions into a ProduceRequest happens at the lowest layer
-// (KafkaDirectProducer); upper layers just shuffle partition groups around.
+// DirectProducer produces pre-encoded partitions to a specific Warpstream agent
+// by its Kafka NodeID. Implementations must be safe for concurrent use. The wire
+// request is assembled at the lowest layer (KafkaDirectProducer) from the
+// already-encoded batches; upper layers just shuffle partition groups around.
 //
-// The signature takes bare topicPartitionRecords (without nodeID, done,
+// The signature takes bare encodedTopicPartitionRecords (without nodeID, done,
 // or nodeState) so the "which agent does this batch go to" decision lives
 // in exactly one place — the nodeID parameter — and the function cannot
-// be called with a mismatched per-RTP nodeID.
+// be called with a mismatched per-partition nodeID.
 type DirectProducer interface {
-	ProduceSync(ctx context.Context, nodeID int32, partitions []topicPartitionRecords) ProduceResult
+	ProduceSync(ctx context.Context, nodeID int32, partitions []encodedTopicPartitionRecords) ProduceResult
 }
 
 // KafkaDirectProducerConfig holds the per-request timings for
@@ -49,8 +49,8 @@ func (c *KafkaDirectProducerConfig) Validate() error {
 	return nil
 }
 
-// KafkaDirectProducer implements DirectProducer using kgo.Client. Wire
-// encoding (buildMultiTopicProduceRequest) and per-request timing are
+// KafkaDirectProducer implements DirectProducer using kgo.Client. Wire request
+// assembly (buildMultiTopicProduceRequestFromEncoded) and per-request timing are
 // enforced here, not at a higher layer.
 //
 // This is the only type in this package that depends on kgo.Client directly.
@@ -76,12 +76,8 @@ func NewKafkaDirectProducer(client *kgo.Client, topicID func(string) ([16]byte, 
 }
 
 // ProduceSync implements DirectProducer.
-func (s *KafkaDirectProducer) ProduceSync(ctx context.Context, nodeID int32, partitions []topicPartitionRecords) (retResult ProduceResult) {
-	var records []*kgo.Record
-	for _, p := range partitions {
-		records = append(records, p.records...)
-	}
-	req, reqStats, err := buildMultiTopicProduceRequest(s.version, s.topicID, records)
+func (s *KafkaDirectProducer) ProduceSync(ctx context.Context, nodeID int32, partitions []encodedTopicPartitionRecords) (retResult ProduceResult) {
+	req, reqStats, err := buildMultiTopicProduceRequestFromEncoded(s.version, s.topicID, partitions)
 	if err != nil {
 		return ProduceResult{err: err}
 	}

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/direct_producer.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/direct_producer.go
@@ -50,8 +50,7 @@ func (c *KafkaDirectProducerConfig) Validate() error {
 }
 
 // KafkaDirectProducer implements DirectProducer using kgo.Client. Wire request
-// assembly (buildMultiTopicProduceRequestFromEncoded) and per-request timing are
-// enforced here, not at a higher layer.
+// assembly and per-request timing are enforced here, not at a higher layer.
 //
 // This is the only type in this package that depends on kgo.Client directly.
 type KafkaDirectProducer struct {

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/encoded_topic_partition.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/encoded_topic_partition.go
@@ -1,0 +1,123 @@
+package wgo
+
+import (
+	"fmt"
+
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+// encodedTopicPartitionRecords is the serialised RecordBatch to produce for one
+// Kafka partition: the encoded bytes plus that batch's producer-state counts.
+type encodedTopicPartitionRecords struct {
+	topic        string
+	partition    int32
+	encoded      []byte
+	encodedStats produceRequestStats
+}
+
+// newEncodedTopicPartitionRecords encodes records into a single RecordBatch for
+// (topic, partition), capturing that batch's producer-state counts. records must
+// be non-empty.
+func newEncodedTopicPartitionRecords(topic string, partition int32, records []*kgo.Record) encodedTopicPartitionRecords {
+	batch, uncompressed, compressed := encodeBatch(records)
+	return encodedTopicPartitionRecords{
+		topic:     topic,
+		partition: partition,
+		encoded:   batch,
+		encodedStats: produceRequestStats{
+			records:           int64(len(records)),
+			batches:           1,
+			uncompressedBytes: int64(uncompressed),
+			compressedBytes:   int64(compressed),
+		},
+	}
+}
+
+// recordCount returns the number of records in the encoded batch.
+func (p encodedTopicPartitionRecords) recordCount() int {
+	return int(p.encodedStats.records)
+}
+
+// payloadBytes returns 0: an encoded batch retains no caller-owned record
+// payload to account for, and the buffered-bytes counter it feeds (on the hedge
+// buffer, which exposes no gauge) is never read anyway.
+func (p encodedTopicPartitionRecords) payloadBytes() int64 {
+	return 0
+}
+
+// routedEncodedTopicPartitionRecords is an encodedTopicPartitionRecords plus the
+// routing decision: the destination nodeID and that agent's state at routing time.
+type routedEncodedTopicPartitionRecords struct {
+	encodedTopicPartitionRecords
+
+	nodeID int32
+
+	// nodeState is the State of the Agent nodeID was picked from, captured at
+	// routing time (e.g. AgentStateDemoted when nodeID is a demoted agent
+	// being probed).
+	nodeState AgentState
+}
+
+func (p routedEncodedTopicPartitionRecords) getTopicPartition() topicPartition {
+	return topicPartition{topic: p.topic, partition: p.partition}
+}
+
+func (p routedEncodedTopicPartitionRecords) getNodeID() int32 { return p.nodeID }
+
+// wireBytes returns the encoded batch length; the batch header is already
+// included in the bytes.
+func (p routedEncodedTopicPartitionRecords) wireBytes() int64 {
+	return int64(len(p.encoded))
+}
+
+// splitByMaxBytes returns the item unchanged: an encoded batch is already sized
+// to fit batchMaxBytes.
+func (p routedEncodedTopicPartitionRecords) splitByMaxBytes(int32) []routedEncodedTopicPartitionRecords {
+	return []routedEncodedTopicPartitionRecords{p}
+}
+
+// mergeWith concatenates other's batch bytes after p's and sums the stats — a
+// partition's wire payload may hold several batches back to back — and takes
+// other's nodeState. A fresh backing slice is allocated so neither input is mutated.
+func (p routedEncodedTopicPartitionRecords) mergeWith(other routedEncodedTopicPartitionRecords) routedEncodedTopicPartitionRecords {
+	// Merging items for a different topic, partition, or nodeID is a bug, not a
+	// runtime case: fail loud rather than silently combine unrelated batches.
+	if p.topic != other.topic || p.partition != other.partition || p.nodeID != other.nodeID {
+		panic(fmt.Sprintf("wgo: mergeWith mismatched routing: %s/%d nodeID=%d vs %s/%d nodeID=%d",
+			p.topic, p.partition, p.nodeID, other.topic, other.partition, other.nodeID))
+	}
+
+	combined := make([]byte, 0, len(p.encoded)+len(other.encoded))
+	combined = append(combined, p.encoded...)
+	combined = append(combined, other.encoded...)
+	p.encoded = combined
+	p.encodedStats = p.encodedStats.add(other.encodedStats)
+	// Take the latest Add's nodeState: it is the freshest
+	// routing-time view of the agent, which is what the hedger
+	// trusts to decide probe (zero-delay) hedging.
+	p.nodeState = other.nodeState
+	return p
+}
+
+// unrouteEncodedTopicPartitionRecords returns the routing-less encodedTopicPartitionRecords view for
+// the DirectProducer chain, which takes the nodeID separately.
+func unrouteEncodedTopicPartitionRecords(parts []routedEncodedTopicPartitionRecords) []encodedTopicPartitionRecords {
+	out := make([]encodedTopicPartitionRecords, len(parts))
+	for i, p := range parts {
+		out[i] = p.encodedTopicPartitionRecords
+	}
+	return out
+}
+
+// newMultiRoutedEncodedTopicPartitionRecords stamps each encoded partition with
+// the same destination nodeID and shared done callback.
+func newMultiRoutedEncodedTopicPartitionRecords(parts []encodedTopicPartitionRecords, nodeID int32, done func(ProduceResult)) []promised[routedEncodedTopicPartitionRecords] {
+	out := make([]promised[routedEncodedTopicPartitionRecords], len(parts))
+	for i, p := range parts {
+		out[i] = promised[routedEncodedTopicPartitionRecords]{
+			item: routedEncodedTopicPartitionRecords{encodedTopicPartitionRecords: p, nodeID: nodeID},
+			done: done,
+		}
+	}
+	return out
+}

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/encoded_topic_partition.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/encoded_topic_partition.go
@@ -38,9 +38,7 @@ func (p encodedTopicPartitionRecords) recordCount() int {
 	return int(p.encodedStats.records)
 }
 
-// payloadBytes returns 0: an encoded batch retains no caller-owned record
-// payload to account for, and the buffered-bytes counter it feeds (on the hedge
-// buffer, which exposes no gauge) is never read anyway.
+// payloadBytes is unsupported and returns 0.
 func (p encodedTopicPartitionRecords) payloadBytes() int64 {
 	return 0
 }
@@ -64,10 +62,13 @@ func (p routedEncodedTopicPartitionRecords) getTopicPartition() topicPartition {
 
 func (p routedEncodedTopicPartitionRecords) getNodeID() int32 { return p.nodeID }
 
-// wireBytes returns the encoded batch length; the batch header is already
-// included in the bytes.
-func (p routedEncodedTopicPartitionRecords) wireBytes() int64 {
-	return int64(len(p.encoded))
+// uncompressedWireBytes returns the RecordBatch's wire size with the records
+// payload uncompressed (its size before Snappy compression).
+func (p routedEncodedTopicPartitionRecords) uncompressedWireBytes() int64 {
+	if p.encodedStats.records == 0 {
+		return 0
+	}
+	return recordBatchHeaderBytes + p.encodedStats.uncompressedBytes
 }
 
 // splitByMaxBytes returns the item unchanged: an encoded batch is already sized
@@ -76,27 +77,40 @@ func (p routedEncodedTopicPartitionRecords) splitByMaxBytes(int32) []routedEncod
 	return []routedEncodedTopicPartitionRecords{p}
 }
 
-// mergeWith concatenates other's batch bytes after p's and sums the stats — a
-// partition's wire payload may hold several batches back to back — and takes
-// other's nodeState. A fresh backing slice is allocated so neither input is mutated.
-func (p routedEncodedTopicPartitionRecords) mergeWith(other routedEncodedTopicPartitionRecords) routedEncodedTopicPartitionRecords {
-	// Merging items for a different topic, partition, or nodeID is a bug, not a
-	// runtime case: fail loud rather than silently combine unrelated batches.
-	if p.topic != other.topic || p.partition != other.partition || p.nodeID != other.nodeID {
-		panic(fmt.Sprintf("wgo: mergeWith mismatched routing: %s/%d nodeID=%d vs %s/%d nodeID=%d",
-			p.topic, p.partition, p.nodeID, other.topic, other.partition, other.nodeID))
+// mergeWith combines p and others into a single RecordBatch for the partition by
+// decoding every batch, concatenating the records in arrival order, and
+// re-encoding once.
+//
+// Returns p unchanged when others is empty, so non-merged partitions never decode.
+// Decoding operates on bytes this client encoded, never the caller's records, so it
+// stays race-free.
+func (p routedEncodedTopicPartitionRecords) mergeWith(others []routedEncodedTopicPartitionRecords) routedEncodedTopicPartitionRecords {
+	if len(others) == 0 {
+		return p
 	}
 
-	combined := make([]byte, 0, len(p.encoded)+len(other.encoded))
-	combined = append(combined, p.encoded...)
-	combined = append(combined, other.encoded...)
-	p.encoded = combined
-	p.encodedStats = p.encodedStats.add(other.encodedStats)
-	// Take the latest Add's nodeState: it is the freshest
-	// routing-time view of the agent, which is what the hedger
-	// trusts to decide probe (zero-delay) hedging.
-	p.nodeState = other.nodeState
-	return p
+	for _, o := range others {
+		// Merging items for a different topic, partition, or nodeID is a bug, not
+		// a runtime case: fail loud rather than silently combine unrelated batches.
+		if p.topic != o.topic || p.partition != o.partition || p.nodeID != o.nodeID {
+			panic(fmt.Sprintf("wgo: mergeWith mismatched routing: %s/%d nodeID=%d vs %s/%d nodeID=%d",
+				p.topic, p.partition, p.nodeID, o.topic, o.partition, o.nodeID))
+		}
+	}
+
+	records := decodeBatch(p.encoded)
+	for _, o := range others {
+		records = append(records, decodeBatch(o.encoded)...)
+	}
+
+	return routedEncodedTopicPartitionRecords{
+		encodedTopicPartitionRecords: newEncodedTopicPartitionRecords(p.topic, p.partition, records),
+		nodeID:                       p.nodeID,
+		// Take the latest Add's nodeState: it is the freshest routing-time view of
+		// the agent, which is what the hedger trusts to decide probe (zero-delay)
+		// hedging.
+		nodeState: others[len(others)-1].nodeState,
+	}
 }
 
 // unrouteEncodedTopicPartitionRecords returns the routing-less encodedTopicPartitionRecords view for

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/hedger.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/hedger.go
@@ -75,10 +75,10 @@ type Hedger struct {
 	metrics  *metrics
 
 	// hedgeBuffer batches per-wave per-agent groups across concurrent
-	// ProduceSync calls heading to the same agent. Its AgentFlushFunc is
-	// h.inner.ProduceSync directly, so hedge-origin flushes go straight
-	// through the DirectProducer chain without recursing into this Hedger.
-	hedgeBuffer *ClusterRecordBuffer
+	// ProduceSync calls heading to the same agent. Its flush hands each wave
+	// straight to inner.ProduceSync (the DirectProducer chain), so hedge-origin
+	// flushes never recurse into this Hedger.
+	hedgeBuffer *ClusterBuffer[routedEncodedTopicPartitionRecords]
 }
 
 // NewHedger wraps inner with the orchestration described on Hedger.
@@ -91,14 +91,14 @@ func NewHedger(inner DirectProducer, tracker AgentStatsReader, strategy Partitio
 		cfg:      cfg,
 		metrics:  m,
 	}
-	h.hedgeBuffer = NewClusterRecordBuffer(linger, batchMaxBytes, func(ctx context.Context, nodeID int32, parts []routedTopicPartitionRecords) ProduceResult {
+	h.hedgeBuffer = NewClusterBuffer[routedEncodedTopicPartitionRecords](linger, batchMaxBytes, func(ctx context.Context, nodeID int32, parts []routedEncodedTopicPartitionRecords) ProduceResult {
 		// Every hedge-buffer flush is one hedge wire request (possibly
 		// covering multiple partitions). The companion primary counter is
 		// incremented in ProduceSync.
 		m.produceRequestsHedgeTotal.Inc()
 
 		// DirectProducer takes unrouted partitions (the nodeID is specified separately), so we strip the routing.
-		return inner.ProduceSync(ctx, nodeID, unrouteTopicPartitionRecords(parts))
+		return inner.ProduceSync(ctx, nodeID, unrouteEncodedTopicPartitionRecords(parts))
 	}, m, nil) // nil reg: the client's main buffer owns the buffered-producer gauges.
 	return h
 }
@@ -111,7 +111,7 @@ func (h *Hedger) Close() {
 
 // ProduceSync resolves every partition to a terminal outcome and returns a
 // ProduceResult whose response merges each partition's outcome.
-func (h *Hedger) ProduceSync(ctx context.Context, primaryID int32, routedPartitions []routedTopicPartitionRecords) ProduceResult {
+func (h *Hedger) ProduceSync(ctx context.Context, primaryID int32, routedPartitions []routedEncodedTopicPartitionRecords) ProduceResult {
 	if len(routedPartitions) == 0 {
 		// Nothing to do is trivially successful. A bare ProduceResult{} would
 		// instead read as the empty/error sentinel via succeeded()/error().
@@ -143,7 +143,7 @@ func (h *Hedger) ProduceSync(ctx context.Context, primaryID int32, routedPartiti
 	// The rest of the Hedger works with unrouted partitions, because it will be
 	// responsible to route partitions to other candidate agents during hedging
 	// and retries.
-	partitions := unrouteTopicPartitionRecords(routedPartitions)
+	partitions := unrouteEncodedTopicPartitionRecords(routedPartitions)
 
 	// workCtx scopes both the primary and any hedge waves to this single
 	// ProduceSync call. Canceling it (fallback wins, or function returns)
@@ -206,7 +206,7 @@ func (h *Hedger) ProduceSync(ctx context.Context, primaryID int32, routedPartiti
 // cancel as soon as this function returns, which unwinds the losing leg.
 // The reported attempts is the depth of the winning leg: 1 when the
 // primary wins, the fallback's own depth when the fallback wins.
-func (h *Hedger) runHedgingAttemptsAndRaceWithPrimary(workCtx context.Context, primaryID int32, partitions []topicPartitionRecords, candidates *hedgerCandidates, primaryCh <-chan ProduceResult) hedgerProduceResult {
+func (h *Hedger) runHedgingAttemptsAndRaceWithPrimary(workCtx context.Context, primaryID int32, partitions []encodedTopicPartitionRecords, candidates *hedgerCandidates, primaryCh <-chan ProduceResult) hedgerProduceResult {
 	fallbackCh := make(chan hedgerProduceResult, 1)
 	go func() {
 		fallbackCh <- h.runHedgingAttempts(workCtx, primaryID, partitions, candidates)
@@ -246,7 +246,7 @@ func (h *Hedger) runHedgingAttemptsAndRaceWithPrimary(workCtx context.Context, p
 // MaxHedgeAgents, or ctx is canceled. The reported attempts is the total
 // attempt depth: 1 (the primary, which this function models as the first
 // tried agent) plus one per hedge wave dispatched.
-func (h *Hedger) runHedgingAttempts(workCtx context.Context, primaryID int32, partitions []topicPartitionRecords, candidates *hedgerCandidates) (out hedgerProduceResult) {
+func (h *Hedger) runHedgingAttempts(workCtx context.Context, primaryID int32, partitions []encodedTopicPartitionRecords, candidates *hedgerCandidates) (out hedgerProduceResult) {
 	h.metrics.hedgeAttemptsTotal.Inc()
 	// Count a win only when the result is successful AND we weren't
 	// preempted by ctx cancellation (e.g. the racing variant aborting
@@ -315,7 +315,7 @@ func (h *Hedger) runHedgingAttempt(workCtx context.Context, acc *produceResultAc
 	// loop: the batch can never produce every partition successfully, so
 	// further waves on the remaining partitions waste effort. Pending
 	// partitions will surface as per-partition errors in result().
-	groups := map[int32][]topicPartitionRecords{}
+	groups := map[int32][]encodedTopicPartitionRecords{}
 	for _, p := range pending {
 		tp := topicPartition{topic: p.topic, partition: p.partition}
 
@@ -367,7 +367,7 @@ func (h *Hedger) runHedgingAttempt(workCtx context.Context, acc *produceResultAc
 		legDone := func(res ProduceResult) {
 			once.Do(func() { results <- res })
 		}
-		h.hedgeBuffer.Add(attemptCtx, newMultiRoutedTopicPartitionRecords(parts, agent, legDone))
+		h.hedgeBuffer.Add(attemptCtx, newMultiRoutedEncodedTopicPartitionRecords(parts, agent, legDone))
 	}
 
 	for remaining := len(groups); remaining > 0; remaining-- {
@@ -388,7 +388,7 @@ func (h *Hedger) runHedgingAttempt(workCtx context.Context, acc *produceResultAc
 }
 
 // shouldHedge returns the hedge delay (and whether to hedge) for primaryID.
-func (h *Hedger) shouldHedge(now time.Time, primaryID int32, partitions []routedTopicPartitionRecords) (time.Duration, bool) {
+func (h *Hedger) shouldHedge(now time.Time, primaryID int32, partitions []routedEncodedTopicPartitionRecords) (time.Duration, bool) {
 	// Probe routing: trust the routing-time nodeState. Re-querying the
 	// strategy would consume another probe slot through the Demoter.
 	for _, p := range partitions {

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/metrics.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/metrics.go
@@ -160,7 +160,7 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 // buffer, neither of which this client uses — it produces via raw
 // Broker.Request — so kprom would report them as a constant zero. We register
 // the same names with real values (the produceWire* counters above and the
-// ClusterRecordBuffer gauges) and drop kprom's versions to avoid a duplicate
+// ClusterBuffer gauges) and drop kprom's versions to avoid a duplicate
 // registration.
 var kpromProducerStateMetricNames = []string{
 	"produce_bytes_total",

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/partition_assignment.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/partition_assignment.go
@@ -80,7 +80,7 @@ type PartitionAssignmentStrategy interface {
 
 // LazyPartitionAssignmentStrategy resolves the underlying strategy on every
 // call. The strategy is rebuilt by AgentPool.Refresh, but consumers like
-// Hedger and ClusterRecordBuffer are wired once at startup; this indirection
+// Hedger and ClusterBuffer are wired once at startup; this indirection
 // lets them pick up the latest snapshot without rewiring.
 type LazyPartitionAssignmentStrategy struct {
 	resolve func() PartitionAssignmentStrategy

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/produce.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/produce.go
@@ -313,6 +313,53 @@ func encodeBatch(records []*kgo.Record) (buf []byte, uncompressedBytes, compress
 	return buf, uncompressedBytes, compressedBytes
 }
 
+// decodeBatch parses a serialised RecordBatch back into records, inverting
+// encodeBatch for the fields this client sets (key, value, headers, timestamp).
+// It is used to re-merge several pre-encoded batches for one partition into a
+// single batch. It expects exactly one complete batch; any bytes trailing the
+// first batch are ignored. The input is always bytes this client encoded, so a
+// decode failure is a bug and panics.
+func decodeBatch(encoded []byte) []*kgo.Record {
+	var rb kmsg.RecordBatch
+	if err := rb.ReadFrom(encoded); err != nil {
+		panic(fmt.Sprintf("wgo: decodeBatch: read RecordBatch: %v", err))
+	}
+
+	payload := rb.Records
+	if rb.Attributes&0x7 == 2 { // CodecSnappy
+		dec, err := s2.Decode(nil, payload)
+		if err != nil {
+			panic(fmt.Sprintf("wgo: decodeBatch: snappy decode: %v", err))
+		}
+		payload = dec
+	}
+
+	records := make([]*kgo.Record, 0, rb.NumRecords)
+	for len(payload) > 0 {
+		var rec kmsg.Record
+		if err := rec.ReadFrom(payload); err != nil {
+			panic(fmt.Sprintf("wgo: decodeBatch: read Record: %v", err))
+		}
+
+		var headers []kgo.RecordHeader
+		if len(rec.Headers) > 0 {
+			headers = make([]kgo.RecordHeader, len(rec.Headers))
+			for i, h := range rec.Headers {
+				headers[i] = kgo.RecordHeader{Key: h.Key, Value: h.Value}
+			}
+		}
+		records = append(records, &kgo.Record{
+			Key:       rec.Key,
+			Value:     rec.Value,
+			Headers:   headers,
+			Timestamp: time.UnixMilli(rb.FirstTimestamp + rec.TimestampDelta64),
+		})
+
+		payload = payload[kbin.VarintLen(rec.Length)+int(rec.Length):]
+	}
+	return records
+}
+
 // putBuf returns a buffer to the pool, dropping it if it grew too large.
 func putBuf(ptr *[]byte, buf []byte) {
 	if cap(buf) <= maxPooledBufCap {

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/produce.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/produce.go
@@ -118,56 +118,79 @@ type produceRequestStats struct {
 	compressedBytes   int64
 }
 
-// buildMultiTopicProduceRequest builds a ProduceRequest covering records that
-// may span multiple topics. topicID maps a topic name to its UUID, returning
-// ok=false when the topic is unknown to the caller; an unknown topic fails
-// the build with an error. Both topic name and UUID are populated per topic
-// so the request is valid across the v0-v12 / v13+ API divide. The returned
-// stats feed the producer-state metrics.
-func buildMultiTopicProduceRequest(version int16, topicID func(string) ([16]byte, bool), records []*kgo.Record) (*kmsg.ProduceRequest, produceRequestStats, error) {
-	byTopic := make(map[string][]*kgo.Record)
-	for _, r := range records {
-		byTopic[r.Topic] = append(byTopic[r.Topic], r)
+// add returns the element-wise sum of two stats.
+func (s produceRequestStats) add(o produceRequestStats) produceRequestStats {
+	return produceRequestStats{
+		records:           s.records + o.records,
+		batches:           s.batches + o.batches,
+		uncompressedBytes: s.uncompressedBytes + o.uncompressedBytes,
+		compressedBytes:   s.compressedBytes + o.compressedBytes,
+	}
+}
+
+// buildMultiTopicProduceRequestFromEncoded builds a ProduceRequest covering pre-encoded
+// partitions that may span multiple topics. topicID maps a topic name to its
+// UUID, returning ok=false when the topic is unknown to the caller; an unknown
+// topic fails the build with an error. Both topic name and UUID are populated
+// per topic so the request is valid across the v0-v12 / v13+ API divide.
+//
+// Each partition contributes its pre-encoded RecordBatch. The returned stats
+// feed the producer-state metrics.
+//
+// partitions must hold at most one entry per (topic, partition); duplicates are
+// rejected with an error rather than merged.
+func buildMultiTopicProduceRequestFromEncoded(version int16, topicID func(string) ([16]byte, bool), partitions []encodedTopicPartitionRecords) (*kmsg.ProduceRequest, produceRequestStats, error) {
+	// Track first-seen topic order and iterate it rather than ranging byTopic
+	// directly: Go randomises map iteration, so ranging the map would emit the
+	// request's topics in a different order on every call. Kafka doesn't care
+	// about topic order, but a stable layout keeps the output deterministic
+	// (reproducible requests, non-flaky tests).
+	byTopic := make(map[string][]encodedTopicPartitionRecords)
+	topicOrder := make([]string, 0)
+	for _, p := range partitions {
+		if _, ok := byTopic[p.topic]; !ok {
+			topicOrder = append(topicOrder, p.topic)
+		}
+		byTopic[p.topic] = append(byTopic[p.topic], p)
 	}
 
 	var stats produceRequestStats
 	req := kmsg.NewProduceRequest()
 	req.Version = version
 	req.Acks = -1 // all ISR
-	for topic, topicRecords := range byTopic {
+	for _, topic := range topicOrder {
 		id, ok := topicID(topic)
 		if !ok {
 			return nil, produceRequestStats{}, fmt.Errorf("topic %q not known", topic)
 		}
-		byPartition := groupByPartition(topicRecords)
-		partitions := make([]kmsg.ProduceRequestTopicPartition, 0, len(byPartition))
-		for partition, recs := range byPartition {
-			batch, uncompressed, compressed := encodeBatch(recs)
-			partitions = append(partitions, kmsg.ProduceRequestTopicPartition{
-				Partition: partition,
-				Records:   batch,
+		topicPartitions := byTopic[topic]
+		reqPartitions := make([]kmsg.ProduceRequestTopicPartition, 0, len(topicPartitions))
+		seen := make(map[int32]struct{}, len(topicPartitions))
+		for _, p := range topicPartitions {
+			// Merging batches for the same partition is not supported: a duplicate
+			// would emit two entries for one partition — a malformed request — so
+			// fail loud instead.
+			if _, dup := seen[p.partition]; dup {
+				return nil, produceRequestStats{}, fmt.Errorf("duplicate partition %d for topic %q", p.partition, topic)
+			}
+			seen[p.partition] = struct{}{}
+
+			if len(p.encoded) == 0 {
+				continue
+			}
+			reqPartitions = append(reqPartitions, kmsg.ProduceRequestTopicPartition{
+				Partition: p.partition,
+				Records:   p.encoded,
 			})
-			stats.records += int64(len(recs))
-			stats.batches++
-			stats.uncompressedBytes += int64(uncompressed)
-			stats.compressedBytes += int64(compressed)
+			stats = stats.add(p.encodedStats)
 		}
 		req.Topics = append(req.Topics, kmsg.ProduceRequestTopic{
 			Topic:      topic,
 			TopicID:    id,
-			Partitions: partitions,
+			Partitions: reqPartitions,
 		})
 	}
 	return &req, stats, nil
-}
-
-// groupByPartition groups records by their partition field.
-func groupByPartition(records []*kgo.Record) map[int32][]*kgo.Record {
-	m := make(map[int32][]*kgo.Record)
-	for _, r := range records {
-		m[r.Partition] = append(m[r.Partition], r)
-	}
-	return m
 }
 
 // parseProduceResponse returns the first per-partition error, or nil on no error.

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/produce_result.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/produce_result.go
@@ -101,7 +101,7 @@ func getProduceResultErr(err error) produceResultErr {
 // produced records are tolerated.
 type produceResultAccumulator struct {
 	mu       sync.Mutex
-	pending  map[topicPartition][]*kgo.Record
+	pending  map[topicPartition]encodedTopicPartitionRecords
 	resolved map[topicPartition]kmsg.ProduceResponseTopicPartition
 	// failed holds the most recent per-partition entry with a non-zero
 	// ErrorCode for partitions still in pending. response() prefers
@@ -121,9 +121,9 @@ type produceResultAccumulator struct {
 // newProduceResultAccumulator returns an accumulator seeded with the
 // topic-partitions to produce. Duplicate (topic, partition) keys return
 // an error.
-func newProduceResultAccumulator(partitions []topicPartitionRecords) (*produceResultAccumulator, error) {
+func newProduceResultAccumulator(partitions []encodedTopicPartitionRecords) (*produceResultAccumulator, error) {
 	a := &produceResultAccumulator{
-		pending:          make(map[topicPartition][]*kgo.Record, len(partitions)),
+		pending:          make(map[topicPartition]encodedTopicPartitionRecords, len(partitions)),
 		resolved:         make(map[topicPartition]kmsg.ProduceResponseTopicPartition),
 		failed:           make(map[topicPartition]kmsg.ProduceResponseTopicPartition),
 		responseTopicIDs: make(map[string][16]byte),
@@ -131,25 +131,22 @@ func newProduceResultAccumulator(partitions []topicPartitionRecords) (*produceRe
 	for _, p := range partitions {
 		key := topicPartition{topic: p.topic, partition: p.partition}
 		if _, exists := a.pending[key]; exists {
-			// Reject duplicates: the merge logic assumes one record set per key.
+			// Reject duplicates: the merge logic assumes one entry per key.
 			return nil, fmt.Errorf("duplicate topic-partition in input: topic=%q partition=%d", p.topic, p.partition)
 		}
-		a.pending[key] = p.records
+		a.pending[key] = p
 	}
 	return a, nil
 }
 
-// remaining returns the partitions still pending.
-func (a *produceResultAccumulator) remaining() []topicPartitionRecords {
+// remaining returns the partitions still pending, each carrying its pre-encoded
+// batch.
+func (a *produceResultAccumulator) remaining() []encodedTopicPartitionRecords {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	out := make([]topicPartitionRecords, 0, len(a.pending))
-	for tp, records := range a.pending {
-		out = append(out, topicPartitionRecords{
-			topic:     tp.topic,
-			partition: tp.partition,
-			records:   records,
-		})
+	out := make([]encodedTopicPartitionRecords, 0, len(a.pending))
+	for _, p := range a.pending {
+		out = append(out, p)
 	}
 	return out
 }

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/routed_batch.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/routed_batch.go
@@ -1,0 +1,110 @@
+package wgo
+
+import "sync"
+
+// routedBatch is the per-item behavior the generic buffer delegates to: the
+// routing key and decision, the accounting sizes, and the split/merge
+// operations that differ between unencoded records and pre-encoded batches.
+type routedBatch[W any] interface {
+	getTopicPartition() topicPartition
+	getNodeID() int32
+	recordCount() int
+	payloadBytes() int64
+	wireBytes() int64
+	splitByMaxBytes(max int32) []W
+	mergeWith(other W) W
+}
+
+// Compile-time assertion that both item types satisfy routedBatch. It also marks
+// methods reached only through the type parameter as used, which the unused
+// linter does not track across generic instantiation.
+var (
+	_ routedBatch[routedTopicPartitionRecords]        = routedTopicPartitionRecords{}
+	_ routedBatch[routedEncodedTopicPartitionRecords] = routedEncodedTopicPartitionRecords{}
+)
+
+// promised pairs a routedBatch item with a done callback that fires exactly once
+// with the item's terminal ProduceResult: a full ProduceResponse on success, or
+// an error result on failure or ctx-cancel (which may still carry a partial
+// response). All records in the item share that outcome.
+type promised[W routedBatch[W]] struct {
+	item W
+	done func(ProduceResult)
+}
+
+// unpromise returns the done-less item view of each promised entry.
+func unpromise[W routedBatch[W]](parts []promised[W]) []W {
+	out := make([]W, len(parts))
+	for i, p := range parts {
+		out[i] = p.item
+	}
+	return out
+}
+
+// splitPromisedRoutedBatchByBatchMaxBytes splits in's item so each returned chunk's
+// standalone wire batch fits within batchMaxBytes, returning in unchanged when
+// it already fits. When split, the chunks share a fan-in done that fires in's
+// done once, after all chunks have resolved.
+func splitPromisedRoutedBatchByBatchMaxBytes[W routedBatch[W]](in promised[W], batchMaxBytes int32) []promised[W] {
+	chunks := in.item.splitByMaxBytes(batchMaxBytes)
+	if len(chunks) <= 1 {
+		return []promised[W]{in}
+	}
+
+	// Capture the done func, not in itself: referencing in.done directly would
+	// make the closure retain all of in until the last chunk completes.
+	origDone := in.done
+	var (
+		mu         sync.Mutex
+		remaining  = len(chunks)
+		chosen     ProduceResult
+		haveChosen bool
+		chosenOK   bool
+	)
+	// The chunks all share in's single (topic, partition), so origDone fires once
+	// after every chunk resolves, choosing a failing result over a success.
+	// Per-chunk responses need no merging: reporting any failure triggers a safe
+	// whole-partition retry under at-least-once.
+	done := func(res ProduceResult) {
+		mu.Lock()
+		remaining--
+		if !haveChosen {
+			chosen = res
+			haveChosen = true
+			chosenOK = res.error() == nil
+		} else if chosenOK && res.error() != nil {
+			chosen = res
+			chosenOK = false
+		}
+		last := remaining == 0
+		result := chosen
+		mu.Unlock()
+		if last {
+			origDone(result)
+		}
+	}
+
+	out := make([]promised[W], len(chunks))
+	for i, c := range chunks {
+		out[i] = promised[W]{item: c, done: done}
+	}
+	return out
+}
+
+// mergePromisedRoutedBatchByTopicPartition returns one done-less wire item per
+// (topic, partition), merging items that share a partition in arrival order via
+// W.mergeWith. Backing arrays of the inputs are never mutated.
+func mergePromisedRoutedBatchByTopicPartition[W routedBatch[W]](entries []promised[W]) []W {
+	out := make([]W, 0, len(entries))
+	index := make(map[topicPartition]int, len(entries))
+	for _, e := range entries {
+		tp := e.item.getTopicPartition()
+		if i, ok := index[tp]; ok {
+			out[i] = out[i].mergeWith(e.item)
+			continue
+		}
+		index[tp] = len(out)
+		out = append(out, e.item)
+	}
+	return out
+}

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/routed_batch.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/routed_batch.go
@@ -10,9 +10,13 @@ type routedBatch[W any] interface {
 	getNodeID() int32
 	recordCount() int
 	payloadBytes() int64
-	wireBytes() int64
+	uncompressedWireBytes() int64
 	splitByMaxBytes(max int32) []W
-	mergeWith(other W) W
+
+	// mergeWith folds the receiver and others (all sharing the receiver's topic,
+	// partition, and nodeID) into one item. Empty others returns the receiver
+	// unchanged and must be cheap.
+	mergeWith(others []W) W
 }
 
 // Compile-time assertion that both item types satisfy routedBatch. It also marks
@@ -95,16 +99,21 @@ func splitPromisedRoutedBatchByBatchMaxBytes[W routedBatch[W]](in promised[W], b
 // (topic, partition), merging items that share a partition in arrival order via
 // W.mergeWith. Backing arrays of the inputs are never mutated.
 func mergePromisedRoutedBatchByTopicPartition[W routedBatch[W]](entries []promised[W]) []W {
-	out := make([]W, 0, len(entries))
-	index := make(map[topicPartition]int, len(entries))
+	order := make([]topicPartition, 0, len(entries))
+	groups := make(map[topicPartition][]W, len(entries))
 	for _, e := range entries {
 		tp := e.item.getTopicPartition()
-		if i, ok := index[tp]; ok {
-			out[i] = out[i].mergeWith(e.item)
-			continue
+		if _, ok := groups[tp]; !ok {
+			order = append(order, tp)
 		}
-		index[tp] = len(out)
-		out = append(out, e.item)
+		groups[tp] = append(groups[tp], e.item)
+	}
+
+	// Merge each partition's items in one shot.
+	out := make([]W, 0, len(order))
+	for _, tp := range order {
+		g := groups[tp]
+		out = append(out, g[0].mergeWith(g[1:]))
 	}
 	return out
 }

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/routed_topic_partition.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/routed_topic_partition.go
@@ -1,28 +1,29 @@
 package wgo
 
 import (
-	"sync"
+	"fmt"
 
 	"github.com/twmb/franz-go/pkg/kgo"
 )
 
-// topicPartitionRecords is the bare "what to produce" data for one Kafka
-// partition: a topic, a partition index, and the records to write. It
-// carries no routing or completion-handling state; the layers below the
-// buffer (the DirectProducer chain) take []topicPartitionRecords as
-// input because all they need to do is encode and ship a wire request.
+// topicPartitionRecords is the records to produce for one Kafka partition,
+// before wire encoding: a topic, a partition index, and the records to write.
 type topicPartitionRecords struct {
 	topic     string
 	partition int32
 	records   []*kgo.Record
 }
 
-// recordPayloadBytes returns the producer-side accounting size of the group,
-// mirroring franz-go's BufferedProduceBytes.
-//
-// It intentionally omits Kafka wire overhead (record batch header, varints,
-// etc.) so the counter matches what franz-go reports for the same records.
-func (p *topicPartitionRecords) recordPayloadBytes() int64 {
+// recordCount returns the number of records in the group.
+func (p topicPartitionRecords) recordCount() int {
+	return len(p.records)
+}
+
+// payloadBytes returns the producer-side accounting size of the group,
+// mirroring franz-go's BufferedProduceBytes. It omits Kafka wire overhead
+// (record batch header, varints) so the counter matches what franz-go reports
+// for the same records.
+func (p topicPartitionRecords) payloadBytes() int64 {
 	var n int64
 	for _, r := range p.records {
 		n += int64(len(r.Key) + len(r.Value))
@@ -46,105 +47,26 @@ type routedTopicPartitionRecords struct {
 	nodeState AgentState
 }
 
-// unrouteTopicPartitionRecords returns the bare topicPartitionRecords
-// slice for callers that don't care about routing or done state.
-func unrouteTopicPartitionRecords(parts []routedTopicPartitionRecords) []topicPartitionRecords {
-	out := make([]topicPartitionRecords, len(parts))
-	for i, p := range parts {
-		out[i] = p.topicPartitionRecords
-	}
-	return out
+func (p routedTopicPartitionRecords) getTopicPartition() topicPartition {
+	return topicPartition{topic: p.topic, partition: p.partition}
 }
 
-// promisedRoutedTopicPartitionRecords is a routedTopicPartitionRecords paired
-// with a done callback that carries the group's terminal ProduceResult.
-type promisedRoutedTopicPartitionRecords struct {
-	routedTopicPartitionRecords
+func (p routedTopicPartitionRecords) getNodeID() int32 { return p.nodeID }
 
-	// done fires exactly once with the partition's terminal ProduceResult: a
-	// full ProduceResponse on success, or an error result on failure or
-	// ctx-cancel — which may still carry a partial response (e.g. the
-	// retry-exhausted kgo.ErrRecordTimeout envelope with per-partition entries).
-	// Callers that only care about the error split it out via
-	// ProduceResult.error(). All records in the group share that outcome —
-	// per-record fan-out is the concern of the caller that built the group
-	// (e.g. WarpstreamClient.ProduceSync).
-	done func(ProduceResult)
+// wireBytes returns the standalone RecordBatch estimate for the group, so the
+// flush-size gate agrees with splitByMaxBytes on what fits.
+func (p routedTopicPartitionRecords) wireBytes() int64 {
+	return multiRecordBatchEstimateBytes(p.records)
 }
 
-// newMultiRoutedTopicPartitionRecords stamps each input with the same
-// routing decision (nodeID) and shared done callback. Used by callers
-// that batch multiple partitions to the same agent in one wave.
-func newMultiRoutedTopicPartitionRecords(parts []topicPartitionRecords, nodeID int32, done func(ProduceResult)) []promisedRoutedTopicPartitionRecords {
-	out := make([]promisedRoutedTopicPartitionRecords, len(parts))
-	for i, p := range parts {
-		out[i] = promisedRoutedTopicPartitionRecords{
-			routedTopicPartitionRecords: routedTopicPartitionRecords{
-				topicPartitionRecords: p,
-				nodeID:                nodeID,
-			},
-			done: done,
-		}
-	}
-	return out
-}
-
-// unpromiseRoutedTopicPartitionRecords returns the done-less
-// routedTopicPartitionRecords view of each entry, for callers that need the
-// routing decision and records but not the completion callback.
-func unpromiseRoutedTopicPartitionRecords(parts []promisedRoutedTopicPartitionRecords) []routedTopicPartitionRecords {
-	out := make([]routedTopicPartitionRecords, len(parts))
-	for i, p := range parts {
-		out[i] = p.routedTopicPartitionRecords
-	}
-	return out
-}
-
-// mergePromisedRoutedTopicPartitionRecordsByTopicPartition returns one
-// routedTopicPartitionRecords per (topic, partition), concatenating the records
-// of entries that share a partition (in arrival order). The merged entry takes
-// the last contributor's nodeState — the freshest routing-time classification
-// of the agent. This is the done-less wire view handed to a flush; completion is fired
-// separately on the original promised entries, so this view drops done. Backing
-// arrays of the inputs are never mutated.
-func mergePromisedRoutedTopicPartitionRecordsByTopicPartition(entries []promisedRoutedTopicPartitionRecords) []routedTopicPartitionRecords {
-	out := make([]routedTopicPartitionRecords, 0, len(entries))
-	for _, e := range entries {
-		merged := false
-		for i := range out {
-			if out[i].topic == e.topic && out[i].partition == e.partition {
-				combined := make([]*kgo.Record, 0, len(out[i].records)+len(e.records))
-				combined = append(combined, out[i].records...)
-				combined = append(combined, e.records...)
-				out[i].records = combined
-				// Take the latest Add's nodeState: it is the freshest
-				// routing-time view of the agent, which is what the hedger
-				// trusts to decide probe (zero-delay) hedging.
-				out[i].nodeState = e.nodeState
-				merged = true
-				break
-			}
-		}
-		if !merged {
-			out = append(out, e.routedTopicPartitionRecords)
-		}
-	}
-	return out
-}
-
-// splitPromisedRoutedTopicPartitionRecordsByBatchMaxBytes splits in's records
-// so each returned group's standalone RecordBatch fits within batchMaxBytes.
-//
-// The whole group is returned unchanged when it already fits (the common case).
-// When it must be split, the chunks share a fan-in done: in.done fires exactly once,
-// after every chunk has resolved, with a failing result if any chunk failed (else a
-// success).
-//
-// Each record's own batch is <= batchMaxBytes (enforced by the per-record gate), so
-// every chunk carries at least one record and the split always terminates.
-func splitPromisedRoutedTopicPartitionRecordsByBatchMaxBytes(in promisedRoutedTopicPartitionRecords, batchMaxBytes int32) []promisedRoutedTopicPartitionRecords {
-	if multiRecordBatchEstimateBytes(in.records) <= int64(batchMaxBytes) {
-		return []promisedRoutedTopicPartitionRecords{in}
+// splitByMaxBytes splits the records so each returned chunk's standalone
+// RecordBatch fits within batchMaxBytes, returning the group unchanged when it
+// already fits. Each record's own batch is <= batchMaxBytes (the per-record
+// gate enforces this), so every chunk carries at least one record and the split
+// terminates.
+func (p routedTopicPartitionRecords) splitByMaxBytes(batchMaxBytes int32) []routedTopicPartitionRecords {
+	if multiRecordBatchEstimateBytes(p.records) <= int64(batchMaxBytes) {
+		return []routedTopicPartitionRecords{p}
 	}
 
 	var (
@@ -153,7 +75,7 @@ func splitPromisedRoutedTopicPartitionRecordsByBatchMaxBytes(in promisedRoutedTo
 		currBytes   int64
 		firstTS     int64
 	)
-	for _, r := range in.records {
+	for _, r := range p.records {
 		if len(currRecords) == 0 {
 			firstTS = r.Timestamp.UnixMilli()
 			currRecords = append(currRecords, r)
@@ -175,47 +97,32 @@ func splitPromisedRoutedTopicPartitionRecordsByBatchMaxBytes(in promisedRoutedTo
 	}
 	chunks = append(chunks, currRecords)
 
-	// Fan-in done: every chunk shares in's single (topic, partition), so
-	// in.done just needs firing once, after all chunks resolve, with the first
-	// failing result if any chunk failed (else a success). No merging of the
-	// per-chunk responses is needed — in.done resolves only that one partition's
-	// outcome, and reporting any chunk's failure triggers a safe whole-partition
-	// retry under at-least-once.
-	// Capture the done func, not in itself: referencing in.done directly would
-	// make the closure retain all of in (notably in.records) until the last
-	// chunk completes.
-	origDone := in.done
-	var (
-		mu         sync.Mutex
-		remaining  = len(chunks)
-		chosen     ProduceResult
-		haveChosen bool
-		chosenOK   bool
-	)
-	done := func(res ProduceResult) {
-		mu.Lock()
-		remaining--
-		if !haveChosen {
-			chosen = res
-			haveChosen = true
-			chosenOK = res.error() == nil
-		} else if chosenOK && res.error() != nil {
-			chosen = res
-			chosenOK = false
-		}
-		last := remaining == 0
-		result := chosen
-		mu.Unlock()
-		if last {
-			origDone(result)
-		}
-	}
-
-	out := make([]promisedRoutedTopicPartitionRecords, len(chunks))
+	out := make([]routedTopicPartitionRecords, len(chunks))
 	for i, c := range chunks {
-		out[i] = in
+		out[i] = p
 		out[i].records = c
-		out[i].done = done
 	}
 	return out
+}
+
+// mergeWith concatenates other's records after p's (arrival order) and takes
+// other's nodeState. A fresh backing slice is allocated so neither input is
+// mutated.
+func (p routedTopicPartitionRecords) mergeWith(other routedTopicPartitionRecords) routedTopicPartitionRecords {
+	// Merging items for a different topic, partition, or nodeID is a bug, not a
+	// runtime case: fail loud rather than silently combine unrelated batches.
+	if p.topic != other.topic || p.partition != other.partition || p.nodeID != other.nodeID {
+		panic(fmt.Sprintf("wgo: mergeWith mismatched routing: %s/%d nodeID=%d vs %s/%d nodeID=%d",
+			p.topic, p.partition, p.nodeID, other.topic, other.partition, other.nodeID))
+	}
+
+	combined := make([]*kgo.Record, 0, len(p.records)+len(other.records))
+	combined = append(combined, p.records...)
+	combined = append(combined, other.records...)
+	p.records = combined
+	// Take the latest Add's nodeState: it is the freshest
+	// routing-time view of the agent, which is what the hedger
+	// trusts to decide probe (zero-delay) hedging.
+	p.nodeState = other.nodeState
+	return p
 }

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/routed_topic_partition.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/routed_topic_partition.go
@@ -53,9 +53,9 @@ func (p routedTopicPartitionRecords) getTopicPartition() topicPartition {
 
 func (p routedTopicPartitionRecords) getNodeID() int32 { return p.nodeID }
 
-// wireBytes returns the standalone RecordBatch estimate for the group, so the
-// flush-size gate agrees with splitByMaxBytes on what fits.
-func (p routedTopicPartitionRecords) wireBytes() int64 {
+// uncompressedWireBytes returns the uncompressed wire size of the group encoded
+// as a single standalone RecordBatch.
+func (p routedTopicPartitionRecords) uncompressedWireBytes() int64 {
 	return multiRecordBatchEstimateBytes(p.records)
 }
 
@@ -105,24 +105,33 @@ func (p routedTopicPartitionRecords) splitByMaxBytes(batchMaxBytes int32) []rout
 	return out
 }
 
-// mergeWith concatenates other's records after p's (arrival order) and takes
-// other's nodeState. A fresh backing slice is allocated so neither input is
-// mutated.
-func (p routedTopicPartitionRecords) mergeWith(other routedTopicPartitionRecords) routedTopicPartitionRecords {
-	// Merging items for a different topic, partition, or nodeID is a bug, not a
-	// runtime case: fail loud rather than silently combine unrelated batches.
-	if p.topic != other.topic || p.partition != other.partition || p.nodeID != other.nodeID {
-		panic(fmt.Sprintf("wgo: mergeWith mismatched routing: %s/%d nodeID=%d vs %s/%d nodeID=%d",
-			p.topic, p.partition, p.nodeID, other.topic, other.partition, other.nodeID))
+// mergeWith concatenates others' records after p's (arrival order) and takes the
+// last contributor's nodeState. A fresh backing slice is allocated so no input
+// is mutated. Returns p unchanged when others is empty.
+func (p routedTopicPartitionRecords) mergeWith(others []routedTopicPartitionRecords) routedTopicPartitionRecords {
+	if len(others) == 0 {
+		return p
 	}
 
-	combined := make([]*kgo.Record, 0, len(p.records)+len(other.records))
+	total := len(p.records)
+	for _, o := range others {
+		// Merging items for a different topic, partition, or nodeID is a bug, not
+		// a runtime case: fail loud rather than silently combine unrelated batches.
+		if p.topic != o.topic || p.partition != o.partition || p.nodeID != o.nodeID {
+			panic(fmt.Sprintf("wgo: mergeWith mismatched routing: %s/%d nodeID=%d vs %s/%d nodeID=%d",
+				p.topic, p.partition, p.nodeID, o.topic, o.partition, o.nodeID))
+		}
+		total += len(o.records)
+	}
+
+	combined := make([]*kgo.Record, 0, total)
 	combined = append(combined, p.records...)
-	combined = append(combined, other.records...)
+	for _, o := range others {
+		combined = append(combined, o.records...)
+	}
 	p.records = combined
-	// Take the latest Add's nodeState: it is the freshest
-	// routing-time view of the agent, which is what the hedger
-	// trusts to decide probe (zero-delay) hedging.
-	p.nodeState = other.nodeState
+	// Take the latest Add's nodeState: it is the freshest routing-time view of the
+	// agent, which is what the hedger trusts to decide probe (zero-delay) hedging.
+	p.nodeState = others[len(others)-1].nodeState
 	return p
 }

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/tracking_producer.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/tracking_producer.go
@@ -19,7 +19,7 @@ func NewTrackingProducer(inner DirectProducer, tracker AgentStatsTracker) *Track
 }
 
 // ProduceSync implements DirectProducer.
-func (p *TrackingProducer) ProduceSync(ctx context.Context, nodeID int32, partitions []topicPartitionRecords) ProduceResult {
+func (p *TrackingProducer) ProduceSync(ctx context.Context, nodeID int32, partitions []encodedTopicPartitionRecords) ProduceResult {
 	start := time.Now()
 	res := p.inner.ProduceSync(ctx, nodeID, partitions)
 	// Use ProduceResult.error() so the tracked error is consistent with what

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/client.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/client.go
@@ -2225,13 +2225,35 @@ func (cl *Client) deleteStaleCoordinatorsByNode(node int32) {
 	cl.coordinatorsMu.Lock()
 	defer cl.coordinatorsMu.Unlock()
 	for k, v := range cl.coordinators {
-		if v == nil || v.node != node {
+		if v == nil {
 			continue
 		}
+		// v.node is written by doLoadCoordinators outside of
+		// coordinatorsMu; that write is published only by the
+		// close(loadWait) ending the load. We must observe the close
+		// before reading v.node, so the v.node check lives inside the
+		// loadWait arm -- not in the range filter above.
+		//
+		// Race walkthrough if we checked v.node before the select:
+		//   1) doLoadCoordinators inserts v with an open loadWait, then
+		//      releases coordinatorsMu and issues FindCoordinator.
+		//   2) The response arrives and the loader writes v.node =
+		//      rc.NodeID, lock-free (doLoadCoordinators, above).
+		//   3) Concurrently a broker disconnect calls us here. We hold
+		//      coordinatorsMu, but the writer in step 2 never takes it,
+		//      so the mutex does not order us against that write --
+		//      reading v.node now is a data race (go test -race flags
+		//      it). close(loadWait) in step 2 has not happened yet, so
+		//      the default arm is what we would take anyway.
+		// Reading inside the loadWait arm makes the read happen-after
+		// the publishing close, so v.node is safe to observe.
 		select {
 		case <-v.loadWait:
-			delete(cl.coordinators, k)
+			if v.node == node {
+				delete(cl.coordinators, k)
+			}
 		default:
+			// Still loading: v.node is not yet published; skip.
 		}
 	}
 }

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/consumer_group.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/consumer_group.go
@@ -1927,7 +1927,9 @@ start:
 		}
 		reqTopic := kmsg.NewOffsetFetchRequestGroupTopic()
 		reqTopic.Topic = topic
-		reqTopic.TopicID = groupTopics.loadTopic(topic).id
+		if td := groupTopics.loadTopic(topic); td != nil {
+			reqTopic.TopicID = td.id
+		}
 		if reqTopic.TopicID == ([16]byte{}) {
 			pinV9 = true
 		}

--- a/vendor/github.com/twmb/franz-go/pkg/kgo/consumer_share.go
+++ b/vendor/github.com/twmb/franz-go/pkg/kgo/consumer_share.go
@@ -2539,14 +2539,17 @@ func (s *source) handleShareReqResp(req *kmsg.ShareFetchRequest, resp *kmsg.Shar
 	sessionStale := s.share.sessionEpoch != epoch
 	if !sessionStale {
 		s.share.sessionEpoch++
-		// Only add cursors that were in the WANT set (usable) to
-		// sessionParts. req.Topics may also contain piggyback-only
-		// partitions for cursors that got revoked after we drained
-		// their acks: adding those to sessionParts would force us
-		// to forget them on the next request, generating an extra
-		// round trip of ForgottenTopicsData.
-		for _, c := range usable {
-			s.share.sessionParts[tidp{c.topicID, c.partition}] = struct{}{}
+		// Mirror the broker's session bookkeeping exactly: the broker
+		// adds EVERY partition we list in the request topics to its
+		// share session, whether the partition carries a fetch or only
+		// piggybacked acks (a cursor that was revoked, paused, or
+		// migrated after we drained its acks). It removes a partition
+		// from the session only when we forget it.
+		for i := range req.Topics {
+			t := &req.Topics[i]
+			for j := range t.Partitions {
+				s.share.sessionParts[tidp{t.TopicID, t.Partitions[j].Partition}] = struct{}{}
+			}
 		}
 		for _, ft := range req.ForgottenTopicsData {
 			for _, p := range ft.Partitions {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -740,7 +740,7 @@ github.com/grafana/pyroscope-go/godeltaprof/internal/pprof
 ## explicit; go 1.21
 github.com/grafana/regexp
 github.com/grafana/regexp/syntax
-# github.com/grafana/warpstream-go v0.0.0-20260708155533-24eb1aa7aa2b
+# github.com/grafana/warpstream-go v0.0.0-20260709145107-2e28adcc4bff
 ## explicit; go 1.25.10
 github.com/grafana/warpstream-go/pkg/wgo
 # github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -740,7 +740,7 @@ github.com/grafana/pyroscope-go/godeltaprof/internal/pprof
 ## explicit; go 1.21
 github.com/grafana/regexp
 github.com/grafana/regexp/syntax
-# github.com/grafana/warpstream-go v0.0.0-20260708135512-e5879b5c8615
+# github.com/grafana/warpstream-go v0.0.0-20260708155533-24eb1aa7aa2b
 ## explicit; go 1.25.10
 github.com/grafana/warpstream-go/pkg/wgo
 # github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -740,7 +740,7 @@ github.com/grafana/pyroscope-go/godeltaprof/internal/pprof
 ## explicit; go 1.21
 github.com/grafana/regexp
 github.com/grafana/regexp/syntax
-# github.com/grafana/warpstream-go v0.0.0-20260625083726-8ebc81451c89
+# github.com/grafana/warpstream-go v0.0.0-20260708135512-e5879b5c8615
 ## explicit; go 1.25.10
 github.com/grafana/warpstream-go/pkg/wgo
 # github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0
@@ -1314,7 +1314,7 @@ github.com/tklauser/go-sysconf
 # github.com/tklauser/numcpus v0.11.0
 ## explicit; go 1.24.0
 github.com/tklauser/numcpus
-# github.com/twmb/franz-go v1.21.4
+# github.com/twmb/franz-go v1.21.5
 ## explicit; go 1.25.0
 github.com/twmb/franz-go/pkg/kbin
 github.com/twmb/franz-go/pkg/kerr


### PR DESCRIPTION
#### What this PR does

Updates `github.com/grafana/warpstream-go` to pull in grafana/warpstream-go#33.

The main fix prevents a hedge produce leg from reading a caller's `*kgo.Record` after its promise has already fired. A caller that reuses or pools the record (the client's documented ownership contract) could otherwise race the hedge encode and ship corrupted values — including a zeroed timestamp that serialises to a negative `UnixMilli` and panics downstream consumers that bucket by timestamp. The update also sizes pre-encoded (hedge) batches by their uncompressed bytes so a same-partition merge stays within the per-partition cap, and stamps the produce time only after routing succeeds.

This affects Mimir only when the Kafka backend is set to `warpstream` (experimental ingest storage). No Mimir source changes — it only re-vendors the dependency.

#### Which issue(s) this PR fixes or relates to

Pulls in grafana/warpstream-go#33

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - not needed: dependency bump affecting only the experimental `warpstream` ingest backend (`changelog-not-needed` label applied).
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.