### PR TITLE
release: Keep old title pattern (ie. no "Mimir" prefix)

### DIFF
--- a/tools/release/create-draft-release.sh
+++ b/tools/release/create-draft-release.sh
@@ -60,8 +60,6 @@ else
   fi
 fi
 
-RELEASE_TITLE="Mimir ${LAST_RELEASE_VERSION}"
-
 # Generate the release notes.
 RELEASE_NOTES_FILE="$(mktemp)"
 trap 'rm -f "${RELEASE_NOTES_FILE}"' EXIT
@@ -94,14 +92,14 @@ else
     gh release edit "${LAST_RELEASE_TAG}" \
       --draft \
       --prerelease="${PRERELEASE}" \
-      --title "${RELEASE_TITLE}" \
+      --title "${LAST_RELEASE_VERSION}" \
       --notes-file "${RELEASE_NOTES_FILE}" > /dev/stderr
   else
     echo "Creating the draft release ${LAST_RELEASE_TAG}..." > /dev/stderr
     gh release create "${LAST_RELEASE_TAG}" \
       --draft \
       --prerelease="${PRERELEASE}" \
-      --title "${RELEASE_TITLE}" \
+      --title "${}" \
       --notes-file "${RELEASE_NOTES_FILE}" > /dev/stderr
   fi
 
@@ -113,7 +111,7 @@ fi
 
 jq -nc \
   --arg tag "${LAST_RELEASE_TAG}" \
-  --arg title "${RELEASE_TITLE}" \
+  --arg title "${LAST_RELEASE_VERSION}" \
   --argjson prerelease "${PRERELEASE}" \
   --argjson latest "${LATEST}" \
   '{tag: $tag, title: $title, prerelease: $prerelease, latest: $latest}'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Restores [the old pattern of just setting the version as the release title](https://github.com/grafana/mimir/releases). It was changed for no reason.

<img width="243" height="395" alt="Screenshot 2026-07-20 at 23 46 36" src="https://github.com/user-attachments/assets/e784ef45-58c0-4155-8cac-7674ec83e820" />

#### Which issue(s) this PR fixes or relates to

Follow up of #15505 

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
