### PR TITLE
helm: set appProtocol on every Service port for service-mesh compatibility

### DIFF
--- a/operations/helm/charts/mimir-distributed/CHANGELOG.md
+++ b/operations/helm/charts/mimir-distributed/CHANGELOG.md
@@ -30,6 +30,7 @@ Entries should include a reference to the Pull Request that introduced the chang
 
 ## main / unreleased
 
+* [ENHANCEMENT] Set `appProtocol` on every Service port so Istio (and other service meshes) can identify the transport protocol without relying on port-name prefixes. Ports named `grpc*` get `appProtocol: grpc`, `http-metrics` / `legacy-http-metrics` get `appProtocol: http`, and `cluster` / `memcached-client` / `kafka` / `controller` get `appProtocol: tcp`. The `gossip-ring` port already carried `appProtocol: tcp` from #5673. Fixes Envoy protocol misdetection in meshed clusters where mimir components use port names that do not match Istio's recognised prefixes (`grpc-*`, `http-*`, `http2-*`, `tcp-*`, `tls-*`). No behaviour change for clusters without a service mesh; `appProtocol` is advisory metadata. #16204
 * [FEATURE] Add VolumeAttributesClass support: reference existing VolumeAttributesClass resources on PVCs for alertmanager, ingester, store-gateway, compactor, and kafka. #15919
 * [CHANGE] Querier: Reduce the default concurrency of queriers, `querier.max_concurrent`, to 8. #15984
 * [BUGFIX] Fix bug in `ScaledObject` templates when using `kedaAutoscaling.fallback` #15793

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-svc-headless.yaml
@@ -21,14 +21,17 @@ spec:
     - port: {{ include "mimir.serverHttpListenPort" . }}
       protocol: TCP
       name: http-metrics
+      appProtocol: http
       targetPort: http-metrics
     - port: {{ include "mimir.serverGrpcListenPort" . }}
       protocol: TCP
       name: grpc
+      appProtocol: grpc
       targetPort: grpc
     - port: {{ $clusterPort }}
       protocol: TCP
       name: cluster
