### PR TITLE
distributor: log Retry-Attempt header on failed push requests

### DIFF
--- a/pkg/distributor/push.go
+++ b/pkg/distributor/push.go
@@ -259,6 +259,9 @@ func handler(
 				if code/100 == 4 {
 					msgs = append(msgs, "insight", true)
 				}
+				if retryAttempt, err := strconv.Atoi(r.Header.Get("Retry-Attempt")); err == nil && retryAttempt > 0 {
+					msgs = append(msgs, "retryAttempt", retryAttempt)
+				}
 				level.Error(logger).Log(msgs...)
 			}
 			addErrorHeaders(w, err, r, code, retryCfg)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR adds the client-supplied `Retry-Attempt` header to the distributor's existing error log for failed push requests. Prometheus set's the header  on retries only, so the header is only logged when present.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
