### PR TITLE
docs: Add Grafana to landing page

### DIFF
--- a/docs/sources/mimir/_index.md
+++ b/docs/sources/mimir/_index.md
@@ -18,7 +18,7 @@ cascade:
 menuTitle: Grafana Mimir
 title: Grafana Mimir documentation
 hero:
-  title: Mimir
+  title: Grafana Mimir
   level: 1
   image: /media/docs/mimir/GrafanaLogo_Mimir_icon.png
   width: 100


### PR DESCRIPTION
#### What this PR does

Adds the word "Grafana" to the Grafana Mimir landing page, both for copyright/legal reasons and to match the landing pages of the other database products.

Before
<img width="764" height="193" alt="Mimir" src="https://github.com/user-attachments/assets/1a04aa66-54a7-4187-aba8-79ce21967f78" />

After
<img width="860" height="200" alt="GrafanaMimir" src="https://github.com/user-attachments/assets/4a7e1b59-15be-4b00-b68b-7da79010ca7a" />

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
