### PR TITLE
ruler: fix test flake where manager .Run() raced with .Stop()

### DIFF
--- a/pkg/ruler/manager.go
+++ b/pkg/ruler/manager.go
@@ -392,8 +392,8 @@ func (r *DefaultMultiTenantManager) Stop() {
 		}(manager, userID)
 		delete(r.userManagers, userID)
 	}
-	r.userManagerMtx.Unlock()
 	r.userManagersWg.Wait()
+	r.userManagerMtx.Unlock()
 	level.Info(r.logger).Log("msg", "all user managers stopped")
 
 	// Stop notifiers after all rule evaluations have finished, so that we have

--- a/pkg/ruler/manager.go
+++ b/pkg/ruler/manager.go
@@ -46,6 +46,7 @@ type DefaultMultiTenantManager struct {
 
 	// Struct for holding per-user Prometheus rules Managers.
 	userManagerMtx sync.RWMutex
+	userManagersWg sync.WaitGroup
 	userManagers   map[string]RulesManager
 
 	// Prometheus rules managers metrics.
@@ -155,7 +156,7 @@ func (r *DefaultMultiTenantManager) Start() {
 	}
 
 	for _, mngr := range r.userManagers {
-		go mngr.Run()
+		r.userManagersWg.Go(mngr.Run)
 	}
 	// set rulerIsRunning to true once user managers are started.
 	r.rulerIsRunning.Store(true)
@@ -258,7 +259,7 @@ func (r *DefaultMultiTenantManager) getOrCreateManager(user string) (RulesManage
 	// Hence run it as another goroutine.
 	// We only start the rule manager if the ruler is in running state.
 	if r.rulerIsRunning.Load() {
-		go manager.Run()
+		r.userManagersWg.Go(manager.Run)
 	}
 
 	r.userManagers[user] = manager
@@ -382,27 +383,24 @@ func (r *DefaultMultiTenantManager) GetRules(userID string) []*promRules.Group {
 
 func (r *DefaultMultiTenantManager) Stop() {
 	level.Info(r.logger).Log("msg", "stopping user managers")
-	wg := sync.WaitGroup{}
 	r.userManagerMtx.Lock()
 	for userID, manager := range r.userManagers {
 		level.Debug(r.logger).Log("msg", "shutting down user manager", "user", userID)
-		wg.Add(1)
 		go func(manager RulesManager, user string) {
 			manager.Stop()
-			wg.Done()
 			level.Debug(r.logger).Log("msg", "user manager shut down", "user", user)
 		}(manager, userID)
 		delete(r.userManagers, userID)
 	}
-	wg.Wait()
 	r.userManagerMtx.Unlock()
+	r.userManagersWg.Wait()
 	level.Info(r.logger).Log("msg", "all user managers stopped")
 
 	// Stop notifiers after all rule evaluations have finished, so that we have
 	// a chance to send any notifications generated while shutting down.
 	// rulerNotifier.stop() may take some time to complete if notifications need to be drained from the queue.
 	level.Info(r.logger).Log("msg", "stopping user notifiers")
-	wg = sync.WaitGroup{}
+	wg := sync.WaitGroup{}
 	r.notifiersMtx.Lock()
 	for _, n := range r.notifiers {
 		wg.Add(1)

--- a/pkg/ruler/manager.go
+++ b/pkg/ruler/manager.go
@@ -383,15 +383,21 @@ func (r *DefaultMultiTenantManager) GetRules(userID string) []*promRules.Group {
 
 func (r *DefaultMultiTenantManager) Stop() {
 	level.Info(r.logger).Log("msg", "stopping user managers")
+	wg := sync.WaitGroup{}
 	r.userManagerMtx.Lock()
 	for userID, manager := range r.userManagers {
 		level.Debug(r.logger).Log("msg", "shutting down user manager", "user", userID)
+		wg.Add(1)
 		go func(manager RulesManager, user string) {
+			defer wg.Done()
 			manager.Stop()
 			level.Debug(r.logger).Log("msg", "user manager shut down", "user", user)
 		}(manager, userID)
 		delete(r.userManagers, userID)
 	}
+	// Wait on calling .Stop() on each manager.
+	wg.Wait()
+	// Wait for the .Run() on each manager to complete.
 	r.userManagersWg.Wait()
 	r.userManagerMtx.Unlock()
 	level.Info(r.logger).Log("msg", "all user managers stopped")
@@ -400,7 +406,7 @@ func (r *DefaultMultiTenantManager) Stop() {
 	// a chance to send any notifications generated while shutting down.
 	// rulerNotifier.stop() may take some time to complete if notifications need to be drained from the queue.
 	level.Info(r.logger).Log("msg", "stopping user notifiers")
-	wg := sync.WaitGroup{}
+	wg = sync.WaitGroup{}
 	r.notifiersMtx.Lock()
 	for _, n := range r.notifiers {
 		wg.Add(1)

--- a/pkg/ruler/manager.go
+++ b/pkg/ruler/manager.go
@@ -46,7 +46,7 @@ type DefaultMultiTenantManager struct {
 
 	// Struct for holding per-user Prometheus rules Managers.
 	userManagerMtx sync.RWMutex
-	userManagersWg sync.WaitGroup
+	userManagerWg  sync.WaitGroup
 	userManagers   map[string]RulesManager
 
 	// Prometheus rules managers metrics.
@@ -156,7 +156,7 @@ func (r *DefaultMultiTenantManager) Start() {
 	}
 
 	for _, mngr := range r.userManagers {
-		r.userManagersWg.Go(mngr.Run)
+		r.userManagerWg.Go(mngr.Run)
 	}
 	// set rulerIsRunning to true once user managers are started.
 	r.rulerIsRunning.Store(true)
@@ -259,7 +259,7 @@ func (r *DefaultMultiTenantManager) getOrCreateManager(user string) (RulesManage
 	// Hence run it as another goroutine.
 	// We only start the rule manager if the ruler is in running state.
 	if r.rulerIsRunning.Load() {
-		r.userManagersWg.Go(manager.Run)
+		r.userManagerWg.Go(manager.Run)
 	}
 
 	r.userManagers[user] = manager
@@ -398,7 +398,7 @@ func (r *DefaultMultiTenantManager) Stop() {
 	// Wait on calling .Stop() on each manager.
 	wg.Wait()
 	// Wait for the .Run() on each manager to complete.
-	r.userManagersWg.Wait()
+	r.userManagerWg.Wait()
 	r.userManagerMtx.Unlock()
 	level.Info(r.logger).Log("msg", "all user managers stopped")
 


### PR DESCRIPTION
#### What this PR does

Fix a test flake when the goroutine used for the ruler manager `.Run()` method started running after the ruler had already `.Stop()`'d in a test, leading to logging to the test logger after the test had ended.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
