### PR TITLE
fix(query-frontend): queue_time_seconds always reporting 0 for cancelled-while-queued queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@
 * [BUGFIX] Query-frontend: Fix issue where series for a range query can be returned in the wrong order if splitting applies and splitting is not running inside MQE. #16036
 * [BUGFIX] Querier: Fix issue where exemplars can be returned in the wrong order if a series contains a label that is a prefix of another (eg. `env="foo"` and `env="foobar"`). #16036
 * [BUGFIX] Querier: Stop querying a partition that has been inactive for longer than `-querier.query-ingesters-within`, preventing query failures when the partition is still registered but has no available ingesters to serve the queries. #15721
+* [BUGFIX] Query-frontend: Fix `queue_time_seconds` in the query stats log always reporting 0 when a query is cancelled while still waiting in the query-scheduler queue. #16094
 
 ### Mixin
 

--- a/pkg/frontend/v2/frontend.go
+++ b/pkg/frontend/v2/frontend.go
@@ -493,6 +493,11 @@ func (f *Frontend) DoProtobufRequest(requestContext context.Context, req proto.M
 			default:
 				freq.spanLogger.DebugLog("msg", "request context cancelled or response stream closed by caller after enqueuing request but before querier started sending response, cancelling by sending notification to scheduler", "cause", context.Cause(streamContext))
 
+				// Cancelled while still queued: no querier will report a real queue time, so record a
+				// wall-clock approximation. This write runs in this background goroutine and is not
+				// synchronized with Next(), so it's best-effort: a consumer reading stats the instant
+				// Next() returns may still see 0. The query-frontend logs queue time only after the
+				// request has fully unwound, well after this runs.
 				stats.FromContext(streamContext).AddQueueTime(time.Since(freq.enqueuedAt))
 
 				select {

--- a/pkg/frontend/v2/frontend.go
+++ b/pkg/frontend/v2/frontend.go
@@ -353,7 +353,17 @@ func (f *Frontend) RoundTripGRPC(ctx context.Context, httpRequest *httpgrpc.HTTP
 			level.Warn(freq.spanLogger).Log("msg", "failed to send cancellation request to scheduler, queue full")
 		}
 
-		stats.FromContext(ctx).AddQueueTime(time.Since(freq.enqueuedAt))
+		select {
+		case resp := <-freq.httpResponse:
+			// The response arrived at (almost) the same time as the cancellation. Prefer its real
+			// queue time over our wall-clock approximation, since select would otherwise pick
+			// between this case and <-ctx.Done() at random and could discard it.
+			if stats.ShouldTrackHTTPGRPCResponse(resp.queryResult.HttpResponse) {
+				stats.FromContext(ctx).Merge(resp.queryResult.Stats) // Safe if stats is nil.
+			}
+		default:
+			stats.FromContext(ctx).AddQueueTime(time.Since(freq.enqueuedAt))
+		}
 
 		return nil, nil, context.Cause(ctx)
 

--- a/pkg/frontend/v2/frontend.go
+++ b/pkg/frontend/v2/frontend.go
@@ -361,6 +361,12 @@ func (f *Frontend) RoundTripGRPC(ctx context.Context, httpRequest *httpgrpc.HTTP
 			if stats.ShouldTrackHTTPGRPCResponse(resp.queryResult.HttpResponse) {
 				stats.FromContext(ctx).Merge(resp.queryResult.Stats) // Safe if stats is nil.
 			}
+			if resp.bodyStream != nil {
+				// We're discarding this response (the caller only gets the cancellation error), but if the
+				// querier sent it via QueryResultStream, that call is blocked writing to this pipe until it's
+				// read or closed. Close it so that goroutine isn't leaked.
+				_ = resp.bodyStream.Close()
+			}
 		default:
 			stats.FromContext(ctx).AddQueueTime(time.Since(freq.enqueuedAt))
 		}

--- a/pkg/frontend/v2/frontend.go
+++ b/pkg/frontend/v2/frontend.go
@@ -166,6 +166,11 @@ type frontendRequest struct {
 
 	enqueue chan enqueueResult
 
+	// enqueuedAt is set once the scheduler has accepted this request into its queue.
+	// Used to approximate queue time if the request is cancelled before a querier
+	// processes it and reports the real queue time.
+	enqueuedAt time.Time
+
 	// If this is a httpgrpc request, then these fields will be populated:
 	httpRequest  *httpgrpc.HTTPRequest
 	httpResponse chan queryResultWithBody
@@ -332,6 +337,7 @@ func (f *Frontend) RoundTripGRPC(ctx context.Context, httpRequest *httpgrpc.HTTP
 	if err != nil {
 		return nil, nil, err
 	}
+	freq.enqueuedAt = time.Now()
 
 	freq.spanLogger.DebugLog("msg", "request enqueued successfully, waiting for response")
 
@@ -346,6 +352,8 @@ func (f *Frontend) RoundTripGRPC(ctx context.Context, httpRequest *httpgrpc.HTTP
 			// failed to cancel, ignore.
 			level.Warn(freq.spanLogger).Log("msg", "failed to send cancellation request to scheduler, queue full")
 		}
+
+		stats.FromContext(ctx).AddQueueTime(time.Since(freq.enqueuedAt))
 
 		return nil, nil, context.Cause(ctx)
 
@@ -428,6 +436,7 @@ func (f *Frontend) DoProtobufRequest(requestContext context.Context, req proto.M
 			freq.protobufResponseStream.writeEnqueueError(err)
 			return
 		}
+		freq.enqueuedAt = time.Now()
 
 		freq.spanLogger.DebugLog("msg", "request enqueued successfully, waiting for response")
 
@@ -467,6 +476,8 @@ func (f *Frontend) DoProtobufRequest(requestContext context.Context, req proto.M
 
 			default:
 				freq.spanLogger.DebugLog("msg", "request context cancelled or response stream closed by caller after enqueuing request but before querier started sending response, cancelling by sending notification to scheduler", "cause", context.Cause(streamContext))
+
+				stats.FromContext(streamContext).AddQueueTime(time.Since(freq.enqueuedAt))
 
 				select {
 				case cancelCh <- freq.queryID:

--- a/pkg/frontend/v2/frontend.go
+++ b/pkg/frontend/v2/frontend.go
@@ -427,18 +427,12 @@ func (f *Frontend) DoProtobufRequest(requestContext context.Context, req proto.M
 		responseStarted: make(chan struct{}),
 		notifyClosed:    make(chan struct{}),
 		isClosed:        atomic.NewBool(false),
-
-		cancellationHandled: make(chan struct{}),
 	}
 
 	f.requests.put(freq)
 	f.inflightRequestCount.Inc()
 
 	go func() {
-		// Closed on every exit path from this goroutine, so that Next()/shouldAbortReading() can safely
-		// wait on it once requestContext is done without risking a deadlock.
-		defer close(freq.protobufResponseStream.cancellationHandled)
-
 		defer func() {
 			f.requests.delete(freq.queryID)
 			cancelStream(errExecutingQueryRoundTripFinished)
@@ -531,13 +525,6 @@ type ProtobufResponseStream struct {
 	notifyClosed    chan struct{}
 	isClosed        *atomic.Bool
 	closeStream     func()
-
-	// cancellationHandled is closed once the goroutine driving this request in DoProtobufRequest has
-	// finished reacting to streamContext being done, including recording an approximate queue time if
-	// applicable. Next() and shouldAbortReading() wait on this before returning due to requestContext
-	// being done, so that a caller reading stats right after Next() returns sees the final value rather
-	// than racing with the goroutine that writes it.
-	cancellationHandled chan struct{}
 }
 
 type protobufResponseMessage struct {
@@ -626,13 +613,6 @@ func (s *ProtobufResponseStream) Next(ctx context.Context) (*frontendv2pb.QueryR
 		// Note that we deliberately wait on s.requestContext, rather than s.streamContext, as s.streamContext is cancelled as soon
 		// as the response has been completely received, but we want to continue reading any outstanding messages
 		// from the stream unless s.requestContext (which presumably represents the query as a whole) is cancelled.
-		//
-		// Wait for the goroutine driving this request to finish reacting to the cancellation (including
-		// recording an approximate queue time) before returning, so a caller reading stats immediately
-		// after this call sees the final value. This can't deadlock: streamContext is a child of
-		// requestContext, so it's guaranteed to become done too, and cancellationHandled is always
-		// closed on every exit path of that goroutine.
-		<-s.cancellationHandled
 		return nil, context.Cause(s.requestContext)
 	case <-s.notifyClosed:
 		// If the stream was closed, then we should stop now as well.
@@ -645,8 +625,6 @@ func (s *ProtobufResponseStream) Next(ctx context.Context) (*frontendv2pb.QueryR
 // shouldAbortReading checks if the request has been cancelled or if this stream has been closed, and returns an error if so.
 func (s *ProtobufResponseStream) shouldAbortReading(ctx context.Context) error {
 	if s.requestContext.Err() != nil {
-		// See the equivalent wait in Next()'s select for why this can't deadlock.
-		<-s.cancellationHandled
 		return context.Cause(s.requestContext)
 	}
 

--- a/pkg/frontend/v2/frontend.go
+++ b/pkg/frontend/v2/frontend.go
@@ -427,12 +427,18 @@ func (f *Frontend) DoProtobufRequest(requestContext context.Context, req proto.M
 		responseStarted: make(chan struct{}),
 		notifyClosed:    make(chan struct{}),
 		isClosed:        atomic.NewBool(false),
+
+		cancellationHandled: make(chan struct{}),
 	}
 
 	f.requests.put(freq)
 	f.inflightRequestCount.Inc()
 
 	go func() {
+		// Closed on every exit path from this goroutine, so that Next()/shouldAbortReading() can safely
+		// wait on it once requestContext is done without risking a deadlock.
+		defer close(freq.protobufResponseStream.cancellationHandled)
+
 		defer func() {
 			f.requests.delete(freq.queryID)
 			cancelStream(errExecutingQueryRoundTripFinished)
@@ -525,6 +531,13 @@ type ProtobufResponseStream struct {
 	notifyClosed    chan struct{}
 	isClosed        *atomic.Bool
 	closeStream     func()
+
+	// cancellationHandled is closed once the goroutine driving this request in DoProtobufRequest has
+	// finished reacting to streamContext being done, including recording an approximate queue time if
+	// applicable. Next() and shouldAbortReading() wait on this before returning due to requestContext
+	// being done, so that a caller reading stats right after Next() returns sees the final value rather
+	// than racing with the goroutine that writes it.
+	cancellationHandled chan struct{}
 }
 
 type protobufResponseMessage struct {
@@ -613,6 +626,13 @@ func (s *ProtobufResponseStream) Next(ctx context.Context) (*frontendv2pb.QueryR
 		// Note that we deliberately wait on s.requestContext, rather than s.streamContext, as s.streamContext is cancelled as soon
 		// as the response has been completely received, but we want to continue reading any outstanding messages
 		// from the stream unless s.requestContext (which presumably represents the query as a whole) is cancelled.
+		//
+		// Wait for the goroutine driving this request to finish reacting to the cancellation (including
+		// recording an approximate queue time) before returning, so a caller reading stats immediately
+		// after this call sees the final value. This can't deadlock: streamContext is a child of
+		// requestContext, so it's guaranteed to become done too, and cancellationHandled is always
+		// closed on every exit path of that goroutine.
+		<-s.cancellationHandled
 		return nil, context.Cause(s.requestContext)
 	case <-s.notifyClosed:
 		// If the stream was closed, then we should stop now as well.
@@ -625,6 +645,8 @@ func (s *ProtobufResponseStream) Next(ctx context.Context) (*frontendv2pb.QueryR
 // shouldAbortReading checks if the request has been cancelled or if this stream has been closed, and returns an error if so.
 func (s *ProtobufResponseStream) shouldAbortReading(ctx context.Context) error {
 	if s.requestContext.Err() != nil {
+		// See the equivalent wait in Next()'s select for why this can't deadlock.
+		<-s.cancellationHandled
 		return context.Cause(s.requestContext)
 	}
 

--- a/pkg/frontend/v2/frontend_test.go
+++ b/pkg/frontend/v2/frontend_test.go
@@ -942,6 +942,7 @@ func TestFrontendCancellation(t *testing.T) {
 
 			ctx, cancel := context.WithTimeout(user.InjectOrgID(context.Background(), "test"), 200*time.Millisecond)
 			ctx = querymiddleware.ContextWithParallelismLimiter(ctx, querymiddleware.NewParallelismLimiter(math.MaxInt))
+			reqStats, ctx := stats.ContextWithEmptyStats(ctx)
 			defer cancel()
 
 			makeRequest(ctx, t, f)
@@ -960,6 +961,8 @@ func TestFrontendCancellation(t *testing.T) {
 				require.Equal(t, schedulerpb.CANCEL, ms.msgs[1].Type)
 				require.Equal(t, ms.msgs[0].QueryID, ms.msgs[1].QueryID)
 			})
+
+			require.Greater(t, reqStats.LoadQueueTime(), time.Duration(0))
 		})
 	}
 


### PR DESCRIPTION
`queue_time_seconds` in the `query_stats` log only got populated when a querier echoed queue time back to the frontend.
Any query whose context ended before reaching a querier logged `queue_time_seconds=0`, regardless of how long it had actually been waiting.
This includes client-side request timeouts, not just explicit cancellations.
Under load, with queriers busy and the queue backed up, this made timed-out queries look like they'd spent no time queued.

With this fix, `query_stats` logs approximate the real queue wait time for these queries instead.
The fix covers both the direct query path (`RoundTripGRPC`) and the experimental remote-execution path (`DoProtobufRequest`).

An alternative was considered: have the scheduler report the exact queue duration back on cancellation instead of the frontend approximating it.
This was discarded because it needs a new field on the scheduler-to-frontend protocol and would make the frontend wait on that response before returning a cancelled request's error, adding latency to how quickly a cancellation reaches the client.
It also wouldn't fully close the gap: if a querier dequeues and discards the request around the same time it's cancelled, the scheduler has no existing path back to the frontend to report a queue duration at all.