### PR TITLE
Enhancement: Allow user to select the desired SA Automount config

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -32,6 +32,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 * [CHANGE] Querier: Reduce the default concurrency of queriers, `querier.max_concurrent`, to 8. #15984
 * [BUGFIX] Fix bug in `ScaledObject` templates when using `kedaAutoscaling.fallback` #15793
+* [ENHANCEMENT] Improve stack security by allowing users to configure `automountServiceAccountToken` and `projectServiceAccountToken` explicitly defining the desired behaviour #15825
 
 ## 6.1.0
 

--- a/operations/helm/charts/mimir-distributed/ci/offline/test-ksa-automount-values.yaml
+++ b/operations/helm/charts/mimir-distributed/ci/offline/test-ksa-automount-values.yaml
@@ -1,0 +1,58 @@
+# CI values to exercise service account token automount and projected token mounts.
+kubeVersionOverride: "1.32"
+
+alertmanager:
+  automountServiceAccountToken: true
+  projectServiceAccountToken: false
+
+compactor:
+  automountServiceAccountToken: true
+  projectServiceAccountToken: false
+
+distributor:
+  automountServiceAccountToken: true
+  projectServiceAccountToken: false
+
+gateway:
+  automountServiceAccountToken: true
+  projectServiceAccountToken: false
+
+ingester:
+  automountServiceAccountToken: true
+  projectServiceAccountToken: false
+
+overrides_exporter:
+  automountServiceAccountToken: true
+  projectServiceAccountToken: false
+
+querier:
+  automountServiceAccountToken: true
+  projectServiceAccountToken: false
+
+query_frontend:
+  automountServiceAccountToken: true
+  projectServiceAccountToken: false
+
+query_scheduler:
+  automountServiceAccountToken: true
+  projectServiceAccountToken: false
+
+ruler:
+  automountServiceAccountToken: true
+  projectServiceAccountToken: false
+
+ruler_querier:
+  automountServiceAccountToken: true
+  projectServiceAccountToken: false
+
+ruler_query_frontend:
+  automountServiceAccountToken: true
+  projectServiceAccountToken: false
+
+ruler_query_scheduler:
+  automountServiceAccountToken: true
+  projectServiceAccountToken: false
+
+store_gateway:
+  automountServiceAccountToken: true
+  projectServiceAccountToken: false

