### PR TITLE
CODEOWNERS: Require explicit approval from mimir-ruler-and-alertmanager maintainers for alertmanager related dependency bumps

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -27,5 +27,5 @@ CHANGELOG.md
 go.mod @stevesg @grafana/mimir-maintainers
 go.sum @stevesg @grafana/mimir-maintainers
 /vendor/ @stevesg @grafana/mimir-maintainers
-/vendor/github.com/prometheus/alertmanager @grafana/mimir-ruler-and-alertmanager-maintainers @grafana/mimir-maintainers
-/vendor/github.com/grafana/alerting @grafana/mimir-ruler-and-alertmanager-maintainers @grafana/mimir-maintainers
+/vendor/github.com/prometheus/alertmanager @grafana/mimir-ruler-and-alertmanager-maintainers
+/vendor/github.com/grafana/alerting @grafana/mimir-ruler-and-alertmanager-maintainers


### PR DESCRIPTION
#### What this PR does
Any changes to `/vendor/github.com/prometheus/alertmanager` or `/vendor/github.com/grafana/alerting` will require an explicit approval from the @grafana/mimir-ruler-and-alertmanager-maintainers team
