### PR TITLE
mimir-mixin: add read compartment dropdown to dashboards

### DIFF
--- a/operations/mimir-mixin/alerts/alerts-utils.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts-utils.libsonnet
@@ -9,9 +9,13 @@
   jobNotMatcher(job)::
     '%s!~"%s%s"' % [$._config.per_job_label, $._config.alert_job_prefix, formatJobForQuery(job)],
 
+  // Some job matchers have Grafana variables that only makes sense in
+  // dashboards, not alerts.
+  local stripDashboardVars(job) = std.strReplace(job, '$read_compartment', ''),
+
   local formatJobForQuery(job) =
-    if std.isArray(job) then '(%s)' % std.join('|', job)
-    else if std.isString(job) then job
+    if std.isArray(job) then '(%s)' % std.join('|', std.map(stripDashboardVars, job))
+    else if std.isString(job) then stripDashboardVars(job)
     else error 'expected job "%s" to be a string or an array, but it is type "%s"' % [job, std.type(job)],
 
   withRunbookURL(url_format, groups)::

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -25,6 +25,10 @@
     // Added default flag for GEM-specific dashboards and alerts.
     gem_enabled: false,
 
+    // If Mimir deployments has compartments enabled, set to true to enable
+    // specific dropdowns and job selectors.
+    compartments_enabled: false,
+
     rollout_operator_alerts_enable: $._config.gem_enabled == false && $._config.deployment_type == 'kubernetes' && $._config.singleBinary == false,
     rollout_operator_dashboard_enable: true,
     rollout_operator_dashboard_title: 'rollout-operator',
@@ -126,6 +130,15 @@
       federation_frontend: ['federation-frontend.*'],  // Match federation-frontend deployments
     },
 
+    // List of job names that are replicated in different compartments.
+    compartmentalizedJobs: [
+      $._config.job_names.ingester,
+      $._config.job_names.block_builder,
+      $._config.job_names.compactor,
+      $._config.job_names.compactor_scheduler,
+      $._config.job_names.store_gateway,
+    ],
+
     // Name selectors for different application instances, using the "per_instance_label".
     instance_names: {
       // Wrap the regexp into an Helm compatible matcher if the deployment type is "kubernetes".
@@ -216,6 +229,8 @@
       job_query: 'cortex_build_info',  // Only used if singleBinary is true.
       cluster_query: 'cortex_build_info',
       namespace_query: 'cortex_build_info{%s=~"$cluster"}' % $._config.per_cluster_label,
+      read_compartments_query: '{%s=~"%s(.*-rc-.*)"}' % [$._config.per_job_label, $._config.job_prefix],
+      read_compartments_query_regex: '/.*-(?<text>rc-[0-9]+)|.*(?<value>-rc-[0-9]+)/g',  // match "-rc-XX" but shown as "rc-XX" in the UI
     },
 
     // Controls whether dashboards show classic or native latency histograms. Allowed values: 'classic' (default), 'native'.

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -128,16 +128,21 @@
       backend: ['ruler|ruler-zone-.*', 'query-scheduler.*', 'ruler-query-scheduler.*', 'store-gateway.*', 'compactor.*', 'alertmanager', 'overrides-exporter'],
 
       federation_frontend: ['federation-frontend.*'],  // Match federation-frontend deployments
-    },
+    } + (
+      // When compartments are enabled, override the job names of the
+      // compartmentalized components so that dashboards select only
+      // the jobs belonging to the currently selected read compartment.
+      if $._config.compartments_enabled then $._config.compartmentalized_job_names else {}
+    ),
 
