### PR TITLE
MQE: Add Antithesis instrumentation for bug error paths

### DIFF
--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/antithesishq/antithesis-sdk-go/assert"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/prometheus/model/labels"
@@ -593,6 +594,14 @@ func cloneStepData(stepData *types.RangeVectorStepData) (bufferedRangeVectorStep
 // The dedicated buffers in bufferedRangeVectorStepData will be nil since the shared buffers are used.
 func (b *RangeVectorDuplicationBuffer) mergeStepData(stepData *types.RangeVectorStepData, seriesIndex int) (bufferedRangeVectorStepData, error) {
 	if stepData.Anchored || stepData.Smoothed {
+		assert.Unreachable("cannot use shared FPoint and HPoint buffers with anchored/smoothed modifiers", map[string]any{
+			"anchored":     stepData.Anchored,
+			"smoothed":     stepData.Smoothed,
+			"range_start":  stepData.RangeStart,
+			"range_end":    stepData.RangeEnd,
+			"step_ts":      stepData.StepT,
+			"series_index": seriesIndex,
+		})
 		return bufferedRangeVectorStepData{}, fmt.Errorf("cannot use shared FPoint and HPoint buffers with anchored/smoothed modifiers (this is a bug)")
 	}
 

--- a/pkg/streamingpromql/optimize/plan/remoteexec/optimization_pass.go
+++ b/pkg/streamingpromql/optimize/plan/remoteexec/optimization_pass.go
@@ -8,6 +8,8 @@ import (
 	"maps"
 	"slices"
 
+	"github.com/antithesishq/antithesis-sdk-go/assert"
+
 	"github.com/grafana/mimir/pkg/streamingpromql/operators/functions"
 	"github.com/grafana/mimir/pkg/streamingpromql/optimize"
 	"github.com/grafana/mimir/pkg/streamingpromql/optimize/plan/splitandcache"
@@ -253,6 +255,10 @@ func (s remoteExecutionGroupSet) GetGroupForNode(node planning.Node, eagerLoad b
 	}
 
 	if selector == nil {
+		assert.Unreachable("could not find selector for node", map[string]any{
+			"eager_load": eagerLoad,
+			"node_type":  fmt.Sprintf("%T", node),
+		})
 		return nil, fmt.Errorf("could not find selector for node of type %T (this is a bug)", node)
 	}
 

--- a/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
+++ b/pkg/streamingpromql/optimize/plan/remove_statically_empty_expressions.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/antithesishq/antithesis-sdk-go/assert"
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -259,6 +260,10 @@ func IsAlwaysEmptyFunctionCall(node *core.FunctionCall, params *planning.QueryPa
 		functions.FUNCTION_TS_OF_MAX_OVER_TIME,
 		functions.FUNCTION_TS_OF_MIN_OVER_TIME:
 		if len(node.Args) < 1 {
+			assert.Unreachable("expected at least one argument in call", map[string]any{
+				"function":      node.Function,
+				"num_arguments": len(node.Args),
+			})
 			return false, fmt.Errorf("%w: expected at least one argument in call to %s, got %d (this is a bug)", ErrInvalidFunctionArgs, node.Function, len(node.Args))
 		}
 
@@ -266,12 +271,20 @@ func IsAlwaysEmptyFunctionCall(node *core.FunctionCall, params *planning.QueryPa
 	case functions.FUNCTION_HISTOGRAM_QUANTILE,
 		functions.FUNCTION_QUANTILE_OVER_TIME:
 		if len(node.Args) < 2 {
+			assert.Unreachable("expected at least two arguments in call", map[string]any{
+				"function":      node.Function,
+				"num_arguments": len(node.Args),
+			})
 			return false, fmt.Errorf("%w: expected at least two arguments in call to %s, got %d (this is a bug)", ErrInvalidFunctionArgs, node.Function, len(node.Args))
 		}
 
 		return isAlwaysEmpty(node.Args[1], params)
 	case functions.FUNCTION_HISTOGRAM_FRACTION:
 		if len(node.Args) < 3 {
+			assert.Unreachable("expected at least three arguments in call", map[string]any{
+				"function":      node.Function,
+				"num_arguments": len(node.Args),
+			})
 			return false, fmt.Errorf("%w: expected at least three arguments in call to %s, got %d (this is a bug)", ErrInvalidFunctionArgs, node.Function, len(node.Args))
 		}
 
@@ -280,6 +293,10 @@ func IsAlwaysEmptyFunctionCall(node *core.FunctionCall, params *planning.QueryPa
 		// histogram_quantiles takes the instant vector as its first argument, followed by the
 		// quantile label name and one or more quantiles.
 		if len(node.Args) < 3 {
+			assert.Unreachable("expected at least three arguments in call", map[string]any{
+				"function":      node.Function,
+				"num_arguments": len(node.Args),
+			})
 			return false, fmt.Errorf("%w: expected at least three arguments in call to %s, got %d (this is a bug)", ErrInvalidFunctionArgs, node.Function, len(node.Args))
 		}
 
@@ -316,6 +333,9 @@ func IsAlwaysEmptyFunctionCall(node *core.FunctionCall, params *planning.QueryPa
 		// on vectors.
 		return false, nil
 	default:
+		assert.Unreachable("unexpected function call", map[string]any{
+			"function": node.Function,
+		})
 		return false, fmt.Errorf("%w: function call %s is unexpected (this is a bug)", ErrUnknownFunction, node.Function)
 	}
 }

--- a/pkg/streamingpromql/types/fpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/fpoint_ring_buffer.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/antithesishq/antithesis-sdk-go/assert"
 	"github.com/prometheus/prometheus/promql"
 
 	"github.com/grafana/mimir/pkg/util/limiter"
@@ -262,6 +263,10 @@ func (b *FPointRingBuffer) ViewBetweenSearchingBackwards(minT, maxT int64, exist
 	}
 
 	if minT > maxT {
+		assert.Unreachable("attempted to create an FPointRingBufferView with minT > maxT", map[string]any{
+			"min_t": minT,
+			"max_t": maxT,
+		})
 		panic(fmt.Sprintf("attempted to create an FPointRingBufferView with minT(%d) > maxT(%d) (this is a bug)", minT, maxT))
 	}
 

--- a/pkg/streamingpromql/types/hpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/hpoint_ring_buffer.go
@@ -5,6 +5,7 @@ package types
 import (
 	"fmt"
 
+	"github.com/antithesishq/antithesis-sdk-go/assert"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/promql"
 
@@ -120,6 +121,10 @@ func (b *HPointRingBuffer) ViewBetweenSearchingBackwards(minT, maxT int64, exist
 	}
 
 	if minT > maxT {
+		assert.Unreachable("attempted to create an HPointRingBufferView with minT > maxT", map[string]any{
+			"min_t": minT,
+			"max_t": maxT,
+		})
 		panic(fmt.Sprintf("attempted to create an HPointRingBufferView with minT(%d) > maxT(%d) (this is a bug)", minT, maxT))
 	}
 


### PR DESCRIPTION
#### What this PR does

Add Antithesis assertions for codepaths in MQE that are always a bug for which we already return errors or panic.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
