### PR TITLE
Store-gateway: tolerate missing shutdown marker directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@
 * [ENHANCEMENT] Query-frontend: Add `query-frontend.cardinality-sharding-max-sharded-queries` to optionally limit sharding for `cardinality/active_series` and `cardinality/active_native_histogram_metrics` endpoints separately from `query-frontend.query-sharding-max-sharded-queries`. #15922
 * [ENHANCEMENT] Ingest storage: Add experimental `-ingest-storage.kafka.write-timeout-overhead` to configure the overhead added on top of the Kafka write timeout (default 2s, unchanged). #16023
 * [BUGFIX] Query-frontend: Fix `cardinality_analysis_max_results` being ignored when set higher than the default of 500. #15581
+* [BUGFIX] Store-gateway: Allow cancelling prepare-shutdown when the sync directory does not exist. #16049
 * [BUGFIX] Ingest storage: Fix `KafkaProducer.ProduceSync()` returning a single result with a nil record when the context is canceled, instead of one result per input record (with the record set) as the underlying franz-go client does. #15199
 * [BUGFIX] Ingest storage: Fix `cortex_ingest_storage_reader_receive_delay_seconds` inflation by no longer setting the Kafka record `Timestamp` on the distributor side; the Kafka client now sets it at produce time. #15572
 * [BUGFIX] Distributor: Return HTTP 200 with OTLP partial-success when only some samples in an OTLP request are rejected by distributor-level validation (e.g. `too_far_in_past`). #15253

--- a/pkg/storegateway/gateway_prepare_shutdown_http_test.go
+++ b/pkg/storegateway/gateway_prepare_shutdown_http_test.go
@@ -5,7 +5,9 @@ package storegateway
 import (
 	"bytes"
 	"context"
+	"net/http"
 	"net/http/httptest"
+	"os"
 	"path"
 	"testing"
 
@@ -139,6 +141,20 @@ func TestStoreGateway_PrepareShutdownHandler(t *testing.T) {
 	response6 := httptest.NewRecorder()
 	g.PrepareShutdownHandler(response6, httptest.NewRequest("POST", "/store-gateway/prepare-shutdown", nil))
 	require.Equal(t, 503, response6.Code)
+}
+
+func TestStoreGateway_PrepareShutdownHandler_DeleteWithoutSyncDir(t *testing.T) {
+	test.VerifyNoLeak(t)
+	g, _ := createStoreGateway(t, prometheus.NewPedanticRegistry())
+
+	require.NoError(t, services.StartAndAwaitRunning(t.Context(), g))
+	require.NoError(t, os.RemoveAll(g.storageCfg.BucketStore.SyncDir))
+
+	response := httptest.NewRecorder()
+	g.PrepareShutdownHandler(response, httptest.NewRequest(http.MethodDelete, "/store-gateway/prepare-shutdown", nil))
+
+	require.Equal(t, http.StatusNoContent, response.Code)
+	require.True(t, g.ringLifecycler.ShouldKeepInstanceInTheRingOnShutdown())
 }
 
 func TestStoreGateway_InitialisePrepareShutdownAtStartup(t *testing.T) {

--- a/pkg/util/shutdownmarker/shutdown_marker.go
+++ b/pkg/util/shutdownmarker/shutdown_marker.go
@@ -25,7 +25,10 @@ func Create(p string) error {
 // Remove removes the shutdown marker file on the given path if it exists.
 func Remove(p string) error {
 	err := os.Remove(p)
-	if err != nil && !os.IsNotExist(err) {
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
 		return err
 	}
 

--- a/pkg/util/shutdownmarker/shutdown_marker_test.go
+++ b/pkg/util/shutdownmarker/shutdown_marker_test.go
@@ -47,3 +47,9 @@ func TestShutdownMarker_Remove(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, exists)
 }
+
+func TestShutdownMarker_Remove_WhenParentDirectoryDoesNotExist(t *testing.T) {
+	shutdownMarkerPath := GetPath(filepath.Join(t.TempDir(), "missing"))
+
+	require.NoError(t, Remove(shutdownMarkerPath))
+}


### PR DESCRIPTION
#### What this PR does

Makes shutdown-marker removal idempotent when both the marker and its parent sync directory are absent. `shutdownmarker.Remove` now returns immediately for `os.IsNotExist`, while retaining the parent-directory sync after an actual deletion.

This prevents `DELETE /store-gateway/prepare-shutdown` from returning HTTP 500 when a store-gateway has no sync directory. The regression coverage exercises both the shared helper and the handler response.

Good catch, @gotjosh. The marker itself was already treated as optional, but the subsequent directory sync reintroduced the same missing-path error.

Validation:

- `go test ./pkg/storegateway ./pkg/util/shutdownmarker -count=1`
- `go test ./pkg/ingester -run 'PrepareShutdown' -count=1`
- `go test -race ./pkg/util/shutdownmarker -run TestShutdownMarker_Remove -count=1`
- `go vet ./pkg/storegateway ./pkg/util/shutdownmarker ./pkg/ingester`
- `go run golang.org/x/tools/cmd/goimports@v0.46.0 -local github.com/grafana/mimir -w <changed Go files>`
- `git diff --check`

`make format` could not run because Docker is unavailable locally; the repository-pinned `goimports` command above completed successfully instead.

#### Which issue(s) this PR fixes or relates to

Fixes #11661

#### Checklist

- [x] Tests updated.
- [ ] Documentation added. Not required; no public API or configuration change.
- [x] `CHANGELOG.md` updated.
- [ ] `about-versioning.md` updated. Not applicable; no experimental feature.
