### PR TITLE
MQE: failing regression tests demonstrating double-free in sum()/avg() over mixed histogram schemas

### DIFF
--- a/pkg/querier/dispatcher_mixed_histogram_schemas_test.go
+++ b/pkg/querier/dispatcher_mixed_histogram_schemas_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package querier
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/grafana/dskit/user"
+	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/promql/promqltest"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/querier/stats"
+	"github.com/grafana/mimir/pkg/streamingpromql"
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+	"github.com/grafana/mimir/pkg/util/propagation"
+)
+
+// TestDispatcher_HandleProtobuf_SumOverMixedHistogramSchemas is a regression test for a double-free
+// of HPoint slices when a sum() group mixes a float sample with histograms that cannot be added
+// together. It evaluates the aggregation subtree through the dispatcher, like the query-frontend
+// does, so results are freed while the query is still running and the double-free surfaces as a
+// panic in FinishedReading rather than at query close.
+//
+// See pkg/streamingpromql/testdata/ours/sum_mixed_histogram_schemas.test for the minimal version.
+func TestDispatcher_HandleProtobuf_SumOverMixedHistogramSchemas(t *testing.T) {
+	storage := promqltest.LoadedStorage(t, `
+		load 1m
+			some_metric{job="q", pod="p1", route_name="a", status_code="200"} {{schema:0 sum:5 count:4 buckets:[1 2 1]}}x10
+			some_metric{job="q", pod="p2", route_name="a", status_code="200"} {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1 0]}} {{schema:-53 sum:2 count:2 custom_values:[5 10] buckets:[2 0]}}
+			some_metric{job="q", pod="p3", route_name="a", status_code="200"} 0 1
+	`)
+	t.Cleanup(func() { require.NoError(t, storage.Close()) })
+
+	opts := streamingpromql.NewTestEngineOpts()
+	ctx := context.Background()
+	planner, err := streamingpromql.NewQueryPlanner(opts, streamingpromql.NewMaximumSupportedVersionQueryPlanVersionProvider())
+	require.NoError(t, err)
+	engine, err := streamingpromql.NewEngine(opts, stats.NewQueryMetrics(nil), planner)
+	require.NoError(t, err)
+
+	startT := timestamp.Time(0)
+	timeRange := types.NewRangeQueryTimeRange(startT, startT.Add(10*time.Minute), time.Minute)
+	req := createQueryRequestForSpecificNodes(t, ctx, planner, `sum by (route_name, status_code) (rate({job="q"}[5m]))`, timeRange, true, true, 1, []string{
+		"DeduplicateAndMerge",
+		"DropName",
+		"AggregateExpression: sum by (route_name, status_code)",
+	})
+
+	_, ctx = stats.ContextWithEmptyStats(ctx)
+	ctx = user.InjectOrgID(ctx, "tenant-1")
+
+	reg, requestMetrics, serverMetrics := newMetrics()
+	stream := &mockQueryResultStream{t: t, route: "querierpb.EvaluateQueryRequest", reg: reg}
+	dispatcher := NewDispatcher(engine, storage, requestMetrics, serverMetrics, &propagation.NoopExtractor{}, opts.Logger)
+
+	dispatcher.HandleProtobuf(ctx, req, &propagation.MapCarrier{}, stream)
+}

