### PR TITLE
Configure the Warpstream Kafka client logger like the franz-go client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853
-	github.com/grafana/warpstream-go v0.0.0-20260709145107-2e28adcc4bff
+	github.com/grafana/warpstream-go v0.0.0-20260709185922-cde46bc835e9
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/hashicorp/vault/api v1.23.0
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db

--- a/go.sum
+++ b/go.sum
@@ -590,8 +590,8 @@ github.com/grafana/pyroscope-go/godeltaprof v0.1.9 h1:c1Us8i6eSmkW+Ez05d3co8kasn
 github.com/grafana/pyroscope-go/godeltaprof v0.1.9/go.mod h1:2+l7K7twW49Ct4wFluZD3tZ6e0SjanjcUUBPVD/UuGU=
 github.com/grafana/regexp v0.0.0-20250905101755-5eb4f3acbf71 h1:A4D22zZV7+EeQk9TeATDDY/PG2wnzdqKcj4IZq+PcwA=
 github.com/grafana/regexp v0.0.0-20250905101755-5eb4f3acbf71/go.mod h1:+JKpmjMGhpgPL+rXZ5nsZieVzvarn86asRlBg4uNGnk=
-github.com/grafana/warpstream-go v0.0.0-20260709145107-2e28adcc4bff h1:mOsGwr9eKhnZ9jPjCyRVDVkrMmDncWZmBzkG54NSyUs=
-github.com/grafana/warpstream-go v0.0.0-20260709145107-2e28adcc4bff/go.mod h1:9iFIyD7D+F+2Hsk+P6PNMBH8E+JYxPsLGIP2p46L1s0=
+github.com/grafana/warpstream-go v0.0.0-20260709185922-cde46bc835e9 h1:qWOLS04YizAmZb0FtpmJQkR/XCtdD/uP9dXH429Upa4=
+github.com/grafana/warpstream-go v0.0.0-20260709185922-cde46bc835e9/go.mod h1:/rfo1TLJ3YxyS1sK6hqcsOqJHmJO0bB/xiWqRYMw1jc=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=

--- a/pkg/storage/ingest/logger_test.go
+++ b/pkg/storage/ingest/logger_test.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package ingest
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+func TestKafkaLogger_Log(t *testing.T) {
+	tests := map[string]struct {
+		level         kgo.LogLevel
+		expectedLevel string
+	}{
+		"debug": {level: kgo.LogLevelDebug, expectedLevel: "level=debug"},
+		"info":  {level: kgo.LogLevelInfo, expectedLevel: "level=info"},
+		"warn":  {level: kgo.LogLevelWarn, expectedLevel: "level=warn"},
+		"error": {level: kgo.LogLevelError, expectedLevel: "level=error"},
+	}
+
+	for name, testData := range tests {
+		t.Run(name, func(t *testing.T) {
+			var buf bytes.Buffer
+			l := NewKafkaLogger(log.NewLogfmtLogger(&buf))
+
+			l.Log(testData.level, "the message", "key", "value")
+
+			out := buf.String()
+			assert.Contains(t, out, testData.expectedLevel)
+			assert.Contains(t, out, "component=kafka_client")
+			assert.Contains(t, out, `msg="the message"`)
+			assert.Contains(t, out, "key=value")
+		})
+	}
+}
+
+func TestKafkaLogger_Level(t *testing.T) {
+	l := NewKafkaLogger(log.NewNopLogger())
+
+	// Always Info so the Kafka client never emits (expensive) debug logs.
+	require.Equal(t, kgo.LogLevelInfo, l.Level())
+}

