### PR TITLE
Add per-tenant series limit alerts to mimir-mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@
 ### Mixin
 
 * [CHANGE] Dashboards: Show maximum queue length, not minimum queue length, on the "Queue length" panel in the "Query-scheduler" row of the "Reads" and "Remote ruler reads" dashboards. #15326
+* [FEATURE] Alerts: Add `MimirTenantReachingSeriesLimit` and `MimirTenantSeriesLimitDiscardingSamples` alerts to detect when a tenant is close to, or is discarding samples because of, its per-tenant series limit (`max_global_series_per_user`). #16018
 * [ENHANCEMENT] Alerts: Make `MimirInconsistentRuntimeConfig` alert less flaky when performing multiple configuration changes in a row in a large Kubernetes cluster. #15257
 * [ENHANCEMENT] Alerts: Widen the `MimirBlockBuilderPersistentJobFailure` lookback window to 20m to prevent the alert from flapping. #15332
 * [ENHANCEMENT] Alerts: Add a native histogram variant of the `MimirRequestLatency` alert, distinguished by the `histogram` label (`classic` or `native`). #15413

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -207,6 +207,42 @@ How to **fix** it:
 1. Ensure shuffle-sharding is enabled in the Mimir cluster
 1. Assuming shuffle-sharding is enabled, scaling up ingesters will lower the number of tenants per ingester. However, the effect of this change will be visible only after `-blocks-storage.tsdb.close-idle-tsdb-timeout` period so you may have to temporarily increase the limit
 
