### PR TITLE
Return HTTP 500 error (rather than 400) from query-frontend if a querier receives a query plan that is too new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,7 @@
 * [BUGFIX] Packaging: Fix the DEB/RPM packages shipping the `mimir`, `mimirtool`, `metaconvert`, and `query-tee` binaries without the executable bit set, which caused `mimir.service` to fail to start. #16166
 * [BUGFIX] Query-frontend: Fix a goroutine leak when a querier's streaming response arrives just as the query is cancelled: the goroutine handling the response could stay blocked forever writing a response body that would never be read. #16151
 * [BUGFIX] MQE: Fix issue where a sentinel value was inadvertently returned to a pool where it could be mutated by multiple threads at once. #16205
+* [BUGFIX] Query-frontend: Return a HTTP 500 error rather than a HTTP 400 when a querier receives a query plan that is too new. #16233
 
 ### Mixin
 

--- a/pkg/frontend/v2/remoteexec.go
+++ b/pkg/frontend/v2/remoteexec.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/util/annotations"
 
+	apierror "github.com/grafana/mimir/pkg/api/error"
 	"github.com/grafana/mimir/pkg/frontend/v2/frontendv2pb"
 	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/querier/querierpb"
@@ -308,7 +309,7 @@ func (g *RemoteExecutionGroupEvaluator) getNodeStreamState(resp *querierpb.Evalu
 func (g *RemoteExecutionGroupEvaluator) readNextMessage(ctx context.Context) (*frontendv2pb.QueryResultStreamRequest, error) {
 	msg, err := g.stream.Next(ctx)
 	if err != nil {
-		return nil, err
+		return nil, translateReadError(err)
 	}
 
 	if msg == nil {
@@ -316,6 +317,19 @@ func (g *RemoteExecutionGroupEvaluator) readNextMessage(ctx context.Context) (*f
 	}
 
 	return msg, nil
+}
+
+// translateReadError translates errors received from queriers so that they surface as the appropriate error to callers.
+func translateReadError(err error) error {
+	// A "not acceptable" error indicates that the querier received a query plan version it doesn't understand. This is a
+	// bug or misconfiguration in the query-frontend rather than a problem with the request, so translate it to an internal
+	// server error (HTTP 500) rather than propagating the "not acceptable" status (HTTP 406) back to the caller.
+	var apiErr *apierror.APIError
+	if errors.As(err, &apiErr) && apiErr.Type == apierror.TypeNotAcceptable {
+		return apierror.New(apierror.TypeInternal, "querier rejected request as not acceptable: "+apiErr.Message)
+	}
+
+	return err
 }
 
 func (g *RemoteExecutionGroupEvaluator) finishedReadingStream(ctx context.Context, nodeStreamIndex remoteExecutionNodeStreamIndex) (stats.Stats, error) {

--- a/pkg/frontend/v2/remoteexec_test.go
+++ b/pkg/frontend/v2/remoteexec_test.go
@@ -797,6 +797,38 @@ func TestExecutionResponses_FinishedReadingAndFinalize(t *testing.T) {
 	})
 }
 
+func TestRemoteExecutionGroupEvaluator_TranslatesNotAcceptableErrorToInternal(t *testing.T) {
+	testCases := map[string]func(ctx context.Context, resp remoteexec.ScalarRemoteExecutionResponse) error{
+		"while reading messages": func(ctx context.Context, resp remoteexec.ScalarRemoteExecutionResponse) error {
+			_, err := resp.GetValues(ctx)
+			return err
+		},
+		"while finishing reading a stream": func(ctx context.Context, resp remoteexec.ScalarRemoteExecutionResponse) error {
+			_, err := resp.FinishedReading(ctx)
+			return err
+		},
+	}
+
+	notAcceptableErr := apierror.New(apierror.TypeNotAcceptable, "query plan has version 123, but the maximum supported query plan version is 1")
+	expectedError := apierror.New(apierror.TypeInternal, "querier rejected request as not acceptable: query plan has version 123, but the maximum supported query plan version is 1")
+
+	for name, fn := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			memoryConsumptionTracker := limiter.NewUnlimitedMemoryConsumptionTracker(ctx)
+			stream := &mockResponseStream{responses: []mockResponse{{err: notAcceptableErr}}}
+			frontend := &mockFrontend{stream: stream}
+			group := NewRemoteExecutionGroupEvaluator(frontend, Config{}, log.NewNopLogger(), false, &planning.QueryParameters{}, memoryConsumptionTracker)
+			response, err := group.CreateScalarExecution(ctx, createDummyNode(), types.NewInstantQueryTimeRange(time.Now()))
+			require.NoError(t, err)
+			require.NoError(t, response.Start(ctx))
+
+			err = fn(ctx, response)
+			require.Equal(t, expectedError, err)
+		})
+	}
+}
+
 type mockResponseStream struct {
 	release   chan struct{}
 	responses []mockResponse

--- a/pkg/streamingpromql/planning/plan.go
+++ b/pkg/streamingpromql/planning/plan.go
@@ -451,7 +451,7 @@ func NodeTypeName(n Node) string {
 // DecodeNodes decodes nodes for the provided nodeIndices from the encoded plan.
 func (p *EncodedQueryPlan) DecodeNodes(nodeIndices ...int64) ([]Node, error) {
 	if p.Version > MaximumSupportedQueryPlanVersion {
-		return nil, apierror.Newf(apierror.TypeBadData, "query plan has version %v, but the maximum supported query plan version is %v", p.Version, MaximumSupportedQueryPlanVersion)
+		return nil, apierror.Newf(apierror.TypeNotAcceptable, "query plan has version %v, but the maximum supported query plan version is %v", p.Version, MaximumSupportedQueryPlanVersion)
 	}
 
 	decoder := newQueryPlanDecoder(p.Nodes)


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue where query-frontends would return a HTTP 400 error to the caller if a querier rejected the query plan because it is too new.

Note that this fix will only apply if queriers are upgraded to run the change from this PR as well, query-frontends running with the changes here calling an older querier without it will still return a HTTP 400 error. Open to feedback on this, but changing the error type from queriers felt like the cleanest way to handle this.

#### Which issue(s) this PR fixes or relates to

Related: https://github.com/grafana/mimir/pull/16227

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
