### PR TITLE
Trace Produce requests via the Warpstream-aware Kafka client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 * [ENHANCEMENT] MQE: Respect the `Cache-Control: no-store` request header when caching intermediate results for range vector splitting. #15148
 * [ENHANCEMENT] MQE: Extend experimental support for computing multiple aggregations over the same data without buffering to quantile aggregations. #15624
 * [ENHANCEMENT] Ingest storage: skip per-record tracing span and attribute allocations on the Kafka fetch path when the producer trace is not sampled. The producer's trace context is still extracted from record headers for every record. #15614
+* [ENHANCEMENT] Ingest storage: the experimental WarpStream Kafka producer backend (`-ingest-storage.kafka.backend=warpstream`) now traces produce requests, emitting the same producer spans and `traceparent` propagation as the default Kafka backend. #16039
 * [ENHANCEMENT] Distributor: Add a tracing span around the OTLP to Prometheus conversion so its latency is independently visible in traces. #15682
 * [ENHANCEMENET] Runtimeconfig: The HTTP client used to fetch runtime configurations from HTTP endpoints now has keep-alives disabled by default. New CLI flag `-runtime-config.http-client-disable-keep-alives` is enabled by default, an can be set to `false` in-order to re-enable keep-alives. #15695
 * [ENHANCEMENT] MQE: Support for native histograms in `smoothed` and `anchored` extended range selector modifiers. #15398

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853
-	github.com/grafana/warpstream-go v0.0.0-20260710115402-9551070a214c
+	github.com/grafana/warpstream-go v0.0.0-20260710130640-f4258f6a3f82
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/hashicorp/vault/api v1.23.0
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853
-	github.com/grafana/warpstream-go v0.0.0-20260709185922-cde46bc835e9
+	github.com/grafana/warpstream-go v0.0.0-20260710082904-2057a436bf0c
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/hashicorp/vault/api v1.23.0
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853
-	github.com/grafana/warpstream-go v0.0.0-20260710082904-2057a436bf0c
+	github.com/grafana/warpstream-go v0.0.0-20260710115402-9551070a214c
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/hashicorp/vault/api v1.23.0
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db

--- a/go.sum
+++ b/go.sum
@@ -590,10 +590,8 @@ github.com/grafana/pyroscope-go/godeltaprof v0.1.9 h1:c1Us8i6eSmkW+Ez05d3co8kasn
 github.com/grafana/pyroscope-go/godeltaprof v0.1.9/go.mod h1:2+l7K7twW49Ct4wFluZD3tZ6e0SjanjcUUBPVD/UuGU=
 github.com/grafana/regexp v0.0.0-20250905101755-5eb4f3acbf71 h1:A4D22zZV7+EeQk9TeATDDY/PG2wnzdqKcj4IZq+PcwA=
 github.com/grafana/regexp v0.0.0-20250905101755-5eb4f3acbf71/go.mod h1:+JKpmjMGhpgPL+rXZ5nsZieVzvarn86asRlBg4uNGnk=
-github.com/grafana/warpstream-go v0.0.0-20260709185922-cde46bc835e9 h1:qWOLS04YizAmZb0FtpmJQkR/XCtdD/uP9dXH429Upa4=
-github.com/grafana/warpstream-go v0.0.0-20260709185922-cde46bc835e9/go.mod h1:/rfo1TLJ3YxyS1sK6hqcsOqJHmJO0bB/xiWqRYMw1jc=
-github.com/grafana/warpstream-go v0.0.0-20260710082904-2057a436bf0c h1:O2nDhqKXpXrE+GJRaJC9sG1StZuOjkOdn+1/1N4Zy9U=
-github.com/grafana/warpstream-go v0.0.0-20260710082904-2057a436bf0c/go.mod h1:6fMYgD9y45lJwXaWpD01ZTNGqc0cNpS5zFvBhauKHfg=
+github.com/grafana/warpstream-go v0.0.0-20260710115402-9551070a214c h1:46QFPi870Im9f8Bx7apTFCH7Y+ogWT10rIL4VdQEV6E=
+github.com/grafana/warpstream-go v0.0.0-20260710115402-9551070a214c/go.mod h1:6fMYgD9y45lJwXaWpD01ZTNGqc0cNpS5zFvBhauKHfg=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=

