### PR TITLE
MQE: Avoid allocation in optimize.Walk() method

### DIFF
--- a/pkg/streamingpromql/optimize/inspect.go
+++ b/pkg/streamingpromql/optimize/inspect.go
@@ -26,8 +26,15 @@ func walk(node planning.Node, path []planning.Node, visitor Visitor) error {
 		return err
 	}
 
-	path = append(path, node)
+	updated := false
 	for child := range planning.ChildrenIter(node) {
+		// Avoid an allocation updating the path when there are no children
+		// of this node that will use it.
+		if !updated {
+			path = append(path, node)
+			updated = true
+		}
+
 		if err := walk(child, path, visitor); err != nil {
 			return err
 		}

--- a/pkg/streamingpromql/optimize/inspect_test.go
+++ b/pkg/streamingpromql/optimize/inspect_test.go
@@ -72,6 +72,29 @@ func TestWalk(t *testing.T) {
 	}
 }
 
+func BenchmarkWalk(b *testing.B) {
+	const query = "sum(rate(some_metric[5m]) + rate(other_metric[5m]))"
+
+	ctx := context.Background()
+	timeRange := types.NewInstantQueryTimeRange(time.Now())
+	observer := streamingpromql.NoopPlanningObserver{}
+
+	opts := streamingpromql.NewTestEngineOpts()
+	planner, err := streamingpromql.NewQueryPlannerWithoutOptimizationPasses(opts, streamingpromql.NewMaximumSupportedVersionQueryPlanVersionProvider())
+	require.NoError(b, err)
+
+	p, err := planner.NewQueryPlan(ctx, query, timeRange, streamingpromql.DefaultLookbackDelta, false, observer)
+	require.NoError(b, err)
+
+	visitor := optimize.VisitorFunc(func(node planning.Node, path []planning.Node) error {
+		return nil // no-op
+	})
+
+	for b.Loop() {
+		_ = optimize.Walk(p.Root, visitor)
+	}
+}
+
 type TestVisitor struct {
 	test *testing.T
 


### PR DESCRIPTION
#### What this PR does

Remove an allocation for building the "path" to a node when it isn't needed.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
