### PR TITLE
Make Kafka writer request timeout overhead configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 * [ENHANCEMENT] MQE: Ensure that intermediate results cache keys can not exceed the cache backend's key-size limit when a query federates over many tenants. #15847
 * [ENHANCEMENT] Query-frontend: add a `retries` field to the "query stats" log line reporting the number of times requests were retried while processing the query. The value is 0 when all requests succeeded on their first attempt. #15929
 * [ENHANCEMENT] Query-frontend: Add `query-frontend.cardinality-sharding-max-sharded-queries` to optionally limit sharding for `cardinality/active_series` and `cardinality/active_native_histogram_metrics` endpoints separately from `query-frontend.query-sharding-max-sharded-queries`. #15922
+* [ENHANCEMENT] Ingest storage: Add experimental `-ingest-storage.kafka.write-timeout-overhead` to configure the overhead added on top of the Kafka write timeout (default 2s, unchanged). #16021
 * [BUGFIX] Query-frontend: Fix `cardinality_analysis_max_results` being ignored when set higher than the default of 500. #15581
 * [BUGFIX] Ingest storage: Fix `KafkaProducer.ProduceSync()` returning a single result with a nil record when the context is canceled, instead of one result per input record (with the record set) as the underlying franz-go client does. #15199
 * [BUGFIX] Ingest storage: Fix `cortex_ingest_storage_reader_receive_delay_seconds` inflation by no longer setting the Kafka record `Timestamp` on the distributor side; the Kafka client now sets it at produce time. #15572

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@
 * [ENHANCEMENT] MQE: Ensure that intermediate results cache keys can not exceed the cache backend's key-size limit when a query federates over many tenants. #15847
 * [ENHANCEMENT] Query-frontend: add a `retries` field to the "query stats" log line reporting the number of times requests were retried while processing the query. The value is 0 when all requests succeeded on their first attempt. #15929
 * [ENHANCEMENT] Query-frontend: Add `query-frontend.cardinality-sharding-max-sharded-queries` to optionally limit sharding for `cardinality/active_series` and `cardinality/active_native_histogram_metrics` endpoints separately from `query-frontend.query-sharding-max-sharded-queries`. #15922
