### PR TITLE
Adjust IngesterKafkaReadFailed & StrongConsistencyEnforcementFailed severity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@
 ### Mixin
 
 * [CHANGE] Dashboards: Show maximum queue length, not minimum queue length, on the "Queue length" panel in the "Query-scheduler" row of the "Reads" and "Remote ruler reads" dashboards. #15326
+* [CHANGE] Alerts: `MimirIngesterKafkaReadFailed` now fires as `warning` after 5m, and escalates to `critical` if it persists for 30m. `MimirStrongConsistencyEnforcementFailed` severity changed from `critical` to `warning`, since queriers retry on a different ingester and fire their own alerts if that retry fails. #16019
 * [ENHANCEMENT] Alerts: Make `MimirInconsistentRuntimeConfig` alert less flaky when performing multiple configuration changes in a row in a large Kubernetes cluster. #15257
 * [ENHANCEMENT] Alerts: Widen the `MimirBlockBuilderPersistentJobFailure` lookback window to 20m to prevent the alert from flapping. #15332
 * [ENHANCEMENT] Alerts: Add a native histogram variant of the `MimirRequestLatency` alert, distinguished by the `histogram` label (`classic` or `native`). #15413

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -1415,6 +1415,16 @@ spec:
               > 0
             for: 5m
             labels:
+              severity: warning
+          - alert: MimirIngesterKafkaReadFailed
+            annotations:
+              message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to read records from Kafka.
+              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterkafkareadfailed
+            expr: |
+              sum by(cluster, namespace, pod, node_id) (rate(cortex_ingest_storage_reader_read_errors_total[1m]))
+              > 0
+            for: 30m
+            labels:
               severity: critical
           - alert: MimirIngesterKafkaFetchErrorsRateTooHigh
             annotations:
@@ -1570,7 +1580,7 @@ spec:
               sum by (cluster, namespace, pod) (rate(cortex_ingest_storage_strong_consistency_failures_total[1m])) > 0
             for: 5m
             labels:
-              severity: critical
+              severity: warning
           - alert: MimirStrongConsistencyOffsetMissing
             annotations:
               message: Mimir ingesters in {{ $labels.cluster }}/{{ $labels.namespace }} are receiving an unexpected high number of strongly consistent requests without an offset specified.

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -1389,6 +1389,16 @@ groups:
             > 0
           for: 5m
           labels:
+            severity: warning
+        - alert: MimirIngesterKafkaReadFailed
+          annotations:
+            message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to read records from Kafka.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterkafkareadfailed
+          expr: |
+            sum by(cluster, namespace, instance, node_id) (rate(cortex_ingest_storage_reader_read_errors_total[1m]))
+            > 0
+          for: 30m
+          labels:
             severity: critical
         - alert: MimirIngesterKafkaFetchErrorsRateTooHigh
           annotations:
@@ -1544,7 +1554,7 @@ groups:
             sum by (cluster, namespace, instance) (rate(cortex_ingest_storage_strong_consistency_failures_total[1m])) > 0
           for: 5m
           labels:
-            severity: critical
+            severity: warning
         - alert: MimirStrongConsistencyOffsetMissing
           annotations:
             message: Mimir ingesters in {{ $labels.cluster }}/{{ $labels.namespace }} are receiving an unexpected high number of strongly consistent requests without an offset specified.

--- a/operations/mimir-mixin-compiled-gem/alerts.yaml
+++ b/operations/mimir-mixin-compiled-gem/alerts.yaml
@@ -1403,6 +1403,16 @@ groups:
             > 0
           for: 5m
           labels:
+            severity: warning
+        - alert: MimirIngesterKafkaReadFailed
+          annotations:
+            message: GEM {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to read records from Kafka.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterkafkareadfailed
+          expr: |
+            sum by(cluster, namespace, pod, node_id) (rate(cortex_ingest_storage_reader_read_errors_total[1m]))
+            > 0
+          for: 30m
+          labels:
             severity: critical
         - alert: MimirIngesterKafkaFetchErrorsRateTooHigh
           annotations:
@@ -1558,7 +1568,7 @@ groups:
             sum by (cluster, namespace, pod) (rate(cortex_ingest_storage_strong_consistency_failures_total[1m])) > 0
           for: 5m
           labels:
-            severity: critical
+            severity: warning
         - alert: MimirStrongConsistencyOffsetMissing
           annotations:
             message: GEM ingesters in {{ $labels.cluster }}/{{ $labels.namespace }} are receiving an unexpected high number of strongly consistent requests without an offset specified.

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -1403,6 +1403,16 @@ groups:
             > 0
           for: 5m
           labels:
+            severity: warning
+        - alert: MimirIngesterKafkaReadFailed
+          annotations:
+            message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to read records from Kafka.
+            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterkafkareadfailed
+          expr: |
+            sum by(cluster, namespace, pod, node_id) (rate(cortex_ingest_storage_reader_read_errors_total[1m]))
+            > 0
+          for: 30m
+          labels:
             severity: critical
         - alert: MimirIngesterKafkaFetchErrorsRateTooHigh
           annotations:
@@ -1558,7 +1568,7 @@ groups:
             sum by (cluster, namespace, pod) (rate(cortex_ingest_storage_strong_consistency_failures_total[1m])) > 0
           for: 5m
           labels:
-            severity: critical
+            severity: warning
         - alert: MimirStrongConsistencyOffsetMissing
           annotations:
             message: Mimir ingesters in {{ $labels.cluster }}/{{ $labels.namespace }} are receiving an unexpected high number of strongly consistent requests without an offset specified.

--- a/operations/mimir-mixin/alerts/ingest-storage.libsonnet
+++ b/operations/mimir-mixin/alerts/ingest-storage.libsonnet
@@ -84,10 +84,10 @@ local utils = import 'mixin-utils/utils.libsonnet';
             message: '%(product)s {{ $labels.%(per_instance_label)s }} in %(alert_aggregation_variables)s is failing to commit the last consumed offset.' % $._config,
           },
         },
