### PR TITLE
docs(runbooks): check for spurious ring members after ingester scale down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,8 @@
 
 ### Documentation
 
+* [ENHANCEMENT] Update `MimirRingMembersMismatch` runbook: check for spurious ingesters left in the ring after a scale down. #16169
+
 ### Tools
 
 * [CHANGE] The `mark-blocks`, `listblocks`, `copyblocks`, `splitblocks`, and `undelete-blocks` tools are now subcommands of `mimirtool blocks`: `mark`, `list`, `copy`, `split`, `undelete`. #15757

--- a/docs/sources/mimir/manage/mimir-runbooks/_index.md
+++ b/docs/sources/mimir/manage/mimir-runbooks/_index.md
@@ -1677,8 +1677,9 @@ How it **works**:
 How to **investigate**:
 
 - Check the [hash ring web page](../../references/http-api/#ingesters-ring-status) for the component for which the alert has fired, and look for unexpected instances in the list.
-- Consider manually forgetting unexpected instances in an `Unhealthy` state.
+- If ingesters were recently scaled down, check whether any scaled-down instances were left in the ring. How to handle spurious instances depends on the circumstances that led to them being left in the ring.
 - Ensure all the registered instances in the ring belong to the Mimir cluster for which the alert fired.
+- Consider manually forgetting unexpected instances in an `Unhealthy` state. Use caution: forgetting an instance that is still running or still owns data can lead to data loss.
 
 ### RolloutOperatorNotReconciling
 


### PR DESCRIPTION
#### What this PR does

Update `MimirRingMembersMismatch` runbook.

- add step to check for spurious ingesters after scale down
- move manual forget step last
- add data loss caution to manual forget step

#### Which issue(s) this PR fixes or relates to

n/a

#### Checklist

- [ ] Tests updated.
- [x] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.