### PR TITLE
MQE: correct capitalisation of "narrow selectors" optimisation pass name

### DIFF
--- a/pkg/streamingpromql/optimize/plan/narrow_selectors.go
+++ b/pkg/streamingpromql/optimize/plan/narrow_selectors.go
@@ -45,7 +45,7 @@ func NewNarrowSelectorsOptimizationPass(reg prometheus.Registerer, logger log.Lo
 }
 
 func (n *NarrowSelectorsOptimizationPass) Name() string {
-	return "narrow selectors"
+	return "Narrow selectors"
 }
 
 func (n *NarrowSelectorsOptimizationPass) Apply(ctx context.Context, plan *planning.QueryPlan, _ planning.QueryPlanVersion) (*planning.QueryPlan, error) {


### PR DESCRIPTION
#### What this PR does

This PR changes the capitalisation of the "narrow selectors" optimisation pass' name to match the capitalisation used for other passes.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
