### PR TITLE
operation: Add missing value to exclusion list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,7 @@
 * [ENHANCEMENT] Make range vector splitting configurable per query path. #15706
 * [ENHANCEMENT] Add `newMimirtoolBlocksJob` and subcommand-specific helpers to run `mimirtool blocks` as Kubernetes Jobs. #15757
 * [BUGFIX] Continuous-test: Include `._config.commonConfig` in arguments passed to continuous-test. #15988
+* [BUGFIX] Add missing `-querier.mimir-query-engine.range-vector-splitting.memcached.addresses` to `multi_zone_config_validation_excluded_args`. #16237
 
 
 ### Documentation

--- a/operations/mimir/multi-zone-common.libsonnet
+++ b/operations/mimir/multi-zone-common.libsonnet
@@ -35,6 +35,7 @@ local jsonpath = import 'github.com/jsonnet-libs/xtd/jsonpath.libsonnet';
         '-blocks-storage.bucket-store.chunks-cache.memcached.addresses',
         '-blocks-storage.bucket-store.index-cache.memcached.addresses',
         '-blocks-storage.bucket-store.metadata-cache.memcached.addresses',
+        '-querier.mimir-query-engine.range-vector-splitting.memcached.addresses',
         '-query-frontend.results-cache.memcached.addresses',
         '-ruler-storage.cache.memcached.addresses',
       ]


### PR DESCRIPTION
#### What this PR does

This new parameter was not added to the exclusion array which is necessary whenever we enable the range-vector-splitting, but don't have multi-zone memcached routing.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [X] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
