### PR TITLE
MQE: Discard unused float and histogram data for CSE buffer 

### DIFF
--- a/pkg/streamingpromql/benchmarks/benchmarks.go
+++ b/pkg/streamingpromql/benchmarks/benchmarks.go
@@ -514,6 +514,11 @@ func TestCases(metricSizes []int) []BenchCase {
 		{
 			Expr: `info(info_dense_2000, {__name__="target_info_X"})`,
 		},
+		// CSE eligible query that uses longer range selectors than the step
+		{
+			Expr:  `histogram_count(sum(rate(nh_X[1h]))) / histogram_fraction(0, +Inf, sum(increase(nh_X[1h])))`,
+			Steps: 50,
+		},
 	}
 
 	// X in an expr will be replaced by different metric sizes.

--- a/pkg/streamingpromql/benchmarks/comparison_test.go
+++ b/pkg/streamingpromql/benchmarks/comparison_test.go
@@ -9,6 +9,9 @@ import (
 	"context"
 	"math"
 	"os"
+	"runtime"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -88,6 +91,69 @@ func BenchmarkQuery(b *testing.B) {
 					}
 				})
 			}
+		})
+	}
+}
+
+func BenchmarkRangeVectorQueryCase(b *testing.B) {
+	metricSizes := []int{10, 100}
+
+	q := createBenchmarkQueryable(b, metricSizes)
+	cases := []BenchCase{
+		{
+			Expr: `
+				histogram_count(
+					sum(
+					  rate(nh_X{
+						route!="madeupfortest4"
+					  }[20m])
+					)
+				) 
+				/
+				histogram_fraction(0, +Inf,
+					sum(
+					  increase(nh_X{
+						route!="madeupfortest4"
+					  }[20m])
+					)
+				)
+			`,
+			Steps: 50,
+		},
+	}
+	var tmp []BenchCase
+	for _, c := range cases {
+		if !strings.Contains(c.Expr, "X") {
+			tmp = append(tmp, c)
+		} else {
+			for _, count := range metricSizes {
+				tmp = append(tmp, BenchCase{Expr: strings.ReplaceAll(c.Expr, "X", strconv.Itoa(count)), Steps: c.Steps, InstantQueryOnly: c.InstantQueryOnly, IgnoreAnnotationDifferences: c.IgnoreAnnotationDifferences})
+			}
+		}
+	}
+	cases = tmp
+	opts := streamingpromql.NewTestEngineOpts()
+
+	planner, err := streamingpromql.NewQueryPlanner(opts, streamingpromql.NewMaximumSupportedVersionQueryPlanVersionProvider())
+	require.NoError(b, err)
+	mimirEngine, err := streamingpromql.NewEngine(opts, stats.NewQueryMetrics(nil), planner)
+	require.NoError(b, err)
+
+	ctx := user.InjectOrgID(context.Background(), UserID)
+	runtime.GC()
+
+	for _, c := range cases {
+		start := time.Unix(int64((NumIntervals-c.Steps)*intervalSeconds), 0)
+		end := time.Unix(int64(NumIntervals*intervalSeconds), 0)
+
+		b.Run(c.Name(), func(b *testing.B) {
+			for b.Loop() {
+				res, cleanup := c.Run(ctx, b, start, end, interval, mimirEngine, q)
+				if res != nil {
+					cleanup()
+				}
+			}
+
 		})
 	}
 }

--- a/pkg/streamingpromql/benchmarks/comparison_test.go
+++ b/pkg/streamingpromql/benchmarks/comparison_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"math"
 	"os"
-	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -140,7 +139,6 @@ func BenchmarkRangeVectorQueryCase(b *testing.B) {
 	require.NoError(b, err)
 
 	ctx := user.InjectOrgID(context.Background(), UserID)
-	runtime.GC()
 
 	for _, c := range cases {
 		start := time.Unix(int64((NumIntervals-c.Steps)*intervalSeconds), 0)

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator.go
@@ -162,6 +162,12 @@ func (b *RangeVectorDuplicationBuffer) bufferUpToAndIncluding(ctx context.Contex
 				b.lastNextStepSamplesCallIndex = b.timeRange.StepCount - 1
 				continue
 			}
+
+			// There are consumers that will read this series so ensure that per-series buffers
+			// for FPoint and HPoints are created before we attempt to merge step data into shared
+			// buffers. Do this now since entries need to be added the respective ring buffers in
+			// order.
+			b.initBuffersForSeries(b.lastNextSeriesCallIndex)
 		}
 
 		stepData, err := b.Inner.NextStepSamples(ctx)
@@ -180,6 +186,31 @@ func (b *RangeVectorDuplicationBuffer) bufferUpToAndIncluding(ctx context.Contex
 	}
 
 	return lastStepData, nil
+}
+
+func (b *RangeVectorDuplicationBuffer) initBuffersForSeries(seriesIndex int) {
+	_ = b.buffer.GetOrCreateFloatBuffer(seriesIndex)
+	_ = b.buffer.GetOrCreateHistogramBuffer(seriesIndex)
+}
+
+// updateDirtyViews updates the FPoint and HPoint views of stepData if the underlying
+// buffers have been modified since the views were created.
+func (b *RangeVectorDuplicationBuffer) updateDirtyViews(seriesIndex int, stepData *types.RangeVectorStepData) {
+	// Steps with anchored or smoothed modifiers use their own dedicated buffers which aren't
+	// ever modified after being created (and hence can't be "dirty").
+	if stepData == nil || stepData.Anchored || stepData.Smoothed {
+		return
+	}
+
+	if stepData.Floats.IsDirty() {
+		floats := b.buffer.GetOrCreateFloatBuffer(seriesIndex)
+		stepData.Floats = floats.ViewBetweenSearchingBackwards(stepData.RangeStart, stepData.RangeEnd, stepData.Floats)
+	}
+
+	if stepData.Histograms.IsDirty() {
+		histograms := b.buffer.GetOrCreateHistogramBuffer(seriesIndex)
+		stepData.Histograms = histograms.ViewBetweenSearchingBackwards(stepData.RangeStart, stepData.RangeEnd, stepData.Histograms)
+	}
 }
 
 // combineStepData copies stepData into buffers owned by this struct (either shared per series or unique
