### PR TITLE
renovate: antithesis-sdk-go is only upgraded to versions with `-default-no-op` tag suffix.

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -125,6 +125,16 @@
       enabled: false,
     },
     {
+      description: 'Only update antithesis-sdk-go to default-no-op release variants',
+      matchManagers: ['gomod'],
+      matchPackageNames: [
+        'github.com/antithesishq/antithesis-sdk-go',
+      ],
+      // Mark -default-no-op as a suffix not used in comparing version numbers.
+      versionCompatibility: '^(?<version>.+)(?<compatibility>-default-no-op)$',
+      versioning: 'semver',
+    },
+    {
       // Update Go version everywhere at once: build image, go.mod and GitHub Actions workflows.
       matchDatasources: [
         'docker',


### PR DESCRIPTION
#### What this PR does

I caught Renovate trying to drop this suffix over here:

* https://github.com/grafana/mimir/pull/16108

Turns out I had to tell it not to. This PR does that.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- (n/a) Tests updated.
- (n/a) Documentation added.
- (n/a) `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- (n/a) [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