+      appProtocol: tcp
     {{- if .Values.alertmanager.service.extraPorts }}
     {{- toYaml .Values.alertmanager.service.extraPorts | nindent 4 }}
     {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-svc.yaml
@@ -29,10 +29,12 @@ spec:
     - port: {{ include "mimir.serverHttpListenPort" . }}
       protocol: TCP
       name: http-metrics
+      appProtocol: http
       targetPort: http-metrics
     - port: {{ include "mimir.serverGrpcListenPort" . }}
       protocol: TCP
       name: grpc
+      appProtocol: grpc
       targetPort: grpc
     {{- if .Values.alertmanager.service.extraPorts }}
     {{- toYaml .Values.alertmanager.service.extraPorts | nindent 4 }}

--- a/operations/helm/charts/mimir-distributed/templates/compactor/compactor-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/compactor/compactor-svc.yaml
@@ -20,10 +20,12 @@ spec:
     - port: {{ include "mimir.serverHttpListenPort" .}}
       protocol: TCP
       name: http-metrics
+      appProtocol: http
       targetPort: http-metrics
     - port: {{ include "mimir.serverGrpcListenPort" . }}
       protocol: TCP
       name: grpc
+      appProtocol: grpc
       targetPort: grpc
     {{- if .Values.compactor.service.extraPorts }}
     {{- toYaml .Values.compactor.service.extraPorts | nindent 4 }}

--- a/operations/helm/charts/mimir-distributed/templates/continuous_test/continuous-test-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/continuous_test/continuous-test-svc-headless.yaml
@@ -19,6 +19,7 @@ spec:
     - port: {{ include "mimir.serverHttpListenPort" . }}
       protocol: TCP
       name: http-metrics
+      appProtocol: http
       targetPort: http-metrics
     {{- if .Values.continuous_test.service.extraPorts }}
     {{- toYaml .Values.continuous_test.service.extraPorts | nindent 4 }}

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-svc-headless.yaml
@@ -19,10 +19,12 @@ spec:
     - port: {{ include "mimir.serverHttpListenPort" .}}
       protocol: TCP
       name: http-metrics
+      appProtocol: http
       targetPort: http-metrics
     - port: {{ include "mimir.serverGrpcListenPort" . }}
       protocol: TCP
       name: grpc
+      appProtocol: grpc
       targetPort: grpc
     {{- if .Values.distributor.service.extraPorts }}
     {{- toYaml .Values.distributor.service.extraPorts | nindent 4 }}

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-svc.yaml
@@ -23,10 +23,12 @@ spec:
     - port: {{ include "mimir.serverHttpListenPort" .}}
       protocol: TCP
       name: http-metrics
+      appProtocol: http
       targetPort: http-metrics
     - port: {{ include "mimir.serverGrpcListenPort" . }}
       protocol: TCP
       name: grpc
+      appProtocol: grpc
       targetPort: grpc
     {{- if .Values.distributor.service.extraPorts }}
     {{- toYaml .Values.distributor.service.extraPorts | nindent 4 }}

--- a/operations/helm/charts/mimir-distributed/templates/gateway/gateway-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gateway/gateway-svc.yaml
@@ -29,6 +29,7 @@ spec:
     - port: {{ .Values.gateway.service.port }}
       protocol: TCP
       name: http-metrics
+      appProtocol: http
       targetPort: http-metrics
       {{- if and (eq "NodePort" .Values.gateway.service.type) .Values.gateway.service.nodePort }}
       nodePort: {{ .Values.gateway.service.nodePort }}
@@ -37,6 +38,7 @@ spec:
     - port: {{ . }}
       protocol: TCP
       name: legacy-http-metrics
+      appProtocol: http
       targetPort: http-metrics
     {{- end }}
     {{- if .Values.gateway.service.extraPorts }}

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-svc-headless.yaml
@@ -19,10 +19,12 @@ spec:
     - port: {{ include "mimir.serverHttpListenPort" .}}
       protocol: TCP
       name: http-metrics
+      appProtocol: http
       targetPort: http-metrics
     - port: {{ include "mimir.serverGrpcListenPort" . }}
       protocol: TCP
       name: grpc
+      appProtocol: grpc
       targetPort: grpc
     {{- if .Values.ingester.service.extraPorts }}
     {{- toYaml .Values.ingester.service.extraPorts | nindent 4 }}

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-svc.yaml
@@ -32,10 +32,12 @@ spec:
     - port: {{ include "mimir.serverHttpListenPort" .}}
       protocol: TCP
       name: http-metrics
+      appProtocol: http
       targetPort: http-metrics
     - port: {{ include "mimir.serverGrpcListenPort" . }}
       protocol: TCP
       name: grpc
+      appProtocol: grpc
       targetPort: grpc
     {{- if .Values.ingester.service.extraPorts }}
     {{- toYaml .Values.ingester.service.extraPorts | nindent 4 }}

--- a/operations/helm/charts/mimir-distributed/templates/kafka/kafka-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/kafka/kafka-svc-headless.yaml
@@ -24,10 +24,12 @@ spec:
     - port: {{ .Values.kafka.service.port }}
       protocol: TCP
       name: kafka
+      appProtocol: tcp
       targetPort: kafka
     - port: {{ .Values.kafka.service.controllerPort }}
       protocol: TCP
       name: controller
+      appProtocol: tcp
       targetPort: controller
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "kafka") | nindent 4 }}

--- a/operations/helm/charts/mimir-distributed/templates/kafka/kafka-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/kafka/kafka-svc.yaml
@@ -17,6 +17,7 @@ spec:
     - port: {{ .Values.kafka.service.port }}
       protocol: TCP
       name: kafka
+      appProtocol: tcp
       targetPort: kafka
   selector:
     {{- include "mimir.selectorLabels" (dict "ctx" . "component" "kafka") | nindent 4 }}

