### PR TITLE
Fix flaky `TestOTLPIngestion` after #16187

### DIFF
--- a/integration/otlp_ingestion_test.go
+++ b/integration/otlp_ingestion_test.go
@@ -86,6 +86,11 @@ func testOTLPIngestion(t *testing.T, opts testOTLPIngestionOpts) {
 	mimir := e2emimir.NewSingleBinary("mimir-1", flags, e2emimir.WithConfigFile(mimirConfigFile), e2emimir.WithPorts(9009, 9095))
 	require.NoError(t, s.StartAndWaitReady(mimir))
 
+	// Wait until the query-frontend has updated the querier ring.
+	require.NoError(t, mimir.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
+		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+
 	c, err := e2emimir.NewClient(mimir.HTTPEndpoint(), mimir.HTTPEndpoint(), "", "", "user-1")
 	require.NoError(t, err)
 


### PR DESCRIPTION
#### What this PR does

This PR is like #16197, but applies the same fix to `TestOTLPIngestion`.

#### Which issue(s) this PR fixes or relates to

#16187

#### Checklist

- [n/a] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
