### PR TITLE
MQE: refactor `optimize.Inspect` to allow skipping children, and use this in remote execution optimization pass

### DIFF
--- a/pkg/streamingpromql/optimize/inspect.go
+++ b/pkg/streamingpromql/optimize/inspect.go
@@ -22,8 +22,10 @@ func Walk(node planning.Node, visitor Visitor) error {
 }
 
 func walk(node planning.Node, path []planning.Node, visitor Visitor) error {
-	if err := visitor.Visit(node, path); err != nil {
+	if visitChildren, err := visitor.Visit(node, path); err != nil {
 		return err
+	} else if !visitChildren {
+		return nil
 	}
 
 	updated := false
@@ -49,12 +51,15 @@ type Visitor interface {
 	// Visit examines node and has access to the path of nodes visited
 	// before node was reached, not including node, with the root in the
 	// first index and closest parent in the last.
-	Visit(node planning.Node, path []planning.Node) error
+	//
+	// Returning false from Visit will skip walking children of node, but continue
+	// walking siblings.
+	Visit(node planning.Node, path []planning.Node) (bool, error)
 }
 
-type VisitorFunc func(node planning.Node, path []planning.Node) error
+type VisitorFunc func(node planning.Node, path []planning.Node) (bool, error)
 
-func (f VisitorFunc) Visit(node planning.Node, path []planning.Node) error {
+func (f VisitorFunc) Visit(node planning.Node, path []planning.Node) (bool, error) {
 	return f(node, path)
 }
 
@@ -73,7 +78,7 @@ type InspectSelectorsResult struct {
 func InspectSelectors(node planning.Node) InspectSelectorsResult {
 	var res InspectSelectorsResult
 
-	_ = Walk(node, VisitorFunc(func(n planning.Node, _ []planning.Node) error {
+	_ = Walk(node, VisitorFunc(func(n planning.Node, _ []planning.Node) (bool, error) {
 		switch e := n.(type) {
 		case *core.MatrixSelector:
 			res.HasSelectors = true
@@ -82,7 +87,7 @@ func InspectSelectors(node planning.Node) InspectSelectorsResult {
 			res.HasSelectors = true
 			res.IsRewrittenByMiddleware = res.IsRewrittenByMiddleware || isSharded(e)
 		}
-		return nil
+		return true, nil
 	}))
 
 	return res

--- a/pkg/streamingpromql/optimize/inspect_test.go
+++ b/pkg/streamingpromql/optimize/inspect_test.go
@@ -17,19 +17,16 @@ import (
 
 func TestWalk(t *testing.T) {
 	testCases := map[string]struct {
-		expr   string
-		visits int
-		paths  [][]string
+		expr           string
+		paths          [][]string
+		skipChildrenOf string
 	}{
 		"success no children": {
-			expr:   "some_metric[5m]",
-			visits: 1,
-			paths:  [][]string{},
+			expr:  "some_metric[5m]",
+			paths: [][]string{},
 		},
-
 		"success with children": {
-			expr:   "sum(rate(some_metric[5m]))",
-			visits: 4,
+			expr: "sum(rate(some_metric[5m]))",
 			paths: [][]string{
 				{"sum"},
 				{"sum", ""}, // Query planning inserts a DeduplicateAndMerge node around the rate function
@@ -37,8 +34,7 @@ func TestWalk(t *testing.T) {
 			},
 		},
 		"success with multiple children": {
-			expr:   "sum(rate(some_metric[5m]) + rate(other_metric[5m]))",
-			visits: 8,
+			expr: "sum(rate(some_metric[5m]) + rate(other_metric[5m]))",
 			paths: [][]string{
 				{"sum"},
 				{"sum", "LHS + RHS"},
@@ -47,6 +43,18 @@ func TestWalk(t *testing.T) {
 				{"sum", "LHS + RHS"},
 				{"sum", "LHS + RHS", ""}, // Query planning inserts a DeduplicateAndMerge node around the rate function
 				{"sum", "LHS + RHS", "", "rate(...)"},
+			},
+		},
+		"success with skipping of some branches": {
+			expr:           `sum(metric_1 * metric_2) + avg(metric_3 * metric_4)`,
+			skipChildrenOf: "avg",
+			paths: [][]string{
+				{"LHS + RHS"},
+				{"LHS + RHS", "sum"},
+				{"LHS + RHS", "sum", "LHS * RHS"},
+				{"LHS + RHS", "sum", "LHS * RHS"},
+				{"LHS + RHS"},
+				{"LHS + RHS", "avg"},
 			},
 		},
 	}
@@ -64,10 +72,10 @@ func TestWalk(t *testing.T) {
 			p, err := planner.NewQueryPlan(ctx, testCase.expr, timeRange, streamingpromql.DefaultLookbackDelta, false, observer)
 			require.NoError(t, err)
 
-			visitor := NewTestVisitor(t)
+			visitor := NewTestVisitor(t, testCase.skipChildrenOf)
 			require.NoError(t, optimize.Walk(p.Root, visitor))
 			require.Equal(t, testCase.paths, visitor.Paths)
-			require.Equal(t, testCase.visits, visitor.Visits)
+			require.Equal(t, len(testCase.paths)+1, visitor.Visits)
 		})
 	}
 }
@@ -86,8 +94,8 @@ func BenchmarkWalk(b *testing.B) {
 	p, err := planner.NewQueryPlan(ctx, query, timeRange, streamingpromql.DefaultLookbackDelta, false, observer)
 	require.NoError(b, err)
 
-	visitor := optimize.VisitorFunc(func(node planning.Node, path []planning.Node) error {
-		return nil // no-op
+	visitor := optimize.VisitorFunc(func(node planning.Node, path []planning.Node) (bool, error) {
+		return true, nil // no-op
 	})
 
 	for b.Loop() {
@@ -98,16 +106,22 @@ func BenchmarkWalk(b *testing.B) {
 type TestVisitor struct {
 	test *testing.T
 
-	Paths  [][]string
-	Visits int
+	SkipChildrenOf string
+	Paths          [][]string
+	Visits         int
 }
 
-func NewTestVisitor(t *testing.T) *TestVisitor {
-	return &TestVisitor{test: t, Paths: [][]string{}}
+func NewTestVisitor(t *testing.T, skipChildrenOf string) *TestVisitor {
+	return &TestVisitor{
+		test:           t,
+		Paths:          [][]string{},
+		SkipChildrenOf: skipChildrenOf,
+	}
 }
 
-func (v *TestVisitor) Visit(node planning.Node, path []planning.Node) error {
+func (v *TestVisitor) Visit(node planning.Node, path []planning.Node) (bool, error) {
 	require.NotNil(v.test, node)
+	v.Visits++
 
 	if len(path) != 0 {
 		thisPath := make([]string, 0, len(path))
@@ -116,10 +130,13 @@ func (v *TestVisitor) Visit(node planning.Node, path []planning.Node) error {
 		}
 
 		v.Paths = append(v.Paths, thisPath)
+
+		if v.SkipChildrenOf != "" && thisPath[len(thisPath)-1] == v.SkipChildrenOf {
+			return false, nil
+		}
 	}
 
-	v.Visits++
-	return nil
+	return true, nil
 }
 
 func TestInspectSelectors(t *testing.T) {

--- a/pkg/streamingpromql/optimize/plan/eliminate_deduplicate_and_merge.go
+++ b/pkg/streamingpromql/optimize/plan/eliminate_deduplicate_and_merge.go
@@ -250,7 +250,7 @@ func areSeriesUniqueDropName(node *core.DropName) bool {
 func walkToSelectors(n planning.Node, examine func(dedupeNeeded int, path []planning.Node) bool) bool {
 	unique := true
 
-	_ = optimize.Walk(n, optimize.VisitorFunc(func(node planning.Node, path []planning.Node) error {
+	_ = optimize.Walk(n, optimize.VisitorFunc(func(node planning.Node, path []planning.Node) (bool, error) {
 		switch e := node.(type) {
 		case *core.VectorSelector:
 			var dedupeNeeded int
@@ -268,7 +268,7 @@ func walkToSelectors(n planning.Node, examine func(dedupeNeeded int, path []plan
 			unique = unique && examine(dedupeNeeded, path)
 		}
 
-		return nil
+		return true, nil
 	}))
 
 	return unique

--- a/pkg/streamingpromql/optimize/plan/multiaggregation/optimization_pass.go
+++ b/pkg/streamingpromql/optimize/plan/multiaggregation/optimization_pass.go
@@ -60,7 +60,7 @@ func (o *OptimizationPass) Apply(ctx context.Context, plan *planning.QueryPlan, 
 	ineligibleDuplicateNodes := make(map[*commonsubexpressionelimination.Duplicate]struct{})
 	candidateDuplicateNodes := make(map[*commonsubexpressionelimination.Duplicate][]aggregateOverDuplicate)
 
-	err := optimize.Walk(plan.Root, optimize.VisitorFunc(func(node planning.Node, path []planning.Node) error {
+	err := optimize.Walk(plan.Root, optimize.VisitorFunc(func(node planning.Node, path []planning.Node) (bool, error) {
 		// If we've reached a Duplicate node, check that its parent on this path is a supported aggregation.
 		// If it's not, then we can't apply this optimisation to this Duplicate node.
 		duplicate, isDuplicate := node.(*commonsubexpressionelimination.Duplicate)
@@ -68,7 +68,7 @@ func (o *OptimizationPass) Apply(ctx context.Context, plan *planning.QueryPlan, 
 			_, isIneligible := ineligibleDuplicateNodes[duplicate]
 			if isIneligible {
 				// We already know this Duplicate node is ineligible, so there's nothing more to do.
-				return nil
+				return true, nil
 			}
 
 			parent := path[len(path)-1]
@@ -134,7 +134,7 @@ func (o *OptimizationPass) Apply(ctx context.Context, plan *planning.QueryPlan, 
 			})
 		}
 
-		return nil
+		return true, nil
 	}))
 
 	if err != nil {

--- a/pkg/streamingpromql/optimize/plan/narrow_selectors.go
+++ b/pkg/streamingpromql/optimize/plan/narrow_selectors.go
@@ -60,21 +60,21 @@ func (n *NarrowSelectorsOptimizationPass) Apply(ctx context.Context, plan *plann
 	n.attempts.Inc()
 	addedHint := false
 
-	_ = optimize.Walk(plan.Root, optimize.VisitorFunc(func(node planning.Node, _ []planning.Node) error {
+	_ = optimize.Walk(plan.Root, optimize.VisitorFunc(func(node planning.Node, _ []planning.Node) (bool, error) {
 		e, ok := node.(*core.BinaryExpression)
 		if !ok {
-			return nil
+			return true, nil
 		}
 
 		// Only set hints for operations that are compatible with adding extra selectors to
 		// the right side of the expression. For example, "logical or" includes series from
 		// the right side only when they _don't_ have matching label sets on the left side.
 		if _, disallowed := disallowedOperations[e.Op]; disallowed {
-			return nil
+			return true, nil
 		}
 
 		if e.VectorMatching == nil {
-			return nil
+			return true, nil
 		}
 
 		// Labels created by label_replace or label_join anywhere within this binary
@@ -90,7 +90,7 @@ func (n *NarrowSelectorsOptimizationPass) Apply(ctx context.Context, plan *plann
 			addedHint = n.hintsForIgnoring(ctx, e, created) || addedHint
 		}
 
-		return nil
+		return true, nil
 	}))
 
 	if addedHint {
@@ -222,7 +222,7 @@ func filterLabels(lbls []string, created map[string]struct{}) []string {
 func createdLabels(node planning.Node) map[string]struct{} {
 	created := make(map[string]struct{})
 
-	_ = optimize.Walk(node, optimize.VisitorFunc(func(n planning.Node, path []planning.Node) error {
+	_ = optimize.Walk(node, optimize.VisitorFunc(func(n planning.Node, path []planning.Node) (bool, error) {
 		if f, ok := n.(*core.FunctionCall); ok {
 			switch f.Function {
 			case functions.FUNCTION_LABEL_REPLACE, functions.FUNCTION_LABEL_JOIN, functions.FUNCTION_HISTOGRAM_QUANTILES:
@@ -237,7 +237,7 @@ func createdLabels(node planning.Node) map[string]struct{} {
 			}
 		}
 
-		return nil
+		return true, nil
 	}))
 
 	return created

--- a/pkg/streamingpromql/optimize/plan/remoteexec/optimization_pass.go
+++ b/pkg/streamingpromql/optimize/plan/remoteexec/optimization_pass.go
@@ -49,7 +49,9 @@ func (o *OptimizationPass) Apply(ctx context.Context, plan *planning.QueryPlan, 
 	// query and must have remote execution applied to it independently: if its subtree is sharded, each
 	// sharded leg is executed remotely; otherwise the entire subtree is. The rest of the plan (the outer
 	// instant query) runs on the query-frontend.
-	if evaluationRoots := collectEvaluationRoots(plan.Root); len(evaluationRoots) > 0 {
+	if evaluationRoots, err := collectEvaluationRoots(plan.Root); err != nil {
+		return nil, err
+	} else if len(evaluationRoots) > 0 {
 		for _, evaluationRoot := range evaluationRoots {
 			if err := o.wrapEvaluationRoot(evaluationRoot, groups, len(evaluationRoots) > 1); err != nil {
 				return nil, err
@@ -136,12 +138,11 @@ func (o *OptimizationPass) applyToRootNode(root planning.Node, groups remoteExec
 }
 
 // collectEvaluationRoots returns the EvaluationRoot nodes in the plan.
-func collectEvaluationRoots(node planning.Node) []*core.EvaluationRoot {
+func collectEvaluationRoots(node planning.Node) ([]*core.EvaluationRoot, error) {
 	var uniqueRoots []*core.EvaluationRoot
 
-	var visit func(planning.Node)
-	visit = func(n planning.Node) {
-		if evaluationRoot, ok := n.(*core.EvaluationRoot); ok {
+	err := optimize.Walk(node, optimize.VisitorFunc(func(node planning.Node, path []planning.Node) (bool, error) {
+		if evaluationRoot, ok := node.(*core.EvaluationRoot); ok {
 			// We might see the same root multiple times if the entire root is a duplicate expression.
 			// We don't expect there to be many EvaluationRoots, so we search a slice (rather than use a map).
 			// This keeps the return order consistent, which keeps behaviour predictable and makes tests simpler.
@@ -150,17 +151,17 @@ func collectEvaluationRoots(node planning.Node) []*core.EvaluationRoot {
 			}
 
 			// EvaluationRoot markers are never nested inside one another, so no need to visit children.
-			return
+			return false, nil
 		}
 
-		for child := range planning.ChildrenIter(n) {
-			visit(child)
-		}
+		return true, nil
+	}))
+
+	if err != nil {
+		return nil, err
 	}
 
-	visit(node)
-
-	return uniqueRoots
+	return uniqueRoots, nil
 }
 
 func (o *OptimizationPass) wrapInRemoteExecutionNode(child planning.Node, eagerLoad bool, groups remoteExecutionGroupSet) (planning.Node, error) {


### PR DESCRIPTION
#### What this PR does

This PR addresses https://github.com/grafana/mimir/pull/16015#discussion_r3555681168.

It refactors `optimize.Inspect` to optionally skip visiting children of a given node.

Given this is not a user-facing change, I have not added a changelog entry.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/pull/16015#discussion_r3555681168

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
