### PR TITLE
MQE: introduce constant for buffer size used for calls to `labels.Labels.Bytes()` and related functions

### DIFF
--- a/pkg/streamingpromql/operators/aggregations/common.go
+++ b/pkg/streamingpromql/operators/aggregations/common.go
@@ -96,8 +96,7 @@ func GroupLabelsBytesFunc(grouping []string, without bool) SeriesToGroupLabelsBy
 		return groupToSingleSeriesLabelsBytesFunc
 	}
 
-	// Why 1024 bytes? It's what labels.Labels.String() uses as a buffer size, so we use that as a sensible starting point too.
-	b := make([]byte, 0, 1024)
+	b := make([]byte, 0, types.LabelBytesBufferSize)
 	if without {
 		return func(l labels.Labels) []byte {
 			// NewAggregation and NewTopKBottomK will add __name__ to Grouping for 'without' aggregations, so no need to add it here.

--- a/pkg/streamingpromql/operators/aggregations/count_values.go
+++ b/pkg/streamingpromql/operators/aggregations/count_values.go
@@ -95,7 +95,7 @@ func (c *CountValues) SeriesMetadata(ctx context.Context, matchers types.Matcher
 	defer types.SeriesMetadataSlicePool.Put(&innerMetadata, c.MemoryConsumptionTracker)
 
 	c.labelsBuilder = labels.NewBuilder(labels.EmptyLabels())
-	c.labelsBytesBuffer = make([]byte, 0, 1024) // Why 1024 bytes? It's what labels.Labels.String() uses as a buffer size, so we use that as a sensible starting point too.
+	c.labelsBytesBuffer = make([]byte, 0, types.LabelBytesBufferSize)
 	defer func() {
 		// Don't hold onto the instances used to generate series labels for longer than necessary.
 		c.labelsBuilder = nil

--- a/pkg/streamingpromql/operators/binops/binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/binary_operation.go
@@ -33,7 +33,7 @@ import (
 //
 // The return value from the function is valid until it is called again.
 func vectorMatchingGroupKeyFunc(vectorMatching parser.VectorMatching) func(labels.Labels) []byte {
-	buf := make([]byte, 0, 1024)
+	buf := make([]byte, 0, types.LabelBytesBufferSize)
 
 	if vectorMatching.On {
 		slices.Sort(vectorMatching.MatchingLabels)

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
@@ -343,7 +343,7 @@ func (g *GroupedVectorVectorBinaryOperation) computeOutputSeries() ([]types.Seri
 	manySideMap := map[string]*manySide{}                                        // Series from the "many" side, grouped by which output series they'll contribute to.
 	manySideGroupKeyFunc := g.manySideGroupKeyFunc()
 	outputSeriesLabelsFunc := g.outputSeriesLabelsFunc()
-	buf := make([]byte, 0, 1024)
+	buf := make([]byte, 0, types.LabelBytesBufferSize)
 
 	manySideSeriesUsed, err := types.BoolSlicePool.Get(len(g.manySideMetadata), g.MemoryConsumptionTracker)
 	if err != nil {
@@ -468,7 +468,7 @@ func (g *GroupedVectorVectorBinaryOperation) additionalLabelsKeyFunc() func(oneS
 		}
 	}
 
-	buf := make([]byte, 0, 1024)
+	buf := make([]byte, 0, types.LabelBytesBufferSize)
 
 	return func(oneSideLabels labels.Labels) []byte {
 		buf = oneSideLabels.BytesWithLabels(buf, g.VectorMatching.Include...)
@@ -479,7 +479,7 @@ func (g *GroupedVectorVectorBinaryOperation) additionalLabelsKeyFunc() func(oneS
 // manySideGroupKeyFunc returns a function that extracts a key representing the set of labels from the "many" side that will contribute
 // to the same set of output series.
 func (g *GroupedVectorVectorBinaryOperation) manySideGroupKeyFunc() func(manySideLabels labels.Labels) []byte {
-	buf := make([]byte, 0, 1024)
+	buf := make([]byte, 0, types.LabelBytesBufferSize)
 
 	if !g.shouldRemoveMetricNameFromManySide() && len(g.VectorMatching.Include) == 0 {
 		return func(manySideLabels labels.Labels) []byte {

--- a/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/one_to_one_vector_vector_binary_operation.go
@@ -280,7 +280,7 @@ func (b *OneToOneVectorVectorBinaryOperation) computeOutputSeries() ([]types.Ser
 	rightSeriesUsed = rightSeriesUsed[:len(b.rightMetadata)]
 	lastRightSeriesUsedIndex := -1
 	labelsFunc := groupLabelsFunc(b.VectorMatching, b.Op, b.ReturnBool)
-	outputSeriesLabelsBytes := make([]byte, 0, 1024)
+	outputSeriesLabelsBytes := make([]byte, 0, types.LabelBytesBufferSize)
 
 	for leftSeriesIndex, s := range b.leftMetadata {
 		outputSeriesLabels := labelsFunc(s.Labels)

--- a/pkg/streamingpromql/operators/deduplicate_and_merge.go
+++ b/pkg/streamingpromql/operators/deduplicate_and_merge.go
@@ -67,8 +67,7 @@ func (d *DeduplicateAndMerge) computeOutputSeriesGroups(innerMetadata []types.Se
 	// Why use a string, rather than the labels hash as a key here? This avoids any issues with hash collisions.
 	outputGroupMap := map[string][]int{}
 
-	// Why 1024 bytes? It's what labels.Labels.String() uses as a buffer size, so we use that as a sensible starting point too.
-	labelBytes := make([]byte, 0, 1024)
+	labelBytes := make([]byte, 0, types.LabelBytesBufferSize)
 
 	for seriesIdx, series := range innerMetadata {
 		labelBytes = series.Labels.Bytes(labelBytes)

--- a/pkg/streamingpromql/operators/functions/histogram_function.go
+++ b/pkg/streamingpromql/operators/functions/histogram_function.go
@@ -314,7 +314,7 @@ func (g *histogramGrouper) buildGroups(innerSeries []types.SeriesMetadata) (map[
 	g.seriesGroupPairs = g.seriesGroupPairs[:len(innerSeries)]
 
 	groups := map[string]groupWithLabels{}
-	b := make([]byte, 0, 1024)
+	b := make([]byte, 0, types.LabelBytesBufferSize)
 	lb := labels.NewBuilder(labels.EmptyLabels())
 
 	for innerIdx, series := range innerSeries {

--- a/pkg/streamingpromql/operators/functions/info.go
+++ b/pkg/streamingpromql/operators/functions/info.go
@@ -191,7 +191,7 @@ func (f *InfoFunction) signature(lset labels.Labels) []byte {
 func (f *InfoFunction) processSamplesFromInfoSeries(ctx context.Context, infoMetadata []types.SeriesMetadata) error {
 	// Initialize dedicated buffer and scratch builder for signature,
 	// since this is also called later when the local buf and lb would be out of scope.
-	f.sigBuf = make([]byte, 0, 1024)
+	f.sigBuf = make([]byte, 0, types.LabelBytesBufferSize)
 	f.sigLb = labels.NewScratchBuilder(0)
 
 	// metric name:(timestamp:(labels-only signature:labels + timestamp))

--- a/pkg/streamingpromql/optimize/plan/rangevectorsplitting/operator.go
+++ b/pkg/streamingpromql/optimize/plan/rangevectorsplitting/operator.go
@@ -307,7 +307,7 @@ func (m *FunctionOverRangeVectorSplit[T]) mergeSplitsMetadata(ctx context.Contex
 	seriesMap := make(map[string]int)
 	var seriesToSplits [][]SplitSeries
 
-	labelBytes := make([]byte, 0, 1024)
+	labelBytes := make([]byte, 0, types.LabelBytesBufferSize)
 
 	// Reuse split 0's metadata as base instead of copying.
 	mergedMetadata, err := m.splits[0].SeriesMetadata(ctx, matchers)

--- a/pkg/streamingpromql/optimize/plan/splitandcache/merge_series_metadata.go
+++ b/pkg/streamingpromql/optimize/plan/splitandcache/merge_series_metadata.go
@@ -62,7 +62,7 @@ func mergeSeriesMetadataFromMultipleSources[S seriesMetadataSource](ctx context.
 
 	// Build up a map of the series labels to their index in the output.
 	seriesIndices := make(map[string]int, len(allSeries))
-	labelBytesBuf := make([]byte, 0, 1024)
+	labelBytesBuf := make([]byte, 0, types.LabelBytesBufferSize)
 	for seriesIdx, series := range allSeries {
 		labelBytesBuf = series.Labels.Bytes(labelBytesBuf)
 		seriesIndices[string(labelBytesBuf)] = seriesIdx // Important: don't extract the string(...) call here - passing it directly allows us to avoid allocating it.

--- a/pkg/streamingpromql/types/data.go
+++ b/pkg/streamingpromql/types/data.go
@@ -17,6 +17,8 @@ import (
 	"github.com/grafana/mimir/pkg/util/limiter"
 )
 
+const LabelBytesBufferSize = 1024 // Why 1024 bytes? It's what labels.Labels.String() uses as a buffer size, so we use that as a sensible starting point too.
+
 type SeriesMetadata struct {
 	Labels   labels.Labels
 	DropName bool


### PR DESCRIPTION
#### What this PR does

This PR refactors a number of places within `pkg/streamingpromql` that use `labels.Labels.Bytes()` and related functions to use a shared constant for the size of the buffer passed.

#### Which issue(s) this PR fixes or relates to

Resolves https://github.com/grafana/mimir/pull/15750#discussion_r3449321401

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
