### PR TITLE
Revert Renovate branch prefix to deps-update/

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -200,7 +200,8 @@
       commitMessageExtra: 'to {{ lookup (split newVersion "/") 1 }}',
     }
   ],
-  branchPrefixOld: 'deps-update/',
+  branchPrefix: 'deps-update/',
+  branchPrefixOld: 'renovate/',
   labels: [
     'dependency-update',
   ],


### PR DESCRIPTION
## Summary
- restore `branchPrefix: 'deps-update/'` after [#16076](https://github.com/grafana/mimir/pull/16076)
- keep `branchPrefixOld: 'renovate/'` so PRs opened during the short migration remain recognized

The org-wide `renovate/**` ruleset blocks `mimir-github-bot` from writing the mimir-build-image Makefile pin back onto Renovate PRs (`Cannot update this protected ref`). Security agreed to keep supporting `deps-update/` in the webhook listener ([deployment_tools#649425](https://github.com/grafana/deployment_tools/pull/649425)) instead of granting a broader bot exception.


Made with [Cursor](https://cursor.com)