### PR TITLE
test(continuoustest): reproduce step-alignment false-positive in range queries

### DIFF
--- a/pkg/continuoustest/util_test.go
+++ b/pkg/continuoustest/util_test.go
@@ -49,6 +49,96 @@ func TestGetQueryStep(t *testing.T) {
 	}
 }
 
+// TestStepAlignmentShiftsQueryMinTimeBackward reproduces the root cause of a
+// continuous-test false-positive: when the query time range grows large enough
+// for getQueryStep to return a step bigger than writeInterval, and the
+// query-frontend has align_queries_with_step=true, the frontend floors the
+// start timestamp via integer division (start = (start/step)*step). If
+// queryMinTime is not a multiple of the new step, this shifts start to a
+// timestamp before queryMinTime where old/stale data causes verifySamplesSum
+// to report a mismatch.
+func TestStepAlignmentShiftsQueryMinTimeBackward(t *testing.T) {
+	const (
+		numSeries     = 5000
+		alignInterval = 20 * time.Second // writeInterval
+	)
+
+	// queryMinTime aligned to writeInterval but NOT to multiples of 40s/60s.
+	// This is the exact value from the incident: 2026-07-16T20:31:40Z.
+	queryMinTime := time.UnixMilli(1784233900000).UTC()
+	require.Equal(t, int64(0), queryMinTime.UnixMilli()%alignInterval.Milliseconds(),
+		"queryMinTime must be aligned to writeInterval")
+
+	tests := map[string]struct {
+		end          time.Time
+		expectedStep time.Duration
+		// The aligned start the query-frontend would compute.
+		expectedAlignedStart time.Time
+	}{
+		"step=20s: queryMinTime is step-aligned, no shift": {
+			end:                  queryMinTime.Add(5 * time.Hour),
+			expectedStep:         alignInterval,
+			expectedAlignedStart: queryMinTime,
+		},
+		"step=40s: queryMinTime is NOT step-aligned, shifted 20s backward": {
+			end:                  queryMinTime.Add(6 * time.Hour),
+			expectedStep:         40 * time.Second,
+			expectedAlignedStart: queryMinTime.Add(-20 * time.Second),
+		},
+		"step=60s: queryMinTime is NOT step-aligned, shifted 40s backward": {
+			end:                  queryMinTime.Add(12 * time.Hour),
+			expectedStep:         60 * time.Second,
+			expectedAlignedStart: queryMinTime.Add(-40 * time.Second),
+		},
+	}
+
+	for testName, tc := range tests {
+		t.Run(testName, func(t *testing.T) {
+			step := getQueryStep(queryMinTime, tc.end, alignInterval)
+			require.Equal(t, tc.expectedStep, step)
+
+			// Simulate the step-align middleware: start = (start/step)*step
+			startMs := queryMinTime.UnixMilli()
+			stepMs := step.Milliseconds()
+			alignedStartMs := (startMs / stepMs) * stepMs
+			alignedStart := time.UnixMilli(alignedStartMs).UTC()
+
+			require.Equal(t, tc.expectedAlignedStart, alignedStart)
+
+			if step == alignInterval {
+				require.Equal(t, queryMinTime, alignedStart,
+					"with step == writeInterval, start must not shift")
+				return
+			}
+
+			// When step > writeInterval, the aligned start is before queryMinTime.
+			require.True(t, alignedStart.Before(queryMinTime),
+				"aligned start %v should be before queryMinTime %v", alignedStart, queryMinTime)
+
+			// Build histogram samples: correct data from queryMinTime onward,
+			// but a wrong value at the shifted-back timestamp to simulate
+			// stale/inconsistent data before the recovery boundary.
+			histProfile := histogramProfilesForWriteProtocol(writeProtocolPrometheus)[0]
+			var histograms []model.SampleHistogramPair
+
+			// The stale pre-recovery sample at the aligned start.
+			staleHist := histProfile.generateSampleHistogram(alignedStart, numSeries)
+			staleHist.Sum += 12345 // corrupt the sum
+			histograms = append(histograms, newSampleHistogramPair(alignedStart, staleHist))
+
+			// Correct samples from queryMinTime onward.
+			for ts := queryMinTime; !ts.After(queryMinTime.Add(3 * step)); ts = ts.Add(step) {
+				histograms = append(histograms, newSampleHistogramPair(ts, histProfile.generateSampleHistogram(ts, numSeries)))
+			}
+
+			matrix := model.Matrix{{Histograms: histograms}}
+			_, err := verifySamplesSum(matrix, numSeries, step, histProfile.generateValue, histProfile.generateSampleHistogram, nil)
+			require.Error(t, err, "verifySamplesSum should fail on the stale pre-queryMinTime sample")
+			require.Contains(t, err.Error(), "has sum")
+		})
+	}
+}
+
 func TestVerifySamplesSum(t *testing.T) {
 	testVerifySamplesSumFloats(t, generateSineWaveValue, "generateSineWaveValue")
 	for _, histProfile := range histogramProfilesForWriteProtocol(writeProtocolPrometheus) {


### PR DESCRIPTION
## Summary

Add a test reproducing the step-alignment false-positive observed in the `mimir-dedicated-17` continuous test. When the query time range grows large enough for `getQueryStep` to bump the step beyond `writeInterval`, the query-frontend `align_queries_with_step` floors `start` to `(start/step)*step`, which can shift it backward past `queryMinTime` into a timestamp where stale or inconsistent data triggers a `verifySamplesSum` mismatch.

- Uses the exact incident timestamps (`queryMinTime=1784233900000`) to show `step=20s` passes while `step=40s `and `step=60s` shift start backward
- Confirms that the shifted-back timestamp lands on a pre-recovery sample, causing the CT to report a spurious failure

### Context

Investigated the mimir-dedicated-17 CT failures and found the error onset at 02:12 UTC was not caused by new data corruption — the underlying bad sample at 2026-07-16T20:31:20Z already existed. The CT switched from `step=20s` to `step=40s` as the query range exceeded `~5h35m`, and `floor(1784233900000/40000)*40000 = 1784233880000` landed exactly on the bad timestamp while the 20s-aligned start skipped it.