--- a/operations/helm/charts/mimir-distributed/ci/offline/test-ksa-projected-values.yaml
+++ b/operations/helm/charts/mimir-distributed/ci/offline/test-ksa-projected-values.yaml
@@ -1,0 +1,58 @@
+# CI values to exercise service account token automount and projected token mounts.
+kubeVersionOverride: "1.32"
+
+alertmanager:
+  automountServiceAccountToken: false
+  projectServiceAccountToken: true
+
+compactor:
+  automountServiceAccountToken: false
+  projectServiceAccountToken: true
+
+distributor:
+  automountServiceAccountToken: false
+  projectServiceAccountToken: true
+
+gateway:
+  automountServiceAccountToken: false
+  projectServiceAccountToken: true
+
+ingester:
+  automountServiceAccountToken: false
+  projectServiceAccountToken: true
+
+overrides_exporter:
+  automountServiceAccountToken: false
+  projectServiceAccountToken: true
+
+querier:
+  automountServiceAccountToken: false
+  projectServiceAccountToken: true
+
+query_frontend:
+  automountServiceAccountToken: false
+  projectServiceAccountToken: true
+
+query_scheduler:
+  automountServiceAccountToken: false
+  projectServiceAccountToken: true
+
+ruler:
+  automountServiceAccountToken: false
+  projectServiceAccountToken: true
+
+ruler_querier:
+  automountServiceAccountToken: false
+  projectServiceAccountToken: true
+
+ruler_query_frontend:
+  automountServiceAccountToken: false
+  projectServiceAccountToken: true
+
+ruler_query_scheduler:
+  automountServiceAccountToken: false
+  projectServiceAccountToken: true
+
+store_gateway:
+  automountServiceAccountToken: false
+  projectServiceAccountToken: true

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-dep.yaml
@@ -31,8 +31,9 @@ spec:
       namespace: {{ .Release.Namespace | quote }}
     spec:
       serviceAccountName: {{ template "mimir.alertmanager.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.alertmanager.automountServiceAccountToken }}
       {{- if .Values.alertmanager.priorityClassName }}
-      priorityClassName: {{ .Values.query_frontend.priorityClassName }}
+      priorityClassName: {{ .Values.alertmanager.priorityClassName }}
       {{- end }}
       securityContext:
         {{- include "mimir.lib.podSecurityContext" (dict "ctx" . "component" "alertmanager") | nindent 8 }}
@@ -63,6 +64,11 @@ spec:
             {{- end }}
             {{- if .Values.global.extraVolumeMounts }}
               {{ toYaml .Values.global.extraVolumeMounts | nindent 12}}
+            {{- end }}
+            {{- if .Values.alertmanager.projectServiceAccountToken }}
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: kube-api-access
+              readOnly: true
             {{- end }}
             - name: config
               mountPath: /etc/mimir
@@ -127,6 +133,23 @@ spec:
         - name: runtime-config
           configMap:
             name: {{ template "mimir.fullname" . }}-runtime
+        {{- if .Values.alertmanager.projectServiceAccountToken }}
+        - name: kube-api-access
+          projected:
+            - serviceAccountToken:
+                path: token
+            - configMap:
+                items:
+                  - key: ca.crt
+                    path: ca.crt
+                name: kube-root-ca.crt
+            - downwardAPI:
+                items:
+                  - fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+                    path: namespace
+        {{- end }}
         {{- if .Values.alertmanager.extraVolumes }}
         {{ toYaml .Values.alertmanager.extraVolumes | nindent 8}}
         {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -87,6 +87,7 @@ spec:
       schedulerName: {{ . | quote }}
       {{- end }}
       serviceAccountName: {{ template "mimir.alertmanager.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.alertmanager.automountServiceAccountToken }}
       {{- if .Values.alertmanager.priorityClassName }}
       priorityClassName: {{ .Values.alertmanager.priorityClassName }}
       {{- end }}
@@ -129,6 +130,23 @@ spec:
         {{- if not .Values.alertmanager.persistentVolume.enabled }}
         - name: {{ .Values.alertmanager.persistentVolume.name }}
           emptyDir: {}
+        {{- end }}
+        {{- if .Values.alertmanager.projectServiceAccountToken }}
+        - name: kube-api-access
+          projected:
+            - serviceAccountToken:
+                path: token
+            - configMap:
+                items:
+                  - key: ca.crt
+                    path: ca.crt
+                name: kube-root-ca.crt
+            - downwardAPI:
+                items:
+                  - fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+                    path: namespace
         {{- end }}
         - name: tmp
           emptyDir: {}
@@ -176,6 +194,11 @@ spec:
             {{- end }}
             {{- if .Values.global.extraVolumeMounts }}
             {{ toYaml .Values.global.extraVolumeMounts | nindent 12}}
+            {{- end }}
+            {{- if .Values.alertmanager.projectServiceAccountToken }}
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: kube-api-access
+              readOnly: true
             {{- end }}
             - name: config
               mountPath: /etc/mimir

--- a/operations/helm/charts/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -64,6 +64,7 @@ spec:
       schedulerName: {{ . | quote }}
       {{- end }}
       serviceAccountName: {{ template "mimir.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.compactor.automountServiceAccountToken }}
       {{- if .Values.compactor.priorityClassName }}
       priorityClassName: {{ .Values.compactor.priorityClassName }}
       {{- end }}
@@ -107,6 +108,23 @@ spec:
         - name: {{ .Values.compactor.persistentVolume.name }}
           emptyDir: {}
         {{- end }}
+        {{- if .Values.compactor.projectServiceAccountToken }}
+        - name: kube-api-access
+          projected:
+            - serviceAccountToken:
+                path: token
+            - configMap:
+                items:
+                  - key: ca.crt
+                    path: ca.crt
+                name: kube-root-ca.crt
+            - downwardAPI:
+                items:
+                  - fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+                    path: namespace
+        {{- end }}
         {{- if .Values.compactor.extraVolumes }}
         {{ toYaml .Values.compactor.extraVolumes | nindent 8 }}
         {{- end }}
@@ -135,6 +153,11 @@ spec:
             {{- end }}
             {{- if .Values.global.extraVolumeMounts }}
             {{ toYaml .Values.global.extraVolumeMounts | nindent 12}}
+            {{- end }}
+            {{- if .Values.compactor.projectServiceAccountToken }}
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: kube-api-access
+              readOnly: true
             {{- end }}
             - name: config
               mountPath: /etc/mimir

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -32,6 +32,7 @@ spec:
       namespace: {{ .Release.Namespace | quote }}
     spec:
       serviceAccountName: {{ template "mimir.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.distributor.automountServiceAccountToken }}
       {{- if .Values.distributor.priorityClassName }}
       priorityClassName: {{ .Values.distributor.priorityClassName }}
       {{- end }}
@@ -79,6 +80,11 @@ spec:
             {{- end }}
             {{- if .Values.global.extraVolumeMounts }}
               {{ toYaml .Values.global.extraVolumeMounts | nindent 12}}
+            {{- end }}
+            {{- if .Values.distributor.projectServiceAccountToken }}
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: kube-api-access
+              readOnly: true
             {{- end }}
             - name: config
               mountPath: /etc/mimir
@@ -143,6 +149,23 @@ spec:
         - name: runtime-config
           configMap:
             name: {{ template "mimir.fullname" . }}-runtime
+        {{- if .Values.distributor.projectServiceAccountToken }}
+        - name: kube-api-access
+          projected:
+            - serviceAccountToken:
+                path: token
+            - configMap:
+                items:
+                  - key: ca.crt
+                    path: ca.crt
+                name: kube-root-ca.crt
+            - downwardAPI:
+                items:
+                  - fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+                    path: namespace
+        {{- end }}
         {{- if .Values.distributor.extraVolumes }}
         {{- toYaml .Values.distributor.extraVolumes | nindent 8}}
         {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/gateway/gateway-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gateway/gateway-dep.yaml
@@ -34,6 +34,7 @@ spec:
       namespace: {{ $.Release.Namespace | quote }}
     spec:
       serviceAccountName: {{ include "mimir.serviceAccountName" $ }}
+      automountServiceAccountToken: {{ .automountServiceAccountToken }}
       {{- if .priorityClassName }}
       priorityClassName: {{ .priorityClassName }}
       {{- end }}
@@ -65,6 +66,11 @@ spec:
             {{- end }}
             {{- if $.Values.global.extraVolumeMounts }}
             {{ toYaml $.Values.global.extraVolumeMounts | nindent 12 }}
+            {{- end }}
+            {{- if .projectServiceAccountToken }}
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: kube-api-access
+              readOnly: true
             {{- end }}
             - name: nginx-config
               mountPath: /etc/nginx/nginx.conf
@@ -132,6 +138,23 @@ spec:
         - name: runtime-config
           configMap:
             name: {{ include "mimir.fullname" $ }}-runtime
+        {{- if .projectServiceAccountToken }}
+        - name: kube-api-access
+          projected:
+            - serviceAccountToken:
+                path: token
+            - configMap:
+                items:
+                  - key: ca.crt
+                    path: ca.crt
+                name: kube-root-ca.crt
+            - downwardAPI:
+                items:
+                  - fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+                    path: namespace
+        {{- end }}
         - name: nginx-config
           configMap:
             name: {{ include "mimir.fullname" $ }}-gateway-nginx

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -89,6 +89,7 @@ spec:
       schedulerName: {{ . | quote }}
       {{- end }}
       serviceAccountName: {{ template "mimir.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.ingester.automountServiceAccountToken }}
       {{- if .Values.ingester.priorityClassName }}
       priorityClassName: {{ .Values.ingester.priorityClassName }}
       {{- end }}
@@ -131,6 +132,23 @@ spec:
         {{- if not .Values.ingester.persistentVolume.enabled }}
         - name: {{ .Values.ingester.persistentVolume.name }}
           emptyDir: {}
+        {{- end }}
+        {{- if .Values.ingester.projectServiceAccountToken }}
+        - name: kube-api-access
+          projected:
+            - serviceAccountToken:
+                path: token
+            - configMap:
+                items:
+                  - key: ca.crt
+                    path: ca.crt
+                name: kube-root-ca.crt
+            - downwardAPI:
+                items:
+                  - fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+                    path: namespace
         {{- end }}
         {{- if .Values.ingester.extraVolumes }}
         {{ toYaml .Values.ingester.extraVolumes | nindent 8 }}
@@ -176,6 +194,11 @@ spec:
             {{- end }}
             {{- if .Values.global.extraVolumeMounts }}
             {{ toYaml .Values.global.extraVolumeMounts | nindent 12}}
+            {{- end }}
+            {{- if .Values.ingester.projectServiceAccountToken }}
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: kube-api-access
+              readOnly: true
             {{- end }}
             - name: config
               mountPath: /etc/mimir

--- a/operations/helm/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
@@ -27,6 +27,7 @@ spec:
       namespace: {{ .Release.Namespace | quote }}
     spec:
       serviceAccountName: {{ template "mimir.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.overrides_exporter.automountServiceAccountToken }}
       {{- if .Values.overrides_exporter.priorityClassName }}
       priorityClassName: {{ .Values.overrides_exporter.priorityClassName }}
       {{- end }}
@@ -59,6 +60,11 @@ spec:
             {{- end }}
             {{- if .Values.global.extraVolumeMounts }}
               {{ toYaml .Values.global.extraVolumeMounts | nindent 12}}
+            {{- end }}
+            {{- if .Values.overrides_exporter.projectServiceAccountToken }}
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: kube-api-access
+              readOnly: true
             {{- end }}
             - name: config
               mountPath: /etc/mimir
@@ -114,6 +120,23 @@ spec:
         - name: runtime-config
           configMap:
             name: {{ template "mimir.fullname" . }}-runtime
+        {{- if .Values.overrides_exporter.projectServiceAccountToken }}
+        - name: kube-api-access
+          projected:
+            - serviceAccountToken:
+                path: token
+            - configMap:
+                items:
+                  - key: ca.crt
+                    path: ca.crt
+                name: kube-root-ca.crt
+            - downwardAPI:
+                items:
+                  - fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+                    path: namespace
+        {{- end }}
         {{- if .Values.overrides_exporter.extraVolumes }}
         {{ toYaml .Values.overrides_exporter.extraVolumes | nindent 8}}
         {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/querier/querier-dep.yaml
@@ -31,6 +31,7 @@ spec:
         {{- include "mimir.podAnnotations" (dict "ctx" . "component" "querier") | nindent 8 }}
     spec:
       serviceAccountName: {{ template "mimir.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.querier.automountServiceAccountToken }}
       {{- if .Values.querier.priorityClassName }}
       priorityClassName: {{ .Values.querier.priorityClassName }}
       {{- end }}
@@ -75,6 +76,11 @@ spec:
             {{- end }}
             {{- if .Values.global.extraVolumeMounts }}
               {{ toYaml .Values.global.extraVolumeMounts | nindent 12}}
+            {{- end }}
+            {{- if .Values.querier.projectServiceAccountToken }}
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: kube-api-access
+              readOnly: true
             {{- end }}
             - name: config
               mountPath: /etc/mimir
@@ -140,6 +146,23 @@ spec:
         - name: runtime-config
           configMap:
             name: {{ template "mimir.fullname" . }}-runtime
+        {{- if .Values.querier.projectServiceAccountToken }}
+        - name: kube-api-access
+          projected:
+            - serviceAccountToken:
+                path: token
+            - configMap:
+                items:
+                  - key: ca.crt
+                    path: ca.crt
+                name: kube-root-ca.crt
+            - downwardAPI:
+                items:
+                  - fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+                    path: namespace
+        {{- end }}
         {{- if .Values.querier.extraVolumes }}
         {{ toYaml .Values.querier.extraVolumes | nindent 8}}
         {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -32,6 +32,7 @@ spec:
       namespace: {{ .Release.Namespace | quote }}
     spec:
       serviceAccountName: {{ template "mimir.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.query_frontend.automountServiceAccountToken }}
       {{- if .Values.query_frontend.priorityClassName }}
       priorityClassName: {{ .Values.query_frontend.priorityClassName }}
       {{- end }}
@@ -67,6 +68,11 @@ spec:
             {{- end }}
             {{- if .Values.global.extraVolumeMounts }}
               {{ toYaml .Values.global.extraVolumeMounts | nindent 12}}
+            {{- end }}
+            {{- if .Values.query_frontend.projectServiceAccountToken }}
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: kube-api-access
+              readOnly: true
             {{- end }}
             - name: runtime-config
               mountPath: /var/{{ include "mimir.name" . }}
@@ -122,6 +128,23 @@ spec:
         - name: runtime-config
           configMap:
             name: {{ template "mimir.fullname" . }}-runtime
+        {{- if .Values.query_frontend.projectServiceAccountToken }}
+        - name: kube-api-access
+          projected:
+            - serviceAccountToken:
+                path: token
+            - configMap:
+                items:
+                  - key: ca.crt
+                    path: ca.crt
+                name: kube-root-ca.crt
+            - downwardAPI:
+                items:
+                  - fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+                    path: namespace
+        {{- end }}
         {{- if .Values.query_frontend.extraVolumes }}
         {{ toYaml .Values.query_frontend.extraVolumes | nindent 8}}
         {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/query-scheduler/query-scheduler-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-scheduler/query-scheduler-dep.yaml
@@ -26,6 +26,7 @@ spec:
         {{- include "mimir.podAnnotations" (dict "ctx" . "component" "query-scheduler") | nindent 8 }}
     spec:
       serviceAccountName: {{ template "mimir.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.query_scheduler.automountServiceAccountToken }}
       {{- if .Values.query_scheduler.priorityClassName }}
       priorityClassName: {{ .Values.query_scheduler.priorityClassName }}
       {{- end }}
@@ -58,6 +59,11 @@ spec:
             {{- end }}
             {{- if .Values.global.extraVolumeMounts }}
               {{ toYaml .Values.global.extraVolumeMounts | nindent 12}}
+            {{- end }}
+            {{- if .Values.query_scheduler.projectServiceAccountToken }}
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: kube-api-access
+              readOnly: true
             {{- end }}
             - name: runtime-config
               mountPath: /var/{{ include "mimir.name" . }}
@@ -113,6 +119,23 @@ spec:
         - name: runtime-config
           configMap:
             name: {{ template "mimir.fullname" . }}-runtime
+        {{- if .Values.query_scheduler.projectServiceAccountToken }}
+        - name: kube-api-access
+          projected:
+            - serviceAccountToken:
+                path: token
+            - configMap:
+                items:
+                  - key: ca.crt
+                    path: ca.crt
+                name: kube-root-ca.crt
+            - downwardAPI:
+                items:
+                  - fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+                    path: namespace
+        {{- end }}
         {{- if .Values.query_scheduler.extraVolumes }}
         {{ toYaml .Values.query_scheduler.extraVolumes | nindent 8}}
         {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/ruler-querier/ruler-querier-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler-querier/ruler-querier-dep.yaml
@@ -31,6 +31,7 @@ spec:
         {{- include "mimir.podAnnotations" (dict "ctx" . "component" "ruler-querier") | nindent 8 }}
     spec:
       serviceAccountName: {{ template "mimir.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.ruler_querier.automountServiceAccountToken }}
       {{- if .Values.ruler_querier.priorityClassName }}
       priorityClassName: {{ .Values.ruler_querier.priorityClassName }}
       {{- end }}
@@ -77,6 +78,11 @@ spec:
             {{- end }}
             {{- if .Values.global.extraVolumeMounts }}
               {{ toYaml .Values.global.extraVolumeMounts | nindent 12}}
+            {{- end }}
+            {{- if .Values.ruler_querier.projectServiceAccountToken }}
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: kube-api-access
+              readOnly: true
             {{- end }}
             - name: config
               mountPath: /etc/mimir
@@ -140,6 +146,23 @@ spec:
         - name: runtime-config
           configMap:
             name: {{ template "mimir.fullname" . }}-runtime
+        {{- if .Values.ruler_querier.projectServiceAccountToken }}
+        - name: kube-api-access
+          projected:
+            - serviceAccountToken:
+                path: token
+            - configMap:
+                items:
+                  - key: ca.crt
+                    path: ca.crt
+                name: kube-root-ca.crt
+            - downwardAPI:
+                items:
+                  - fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+                    path: namespace
+        {{- end }}
         {{- if .Values.ruler_querier.extraVolumes }}
         {{ toYaml .Values.ruler_querier.extraVolumes | nindent 8}}
         {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-dep.yaml
@@ -32,6 +32,7 @@ spec:
       namespace: {{ .Release.Namespace | quote }}
     spec:
       serviceAccountName: {{ template "mimir.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.ruler_query_frontend.automountServiceAccountToken }}
       {{- if .Values.ruler_query_frontend.priorityClassName }}
       priorityClassName: {{ .Values.ruler_query_frontend.priorityClassName }}
       {{- end }}
@@ -70,6 +71,11 @@ spec:
             {{- end }}
             {{- if .Values.global.extraVolumeMounts }}
               {{ toYaml .Values.global.extraVolumeMounts | nindent 12}}
+            {{- end }}
+            {{- if .Values.ruler_query_frontend.projectServiceAccountToken }}
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: kube-api-access
+              readOnly: true
             {{- end }}
             - name: runtime-config
               mountPath: /var/{{ include "mimir.name" . }}
@@ -125,6 +131,23 @@ spec:
         - name: runtime-config
           configMap:
             name: {{ template "mimir.fullname" . }}-runtime
+        {{- if .Values.ruler_query_frontend.projectServiceAccountToken }}
+        - name: kube-api-access
+          projected:
+            - serviceAccountToken:
+                path: token
+            - configMap:
+                items:
+                  - key: ca.crt
+                    path: ca.crt
+                name: kube-root-ca.crt
+            - downwardAPI:
+                items:
+                  - fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+                    path: namespace
+        {{- end }}
         {{- if .Values.ruler_query_frontend.extraVolumes }}
         {{ toYaml .Values.ruler_query_frontend.extraVolumes | nindent 8}}
         {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/ruler-query-scheduler/ruler-query-scheduler-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler-query-scheduler/ruler-query-scheduler-dep.yaml
@@ -26,6 +26,7 @@ spec:
         {{- include "mimir.podAnnotations" (dict "ctx" . "component" "ruler-query-scheduler") | nindent 8 }}
     spec:
       serviceAccountName: {{ template "mimir.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.ruler_query_scheduler.automountServiceAccountToken }}
       {{- if .Values.ruler_query_scheduler.priorityClassName }}
       priorityClassName: {{ .Values.ruler_query_scheduler.priorityClassName }}
       {{- end }}
@@ -58,6 +59,11 @@ spec:
             {{- end }}
             {{- if .Values.global.extraVolumeMounts }}
               {{ toYaml .Values.global.extraVolumeMounts | nindent 12}}
+            {{- end }}
+            {{- if .Values.ruler_query_scheduler.projectServiceAccountToken }}
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: kube-api-access
+              readOnly: true
             {{- end }}
             - name: runtime-config
               mountPath: /var/{{ include "mimir.name" . }}
@@ -113,6 +119,23 @@ spec:
         - name: runtime-config
           configMap:
             name: {{ template "mimir.fullname" . }}-runtime
+        {{- if .Values.ruler_query_scheduler.projectServiceAccountToken }}
+        - name: kube-api-access
+          projected:
+            - serviceAccountToken:
+                path: token
+            - configMap:
+                items:
+                  - key: ca.crt
+                    path: ca.crt
+                name: kube-root-ca.crt
+            - downwardAPI:
+                items:
+                  - fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+                    path: namespace
+        {{- end }}
         {{- if .Values.ruler_query_scheduler.extraVolumes }}
         {{ toYaml .Values.ruler_query_scheduler.extraVolumes | nindent 8}}
         {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -29,6 +29,7 @@ spec:
       namespace: {{ .Release.Namespace | quote }}
     spec:
       serviceAccountName: {{ template "mimir.ruler.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.ruler.automountServiceAccountToken }}
       {{- if .Values.ruler.priorityClassName }}
       priorityClassName: {{ .Values.ruler.priorityClassName }}
       {{- end }}
@@ -79,6 +80,11 @@ spec:
             {{- end }}
             {{- if .Values.global.extraVolumeMounts }}
               {{ toYaml .Values.global.extraVolumeMounts | nindent 12}}
+            {{- end }}
+            {{- if .Values.ruler.projectServiceAccountToken }}
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: kube-api-access
+              readOnly: true
             {{- end }}
             - name: config
               mountPath: /etc/mimir
@@ -137,6 +143,23 @@ spec:
         - name: runtime-config
           configMap:
             name: {{ template "mimir.fullname" . }}-runtime
+        {{- if .Values.ruler.projectServiceAccountToken }}
+        - name: kube-api-access
+          projected:
+            - serviceAccountToken:
+                path: token
+            - configMap:
+                items:
+                  - key: ca.crt
+                    path: ca.crt
+                name: kube-root-ca.crt
+            - downwardAPI:
+                items:
+                  - fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+                    path: namespace
+        {{- end }}
         {{- if .Values.ruler.extraVolumes }}
         {{ toYaml .Values.ruler.extraVolumes | nindent 8}}
         {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/serviceaccount.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/serviceaccount.yaml
@@ -11,4 +11,5 @@ metadata:
   annotations:
     {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
   namespace: {{ .Release.Namespace | quote }}
+  automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -89,6 +89,7 @@ spec:
       schedulerName: {{ . | quote }}
       {{- end }}
       serviceAccountName: {{ template "mimir.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.store_gateway.automountServiceAccountToken }}
       {{- if .Values.store_gateway.priorityClassName }}
       priorityClassName: {{ .Values.store_gateway.priorityClassName }}
       {{- end }}
@@ -133,6 +134,23 @@ spec:
           emptyDir:
             {{- toYaml .Values.store_gateway.persistentVolume.emptyDir | nindent 12 }}
         {{- end }}
+        {{- if .Values.store_gateway.projectServiceAccountToken }}
+        - name: kube-api-access
+          projected:
+            - serviceAccountToken:
+                path: token
+            - configMap:
+                items:
+                  - key: ca.crt
+                    path: ca.crt
+                name: kube-root-ca.crt
+            - downwardAPI:
+                items:
+                  - fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+                    path: namespace
+        {{- end }}
         {{- if .Values.store_gateway.extraVolumes }}
         {{ toYaml .Values.store_gateway.extraVolumes | nindent 8 }}
         {{- end }}
@@ -170,6 +188,11 @@ spec:
             {{- end }}
             {{- if .Values.global.extraVolumeMounts }}
             {{ toYaml .Values.global.extraVolumeMounts | nindent 12}}
+            {{- end }}
+            {{- if .Values.store_gateway.projectServiceAccountToken }}
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: kube-api-access
+              readOnly: true
             {{- end }}
             - name: config
               mountPath: /etc/mimir

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -83,6 +83,7 @@ serviceAccount:
   name:
   annotations: {}
   labels: {}
+  automountServiceAccountToken: true
 
 # -- Configuration is loaded from the secret called 'externalConfigSecretName'. If 'useExternalConfig' is true, then the configuration is not generated, just consumed.
 useExternalConfig: false
@@ -509,6 +510,10 @@ alertmanager:
     #   name: reverse-proxy
     #   targetPort: 11811
 
+  # -- Configuration for alertmanager's pod Service Account Token Automounting.
+  automountServiceAccountToken: true
+  projectServiceAccountToken: false
+
   # -- Optionally set the scheduler for pods of the alertmanager
   schedulerName: ""
 
@@ -825,6 +830,9 @@ distributor:
     # -- https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution
     trafficDistribution: ""
 
+  # -- Configuration for distributor's pod Service Account Token Automounting.
+  automountServiceAccountToken: true
+  projectServiceAccountToken: false
 
   resources:
     requests:
@@ -929,6 +937,10 @@ ingester:
     # -- https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution
     # Note: This service is only used for admin endpoints like TSDB statistics, not for write or read path traffic.
     trafficDistribution: ""
+
+  # -- Configuration for ingester's pod Service Account Token Automounting.
+  automountServiceAccountToken: true
+  projectServiceAccountToken: false
 
   # -- Optionally set the scheduler for pods of the ingester
   schedulerName: ""
@@ -1203,6 +1215,10 @@ overrides_exporter:
     type: ClusterIP
     extraPorts: []
 
+  # -- Configuration for overrides_exporter's pod Service Account Token Automounting.
+  automountServiceAccountToken: true
+  projectServiceAccountToken: false
+
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -1321,6 +1337,10 @@ ruler:
     internalTrafficPolicy: Cluster
     type: ClusterIP
     extraPorts: []
+
+  # -- Configuration for ruler's pod Service Account Token Automounting.
+  automountServiceAccountToken: true
+  projectServiceAccountToken: false
 
   # -- Dedicated service account for ruler pods.
   # If not set, the default service account defined at the begining of this file will be used.
@@ -1460,6 +1480,10 @@ ruler_querier:
     type: ClusterIP
     extraPorts: []
 
+  # -- Configuration for ruler-querier's pod Service Account Token Automounting.
+  automountServiceAccountToken: true
+  projectServiceAccountToken: false
+
   resources:
     requests:
       cpu: 100m
@@ -1581,6 +1605,10 @@ ruler_query_frontend:
     type: ClusterIP
     extraPorts: []
 
+  # -- Configuration for ruler-query-frontend's pod Service Account Token Automounting.
+  automountServiceAccountToken: true
+  projectServiceAccountToken: false
+
   resources:
     requests:
       cpu: 100m
@@ -1672,6 +1700,10 @@ ruler_query_scheduler:
     internalTrafficPolicy: Cluster
     type: ClusterIP
     extraPorts: []
+
+  # -- Configuration for ruler-query-scheduler's pod Service Account Token Automounting.
+  automountServiceAccountToken: true
+  projectServiceAccountToken: false
 
   resources:
     requests:
@@ -1813,6 +1845,10 @@ querier:
     # -- https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution
     trafficDistribution: ""
 
+  # -- Configuration for querier's pod Service Account Token Automounting.
+  automountServiceAccountToken: true
+  projectServiceAccountToken: false
+
   resources:
     requests:
       cpu: 100m
@@ -1938,6 +1974,10 @@ query_frontend:
     # -- https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution
     trafficDistribution: ""
 
+  # -- Configuration for query-frontend's pod Service Account Token Automounting.
+  automountServiceAccountToken: true
+  projectServiceAccountToken: false
+
   resources:
     requests:
       cpu: 100m
@@ -2032,6 +2072,10 @@ query_scheduler:
     extraPorts: []
     # -- https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution
     trafficDistribution: ""
+
+  # -- Configuration for query-scheduler's pod Service Account Token Automounting.
+  automountServiceAccountToken: true
+  projectServiceAccountToken: false
 
   resources:
     requests:
@@ -2132,6 +2176,10 @@ store_gateway:
     # -- https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution
     # Note: This service is not responsible for read path traffic.
     trafficDistribution: ""
+
+  # -- Configuration for store-gateway's pod Service Account Token Automounting.
+  automountServiceAccountToken: true
+  projectServiceAccountToken: false
 
   # -- Optionally set the scheduler for pods of the store-gateway
   schedulerName: ""
@@ -2395,6 +2443,10 @@ compactor:
     internalTrafficPolicy: Cluster
     type: ClusterIP
     extraPorts: []
+
+  # -- Configuration for compactor's pod Service Account Token Automounting.
+  automountServiceAccountToken: true
+  projectServiceAccountToken: false
 
   # -- Optionally set the scheduler for pods of the compactor
   schedulerName: ""
@@ -3287,6 +3339,9 @@ gateway:
     # -- https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution
     trafficDistribution: ""
 
+  # -- Configuration for gateway's pod Service Account Token Automounting.
+  automountServiceAccountToken: true
+  projectServiceAccountToken: false
 
   ingress:
     enabled: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
Adds the option in the Helm Chart to secure the Kubernetes Service Account mounting to specific containers `projectServiceAccountToken` and allows disabling `automountServiceAccountToken`
#### Which issue(s) this PR fixes or relates to

Fixes #15825 

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
