### PR TITLE
mimirtool: don't collapse multi-line PromQL expressions in rules lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Grafana Mimir
 
+* [BUGFIX] Mimirtool: `mimirtool rules lint` no longer collapses multi-line PromQL expressions into a single line. Expressions are now formatted with the PromQL prettifier, which keeps expressions longer than 100 characters on multiple lines, like the query formatter in the Prometheus UI. #16196
 * [CHANGE] MQE: validate that delayed name removal is only set using `-querier.enable-delayed-name-removal` or the per-tenant setting when MQE is in use. #16207
 * [BUGFIX] Query-frontend: Return a HTTP 500 error rather than a HTTP 400 when a querier receives a query plan that is too new. #16233
 
@@ -151,8 +152,6 @@
 * [BUGFIX] Packaging: Fix the DEB/RPM packages shipping the `mimir`, `mimirtool`, `metaconvert`, and `query-tee` binaries without the executable bit set, which caused `mimir.service` to fail to start. #16166
 * [BUGFIX] Query-frontend: Fix a goroutine leak when a querier's streaming response arrives just as the query is cancelled: the goroutine handling the response could stay blocked forever writing a response body that would never be read. #16151
 * [BUGFIX] MQE: Fix issue where a sentinel value was inadvertently returned to a pool where it could be mutated by multiple threads at once. #16205
-* [BUGFIX] Query-frontend: Return a HTTP 500 error rather than a HTTP 400 when a querier receives a query plan that is too new. #16233
-* [BUGFIX] Mimirtool: `mimirtool rules lint` no longer collapses multi-line PromQL expressions into a single line. Expressions are now formatted with the PromQL prettifier, which keeps expressions longer than 100 characters on multiple lines, like the query formatter in the Prometheus UI. #16196
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,8 @@
 * [BUGFIX] Packaging: Fix the DEB/RPM packages shipping the `mimir`, `mimirtool`, `metaconvert`, and `query-tee` binaries without the executable bit set, which caused `mimir.service` to fail to start. #16166
 * [BUGFIX] Query-frontend: Fix a goroutine leak when a querier's streaming response arrives just as the query is cancelled: the goroutine handling the response could stay blocked forever writing a response body that would never be read. #16151
 * [BUGFIX] MQE: Fix issue where a sentinel value was inadvertently returned to a pool where it could be mutated by multiple threads at once. #16205
+* [BUGFIX] Query-frontend: Return a HTTP 500 error rather than a HTTP 400 when a querier receives a query plan that is too new. #16233
+* [BUGFIX] Mimirtool: `mimirtool rules lint` no longer collapses multi-line PromQL expressions into a single line. Expressions are now formatted with the PromQL prettifier, which keeps expressions longer than 100 characters on multiple lines, like the query formatter in the Prometheus UI. #16196
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Grafana Mimir
 
 * [CHANGE] Rename the experimental `-ingester.float-chunk-encoding` flag to `-blocks-storage.tsdb.float-chunk-encoding` because it applies to the ingester, block-builder, and compactor. The per-tenant `float_chunk_encoding` setting is unchanged. #16544
+* [BUGFIX] Mimirtool: `mimirtool rules lint` no longer collapses multi-line PromQL expressions into a single line. Expressions are now formatted with the PromQL prettifier, which keeps expressions longer than 100 characters on multiple lines, like the query formatter in the Prometheus UI. #16196
 * [CHANGE] MQE: validate that delayed name removal is only set using `-querier.enable-delayed-name-removal` or the per-tenant setting when MQE is in use. #16207
 * [CHANGE] Query-frontend, MQE: Matcher propagation for binary operations now works as one of the optimization passes in MQE rather than as part of the rewrite middleware, configured with `querier.mimir-query-engine.enable-propagate-matchers` instead of `query-frontend.rewrite-propagate-matchers`. #15092
 * [CHANGE] Removed the following deprecated config: `-querier.filter-queryables-enabled`, `-query-frontend.cache-samples-processed-stats`, `-ingest-storage.kafka.write-clients`, `-blocks-storage.tsdb.head-postings-for-matchers-cache-size`, `-blocks-storage.tsdb.block-postings-for-matchers-cache-size`. #16352
@@ -220,8 +221,6 @@
 * [BUGFIX] Packaging: Fix the DEB/RPM packages shipping the `mimir`, `mimirtool`, `metaconvert`, and `query-tee` binaries without the executable bit set, which caused `mimir.service` to fail to start. #16166
 * [BUGFIX] Query-frontend: Fix a goroutine leak when a querier's streaming response arrives just as the query is cancelled: the goroutine handling the response could stay blocked forever writing a response body that would never be read. #16151
 * [BUGFIX] MQE: Fix issue where a sentinel value was inadvertently returned to a pool where it could be mutated by multiple threads at once. #16205
