### PR TITLE
Fix `TestBlocksCleaner_RaceCondition...` flakiness

### DIFF
--- a/pkg/compactor/blocks_cleaner_test.go
+++ b/pkg/compactor/blocks_cleaner_test.go
@@ -1707,10 +1707,9 @@ func TestBlocksCleaner_RaceCondition_CleanerUpdatesBucketIndexWhileAnotherCleane
 			bucketClient, _ := mimir_testutil.PrepareFilesystemBucket(t)
 			bucketClient = block.BucketWithGlobalMarkers(bucketClient)
 
-			// The filesystem bucket fails concurrent uploads of the same object, unlike real
-			// object storages where the last writer wins. Serialize uploads to restore the
-			// real-world behavior: both cleaners are expected to upload the bucket index
-			// concurrently at the end of their cleanup run.
+			// Our filesystem bucket for testing fails concurrent uploads of the same object,
+			// unlike real object storages where the last writer wins. Serializing uploads
+			// avoids this error and allows us to test with concurrency.
 			bucketClient = &serializedUploadBucket{Bucket: bucketClient}
 
 			// Create two blocks and mark one of them for deletion at a time before the deletion delay.

--- a/pkg/compactor/blocks_cleaner_test.go
+++ b/pkg/compactor/blocks_cleaner_test.go
@@ -1707,6 +1707,12 @@ func TestBlocksCleaner_RaceCondition_CleanerUpdatesBucketIndexWhileAnotherCleane
 			bucketClient, _ := mimir_testutil.PrepareFilesystemBucket(t)
 			bucketClient = block.BucketWithGlobalMarkers(bucketClient)
 
+			// The filesystem bucket fails concurrent uploads of the same object, unlike real
+			// object storages where the last writer wins. Serialize uploads to restore the
+			// real-world behavior: both cleaners are expected to upload the bucket index
+			// concurrently at the end of their cleanup run.
+			bucketClient = &serializedUploadBucket{Bucket: bucketClient}
+
 			// Create two blocks and mark one of them for deletion at a time before the deletion delay.
 			block1 := createTSDBBlock(t, bucketClient, tenantID, 10, 20, 1, nil)
 			block2 := createTSDBBlock(t, bucketClient, tenantID, 20, 30, 1, nil)
