### PR TITLE
Packaging: fix issue where binaries in RPM and DEB packages do not have the executable bit set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@
 * [BUGFIX] Querier: Stop querying a partition that has been inactive for longer than `-querier.query-ingesters-within`, preventing query failures when the partition is still registered but has no available ingesters to serve the queries. #15721
 * [BUGFIX] Query-frontend: Fix `queue_time_seconds` in the query stats log always reporting 0 when a query is cancelled while still waiting in the query-scheduler queue. #16094
 * [BUGFIX] MQE: Fix the binary operation narrow-selectors optimization incorrectly using binary operation matchers across an `on()` / `on(...) group_left`/`group_right` join boundary, which could cause some queries to unexpectedly evaluate as an empty result. #16155
+* [BUGFIX] Packaging: Fix the DEB/RPM packages shipping the `mimir`, `mimirtool`, `metaconvert`, and `query-tee` binaries without the executable bit set, which caused `mimir.service` to fail to start. #16166
 
 ### Mixin
 

--- a/packaging/nfpm/nfpm.jsonnet
+++ b/packaging/nfpm/nfpm.jsonnet
@@ -88,5 +88,8 @@ local overrides = {
   contents: [{
     src: './dist/tmp/packages/%s-linux-%s' % [name, arch],
     dst: '/usr/local/bin/%s' % name,
+    file_info: {
+      mode: std.parseOctal("755"),
+    },
   }],
 } + overrides[name]


### PR DESCRIPTION
#### What this PR does

This PR fixes the issue where binaries in RPM and DEB packages do not have the executable bit set.

#### Which issue(s) this PR fixes or relates to

Fixes #16120

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
