### PR TITLE
MQE: Fix issue binary operation over-narrowing bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@
 * [BUGFIX] Querier: Fix issue where exemplars can be returned in the wrong order if a series contains a label that is a prefix of another (eg. `env="foo"` and `env="foobar"`). #16036
 * [BUGFIX] Querier: Stop querying a partition that has been inactive for longer than `-querier.query-ingesters-within`, preventing query failures when the partition is still registered but has no available ingesters to serve the queries. #15721
 * [BUGFIX] Query-frontend: Fix `queue_time_seconds` in the query stats log always reporting 0 when a query is cancelled while still waiting in the query-scheduler queue. #16094
+* [BUGFIX] MQE: Fix the binary operation narrow-selectors optimization incorrectly using binary operation matchers across an `on()` / `on(...) group_left`/`group_right` join boundary, which could cause some queries to unexpectedly evaluate as an empty result. #16155
 
 ### Mixin
 

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/grafana/mimir/pkg/streamingpromql/compat"
 	"github.com/grafana/mimir/pkg/streamingpromql/operators"
 	"github.com/grafana/mimir/pkg/streamingpromql/operators/aggregations"
+	"github.com/grafana/mimir/pkg/streamingpromql/optimize/plan"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning/core"
 	mqetest "github.com/grafana/mimir/pkg/streamingpromql/testutils"
@@ -5977,4 +5978,88 @@ type dummyMaterializer struct{}
 
 func (d dummyMaterializer) Materialize(ctx context.Context, n planning.Node, materializer *planning.Materializer, timeRange types.QueryTimeRange, params *planning.OperatorParameters, overrideRangeParams planning.RangeParams) (planning.OperatorFactory, error) {
 	panic("not implemented")
+}
+
+// TestNarrowSelectorsOnEmptyGroupLeftBoundary is an end-to-end regression test for a bug in the
+// narrow-binary-selectors optimization pass (enabled via
+// -querier.mimir-query-engine.enable-narrow-binary-selectors).
+//
+// The Asserts anomaly-threshold recording rules have the shape:
+//
+//	prediction + prediction * on() group_left threshold_margin
+//
+// where "threshold_margin" is a low-cardinality cross-metric series that legitimately does NOT
+// share the many-side's labels (which is exactly why the rule joins with "on()"). With narrow
+// selectors enabled, the outer default-matching "+" is given an empty-exclude hint and, at query
+// time, builds matchers from all of the LHS ("prediction") labels. Those matchers are pushed
+// through the inner "on() group_left" join boundary into the one-side ("threshold_margin")
+// selector, which doesn't carry those labels, filtering it to empty and making the whole
+// expression silently evaluate to empty.
+//
+// This test loads data where the one-side has a disjoint label set, then asserts that the Mimir
+// engine (with narrow selectors enabled) produces the same result as both the Mimir engine with
+// the pass disabled and the Prometheus reference engine. It fails while the bug is present.
+func TestNarrowSelectorsOnEmptyGroupLeftBoundary(t *testing.T) {
+	// "prediction" carries rich labels; "threshold_margin" is a single cross-metric series with a
+	// disjoint label set. This is what forces the rule to use "on() group_left".
+	data := `
+		load 1m
+			prediction{asserts_source="model-builder", job="asserts/latency", service="checkout"} 10+0x5
+			prediction{asserts_source="model-builder", job="asserts/latency", service="cart"}     20+0x5
+			threshold_margin 0.25+0x5
+	`
+
+	// The exact shape of the failing Asserts anomaly-threshold rules, plus the inner subexpression
+	// on its own (which is correctly left unhinted and must keep working).
+	testCases := map[string]string{
+		"inner on() group_left only":                    `prediction * on() group_left threshold_margin`,
+		"outer binop over inner on() group_left (rule)": `prediction + prediction * on() group_left threshold_margin`,
+	}
+
+	store := promqltest.LoadedStorage(t, data)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	ctx := context.Background()
+	queryTime := timestamp.Time(0).Add(5 * time.Minute)
+
+	// newMimirEngine builds a Mimir engine whose planner registers only the narrow-selectors
+	// optimization pass (when enabled), so we isolate this pass from all other optimizations.
+	newMimirEngine := func(t *testing.T, narrowSelectorsEnabled bool) promql.QueryEngine {
+		opts := NewTestEngineOpts()
+		planner, err := NewQueryPlannerWithoutOptimizationPasses(opts, NewMaximumSupportedVersionQueryPlanVersionProvider())
+		require.NoError(t, err)
+		if narrowSelectorsEnabled {
+			planner.RegisterQueryPlanOptimizationPass(plan.NewNarrowSelectorsOptimizationPass(opts.CommonOpts.Reg, opts.Logger))
+		}
+		engine, err := NewEngine(opts, stats.NewQueryMetrics(nil), planner)
+		require.NoError(t, err)
+		return engine
+	}
+
+	exec := func(t *testing.T, engine promql.QueryEngine, expr string) *promql.Result {
+		q, err := engine.NewInstantQuery(ctx, store, nil, expr, queryTime)
+		require.NoError(t, err)
+		t.Cleanup(q.Close)
+		res := q.Exec(ctx)
+		require.NoError(t, res.Err)
+		return res
+	}
+
+	prometheusEngine := promql.NewEngine(NewTestEngineOpts().CommonOpts)
+
+	for name, expr := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// Source of truth: the Prometheus reference engine, which has no such optimization.
+			expected := exec(t, prometheusEngine, expr)
+			require.NotEmpty(t, expected.String(), "test setup error: reference result should not be empty")
+
+			// Sanity check: the Mimir engine WITHOUT the pass matches the reference.
+			withoutPass := exec(t, newMimirEngine(t, false), expr)
+			mqetest.RequireEqualResults(t, expr, expected, withoutPass, false)
+
+			// The bug: the Mimir engine WITH the narrow-selectors pass drops all series.
+			withPass := exec(t, newMimirEngine(t, true), expr)
+			mqetest.RequireEqualResults(t, expr, expected, withPass, false)
+		})
+	}
 }