-* [ENHANCEMENT] Ingest storage: Add experimental `-ingest-storage.kafka.write-timeout-overhead` to configure the overhead added on top of the Kafka write timeout (default 2s, unchanged). #16021
+* [ENHANCEMENT] Ingest storage: Add experimental `-ingest-storage.kafka.write-timeout-overhead` to configure the overhead added on top of the Kafka write timeout (default 2s, unchanged). #16023
 * [BUGFIX] Query-frontend: Fix `cardinality_analysis_max_results` being ignored when set higher than the default of 500. #15581
 * [BUGFIX] Ingest storage: Fix `KafkaProducer.ProduceSync()` returning a single result with a nil record when the context is canceled, instead of one result per input record (with the record set) as the underlying franz-go client does. #15199
 * [BUGFIX] Ingest storage: Fix `cortex_ingest_storage_reader_receive_delay_seconds` inflation by no longer setting the Kafka record `Timestamp` on the distributor side; the Kafka client now sets it at produce time. #15572

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -9162,6 +9162,17 @@
             },
             {
               "kind": "field",
+              "name": "write_timeout_overhead",
+              "required": false,
+              "desc": "Additional time added on top of the write timeout, accounting for a write request sitting in the client buffer and travelling over the network before the Kafka backend starts processing it. Lower values fail slow writes faster, at the cost of less tolerance to network and buffer latency.",
+              "fieldValue": null,
+              "fieldDefaultValue": 2000000000,
+              "fieldFlag": "ingest-storage.kafka.write-timeout-overhead",
+              "fieldType": "duration",
+              "fieldCategory": "experimental"
+            },
+            {
+              "kind": "field",
               "name": "write_clients",
               "required": false,
               "desc": "The number of Kafka clients used by producers. When the configured number of clients is greater than 1, partitions are sharded among Kafka clients. A higher number of clients may provide higher write throughput at the cost of additional Metadata requests pressure to Kafka. Deprecated: has no effect (Mimir always uses a single Kafka write client).",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1645,6 +1645,8 @@ Usage of ./cmd/mimir/mimir:
     	[deprecated] The number of Kafka clients used by producers. When the configured number of clients is greater than 1, partitions are sharded among Kafka clients. A higher number of clients may provide higher write throughput at the cost of additional Metadata requests pressure to Kafka. Deprecated: has no effect (Mimir always uses a single Kafka write client). (default 1)
   -ingest-storage.kafka.write-timeout duration
     	How long to wait for an incoming write request to be successfully committed to the Kafka backend. (default 10s)
+  -ingest-storage.kafka.write-timeout-overhead duration
+    	[experimental] Additional time added on top of the write timeout, accounting for a write request sitting in the client buffer and travelling over the network before the Kafka backend starts processing it. Lower values fail slow writes faster, at the cost of less tolerance to network and buffer latency. (default 2s)
   -ingest-storage.migration.distributor-send-to-ingesters-enabled
     	When both this option and ingest storage are enabled, distributors write to both Kafka and ingesters. A write request is considered successful only when written to both backends.
   -ingest-storage.migration.ignore-ingest-storage-errors

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -217,6 +217,8 @@ The following features are currently experimental:
   - WarpStream-aware Kafka producer backend
     - `-ingest-storage.kafka.backend`
     - all flags beginning with `-ingest-storage.kafka.warpstream-`
+  - Kafka write request timeout overhead
+    - `-ingest-storage.kafka.write-timeout-overhead`
 - Querier
   - Streaming label/value search HTTP endpoints `/api/v1/search/{metric_names,label_names,label_values}` returning NDJSON, mirroring the [Prometheus search API](https://github.com/prometheus/prometheus/pull/18573) (`-querier.experimental-search-api-enabled`).
   - Max concurrency for tenant federated queries (`-tenant-federation.max-concurrent`)

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -5389,6 +5389,14 @@ kafka:
   # CLI flag: -ingest-storage.kafka.write-timeout
   [write_timeout: <duration> | default = 10s]
 
+  # (experimental) Additional time added on top of the write timeout, accounting
+  # for a write request sitting in the client buffer and travelling over the
+  # network before the Kafka backend starts processing it. Lower values fail
+  # slow writes faster, at the cost of less tolerance to network and buffer
+  # latency.
+  # CLI flag: -ingest-storage.kafka.write-timeout-overhead
+  [write_timeout_overhead: <duration> | default = 2s]
+
   # (deprecated) The number of Kafka clients used by producers. When the
   # configured number of clients is greater than 1, partitions are sharded among
   # Kafka clients. A higher number of clients may provide higher write

--- a/operations/mimir/mimir-flags-defaults.json
+++ b/operations/mimir/mimir-flags-defaults.json
@@ -615,6 +615,7 @@
   "ingest-storage.kafka.client-rack": "",
   "ingest-storage.kafka.dial-timeout": 2000000000,
   "ingest-storage.kafka.write-timeout": 10000000000,
+  "ingest-storage.kafka.write-timeout-overhead": 2000000000,
   "ingest-storage.kafka.write-clients": 1,
   "ingest-storage.kafka.warpstream-health-check-slow-multiplier": 2,
   "ingest-storage.kafka.warpstream-health-check-max-slow-fraction": 0.3,

--- a/pkg/storage/ingest/config.go
+++ b/pkg/storage/ingest/config.go
@@ -37,6 +37,18 @@ const (
 	KafkaBackendWarpstream = "warpstream"
 )
 
+const (
+	// DefaultKafkaRequestTimeoutOverhead is the default overhead applied by the writer on top of
+	// every Kafka write timeout. It accounts for the extra time a request sits in the client's
+	// buffer before being sent on the wire, plus the time to send it over the network and have
+	// Kafka start processing it.
+	DefaultKafkaRequestTimeoutOverhead = 2 * time.Second
+
+	// MinKafkaRequestTimeoutOverhead is the minimum allowed request timeout overhead. It matches
+	// the lower bound the franz-go client enforces on its request timeout overhead.
+	MinKafkaRequestTimeoutOverhead = 100 * time.Millisecond
+)
+
 var kafkaBackendOptions = []string{KafkaBackendKafka, KafkaBackendWarpstream}
 
 var (
@@ -59,7 +71,8 @@ var (
 	ErrInvalidFetchMaxWait               = errors.New("the Kafka fetch max wait must be between 5s and 30s")
 	ErrInvalidRecordVersion              = errors.New("invalid record format version")
 	ErrInvalidWriteLogsFsyncConcurrency  = errors.New("the configured number of tenants to fsync concurrently before Kafka offsets are committed must be at least 1")
-	ErrInvalidWarpstreamWriteTimeout     = fmt.Errorf("ingest-storage.kafka.write-timeout must be greater than %s when ingest-storage.kafka.backend=%s", writerRequestTimeoutOverhead*2, KafkaBackendWarpstream)
+	ErrInvalidWriteTimeoutOverhead       = fmt.Errorf("ingest-storage.kafka.write-timeout-overhead must be at least %s", MinKafkaRequestTimeoutOverhead)
+	ErrInvalidWarpstreamWriteTimeout     = fmt.Errorf("ingest-storage.kafka.write-timeout must be greater than or equal to twice ingest-storage.kafka.write-timeout-overhead when ingest-storage.kafka.backend=%s", KafkaBackendWarpstream)
 
 	consumeFromPositionOptions = []string{consumeFromLastOffset, consumeFromStart, consumeFromEnd, consumeFromTimestamp}
 
@@ -116,13 +129,14 @@ type KafkaConfig struct {
 	Backend string `yaml:"backend" category:"experimental"`
 
 	// Address is a list of seed brokers. The config name is singular for backward compatibility.
-	Address      flagext.StringSliceCSV `yaml:"address"`
-	Topic        string                 `yaml:"topic"`
-	ClientID     string                 `yaml:"client_id"`
-	ClientRack   string                 `yaml:"client_rack"`
-	DialTimeout  time.Duration          `yaml:"dial_timeout"`
-	WriteTimeout time.Duration          `yaml:"write_timeout"`
-	WriteClients int                    `yaml:"write_clients" category:"deprecated"` // TODO Remove in Mimir 3.3.
+	Address              flagext.StringSliceCSV `yaml:"address"`
+	Topic                string                 `yaml:"topic"`
+	ClientID             string                 `yaml:"client_id"`
+	ClientRack           string                 `yaml:"client_rack"`
+	DialTimeout          time.Duration          `yaml:"dial_timeout"`
+	WriteTimeout         time.Duration          `yaml:"write_timeout"`
+	WriteTimeoutOverhead time.Duration          `yaml:"write_timeout_overhead" category:"experimental"`
+	WriteClients         int                    `yaml:"write_clients" category:"deprecated"` // TODO Remove in Mimir 3.3.
 
 	// Warpstream-only settings, ignored when Backend != KafkaBackendWarpstream.
 	WarpstreamHealthCheckSlowMultiplier    float64 `yaml:"warpstream_health_check_slow_multiplier" category:"experimental"`
@@ -231,6 +245,7 @@ func (cfg *KafkaConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) 
 	f.StringVar(&cfg.ClientRack, prefix+"client-rack", "", "The rack identifier for this Kafka client. Corresponds to the Kafka client.rack setting. Only supported when "+prefix+"backend=kafka.")
 	f.DurationVar(&cfg.DialTimeout, prefix+"dial-timeout", 2*time.Second, "The maximum time allowed to establish the TCP connection to a Kafka broker, including the TLS handshake when TLS is enabled. It does not include the subsequent SASL authentication handshake.")
 	f.DurationVar(&cfg.WriteTimeout, prefix+"write-timeout", 10*time.Second, "How long to wait for an incoming write request to be successfully committed to the Kafka backend.")
+	f.DurationVar(&cfg.WriteTimeoutOverhead, prefix+"write-timeout-overhead", DefaultKafkaRequestTimeoutOverhead, "Additional time added on top of the write timeout, accounting for a write request sitting in the client buffer and travelling over the network before the Kafka backend starts processing it. Lower values fail slow writes faster, at the cost of less tolerance to network and buffer latency.")
 	f.IntVar(&cfg.WriteClients, prefix+"write-clients", 1, "The number of Kafka clients used by producers. When the configured number of clients is greater than 1, partitions are sharded among Kafka clients. A higher number of clients may provide higher write throughput at the cost of additional Metadata requests pressure to Kafka. Deprecated: has no effect (Mimir always uses a single Kafka write client).")
 
 	f.StringVar(&cfg.ConsumerGroup, prefix+"consumer-group", "", "The consumer group used by the consumer to track the last consumed offset. The consumer group must be different for each ingester. If the configured consumer group contains the '<partition>' placeholder, it is replaced with the actual partition ID owned by the ingester. When empty (recommended), Mimir uses the ingester instance ID to guarantee uniqueness.")
@@ -349,12 +364,18 @@ func (cfg *KafkaConfig) Validate() error {
 		}
 	}
 
-	// The Warpstream backend derives the per-attempt produce timeout as
-	// write-timeout minus the request overhead. That only leaves a per-attempt
-	// timeout larger than the overhead itself when write-timeout exceeds twice
-	// the overhead; below that the split stops making sense.
-	if cfg.Backend == KafkaBackendWarpstream && cfg.WriteTimeout <= writerRequestTimeoutOverhead*2 {
-		return ErrInvalidWarpstreamWriteTimeout
+	// The franz-go client rejects a request timeout overhead below 100ms, and the Warpstream
+	// backend requires a positive overhead. Enforce the franz-go floor for both backends so a
+	// misconfiguration surfaces here instead of as a cryptic client construction error.
+	if cfg.WriteTimeoutOverhead < MinKafkaRequestTimeoutOverhead {
+		return fmt.Errorf("%w, is %s", ErrInvalidWriteTimeoutOverhead, cfg.WriteTimeoutOverhead)
+	}
+
+	// The Warpstream backend derives the per-attempt produce timeout as write-timeout minus the
+	// request overhead, then adds the overhead back as client-side slack. That split only holds
+	// when write-timeout is at least twice the overhead, so the per-attempt timeout stays positive.
+	if cfg.Backend == KafkaBackendWarpstream && cfg.WriteTimeout < cfg.WriteTimeoutOverhead*2 {
+		return fmt.Errorf("%w (write-timeout=%s, write-timeout-overhead=%s)", ErrInvalidWarpstreamWriteTimeout, cfg.WriteTimeout, cfg.WriteTimeoutOverhead)
 	}
 
 	// The dialer is only expected to be used in tests.
@@ -391,10 +412,10 @@ func (cfg *KafkaConfig) ToWarpstreamClientOptions() ([]wgo.Opt, error) {
 		wgo.WithMetadataRefreshInterval(defaultMetadataRefreshInterval),
 		// WriteTimeout bounds the whole hedge cascade, so the per-attempt produce
 		// timeout plus its overhead must fit within it (wgo rejects a config where
-		// they don't). Validate guarantees WriteTimeout exceeds twice the overhead,
-		// so the per-attempt timeout stays larger than the overhead.
-		wgo.WithProduceRequestTimeout(cfg.WriteTimeout - writerRequestTimeoutOverhead),
-		wgo.WithProduceRequestTimeoutOverhead(writerRequestTimeoutOverhead),
+		// they don't). Validate guarantees WriteTimeout is at least twice the overhead,
+		// so the per-attempt timeout stays positive.
+		wgo.WithProduceRequestTimeout(cfg.WriteTimeout - cfg.WriteTimeoutOverhead),
+		wgo.WithProduceRequestTimeoutOverhead(cfg.WriteTimeoutOverhead),
 	}
 
 	// The dialer is only expected to be used in tests (e.g. kfake's virtual network).

--- a/pkg/storage/ingest/config_test.go
+++ b/pkg/storage/ingest/config_test.go
@@ -52,15 +52,24 @@ func TestConfig_Validate(t *testing.T) {
 				cfg.KafkaConfig.Backend = KafkaBackendWarpstream
 			},
 		},
-		"should fail if backend is warpstream and write timeout is not greater than twice the request overhead": {
+		"should fail if backend is warpstream and write timeout is less than twice the request overhead": {
 			setup: func(cfg *Config) {
 				cfg.Enabled = true
 				cfg.KafkaConfig.Address = flagext.StringSliceCSV{"localhost"}
 				cfg.KafkaConfig.Topic = "test"
 				cfg.KafkaConfig.Backend = KafkaBackendWarpstream
-				cfg.KafkaConfig.WriteTimeout = writerRequestTimeoutOverhead * 2
+				cfg.KafkaConfig.WriteTimeout = DefaultKafkaRequestTimeoutOverhead*2 - time.Millisecond
 			},
 			expectedErr: ErrInvalidWarpstreamWriteTimeout,
+		},
+		"should pass if backend is warpstream and write timeout equals twice the request overhead": {
+			setup: func(cfg *Config) {
+				cfg.Enabled = true
+				cfg.KafkaConfig.Address = flagext.StringSliceCSV{"localhost"}
+				cfg.KafkaConfig.Topic = "test"
+				cfg.KafkaConfig.Backend = KafkaBackendWarpstream
+				cfg.KafkaConfig.WriteTimeout = DefaultKafkaRequestTimeoutOverhead * 2
+			},
 		},
 		"should pass if backend is warpstream and write timeout is just above twice the request overhead": {
 			setup: func(cfg *Config) {
@@ -68,7 +77,35 @@ func TestConfig_Validate(t *testing.T) {
 				cfg.KafkaConfig.Address = flagext.StringSliceCSV{"localhost"}
 				cfg.KafkaConfig.Topic = "test"
 				cfg.KafkaConfig.Backend = KafkaBackendWarpstream
-				cfg.KafkaConfig.WriteTimeout = writerRequestTimeoutOverhead*2 + time.Millisecond
+				cfg.KafkaConfig.WriteTimeout = DefaultKafkaRequestTimeoutOverhead*2 + time.Millisecond
+			},
+		},
+		"should honor a custom write timeout overhead when enforcing the warpstream write timeout floor": {
+			setup: func(cfg *Config) {
+				cfg.Enabled = true
+				cfg.KafkaConfig.Address = flagext.StringSliceCSV{"localhost"}
+				cfg.KafkaConfig.Topic = "test"
+				cfg.KafkaConfig.Backend = KafkaBackendWarpstream
+				cfg.KafkaConfig.WriteTimeoutOverhead = 500 * time.Millisecond
+				cfg.KafkaConfig.WriteTimeout = 500*time.Millisecond*2 - time.Millisecond
+			},
+			expectedErr: ErrInvalidWarpstreamWriteTimeout,
+		},
+		"should fail if the write timeout overhead is below the minimum": {
+			setup: func(cfg *Config) {
+				cfg.Enabled = true
+				cfg.KafkaConfig.Address = flagext.StringSliceCSV{"localhost"}
+				cfg.KafkaConfig.Topic = "test"
+				cfg.KafkaConfig.WriteTimeoutOverhead = MinKafkaRequestTimeoutOverhead - time.Millisecond
+			},
+			expectedErr: ErrInvalidWriteTimeoutOverhead,
+		},
+		"should pass if the write timeout overhead equals the minimum": {
+			setup: func(cfg *Config) {
+				cfg.Enabled = true
+				cfg.KafkaConfig.Address = flagext.StringSliceCSV{"localhost"}
+				cfg.KafkaConfig.Topic = "test"
+				cfg.KafkaConfig.WriteTimeoutOverhead = MinKafkaRequestTimeoutOverhead
 			},
 		},
 		"should not enforce the warpstream write timeout floor for the kafka backend": {
@@ -642,6 +679,7 @@ func TestKafkaConfig_ToWarpstreamClientOptions(t *testing.T) {
 			ClientID:                               "client-1",
 			DialTimeout:                            3 * time.Second,
 			WriteTimeout:                           7 * time.Second,
+			WriteTimeoutOverhead:                   DefaultKafkaRequestTimeoutOverhead,
 			WarpstreamHealthCheckSlowMultiplier:    1.5,
 			WarpstreamHealthCheckMaxSlowFraction:   0.4,
 			WarpstreamHealthCheckFaultyThreshold:   0.06,
@@ -681,12 +719,25 @@ func TestKafkaConfig_ToWarpstreamClientOptions(t *testing.T) {
 		assert.Equal(t, 2*time.Second, wsCfg.Demoter.ProbeInterval)
 		// The per-attempt produce timeout plus its overhead must sum to
 		// WriteTimeout so the whole hedge cascade fits within it.
-		assert.Equal(t, 7*time.Second-writerRequestTimeoutOverhead, wsCfg.DirectProducer.ProduceRequestTimeout)
-		assert.Equal(t, writerRequestTimeoutOverhead, wsCfg.DirectProducer.ProduceRequestTimeoutOverhead)
+		assert.Equal(t, 7*time.Second-DefaultKafkaRequestTimeoutOverhead, wsCfg.DirectProducer.ProduceRequestTimeout)
+		assert.Equal(t, DefaultKafkaRequestTimeoutOverhead, wsCfg.DirectProducer.ProduceRequestTimeoutOverhead)
 		assert.False(t, wsCfg.TLSEnabled)
 		assert.Nil(t, wsCfg.TLSConfig)
 
 		// The applied config must satisfy wgo's own validation.
+		require.NoError(t, wsCfg.Validate())
+	})
+
+	t.Run("honors a custom write timeout overhead", func(t *testing.T) {
+		cfg := baseConfig()
+		cfg.WriteTimeoutOverhead = time.Second
+
+		opts, err := cfg.ToWarpstreamClientOptions()
+		require.NoError(t, err)
+
+		wsCfg := wgo.NewConfig(opts...)
+		assert.Equal(t, 7*time.Second-time.Second, wsCfg.DirectProducer.ProduceRequestTimeout)
+		assert.Equal(t, time.Second, wsCfg.DirectProducer.ProduceRequestTimeoutOverhead)
 		require.NoError(t, wsCfg.Validate())
 	})
 

--- a/pkg/storage/ingest/writer.go
+++ b/pkg/storage/ingest/writer.go
@@ -21,12 +21,6 @@ import (
 )
 
 const (
-	// writerRequestTimeoutOverhead is the overhead applied by the Writer to every Kafka timeout.
-	// You can think about this overhead as an extra time for requests sitting in the client's buffer
-	// before being sent on the wire and the actual time it takes to send it over the network and
-	// start being processed by Kafka.
-	writerRequestTimeoutOverhead = 2 * time.Second
-
 	// producerBatchMaxBytes is the max allowed size of a batch of Kafka records.
 	producerBatchMaxBytes = 16_000_000
 

--- a/pkg/storage/ingest/writer_client.go
+++ b/pkg/storage/ingest/writer_client.go
@@ -136,7 +136,7 @@ func NewKafkaWriterClient(kafkaCfg KafkaConfig, maxInflightProduceRequests int, 
 		kgo.RecordRetries(math.MaxInt64),
 		kgo.RecordDeliveryTimeout(kafkaCfg.WriteTimeout),
 		kgo.ProduceRequestTimeout(kafkaCfg.WriteTimeout),
-		kgo.RequestTimeoutOverhead(writerRequestTimeoutOverhead),
+		kgo.RequestTimeoutOverhead(kafkaCfg.WriteTimeoutOverhead),
 
 		// Unlimited number of buffered records because we limit on bytes in Writer. The reason why we don't use
 		// kgo.MaxBufferedBytes() is because it suffers a deadlock issue:

--- a/pkg/storage/ingest/writer_client_test.go
+++ b/pkg/storage/ingest/writer_client_test.go
@@ -94,6 +94,24 @@ func TestNewKafkaWriterClient_ShouldSupportSASLPlainAuthentication(t *testing.T)
 	})
 }
 
+func TestNewKafkaWriterClient_ShouldConfigureRequestTimeoutOverhead(t *testing.T) {
+	const (
+		topicName     = "test"
+		numPartitions = 1
+	)
+
+	_, clusterAddr := testkafka.CreateCluster(t, numPartitions, topicName)
+
+	cfg := createTestKafkaConfig(clusterAddr, topicName)
+	cfg.WriteTimeoutOverhead = time.Second
+
+	client, err := NewKafkaWriterClient(cfg, 1, log.NewNopLogger(), prometheus.NewPedanticRegistry())
+	require.NoError(t, err)
+	t.Cleanup(client.Close)
+
+	assert.Equal(t, time.Second, client.OptValue(kgo.RequestTimeoutOverhead))
+}
+
 func TestNewKafkaWriterClient_ShouldTrackExtendedKafkaClientMetrics(t *testing.T) {
 	const (
 		topicName     = "test"

--- a/pkg/storage/ingest/writer_test.go
+++ b/pkg/storage/ingest/writer_test.go
@@ -580,7 +580,7 @@ func testWriter_WriteSync(t *testing.T, backend string) {
 
 					// Inject a slowdown on the 1st Produce request received by Kafka.
 					// NOTE: the slowdown is 1s longer than the client timeout.
-					time.Sleep(kafkaCfg.WriteTimeout + writerRequestTimeoutOverhead + time.Second)
+					time.Sleep(kafkaCfg.WriteTimeout + kafkaCfg.WriteTimeoutOverhead + time.Second)
 				}
 
 				return nil, nil, false
@@ -593,7 +593,7 @@ func testWriter_WriteSync(t *testing.T, backend string) {
 				elapsedTime := time.Since(startTime)
 
 				// It should take nearly the client's write timeout.
-				expectedElapsedTime := kafkaCfg.WriteTimeout + writerRequestTimeoutOverhead
+				expectedElapsedTime := kafkaCfg.WriteTimeout + kafkaCfg.WriteTimeoutOverhead
 				assert.InDelta(t, expectedElapsedTime, elapsedTime, float64(time.Second))
 			})
 
@@ -604,7 +604,7 @@ func testWriter_WriteSync(t *testing.T, backend string) {
 
 				// Wait 500ms less than the client timeout.
 				delay := 500 * time.Millisecond
-				time.Sleep(kafkaCfg.WriteTimeout + writerRequestTimeoutOverhead - delay)
+				time.Sleep(kafkaCfg.WriteTimeout + kafkaCfg.WriteTimeoutOverhead - delay)
 
 				startTime := time.Now()
 				assert.ErrorIs(t, writer.WriteSync(ctx, topicName, partitionID, tenantID, &mimirpb.WriteRequest{Timeseries: series2, Metadata: nil, Source: mimirpb.API}), kgo.ErrRecordTimeout)
@@ -803,7 +803,7 @@ func testWriter_WriteSync(t *testing.T, backend string) {
 				writeErrsMx.Lock()
 				defer writeErrsMx.Unlock()
 				return len(writeErrs) == 10
-			}, cfg.WriteTimeout+writerRequestTimeoutOverhead+time.Second, 100*time.Millisecond)
+			}, cfg.WriteTimeout+cfg.WriteTimeoutOverhead+time.Second, 100*time.Millisecond)
 
 			// Assert on the actual errors returned by WriteSync().
 			actualErrRecordTimeoutCount := 0


### PR DESCRIPTION
#### What this PR does

The Kafka writer request timeout overhead was hardcoded to 2s and shared by both the `kafka` (franz-go) and `warpstream` backends. This exposes it as the experimental `-ingest-storage.kafka.write-timeout-overhead` flag, with the default unchanged, so it can be lowered in selected clusters to experiment with its effect on write tail latency without a code change.

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
