### PR TITLE
MQE: ensure all slices are mangled or cleared on return to a pool in tests

### DIFF
--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -2456,6 +2456,12 @@ func runAnnotationTests(t *testing.T, testCases map[string]annotationTestCase) {
 					subTestName := fmt.Sprintf("%s - delayed name removal enabled=%t", queryType, engineSet.delayedNameRemovalEnabled)
 					t.Run(subTestName, func(t *testing.T) {
 						results := make([]*promql.Result, 0, 2)
+						cleanups := make([]func(), 0, 2)
+						t.Cleanup(func() {
+							for _, cleanup := range cleanups {
+								cleanup()
+							}
+						})
 
 						for _, engine := range []promql.QueryEngine{engineSet.mimirEngine, engineSet.prometheusEngine} {
 							if engine == engineSet.prometheusEngine && testCase.skipComparisonWithPrometheusReason != "" {
@@ -2469,7 +2475,7 @@ func runAnnotationTests(t *testing.T, testCases map[string]annotationTestCase) {
 							t.Run(engineName, func(t *testing.T) {
 								query, err := generator(engine)
 								require.NoError(t, err)
-								t.Cleanup(query.Close)
+								cleanups = append(cleanups, query.Close)
 
 								res := query.Exec(context.Background())
 								require.NoError(t, res.Err)
@@ -3455,8 +3461,7 @@ func TestQueryStats(t *testing.T) {
 		}
 
 		require.NoError(t, err)
-
-		defer q.Close()
+		t.Cleanup(q.Close)
 
 		res := q.Exec(context.Background())
 		require.NoError(t, res.Err)
@@ -4131,7 +4136,7 @@ func TestQueryStatsUpstreamTestCases(t *testing.T) {
 		}
 
 		require.NoError(t, err)
-		defer q.Close()
+		t.Cleanup(q.Close)
 
 		res := q.Exec(context.Background())
 		require.NoError(t, res.Err)

--- a/pkg/streamingpromql/operators/aggregations/quantile.go
+++ b/pkg/streamingpromql/operators/aggregations/quantile.go
@@ -153,7 +153,7 @@ var qGroupPool = types.NewLimitingBucketedPool(
 	}),
 	limiter.QuantileGroupSlices,
 	uint64(unsafe.Sizeof(qGroup{})),
-	false,
+	true,
 	nil,
 	nil,
 )

--- a/pkg/streamingpromql/optimize/plan/rangevectorsplitting/range_vector_splitting_test.go
+++ b/pkg/streamingpromql/optimize/plan/rangevectorsplitting/range_vector_splitting_test.go
@@ -1537,7 +1537,7 @@ func runInstantQueryWithContext(t *testing.T, ctx context.Context, eng promql.Qu
 	ctx = user.InjectOrgID(ctx, "test-user")
 	q, err := eng.NewInstantQuery(ctx, storage, nil, expr, ts)
 	require.NoError(t, err)
-	defer q.Close()
+	t.Cleanup(q.Close)
 
 	return q.Exec(ctx), q.Stats().Samples
 }
@@ -1549,7 +1549,8 @@ func executeQuery(t *testing.T, engine promql.QueryEngine, storage storage.Stora
 	require.NoError(t, err)
 	result := q.Exec(ctx)
 	stats := q.Stats().Samples
-	q.Close()
+	t.Cleanup(q.Close)
+
 	return result, stats, wrapped.ranges
 }
 

--- a/pkg/streamingpromql/types/limiting_pool.go
+++ b/pkg/streamingpromql/types/limiting_pool.go
@@ -49,7 +49,7 @@ var (
 		limiter.FPointSlices,
 		FPointSize,
 		false,
-		nil,
+		mangleFPoint,
 		nil,
 	)
 
@@ -74,7 +74,7 @@ var (
 		limiter.Vectors,
 		VectorSampleSize,
 		false,
-		nil,
+		mangleSample,
 		nil,
 	)
 
@@ -161,6 +161,32 @@ var (
 	)
 )
 
+func mangleFPoint(point promql.FPoint) promql.FPoint {
+	point.T = mangleInt64(point.T)
+	point.F = mangleFloat64(point.F)
+	return point
+}
+
+func mangleInt64(_ int64) int64 {
+	return 123456789
+}
+
+func mangleFloat64(_ float64) float64 {
+	return 123456789.987654321
+}
+
+func mangleSample(sample promql.Sample) promql.Sample {
+	sample.T = mangleInt64(sample.T)
+
+	if sample.H == nil {
+		sample.F = mangleFloat64(sample.F)
+	} else {
+		sample.H = mangleHistogram(sample.H)
+	}
+
+	return sample
+}
+
 func mangleHistogram(h *histogram.FloatHistogram) *histogram.FloatHistogram {
 	if h == nil {
 		return nil
@@ -199,6 +225,10 @@ type LimitingBucketedPool[S ~[]E, E any] struct {
 }
 
 func NewLimitingBucketedPool[S ~[]E, E any](inner *pool.BucketedPool[S, E], source limiter.MemoryConsumptionSource, elementSize uint64, clearOnGet bool, mangle func(E) E, onPutHook func(S, *limiter.MemoryConsumptionTracker)) *LimitingBucketedPool[S, E] {
+	if !clearOnGet && mangle == nil {
+		panic("must provide a mangling function for pools where items are not cleared on retrieval")
+	}
+
 	return &LimitingBucketedPool[S, E]{
 		inner:       inner,
 		source:      source,
@@ -249,9 +279,16 @@ func (p *LimitingBucketedPool[S, E]) Put(s *S, tracker *limiter.MemoryConsumptio
 		p.onPutHook(*s, tracker)
 	}
 
-	if EnableManglingReturnedSlices && p.mangle != nil {
-		for i, e := range *s {
-			(*s)[i] = p.mangle(e)
+	if EnableManglingReturnedSlices {
+		if p.mangle != nil {
+			for i, e := range *s {
+				(*s)[i] = p.mangle(e)
+			}
+		}
+
+		if p.clearOnGet {
+			// Clear the slice now, to catch any instances where the slice is still referenced after being returned to the pool.
+			clear(*s)
 		}
 	}
 

--- a/pkg/streamingpromql/types/limiting_pool.go
+++ b/pkg/streamingpromql/types/limiting_pool.go
@@ -244,16 +244,17 @@ func (p *LimitingBucketedPool[S, E]) Put(s *S, tracker *limiter.MemoryConsumptio
 		return
 	}
 
+	tracker.DecreaseMemoryConsumption(uint64(cap(*s))*p.elementSize, p.source)
+	if p.onPutHook != nil {
+		p.onPutHook(*s, tracker)
+	}
+
 	if EnableManglingReturnedSlices && p.mangle != nil {
 		for i, e := range *s {
 			(*s)[i] = p.mangle(e)
 		}
 	}
 
-	tracker.DecreaseMemoryConsumption(uint64(cap(*s))*p.elementSize, p.source)
-	if p.onPutHook != nil {
-		p.onPutHook(*s, tracker)
-	}
 	p.inner.Put(*s)
 
 	*s = nil

--- a/pkg/streamingpromql/types/limiting_pool_test.go
+++ b/pkg/streamingpromql/types/limiting_pool_test.go
@@ -31,7 +31,7 @@ func TestLimitingBucketedPool_Unlimited(t *testing.T) {
 		limiter.FPointSlices,
 		FPointSize,
 		false,
-		nil,
+		func(point promql.FPoint) promql.FPoint { return point },
 		nil,
 	)
 
@@ -86,7 +86,7 @@ func TestLimitingPool_Limited(t *testing.T) {
 		limiter.FPointSlices,
 		FPointSize,
 		false,
-		nil,
+		func(point promql.FPoint) promql.FPoint { return point },
 		nil,
 	)
 
@@ -209,40 +209,80 @@ func TestLimitingPool_Mangling(t *testing.T) {
 	}()
 
 	_, metric := createRejectedMetric()
-	tracker := limiter.NewMemoryConsumptionTracker(context.Background(), 0, metric, "")
 
-	p := NewLimitingBucketedPool(
-		pool.NewBucketedPool(1024, func(size int) []int { return make([]int, 0, size) }),
-		limiter.IntSlices,
-		1,
-		false,
-		func(_ int) int { return 123 },
-		func(s []int, _ *limiter.MemoryConsumptionTracker) {
-			for idx, i := range s {
-				require.NotEqualf(t, 123, i, "Put() hook should be called before mangling, but element at index %d was mangled already", idx)
-			}
-		},
-	)
+	t.Run("with mangling function", func(t *testing.T) {
+		tracker := limiter.NewMemoryConsumptionTracker(context.Background(), 0, metric, "")
 
-	// Test with mangling disabled.
-	EnableManglingReturnedSlices = false
-	s, err := p.Get(4, tracker)
-	require.NoError(t, err)
-	s = append(s, 1000, 2000, 3000, 4000)
-	sCopy := s // Take another reference to s, so that we can check that it was mangled. (Put will set s to nil when it is called below, so we need to take a copy.)
+		p := NewLimitingBucketedPool(
+			pool.NewBucketedPool(1024, func(size int) []int { return make([]int, 0, size) }),
+			limiter.IntSlices,
+			1,
+			false,
+			func(_ int) int { return 123 },
+			func(s []int, _ *limiter.MemoryConsumptionTracker) {
+				for idx, i := range s {
+					require.NotEqualf(t, 123, i, "Put() hook should be called before mangling, but element at index %d was mangled already", idx)
+				}
+			},
+		)
 
-	p.Put(&s, tracker)
-	require.Equal(t, []int{1000, 2000, 3000, 4000}, sCopy, "returned slice should not be mangled when mangling is disabled")
+		// Test with mangling disabled.
+		EnableManglingReturnedSlices = false
+		s, err := p.Get(4, tracker)
+		require.NoError(t, err)
+		s = append(s, 1000, 2000, 3000, 4000)
+		sCopy := s // Take another reference to s, so that we can check that it was mangled. (Put will set s to nil when it is called below, so we need to take a copy.)
 
-	// Test with mangling enabled.
-	EnableManglingReturnedSlices = true
-	s, err = p.Get(4, tracker)
-	require.NoError(t, err)
-	s = append(s, 1000, 2000, 3000, 4000)
-	sCopy = s
+		p.Put(&s, tracker)
+		require.Equal(t, []int{1000, 2000, 3000, 4000}, sCopy, "returned slice should not be mangled when mangling is disabled")
+		require.Nil(t, s, "provided slice should be nil-ed out")
 
-	p.Put(&s, tracker)
-	require.Equal(t, []int{123, 123, 123, 123}, sCopy, "returned slice should be mangled when mangling is enabled")
+		// Test with mangling enabled.
+		EnableManglingReturnedSlices = true
+		s, err = p.Get(4, tracker)
+		require.NoError(t, err)
+		s = append(s, 1000, 2000, 3000, 4000)
+		sCopy = s
+
+		p.Put(&s, tracker)
+		require.Equal(t, []int{123, 123, 123, 123}, sCopy, "returned slice should be mangled when mangling is enabled")
+		require.Nil(t, s, "provided slice should be nil-ed out")
+	})
+
+	t.Run("without mangling function but 'clear on get' set", func(t *testing.T) {
+		tracker := limiter.NewMemoryConsumptionTracker(context.Background(), 0, metric, "")
+
+		p := NewLimitingBucketedPool(
+			pool.NewBucketedPool(1024, func(size int) []int { return make([]int, 0, size) }),
+			limiter.IntSlices,
+			1,
+			true,
+			func(_ int) int { return 123 },
+			nil,
+		)
+
+		// Test with mangling disabled.
+		EnableManglingReturnedSlices = false
+		s, err := p.Get(4, tracker)
+		require.NoError(t, err)
+		s = append(s, 1000, 2000, 3000, 4000)
+		sCopy := s // Take another reference to s, so that we can check that it was mangled. (Put will set s to nil when it is called below, so we need to take a copy.)
+
+		p.Put(&s, tracker)
+		require.Equal(t, []int{1000, 2000, 3000, 4000}, sCopy, "returned slice should not be cleared when mangling is disabled")
+		require.Nil(t, s, "provided slice should be nil-ed out")
+
+		// Test with mangling enabled.
+		EnableManglingReturnedSlices = true
+		s, err = p.Get(4, tracker)
+		require.NoError(t, err)
+		s = append(s, 1000, 2000, 3000, 4000)
+		sCopy = s
+
+		p.Put(&s, tracker)
+		require.Equal(t, []int{0, 0, 0, 0}, sCopy, "returned slice should be cleared when mangling is enabled")
+		require.Nil(t, s, "provided slice should be nil-ed out")
+	})
 }
 
 func TestLimitingBucketedPool_AppendToSlice(t *testing.T) {
@@ -253,7 +293,7 @@ func TestLimitingBucketedPool_AppendToSlice(t *testing.T) {
 		limiter.FPointSlices,
 		FPointSize,
 		false,
-		nil,
+		func(point promql.FPoint) promql.FPoint { return point },
 		func(s []promql.FPoint, _ *limiter.MemoryConsumptionTracker) {
 			onPutHookSlices = append(onPutHookSlices, s)
 		},
@@ -303,7 +343,7 @@ func TestLimitingBucketedPool_AppendToSlice_Error(t *testing.T) {
 		limiter.FPointSlices,
 		FPointSize,
 		false,
-		nil,
+		func(point promql.FPoint) promql.FPoint { return point },
 		nil,
 	)
 

--- a/pkg/streamingpromql/types/limiting_pool_test.go
+++ b/pkg/streamingpromql/types/limiting_pool_test.go
@@ -217,7 +217,11 @@ func TestLimitingPool_Mangling(t *testing.T) {
 		1,
 		false,
 		func(_ int) int { return 123 },
-		nil,
+		func(s []int, _ *limiter.MemoryConsumptionTracker) {
+			for idx, i := range s {
+				require.NotEqualf(t, 123, i, "Put() hook should be called before mangling, but element at index %d was mangled already", idx)
+			}
+		},
 	)
 
 	// Test with mangling disabled.


### PR DESCRIPTION
#### What this PR does

This PR builds upon https://github.com/grafana/mimir/pull/16000. 

#16000 enforced that mangling was enabled in all tests, but not all pools register a mangling function. This PR addresses that last limitation: now, all pools must either be configured to clear returned slices on retrieval, or provide a mangling function. (Providing a mangling function for a pool where slices are cleared on retrieval is still valid: this is useful for slices that contain pointers that might be retained beyond the life of the slice.)

If mangling slices is enabled, and the pool is configured to clear returned slices on retrieval, then slices are cleared as soon as they are returned, to help catch use-after-return bugs.

Given there is no user-facing impact to this change, I've chosen to not add a changelog entry.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
