### PR TITLE
MQE: enable CSE deduplication of split range vector functions with SSE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 * [ENHANCEMENT] MQE: Simplify `unless` and `or` operations where one side can be proven to be empty by inspecting the expression. #15198
 * [ENHANCEMENT] Store-gateway: Remove outdated limit on caching LabelValues responses that contain more than 655360 values. The gob library panic which required workaround was fixed. #5021 #15271
 * [ENHANCEMENT] MQE: Reduce memory consumption of range vector splitting when many consecutive intervals are not cached. #15173
+* [ENHANCEMENT] MQE: Allow common subexpression elimination to deduplicate range vector splitting nodes when subset selector elimination has merged the selectors. #16199
 * [ENHANCEMENT] MQE: Reduce the number of requests to the intermediate result cache of range vector splitting by using the batch API. #16024
 * [ENHANCEMENT] Querier: track physical and equivalent samples read for remote read requests in query statistics, mirroring the statistics emitted for instant and range queries. #15694
 * [ENHANCEMENT] Ingest storage: Add `cortex_ingest_storage_writer_serialize_duration_seconds` native histogram metric tracking the time spent serializing an incoming request to Kafka records. #15527

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@
 * [ENHANCEMENT] MQE: Simplify `unless` and `or` operations where one side can be proven to be empty by inspecting the expression. #15198
 * [ENHANCEMENT] Store-gateway: Remove outdated limit on caching LabelValues responses that contain more than 655360 values. The gob library panic which required workaround was fixed. #5021 #15271
 * [ENHANCEMENT] MQE: Reduce memory consumption of range vector splitting when many consecutive intervals are not cached. #15173