--- a/go.sum
+++ b/go.sum
@@ -590,8 +590,8 @@ github.com/grafana/pyroscope-go/godeltaprof v0.1.9 h1:c1Us8i6eSmkW+Ez05d3co8kasn
 github.com/grafana/pyroscope-go/godeltaprof v0.1.9/go.mod h1:2+l7K7twW49Ct4wFluZD3tZ6e0SjanjcUUBPVD/UuGU=
 github.com/grafana/regexp v0.0.0-20250905101755-5eb4f3acbf71 h1:A4D22zZV7+EeQk9TeATDDY/PG2wnzdqKcj4IZq+PcwA=
 github.com/grafana/regexp v0.0.0-20250905101755-5eb4f3acbf71/go.mod h1:+JKpmjMGhpgPL+rXZ5nsZieVzvarn86asRlBg4uNGnk=
-github.com/grafana/warpstream-go v0.0.0-20260710115402-9551070a214c h1:46QFPi870Im9f8Bx7apTFCH7Y+ogWT10rIL4VdQEV6E=
-github.com/grafana/warpstream-go v0.0.0-20260710115402-9551070a214c/go.mod h1:6fMYgD9y45lJwXaWpD01ZTNGqc0cNpS5zFvBhauKHfg=
+github.com/grafana/warpstream-go v0.0.0-20260710130640-f4258f6a3f82 h1:/SqUBXaqvxPeIx7y/PeV1OEWpmtNZO60sAc4W7qfjoY=
+github.com/grafana/warpstream-go v0.0.0-20260710130640-f4258f6a3f82/go.mod h1:6fMYgD9y45lJwXaWpD01ZTNGqc0cNpS5zFvBhauKHfg=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=

--- a/go.sum
+++ b/go.sum
@@ -592,6 +592,8 @@ github.com/grafana/regexp v0.0.0-20250905101755-5eb4f3acbf71 h1:A4D22zZV7+EeQk9T
 github.com/grafana/regexp v0.0.0-20250905101755-5eb4f3acbf71/go.mod h1:+JKpmjMGhpgPL+rXZ5nsZieVzvarn86asRlBg4uNGnk=
 github.com/grafana/warpstream-go v0.0.0-20260709185922-cde46bc835e9 h1:qWOLS04YizAmZb0FtpmJQkR/XCtdD/uP9dXH429Upa4=
 github.com/grafana/warpstream-go v0.0.0-20260709185922-cde46bc835e9/go.mod h1:/rfo1TLJ3YxyS1sK6hqcsOqJHmJO0bB/xiWqRYMw1jc=
+github.com/grafana/warpstream-go v0.0.0-20260710082904-2057a436bf0c h1:O2nDhqKXpXrE+GJRaJC9sG1StZuOjkOdn+1/1N4Zy9U=
+github.com/grafana/warpstream-go v0.0.0-20260710082904-2057a436bf0c/go.mod h1:6fMYgD9y45lJwXaWpD01ZTNGqc0cNpS5zFvBhauKHfg=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=