+### MimirTenantReachingSeriesLimit
+
+This alert fires when a tenant is close to reaching its per-tenant series limit (`max_global_series_per_user`) on at least one ingester.
+The threshold is set at 80% (`warning`) and 90% (`critical`) to give the chance to react before the limit is reached.
+
+Unlike the `max_series` per ingester instance limit (see [`MimirIngesterReachingSeriesLimit`](#MimirIngesterReachingSeriesLimit)), which is a "server error" (5xx), reaching the per-tenant series limit is considered a "client error" (4xx): once the limit is reached, appending samples to new series is rejected and the excess data is discarded (the tenant sees `err-mimir-max-series-per-user` errors). Appending samples to existing series continues to succeed.
+
+The limit is enforced per ingester against the tenant's local share of the global limit, so a tenant with an uneven series distribution across ingesters may reach the limit on some ingesters before its global series count reaches `max_global_series_per_user`.
+
+How the limit is **configured**:
+
+- The limit can be configured either on CLI (`-ingester.max-global-series-per-user`) or in the runtime config:
+  ```
+  overrides:
+    <tenant>:
+      max_global_series_per_user: <int>
+  ```
+- The per-ingester local share of the limit can be queried via `cortex_ingester_local_limits{limit="max_global_series_per_user"}`, and the configured global limit via `cortex_limits_overrides{limit_name="max_global_series_per_user"}` (or `cortex_limits_defaults` when the tenant uses the default).
+
+How to **fix** it:
+
+1. Use the `Mimir / Tenants` dashboard to inspect the tenant's in-memory and owned series against its limit, and to identify whether the series are unevenly distributed across ingesters.
+2. If the tenant's series growth is legitimate, increase the `max_global_series_per_user` limit for the affected tenant via the runtime config (applied live, no restart required). Increasing the limit will increase the ingesters' memory utilization, so monitor it via the `Mimir / Writes Resources` dashboard.
+3. If the series are unevenly distributed across ingesters, check that the tenant's `ingestion_tenant_shard_size` (and `ingestion_partitions_tenant_shard_size` when ingest storage is enabled) is appropriate.
+4. If the growth is unexpected, investigate the tenant for a cardinality explosion using the `Mimir / Tenants` dashboard and the cardinality API.
+
+### MimirTenantSeriesLimitDiscardingSamples
+
+This alert fires when Mimir is actively discarding samples for a tenant because it reached its per-tenant series limit (`max_global_series_per_user`).
+This is the symptom that immediately follows [`MimirTenantReachingSeriesLimit`](#MimirTenantReachingSeriesLimit): samples for new series are being rejected with `err-mimir-max-series-per-user` and the excess data is lost.
+
+How to **fix** it:
+
+1. Follow the steps in the [`MimirTenantReachingSeriesLimit`](#MimirTenantReachingSeriesLimit) runbook to either raise the tenant's `max_global_series_per_user` limit or reduce the tenant's series cardinality.
+2. The rate of discarded samples per tenant can be queried via `sum by (user) (rate(cortex_discarded_samples_total{reason="per_user_series_limit"}[5m]))`.
+
 ### MimirDistributorGcUsesTooMuchCpu
 
 This alert fires when distributors spend too much CPU time on garbage collection.

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -487,6 +487,54 @@ groups:
           for: 5m
           labels:
             severity: critical
+    - name: mimir_tenant_limits_alerts
+      rules:
+        - alert: MimirTenantReachingSeriesLimit
+          annotations:
+            message: |
+                Tenant {{ $labels.user }} in {{ $labels.cluster }}/{{ $labels.namespace }} has reached {{ $value | humanizePercentage }} of its per-tenant series limit (max_global_series_per_user) on at least one ingester.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirtenantreachingserieslimit
+          expr: |
+            max by (cluster, namespace, user) (
+              (
+                (cortex_ingester_memory_series_created_total{job=~".*/(ingester.*|cortex|mimir)"} - cortex_ingester_memory_series_removed_total{job=~".*/(ingester.*|cortex|mimir)"})
+                / ignoring(limit) cortex_ingester_local_limits{job=~".*/(ingester.*|cortex|mimir)", limit="max_global_series_per_user"}
+              )
+              and ignoring(limit)
+              (cortex_ingester_local_limits{job=~".*/(ingester.*|cortex|mimir)", limit="max_global_series_per_user"} > 0)
+            ) > 0.8
+          for: 1h
+          labels:
+            severity: warning
+        - alert: MimirTenantReachingSeriesLimit
+          annotations:
+            message: |
+                Tenant {{ $labels.user }} in {{ $labels.cluster }}/{{ $labels.namespace }} has reached {{ $value | humanizePercentage }} of its per-tenant series limit (max_global_series_per_user) on at least one ingester.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirtenantreachingserieslimit
+          expr: |
+            max by (cluster, namespace, user) (
+              (
+                (cortex_ingester_memory_series_created_total{job=~".*/(ingester.*|cortex|mimir)"} - cortex_ingester_memory_series_removed_total{job=~".*/(ingester.*|cortex|mimir)"})
+                / ignoring(limit) cortex_ingester_local_limits{job=~".*/(ingester.*|cortex|mimir)", limit="max_global_series_per_user"}
+              )
+              and ignoring(limit)
+              (cortex_ingester_local_limits{job=~".*/(ingester.*|cortex|mimir)", limit="max_global_series_per_user"} > 0)
+            ) > 0.9
+          for: 15m
+          labels:
+            severity: critical
+        - alert: MimirTenantSeriesLimitDiscardingSamples
+          annotations:
+            message: |
+                Mimir is discarding samples for tenant {{ $labels.user }} in {{ $labels.cluster }}/{{ $labels.namespace }} because it reached the per-tenant series limit (max_global_series_per_user).
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirtenantserieslimitdiscardingsamples
+          expr: |
+            sum by (cluster, namespace, user) (
+              rate(cortex_discarded_samples_total{reason="per_user_series_limit", job=~".*/(ingester.*|cortex|mimir)"}[5m])
+            ) > 0
+          for: 15m
+          labels:
+            severity: critical
     - name: mimir-rollout-alerts
       rules:
         - alert: MimirRolloutStuck

--- a/operations/mimir-mixin-compiled-gem/alerts.yaml
+++ b/operations/mimir-mixin-compiled-gem/alerts.yaml
@@ -487,6 +487,54 @@ groups:
           for: 5m
           labels:
             severity: critical
+    - name: mimir_tenant_limits_alerts
+      rules:
+        - alert: MimirTenantReachingSeriesLimit
+          annotations:
+            message: |
+                Tenant {{ $labels.user }} in {{ $labels.cluster }}/{{ $labels.namespace }} has reached {{ $value | humanizePercentage }} of its per-tenant series limit (max_global_series_per_user) on at least one ingester.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirtenantreachingserieslimit
+          expr: |
+            max by (cluster, namespace, user) (
+              (
+                (cortex_ingester_memory_series_created_total{job=~".*/(ingester.*|cortex|mimir)"} - cortex_ingester_memory_series_removed_total{job=~".*/(ingester.*|cortex|mimir)"})
+                / ignoring(limit) cortex_ingester_local_limits{job=~".*/(ingester.*|cortex|mimir)", limit="max_global_series_per_user"}
+              )
+              and ignoring(limit)
+              (cortex_ingester_local_limits{job=~".*/(ingester.*|cortex|mimir)", limit="max_global_series_per_user"} > 0)
+            ) > 0.8
+          for: 1h
+          labels:
+            severity: warning
+        - alert: MimirTenantReachingSeriesLimit
+          annotations:
+            message: |
+                Tenant {{ $labels.user }} in {{ $labels.cluster }}/{{ $labels.namespace }} has reached {{ $value | humanizePercentage }} of its per-tenant series limit (max_global_series_per_user) on at least one ingester.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirtenantreachingserieslimit
+          expr: |
+            max by (cluster, namespace, user) (
+              (
+                (cortex_ingester_memory_series_created_total{job=~".*/(ingester.*|cortex|mimir)"} - cortex_ingester_memory_series_removed_total{job=~".*/(ingester.*|cortex|mimir)"})
+                / ignoring(limit) cortex_ingester_local_limits{job=~".*/(ingester.*|cortex|mimir)", limit="max_global_series_per_user"}
+              )
+              and ignoring(limit)
+              (cortex_ingester_local_limits{job=~".*/(ingester.*|cortex|mimir)", limit="max_global_series_per_user"} > 0)
+            ) > 0.9
+          for: 15m
+          labels:
+            severity: critical
+        - alert: MimirTenantSeriesLimitDiscardingSamples
+          annotations:
+            message: |
+                GEM is discarding samples for tenant {{ $labels.user }} in {{ $labels.cluster }}/{{ $labels.namespace }} because it reached the per-tenant series limit (max_global_series_per_user).
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirtenantserieslimitdiscardingsamples
+          expr: |
+            sum by (cluster, namespace, user) (
+              rate(cortex_discarded_samples_total{reason="per_user_series_limit", job=~".*/(ingester.*|cortex|mimir)"}[5m])
+            ) > 0
+          for: 15m
+          labels:
+            severity: critical
     - name: mimir-rollout-alerts
       rules:
         - alert: MimirRolloutStuck

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -487,6 +487,54 @@ groups:
           for: 5m
           labels:
             severity: critical
+    - name: mimir_tenant_limits_alerts
+      rules:
+        - alert: MimirTenantReachingSeriesLimit
+          annotations:
+            message: |
+                Tenant {{ $labels.user }} in {{ $labels.cluster }}/{{ $labels.namespace }} has reached {{ $value | humanizePercentage }} of its per-tenant series limit (max_global_series_per_user) on at least one ingester.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirtenantreachingserieslimit
+          expr: |
+            max by (cluster, namespace, user) (
+              (
+                (cortex_ingester_memory_series_created_total{job=~".*/(ingester.*|cortex|mimir)"} - cortex_ingester_memory_series_removed_total{job=~".*/(ingester.*|cortex|mimir)"})
+                / ignoring(limit) cortex_ingester_local_limits{job=~".*/(ingester.*|cortex|mimir)", limit="max_global_series_per_user"}
+              )
+              and ignoring(limit)
+              (cortex_ingester_local_limits{job=~".*/(ingester.*|cortex|mimir)", limit="max_global_series_per_user"} > 0)
+            ) > 0.8
+          for: 1h
+          labels:
+            severity: warning
+        - alert: MimirTenantReachingSeriesLimit
+          annotations:
+            message: |
+                Tenant {{ $labels.user }} in {{ $labels.cluster }}/{{ $labels.namespace }} has reached {{ $value | humanizePercentage }} of its per-tenant series limit (max_global_series_per_user) on at least one ingester.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirtenantreachingserieslimit
+          expr: |
+            max by (cluster, namespace, user) (
+              (
+                (cortex_ingester_memory_series_created_total{job=~".*/(ingester.*|cortex|mimir)"} - cortex_ingester_memory_series_removed_total{job=~".*/(ingester.*|cortex|mimir)"})
+                / ignoring(limit) cortex_ingester_local_limits{job=~".*/(ingester.*|cortex|mimir)", limit="max_global_series_per_user"}
+              )
+              and ignoring(limit)
+              (cortex_ingester_local_limits{job=~".*/(ingester.*|cortex|mimir)", limit="max_global_series_per_user"} > 0)
+            ) > 0.9
+          for: 15m
+          labels:
+            severity: critical
+        - alert: MimirTenantSeriesLimitDiscardingSamples
+          annotations:
+            message: |
+                Mimir is discarding samples for tenant {{ $labels.user }} in {{ $labels.cluster }}/{{ $labels.namespace }} because it reached the per-tenant series limit (max_global_series_per_user).
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirtenantserieslimitdiscardingsamples
+          expr: |
+            sum by (cluster, namespace, user) (
+              rate(cortex_discarded_samples_total{reason="per_user_series_limit", job=~".*/(ingester.*|cortex|mimir)"}[5m])
+            ) > 0
+          for: 15m
+          labels:
+            severity: critical
     - name: mimir-rollout-alerts
       rules:
         - alert: MimirRolloutStuck

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -746,6 +746,82 @@ local utils = import 'mixin-utils/utils.libsonnet';
       ],
     },
     {
+      name: 'mimir_tenant_limits_alerts',
+      rules: [
+        {
+          alert: $.alertName('TenantReachingSeriesLimit'),
+          expr: |||
+            max by (%(alert_aggregation_labels)s, user) (
+              (
+                (cortex_ingester_memory_series_created_total{%(ingester)s} - cortex_ingester_memory_series_removed_total{%(ingester)s})
+                / ignoring(limit) cortex_ingester_local_limits{%(ingester)s, limit="max_global_series_per_user"}
+              )
+              and ignoring(limit)
+              (cortex_ingester_local_limits{%(ingester)s, limit="max_global_series_per_user"} > 0)
+            ) > 0.8
+          ||| % {
+            alert_aggregation_labels: $._config.alert_aggregation_labels,
+            ingester: $.jobMatcher($._config.job_names.ingester),
+          },
+          'for': '1h',
+          labels: {
+            severity: 'warning',
+          },
+          annotations: {
+            message: |||
+              Tenant {{ $labels.user }} in %(alert_aggregation_variables)s has reached {{ $value | humanizePercentage }} of its per-tenant series limit (max_global_series_per_user) on at least one ingester.
+            ||| % $._config,
+          } + $.dashboardURLAnnotation('mimir-tenants.json'),
+        },
+        {
+          alert: $.alertName('TenantReachingSeriesLimit'),
+          expr: |||
+            max by (%(alert_aggregation_labels)s, user) (
+              (
+                (cortex_ingester_memory_series_created_total{%(ingester)s} - cortex_ingester_memory_series_removed_total{%(ingester)s})
+                / ignoring(limit) cortex_ingester_local_limits{%(ingester)s, limit="max_global_series_per_user"}
+              )
+              and ignoring(limit)
+              (cortex_ingester_local_limits{%(ingester)s, limit="max_global_series_per_user"} > 0)
+            ) > 0.9
+          ||| % {
+            alert_aggregation_labels: $._config.alert_aggregation_labels,
+            ingester: $.jobMatcher($._config.job_names.ingester),
+          },
+          'for': '15m',
+          labels: {
+            severity: 'critical',
+          },
+          annotations: {
+            message: |||
+              Tenant {{ $labels.user }} in %(alert_aggregation_variables)s has reached {{ $value | humanizePercentage }} of its per-tenant series limit (max_global_series_per_user) on at least one ingester.
+            ||| % $._config,
+          } + $.dashboardURLAnnotation('mimir-tenants.json'),
+        },
+        {
+          alert: $.alertName('TenantSeriesLimitDiscardingSamples'),
+          expr: |||
+            sum by (%(alert_aggregation_labels)s, user) (
+              rate(cortex_discarded_samples_total{reason="per_user_series_limit", %(ingester)s}[%(rate_interval)s])
+            ) > 0
+          ||| % {
+            alert_aggregation_labels: $._config.alert_aggregation_labels,
+            ingester: $.jobMatcher($._config.job_names.ingester),
+            rate_interval: $.rateInterval('5m'),
+          },
+          'for': '15m',
+          labels: {
+            severity: 'critical',
+          },
+          annotations: {
+            message: |||
+              %(product)s is discarding samples for tenant {{ $labels.user }} in %(alert_aggregation_variables)s because it reached the per-tenant series limit (max_global_series_per_user).
+            ||| % $._config,
+          } + $.dashboardURLAnnotation('mimir-tenants.json'),
+        },
+      ],
+    },
+    {
       local statefulset_rollout_stuck(for_duration, severity) = {
         alert: $.alertName('RolloutStuck'),
         expr: |||


### PR DESCRIPTION
#### What this PR does

Adds two alerts to the mimir-mixin to detect when a tenant is reaching, or is being throttled by, its per-tenant series limit (`max_global_series_per_user`). Until now the mixin only alerted on the per-ingester-instance `max_series` limit (`MimirIngesterReachingSeriesLimit`), so operators had no alert for tenants hitting the `err-mimir-max-series-per-user` limit, which is a client-facing (4xx) error that silently discards samples.

New alert group `mimir_tenant_limits_alerts`:

- **`MimirTenantReachingSeriesLimit`** (`warning` at 80%, `critical` at 90%): proactive alert comparing a tenant's in-memory series against its per-ingester local share of the global series limit (`cortex_ingester_local_limits{limit="max_global_series_per_user"}`). Because the limit is enforced per ingester, an uneven series distribution can trigger `err-mimir-max-series-per-user` before the global count reaches the limit, so the ratio is evaluated per ingester and aggregated (`max`) per tenant. This mirrors the structure of the existing `MimirIngesterReachingSeriesLimit` alert.
- **`MimirTenantSeriesLimitDiscardingSamples`** (`critical`): symptom alert that fires when `rate(cortex_discarded_samples_total{reason="per_user_series_limit"})` is non-zero, i.e. samples are actively being discarded because the tenant hit the limit.

Both alerts link to the `Mimir / Tenants` dashboard and use the standard aggregation-label and job-matcher config helpers, so they respect custom label configurations.

Also adds matching runbook entries and a `CHANGELOG.md` entry.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