@@ -255,6 +286,20 @@ func (b *RangeVectorDuplicationBuffer) releaseLastReadSamples() {
 	// Release the previously read series, if we can.
 	if !b.anyConsumerWillReadStep(b.lastReturnedSeriesIndex, b.lastReturnedStepSamplesIndex) {
 		if d, present := b.buffer.RemoveIfPresent(b.lastReturnedSeriesIndex, b.lastReturnedStepSamplesIndex); present {
+
+			// If this query isn't using smoothed or anchored modifiers, discard any parts of the shared
+			// per-series buffers that we don't need. This frees up space in the buffers and some of underlying
+			// histogram objects for reuse with new points.
+			if !d.stepData.Smoothed && !d.stepData.Anchored {
+				if floats, ok := b.buffer.seriesFloatData.GetIfPresent(b.lastReturnedSeriesIndex); ok {
+					floats.DiscardPointsAtOrBefore(d.stepData.RangeStart)
+				}
+
+				if histograms, ok := b.buffer.seriesHistogramData.GetIfPresent(b.lastReturnedSeriesIndex); ok {
+					histograms.DiscardPointsAtOrBefore(d.stepData.RangeStart)
+				}
+			}
+
 			d.Close()
 		}
 	}
@@ -274,11 +319,14 @@ func (b *RangeVectorDuplicationBuffer) NextStepSamples(ctx context.Context, cons
 
 	// Release the previous step if all consumers are done with it.
 	b.releaseLastReadSamples()
+
 	b.lastReturnedSeriesIndex = seriesIdx
 	b.lastReturnedStepSamplesIndex = stepIdx
 
 	// Check if the series is already buffered (e.g., another consumer triggered buffering first).
 	if d, ok := b.buffer.GetIfPresent(seriesIdx, stepIdx); ok {
+		// Update the float and histogram views based on the current state of the buffer if needed.
+		b.updateDirtyViews(seriesIdx, d.stepData)
 		// We can't remove the step data from the buffer now even if this is the last consumer for this series -
 		// we'll do this in the next call to NextSeries so that we can return the cloned sample ring buffers to their pools.
 		return d.stepData, nil
@@ -323,6 +371,10 @@ func (b *RangeVectorDuplicationBuffer) NextStepSamples(ctx context.Context, cons
 		return nil, err
 	}
 
+	// Update float and histogram views based on currently buffered data before
+	// returning since step data is created with empty views immediately after it
+	// is buffered.
+	b.updateDirtyViews(seriesIdx, d.stepData)
 	return d.stepData, nil
 }
 
@@ -665,14 +717,19 @@ func (b *RangeVectorDuplicationBuffer) mergeStepData(stepData *types.RangeVector
 	merged.RangeEnd = stepData.RangeEnd
 	merged.StepT = stepData.StepT
 
+	// Note that even when there are floats or histograms for this step we don't create
+	// a real view for it now. Instead, we create an empty view that is marked as dirty.
+	// This will be replaced by a real view before being returned to a consumer and marked
+	// as clean then.
+
 	if floats != nil {
-		merged.Floats = floats.ViewBetweenSearchingBackwards(stepData.RangeStart, stepData.RangeEnd, nil)
+		merged.Floats = floats.EmptyView()
 	} else {
 		merged.Floats = &types.FPointRingBufferView{}
 	}
 
 	if histograms != nil {
-		merged.Histograms = histograms.ViewBetweenSearchingBackwards(stepData.RangeStart, stepData.RangeEnd, nil)
+		merged.Histograms = histograms.EmptyView()
 	} else {
 		merged.Histograms = &types.HPointRingBufferView{}
 	}

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator_test.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator_test.go
@@ -222,12 +222,31 @@ func TestRangeVectorOperator_Buffering_NoFiltering_OverlappingRanges(t *testing.
 			types.SeriesMetadataSlicePool.Put(&metadata1, memoryConsumptionTracker)
 			types.SeriesMetadataSlicePool.Put(&metadata2, memoryConsumptionTracker)
 
-			consumer1Data := testReadConsumerToEnd(t, expectedSeries, consumer1)
-			consumer2Data := testReadConsumerToEnd(t, expectedSeries, consumer2)
+			consumer1Floats, consumer1Histograms := testReadConsumerToEnd(t, expectedSeries, consumer1)
+			consumer2Floats, consumer2Histograms := testReadConsumerToEnd(t, expectedSeries, consumer2)
 
-			require.Len(t, consumer1Data, expectedStepsPerSeries*expectedSeries)
-			require.Len(t, consumer2Data, expectedStepsPerSeries*expectedSeries)
-			require.Equal(t, consumer1Data, consumer2Data)
+			require.Len(t, consumer1Floats, expectedStepsPerSeries*expectedSeries)
+			require.Len(t, consumer1Histograms, expectedStepsPerSeries*expectedSeries)
+			require.Len(t, consumer2Floats, expectedStepsPerSeries*expectedSeries)
+			require.Len(t, consumer2Histograms, expectedStepsPerSeries*expectedSeries)
+
+			for i := range len(consumer1Floats) {
+				testutils.RequireEqualFPoints(t, consumer1Floats[i], consumer2Floats[i])
+			}
+
+			for i := range len(consumer1Histograms) {
+				testutils.RequireEqualHPoints(t, consumer1Histograms[i], consumer2Histograms[i])
+			}
+
+			for i := range len(consumer1Floats) {
+				types.FPointSlicePool.Put(&consumer1Floats[i], memoryConsumptionTracker)
+				types.FPointSlicePool.Put(&consumer2Floats[i], memoryConsumptionTracker)
+			}
+
+			for i := range len(consumer1Histograms) {
+				types.HPointSlicePool.Put(&consumer1Histograms[i], memoryConsumptionTracker)
+				types.HPointSlicePool.Put(&consumer2Histograms[i], memoryConsumptionTracker)
+			}
 
 			require.NoError(t, consumer1.FinishedReading(ctx))
 			require.NoError(t, consumer2.FinishedReading(ctx))
@@ -248,10 +267,13 @@ func TestRangeVectorOperator_Buffering_NoFiltering_OverlappingRanges(t *testing.
 	}
 }
 
-func testReadConsumerToEnd(t *testing.T, numSeries int, consumer *RangeVectorDuplicationConsumer) []*types.RangeVectorStepData {
+func testReadConsumerToEnd(t *testing.T, numSeries int, consumer *RangeVectorDuplicationConsumer) ([][]promql.FPoint, [][]promql.HPoint) {
 	t.Helper()
 
-	var out []*types.RangeVectorStepData
+	var (
+		outFloats     [][]promql.FPoint
+		outHistograms [][]promql.HPoint
+	)
 	for range numSeries {
 		err := consumer.NextSeries(context.Background())
 		if errors.Is(err, types.EOS) {
@@ -267,10 +289,17 @@ func testReadConsumerToEnd(t *testing.T, numSeries int, consumer *RangeVectorDup
 			}
 
 			require.NoError(t, err)
-			out = append(out, d)
+
+			floats, err := d.Floats.CopyPoints()
+			require.NoError(t, err)
+			outFloats = append(outFloats, floats)
+
+			histograms, err := d.Histograms.CopyPoints()
+			require.NoError(t, err)
+			outHistograms = append(outHistograms, histograms)
 		}
 	}
-	return out
+	return outFloats, outHistograms
 }
 
 func TestRangeVectorOperator_Buffering_Filtering_AllConsumersOpen(t *testing.T) {
@@ -844,7 +873,7 @@ func TestRangeVectorOperator_CloneStepDataStructure(t *testing.T) {
 
 	// set explicitly to avoid reflection complexity in handling these
 	data.Floats = fpoints.ViewAll(nil)
-	data.Histograms = hpoints.ViewUntilSearchingBackwards(0, nil)
+	data.Histograms = hpoints.ViewAll(nil)
 
 	v := reflect.ValueOf(data).Elem() // reflect on struct value
 	r := v.Type()                     // struct type

--- a/pkg/streamingpromql/testutils/utils.go
+++ b/pkg/streamingpromql/testutils/utils.go
@@ -288,6 +288,8 @@ func RequireEqualFPoints(t *testing.T, expected, actual []promql.FPoint) {
 		return
 	}
 
+	require.Len(t, actual, len(expected))
+
 	for i, expectedPoint := range expected {
 		actualPoint := actual[i]
 		require.Equal(t, expectedPoint.T, actualPoint.T)
@@ -300,6 +302,8 @@ func RequireEqualHPoints(t *testing.T, expected, actual []promql.HPoint) {
 		require.Nil(t, actual, "expected nil result")
 		return
 	}
+
+	require.Len(t, actual, len(expected))
 
 	for i, expectedPoint := range expected {
 		actualPoint := actual[i]

--- a/pkg/streamingpromql/testutils/utils.go
+++ b/pkg/streamingpromql/testutils/utils.go
@@ -281,3 +281,29 @@ func TrimIndent(s string) string {
 func isEmpty(s string) bool {
 	return strings.TrimSpace(s) == ""
 }
+
+func RequireEqualFPoints(t *testing.T, expected, actual []promql.FPoint) {
+	if expected == nil {
+		require.Nil(t, actual, "expected nil result")
+		return
+	}
+
+	for i, expectedPoint := range expected {
+		actualPoint := actual[i]
+		require.Equal(t, expectedPoint.T, actualPoint.T)
+		requireInEpsilonIfNotZeroOrInf(t, expectedPoint.F, actualPoint.F, "expected point %+v, but have %+v", expectedPoint, actualPoint)
+	}
+}
+
+func RequireEqualHPoints(t *testing.T, expected, actual []promql.HPoint) {
+	if expected == nil {
+		require.Nil(t, actual, "expected nil result")
+		return
+	}
+
+	for i, expectedPoint := range expected {
+		actualPoint := actual[i]
+		require.Equal(t, expectedPoint.T, actualPoint.T)
+		requireHistogramMatch(t, expectedPoint.H, actualPoint.H)
+	}
+}

--- a/pkg/streamingpromql/types/fpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/fpoint_ring_buffer.go
@@ -426,8 +426,9 @@ type FPointRingBufferView struct {
 }
 
 // IsDirty returns true if this view is associated with a buffer and the buffer
-// has been modified since the view was created. When this is the case, the view
-// must be recreated before being used by callers.
+// has been modified in a way that invalidates the view. Not all changes to the
+// buffer invalidate the view. When it is the case that the view has been
+// invalidated, the view must be recreated before being used by callers.
 func (v *FPointRingBufferView) IsDirty() bool {
 	if v.buffer == nil {
 		return false

--- a/pkg/streamingpromql/types/fpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/fpoint_ring_buffer.go
@@ -27,6 +27,7 @@ type FPointRingBuffer struct {
 	pointsIndexMask          int // Bitmask used to calculate indices into points efficiently. Computing modulo is relatively expensive, but points is always sized as a power of two, so we can a bitmask to calculate remainders cheaply.
 	firstIndex               int // Index into 'points' of first point in this buffer.
 	size                     int // Number of points in this buffer.
+	generation               int // Incremented when views of this buffer are invalidated.
 }
 
 func NewFPointRingBuffer(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) *FPointRingBuffer {
@@ -80,6 +81,8 @@ func (b *FPointRingBuffer) resizeIfRequired(additionalPoints int, appendingAtSta
 	putFPointSliceForRingBuffer(&b.points, b.memoryConsumptionTracker)
 	b.points = newSlice
 	b.pointsIndexMask = cap(newSlice) - 1
+	b.generation++
+
 	return true, nil
 }
 
@@ -87,6 +90,7 @@ func (b *FPointRingBuffer) resizeIfRequired(additionalPoints int, appendingAtSta
 // Note that the actual underlying points buffer is not reduced in size.
 func (b *FPointRingBuffer) DiscardPointsAtOrBefore(t int64) {
 	for b.size > 0 && b.points[b.firstIndex].T <= t {
+		b.generation++
 		b.firstIndex++
 		b.size--
 
@@ -104,12 +108,14 @@ func (b *FPointRingBuffer) DiscardPointsAtOrBefore(t int64) {
 // It is safe to call this function on an empty buffer.
 func (b *FPointRingBuffer) RemoveLast() {
 	if b.size > 0 {
+		b.generation++
 		b.size--
 	}
 }
 
 func (b *FPointRingBuffer) RemoveFirst() {
 	if b.size > 0 {
+		b.generation++
 		b.firstIndex++
 		b.size--
 
@@ -127,6 +133,7 @@ func (b *FPointRingBuffer) ReplaceLast(point promql.FPoint) error {
 		return errors.New("unable to replace point to the tail of the buffer - current buffer is empty")
 	}
 
+	// No generation change since we aren't changing the buffer size.
 	position := b.size - 1
 	b.points[(b.firstIndex+position)&b.pointsIndexMask] = point
 	return nil
@@ -140,6 +147,7 @@ func (b *FPointRingBuffer) ReplaceFirst(point promql.FPoint) error {
 		return errors.New("unable to replace point to the head of the buffer - current buffer is empty")
 	}
 
+	// No generation change since we aren't changing the buffer size.
 	b.points[b.firstIndex] = point
 	return nil
 }
@@ -204,6 +212,17 @@ func (b *FPointRingBuffer) AppendSlice(points []promql.FPoint) (bool, error) {
 	return resized, nil
 }
 
+// EmptyView returns an empty view associated with this buffer that is marked as dirty. This
+// view cannot be used directly and instead must be recreated (using "existing") before being
+// used by a caller. This differs from creating an empty FPointRingBufferView directly since
+// this instance will be "dirty" while the struct created directly is not.
+func (b *FPointRingBuffer) EmptyView() *FPointRingBufferView {
+	return &FPointRingBufferView{
+		buffer:     b,
+		generation: -1,
+	}
+}
+
 // ViewUntilSearchingForwards returns a view into this buffer, including only points with timestamps less than or equal to maxT.
 // ViewUntilSearchingForwards examines the points in the buffer starting from the front of the buffer, so is preferred over
 // ViewUntilSearchingBackwards if it is expected that there are many points with timestamp greater than maxT, and few points with
@@ -221,6 +240,7 @@ func (b *FPointRingBuffer) ViewUntilSearchingForwards(maxT int64, existing *FPoi
 		size++
 	}
 
+	existing.generation = b.generation
 	existing.offset = 0
 	existing.size = size
 	return existing
@@ -232,6 +252,8 @@ func (b *FPointRingBuffer) ViewAll(existing *FPointRingBufferView) *FPointRingBu
 	if existing == nil {
 		existing = &FPointRingBufferView{buffer: b}
 	}
+
+	existing.generation = b.generation
 	existing.offset = 0
 	existing.size = b.size
 	return existing
@@ -250,6 +272,7 @@ func (b *FPointRingBuffer) ViewUntilSearchingBackwards(maxT int64, existing *FPo
 		nextPositionToCheck--
 	}
 
+	existing.generation = b.generation
 	existing.offset = 0
 	existing.size = nextPositionToCheck + 1
 	return existing
@@ -269,6 +292,8 @@ func (b *FPointRingBuffer) ViewBetweenSearchingBackwards(minT, maxT int64, exist
 		})
 		panic(fmt.Sprintf("attempted to create an FPointRingBufferView with minT(%d) > maxT(%d) (this is a bug)", minT, maxT))
 	}
+
+	existing.generation = b.generation
 
 	// If the buffer is empty or min time is beyond the last point in this buffer,
 	// return a zero-sized view since there are no points or no matching points.
@@ -348,6 +373,7 @@ func (b *FPointRingBuffer) CountBetween(minT, maxT int64) int {
 
 // Reset clears the contents of this buffer, but retains the underlying point slice for future reuse.
 func (b *FPointRingBuffer) Reset() {
+	b.generation++
 	b.firstIndex = 0
 	b.size = 0
 }
@@ -374,6 +400,7 @@ func (b *FPointRingBuffer) Use(s []promql.FPoint) error {
 
 	putFPointSliceForRingBuffer(&b.points, b.memoryConsumptionTracker)
 
+	b.generation++
 	b.points = s[:cap(s)]
 	b.firstIndex = 0
 	b.size = len(s)
@@ -388,9 +415,21 @@ func (b *FPointRingBuffer) Close() {
 }
 
 type FPointRingBufferView struct {
-	buffer *FPointRingBuffer
-	offset int // Offset from buffer's firstIndex where this view starts
-	size   int
+	buffer     *FPointRingBuffer
+	offset     int // Offset from buffer's firstIndex where this view starts
+	size       int
+	generation int // Generation of the buffer when this view was created
+}
+
+// IsDirty returns true if this view is associated with a buffer and the buffer
+// has been modified since the view was created. When this is the case, the view
+// must be recreated before being used by callers.
+func (v *FPointRingBufferView) IsDirty() bool {
+	if v.buffer == nil {
+		return false
+	}
+
+	return v.generation != v.buffer.generation
 }
 
 // UnsafePoints returns slices of the points in this buffer view.
@@ -506,10 +545,10 @@ func (v *FPointRingBufferView) Clone() (*FPointRingBufferView, *FPointRingBuffer
 		return nil, nil, err
 	}
 
-	view := &FPointRingBufferView{
-		buffer: buffer,
-		size:   v.size,
-	}
+	// Ensure that the newly created buffer (and hence view) has the same generation
+	// as this view so they will compare as equal to this view (some tests rely on this).
+	buffer.generation = v.generation
+	view := buffer.ViewAll(nil)
 
 	return view, buffer, nil
 }

--- a/pkg/streamingpromql/types/fpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/fpoint_ring_buffer.go
@@ -162,6 +162,10 @@ func (b *FPointRingBuffer) AppendAtStart(point promql.FPoint) (bool, error) {
 		return resized, err
 	}
 
+	// Explicitly increase the generation here even if the underlying buffer was not
+	// resized since appending at the start of the buffer changes what the "first" item
+	// in the buffer and views are.
+	b.generation++
 	b.firstIndex = (b.firstIndex - 1) & b.pointsIndexMask
 	b.points[b.firstIndex] = point
 	b.size++

--- a/pkg/streamingpromql/types/fpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/fpoint_ring_buffer.go
@@ -232,7 +232,7 @@ func (b *FPointRingBuffer) EmptyView() *FPointRingBufferView {
 // ViewUntilSearchingBackwards if it is expected that there are many points with timestamp greater than maxT, and few points with
 // earlier timestamps.
 // existing is an existing view instance for this buffer that is reused if provided. It can be nil.
-// The returned view is no longer valid if this buffer is modified (eg. a point is added, or the buffer is reset or closed).
+// The returned view is no longer valid if the buffer is modified in a way that causes FPointRingBufferView.IsDirty() to return true.
 func (b *FPointRingBuffer) ViewUntilSearchingForwards(maxT int64, existing *FPointRingBufferView) *FPointRingBufferView {
 	if existing == nil {
 		existing = &FPointRingBufferView{buffer: b}
@@ -251,7 +251,7 @@ func (b *FPointRingBuffer) ViewUntilSearchingForwards(maxT int64, existing *FPoi
 }
 
 // ViewAll returns a view which includes all points in the ring buffer.
-// The returned view is no longer valid if this buffer is modified (eg. a point is added, or the buffer is reset or closed).
+// The returned view is no longer valid if the buffer is modified in a way that causes FPointRingBufferView.IsDirty() to return true.
 func (b *FPointRingBuffer) ViewAll(existing *FPointRingBufferView) *FPointRingBufferView {
 	if existing == nil {
 		existing = &FPointRingBufferView{buffer: b}
@@ -265,6 +265,7 @@ func (b *FPointRingBuffer) ViewAll(existing *FPointRingBufferView) *FPointRingBu
 
 // ViewUntilSearchingBackwards is like ViewUntilSearchingForwards, except it examines the points from the end of the buffer, so
 // is preferred over ViewUntilSearchingForwards if it is expected that only a few of the points will have timestamp greater than maxT.
+// The returned view is no longer valid if the buffer is modified in a way that causes FPointRingBufferView.IsDirty() to return true.
 func (b *FPointRingBuffer) ViewUntilSearchingBackwards(maxT int64, existing *FPointRingBufferView) *FPointRingBufferView {
 	if existing == nil {
 		existing = &FPointRingBufferView{buffer: b}
@@ -284,6 +285,7 @@ func (b *FPointRingBuffer) ViewUntilSearchingBackwards(maxT int64, existing *FPo
 
 // ViewBetweenSearchingBackwards returns a view into this buffer including only points with timestamps
 // greater than minT and less than or equal to maxT. The method panics if minT is greater than maxT.
+// The returned view is no longer valid if the buffer is modified in a way that causes FPointRingBufferView.IsDirty() to return true.
 func (b *FPointRingBuffer) ViewBetweenSearchingBackwards(minT, maxT int64, existing *FPointRingBufferView) *FPointRingBufferView {
 	if existing == nil {
 		existing = &FPointRingBufferView{buffer: b}

--- a/pkg/streamingpromql/types/hpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/hpoint_ring_buffer.go
@@ -26,6 +26,7 @@ type HPointRingBuffer struct {
 	pointsIndexMask          int // Bitmask used to calculate indices into points efficiently. Computing modulo is relatively expensive, but points is always sized as a power of two, so we can a bitmask to calculate remainders cheaply.
 	firstIndex               int // Index into 'points' of first point in this buffer.
 	size                     int // Number of points in this buffer.
+	generation               int // Incremented when views of this buffer are invalidated.
 }
 
 func NewHPointRingBuffer(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) *HPointRingBuffer {
@@ -35,6 +36,7 @@ func NewHPointRingBuffer(memoryConsumptionTracker *limiter.MemoryConsumptionTrac
 // DiscardPointsAtOrBefore discards all points in this buffer with timestamp less than or equal to t.
 func (b *HPointRingBuffer) DiscardPointsAtOrBefore(t int64) {
 	for b.size > 0 && b.points[b.firstIndex].T <= t {
+		b.generation++
 		b.firstIndex++
 		b.size--
 
@@ -50,6 +52,7 @@ func (b *HPointRingBuffer) DiscardPointsAtOrBefore(t int64) {
 
 func (b *HPointRingBuffer) RemoveFirst() {
 	if b.size > 0 {
+		b.generation++
 		b.firstIndex++
 		b.size--
 
@@ -73,6 +76,17 @@ func (b *HPointRingBuffer) Append(p promql.HPoint) (bool, error) {
 	return resized, nil
 }
 
+// EmptyView returns an empty view associated with this buffer that is marked as dirty. This
+// view cannot be used directly and instead must be recreated (using "existing") before being
+// used by a caller. This differs from creating an empty HPointRingBufferView directly since
+// this instance will be "dirty" while the struct created directly is not.
+func (b *HPointRingBuffer) EmptyView() *HPointRingBufferView {
+	return &HPointRingBufferView{
+		buffer:     b,
+		generation: -1,
+	}
+}
+
 // ViewUntilSearchingForwards returns a view into this buffer, including only points with timestamps less than or equal to maxT.
 // ViewUntilSearchingForwards examines the points in the buffer starting from the front of the buffer, so is preferred over
 // ViewUntilSearchingBackwards if it is expected that there are many points with timestamp greater than maxT, and few points with
@@ -90,8 +104,22 @@ func (b *HPointRingBuffer) ViewUntilSearchingForwards(maxT int64, existing *HPoi
 		size++
 	}
 
+	existing.generation = b.generation
 	existing.offset = 0
 	existing.size = size
+	return existing
+}
+
+// ViewAll returns a view which includes all points in the ring buffer.
+// The returned view is no longer valid if this buffer is modified (eg. a point is added, or the buffer is reset or closed).
+func (b *HPointRingBuffer) ViewAll(existing *HPointRingBufferView) *HPointRingBufferView {
+	if existing == nil {
+		existing = &HPointRingBufferView{buffer: b}
+	}
+
+	existing.generation = b.generation
+	existing.offset = 0
+	existing.size = b.size
 	return existing
 }
 
@@ -108,6 +136,7 @@ func (b *HPointRingBuffer) ViewUntilSearchingBackwards(maxT int64, existing *HPo
 		nextPositionToCheck--
 	}
 
+	existing.generation = b.generation
 	existing.offset = 0
 	existing.size = nextPositionToCheck + 1
 	return existing
@@ -127,6 +156,8 @@ func (b *HPointRingBuffer) ViewBetweenSearchingBackwards(minT, maxT int64, exist
 		})
 		panic(fmt.Sprintf("attempted to create an HPointRingBufferView with minT(%d) > maxT(%d) (this is a bug)", minT, maxT))
 	}
+
+	existing.generation = b.generation
 
 	// If the buffer is empty or min time is beyond the last point in this buffer,
 	// return a zero-sized view since there are no points or no matching points.
@@ -218,10 +249,12 @@ func (b *HPointRingBuffer) NextPoint() (*promql.HPoint, bool, error) {
 		b.points = newSlice
 		b.firstIndex = 0
 		b.pointsIndexMask = cap(newSlice) - 1
+		b.generation++
 	}
 
 	nextIndex := (b.firstIndex + b.size) & b.pointsIndexMask
 	b.size++
+
 	return &b.points[nextIndex], resized, nil
 }
 
@@ -235,6 +268,7 @@ func (b *HPointRingBuffer) RemoveLastPoint() {
 		panic("There are no points to remove")
 	}
 
+	b.generation++
 	b.size--
 	if b.size == 0 {
 		b.firstIndex = 0
@@ -274,6 +308,7 @@ func (b *HPointRingBuffer) CountBetween(minT, maxT int64) int {
 
 // Reset clears the contents of this buffer, but retains the underlying point slice for future reuse.
 func (b *HPointRingBuffer) Reset() {
+	b.generation++
 	b.firstIndex = 0
 	b.size = 0
 }
@@ -300,6 +335,7 @@ func (b *HPointRingBuffer) Use(s []promql.HPoint) error {
 
 	putHPointSliceForRingBuffer(&b.points, b.memoryConsumptionTracker)
 
+	b.generation++
 	b.points = s[:cap(s)]
 	b.firstIndex = 0
 	b.size = len(s)
@@ -314,9 +350,21 @@ func (b *HPointRingBuffer) Close() {
 }
 
 type HPointRingBufferView struct {
-	buffer *HPointRingBuffer
-	offset int // Offset from buffer's firstIndex where this view starts
-	size   int
+	buffer     *HPointRingBuffer
+	offset     int // Offset from buffer's firstIndex where this view starts
+	size       int
+	generation int // Generation of the buffer when this view was created
+}
+
+// IsDirty returns true if this view is associated with a buffer and the buffer
+// has been modified since the view was created. When this is the case, the view
+// must be recreated before being used by callers.
+func (v *HPointRingBufferView) IsDirty() bool {
+	if v.buffer == nil {
+		return false
+	}
+
+	return v.generation != v.buffer.generation
 }
 
 // UnsafePoints returns slices of the points in this buffer view.
@@ -328,7 +376,7 @@ type HPointRingBufferView struct {
 //
 // FIXME: the fact we have to expose this is a bit gross, but the overhead of calling a function with ForEach is terrible.
 // Perhaps we can use range-over function iterators (https://go.dev/wiki/RangefuncExperiment) once this is not experimental?
-func (v HPointRingBufferView) UnsafePoints() (head []promql.HPoint, tail []promql.HPoint) {
+func (v *HPointRingBufferView) UnsafePoints() (head []promql.HPoint, tail []promql.HPoint) {
 	if v.size == 0 {
 		return nil, nil
 	}
@@ -352,7 +400,7 @@ func (v HPointRingBufferView) UnsafePoints() (head []promql.HPoint, tail []promq
 // iterate a sub-range with a plain slice range loop instead of repeated PointAt calls.
 // Like UnsafePoints, the returned slices alias the buffer and must not be modified nor returned to
 // a pool.
-func (v HPointRingBufferView) UnsafePointsInIndexRange(first, last int) (head []promql.HPoint, tail []promql.HPoint) {
+func (v *HPointRingBufferView) UnsafePointsInIndexRange(first, last int) (head []promql.HPoint, tail []promql.HPoint) {
 	if first < 0 || last >= v.size || first > last {
 		panic("HPointRingBufferView.UnsafePointsInIndexRange(): index out of range")
 	}
@@ -368,7 +416,7 @@ func (v HPointRingBufferView) UnsafePointsInIndexRange(first, last int) (head []
 // PutHPointSlice when it is no longer needed.
 // Calling UnsafePoints is more efficient than calling CopyPoints, as CopyPoints will create a new slice and copy all
 // points into the slice, whereas UnsafePoints returns a view into the internal state of this buffer.
-func (v HPointRingBufferView) CopyPoints() ([]promql.HPoint, error) {
+func (v *HPointRingBufferView) CopyPoints() ([]promql.HPoint, error) {
 	if v.size == 0 {
 		return nil, nil
 	}
@@ -402,7 +450,7 @@ func (v HPointRingBufferView) CopyPoints() ([]promql.HPoint, error) {
 }
 
 // ForEach calls f for each point in this buffer view.
-func (v HPointRingBufferView) ForEach(f func(p promql.HPoint)) {
+func (v *HPointRingBufferView) ForEach(f func(p promql.HPoint)) {
 	for i := 0; i < v.size; i++ {
 		f(v.PointAt(i))
 	}
@@ -410,7 +458,7 @@ func (v HPointRingBufferView) ForEach(f func(p promql.HPoint)) {
 
 // First returns the first point in this ring buffer view.
 // It panics if the buffer is empty.
-func (v HPointRingBufferView) First() promql.HPoint {
+func (v *HPointRingBufferView) First() promql.HPoint {
 	if v.size == 0 {
 		panic("Can't get first element of empty buffer")
 	}
@@ -420,7 +468,7 @@ func (v HPointRingBufferView) First() promql.HPoint {
 
 // Last returns the last point in this ring buffer view.
 // It returns false if the view is empty.
-func (v HPointRingBufferView) Last() (promql.HPoint, bool) {
+func (v *HPointRingBufferView) Last() (promql.HPoint, bool) {
 	if v.size == 0 {
 		return promql.HPoint{}, false
 	}
@@ -429,12 +477,12 @@ func (v HPointRingBufferView) Last() (promql.HPoint, bool) {
 }
 
 // Count returns the number of points in this ring buffer view.
-func (v HPointRingBufferView) Count() int {
+func (v *HPointRingBufferView) Count() int {
 	return v.size
 }
 
 // EquivalentFloatSampleCount returns the equivalent number of float samples in this ring buffer view.
-func (v HPointRingBufferView) EquivalentFloatSampleCount() int64 {
+func (v *HPointRingBufferView) EquivalentFloatSampleCount() int64 {
 	count := int64(0)
 	head, tail := v.UnsafePoints()
 
@@ -488,13 +536,13 @@ func (b *HPointRingBuffer) EquivalentFloatSampleCountBetween(minT, maxT int64) i
 }
 
 // Any returns true if this ring buffer view contains any points.
-func (v HPointRingBufferView) Any() bool {
+func (v *HPointRingBufferView) Any() bool {
 	return v.size != 0
 }
 
 // PointAt returns the point at index i in this ring buffer view.
 // It panics if i is outside the range of points in this view.
-func (v HPointRingBufferView) PointAt(i int) promql.HPoint {
+func (v *HPointRingBufferView) PointAt(i int) promql.HPoint {
 	if i >= v.size {
 		// A constant-string panic (rather than fmt.Sprintf) keeps PointAt cheap enough to be
 		// inlined into hot loops, e.g. the per-sample passes in extendedHistogramRate.
@@ -507,7 +555,7 @@ func (v HPointRingBufferView) PointAt(i int) promql.HPoint {
 // Clone returns a clone of this view and its underlying ring buffer.
 // All histogram.FloatHistogram instances in the underlying buffer are cloned.
 // The caller is responsible for closing the returned ring buffer when it is no longer needed.
-func (v HPointRingBufferView) Clone() (*HPointRingBufferView, *HPointRingBuffer, error) {
+func (v *HPointRingBufferView) Clone() (*HPointRingBufferView, *HPointRingBuffer, error) {
 	if v.size == 0 {
 		return &HPointRingBufferView{}, nil, nil
 	}
@@ -522,10 +570,10 @@ func (v HPointRingBufferView) Clone() (*HPointRingBufferView, *HPointRingBuffer,
 		return nil, nil, err
 	}
 
-	view := &HPointRingBufferView{
-		buffer: buffer,
-		size:   v.size,
-	}
+	// Ensure that the newly created buffer (and hence view) has the same generation
+	// as this view so they will compare as equal to this view (some tests rely on this).
+	buffer.generation = v.generation
+	view := buffer.ViewAll(nil)
 
 	return view, buffer, nil
 }

--- a/pkg/streamingpromql/types/hpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/hpoint_ring_buffer.go
@@ -357,8 +357,9 @@ type HPointRingBufferView struct {
 }
 
 // IsDirty returns true if this view is associated with a buffer and the buffer
-// has been modified since the view was created. When this is the case, the view
-// must be recreated before being used by callers.
+// has been modified in a way that invalidates the view. Not all changes to the
+// buffer invalidate the view. When it is the case that the view has been
+// invalidated, the view must be recreated before being used by callers.
 func (v *HPointRingBufferView) IsDirty() bool {
 	if v.buffer == nil {
 		return false

--- a/pkg/streamingpromql/types/hpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/hpoint_ring_buffer.go
@@ -92,7 +92,7 @@ func (b *HPointRingBuffer) EmptyView() *HPointRingBufferView {
 // ViewUntilSearchingBackwards if it is expected that there are many points with timestamp greater than maxT, and few points with
 // earlier timestamps.
 // existing is an existing view instance for this buffer that is reused if provided. It can be nil.
-// The returned view is no longer valid if this buffer is modified (eg. a point is added, or the buffer is reset or closed).
+// The returned view is no longer valid if the buffer is modified in a way that causes HPointRingBufferView.IsDirty() to return true.
 func (b *HPointRingBuffer) ViewUntilSearchingForwards(maxT int64, existing *HPointRingBufferView) *HPointRingBufferView {
 	if existing == nil {
 		existing = &HPointRingBufferView{buffer: b}
@@ -111,7 +111,7 @@ func (b *HPointRingBuffer) ViewUntilSearchingForwards(maxT int64, existing *HPoi
 }
 
 // ViewAll returns a view which includes all points in the ring buffer.
-// The returned view is no longer valid if this buffer is modified (eg. a point is added, or the buffer is reset or closed).
+// The returned view is no longer valid if the buffer is modified in a way that causes HPointRingBufferView.IsDirty() to return true.
 func (b *HPointRingBuffer) ViewAll(existing *HPointRingBufferView) *HPointRingBufferView {
 	if existing == nil {
 		existing = &HPointRingBufferView{buffer: b}
@@ -125,6 +125,7 @@ func (b *HPointRingBuffer) ViewAll(existing *HPointRingBufferView) *HPointRingBu
 
 // ViewUntilSearchingBackwards is like ViewUntilSearchingForwards, except it examines the points from the end of the buffer, so
 // is preferred over ViewUntilSearchingForwards if it is expected that only a few of the points will have timestamp greater than maxT.
+// The returned view is no longer valid if the buffer is modified in a way that causes HPointRingBufferView.IsDirty() to return true.
 func (b *HPointRingBuffer) ViewUntilSearchingBackwards(maxT int64, existing *HPointRingBufferView) *HPointRingBufferView {
 	if existing == nil {
 		existing = &HPointRingBufferView{buffer: b}
@@ -144,6 +145,7 @@ func (b *HPointRingBuffer) ViewUntilSearchingBackwards(maxT int64, existing *HPo
 
 // ViewBetweenSearchingBackwards returns a view into this buffer including only points with timestamps
 // greater than minT and less than or equal to maxT. The method panics if minT is greater than maxT.
+// The returned view is no longer valid if the buffer is modified in a way that causes HPointRingBufferView.IsDirty() to return true.
 func (b *HPointRingBuffer) ViewBetweenSearchingBackwards(minT, maxT int64, existing *HPointRingBufferView) *HPointRingBufferView {
 	if existing == nil {
 		existing = &HPointRingBufferView{buffer: b}

--- a/pkg/streamingpromql/types/operator.go
+++ b/pkg/streamingpromql/types/operator.go
@@ -103,7 +103,7 @@ type RangeVectorOperator interface {
 	// steps are available.
 	//
 	// Returned views of FPoints or HPoints are only valid until the next call to NextSeries or
-	// NextStepSamples. The views must be cloned to in order to use them beyond the next call.
+	// NextStepSamples. The views must be cloned in order to use them beyond the next call.
 	NextStepSamples(ctx context.Context) (*RangeVectorStepData, error)
 }
 

--- a/pkg/streamingpromql/types/operator.go
+++ b/pkg/streamingpromql/types/operator.go
@@ -101,6 +101,9 @@ type RangeVectorOperator interface {
 	// NextStepSamples returns populated RingBuffers with the samples for the next time step for the
 	// current series and the timestamps of the next time step, or returns EOS if no more time
 	// steps are available.
+	//
+	// Returned views of FPoints or HPoints are only valid until the next call to NextSeries or
+	// NextStepSamples. The views must be cloned to in order to use them beyond the next call.
 	NextStepSamples(ctx context.Context) (*RangeVectorStepData, error)
 }
 

--- a/pkg/streamingpromql/types/ring_buffer_test.go
+++ b/pkg/streamingpromql/types/ring_buffer_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/promql"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/util/limiter"
@@ -23,6 +24,7 @@ type ringBuffer[T any] interface {
 	Reset()
 	Use(s []T) error
 	Release()
+	ViewBetweenSearchingBackwardsForTesting(minT, maxT int64) ringBufferView[T]
 	ViewUntilSearchingForwardsForTesting(maxT int64) ringBufferView[T]
 	ViewUntilSearchingBackwardsForTesting(maxT int64) ringBufferView[T]
 	GetPoints() []T
@@ -31,6 +33,7 @@ type ringBuffer[T any] interface {
 }
 
 type ringBufferView[T any] interface {
+	IsDirty() bool
 	ForEach(f func(p T))
 	UnsafePoints() (head []T, tail []T)
 	CopyPoints() ([]T, error)
@@ -495,6 +498,35 @@ func shouldHavePointsAtOrBeforeTime[T any](t *testing.T, buf ringBuffer[T], ts i
 	viewShouldHavePoints(t, buf.ViewUntilSearchingBackwardsForTesting(ts), expected...)
 }
 
+type viewsForIsDirtyTests[T any] struct {
+	untilForwards  ringBufferView[T]
+	untilBackwards ringBufferView[T]
+	between        ringBufferView[T]
+}
+
+func shouldHaveCleanViews[T any](t *testing.T, buf ringBuffer[T]) viewsForIsDirtyTests[T] {
+	untilForwards := buf.ViewUntilSearchingForwardsForTesting(math.MaxInt64)
+	require.False(t, untilForwards.IsDirty(), "expected ViewUntilSearchingForwards to not return dirty view")
+
+	untilBackwards := buf.ViewUntilSearchingBackwardsForTesting(math.MaxInt64)
+	require.False(t, untilBackwards.IsDirty(), "expected ViewUntilSearchingBackwards to not return dirty view")
+
+	between := buf.ViewBetweenSearchingBackwardsForTesting(math.MinInt64, math.MaxInt64)
+	require.False(t, between.IsDirty(), "expected ViewBetweenSearchingBackwards to not return dirty view")
+
+	return viewsForIsDirtyTests[T]{
+		untilForwards:  untilForwards,
+		untilBackwards: untilBackwards,
+		between:        between,
+	}
+}
+
+func shouldHaveDirtyViews[T any](t *testing.T, buf ringBuffer[T], views viewsForIsDirtyTests[T]) {
+	assert.True(t, views.untilForwards.IsDirty(), "expected view created by ViewUntilSearchingForwards from %+v to be dirty. view: %+v", buf, views.untilForwards)
+	assert.True(t, views.untilBackwards.IsDirty(), "expected view created by ViewUntilSearchingBackwards from %+v to be dirty. view: %+v", buf, views.untilBackwards)
+	assert.True(t, views.between.IsDirty(), "expected view created by ViewBetweenSearchingBackwards from %+v to be dirty. view: %+v", buf, views.between)
+}
+
 func viewShouldHavePoints[T any](t *testing.T, view ringBufferView[T], expected ...T) {
 	head, tail := view.UnsafePoints()
 	combinedPoints := append(head, tail...)
@@ -538,6 +570,10 @@ type fPointRingBufferWrapper struct {
 	*FPointRingBuffer
 }
 
+func (w *fPointRingBufferWrapper) ViewBetweenSearchingBackwardsForTesting(minT, maxT int64) ringBufferView[promql.FPoint] {
+	return w.ViewBetweenSearchingBackwards(minT, maxT, nil)
+}
+
 func (w *fPointRingBufferWrapper) ViewUntilSearchingForwardsForTesting(maxT int64) ringBufferView[promql.FPoint] {
 	return w.ViewUntilSearchingForwards(maxT, nil)
 }
@@ -561,6 +597,10 @@ func (w *fPointRingBufferWrapper) GetTimestamp(point promql.FPoint) int64 {
 // Wrapper for HPointRingBuffer to work around indirection to get points
 type hPointRingBufferWrapper struct {
 	*HPointRingBuffer
+}
+
+func (w *hPointRingBufferWrapper) ViewBetweenSearchingBackwardsForTesting(minT, maxT int64) ringBufferView[promql.HPoint] {
+	return w.ViewBetweenSearchingBackwards(minT, maxT, nil)
 }
 
 func (w *hPointRingBufferWrapper) ViewUntilSearchingForwardsForTesting(maxT int64) ringBufferView[promql.HPoint] {
@@ -1238,4 +1278,118 @@ func TestHPointRingBufferView_UnsafePointsInIndexRange(t *testing.T) {
 		require.Panics(t, func() { view.UnsafePointsInIndexRange(0, view.Count()) })
 		require.Panics(t, func() { view.UnsafePointsInIndexRange(2, 1) })
 	})
+}
+
+func TestRingBufferView_IsDirty(t *testing.T) {
+	t.Run("resize", func(t *testing.T) {
+		fbuff := &fPointRingBufferWrapper{NewFPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))}
+		hbuff := &hPointRingBufferWrapper{NewHPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))}
+
+		fviews := shouldHaveCleanViews(t, fbuff)
+		hviews := shouldHaveCleanViews(t, hbuff)
+
+		for ts := int64(10); ts < 90; ts += 10 {
+			mustAppend(t, fbuff, promql.FPoint{T: ts})
+			mustAppend(t, hbuff, promql.HPoint{T: ts, H: &histogram.FloatHistogram{}})
+		}
+
+		shouldHaveDirtyViews(t, fbuff, fviews)
+		shouldHaveDirtyViews(t, hbuff, hviews)
+	})
+
+	t.Run("discard points", func(t *testing.T) {
+		fbuff := &fPointRingBufferWrapper{NewFPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))}
+		hbuff := &hPointRingBufferWrapper{NewHPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))}
+
+		for ts := int64(10); ts < 90; ts += 10 {
+			mustAppend(t, fbuff, promql.FPoint{T: ts})
+			mustAppend(t, hbuff, promql.HPoint{T: ts, H: &histogram.FloatHistogram{}})
+		}
+
+		fviews := shouldHaveCleanViews(t, fbuff)
+		hviews := shouldHaveCleanViews(t, hbuff)
+
+		fbuff.DiscardPointsAtOrBefore(30)
+		hbuff.DiscardPointsAtOrBefore(30)
+
+		shouldHaveDirtyViews(t, fbuff, fviews)
+		shouldHaveDirtyViews(t, hbuff, hviews)
+	})
+
+	t.Run("remove last", func(t *testing.T) {
+		fbuff := &fPointRingBufferWrapper{NewFPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))}
+		hbuff := &hPointRingBufferWrapper{NewHPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))}
+
+		for ts := int64(10); ts < 90; ts += 10 {
+			mustAppend(t, fbuff, promql.FPoint{T: ts})
+			mustAppend(t, hbuff, promql.HPoint{T: ts, H: &histogram.FloatHistogram{}})
+		}
+
+		fviews := shouldHaveCleanViews(t, fbuff)
+		hviews := shouldHaveCleanViews(t, hbuff)
+
+		fbuff.RemoveLast()
+		hbuff.RemoveLastPoint()
+
+		shouldHaveDirtyViews(t, fbuff, fviews)
+		shouldHaveDirtyViews(t, hbuff, hviews)
+	})
+
+	t.Run("remove first", func(t *testing.T) {
+		fbuff := &fPointRingBufferWrapper{NewFPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))}
+		hbuff := &hPointRingBufferWrapper{NewHPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))}
+
+		for ts := int64(10); ts < 90; ts += 10 {
+			mustAppend(t, fbuff, promql.FPoint{T: ts})
+			mustAppend(t, hbuff, promql.HPoint{T: ts, H: &histogram.FloatHistogram{}})
+		}
+
+		fviews := shouldHaveCleanViews(t, fbuff)
+		hviews := shouldHaveCleanViews(t, hbuff)
+
+		fbuff.RemoveFirst()
+		hbuff.RemoveFirst()
+
+		shouldHaveDirtyViews(t, fbuff, fviews)
+		shouldHaveDirtyViews(t, hbuff, hviews)
+	})
+
+	t.Run("reset", func(t *testing.T) {
+		fbuff := &fPointRingBufferWrapper{NewFPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))}
+		hbuff := &hPointRingBufferWrapper{NewHPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))}
+
+		for ts := int64(10); ts < 90; ts += 10 {
+			mustAppend(t, fbuff, promql.FPoint{T: ts})
+			mustAppend(t, hbuff, promql.HPoint{T: ts, H: &histogram.FloatHistogram{}})
+		}
+
+		fviews := shouldHaveCleanViews(t, fbuff)
+		hviews := shouldHaveCleanViews(t, hbuff)
+
+		fbuff.Reset()
+		hbuff.Reset()
+
+		shouldHaveDirtyViews(t, fbuff, fviews)
+		shouldHaveDirtyViews(t, hbuff, hviews)
+	})
+
+	t.Run("use", func(t *testing.T) {
+		fbuff := &fPointRingBufferWrapper{NewFPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))}
+		hbuff := &hPointRingBufferWrapper{NewHPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))}
+
+		for ts := int64(10); ts < 90; ts += 10 {
+			mustAppend(t, fbuff, promql.FPoint{T: ts})
+			mustAppend(t, hbuff, promql.HPoint{T: ts, H: &histogram.FloatHistogram{}})
+		}
+
+		fviews := shouldHaveCleanViews(t, fbuff)
+		hviews := shouldHaveCleanViews(t, hbuff)
+
+		require.NoError(t, fbuff.Use(make([]promql.FPoint, 0, 16)))
+		require.NoError(t, hbuff.Use(make([]promql.HPoint, 0, 16)))
+
+		shouldHaveDirtyViews(t, fbuff, fviews)
+		shouldHaveDirtyViews(t, hbuff, hviews)
+	})
+
 }

--- a/pkg/streamingpromql/types/ring_buffer_test.go
+++ b/pkg/streamingpromql/types/ring_buffer_test.go
@@ -1297,6 +1297,22 @@ func TestRingBufferView_IsDirty(t *testing.T) {
 		shouldHaveDirtyViews(t, hbuff, hviews)
 	})
 
+	t.Run("append at start", func(t *testing.T) {
+		// Note that HPoint buffers don't have an AppendAtStart() method
+		fbuff := &fPointRingBufferWrapper{NewFPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))}
+
+		for ts := int64(10); ts < 90; ts += 10 {
+			mustAppend(t, fbuff, promql.FPoint{T: ts})
+		}
+
+		fviews := shouldHaveCleanViews(t, fbuff)
+
+		_, err := fbuff.AppendAtStart(promql.FPoint{T: 0})
+		require.NoError(t, err)
+
+		shouldHaveDirtyViews(t, fbuff, fviews)
+	})
+
 	t.Run("discard points", func(t *testing.T) {
 		fbuff := &fPointRingBufferWrapper{NewFPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))}
 		hbuff := &hPointRingBufferWrapper{NewHPointRingBuffer(limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()))}


### PR DESCRIPTION
#### What this PR does

Follow up to https://github.com/grafana/mimir/pull/15412, discard histograms and float points as soon as
they are not needed by any steps.

#### Which issue(s) this PR fixes or relates to

Follow up #15412

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
