### PR TITLE
docs: document per-compartment block-builders

### DIFF
--- a/docs/internal/compartments/read-compartments.md
+++ b/docs/internal/compartments/read-compartments.md
@@ -40,6 +40,19 @@ resources dedicated to consumption are divided across these consumers, so the co
 consumption resource usage stays independent of the number of write compartments instead of growing
 with it.
 
+### Ordering records across write compartments
+
+A component that consumes the same partition from every write compartment's Kafka cluster sees each
+cluster's stream independently, with no inherent ordering between them. Appending one cluster's records
+and then the next's could produce out-of-order samples if the clusters' records overlap in time, since
+the second cluster's timestamps then rewind to earlier in the window. To reduce this, the per-cluster
+streams can be merged into a single stream ordered by Kafka record timestamp before being consumed.
+
+- **Ingesters** can optionally merge on the live path. A live stream is unbounded, so the merge is
+  best-effort within a bounded window.
+- **Block-builders** always merge a job's per-cluster ranges this way. Because a job's start and end
+  offsets are known up front, the merge sorts exactly across clusters for the window.
+
 ## Blocks storage
 
 Each read compartment owns its blocks storage end to end:
@@ -61,6 +74,29 @@ bucket scale independently of the others.
 The global query layer queries each read compartment's store-gateways the same way it queries that
 compartment's ingesters: it narrows a query to the compartments that can hold the selected metric
 names and fans out otherwise (see [Querying read compartments](#querying-read-compartments)).
+
+## Block-builders
+
+Each read compartment runs its own block-builder scheduler and pool of block-builders. The scheduler
+monitors the compartment's topic across every write compartment's Kafka cluster and cuts jobs; the
+block-builders consume those clusters, build the compartment's blocks, and upload them to its bucket.
+
+- **One job spans every write compartment.** A job is scoped to one partition but carries a separate
+  offset range per cluster, built into a single block with the ranges merged in record-timestamp order.
+  Scoping a job to a single cluster instead would produce a separate block per cluster for the same
+  window, multiplying blocks and chunks by roughly the number of write compartments until compaction
+  merges them away — raising object-storage cost and query load, since store-gateways then load more
+  blocks per query.
+- **A job is all-or-nothing across its clusters.** The block-builder reads every cluster's range
+  together, and if any read fails the whole job is retried, so committed offsets never advance past
+  unread data. One unhealthy write compartment therefore blocks the compartment's block building until
+  it recovers — acceptable because block building is delayed (store-gateways don't need a block for
+  hours) and no worse than a single Kafka cluster being down without compartments.
+- **Backlog reconstruction on restart.** As in non-compartments mode, on restart the scheduler rebuilds
+  the backlog from what already sits in Kafka — probing historical offsets and replaying them by
+  timestamp to reproduce the job boundaries it would have cut live. The compartment difference is that
+  the probed offsets from every cluster are grouped by time, so data ingested around the same time
+  across clusters lands in the same job, keeping one block per window.
 
 ## Querying read compartments
 
@@ -112,6 +148,3 @@ are specific to Warpstream; the design above is Kafka-cluster-generic.
   fetch portions of files from one another. As a result, consuming a partition across all VCs may, under
   the hood, require data from any read agent in any write compartment. This is a potential scalability
   and availability limitation that needs further investigation.
-- **Cross-VC consumption ordering.** An ingester consumes from multiple VCs, and consumption from each VC
-  is independent, so there is no guarantee of in-order consumption across VCs. The plan is to offset this
-  by merging the per-VC streams with a heap that orders Kafka records by their creation timestamp.

--- a/docs/internal/compartments/read-compartments.md
+++ b/docs/internal/compartments/read-compartments.md
@@ -90,8 +90,9 @@ block-builders consume those clusters, build the compartment's blocks, and uploa
 - **A job is all-or-nothing across its clusters.** The block-builder reads every cluster's range
   together, and if any read fails the whole job is retried, so committed offsets never advance past
   unread data. One unhealthy write compartment therefore blocks the compartment's block building until
-  it recovers — acceptable because block building is delayed (store-gateways don't need a block for
-  hours) and no worse than a single Kafka cluster being down without compartments.
+  it recovers — no worse than a single Kafka cluster being down without compartments. Block building
+  runs behind live querying rather than on the ingest critical path, so it can absorb some delay,
+  bounded by how long ingesters keep serving the not-yet-built data.
 - **Backlog reconstruction on restart.** As in non-compartments mode, on restart the scheduler rebuilds
   the backlog from what already sits in Kafka — probing historical offsets and replaying them by
   timestamp to reproduce the job boundaries it would have cut live. The compartment difference is that

--- a/docs/internal/compartments/read-compartments.md
+++ b/docs/internal/compartments/read-compartments.md
@@ -81,7 +81,7 @@ Each read compartment runs its own block-builder scheduler and pool of block-bui
 monitors the compartment's topic across every write compartment's Kafka cluster and cuts jobs; the
 block-builders consume those clusters, build the compartment's blocks, and upload them to its bucket.
 
-- **One job spans every write compartment.** A job is scoped to one partition but carries a separate
+- **One job can span every write compartment.** A job is scoped to one partition but carries a separate
   offset range per cluster, built into a single block with the ranges merged in record-timestamp order.
   Scoping a job to a single cluster instead would produce a separate block per cluster for the same
   window, multiplying blocks and chunks by roughly the number of write compartments until compaction

--- a/docs/internal/compartments/status-and-limitations.md
+++ b/docs/internal/compartments/status-and-limitations.md
@@ -21,6 +21,10 @@ the other files is implemented today; this page tracks the gap.
 - **Per-compartment store-gateway and compactor rings**: a store-gateway or compactor configured for a
   read compartment registers into that compartment's own dedicated ring, separate from the
   non-compartment ring and from the other compartments' rings.
+- **Compartment-aware block-builders**: each read compartment runs its own block-builder scheduler and
+  pool of block-builders. The scheduler cuts a single job per partition and time window that bundles
+  each write compartment cluster's offset range, and the block-builder consumes those ranges together,
+  merges them by record timestamp, and builds one block per window into the compartment's bucket.
 - **Compartment-aware strong read consistency**: the query-frontend monitors the last produced offset of
   every read compartment's topic in every write compartment's Kafka cluster and propagates them to the
   ingesters, so an ingester enforcing strong read consistency waits for the specific requested offsets of
@@ -31,19 +35,10 @@ the other files is implemented today; this page tracks the gap.
   [Ruler](./ruler.md)).
 - A local development environment (`development/mimir-compartments`).
 
-## Blocks storage is only partially compartment-aware
-
-- Running store-gateways and compactors as separate per-compartment deployments, each with a dedicated
-  object-storage bucket, is wired in the local development environment but not yet in the production
-  deployment tooling.
-- The block-builder is not compartment-aware yet, so blocks for every read compartment are not produced
-  independently.
-
 ## Not yet addressed
 
-- **Cross-cluster ordering.** Consumption from each write compartment's Kafka cluster is independent, so
-  there is no guarantee of in-order consumption across clusters. Merging the per-cluster streams to
-  reduce out-of-order samples (see [Read compartments](./read-compartments.md)) is not implemented yet.
+- Per-compartment block-builders run only in the local development environment; they are not part of
+  the jsonnet deployment library yet.
 - Even on the write path, some things are not done yet — for example shuffle sharding and integration
   tests. There is no changelog or experimental-feature documentation entry until compartments work
   end-to-end.


### PR DESCRIPTION
Documents how block-builders work with Mimir compartments, in the internal compartments docs.

Also updates some other stale documentation for compartments.

Docs-only; no behavior change.