### PR TITLE
Fix issue where exemplar queries and split range queries can return series in the wrong order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@
 * [BUGFIX] MQE: Don't evaluate unnecessary range vector splitting ranges when a split range vector is part of a spun-off subquery and running time-splitting and caching inside MQE is enabled. #15931
 * [BUGFIX] MQE: Fix `info()` function incorrectly handling negated name matchers. #15168
 * [BUGFIX] Query-frontend: Fix issue where series for a range query can be returned in the wrong order if splitting applies and splitting is not running inside MQE. #16036
+* [BUGFIX] Querier: Fix issue where exemplars can be returned in the wrong order if a series contains a label that is a prefix of another (eg. `env="foo"` and `env="foobar"`). #16036
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@
 * [BUGFIX] Compactor: Fix `GatherBlockHealthStats` postings walk error check to prevent swallowing errors. #15895
 * [BUGFIX] MQE: Don't evaluate unnecessary range vector splitting ranges when a split range vector is part of a spun-off subquery and running time-splitting and caching inside MQE is enabled. #15931
 * [BUGFIX] MQE: Fix `info()` function incorrectly handling negated name matchers. #15168
+* [BUGFIX] Query-frontend: Fix issue where series for a range query can be returned in the wrong order if splitting applies and splitting is not running inside MQE. #16036
 
 ### Mixin
 

