### PR TITLE
Export DefaultMetadataRefreshInterval constant

### DIFF
--- a/pkg/storage/ingest/config.go
+++ b/pkg/storage/ingest/config.go
@@ -388,7 +388,7 @@ func (cfg *KafkaConfig) ToWarpstreamClientOptions() ([]wgo.Opt, error) {
 		wgo.WithHedgerMaxHedgeAgents(cfg.WarpstreamHedgeMaxAgents),
 		wgo.WithDemoterProbeInterval(cfg.WarpstreamDemoterProbeInterval),
 		wgo.WithClusterStatsTTL(time.Second),
-		wgo.WithMetadataRefreshInterval(defaultMetadataRefreshInterval),
+		wgo.WithMetadataRefreshInterval(DefaultMetadataRefreshInterval),
 		// WriteTimeout bounds the whole hedge cascade, so the per-attempt produce
 		// timeout plus its overhead must fit within it (wgo rejects a config where
 		// they don't). Validate guarantees WriteTimeout exceeds twice the overhead,

--- a/pkg/storage/ingest/config_test.go
+++ b/pkg/storage/ingest/config_test.go
@@ -670,7 +670,7 @@ func TestKafkaConfig_ToWarpstreamClientOptions(t *testing.T) {
 		// kafka-backend defaults; ClusterStatsTTL is hardcoded to 1s.
 		assert.Equal(t, defaultProducerLinger, wsCfg.Linger)
 		assert.Equal(t, int32(producerBatchMaxBytes), wsCfg.BatchMaxBytes)
-		assert.Equal(t, defaultMetadataRefreshInterval, wsCfg.MetadataRefreshInterval)
+		assert.Equal(t, DefaultMetadataRefreshInterval, wsCfg.MetadataRefreshInterval)
 		assert.Equal(t, time.Second, wsCfg.ClusterStatsTTL)
 		assert.Equal(t, 1.5, wsCfg.HealthCheck.SlowMultiplier)
 		assert.Equal(t, 0.4, wsCfg.HealthCheck.MaxSlowFraction)

--- a/pkg/storage/ingest/util.go
+++ b/pkg/storage/ingest/util.go
@@ -170,8 +170,8 @@ func commonKafkaClientOptions(cfg KafkaConfig, metrics *kprom.Metrics, logger lo
 		//
 		// We currently set min and max age to the same value to have constant load on the Kafka backend: regardless
 		// there are errors or not, the metadata requests frequency doesn't change.
-		kgo.MetadataMinAge(defaultMetadataRefreshInterval),
-		kgo.MetadataMaxAge(defaultMetadataRefreshInterval),
+		kgo.MetadataMinAge(DefaultMetadataRefreshInterval),
+		kgo.MetadataMaxAge(DefaultMetadataRefreshInterval),
 
 		kgo.WithLogger(NewKafkaLogger(logger)),
 

--- a/pkg/storage/ingest/writer_client.go
+++ b/pkg/storage/ingest/writer_client.go
@@ -23,9 +23,11 @@ const (
 	// defaultProducerLinger is the producer-side batching delay.
 	defaultProducerLinger = 50 * time.Millisecond
 
-	// defaultMetadataRefreshInterval is how often Kafka metadata (broker
-	// list and partition leaders) is refreshed in the background.
-	defaultMetadataRefreshInterval = 10 * time.Second
+	// DefaultMetadataRefreshInterval is how often Kafka metadata (broker
+	// list and partition leaders) is refreshed. It is used for both the
+	// minimum and maximum metadata age so the metadata request frequency
+	// stays constant regardless of errors.
+	DefaultMetadataRefreshInterval = 10 * time.Second
 )
 
 // newKafkaProducerForBackend selects and constructs the producer


### PR DESCRIPTION
#### What this PR does

Exports the Kafka metadata refresh interval constant (previously the unexported `defaultMetadataRefreshInterval`) as `DefaultMetadataRefreshInterval`.

Mimir hardcodes this single value for both `MetadataMinAge` and `MetadataMaxAge` on its Kafka clients, and for the Warpstream metadata refresh. Exporting it lets downstream consumers that vendor Mimir (e.g. Grafana Enterprise Metrics' adaptive metrics Kafka client) reference the same value and keep their metadata refresh configuration aligned with Mimir.

No behavior change.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated (renamed reference in existing test; no behavior change).
- [ ] Documentation added. n/a
- [x] `CHANGELOG.md` updated - not needed (internal, no user-facing change); `changelog-not-needed` label added.
- [ ] `about-versioning.md` updated with experimental features. n/a