### PR TITLE
fix(conftest): match registry-prefixed Mimir and GEM images

### DIFF
--- a/operations/policies/policies.rego
+++ b/operations/policies/policies.rego
@@ -66,7 +66,15 @@ is_mimir_or_gem_image(image) {
 }
 
 is_mimir_or_gem_image(image) {
+	startswith(image, "docker.io/grafana/mimir")
+}
+
+is_mimir_or_gem_image(image) {
 	startswith(image, "grafana/enterprise-metrics")
+}
+
+is_mimir_or_gem_image(image) {
+	startswith(image, "docker.io/grafana/enterprise-metrics")
 }
 
 is_openshift(x) {


### PR DESCRIPTION
#### What this PR does

The `is_mimir_or_gem_image` helper in the conftest policies is being updated to be aware of the Docker Hub image naming. It previously only matched images starting with the bare `grafana/mimir` or `grafana/enterprise-metrics` prefixes, and not `docker.io`. This is required as Docker Hub is the default (since #13267), so the rendered manifests for `helm-conftest-quick-test` evaluation have never matched these old non-prefixed rules.

#### Which issue(s) this PR fixes or relates to

Relates to #16127 as Cursor flagged this issue.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.