### PR TITLE
chore(dev): ignore .data-* dirs in docker-compose setups

### DIFF
--- a/development/mimir-compartments/docker-compose.jsonnet
+++ b/development/mimir-compartments/docker-compose.jsonnet
@@ -300,8 +300,8 @@ std.manifestYamlDoc({
                     ['mimir-ruler', 'mimir-alertmanager', 'usage-tracker-snapshots'],
     minio: {
       image: 'minio/minio:RELEASE.2025-05-24T17-08-30Z',
-      // MinIO treats top-level directories under /data as buckets. Create the buckets the dev cluster
-      // needs before starting the server, since this env doesn't ship a pre-seeded data directory.
+      // MinIO serves each top-level directory under /data as a bucket. The data dir is gitignored and
+      // starts empty, so create the buckets the dev cluster needs before starting the server.
       entrypoint: ['sh', '-c', 'mkdir -p %s && exec minio server --console-address :9001 /data' % std.join(' ', ['/data/%s' % bucket for bucket in buckets])],
       environment: ['MINIO_ROOT_USER=mimir', 'MINIO_ROOT_PASSWORD=supersecret'],
       ports: [

--- a/development/mimir-ingest-storage/.data-ingester-zone-a-1/.gitignore
+++ b/development/mimir-ingest-storage/.data-ingester-zone-a-1/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/development/mimir-ingest-storage/.data-ingester-zone-b-1/.gitignore
+++ b/development/mimir-ingest-storage/.data-ingester-zone-b-1/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/development/mimir-ingest-storage/.data-minio/.gitignore
+++ b/development/mimir-ingest-storage/.data-minio/.gitignore
@@ -1,6 +1,0 @@
-*
-!mimir-ruler
-!mimir-blocks
-!mimir-alertmanager
-!usage-tracker-snapshots
-!.gitignore

--- a/development/mimir-ingest-storage/.data-minio/mimir-alertmanager/.gitignore
+++ b/development/mimir-ingest-storage/.data-minio/mimir-alertmanager/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/development/mimir-ingest-storage/.data-minio/mimir-blocks/.gitignore
+++ b/development/mimir-ingest-storage/.data-minio/mimir-blocks/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/development/mimir-ingest-storage/.data-minio/mimir-ruler/.gitignore
+++ b/development/mimir-ingest-storage/.data-minio/mimir-ruler/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/development/mimir-ingest-storage/.data-minio/usage-tracker-snapshots/.gitignore
+++ b/development/mimir-ingest-storage/.data-minio/usage-tracker-snapshots/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/development/mimir-ingest-storage/.gitignore
+++ b/development/mimir-ingest-storage/.gitignore
@@ -1,1 +1,2 @@
 mimir
+.data-*

--- a/development/mimir-ingest-storage/docker-compose.jsonnet
+++ b/development/mimir-ingest-storage/docker-compose.jsonnet
@@ -205,9 +205,12 @@ std.manifestYamlDoc({
   },
 
   minio:: {
+    local buckets = ['mimir-blocks', 'mimir-ruler', 'mimir-alertmanager', 'usage-tracker-snapshots'],
     minio: {
       image: 'minio/minio:RELEASE.2025-05-24T17-08-30Z',
-      command: ['server', '--console-address', ':9001', '/data'],
+      // MinIO serves each top-level directory under /data as a bucket. The data dir is gitignored and
+      // starts empty, so create the buckets the dev cluster needs before starting the server.
+      entrypoint: ['sh', '-c', 'mkdir -p %s && exec minio server --console-address :9001 /data' % std.join(' ', ['/data/%s' % bucket for bucket in buckets])],
       environment: ['MINIO_ROOT_USER=mimir', 'MINIO_ROOT_PASSWORD=supersecret'],
       ports: [
         '9000:9000',

--- a/development/mimir-ingest-storage/docker-compose.yml
+++ b/development/mimir-ingest-storage/docker-compose.yml
@@ -275,11 +275,10 @@
   "memcached":
     "image": "memcached:1.6.19-alpine"
   "minio":
-    "command":
-      - "server"
-      - "--console-address"
-      - ":9001"
-      - "/data"
+    "entrypoint":
+      - "sh"
+      - "-c"
+      - "mkdir -p /data/mimir-blocks /data/mimir-ruler /data/mimir-alertmanager /data/usage-tracker-snapshots && exec minio server --console-address :9001 /data"
     "environment":
       - "MINIO_ROOT_USER=mimir"
       - "MINIO_ROOT_PASSWORD=supersecret"

--- a/development/mimir-microservices-mode/.data-ingester-1/.gitignore
+++ b/development/mimir-microservices-mode/.data-ingester-1/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/development/mimir-microservices-mode/.data-ingester-2/.gitignore
+++ b/development/mimir-microservices-mode/.data-ingester-2/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/development/mimir-microservices-mode/.data-ingester-3/.gitignore
+++ b/development/mimir-microservices-mode/.data-ingester-3/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/development/mimir-microservices-mode/.data-minio/.gitignore
+++ b/development/mimir-microservices-mode/.data-minio/.gitignore
@@ -1,5 +1,0 @@
-*
-!.gitignore
-!mimir-tsdb
-!mimir-alertmanager
-!mimir-ruler

--- a/development/mimir-microservices-mode/.data-minio/mimir-alertmanager/.gitignore
+++ b/development/mimir-microservices-mode/.data-minio/mimir-alertmanager/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/development/mimir-microservices-mode/.data-minio/mimir-ruler/.gitignore
+++ b/development/mimir-microservices-mode/.data-minio/mimir-ruler/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/development/mimir-microservices-mode/.data-minio/mimir-tsdb/.gitignore
+++ b/development/mimir-microservices-mode/.data-minio/mimir-tsdb/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/development/mimir-microservices-mode/.gitignore
+++ b/development/mimir-microservices-mode/.gitignore
@@ -1,1 +1,2 @@
 mimir
+.data-*

--- a/development/mimir-microservices-mode/docker-compose.jsonnet
+++ b/development/mimir-microservices-mode/docker-compose.jsonnet
@@ -319,9 +319,12 @@ std.manifestYamlDoc({
   },
 
   minio:: {
+    local buckets = ['mimir-tsdb', 'mimir-ruler', 'mimir-alertmanager'],
     minio: {
       image: 'minio/minio:RELEASE.2025-05-24T17-08-30Z',
-      command: ['server', '--console-address', ':9001', '/data'],
+      // MinIO serves each top-level directory under /data as a bucket. The data dir is gitignored and
+      // starts empty, so create the buckets the dev cluster needs before starting the server.
+      entrypoint: ['sh', '-c', 'mkdir -p %s && exec minio server --console-address :9001 /data' % std.join(' ', ['/data/%s' % bucket for bucket in buckets])],
       environment: ['MINIO_ROOT_USER=mimir', 'MINIO_ROOT_PASSWORD=supersecret'],
       ports: [
         '9000:9000',

--- a/development/mimir-microservices-mode/docker-compose.yml
+++ b/development/mimir-microservices-mode/docker-compose.yml
@@ -281,11 +281,10 @@
     "ports":
       - "11211:11211"
   "minio":
-    "command":
-      - "server"
-      - "--console-address"
-      - ":9001"
-      - "/data"
+    "entrypoint":
+      - "sh"
+      - "-c"
+      - "mkdir -p /data/mimir-tsdb /data/mimir-ruler /data/mimir-alertmanager && exec minio server --console-address :9001 /data"
     "environment":
       - "MINIO_ROOT_USER=mimir"
       - "MINIO_ROOT_PASSWORD=supersecret"

--- a/development/mimir-monolithic-mode-with-swift-storage/.data-mimir-1/.gitignore
+++ b/development/mimir-monolithic-mode-with-swift-storage/.data-mimir-1/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/development/mimir-monolithic-mode-with-swift-storage/.data-mimir-2/.gitignore
+++ b/development/mimir-monolithic-mode-with-swift-storage/.data-mimir-2/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/development/mimir-monolithic-mode-with-swift-storage/.gitignore
+++ b/development/mimir-monolithic-mode-with-swift-storage/.gitignore
@@ -1,2 +1,2 @@
 mimir
-.data-swift
+.data-*

--- a/development/mimir-monolithic-mode/.data-mimir-1/.gitignore
+++ b/development/mimir-monolithic-mode/.data-mimir-1/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/development/mimir-monolithic-mode/.data-mimir-2/.gitignore
+++ b/development/mimir-monolithic-mode/.data-mimir-2/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/development/mimir-monolithic-mode/.data-minio/.gitignore
+++ b/development/mimir-monolithic-mode/.data-minio/.gitignore
@@ -1,4 +1,0 @@
-*
-!mimir-rules
-!mimir-tsdb
-!.gitignore

--- a/development/mimir-monolithic-mode/.data-minio/mimir-rules/.gitignore
+++ b/development/mimir-monolithic-mode/.data-minio/mimir-rules/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/development/mimir-monolithic-mode/.data-minio/mimir-tsdb/.gitignore
+++ b/development/mimir-monolithic-mode/.data-minio/mimir-tsdb/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/development/mimir-monolithic-mode/.gitignore
+++ b/development/mimir-monolithic-mode/.gitignore
@@ -1,1 +1,2 @@
 mimir
+.data-*

--- a/development/mimir-monolithic-mode/docker-compose.yml
+++ b/development/mimir-monolithic-mode/docker-compose.yml
@@ -8,7 +8,9 @@ services:
 
   minio:
     image: minio/minio:RELEASE.2025-05-24T17-08-30Z
-    command: [ "server", "--console-address", ":9101", "/data" ]
+    # MinIO serves each top-level directory under /data as a bucket. The data dir is gitignored and
+    # starts empty, so create the buckets the dev cluster needs before starting the server.
+    entrypoint: [ "sh", "-c", "mkdir -p /data/mimir-tsdb /data/mimir-rules && exec minio server --console-address :9101 /data" ]
     environment:
       - MINIO_ROOT_USER=mimir
       - MINIO_ROOT_PASSWORD=supersecret


### PR DESCRIPTION
Standardise the `development/` compose setups on the newer `mimir-compartments` `.gitignore` convention.

- horizontally scaled components (e.g. adding extra ingesters) no longer leave new data directories in git
- cleanup is just `rm -rf .data-*`, without disrupting git
- MinIO creates its buckets on startup, so fresh clones no longer depend on committed bucket directories