--- a/pkg/storage/ingest/writer_client.go
+++ b/pkg/storage/ingest/writer_client.go
@@ -46,7 +46,9 @@ func newKafkaProducerForBackend(cfg KafkaConfig, maxInflight int, logger log.Log
 		// kafka_* extended latency metrics, to match the kafka backend.
 		warpstreamOpts = append(warpstreamOpts, wgo.WithHooks(NewKafkaClientExtendedMetrics(reg)))
 
-		warpstreamClient, err := wgo.NewWarpstreamClient(logger, reg, warpstreamOpts...)
+		// Use the same logger adapter as the kafka backend so warpstream-go's own
+		// logs and its embedded franz-go client both log with component=kafka_client.
+		warpstreamClient, err := wgo.NewWarpstreamClient(NewKafkaLogger(logger), reg, warpstreamOpts...)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/storage/ingest/writer_client.go
+++ b/pkg/storage/ingest/writer_client.go
@@ -46,8 +46,6 @@ func newKafkaProducerForBackend(cfg KafkaConfig, maxInflight int, logger log.Log
 		// kafka_* extended latency metrics, to match the kafka backend.
 		warpstreamOpts = append(warpstreamOpts, wgo.WithHooks(NewKafkaClientExtendedMetrics(reg)))
 
-		// Use the same logger adapter as the kafka backend so warpstream-go's own
-		// logs and its embedded franz-go client both log with component=kafka_client.
 		warpstreamClient, err := wgo.NewWarpstreamClient(NewKafkaLogger(logger), reg, warpstreamOpts...)
 		if err != nil {
 			return nil, err

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/client.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/client.go
@@ -7,8 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
@@ -71,7 +69,7 @@ type WarpstreamClient struct {
 	*kgo.Client
 
 	cfg     Config
-	logger  log.Logger
+	logger  kgo.Logger
 	metrics *metrics
 
 	pool           *AgentPool
@@ -93,13 +91,20 @@ type WarpstreamClient struct {
 // from DefaultConfig and is overridden by opts. The initial AgentPool refresh
 // is synchronous: if Metadata cannot be reached on startup we fail fast rather
 // than serving traffic against an empty pool.
-func NewWarpstreamClient(logger log.Logger, reg prometheus.Registerer, opts ...Opt) (*WarpstreamClient, error) {
+//
+// logger is used both for the client's own logs and installed on the embedded
+// franz-go client, so the two share a single logger. A nil logger disables logging.
+func NewWarpstreamClient(logger kgo.Logger, reg prometheus.Registerer, opts ...Opt) (*WarpstreamClient, error) {
+	if logger == nil {
+		logger = nopLogger{}
+	}
+
 	cfg := NewConfig(opts...)
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid warpstream client config: %w", err)
 	}
 
-	kgoClient, err := newKgoClient(cfg, reg)
+	kgoClient, err := newKgoClient(cfg, logger, reg)
 	if err != nil {
 		return nil, fmt.Errorf("creating kgo client: %w", err)
 	}
@@ -335,7 +340,7 @@ func (c *WarpstreamClient) startBackgroundRefresh() {
 			case <-ticker.C:
 				removed, err := c.pool.Refresh(c.refreshCtx)
 				if err != nil {
-					level.Warn(c.logger).Log("msg", "warpstream client metadata refresh failed", "err", err)
+					log(c.logger, kgo.LogLevelWarn, "warpstream client metadata refresh failed", "err", err)
 					continue
 				}
 				if len(removed) > 0 {
@@ -457,10 +462,11 @@ func perRecordDone(record *kgo.Record, promise func(*kgo.Record, error)) func(Pr
 // newKgoClient constructs the kgo.Client used by the WarpstreamClient for
 // connection management and metadata. It wires the kprom transport-metrics
 // hook (registered on reg) alongside any caller hooks from cfg.
-func newKgoClient(cfg Config, reg prometheus.Registerer) (*kgo.Client, error) {
+func newKgoClient(cfg Config, logger kgo.Logger, reg prometheus.Registerer) (*kgo.Client, error) {
 	opts := []kgo.Opt{
 		kgo.SeedBrokers(cfg.Address...),
 		kgo.ClientID(cfg.ClientID),
+		kgo.WithLogger(logger),
 		kgo.DialTimeout(cfg.DialTimeout),
 		kgo.RequestTimeoutOverhead(cfg.WriteTimeout),
 		kgo.MetadataMaxAge(cfg.MetadataRefreshInterval),
@@ -524,4 +530,18 @@ func produceMaxVersions() *kversion.Versions {
 // to the configured cap.
 func errRecordTooLarge(r *kgo.Record) error {
 	return fmt.Errorf("%w (uncompressed_bytes=%d)", kerr.MessageTooLarge, singleRecordBatchEstimateBytes(r))
+}
+
+// nopLogger is a kgo.Logger that discards all messages.
+type nopLogger struct{}
+
+func (nopLogger) Level() kgo.LogLevel              { return kgo.LogLevelNone }
+func (nopLogger) Log(kgo.LogLevel, string, ...any) {}
+
+// log emits msg through logger only when level is enabled, matching how the
+// embedded franz-go client gates its own logs by Logger.Level().
+func log(logger kgo.Logger, level kgo.LogLevel, msg string, keyvals ...any) {
+	if level <= logger.Level() {
+		logger.Log(level, msg, keyvals...)
+	}
 }

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/demoter.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/demoter.go
@@ -5,10 +5,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/twmb/franz-go/pkg/kgo"
 )
 
 // demotionSuppressionReason is why demotion is suppressed. Its string value is
@@ -93,7 +92,7 @@ type Demoter struct {
 	tracker    AgentStatsReader
 	healthCfg  HealthCheckConfig
 	demoterCfg DemoterConfig
-	logger     log.Logger
+	logger     kgo.Logger
 
 	// now is injectable for testing; defaults to time.Now.
 	now func() time.Time
@@ -110,9 +109,9 @@ type Demoter struct {
 }
 
 // NewDemoter wraps inner with the demotion policy described on Demoter.
-func NewDemoter(inner PartitionAssignmentStrategy, tracker AgentStatsReader, health HealthCheckConfig, cfg DemoterConfig, logger log.Logger, reg prometheus.Registerer) *Demoter {
+func NewDemoter(inner PartitionAssignmentStrategy, tracker AgentStatsReader, health HealthCheckConfig, cfg DemoterConfig, logger kgo.Logger, reg prometheus.Registerer) *Demoter {
 	if logger == nil {
-		logger = log.NewNopLogger()
+		logger = nopLogger{}
 	}
 	d := &Demoter{
 		inner:            inner,
@@ -285,9 +284,9 @@ func (d *Demoter) isDemoted(now time.Time, nodeID int32, clusterStats ClusterSta
 
 	switch {
 	case demoted:
-		level.Info(d.logger).Log("msg", "warpstream agent demoted", "node_id", nodeID, "error_rate", stats.ErrorRate, "request_count", stats.RequestCount, "min_requests", minRequests, "faulty_threshold", clusterStats.FaultyThreshold)
+		log(d.logger, kgo.LogLevelInfo, "warpstream agent demoted", "node_id", nodeID, "error_rate", stats.ErrorRate, "request_count", stats.RequestCount, "min_requests", minRequests, "faulty_threshold", clusterStats.FaultyThreshold)
 	case restored:
-		level.Info(d.logger).Log("msg", "warpstream agent restored", "node_id", nodeID)
+		log(d.logger, kgo.LogLevelInfo, "warpstream agent restored", "node_id", nodeID)
 	}
 
 	return isFaulty

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -740,7 +740,7 @@ github.com/grafana/pyroscope-go/godeltaprof/internal/pprof
 ## explicit; go 1.21
 github.com/grafana/regexp
 github.com/grafana/regexp/syntax
-# github.com/grafana/warpstream-go v0.0.0-20260709145107-2e28adcc4bff
+# github.com/grafana/warpstream-go v0.0.0-20260709185922-cde46bc835e9
 ## explicit; go 1.25.10
 github.com/grafana/warpstream-go/pkg/wgo
 # github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0


### PR DESCRIPTION
#### What this PR does

Makes the experimental Warpstream Kafka client backend log the same way as the `kafka` (franz-go) backend.

`wgo.NewWarpstreamClient` is now given `NewKafkaLogger(logger)` — the same adapter the franz-go backend installs on its client. So both warpstream-go's own operational logs (metadata refresh, agent demotion/restore) and its embedded franz-go client now log with `component=kafka_client`. Previously that embedded franz-go client had no logger configured and silently dropped all of its diagnostics.

This bumps `github.com/grafana/warpstream-go` to the version whose constructor takes a single `kgo.Logger` (grafana/warpstream-go#34). The bump also pulls in an unrelated record-ownership fix and updates `github.com/twmb/franz-go` v1.21.4 → v1.21.5.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - not needed: the Warpstream backend is experimental and this only changes internal client logging.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
