### PR TITLE
MQE: remove unnecessary step-invariant expression wrappers after collapsing constants

### DIFF
--- a/pkg/streamingpromql/optimize/ast/collapse_constants.go
+++ b/pkg/streamingpromql/optimize/ast/collapse_constants.go
@@ -94,6 +94,12 @@ func (c *CollapseConstants) apply(expr parser.Expr) parser.Expr {
 		return expr
 	case *parser.StepInvariantExpr:
 		expr.Expr = c.apply(expr.Expr)
+
+		// If the inner expression is now just a number literal, drop the step invariant expression wrapper.
+		if _, ok := expr.Expr.(*parser.NumberLiteral); ok {
+			return expr.Expr
+		}
+
 		return expr
 	case *parser.VectorSelector, *parser.MatrixSelector, *parser.StringLiteral, *parser.NumberLiteral:
 		// Nothing to do.

--- a/pkg/streamingpromql/optimize/ast/collapse_constants_test.go
+++ b/pkg/streamingpromql/optimize/ast/collapse_constants_test.go
@@ -15,6 +15,8 @@ import (
 func TestCollapseConstants(t *testing.T) {
 	testCases := map[string]string{
 		"2":                                  "2",
+		"(2)":                                "2",
+		"((((2))))":                          "2",
 		"-2":                                 "-2",
 		"-(2)":                               "-2",
 		"+(2)":                               "2",
@@ -61,11 +63,25 @@ func TestCollapseConstants(t *testing.T) {
 			result := runASTOptimizationPassWithoutMetrics(t, ctx, input, collapseConstants)
 			require.Equal(t, expected, result.String())
 
-			// Check for unnecessary unary expressions.
-			if u, ok := result.(*parser.UnaryExpr); ok {
-				_, isNumberLiteral := u.Expr.(*parser.NumberLiteral)
-				require.Falsef(t, isNumberLiteral, "should not have a unary expression wrapping a number literal:\n%v", parser.Tree(result))
-			}
+			// Check for unnecessary unary or step-invariant expressions or parentheses.
+			parser.Inspect(result, func(node parser.Node, _ []parser.Node) error {
+				if u, ok := result.(*parser.UnaryExpr); ok {
+					_, isNumberLiteral := u.Expr.(*parser.NumberLiteral)
+					require.Falsef(t, isNumberLiteral, "should not have a unary expression wrapping a number literal:\n%v", parser.Tree(result))
+				}
+
+				if s, ok := result.(*parser.StepInvariantExpr); ok {
+					_, isNumberLiteral := s.Expr.(*parser.NumberLiteral)
+					require.Falsef(t, isNumberLiteral, "should not have a step-invariant expression wrapping a number literal:\n%v", parser.Tree(result))
+				}
+
+				if p, ok := result.(*parser.ParenExpr); ok {
+					_, isNumberLiteral := p.Expr.(*parser.NumberLiteral)
+					require.Falsef(t, isNumberLiteral, "should not have parentheses expression wrapping a number literal:\n%v", parser.Tree(result))
+				}
+
+				return nil
+			})
 		})
 	}
 }

--- a/pkg/streamingpromql/optimize/ast/collapse_constants_test.go
+++ b/pkg/streamingpromql/optimize/ast/collapse_constants_test.go
@@ -65,17 +65,17 @@ func TestCollapseConstants(t *testing.T) {
 
 			// Check for unnecessary unary or step-invariant expressions or parentheses.
 			parser.Inspect(result, func(node parser.Node, _ []parser.Node) error {
-				if u, ok := result.(*parser.UnaryExpr); ok {
+				if u, ok := node.(*parser.UnaryExpr); ok {
 					_, isNumberLiteral := u.Expr.(*parser.NumberLiteral)
 					require.Falsef(t, isNumberLiteral, "should not have a unary expression wrapping a number literal:\n%v", parser.Tree(result))
 				}
 
-				if s, ok := result.(*parser.StepInvariantExpr); ok {
+				if s, ok := node.(*parser.StepInvariantExpr); ok {
 					_, isNumberLiteral := s.Expr.(*parser.NumberLiteral)
 					require.Falsef(t, isNumberLiteral, "should not have a step-invariant expression wrapping a number literal:\n%v", parser.Tree(result))
 				}
 
-				if p, ok := result.(*parser.ParenExpr); ok {
+				if p, ok := node.(*parser.ParenExpr); ok {
 					_, isNumberLiteral := p.Expr.(*parser.NumberLiteral)
 					require.Falsef(t, isNumberLiteral, "should not have parentheses expression wrapping a number literal:\n%v", parser.Tree(result))
 				}


### PR DESCRIPTION
#### What this PR does

This PR improves the "collapse constants" optimisation pass to drop unnecessary step invariant expression wrapper nodes if the contents of that node are reduced to a single literal value.

This change has no user-visible impact, so I've chosen not to add a changelog entry.
 
#### Which issue(s) this PR fixes or relates to

Related: https://github.com/grafana/mimir/pull/16227

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
