### PR TITLE
MQE: Remove "resized" return from buffer .Append() methods

### DIFF
--- a/pkg/streamingpromql/operators/functions/extended_histogram_rate_test.go
+++ b/pkg/streamingpromql/operators/functions/extended_histogram_rate_test.go
@@ -5,7 +5,6 @@ package functions
 import (
 	"context"
 	"errors"
-	"math"
 	"testing"
 
 	"github.com/prometheus/prometheus/model/histogram"
@@ -24,10 +23,9 @@ func newHistogramView(t *testing.T, points []promql.HPoint) *types.HPointRingBuf
 	tracker := limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, "")
 	buf := types.NewHPointRingBuffer(tracker)
 	for _, p := range points {
-		_, err := buf.Append(p)
-		require.NoError(t, err)
+		require.NoError(t, buf.Append(p))
 	}
-	return buf.ViewUntilSearchingForwards(math.MaxInt64, nil)
+	return buf.ViewAll(nil)
 }
 
 // recordingEmitter returns an EmitAnnotationFunc that records the rendered message of every

--- a/pkg/streamingpromql/operators/selectors/extend_range_vector.go
+++ b/pkg/streamingpromql/operators/selectors/extend_range_vector.go
@@ -175,7 +175,7 @@ func (m *RevertibleExtendedPointsState) ApplyBoundaryMutations(rangeStart, range
 
 	// Add synthetic or clamp start boundary
 	if m.first.T > rangeStart {
-		if _, err := m.buff.AppendAtStart(promql.FPoint{T: rangeStart, F: m.first.F}); err != nil {
+		if err := m.buff.AppendAtStart(promql.FPoint{T: rangeStart, F: m.first.F}); err != nil {
 			return err
 		}
 		m.undoHeadModifications = removed
@@ -194,7 +194,7 @@ func (m *RevertibleExtendedPointsState) ApplyBoundaryMutations(rangeStart, range
 
 	// Add synthetic or clamp end boundary
 	if m.last.T < rangeEnd {
-		if _, err := m.buff.Append(promql.FPoint{T: rangeEnd, F: m.last.F}); err != nil {
+		if err := m.buff.Append(promql.FPoint{T: rangeEnd, F: m.last.F}); err != nil {
 			return err
 		}
 		m.undoTailModifications = removed
@@ -241,13 +241,13 @@ func (m *RevertibleExtendedPointsState) UndoChanges() error {
 
 	// Restore trailing points in their original order
 	for i := len(m.excludedTrailing) - 1; i >= 0; i-- {
-		if _, err := m.buff.Append(m.excludedTrailing[i]); err != nil {
+		if err := m.buff.Append(m.excludedTrailing[i]); err != nil {
 			return err
 		}
 	}
 
 	if m.restoreExcludedFirst {
-		if _, err := m.buff.AppendAtStart(m.excludedFirst); err != nil {
+		if err := m.buff.AppendAtStart(m.excludedFirst); err != nil {
 			return err
 		}
 	}

--- a/pkg/streamingpromql/operators/selectors/range_vector_selector.go
+++ b/pkg/streamingpromql/operators/selectors/range_vector_selector.go
@@ -246,7 +246,7 @@ func (m *RangeVectorSelector) fillBuffer(floats *types.FPointRingBuffer, histogr
 			// We might append a sample beyond the range end, but this is OK:
 			// - callers of NextStepSamples are expected to pass the same RingBuffer to subsequent calls, so the point is not lost
 			// - callers of NextStepSamples are expected to handle the case where the buffer contains points beyond the end of the range
-			if _, err := floats.Append(promql.FPoint{T: t, F: f}); err != nil {
+			if err := floats.Append(promql.FPoint{T: t, F: f}); err != nil {
 				return err
 			}
 
@@ -260,7 +260,7 @@ func (m *RangeVectorSelector) fillBuffer(floats *types.FPointRingBuffer, histogr
 				continue
 			}
 
-			hPoint, _, err := histograms.NextPoint()
+			hPoint, err := histograms.NextPoint()
 			if err != nil {
 				return err
 			}

--- a/pkg/streamingpromql/operators/test_operator.go
+++ b/pkg/streamingpromql/operators/test_operator.go
@@ -233,7 +233,7 @@ func (t *TestRangeOperator) NextStepSamples(_ context.Context) (*types.RangeVect
 
 	t.Floats.Reset()
 	for _, p := range d.Floats {
-		if _, err := t.Floats.Append(p); err != nil {
+		if err := t.Floats.Append(p); err != nil {
 			return nil, err
 		}
 	}
@@ -246,7 +246,7 @@ func (t *TestRangeOperator) NextStepSamples(_ context.Context) (*types.RangeVect
 
 	t.Histograms.Reset()
 	for _, p := range d.Histograms {
-		if _, err := t.Histograms.Append(p); err != nil {
+		if err := t.Histograms.Append(p); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator.go
@@ -682,7 +682,7 @@ func (b *RangeVectorDuplicationBuffer) mergeStepData(stepData *types.RangeVector
 	for _, section := range [][]promql.FPoint{headF, tailF} {
 		for _, p := range section {
 			if floats != nil && (floats.Count() == 0 || p.T > lastF.T) {
-				_, err := floats.Append(promql.FPoint{T: p.T, F: p.F})
+				err := floats.Append(promql.FPoint{T: p.T, F: p.F})
 				if err != nil {
 					return bufferedRangeVectorStepData{}, err
 				}
@@ -695,7 +695,7 @@ func (b *RangeVectorDuplicationBuffer) mergeStepData(stepData *types.RangeVector
 		for _, p := range section {
 			if histograms != nil && (histograms.Count() == 0 || p.T > lastH.T) {
 				// Try to reuse an existing HPoint and FloatHistogram if possible.
-				dest, _, err := histograms.NextPoint()
+				dest, err := histograms.NextPoint()
 				if err != nil {
 					return bufferedRangeVectorStepData{}, err
 				}

--- a/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator_test.go
+++ b/pkg/streamingpromql/optimize/plan/commonsubexpressionelimination/range_vector_operator_test.go
@@ -1156,7 +1156,7 @@ func (o *failingRangeVectorOperator) NextStepSamples(_ context.Context) (*types.
 	if o.floats == nil {
 		o.floats = types.NewFPointRingBuffer(o.memoryConsumptionTracker)
 
-		if _, err := o.floats.Append(promql.FPoint{T: 1000, F: 1234}); err != nil {
+		if err := o.floats.Append(promql.FPoint{T: 1000, F: 1234}); err != nil {
 			return nil, err
 		}
 
@@ -1167,7 +1167,7 @@ func (o *failingRangeVectorOperator) NextStepSamples(_ context.Context) (*types.
 	if o.histograms == nil {
 		o.histograms = types.NewHPointRingBuffer(o.memoryConsumptionTracker)
 
-		if _, err := o.histograms.Append(promql.HPoint{T: 1000, H: &histogram.FloatHistogram{Count: 100, Sum: 2}}); err != nil {
+		if err := o.histograms.Append(promql.HPoint{T: 1000, H: &histogram.FloatHistogram{Count: 100, Sum: 2}}); err != nil {
 			return nil, err
 		}
 

--- a/pkg/streamingpromql/types/fpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/fpoint_ring_buffer.go
@@ -35,13 +35,12 @@ func NewFPointRingBuffer(memoryConsumptionTracker *limiter.MemoryConsumptionTrac
 }
 
 // resizeIfRequired resizes the underlying buffer if required to hold additionalPoints and returns
-// a boolean indicating if the underlying buffer was resized or an error if the buffer could not be
-// resized.
-func (b *FPointRingBuffer) resizeIfRequired(additionalPoints int, appendingAtStart bool) (bool, error) {
+// an error if the buffer could not be resized.
+func (b *FPointRingBuffer) resizeIfRequired(additionalPoints int, appendingAtStart bool) error {
 	newRequestedSize := b.size + additionalPoints
 
 	if newRequestedSize <= len(b.points) {
-		return false, nil
+		return nil
 	}
 
 	newSize := math.NextPowerTwo(newRequestedSize)
@@ -49,14 +48,14 @@ func (b *FPointRingBuffer) resizeIfRequired(additionalPoints int, appendingAtSta
 	// We create a new slice, and we will copy the elements from the current slice to the new slice
 	newSlice, err := getFPointSliceForRingBuffer(newSize, b.memoryConsumptionTracker)
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	if !pool.IsPowerOfTwo(cap(newSlice)) {
 		// We rely on the capacity being a power of two for the pointsIndexMask optimisation below.
 		// If we can guarantee that newSlice has a capacity that is a power of two in the future, then we can drop this check.
 		// Note that the capacity of newSlice is guaranteed to be at least 2 due to the implementation in math.NextPowerTwo()
-		return false, fmt.Errorf("pool returned slice of capacity %v (requested %v), but wanted a power of two", cap(newSlice), newSize)
+		return fmt.Errorf("pool returned slice of capacity %v (requested %v), but wanted a power of two", cap(newSlice), newSize)
 	}
 
 	newSlice = newSlice[:cap(newSlice)]
@@ -83,7 +82,7 @@ func (b *FPointRingBuffer) resizeIfRequired(additionalPoints int, appendingAtSta
 	b.pointsIndexMask = cap(newSlice) - 1
 	b.generation++
 
-	return true, nil
+	return nil
 }
 
 // DiscardPointsAtOrBefore discards all points in this buffer with timestamp less than or equal to the given timestamp.
@@ -153,13 +152,11 @@ func (b *FPointRingBuffer) ReplaceFirst(point promql.FPoint) error {
 }
 
 // AppendAtStart will insert the given point into the head of this buffer, expanding if required.
-// A boolean is returned indicating if the underlying buffer had to be resized. Subsequently calling
-// PointAt(0) will return this point. It is the responsibility of the caller to ensure that inserting
-// this point maintains chronological order of the buffer.
-func (b *FPointRingBuffer) AppendAtStart(point promql.FPoint) (bool, error) {
-	resized, err := b.resizeIfRequired(1, true)
-	if err != nil {
-		return resized, err
+// Subsequently, calling PointAt(0) will return this point. It is the responsibility of the caller
+// to ensure that inserting this point maintains chronological order of the buffer.
+func (b *FPointRingBuffer) AppendAtStart(point promql.FPoint) error {
+	if err := b.resizeIfRequired(1, true); err != nil {
+		return err
 	}
 
 	// Explicitly increase the generation here even if the underlying buffer was not
@@ -170,26 +167,24 @@ func (b *FPointRingBuffer) AppendAtStart(point promql.FPoint) (bool, error) {
 	b.points[b.firstIndex] = point
 	b.size++
 
-	return resized, nil
+	return nil
 }
 
 // Append adds p to this buffer, expanding it if required.
-// A boolean is returned indicating if the underlying buffer had to be resized.
 // It is the responsibility of the caller to ensure that inserting this point maintains chronological order of the buffer.
-func (b *FPointRingBuffer) Append(p promql.FPoint) (bool, error) {
-	resized, err := b.resizeIfRequired(1, false)
-	if err != nil {
-		return resized, err
+func (b *FPointRingBuffer) Append(p promql.FPoint) error {
+	// resizeIfRequired increases the generation if the slice was resized.
+	if err := b.resizeIfRequired(1, false); err != nil {
+		return err
 	}
 
 	nextIndex := (b.firstIndex + b.size) & b.pointsIndexMask
 	b.points[nextIndex] = p
 	b.size++
-	return resized, nil
+	return nil
 }
 
-// AppendSlice will append all the given points to the buffer returning a boolean if
-// the underlying buffer had to be resized.
+// AppendSlice will append all the given points to the buffer.
 //
 // It is more efficient to call this for a collection of points then to call Append()
 // for each individual point. In this function the underlying buffer will only be grown once based
@@ -197,14 +192,14 @@ func (b *FPointRingBuffer) Append(p promql.FPoint) (bool, error) {
 //
 // It is the caller's responsibility to ensure that the given points are in chronological order
 // and that the points chronologically follow any existing points in the buffer.
-func (b *FPointRingBuffer) AppendSlice(points []promql.FPoint) (bool, error) {
+func (b *FPointRingBuffer) AppendSlice(points []promql.FPoint) error {
 	if len(points) == 0 {
-		return false, nil
+		return nil
 	}
 
-	resized, err := b.resizeIfRequired(len(points), false)
-	if err != nil {
-		return resized, err
+	// resizeIfRequired increases the generation if the slice was resized.
+	if err := b.resizeIfRequired(len(points), false); err != nil {
+		return err
 	}
 
 	for _, pt := range points {
@@ -213,7 +208,7 @@ func (b *FPointRingBuffer) AppendSlice(points []promql.FPoint) (bool, error) {
 		b.size++
 	}
 
-	return resized, nil
+	return nil
 }
 
 // EmptyView returns an empty view associated with this buffer that is marked as dirty. This

--- a/pkg/streamingpromql/types/hpoint_ring_buffer.go
+++ b/pkg/streamingpromql/types/hpoint_ring_buffer.go
@@ -63,17 +63,16 @@ func (b *HPointRingBuffer) RemoveFirst() {
 }
 
 // Append adds p to this buffer, expanding it if required.
-// A boolean is returned indicating if the underlying buffer had to be resized.
 // If this buffer is non-empty, p.T must be greater than or equal to the
 // timestamp of the last point in the buffer.
-func (b *HPointRingBuffer) Append(p promql.HPoint) (bool, error) {
-	hPoint, resized, err := b.NextPoint()
+func (b *HPointRingBuffer) Append(p promql.HPoint) error {
+	hPoint, err := b.NextPoint()
 	if err != nil {
-		return resized, err
+		return err
 	}
 	hPoint.T = p.T
 	hPoint.H = p.H
-	return resized, nil
+	return nil
 }
 
 // EmptyView returns an empty view associated with this buffer that is marked as dirty. This
@@ -207,17 +206,13 @@ func (b *HPointRingBuffer) Count() int {
 
 // NextPoint gets the next point in this buffer, expanding it if required.
 //
-// A boolean is returned indicating if the underlying buffer had to be resized.
-//
 // The returned point's timestamp (HPoint.T) must be set to greater than or equal
 // to the timestamp of the last point in the buffer before further methods
 // are called on this buffer (with the exception of RemoveLastPoint, Reset or Close).
 //
 // This method allows reusing an existing HPoint in this buffer where possible,
 // reducing the number of FloatHistograms allocated.
-func (b *HPointRingBuffer) NextPoint() (*promql.HPoint, bool, error) {
-	resized := false
-
+func (b *HPointRingBuffer) NextPoint() (*promql.HPoint, error) {
 	if b.size == len(b.points) {
 		// Create a new slice, copy the elements from the current slice.
 		newSize := b.size * 2
@@ -227,16 +222,15 @@ func (b *HPointRingBuffer) NextPoint() (*promql.HPoint, bool, error) {
 
 		newSlice, err := getHPointSliceForRingBuffer(newSize, b.memoryConsumptionTracker)
 		if err != nil {
-			return nil, resized, err
+			return nil, err
 		}
 
 		if !pool.IsPowerOfTwo(cap(newSlice)) {
 			// We rely on the capacity being a power of two for the pointsIndexMask optimisation below.
 			// If we can guarantee that newSlice has a capacity that is a power of two in the future, then we can drop this check.
-			return nil, resized, fmt.Errorf("pool returned slice of capacity %v (requested %v), but wanted a power of two", cap(newSlice), newSize)
+			return nil, fmt.Errorf("pool returned slice of capacity %v (requested %v), but wanted a power of two", cap(newSlice), newSize)
 		}
 
-		resized = true
 		newSlice = newSlice[:cap(newSlice)]
 		pointsAtEnd := b.size - b.firstIndex
 		copy(newSlice, b.points[b.firstIndex:])
@@ -257,7 +251,7 @@ func (b *HPointRingBuffer) NextPoint() (*promql.HPoint, bool, error) {
 	nextIndex := (b.firstIndex + b.size) & b.pointsIndexMask
 	b.size++
 
-	return &b.points[nextIndex], resized, nil
+	return &b.points[nextIndex], nil
 }
 
 // RemoveLastPoint removes the last point that was allocated.

--- a/pkg/streamingpromql/types/ring_buffer_test.go
+++ b/pkg/streamingpromql/types/ring_buffer_test.go
@@ -20,7 +20,7 @@ import (
 // and we don't care about performance here so we can use an interface+generics.
 type ringBuffer[T any] interface {
 	DiscardPointsAtOrBefore(t int64)
-	Append(p T) (bool, error)
+	Append(p T) error
 	Reset()
 	Use(s []T) error
 	Release()
@@ -109,12 +109,10 @@ func testRingBuffer[T any](t *testing.T, buf ringBuffer[T], points []T) {
 	shouldHavePoints(t, buf, points[3:5]...)
 
 	// Trigger expansion of buffer (we resize in powers of two, and the underlying slice comes from a pool that uses a factor of 2 as well).
-	resized, err := buf.Append(points[5])
+	err := buf.Append(points[5])
 	require.NoError(t, err)
-	require.True(t, resized, "expected Append() to trigger a resize")
-	resized, err = buf.Append(points[6])
+	err = buf.Append(points[6])
 	require.NoError(t, err)
-	require.False(t, resized, "expected Append() not to trigger a resize")
 
 	shouldHavePoints(t, buf, points[3:7]...)
 
@@ -232,9 +230,8 @@ func TestRingBuffer_RemoveLastPoint(t *testing.T) {
 		require.Equal(t, 2, len(buf.GetPoints()))
 		require.Equal(t, 2, buf.size)
 
-		nextPoint, resized, err := buf.NextPoint()
+		nextPoint, err := buf.NextPoint()
 		require.NoError(t, err)
-		require.True(t, resized, "expected NextPoint() to trigger a resize")
 
 		*nextPoint = points[2]
 		// We assign "NextPoint" points[2], and then check it is in the ring
@@ -280,9 +277,8 @@ func TestRingBuffer_RemoveLastPoint(t *testing.T) {
 		// Check we only have the expected points
 		shouldHavePoints(t, buf, points[2:4]...)
 
-		nextPoint, resized, err := buf.NextPoint()
+		nextPoint, err := buf.NextPoint()
 		require.NoError(t, err)
-		require.False(t, resized, "expected NextPoint() not to trigger a resize")
 
 		*nextPoint = points[4]
 		// We assign "NextPoint" points[4], and then check it is in the ring
@@ -443,8 +439,7 @@ func TestRingBuffer_ViewBetweenSearchingBackwards(t *testing.T) {
 }
 
 func mustAppend[T any](t *testing.T, buf ringBuffer[T], point T) {
-	_, err := buf.Append(point)
-	require.NoError(t, err)
+	require.NoError(t, buf.Append(point))
 }
 
 func shouldHaveNoPoints[T any](t *testing.T, buf ringBuffer[T]) {
@@ -907,7 +902,7 @@ func TestFPointRingBuffer_AppendSlice(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			buff := NewFPointRingBuffer(limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, ""))
 			require.NoError(t, buff.Use(tc.buff))
-			_, err := buff.AppendSlice(tc.append)
+			err := buff.AppendSlice(tc.append)
 			require.NoError(t, err)
 			shouldHavePoints(t, &fPointRingBufferWrapper{FPointRingBuffer: buff}, tc.expected...)
 		})
@@ -922,36 +917,32 @@ func TestFPointRingBuffer_AppendAtStart(t *testing.T) {
 	require.Len(t, buff.points, 2)
 
 	// inserting another point will not grow the underlying buffer, so the new point is stored in the upper end of the existing 2 slot buffer
-	resized, err := buff.AppendAtStart(promql.FPoint{T: 9, F: 20})
+	err := buff.AppendAtStart(promql.FPoint{T: 9, F: 20})
 	require.NoError(t, err)
-	require.False(t, resized, "expected AppendAtStart() not to trigger a buffer resize")
 	require.Equal(t, 2, buff.size)
 	require.Equal(t, 1, buff.firstIndex)
 	require.Len(t, buff.points, 2)
 	require.Equal(t, promql.FPoint{T: 9, F: 20}, buff.PointAt(0))
 
 	// inserting another point will grow the underlying buffer - since we are growing the buffer we can re-align so that the firstIndex is 0 for the new head
-	resized, err = buff.AppendAtStart(promql.FPoint{T: 8, F: 20})
+	err = buff.AppendAtStart(promql.FPoint{T: 8, F: 20})
 	require.NoError(t, err)
-	require.True(t, resized, "expected AppendAtStart() to trigger a buffer resize")
 	require.Equal(t, 3, buff.size)
 	require.Equal(t, 0, buff.firstIndex)
 	require.Len(t, buff.points, 4)
 	require.Equal(t, promql.FPoint{T: 8, F: 20}, buff.PointAt(0))
 
 	// inserting another point will not grow the underlying buffer, so the new point is stored at the end of the existing buffer
-	resized, err = buff.AppendAtStart(promql.FPoint{T: 7, F: 20})
+	err = buff.AppendAtStart(promql.FPoint{T: 7, F: 20})
 	require.NoError(t, err)
-	require.False(t, resized, "expected AppendAtStart() not to trigger a buffer resize")
 	require.Equal(t, 4, buff.size)
 	require.Equal(t, 3, buff.firstIndex)
 	require.Len(t, buff.points, 4)
 	require.Equal(t, promql.FPoint{T: 7, F: 20}, buff.PointAt(0))
 
 	// inserting another point will grow the underlying buffer - since we are growing the buffer we can re-align so that the firstIndex is 0 for the new head
-	resized, err = buff.AppendAtStart(promql.FPoint{T: 6, F: 20})
+	err = buff.AppendAtStart(promql.FPoint{T: 6, F: 20})
 	require.NoError(t, err)
-	require.True(t, resized, "expected AppendAtStart() to trigger a buffer resize")
 	require.Equal(t, 5, buff.size)
 	require.Equal(t, 0, buff.firstIndex)
 	require.Len(t, buff.points, 8)
@@ -961,9 +952,9 @@ func TestFPointRingBuffer_AppendAtStart(t *testing.T) {
 func TestFPointRingBuffer_AppendSlice_Alignment(t *testing.T) {
 	buff := NewFPointRingBuffer(limiter.NewMemoryConsumptionTracker(context.Background(), 0, nil, ""))
 	// insert 2 samples - the first point will be at the tail of the ring
-	_, err := buff.AppendAtStart(promql.FPoint{T: 10, F: 20})
+	err := buff.AppendAtStart(promql.FPoint{T: 10, F: 20})
 	require.NoError(t, err)
-	_, err = buff.AppendAtStart(promql.FPoint{T: 5, F: 20})
+	err = buff.AppendAtStart(promql.FPoint{T: 5, F: 20})
 	require.NoError(t, err)
 
 	require.Equal(t, 2, buff.size)
@@ -971,9 +962,8 @@ func TestFPointRingBuffer_AppendSlice_Alignment(t *testing.T) {
 	require.Len(t, buff.points, 2)
 
 	// append a slice and validate that the buffer has been re-aligned to start at firstIndex=0
-	resized, err := buff.AppendSlice([]promql.FPoint{{T: 20, F: 20}, {T: 30, F: 20}, {T: 40, F: 20}})
+	err = buff.AppendSlice([]promql.FPoint{{T: 20, F: 20}, {T: 30, F: 20}, {T: 40, F: 20}})
 	require.NoError(t, err)
-	require.True(t, resized, "expected AppendSlice() to trigger a buffer resize")
 	shouldHavePoints(t, &fPointRingBufferWrapper{FPointRingBuffer: buff}, []promql.FPoint{{T: 5, F: 20}, {T: 10, F: 20}, {T: 20, F: 20}, {T: 30, F: 20}, {T: 40, F: 20}}...)
 
 	require.Equal(t, 0, buff.firstIndex)
@@ -992,7 +982,7 @@ func TestFPointRingBuffer_AppendSlice_SizeLessThanFirstIndex(t *testing.T) {
 	require.Equal(t, 0, buff.firstIndex)
 
 	buff.RemoveLast()
-	_, err := buff.AppendAtStart(promql.FPoint{T: 5})
+	err := buff.AppendAtStart(promql.FPoint{T: 5})
 	require.NoError(t, err)
 	require.Equal(t, 4, buff.size)
 	require.Len(t, buff.points, 4)
@@ -1005,7 +995,7 @@ func TestFPointRingBuffer_AppendSlice_SizeLessThanFirstIndex(t *testing.T) {
 	require.Len(t, buff.points, 4)
 	require.Equal(t, 3, buff.firstIndex)
 
-	_, err = buff.AppendSlice([]promql.FPoint{{T: 50}, {T: 60}, {T: 70}, {T: 80}})
+	err = buff.AppendSlice([]promql.FPoint{{T: 50}, {T: 60}, {T: 70}, {T: 80}})
 	require.NoError(t, err)
 }
 
@@ -1307,7 +1297,7 @@ func TestRingBufferView_IsDirty(t *testing.T) {
 
 		fviews := shouldHaveCleanViews(t, fbuff)
 
-		_, err := fbuff.AppendAtStart(promql.FPoint{T: 0})
+		err := fbuff.AppendAtStart(promql.FPoint{T: 0})
 		require.NoError(t, err)
 
 		shouldHaveDirtyViews(t, fbuff, fviews)

--- a/pkg/streamingpromql/types/stats_test.go
+++ b/pkg/streamingpromql/types/stats_test.go
@@ -68,15 +68,13 @@ func TestOperatorEvaluationStats_TrackSamplesForRangeVectorSelector(t *testing.T
 	}{
 		"floats": {
 			append: func(ts int64, floats *FPointRingBuffer, histograms *HPointRingBuffer) error {
-				_, err := floats.Append(promql.FPoint{T: ts})
-				return err
+				return floats.Append(promql.FPoint{T: ts})
 			},
 			samplesPerPoint: 1,
 		},
 		"histograms": {
 			append: func(ts int64, floatsf *FPointRingBuffer, histograms *HPointRingBuffer) error {
-				_, err := histograms.Append(promql.HPoint{T: ts, H: &histogram.FloatHistogram{}})
-				return err
+				return histograms.Append(promql.HPoint{T: ts, H: &histogram.FloatHistogram{}})
 			},
 			samplesPerPoint: EquivalentFloatSampleCount(&histogram.FloatHistogram{}),
 		},
@@ -186,12 +184,9 @@ func TestOperatorEvaluationStats_TrackSamplesForRangeVectorSelector_FloatsAndHis
 	histograms := NewHPointRingBuffer(memoryConsumptionTracker)
 
 	h := &histogram.FloatHistogram{}
-	_, err = floats.Append(promql.FPoint{T: timestamp.FromTime(start.Add(-3 * time.Second))})
-	require.NoError(t, err)
-	_, err = histograms.Append(promql.HPoint{T: timestamp.FromTime(start.Add(-2 * time.Second)), H: h})
-	require.NoError(t, err)
-	_, err = floats.Append(promql.FPoint{T: timestamp.FromTime(start.Add(-time.Second))})
-	require.NoError(t, err)
+	require.NoError(t, floats.Append(promql.FPoint{T: timestamp.FromTime(start.Add(-3 * time.Second))}))
+	require.NoError(t, histograms.Append(promql.HPoint{T: timestamp.FromTime(start.Add(-2 * time.Second)), H: h}))
+	require.NoError(t, floats.Append(promql.FPoint{T: timestamp.FromTime(start.Add(-time.Second))}))
 
 	stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start), floats, histograms, timestamp.FromTime(start.Add(-4*time.Second)), timestamp.FromTime(start), false, nil)
 	samplesProcessedPerStep.requireChange(t, stats.allSeries.samplesProcessedPerStep, 2+EquivalentFloatSampleCount(h), 0, 0)
@@ -225,10 +220,8 @@ func TestOperatorEvaluationStats_TrackSamplesForRangeVectorSelector_FixedTimesta
 	floats := NewFPointRingBuffer(memoryConsumptionTracker)
 	histograms := NewHPointRingBuffer(memoryConsumptionTracker)
 
-	_, err = floats.Append(promql.FPoint{T: timestamp.FromTime(start.Add(-2 * time.Second))})
-	require.NoError(t, err)
-	_, err = floats.Append(promql.FPoint{T: timestamp.FromTime(start.Add(-time.Second))})
-	require.NoError(t, err)
+	require.NoError(t, floats.Append(promql.FPoint{T: timestamp.FromTime(start.Add(-2 * time.Second))}))
+	require.NoError(t, floats.Append(promql.FPoint{T: timestamp.FromTime(start.Add(-time.Second))}))
 
 	haveTimestamp := true
 	stats.TrackSamplesForRangeVectorSelector(timestamp.FromTime(start), floats, histograms, timestamp.FromTime(start.Add(-4*time.Second)), timestamp.FromTime(start), haveTimestamp, nil)
@@ -331,14 +324,10 @@ func TestOperatorEvaluationStats_Subsets_TrackSamplesForRangeVectorSelector(t *t
 
 	floats := NewFPointRingBuffer(memoryConsumptionTracker)
 	histograms := NewHPointRingBuffer(memoryConsumptionTracker)
-	_, err = floats.Append(promql.FPoint{T: timestamp.FromTime(start.Add(-3 * time.Second))})
-	require.NoError(t, err)
-	_, err = floats.Append(promql.FPoint{T: timestamp.FromTime(start.Add(-2 * time.Second))})
-	require.NoError(t, err)
-	_, err = floats.Append(promql.FPoint{T: timestamp.FromTime(start.Add(-time.Second))})
-	require.NoError(t, err)
-	_, err = floats.Append(promql.FPoint{T: timestamp.FromTime(start)})
-	require.NoError(t, err)
+	require.NoError(t, floats.Append(promql.FPoint{T: timestamp.FromTime(start.Add(-3 * time.Second))}))
+	require.NoError(t, floats.Append(promql.FPoint{T: timestamp.FromTime(start.Add(-2 * time.Second))}))
+	require.NoError(t, floats.Append(promql.FPoint{T: timestamp.FromTime(start.Add(-time.Second))}))
+	require.NoError(t, floats.Append(promql.FPoint{T: timestamp.FromTime(start)}))
 
 	overallProcessed := newPerStepTracker("overall samples processed", timeRange.StepCount)
 	overallReadIfSubsequentStep := newPerStepTracker("overall samples read if subsequent step", timeRange.StepCount)


### PR DESCRIPTION
#### What this PR does

This was intended to be used to determine if views of the buffers were no longer valid but that was instead done with the `.IsDirty()` method.

#### Which issue(s) this PR fixes or relates to

Follow up to #16064

#### Checklist

- [X] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
