### PR TITLE
MQE: enable previously unsupported upstream test cases

### DIFF
--- a/pkg/streamingpromql/testdata/upstream/histograms.test
+++ b/pkg/streamingpromql/testdata/upstream/histograms.test
@@ -1160,23 +1160,20 @@ load 1m
   series{host="a", le="1000"} 8
   series{host="a", le="+Inf"} 9
 
-# Unsupported by streaming engine.
-# eval instant at 0 histogram_quantile(0.8, series)
-#   expect no_info
-#   expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "series"
-#   # Should return no results.
+eval instant at 0 histogram_quantile(0.8, series)
+  expect no_info
+  expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "series"
+  # Should return no results.
 
-# Unsupported by streaming engine.
-# eval instant at 0 histogram_quantiles(series, "q", 0.1, 0.2)
-#   expect no_info
-#   expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "series"
-#   # Should return no results.
+eval instant at 0 histogram_quantiles(series, "q", 0.1, 0.2)
+  expect no_info
+  expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "series"
+  # Should return no results.
 
-# Unsupported by streaming engine.
-# eval instant at 0 histogram_fraction(-Inf, 1, series)
-#   expect no_info
-#   expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "series"
-#   # Should return no results.
+eval instant at 0 histogram_fraction(-Inf, 1, series)
+  expect no_info
+  expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "series"
+  # Should return no results.
 
 clear
 
@@ -1184,23 +1181,20 @@ clear
 load 1m
   series{ale="0.1"}   2
 
-# Unsupported by streaming engine.
-# eval instant at 0 histogram_quantile(0.8, series)
-#	expect no_info
-#	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of "" for metric name "series"
-#	# Should return no results.
+eval instant at 0 histogram_quantile(0.8, series)
+	expect no_info
+	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of "" for metric name "series"
+	# Should return no results.
 
-# Unsupported by streaming engine.
-# eval instant at 0 histogram_quantiles(series, "q", 0.1, 0.2)
-#	expect no_info
-#	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of "" for metric name "series"
-#	# Should return no results.
+eval instant at 0 histogram_quantiles(series, "q", 0.1, 0.2)
+	expect no_info
+	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of "" for metric name "series"
+	# Should return no results.
 
-# Unsupported by streaming engine.
-# eval instant at 0 histogram_fraction(-Inf, 1, series)
-#	expect no_info
-#	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of "" for metric name "series"
-#	# Should return no results.
+eval instant at 0 histogram_fraction(-Inf, 1, series)
+	expect no_info
+	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of "" for metric name "series"
+	# Should return no results.
 
 clear
 
@@ -1208,23 +1202,20 @@ clear
 load 1m
   series{le="Hello World"}   2
 
-# Unsupported by streaming engine.
-# eval instant at 0 histogram_quantile(0.8, series)
-#	expect no_info
-#	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of "Hello World" for metric name "series"
-#	# Should return no results.
+eval instant at 0 histogram_quantile(0.8, series)
+	expect no_info
+	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of "Hello World" for metric name "series"
+	# Should return no results.
 
-# Unsupported by streaming engine.
-# eval instant at 0 histogram_quantiles(series, "q", 0.1, 0.2)
-#	expect no_info
-#	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of "Hello World" for metric name "series"
-#	# Should return no results.
+eval instant at 0 histogram_quantiles(series, "q", 0.1, 0.2)
+	expect no_info
+	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of "Hello World" for metric name "series"
+	# Should return no results.
 
-# Unsupported by streaming engine.
-# eval instant at 0 histogram_fraction(-Inf, 1, series)
-#	expect no_info
-#	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of "Hello World" for metric name "series"
-#	# Should return no results.
+eval instant at 0 histogram_fraction(-Inf, 1, series)
+	expect no_info
+	expect warn msg: PromQL warning: bucket label "le" is missing or has a malformed value of "Hello World" for metric name "series"
+	# Should return no results.
 
 clear
 
@@ -1234,20 +1225,17 @@ load 1m
   series{le="1"}     2
   series{}           {{schema:0 count:10 sum:50 buckets:[1 2 3]}}
 
-# Unsupported by streaming engine.
-# eval instant at 0 histogram_quantile(0.8, series)
-#	expect no_info
-#	expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "series"
-#	# Should return no results.
+eval instant at 0 histogram_quantile(0.8, series)
+	expect no_info
+	expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "series"
+	# Should return no results.
 
-# Unsupported by streaming engine.
-# eval instant at 0 histogram_quantiles(series, "q", 0.1, 0.2)
-#	expect no_info
-#	expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "series"
-#	# Should return no results.
+eval instant at 0 histogram_quantiles(series, "q", 0.1, 0.2)
+	expect no_info
+	expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "series"
+	# Should return no results.
 
-# Unsupported by streaming engine.
-# eval instant at 0 histogram_fraction(-Inf, 1, series)
-#	expect no_info
-#	expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "series"
-#	# Should return no results.
+eval instant at 0 histogram_fraction(-Inf, 1, series)
+	expect no_info
+	expect warn msg: PromQL warning: vector contains a mix of classic and native histograms for metric name "series"
+	# Should return no results.


### PR DESCRIPTION
#### What this PR does

This PR enables some previously disabled upstream test cases that are now supported in MQE.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
