### PR TITLE
Revert "Use default Renovate branch prefix"

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -200,7 +200,7 @@
       commitMessageExtra: 'to {{ lookup (split newVersion "/") 1 }}',
     }
   ],
-  branchPrefixOld: 'deps-update/',
+  branchPrefix: 'deps-update/',
   labels: [
     'dependency-update',
   ],


### PR DESCRIPTION
Reverts grafana/mimir#16076

We are going to merge https://github.com/grafana/deployment_tools/pull/649425 instead