### PR TITLE
MQE: Instrument double-frees with Antithesis assert

### DIFF
--- a/pkg/util/limiter/memory_consumption.go
+++ b/pkg/util/limiter/memory_consumption.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/antithesishq/antithesis-sdk-go/assert"
 	"github.com/grafana/dskit/tracing"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/labels"
@@ -406,6 +407,14 @@ func (l *MemoryConsumptionTracker) DecreaseMemoryConsumption(b uint64, source Me
 		if l.traceID != "" {
 			traceDescription = fmt.Sprintf(" (trace ID: %v)", l.traceID)
 		}
+
+		assert.Unreachable("returning memory to consumption tracker would result in negative number of bytes", map[string]any{
+			"source":              source,
+			"current_consumption": l.currentEstimatedMemoryConsumptionBySource[source],
+			"num_bytes":           b,
+			"current_query":       l.queryDescription,
+			"trace_description":   traceDescription,
+		})
 
 		panic(fmt.Sprintf(
 			"Estimated memory consumption of all instances of %s in this query is %d bytes when trying to return %d bytes. This indicates something has been returned to a pool more than once, which is a bug. The affected query is: %v%v",


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

It should never be the case that we free memory more than once and end up with a negative number of bytes used. This indicates the memory was being used by a query when it should not have been. Add an unreachable assert for this case.


#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
