### PR TITLE
Pass node affinity matchers to per-compartment compactor-schedulers

### DIFF
--- a/operations/mimir-tests/test-compartments.jsonnet
+++ b/operations/mimir-tests/test-compartments.jsonnet
@@ -97,4 +97,20 @@ assert rulerBlocksBucket(env.ruler_zone_a_args) == env._config.compartments_bloc
 assert rulerBlocksBucket(env.ruler_zone_b_args) == env._config.compartments_blocks_storage_bucket_name :
        'expected zone-b ruler to use the parametrised blocks bucket';
 
+local schedulerAffinityMatchers = [
+  { key: 'topology.kubernetes.io/zone', operator: 'In', values: ['us-east-2a'] },
+];
+local schedulerAffinityEnv = env {
+  compactor_scheduler_node_affinity_matchers:: schedulerAffinityMatchers,
+};
+local compartmentSchedulerNodeSelectorTerms(compartmentIdx) =
+  local podSpec = schedulerAffinityEnv.compactor_scheduler_statefulsets['compartment_%d' % compartmentIdx].spec.template.spec;
+  if std.objectHas(podSpec, 'affinity')
+  then podSpec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms
+  else [];
+assert compartmentSchedulerNodeSelectorTerms(0) == [{ matchExpressions: schedulerAffinityMatchers }] :
+       'expected per-compartment compactor-schedulers to inherit compactor_scheduler_node_affinity_matchers';
+assert compartmentSchedulerNodeSelectorTerms(1) == [{ matchExpressions: schedulerAffinityMatchers }] :
+       'expected per-compartment compactor-schedulers to inherit compactor_scheduler_node_affinity_matchers';
+
 env

--- a/operations/mimir/compartments-compactor-scheduler.libsonnet
+++ b/operations/mimir/compartments-compactor-scheduler.libsonnet
@@ -38,7 +38,7 @@
   // StatefulSets, Services and PDBs.
   newCompactorSchedulerCompartmentStatefulSet(compartmentIdx)::
     local name = 'compactor-scheduler-rc-%d' % compartmentIdx;
-    $.newCompactorSchedulerStatefulSet(name, $.compactor_scheduler_containers['compartment_%d' % compartmentIdx]) +
+    $.newCompactorSchedulerStatefulSet(name, $.compactor_scheduler_containers['compartment_%d' % compartmentIdx], $.compactor_scheduler_node_affinity_matchers) +
     statefulSet.mixin.metadata.withLabelsMixin({ 'mimir-rc': std.toString(compartmentIdx) }) +
     statefulSet.mixin.spec.template.metadata.withLabelsMixin({ 'mimir-rc': std.toString(compartmentIdx) }),
 


### PR DESCRIPTION
The per-compartment compactor-schedulers were deployed without node affinity. Their StatefulSet builder is invoked without the `compactor_scheduler_node_affinity_matchers` argument, so it falls back to an empty default — unlike the non-compartment compactor-scheduler and the per-compartment compactor, which both pass their matchers through.

This threads `compactor_scheduler_node_affinity_matchers` through to the per-compartment scheduler StatefulSets, so they now honor the configured node affinity like every other component.

Compartments are an experimental, unreleased feature, so no changelog entry is added.
