### PR TITLE
MQE: Fix case where sentinel histogram was returned to pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,7 +120,7 @@
 * [BUGFIX] MQE: Fix the binary operation narrow-selectors optimization incorrectly using binary operation matchers across an `on()` / `on(...) group_left`/`group_right` join boundary, which could cause some queries to unexpectedly evaluate as an empty result. #16155
 * [BUGFIX] Packaging: Fix the DEB/RPM packages shipping the `mimir`, `mimirtool`, `metaconvert`, and `query-tee` binaries without the executable bit set, which caused `mimir.service` to fail to start. #16166
 * [BUGFIX] Query-frontend: Fix a goroutine leak when a querier's streaming response arrives just as the query is cancelled: the goroutine handling the response could stay blocked forever writing a response body that would never be read. #16151
-* [BUGFIX] MQE: Fix issue where a sentinel value was in advertently returned to a pool where it could be mutated by multiple threads at once. #16205
+* [BUGFIX] MQE: Fix issue where a sentinel value was inadvertently returned to a pool where it could be mutated by multiple threads at once. #16205
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@
 * [BUGFIX] MQE: Fix the binary operation narrow-selectors optimization incorrectly using binary operation matchers across an `on()` / `on(...) group_left`/`group_right` join boundary, which could cause some queries to unexpectedly evaluate as an empty result. #16155
 * [BUGFIX] Packaging: Fix the DEB/RPM packages shipping the `mimir`, `mimirtool`, `metaconvert`, and `query-tee` binaries without the executable bit set, which caused `mimir.service` to fail to start. #16166
 * [BUGFIX] Query-frontend: Fix a goroutine leak when a querier's streaming response arrives just as the query is cancelled: the goroutine handling the response could stay blocked forever writing a response body that would never be read. #16151
+* [BUGFIX] MQE: Fix issue where a sentinel value was in advertently returned to a pool where it could be mutated by multiple threads at once. #16205
 
 ### Mixin
 

--- a/pkg/streamingpromql/operators/aggregations/avg.go
+++ b/pkg/streamingpromql/operators/aggregations/avg.go
@@ -357,6 +357,9 @@ func (g *AvgAggregationGroup) ComputeOutputSeries(_ types.ScalarData, timeRange 
 }
 
 func (g *AvgAggregationGroup) Close(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
+	// Remove sentinel histograms from slice to ensure it's not mutated when the slice is reused.
+	removeSentinelValue(g.histograms)
+
 	types.Float64SlicePool.Put(&g.floats, memoryConsumptionTracker)
 	types.Float64SlicePool.Put(&g.floatMeans, memoryConsumptionTracker)
 	types.Float64SlicePool.Put(&g.floatCompensatingMeans, memoryConsumptionTracker)

--- a/pkg/streamingpromql/operators/aggregations/common.go
+++ b/pkg/streamingpromql/operators/aggregations/common.go
@@ -71,6 +71,16 @@ var AggregationGroupFactories = map[parser.ItemType]*AggregationGroupFactory{
 // Invalid combinations include exponential and custom buckets, and histograms with incompatible custom buckets.
 var invalidCombinationOfHistograms = &histogram.FloatHistogram{}
 
+// removeSentinelValue removes any sentinel histograms from the provided slice. This must be called
+// before slices are returned to shared pools.
+func removeSentinelValue(s []*histogram.FloatHistogram) {
+	for i, h := range s {
+		if h == invalidCombinationOfHistograms {
+			s[i] = nil
+		}
+	}
+}
+
 // SeriesToGroupLabelsBytesFunc is a function that computes a string-like representation of the output group labels for the given input series.
 //
 // It returns a byte slice rather than a string to make it possible to avoid unnecessarily allocating a string.

--- a/pkg/streamingpromql/operators/aggregations/sum.go
+++ b/pkg/streamingpromql/operators/aggregations/sum.go
@@ -248,6 +248,9 @@ func (g *SumAggregationGroup) ComputeOutputSeries(_ types.ScalarData, timeRange 
 }
 
 func (g *SumAggregationGroup) Close(memoryConsumptionTracker *limiter.MemoryConsumptionTracker) {
+	// Remove sentinel histograms from slice to ensure it's not mutated when the slice is reused.
+	removeSentinelValue(g.histogramSums)
+
 	types.Float64SlicePool.Put(&g.floatSums, memoryConsumptionTracker)
 	types.Float64SlicePool.Put(&g.floatCompensatingValues, memoryConsumptionTracker)
 	types.BoolSlicePool.Put(&g.floatPresent, memoryConsumptionTracker)


### PR DESCRIPTION
#### What this PR does

Fixes a race condition where a sentinel value was returned to a pool and then mutated (when mangling is enabled for tests) while being used by another thread.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