--- a/pkg/streamingpromql/testdata/ours/sum_mixed_histogram_schemas.test
+++ b/pkg/streamingpromql/testdata/ours/sum_mixed_histogram_schemas.test
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Regression test for a double-free of HPoint slices in sum() and avg(): when a float sample
+# coexists at the same output step with histograms that cannot be added together (exponential +
+# custom bucket schemas), histogramPointCount was decremented twice, so an undersized slice was
+# requested from the pool and grown with append, returning untracked memory to the pool.
+
+load 1m
+  some_metric{pod="p1"} {{schema:0 sum:5 count:4 buckets:[1 2 1]}}x10
+  some_metric{pod="p2"} {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1 0]}}
+  some_metric{pod="p3"} 0
+
+eval range from 0 to 10m step 1m sum(some_metric)
+  expect warn
+  {} _ _ _ _ _ {{schema:0 sum:5 count:4 buckets:[1 2 1]}} {{schema:0 sum:5 count:4 buckets:[1 2 1]}} {{schema:0 sum:5 count:4 buckets:[1 2 1]}} {{schema:0 sum:5 count:4 buckets:[1 2 1]}} {{schema:0 sum:5 count:4 buckets:[1 2 1]}} {{schema:0 sum:5 count:4 buckets:[1 2 1]}}
+
+eval range from 0 to 10m step 1m avg(some_metric)
+  expect warn
+  {} _ _ _ _ _ {{schema:0 sum:5 count:4 buckets:[1 2 1]}} {{schema:0 sum:5 count:4 buckets:[1 2 1]}} {{schema:0 sum:5 count:4 buckets:[1 2 1]}} {{schema:0 sum:5 count:4 buckets:[1 2 1]}} {{schema:0 sum:5 count:4 buckets:[1 2 1]}} {{schema:0 sum:5 count:4 buckets:[1 2 1]}}


### PR DESCRIPTION
#### What this PR does

**Demonstration PR, not intended to merge as-is.** Adds failing tests that reproduce a `[]promql.HPoint` pool double-free panic seen in production queriers, using fully synthetic data. CI on this PR is expected to fail; that is the point. The fix, including these tests, is in #16059.

**1. Minimal promqltest repro** in `pkg/streamingpromql/testdata/ours/sum_mixed_histogram_schemas.test`:

```
load 1m
  some_metric{pod="p1"} {{schema:0 sum:5 count:4 buckets:[1 2 1]}}x10
  some_metric{pod="p2"} {{schema:-53 sum:1 count:1 custom_values:[5 10] buckets:[1 0]}}
  some_metric{pod="p3"} 0

eval range from 0 to 10m step 1m sum(some_metric)
```

Prometheus' engine passes; Mimir's engine panics at `Query.Close`:

```
panic: Estimated memory consumption of all instances of []promql.HPoint in this query is 304 bytes when trying to return 2432 bytes. This indicates something has been returned to a pool more than once, which is a bug.
```

**2. Dispatcher-path repro matching the production stack frame for frame** in `pkg/querier/dispatcher_mixed_histogram_schemas_test.go`. It evaluates a `sum by (route_name, status_code) (rate({job="q"}[5m]))` AggregateExpression subtree through `Dispatcher.HandleProtobuf`, the same entry point and node granularity the query-frontend dispatches to queriers. Because the dispatcher streams and frees each result series during evaluation, the accounting deficit is exposed when `FinishedReading` runs:

```
limiter.(*MemoryConsumptionTracker).DecreaseMemoryConsumption
types.(*LimitingBucketedPool[...]).Put
types.(*HPointRingBuffer).Close
selectors.(*RangeVectorSelector).FinishedReading
functions.(*FunctionOverRangeVector).FinishedReading
aggregations.(*Aggregation).FinishedReading
streamingpromql.(*instantVectorEvaluator).finishedReading
streamingpromql.(*Evaluator).Evaluate
querier.(*Dispatcher).evaluateQuery
querier.(*Dispatcher).HandleProtobuf
```

#### Root cause (confirmed by instrumenting the pool's Get/Put with stack traces)

A double-decrement of `histogramPointCount` in `SumAggregationGroup` and `AvgAggregationGroup`:

1. `accumulateHistograms`: when two histograms at the same output step cannot be added (exponential + custom bucket schemas), the group stores the `invalidCombinationOfHistograms` sentinel and decrements `histogramPointCount`.
2. `reconcileAndCountFloatPoints`: if a float also exists at that step, it checks `!= nil`. The sentinel is non-nil, so it decrements `histogramPointCount` a second time.
3. `ComputeOutputSeries` requests an undersized slice from `HPointSlicePool` and grows it with `append`. The reallocated slice carries untracked memory back to the pool, so a later `Put` underflows the tracker and panics at an innocent victim site, which is why the production stack points away from the culprit.

See #16059 for the fix and full analysis.

#### Which issue(s) this PR fixes or relates to

Relates to an internally reported querier panic (internal issue 3813). Superseded by #16059.

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated (demonstration PR; the changelog entry is in #16059).
- [n/a] `about-versioning.md` updated with experimental features.