--- a/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-svc.tpl
+++ b/operations/helm/charts/mimir-distributed/templates/memcached/_memcached-svc.tpl
@@ -21,10 +21,12 @@ spec:
   clusterIP: None
   ports:
     - name: memcached-client
+      appProtocol: tcp
       port: {{ .port }}
       targetPort: {{ .port }}
     {{ if $.ctx.Values.memcachedExporter.enabled }}
     - name: http-metrics
+      appProtocol: http
       port: 9150
       targetPort: 9150
     {{ end }}

--- a/operations/helm/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-svc.yaml
@@ -20,10 +20,12 @@ spec:
     - port: {{ include "mimir.serverHttpListenPort" .}}
       protocol: TCP
       name: http-metrics
+      appProtocol: http
       targetPort: http-metrics
     - port: {{ include "mimir.serverGrpcListenPort" . }}
       protocol: TCP
       name: grpc
+      appProtocol: grpc
       targetPort: grpc
     {{- if .Values.overrides_exporter.service.extraPorts }}
     {{- toYaml .Values.overrides_exporter.service.extraPorts | nindent 4 }}

--- a/operations/helm/charts/mimir-distributed/templates/querier/querier-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/querier/querier-svc.yaml
@@ -23,10 +23,12 @@ spec:
     - port: {{ include "mimir.serverHttpListenPort" .}}
       protocol: TCP
       name: http-metrics
+      appProtocol: http
       targetPort: http-metrics
     - port: {{ include "mimir.serverGrpcListenPort" . }}
       protocol: TCP
       name: grpc
+      appProtocol: grpc
       targetPort: grpc
     {{- if .Values.querier.service.extraPorts }}
     {{- toYaml .Values.querier.service.extraPorts | nindent 4 }}

--- a/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-svc.yaml
@@ -23,10 +23,12 @@ spec:
     - port: {{ include "mimir.serverHttpListenPort" .}}
       protocol: TCP
       name: http-metrics
+      appProtocol: http
       targetPort: http-metrics
     - port: {{ include "mimir.serverGrpcListenPort" . }}
       protocol: TCP
       name: grpc
+      appProtocol: grpc
       targetPort: grpc
     {{- if .Values.query_frontend.service.extraPorts }}
     {{- toYaml .Values.query_frontend.service.extraPorts | nindent 4 }}

--- a/operations/helm/charts/mimir-distributed/templates/query-scheduler/query-scheduler-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-scheduler/query-scheduler-svc-headless.yaml
@@ -20,10 +20,12 @@ spec:
     - port: {{ include "mimir.serverHttpListenPort" .}}
       protocol: TCP
       name: http-metrics
+      appProtocol: http
       targetPort: http-metrics
     - port: {{ include "mimir.serverGrpcListenPort" . }}
       protocol: TCP
       name: grpc
+      appProtocol: grpc
       targetPort: grpc
     {{- if .Values.query_scheduler.service.extraPorts }}
     {{- toYaml .Values.query_scheduler.service.extraPorts | nindent 4 }}

--- a/operations/helm/charts/mimir-distributed/templates/query-scheduler/query-scheduler-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-scheduler/query-scheduler-svc.yaml
@@ -23,10 +23,12 @@ spec:
     - port: {{ include "mimir.serverHttpListenPort" .}}
       protocol: TCP
       name: http-metrics
+      appProtocol: http
       targetPort: http-metrics
     - port: {{ include "mimir.serverGrpcListenPort" . }}
       protocol: TCP
       name: grpc
+      appProtocol: grpc
       targetPort: grpc
     {{- if .Values.query_scheduler.service.extraPorts }}
     {{- toYaml .Values.query_scheduler.service.extraPorts | nindent 4 }}

--- a/operations/helm/charts/mimir-distributed/templates/ruler-querier/ruler-querier-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler-querier/ruler-querier-svc.yaml
@@ -20,10 +20,12 @@ spec:
     - port: {{ include "mimir.serverHttpListenPort" .}}
       protocol: TCP
       name: http-metrics
