### PR TITLE
MQE: Optimise info function by reducing usage of makeLabelSetsHash

### DIFF
--- a/pkg/streamingpromql/operators/functions/info.go
+++ b/pkg/streamingpromql/operators/functions/info.go
@@ -31,6 +31,10 @@ type DataLabelSelector struct {
 // Currently hard coded, so we don't need knowledge of individual info metrics.
 var identifyingLabels = []string{"instance", "job"}
 
+// innerSeriesKey is the sentinel label sets hash used to represent the original, un-enriched
+// inner series (i.e. no matching info series contributes any labels).
+const innerSeriesKey = "inner"
+
 type labelsTime struct {
 	labels labels.Labels
 	time   int64
@@ -287,7 +291,7 @@ func (f *InfoFunction) processSamplesFromInfoSeries(ctx context.Context, infoMet
 func makeLabelSetsHash(labelSets []labels.Labels) string {
 	length := len(labelSets)
 	if length == 0 {
-		return "inner"
+		return innerSeriesKey
 	}
 
 	hashArr := make([]uint64, length)
@@ -432,7 +436,7 @@ func (f *InfoFunction) combineSeriesMetadata(innerMetadata []types.SeriesMetadat
 	for i, innerSeries := range innerMetadata {
 		// If this inner series is an info series, pass the original series metadata along unchanged.
 		if _, shouldIgnore := ignoreSeries[i]; shouldIgnore {
-			f.labelSetsOrder[i] = map[string]int{"inner": 0}
+			f.labelSetsOrder[i] = map[string]int{innerSeriesKey: 0}
 			totalLabelSetsCount++
 			continue
 		}
@@ -447,7 +451,7 @@ func (f *InfoFunction) combineSeriesMetadata(innerMetadata []types.SeriesMetadat
 			if hasNonEmptyDataLabelMatcher {
 				continue
 			}
-			f.labelSetsOrder[i] = map[string]int{"inner": 0}
+			f.labelSetsOrder[i] = map[string]int{innerSeriesKey: 0}
 			totalLabelSetsCount++
 			continue
 		}
@@ -470,7 +474,7 @@ func (f *InfoFunction) combineSeriesMetadata(innerMetadata []types.SeriesMetadat
 		// info series when all data label matchers match empty string.
 		offset := 0
 		if !hasNonEmptyDataLabelMatcher {
-			f.labelSetsOrder[i]["inner"] = 0
+			f.labelSetsOrder[i][innerSeriesKey] = 0
 			totalLabelSetsCount++
 			offset = 1
 		}
@@ -492,7 +496,7 @@ func (f *InfoFunction) combineSeriesMetadata(innerMetadata []types.SeriesMetadat
 	// Do a second pass to actually produce final series metadata using exact numbers from the pool,
 	// while checking for any clashes in final label sets that come from different input series.
 	for i, innerSeries := range innerMetadata {
-		if _, shouldPassInner := f.labelSetsOrder[i]["inner"]; shouldPassInner {
+		if _, shouldPassInner := f.labelSetsOrder[i][innerSeriesKey]; shouldPassInner {
 			hash := innerSeries.Labels.Hash()
 			if existingSeriesIndex, exists := labelSetsHashes[hash]; exists && existingSeriesIndex != i {
 				return nil, fmt.Errorf("vector cannot contain metrics with the same labelset")
@@ -696,11 +700,11 @@ func (f *InfoFunction) getSplitResult(ts int64, sig string, storedSeriesResults 
 			labelSetsHash = makeLabelSetsHash(labelSets)
 		} else {
 			// Use the original inner series labels unchanged.
-			labelSetsHash = "inner"
+			labelSetsHash = innerSeriesKey
 		}
 	} else {
 		// Use the original inner series labels unchanged.
-		labelSetsHash = "inner"
+		labelSetsHash = innerSeriesKey
 	}
 
 	// If this label sets hash is not in the order map, it means we shouldn't create a series for it.

--- a/pkg/streamingpromql/operators/functions/info.go
+++ b/pkg/streamingpromql/operators/functions/info.go
@@ -51,8 +51,9 @@ type InfoFunction struct {
 	// dedicated buffer and scratch builder for signature
 	sigBuf []byte
 	sigLb  labels.ScratchBuilder
-	// timestamp:(signature:array of info series labels)
-	sigTimestamps map[int64]map[string][]labels.Labels
+	// timestamp:(signature:label sets hash) - the precomputed hash of the group of info series
+	// label sets seen for that timestamp and signature, used to route samples to split series.
+	sigTimestamps map[int64]map[string]string
 	// signature:(label sets hash:array of info series labels)
 	labelSets map[string]map[string][]labels.Labels
 	// inner series index - (info series label sets hash: index for ordering)
@@ -200,7 +201,7 @@ func (f *InfoFunction) processSamplesFromInfoSeries(ctx context.Context, infoMet
 
 	// metric name:(timestamp:(labels-only signature:labels + timestamp))
 	sigTimestampsByMetric := make(map[string]map[int64]map[string]labelsTime)
-	f.sigTimestamps = make(map[int64]map[string][]labels.Labels, f.timeRange.StepCount)
+	f.sigTimestamps = make(map[int64]map[string]string, f.timeRange.StepCount)
 	f.labelSets = make(map[string]map[string][]labels.Labels)
 
 	for _, metadata := range infoMetadata {
@@ -257,41 +258,55 @@ func (f *InfoFunction) processSamplesFromInfoSeries(ctx context.Context, infoMet
 	// Summarise the info series by recording per timestamp and labels-only signature
 	// the series labels we've seen. We do this in a second pass so the inner loop's
 	// per-(metric, sig) duplicate resolution finalises before we write the result.
+	// This intermediate structure is local: it is only needed to derive the per-(timestamp,
+	// signature) group hash below, and is discarded when this function returns.
+	tsSigLabelSets := make(map[int64]map[string][]labels.Labels, f.timeRange.StepCount)
 	for _, metricSigTimestamps := range sigTimestampsByMetric {
 		for t, sigsAtTimestamp := range metricSigTimestamps {
-			sigAtTimestamp, exists := f.sigTimestamps[t]
+			sigAtTimestamp, exists := tsSigLabelSets[t]
 			if !exists {
 				sigAtTimestamp = make(map[string][]labels.Labels)
 			}
 			for sig, lt := range sigsAtTimestamp {
 				sigAtTimestamp[sig] = append(sigAtTimestamp[sig], lt.labels)
 			}
-			f.sigTimestamps[t] = sigAtTimestamp
+			tsSigLabelSets[t] = sigAtTimestamp
 		}
 	}
 
-	// Now that we've seen all info series, summarise them overall across all timestamps.
-	// This will be used to generate all label sets for each inner series that can actually
-	// be used, instead of generating all theoretically possible combinations which grows
-	// exponentially.
-	for _, sigAtTimestamp := range f.sigTimestamps {
+	// Compute the group hash once per (timestamp, signature) and record it in f.sigTimestamps,
+	// so the per-sample path (getSplitResult) only needs map lookups. At the same time, summarise
+	// the label sets overall across all timestamps into f.labelSets keyed by that same hash. This
+	// is used to generate all label sets for each inner series that can actually be used, instead
+	// of generating all theoretically possible combinations which grows exponentially.
+	for t, sigAtTimestamp := range tsSigLabelSets {
+		hashesAtTimestamp := make(map[string]string, len(sigAtTimestamp))
 		for sig, labelSets := range sigAtTimestamp {
-			labelsArr := append([]labels.Labels(nil), labelSets...)
+			hash := makeLabelSetsHash(labelSets)
+			hashesAtTimestamp[sig] = hash
 			if _, exists := f.labelSets[sig]; !exists {
 				f.labelSets[sig] = make(map[string][]labels.Labels)
 			}
-			f.labelSets[sig][makeLabelSetsHash(labelSets)] = labelsArr
+			f.labelSets[sig][hash] = append([]labels.Labels(nil), labelSets...)
 		}
+		f.sigTimestamps[t] = hashesAtTimestamp
 	}
 
 	return nil
 }
 
 // makeLabelSetsHash creates a hash string to identify a unique set of label sets.
+// The result is independent of the order of labelSets.
 func makeLabelSetsHash(labelSets []labels.Labels) string {
 	length := len(labelSets)
 	if length == 0 {
 		return innerSeriesKey
+	}
+
+	if length == 1 {
+		// Common case: a single info series contributes labels. Avoid the slice allocation and
+		// sort of the general path.
+		return strconv.FormatUint(labelSets[0].Hash(), 16)
 	}
 
 	hashArr := make([]uint64, length)
@@ -532,7 +547,7 @@ func combineLabels(lb *labels.Builder, innerSeries types.SeriesMetadata, labelSe
 	newLabelSets := make([]labels.Labels, 0, len(labelSetsMap))
 	labelSetsOrder := make([]string, 0, len(labelSetsMap))
 	savedLabels := make(map[string]struct{})
-	for _, labelSets := range labelSetsMap {
+	for labelSetsHash, labelSets := range labelSetsMap {
 		// Reset the builder at the start of each iteration to avoid labels bleeding over.
 		lb.Reset(innerSeries.Labels)
 		clear(savedLabels)
@@ -598,7 +613,9 @@ func combineLabels(lb *labels.Builder, innerSeries types.SeriesMetadata, labelSe
 		}
 
 		newLabelSets = append(newLabelSets, lb.Labels())
-		labelSetsOrder = append(labelSetsOrder, makeLabelSetsHash(labelSets))
+		// labelSetsHash is the map key, which is exactly makeLabelSetsHash(labelSets) computed
+		// when f.labelSets was built; recomputing it here would be redundant.
+		labelSetsOrder = append(labelSetsOrder, labelSetsHash)
 	}
 
 	return newLabelSets, labelSetsOrder, nil
@@ -691,20 +708,14 @@ func (f *InfoFunction) NextSeries(ctx context.Context) (types.InstantVectorSerie
 }
 
 func (f *InfoFunction) getSplitResult(ts int64, sig string, storedSeriesResults map[string]types.InstantVectorSeriesData, labelSetsOrder map[string]int, lenFloats, lenHistograms int) (types.InstantVectorSeriesData, string, bool, error) {
-	// Get the label sets seen for this timestamp and labels-only signature and create a hash.
-	var labelSetsHash string
-	labelSetsBySig, exists := f.sigTimestamps[ts]
-	if exists {
-		labelSets, exists := labelSetsBySig[sig]
-		if exists {
-			labelSetsHash = makeLabelSetsHash(labelSets)
-		} else {
-			// Use the original inner series labels unchanged.
-			labelSetsHash = innerSeriesKey
+	// Look up the precomputed group hash for this timestamp and labels-only signature. It was
+	// computed once per (timestamp, signature) in processSamplesFromInfoSeries, so the per-sample
+	// path here is a pure map lookup with no hashing or allocation.
+	labelSetsHash := innerSeriesKey // Default: use the original inner series labels unchanged.
+	if hashBySig, exists := f.sigTimestamps[ts]; exists {
+		if hash, exists := hashBySig[sig]; exists {
+			labelSetsHash = hash
 		}
-	} else {
-		// Use the original inner series labels unchanged.
-		labelSetsHash = innerSeriesKey
 	}
 
 	// If this label sets hash is not in the order map, it means we shouldn't create a series for it.

--- a/pkg/streamingpromql/operators/functions/info.go
+++ b/pkg/streamingpromql/operators/functions/info.go
@@ -35,9 +35,49 @@ var identifyingLabels = []string{"instance", "job"}
 // inner series (i.e. no matching info series contributes any labels).
 const innerSeriesKey = "inner"
 
+type labelSetsHashID uint32
+
+const innerSeriesHashID labelSetsHashID = 0
+
+const noAdditionalInfoSeries = ^uint32(0)
+
 type labelsTime struct {
 	labels labels.Labels
 	time   int64
+}
+
+type infoSeriesGroups struct {
+	firstLabelSets      []labels.Labels
+	additionalHeads     []uint32
+	additionalLabelSets []labels.Labels
+	additionalNext      []uint32
+}
+
+func (g *infoSeriesGroups) addGroup(labelSet labels.Labels) labelSetsHashID {
+	groupID := labelSetsHashID(len(g.firstLabelSets))
+	g.firstLabelSets = append(g.firstLabelSets, labelSet)
+	g.additionalHeads = append(g.additionalHeads, noAdditionalInfoSeries)
+	return groupID
+}
+
+func (g *infoSeriesGroups) addToGroup(groupID labelSetsHashID, labelSet labels.Labels) {
+	additionalIndex := uint32(len(g.additionalLabelSets))
+	g.additionalLabelSets = append(g.additionalLabelSets, labelSet)
+	g.additionalNext = append(g.additionalNext, g.additionalHeads[groupID])
+	g.additionalHeads[groupID] = additionalIndex
+}
+
+func (g *infoSeriesGroups) labelSets(groupID labelSetsHashID, scratch []labels.Labels) []labels.Labels {
+	head := g.additionalHeads[groupID]
+	if head == noAdditionalInfoSeries {
+		return g.firstLabelSets[groupID : groupID+1]
+	}
+
+	scratch = append(scratch[:0], g.firstLabelSets[groupID])
+	for i := head; i != noAdditionalInfoSeries; i = g.additionalNext[i] {
+		scratch = append(scratch, g.additionalLabelSets[i])
+	}
+	return scratch
 }
 
 type InfoFunction struct {
@@ -51,9 +91,10 @@ type InfoFunction struct {
 	// dedicated buffer and scratch builder for signature
 	sigBuf []byte
 	sigLb  labels.ScratchBuilder
-	// timestamp:(signature:label sets hash) - the precomputed hash of the group of info series
-	// label sets seen for that timestamp and signature, used to route samples to split series.
-	sigTimestamps map[int64]map[string]string
+	// timestamp:(signature:label sets hash ID)
+	sigTimestamps map[int64]map[string]labelSetsHashID
+	// label sets hash ID:label sets hash; index zero is innerSeriesKey.
+	labelSetsHashesByID []string
 	// signature:(label sets hash:array of info series labels)
 	labelSets map[string]map[string][]labels.Labels
 	// inner series index - (info series label sets hash: index for ordering)
@@ -201,7 +242,7 @@ func (f *InfoFunction) processSamplesFromInfoSeries(ctx context.Context, infoMet
 
 	// metric name:(timestamp:(labels-only signature:labels + timestamp))
 	sigTimestampsByMetric := make(map[string]map[int64]map[string]labelsTime)
-	f.sigTimestamps = make(map[int64]map[string]string, f.timeRange.StepCount)
+	f.sigTimestamps = make(map[int64]map[string]labelSetsHashID, f.timeRange.StepCount)
 	f.labelSets = make(map[string]map[string][]labels.Labels)
 
 	for _, metadata := range infoMetadata {
@@ -258,41 +299,66 @@ func (f *InfoFunction) processSamplesFromInfoSeries(ctx context.Context, infoMet
 	// Summarise the info series by recording per timestamp and labels-only signature
 	// the series labels we've seen. We do this in a second pass so the inner loop's
 	// per-(metric, sig) duplicate resolution finalises before we write the result.
-	// This intermediate structure is local: it is only needed to derive the per-(timestamp,
-	// signature) group hash below, and is discarded when this function returns.
-	tsSigLabelSets := make(map[int64]map[string][]labels.Labels, f.timeRange.StepCount)
+	// Values in f.sigTimestamps temporarily identify groups built below; finalization
+	// replaces them with interned hash IDs without allocating another timestamp map.
+	var groups infoSeriesGroups
 	for _, metricSigTimestamps := range sigTimestampsByMetric {
 		for t, sigsAtTimestamp := range metricSigTimestamps {
-			sigAtTimestamp, exists := tsSigLabelSets[t]
+			groupIDsAtTimestamp, exists := f.sigTimestamps[t]
 			if !exists {
-				sigAtTimestamp = make(map[string][]labels.Labels)
+				groupIDsAtTimestamp = make(map[string]labelSetsHashID)
 			}
 			for sig, lt := range sigsAtTimestamp {
-				sigAtTimestamp[sig] = append(sigAtTimestamp[sig], lt.labels)
+				groupID, exists := groupIDsAtTimestamp[sig]
+				if !exists {
+					groupID = groups.addGroup(lt.labels)
+					groupIDsAtTimestamp[sig] = groupID
+				} else {
+					groups.addToGroup(groupID, lt.labels)
+				}
 			}
-			tsSigLabelSets[t] = sigAtTimestamp
+			f.sigTimestamps[t] = groupIDsAtTimestamp
 		}
 	}
 
-	// Compute the group hash once per (timestamp, signature) and record it in f.sigTimestamps,
-	// so the per-sample path (getSplitResult) only needs map lookups. At the same time, summarise
-	// the label sets overall across all timestamps into f.labelSets keyed by that same hash. This
-	// is used to generate all label sets for each inner series that can actually be used, instead
-	// of generating all theoretically possible combinations which grows exponentially.
-	for t, sigAtTimestamp := range tsSigLabelSets {
-		hashesAtTimestamp := make(map[string]string, len(sigAtTimestamp))
-		for sig, labelSets := range sigAtTimestamp {
-			hash := makeLabelSetsHash(labelSets)
-			hashesAtTimestamp[sig] = hash
-			if _, exists := f.labelSets[sig]; !exists {
-				f.labelSets[sig] = make(map[string][]labels.Labels)
-			}
-			f.labelSets[sig][hash] = append([]labels.Labels(nil), labelSets...)
-		}
-		f.sigTimestamps[t] = hashesAtTimestamp
-	}
+	f.finalizeInfoSeriesGroups(&groups)
 
 	return nil
+}
+
+func (f *InfoFunction) finalizeInfoSeriesGroups(groups *infoSeriesGroups) {
+	f.labelSetsHashesByID = []string{innerSeriesKey}
+	hashIDs := map[string]labelSetsHashID{innerSeriesKey: innerSeriesHashID}
+	var scratch []labels.Labels
+
+	// Compute each group hash once and intern it, so timestamp entries retain only compact IDs.
+	// At the same time, summarise the groups across all timestamps for metadata construction.
+	for _, groupIDsAtTimestamp := range f.sigTimestamps {
+		for sig, groupID := range groupIDsAtTimestamp {
+			labelSets := groups.labelSets(groupID, scratch)
+			if len(labelSets) > 1 {
+				scratch = labelSets
+			}
+			hash := makeLabelSetsHash(labelSets)
+			hashID, exists := hashIDs[hash]
+			if !exists {
+				hashID = labelSetsHashID(len(f.labelSetsHashesByID))
+				hashIDs[hash] = hashID
+				f.labelSetsHashesByID = append(f.labelSetsHashesByID, hash)
+			}
+
+			canonicalHash := f.labelSetsHashesByID[hashID]
+			labelSetsByHash, exists := f.labelSets[sig]
+			if !exists {
+				labelSetsByHash = make(map[string][]labels.Labels)
+				f.labelSets[sig] = labelSetsByHash
+			}
+			if _, exists := labelSetsByHash[canonicalHash]; !exists {
+				labelSetsByHash[canonicalHash] = append([]labels.Labels(nil), labelSets...)
+			}
+			groupIDsAtTimestamp[sig] = hashID
+		}
+	}
 }
 
 // makeLabelSetsHash creates a hash string to identify a unique set of label sets.
@@ -708,15 +774,14 @@ func (f *InfoFunction) NextSeries(ctx context.Context) (types.InstantVectorSerie
 }
 
 func (f *InfoFunction) getSplitResult(ts int64, sig string, storedSeriesResults map[string]types.InstantVectorSeriesData, labelSetsOrder map[string]int, lenFloats, lenHistograms int) (types.InstantVectorSeriesData, string, bool, error) {
-	// Look up the precomputed group hash for this timestamp and labels-only signature. It was
-	// computed once per (timestamp, signature) in processSamplesFromInfoSeries, so the per-sample
-	// path here is a pure map lookup with no hashing or allocation.
-	labelSetsHash := innerSeriesKey // Default: use the original inner series labels unchanged.
-	if hashBySig, exists := f.sigTimestamps[ts]; exists {
-		if hash, exists := hashBySig[sig]; exists {
-			labelSetsHash = hash
+	// Look up the interned group hash for this timestamp and labels-only signature.
+	hashID := innerSeriesHashID // Default: use the original inner series labels unchanged.
+	if hashIDsBySig, exists := f.sigTimestamps[ts]; exists {
+		if id, exists := hashIDsBySig[sig]; exists {
+			hashID = id
 		}
 	}
+	labelSetsHash := f.labelSetsHashesByID[hashID]
 
 	// If this label sets hash is not in the order map, it means we shouldn't create a series for it.
 	if _, exists := labelSetsOrder[labelSetsHash]; !exists {

--- a/pkg/streamingpromql/operators/functions/info.go
+++ b/pkg/streamingpromql/operators/functions/info.go
@@ -35,6 +35,7 @@ var identifyingLabels = []string{"instance", "job"}
 // inner series (i.e. no matching info series contributes any labels).
 const innerSeriesKey = "inner"
 
+// labelSetsHashID indexes labelSetsHashesByID, i.e. it identifies an interned group hash.
 type labelSetsHashID uint32
 
 const innerSeriesHashID labelSetsHashID = 0
@@ -299,8 +300,10 @@ func (f *InfoFunction) processSamplesFromInfoSeries(ctx context.Context, infoMet
 	// Summarise the info series by recording per timestamp and labels-only signature
 	// the series labels we've seen. We do this in a second pass so the inner loop's
 	// per-(metric, sig) duplicate resolution finalises before we write the result.
-	// Values in f.sigTimestamps temporarily identify groups built below; finalization
-	// replaces them with interned hash IDs without allocating another timestamp map.
+	// Values in f.sigTimestamps temporarily hold indexes into groups rather than interned hash
+	// IDs (reusing the same slots avoids allocating another timestamp map); finalization below
+	// replaces them in place with the interned hash IDs, so nothing may read f.sigTimestamps as
+	// hash IDs until it has run.
 	var groups infoSeriesGroups
 	for _, metricSigTimestamps := range sigTimestampsByMetric {
 		for t, sigsAtTimestamp := range metricSigTimestamps {

--- a/pkg/streamingpromql/operators/functions/info_test.go
+++ b/pkg/streamingpromql/operators/functions/info_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package functions
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/streamingpromql/types"
+)
+
+func TestFinalizeInfoSeriesGroups(t *testing.T) {
+	targetInfo := labels.FromStrings("__name__", "target_info", "instance", "a", "job", "1", "env", "prod")
+	buildInfo := labels.FromStrings("__name__", "build_info", "instance", "a", "job", "1", "version", "1")
+	updatedTargetInfo := labels.FromStrings("__name__", "target_info", "instance", "a", "job", "1", "env", "staging")
+
+	f := &InfoFunction{
+		sigTimestamps: map[int64]map[string]labelSetsHashID{
+			0: {},
+			1: {},
+			2: {},
+		},
+		labelSets: make(map[string]map[string][]labels.Labels),
+	}
+
+	var groups infoSeriesGroups
+	firstGroupID := groups.addGroup(targetInfo)
+	groups.addToGroup(firstGroupID, buildInfo)
+	reorderedGroupID := groups.addGroup(buildInfo)
+	groups.addToGroup(reorderedGroupID, targetInfo)
+	updatedGroupID := groups.addGroup(updatedTargetInfo)
+	groups.addToGroup(updatedGroupID, buildInfo)
+	f.sigTimestamps[0]["signature"] = firstGroupID
+	f.sigTimestamps[1]["signature"] = reorderedGroupID
+	f.sigTimestamps[2]["signature"] = updatedGroupID
+	f.finalizeInfoSeriesGroups(&groups)
+
+	firstGroupHashID := f.sigTimestamps[0]["signature"]
+	reorderedGroupHashID := f.sigTimestamps[1]["signature"]
+	updatedGroupHashID := f.sigTimestamps[2]["signature"]
+
+	require.Equal(t, firstGroupHashID, reorderedGroupHashID)
+	require.NotEqual(t, firstGroupHashID, updatedGroupHashID)
+	require.NotEqual(t, innerSeriesHashID, firstGroupHashID)
+	require.Equal(t, innerSeriesKey, f.labelSetsHashesByID[innerSeriesHashID])
+	require.Len(t, f.labelSetsHashesByID, 3)
+	require.Len(t, f.labelSets["signature"], 2)
+
+	storedResults := map[string]types.InstantVectorSeriesData{
+		innerSeriesKey:                          {},
+		f.labelSetsHashesByID[firstGroupHashID]: {},
+	}
+
+	_, hash, skip, err := f.getSplitResult(0, "signature", storedResults, map[string]int{f.labelSetsHashesByID[firstGroupHashID]: 0}, 0, 0)
+	require.NoError(t, err)
+	require.False(t, skip)
+	require.Equal(t, f.labelSetsHashesByID[firstGroupHashID], hash)
+
+	_, hash, skip, err = f.getSplitResult(3, "signature", storedResults, map[string]int{innerSeriesKey: 0}, 0, 0)
+	require.NoError(t, err)
+	require.False(t, skip)
+	require.Equal(t, innerSeriesKey, hash)
+}


### PR DESCRIPTION
#### What this PR does

See title.

Benchmark results run with `MIMIR_PROMQL_ENGINE_BENCHMARK_SKIP_COMPARE_RESULTS=true go run . -use-existing-ingester=127.0.0.1:43009 -bench='info.*engine=Mimir' -count=6`: [comparehash.txt](https://github.com/user-attachments/files/30324496/comparehash.txt)

Based on the benchmark, this optimisation seems quite worthwhile.

#### Which issue(s) this PR fixes or relates to

Fixes https://github.com/grafana/mimir/pull/13443#pullrequestreview-3742594807 : [finding ways to reduce / eliminate the use of makeLabelSetsHash](https://github.com/grafana/mimir/pull/13443#discussion_r2756977167)

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

No user-facing change in behaviour, just performance optimisation