-* [ENHANCEMENT] MQE: Allow common subexpression elimination to deduplicate range vector splitting nodes when subset selector elimination has merged the selectors. #16199
+* [ENHANCEMENT] MQE: Allow common subexpression elimination to deduplicate range vector splitting nodes when subset selector elimination has merged the selectors. #16215
 * [ENHANCEMENT] MQE: Reduce the number of requests to the intermediate result cache of range vector splitting by using the batch API. #16024
 * [ENHANCEMENT] Querier: track physical and equivalent samples read for remote read requests in query statistics, mirroring the statistics emitted for instant and range queries. #15694
 * [ENHANCEMENT] Ingest storage: Add `cortex_ingest_storage_writer_serialize_duration_seconds` native histogram metric tracking the time spent serializing an incoming request to Kafka records. #15527

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/optimization_pass.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/optimization_pass.go
@@ -609,11 +609,7 @@ func (e *OptimizationPass) findCommonSubexpressionLength(group SharedSelectorGro
 		firstSelector, _ := firstPath.NodeAtOffsetFromLeaf(0)
 
 		if group.hasSubsetSelectors() {
-			// The call below is safe to do without a bounds check: we explicitly exclude the root node above,
-			// so we'll always be able to get the parent of the current node.
-			parent, _ := firstPath.NodeAtOffsetFromLeaf(length + 1)
-
-			if safe, err := IsSafeToApplyFilteringAfter(firstNode, parent, group, delayedNameRemovalEnabled); err != nil {
+			if safe, err := IsSafeToApplyFilteringAfter(firstNode, group, delayedNameRemovalEnabled); err != nil {
 				return -1, err
 			} else if !safe {
 				return length, nil
@@ -649,19 +645,19 @@ func (e *OptimizationPass) findCommonSubexpressionLength(group SharedSelectorGro
 	return length, nil
 }
 
-func IsSafeToApplyFilteringAfter(node planning.Node, parent planning.Node, group SharedSelectorGroup, delayedNameRemovalEnabled bool) (bool, error) {
+func IsSafeToApplyFilteringAfter(node planning.Node, group SharedSelectorGroup, delayedNameRemovalEnabled bool) (bool, error) {
 	switch node := node.(type) {
 	case *core.Subquery:
 		// Subqueries return the inner series' labels as-is, so it's always safe to apply filtering afterwards.
 		return true, nil
 
 	case *core.FunctionCall:
-		if _, ok := parent.(*rangevectorsplitting.SplitFunctionCall); ok {
-			// SplitFunctionCall must have the FunctionCall node as its child, so filtering must occur beneath the function call.
-			return false, nil
-		}
-
 		return IsSafeToApplyFilteringAfterFunction(node, group, delayedNameRemovalEnabled)
+
+	case *rangevectorsplitting.SplitFunctionCall:
+		// SplitFunctionCall produces the same series as its inner FunctionCall, so filtering after it is safe
+		// when filtering after that FunctionCall is.
+		return IsSafeToApplyFilteringAfterFunction(node.Inner, group, delayedNameRemovalEnabled)
 
 	case *core.UnaryExpression:
 		if delayedNameRemovalEnabled {

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/optimization_pass_test.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/optimization_pass_test.go
@@ -22,6 +22,7 @@ import (
 	_ "github.com/grafana/mimir/pkg/streamingpromql/optimize/ast/sharding" // Imported for side effects: registering the __sharded_concat__ function with the parser.
 	"github.com/grafana/mimir/pkg/streamingpromql/optimize/plan"
 	"github.com/grafana/mimir/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination"
+	"github.com/grafana/mimir/pkg/streamingpromql/optimize/plan/rangevectorsplitting"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning/core"
 	"github.com/grafana/mimir/pkg/streamingpromql/testutils"
@@ -2357,6 +2358,31 @@ func TestIsSafeToApplyFilteringAfter(t *testing.T) {
 			expectedSafeWithDelayedNameRemovalEnabled:  true,
 		},
 
+		"split function call with filter on other label": {
+			node: &rangevectorsplitting.SplitFunctionCall{
+				Inner: &core.FunctionCall{
+					FunctionCallDetails: &core.FunctionCallDetails{
+						Function: functions.FUNCTION_RATE,
+					},
+				},
+			},
+			group: groupWithFilterOnEnvLabel,
+			expectedSafeWithDelayedNameRemovalDisabled: true,
+			expectedSafeWithDelayedNameRemovalEnabled:  true,
+		},
+		"split function call with filter on __name__": {
+			node: &rangevectorsplitting.SplitFunctionCall{
+				Inner: &core.FunctionCall{
+					FunctionCallDetails: &core.FunctionCallDetails{
+						Function: functions.FUNCTION_RATE,
+					},
+				},
+			},
+			group: groupWithFilterOnMetricName,
+			expectedSafeWithDelayedNameRemovalDisabled: false,
+			expectedSafeWithDelayedNameRemovalEnabled:  true,
+		},
+
 		"node with no special handling in IsSafeToApplyFilteringAfter": {
 			node:  &core.NumberLiteral{},
 			group: groupWithNoFilters,
@@ -2367,11 +2393,11 @@ func TestIsSafeToApplyFilteringAfter(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			safe, err := commonsubexpressionelimination.IsSafeToApplyFilteringAfter(testCase.node, nil, testCase.group, false)
+			safe, err := commonsubexpressionelimination.IsSafeToApplyFilteringAfter(testCase.node, testCase.group, false)
 			require.NoError(t, err)
 			require.Equal(t, testCase.expectedSafeWithDelayedNameRemovalDisabled, safe)
 
-			safe, err = commonsubexpressionelimination.IsSafeToApplyFilteringAfter(testCase.node, nil, testCase.group, true)
+			safe, err = commonsubexpressionelimination.IsSafeToApplyFilteringAfter(testCase.node, testCase.group, true)
 			require.NoError(t, err)
 			require.Equal(t, testCase.expectedSafeWithDelayedNameRemovalEnabled, safe)
 		})

--- a/pkg/streamingpromql/optimize/plan/rangevectorsplitting/range_vector_splitting_test.go
+++ b/pkg/streamingpromql/optimize/plan/rangevectorsplitting/range_vector_splitting_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/grafana/mimir/pkg/streamingpromql"
 	"github.com/grafana/mimir/pkg/streamingpromql/caching"
 	"github.com/grafana/mimir/pkg/streamingpromql/operators/functions"
-	"github.com/grafana/mimir/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination"
 	"github.com/grafana/mimir/pkg/streamingpromql/optimize/plan/rangevectorsplitting"
 	"github.com/grafana/mimir/pkg/streamingpromql/optimize/plan/rangevectorsplitting/cache"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning"
@@ -518,6 +517,46 @@ func TestQuerySplitting_WithCSE(t *testing.T) {
 	}, trackingStorage.ranges)
 }
 
+// TestQuerySplitting_DuplicateAboveSplitFunctionCall verifies that a shared, split range vector function has its
+// Duplicate injected above the SplitFunctionCall.
+func TestQuerySplitting_DuplicateAboveSplitFunctionCall(t *testing.T) {
+	planner, err := streamingpromql.NewQueryPlanner(defaultSplittingOpts(), streamingpromql.NewMaximumSupportedVersionQueryPlanVersionProvider())
+	require.NoError(t, err)
+
+	buildPlan := func(t *testing.T, expr string) *planning.QueryPlan {
+		t.Helper()
+		p, err := planner.NewQueryPlan(context.Background(), expr, types.NewInstantQueryTimeRange(timestamp.Time(0).Add(6*time.Hour)),
+			streamingpromql.DefaultLookbackDelta, false, &streamingpromql.NoopPlanningObserver{})
+		require.NoError(t, err)
+		return p
+	}
+
+	t.Run("subset selector elimination", func(t *testing.T) {
+		p := buildPlan(t, `rate(foo{a="1"}[3h]) / rate(foo[3h])`)
+		require.Equal(t, testutils.TrimIndent(`
+			- BinaryExpression: LHS / RHS, hints exclude ()
+				- LHS: DuplicateFilter: {a="1"}, subset index: 0
+					- ref#1 Duplicate
+						- SplitFunctionCall
+							- FunctionCall: rate(...)
+								- MatrixSelector: {__name__="foo"}[3h0m0s], subsets: {a="1"}
+				- RHS: ref#1 Duplicate ...
+		`), p.String())
+	})
+
+	t.Run("identical subexpression", func(t *testing.T) {
+		p := buildPlan(t, `rate(foo[3h]) + rate(foo[3h])`)
+		require.Equal(t, testutils.TrimIndent(`
+			- BinaryExpression: LHS + RHS, hints exclude ()
+				- LHS: ref#1 Duplicate
+					- SplitFunctionCall
+						- FunctionCall: rate(...)
+							- MatrixSelector: {__name__="foo"}[3h0m0s]
+				- RHS: ref#1 Duplicate ...
+		`), p.String())
+	})
+}
+
 func TestQuerySplitting_WithSSE(t *testing.T) {
 	baseT := timestamp.Time(0)
 	ts := baseT.Add(4 * time.Hour)
@@ -547,8 +586,10 @@ func TestQuerySplitting_WithSSE(t *testing.T) {
 	verifyEvaluationStats(t, stats, 24, 24)
 
 	// With a 4h range at ts=4h and 2h split interval, the single cacheable block is (2h-1ms, 4h-1ms].
-	// After SSE: histogram_fraction's inner is DuplicateFilter -> Duplicate -> broad MatrixSelector;
-	// histogram_count's inner is Duplicate -> broad MatrixSelector.
+	// After SSE, both branches share a single SplitFunctionCall through a Duplicate node:
+	// histogram_fraction's inner is DuplicateFilter -> Duplicate -> SplitFunctionCall -> last_over_time -> broad MatrixSelector;
+	// histogram_count's inner is Duplicate consumer of the same SplitFunctionCall.
+	// The shared split node's inner is the broad MatrixSelector, so there is a single cache entry.
 	broadSelector := &core.MatrixSelector{MatrixSelectorDetails: &core.MatrixSelectorDetails{
 		Matchers: []*core.LabelMatcher{
 			{Name: "__name__", Type: labels.MatchEqual, Value: "hist"},
@@ -560,44 +601,22 @@ func TestQuerySplitting_WithSSE(t *testing.T) {
 			{Matchers: []*core.LabelMatcher{{Name: "code", Type: labels.MatchNotEqual, Value: "err"}}},
 		},
 	}}
-	fractionSplit := &commonsubexpressionelimination.DuplicateFilter{
-		DuplicateFilterDetails: &commonsubexpressionelimination.DuplicateFilterDetails{
-			Filters:     []*core.LabelMatcher{{Name: "code", Type: labels.MatchNotEqual, Value: "err"}},
-			SubsetIndex: 0,
-		},
-		Inner: &commonsubexpressionelimination.Duplicate{
-			DuplicateDetails: &commonsubexpressionelimination.DuplicateDetails{},
-			Inner:            broadSelector,
-		},
-	}
-	countSplit := &commonsubexpressionelimination.Duplicate{
-		DuplicateDetails: &commonsubexpressionelimination.DuplicateDetails{},
-		Inner:            broadSelector,
-	}
 	params := &planning.QueryParameters{LookbackDelta: streamingpromql.DefaultLookbackDelta}
 
-	require.Len(t, backend.Entries, 2)
+	require.Len(t, backend.Entries, 1)
 
 	expectedH := mimirpb.FromFloatHistogramToHistogramProto(0, h)
 	expectedIntermediate := rangevectorsplitting.FirstLastOverTimeIntermediate{H: &expectedH}
 
 	cacheKeyGenerator := createEmptyPrefixCacheKeyGenerator()
-	// Both keys must contain the full histogram (skip=false fetches buckets).
-	countKey, err := cache.TestGenerateHashedCacheKey(t.Context(), cacheKeyGenerator, functions.FUNCTION_LAST_OVER_TIME, splittingCacheKey(t, countSplit, params), 2*hourInMs-1, 4*hourInMs-1)
+	// The key must contain the full histogram (skip=false fetches buckets).
+	sharedKey, err := cache.TestGenerateHashedCacheKey(t.Context(), cacheKeyGenerator, functions.FUNCTION_LAST_OVER_TIME, splittingCacheKey(t, broadSelector, params), 2*hourInMs-1, 4*hourInMs-1)
 	require.NoError(t, err)
-	var countEntry cache.CachedSeries
-	require.NoError(t, countEntry.Unmarshal(backend.Entries[countKey].Value))
-	var countList rangevectorsplitting.FirstLastOverTimeIntermediateList
-	require.NoError(t, countList.Unmarshal(countEntry.Results))
-	require.Equal(t, []rangevectorsplitting.FirstLastOverTimeIntermediate{expectedIntermediate}, countList.Results)
-
-	fractionKey, err := cache.TestGenerateHashedCacheKey(t.Context(), cacheKeyGenerator, functions.FUNCTION_LAST_OVER_TIME, splittingCacheKey(t, fractionSplit, params), 2*hourInMs-1, 4*hourInMs-1)
-	require.NoError(t, err)
-	var fractionEntry cache.CachedSeries
-	require.NoError(t, fractionEntry.Unmarshal(backend.Entries[fractionKey].Value))
-	var fractionList rangevectorsplitting.FirstLastOverTimeIntermediateList
-	require.NoError(t, fractionList.Unmarshal(fractionEntry.Results))
-	require.Equal(t, []rangevectorsplitting.FirstLastOverTimeIntermediate{expectedIntermediate}, fractionList.Results)
+	var sharedEntry cache.CachedSeries
+	require.NoError(t, sharedEntry.Unmarshal(backend.Entries[sharedKey].Value))
+	var sharedList rangevectorsplitting.FirstLastOverTimeIntermediateList
+	require.NoError(t, sharedList.Unmarshal(sharedEntry.Results))
+	require.Equal(t, []rangevectorsplitting.FirstLastOverTimeIntermediate{expectedIntermediate}, sharedList.Results)
 }
 
 func TestQuerySplitting_SkipHistogramBucketsNotApplied(t *testing.T) {
@@ -676,6 +695,8 @@ func TestQuerySplitting_CacheKeyReflectsPostOptimizationState(t *testing.T) {
 
 	// With SSE: the narrow MatrixSelector is rewritten into DuplicateFilter -> Duplicate -> broad MatrixSelector,
 	// and the broad MatrixSelector picks up the narrow side's region="us" as a subset.
+	// Because Duplicate is injected above the shared SplitFunctionCall, both branches share a single split node whose inner is the broad
+	// MatrixSelector, so there is one cache entry keyed by that broad (subset-aware) selector.
 	withSSE := defaultSplittingOpts()
 	withSSE.EnableSubsetSelectorElimination = true
 	backendSSE, engineSSE := setupEngineAndCacheWithOpts(t, withSSE)
@@ -694,30 +715,12 @@ func TestQuerySplitting_CacheKeyReflectsPostOptimizationState(t *testing.T) {
 			{Matchers: []*core.LabelMatcher{{Name: "region", Type: labels.MatchEqual, Value: "us"}}},
 		},
 	}}
-	narrowSSE := &commonsubexpressionelimination.DuplicateFilter{
-		DuplicateFilterDetails: &commonsubexpressionelimination.DuplicateFilterDetails{
-			Filters:     []*core.LabelMatcher{{Name: "region", Type: labels.MatchEqual, Value: "us"}},
-			SubsetIndex: 0,
-		},
-		Inner: &commonsubexpressionelimination.Duplicate{
-			DuplicateDetails: &commonsubexpressionelimination.DuplicateDetails{},
-			Inner:            broadSSE,
-		},
-	}
-	broadSplitSSE := &commonsubexpressionelimination.Duplicate{
-		DuplicateDetails: &commonsubexpressionelimination.DuplicateDetails{},
-		Inner:            broadSSE,
-	}
 
 	cacheKeyGenerator = createEmptyPrefixCacheKeyGenerator()
-	narrowKeySSE, err := cache.TestGenerateHashedCacheKey(t.Context(), cacheKeyGenerator, functions.FUNCTION_SUM_OVER_TIME, splittingCacheKey(t, narrowSSE, params), blockStart, blockEnd)
+	sharedKeySSE, err := cache.TestGenerateHashedCacheKey(t.Context(), cacheKeyGenerator, functions.FUNCTION_SUM_OVER_TIME, splittingCacheKey(t, broadSSE, params), blockStart, blockEnd)
 	require.NoError(t, err)
-	broadKeySSE, err := cache.TestGenerateHashedCacheKey(t.Context(), cacheKeyGenerator, functions.FUNCTION_SUM_OVER_TIME, splittingCacheKey(t, broadSplitSSE, params), blockStart, blockEnd)
-	require.NoError(t, err)
-	require.Contains(t, backendSSE.Entries, narrowKeySSE, "expected duplicate_filter cache key for narrow selector when SSE is on")
-	require.Contains(t, backendSSE.Entries, broadKeySSE, "expected subset-aware cache key for broad selector when SSE is on")
-	require.NotContains(t, backendNoSSE.Entries, narrowKeySSE, "narrow SSE cache key must not exist in no-SSE backend (key reflects post-optimization plan)")
-	require.NotContains(t, backendNoSSE.Entries, broadKeySSE, "broad SSE cache key must not exist in no-SSE backend (key reflects post-optimization plan)")
+	require.Contains(t, backendSSE.Entries, sharedKeySSE, "expected subset-aware cache key for the shared split node when SSE is on")
+	require.NotContains(t, backendNoSSE.Entries, sharedKeySSE, "SSE cache key must not exist in no-SSE backend (key reflects post-optimization plan)")
 }
 
 func TestQuerySplitting_ProjectionNotApplied(t *testing.T) {


### PR DESCRIPTION
#### What this PR does

Previously, enabling range vector splitting alongside subset selector elimination stopped common subexpression elimination from sharing a range vector node. CSE now recognises `SplitFunctionCall` as safe to filter after whenever its inner function is. The shared subexpression can reach above the split node and `Duplicate` node lands there and both branches end up sharing a single split node.

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