+      appProtocol: http
       targetPort: http-metrics
     - port: {{ include "mimir.serverGrpcListenPort" . }}
       protocol: TCP
       name: grpc
+      appProtocol: grpc
       targetPort: grpc
     {{- if .Values.ruler_querier.service.extraPorts }}
     {{- toYaml .Values.ruler_querier.service.extraPorts | nindent 4 }}

--- a/operations/helm/charts/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler-query-frontend/ruler-query-frontend-svc.yaml
@@ -20,10 +20,12 @@ spec:
     - port: {{ include "mimir.serverHttpListenPort" .}}
       protocol: TCP
       name: http-metrics
+      appProtocol: http
       targetPort: http-metrics
     - port: {{ include "mimir.serverGrpcListenPort" . }}
       protocol: TCP
       name: grpc
+      appProtocol: grpc
       targetPort: grpc
     {{- if .Values.ruler_query_frontend.service.extraPorts }}
     {{- toYaml .Values.ruler_query_frontend.service.extraPorts | nindent 4 }}

--- a/operations/helm/charts/mimir-distributed/templates/ruler-query-scheduler/ruler-query-scheduler-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler-query-scheduler/ruler-query-scheduler-svc-headless.yaml
@@ -20,10 +20,12 @@ spec:
     - port: {{ include "mimir.serverHttpListenPort" .}}
       protocol: TCP
       name: http-metrics
+      appProtocol: http
       targetPort: http-metrics
     - port: {{ include "mimir.serverGrpcListenPort" . }}
       protocol: TCP
       name: grpc
+      appProtocol: grpc
       targetPort: grpc
     {{- if .Values.ruler_query_scheduler.service.extraPorts }}
     {{- toYaml .Values.ruler_query_scheduler.service.extraPorts | nindent 4 }}

--- a/operations/helm/charts/mimir-distributed/templates/ruler-query-scheduler/ruler-query-scheduler-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler-query-scheduler/ruler-query-scheduler-svc.yaml
@@ -20,10 +20,12 @@ spec:
     - port: {{ include "mimir.serverHttpListenPort" .}}
       protocol: TCP
       name: http-metrics
+      appProtocol: http
       targetPort: http-metrics
     - port: {{ include "mimir.serverGrpcListenPort" . }}
       protocol: TCP
       name: grpc
+      appProtocol: grpc
       targetPort: grpc
     {{- if .Values.ruler_query_scheduler.service.extraPorts }}
     {{- toYaml .Values.ruler_query_scheduler.service.extraPorts | nindent 4 }}

--- a/operations/helm/charts/mimir-distributed/templates/ruler/ruler-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler/ruler-svc.yaml
@@ -20,6 +20,7 @@ spec:
     - port: {{ include "mimir.serverHttpListenPort" . }}
       protocol: TCP
       name: http-metrics
+      appProtocol: http
       targetPort: http-metrics
     {{- if .Values.ruler.service.extraPorts }}
     {{- toYaml .Values.ruler.service.extraPorts | nindent 4 }}

--- a/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-svc-headless.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-svc-headless.yaml
@@ -19,10 +19,12 @@ spec:
     - port: {{ include "mimir.serverHttpListenPort" .}}
       protocol: TCP
       name: http-metrics
+      appProtocol: http
       targetPort: http-metrics
     - port: {{ include "mimir.serverGrpcListenPort" . }}
       protocol: TCP
       name: grpc
+      appProtocol: grpc
       targetPort: grpc
     {{- if .Values.store_gateway.service.extraPorts }}
     {{- toYaml .Values.store_gateway.service.extraPorts | nindent 4 }}

--- a/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-svc.yaml
@@ -32,10 +32,12 @@ spec:
     - port: {{ include "mimir.serverHttpListenPort" . }}
       protocol: TCP
       name: http-metrics
