### PR TITLE
Use default Renovate branch prefix

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -200,7 +200,7 @@
       commitMessageExtra: 'to {{ lookup (split newVersion "/") 1 }}',
     }
   ],
-  branchPrefix: 'deps-update/',
+  branchPrefixOld: 'deps-update/',
   labels: [
     'dependency-update',
   ],


### PR DESCRIPTION
## Summary
- use Renovate's default `renovate/` branch prefix
- retain `deps-update/` as `branchPrefixOld` so existing dependency PRs and history remain recognized during migration

This aligns Mimir with the branch prefixes supported by the shared Renovate webhook and allows us to do on-demand rebases of Renovate PRs.

Made with [Cursor](https://cursor.com)