### PR TITLE
mixin: Only alert when rulers have no rules and > 2 rulers per zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@
 * [ENHANCEMENT] Store-gateway, Querier: Push down the `limit` parameter of the `/prometheus/api/v1/series` endpoint to store-gateways, so they stop loading series (and their chunks) once the limit is reached instead of fetching all matching series and discarding the excess downstream. #15834
 * [ENHANCEMENT] Dashboards: Split the server-side "Usage Tracker" row of the "Writes" dashboard into separate "TrackSeries" (non-batched) and "TrackSeriesBatch" (batched) rows, so batched tracking RPCs are visible now that synchronous batched tracking can drive `TrackSeriesBatch`. #15805
 * [BUGFIX] Dashboards: Fix the classic/ingest-storage split in the "Tenants", "Top tenants" and "Writes" dashboards so that selecting multiple clusters with a mix of architectures no longer drops the classic clusters' data. The `unless on (job)` filter against `cortex_partition_ring_partitions` now also matches on the cluster aggregation labels. #15400
+* [BUGFIX] Alerts: Update `MimirRulerInstanceHasNoRuleGroups` to not alert on false-positives when rulers are running in multiple zones. #16029
 
 ### Jsonnet
 

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -65,6 +65,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 * [BUGFIX] Fix Kafka image reference to include the registry in the StatefulSet template. #14211.
 * [BUGFIX] Helm: Removed helm's empty selector for the smoke-test-job file that is throwing errors in ArgoCD #14684
 * [BUGFIX] Meta-monitoring: Do not emit `spec.clients: null` on `LogsInstance` or `basicAuth: null` on `MetricsInstance.spec.remoteWrite[*]` when the corresponding `metaMonitoring.grafanaAgent.{logs,metrics}.remote.url` / `auth` fields are empty. The resulting manifests failed CRD validation under ArgoCD ServerSideApply. #15135
+* [BUGFIX] Meta-monitoring: Update `MimirRulerInstanceHasNoRuleGroups` to not alert on false-positives when rulers are running in multiple zones. #16029
 
 ## 6.0.6
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -264,9 +264,9 @@ spec:
               # but only if other ruler instances of the same cell do have rule groups assigned
               and on (cluster, namespace)
               (max by(cluster, namespace) (cortex_ruler_managers_total) > 0)
-              # and there are more than two instances overall
+              # and there are more than two instances in any zone (or overall)
               and on (cluster, namespace)
-              (count by (cluster, namespace) (cortex_ruler_managers_total) > 2)
+              (max by (cluster, namespace) (count by (cluster, namespace, job) (cortex_ruler_managers_total) > 2))
             for: 1h
             labels:
               severity: warning

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -252,9 +252,9 @@ groups:
             # but only if other ruler instances of the same cell do have rule groups assigned
             and on (cluster, namespace)
             (max by(cluster, namespace) (cortex_ruler_managers_total) > 0)
-            # and there are more than two instances overall
+            # and there are more than two instances in any zone (or overall)
             and on (cluster, namespace)
-            (count by (cluster, namespace) (cortex_ruler_managers_total) > 2)
+            (max by (cluster, namespace) (count by (cluster, namespace, job) (cortex_ruler_managers_total) > 2))
           for: 1h
           labels:
             severity: warning

--- a/operations/mimir-mixin-compiled-gem/alerts.yaml
+++ b/operations/mimir-mixin-compiled-gem/alerts.yaml
@@ -252,9 +252,9 @@ groups:
             # but only if other ruler instances of the same cell do have rule groups assigned
             and on (cluster, namespace)
             (max by(cluster, namespace) (cortex_ruler_managers_total) > 0)
-            # and there are more than two instances overall
+            # and there are more than two instances in any zone (or overall)
             and on (cluster, namespace)
-            (count by (cluster, namespace) (cortex_ruler_managers_total) > 2)
+            (max by (cluster, namespace) (count by (cluster, namespace, job) (cortex_ruler_managers_total) > 2))
           for: 1h
           labels:
             severity: warning

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -252,9 +252,9 @@ groups:
             # but only if other ruler instances of the same cell do have rule groups assigned
             and on (cluster, namespace)
             (max by(cluster, namespace) (cortex_ruler_managers_total) > 0)
-            # and there are more than two instances overall
+            # and there are more than two instances in any zone (or overall)
             and on (cluster, namespace)
-            (count by (cluster, namespace) (cortex_ruler_managers_total) > 2)
+            (max by (cluster, namespace) (count by (cluster, namespace, job) (cortex_ruler_managers_total) > 2))
           for: 1h
           labels:
             severity: warning

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -385,11 +385,12 @@ local utils = import 'mixin-utils/utils.libsonnet';
             # but only if other ruler instances of the same cell do have rule groups assigned
             and on (%(alert_aggregation_labels)s)
             (max by(%(alert_aggregation_labels)s) (cortex_ruler_managers_total) > 0)
-            # and there are more than two instances overall
+            # and there are more than two instances in any zone (or overall)
             and on (%(alert_aggregation_labels)s)
-            (count by (%(alert_aggregation_labels)s) (cortex_ruler_managers_total) > 2)
+            (max by (%(alert_aggregation_labels)s) (count by (%(per_job_labels)s) (cortex_ruler_managers_total) > 2))
           ||| % {
             alert_aggregation_labels: $._config.alert_aggregation_labels,
+            per_job_labels: $._config.group_by_job,
             per_instance_label: $._config.per_instance_label,
             rulerInstanceName: $._config.instance_names.ruler,
           },


### PR DESCRIPTION
#### What this PR does

Update the logic used for alerting when some rulers have no rules assigned. It previously checked that there were more than two pods running but two pods per-zone is now the minimum (giving 4 pods total minimum in Grafana Cloud) so the alert fired even when it should not have.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