--- a/pkg/storage/ingest/writer_client.go
+++ b/pkg/storage/ingest/writer_client.go
@@ -46,6 +46,12 @@ func newKafkaProducerForBackend(cfg KafkaConfig, maxInflight int, logger log.Log
 		// kafka_* extended latency metrics, to match the kafka backend.
 		warpstreamOpts = append(warpstreamOpts, wgo.WithHooks(NewKafkaClientExtendedMetrics(reg)))
 
+		// Trace produces like the kafka backend. warpstream-go drives the
+		// produce-record hooks on its own produce path, so the same sampled-only
+		// tracer yields the same producer spans and traceparent propagation as a
+		// franz-go client.
+		warpstreamOpts = append(warpstreamOpts, wgo.WithHooks(newSampledOnlyTracer()))
+
 		warpstreamClient, err := wgo.NewWarpstreamClient(NewKafkaLogger(logger), reg, warpstreamOpts...)
 		if err != nil {
 			return nil, err

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/agent_record_buffer.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/agent_record_buffer.go
@@ -77,9 +77,38 @@ func NewAgentBuffer[W routedBatch[W]](nodeID int32, linger time.Duration, batchM
 	}
 }
 
-// Add buffers items for produce. Each item's done fires exactly once with its
+// Add buffers a single item for produce. Its done fires exactly once with its
 // terminal outcome.
-func (a *AgentBuffer[W]) Add(items []promised[W]) {
+func (a *AgentBuffer[W]) Add(p promised[W]) {
+	if p.item.recordCount() == 0 {
+		return
+	}
+
+	// A fitting item is added directly, skipping the chunk slice and the split. An
+	// item that overflows batchMaxBytes must be split so no flushed per-partition
+	// batch is rejected MessageTooLarge; that case delegates to MultiAdd rather
+	// than duplicating the split here.
+	if p.item.uncompressedWireBytes() > int64(a.batchMaxBytes) {
+		a.MultiAdd([]promised[W]{p})
+		return
+	}
+
+	a.mu.Lock()
+	if a.closed {
+		// Closed buffer: there is no flush to carry the outcome, so resolve the
+		// item's done synchronously with errBufferClosed.
+		a.mu.Unlock()
+		p.done(ProduceResult{err: errBufferClosed})
+		return
+	}
+
+	a.addToNextProduceLocked(p)
+	a.maybeStartNextFlushTimerLocked()
+	a.mu.Unlock()
+}
+
+// MultiAdd is Add for a batch of items.
+func (a *AgentBuffer[W]) MultiAdd(items []promised[W]) {
 	incoming := 0
 	for i := range items {
 		incoming += items[i].item.recordCount()
@@ -112,10 +141,16 @@ func (a *AgentBuffer[W]) Add(items []promised[W]) {
 	for i := range chunks {
 		a.addToNextProduceLocked(chunks[i])
 	}
+	a.maybeStartNextFlushTimerLocked()
+	a.mu.Unlock()
+}
+
+// maybeStartNextFlushTimerLocked starts the linger flush timer when work is pending and no
+// timer is already running. Caller must hold a.mu.
+func (a *AgentBuffer[W]) maybeStartNextFlushTimerLocked() {
 	if a.nextProduceRecords > 0 && a.nextProduceFlushTimer == nil {
 		a.nextProduceFlushTimer = time.AfterFunc(a.linger, a.timerFlush)
 	}
-	a.mu.Unlock()
 }
 
 // addToNextProduceLocked appends one item (already <= batchMaxBytes) to the

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/client.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/client.go
@@ -209,7 +209,7 @@ func (c *WarpstreamClient) Produce(ctx context.Context, record *kgo.Record, prom
 	// Stamp the produce time only after routing succeeds, so a failed produce
 	// leaves the caller's record unchanged. Mirrors franz-go's bufferRecord.
 	ensureRecordTimestamp(record, time.Now())
-	c.buffer.Add(ctx, []promised[routedTopicPartitionRecords]{routed})
+	c.buffer.Add(ctx, routed)
 }
 
 // ProduceSync produces records and blocks until each has been
@@ -307,7 +307,7 @@ func (c *WarpstreamClient) ProduceSync(ctx context.Context, records []*kgo.Recor
 		ensureRecordTimestamp(r, now)
 	}
 
-	c.buffer.Add(ctx, routed)
+	c.buffer.MultiAdd(ctx, routed)
 	wg.Wait()
 	return results
 }

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/client.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/client.go
@@ -72,6 +72,10 @@ type WarpstreamClient struct {
 	logger  kgo.Logger
 	metrics *metrics
 
+	// produceHooks are the produce-record lifecycle hooks driven on this
+	// client's own produce path.
+	produceHooks produceHooks
+
 	pool           *AgentPool
 	tracker        *CachedAgentStatsTracker
 	demoter        *Demoter
@@ -131,6 +135,7 @@ func NewWarpstreamClient(logger kgo.Logger, reg prometheus.Registerer, opts ...O
 		cfg:            cfg,
 		logger:         logger,
 		metrics:        m,
+		produceHooks:   newProduceHooks(cfg.Hooks),
 		Client:         kgoClient,
 		pool:           pool,
 		tracker:        tracker,
@@ -164,6 +169,21 @@ func NewWarpstreamClient(logger kgo.Logger, reg prometheus.Registerer, opts ...O
 // completion: it detaches the caller while the background produce keeps the
 // record, so a record whose produce was cancelled must not be reused.
 func (c *WarpstreamClient) Produce(ctx context.Context, record *kgo.Record, promise func(*kgo.Record, error)) {
+	// Seed the record's parent context (like franz-go).
+	ensureRecordContext(record, ctx)
+
+	// Fire the buffered hook (which may inject a trace header) before any rejection,
+	// and wrap the promise so the unbuffered hook fires just before the caller sees
+	// the outcome on every path.
+	if c.produceHooks.enabled() {
+		c.produceHooks.fireBuffered(record)
+		userPromise := promise
+		promise = func(r *kgo.Record, err error) {
+			c.produceHooks.fireUnbuffered(r, err)
+			userPromise(r, err)
+		}
+	}
+
 	c.metrics.produceRecordsTotal.Inc()
 
 	if singleRecordBatchEstimateBytes(record) > int64(c.cfg.BatchMaxBytes) {
@@ -208,7 +228,30 @@ func (c *WarpstreamClient) ProduceSync(ctx context.Context, records []*kgo.Recor
 	}
 	c.metrics.produceRecordsTotal.Add(float64(len(records)))
 
+	// Seed each record's parent context (like franz-go) and fire the buffered
+	// hook for every record up front, before any rejection.
+	hasProduceHooks := c.produceHooks.enabled()
+	for _, r := range records {
+		ensureRecordContext(r, ctx)
+		if hasProduceHooks {
+			c.produceHooks.fireBuffered(r)
+		}
+	}
+
 	results := make(kgo.ProduceResults, len(records))
+
+	// Fire the unbuffered hook for each record from this goroutine, in input order,
+	// just before returning. Every return path below fully populates results first
+	// (wg.Wait blocks until the async completions have run), so the terminal error
+	// is final here. Mirrors franz-go's "unbuffered hook, then the record's outcome".
+	if hasProduceHooks {
+		defer func() {
+			for i, r := range records {
+				c.produceHooks.fireUnbuffered(r, results[i].Err)
+			}
+		}()
+	}
+
 	var (
 		okRecords []*kgo.Record
 		okIndices []int

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/cluster_record_buffer.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/cluster_record_buffer.go
@@ -89,64 +89,71 @@ func NewClusterBuffer[W routedBatch[W]](linger time.Duration, batchMaxBytes int3
 	return c
 }
 
-// Add buffers items for produce. Each item's done fires exactly once with its
+// Add buffers a single item for produce. Its done fires exactly once with its
 // final outcome (nil on success, an error on terminal failure, or ctx.Err() if
 // ctx is canceled before the producer resolves the partition). Cancelling ctx
 // detaches the caller but does not stop the in-flight produce.
-func (c *ClusterBuffer[W]) Add(ctx context.Context, items []promised[W]) {
+func (c *ClusterBuffer[W]) Add(ctx context.Context, item promised[W]) {
+	c.addToBuffer(ctx, c.wrap(ctx, item))
+}
+
+// MultiAdd is Add for a batch of items: the same per-item completion contract,
+// binned by destination agent in a single pass.
+func (c *ClusterBuffer[W]) MultiAdd(ctx context.Context, items []promised[W]) {
 	if len(items) == 0 {
 		return
 	}
-
-	// Wrap each item's done with two layers:
-	//   - a once-fire that delivers either the produce outcome or
-	//     ctx.Err() (whichever first) to the original done;
-	//   - an accounting hook that decrements the buffered counters on
-	//     actual flush completion regardless of whether ctx already fired.
 	wrapped := make([]promised[W], len(items))
 	for i, p := range items {
-		payloadBytes := p.item.payloadBytes()
-		recCount := int64(p.item.recordCount())
-		c.bufferedBytes.Add(payloadBytes)
-		c.bufferedRecords.Add(recCount)
+		wrapped[i] = c.wrap(ctx, p)
+	}
+	c.addToBuffers(ctx, wrapped)
+}
 
-		var (
-			origDone = p.done
+// wrap layers p's done with two hooks:
+//   - a once-fire that delivers either the produce outcome or ctx.Err()
+//     (whichever first) to the original done;
+//   - an accounting hook that decrements the buffered counters on actual flush
+//     completion regardless of whether ctx already fired.
+func (c *ClusterBuffer[W]) wrap(ctx context.Context, p promised[W]) promised[W] {
+	payloadBytes := p.item.payloadBytes()
+	recCount := int64(p.item.recordCount())
+	c.bufferedBytes.Add(payloadBytes)
+	c.bufferedRecords.Add(recCount)
 
-			// origDoneFired gates the original done ("ctx-cancel vs flush" race).
-			origDoneFired atomic.Bool
+	var (
+		origDone = p.done
 
-			// ourDoneFired gates the accounting decrement (flush only).
-			ourDoneFired atomic.Bool
-		)
+		// origDoneFired gates the original done ("ctx-cancel vs flush" race).
+		origDoneFired atomic.Bool
 
-		fireOrigDone := func(res ProduceResult) {
-			if origDoneFired.CompareAndSwap(false, true) {
-				origDone(res)
-			}
+		// ourDoneFired gates the accounting decrement (flush only).
+		ourDoneFired atomic.Bool
+	)
+
+	fireOrigDone := func(res ProduceResult) {
+		if origDoneFired.CompareAndSwap(false, true) {
+			origDone(res)
 		}
-
-		// AfterFunc's callback always runs in a separate goroutine and
-		// never races with the stopCtxWatch assignment below — done()
-		// can only fire via addToBuffers further down (synchronous on
-		// pre-canceled ctx) or via the flush (later still), so
-		// stopCtxWatch is already bound by the time it's read.
-		stopCtxWatch := context.AfterFunc(ctx, func() {
-			fireOrigDone(ProduceResult{err: ctx.Err()})
-		})
-
-		p.done = func(res ProduceResult) {
-			if ourDoneFired.CompareAndSwap(false, true) {
-				stopCtxWatch()
-				c.bufferedBytes.Add(-payloadBytes)
-				c.bufferedRecords.Add(-recCount)
-			}
-			fireOrigDone(res)
-		}
-		wrapped[i] = p
 	}
 
-	c.addToBuffers(ctx, wrapped)
+	// AfterFunc's callback always runs in a separate goroutine and never races
+	// with the stopCtxWatch assignment below — done() can only fire via
+	// addToBuffers/addToBuffer (synchronous on pre-canceled ctx) or via the
+	// flush (later still), so stopCtxWatch is already bound by the time it's read.
+	stopCtxWatch := context.AfterFunc(ctx, func() {
+		fireOrigDone(ProduceResult{err: ctx.Err()})
+	})
+
+	p.done = func(res ProduceResult) {
+		if ourDoneFired.CompareAndSwap(false, true) {
+			stopCtxWatch()
+			c.bufferedBytes.Add(-payloadBytes)
+			c.bufferedRecords.Add(-recCount)
+		}
+		fireOrigDone(res)
+	}
+	return p
 }
 
 // addToBuffers bins items by destination and dispatches them to the matching
@@ -179,8 +186,28 @@ func (c *ClusterBuffer[W]) addToBuffers(ctx context.Context, items []promised[W]
 			}
 			continue
 		}
-		buffer.Add(agentItems)
+		buffer.MultiAdd(agentItems)
 	}
+}
+
+// addToBuffer is addToBuffers for a single already-wrapped item.
+func (c *ClusterBuffer[W]) addToBuffer(ctx context.Context, p promised[W]) {
+	if err := ctx.Err(); err != nil {
+		// Pre-canceled fast path: fail the item without dispatching. Distinct
+		// from a mid-flight cancel (which still buffers and lets the batch flush
+		// in the background); this matters because the caller may otherwise
+		// observe a duplicate from a "no-op" call.
+		p.done(ProduceResult{err: err})
+		return
+	}
+
+	buffer, err := c.agentBufferFor(p.item.getNodeID())
+	if err != nil {
+		p.done(ProduceResult{err: err})
+		return
+	}
+
+	buffer.Add(p)
 }
 
 // BufferedBytes returns the bytes of all records awaiting ack.

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/config.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/config.go
@@ -26,8 +26,10 @@ type Config struct {
 	// SASLOptions are pre-built kgo options for SASL authentication.
 	SASLOptions []kgo.Opt
 
-	// Hooks are franz-go hooks appended to the internal kgo.Client, letting
-	// callers observe the wire layer (e.g. their own metrics or tracing hooks).
+	// Hooks are franz-go hooks the client observes: broker, consume, and lifecycle
+	// hooks fire on the embedded kgo.Client, while the produce-record hooks are driven
+	// on the client's own produce path (e.g. for metrics or tracing). See WithHooks for
+	// the two produce hooks that are not supported.
 	Hooks []kgo.Hook
 
 	// Producer settings.
@@ -235,10 +237,10 @@ func WithSASL(opts ...kgo.Opt) Opt {
 	return opt{func(c *Config) { c.SASLOptions = opts }}
 }
 
-// WithHooks appends franz-go hooks to the internal kgo.Client. Hooks observe
-// the wire layer (broker connect/read/write, throttling, request E2E), so a
-// caller can attach its own metrics or tracing. The client also installs its
-// own kprom hook internally; these are added on top.
+// WithHooks appends franz-go hooks to the client. All franz-go hooks are
+// supported except:
+// - kgo.HookProduceBatchWritten
+// - kgo.HookProduceRecordPartitioned
 func WithHooks(hooks ...kgo.Hook) Opt {
 	return opt{func(c *Config) { c.Hooks = append(c.Hooks, hooks...) }}
 }

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/hedger.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/hedger.go
@@ -351,12 +351,12 @@ func (h *Hedger) runHedgingAttempt(workCtx context.Context, acc *produceResultAc
 
 	// Wave-local workCtx so we can short-circuit the wait the moment the
 	// batch is fully resolved (or aborted). Cancellation flows through
-	// hedgeBuffer.Add's ctx-watch, making slow agents fire their legDone
+	// hedgeBuffer.MultiAdd's ctx-watch, making slow agents fire their legDone
 	// with ctx.Err() instead of blocking us on their actual flush.
 	attemptCtx, cancel := context.WithCancel(workCtx)
 	defer cancel()
 
-	// hedgeBuffer.Add is async: issue every group's Add then collect
+	// hedgeBuffer.MultiAdd is async: issue every group's MultiAdd then collect
 	// outcomes on a shared channel. One slot per group; sync.Once gates
 	// legDone so each group sends at most once. The buffered capacity
 	// ensures a late legDone (e.g. fired after we returned because the
@@ -367,7 +367,7 @@ func (h *Hedger) runHedgingAttempt(workCtx context.Context, acc *produceResultAc
 		legDone := func(res ProduceResult) {
 			once.Do(func() { results <- res })
 		}
-		h.hedgeBuffer.Add(attemptCtx, newMultiRoutedEncodedTopicPartitionRecords(parts, agent, legDone))
+		h.hedgeBuffer.MultiAdd(attemptCtx, newMultiRoutedEncodedTopicPartitionRecords(parts, agent, legDone))
 	}
 
 	for remaining := len(groups); remaining > 0; remaining-- {

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/produce.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/produce.go
@@ -1,6 +1,7 @@
 package wgo
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"hash/crc32"
@@ -60,6 +61,14 @@ const batchMaxBytesCeiling int32 = 1 << 30 // 1 GiB
 func ensureRecordTimestamp(record *kgo.Record, now time.Time) {
 	if record.Timestamp.IsZero() {
 		record.Timestamp = now.Truncate(time.Millisecond)
+	}
+}
+
+// ensureRecordContext defaults an unset record context to ctx, mirroring
+// franz-go, which seeds Record.Context from the Produce ctx.
+func ensureRecordContext(record *kgo.Record, ctx context.Context) {
+	if record.Context == nil {
+		record.Context = ctx
 	}
 }
 

--- a/vendor/github.com/grafana/warpstream-go/pkg/wgo/produce_hooks.go
+++ b/vendor/github.com/grafana/warpstream-go/pkg/wgo/produce_hooks.go
@@ -1,0 +1,49 @@
+package wgo
+
+import (
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+// produceHooks holds the produce-record lifecycle hooks driven on this client's
+// own produce path. franz-go fires these from its producer state machine, which
+// this client bypasses (it produces via Broker.Request), so they would never
+// fire for a wgo produce unless invoked here.
+//
+// The slices are set once by newProduceHooks and never mutated afterwards, so
+// firing from the caller and background flush goroutines needs no locking.
+type produceHooks struct {
+	buffered   []kgo.HookProduceRecordBuffered
+	unbuffered []kgo.HookProduceRecordUnbuffered
+}
+
+// newProduceHooks selects the produce-record hooks from the caller-supplied
+// hooks. A single hook may implement either or both interfaces.
+func newProduceHooks(hooks []kgo.Hook) produceHooks {
+	var ph produceHooks
+	for _, h := range hooks {
+		if hb, ok := h.(kgo.HookProduceRecordBuffered); ok {
+			ph.buffered = append(ph.buffered, hb)
+		}
+		if hu, ok := h.(kgo.HookProduceRecordUnbuffered); ok {
+			ph.unbuffered = append(ph.unbuffered, hu)
+		}
+	}
+	return ph
+}
+
+// enabled reports whether any produce-record hook was supplied.
+func (p produceHooks) enabled() bool {
+	return len(p.buffered) > 0 || len(p.unbuffered) > 0
+}
+
+func (p produceHooks) fireBuffered(record *kgo.Record) {
+	for _, h := range p.buffered {
+		h.OnProduceRecordBuffered(record)
+	}
+}
+
+func (p produceHooks) fireUnbuffered(record *kgo.Record, err error) {
+	for _, h := range p.unbuffered {
+		h.OnProduceRecordUnbuffered(record, err)
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -740,7 +740,7 @@ github.com/grafana/pyroscope-go/godeltaprof/internal/pprof
 ## explicit; go 1.21
 github.com/grafana/regexp
 github.com/grafana/regexp/syntax
-# github.com/grafana/warpstream-go v0.0.0-20260709185922-cde46bc835e9
+# github.com/grafana/warpstream-go v0.0.0-20260710082904-2057a436bf0c
 ## explicit; go 1.25.10
 github.com/grafana/warpstream-go/pkg/wgo
 # github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -740,7 +740,7 @@ github.com/grafana/pyroscope-go/godeltaprof/internal/pprof
 ## explicit; go 1.21
 github.com/grafana/regexp
 github.com/grafana/regexp/syntax
-# github.com/grafana/warpstream-go v0.0.0-20260710115402-9551070a214c
+# github.com/grafana/warpstream-go v0.0.0-20260710130640-f4258f6a3f82
 ## explicit; go 1.25.10
 github.com/grafana/warpstream-go/pkg/wgo
 # github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -740,7 +740,7 @@ github.com/grafana/pyroscope-go/godeltaprof/internal/pprof
 ## explicit; go 1.21
 github.com/grafana/regexp
 github.com/grafana/regexp/syntax
-# github.com/grafana/warpstream-go v0.0.0-20260710082904-2057a436bf0c
+# github.com/grafana/warpstream-go v0.0.0-20260710115402-9551070a214c
 ## explicit; go 1.25.10
 github.com/grafana/warpstream-go/pkg/wgo
 # github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0


### PR DESCRIPTION
#### What this PR does

This PR adds support to trace produce requests on the experimental **Warpstream** ingest-storage backend, bringing it to parity with the default `kafka` backend.

The Warpstream backend produced records untraced. `warpstream-go` bypasses franz-go's producer state machine (it produces via `Broker.Request`), so the `kotel`-based sampled-only tracer we attach to the `kafka` backend never fired on the Warpstream produce path — only its metrics hook was attached.

[grafana/warpstream-go#36](https://github.com/grafana/warpstream-go/pull/36) (now merged) makes `warpstream-go` drive the produce-record hooks (`OnProduceRecordBuffered`/`OnProduceRecordUnbuffered`) on its own produce path. This PR:

- bumps the vendored `warpstream-go` to the merged commit, and
- attaches the existing `newSampledOnlyTracer()` to the Warpstream client via `wgo.WithHooks` in `newKafkaProducerForBackend`.

The result: the Warpstream backend emits the same producer spans and injects the same `traceparent` header as the `kafka` backend, so a record's trace propagates to the consumer. Consume-side tracing already worked via the embedded `*kgo.Client`.

#### Which issue(s) this PR fixes or relates to

Follows up [grafana/warpstream-go#36](https://github.com/grafana/warpstream-go/pull/36).

#### Checklist

- [ ] Tests updated. _(no behavior change beyond wiring; covered by warpstream-go#36's tests)_
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - added an `[ENHANCEMENT]` entry under Ingest storage.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
