### PR TITLE
mimirtool: operate on the prefixed partition ring key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 ### Tools
 
 * [CHANGE] `create-draft-release-notes.sh` doesn't require release notes ready for release candidate. #16286
+* [BUGFIX] Mimirtool: `partition-ring` subcommands now operate on the partition ring key under the KV store prefix used by Mimir (`collectors/` by default), instead of the bare key, which made commands fail with errors like `partition 1 does not exist in the ring` against a healthy cluster. Use the new `--partition-ring.prefix` flag if Mimir runs with a custom `-ingester.partition-ring.prefix`. #16045
 
 ## 3.2.0-rc.0
 

--- a/docs/sources/mimir/manage/tools/mimirtool.md
+++ b/docs/sources/mimir/manage/tools/mimirtool.md
@@ -1353,6 +1353,7 @@ Forcefully adds one or more partitions to the partition ring.
 | `--memberlist.cluster-label` | The cluster label to use when joining the memberlist cluster.                                               |
 | `--memberlist.bind-port`     | Port to listen on for memberlist gossip messages. Default: `7946`. Use `0` to pick a random available port. |
 | `--partition-ring.key`       | The KV store key under which the partition ring is stored. Default: `ingester-partitions`.                  |
+| `--partition-ring.prefix`    | The KV store key prefix. Must match Mimir's `-ingester.partition-ring.prefix`. Default: `collectors/`.      |
 | `--verbose`                  | Enable verbose logging.                                                                                     |
 
 ##### Example
@@ -1377,6 +1378,7 @@ Forcefully removes one or more partitions from the partition ring. A partition c
 | `--memberlist.cluster-label` | The cluster label to use when joining the memberlist cluster.                                               |
 | `--memberlist.bind-port`     | Port to listen on for memberlist gossip messages. Default: `7946`. Use `0` to pick a random available port. |
 | `--partition-ring.key`       | The KV store key under which the partition ring is stored. Default: `ingester-partitions`.                  |
+| `--partition-ring.prefix`    | The KV store key prefix. Must match Mimir's `-ingester.partition-ring.prefix`. Default: `collectors/`.      |
 | `--verbose`                  | Enable verbose logging.                                                                                     |
 
 ##### Example
@@ -1401,6 +1403,7 @@ Forcefully adds one or more owners (ingester instances) to the partition ring, a
 | `--memberlist.cluster-label` | The cluster label to use when joining the memberlist cluster.                                               |
 | `--memberlist.bind-port`     | Port to listen on for memberlist gossip messages. Default: `7946`. Use `0` to pick a random available port. |
 | `--partition-ring.key`       | The KV store key under which the partition ring is stored. Default: `ingester-partitions`.                  |
+| `--partition-ring.prefix`    | The KV store key prefix. Must match Mimir's `-ingester.partition-ring.prefix`. Default: `collectors/`.      |
 | `--verbose`                  | Enable verbose logging.                                                                                     |
 
 ##### Example
@@ -1425,6 +1428,7 @@ Forcefully removes one or more owners (ingester instances) from the partition ri
 | `--memberlist.cluster-label` | The cluster label to use when joining the memberlist cluster.                                               |
 | `--memberlist.bind-port`     | Port to listen on for memberlist gossip messages. Default: `7946`. Use `0` to pick a random available port. |
 | `--partition-ring.key`       | The KV store key under which the partition ring is stored. Default: `ingester-partitions`.                  |
+| `--partition-ring.prefix`    | The KV store key prefix. Must match Mimir's `-ingester.partition-ring.prefix`. Default: `collectors/`.      |
 | `--verbose`                  | Enable verbose logging.                                                                                     |
 
 ##### Example

--- a/pkg/mimirtool/commands/partition_ring.go
+++ b/pkg/mimirtool/commands/partition_ring.go
@@ -27,6 +27,11 @@ import (
 	"github.com/grafana/mimir/pkg/ingester"
 )
 
+// defaultPartitionRingKeyPrefix is the default prefix under which Mimir stores the partition
+// ring key in the KV store. It matches the default value of the -ingester.partition-ring.prefix
+// Mimir configuration option.
+const defaultPartitionRingKeyPrefix = "collectors/"
+
 // PartitionRingCommand is the kingpin command for partition ring operations.
 type PartitionRingCommand struct{}
 
