### PR TITLE
ci:  Add Workflow to Generate and Attach SBOM on Release

### DIFF
--- a/.github/workflows/sbom-on-release.yml
+++ b/.github/workflows/sbom-on-release.yml
@@ -1,0 +1,39 @@
+name: "SBOM on Release"
+
+on:
+  release:
+    types:
+      - published
+
+permissions: {}
+
+jobs:
+  export-sbom:
+    name: "Export SBOM and attach to release"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # to upload the SBOM as a release asset
+      id-token: write # to authenticate to Vault
+    steps:
+      - name: "Get Socket API token from Vault"
+        id: vault-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@e46fe1e9a2bf9e618bcf8d8d32f3a7381b45c06d # get-vault-secrets/v2.0.0
+        with:
+          common_secrets: |
+            SOCKET_API_TOKEN=socket:SOCKET_API_KEY
+
+      - name: "Export SPDX SBOM from Socket"
+        id: export-sbom
+        uses: grafana/shared-workflows/actions/socket-export-sbom@ff9aaa53f25716fcd6dde39f6d4e41c4e16fb5e1 # socket-export-sbom/v0.1.2
+        with:
+          socket_api_token: ${{ fromJSON(steps.vault-secrets.outputs.secrets).SOCKET_API_TOKEN }}
+          socket_org: grafana
+          output_file: ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}.spdx.json
+
+      - name: "Upload SBOM to release"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ github.event.release.tag_name }}
+          SBOM_PATH: ${{ steps.export-sbom.outputs.path }}
+        run: gh release upload "$TAG" "$SBOM_PATH" --clobber

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,6 +4,7 @@
 # Documentation.
 /.github/workflows/deploy-pr-preview-mimir.yml                              @grafana/docs-tooling @grafana/mimir-maintainers
 /.github/workflows/deploy-pr-preview-helm-charts.yml                        @grafana/docs-tooling @grafana/mimir-maintainers
+/.github/workflows/sbom-on-release.yml                                      @grafana/security
 
 /docs/                                                                      @grafana/docs-metrics @grafana/mimir-maintainers
 /docs/docs.mk                                                               @grafana/docs-tooling @grafana/mimir-maintainers


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does
CI workflow for generating an SBOM on release, which is added to the release assets. SBOMs are generated using the socket.dev API.

#### Which issue(s) this PR fixes or relates to
The GRC team semi-frequently gets requests for Software Bill of Materials (SBOMs) from contracted customers and prospects. Grafana's Open Source repos are enrolled in and scanned for dependencies by socket.dev, which also generates SBOMs. Currently, the GRC team generates SBOMs ad-hoc using Socket's API. Adding a standardized workflow for SBOM generation reduces the burden for the GRC team and also makes SBOMs available for consumption by members of our OSS community.

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
