### PR TITLE
MQE: rename range vector splitting cache metrics

### DIFF
--- a/pkg/streamingpromql/optimize/plan/rangevectorsplitting/cache/cache.go
+++ b/pkg/streamingpromql/optimize/plan/rangevectorsplitting/cache/cache.go
@@ -53,7 +53,7 @@ func newCacheMetrics(reg prometheus.Registerer) *cacheMetrics {
 }
 
 func NewCacheFactory(cfg Config, ttlProvider TTLProvider, prefixGenerator caching.PrefixGenerator, logger log.Logger, reg prometheus.Registerer) (*CacheFactory, error) {
-	client, err := cache.CreateClient("intermediate-result-cache", cfg.BackendConfig, logger, prometheus.WrapRegistererWithPrefix("mimir_", reg))
+	client, err := cache.CreateClient("intermediate-result-cache", cfg.BackendConfig, logger, prometheus.WrapRegistererWithPrefix("thanos_", reg))
 	if err != nil {
 		return nil, err
 	} else if client == nil {


### PR DESCRIPTION
#### What this PR does

Use the `thanos_` prefix since that's what we use for other caches and what our alerting and dashboards are based on.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
