### PR TITLE
Helm: make ruler memory ballast size configurable

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -30,6 +30,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
+* [ENHANCEMENT] Ruler: make the memory ballast size configurable via `ruler.memBallastSizeBytes` and allow disabling it by setting the value to `0`. The default stays at 1GiB. A ballast larger than the ruler's `GOMEMLIMIT` causes permanent GC thrashing, so deployments setting a lower `GOMEMLIMIT` need to lower or disable the ballast. #16159
 * [FEATURE] Add VolumeAttributesClass support: reference existing VolumeAttributesClass resources on PVCs for alertmanager, ingester, store-gateway, compactor, and kafka. #15919
 * [CHANGE] Querier: Reduce the default concurrency of queriers, `querier.max_concurrent`, to 8. #15984
 * [BUGFIX] Fix bug in `ScaledObject` templates when using `kedaAutoscaling.fallback` #15793

--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -30,13 +30,13 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
-* [ENHANCEMENT] Ruler: make the memory ballast size configurable via `ruler.memBallastSizeBytes` and allow disabling it by setting the value to `0`. The default stays at 1GiB. A ballast larger than the ruler's `GOMEMLIMIT` causes permanent GC thrashing, so deployments setting a lower `GOMEMLIMIT` need to lower or disable the ballast. #16159
 * [FEATURE] Add VolumeAttributesClass support: reference existing VolumeAttributesClass resources on PVCs for alertmanager, ingester, store-gateway, compactor, and kafka. #15919
 * [CHANGE] Querier: Reduce the default concurrency of queriers, `querier.max_concurrent`, to 8. #15984
 * [BUGFIX] Fix bug in `ScaledObject` templates when using `kedaAutoscaling.fallback` #15793
 * [ENHANCEMENT] Add support for `revisionHistoryLimit` on StatefulSet-based components: `alertmanager`, `ingester`, `store_gateway`, `compactor`, and the `chunks-cache`, `index-cache`, `metadata-cache`, and `results-cache` memcached StatefulSets. Previously `revisionHistoryLimit` was only honored on Deployment-based components. #PR
 * [ENHANCEMENT] Add support for `revisionHistoryLimit` on StatefulSet-based components: `alertmanager`, `ingester`, `store_gateway`, `compactor`, and the `chunks-cache`, `index-cache`, `metadata-cache`, and `results-cache` memcached StatefulSets. Previously `revisionHistoryLimit` was only honored on Deployment-based components. #15950
 * [ENHANCEMENT] Upgrade rollout-operator chart to [0.38.1](https://github.com/grafana/helm-charts/blob/main/charts/rollout-operator/README.md#upgrade-of-grafana-rollout-operator--v0380). Note required actions for upgrading the rollout-operator chart. #16129
+* [ENHANCEMENT] Ruler: make the memory ballast size configurable via `ruler.memBallastSizeBytes` and allow disabling it by setting the value to `0`. The default stays at 1GiB. A ballast larger than the ruler's `GOMEMLIMIT` causes permanent GC thrashing, so deployments setting a lower `GOMEMLIMIT` need to lower or disable the ballast. #16159
 * [BUGFIX]: Fix bug in `ScaledObject` templates when using `kedaAutoscaling.fallback` #15793
 
 

--- a/operations/helm/charts/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -52,9 +52,11 @@ spec:
             - "-target=ruler"
             - "-config.expand-env=true"
             - "-config.file=/etc/mimir/mimir.yaml"
+          {{- if gt (int64 .Values.ruler.memBallastSizeBytes) 0 }}
             # Set the memory ballast to help with extensive CPU usage due to GC at ruler's start. This prevents the autoscaler
             # from adding more replicas around rollouts, and reduces the effect of GC on a restart overall.
-            - "-mem-ballast-size-bytes=1073741824"
+            - "-mem-ballast-size-bytes={{ .Values.ruler.memBallastSizeBytes | int64 }}"
+          {{- end }}
             - "-distributor.remote-timeout=10s"
           {{- if .Values.ingester.zoneAwareReplication.migration.enabled }}
             {{- if not .Values.ingester.zoneAwareReplication.migration.writePath }}

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -1375,6 +1375,11 @@ ruler:
   extraArgs: {}
     # log.level: debug
 
+  # -- Size in bytes of the memory ballast (-mem-ballast-size-bytes). The ballast reduces GC frequency
+  # and CPU usage around ruler start and rollouts. It must be smaller than any GOMEMLIMIT set on the
+  # ruler, otherwise the GC thrashes permanently. Set to 0 to disable the ballast.
+  memBallastSizeBytes: 1073741824
+
   # Pod Labels
   podLabels: {}
 


### PR DESCRIPTION
#### What this PR does

Adds a new value `ruler.memBallastSizeBytes` to the mimir-distributed chart, so the ruler's memory ballast can be changed or disabled (set to `0`). The default stays at 1GiB, so nothing changes for existing users. The golden-record test manifests did not change.

Chart 6.1.0 added a hardcoded `-mem-ballast-size-bytes=1073741824` to the ruler (#13376), and there is no way to change it. The problem: the chart also supports setting `GOMEMLIMIT` on the ruler (via `ruler.env`), and if the ballast is larger than `GOMEMLIMIT`, the heap is always above the GC target and the GC runs constantly. The [Go GC guide](https://go.dev/doc/gc-guide) recommends `GOMEMLIMIT` instead of ballasts, and the same flag in the Tempo chart is deprecated for this reason (grafana/helm-charts#2887).

#### What we saw in production

After upgrading chart 6.0.6 to 6.1.0 (Mimir 2.16 to 3.1.2), with `GOMEMLIMIT=270MiB` and a 300Mi memory limit on the ruler:

- Ruler CPU: 0.19 to 1.22 cores (~6x), 0.76 of that was GC (`go_cpu_classes_gc_total_cpu_seconds_total`)
- GC cycles: 0.4/s to 78/s (`go_gc_duration_seconds_count`)
- `go_memstats_heap_alloc_bytes`: 42MB to 1142MB, while the container working set stayed at ~38MB (the ballast pages are never touched)
- pprof heap profile: 97.5% of in-use space (1030MB) in `github.com/grafana/dskit/ballast.Allocate`
- Rule evaluation got ~2.4x slower
- Setting the flag to `0` (duplicate flag via `ruler.extraArgs`, last one wins) brought heap back to ~32MB and GC to ~0.1/s

With this PR, such deployments can simply set `ruler.memBallastSizeBytes: 0` or a value below their `GOMEMLIMIT`.

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [x] Tests updated. (`make build-helm-tests` produced no diff; the default rendering is unchanged.)
- [ ] Documentation added. (The value is documented inline in `values.yaml`.)
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features. (Not applicable.)