-    // List of job names that are replicated in different compartments.
-    compartmentalizedJobs: [
-      $._config.job_names.ingester,
-      $._config.job_names.block_builder,
-      $._config.job_names.compactor,
-      $._config.job_names.compactor_scheduler,
-      $._config.job_names.store_gateway,
-    ],
+    // These are overrides for the job names for matching a specific compartment.
+    compartmentalized_job_names: {
+      ingester: ['ingester.*$read_compartment', 'cortex', 'mimir'],
+      block_builder: ['block-builder.*$read_compartment'],
+      compactor: ['compactor.*$read_compartment', 'cortex', 'mimir'],
+      compactor_scheduler: ['compactor-scheduler.*$read_compartment'],
+      store_gateway: ['store-gateway.*$read_compartment', 'cortex', 'mimir'],
+    },
 
     // Name selectors for different application instances, using the "per_instance_label".
     instance_names: {

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -235,7 +235,7 @@
       job_query: 'cortex_build_info',  // Only used if singleBinary is true.
       cluster_query: 'cortex_build_info',
       namespace_query: 'cortex_build_info{%s=~"$cluster"}' % $._config.per_cluster_label,
-      read_compartments_query: '{%s=~"%s(.*-rc-.*)"}' % [$._config.per_job_label, $._config.job_prefix],
+      read_compartments_query: 'cortex_build_info{%s=~"%s(.*-rc-.*)"}' % [$._config.per_job_label, $._config.job_prefix],
       read_compartments_query_regex: '/.*-(?<text>rc-[0-9]+)|.*(?<value>-rc-[0-9]+)/g',  // match "-rc-XX" but shown as "rc-XX" in the UI
     },
 

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -139,6 +139,7 @@
     compartmentalized_job_names: {
       ingester: ['ingester.*$read_compartment', 'cortex', 'mimir'],
       block_builder: ['block-builder.*$read_compartment'],
+      block_builder_scheduler: ['block-builder-scheduler.*$read_compartment'],
       compactor: ['compactor.*$read_compartment', 'cortex', 'mimir'],
       compactor_scheduler: ['compactor-scheduler.*$read_compartment'],
       store_gateway: ['store-gateway.*$read_compartment', 'cortex', 'mimir'],

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -142,15 +142,23 @@ local utils = import 'mixin-utils/utils.libsonnet';
         if multi then
           if $._config.singleBinary
           then d.addMultiTemplate('job', $._config.dashboard_variables.job_query, $._config.per_job_label, sort=sortAscending, includeAll=false)
-          else d
-               .addMultiTemplate('cluster', $._config.dashboard_variables.cluster_query, '%s' % $._config.per_cluster_label, sort=sortAscending)
-               .addMultiTemplate('namespace', $._config.dashboard_variables.namespace_query, '%s' % $._config.per_namespace_label, sort=sortAscending, includeAll=false)
+          else
+            local base = d
+                         .addMultiTemplate('cluster', $._config.dashboard_variables.cluster_query, '%s' % $._config.per_cluster_label, sort=sortAscending)
+                         .addMultiTemplate('namespace', $._config.dashboard_variables.namespace_query, '%s' % $._config.per_namespace_label, sort=sortAscending, includeAll=false);
+            if $._config.compartments_enabled
+            then base.addMultiTemplate('read_compartment', $._config.dashboard_variables.read_compartments_query, $._config.per_job_label, sort=sortAscending, includeAll=true, regex=$._config.dashboard_variables.read_compartments_query_regex, allValue='')
+            else base
         else
           if $._config.singleBinary
           then d.addTemplate('job', $._config.dashboard_variables.job_query, $._config.per_job_label, sort=sortAscending)
-          else d
-               .addTemplate('cluster', $._config.dashboard_variables.cluster_query, '%s' % $._config.per_cluster_label, allValue='.*', includeAll=true, sort=sortAscending)
-               .addTemplate('namespace', $._config.dashboard_variables.namespace_query, '%s' % $._config.per_namespace_label, sort=sortAscending),
+          else
+            local base = d
+                         .addTemplate('cluster', $._config.dashboard_variables.cluster_query, '%s' % $._config.per_cluster_label, allValue='.*', includeAll=true, sort=sortAscending)
+                         .addTemplate('namespace', $._config.dashboard_variables.namespace_query, '%s' % $._config.per_namespace_label, sort=sortAscending);
+            if $._config.compartments_enabled
+            then base.addTemplate('read_compartment', $._config.dashboard_variables.read_compartments_query, $._config.per_job_label, sort=sortAscending, includeAll=true, regex=$._config.dashboard_variables.read_compartments_query_regex, allValue='')
+            else base,
 
       addActiveUserSelectorTemplates()::
         self.addTemplate('user', 'cortex_ingester_active_series{%s=~"$cluster", %s=~"$namespace"}' % [$._config.per_cluster_label, $._config.per_namespace_label], 'user', sort=sortNaturalAscending),
@@ -209,7 +217,18 @@ local utils = import 'mixin-utils/utils.libsonnet';
   jobMatcher(job)::
     if $._config.singleBinary
     then '%s=~"$job"' % $._config.per_job_label
-    else '%s=~"$cluster", %s=~"%s(%s)"' % [$._config.per_cluster_label, $._config.per_job_label, $._config.job_prefix, formatJobForQuery(job)],
+    else std.join(', ', std.prune([
+      '%s=~"$cluster"' % [$._config.per_cluster_label],
+      '%s=~"%s(%s)"' % [$._config.per_job_label, $._config.job_prefix, formatJobForQuery(job)],
+      compartmentalizedJobMatcher(job),
+    ])),
+
+  local compartmentalizedJobMatcher(job) =
+    // Add the read_compartment filter only for jobs that are known to be
+    // compartmentalized (defined in $._config.compartmentalizedJobs).
+    if $._config.compartments_enabled && std.contains($._config.compartmentalizedJobs, job)
+    then '%s=~".*$read_compartment($|-.*)"' % [$._config.per_job_label]
+    else null,
 
   local formatJobForQuery(job) =
     if std.isArray(job) then '(%s)' % std.join('|', job)
@@ -224,7 +243,18 @@ local utils = import 'mixin-utils/utils.libsonnet';
   jobSelector(job)::
     if $._config.singleBinary
     then [utils.selector.noop('%s' % $._config.per_cluster_label), utils.selector.re($._config.per_job_label, '$job')]
-    else [utils.selector.re('%s' % $._config.per_cluster_label, '$cluster'), utils.selector.re($._config.per_job_label, '%s(%s)' % [$._config.job_prefix, formatJobForQuery(job)])],
+    else std.prune([
+      utils.selector.re('%s' % $._config.per_cluster_label, '$cluster'),
+      utils.selector.re($._config.per_job_label, '%s(%s)' % [$._config.job_prefix, formatJobForQuery(job)]),
+      compartmentalizedJobSelector(job),
+    ]),
+
+  local compartmentalizedJobSelector(job) =
+    // Add the read_compartment filter only for jobs that are known to be
+    // compartmentalized (defined in $._config.compartmentalizedJobs).
+    if $._config.compartments_enabled && std.contains($._config.compartmentalizedJobs, job)
+    then utils.selector.re($._config.per_job_label, '.*$read_compartment($|-.*)')
+    else null,
 
   recordingRulePrefix(selectors)::
     std.join('_', [matcher.label for matcher in selectors]),

--- a/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
+++ b/operations/mimir-mixin/dashboards/dashboard-utils.libsonnet
@@ -220,15 +220,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     else std.join(', ', std.prune([
       '%s=~"$cluster"' % [$._config.per_cluster_label],
       '%s=~"%s(%s)"' % [$._config.per_job_label, $._config.job_prefix, formatJobForQuery(job)],
-      compartmentalizedJobMatcher(job),
     ])),
-
-  local compartmentalizedJobMatcher(job) =
-    // Add the read_compartment filter only for jobs that are known to be
-    // compartmentalized (defined in $._config.compartmentalizedJobs).
-    if $._config.compartments_enabled && std.contains($._config.compartmentalizedJobs, job)
-    then '%s=~".*$read_compartment($|-.*)"' % [$._config.per_job_label]
-    else null,
 
   local formatJobForQuery(job) =
     if std.isArray(job) then '(%s)' % std.join('|', job)
@@ -246,15 +238,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
     else std.prune([
       utils.selector.re('%s' % $._config.per_cluster_label, '$cluster'),
       utils.selector.re($._config.per_job_label, '%s(%s)' % [$._config.job_prefix, formatJobForQuery(job)]),
-      compartmentalizedJobSelector(job),
     ]),
-
-  local compartmentalizedJobSelector(job) =
-    // Add the read_compartment filter only for jobs that are known to be
-    // compartmentalized (defined in $._config.compartmentalizedJobs).
-    if $._config.compartments_enabled && std.contains($._config.compartmentalizedJobs, job)
-    then utils.selector.re($._config.per_job_label, '.*$read_compartment($|-.*)')
-    else null,
 
   recordingRulePrefix(selectors)::
     std.join('_', [matcher.label for matcher in selectors]),

--- a/operations/mimir-mixin/jsonnetfile.lock.json
+++ b/operations/mimir-mixin/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "grafana-builder"
         }
       },
-      "version": "f53b1c9f855e11adce73b0aa6d6b08f511b89274",
-      "sum": "TWpxm5vPO23V3hoF3pdwGs1NvR+PQce9baN716mJq+4="
+      "version": "5a6567a1aba8ead9f159bcbe9091ab5b0956ecfe",
+      "sum": "FqEJAICz9T90PMJLW8i4HXazyWQPNzi68A8UauXa7GQ="
     },
     {
       "source": {


### PR DESCRIPTION
#### What this PR does

Add a new dropdown ("read_compartment") to all the dashboards, default to "All". (This is essentially a no-op for deployments without compartments, but you still get the dropdown)

When used, the jobs across all panels will be filtered by the selected compartment(s). This doesn't apply to jobs that are not compartmentalized.

To enable the new dropdown and selectors, `$._config.compartments_enabled` must be set to true.

The resulting dashboards changes can be previewed here: https://github.com/grafana/mimir/compare/add-rc-dropdown-dashboards..preview-rc-dashboards.