-
+      ] + [
         {
           alert: $.alertName('IngesterKafkaReadFailed'),
-          'for': '5m',
+          'for': alert["for"],
 
           // Metric used by this alert is reported by Kafka client on read errors from connection to Kafka.
           // We use node_id to only alert if problems to the same Kafka node are repeating.
@@ -101,12 +101,17 @@ local utils = import 'mixin-utils/utils.libsonnet';
             range: $.rateInterval('1m'),
           },
           labels: {
-            severity: 'critical',
+            severity: alert.severity,
           },
           annotations: {
             message: '%(product)s {{ $labels.%(per_instance_label)s }} in %(alert_aggregation_variables)s is failing to read records from Kafka.' % $._config,
           },
-        },
+        } for alert in [
+        // It's not really an issue if one ingester has a transient issue, queriers should retry on a different zone, so we just warn in that case.
+        { 'for': '5m', severity: 'warning' },
+        // If issues persist in time, we send a critical alert to bring the oncall engineer's attention to investigate.
+        { 'for': '30m', severity: 'critical' },
+      ] + [
 
         {
           alert: $.alertName('IngesterKafkaFetchErrorsRateTooHigh'),
@@ -206,6 +211,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
         },
 
         // Alert firing if Mimir is failing to enforce strong read consistency.
+        // This is a warning because queriers are expected to retry on a different ingester if one fails.
+        // If querier's retry fails, it should fire it's own alerts.
         {
           alert: $.alertName('StrongConsistencyEnforcementFailed'),
           'for': '5m',
@@ -217,7 +224,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
             range: $.rateInterval('1m'),
           },
           labels: {
-            severity: 'critical',
+            severity: 'warning',
           },
           annotations: {
             message: '%(product)s {{ $labels.%(per_instance_label)s }} in %(alert_aggregation_variables)s fails to enforce strong-consistency on read-path.' % $._config,

--- a/operations/mimir-mixin/alerts/ingest-storage.libsonnet
+++ b/operations/mimir-mixin/alerts/ingest-storage.libsonnet
@@ -87,7 +87,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
       ] + [
         {
           alert: $.alertName('IngesterKafkaReadFailed'),
-          'for': alert["for"],
+          'for': alert['for'],
 
           // Metric used by this alert is reported by Kafka client on read errors from connection to Kafka.
           // We use node_id to only alert if problems to the same Kafka node are repeating.
@@ -106,11 +106,13 @@ local utils = import 'mixin-utils/utils.libsonnet';
           annotations: {
             message: '%(product)s {{ $labels.%(per_instance_label)s }} in %(alert_aggregation_variables)s is failing to read records from Kafka.' % $._config,
           },
-        } for alert in [
-        // It's not really an issue if one ingester has a transient issue, queriers should retry on a different zone, so we just warn in that case.
-        { 'for': '5m', severity: 'warning' },
-        // If issues persist in time, we send a critical alert to bring the oncall engineer's attention to investigate.
-        { 'for': '30m', severity: 'critical' },
+        }
+        for alert in [
+          // It's not really an issue if one ingester has a transient issue, queriers should retry on a different zone, so we just warn in that case.
+          { 'for': '5m', severity: 'warning' },
+          // If issues persist in time, we send a critical alert to bring the oncall engineer's attention to investigate.
+          { 'for': '30m', severity: 'critical' },
+        ]
       ] + [
 
         {


### PR DESCRIPTION
#### What this PR does

Both alerts fire when a single ingester has transient trouble reading from Kafka / enforcing strong read consistency, cases queriers already recover from by retrying against a different ingester or zone. Paging on every transient blip was noisy for on-call.

- `MimirIngesterKafkaReadFailed` now fires as `warning` after 5m, escalating to `critical` if the failure persists for 30m.
- `MimirStrongConsistencyEnforcementFailed` severity changed from `critical` to `warning`, since a failed querier retry will surface its own alert.

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.