--- a/pkg/streamingpromql/engine_test.go
+++ b/pkg/streamingpromql/engine_test.go
@@ -5980,28 +5980,17 @@ func (d dummyMaterializer) Materialize(ctx context.Context, n planning.Node, mat
 	panic("not implemented")
 }
 
-// TestNarrowSelectorsOnEmptyGroupLeftBoundary is an end-to-end regression test for a bug in the
-// narrow-binary-selectors optimization pass (enabled via
-// -querier.mimir-query-engine.enable-narrow-binary-selectors).
+// TestNarrowSelectorsOnEmptyGroupLeftBoundary is an end-to-end regression test for the
+// narrow-binary-selectors optimization (-querier.mimir-query-engine.enable-narrow-binary-selectors).
 //
-// The Asserts anomaly-threshold recording rules have the shape:
-//
-//	prediction + prediction * on() group_left threshold_margin
-//
-// where "threshold_margin" is a low-cardinality cross-metric series that legitimately does NOT
-// share the many-side's labels (which is exactly why the rule joins with "on()"). With narrow
-// selectors enabled, the outer default-matching "+" is given an empty-exclude hint and, at query
-// time, builds matchers from all of the LHS ("prediction") labels. Those matchers are pushed
-// through the inner "on() group_left" join boundary into the one-side ("threshold_margin")
-// selector, which doesn't carry those labels, filtering it to empty and making the whole
-// expression silently evaluate to empty.
-//
-// This test loads data where the one-side has a disjoint label set, then asserts that the Mimir
-// engine (with narrow selectors enabled) produces the same result as both the Mimir engine with
-// the pass disabled and the Prometheus reference engine. It fails while the bug is present.
+// For "prediction + prediction * on() group_left threshold_margin", the optimization pushed
+// matchers built from the outer "+" LHS through the inner "on()" join into the one-side
+// ("threshold_margin") selector, which doesn't carry those labels, filtering it to empty. The test
+// uses a disjoint one-side label set and asserts the Mimir engine (pass enabled) matches both the
+// Mimir engine with the pass disabled and the Prometheus reference engine.
 func TestNarrowSelectorsOnEmptyGroupLeftBoundary(t *testing.T) {
-	// "prediction" carries rich labels; "threshold_margin" is a single cross-metric series with a
-	// disjoint label set. This is what forces the rule to use "on() group_left".
+	// "prediction" has rich labels; "threshold_margin" is a single cross-metric series with a
+	// disjoint label set, forcing the rule to use "on() group_left".
 	data := `
 		load 1m
 			prediction{asserts_source="model-builder", job="asserts/latency", service="checkout"} 10+0x5
@@ -6009,8 +5998,7 @@ func TestNarrowSelectorsOnEmptyGroupLeftBoundary(t *testing.T) {
 			threshold_margin 0.25+0x5
 	`
 
-	// The exact shape of the failing Asserts anomaly-threshold rules, plus the inner subexpression
-	// on its own (which is correctly left unhinted and must keep working).
+	// The failing rule shape, plus the inner subexpression on its own (which must keep working).
 	testCases := map[string]string{
 		"inner on() group_left only":                    `prediction * on() group_left threshold_margin`,
 		"outer binop over inner on() group_left (rule)": `prediction + prediction * on() group_left threshold_margin`,
@@ -6022,8 +6010,7 @@ func TestNarrowSelectorsOnEmptyGroupLeftBoundary(t *testing.T) {
 	ctx := context.Background()
 	queryTime := timestamp.Time(0).Add(5 * time.Minute)
 
-	// newMimirEngine builds a Mimir engine whose planner registers only the narrow-selectors
-	// optimization pass (when enabled), so we isolate this pass from all other optimizations.
+	// newMimirEngine registers only the narrow-selectors pass (when enabled) to isolate it.
 	newMimirEngine := func(t *testing.T, narrowSelectorsEnabled bool) promql.QueryEngine {
 		opts := NewTestEngineOpts()
 		planner, err := NewQueryPlannerWithoutOptimizationPasses(opts, NewMaximumSupportedVersionQueryPlanVersionProvider())
@@ -6049,15 +6036,15 @@ func TestNarrowSelectorsOnEmptyGroupLeftBoundary(t *testing.T) {
 
 	for name, expr := range testCases {
 		t.Run(name, func(t *testing.T) {
-			// Source of truth: the Prometheus reference engine, which has no such optimization.
+			// Source of truth: the Prometheus reference engine.
 			expected := exec(t, prometheusEngine, expr)
 			require.NotEmpty(t, expected.String(), "test setup error: reference result should not be empty")
 
-			// Sanity check: the Mimir engine WITHOUT the pass matches the reference.
+			// Mimir without the pass must match the reference.
 			withoutPass := exec(t, newMimirEngine(t, false), expr)
 			mqetest.RequireEqualResults(t, expr, expected, withoutPass, false)
 
-			// The bug: the Mimir engine WITH the narrow-selectors pass drops all series.
+			// Mimir with the pass must also match (previously dropped all series).
 			withPass := exec(t, newMimirEngine(t, true), expr)
 			mqetest.RequireEqualResults(t, expr, expected, withPass, false)
 		})

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation.go
@@ -252,11 +252,11 @@ func (g *GroupedVectorVectorBinaryOperation) loadSeriesMetadata(ctx context.Cont
 	// Load the "one" side first: it is the smaller side, and once we have its metadata
 	// we can use it to build hint-based matchers for the "many" side.
 	//
-	// Labels in VectorMatching.Include come from the many side, so any outer matchers for
-	// those labels must not be forwarded to the one side: the one side won't have them and
-	// would be incorrectly over-filtered. Split them out and keep them to forward to the
-	// many side instead.
-	oneSideMatchers, includeMatchers := separateIncludeLabelMatchers(matchers, g.VectorMatching.Include)
+	// Only forward outer matchers to the one side for labels it participates in the join through:
+	// with "on(...)" that's MatchingLabels (so "on()" forwards none), and Include labels are never
+	// forwarded (they come from the many side). Other matchers go to the many side instead;
+	// forwarding them to the one side would incorrectly filter it to empty (see separateIncludeLabelMatchers).
+	oneSideMatchers, includeMatchers := separateIncludeLabelMatchers(matchers, g.VectorMatching.Include, g.VectorMatching.On, g.VectorMatching.MatchingLabels)
 
 	var err error
 	g.oneSideMetadata, err = g.oneSide.SeriesMetadata(ctx, oneSideMatchers)
@@ -780,12 +780,19 @@ func (g *GroupedVectorVectorBinaryOperation) mergeManySide(data []types.InstantV
 	return merged, nil
 }
 
-// separateIncludeLabelMatchers partitions matchers into two groups: those whose label name
-// appears in includeLabels (extra labels sourced from the many side), and all others.
-// If includeLabels is empty or matchers is empty, the original slice is returned unchanged
-// and includeMatchers is nil.
-func separateIncludeLabelMatchers(matchers types.Matchers, includeLabels []string) (otherMatchers, includeMatchers types.Matchers) {
-	if len(matchers) == 0 || len(includeLabels) == 0 {
+// separateIncludeLabelMatchers splits matchers into those describing the one side (oneSideMatchers)
+// and those to route to the many side (manySideMatchers).
+//
+// A matcher is kept for the one side only if its label is not in includeLabels (those come from the
+// many side) and, when using "on(...)", is in matchingLabels. For "ignoring(...)"/default matching
+// (on is false) this reduces to only splitting out include-label matchers.
+func separateIncludeLabelMatchers(matchers types.Matchers, includeLabels []string, on bool, matchingLabels []string) (oneSideMatchers, manySideMatchers types.Matchers) {
+	if len(matchers) == 0 {
+		return matchers, nil
+	}
+
+	// Fast path: ignoring/default matching with no include labels keeps every matcher on the one side.
+	if !on && len(includeLabels) == 0 {
 		return matchers, nil
 	}
 
@@ -794,14 +801,29 @@ func separateIncludeLabelMatchers(matchers types.Matchers, includeLabels []strin
 		includeSet[l] = struct{}{}
 	}
 
-	for _, m := range matchers {
-		if _, ok := includeSet[m.Name]; ok {
-			includeMatchers = append(includeMatchers, m)
-		} else {
-			otherMatchers = append(otherMatchers, m)
+	var matchingSet map[string]struct{}
+	if on {
+		matchingSet = make(map[string]struct{}, len(matchingLabels))
+		for _, l := range matchingLabels {
+			matchingSet[l] = struct{}{}
 		}
 	}
-	return otherMatchers, includeMatchers
+
+	for _, m := range matchers {
+		_, isInclude := includeSet[m.Name]
+		keepForOneSide := !isInclude
+		if on {
+			_, isMatching := matchingSet[m.Name]
+			keepForOneSide = keepForOneSide && isMatching
+		}
+
+		if keepForOneSide {
+			oneSideMatchers = append(oneSideMatchers, m)
+		} else {
+			manySideMatchers = append(manySideMatchers, m)
+		}
+	}
+	return oneSideMatchers, manySideMatchers
 }
 
 func (g *GroupedVectorVectorBinaryOperation) oneSideHandedness() string {

--- a/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
+++ b/pkg/streamingpromql/operators/binops/grouped_vector_vector_binary_operation_test.go
@@ -690,18 +690,22 @@ func TestGroupedVectorVectorBinaryOperation_ReleasesIntermediateStateIfClosedEar
 
 func TestGroupedVectorVectorBinaryOperation_HintsPassedToManySide(t *testing.T) {
 	testCases := map[string]struct {
-		card          parser.VectorMatchCardinality
-		includeLabels []string // VectorMatching.Include: extra labels sourced from the many side
-		leftSeries    []labels.Labels
-		rightSeries   []labels.Labels
-		hints         *Hints
-		outerMatchers types.Matchers
+		card           parser.VectorMatchCardinality
+		matchingLabels []string // VectorMatching.MatchingLabels: labels the sides join on (with On).
+		on             bool     // VectorMatching.On: "on(...)" (true) vs "ignoring(...)"/default (false).
+		includeLabels  []string // VectorMatching.Include: extra labels sourced from the many side.
+		leftSeries     []labels.Labels
+		rightSeries    []labels.Labels
+		hints          *Hints
+		outerMatchers  types.Matchers
 
 		expectedLeftMatchers  types.Matchers
 		expectedRightMatchers types.Matchers
 	}{
 		"group_left with hints: left (many) side receives hint-built matchers": {
-			card: parser.CardManyToOne,
+			card:           parser.CardManyToOne,
+			matchingLabels: []string{"env"},
+			on:             true,
 			leftSeries: []labels.Labels{
 				labels.FromStrings("env", "prod", "pod", "1"),
 				labels.FromStrings("env", "staging", "pod", "1"),
@@ -720,7 +724,9 @@ func TestGroupedVectorVectorBinaryOperation_HintsPassedToManySide(t *testing.T) 
 			},
 		},
 		"group_right with hints: right (many) side receives hint-built matchers": {
-			card: parser.CardOneToMany,
+			card:           parser.CardOneToMany,
+			matchingLabels: []string{"env"},
+			on:             true,
 			leftSeries: []labels.Labels{
 				labels.FromStrings("env", "prod"),
 			},
@@ -738,7 +744,9 @@ func TestGroupedVectorVectorBinaryOperation_HintsPassedToManySide(t *testing.T) 
 			},
 		},
 		"group_left without hints: left (many) side receives the same outer matchers as one side": {
-			card: parser.CardManyToOne,
+			card:           parser.CardManyToOne,
+			matchingLabels: []string{"env"},
+			on:             true,
 			leftSeries: []labels.Labels{
 				labels.FromStrings("env", "prod", "pod", "1"),
 			},
@@ -752,7 +760,9 @@ func TestGroupedVectorVectorBinaryOperation_HintsPassedToManySide(t *testing.T) 
 			expectedRightMatchers: nil,
 		},
 		"group_right without hints: right (many) side receives the same outer matchers as one side": {
-			card: parser.CardOneToMany,
+			card:           parser.CardOneToMany,
+			matchingLabels: []string{"env"},
+			on:             true,
 			leftSeries: []labels.Labels{
 				labels.FromStrings("env", "prod"),
 			},
@@ -771,8 +781,10 @@ func TestGroupedVectorVectorBinaryOperation_HintsPassedToManySide(t *testing.T) 
 		// and were discarded instead of being passed to the many side when hints were set.
 
 		"group_left with hints and include-label outer matchers: include-label matchers stripped from one side and merged onto many side": {
-			card:          parser.CardManyToOne,
-			includeLabels: []string{"region"}, // region comes from the many (left) side
+			card:           parser.CardManyToOne,
+			matchingLabels: []string{"env"},
+			on:             true,
+			includeLabels:  []string{"region"}, // region comes from the many (left) side
 			leftSeries: []labels.Labels{
 				labels.FromStrings("env", "prod", "region", "us"),
 				labels.FromStrings("env", "prod", "region", "eu"),
@@ -796,8 +808,10 @@ func TestGroupedVectorVectorBinaryOperation_HintsPassedToManySide(t *testing.T) 
 			},
 		},
 		"group_right with hints and include-label outer matchers: include-label matchers stripped from one side and merged onto many side": {
-			card:          parser.CardOneToMany,
-			includeLabels: []string{"region"}, // region comes from the many (right) side
+			card:           parser.CardOneToMany,
+			matchingLabels: []string{"env"},
+			on:             true,
+			includeLabels:  []string{"region"}, // region comes from the many (right) side
 			leftSeries: []labels.Labels{
 				labels.FromStrings("env", "prod"),
 			},
@@ -821,8 +835,10 @@ func TestGroupedVectorVectorBinaryOperation_HintsPassedToManySide(t *testing.T) 
 			},
 		},
 		"group_left without hints and include-label outer matchers: include-label matchers still stripped from one side": {
-			card:          parser.CardManyToOne,
-			includeLabels: []string{"region"},
+			card:           parser.CardManyToOne,
+			matchingLabels: []string{"env"},
+			on:             true,
+			includeLabels:  []string{"region"},
 			leftSeries: []labels.Labels{
 				labels.FromStrings("env", "prod", "region", "us"),
 			},
@@ -844,6 +860,86 @@ func TestGroupedVectorVectorBinaryOperation_HintsPassedToManySide(t *testing.T) 
 				{Type: labels.MatchEqual, Name: "region", Value: "us"},
 			},
 		},
+
+		// Regression: outer matchers for labels the one side does not join on (on() with no
+		// matching labels, or on(...) matchers outside the matching set) must not reach the
+		// one-side selector, else it is filtered to empty.
+		// Shape: "prediction + prediction * on() group_left threshold_margin".
+
+		"group_left with on() (empty matching labels): non-matching outer matchers routed to many side, one side receives none": {
+			card:           parser.CardManyToOne,
+			matchingLabels: []string{}, // on(): one side joins on nothing.
+			on:             true,
+			leftSeries: []labels.Labels{
+				labels.FromStrings("env", "prod", "service", "checkout"),
+				labels.FromStrings("env", "prod", "service", "cart"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("env", "prod"), // one side: no "service" label.
+			},
+			hints: nil,
+			outerMatchers: types.Matchers{
+				{Type: labels.MatchRegexp, Name: "service", Value: "cart|checkout"},
+				{Type: labels.MatchRegexp, Name: "job", Value: "asserts/latency"},
+			},
+			// one side (right) joins on nothing, so it must receive no outer matchers.
+			expectedRightMatchers: nil,
+			// many side (left) still gets the outer matchers to narrow it.
+			expectedLeftMatchers: types.Matchers{
+				{Type: labels.MatchRegexp, Name: "service", Value: "cart|checkout"},
+				{Type: labels.MatchRegexp, Name: "job", Value: "asserts/latency"},
+			},
+		},
+		"group_right with on() (empty matching labels): non-matching outer matchers routed to many side, one side receives none": {
+			card:           parser.CardOneToMany,
+			matchingLabels: []string{}, // on(): one side joins on nothing.
+			on:             true,
+			leftSeries: []labels.Labels{
+				labels.FromStrings("env", "prod"), // one side: no "service" label.
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("env", "prod", "service", "checkout"),
+				labels.FromStrings("env", "prod", "service", "cart"),
+			},
+			hints: nil,
+			outerMatchers: types.Matchers{
+				{Type: labels.MatchRegexp, Name: "service", Value: "cart|checkout"},
+				{Type: labels.MatchRegexp, Name: "job", Value: "asserts/latency"},
+			},
+			// one side (left) joins on nothing, so it must receive no outer matchers.
+			expectedLeftMatchers: nil,
+			// many side (right) still gets the outer matchers to narrow it.
+			expectedRightMatchers: types.Matchers{
+				{Type: labels.MatchRegexp, Name: "service", Value: "cart|checkout"},
+				{Type: labels.MatchRegexp, Name: "job", Value: "asserts/latency"},
+			},
+		},
+		"group_left with on(env) and mixed outer matchers: matching-label matcher kept for one side, non-matching routed to many side": {
+			card:           parser.CardManyToOne,
+			matchingLabels: []string{"env"}, // join on "env"; "service" is not a matching label.
+			on:             true,
+			hints:          &Hints{Include: []string{"env"}},
+			leftSeries: []labels.Labels{
+				labels.FromStrings("env", "prod", "service", "checkout"),
+				labels.FromStrings("env", "prod", "service", "cart"),
+			},
+			rightSeries: []labels.Labels{
+				labels.FromStrings("env", "prod"), // one side: has "env", no "service".
+			},
+			outerMatchers: types.Matchers{
+				{Type: labels.MatchEqual, Name: "env", Value: "prod"},
+				{Type: labels.MatchRegexp, Name: "service", Value: "cart|checkout"},
+			},
+			// one side (right) gets only the matching-label ("env") matcher; "service" is routed away.
+			expectedRightMatchers: types.Matchers{
+				{Type: labels.MatchEqual, Name: "env", Value: "prod"},
+			},
+			// many side (left) gets the hint-built env matcher merged with the routed "service" matcher.
+			expectedLeftMatchers: types.Matchers{
+				{Type: labels.MatchRegexp, Name: "env", Value: "prod"},
+				{Type: labels.MatchRegexp, Name: "service", Value: "cart|checkout"},
+			},
+		},
 	}
 
 	for name, testCase := range testCases {
@@ -856,7 +952,7 @@ func TestGroupedVectorVectorBinaryOperation_HintsPassedToManySide(t *testing.T) 
 			o, err := NewGroupedVectorVectorBinaryOperation(
 				left,
 				right,
-				parser.VectorMatching{Card: testCase.card, MatchingLabels: []string{"env"}, On: true, Include: testCase.includeLabels},
+				parser.VectorMatching{Card: testCase.card, MatchingLabels: testCase.matchingLabels, On: testCase.on, Include: testCase.includeLabels},
 				parser.ADD,
 				false,
 				memoryConsumptionTracker,

--- a/pkg/streamingpromql/optimize/plan/narrow_selectors_test.go
+++ b/pkg/streamingpromql/optimize/plan/narrow_selectors_test.go
@@ -527,14 +527,10 @@ func TestNarrowSelectorsOptimizationPass(t *testing.T) {
 			expectedAttempts: 1,
 			expectedModified: 0,
 		},
-		// Regression test for a bug where an outer exclude-matching binary expression pushed
-		// matchers built from its LHS labels through an inner "on () group_left" join boundary
-		// into the one-side (RHS) selector, which legitimately doesn't carry those labels,
-		// filtering it to empty. This is the shape of the Asserts anomaly-threshold recording
-		// rules ("prediction + prediction * on() group_left threshold_margin"). The inner
-		// "* on () group_left" is correctly left unhinted (empty on() matches everything), but
-		// the outer "+" still receives an empty-exclude hint. See TestNarrowSelectorsOnEmptyGroupLeftBoundary
-		// for the end-to-end result-correctness reproduction.
+		// Regression: the inner "* on () group_left" is correctly left unhinted, but the outer
+		// "+" still gets an empty-exclude hint. Whose matchers must not reach the one-side
+		// selector is enforced at the operator level; see TestNarrowSelectorsOnEmptyGroupLeftBoundary
+		// for the end-to-end result-correctness check.
 		"outer exclude-matching binop over inner on() group_left cross-metric": {
 			expr: `prediction + prediction * on() group_left threshold_margin`,
 			expectedPlan: `

--- a/pkg/streamingpromql/optimize/plan/narrow_selectors_test.go
+++ b/pkg/streamingpromql/optimize/plan/narrow_selectors_test.go
@@ -527,6 +527,26 @@ func TestNarrowSelectorsOptimizationPass(t *testing.T) {
 			expectedAttempts: 1,
 			expectedModified: 0,
 		},
+		// Regression test for a bug where an outer exclude-matching binary expression pushed
+		// matchers built from its LHS labels through an inner "on () group_left" join boundary
+		// into the one-side (RHS) selector, which legitimately doesn't carry those labels,
+		// filtering it to empty. This is the shape of the Asserts anomaly-threshold recording
+		// rules ("prediction + prediction * on() group_left threshold_margin"). The inner
+		// "* on () group_left" is correctly left unhinted (empty on() matches everything), but
+		// the outer "+" still receives an empty-exclude hint. See TestNarrowSelectorsOnEmptyGroupLeftBoundary
+		// for the end-to-end result-correctness reproduction.
+		"outer exclude-matching binop over inner on() group_left cross-metric": {
+			expr: `prediction + prediction * on() group_left threshold_margin`,
+			expectedPlan: `
+				- BinaryExpression: LHS + RHS, hints exclude ()
+					- LHS: VectorSelector: {__name__="prediction"}
+					- RHS: BinaryExpression: LHS * on () group_left () RHS
+						- LHS: VectorSelector: {__name__="prediction"}
+						- RHS: VectorSelector: {__name__="threshold_margin"}
+			`,
+			expectedAttempts: 1,
+			expectedModified: 1,
+		},
 		"binary expression with on (synthesized_label) gets no hints: synthesized label cannot narrow storage selectors": {
 			// "foo" is produced by label_replace on the LHS; it does not exist on the raw
 			// series in storage. filterLabels removes it from the MatchingLabels list, leaving


### PR DESCRIPTION
#### What this PR does
This PR fixes a query correctness issue related to binop narrow selectors, where the narrow selector matchers for an outer  operation of a group/on operation pair would leak into the narrowing scope of the inner operation, causing an over-narrowing of the data and in some cases resulting in a unexpectedly empty result set. 

The fix is just to check labels before forwarding the outer matchers at the planning level and only forward the ones the where the one side actually matches.


#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