-* [BUGFIX] Query-frontend: Return a HTTP 500 error rather than a HTTP 400 when a querier receives a query plan that is too new. #16233
-* [BUGFIX] Mimirtool: `mimirtool rules lint` no longer collapses multi-line PromQL expressions into a single line. Expressions are now formatted with the PromQL prettifier, which keeps expressions longer than 100 characters on multiple lines, like the query formatter in the Prometheus UI. #16196
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,6 +220,8 @@
 * [BUGFIX] Packaging: Fix the DEB/RPM packages shipping the `mimir`, `mimirtool`, `metaconvert`, and `query-tee` binaries without the executable bit set, which caused `mimir.service` to fail to start. #16166
 * [BUGFIX] Query-frontend: Fix a goroutine leak when a querier's streaming response arrives just as the query is cancelled: the goroutine handling the response could stay blocked forever writing a response body that would never be read. #16151
 * [BUGFIX] MQE: Fix issue where a sentinel value was inadvertently returned to a pool where it could be mutated by multiple threads at once. #16205
+* [BUGFIX] Query-frontend: Return a HTTP 500 error rather than a HTTP 400 when a querier receives a query plan that is too new. #16233
+* [BUGFIX] Mimirtool: `mimirtool rules lint` no longer collapses multi-line PromQL expressions into a single line. Expressions are now formatted with the PromQL prettifier, which keeps expressions longer than 100 characters on multiple lines, like the query formatter in the Prometheus UI. #16196
 
 ### Mixin
 

--- a/pkg/mimirtool/rules/rules.go
+++ b/pkg/mimirtool/rules/rules.go
@@ -29,17 +29,23 @@ type RuleNamespace struct {
 	Groups []rwrulefmt.RuleGroup `yaml:"groups"`
 }
 
-// LintExpressions runs the `expr` from a rule through the PromQL or LogQL parser and
+// LintExpressions runs the `expr` from a rule through the PromQL parser and
 // compares its output. If it differs from the parser, it uses the parser's instead.
