### PR TITLE
MQE: batch intermediate result cache lookups in range vector splitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * [ENHANCEMENT] MQE: Simplify `unless` and `or` operations where one side can be proven to be empty by inspecting the expression. #15198
 * [ENHANCEMENT] Store-gateway: Remove outdated limit on caching LabelValues responses that contain more than 655360 values. The gob library panic which required workaround was fixed. #5021 #15271
 * [ENHANCEMENT] MQE: Reduce memory consumption of range vector splitting when many consecutive intervals are not cached. #15173
+* [ENHANCEMENT] MQE: Reduce the number of requests to the intermediate result cache of range vector splitting by using the batch API. #16021
 * [ENHANCEMENT] Querier: track physical and equivalent samples read for remote read requests in query statistics, mirroring the statistics emitted for instant and range queries. #15694
 * [ENHANCEMENT] Ingest storage: Add `cortex_ingest_storage_writer_serialize_duration_seconds` native histogram metric tracking the time spent serializing an incoming request to Kafka records. #15527
 * [ENHANCEMENT] Memberlist: Add `-memberlist.compression-algorithm` flag to select the algorithm used to compress outgoing messages. Supported values: `lzw` (default) and `snappy`. The flag is ignored when `-memberlist.compression-enabled` is false. Before reconfiguring any node to emit a new algorithm, upgrade every cluster member to a build that can decode it, otherwise messages are dropped. #15357

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@
 * [ENHANCEMENT] MQE: Simplify `unless` and `or` operations where one side can be proven to be empty by inspecting the expression. #15198
 * [ENHANCEMENT] Store-gateway: Remove outdated limit on caching LabelValues responses that contain more than 655360 values. The gob library panic which required workaround was fixed. #5021 #15271
 * [ENHANCEMENT] MQE: Reduce memory consumption of range vector splitting when many consecutive intervals are not cached. #15173
-* [ENHANCEMENT] MQE: Reduce the number of requests to the intermediate result cache of range vector splitting by using the batch API. #16021
+* [ENHANCEMENT] MQE: Reduce the number of requests to the intermediate result cache of range vector splitting by using the batch API. #16024
 * [ENHANCEMENT] Querier: track physical and equivalent samples read for remote read requests in query statistics, mirroring the statistics emitted for instant and range queries. #15694
 * [ENHANCEMENT] Ingest storage: Add `cortex_ingest_storage_writer_serialize_duration_seconds` native histogram metric tracking the time spent serializing an incoming request to Kafka records. #15527
 * [ENHANCEMENT] Memberlist: Add `-memberlist.compression-algorithm` flag to select the algorithm used to compress outgoing messages. Supported values: `lzw` (default) and `snappy`. The flag is ignored when `-memberlist.compression-enabled` is false. Before reconfiguring any node to emit a new algorithm, upgrade every cluster member to a build that can decode it, otherwise messages are dropped. #15357

