### PR TITLE
Ruler: preserve leading whitespace in rule expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@
 * [BUGFIX] Compactor: Fix `GatherBlockHealthStats` postings walk error check to prevent swallowing errors. #15895
 * [BUGFIX] MQE: Don't evaluate unnecessary range vector splitting ranges when a split range vector is part of a spun-off subquery and running time-splitting and caching inside MQE is enabled. #15931
 * [BUGFIX] MQE: Fix `info()` function incorrectly handling negated name matchers. #15168
+* [BUGFIX] Ruler: Preserve leading whitespace in rule expressions returned by the configuration API. #16047
 
 ### Mixin
 

--- a/pkg/ruler/api.go
+++ b/pkg/ruler/api.go
@@ -6,6 +6,7 @@
 package ruler
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -388,7 +389,7 @@ var (
 )
 
 func marshalAndSend(output interface{}, w http.ResponseWriter, logger log.Logger, headers ...http.Header) {
-	d, err := yaml.Marshal(&output)
+	d, err := marshalRuleGroupsYAML(output)
 	if err != nil {
 		level.Error(logger).Log("msg", "error marshalling yaml rule groups", "err", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -407,6 +408,34 @@ func marshalAndSend(output interface{}, w http.ResponseWriter, logger log.Logger
 	if _, err := w.Write(d); err != nil {
 		level.Error(logger).Log("msg", "error writing yaml response", "err", err)
 		return
+	}
+}
+
+func marshalRuleGroupsYAML(output interface{}) ([]byte, error) {
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(&output); err != nil {
+		return nil, err
+	}
+	if err := encoder.Close(); err != nil {
+		return nil, err
+	}
+
+	var node yaml.Node
+	if err := yaml.Unmarshal(buf.Bytes(), &node); err != nil {
+		return nil, err
+	}
+	quoteMultilineStringsWithLeadingWhitespace(&node)
+	return yaml.Marshal(&node)
+}
+
+func quoteMultilineStringsWithLeadingWhitespace(node *yaml.Node) {
+	if node.Kind == yaml.ScalarNode && node.Tag == "!!str" && strings.HasPrefix(node.Value, " ") && strings.Contains(node.Value, "\n") {
+		node.Style = yaml.DoubleQuotedStyle
+	}
+	for _, child := range node.Content {
+		quoteMultilineStringsWithLeadingWhitespace(child)
 	}
 }
 

--- a/pkg/ruler/api_test.go
+++ b/pkg/ruler/api_test.go
@@ -1504,6 +1504,20 @@ rules:
 			status: 202,
 		},
 		{
+			name: "with leading whitespace in a rule expression",
+			cfg:  defaultCfg,
+			input: `
+name: test
+interval: 15s
+rules:
+    - alert: TestRule
+      expr: |2
+            vector(0)
+      for: 1m
+`,
+			status: 202,
+		},
+		{
 			name: "with valid rules and both evaluation delay and query offset set to the same value",
 			cfg:  defaultCfg,
 			input: `


### PR DESCRIPTION
#### What this PR does

Preserves leading whitespace in Ruler rule expressions returned by the configuration API.

The YAML emitter’s default four-space indentation can produce a block scalar indentation indicator that changes strings beginning with spaces when clients decode the response. The response path now creates a semantically correct node tree with two-space indentation, quotes only multiline string nodes that begin with whitespace, then emits the normal four-space layout. Unaffected rule group YAML keeps its existing formatting.

Good catch by @timonegk; the reproduction isolated the YAML round-trip mutation.

Validation: `go test -mod=vendor ./pkg/ruler/...`

#### Which issue(s) this PR fixes or relates to

Fixes #15005

#### Checklist

- [x] Tests updated.
- [ ] Documentation added. Not required; no public API or configuration change.
- [x] `CHANGELOG.md` updated.
- [ ] `about-versioning.md` updated. Not applicable; no experimental feature.