### PR TITLE
MQE: Use atomic bool for global mangle/don't mangle pool flag

### DIFF
--- a/pkg/streamingpromql/caching/init_test.go
+++ b/pkg/streamingpromql/caching/init_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func init() {
-	types.EnableManglingReturnedSlices = true
+	types.EnableManglingReturnedSlices.Store(true)
 }

--- a/pkg/streamingpromql/comparisons/init_test.go
+++ b/pkg/streamingpromql/comparisons/init_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func init() {
-	types.EnableManglingReturnedSlices = true
+	types.EnableManglingReturnedSlices.Store(true)
 }

--- a/pkg/streamingpromql/compat/init_test.go
+++ b/pkg/streamingpromql/compat/init_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func init() {
-	types.EnableManglingReturnedSlices = true
+	types.EnableManglingReturnedSlices.Store(true)
 }

--- a/pkg/streamingpromql/floats/init_test.go
+++ b/pkg/streamingpromql/floats/init_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func init() {
-	types.EnableManglingReturnedSlices = true
+	types.EnableManglingReturnedSlices.Store(true)
 }

--- a/pkg/streamingpromql/fuzz/init_test.go
+++ b/pkg/streamingpromql/fuzz/init_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func init() {
-	types.EnableManglingReturnedSlices = true
+	types.EnableManglingReturnedSlices.Store(true)
 }

--- a/pkg/streamingpromql/init_test.go
+++ b/pkg/streamingpromql/init_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func init() {
-	types.EnableManglingReturnedSlices = true
+	types.EnableManglingReturnedSlices.Store(true)
 }

--- a/pkg/streamingpromql/operators/aggregations/aggregation.go
+++ b/pkg/streamingpromql/operators/aggregations/aggregation.go
@@ -91,7 +91,10 @@ var groupPointerSlicePool = types.NewLimitingBucketedPool(
 	}),
 	limiter.GroupPointerSlices,
 	groupPointerSize,