@@ -1794,6 +1800,19 @@ func tsOffset(dt time.Time, hours int) int64 {
 
 func checkBlockDeletionMarker(t *testing.T, user string, cl objstore.Bucket, blockID ulid.ULID, deletionMarkerExists bool) {
 	checkBlock(t, user, cl, blockID, true, deletionMarkerExists)
+}
+
+type serializedUploadBucket struct {
+	objstore.Bucket
+
+	uploadMx sync.Mutex
+}
+
+func (b *serializedUploadBucket) Upload(ctx context.Context, name string, r io.Reader, opts ...objstore.ObjectUploadOption) error {
+	b.uploadMx.Lock()
+	defer b.uploadMx.Unlock()
+
+	return b.Bucket.Upload(ctx, name, r, opts...)
 }
 
 type hookBucket struct {

--- a/pkg/compactor/blocks_cleaner_test.go
+++ b/pkg/compactor/blocks_cleaner_test.go
@@ -1707,11 +1707,6 @@ func TestBlocksCleaner_RaceCondition_CleanerUpdatesBucketIndexWhileAnotherCleane
 			bucketClient, _ := mimir_testutil.PrepareFilesystemBucket(t)
 			bucketClient = block.BucketWithGlobalMarkers(bucketClient)
 
-			// Our filesystem bucket for testing fails concurrent uploads of the same object,
-			// unlike real object storages where the last writer wins. Serializing uploads
-			// avoids this error and allows us to test with concurrency.
-			bucketClient = &serializedUploadBucket{Bucket: bucketClient}
-
 			// Create two blocks and mark one of them for deletion at a time before the deletion delay.
 			block1 := createTSDBBlock(t, bucketClient, tenantID, 10, 20, 1, nil)
 			block2 := createTSDBBlock(t, bucketClient, tenantID, 20, 30, 1, nil)
@@ -1799,19 +1794,6 @@ func tsOffset(dt time.Time, hours int) int64 {
 
 func checkBlockDeletionMarker(t *testing.T, user string, cl objstore.Bucket, blockID ulid.ULID, deletionMarkerExists bool) {
 	checkBlock(t, user, cl, blockID, true, deletionMarkerExists)
-}
-
-type serializedUploadBucket struct {
-	objstore.Bucket
-
-	uploadMx sync.Mutex
-}
-
-func (b *serializedUploadBucket) Upload(ctx context.Context, name string, r io.Reader, opts ...objstore.ObjectUploadOption) error {
-	b.uploadMx.Lock()
-	defer b.uploadMx.Unlock()
-
-	return b.Bucket.Upload(ctx, name, r, opts...)
 }
 
 type hookBucket struct {

--- a/pkg/storage/tsdb/testutil/objstore.go
+++ b/pkg/storage/tsdb/testutil/objstore.go
@@ -6,6 +6,9 @@
 package testutil
 
 import (
+	"context"
+	"io"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -20,5 +23,22 @@ func PrepareFilesystemBucket(t testing.TB) (objstore.Bucket, string) {
 	bkt, err := filesystem.NewBucketClient(filesystem.Config{Directory: storageDir})
 	require.NoError(t, err)
 
-	return objstore.WrapWithMetrics(bkt, nil, "test"), storageDir
+	return objstore.WrapWithMetrics(&serializedUploadBucket{Bucket: bkt}, nil, "test"), storageDir
+}
+
+// serializedUploadBucket serializes Upload calls because the objstore filesystem provider
+// fails concurrent uploads of the same object, unlike real object storages where the last
+// writer wins. Serializing uploads avoids this error and allows us to test with concurrency.
+// This wrapper can be removed once/if the filesystem Bucket is fixed to allow for this.
+type serializedUploadBucket struct {
+	objstore.Bucket
+
+	uploadMx sync.Mutex
+}
+
+func (b *serializedUploadBucket) Upload(ctx context.Context, name string, r io.Reader, opts ...objstore.ObjectUploadOption) error {
+	b.uploadMx.Lock()
+	defer b.uploadMx.Unlock()
+
+	return b.Bucket.Upload(ctx, name, r, opts...)
 }


### PR DESCRIPTION

**What this PR does**

Fixes the flakiness of `TestBlocksCleaner_RaceCondition_CleanerUpdatesBucketIndexWhileAnotherCleanerDeletesBlocks`, which sometimes fails with `upload already in progress for user-1/bucket-index.json.gz, retry, creating swap file failed:  ...`

```
--- FAIL: TestBlocksCleaner_RaceCondition_CleanerUpdatesBucketIndexWhileAnotherCleanerDeletesBlocks (0.17s)
    --- FAIL: TestBlocksCleaner_RaceCondition_CleanerUpdatesBucketIndexWhileAnotherCleanerDeletesBlocks/the_2nd_cleaner_fetches_new_deletion_marks_after_the_1st_cleaner_has_started_deleting_blocks_for_the_new_deletion_marks (0.10s)
        blocks_cleaner_test.go:1730:
            	Error Trace:	/__w/mimir/mimir/pkg/compactor/blocks_cleaner_test.go:1730
            	            				/usr/local/go/src/runtime/asm_amd64.s:1771
            	Error:      	Received unexpected error:
            	            	upload already in progress for user-1/bucket-index.json.gz, retry, creating swap file failed: open /tmp/TestBlocksCleaner_RaceCondition_CleanerUpdatesBucketIndexWhileAn1005483577/001/user-1/bucket-index.json.gz.swap: file exists
            	            	upload bucket index
            	            	github.com/grafana/mimir/pkg/storage/tsdb/bucketindex.WriteIndex
            	            		/__w/mimir/mimir/pkg/storage/tsdb/bucketindex/storage.go:99
            	            	github.com/grafana/mimir/pkg/compactor.(*BlocksCleaner).cleanUser
            	            		/__w/mimir/mimir/pkg/compactor/blocks_cleaner.go:517
            	            	github.com/grafana/mimir/pkg/compactor.TestBlocksCleaner_RaceCondition_CleanerUpdatesBucketIndexWhileAnotherCleanerDeletesBlocks.func3.2
            	            		/__w/mimir/mimir/pkg/compactor/blocks_cleaner_test.go:1730
            	            	runtime.goexit
            	            		/usr/local/go/src/runtime/asm_amd64.s:1771
            	Test:       	TestBlocksCleaner_RaceCondition_CleanerUpdatesBucketIndexWhileAnotherCleanerDeletesBlocks/
```

**Why it fails randomly**

The thanos-io/objstore update in https://github.com/grafana/mimir/pull/15939 brought https://github.com/thanos-io/objstore/pull/178, which adds support for conditional writes. The filesystem bucket implementation for it achieves this with temporary file locks (the `<name>.swap` file) that are held during an Upload, and can fail to be acquired. The catch is this mutual exclusion was introduced for all uploads, no matter if conditional or not. This makes it so concurrent Upload calls now fail.

The test in question is exercising two cleaners concurrently working on the same tenant, and they sometimes happen to call Upload on the same object at the same time.

**The fix**

I'd expect the filesystem bucket to mimic S3 and friends by allowing concurrent writes with [last-writer-wins semantics](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html#Concurrent-applications). I looked into fixing this myself upstream, but it was not trivial, and every solution I thought of had its caveats. 

So I opted to just fix our test by ensuring `Upload` calls are serialized.