### PR TITLE
Support tenant matcher metadata restrictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,7 +114,7 @@
 * [BUGFIX] MQE: Fix `this indicates something has been returned to a pool more than once` panic when a `sum()` or `avg()` group contains, at the same output step, a float sample and native histograms that cannot be added together (e.g. exponential and custom bucket schemas). #16059
 * [BUGFIX] Query-frontend: Fix issue where series for a range query can be returned in the wrong order if splitting applies and splitting is not running inside MQE. #16036
 * [BUGFIX] Querier: Fix issue where exemplars can be returned in the wrong order if a series contains a label that is a prefix of another (eg. `env="foo"` and `env="foobar"`). #16036
-* [BUGFIX] Querier: Fix experimental search `/api/v1/search/metric_names?include_metadata=true` almost never returning metric metadata. #16062
+* [BUGFIX] Querier: Fix experimental search `/api/v1/search/metric_names?include_metadata=true` almost never returning metric metadata. #16062, #16214
 * [BUGFIX] Querier: Stop querying a partition that has been inactive for longer than `-querier.query-ingesters-within`, preventing query failures when the partition is still registered but has no available ingesters to serve the queries. #15721
 * [BUGFIX] Query-frontend: Fix `queue_time_seconds` in the query stats log always reporting 0 when a query is cancelled while still waiting in the query-scheduler queue. #16094
 * [BUGFIX] MQE: Fix the binary operation narrow-selectors optimization incorrectly using binary operation matchers across an `on()` / `on(...) group_left`/`group_right` join boundary, which could cause some queries to unexpectedly evaluate as an empty result. #16155

