### PR TITLE
Query-frontend: fix goroutine leak when streaming response races with cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@
 * [BUGFIX] Query-frontend: Fix `queue_time_seconds` in the query stats log always reporting 0 when a query is cancelled while still waiting in the query-scheduler queue. #16094
 * [BUGFIX] MQE: Fix the binary operation narrow-selectors optimization incorrectly using binary operation matchers across an `on()` / `on(...) group_left`/`group_right` join boundary, which could cause some queries to unexpectedly evaluate as an empty result. #16155
 * [BUGFIX] Packaging: Fix the DEB/RPM packages shipping the `mimir`, `mimirtool`, `metaconvert`, and `query-tee` binaries without the executable bit set, which caused `mimir.service` to fail to start. #16166
+* [BUGFIX] Query-frontend: Fix a goroutine leak when a querier's streaming response arrives just as the query is cancelled: the goroutine handling the response could stay blocked forever writing a response body that would never be read. #16151
 
 ### Mixin
 

--- a/pkg/frontend/v2/frontend.go
+++ b/pkg/frontend/v2/frontend.go
@@ -361,12 +361,10 @@ func (f *Frontend) RoundTripGRPC(ctx context.Context, httpRequest *httpgrpc.HTTP
 			if stats.ShouldTrackHTTPGRPCResponse(resp.queryResult.HttpResponse) {
 				stats.FromContext(ctx).Merge(resp.queryResult.Stats) // Safe if stats is nil.
 			}
-			if resp.bodyStream != nil {
-				// We're discarding this response (the caller only gets the cancellation error), but if the
-				// querier sent it via QueryResultStream, that call is blocked writing to this pipe until it's
-				// read or closed. Close it so that goroutine isn't leaked.
-				_ = resp.bodyStream.Close()
-			}
+			// We're discarding this response (the caller only gets the cancellation error). If the
+			// querier sent it via QueryResultStream, receiveResultForHTTPRequest closes its body
+			// pipe once the deferred cleanup cancels the request context, so the handler blocked
+			// writing to the pipe isn't leaked.
 		default:
 			stats.FromContext(ctx).AddQueueTime(time.Since(freq.enqueuedAt))
 		}

--- a/pkg/frontend/v2/frontend.go
+++ b/pkg/frontend/v2/frontend.go
@@ -900,12 +900,15 @@ func (f *Frontend) receiveResultForHTTPRequest(req *frontendRequest, firstMessag
 		}
 	}(writer)
 
-	// req.ctx is cancelled when RoundTripGRPC returns without handing this response to its
-	// caller (eg. its cancellation branch found the httpResponse channel still empty), or later
-	// when the caller closes the response body. Either way nobody will read the pipe anymore,
-	// so close it to make sure this goroutine isn't left blocked writing body chunks forever.
+	// Normally the client reads the body stream completely, hits EOF, and closes the body via
+	// cleanupReadCloser.Close. This function returns once the querier's stream ends, before that
+	// close happens. On this successful path the caller closes the reader, so defer stop() disarms
+	// the callback below.
+	// In the unsuccessful case the client never reads the body (timeout or cancellation). req.ctx is
+	// cancelled, the callback closes the reader, and writer.Write unblocks so this goroutine finishes
+	// instead of leaking. Close the read side so writer.Write returns the cancel cause, not io.ErrClosedPipe.
 	stop := context.AfterFunc(req.ctx, func() {
-		_ = writer.CloseWithError(context.Cause(req.ctx))
+		_ = reader.CloseWithError(context.Cause(req.ctx))
 	})
 	defer stop()
 

--- a/pkg/frontend/v2/frontend.go
+++ b/pkg/frontend/v2/frontend.go
@@ -902,6 +902,15 @@ func (f *Frontend) receiveResultForHTTPRequest(req *frontendRequest, firstMessag
 		}
 	}(writer)
 