+// PromQL expressions are formatted with the PromQL prettifier, which splits long
+// expressions across multiple lines, like the query formatter in the Prometheus UI.
 func (r RuleNamespace) LintExpressions(backend string, promqlParser parser.Parser, logger log.Logger) (int, int, error) {
-	var parseFn func(string) (fmt.Stringer, error)
+	var lintFn func(string) (string, error)
 	var queryLanguage string
 
 	switch backend {
 	case MimirBackend:
 		queryLanguage = "PromQL"
-		parseFn = func(s string) (fmt.Stringer, error) {
-			return promqlParser.ParseExpr(s)
+		lintFn = func(s string) (string, error) {
+			exp, err := promqlParser.ParseExpr(s)
+			if err != nil {
+				return "", err
+			}
+			return parser.Prettify(exp), nil
 		}
 	default:
 		return 0, 0, errInvalidBackend
@@ -51,17 +57,17 @@ func (r RuleNamespace) LintExpressions(backend string, promqlParser parser.Parse
 	for i, group := range r.Groups {
 		for j, rule := range group.Rules {
 			level.Debug(logger).Log("msg", "linting expression", "language", queryLanguage, "rule", getRuleName(rule))
-			exp, err := parseFn(rule.Expr)
+			exp, err := lintFn(rule.Expr)
 			if err != nil {
 				return count, mod, err
 			}
 
 			count++
-			if rule.Expr != exp.String() {
-				level.Debug(logger).Log("msg", "expression differs", "rule", getRuleName(rule), "currentExpr", rule.Expr, "afterExpr", exp.String())
+			if rule.Expr != exp {
+				level.Debug(logger).Log("msg", "expression differs", "rule", getRuleName(rule), "currentExpr", rule.Expr, "afterExpr", exp)
 
 				mod++
-				r.Groups[i].Rules[j].Expr = exp.String()
+				r.Groups[i].Rules[j].Expr = exp
 			}
 		}
 	}

--- a/pkg/mimirtool/rules/rules_test.go
+++ b/pkg/mimirtool/rules/rules_test.go
@@ -268,10 +268,53 @@ func TestLintExpressions(t *testing.T) {
 			err: "",
 		},
 		{
-			name:     "with a complex expression",
-			expr:     `sum by (cluster, namespace) (sum_over_time((rate(loki_distributor_bytes_received_total{job=~".*/distributor"}[1m]) * 60)[1h:1m])) / 1000000000 / 5 * 1 > (sum by (cluster, namespace) (memcached_limit_bytes{job=~".+/memcached"}) / 1000000000)`,
-			expected: `sum by (cluster, namespace) (sum_over_time((rate(loki_distributor_bytes_received_total{job=~".*/distributor"}[1m]) * 60)[1h:1m])) / 1000000000 / 5 * 1 > (sum by (cluster, namespace) (memcached_limit_bytes{job=~".+/memcached"}) / 1000000000)`,
-			count:    1, modified: 0,
+			name: "with a complex expression",
+			expr: `sum by (cluster, namespace) (sum_over_time((rate(loki_distributor_bytes_received_total{job=~".*/distributor"}[1m]) * 60)[1h:1m])) / 1000000000 / 5 * 1 > (sum by (cluster, namespace) (memcached_limit_bytes{job=~".+/memcached"}) / 1000000000)`,
+			expected: `        sum by (cluster, namespace) (
+          sum_over_time((rate(loki_distributor_bytes_received_total{job=~".*/distributor"}[1m]) * 60)[1h:1m])
+        )
+      /
+        1000000000
+    /
+      5
+  *
+    1
+>
+  (sum by (cluster, namespace) (memcached_limit_bytes{job=~".+/memcached"}) / 1000000000)`,
+			count: 1, modified: 1,
+			err: "",
+		},
+		{
+			name: "it merges a short multi-line expression into one line",
+			expr: `  instance_path:request_failures:rate5m{job="myjob"}
+/
+  instance_path:requests:rate5m{job="myjob"}`,
+			expected: `instance_path:request_failures:rate5m{job="myjob"} / instance_path:requests:rate5m{job="myjob"}`,
+			count:    1, modified: 1,
+			err: "",
+		},
+		{
+			name: "it keeps a long multi-line expression on multiple lines",
+			expr: `sum by (x) (
+  instance_path:request_failures:rate5m{job="myjob"}
+  /
+  instance_path:requests:rate5m{job="myjob"}
+)`,
+			expected: `sum by (x) (
+  instance_path:request_failures:rate5m{job="myjob"} / instance_path:requests:rate5m{job="myjob"}
+)`,
+			count: 1, modified: 1,
+			err: "",
+		},
+		{
+			name: "with an already formatted multi-line expression",
+			expr: `sum by (x) (
+  instance_path:request_failures:rate5m{job="myjob"} / instance_path:requests:rate5m{job="myjob"}
+)`,
+			expected: `sum by (x) (
+  instance_path:request_failures:rate5m{job="myjob"} / instance_path:requests:rate5m{job="myjob"}
+)`,
+			count: 1, modified: 0,
 			err: "",
 		},
 		{


### PR DESCRIPTION
#### What this PR does

`mimirtool rules lint` rewrites every rule expression with the parsed expression's `String()` representation, which collapses multi-line PromQL onto a single line. For larger rule files this significantly hurts readability, especially when lint runs in CI and rewrites files in place.

This PR formats expressions with the PromQL prettifier (`parser.Prettify`) instead, following the direction discussed in the issue: @dimitarvdimitrov suggested introducing better PromQL formatting that matches the query formatter in the Prometheus UI, and @narqo verified that `parser.Prettify` (available since prometheus/prometheus#10544) produces exactly that output. Expressions longer than 100 characters are split across multiple lines; shorter ones stay on a single line. The prettified output is stable, so re-running lint over an already formatted file makes no further changes.

Before (input from the issue):

```yaml
groups:
    - name: test.rules.2
      rules:
        - record: instance_path:request_failures_per_requests:ratio_rate5m
          expr: |2
            sum by (x) (
              instance_path:request_failures:rate5m{job="myjob"}
              /
              instance_path:requests:rate5m{job="myjob"}
            )
```

`mimirtool rules lint` previously produced:

```yaml
          expr: sum by (x) (instance_path:request_failures:rate5m{job="myjob"} / instance_path:requests:rate5m{job="myjob"})
```

After this PR:

```yaml
          expr: |-
            sum by (x) (
              instance_path:request_failures:rate5m{job="myjob"} / instance_path:requests:rate5m{job="myjob"}
            )
```

Testing: extended `TestLintExpressions` with the examples from the issue (a short multi-line expression that fits on one line, a long multi-line expression that must stay on multiple lines, and an already-formatted expression that must be left unchanged, i.e. idempotency). Also verified end-to-end by running the built `mimirtool rules lint` twice on the reproduction file from the issue: the first run produces the output above, the second run reports `linted_expressions=0`.

If you'd prefer to keep the current single-line behavior as the default and put the prettified formatting behind a flag (e.g. `--pretty-expr`), I'm happy to adjust.

#### Which issue(s) this PR fixes or relates to

Fixes #4501

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