--- a/pkg/querier/api/api.go
+++ b/pkg/querier/api/api.go
@@ -55,6 +55,14 @@ type ActiveSeriesResponse struct {
 
 // MetricMetadataFetcher fetches metric metadata for a set of metric names,
 // returning it keyed by metric name.
+//
+// matcherSets are the request's OR-ed search selectors (one inner slice per
+// match[] entry). A tenant-federation-aware implementation uses only their
+// tenant (__tenant_id__) matchers, to scope the fetch to the union of tenants
+// the selectors touched — so metadata matches the tenants the search saw.
+// Implementations backed by the ingester metadata store are keyed by (tenant,
+// metric name) and cannot filter by any other label, so they ignore
+// matcherSets entirely.
 type MetricMetadataFetcher interface {
-	FetchMetricMetadata(ctx context.Context, names []string) (map[string]metadata.Metadata, error)
+	FetchMetricMetadata(ctx context.Context, names []string, matcherSets [][]*labels.Matcher) (map[string]metadata.Metadata, error)
 }

--- a/pkg/querier/distributor_queryable_search.go
+++ b/pkg/querier/distributor_queryable_search.go
@@ -81,7 +81,12 @@ func (q *distributorQuerier) SearchLabelValues(
 // FetchMetricMetadata fetches metric metadata for the given metric names from
 // the ingesters. When a metric has more than one metadata record, the first one
 // seen wins.
-func (q *distributorQuerier) FetchMetricMetadata(ctx context.Context, names []string) (map[string]metadata.Metadata, error) {
+//
+// matcherSets are ignored: the ingester metadata store (MetricsMetadataRequest)
+// is keyed by metric name and cannot filter by label matchers. Tenant scoping,
+// when federation is involved, is applied above this leaf by the tenant
+// federation merge querier selecting which tenants to fetch from.
+func (q *distributorQuerier) FetchMetricMetadata(ctx context.Context, names []string, _ [][]*labels.Matcher) (map[string]metadata.Metadata, error) {
 	resp, err := q.distributor.MetricsMetadata(ctx, &client.MetricsMetadataRequest{
 		MetricNames: names,
 		// Bound the response to the number of requested names. With

--- a/pkg/querier/distributor_queryable_search_test.go
+++ b/pkg/querier/distributor_queryable_search_test.go
@@ -158,7 +158,7 @@ func TestDistributorQuerier_FetchMetricMetadata(t *testing.T) {
 			}, nil)
 		q := newTestDistributorQuerier(t, dist, newMockConfigProvider(time.Hour), 0, nowMs)
 
-		got, err := q.FetchMetricMetadata(user.InjectOrgID(t.Context(), "user-1"), []string{"a", "b"})
+		got, err := q.FetchMetricMetadata(user.InjectOrgID(t.Context(), "user-1"), []string{"a", "b"}, nil)
 		require.NoError(t, err)
 		assert.Equal(t, map[string]metadata.Metadata{
 			"a": {Type: model.MetricTypeCounter, Help: "help a", Unit: "s"},
@@ -177,7 +177,7 @@ func TestDistributorQuerier_FetchMetricMetadata(t *testing.T) {
 		dist.On("MetricsMetadata", mock.Anything, mock.Anything).Return([]scrape.MetricMetadata(nil), errors.New("boom"))
 		q := newTestDistributorQuerier(t, dist, newMockConfigProvider(time.Hour), 0, nowMs)
 
-		_, err := q.FetchMetricMetadata(user.InjectOrgID(t.Context(), "user-1"), []string{"a"})
+		_, err := q.FetchMetricMetadata(user.InjectOrgID(t.Context(), "user-1"), []string{"a"}, nil)
 		require.EqualError(t, err, "boom")
 	})
 }

--- a/pkg/querier/memory_tracking_queryable.go
+++ b/pkg/querier/memory_tracking_queryable.go
@@ -88,12 +88,12 @@ func (q *memoryTrackingQuerier) SearchLabelValues(ctx context.Context, name stri
 }
 
 // FetchMetricMetadata passes through to the inner querier's metadata fetcher.
-func (q *memoryTrackingQuerier) FetchMetricMetadata(ctx context.Context, names []string) (map[string]metadata.Metadata, error) {
+func (q *memoryTrackingQuerier) FetchMetricMetadata(ctx context.Context, names []string, matcherSets [][]*labels.Matcher) (map[string]metadata.Metadata, error) {
 	f, ok := q.inner.(querierapi.MetricMetadataFetcher)
 	if !ok {
 		return nil, fmt.Errorf("inner querier %T does not support metric metadata fetch", q.inner)
 	}
-	return f.FetchMetricMetadata(ctx, names)
+	return f.FetchMetricMetadata(ctx, names, matcherSets)
 }
 
 func (q *memoryTrackingQuerier) Close() error {

--- a/pkg/querier/multi_searcher.go
+++ b/pkg/querier/multi_searcher.go
@@ -42,7 +42,7 @@ func findMetadataFetcher(queriers []storage.Querier) querierapi.MetricMetadataFe
 
 // FetchMetricMetadata delegates to the per-source querier that can supply
 // metadata. It returns nil when no such source is available.
-func (mq *multiQuerier) FetchMetricMetadata(ctx context.Context, names []string) (map[string]metadata.Metadata, error) {
+func (mq *multiQuerier) FetchMetricMetadata(ctx context.Context, names []string, matcherSets [][]*labels.Matcher) (map[string]metadata.Metadata, error) {
 	// Metadata lives in the ingesters, keyed by metric name and independent of
 	// the query time range, so fetch it from the distributor querier directly
 	// rather than via getQueriers. getQueriers gates the ingester leaf on the
@@ -70,7 +70,7 @@ func (mq *multiQuerier) FetchMetricMetadata(ctx context.Context, names []string)
 		}
 	}
 
-	return fetcher.FetchMetricMetadata(ctx, names)
+	return fetcher.FetchMetricMetadata(ctx, names, matcherSets)
 }
 
 // mimirSearcher is the cross-source Searcher interface used at the querier

--- a/pkg/querier/multi_searcher_test.go
+++ b/pkg/querier/multi_searcher_test.go
@@ -66,7 +66,7 @@ func (m *mockSearchQuerier) SearchLabelValues(_ context.Context, _ string, _ *st
 	return storage.NewSearchResultSetFromSlice(m.valuesResults, nil)
 }
 
-func (m *mockSearchQuerier) FetchMetricMetadata(_ context.Context, names []string) (map[string]metadata.Metadata, error) {
+func (m *mockSearchQuerier) FetchMetricMetadata(_ context.Context, names []string, _ [][]*labels.Matcher) (map[string]metadata.Metadata, error) {
 	m.metadataFetchCall++
 	if m.metadataErr != nil {
 		return nil, m.metadataErr
@@ -338,7 +338,7 @@ func TestMultiQuerier_FetchMetricMetadata(t *testing.T) {
 		mq := buildSearchTestMultiQuerier(t, distQ, nil)
 		mq.blockStore = nonMetadataSearchQueryable{q: nonMetadataSearchQuerier{}}
 
-		got, err := mq.FetchMetricMetadata(ctx, []string{"a", "b"})
+		got, err := mq.FetchMetricMetadata(ctx, []string{"a", "b"}, nil)
 		require.NoError(t, err)
 		assert.Equal(t, map[string]metadata.Metadata{"a": {Type: model.MetricTypeCounter, Help: "help a", Unit: "s"}}, got)
 	})
@@ -347,7 +347,7 @@ func TestMultiQuerier_FetchMetricMetadata(t *testing.T) {
 		mq := buildSearchTestMultiQuerier(t, nil, nil)
 		mq.blockStore = nonMetadataSearchQueryable{q: nonMetadataSearchQuerier{}}
 
-		got, err := mq.FetchMetricMetadata(ctx, []string{"a"})
+		got, err := mq.FetchMetricMetadata(ctx, []string{"a"}, nil)
 		require.NoError(t, err)
 		assert.Nil(t, got)
 	})

--- a/pkg/querier/search_handler.go
+++ b/pkg/querier/search_handler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/grafana/dskit/tenant"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/metadata"
 	"github.com/prometheus/prometheus/storage"
 
 	querierapi "github.com/grafana/mimir/pkg/querier/api"
@@ -541,7 +542,8 @@ func SearchMetricNamesHandler(queryable storage.Queryable, querierCfg Config, _ 
 		// so a single batched fetch covers the fully-deduped result.
 		//
 		// This handler stays tenant federation agnostic, but if the queryable is
-		// tenant federation aware then the metadata will be fetched across tenants.
+		// tenant federation aware then the metadata will be fetched across the
+		// tenants the request's selectors scope to.
 		//
 		// Metadata enrichment is best-effort: a missing fetcher or a fetch error
 		// just leaves results un-enriched.
@@ -551,7 +553,14 @@ func SearchMetricNamesHandler(queryable storage.Queryable, querierCfg Config, _ 
 				// small batch_size requested via the API) can't turn into one all-ingester
 				// metadata fan-out per single/few results.
 				fetchBatchSize := max(req.batchSize, searchDefaultBatchSize)
-				rs = newMetadataEnrichingSearchResultSet(ctx, rs, fetcher.FetchMetricMetadata, fetchBatchSize, logger)
+				// Pass down the request's selectors so a tenant-federation aware
+				// fetcher scopes metadata to the union of tenants the selectors
+				// touched.
+				matcherSets := req.matchers
+				fetch := func(ctx context.Context, names []string) (map[string]metadata.Metadata, error) {
+					return fetcher.FetchMetricMetadata(ctx, names, matcherSets)
+				}
+				rs = newMetadataEnrichingSearchResultSet(ctx, rs, fetch, fetchBatchSize, logger)
 			}
 		}
 

--- a/pkg/querier/search_handler_test.go
+++ b/pkg/querier/search_handler_test.go
@@ -12,6 +12,7 @@ import (
 	"math"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -43,16 +44,18 @@ import (
 //
 // When metadata is non-nil the mock also satisfies querierapi.MetricMetadataFetcher, so
 // the metric-names handler can enrich results from it (mirroring the querier's
-// ingester metadata fan-out). metadataFetchCalls counts the fetches.
+// ingester metadata fan-out). fetchedNames and fetchedMatcherSets record the
+// names and selector sets passed on each fetch (one entry per call).
 type searchMockQuerier struct {
-	namesFn      func(params *streaminglabelvalues.Params, hints *storage.SearchHints, matchers ...*labels.Matcher) storage.SearchResultSet
-	valuesFn     func(name string, params *streaminglabelvalues.Params, hints *storage.SearchHints, matchers ...*labels.Matcher) storage.SearchResultSet
-	metadata     map[string]metadata.Metadata
-	fetchedNames [][]string
-	lastName     string
-	lastParams   *streaminglabelvalues.Params
-	lastHints    *storage.SearchHints
-	lastMatchers []*labels.Matcher
+	namesFn            func(params *streaminglabelvalues.Params, hints *storage.SearchHints, matchers ...*labels.Matcher) storage.SearchResultSet
+	valuesFn           func(name string, params *streaminglabelvalues.Params, hints *storage.SearchHints, matchers ...*labels.Matcher) storage.SearchResultSet
+	metadata           map[string]metadata.Metadata
+	fetchedNames       [][]string
+	fetchedMatcherSets [][][]*labels.Matcher
+	lastName           string
+	lastParams         *streaminglabelvalues.Params
+	lastHints          *storage.SearchHints
+	lastMatchers       []*labels.Matcher
 }
 
 func (s *searchMockQuerier) Select(_ context.Context, _ bool, _ *storage.SelectHints, _ ...*labels.Matcher) storage.SeriesSet {
@@ -90,8 +93,9 @@ func (s *searchMockQuerier) SearchLabelValues(_ context.Context, name string, pa
 // FetchMetricMetadata is only present (as far as the querierapi.MetricMetadataFetcher
 // type-assert is concerned) to let the handler enrich; it returns metadata for
 // the requested names found in the configured map.
-func (s *searchMockQuerier) FetchMetricMetadata(_ context.Context, names []string) (map[string]metadata.Metadata, error) {
+func (s *searchMockQuerier) FetchMetricMetadata(_ context.Context, names []string, matcherSets [][]*labels.Matcher) (map[string]metadata.Metadata, error) {
 	s.fetchedNames = append(s.fetchedNames, append([]string(nil), names...))
+	s.fetchedMatcherSets = append(s.fetchedMatcherSets, matcherSets)
 	out := make(map[string]metadata.Metadata, len(names))
 	for _, n := range names {
 		if md, ok := s.metadata[n]; ok {
@@ -1107,6 +1111,34 @@ func TestSearchMetricNamesHandler_MetadataEnrichesRecords(t *testing.T) {
 	assert.Equal(t, "cpu_usage_seconds", second["name"])
 	assert.Equal(t, "gauge", second["type"])
 	assert.Equal(t, "seconds", second["unit"])
+}
+
+func TestSearchMetricNamesHandler_MetadataFetchScopedByMatchers(t *testing.T) {
+	// The handler must thread the request's selector into the metadata fetch, so
+	// a tenant-federation-aware fetcher can scope metadata to the same tenants
+	// each selector's search touched (via a __tenant_id__ matcher).
+	mq := &searchMockQuerier{
+		valuesFn: func(_ string, _ *streaminglabelvalues.Params, _ *storage.SearchHints, _ ...*labels.Matcher) storage.SearchResultSet {
+			return storage.NewSearchResultSetFromSlice([]storage.SearchResult{sr("http_requests_total", 1.0)}, nil)
+		},
+		metadata: map[string]metadata.Metadata{
+			"http_requests_total": {Type: model.MetricTypeCounter},
+		},
+	}
+	h := SearchMetricNamesHandler(newSearchMockQueryable(mq), enabledSearchConfig(), nil, log.NewNopLogger())
+
+	target := "/api/v1/search/metric_names?include_metadata=true&" + url.Values{"match[]": {`{job="api"}`}}.Encode()
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newSearchHandlerRequest(t, target))
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	require.NotEmpty(t, mq.fetchedMatcherSets, "the handler must fetch metadata")
+	require.Len(t, mq.fetchedMatcherSets[0], 1, "the request's one selector set must be forwarded to the metadata fetch")
+	require.Len(t, mq.fetchedMatcherSets[0][0], 1, "the selector's single matcher must be forwarded")
+	got := mq.fetchedMatcherSets[0][0][0]
+	assert.Equal(t, labels.MatchEqual, got.Type)
+	assert.Equal(t, "job", got.Name)
+	assert.Equal(t, "api", got.Value)
 }
 
 func TestSearchMetricNamesHandler_MissingMetadataLeavesFieldsEmpty(t *testing.T) {

--- a/pkg/querier/tenantfederation/merge_queryable.go
+++ b/pkg/querier/tenantfederation/merge_queryable.go
@@ -128,7 +128,9 @@ func (q *tenantQuerier) FetchMetricMetadata(ctx context.Context, id string, name
 	if !ok {
 		return nil, errors.Errorf("upstream %T does not support metric metadata fetch", q.upstream)
 	}
-	return f.FetchMetricMetadata(user.InjectOrgID(ctx, id), names)
+	// The tenant is already selected (its org ID is injected below), so no
+	// selector sets are forwarded — scoping happened in the caller.
+	return f.FetchMetricMetadata(user.InjectOrgID(ctx, id), names, nil)
 }
 
 func (q *tenantQuerier) Close() error {
@@ -432,33 +434,52 @@ func (m *mergeQuerier) SearchLabelValues(ctx context.Context, name string, param
 	return storage.MergeSearchResultSets(sets, hints)
 }
 
-// FetchMetricMetadata fetches metric metadata across all involved federation
-// IDs and unions the per-tenant results by metric name. When a name exists in
-// several tenants, the first tenant wins, so the union is deterministic:
-// resolver.TenantIDs returns the IDs sorted (as the sibling search methods also
-// rely on). Per-tenant fetch errors are best-effort: they are logged and that
-// tenant is skipped, since metadata enrichment is optional.
-func (m *mergeQuerier) FetchMetricMetadata(ctx context.Context, names []string) (map[string]metadata.Metadata, error) {
+// FetchMetricMetadata fetches metric metadata across the federation IDs the
+// request's selectors scope to and unions the per-tenant results by metric
+// name. When a name exists in several tenants, the first tenant wins, so the
+// union is deterministic: jobs is sorted below. Per-tenant fetch errors are
+// best-effort: they are logged and that tenant is skipped, since metadata
+// enrichment is optional.
+//
+// Only the tenant dimension of the selectors is honoured. metadataTenantJobs
+// unions the __tenant_id__ scope of each OR-ed selector set, so metadata is
+// fetched from exactly the tenants the search touched (e.g. a search scoped to
+// t2 OR t3 never enriches from an excluded tenant). A selector without a
+// tenant matcher matches every tenant, so it widens the fetch to all of them.
+//
+// Any other matcher (e.g. env="dev") cannot filter metadata: the ingester
+// stores it keyed by (tenant, metric name) with no series labels attached (see
+// userMetricsMetadata), so it has no way to tell the env="dev" gauge "foo" from
+// the env="prod" counter "foo" — both are just records under "foo". When a name
+// carries several such records the fetch is best-effort and returns an
+// arbitrary one. This is a property of the metadata store, not federation: the
+// same limitation applies to a single tenant.
+func (m *mergeQuerier) FetchMetricMetadata(ctx context.Context, names []string, matcherSets [][]*labels.Matcher) (map[string]metadata.Metadata, error) {
 	ids, err := m.resolver.TenantIDs(ctx)
 	if err != nil {
 		return nil, err
 	}
-	if len(ids) == 1 {
-		return m.upstream.FetchMetricMetadata(ctx, ids[0], names)
+
+	// metadataTenantJobs builds jobs from a map, so sort to keep the "first
+	// tenant by sorted ID wins" tie-break deterministic.
+	jobs := metadataTenantJobs(m.idLabelName, ids, matcherSets)
+	slices.Sort(jobs)
+	if len(jobs) == 1 {
+		return m.upstream.FetchMetricMetadata(ctx, jobs[0], names)
 	}
 
-	perTenant := make([]map[string]metadata.Metadata, len(ids))
-	errs := make([]error, len(ids))
+	perTenant := make([]map[string]metadata.Metadata, len(jobs))
+	errs := make([]error, len(jobs))
 	run := func(_ context.Context, idx int) error {
-		perTenant[idx], errs[idx] = m.upstream.FetchMetricMetadata(ctx, ids[idx], names)
+		perTenant[idx], errs[idx] = m.upstream.FetchMetricMetadata(ctx, jobs[idx], names)
 		return nil
 	}
-	if err := concurrency.ForEachJob(ctx, len(ids), m.maxConcurrency, run); err != nil {
+	if err := concurrency.ForEachJob(ctx, len(jobs), m.maxConcurrency, run); err != nil {
 		return nil, err
 	}
 
 	out := make(map[string]metadata.Metadata)
-	for i, id := range ids {
+	for i, id := range jobs {
 		if errs[i] != nil {
 			level.Warn(m.logger).Log("msg", "failed to fetch metric metadata for a tenant during federated search enrichment", "tenant", id, "err", errs[i])
 			continue
@@ -738,15 +759,7 @@ func (a *addLabelsSeries) Iterator(i chunkenc.Iterator) chunkenc.Iterator {
 // FilterValuesByMatchers which prunes the survivor set per matcher and
 // returns the unrelated matchers under the original label name.
 func tenantJobsForSearch(idLabelName string, ids []string, matchers []*labels.Matcher) (jobs []string, filteredMatchers []*labels.Matcher) {
-	retainedName := retainExistingPrefix + idLabelName
-	hasIDMatcher := false
-	for _, m := range matchers {
-		if m.Name == idLabelName || m.Name == retainedName {
-			hasIDMatcher = true
-			break
-		}
-	}
-	if !hasIDMatcher {
+	if !hasIDMatcher(idLabelName, matchers) {
 		return ids, matchers
 	}
 
@@ -756,4 +769,47 @@ func tenantJobsForSearch(idLabelName string, ids []string, matchers []*labels.Ma
 		jobs = append(jobs, id)
 	}
 	return jobs, fm
+}
+
+// hasIDMatcher reports whether any matcher targets the federation id label
+// (or its retain-prefix alias), i.e. whether the selector scopes the tenant
+// set. A selector without one matches every tenant.
+func hasIDMatcher(idLabelName string, matchers []*labels.Matcher) bool {
+	retainedName := retainExistingPrefix + idLabelName
+	for _, m := range matchers {
+		if m.Name == idLabelName || m.Name == retainedName {
+			return true
+		}
+	}
+	return false
+}
+
+// metadataTenantJobs returns the tenants a federated metadata fetch must cover:
+// the union, across the OR-ed selector sets, of the tenants each set scopes to.
+// A set without an id-label matcher matches every tenant, so if any set is
+// unscoped — or there are no sets at all — the result is all ids. Otherwise it
+// is the deduped union of each set's id-label-selected tenants, so a search
+// scoped to (t2 OR t3) enriches from exactly t2 and t3, never an excluded
+// tenant. The result is unsorted; callers that rely on the first-tenant-wins
+// tie-break must sort it.
+func metadataTenantJobs(idLabelName string, ids []string, matcherSets [][]*labels.Matcher) []string {
+	if len(matcherSets) == 0 {
+		return ids
+	}
+	seen := make(map[string]struct{}, len(ids))
+	jobs := make([]string, 0, len(ids))
+	for _, set := range matcherSets {
+		if !hasIDMatcher(idLabelName, set) {
+			// This selector can match any tenant, so the union is every tenant.
+			return ids
+		}
+		matchedIDs, _ := FilterValuesByMatchers(idLabelName, ids, set...)
+		for id := range matchedIDs {
+			if _, ok := seen[id]; !ok {
+				seen[id] = struct{}{}
+				jobs = append(jobs, id)
+			}
+		}
+	}
+	return jobs
 }

--- a/pkg/querier/tenantfederation/merge_queryable_test.go
+++ b/pkg/querier/tenantfederation/merge_queryable_test.go
@@ -1152,7 +1152,7 @@ func (q *searchableTenantQuerier) SearchLabelValues(ctx context.Context, name st
 	return storage.NewSearchResultSetFromSlice(q.src.resultsByTenant[tenantID], nil)
 }
 
-func (q *searchableTenantQuerier) FetchMetricMetadata(ctx context.Context, names []string) (map[string]metadata.Metadata, error) {
+func (q *searchableTenantQuerier) FetchMetricMetadata(ctx context.Context, names []string, _ [][]*labels.Matcher) (map[string]metadata.Metadata, error) {
 	tenantID, _ := tenant.TenantID(ctx)
 	tenantMD := q.src.metadataByTenant[tenantID]
 	out := make(map[string]metadata.Metadata, len(names))
@@ -1366,7 +1366,7 @@ func TestMergeQueryable_FetchMetricMetadata(t *testing.T) {
 		require.True(t, ok, "mergeQuerier must satisfy the metadata fetcher interface")
 
 		ctx := user.InjectOrgID(t.Context(), "t1|t2")
-		got, err := f.FetchMetricMetadata(ctx, []string{"shared", "only_t2"})
+		got, err := f.FetchMetricMetadata(ctx, []string{"shared", "only_t2"}, nil)
 		require.NoError(t, err)
 		assert.Equal(t, map[string]metadata.Metadata{
 			"shared":  {Type: model.MetricTypeCounter, Help: "from t1"},
@@ -1388,10 +1388,200 @@ func TestMergeQueryable_FetchMetricMetadata(t *testing.T) {
 		f := querier.(querierapi.MetricMetadataFetcher)
 
 		ctx := user.InjectOrgID(t.Context(), "only")
-		got, err := f.FetchMetricMetadata(ctx, []string{"a", "missing"})
+		got, err := f.FetchMetricMetadata(ctx, []string{"a", "missing"}, nil)
 		require.NoError(t, err)
 		assert.Equal(t, map[string]metadata.Metadata{"a": {Type: model.MetricTypeCounter, Help: "h"}}, got)
 	})
+}
+
+// TestMergeQueryable_FetchMetricMetadata_HonorsTenantScope validates a specific
+// multi tenant federated query edge case.
+//
+// The metric metadata map is indexed per tenant. It is possible that for a given metric name
+// there are different metadata records between tenants.
+//
+// In this unit test, tenants t1, t2 and t3 each have a metric called `shared`.
+// t1 has submitted it as a counter whereas t2 and t3 have submitted it as a gauge
+// (with distinct help strings so they can be told apart). t4 does not own `shared`.
+//
+// It is technically possible for a federated search (t1|t2|t3|t4) to be issued with a matcher
+// limiting the results to a specific tenant (__tenant_id__="t2"), to exclude a tenant
+// (__tenant_id__!="t1"), or to the union of several tenants via repeated match[] selectors.
+//
+// Without specific handling of this we would return the first federated tenant's metadata record.
+//
+// It should be noted that no other selectors will have any effect here. If we have a metric name
+// from a conflicting series foo{env="prod"} gauge, foo{env="dev"} counter this will not be
+// filterable since the ingester storing the metadata stores the metadata keyed only under the metric name.
+//
+// It is only via tenant federation that we can differentiate between multiple metadata records keyed
+// under the same name.
+func TestMergeQueryable_FetchMetricMetadata_HonorsTenantScope(t *testing.T) {
+	t1Metadata := metadata.Metadata{Type: model.MetricTypeCounter, Help: "from t1"}
+	t2Metadata := metadata.Metadata{Type: model.MetricTypeGauge, Help: "from t2"}
+	t3Metadata := metadata.Metadata{Type: model.MetricTypeGauge, Help: "from t3"}
+
+	src := &searchableTenantQueryable{
+		metadataByTenant: map[string]map[string]metadata.Metadata{
+			"t1": {"shared": t1Metadata},
+			"t2": {"shared": t2Metadata},
+			"t3": {"shared": t3Metadata},
+			"t4": {"only_t4": {Type: model.MetricTypeGauge, Help: "t4 only"}},
+		},
+	}
+	q := NewQueryable(src, false, defaultConcurrency, prometheus.NewRegistry(), log.NewNopLogger())
+
+	querier, err := q.Querier(0, 1000)
+	require.NoError(t, err)
+	defer querier.Close()
+	f, ok := querier.(querierapi.MetricMetadataFetcher)
+	require.True(t, ok, "mergeQuerier must satisfy the metadata fetcher interface")
+
+	ctx := user.InjectOrgID(t.Context(), "t1|t2|t3|t4")
+
+	eq := func(val string) *labels.Matcher {
+		return labels.MustNewMatcher(labels.MatchEqual, defaultTenantLabel, val)
+	}
+	neq := func(val string) *labels.Matcher {
+		return labels.MustNewMatcher(labels.MatchNotEqual, defaultTenantLabel, val)
+	}
+
+	tc := map[string]struct {
+		matcher  [][]*labels.Matcher
+		expected *metadata.Metadata
+	}{
+		"no tenant selector - first ordered tenant record is used": {
+			matcher:  nil,
+			expected: &t1Metadata,
+		},
+		"t1 tenant selector": {
+			matcher:  [][]*labels.Matcher{{eq("t1")}},
+			expected: &t1Metadata,
+		},
+		"t2 tenant selector": {
+			matcher:  [][]*labels.Matcher{{eq("t2")}},
+			expected: &t2Metadata,
+		},
+		// t1 sorts first and also owns "shared", but scoping to t3 must return t3's record.
+		"t3 tenant selector": {
+			matcher:  [][]*labels.Matcher{{eq("t3")}},
+			expected: &t3Metadata,
+		},
+		// t4 does not own "shared", so a t4-scoped fetch returns nothing.
+		"t4 tenant selector - tenant lacks the metric": {
+			matcher:  [][]*labels.Matcher{{eq("t4")}},
+			expected: nil,
+		},
+		"unknown tenant selector - no tenant metadata": {
+			matcher:  [][]*labels.Matcher{{eq("t9")}},
+			expected: nil,
+		},
+		// Excluding t1 leaves the union {t2, t3, t4}; t2 sorts first among the owners of "shared".
+		"exclude t1 tenant selector": {
+			matcher:  [][]*labels.Matcher{{neq("t1")}},
+			expected: &t2Metadata,
+		},
+		// Both exclusions must live in ONE selector (AND within a set) to exclude
+		// t1 and t2. As two separate match[] selectors they would be OR-ed, and
+		// the union {t2,t3,t4} ∪ {t1,t3,t4} is every tenant — the exclusions cancel.
+		"exclude t1 and t2 in one selector": {
+			matcher:  [][]*labels.Matcher{{neq("t1"), neq("t2")}},
+			expected: &t3Metadata,
+		},
+		// The union (t4 OR t3) must cover both tenants: t4 has no "shared" record, so it falls
+		// through to t3's, and the excluded t1 (which sorts first and owns "shared") must never win.
+		"union of tenant selectors falls through to the covering tenant": {
+			matcher:  [][]*labels.Matcher{{eq("t4")}, {eq("t3")}},
+			expected: &t3Metadata,
+		},
+	}
+
+	for name, test := range tc {
+		t.Run(name, func(t *testing.T) {
+			got, err := f.FetchMetricMetadata(ctx, []string{"shared"}, test.matcher)
+			require.NoError(t, err)
+			md, ok := got["shared"]
+			if test.expected != nil {
+				require.True(t, ok)
+				require.Equal(t, *test.expected, md)
+			} else {
+				require.False(t, ok)
+			}
+		})
+	}
+}
+
+// TestMetadataTenantJobs pins the tenant-scoping logic that backs the federated
+// metadata fetch: which tenants a fetch must cover given the request's OR-ed
+// selector sets. The returned slice is the fan-out job list (one upstream fetch
+// per entry), so asserting it also pins that there is no redundant per-selector
+// fetch.
+func TestMetadataTenantJobs(t *testing.T) {
+	ids := []string{"t1", "t2", "t3"}
+	eq := func(name, val string) *labels.Matcher { return labels.MustNewMatcher(labels.MatchEqual, name, val) }
+
+	tests := []struct {
+		name        string
+		matcherSets [][]*labels.Matcher
+		want        []string
+	}{
+		{
+			name:        "no selector sets fetches all tenants",
+			matcherSets: nil,
+			want:        []string{"t1", "t2", "t3"},
+		},
+		{
+			name:        "a single set without a tenant matcher fetches all tenants",
+			matcherSets: [][]*labels.Matcher{{eq("job", "a")}},
+			want:        []string{"t1", "t2", "t3"},
+		},
+		{
+			name:        "a single set scoped to one tenant fetches only that tenant",
+			matcherSets: [][]*labels.Matcher{{eq(defaultTenantLabel, "t2"), eq("foo", "x")}},
+			want:        []string{"t2"},
+		},
+		{
+			name: "two sets scoped to the same tenant dedupe to a single fetch",
+			matcherSets: [][]*labels.Matcher{
+				{eq(defaultTenantLabel, "t2"), eq("foo", "x")},
+				{eq(defaultTenantLabel, "t2"), eq("bar", "y")},
+			},
+			want: []string{"t2"},
+		},
+		{
+			name: "two sets scoped to distinct tenants union them",
+			matcherSets: [][]*labels.Matcher{
+				{eq(defaultTenantLabel, "t2")},
+				{eq(defaultTenantLabel, "t3")},
+			},
+			want: []string{"t2", "t3"},
+		},
+		{
+			name: "multiple sets, none with a tenant matcher, widen to all tenants",
+			matcherSets: [][]*labels.Matcher{
+				{eq("job", "a")},
+				{eq("job", "b")},
+			},
+			want: []string{"t1", "t2", "t3"},
+		},
+		{
+			name: "one unscoped set widens the union to all tenants even alongside a scoped set",
+			matcherSets: [][]*labels.Matcher{
+				{eq(defaultTenantLabel, "t2")},
+				{eq("job", "b")},
+			},
+			want: []string{"t1", "t2", "t3"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := metadataTenantJobs(defaultTenantLabel, ids, tc.matcherSets)
+			// The caller sorts before its first-tenant-wins union; mirror that so
+			// the map-derived order in the scoped paths is deterministic here.
+			slices.Sort(got)
+			assert.Equal(t, tc.want, got)
+		})
+	}
 }
 
 // TestMergeQueryable_SearchLabelValues_SingleTenantBypass pins the bypass

--- a/pkg/storage/lazyquery/lazyquery.go
+++ b/pkg/storage/lazyquery/lazyquery.go
@@ -122,12 +122,12 @@ func (l LazyQuerier) SearchLabelValues(ctx context.Context, name string, params 
 
 // FetchMetricMetadata passes through to the wrapped querier when it can fetch
 // metric metadata; otherwise surfaces a clear error.
-func (l LazyQuerier) FetchMetricMetadata(ctx context.Context, names []string) (map[string]metadata.Metadata, error) {
+func (l LazyQuerier) FetchMetricMetadata(ctx context.Context, names []string, matcherSets [][]*labels.Matcher) (map[string]metadata.Metadata, error) {
 	f, ok := l.next.(querierapi.MetricMetadataFetcher)
 	if !ok {
 		return nil, fmt.Errorf("wrapped querier %T does not support metric metadata fetch", l.next)
 	}
-	return f.FetchMetricMetadata(ctx, names)
+	return f.FetchMetricMetadata(ctx, names, matcherSets)
 }
 
 // Close implements Storage.Querier


### PR DESCRIPTION
#### What this PR does

This PR is a follow up to #16062.

In the streaming search metric names API we allow for metadata to be decorated into the metric name results.

In a federated query, each set of metric metadata is maintained per tenant. A request for metric metadata will return the metadata from the first tenant's metadata map who has an entry for this metric. 

There is an edge case where by the API allows for optional matchers to be included with the search. If the matcher was to restrict on the `__tenant_id__` label it is possible to control which tenant's metadata is used.

For instance, consider a scenario with 2 tenants (t1, t2). Each has a metadata entry for a metric called `foo`. t1 has this metric as a counter, whereas t2 has this metric has a gauge. 

If a federated search request comes in without any additional matchers, the t1 metadata entry will be selected for `foo`. 

But if a matcher is included specifically requesting `__tenant_id__="t2"` we should ensure that the t2 metadata entry is returned. 

This PR adds the handling of passing down the matchers into the fetching of metadata records and ensures that if a federated label is presented in a selector that this is honored in the metadata lookup.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