-	true, nil, nil,
+	true,
+	types.EnableManglingReturnedSlices,
+	nil,
+	nil,
 )
 
 func (a *Aggregation) ExpressionPosition() posrange.PositionRange {

--- a/pkg/streamingpromql/operators/aggregations/init_test.go
+++ b/pkg/streamingpromql/operators/aggregations/init_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func init() {
-	types.EnableManglingReturnedSlices = true
+	types.EnableManglingReturnedSlices.Store(true)
 }

--- a/pkg/streamingpromql/operators/aggregations/quantile.go
+++ b/pkg/streamingpromql/operators/aggregations/quantile.go
@@ -154,6 +154,7 @@ var qGroupPool = types.NewLimitingBucketedPool(
 	limiter.QuantileGroupSlices,
 	uint64(unsafe.Sizeof(qGroup{})),
 	true,
+	types.EnableManglingReturnedSlices,
 	nil,
 	nil,
 )

--- a/pkg/streamingpromql/operators/aggregations/topkbottomk/init_test.go
+++ b/pkg/streamingpromql/operators/aggregations/topkbottomk/init_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func init() {
-	types.EnableManglingReturnedSlices = true
+	types.EnableManglingReturnedSlices.Store(true)
 }

--- a/pkg/streamingpromql/operators/aggregations/topkbottomk/instant_query.go
+++ b/pkg/streamingpromql/operators/aggregations/topkbottomk/instant_query.go
@@ -353,6 +353,7 @@ var instantQuerySeriesSlicePool = types.NewLimitingBucketedPool(
 	limiter.TopKBottomKInstantQuerySeriesSlices,
 	uint64(unsafe.Sizeof(instantQuerySeries{})),
 	true,
+	types.EnableManglingReturnedSlices,
 	nil,
 	nil,
 )

--- a/pkg/streamingpromql/operators/aggregations/topkbottomk/range_query.go
+++ b/pkg/streamingpromql/operators/aggregations/topkbottomk/range_query.go
@@ -526,6 +526,7 @@ var rangeQuerySeriesSlicePool = types.NewLimitingBucketedPool(
 	limiter.TopKBottomKRangeQuerySeriesSlices,
 	uint64(unsafe.Sizeof(rangeQuerySeries{})),
 	true,
+	types.EnableManglingReturnedSlices,
 	nil,
 	nil,
 )
@@ -537,6 +538,7 @@ var intSliceSlicePool = types.NewLimitingBucketedPool(
 	limiter.IntSliceSlice,
 	uint64(unsafe.Sizeof([][]int{})),
 	true,
+	types.EnableManglingReturnedSlices,
 	nil,
 	nil,
 )

--- a/pkg/streamingpromql/operators/binops/init_test.go
+++ b/pkg/streamingpromql/operators/binops/init_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func init() {
-	types.EnableManglingReturnedSlices = true
+	types.EnableManglingReturnedSlices.Store(true)
 }

--- a/pkg/streamingpromql/operators/functions/histogram_function.go
+++ b/pkg/streamingpromql/operators/functions/histogram_function.go
@@ -119,6 +119,7 @@ var seriesGroupPairPool = types.NewLimitingBucketedPool(
 	limiter.SeriesGroupPairSlices,
 	seriesGroupPairSize,
 	true, // clearOnGet: zero out stale pointers and strings from previous use
+	types.EnableManglingReturnedSlices,
 	nil,
 	nil,
 )
@@ -131,6 +132,7 @@ var bucketGroupPointerSlicePool = types.NewLimitingBucketedPool(
 	limiter.BucketGroupPointerSlices,
 	bucketGroupPointerSize,
 	true, // clearOnGet: zero out stale pointers from previous use
+	types.EnableManglingReturnedSlices,
 	nil,
 	nil,
 )
@@ -142,6 +144,7 @@ var pointBucketPool = types.NewLimitingBucketedPool(
 	limiter.BucketsSlices,
 	uint64(unsafe.Sizeof(promql.Buckets{})),
 	true,
+	types.EnableManglingReturnedSlices,
 	mangleBuckets,
 	nil,
 )
@@ -162,6 +165,7 @@ var bucketSliceBucketedPool = types.NewLimitingBucketedPool(
 	limiter.BucketSlices,
 	uint64(unsafe.Sizeof(promql.Bucket{})),
 	true,
+	types.EnableManglingReturnedSlices,
 	mangleBucket,
 	nil,
 )

--- a/pkg/streamingpromql/operators/functions/init_test.go
+++ b/pkg/streamingpromql/operators/functions/init_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func init() {
-	types.EnableManglingReturnedSlices = true
+	types.EnableManglingReturnedSlices.Store(true)
 }

--- a/pkg/streamingpromql/operators/init_test.go
+++ b/pkg/streamingpromql/operators/init_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func init() {
-	types.EnableManglingReturnedSlices = true
+	types.EnableManglingReturnedSlices.Store(true)
 }

--- a/pkg/streamingpromql/operators/scalars/init_test.go
+++ b/pkg/streamingpromql/operators/scalars/init_test.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package benchmarks_test
+package scalars
 
 import (
 	"github.com/grafana/mimir/pkg/streamingpromql/types"

--- a/pkg/streamingpromql/operators/selectors/init_test.go
+++ b/pkg/streamingpromql/operators/selectors/init_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func init() {
-	types.EnableManglingReturnedSlices = true
+	types.EnableManglingReturnedSlices.Store(true)
 }

--- a/pkg/streamingpromql/optimize/ast/init_test.go
+++ b/pkg/streamingpromql/optimize/ast/init_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func init() {
-	types.EnableManglingReturnedSlices = true
+	types.EnableManglingReturnedSlices.Store(true)
 }

--- a/pkg/streamingpromql/optimize/ast/sharding/init_test.go
+++ b/pkg/streamingpromql/optimize/ast/sharding/init_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func init() {
-	types.EnableManglingReturnedSlices = true
+	types.EnableManglingReturnedSlices.Store(true)
 }

--- a/pkg/streamingpromql/optimize/ast/subqueryspinoff/init_test.go
+++ b/pkg/streamingpromql/optimize/ast/subqueryspinoff/init_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func init() {
-	types.EnableManglingReturnedSlices = true
+	types.EnableManglingReturnedSlices.Store(true)
 }

--- a/pkg/streamingpromql/optimize/init_test.go
+++ b/pkg/streamingpromql/optimize/init_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func init() {
-	types.EnableManglingReturnedSlices = true
+	types.EnableManglingReturnedSlices.Store(true)
 }

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/init_test.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/init_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func init() {
-	types.EnableManglingReturnedSlices = true
+	types.EnableManglingReturnedSlices.Store(true)
 }

--- a/pkg/streamingpromql/optimize/plan/init_test.go
+++ b/pkg/streamingpromql/optimize/plan/init_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func init() {
-	types.EnableManglingReturnedSlices = true
+	types.EnableManglingReturnedSlices.Store(true)
 }

--- a/pkg/streamingpromql/optimize/plan/multiaggregation/init_test.go
+++ b/pkg/streamingpromql/optimize/plan/multiaggregation/init_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func init() {
-	types.EnableManglingReturnedSlices = true
+	types.EnableManglingReturnedSlices.Store(true)
 }

--- a/pkg/streamingpromql/optimize/plan/rangevectorsplitting/cache/init_test.go
+++ b/pkg/streamingpromql/optimize/plan/rangevectorsplitting/cache/init_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func init() {
-	types.EnableManglingReturnedSlices = true
+	types.EnableManglingReturnedSlices.Store(true)
 }

--- a/pkg/streamingpromql/optimize/plan/rangevectorsplitting/init_test.go
+++ b/pkg/streamingpromql/optimize/plan/rangevectorsplitting/init_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func init() {
-	types.EnableManglingReturnedSlices = true
+	types.EnableManglingReturnedSlices.Store(true)
 }

--- a/pkg/streamingpromql/optimize/plan/remoteexec/init_test.go
+++ b/pkg/streamingpromql/optimize/plan/remoteexec/init_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func init() {
-	types.EnableManglingReturnedSlices = true
+	types.EnableManglingReturnedSlices.Store(true)
 }

--- a/pkg/streamingpromql/optimize/plan/splitandcache/init_test.go
+++ b/pkg/streamingpromql/optimize/plan/splitandcache/init_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func init() {
-	types.EnableManglingReturnedSlices = true
+	types.EnableManglingReturnedSlices.Store(true)
 }

--- a/pkg/streamingpromql/planning/analysis/init_test.go
+++ b/pkg/streamingpromql/planning/analysis/init_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func init() {
-	types.EnableManglingReturnedSlices = true
+	types.EnableManglingReturnedSlices.Store(true)
 }

--- a/pkg/streamingpromql/planning/core/init_test.go
+++ b/pkg/streamingpromql/planning/core/init_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func init() {
-	types.EnableManglingReturnedSlices = true
+	types.EnableManglingReturnedSlices.Store(true)
 }

--- a/pkg/streamingpromql/planning/init_test.go
+++ b/pkg/streamingpromql/planning/init_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func init() {
-	types.EnableManglingReturnedSlices = true
+	types.EnableManglingReturnedSlices.Store(true)
 }

--- a/pkg/streamingpromql/planning/metrics/init_test.go
+++ b/pkg/streamingpromql/planning/metrics/init_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func init() {
-	types.EnableManglingReturnedSlices = true
+	types.EnableManglingReturnedSlices.Store(true)
 }

--- a/pkg/streamingpromql/requestoptions/init_test.go
+++ b/pkg/streamingpromql/requestoptions/init_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func init() {
-	types.EnableManglingReturnedSlices = true
+	types.EnableManglingReturnedSlices.Store(true)
 }

--- a/pkg/streamingpromql/sliceutil/init_test.go
+++ b/pkg/streamingpromql/sliceutil/init_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func init() {
-	types.EnableManglingReturnedSlices = true
+	types.EnableManglingReturnedSlices.Store(true)
 }

--- a/pkg/streamingpromql/testutils/init_test.go
+++ b/pkg/streamingpromql/testutils/init_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func init() {
-	types.EnableManglingReturnedSlices = true
+	types.EnableManglingReturnedSlices.Store(true)
 }

--- a/pkg/streamingpromql/types/init_test.go
+++ b/pkg/streamingpromql/types/init_test.go
@@ -3,5 +3,5 @@
 package types
 
 func init() {
-	EnableManglingReturnedSlices = true
+	EnableManglingReturnedSlices.Store(true)
 }

--- a/pkg/streamingpromql/types/limiting_pool.go
+++ b/pkg/streamingpromql/types/limiting_pool.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/promql"
+	"go.uber.org/atomic"
 
 	"github.com/grafana/mimir/pkg/util/limiter"
 	"github.com/grafana/mimir/pkg/util/pool"
@@ -40,7 +41,7 @@ const (
 var (
 	// EnableManglingReturnedSlices enables mangling values in slices returned to pool to aid in detecting use-after-return bugs.
 	// Only used in tests.
-	EnableManglingReturnedSlices = false
+	EnableManglingReturnedSlices = atomic.NewBool(false)
 
 	FPointSlicePool = NewLimitingBucketedPool(
 		pool.NewBucketedPool(MaxExpectedPointsPerSeries, func(size int) []promql.FPoint {
@@ -49,6 +50,7 @@ var (
 		limiter.FPointSlices,
 		FPointSize,
 		false,
+		EnableManglingReturnedSlices,
 		mangleFPoint,
 		nil,
 	)
@@ -60,6 +62,7 @@ var (
 		limiter.HPointSlices,
 		HPointSize,
 		false,
+		EnableManglingReturnedSlices,
 		func(point promql.HPoint) promql.HPoint {
 			point.H = mangleHistogram(point.H)
 			return point
@@ -74,6 +77,7 @@ var (
 		limiter.Vectors,
 		VectorSampleSize,
 		false,
+		EnableManglingReturnedSlices,
 		mangleSample,
 		nil,
 	)
@@ -85,6 +89,7 @@ var (
 		limiter.Float64Slices,
 		Float64Size,
 		true,
+		EnableManglingReturnedSlices,
 		nil,
 		nil,
 	)
@@ -96,6 +101,7 @@ var (
 		limiter.IntSlices,
 		IntSize,
 		true,
+		EnableManglingReturnedSlices,
 		nil,
 		nil,
 	)
@@ -107,6 +113,7 @@ var (
 		limiter.CounterResetHintSlices,
 		CounterResetHintSize,
 		true,
+		EnableManglingReturnedSlices,
 		nil,
 		nil,
 	)
@@ -118,6 +125,7 @@ var (
 		limiter.Int64Slices,
 		Int64Size,
 		true,
+		EnableManglingReturnedSlices,
 		nil,
 		nil,
 	)
@@ -129,6 +137,7 @@ var (
 		limiter.BoolSlices,
 		BoolSize,
 		true,
+		EnableManglingReturnedSlices,
 		nil,
 		nil,
 	)
@@ -140,6 +149,7 @@ var (
 		limiter.HistogramPointerSlices,
 		HistogramPointerSize,
 		true,
+		EnableManglingReturnedSlices,
 		mangleHistogram,
 		nil,
 	)
@@ -151,6 +161,7 @@ var (
 		limiter.SeriesMetadataSlices,
 		SeriesMetadataSize,
 		true,
+		EnableManglingReturnedSlices,
 		nil,
 		func(sms []SeriesMetadata, tracker *limiter.MemoryConsumptionTracker) {
 			// When putting SeriesMetadata slices back to the pool, we decrease the memory consumption for each label in the metadata.
@@ -220,11 +231,12 @@ type LimitingBucketedPool[S ~[]E, E any] struct {
 	source      limiter.MemoryConsumptionSource
 	elementSize uint64
 	clearOnGet  bool
+	mangleOnPut *atomic.Bool
 	mangle      func(E) E
 	onPutHook   func(S, *limiter.MemoryConsumptionTracker)
 }
 
-func NewLimitingBucketedPool[S ~[]E, E any](inner *pool.BucketedPool[S, E], source limiter.MemoryConsumptionSource, elementSize uint64, clearOnGet bool, mangle func(E) E, onPutHook func(S, *limiter.MemoryConsumptionTracker)) *LimitingBucketedPool[S, E] {
+func NewLimitingBucketedPool[S ~[]E, E any](inner *pool.BucketedPool[S, E], source limiter.MemoryConsumptionSource, elementSize uint64, clearOnGet bool, mangleOnPut *atomic.Bool, mangle func(E) E, onPutHook func(S, *limiter.MemoryConsumptionTracker)) *LimitingBucketedPool[S, E] {
 	if !clearOnGet && mangle == nil {
 		panic("must provide a mangling function for pools where items are not cleared on retrieval")
 	}
@@ -234,6 +246,7 @@ func NewLimitingBucketedPool[S ~[]E, E any](inner *pool.BucketedPool[S, E], sour
 		source:      source,
 		elementSize: elementSize,
 		clearOnGet:  clearOnGet,
+		mangleOnPut: mangleOnPut,
 		mangle:      mangle,
 		onPutHook:   onPutHook,
 	}
@@ -279,7 +292,7 @@ func (p *LimitingBucketedPool[S, E]) Put(s *S, tracker *limiter.MemoryConsumptio
 		p.onPutHook(*s, tracker)
 	}
 
-	if EnableManglingReturnedSlices {
+	if p.mangleOnPut.Load() {
 		if p.mangle != nil {
 			for i, e := range *s {
 				(*s)[i] = p.mangle(e)

--- a/pkg/streamingpromql/types/limiting_pool_test.go
+++ b/pkg/streamingpromql/types/limiting_pool_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 
 	"github.com/grafana/mimir/pkg/util/limiter"
 	"github.com/grafana/mimir/pkg/util/pool"
@@ -31,6 +32,7 @@ func TestLimitingBucketedPool_Unlimited(t *testing.T) {
 		limiter.FPointSlices,
 		FPointSize,
 		false,
+		atomic.NewBool(true),
 		func(point promql.FPoint) promql.FPoint { return point },
 		nil,
 	)
@@ -86,6 +88,7 @@ func TestLimitingPool_Limited(t *testing.T) {
 		limiter.FPointSlices,
 		FPointSize,
 		false,
+		atomic.NewBool(true),
 		func(point promql.FPoint) promql.FPoint { return point },
 		nil,
 	)
@@ -202,12 +205,6 @@ func TestLimitingPool_ClearsReturnedSlices(t *testing.T) {
 }
 
 func TestLimitingPool_Mangling(t *testing.T) {
-	currentEnableManglingReturnedSlices := EnableManglingReturnedSlices
-	defer func() {
-		// Ensure we reset this back to the default state given it applies globally.
-		EnableManglingReturnedSlices = currentEnableManglingReturnedSlices
-	}()
-
 	_, metric := createRejectedMetric()
 
 	t.Run("with mangling function", func(t *testing.T) {
@@ -218,7 +215,9 @@ func TestLimitingPool_Mangling(t *testing.T) {
 			limiter.IntSlices,
 			1,
 			false,
+			atomic.NewBool(false),
 			func(_ int) int { return 123 },
+
 			func(s []int, _ *limiter.MemoryConsumptionTracker) {
 				for idx, i := range s {
 					require.NotEqualf(t, 123, i, "Put() hook should be called before mangling, but element at index %d was mangled already", idx)
@@ -227,7 +226,6 @@ func TestLimitingPool_Mangling(t *testing.T) {
 		)
 
 		// Test with mangling disabled.
-		EnableManglingReturnedSlices = false
 		s, err := p.Get(4, tracker)
 		require.NoError(t, err)
 		s = append(s, 1000, 2000, 3000, 4000)
@@ -238,7 +236,7 @@ func TestLimitingPool_Mangling(t *testing.T) {
 		require.Nil(t, s, "provided slice should be nil-ed out")
 
 		// Test with mangling enabled.
-		EnableManglingReturnedSlices = true
+		p.mangleOnPut.Store(true)
 		s, err = p.Get(4, tracker)
 		require.NoError(t, err)
 		s = append(s, 1000, 2000, 3000, 4000)
@@ -257,12 +255,12 @@ func TestLimitingPool_Mangling(t *testing.T) {
 			limiter.IntSlices,
 			1,
 			true,
+			atomic.NewBool(false),
 			func(_ int) int { return 123 },
 			nil,
 		)
 
 		// Test with mangling disabled.
-		EnableManglingReturnedSlices = false
 		s, err := p.Get(4, tracker)
 		require.NoError(t, err)
 		s = append(s, 1000, 2000, 3000, 4000)
@@ -273,7 +271,7 @@ func TestLimitingPool_Mangling(t *testing.T) {
 		require.Nil(t, s, "provided slice should be nil-ed out")
 
 		// Test with mangling enabled.
-		EnableManglingReturnedSlices = true
+		p.mangleOnPut.Store(true)
 		s, err = p.Get(4, tracker)
 		require.NoError(t, err)
 		s = append(s, 1000, 2000, 3000, 4000)
@@ -293,6 +291,7 @@ func TestLimitingBucketedPool_AppendToSlice(t *testing.T) {
 		limiter.FPointSlices,
 		FPointSize,
 		false,
+		atomic.NewBool(true),
 		func(point promql.FPoint) promql.FPoint { return point },
 		func(s []promql.FPoint, _ *limiter.MemoryConsumptionTracker) {
 			onPutHookSlices = append(onPutHookSlices, s)
@@ -343,6 +342,7 @@ func TestLimitingBucketedPool_AppendToSlice_Error(t *testing.T) {
 		limiter.FPointSlices,
 		FPointSize,
 		false,
+		atomic.NewBool(true),
 		func(point promql.FPoint) promql.FPoint { return point },
 		nil,
 	)

--- a/pkg/streamingpromql/types/limiting_pool_test.go
+++ b/pkg/streamingpromql/types/limiting_pool_test.go
@@ -384,3 +384,30 @@ func createRejectedMetric() (*prometheus.Registry, prometheus.Counter) {
 
 	return reg, metric
 }
+
+func BenchmarkLimitingPool_GetPut(b *testing.B) {
+	for _, mangle := range []bool{false, true} {
+		b.Run(fmt.Sprintf("unlimited pool, mangle=%t", mangle), func(b *testing.B) {
+			p := NewLimitingBucketedPool(
+				pool.NewBucketedPool(1024, func(size int) []promql.FPoint { return make([]promql.FPoint, 0, size) }),
+				limiter.FPointSlices,
+				FPointSize,
+				false,
+				atomic.NewBool(mangle),
+				mangleFPoint,
+				nil,
+			)
+
+			tracker := limiter.NewUnlimitedMemoryConsumptionTracker(context.Background())
+
+			for b.Loop() {
+				s, err := p.Get(128, tracker)
+				if err != nil {
+					require.NoError(b, err)
+				}
+
+				p.Put(&s, tracker)
+			}
+		})
+	}
+}

--- a/tools/check-mangling-returned-slices-enabled.sh
+++ b/tools/check-mangling-returned-slices-enabled.sh
@@ -69,7 +69,7 @@ main() {
     echo "  )"
     echo
     echo "  func init() {"
-    echo "  	types.EnableManglingReturnedSlices = true"
+    echo "  	types.EnableManglingReturnedSlices.Store(true)"
     echo "  }"
     echo
     echo "This helps detect use-after-return bugs by mangling slices returned to the pool."
@@ -92,7 +92,7 @@ import (
 )
 
 func init() {
-	types.EnableManglingReturnedSlices = true
+	types.EnableManglingReturnedSlices.Store(true)
 }
 EOF
 }
@@ -106,7 +106,7 @@ expected_without_import() {
 package $1
 
 func init() {
-	EnableManglingReturnedSlices = true
+	EnableManglingReturnedSlices.Store(true)
 }
 EOF
 }


### PR DESCRIPTION
#### What this PR does

Switch from a global bool to an atomic bool for the flag used to switch between not mangling pooled slices when returned (production) and mangling them (tests). This allows the pool code to _not_ depend on global state but still allow mangling to be toggled on and off for tests beacuse we use the global atomic.Bool when creating the default pools.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
