### PR TITLE
Fix flaky tests after #16187

### DIFF
--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -301,6 +301,11 @@ func checkQueries(
 				labels.MustNewMatcher(labels.MatchEqual, "name", "store-gateway-client"),
 				labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
 
+			// Wait until the query-frontend has updated the querier ring.
+			require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+				labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
+				labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+
 			// Wait until the store-gateway has loaded the blocks before querying.
 			//
 			// The store-gateway switches to ACTIVE in the ring only after its initial block sync completes,

--- a/integration/compartments_test.go
+++ b/integration/compartments_test.go
@@ -94,6 +94,11 @@ func TestIngesterQuerying_ShouldSupportCompartments(t *testing.T) {
 	}
 	require.NoError(t, s.StartAndWaitReady(mimirServices...))
 
+	// Wait until the query-frontend has updated the querier ring.
+	require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
+		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+
 	// The ingester instance ring is shared across compartments, so the distributor and querier should
 	// see every ingester ACTIVE in it.
 	for _, svc := range []*e2emimir.MimirService{distributors[0], querier} {
@@ -284,6 +289,11 @@ func TestStoreGatewayQuerying_ShouldSupportCompartments(t *testing.T) {
 		mimirServices = append(mimirServices, sg)
 	}
 	require.NoError(t, s.StartAndWaitReady(mimirServices...))
+
+	// Wait until the query-frontend has updated the querier ring.
+	require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
+		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
 
 	// The ingester instance ring is shared across compartments, so the distributor and querier should
 	// see every ingester ACTIVE in it.

--- a/integration/distributor_test.go
+++ b/integration/distributor_test.go
@@ -1442,6 +1442,11 @@ func testDistributorNameValidation(
 		labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
 		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
 
+	// Wait until the query-frontend has updated the querier ring.
+	require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
+		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+
 	client, err := e2emimir.NewClient(distributor.HTTPEndpoint(), queryFrontend.HTTPEndpoint(), "", "", userID)
 	require.NoError(t, err)
 

--- a/integration/querier_label_name_values_test.go
+++ b/integration/querier_label_name_values_test.go
@@ -139,6 +139,11 @@ func TestQuerierLabelNamesAndValues(t *testing.T) {
 				labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
 				labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
 
+			// Wait until the query-frontend has updated the querier ring.
+			require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+				labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
+				labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+
 			// Push series.
 			now := time.Now()
 
@@ -343,6 +348,11 @@ func TestQuerierLabelValuesCardinality(t *testing.T) {
 				labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
 				labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))),
 			)
+
+			// Wait until the query-frontend has updated the querier ring.
+			require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+				labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
+				labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
 
 			// Push series.
 			now := time.Now()

--- a/integration/querier_test.go
+++ b/integration/querier_test.go
@@ -16,6 +16,7 @@ import (
 	e2edb "github.com/grafana/e2e/db"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -178,6 +179,11 @@ func testQuerierWithBlocksStorageRunningInMicroservicesMode(t *testing.T, series
 			// Wait until the querier has updated the ring. The querier will also watch
 			// the store-gateway ring if blocks sharding is enabled.
 			require.NoError(t, querier.WaitSumMetrics(e2e.Equals(float64(512+(512*storeGateways.NumInstances()))), "cortex_ring_tokens_total"))
+
+			// Wait until the query-frontend has updated the querier ring.
+			require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+				labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
+				labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
 
 			// Wait until the store-gateway has synched the new uploaded blocks. When sharding is enabled
 			// we don't known which store-gateway instance will synch the blocks, so we need to wait on

--- a/integration/query_frontend_active_series_test.go
+++ b/integration/query_frontend_active_series_test.go
@@ -163,6 +163,11 @@ func setupComponentsForActiveSeriesTest(t *testing.T, cfg queryFrontendTestConfi
 		labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
 		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
 
+	// Wait until the query-frontend has updated the querier ring.
+	require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
+		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+
 	// Push series for the test user to Mimir.
 	c, err := e2emimir.NewClient(distributor.HTTPEndpoint(), queryFrontend.HTTPEndpoint(), "", "", userID)
 	require.NoError(t, err)

--- a/integration/query_frontend_cache_test.go
+++ b/integration/query_frontend_cache_test.go
@@ -10,6 +10,7 @@ import (
 	e2ecache "github.com/grafana/e2e/cache"
 	e2edb "github.com/grafana/e2e/db"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/integration/e2emimir"
@@ -70,6 +71,16 @@ func TestQueryFrontendUnalignedQuery(t *testing.T) {
 	require.NoError(t, distributor.WaitSumMetrics(e2e.Equals(512+1), "cortex_ring_tokens_total"))
 	require.NoError(t, querierAligned.WaitSumMetrics(e2e.Equals(512), "cortex_ring_tokens_total"))
 	require.NoError(t, querierUnaligned.WaitSumMetrics(e2e.Equals(512), "cortex_ring_tokens_total"))
+
+	// Wait until the query-frontends have updated the querier ring.
+	// Both query-frontends will see both queriers, but this is OK for this test given the configuration only applies to the query-frontend.
+	require.NoError(t, queryFrontendAligned.WaitSumMetricsWithOptions(e2e.Equals(2), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
+		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+
+	require.NoError(t, queryFrontendUnaligned.WaitSumMetricsWithOptions(e2e.Equals(2), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
+		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
 
 	// Push a series for each user to Mimir.
 	const user = "user"

--- a/integration/query_frontend_labels_query_optimizer_test.go
+++ b/integration/query_frontend_labels_query_optimizer_test.go
@@ -125,6 +125,11 @@ func TestQueryFrontendLabelsQueryOptimizerIdempotency(t *testing.T) {
 			labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
 			labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
 
+		// Wait until the query-frontend has updated the querier ring.
+		require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+			labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
+			labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+
 		// Push series
 		client, err := e2emimir.NewClient(distributor.HTTPEndpoint(), queryFrontend.HTTPEndpoint(), "", "", userID)
 		require.NoError(t, err)

--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -1033,6 +1033,11 @@ func runQueryFrontendWithQueryShardingHTTPTest(t *testing.T, cfg queryFrontendTe
 		labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
 		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
 
+	// Wait until the query-frontend has updated the querier ring.
+	require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
+		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+
 	// Push series for the test user to Mimir.
 	now := time.Now()
 	c, err := e2emimir.NewClient(distributor.HTTPEndpoint(), queryFrontend.HTTPEndpoint(), "", "", userID)

--- a/integration/query_scheduler_test.go
+++ b/integration/query_scheduler_test.go
@@ -80,6 +80,11 @@ func runTestQuerySchedulerWithMaxUsedInstances(t *testing.T, seriesName string, 
 		labels.MustNewMatcher(labels.MatchEqual, "name", "querier-query-scheduler-client"),
 		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
 
+	// Wait until the query-frontend has updated the querier ring.
+	require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
+		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+
 	// Compute which is the expected in-use query-scheduler.
 	schedulers := []*e2emimir.MimirService{queryScheduler1, queryScheduler2}
 	slices.SortFunc(schedulers, func(a, b *e2emimir.MimirService) int {

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -1230,6 +1230,11 @@ func TestRulerRemoteEvaluation(t *testing.T) {
 	// The distributor should have 512 tokens for the ingester ring and 1 for the distributor ring
 	require.NoError(t, distributor.WaitSumMetrics(e2e.Equals(512+1), "cortex_ring_tokens_total"))
 
+	// Wait until the query-frontend has updated the querier ring.
+	require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
+		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+
 	for tName, tc := range tcs {
 		t.Run(tName, func(t *testing.T) {
 			if tc.queryResultPayloadFormat == "" {
@@ -1368,6 +1373,11 @@ func TestRulerRemoteEvaluationErrorClassification(t *testing.T) {
 	require.NoError(t, distributor.WaitSumMetrics(e2e.Equals(512+1), "cortex_ring_tokens_total"))
 	// Ruler will see 512 tokens from ingester, and 128 tokens from itself.
 	require.NoError(t, ruler.WaitSumMetrics(e2e.Equals(512+128), "cortex_ring_tokens_total"))
+
+	// Wait until the query-frontend has updated the querier ring.
+	require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
+		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
 
 	const user = "user"
 	const namespace = "test"
@@ -1562,6 +1572,11 @@ func TestRulerRemoteEvaluation_ShouldEnforceStrongReadConsistencyForDependentRul
 	// Wait until the distributor is ready.
 	// The distributor should have 512 tokens for the ingester ring and 1 for the distributor ring.
 	require.NoError(t, distributor.WaitSumMetrics(e2e.Equals(512+1), "cortex_ring_tokens_total"))
+
+	// Wait until the query-frontend has updated the querier ring.
+	require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
+		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
 
 	// Wait until partitions are ACTIVE in the ring.
 	for _, service := range []*e2emimir.MimirService{distributor, queryFrontend, querier} {


### PR DESCRIPTION
#### What this PR does

#16187 enabled remote execution by default.

This requires query-frontends to have observed the querier in the querier ring, otherwise requests fail with `could not determine maximum supported query plan version: could not compute maximum supported query plan version: could not get all queriers from the ring: empty ring`.

Some integration tests already waited for the query-frontend to observe the querier joining the ring, but other tests did not, so this PR adds the wait to the remaining tests that need it.

#### Which issue(s) this PR fixes or relates to

Relates to #16187

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