+	// The request context is cancelled once RoundTripGRPC returns on any path. If it returned
+	// without receiving this response (eg. the caller cancelled the request and the cancellation
+	// branch found the httpResponse channel still empty), nothing will ever read the pipe, so
+	// close it to make sure this goroutine isn't left blocked writing body chunks forever.
+	stop := context.AfterFunc(req.ctx, func() {
+		_ = writer.CloseWithError(context.Cause(req.ctx))
+	})
+	defer stop()
+
 	res := queryResultWithBody{
 		queryResult: &frontendv2pb.QueryResultRequest{
 			QueryID: firstMessage.QueryID,

--- a/pkg/frontend/v2/frontend.go
+++ b/pkg/frontend/v2/frontend.go
@@ -902,10 +902,10 @@ func (f *Frontend) receiveResultForHTTPRequest(req *frontendRequest, firstMessag
 		}
 	}(writer)
 
-	// The request context is cancelled once RoundTripGRPC returns on any path. If it returned
-	// without receiving this response (eg. the caller cancelled the request and the cancellation
-	// branch found the httpResponse channel still empty), nothing will ever read the pipe, so
-	// close it to make sure this goroutine isn't left blocked writing body chunks forever.
+	// req.ctx is cancelled when RoundTripGRPC returns without handing this response to its
+	// caller (eg. its cancellation branch found the httpResponse channel still empty), or later
+	// when the caller closes the response body. Either way nobody will read the pipe anymore,
+	// so close it to make sure this goroutine isn't left blocked writing body chunks forever.
 	stop := context.AfterFunc(req.ctx, func() {
 		_ = writer.CloseWithError(context.Cause(req.ctx))
 	})

--- a/pkg/frontend/v2/frontend_test.go
+++ b/pkg/frontend/v2/frontend_test.go
@@ -1614,7 +1614,8 @@ func TestFrontendStreamingResponseAfterCancellationDoesNotLeak(t *testing.T) {
 	f.requests.put(freq)
 
 	// RoundTripGRPC's cancellation branch has already returned and cancelled the request context.
-	cancel(cancellation.NewErrorf("request cancelled"))
+	cause := cancellation.NewErrorf("request cancelled")
+	cancel(cause)
 
 	msg := &schedulerpb.FrontendToScheduler{QueryID: freq.queryID}
 	stream := &mockQueryResultStreamServer{
@@ -1632,7 +1633,7 @@ func TestFrontendStreamingResponseAfterCancellationDoesNotLeak(t *testing.T) {
 
 	select {
 	case err := <-streamReturned:
-		require.ErrorIs(t, err, io.ErrClosedPipe)
+		require.ErrorIs(t, err, cause)
 	case <-time.After(time.Second):
 		// Unblock the handler goroutine so it doesn't also trip the leak detector.
 		res := <-freq.httpResponse
@@ -1676,11 +1677,12 @@ func TestFrontendStreamingResponseDiscardedAfterDrainDoesNotLeak(t *testing.T) {
 	// RoundTripGRPC's cancellation branch drains the response, discarding it without reading the
 	// body, and then its deferred cleanup cancels the request context.
 	res := <-freq.httpResponse
-	cancel(cancellation.NewErrorf("request cancelled"))
+	cause := cancellation.NewErrorf("request cancelled")
+	cancel(cause)
 
 	select {
 	case err := <-streamReturned:
-		require.ErrorIs(t, err, io.ErrClosedPipe)
+		require.ErrorIs(t, err, cause)
 	case <-time.After(time.Second):
 		// Unblock the handler goroutine so it doesn't also trip the leak detector.
 		_ = res.bodyStream.Close()

--- a/pkg/frontend/v2/frontend_test.go
+++ b/pkg/frontend/v2/frontend_test.go
@@ -1595,6 +1595,52 @@ func TestFrontendStreamingResponse(t *testing.T) {
 	}
 }
 
+// TestFrontendStreamingResponseAfterCancellationDoesNotLeak reproduces the race where the querier's
+// streaming response claims the request just after RoundTripGRPC's cancellation branch found the
+// httpResponse channel still empty and returned: nothing will ever read the response or its body pipe,
+// so the handler must not stay blocked writing body chunks once the request context is done.
+func TestFrontendStreamingResponseAfterCancellationDoesNotLeak(t *testing.T) {
+	const userID = "test"
+
+	f, _ := setupFrontend(t, nil, nil)
+
+	ctx, cancel := context.WithCancelCause(user.InjectOrgID(t.Context(), userID))
+	freq := &frontendRequest{
+		queryID:      117,
+		userID:       userID,
+		ctx:          ctx,
+		httpResponse: make(chan queryResultWithBody, 1),
+	}
+	f.requests.put(freq)
+
+	// RoundTripGRPC's cancellation branch has already returned and cancelled the request context.
+	cancel(cancellation.NewErrorf("request cancelled"))
+
+	msg := &schedulerpb.FrontendToScheduler{QueryID: freq.queryID}
+	stream := &mockQueryResultStreamServer{
+		ctx: user.InjectOrgID(t.Context(), userID),
+		msgs: []*frontendv2pb.QueryResultStreamRequest{
+			metadataRequest(msg, http.StatusOK, nil),
+			bodyChunkRequest(msg, []byte("a body chunk nobody will read")),
+		},
+	}
+
+	streamReturned := make(chan error, 1)
+	go func() {
+		streamReturned <- f.QueryResultStream(stream)
+	}()
+
+	select {
+	case err := <-streamReturned:
+		require.ErrorIs(t, err, io.ErrClosedPipe)
+	case <-time.After(time.Second):
+		// Unblock the handler goroutine so it doesn't also trip the leak detector.
+		res := <-freq.httpResponse
+		_ = res.bodyStream.Close()
+		t.Fatal("QueryResultStream is still blocked writing the body of a response nobody will read")
+	}
+}
+
 func metadataRequest(msg *schedulerpb.FrontendToScheduler, statusCode int, headers []*httpgrpc.Header) *frontendv2pb.QueryResultStreamRequest {
 	return &frontendv2pb.QueryResultStreamRequest{
 		QueryID: msg.QueryID,

--- a/pkg/frontend/v2/frontend_test.go
+++ b/pkg/frontend/v2/frontend_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/go-kit/log"
@@ -1600,46 +1601,50 @@ func TestFrontendStreamingResponse(t *testing.T) {
 // httpResponse channel still empty and returned: nothing will ever read the response or its body pipe,
 // so the handler must not stay blocked writing body chunks once the request context is done.
 func TestFrontendStreamingResponseAfterCancellationDoesNotLeak(t *testing.T) {
-	const userID = "test"
+	synctest.Test(t, func(t *testing.T) {
+		const userID = "test"
 
-	f, _ := setupFrontend(t, nil, nil)
+		f := &Frontend{requests: newRequestsInProgress(), log: log.NewNopLogger()}
 
-	ctx, cancel := context.WithCancelCause(user.InjectOrgID(t.Context(), userID))
-	freq := &frontendRequest{
-		queryID:      117,
-		userID:       userID,
-		ctx:          ctx,
-		httpResponse: make(chan queryResultWithBody, 1),
-	}
-	f.requests.put(freq)
+		ctx, cancel := context.WithCancelCause(user.InjectOrgID(t.Context(), userID))
+		freq := &frontendRequest{
+			queryID:      117,
+			userID:       userID,
+			ctx:          ctx,
+			httpResponse: make(chan queryResultWithBody, 1),
+		}
+		f.requests.put(freq)
 
-	// RoundTripGRPC's cancellation branch has already returned and cancelled the request context.
-	cause := cancellation.NewErrorf("request cancelled")
-	cancel(cause)
+		// RoundTripGRPC's cancellation branch has already returned and cancelled the request context.
+		cause := cancellation.NewErrorf("request cancelled")
+		cancel(cause)
 
-	msg := &schedulerpb.FrontendToScheduler{QueryID: freq.queryID}
-	stream := &mockQueryResultStreamServer{
-		ctx: user.InjectOrgID(t.Context(), userID),
-		msgs: []*frontendv2pb.QueryResultStreamRequest{
-			metadataRequest(msg, http.StatusOK, nil),
-			bodyChunkRequest(msg, []byte("a body chunk nobody will read")),
-		},
-	}
+		msg := &schedulerpb.FrontendToScheduler{QueryID: freq.queryID}
+		stream := &mockQueryResultStreamServer{
+			ctx: user.InjectOrgID(t.Context(), userID),
+			msgs: []*frontendv2pb.QueryResultStreamRequest{
+				metadataRequest(msg, http.StatusOK, nil),
+				bodyChunkRequest(msg, []byte("a body chunk nobody will read")),
+			},
+		}
 
-	streamReturned := make(chan error, 1)
-	go func() {
-		streamReturned <- f.QueryResultStream(stream)
-	}()
+		streamReturned := make(chan error, 1)
+		go func() {
+			streamReturned <- f.QueryResultStream(stream)
+		}()
 
-	select {
-	case err := <-streamReturned:
-		require.ErrorIs(t, err, cause)
-	case <-time.After(time.Second):
-		// Unblock the handler goroutine so it doesn't also trip the leak detector.
-		res := <-freq.httpResponse
-		_ = res.bodyStream.Close()
-		t.Fatal("QueryResultStream is still blocked writing the body of a response nobody will read")
-	}
+		select {
+		case err := <-streamReturned:
+			require.ErrorIs(t, err, cause)
+		case <-time.After(time.Second):
+			// Only reached when the handler is stuck: synctest's fake clock advances once no
+			// goroutine in the bubble can run. Unblock the handler so its goroutine doesn't
+			// also trip the leak detector.
+			res := <-freq.httpResponse
+			_ = res.bodyStream.Close()
+			t.Fatal("QueryResultStream is still blocked writing the body of a response nobody will read")
+		}
+	})
 }
 
 // TestFrontendStreamingResponseDiscardedAfterDrainDoesNotLeak reproduces the case where
@@ -1647,47 +1652,51 @@ func TestFrontendStreamingResponseAfterCancellationDoesNotLeak(t *testing.T) {
 // but discards it without ever reading its body: cancelling the request context alone (which the
 // deferred cleanup does) must be enough to unblock the handler writing body chunks to the pipe.
 func TestFrontendStreamingResponseDiscardedAfterDrainDoesNotLeak(t *testing.T) {
-	const userID = "test"
+	synctest.Test(t, func(t *testing.T) {
+		const userID = "test"
 
-	f, _ := setupFrontend(t, nil, nil)
+		f := &Frontend{requests: newRequestsInProgress(), log: log.NewNopLogger()}
 
-	ctx, cancel := context.WithCancelCause(user.InjectOrgID(t.Context(), userID))
-	freq := &frontendRequest{
-		queryID:      118,
-		userID:       userID,
-		ctx:          ctx,
-		httpResponse: make(chan queryResultWithBody, 1),
-	}
-	f.requests.put(freq)
+		ctx, cancel := context.WithCancelCause(user.InjectOrgID(t.Context(), userID))
+		freq := &frontendRequest{
+			queryID:      118,
+			userID:       userID,
+			ctx:          ctx,
+			httpResponse: make(chan queryResultWithBody, 1),
+		}
+		f.requests.put(freq)
 
-	msg := &schedulerpb.FrontendToScheduler{QueryID: freq.queryID}
-	stream := &mockQueryResultStreamServer{
-		ctx: user.InjectOrgID(t.Context(), userID),
-		msgs: []*frontendv2pb.QueryResultStreamRequest{
-			metadataRequest(msg, http.StatusOK, nil),
-			bodyChunkRequest(msg, []byte("a body chunk nobody will read")),
-		},
-	}
+		msg := &schedulerpb.FrontendToScheduler{QueryID: freq.queryID}
+		stream := &mockQueryResultStreamServer{
+			ctx: user.InjectOrgID(t.Context(), userID),
+			msgs: []*frontendv2pb.QueryResultStreamRequest{
+				metadataRequest(msg, http.StatusOK, nil),
+				bodyChunkRequest(msg, []byte("a body chunk nobody will read")),
+			},
+		}
 
-	streamReturned := make(chan error, 1)
-	go func() {
-		streamReturned <- f.QueryResultStream(stream)
-	}()
+		streamReturned := make(chan error, 1)
+		go func() {
+			streamReturned <- f.QueryResultStream(stream)
+		}()
 
-	// RoundTripGRPC's cancellation branch drains the response, discarding it without reading the
-	// body, and then its deferred cleanup cancels the request context.
-	res := <-freq.httpResponse
-	cause := cancellation.NewErrorf("request cancelled")
-	cancel(cause)
+		// RoundTripGRPC's cancellation branch drains the response, discarding it without reading the
+		// body, and then its deferred cleanup cancels the request context.
+		res := <-freq.httpResponse
+		cause := cancellation.NewErrorf("request cancelled")
+		cancel(cause)
 
-	select {
-	case err := <-streamReturned:
-		require.ErrorIs(t, err, cause)
-	case <-time.After(time.Second):
-		// Unblock the handler goroutine so it doesn't also trip the leak detector.
-		_ = res.bodyStream.Close()
-		t.Fatal("QueryResultStream is still blocked writing the body of a discarded response")
-	}
+		select {
+		case err := <-streamReturned:
+			require.ErrorIs(t, err, cause)
+		case <-time.After(time.Second):
+			// Only reached when the handler is stuck: synctest's fake clock advances once no
+			// goroutine in the bubble can run. Unblock the handler so its goroutine doesn't
+			// also trip the leak detector.
+			_ = res.bodyStream.Close()
+			t.Fatal("QueryResultStream is still blocked writing the body of a discarded response")
+		}
+	})
 }
 
 func metadataRequest(msg *schedulerpb.FrontendToScheduler, statusCode int, headers []*httpgrpc.Header) *frontendv2pb.QueryResultStreamRequest {

--- a/pkg/frontend/v2/frontend_test.go
+++ b/pkg/frontend/v2/frontend_test.go
@@ -1641,6 +1641,53 @@ func TestFrontendStreamingResponseAfterCancellationDoesNotLeak(t *testing.T) {
 	}
 }
 
+// TestFrontendStreamingResponseDiscardedAfterDrainDoesNotLeak reproduces the case where
+// RoundTripGRPC's cancellation branch drains the streaming response from the httpResponse channel
+// but discards it without ever reading its body: cancelling the request context alone (which the
+// deferred cleanup does) must be enough to unblock the handler writing body chunks to the pipe.
+func TestFrontendStreamingResponseDiscardedAfterDrainDoesNotLeak(t *testing.T) {
+	const userID = "test"
+
+	f, _ := setupFrontend(t, nil, nil)
+
+	ctx, cancel := context.WithCancelCause(user.InjectOrgID(t.Context(), userID))
+	freq := &frontendRequest{
+		queryID:      118,
+		userID:       userID,
+		ctx:          ctx,
+		httpResponse: make(chan queryResultWithBody, 1),
+	}
+	f.requests.put(freq)
+
+	msg := &schedulerpb.FrontendToScheduler{QueryID: freq.queryID}
+	stream := &mockQueryResultStreamServer{
+		ctx: user.InjectOrgID(t.Context(), userID),
+		msgs: []*frontendv2pb.QueryResultStreamRequest{
+			metadataRequest(msg, http.StatusOK, nil),
+			bodyChunkRequest(msg, []byte("a body chunk nobody will read")),
+		},
+	}
+
+	streamReturned := make(chan error, 1)
+	go func() {
+		streamReturned <- f.QueryResultStream(stream)
+	}()
+
+	// RoundTripGRPC's cancellation branch drains the response, discarding it without reading the
+	// body, and then its deferred cleanup cancels the request context.
+	res := <-freq.httpResponse
+	cancel(cancellation.NewErrorf("request cancelled"))
+
+	select {
+	case err := <-streamReturned:
+		require.ErrorIs(t, err, io.ErrClosedPipe)
+	case <-time.After(time.Second):
+		// Unblock the handler goroutine so it doesn't also trip the leak detector.
+		_ = res.bodyStream.Close()
+		t.Fatal("QueryResultStream is still blocked writing the body of a discarded response")
+	}
+}
+
 func metadataRequest(msg *schedulerpb.FrontendToScheduler, statusCode int, headers []*httpgrpc.Header) *frontendv2pb.QueryResultStreamRequest {
 	return &frontendv2pb.QueryResultStreamRequest{
 		QueryID: msg.QueryID,


### PR DESCRIPTION
#### What this PR does

The query-frontend streams a query response by piping body chunks from the querier to the HTTP client. 
On cancellation, `RoundTripGRPC` returns without reading that pipe.
If the querier's response claims the request in the small window after the cancel path last checked for it, the goroutine writing chunks blocks forever. 
Nothing reclaims it before a process restart. 

The race is narrow and needs a large streamed response, so it is rare in practice.

Follow-up to #16094, whose drain-path close covered only part of this race.

- close the response body pipe when the request context ends
- fail the querier's stream with the cancellation cause instead of hanging
- remove the now-redundant drain-path body close
- add tests reproducing the cancellation races

#### Which issue(s) this PR fixes or relates to

Relates to #16094.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
