### PR TITLE
Add opt-in warmup period to EwmaRate

### DIFF
--- a/pkg/util/math/rate.go
+++ b/pkg/util/math/rate.go
@@ -19,15 +19,27 @@ type EwmaRate struct {
 	alpha    float64
 	interval time.Duration
 
-	mutex    sync.RWMutex
-	lastRate float64
-	init     bool
+	mutex         sync.RWMutex
+	lastRate      float64
+	init          bool
+	count         uint8
+	warmupSamples uint8
+	warmupSum     float64
 }
 
 func NewEWMARate(alpha float64, interval time.Duration) *EwmaRate {
 	return &EwmaRate{
-		alpha:    alpha,
-		interval: interval,
+		alpha:         alpha,
+		interval:      interval,
+		warmupSamples: 0,
+	}
+}
+
+func NewEWMARateWithWarmup(alpha float64, interval time.Duration, warmupSamples uint8) *EwmaRate {
+	return &EwmaRate{
+		alpha:         alpha,
+		interval:      interval,
+		warmupSamples: warmupSamples,
 	}
 }
 
@@ -35,6 +47,11 @@ func NewEWMARate(alpha float64, interval time.Duration) *EwmaRate {
 func (r *EwmaRate) Rate() float64 {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
+
+	if r.count < r.warmupSamples {
+		return 0
+	}
+
 	return r.lastRate
 }
 
@@ -45,6 +62,16 @@ func (r *EwmaRate) Tick() {
 
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
+
+	if r.count < r.warmupSamples {
+		r.warmupSum += instantRate
+		r.count++
+		if r.count == r.warmupSamples {
+			r.lastRate = r.warmupSum / float64(r.count)
+			r.init = true
+		}
+		return
+	}
 
 	if r.init {
 		r.lastRate += r.alpha * (instantRate - r.lastRate)

--- a/pkg/util/math/rate.go
+++ b/pkg/util/math/rate.go
@@ -22,11 +22,12 @@ type EwmaRate struct {
 	mutex         sync.RWMutex
 	lastRate      float64
 	init          bool
-	count         uint8
-	warmupSamples uint8
-	warmupSum     float64
+	count         uint8   // count is the number of warmup ticks observed so far.
+	warmupSamples uint8   // warmupSamples is the number of ticks to accumulate before the rate is seeded; zero disables warmup.
+	warmupSum     float64 // warmupSum is the running sum of instant rates observed during warmup.
 }
 
+// NewEWMARate returns an EwmaRate with no warmup; a rate is reported from the first tick.
 func NewEWMARate(alpha float64, interval time.Duration) *EwmaRate {
 	return &EwmaRate{
 		alpha:         alpha,
@@ -35,6 +36,9 @@ func NewEWMARate(alpha float64, interval time.Duration) *EwmaRate {
 	}
 }
 
+// NewEWMARateWithWarmup returns an EwmaRate that reports a rate of 0 until warmupSamples ticks have been observed.
+// Once warmup completes, the rate is seeded from the arithmetic mean of the warmup samples, after which normal EWMA blending begins.
+// A warmupSamples value of 0 behaves identically to NewEWMARate with no warmup phase.
 func NewEWMARateWithWarmup(alpha float64, interval time.Duration, warmupSamples uint8) *EwmaRate {
 	return &EwmaRate{
 		alpha:         alpha,
@@ -44,6 +48,7 @@ func NewEWMARateWithWarmup(alpha float64, interval time.Duration, warmupSamples 
 }
 
 // Rate returns the per-second rate.
+// It returns 0 until the warmup phase is complete.
 func (r *EwmaRate) Rate() float64 {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
@@ -67,7 +72,7 @@ func (r *EwmaRate) Tick() {
 		r.warmupSum += instantRate
 		r.count++
 		if r.count == r.warmupSamples {
-			r.lastRate = r.warmupSum / float64(r.count)
+			r.lastRate = r.warmupSum / float64(r.count) // Seed from the arithmetic mean of the warmup samples so no single reading dominates the initial rate.
 			r.init = true
 		}
 		return

--- a/pkg/util/math/rate_test.go
+++ b/pkg/util/math/rate_test.go
@@ -83,3 +83,23 @@ func TestRateWithZeroWarmupMatchesDefault(t *testing.T) {
 		require.InDelta(t, defaultRate.Rate(), zeroWarmupRate.Rate(), 0.0000000001)
 	}
 }
+
+func TestRateWithWarmupSeedsMean(t *testing.T) {
+	ticks := []struct {
+		events int64
+		want   float64
+	}{
+		{60, 0},
+		{30, 0},
+		{0, 0.5},
+		{0, 0.4},
+	}
+
+	r := NewEWMARateWithWarmup(0.2, time.Minute, 3)
+
+	for _, tick := range ticks {
+		r.Add(tick.events)
+		r.Tick()
+		require.InDelta(t, tick.want, r.Rate(), 0.0000000001, "unexpected rate")
+	}
+}

--- a/pkg/util/math/rate_test.go
+++ b/pkg/util/math/rate_test.go
@@ -50,3 +50,36 @@ func TestRate(t *testing.T) {
 		require.InDelta(t, tick.want, r.Rate(), 0.0000000001, "unexpected rate")
 	}
 }
+
+func TestRateWithWarmup(t *testing.T) {
+	ticks := []struct {
+		events int64
+		want   float64
+	}{
+		{120, 0},
+		{0, 0},
+		{60, 1},
+		{120, 1.2},
+	}
+	r := NewEWMARateWithWarmup(0.2, time.Minute, 3)
+
+	for _, tick := range ticks {
+		r.Add(tick.events)
+		r.Tick()
+		require.InDelta(t, tick.want, r.Rate(), 0.0000000001, "unexpected rate")
+	}
+}
+
+func TestRateWithZeroWarmupMatchesDefault(t *testing.T) {
+	defaultRate := NewEWMARate(0.2, time.Minute)
+	zeroWarmupRate := NewEWMARateWithWarmup(0.2, time.Minute, 0)
+
+	for _, events := range []int64{60, 30, 0, 60} {
+		defaultRate.Add(events)
+		zeroWarmupRate.Add(events)
+		defaultRate.Tick()
+		zeroWarmupRate.Tick()
+
+		require.InDelta(t, defaultRate.Rate(), zeroWarmupRate.Rate(), 0.0000000001)
+	}
+}


### PR DESCRIPTION
#### What this PR does
Adds an opt-in warmup period to `math.EwmaRate` via a new `NewEWMARateWithWarmup(alpha, interval, warmupSamples)` constructor.

Without the warmup, `EwmaRate` reports a rate after a single sample, which seeds the moving average from just that one data point. An early burst in the lifetime of the rate is then indistinguishable from a true sustained high rate (the problem that was observed in #5394, where CPU-based limiting triggered immediately after ingester startup).

During warmup, `Rate()` returns 0 while instant rates accumulate. Then, on the Nth tick, the EWMA is seeded from the arithmetic mean of the warmup samples, and then normal EWMA blending continues from there. This design follows the approach used by [VividCortex's VariableEWMA](https://github.com/VividCortex/ewma#readme), which #5394 also referenced. 

This also carries forward the direction of the earlier (now stale and closed) #9514, with two intentional differences. The first being that `NewEWMARate` behavior is unchanged. Existing callers get no warmup (`warmupSamples: 0`), so this is backward compatible by construction, not convention. #9514 applied a default warmup of 60 samples to the existing constructor, which would change behavior for every existing caller. And secondly, warmup seeds the average rather than masking it. Suppressing `Rate()` for N ticks alone still leaves the EWMA seeded from the first sample. Seeding from the warmup mean, however, addresses the cold-start bias itself.

Because `Rate()` returns 0 during warmup, consumers fail open: a zero-rate reads as "no observed load", so nothing engages limiting on invalid data. The alternative would be reporting the raw early average, which risks falsely triggering limiting off incomplete data, the same failure mode from #5394.

Migration of `UtilizationBasedLimiter` off its external warmup implementation is deliberately left as a follow-up. Swapping it to this constructor would not be a like-for-like change; it would alter behavior in two ways. First, the limiter's existing warmup is time-based, while this constructor's is count-based, and because the limiter skips updates that arrive too close together, a count-based warmup could complete later, changing when limiting is first engaged on an overloaded process. Second, the limiter today only masks the reported rate during warmup, while this constructor seeds from the warmup mean. That is a likely improvement, but it's also a production behavior change on a live limiting path and thus should have its own PR and review, mirroring the scope of #5394.

**Note:** No user-visible change, so I believe no changelog entry is necessary. Happy to add one if preferred. Documentation is the code comments. Requesting the changelog-not-needed label. 

#### Which issue(s) this PR fixes or relates to

Fixes #5443 

#### Checklist

- [x] Tests updated.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features. N/A — internal utility, no config surface.