@@ -36,6 +41,7 @@ type AddPartitionCommand struct {
 	memberlistClusterLabel string
 	memberlistBindPort     int
 	ringKey                string
+	ringPrefix             string
 	partitionIDs           string
 	partitionState         string
 	verbose                bool
@@ -49,6 +55,7 @@ type RemovePartitionCommand struct {
 	memberlistClusterLabel string
 	memberlistBindPort     int
 	ringKey                string
+	ringPrefix             string
 	partitionIDs           string
 	verbose                bool
 	logger                 log.Logger
@@ -61,6 +68,7 @@ type AddOwnerCommand struct {
 	memberlistClusterLabel string
 	memberlistBindPort     int
 	ringKey                string
+	ringPrefix             string
 	ownerIDs               string
 	partitionID            string
 	verbose                bool
@@ -74,6 +82,7 @@ type RemoveOwnerCommand struct {
 	memberlistClusterLabel string
 	memberlistBindPort     int
 	ringKey                string
+	ringPrefix             string
 	ownerIDs               string
 	verbose                bool
 	logger                 log.Logger
@@ -86,6 +95,7 @@ type RemoveAllOwnersAndPartitionsCommand struct {
 	memberlistClusterLabel string
 	memberlistBindPort     int
 	ringKey                string
+	ringPrefix             string
 	verbose                bool
 	logger                 log.Logger
 	stdin                  io.Reader // For testing; defaults to os.Stdin if nil.
@@ -193,13 +203,14 @@ func (c *PartitionRingCommand) Register(app *kingpin.Application, _ EnvVarNames,
 		memberlistClusterLabel *string
 		memberlistBindPort     *int
 		ringKey                *string
+		ringPrefix             *string
 		verbose                *bool
 	}{
-		{addPartitionCmd, &addCmd.memberlistJoin, &addCmd.memberlistClusterLabel, &addCmd.memberlistBindPort, &addCmd.ringKey, &addCmd.verbose},
-		{removePartitionCmd, &removeCmd.memberlistJoin, &removeCmd.memberlistClusterLabel, &removeCmd.memberlistBindPort, &removeCmd.ringKey, &removeCmd.verbose},
-		{addOwnerCmdClause, &addOwnerCmd.memberlistJoin, &addOwnerCmd.memberlistClusterLabel, &addOwnerCmd.memberlistBindPort, &addOwnerCmd.ringKey, &addOwnerCmd.verbose},
-		{removeOwnerCmdClause, &removeOwnerCmd.memberlistJoin, &removeOwnerCmd.memberlistClusterLabel, &removeOwnerCmd.memberlistBindPort, &removeOwnerCmd.ringKey, &removeOwnerCmd.verbose},
-		{removeAllCmdClause, &removeAllCmd.memberlistJoin, &removeAllCmd.memberlistClusterLabel, &removeAllCmd.memberlistBindPort, &removeAllCmd.ringKey, &removeAllCmd.verbose},
+		{addPartitionCmd, &addCmd.memberlistJoin, &addCmd.memberlistClusterLabel, &addCmd.memberlistBindPort, &addCmd.ringKey, &addCmd.ringPrefix, &addCmd.verbose},
+		{removePartitionCmd, &removeCmd.memberlistJoin, &removeCmd.memberlistClusterLabel, &removeCmd.memberlistBindPort, &removeCmd.ringKey, &removeCmd.ringPrefix, &removeCmd.verbose},
+		{addOwnerCmdClause, &addOwnerCmd.memberlistJoin, &addOwnerCmd.memberlistClusterLabel, &addOwnerCmd.memberlistBindPort, &addOwnerCmd.ringKey, &addOwnerCmd.ringPrefix, &addOwnerCmd.verbose},
+		{removeOwnerCmdClause, &removeOwnerCmd.memberlistJoin, &removeOwnerCmd.memberlistClusterLabel, &removeOwnerCmd.memberlistBindPort, &removeOwnerCmd.ringKey, &removeOwnerCmd.ringPrefix, &removeOwnerCmd.verbose},
+		{removeAllCmdClause, &removeAllCmd.memberlistJoin, &removeAllCmd.memberlistClusterLabel, &removeAllCmd.memberlistBindPort, &removeAllCmd.ringKey, &removeAllCmd.ringPrefix, &removeAllCmd.verbose},
 	} {
 		cfg.cmd.Flag("memberlist.join", "Address of a memberlist node to join. Can be specified multiple times.").
 			Required().
@@ -218,6 +229,10 @@ func (c *PartitionRingCommand) Register(app *kingpin.Application, _ EnvVarNames,
 		cfg.cmd.Flag("partition-ring.key", "The KV store key under which the partition ring is stored.").
 			Default(ingester.PartitionRingKey).
 			StringVar(cfg.ringKey)
+
+		cfg.cmd.Flag("partition-ring.prefix", "The prefix for the keys in the KV store. Must match the -ingester.partition-ring.prefix Mimir configuration option. Should end with a /.").
+			Default(defaultPartitionRingKeyPrefix).
+			StringVar(cfg.ringPrefix)
 
 		cfg.cmd.Flag("verbose", "Enable verbose logging.").
 			Default("false").
@@ -252,7 +267,7 @@ About to add partition(s) %v with state '%s' to the ring.`, partitionIDs, state.
 
 	// Initialize memberlist KV.
 	fmt.Fprintln(os.Stderr, "Joining memberlist cluster...")
-	kvClient, cleanup, err := initMemberlistKV(ctx, c.memberlistJoin, c.memberlistClusterLabel, c.memberlistBindPort, c.logger)
+	kvClient, cleanup, err := initMemberlistKV(ctx, c.memberlistJoin, c.memberlistClusterLabel, c.memberlistBindPort, c.ringPrefix, c.logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize memberlist KV")
 	}
@@ -289,7 +304,7 @@ About to remove partition(s) %v from the ring.`, partitionIDs)
 
 	// Initialize memberlist KV.
 	fmt.Fprintln(os.Stderr, "Joining memberlist cluster...")
-	kvClient, cleanup, err := initMemberlistKV(ctx, c.memberlistJoin, c.memberlistClusterLabel, c.memberlistBindPort, c.logger)
+	kvClient, cleanup, err := initMemberlistKV(ctx, c.memberlistJoin, c.memberlistClusterLabel, c.memberlistBindPort, c.ringPrefix, c.logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize memberlist KV")
 	}
@@ -391,7 +406,7 @@ About to add owner(s) %v to partition %d.`, ownerIDs, partitionID)
 
 	// Initialize memberlist KV.
 	fmt.Fprintln(os.Stderr, "Joining memberlist cluster...")
-	kvClient, cleanup, err := initMemberlistKV(ctx, c.memberlistJoin, c.memberlistClusterLabel, c.memberlistBindPort, c.logger)
+	kvClient, cleanup, err := initMemberlistKV(ctx, c.memberlistJoin, c.memberlistClusterLabel, c.memberlistBindPort, c.ringPrefix, c.logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize memberlist KV")
 	}
@@ -435,7 +450,7 @@ About to remove owner(s) %v from the ring.`, ownerIDs)
 
 	// Initialize memberlist KV.
 	fmt.Fprintln(os.Stderr, "Joining memberlist cluster...")
-	kvClient, cleanup, err := initMemberlistKV(ctx, c.memberlistJoin, c.memberlistClusterLabel, c.memberlistBindPort, c.logger)
+	kvClient, cleanup, err := initMemberlistKV(ctx, c.memberlistJoin, c.memberlistClusterLabel, c.memberlistBindPort, c.ringPrefix, c.logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize memberlist KV")
 	}
@@ -471,7 +486,7 @@ About to remove ALL partitions and owners from ring %q.`, c.ringKey)
 	defer cancel()
 
 	fmt.Fprintln(os.Stderr, "Joining memberlist cluster...")
-	kvClient, cleanup, err := initMemberlistKV(ctx, c.memberlistJoin, c.memberlistClusterLabel, c.memberlistBindPort, c.logger)
+	kvClient, cleanup, err := initMemberlistKV(ctx, c.memberlistJoin, c.memberlistClusterLabel, c.memberlistBindPort, c.ringPrefix, c.logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize memberlist KV")
 	}
@@ -511,7 +526,7 @@ func askForConfirmation(message string, stdin io.Reader) error {
 	return nil
 }
 
-func initMemberlistKV(ctx context.Context, joinAddrs []string, clusterLabel string, bindPort int, logger log.Logger) (_ kv.Client, _ func(), returnErr error) {
+func initMemberlistKV(ctx context.Context, joinAddrs []string, clusterLabel string, bindPort int, keyPrefix string, logger log.Logger) (_ kv.Client, _ func(), returnErr error) {
 	// Create memberlist config with defaults.
 	cfg := memberlist.KVConfig{}
 	flagext.DefaultValues(&cfg)
@@ -566,7 +581,16 @@ func initMemberlistKV(ctx context.Context, joinAddrs []string, clusterLabel stri
 		return nil, nil, errors.Wrap(err, "failed to create memberlist client")
 	}
 
-	return kvClient, cleanup, nil
+	// Mimir accesses the ring through a KV client that prepends a configured prefix to all keys
+	// (see the -ingester.partition-ring.prefix configuration option, "collectors/" by default).
+	// Wrap the client the same way so that the commands operate on the same keys as Mimir.
+	// An empty prefix leaves the keys unchanged.
+	client := kv.Client(kvClient)
+	if keyPrefix != "" {
+		client = kv.PrefixClient(client, keyPrefix)
+	}
+
+	return client, cleanup, nil
 }
 
 func addPartitions(ctx context.Context, kvClient kv.Client, ringKey string, partitionIDs []int32, state ring.PartitionState) error {

--- a/pkg/mimirtool/commands/partition_ring_test.go
+++ b/pkg/mimirtool/commands/partition_ring_test.go
@@ -22,6 +22,11 @@ import (
 	"github.com/grafana/mimir/pkg/ingester"
 )
 
+// prefixedRingKey is the actual KV store key of the partition ring: Mimir stores the ring
+// under the configured key prefix (see the -ingester.partition-ring.prefix configuration
+// option, "collectors/" by default).
+const prefixedRingKey = defaultPartitionRingKeyPrefix + ingester.PartitionRingKey
+
 func TestAddPartitionCommand(t *testing.T) {
 	t.Parallel()
 
@@ -40,6 +45,7 @@ func TestAddPartitionCommand(t *testing.T) {
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0, // random port
 			ringKey:            ingester.PartitionRingKey,
+			ringPrefix:         defaultPartitionRingKeyPrefix,
 			partitionIDs:       "0",
 			partitionState:     "active",
 			stdin:              strings.NewReader("yes\n"),
@@ -53,7 +59,7 @@ func TestAddPartitionCommand(t *testing.T) {
 		// Verify the partition was added by reading from the seed KV.
 		// Use polling because memberlist is eventually consistent.
 		require.Eventually(t, func() bool {
-			val, err := seedClient.Get(ctx, ingester.PartitionRingKey)
+			val, err := seedClient.Get(ctx, prefixedRingKey)
 			if err != nil || val == nil {
 				return false
 			}
@@ -77,7 +83,7 @@ func TestAddPartitionCommand(t *testing.T) {
 		seedKV, seedClient := startMemberlistKV(t)
 
 		// Pre-create partition 0.
-		err := seedClient.CAS(ctx, ingester.PartitionRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		err := seedClient.CAS(ctx, prefixedRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
 			ringDesc := ring.GetOrCreatePartitionRingDesc(in)
 			ringDesc.AddPartition(0, ring.PartitionActive, time.Now())
 			return ringDesc, true, nil
@@ -92,6 +98,7 @@ func TestAddPartitionCommand(t *testing.T) {
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
 			ringKey:            ingester.PartitionRingKey,
+			ringPrefix:         defaultPartitionRingKeyPrefix,
 			partitionIDs:       "0",
 			partitionState:     "active",
 			stdin:              strings.NewReader("yes\n"),
@@ -111,7 +118,7 @@ func TestAddPartitionCommand(t *testing.T) {
 		seedKV, seedClient := startMemberlistKV(t)
 
 		// Pre-create partition 0 to simulate an existing ring.
-		err := seedClient.CAS(ctx, ingester.PartitionRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		err := seedClient.CAS(ctx, prefixedRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
 			ringDesc := ring.GetOrCreatePartitionRingDesc(in)
 			ringDesc.AddPartition(0, ring.PartitionActive, time.Now())
 			return ringDesc, true, nil
@@ -126,6 +133,7 @@ func TestAddPartitionCommand(t *testing.T) {
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
 			ringKey:            ingester.PartitionRingKey,
+			ringPrefix:         defaultPartitionRingKeyPrefix,
 			partitionIDs:       "2",
 			partitionState:     "active",
 			stdin:              strings.NewReader("yes\n"),
@@ -137,7 +145,7 @@ func TestAddPartitionCommand(t *testing.T) {
 
 		// Verify partition 2 was added.
 		require.Eventually(t, func() bool {
-			val, err := seedClient.Get(ctx, ingester.PartitionRingKey)
+			val, err := seedClient.Get(ctx, prefixedRingKey)
 			if err != nil || val == nil {
 				return false
 			}
@@ -164,6 +172,7 @@ func TestAddPartitionCommand(t *testing.T) {
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
 			ringKey:            ingester.PartitionRingKey,
+			ringPrefix:         defaultPartitionRingKeyPrefix,
 			partitionIDs:       "0, 1, 2",
 			partitionState:     "active",
 			stdin:              strings.NewReader("yes\n"),
@@ -176,7 +185,7 @@ func TestAddPartitionCommand(t *testing.T) {
 
 		// Verify all partitions were added.
 		require.Eventually(t, func() bool {
-			val, err := seedClient.Get(ctx, ingester.PartitionRingKey)
+			val, err := seedClient.Get(ctx, prefixedRingKey)
 			if err != nil || val == nil {
 				return false
 			}
@@ -196,7 +205,7 @@ func TestAddPartitionCommand(t *testing.T) {
 		seedKV, seedClient := startMemberlistKV(t)
 
 		// Pre-create partition 1.
-		err := seedClient.CAS(ctx, ingester.PartitionRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		err := seedClient.CAS(ctx, prefixedRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
 			ringDesc := ring.GetOrCreatePartitionRingDesc(in)
 			ringDesc.AddPartition(1, ring.PartitionActive, time.Now())
 			return ringDesc, true, nil
@@ -211,6 +220,7 @@ func TestAddPartitionCommand(t *testing.T) {
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
 			ringKey:            ingester.PartitionRingKey,
+			ringPrefix:         defaultPartitionRingKeyPrefix,
 			partitionIDs:       "0,1,2",
 			partitionState:     "active",
 			stdin:              strings.NewReader("yes\n"),
@@ -222,7 +232,7 @@ func TestAddPartitionCommand(t *testing.T) {
 		require.Contains(t, err.Error(), "partition 1 already exists")
 
 		// Verify that partition 0 was NOT added (atomic failure).
-		val, err := seedClient.Get(ctx, ingester.PartitionRingKey)
+		val, err := seedClient.Get(ctx, prefixedRingKey)
 		require.NoError(t, err)
 		ringDesc := val.(*ring.PartitionRingDesc)
 		require.False(t, ringDesc.HasPartition(0), "partition 0 should not be added when operation fails")
@@ -245,6 +255,7 @@ func TestAddPartitionCommand(t *testing.T) {
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
 			ringKey:            customRingKey,
+			ringPrefix:         "", // An empty prefix uses the ring key verbatim.
 			partitionIDs:       "0",
 			partitionState:     "active",
 			stdin:              strings.NewReader("yes\n"),
@@ -263,7 +274,7 @@ func TestAddPartitionCommand(t *testing.T) {
 		}, 5*time.Second, 100*time.Millisecond, "partition 0 should be added under the custom ring key")
 
 		// The default ring key is left untouched.
-		val, err := seedClient.Get(ctx, ingester.PartitionRingKey)
+		val, err := seedClient.Get(ctx, prefixedRingKey)
 		require.NoError(t, err)
 		if val != nil {
 			require.False(t, val.(*ring.PartitionRingDesc).HasPartition(0), "partition must not be added under the default ring key")
@@ -282,7 +293,7 @@ func TestRemovePartitionCommand(t *testing.T) {
 		seedKV, seedClient := startMemberlistKV(t)
 
 		// Pre-create partition 0 with no owners.
-		err := seedClient.CAS(ctx, ingester.PartitionRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		err := seedClient.CAS(ctx, prefixedRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
 			ringDesc := ring.GetOrCreatePartitionRingDesc(in)
 			ringDesc.AddPartition(0, ring.PartitionInactive, time.Now())
 			return ringDesc, true, nil
@@ -297,6 +308,7 @@ func TestRemovePartitionCommand(t *testing.T) {
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0, // random port
 			ringKey:            ingester.PartitionRingKey,
+			ringPrefix:         defaultPartitionRingKeyPrefix,
 			partitionIDs:       "0",
 			stdin:              strings.NewReader("yes\n"),
 			logger:             log.NewNopLogger(),
@@ -309,7 +321,7 @@ func TestRemovePartitionCommand(t *testing.T) {
 		// Verify the partition was removed by reading from the seed KV.
 		// Use polling because memberlist is eventually consistent.
 		require.Eventually(t, func() bool {
-			val, err := seedClient.Get(ctx, ingester.PartitionRingKey)
+			val, err := seedClient.Get(ctx, prefixedRingKey)
 			if err != nil || val == nil {
 				return false
 			}
@@ -334,6 +346,7 @@ func TestRemovePartitionCommand(t *testing.T) {
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
 			ringKey:            ingester.PartitionRingKey,
+			ringPrefix:         defaultPartitionRingKeyPrefix,
 			partitionIDs:       "0",
 			stdin:              strings.NewReader("yes\n"),
 			logger:             log.NewNopLogger(),
@@ -352,7 +365,7 @@ func TestRemovePartitionCommand(t *testing.T) {
 		seedKV, seedClient := startMemberlistKV(t)
 
 		// Pre-create partition 0 with an owner.
-		err := seedClient.CAS(ctx, ingester.PartitionRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		err := seedClient.CAS(ctx, prefixedRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
 			ringDesc := ring.GetOrCreatePartitionRingDesc(in)
 			now := time.Now()
 			ringDesc.AddPartition(0, ring.PartitionActive, now)
@@ -369,6 +382,7 @@ func TestRemovePartitionCommand(t *testing.T) {
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
 			ringKey:            ingester.PartitionRingKey,
+			ringPrefix:         defaultPartitionRingKeyPrefix,
 			partitionIDs:       "0",
 			stdin:              strings.NewReader("yes\n"),
 			logger:             log.NewNopLogger(),
@@ -387,7 +401,7 @@ func TestRemovePartitionCommand(t *testing.T) {
 		seedKV, seedClient := startMemberlistKV(t)
 
 		// Pre-create partitions 0, 1, 2 with no owners.
-		err := seedClient.CAS(ctx, ingester.PartitionRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		err := seedClient.CAS(ctx, prefixedRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
 			ringDesc := ring.GetOrCreatePartitionRingDesc(in)
 			now := time.Now()
 			ringDesc.AddPartition(0, ring.PartitionInactive, now)
@@ -405,6 +419,7 @@ func TestRemovePartitionCommand(t *testing.T) {
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
 			ringKey:            ingester.PartitionRingKey,
+			ringPrefix:         defaultPartitionRingKeyPrefix,
 			partitionIDs:       "0,2",
 			stdin:              strings.NewReader("yes\n"),
 			logger:             log.NewNopLogger(),
@@ -415,7 +430,7 @@ func TestRemovePartitionCommand(t *testing.T) {
 
 		// Verify partitions 0 and 2 were removed, but 1 remains.
 		require.Eventually(t, func() bool {
-			val, err := seedClient.Get(ctx, ingester.PartitionRingKey)
+			val, err := seedClient.Get(ctx, prefixedRingKey)
 			if err != nil || val == nil {
 				return false
 			}
@@ -435,7 +450,7 @@ func TestRemovePartitionCommand(t *testing.T) {
 		seedKV, seedClient := startMemberlistKV(t)
 
 		// Pre-create partitions 0, 1, 2 where partition 1 has an owner.
-		err := seedClient.CAS(ctx, ingester.PartitionRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		err := seedClient.CAS(ctx, prefixedRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
 			ringDesc := ring.GetOrCreatePartitionRingDesc(in)
 			now := time.Now()
 			ringDesc.AddPartition(0, ring.PartitionInactive, now)
@@ -454,6 +469,7 @@ func TestRemovePartitionCommand(t *testing.T) {
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
 			ringKey:            ingester.PartitionRingKey,
+			ringPrefix:         defaultPartitionRingKeyPrefix,
 			partitionIDs:       "0,1,2",
 			stdin:              strings.NewReader("yes\n"),
 			logger:             log.NewNopLogger(),
@@ -464,7 +480,7 @@ func TestRemovePartitionCommand(t *testing.T) {
 		require.Contains(t, err.Error(), "partition 1 has 1 owner(s), cannot remove")
 
 		// Verify that partition 0 was NOT removed (atomic failure).
-		val, err := seedClient.Get(ctx, ingester.PartitionRingKey)
+		val, err := seedClient.Get(ctx, prefixedRingKey)
 		require.NoError(t, err)
 		ringDesc := val.(*ring.PartitionRingDesc)
 		require.True(t, ringDesc.HasPartition(0), "partition 0 should still exist when operation fails")
@@ -495,6 +511,7 @@ func TestRemovePartitionCommand(t *testing.T) {
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
 			ringKey:            customRingKey,
+			ringPrefix:         "", // An empty prefix uses the ring key verbatim.
 			partitionIDs:       "0",
 			stdin:              strings.NewReader("yes\n"),
 			logger:             log.NewNopLogger(),
@@ -524,7 +541,7 @@ func TestAddOwnerCommand(t *testing.T) {
 		seedKV, seedClient := startMemberlistKV(t)
 
 		// Pre-create the partition the owner will own.
-		err := seedClient.CAS(ctx, ingester.PartitionRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		err := seedClient.CAS(ctx, prefixedRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
 			ringDesc := ring.GetOrCreatePartitionRingDesc(in)
 			ringDesc.AddPartition(0, ring.PartitionActive, time.Now())
 			return ringDesc, true, nil
@@ -539,6 +556,7 @@ func TestAddOwnerCommand(t *testing.T) {
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
 			ringKey:            ingester.PartitionRingKey,
+			ringPrefix:         defaultPartitionRingKeyPrefix,
 			ownerIDs:           "ingester-zone-a-0",
 			partitionID:        "0",
 			stdin:              strings.NewReader("yes\n"),
@@ -550,7 +568,7 @@ func TestAddOwnerCommand(t *testing.T) {
 
 		// Verify the owner was added.
 		require.Eventually(t, func() bool {
-			val, err := seedClient.Get(ctx, ingester.PartitionRingKey)
+			val, err := seedClient.Get(ctx, prefixedRingKey)
 			if err != nil || val == nil {
 				return false
 			}
@@ -574,7 +592,7 @@ func TestAddOwnerCommand(t *testing.T) {
 		seedKV, seedClient := startMemberlistKV(t)
 
 		// Pre-create a partition and owner.
-		err := seedClient.CAS(ctx, ingester.PartitionRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		err := seedClient.CAS(ctx, prefixedRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
 			ringDesc := ring.GetOrCreatePartitionRingDesc(in)
 			now := time.Now()
 			ringDesc.AddPartition(0, ring.PartitionActive, now)
@@ -591,6 +609,7 @@ func TestAddOwnerCommand(t *testing.T) {
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
 			ringKey:            ingester.PartitionRingKey,
+			ringPrefix:         defaultPartitionRingKeyPrefix,
 			ownerIDs:           "ingester-zone-a-0",
 			partitionID:        "0",
 			stdin:              strings.NewReader("yes\n"),
@@ -610,7 +629,7 @@ func TestAddOwnerCommand(t *testing.T) {
 		seedKV, seedClient := startMemberlistKV(t)
 
 		// Pre-create the partition.
-		err := seedClient.CAS(ctx, ingester.PartitionRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		err := seedClient.CAS(ctx, prefixedRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
 			ringDesc := ring.GetOrCreatePartitionRingDesc(in)
 			ringDesc.AddPartition(0, ring.PartitionActive, time.Now())
 			return ringDesc, true, nil
@@ -625,6 +644,7 @@ func TestAddOwnerCommand(t *testing.T) {
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
 			ringKey:            ingester.PartitionRingKey,
+			ringPrefix:         defaultPartitionRingKeyPrefix,
 			ownerIDs:           "ingester-zone-a-0,ingester-zone-b-0",
 			partitionID:        "0",
 			stdin:              strings.NewReader("yes\n"),
@@ -636,7 +656,7 @@ func TestAddOwnerCommand(t *testing.T) {
 
 		// Verify both owners were added.
 		require.Eventually(t, func() bool {
-			val, err := seedClient.Get(ctx, ingester.PartitionRingKey)
+			val, err := seedClient.Get(ctx, prefixedRingKey)
 			if err != nil || val == nil {
 				return false
 			}
@@ -656,7 +676,7 @@ func TestAddOwnerCommand(t *testing.T) {
 		seedKV, seedClient := startMemberlistKV(t)
 
 		// Pre-create a partition and one existing owner.
-		err := seedClient.CAS(ctx, ingester.PartitionRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		err := seedClient.CAS(ctx, prefixedRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
 			ringDesc := ring.GetOrCreatePartitionRingDesc(in)
 			now := time.Now()
 			ringDesc.AddPartition(0, ring.PartitionActive, now)
@@ -673,6 +693,7 @@ func TestAddOwnerCommand(t *testing.T) {
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
 			ringKey:            ingester.PartitionRingKey,
+			ringPrefix:         defaultPartitionRingKeyPrefix,
 			ownerIDs:           "ingester-zone-a-0,ingester-zone-b-0",
 			partitionID:        "0",
 			stdin:              strings.NewReader("yes\n"),
@@ -684,7 +705,7 @@ func TestAddOwnerCommand(t *testing.T) {
 		require.Contains(t, err.Error(), `owner "ingester-zone-b-0" already exists`)
 
 		// Verify zone-a was NOT added (atomic failure).
-		val, err := seedClient.Get(ctx, ingester.PartitionRingKey)
+		val, err := seedClient.Get(ctx, prefixedRingKey)
 		require.NoError(t, err)
 		ringDesc := val.(*ring.PartitionRingDesc)
 		require.False(t, ringDesc.HasOwner("ingester-zone-a-0"), "zone-a owner should not be added when operation fails")
@@ -714,6 +735,7 @@ func TestAddOwnerCommand(t *testing.T) {
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
 			ringKey:            customRingKey,
+			ringPrefix:         "", // An empty prefix uses the ring key verbatim.
 			ownerIDs:           "ingester-zone-a-0",
 			partitionID:        "0",
 			stdin:              strings.NewReader("yes\n"),
@@ -744,7 +766,7 @@ func TestRemoveOwnerCommand(t *testing.T) {
 		seedKV, seedClient := startMemberlistKV(t)
 
 		// Pre-create a partition with an owner.
-		err := seedClient.CAS(ctx, ingester.PartitionRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		err := seedClient.CAS(ctx, prefixedRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
 			ringDesc := ring.GetOrCreatePartitionRingDesc(in)
 			now := time.Now()
 			ringDesc.AddPartition(0, ring.PartitionActive, now)
@@ -761,6 +783,7 @@ func TestRemoveOwnerCommand(t *testing.T) {
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
 			ringKey:            ingester.PartitionRingKey,
+			ringPrefix:         defaultPartitionRingKeyPrefix,
 			ownerIDs:           "ingester-zone-c-0",
 			stdin:              strings.NewReader("yes\n"),
 			logger:             log.NewNopLogger(),
@@ -771,7 +794,7 @@ func TestRemoveOwnerCommand(t *testing.T) {
 
 		// Verify the owner was removed but the partition still exists.
 		require.Eventually(t, func() bool {
-			val, err := seedClient.Get(ctx, ingester.PartitionRingKey)
+			val, err := seedClient.Get(ctx, prefixedRingKey)
 			if err != nil || val == nil {
 				return false
 			}
@@ -797,6 +820,7 @@ func TestRemoveOwnerCommand(t *testing.T) {
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
 			ringKey:            ingester.PartitionRingKey,
+			ringPrefix:         defaultPartitionRingKeyPrefix,
 			ownerIDs:           "ingester-zone-c-0",
 			stdin:              strings.NewReader("yes\n"),
 			logger:             log.NewNopLogger(),
@@ -815,7 +839,7 @@ func TestRemoveOwnerCommand(t *testing.T) {
 		seedKV, seedClient := startMemberlistKV(t)
 
 		// Pre-create a partition with multiple owners.
-		err := seedClient.CAS(ctx, ingester.PartitionRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		err := seedClient.CAS(ctx, prefixedRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
 			ringDesc := ring.GetOrCreatePartitionRingDesc(in)
 			now := time.Now()
 			ringDesc.AddPartition(0, ring.PartitionActive, now)
@@ -834,6 +858,7 @@ func TestRemoveOwnerCommand(t *testing.T) {
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
 			ringKey:            ingester.PartitionRingKey,
+			ringPrefix:         defaultPartitionRingKeyPrefix,
 			ownerIDs:           "ingester-zone-b-0,ingester-zone-c-0",
 			stdin:              strings.NewReader("yes\n"),
 			logger:             log.NewNopLogger(),
@@ -844,7 +869,7 @@ func TestRemoveOwnerCommand(t *testing.T) {
 
 		// Verify zone-b and zone-c owners are removed, zone-a remains.
 		require.Eventually(t, func() bool {
-			val, err := seedClient.Get(ctx, ingester.PartitionRingKey)
+			val, err := seedClient.Get(ctx, prefixedRingKey)
 			if err != nil || val == nil {
 				return false
 			}
@@ -866,7 +891,7 @@ func TestRemoveOwnerCommand(t *testing.T) {
 		seedKV, seedClient := startMemberlistKV(t)
 
 		// Pre-create one owner.
-		err := seedClient.CAS(ctx, ingester.PartitionRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
+		err := seedClient.CAS(ctx, prefixedRingKey, func(in interface{}) (out interface{}, retry bool, err error) {
 			ringDesc := ring.GetOrCreatePartitionRingDesc(in)
 			now := time.Now()
 			ringDesc.AddPartition(0, ring.PartitionActive, now)
@@ -883,6 +908,7 @@ func TestRemoveOwnerCommand(t *testing.T) {
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
 			ringKey:            ingester.PartitionRingKey,
+			ringPrefix:         defaultPartitionRingKeyPrefix,
 			ownerIDs:           "ingester-zone-a-0,ingester-zone-b-0",
 			stdin:              strings.NewReader("yes\n"),
 			logger:             log.NewNopLogger(),
@@ -893,7 +919,7 @@ func TestRemoveOwnerCommand(t *testing.T) {
 		require.Contains(t, err.Error(), `owner "ingester-zone-b-0" does not exist`)
 
 		// Verify zone-a was NOT removed (atomic failure).
-		val, err := seedClient.Get(ctx, ingester.PartitionRingKey)
+		val, err := seedClient.Get(ctx, prefixedRingKey)
 		require.NoError(t, err)
 		ringDesc := val.(*ring.PartitionRingDesc)
 		require.True(t, ringDesc.HasOwner("ingester-zone-a-0"), "zone-a owner should still exist when operation fails")
@@ -924,6 +950,7 @@ func TestRemoveOwnerCommand(t *testing.T) {
 			memberlistJoin:     []string{seedAddr},
 			memberlistBindPort: 0,
 			ringKey:            customRingKey,
+			ringPrefix:         "", // An empty prefix uses the ring key verbatim.
 			ownerIDs:           "ingester-zone-c-0",
 			stdin:              strings.NewReader("yes\n"),
 			logger:             log.NewNopLogger(),


### PR DESCRIPTION
#### What this PR does

Fixes the `mimirtool partition-ring` subcommands (`add-partition`, `remove-partition`, `add-owner`, `remove-owner`) failing with errors like `partition 1 does not exist in the ring` against a healthy cluster.

Mimir stores the ingester partition ring under a configurable KV store key prefix (`collectors/` by default, `-ingester.partition-ring.prefix`): `kv.NewClient` wraps every ring KV client with a `PrefixClient`. The `partition-ring` subcommands built their memberlist KV client directly — without the prefix — so they read and CAS-updated the bare `ingester-partitions` key, which Mimir never uses:

```
$ mimirtool partition-ring remove-partition --partition.id=1 ...
mimirtool: error: failed to CAS-update key ingester-partitions: fn returned error: partition 1 does not exist in the ring, try --help
```

This PR wraps the commands' KV client with the same prefix, configurable through a new `--partition-ring.prefix` flag (`collectors/` by default, mirroring `-ingester.partition-ring.prefix`), so the commands operate on the same key as Mimir.

Notes:

- An empty prefix (`--partition-ring.prefix=""`) preserves the previous behavior of using the ring key verbatim. Anyone who previously worked around the bug by passing `--partition-ring.key=collectors/ingester-partitions` should drop the manual prefix (or set an empty prefix).
- Existing tests are updated to seed and verify the ring under the prefixed key — the shape a real Mimir cluster uses — so they fail on the previous code. The custom-ring-key subtests keep an explicit empty prefix to cover the verbatim-key path.
- `about-versioning.md` not updated: the `partition-ring` commands aren't tracked there and this adds no experimental Mimir feature.

#### Which issue(s) this PR fixes or relates to

Fixes #15696

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.