--- a/pkg/distributor/query.go
+++ b/pkg/distributor/query.go
@@ -214,7 +214,6 @@ func mergeExemplarSets(a, b []mimirpb.Exemplar) []mimirpb.Exemplar {
 }
 
 func mergeExemplarQueryResponses(results []*ingester_client.ExemplarQueryResponse) *ingester_client.ExemplarQueryResponse {
-	var keys []string
 	exemplarResults := make(map[string]mimirpb.TimeSeries)
 	for _, r := range results {
 		for _, ts := range r.Timeseries {
@@ -222,7 +221,6 @@ func mergeExemplarQueryResponses(results []*ingester_client.ExemplarQueryRespons
 			e, ok := exemplarResults[lbls]
 			if !ok {
 				exemplarResults[lbls] = ts
-				keys = append(keys, lbls)
 			} else {
 				// Merge in any missing values from another ingesters exemplars for this series.
 				ts.Exemplars = mergeExemplarSets(e.Exemplars, ts.Exemplars)
@@ -231,14 +229,16 @@ func mergeExemplarQueryResponses(results []*ingester_client.ExemplarQueryRespons
 		}
 	}
 
-	// Query results from each ingester were sorted, but are not necessarily still sorted after merging.
-	slices.Sort(keys)
-
-	result := make([]mimirpb.TimeSeries, len(exemplarResults))
-	for i, k := range keys {
-		result[i] = exemplarResults[k]
-		result[i].MakeReferencesSafeToRetain()
+	result := make([]mimirpb.TimeSeries, 0, len(exemplarResults))
+	for _, r := range exemplarResults {
+		r.MakeReferencesSafeToRetain()
+		result = append(result, r)
 	}
+
+	// Query results from each ingester were sorted, but are not necessarily still sorted after merging.
+	slices.SortFunc(result, func(a, b mimirpb.TimeSeries) int {
+		return mimirpb.CompareLabelAdapters(a.Labels, b.Labels)
+	})
 
 	return &ingester_client.ExemplarQueryResponse{Timeseries: result}
 }

--- a/pkg/distributor/query_test.go
+++ b/pkg/distributor/query_test.go
@@ -518,6 +518,8 @@ func TestMergeExemplars(t *testing.T) {
 	exemplar5 := mimirpb.Exemplar{Labels: mimirpb.FromLabelsToLabelAdapters(labels.FromStrings("traceID", "trace-4")), TimestampMs: now, Value: 7}
 	labels1 := []mimirpb.LabelAdapter{{Name: "label1", Value: "foo1"}}
 	labels2 := []mimirpb.LabelAdapter{{Name: "label1", Value: "foo2"}}
+	labelsWithoutPrefix := []mimirpb.LabelAdapter{{Name: "region", Value: "abc"}, {Name: "pod", Value: "xyz"}}
+	labelsWithPrefix := []mimirpb.LabelAdapter{{Name: "region", Value: "abc-123"}, {Name: "pod", Value: "xyz"}}
 
 	for i, c := range []struct {
 		seriesA       []mimirpb.TimeSeries
@@ -566,6 +568,14 @@ func TestMergeExemplars(t *testing.T) {
 			expected: []mimirpb.TimeSeries{
 				{Labels: labels1, Exemplars: []mimirpb.Exemplar{exemplar1, exemplar2}},
 				{Labels: labels2, Exemplars: []mimirpb.Exemplar{exemplar3, exemplar4}}},
+		},
+		{ // Ensure that series are returned sorted in label order when one label's value is a prefix of another.
+			seriesA: []mimirpb.TimeSeries{{Labels: labelsWithoutPrefix, Exemplars: []mimirpb.Exemplar{exemplar1, exemplar2}}},
+			seriesB: []mimirpb.TimeSeries{{Labels: labelsWithPrefix, Exemplars: []mimirpb.Exemplar{exemplar3, exemplar4}}},
+			expected: []mimirpb.TimeSeries{
+				{Labels: labelsWithoutPrefix, Exemplars: []mimirpb.Exemplar{exemplar1, exemplar2}},
+				{Labels: labelsWithPrefix, Exemplars: []mimirpb.Exemplar{exemplar3, exemplar4}},
+			},
 		},
 	} {
 		t.Run(fmt.Sprint("test", i), func(t *testing.T) {

--- a/pkg/frontend/querymiddleware/codec.go
+++ b/pkg/frontend/querymiddleware/codec.go
@@ -1331,16 +1331,14 @@ func matrixMerge(resps []*PrometheusResponse) []SampleStream {
 		}
 	}
 
-	keys := make([]string, 0, len(output))
-	for key := range output {
-		keys = append(keys, key)
-	}
-	slices.Sort(keys)
-
 	result := make([]SampleStream, 0, len(output))
-	for _, key := range keys {
-		result = append(result, *output[key])
+	for _, s := range output {
+		result = append(result, *s)
 	}
+
+	slices.SortFunc(result, func(a, b SampleStream) int {
+		return mimirpb.CompareLabelAdapters(a.Labels, b.Labels)
+	})
 
 	return result
 }

--- a/pkg/frontend/querymiddleware/codec_test.go
+++ b/pkg/frontend/querymiddleware/codec_test.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/url"
 	"slices"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -26,6 +27,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
 	v1API "github.com/prometheus/prometheus/web/api/v1"
 	"github.com/stretchr/testify/assert"
@@ -2390,4 +2393,91 @@ func TestCodec_MergeResponse_TransfersOwnershipOnSuccess(t *testing.T) {
 	merged.Close()
 	require.True(t, in1.Closed(), "closing the merged response must close each input")
 	require.True(t, in2.Closed(), "closing the merged response must close each input")
+}
+
+func TestCodec_MatrixMerge_SeriesSortingShouldBeConsistentWithEngine(t *testing.T) {
+	testCases := [][]labels.Labels{
+		{
+			labels.FromStrings("foo", "1"),
+			labels.FromStrings("foo", "2"),
+		},
+		{
+			labels.FromStrings("bar", "1", "baz", "1"),
+			labels.FromStrings("bar", "1", "foo", "1"),
+		},
+		{
+			labels.FromStrings("bar", "1", "baz", "1"),
+			labels.FromStrings("bar", "2", "baz", "1"),
+		},
+		{
+			labels.FromStrings("bar", "abc", "baz", "1"),
+			labels.FromStrings("bar", "abcdef", "baz", "1"),
+		},
+		{
+			labels.FromStrings("bar", "1", "baz", "1"),
+			labels.FromStrings("bar", "1", "bazzzz", "1"),
+		},
+		{
+			labels.FromStrings("bar", "1", "baz", "aaa"),
+			labels.FromStrings("bar", "1", "baz", "aaabbb"),
+		},
+	}
+
+	runTestCase := func(testCase []labels.Labels, expectedOrder []labels.Labels) {
+		t.Run(fmt.Sprintf("%v", testCase), func(t *testing.T) {
+			resp := createResponseWithLabels(testCase)
+			merged := matrixMerge([]*PrometheusResponse{resp})
+			mergedSeries := getSeriesLabels(merged)
+			require.Equal(t, expectedOrder, mergedSeries)
+		})
+	}
+
+	for _, testCase := range testCases {
+		expectedOrder := getExpectedMatrixLabelOrder(testCase)
+
+		reversed := slices.Clone(testCase)
+		slices.Reverse(reversed)
+
+		runTestCase(testCase, expectedOrder)
+		runTestCase(reversed, expectedOrder)
+	}
+}
+
+func getExpectedMatrixLabelOrder(lbls []labels.Labels) []labels.Labels {
+	m := promql.Matrix{}
+
+	for _, l := range lbls {
+		m = append(m, promql.Series{Metric: l})
+	}
+
+	sort.Sort(m)
+	sortedLabels := make([]labels.Labels, 0, len(m))
+
+	for _, s := range m {
+		sortedLabels = append(sortedLabels, s.Metric)
+	}
+	return sortedLabels
+}
+
+func createResponseWithLabels(lbls []labels.Labels) *PrometheusResponse {
+	series := make([]SampleStream, 0, len(lbls))
+
+	for _, l := range lbls {
+		series = append(series, SampleStream{Labels: mimirpb.FromLabelsToLabelAdapters(l)})
+	}
+
+	return &PrometheusResponse{
+		Data: &PrometheusData{
+			ResultType: model.ValMatrix.String(),
+			Result:     series,
+		},
+	}
+}
+
+func getSeriesLabels(ss []SampleStream) []labels.Labels {
+	lbls := make([]labels.Labels, 0, len(ss))
+	for _, s := range ss {
+		lbls = append(lbls, mimirpb.FromLabelAdaptersToLabels(s.Labels))
+	}
+	return lbls
 }

--- a/pkg/mimirpb/compat.go
+++ b/pkg/mimirpb/compat.go
@@ -110,6 +110,9 @@ func FromLabelAdaptersToMetric(ls []LabelAdapter) model.Metric {
 
 // FromLabelAdaptersToKeyString makes a string to be used as a key to a map.
 // It's much simpler than FromLabelAdaptersToString, but not human-readable.
+//
+// This value should not be used for sorting series, as it does not produce the same sort order as labels.Labels.Compare().
+// Use CompareLabelAdapters instead.
 func FromLabelAdaptersToKeyString(ls []LabelAdapter) string {
 	buf := make([]byte, 0, 1024)
 	for i := range ls {

--- a/pkg/querier/distributor_queryable.go
+++ b/pkg/querier/distributor_queryable.go
@@ -260,7 +260,7 @@ type distributorExemplarQuerier struct {
 	logger      log.Logger
 }
 
-// Select querys for exemplars, prometheus' storage.ExemplarQuerier's Select function takes the time range as two int64 values.
+// Select queries for exemplars, prometheus' storage.ExemplarQuerier's Select function takes the time range as two int64 values.
 func (q *distributorExemplarQuerier) Select(start, end int64, matchers ...[]*labels.Matcher) ([]exemplar.QueryResult, error) {
 	spanlog, ctx := spanlogger.New(q.ctx, q.logger, tracer, "distributorExemplarQuerier.Select")
 	defer spanlog.Finish()


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue where split range queries can return series in the wrong order if any label name or value is a substring of another series that is otherwise identical, and the query-frontend middleware implementation of splitting is in use.

For example, Prometheus' query engine (and MQE) would return these series in this order, based on the result from `labels.Labels.Compare()`:

```
container="api", namespace="prod-01"
container="api-readonly", namespace="prod-01"
```

But the splitting middleware would return them in the other order:

```
container="api-readonly", namespace="prod-01"
container="api", namespace="prod-01"
```

This PR also fixes a similar issue that affects exemplar query requests.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