--- a/pkg/streamingpromql/caching/in_memory.go
+++ b/pkg/streamingpromql/caching/in_memory.go
@@ -13,9 +13,10 @@ import (
 type InMemoryCache struct {
 	Entries map[string]InMemoryCacheEntry
 
-	GetCount int
-	HitCount int
-	SetCount int
+	GetCount  int
+	HitCount  int
+	SetCount  int
+	KeysCount int
 }
 
 // NewInMemoryCache creates a new in-memory cache.
@@ -33,6 +34,7 @@ type InMemoryCacheEntry struct {
 
 func (c *InMemoryCache) GetMulti(ctx context.Context, keys []string, opts ...cache.Option) (map[string][]byte, error) {
 	c.GetCount++
+	c.KeysCount += len(keys)
 	results := make(map[string][]byte, len(keys))
 
 	for _, key := range keys {
@@ -59,5 +61,6 @@ func (c *InMemoryCache) Reset() {
 	c.Entries = make(map[string]InMemoryCacheEntry)
 	c.SetCount = 0
 	c.GetCount = 0
+	c.KeysCount = 0
 	c.HitCount = 0
 }

--- a/pkg/streamingpromql/optimize/plan/rangevectorsplitting/cache/cache.go
+++ b/pkg/streamingpromql/optimize/plan/rangevectorsplitting/cache/cache.go
@@ -137,56 +137,102 @@ func (c *Cache[T]) cacheKeys(ctx context.Context, function functions.Function, i
 	return fullKey, hashed, nil
 }
 
-func (c *Cache[T]) Get(
-	ctx context.Context,
-	function functions.Function,
-	innerKey []byte,
-	start, end int64,
-	stats *CacheStats,
-) (seriesMetadata []querierpb.SeriesMetadata, annotations querierpb.Annotations, results []T, operatorStats types.EncodedOperatorEvaluationStats, found bool, err error) {
-	tenant, err := user.ExtractOrgID(ctx)
+// GetRange identifies the time range of a single cache entry to look up.
+type GetRange struct {
+	Start int64
+	End   int64
+}
+
+// GetResult holds the outcome of the lookup of a single range. When Found is false, all other fields are zero.
+type GetResult[T any] struct {
+	SeriesMetadata []querierpb.SeriesMetadata
+	Annotations    querierpb.Annotations
+	Results        []T
+	Stats          types.EncodedOperatorEvaluationStats
+	Found          bool
+}
+
+// GetMulti looks up the cache entries for all the given ranges using a single backend request.
+// The returned slice is aligned with ranges. An entry that is missing, fails to decode or
+// collides on its hashed key is reported as not found. Only backend or codec errors fail the call.
+func (c *Cache[T]) GetMulti(ctx context.Context, function functions.Function, innerKey []byte, ranges []GetRange, stats *CacheStats) ([]GetResult[T], error) {
+	if len(ranges) == 0 {
+		return nil, nil
+	}
+
+	tenantID, err := user.ExtractOrgID(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	c.metrics.cacheRequests.Add(float64(len(ranges)))
+
+	cacheKeys := make([][]byte, len(ranges))
+	hashedKeys := make([]string, len(ranges))
+	for i, r := range ranges {
+		cacheKeys[i], hashedKeys[i], err = c.cacheKeys(ctx, function, innerKey, r.Start, r.End)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	foundData, err := c.backend.GetMulti(ctx, hashedKeys)
+	if err != nil {
+		return nil, fmt.Errorf("getting cached results: %w", err)
+	}
+
+	results := make([]GetResult[T], len(ranges))
+
+	for i, r := range ranges {
+		hashedKey := hashedKeys[i]
+
+		data, ok := foundData[hashedKey]
+		if !ok || len(data) == 0 {
+			continue
+		}
+
+		var cached CachedSeries
+		if err := cached.Unmarshal(data); err != nil {
+			level.Warn(c.logger).Log("msg", "failed to decode cached result", "hashed_cache_key", hashedKey, "err", err)
+			continue
+		}
+
+		if !bytes.Equal(cached.CacheKey, cacheKeys[i]) {
+			level.Warn(c.logger).Log("msg", "skipped cached result because a cache key collision has been found", "hashed_cache_key", hashedKey)
+			continue
+		}
+
+		decoded, err := c.codec.Unmarshal(cached.Results)
+		if err != nil {
+			return nil, fmt.Errorf("unmarshaling cached results: %w", err)
+		}
+
+		c.metrics.cacheHits.Inc()
+		level.Debug(c.logger).Log("msg", "cache hit", "tenant", tenantID, "function", function, "hashed_cache_key", hashedKey, "start", r.Start, "end", r.End)
+
+		stats.AddReadEntryStat(len(cached.SeriesMetadata), len(data))
+
+		results[i] = GetResult[T]{
+			SeriesMetadata: cached.SeriesMetadata,
+			Annotations:    cached.Annotations,
+			Results:        decoded,
+			Stats:          cached.Stats,
+			Found:          true,
+		}
+	}
+
+	return results, nil
+}
+
+// Get looks up the cache entry for a single range. It is a convenience wrapper around GetMulti.
+func (c *Cache[T]) Get(ctx context.Context, function functions.Function, innerKey []byte, start, end int64, stats *CacheStats) (seriesMetadata []querierpb.SeriesMetadata, annotations querierpb.Annotations, results []T, operatorStats types.EncodedOperatorEvaluationStats, found bool, err error) {
+	getResults, err := c.GetMulti(ctx, function, innerKey, []GetRange{{Start: start, End: end}}, stats)
 	if err != nil {
 		return nil, querierpb.Annotations{}, nil, types.EncodedOperatorEvaluationStats{}, false, err
 	}
 
-	c.metrics.cacheRequests.Inc()
-	cacheKey, hashedKey, err := c.cacheKeys(ctx, function, innerKey, start, end)
-	if err != nil {
-		return nil, querierpb.Annotations{}, nil, types.EncodedOperatorEvaluationStats{}, false, err
-	}
-
-	foundData, err := c.backend.GetMulti(ctx, []string{hashedKey})
-	if err != nil {
-		return nil, querierpb.Annotations{}, nil, types.EncodedOperatorEvaluationStats{}, false, fmt.Errorf("getting cached results: %w", err)
-	}
-
-	data, ok := foundData[hashedKey]
-	if !ok || len(data) == 0 {
-		return nil, querierpb.Annotations{}, nil, types.EncodedOperatorEvaluationStats{}, false, nil
-	}
-
-	var cached CachedSeries
-	if err := cached.Unmarshal(data); err != nil {
-		level.Warn(c.logger).Log("msg", "failed to decode cached result", "hashed_cache_key", hashedKey, "err", err)
-		return nil, querierpb.Annotations{}, nil, types.EncodedOperatorEvaluationStats{}, false, nil
-	}
-
-	if !bytes.Equal(cached.CacheKey, cacheKey) {
-		level.Warn(c.logger).Log("msg", "skipped cached result because a cache key collision has been found", "hashed_cache_key", hashedKey)
-		return nil, querierpb.Annotations{}, nil, types.EncodedOperatorEvaluationStats{}, false, nil
-	}
-
-	c.metrics.cacheHits.Inc()
-	level.Debug(c.logger).Log("msg", "cache hit", "tenant", tenant, "function", function, "hashed_cache_key", hashedKey, "start", start, "end", end)
-
-	stats.AddReadEntryStat(len(cached.SeriesMetadata), len(data))
-
-	results, err = c.codec.Unmarshal(cached.Results)
-	if err != nil {
-		return nil, querierpb.Annotations{}, nil, types.EncodedOperatorEvaluationStats{}, false, fmt.Errorf("unmarshaling cached results: %w", err)
-	}
-
-	return cached.SeriesMetadata, cached.Annotations, results, cached.Stats, true, nil
+	r := getResults[0]
+	return r.SeriesMetadata, r.Annotations, r.Results, r.Stats, r.Found, nil
 }
 
 func (c *Cache[T]) Set(

--- a/pkg/streamingpromql/optimize/plan/rangevectorsplitting/cache/cache.go
+++ b/pkg/streamingpromql/optimize/plan/rangevectorsplitting/cache/cache.go
@@ -143,12 +143,14 @@ type GetRange struct {
 	End   int64
 }
 
-// GetResult holds the outcome of the lookup of a single range. When Found is false, all other fields are zero.
+// GetResult holds the outcome of the lookup of a single range. When Found is false, data fields are zero.
 type GetResult[T any] struct {
 	SeriesMetadata []querierpb.SeriesMetadata
 	Annotations    querierpb.Annotations
 	Results        []T
 	Stats          types.EncodedOperatorEvaluationStats
+	Start          int64
+	End            int64
 	Found          bool
 }
 
@@ -184,6 +186,8 @@ func (c *Cache[T]) GetMulti(ctx context.Context, function functions.Function, in
 	results := make([]GetResult[T], len(ranges))
 
 	for i, r := range ranges {
+		results[i] = GetResult[T]{Start: r.Start, End: r.End}
+
 		hashedKey := hashedKeys[i]
 
 		data, ok := foundData[hashedKey]
@@ -217,21 +221,13 @@ func (c *Cache[T]) GetMulti(ctx context.Context, function functions.Function, in
 			Annotations:    cached.Annotations,
 			Results:        decoded,
 			Stats:          cached.Stats,
+			Start:          cached.Start,
+			End:            cached.End,
 			Found:          true,
 		}
 	}
 
 	return results, nil
-}
-
-func (c *Cache[T]) Get(ctx context.Context, function functions.Function, innerKey []byte, start, end int64, stats *CacheStats) (seriesMetadata []querierpb.SeriesMetadata, annotations querierpb.Annotations, results []T, operatorStats types.EncodedOperatorEvaluationStats, found bool, err error) {
-	getResults, err := c.GetMulti(ctx, function, innerKey, []GetRange{{Start: start, End: end}}, stats)
-	if err != nil {
-		return nil, querierpb.Annotations{}, nil, types.EncodedOperatorEvaluationStats{}, false, err
-	}
-
-	r := getResults[0]
-	return r.SeriesMetadata, r.Annotations, r.Results, r.Stats, r.Found, nil
 }
 
 func (c *Cache[T]) Set(

--- a/pkg/streamingpromql/optimize/plan/rangevectorsplitting/cache/cache.go
+++ b/pkg/streamingpromql/optimize/plan/rangevectorsplitting/cache/cache.go
@@ -224,7 +224,6 @@ func (c *Cache[T]) GetMulti(ctx context.Context, function functions.Function, in
 	return results, nil
 }
 
-// Get looks up the cache entry for a single range. It is a convenience wrapper around GetMulti.
 func (c *Cache[T]) Get(ctx context.Context, function functions.Function, innerKey []byte, start, end int64, stats *CacheStats) (seriesMetadata []querierpb.SeriesMetadata, annotations querierpb.Annotations, results []T, operatorStats types.EncodedOperatorEvaluationStats, found bool, err error) {
 	getResults, err := c.GetMulti(ctx, function, innerKey, []GetRange{{Start: start, End: end}}, stats)
 	if err != nil {

--- a/pkg/streamingpromql/optimize/plan/rangevectorsplitting/cache/cache_test.go
+++ b/pkg/streamingpromql/optimize/plan/rangevectorsplitting/cache/cache_test.go
@@ -54,12 +54,11 @@ func TestCacheGetMulti(t *testing.T) {
 	require.NoError(t, c.Set(ctx, testFunction, inner, hit1.Start, hit1.End, nil, querierpb.Annotations{}, []int{1, 2}, types.EncodedOperatorEvaluationStats{}, 2, &CacheStats{}))
 	require.NoError(t, c.Set(ctx, testFunction, inner, hit2.Start, hit2.End, nil, querierpb.Annotations{}, []int{3}, types.EncodedOperatorEvaluationStats{}, 1, &CacheStats{}))
 
-	// Store bytes that don't decode as a CachedSeries under the undecodable range's key.
+	// Store bytes that don't decode as a CachedSeries
 	undecodableKey, err := TestGenerateHashedCacheKey(ctx, keyGenerator, testFunction, inner, undecodable.Start, undecodable.End)
 	require.NoError(t, err)
 	require.NoError(t, backend.SetAsync(ctx, undecodableKey, []byte{0xff, 0xff, 0xff}, time.Hour))
 
-	// Store a valid entry whose embedded full key doesn't match under the colliding range's key.
 	collided := &CachedSeries{CacheKey: []byte("some-other-key")}
 	collidedData, err := collided.Marshal()
 	require.NoError(t, err)

--- a/pkg/streamingpromql/optimize/plan/rangevectorsplitting/cache/cache_test.go
+++ b/pkg/streamingpromql/optimize/plan/rangevectorsplitting/cache/cache_test.go
@@ -72,8 +72,14 @@ func TestCacheGetMulti(t *testing.T) {
 	require.Len(t, results, 5)
 
 	require.True(t, results[0].Found)
+	require.Equal(t, hit1.Start, results[0].Start)
+	require.Equal(t, hit1.End, results[0].End)
 	require.False(t, results[1].Found, "range without a cache entry should be a miss")
+	require.Equal(t, miss.Start, results[1].Start)
+	require.Equal(t, miss.End, results[1].End)
 	require.True(t, results[2].Found)
+	require.Equal(t, hit2.Start, results[2].Start)
+	require.Equal(t, hit2.End, results[2].End)
 	require.False(t, results[3].Found, "range with an undecodable cache entry should be a miss")
 	require.False(t, results[4].Found, "range with a colliding cache entry should be a miss")
 
@@ -115,20 +121,20 @@ func TestCacheIsolatesTenants(t *testing.T) {
 	factory := NewCacheFactoryWithBackend(backend, testTTLProvider{}, caching.NewCacheKeyGenerator(nil, prefixGeneratorFunc), prometheus.NewRegistry(), log.NewNopLogger())
 	c := NewCache[int](factory, testCodec{})
 
-	// Get extracts the org ID for logging, so an org ID must be present in the context.
+	// GetMulti extracts the org ID for logging, so an org ID must be present in the context.
 	ctx := user.InjectOrgID(context.Background(), "tenant-a")
 	function := testFunction
 	inner := []byte("inner")
-	var start, end int64 = 0, 100
+	ranges := []GetRange{{Start: 0, End: 100}}
 
-	require.NoError(t, c.Set(ctx, function, inner, start, end, nil, querierpb.Annotations{}, []int{1}, types.EncodedOperatorEvaluationStats{}, 1, &CacheStats{}))
+	require.NoError(t, c.Set(ctx, function, inner, ranges[0].Start, ranges[0].End, nil, querierpb.Annotations{}, []int{1}, types.EncodedOperatorEvaluationStats{}, 1, &CacheStats{}))
 
-	_, _, _, _, found, err := c.Get(ctx, function, inner, start, end, &CacheStats{})
+	results, err := c.GetMulti(ctx, function, inner, ranges, &CacheStats{})
 	require.NoError(t, err)
-	require.True(t, found, "entry should be found when the same prefix is active")
+	require.True(t, results[0].Found, "entry should be found when the same prefix is active")
 
 	prefix = "tenant-b:"
-	_, _, _, _, found, err = c.Get(ctx, function, inner, start, end, &CacheStats{})
+	results, err = c.GetMulti(ctx, function, inner, ranges, &CacheStats{})
 	require.NoError(t, err)
-	require.False(t, found, "entry written under one prefix must not be visible under another prefix")
+	require.False(t, results[0].Found, "entry written under one prefix must not be visible under another prefix")
 }

--- a/pkg/streamingpromql/optimize/plan/rangevectorsplitting/cache/cache_test.go
+++ b/pkg/streamingpromql/optimize/plan/rangevectorsplitting/cache/cache_test.go
@@ -34,6 +34,54 @@ const (
 	testFunction = functions.FUNCTION_SUM_OVER_TIME
 )
 
+// TestCacheGetMulti verifies that a single GetMulti call handles a mix of hits, misses, undecodable entries and
+// hashed-key collisions, degrading each problematic entry to a miss without failing the whole batch.
+func TestCacheGetMulti(t *testing.T) {
+	backend := caching.NewInMemoryCache()
+	keyGenerator := caching.NewCacheKeyGenerator(nil, caching.StaticPrefixGenerator("tenant-a:"))
+	factory := NewCacheFactoryWithBackend(backend, testTTLProvider{}, keyGenerator, prometheus.NewRegistry(), log.NewNopLogger())
+	c := NewCache[int](factory, testCodec{})
+
+	ctx := user.InjectOrgID(context.Background(), "tenant-a")
+	inner := []byte("inner")
+
+	hit1 := GetRange{Start: 0, End: 100}
+	miss := GetRange{Start: 100, End: 200}
+	hit2 := GetRange{Start: 200, End: 300}
+	undecodable := GetRange{Start: 300, End: 400}
+	collision := GetRange{Start: 400, End: 500}
+
+	require.NoError(t, c.Set(ctx, testFunction, inner, hit1.Start, hit1.End, nil, querierpb.Annotations{}, []int{1, 2}, types.EncodedOperatorEvaluationStats{}, 2, &CacheStats{}))
+	require.NoError(t, c.Set(ctx, testFunction, inner, hit2.Start, hit2.End, nil, querierpb.Annotations{}, []int{3}, types.EncodedOperatorEvaluationStats{}, 1, &CacheStats{}))
+
+	// Store bytes that don't decode as a CachedSeries under the undecodable range's key.
+	undecodableKey, err := TestGenerateHashedCacheKey(ctx, keyGenerator, testFunction, inner, undecodable.Start, undecodable.End)
+	require.NoError(t, err)
+	require.NoError(t, backend.SetAsync(ctx, undecodableKey, []byte{0xff, 0xff, 0xff}, time.Hour))
+
+	// Store a valid entry whose embedded full key doesn't match under the colliding range's key.
+	collided := &CachedSeries{CacheKey: []byte("some-other-key")}
+	collidedData, err := collided.Marshal()
+	require.NoError(t, err)
+	collisionKey, err := TestGenerateHashedCacheKey(ctx, keyGenerator, testFunction, inner, collision.Start, collision.End)
+	require.NoError(t, err)
+	require.NoError(t, backend.SetAsync(ctx, collisionKey, collidedData, time.Hour))
+
+	stats := &CacheStats{}
+	results, err := c.GetMulti(ctx, testFunction, inner, []GetRange{hit1, miss, hit2, undecodable, collision}, stats)
+	require.NoError(t, err)
+	require.Len(t, results, 5)
+
+	require.True(t, results[0].Found)
+	require.False(t, results[1].Found, "range without a cache entry should be a miss")
+	require.True(t, results[2].Found)
+	require.False(t, results[3].Found, "range with an undecodable cache entry should be a miss")
+	require.False(t, results[4].Found, "range with a colliding cache entry should be a miss")
+
+	require.Equal(t, 1, backend.GetCount, "all ranges should be fetched with a single backend request")
+	require.Equal(t, 5, backend.KeysCount)
+}
+
 // TestCacheKeysIsolatesPrefixes verifies that the same inner query under two different prefixes
 // produces different full keys and different hashed keys. Because the prefix is part of the full
 // key stored in the cache entry, even a hash collision across tenants or label policies would be

--- a/pkg/streamingpromql/optimize/plan/rangevectorsplitting/operator.go
+++ b/pkg/streamingpromql/optimize/plan/rangevectorsplitting/operator.go
@@ -177,6 +177,11 @@ func (m *FunctionOverRangeVectorSplit[T]) AfterPrepare(ctx context.Context) erro
 }
 
 func (m *FunctionOverRangeVectorSplit[T]) createSplits(ctx context.Context) error {
+	cachedResults, err := m.getCachedResults(ctx)
+	if err != nil {
+		return err
+	}
+
 	var currentUncachedRanges []Range
 	var currentRangeLength int64
 
@@ -195,20 +200,14 @@ func (m *FunctionOverRangeVectorSplit[T]) createSplits(ctx context.Context) erro
 		return nil
 	}
 
-	for _, splitRange := range m.splitRanges {
+	for i, splitRange := range m.splitRanges {
 		if splitRange.Cacheable {
-			// TODO: considering using a single call to retrieve all the cache entries.
-			metadata, annotations, results, stats, found, err := m.cache.Get(ctx, m.FuncId, m.innerCacheKey, splitRange.Start, splitRange.End, m.cacheStats)
-			if err != nil {
-				return err
-			}
-
-			if found {
+			if cached := cachedResults[i]; cached.Found {
 				if err := flushCurrentUncachedRanges(); err != nil {
 					return err
 				}
 
-				cachedSplit, err := NewCachedSplit(ctx, metadata, annotations, results, stats, m)
+				cachedSplit, err := NewCachedSplit(ctx, cached.SeriesMetadata, cached.Annotations, cached.Results, cached.Stats, m)
 				if err != nil {
 					return err
 				}
@@ -233,6 +232,39 @@ func (m *FunctionOverRangeVectorSplit[T]) createSplits(ctx context.Context) erro
 
 	// Create split from final uncached ranges if they exist.
 	return flushCurrentUncachedRanges()
+}
+
+// getCachedResults looks up the cache entries for all cacheable split ranges using a single cache request.
+// The returned slice is aligned with m.splitRanges. Entries for non-cacheable ranges are always not found.
+func (m *FunctionOverRangeVectorSplit[T]) getCachedResults(ctx context.Context) ([]cache.GetResult[T], error) {
+	var cacheableRanges []cache.GetRange
+
+	for _, splitRange := range m.splitRanges {
+		if splitRange.Cacheable {
+			cacheableRanges = append(cacheableRanges, cache.GetRange{Start: splitRange.Start, End: splitRange.End})
+		}
+	}
+
+	if len(cacheableRanges) == 0 {
+		return nil, nil
+	}
+
+	cachedResults, err := m.cache.GetMulti(ctx, m.FuncId, m.innerCacheKey, cacheableRanges, m.cacheStats)
+	if err != nil {
+		return nil, err
+	}
+
+	// cachedResults only contains entries for the cacheable ranges, so return them aligned with m.splitRanges.
+	results := make([]cache.GetResult[T], len(m.splitRanges))
+	nextCachedResult := 0
+	for i, splitRange := range m.splitRanges {
+		if splitRange.Cacheable {
+			results[i] = cachedResults[nextCachedResult]
+			nextCachedResult++
+		}
+	}
+
+	return results, nil
 }
 
 func (m *FunctionOverRangeVectorSplit[T]) materializeOperatorForTimeRange(ctx context.Context, start int64, end int64, step int64) (types.RangeVectorOperator, error) {

--- a/pkg/streamingpromql/optimize/plan/rangevectorsplitting/operator.go
+++ b/pkg/streamingpromql/optimize/plan/rangevectorsplitting/operator.go
@@ -259,7 +259,12 @@ func (m *FunctionOverRangeVectorSplit[T]) getCachedResults(ctx context.Context) 
 	nextCachedResult := 0
 	for i, splitRange := range m.splitRanges {
 		if splitRange.Cacheable {
-			results[i] = cachedResults[nextCachedResult]
+			result := cachedResults[nextCachedResult]
+			if result.Start != splitRange.Start || result.End != splitRange.End {
+				panic(fmt.Sprintf("cached result time range (%d, %d] does not match split range (%d, %d]",
+					result.Start, result.End, splitRange.Start, splitRange.End))
+			}
+			results[i] = result
 			nextCachedResult++
 		}
 	}

--- a/pkg/streamingpromql/optimize/plan/rangevectorsplitting/range_vector_splitting_test.go
+++ b/pkg/streamingpromql/optimize/plan/rangevectorsplitting/range_vector_splitting_test.go
@@ -73,6 +73,24 @@ func TestQuerySplitting_InstantQueryWith1hRange_NotCached(t *testing.T) {
 	verifyCacheStats(t, testCache, 0, 0, 0)
 }
 
+func TestQuerySplitting_CacheLookupsAreBatched(t *testing.T) {
+	testCache, mimirEngine := setupEngineAndCache(t)
+
+	promStorage := promqltest.LoadedStorage(t, `
+		load 10m
+			some_metric{env="1"} 0+1x140
+	`)
+	t.Cleanup(func() { require.NoError(t, promStorage.Close()) })
+
+	// A 21h range queried at 22h produces ten cacheable blocks: (2h-1ms, 4h-1ms], (4h-1ms, 6h-1ms], ..., (20h-1ms, 22h-1ms].
+	ts := timestamp.Time(0).Add(22 * time.Hour)
+	result, _, _ := executeQuery(t, mimirEngine, promStorage, "sum_over_time(some_metric[21h])", ts)
+	require.NoError(t, result.Err)
+
+	require.Equal(t, 10, testCache.KeysCount, "expected a lookup for each cacheable range")
+	require.Equal(t, 1, testCache.GetCount, "expected all cacheable ranges to be looked up with a single backend request")
+}
+
 // TestQuerySplitting_InstantQueryWith5hRange_UsesCache validates query splitting with caching.
 //
 // Important: SplitRanges use PromQL notation (Start, End] (left-open, right-closed), but storage
@@ -1553,8 +1571,8 @@ func verifyEvaluationStats(t *testing.T, stats *promstats.QuerySamples, expected
 	require.Equal(t, expectedSamplesRead, stats.SamplesRead, "Expected %d samples read, got %d", expectedSamplesRead, stats.SamplesRead)
 }
 
-func verifyCacheStats(t *testing.T, backend *caching.InMemoryCache, expectedGets, expectedHits, expectedSets int) {
-	require.Equal(t, expectedGets, backend.GetCount, "Expected %d cache gets, got %d", expectedGets, backend.GetCount)
+func verifyCacheStats(t *testing.T, backend *caching.InMemoryCache, expectedKeys, expectedHits, expectedSets int) {
+	require.Equal(t, expectedKeys, backend.KeysCount, "Expected %d cache key lookups, got %d", expectedKeys, backend.KeysCount)
 	require.Equal(t, expectedHits, backend.HitCount, "Expected %d cache hits, got %d", expectedHits, backend.HitCount)
 	require.Equal(t, expectedSets, backend.SetCount, "Expected %d cache sets, got %d", expectedSets, backend.SetCount)
 }


### PR DESCRIPTION
#### What this PR does

Reduces the number of requests to the intermediate result cache of range vector splitting by using the batch API. All cacheable split ranges of a split range vector are now fetched with a single `GetMulti` request instead of one request per range.

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