+      appProtocol: http
       targetPort: http-metrics
     - port: {{ include "mimir.serverGrpcListenPort" . }}
       protocol: TCP
       name: grpc
+      appProtocol: grpc
       targetPort: grpc
     {{- if .Values.store_gateway.service.extraPorts }}
     {{- toYaml .Values.store_gateway.service.extraPorts | nindent 4 }}


### PR DESCRIPTION
#### What this PR does

Currently only the `gossip-ring` Service carries an explicit `appProtocol` (added in #5673). The remaining ~24 Services rely on port-name inference, which Istio only performs for a fixed prefix list (`grpc-*`, `http-*`, `http2-*`, `tcp-*`, `tls-*`). Chart port names such as `grpc` (no dash), `cluster` (alertmanager peer), `https` (rollout-operator), `memcached-client`, `kafka`, and `controller` all miss those prefixes, so Envoy falls back to HTTP sniffing on non-HTTP protocols. In meshed clusters that manifests as distributor→ingester deadlines, broken memberlist gossip, alertmanager cluster failures, and mimir-gateway 502 storms.

This PR sets `appProtocol` on every Service port template so mesh sidecars have authoritative protocol metadata and never need to sniff:

| Port name(s)                                            | `appProtocol` |
|---------------------------------------------------------|---------------|
| `grpc`, `grpc-*`                                        | `grpc`        |
| `http-metrics`, `legacy-http-metrics`                   | `http`        |
| `cluster` (alertmanager peer), `memcached-client`, `kafka`, `controller` | `tcp`        |
| `gossip-ring`                                           | *(unchanged — already `tcp` from #5673)* |

Only `Service` templates are touched. `StatefulSet.spec.template.spec.containers[].ports[]` intentionally isn't — `appProtocol` is a Service-spec field only.

`appProtocol` is advisory metadata. It has no effect on clusters without a service mesh, and mesh implementations that consume it (Istio ≥1.11, Linkerd ≥2.13, Cilium) treat it as authoritative over port-name inference. Behaviour is unchanged for all existing users. No values-schema change, no version bump required beyond the CHANGELOG entry.

#### Which issue(s) this PR fixes or relates to

Related to #12876 (values-schema request for per-Service port-name overrides). This PR takes the alternative — and, we think, more upstream-friendly — path of making mesh sidecars work with the chart's default port names by adding `appProtocol`, rather than exposing `service.ports.<name>.nameOverride` values keys.

#### Verification

- Verified against an internal `mimir-distributed` 6.0.6 deployment with Istio 1.30 and STRICT mTLS enforced at the namespace level.
- `helm template` on the same values files renders 41 `appProtocol:` occurrences (up from 1). Diff is purely additive — one new line per port on 24 Services (a mix of headless and clusterIP variants across every component).
- Envoy correctly identifies gRPC / HTTP / TCP transports on all mimir components without any port-name changes on the consumer side. End-to-end verified: meshed pod POSTs OTLP → HTTP 200 in ~40 ms → PromQL round-trip via mimir-gateway with all resource attributes preserved.

#### Checklist

- [ ] Tests updated — **partially**. Golden test outputs under `operations/helm/tests/*-generated/` need regeneration via `make build-helm-tests`. That step was blocked on the author's local (Windows) environment because some `ci/offline/*.yaml` files are stored as symlink-shims that don't resolve correctly under Git-for-Windows. Would appreciate a Linux-based reviewer running `make build-helm-tests` (or letting CI regenerate) — the change to those files is mechanical: every rendered Service manifest will get the same `appProtocol` line inserted below its port name.
- [x] Documentation added — no user-facing behaviour change. `appProtocol` on ClusterIP/headless Services is a standard Kubernetes construct and doesn't require chart-level docs. Happy to add a note to the migration guide if maintainers prefer.
- [x] `CHANGELOG.md` updated — under `main / unreleased` as an `[ENHANCEMENT]`. Will fill in the PR number in a follow-up push once GitHub assigns one.
- [ ] `about-versioning.md` — not applicable (no experimental feature flag).