### PR TITLE
Add query sharding integration test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/alertmanager v0.33.1
-	github.com/prometheus/client_golang v1.24.1
+	github.com/prometheus/client_golang v1.24.2-0.20260812154952-0c5dccd910c0
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.70.1
 	github.com/prometheus/prometheus v1.99.0

--- a/go.sum
+++ b/go.sum
@@ -905,8 +905,8 @@ github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5Fsn
 github.com/prometheus/client_golang v1.4.0/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3OK1iX/F2sw+iXX5zU=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_golang v1.11.1/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
-github.com/prometheus/client_golang v1.24.1 h1:JnJkREXzWxUdCuPFpIWZiPispT9xVV59uiuyR2bPlnU=
-github.com/prometheus/client_golang v1.24.1/go.mod h1:F+oSRECHg4sse5ucfYpYDeIv/hu68Zo0uoHKetWnzcE=
+github.com/prometheus/client_golang v1.24.2-0.20260812154952-0c5dccd910c0 h1:p4ZEpjBR5tNQIYd9z2A7M7GpbYovkUVE/bc4b+zg+MY=
+github.com/prometheus/client_golang v1.24.2-0.20260812154952-0c5dccd910c0/go.mod h1:F+oSRECHg4sse5ucfYpYDeIv/hu68Zo0uoHKetWnzcE=
 github.com/prometheus/client_golang/exp v0.0.0-20260724065723-ecdb8254ba61 h1:SgKx/5u9SwqzZ27E1T4bfuisjTOkI3GagC6WtdEE5lg=
 github.com/prometheus/client_golang/exp v0.0.0-20260724065723-ecdb8254ba61/go.mod h1:CoLfLGxCH1vzpdmZ+p2uaUGH43j+99HYmnK1Wak6rS4=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=

--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -325,7 +325,7 @@ func checkQueries(
 
 			for _, query := range instantQueries {
 				t.Run(fmt.Sprintf("instant query: %s", query.expr), func(t *testing.T) {
-					result, err := c.Query(query.expr, query.time)
+					result, _, _, err := c.Query(query.expr, query.time)
 					require.NoError(t, err)
 					require.Equal(t, model.ValVector, result.Type())
 					require.Equal(t, query.expectedVector, result.(model.Vector))

--- a/integration/compartments_test.go
+++ b/integration/compartments_test.go
@@ -156,7 +156,7 @@ func TestIngesterQuerying_ShouldSupportCompartments(t *testing.T) {
 	require.NoError(t, err)
 
 	for name, expectedVector := range expectedVectors {
-		result, err := queryClient.Query(name, now)
+		result, _, _, err := queryClient.Query(name, now)
 		require.NoErrorf(t, err, "metric: %s", name)
 		require.Equalf(t, model.ValVector, result.Type(), "metric: %s", name)
 		assert.Equalf(t, expectedVector, result.(model.Vector), "metric: %s", name)
@@ -389,7 +389,7 @@ func TestStoreGatewayQuerying_ShouldSupportCompartments(t *testing.T) {
 	// expected series is returned.
 	for name, expectedVector := range expectedVectors {
 		test.Poll(t, 30*time.Second, expectedVector, func() interface{} {
-			res, err := queryClient.Query(name, now)
+			res, _, _, err := queryClient.Query(name, now)
 			if err != nil || res.Type() != model.ValVector {
 				return model.Vector(nil)
 			}
@@ -408,7 +408,7 @@ func TestStoreGatewayQuerying_ShouldSupportCompartments(t *testing.T) {
 		}
 		querierSumBefore, querierCountBefore := querierStoreGatewayCompartmentsHit(t, querier)
 
-		_, err := queryClient.Query(name, now)
+		_, _, _, err := queryClient.Query(name, now)
 		require.NoErrorf(t, err, "metric: %s", name)
 
 		// The targeted compartment's store-gateway served one more Series request...
@@ -440,7 +440,7 @@ func TestStoreGatewayQuerying_ShouldSupportCompartments(t *testing.T) {
 		}
 		querierSumBefore, querierCountBefore := querierStoreGatewayCompartmentsHit(t, querier)
 
-		_, err := queryClient.Query(`{__name__=~"compartment_series_.*"}`, now)
+		_, _, _, err := queryClient.Query(`{__name__=~"compartment_series_.*"}`, now)
 		require.NoError(t, err)
 
 		for i := range storeGateways {

--- a/integration/distributor_test.go
+++ b/integration/distributor_test.go
@@ -1135,7 +1135,7 @@ func TestDistributor_RW2_RC3_CreatedTimestamp(t *testing.T) {
 			{Timestamp: model.Time(queryStart.Add(5 * time.Minute).UnixMilli()), Value: model.SampleValue(100)},
 		},
 	}}
-	got, err := client.QueryRange("foobarC_CT_total", queryStart, queryEnd, queryStep)
+	got, _, _, err := client.QueryRange("foobarC_CT_total", queryStart, queryEnd, queryStep)
 	require.NoError(t, err)
 	require.Equal(t, want.String(), got.String())
 }
@@ -1288,7 +1288,7 @@ func testDistributorCases(t *testing.T, cachingUnmarshalDataEnabled bool, rwVers
 			}
 
 			for q, res := range tc.queries {
-				result, err := client.QueryRange(q, queryStart, queryEnd, queryStep)
+				result, _, _, err := client.QueryRange(q, queryStart, queryEnd, queryStep)
 				require.NoError(t, err)
 
 				require.Equal(t, res.String(), result.String())
@@ -1599,7 +1599,7 @@ func testDistributorNameValidation(
 				return
 			}
 			for q, want := range tc.queries {
-				got, err := client.QueryRange(q, queryStart, queryEnd, queryStep)
+				got, _, _, err := client.QueryRange(q, queryStart, queryEnd, queryStep)
 				require.NoError(t, err)
 				require.Equal(t, want.String(), got.String())
 			}

--- a/integration/e2emimir/client.go
+++ b/integration/e2emimir/client.go
@@ -319,25 +319,25 @@ func (c *Client) PushOTLPPayload(payload []byte, contentType string) (*http.Resp
 }
 
 // Query runs an instant query.
-func (c *Client) Query(query string, ts time.Time, opts ...promv1.Option) (model.Value, error) {
+func (c *Client) Query(query string, ts time.Time, opts ...promv1.Option) (model.Value, promv1.Warnings, promv1.Infos, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
 	defer cancel()
 
-	value, _, err := c.querierClient.Query(ctx, query, ts, opts...)
-	return value, err
+	value, warnings, infos, err := c.querierClient.Query(ctx, query, ts, opts...)
+	return value, warnings, infos, err
 }
 
 // QueryRange runs a range query.
-func (c *Client) QueryRange(query string, start, end time.Time, step time.Duration, opts ...promv1.Option) (model.Value, error) {
+func (c *Client) QueryRange(query string, start, end time.Time, step time.Duration, opts ...promv1.Option) (model.Value, promv1.Warnings, promv1.Infos, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
 	defer cancel()
 
-	value, _, err := c.querierClient.QueryRange(ctx, query, promv1.Range{
+	value, warnings, infos, err := c.querierClient.QueryRange(ctx, query, promv1.Range{
 		Start: start,
 		End:   end,
 		Step:  step,
 	}, opts...)
-	return value, err
+	return value, warnings, infos, err
 }
 
 // QueryRangeRaw runs a ranged query directly against the querier API.
@@ -500,7 +500,7 @@ func (c *Client) Series(matches []string, start, end time.Time, opts ...promv1.O
 	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
 	defer cancel()
 
-	result, _, err := c.querierClient.Series(ctx, matches, start, end, opts...)
+	result, _, _, err := c.querierClient.Series(ctx, matches, start, end, opts...)
 	return result, err
 }
 
@@ -509,7 +509,7 @@ func (c *Client) LabelValues(label string, start, end time.Time, matches []strin
 	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
 	defer cancel()
 
-	result, _, err := c.querierClient.LabelValues(ctx, label, matches, start, end, opts...)
+	result, _, _, err := c.querierClient.LabelValues(ctx, label, matches, start, end, opts...)
 	return result, err
 }
 
@@ -518,7 +518,7 @@ func (c *Client) LabelNames(start, end time.Time, matches []string, opts ...prom
 	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
 	defer cancel()
 
-	result, _, err := c.querierClient.LabelNames(ctx, matches, start, end, opts...)
+	result, _, _, err := c.querierClient.LabelNames(ctx, matches, start, end, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/integration/getting_started_with_gossiped_ring_test.go
+++ b/integration/getting_started_with_gossiped_ring_test.go
@@ -123,7 +123,7 @@ func runTestGettingStartedWithGossipedRing(t *testing.T, mimir1 *e2emimir.MimirS
 	require.Equal(t, 200, res.StatusCode)
 
 	// Query the series via Mimir 1
-	result, err := c1.Query(seriesName, now)
+	result, _, _, err := c1.Query(seriesName, now)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, result.Type())
 	assert.Equal(t, expectedVector, result.(model.Vector))

--- a/integration/getting_started_with_grafana_mimir_test.go
+++ b/integration/getting_started_with_grafana_mimir_test.go
@@ -87,7 +87,7 @@ func runTestPushSeriesAndQueryBack(t *testing.T, mimir *e2emimir.MimirService, s
 	require.Equal(t, http.StatusOK, res.StatusCode)
 
 	// Query the series.
-	result, err := c.Query(seriesName, now)
+	result, _, _, err := c.Query(seriesName, now)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, result.Type())
 	assert.Equal(t, expectedVector, result.(model.Vector))
@@ -100,7 +100,7 @@ func runTestPushSeriesAndQueryBack(t *testing.T, mimir *e2emimir.MimirService, s
 	require.NoError(t, err)
 	require.Equal(t, []string{"__name__", "foo"}, labelNames)
 
-	rangeResult, err := c.QueryRange(seriesName, now.Add(-15*time.Minute), now, 15*time.Second)
+	rangeResult, _, _, err := c.QueryRange(seriesName, now.Add(-15*time.Minute), now, 15*time.Second)
 	require.NoError(t, err)
 	require.Equal(t, model.ValMatrix, rangeResult.Type())
 	require.Equal(t, expectedMatrix, rangeResult.(model.Matrix))

--- a/integration/influx_ingestion_test.go
+++ b/integration/influx_ingestion_test.go
@@ -76,7 +76,7 @@ func TestInfluxIngestion(t *testing.T) {
 		labels.MustNewMatcher(labels.MatchEqual, "user", "user-1"))))
 
 	// Query the series.
-	result, err := c.Query("series_f1", now)
+	result, _, _, err := c.Query("series_f1", now)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, result.Type())
 	assert.Equal(t, expectedVector, result.(model.Vector))
@@ -89,7 +89,7 @@ func TestInfluxIngestion(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []string{"__name__", "__proxy_source__", "foo"}, labelNames)
 
-	rangeResult, err := c.QueryRange("series_f1", now.Add(-15*time.Minute), now, 15*time.Second)
+	rangeResult, _, _, err := c.QueryRange("series_f1", now.Add(-15*time.Minute), now, 15*time.Second)
 	require.NoError(t, err)
 	require.Equal(t, model.ValMatrix, rangeResult.Type())
 	require.Equal(t, expectedMatrix, rangeResult.(model.Matrix))

--- a/integration/ingester_sharding_test.go
+++ b/integration/ingester_sharding_test.go
@@ -149,7 +149,7 @@ func TestIngesterSharding(t *testing.T) {
 
 			// Query back series.
 			for metricName, expectedVector := range expectedVectors {
-				result, err := client.Query(metricName, now)
+				result, _, _, err := client.Query(metricName, now)
 				require.NoError(t, err)
 				require.Equal(t, model.ValVector, result.Type())
 				assert.Equal(t, expectedVector, result.(model.Vector))

--- a/integration/ingester_test.go
+++ b/integration/ingester_test.go
@@ -535,14 +535,14 @@ func TestIngesterQuerying(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, http.StatusOK, res.StatusCode)
 
-			result, err := client.QueryRange(query, queryStart, queryEnd, queryStep)
+			result, _, _, err := client.QueryRange(query, queryStart, queryEnd, queryStep)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedQueryResult, result)
 
 			// The PromQL engine does some special handling for the timestamp() function which previously
 			// caused queries to fail when streaming chunks was enabled, so check that this regression
 			// has not been reintroduced.
-			result, err = client.QueryRange(timestampQuery, queryStart, queryEnd, queryStep)
+			result, _, _, err = client.QueryRange(timestampQuery, queryStart, queryEnd, queryStep)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedTimestampQueryResult, result)
 
@@ -639,7 +639,7 @@ func TestIngesterQueryingWithRequestMinimization(t *testing.T) {
 	require.Equal(t, 200, res.StatusCode)
 
 	// Verify we can query the data we just pushed.
-	queryResult, err := client.Query(seriesName, now)
+	queryResult, _, _, err := client.Query(seriesName, now)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, queryResult.Type())
 	require.Equal(t, expectedVector, queryResult.(model.Vector))
@@ -748,7 +748,7 @@ func TestIngesterReportGRPCStatusCodes(t *testing.T) {
 	pushRequests := sums[0]
 	require.Equal(t, pushRequests, 1.0)
 
-	result, err := client.QueryRange(query, queryStart, queryEnd, queryStep)
+	result, _, _, err := client.QueryRange(query, queryStart, queryEnd, queryStep)
 	require.NoError(t, err)
 	require.Equal(t, expectedQueryResult, result)
 

--- a/integration/kafka_auth_test.go
+++ b/integration/kafka_auth_test.go
@@ -231,7 +231,7 @@ printf '%s' "$BODY"
 
 			// Query the series back and verify the result matches what was pushed.
 			require.EventuallyWithT(t, func(c *assert.CollectT) {
-				result, err := client.Query("test_series", now)
+				result, _, _, err := client.Query("test_series", now)
 				require.NoError(c, err)
 				require.Equal(c, model.ValVector, result.Type())
 				assert.Equal(c, expectedVector, result.(model.Vector))

--- a/integration/ooo_ingestion_test.go
+++ b/integration/ooo_ingestion_test.go
@@ -80,7 +80,7 @@ func TestOOOIngestion(t *testing.T) {
 	expectedMatrix[0].Values = append(expectedMatrix[0].Values, model.SamplePair{Timestamp: expectedVector[0].Timestamp, Value: expectedVector[0].Value})
 
 	// Query float series.
-	rangeResult, err := c.QueryRange(floatSeriesName, nowTS.Add(-time.Minute), nowTS, time.Minute)
+	rangeResult, _, _, err := c.QueryRange(floatSeriesName, nowTS.Add(-time.Minute), nowTS, time.Minute)
 	require.NoError(t, err)
 	require.Equal(t, model.ValMatrix, rangeResult.Type())
 	require.Equal(t, expectedMatrix, rangeResult.(model.Matrix))
@@ -109,7 +109,7 @@ func TestOOOIngestion(t *testing.T) {
 	expectedMatrix[0].Histograms = append(expectedMatrix[0].Histograms, model.SampleHistogramPair{Timestamp: expectedVector[0].Timestamp, Histogram: expectedVector[0].Histogram})
 
 	// Query int histogram series.
-	rangeResult, err = c.QueryRange(intHistogramSeriesName, nowTS.Add(-time.Minute), nowTS, time.Minute)
+	rangeResult, _, _, err = c.QueryRange(intHistogramSeriesName, nowTS.Add(-time.Minute), nowTS, time.Minute)
 	require.NoError(t, err)
 	require.Equal(t, model.ValMatrix, rangeResult.Type())
 	require.Equal(t, expectedMatrix, rangeResult.(model.Matrix))
@@ -138,7 +138,7 @@ func TestOOOIngestion(t *testing.T) {
 	expectedMatrix[0].Histograms = append(expectedMatrix[0].Histograms, model.SampleHistogramPair{Timestamp: expectedVector[0].Timestamp, Histogram: expectedVector[0].Histogram})
 
 	// Query float histogram series.
-	rangeResult, err = c.QueryRange(floatHistogramSeriesName, nowTS.Add(-time.Minute), nowTS, time.Minute)
+	rangeResult, _, _, err = c.QueryRange(floatHistogramSeriesName, nowTS.Add(-time.Minute), nowTS, time.Minute)
 	require.NoError(t, err)
 	require.Equal(t, model.ValMatrix, rangeResult.Type())
 	require.Equal(t, expectedMatrix, rangeResult.(model.Matrix))

--- a/integration/otlp_ingestion_test.go
+++ b/integration/otlp_ingestion_test.go
@@ -126,7 +126,7 @@ func testOTLPIngestion(t *testing.T, opts testOTLPIngestionOpts) {
 	metricQuery := fmt.Sprintf(`{"%s"}`, convertedMetricName)
 
 	// Query the series.
-	result, err := c.Query(metricQuery, now)
+	result, _, _, err := c.Query(metricQuery, now)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, result.Type())
 	assert.Equal(t, expectedVector, result.(model.Vector))
@@ -139,7 +139,7 @@ func testOTLPIngestion(t *testing.T, opts testOTLPIngestionOpts) {
 	require.NoError(t, err)
 	require.Equal(t, []string{"__name__", "foo"}, labelNames)
 
-	rangeResult, err := c.QueryRange(metricQuery, now.Add(-15*time.Minute), now, 15*time.Second)
+	rangeResult, _, _, err := c.QueryRange(metricQuery, now.Add(-15*time.Minute), now, 15*time.Second)
 	require.NoError(t, err)
 	require.Equal(t, model.ValMatrix, rangeResult.Type())
 	require.Equal(t, expectedMatrix, rangeResult.(model.Matrix))
@@ -193,7 +193,7 @@ func testOTLPIngestion(t *testing.T, opts testOTLPIngestionOpts) {
 
 	// UTF-8 format names have to be in quotes.
 	histogramQuery := fmt.Sprintf(`{"%s"}`, convertedHistogramName)
-	result, err = c.Query(histogramQuery, now)
+	result, _, _, err = c.Query(histogramQuery, now)
 	require.NoError(t, err)
 
 	want := expectedVector[0]
@@ -368,7 +368,7 @@ func testOTLPHistogramIngestion(t *testing.T, enableExplicitHistogramToNHCB bool
 	// Query the histogram series
 	if enableExplicitHistogramToNHCB {
 		// Verify that when flag is disabled, OTel explicit bucket histograms are converted to native histograms with custom buckets
-		result, err := c.Query("explicit_bucket_histogram_series", now)
+		result, _, _, err := c.Query("explicit_bucket_histogram_series", now)
 		require.NoError(t, err)
 		require.Equal(t, result.(model.Vector)[0].Histogram, &model.SampleHistogram{
 			Count: model.FloatString(10),
@@ -406,14 +406,14 @@ func testOTLPHistogramIngestion(t *testing.T, enableExplicitHistogramToNHCB bool
 			{`explicit_bucket_histogram_series_bucket{le="+Inf"}`, 10},
 		}
 		for _, exp := range expected {
-			result, err := c.Query(exp.name, now)
+			result, _, _, err := c.Query(exp.name, now)
 			require.NoError(t, err)
 			require.Equal(t, exp.value, result.(model.Vector)[0].Value)
 		}
 	}
 
 	// Verify that OTel exponential histograms are converted to native histograms
-	result, err := c.Query("exponential_histogram_series", now)
+	result, _, _, err := c.Query("exponential_histogram_series", now)
 	require.NoError(t, err)
 	require.Equal(t, result.(model.Vector)[0].Histogram.Count, model.FloatString(15))
 	require.Equal(t, result.(model.Vector)[0].Histogram.Sum, model.FloatString(25))
@@ -598,7 +598,7 @@ func testStartTimeHandling(t *testing.T, enableCTzero bool) {
 
 			for _, metric := range []string{counterMetric, histogramMetric} {
 				t.Run(metric, func(t *testing.T) {
-					result, err := c.Query(metric+"[1h]", now.Add(30*time.Minute))
+					result, _, _, err := c.Query(metric+"[1h]", now.Add(30*time.Minute))
 					require.NoError(t, err)
 
 					m, ok := result.(model.Matrix)
@@ -651,7 +651,7 @@ func testStartTimeHandling(t *testing.T, enableCTzero bool) {
 					// the injected zero histogram has a scale == 0.
 					// The resolution isn't returned directly, but we can check the
 					// number of buckets to see if some were merged together.
-					result, err = c.Query("rate("+metric+"[1m])", now.Add(1*time.Second))
+					result, _, _, err = c.Query("rate("+metric+"[1m])", now.Add(1*time.Second))
 					require.NoError(t, err)
 
 					v, ok := result.(model.Vector)

--- a/integration/querier_sharding_test.go
+++ b/integration/querier_sharding_test.go
@@ -233,16 +233,16 @@ func TestQuerySharding_ResultConsistency(t *testing.T) {
 	require.NoError(t, err)
 	defer s.Close()
 
-	memcached := e2ecache.NewMemcached()
 	consul := e2edb.NewConsul()
-	require.NoError(t, s.StartAndWaitReady(consul, memcached))
+	require.NoError(t, s.StartAndWaitReady(consul))
 
 	flags := mergeFlags(BlocksStorageFlags(), BlocksStorageS3Flags(), map[string]string{
+		// Results caching is deliberately disabled (also the default): the sharded and unsharded requests
+		// share tenant, query, and time range, so a shared results cache could serve one path's response to
+		// the other and make the comparison pass even if sharded evaluation were wrong.
 		"-query-frontend.cache-results":                       "false",
 		"-query-frontend.parallelize-shardable-queries":       "true",
 		"-query-frontend.query-sharding-total-shards":         "0", // Disable sharding by default.
-		"-query-frontend.results-cache.backend":               "memcached",
-		"-query-frontend.results-cache.memcached.addresses":   "dns+" + memcached.NetworkEndpoint(e2ecache.MemcachedPort),
 		"-query-frontend.enable-remote-execution":             "true",
 		"-query-frontend.use-mimir-query-engine-for-sharding": "true",
 	})

--- a/integration/querier_sharding_test.go
+++ b/integration/querier_sharding_test.go
@@ -7,6 +7,8 @@ package integration
 
 import (
 	"fmt"
+	"math"
+	"path/filepath"
 	"strconv"
 	"sync"
 	"testing"
@@ -17,6 +19,7 @@ import (
 	e2edb "github.com/grafana/e2e/db"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -218,4 +221,198 @@ func runQuerierShardingTest(t *testing.T, cfg querierShardingTestConfig) {
 	assertServiceMetricsPrefixes(t, Querier, querier2)
 	assertServiceMetricsPrefixes(t, QueryFrontend, queryFrontend)
 	assertServiceMetricsPrefixes(t, QueryScheduler, queryScheduler)
+}
+
+// TestQuerySharding_ResultConsistency verifies that sharded queries (via query-frontend)
+// produce the same results as unsharded queries (direct to querier) for functions like
+// rate(), sum(), avg(), etc. that operate over range vectors.
+func TestQuerySharding_ResultConsistency(t *testing.T) {
+	s, err := e2e.NewScenario(networkName)
+	require.NoError(t, err)
+	defer s.Close()
+
+	memcached := e2ecache.NewMemcached()
+	consul := e2edb.NewConsul()
+	require.NoError(t, s.StartAndWaitReady(consul, memcached))
+
+	flags := mergeFlags(BlocksStorageFlags(), BlocksStorageS3Flags(), map[string]string{
+		"-query-frontend.cache-results":                       "false",
+		"-query-frontend.parallelize-shardable-queries":       "true",
+		"-query-frontend.query-sharding-total-shards":         "0", // Disable sharding by default.
+		"-query-frontend.results-cache.backend":               "memcached",
+		"-query-frontend.results-cache.memcached.addresses":   "dns+" + memcached.NetworkEndpoint(e2ecache.MemcachedPort),
+		"-query-frontend.enable-remote-execution":             "true",
+		"-query-frontend.use-mimir-query-engine-for-sharding": "true",
+	})
+
+	minio := e2edb.NewMinio(9000, flags["-blocks-storage.s3.bucket-name"])
+	require.NoError(t, s.StartAndWaitReady(minio))
+
+	// Enable query sharding for a specific tenant via runtime config.
+	runtimeConfig := "runtime-config.yaml"
+	require.NoError(t, writeFileToSharedDir(s, runtimeConfig, []byte(`
+overrides:
+  sharded-tenant:
+    query_sharding_total_shards: 8
+`)))
+	flags["-runtime-config.file"] = filepath.Join(e2e.ContainerSharedDir, runtimeConfig)
+
+	// Start query-scheduler.
+	queryScheduler := e2emimir.NewQueryScheduler("query-scheduler", flags)
+	require.NoError(t, s.StartAndWaitReady(queryScheduler))
+	flags["-query-frontend.scheduler-address"] = queryScheduler.NetworkGRPCEndpoint()
+	flags["-querier.scheduler-address"] = queryScheduler.NetworkGRPCEndpoint()
+
+	// Start services.
+	queryFrontend := e2emimir.NewQueryFrontend("query-frontend", consul.NetworkHTTPEndpoint(), flags)
+	require.NoError(t, s.Start(queryFrontend))
+
+	ingester := e2emimir.NewIngester("ingester", consul.NetworkHTTPEndpoint(), flags)
+	distributor := e2emimir.NewDistributor("distributor", consul.NetworkHTTPEndpoint(), flags)
+	querier1 := e2emimir.NewQuerier("querier-1", consul.NetworkHTTPEndpoint(), flags)
+	querier2 := e2emimir.NewQuerier("querier-2", consul.NetworkHTTPEndpoint(), flags)
+
+	require.NoError(t, s.StartAndWaitReady(querier1, querier2, ingester, distributor))
+	require.NoError(t, s.WaitReady(queryFrontend))
+
+	require.NoError(t, distributor.WaitSumMetrics(e2e.Equals(512+1), "cortex_ring_tokens_total"))
+	require.NoError(t, querier1.WaitSumMetrics(e2e.Equals(512), "cortex_ring_tokens_total"))
+	require.NoError(t, querier2.WaitSumMetrics(e2e.Equals(512), "cortex_ring_tokens_total"))
+
+	now := time.Now()
+	numSamples := 20
+	numSeries := 10
+
+	// Push multiple counter-like series with samples spanning 20 minutes (one per minute).
+	// Build all series upfront and push in a single batch per tenant to avoid timestamp-too-old rejections.
+	for _, tenant := range []string{userID, "sharded-tenant"} {
+		writeClient, err := e2emimir.NewClient(distributor.HTTPEndpoint(), "", "", "", tenant)
+		require.NoError(t, err)
+
+		var allSeries []prompb.TimeSeries
+		for seriesIdx := 0; seriesIdx < numSeries; seriesIdx++ {
+			samples := make([]prompb.Sample, numSamples)
+			for i := 0; i < numSamples; i++ {
+				// Monotonically increasing values (counter-like).
+				samples[i] = prompb.Sample{
+					Value:     float64((seriesIdx+1)*100 + i),
+					Timestamp: now.Add(time.Duration(i-numSamples+1) * time.Minute).UnixMilli(),
+				}
+			}
+
+			allSeries = append(allSeries, prompb.TimeSeries{
+				Labels: []prompb.Label{
+					{Name: model.MetricNameLabel, Value: "test_counter"},
+					{Name: "instance", Value: fmt.Sprintf("instance_%d", seriesIdx)},
+					{Name: "group", Value: fmt.Sprintf("group_%d", seriesIdx%3)},
+				},
+				Samples: samples,
+			})
+		}
+
+		res, err := writeClient.Push(allSeries)
+		require.NoError(t, err)
+		require.Equal(t, 200, res.StatusCode)
+	}
+
+	// Create clients:
+	// - unshardedClient queries the querier directly (no sharding).
+	// - shardedClient queries the query-frontend with sharding enabled (via per-tenant override).
+	unshardedClient, err := e2emimir.NewClient("", querier1.HTTPEndpoint(), "", "", userID)
+	require.NoError(t, err)
+	shardedClient, err := e2emimir.NewClient("", queryFrontend.HTTPEndpoint(), "", "", "sharded-tenant")
+	require.NoError(t, err)
+
+	queries := []struct {
+		name  string
+		query string
+	}{
+		{"sum_rate", `sum(rate(test_counter[5m]))`},
+		{"avg_rate", `avg(rate(test_counter[5m]))`},
+	}
+
+	queryStart := now.Add(-15 * time.Minute)
+	queryEnd := now.Add(-1 * time.Minute)
+	queryStep := time.Minute
+
+	for _, tc := range queries {
+		t.Run(tc.name+"/instant", func(t *testing.T) {
+			unshardedResult, unshardedResultWarnings, unshardedResultInfos, err := unshardedClient.Query(tc.query, queryEnd)
+			require.NoError(t, err)
+			require.NotNil(t, unshardedResult)
+
+			shardedResult, shardedResultWarnings, shardedResultInfos, err := shardedClient.Query(tc.query, queryEnd)
+			require.NoError(t, err)
+			require.NotNil(t, shardedResult)
+
+			requireModelValueApproxEqual(t, unshardedResult, shardedResult)
+			require.Equal(t, unshardedResultWarnings, shardedResultWarnings)
+			require.Equal(t, unshardedResultInfos, shardedResultInfos)
+			require.Equal(t, 1, len(unshardedResultInfos))
+		})
+
+		t.Run(tc.name+"/range", func(t *testing.T) {
+			unshardedResult, unshardedResultWarnings, unshardedResultInfos, err := unshardedClient.QueryRange(tc.query, queryStart, queryEnd, queryStep)
+			require.NoError(t, err)
+			require.NotNil(t, unshardedResult)
+
+			shardedResult, shardedResultWarnings, shardedResultInfos, err := shardedClient.QueryRange(tc.query, queryStart, queryEnd, queryStep)
+			require.NoError(t, err)
+			require.NotNil(t, shardedResult)
+
+			requireModelValueApproxEqual(t, unshardedResult, shardedResult)
+			require.Equal(t, unshardedResultWarnings, shardedResultWarnings)
+			require.Equal(t, unshardedResultInfos, shardedResultInfos)
+			require.Equal(t, 1, len(unshardedResultInfos))
+		})
+	}
+}
+
+// requireModelValueApproxEqual compares two model.Value results allowing for small
+// floating-point precision differences that can arise from sharded vs unsharded evaluation.
+func requireModelValueApproxEqual(t *testing.T, expected, actual model.Value) {
+	t.Helper()
+	require.Equal(t, expected.Type(), actual.Type(), "result types differ")
+
+	const epsilon = 1e-12
+
+	switch exp := expected.(type) {
+	case model.Vector:
+		act := actual.(model.Vector)
+		require.Equal(t, len(exp), len(act), "vector lengths differ")
+		for i := range exp {
+			require.Equal(t, exp[i].Metric, act[i].Metric, "sample %d: metric labels differ", i)
+			require.Equal(t, exp[i].Timestamp, act[i].Timestamp, "sample %d: timestamps differ", i)
+			if math.IsNaN(float64(exp[i].Value)) {
+				require.True(t, math.IsNaN(float64(act[i].Value)), "sample %d: expected NaN", i)
+			} else {
+				require.InEpsilon(t, float64(exp[i].Value), float64(act[i].Value), epsilon,
+					"sample %d: values differ beyond tolerance", i)
+			}
+		}
+	case *model.Scalar:
+		act := actual.(*model.Scalar)
+		require.Equal(t, exp.Timestamp, act.Timestamp)
+		require.InEpsilon(t, float64(exp.Value), float64(act.Value), epsilon)
+	case model.Matrix:
+		act := actual.(model.Matrix)
+		require.Equal(t, len(exp), len(act), "matrix series count differs")
+		for i := range exp {
+			require.Equal(t, exp[i].Metric, act[i].Metric, "series %d: metric labels differ", i)
+			require.Equal(t, len(exp[i].Values), len(act[i].Values), "series %d: sample count differs", i)
+			for j := range exp[i].Values {
+				require.Equal(t, exp[i].Values[j].Timestamp, act[i].Values[j].Timestamp,
+					"series %d sample %d: timestamps differ", i, j)
+				if math.IsNaN(float64(exp[i].Values[j].Value)) {
+					require.True(t, math.IsNaN(float64(act[i].Values[j].Value)),
+						"series %d sample %d: expected NaN", i, j)
+				} else {
+					require.InEpsilon(t, float64(exp[i].Values[j].Value), float64(act[i].Values[j].Value), epsilon,
+						"series %d sample %d: values differ beyond tolerance", i, j)
+				}
+			}
+		}
+	default:
+		require.Equal(t, expected, actual, "unsupported model.Value type")
+	}
 }

--- a/integration/querier_sharding_test.go
+++ b/integration/querier_sharding_test.go
@@ -6,7 +6,9 @@
 package integration
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"path/filepath"
 	"strconv"
 	"sync"
@@ -19,11 +21,11 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/prompb"
-	"github.com/prometheus/prometheus/util/almost"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/integration/e2emimir"
+	"github.com/grafana/mimir/tools/querytee"
 )
 
 type querierShardingTestConfig struct {
@@ -344,35 +346,38 @@ overrides:
 	queryEnd := now.Add(-1 * time.Minute)
 	queryStep := time.Minute
 
+	// Reuse query-tee's response comparator (the same logic query-tee uses to compare two backends) rather
+	// than hand-rolling one. It compares the raw JSON responses of both paths: sample values (with float
+	// tolerance and NaN/Inf/StaleNaN handling), result type, and warning/info annotations. Skip options are
+	// left at zero so no samples are excluded from the comparison.
+	comparator := querytee.NewSamplesComparator(querytee.SampleComparisonOptions{
+		Tolerance:        1e-6, // Matches promqltest's defaultEpsilon.
+		UseRelativeError: true,
+	})
+
 	for _, tc := range queries {
 		t.Run(tc.name+"/instant", func(t *testing.T) {
-			unshardedResult, unshardedResultWarnings, unshardedResultInfos, err := unshardedClient.Query(tc.query, queryEnd)
-			require.NoError(t, err)
-			require.NotNil(t, unshardedResult)
+			unshardedRes, unshardedBody, unshardedErr := unshardedClient.QueryRawAt(tc.query, queryEnd)
+			unshardedResp := requireSuccessfulQueryResponse(t, unshardedRes, unshardedBody, unshardedErr)
 
-			shardedResult, shardedResultWarnings, shardedResultInfos, err := shardedClient.Query(tc.query, queryEnd)
-			require.NoError(t, err)
-			require.NotNil(t, shardedResult)
+			shardedRes, shardedBody, shardedErr := shardedClient.QueryRawAt(tc.query, queryEnd)
+			shardedResp := requireSuccessfulQueryResponse(t, shardedRes, shardedBody, shardedErr)
 
-			requireModelValueApproxEqual(t, unshardedResult, shardedResult)
-			require.Equal(t, unshardedResultWarnings, shardedResultWarnings)
-			require.Equal(t, unshardedResultInfos, shardedResultInfos)
-			require.Equal(t, 1, len(unshardedResultInfos))
+			_, err := comparator.Compare(unshardedResp, shardedResp, queryEnd)
+			require.NoError(t, err)
+			requireSingleInfoAnnotation(t, unshardedResp)
 		})
 
 		t.Run(tc.name+"/range", func(t *testing.T) {
-			unshardedResult, unshardedResultWarnings, unshardedResultInfos, err := unshardedClient.QueryRange(tc.query, queryStart, queryEnd, queryStep)
-			require.NoError(t, err)
-			require.NotNil(t, unshardedResult)
+			unshardedRes, unshardedBody, unshardedErr := unshardedClient.QueryRangeRaw(tc.query, queryStart, queryEnd, queryStep)
+			unshardedResp := requireSuccessfulQueryResponse(t, unshardedRes, unshardedBody, unshardedErr)
 
-			shardedResult, shardedResultWarnings, shardedResultInfos, err := shardedClient.QueryRange(tc.query, queryStart, queryEnd, queryStep)
-			require.NoError(t, err)
-			require.NotNil(t, shardedResult)
+			shardedRes, shardedBody, shardedErr := shardedClient.QueryRangeRaw(tc.query, queryStart, queryEnd, queryStep)
+			shardedResp := requireSuccessfulQueryResponse(t, shardedRes, shardedBody, shardedErr)
 
-			requireModelValueApproxEqual(t, unshardedResult, shardedResult)
-			require.Equal(t, unshardedResultWarnings, shardedResultWarnings)
-			require.Equal(t, unshardedResultInfos, shardedResultInfos)
-			require.Equal(t, 1, len(unshardedResultInfos))
+			_, err := comparator.Compare(unshardedResp, shardedResp, queryEnd)
+			require.NoError(t, err)
+			requireSingleInfoAnnotation(t, unshardedResp)
 		})
 	}
 
@@ -382,52 +387,21 @@ overrides:
 	require.NoError(t, queryFrontend.WaitSumMetrics(e2e.Greater(0), "cortex_frontend_query_sharding_rewrites_succeeded_total"))
 }
 
-// requireModelValueApproxEqual compares two model.Value results allowing for small
-// floating-point precision differences that can arise from sharded vs unsharded evaluation.
-func requireModelValueApproxEqual(t *testing.T, expected, actual model.Value) {
+// requireSuccessfulQueryResponse asserts a raw query response was returned with HTTP 200 and returns its body
+// for further comparison.
+func requireSuccessfulQueryResponse(t *testing.T, res *http.Response, body []byte, err error) []byte {
 	t.Helper()
-	require.Equal(t, expected.Type(), actual.Type(), "result types differ")
-
-	switch exp := expected.(type) {
-	case model.Vector:
-		act := actual.(model.Vector)
-		require.Equal(t, len(exp), len(act), "vector lengths differ")
-		for i := range exp {
-			require.Equal(t, exp[i].Metric, act[i].Metric, "sample %d: metric labels differ", i)
-			require.Equal(t, exp[i].Timestamp, act[i].Timestamp, "sample %d: timestamps differ", i)
-			requireSampleValueApproxEqual(t, exp[i].Value, act[i].Value, "sample %d: values differ beyond tolerance", i)
-		}
-	case *model.Scalar:
-		act := actual.(*model.Scalar)
-		require.Equal(t, exp.Timestamp, act.Timestamp)
-		requireSampleValueApproxEqual(t, exp.Value, act.Value, "scalar values differ beyond tolerance")
-	case model.Matrix:
-		act := actual.(model.Matrix)
-		require.Equal(t, len(exp), len(act), "matrix series count differs")
-		for i := range exp {
-			require.Equal(t, exp[i].Metric, act[i].Metric, "series %d: metric labels differ", i)
-			require.Equal(t, len(exp[i].Values), len(act[i].Values), "series %d: sample count differs", i)
-			for j := range exp[i].Values {
-				require.Equal(t, exp[i].Values[j].Timestamp, act[i].Values[j].Timestamp,
-					"series %d sample %d: timestamps differ", i, j)
-				requireSampleValueApproxEqual(t, exp[i].Values[j].Value, act[i].Values[j].Value,
-					"series %d sample %d: values differ beyond tolerance", i, j)
-			}
-		}
-	default:
-		require.Equal(t, expected, actual, "unsupported model.Value type")
-	}
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode, "unexpected status code, body: %s", body)
+	return body
 }
 
-// requireSampleValueApproxEqual compares two sample values allowing for small floating-point precision
-// differences that can arise from sharded vs unsharded evaluation. It delegates to Prometheus' almost.Equal,
-// which handles NaN, StaleNaN, ±Inf, and zero (a plain relative-epsilon check rejects a zero expected value
-// and can't compare infinities). The epsilon matches promqltest's default.
-func requireSampleValueApproxEqual(t *testing.T, expected, actual model.SampleValue, msg string, args ...any) {
+// requireSingleInfoAnnotation asserts the raw query response carries exactly one info-level annotation. The
+// comparator only checks that both responses' annotations match each other, so this guards that annotations
+// are actually present (rate() over the counter data emits one info annotation).
+func requireSingleInfoAnnotation(t *testing.T, body []byte) {
 	t.Helper()
-
-	const epsilon = 1e-6 // Matches promqltest's defaultEpsilon.
-
-	require.Truef(t, almost.Equal(float64(expected), float64(actual), epsilon),
-		msg+" (expected %v, got %v)", append(args, expected, actual)...)
+	var resp querytee.SamplesResponse
+	require.NoError(t, json.Unmarshal(body, &resp))
+	require.Len(t, resp.Infos, 1)
 }

--- a/integration/querier_sharding_test.go
+++ b/integration/querier_sharding_test.go
@@ -355,13 +355,34 @@ overrides:
 		UseRelativeError: true,
 	})
 
+	// runQuery issues a single raw query and asserts how it affected the query-frontend's sharding-rewrite
+	// counter: an unsharded request (Sharding-Control: 0) must leave it unchanged, while a sharded request
+	// must increase it. Measuring the delta per request keeps the sharded and unsharded paths separate, so we
+	// verify each independently instead of only their combined total (which could hide, e.g., the
+	// Sharding-Control header being ignored). Only the direction of the change is checked, so this doesn't
+	// assume a fixed number of rewrites per query (e.g. it tolerates query splitting).
+	runQuery := func(t *testing.T, expectSharded bool, do func() (*http.Response, []byte, error)) []byte {
+		t.Helper()
+		const rewritesMetric = "cortex_frontend_query_sharding_rewrites_succeeded_total"
+
+		before, err := queryFrontend.SumMetrics([]string{rewritesMetric})
+		require.NoError(t, err)
+
+		res, body, reqErr := do()
+		resp := requireSuccessfulQueryResponse(t, res, body, reqErr)
+
+		if expectSharded {
+			require.NoError(t, queryFrontend.WaitSumMetrics(e2e.Greater(before[0]), rewritesMetric))
+		} else {
+			require.NoError(t, queryFrontend.WaitSumMetrics(e2e.Equals(before[0]), rewritesMetric))
+		}
+		return resp
+	}
+
 	for _, tc := range queries {
 		t.Run(tc.name+"/instant", func(t *testing.T) {
-			unshardedRes, unshardedBody, unshardedErr := unshardedClient.QueryRawAt(tc.query, queryEnd)
-			unshardedResp := requireSuccessfulQueryResponse(t, unshardedRes, unshardedBody, unshardedErr)
-
-			shardedRes, shardedBody, shardedErr := shardedClient.QueryRawAt(tc.query, queryEnd)
-			shardedResp := requireSuccessfulQueryResponse(t, shardedRes, shardedBody, shardedErr)
+			unshardedResp := runQuery(t, false, func() (*http.Response, []byte, error) { return unshardedClient.QueryRawAt(tc.query, queryEnd) })
+			shardedResp := runQuery(t, true, func() (*http.Response, []byte, error) { return shardedClient.QueryRawAt(tc.query, queryEnd) })
 
 			_, err := comparator.Compare(unshardedResp, shardedResp, queryEnd)
 			require.NoError(t, err)
@@ -369,22 +390,18 @@ overrides:
 		})
 
 		t.Run(tc.name+"/range", func(t *testing.T) {
-			unshardedRes, unshardedBody, unshardedErr := unshardedClient.QueryRangeRaw(tc.query, queryStart, queryEnd, queryStep)
-			unshardedResp := requireSuccessfulQueryResponse(t, unshardedRes, unshardedBody, unshardedErr)
-
-			shardedRes, shardedBody, shardedErr := shardedClient.QueryRangeRaw(tc.query, queryStart, queryEnd, queryStep)
-			shardedResp := requireSuccessfulQueryResponse(t, shardedRes, shardedBody, shardedErr)
+			unshardedResp := runQuery(t, false, func() (*http.Response, []byte, error) {
+				return unshardedClient.QueryRangeRaw(tc.query, queryStart, queryEnd, queryStep)
+			})
+			shardedResp := runQuery(t, true, func() (*http.Response, []byte, error) {
+				return shardedClient.QueryRangeRaw(tc.query, queryStart, queryEnd, queryStep)
+			})
 
 			_, err := comparator.Compare(unshardedResp, shardedResp, queryEnd)
 			require.NoError(t, err)
 			requireSingleInfoAnnotation(t, unshardedResp)
 		})
 	}
-
-	// Ensure the sharded path was actually exercised. Without this, the test would still pass if sharding
-	// silently no-opped (e.g. misconfigured shard count), since both paths would then return identical
-	// unsharded results.
-	require.NoError(t, queryFrontend.WaitSumMetrics(e2e.Greater(0), "cortex_frontend_query_sharding_rewrites_succeeded_total"))
 }
 
 // requireSuccessfulQueryResponse asserts a raw query response was returned with HTTP 200 and returns its body

--- a/integration/querier_sharding_test.go
+++ b/integration/querier_sharding_test.go
@@ -7,7 +7,6 @@ package integration
 
 import (
 	"fmt"
-	"math"
 	"path/filepath"
 	"strconv"
 	"sync"
@@ -20,6 +19,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/prompb"
+	"github.com/prometheus/prometheus/util/almost"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -376,6 +376,11 @@ overrides:
 			require.Equal(t, 1, len(unshardedResultInfos))
 		})
 	}
+
+	// Ensure the sharded path was actually exercised. Without this, the test would still pass if sharding
+	// silently no-opped (e.g. misconfigured shard count), since both paths would then return identical
+	// unsharded results.
+	require.NoError(t, queryFrontend.WaitSumMetrics(e2e.Greater(0), "cortex_frontend_query_sharding_rewrites_succeeded_total"))
 }
 
 // requireModelValueApproxEqual compares two model.Value results allowing for small
@@ -384,8 +389,6 @@ func requireModelValueApproxEqual(t *testing.T, expected, actual model.Value) {
 	t.Helper()
 	require.Equal(t, expected.Type(), actual.Type(), "result types differ")
 
-	const epsilon = 1e-12
-
 	switch exp := expected.(type) {
 	case model.Vector:
 		act := actual.(model.Vector)
@@ -393,17 +396,12 @@ func requireModelValueApproxEqual(t *testing.T, expected, actual model.Value) {
 		for i := range exp {
 			require.Equal(t, exp[i].Metric, act[i].Metric, "sample %d: metric labels differ", i)
 			require.Equal(t, exp[i].Timestamp, act[i].Timestamp, "sample %d: timestamps differ", i)
-			if math.IsNaN(float64(exp[i].Value)) {
-				require.True(t, math.IsNaN(float64(act[i].Value)), "sample %d: expected NaN", i)
-			} else {
-				require.InEpsilon(t, float64(exp[i].Value), float64(act[i].Value), epsilon,
-					"sample %d: values differ beyond tolerance", i)
-			}
+			requireSampleValueApproxEqual(t, exp[i].Value, act[i].Value, "sample %d: values differ beyond tolerance", i)
 		}
 	case *model.Scalar:
 		act := actual.(*model.Scalar)
 		require.Equal(t, exp.Timestamp, act.Timestamp)
-		require.InEpsilon(t, float64(exp.Value), float64(act.Value), epsilon)
+		requireSampleValueApproxEqual(t, exp.Value, act.Value, "scalar values differ beyond tolerance")
 	case model.Matrix:
 		act := actual.(model.Matrix)
 		require.Equal(t, len(exp), len(act), "matrix series count differs")
@@ -413,16 +411,24 @@ func requireModelValueApproxEqual(t *testing.T, expected, actual model.Value) {
 			for j := range exp[i].Values {
 				require.Equal(t, exp[i].Values[j].Timestamp, act[i].Values[j].Timestamp,
 					"series %d sample %d: timestamps differ", i, j)
-				if math.IsNaN(float64(exp[i].Values[j].Value)) {
-					require.True(t, math.IsNaN(float64(act[i].Values[j].Value)),
-						"series %d sample %d: expected NaN", i, j)
-				} else {
-					require.InEpsilon(t, float64(exp[i].Values[j].Value), float64(act[i].Values[j].Value), epsilon,
-						"series %d sample %d: values differ beyond tolerance", i, j)
-				}
+				requireSampleValueApproxEqual(t, exp[i].Values[j].Value, act[i].Values[j].Value,
+					"series %d sample %d: values differ beyond tolerance", i, j)
 			}
 		}
 	default:
 		require.Equal(t, expected, actual, "unsupported model.Value type")
 	}
+}
+
+// requireSampleValueApproxEqual compares two sample values allowing for small floating-point precision
+// differences that can arise from sharded vs unsharded evaluation. It delegates to Prometheus' almost.Equal,
+// which handles NaN, StaleNaN, ±Inf, and zero (a plain relative-epsilon check rejects a zero expected value
+// and can't compare infinities). The epsilon matches promqltest's default.
+func requireSampleValueApproxEqual(t *testing.T, expected, actual model.SampleValue, msg string, args ...any) {
+	t.Helper()
+
+	const epsilon = 1e-6 // Matches promqltest's defaultEpsilon.
+
+	require.Truef(t, almost.Equal(float64(expected), float64(actual), epsilon),
+		msg+" (expected %v, got %v)", append(args, expected, actual)...)
 }

--- a/integration/querier_sharding_test.go
+++ b/integration/querier_sharding_test.go
@@ -152,7 +152,7 @@ func runQuerierShardingTest(t *testing.T, cfg querierShardingTestConfig) {
 		c, err := e2emimir.NewClient("", q.HTTPEndpoint(), "", "", userID)
 		require.NoError(t, err)
 
-		_, err = c.Query("series_1", now)
+		_, _, _, err = c.Query("series_1", now)
 		require.NoError(t, err)
 	}
 
@@ -170,7 +170,7 @@ func runQuerierShardingTest(t *testing.T, cfg querierShardingTestConfig) {
 			c, err := e2emimir.NewClient("", queryFrontend.HTTPEndpoint(), "", "", userID)
 			require.NoError(t, err)
 
-			result, err := c.Query("series_1", now)
+			result, _, _, err := c.Query("series_1", now)
 			require.NoError(t, err)
 			require.Equal(t, model.ValVector, result.Type())
 			assert.Equal(t, expectedVector, result.(model.Vector))

--- a/integration/querier_sharding_test.go
+++ b/integration/querier_sharding_test.go
@@ -279,6 +279,16 @@ overrides:
 	require.NoError(t, querier1.WaitSumMetrics(e2e.Equals(512), "cortex_ring_tokens_total"))
 	require.NoError(t, querier2.WaitSumMetrics(e2e.Equals(512), "cortex_ring_tokens_total"))
 
+	// Wait until the query-frontend has updated the querier ring.
+	require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Equals(2), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
+		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+
+	// Wait until both queriers connect to the query-scheduler, each with the minimum 4 connections.
+	// Without this, sharded queries issued through the query-frontend can race the querier-to-scheduler
+	// worker connections and time out while no querier is connected yet.
+	require.NoError(t, queryScheduler.WaitSumMetrics(e2e.Equals(8), "cortex_query_scheduler_connected_querier_clients"))
+
 	now := time.Now()
 	numSamples := 20
 	numSeries := 10

--- a/integration/querier_sharding_test.go
+++ b/integration/querier_sharding_test.go
@@ -294,41 +294,40 @@ overrides:
 	numSeries := 10
 
 	// Push multiple counter-like series with samples spanning 20 minutes (one per minute).
-	// Build all series upfront and push in a single batch per tenant to avoid timestamp-too-old rejections.
-	for _, tenant := range []string{userID, "sharded-tenant"} {
-		writeClient, err := e2emimir.NewClient(distributor.HTTPEndpoint(), "", "", "", tenant)
-		require.NoError(t, err)
+	// Build all series upfront and push in a single batch to avoid timestamp-too-old rejections.
+	writeClient, err := e2emimir.NewClient(distributor.HTTPEndpoint(), "", "", "", "sharded-tenant")
+	require.NoError(t, err)
 
-		var allSeries []prompb.TimeSeries
-		for seriesIdx := 0; seriesIdx < numSeries; seriesIdx++ {
-			samples := make([]prompb.Sample, numSamples)
-			for i := 0; i < numSamples; i++ {
-				// Monotonically increasing values (counter-like).
-				samples[i] = prompb.Sample{
-					Value:     float64((seriesIdx+1)*100 + i),
-					Timestamp: now.Add(time.Duration(i-numSamples+1) * time.Minute).UnixMilli(),
-				}
+	var allSeries []prompb.TimeSeries
+	for seriesIdx := 0; seriesIdx < numSeries; seriesIdx++ {
+		samples := make([]prompb.Sample, numSamples)
+		for i := 0; i < numSamples; i++ {
+			// Monotonically increasing values (counter-like).
+			samples[i] = prompb.Sample{
+				Value:     float64((seriesIdx+1)*100 + i),
+				Timestamp: now.Add(time.Duration(i-numSamples+1) * time.Minute).UnixMilli(),
 			}
-
-			allSeries = append(allSeries, prompb.TimeSeries{
-				Labels: []prompb.Label{
-					{Name: model.MetricNameLabel, Value: "test_counter"},
-					{Name: "instance", Value: fmt.Sprintf("instance_%d", seriesIdx)},
-					{Name: "group", Value: fmt.Sprintf("group_%d", seriesIdx%3)},
-				},
-				Samples: samples,
-			})
 		}
 
-		res, err := writeClient.Push(allSeries)
-		require.NoError(t, err)
-		require.Equal(t, 200, res.StatusCode)
+		allSeries = append(allSeries, prompb.TimeSeries{
+			Labels: []prompb.Label{
+				{Name: model.MetricNameLabel, Value: "test_counter"},
+				{Name: "instance", Value: fmt.Sprintf("instance_%d", seriesIdx)},
+				{Name: "group", Value: fmt.Sprintf("group_%d", seriesIdx%3)},
+			},
+			Samples: samples,
+		})
 	}
 
-	// Create clients:
-	// - unshardedClient queries the querier directly (no sharding).
-	// - shardedClient queries the query-frontend with sharding enabled (via per-tenant override).
-	unshardedClient, err := e2emimir.NewClient("", querier1.HTTPEndpoint(), "", "", userID)
+	res, err := writeClient.Push(allSeries)
+	require.NoError(t, err)
+	require.Equal(t, 200, res.StatusCode)
+
+	// Both clients query the same tenant and data through the query-frontend, so the only difference is
+	// whether the request is sharded. unshardedClient disables sharding per-request via the internal
+	// Sharding-Control header (querying the querier directly is avoided since those HTTP endpoints are
+	// being phased out).
+	unshardedClient, err := e2emimir.NewClient("", queryFrontend.HTTPEndpoint(), "", "", "sharded-tenant", e2emimir.WithAddHeader("Sharding-Control", "0"))
 	require.NoError(t, err)
 	shardedClient, err := e2emimir.NewClient("", queryFrontend.HTTPEndpoint(), "", "", "sharded-tenant")
 	require.NoError(t, err)

--- a/integration/querier_tenant_federation_test.go
+++ b/integration/querier_tenant_federation_test.go
@@ -131,7 +131,7 @@ func runQuerierTenantFederationTest(t *testing.T, cfg querierTenantFederationCon
 	c, err := e2emimir.NewClient(distributor.HTTPEndpoint(), queryFrontend.HTTPEndpoint(), "", "", strings.Join(tenantIDs, "|"))
 	require.NoError(t, err)
 
-	result, err := c.Query("series_1", now)
+	result, _, _, err := c.Query("series_1", now)
 	require.NoError(t, err)
 
 	assert.ElementsMatch(t, mergeResults(tenantIDs, expectedVectors), result.(model.Vector))

--- a/integration/querier_test.go
+++ b/integration/querier_test.go
@@ -200,7 +200,7 @@ func testQuerierWithBlocksStorageRunningInMicroservicesMode(t *testing.T, series
 			require.NoError(t, err)
 			instantQueriesCount++
 
-			result, err := c.Query(series1Name, series1Timestamp)
+			result, _, _, err := c.Query(series1Name, series1Timestamp)
 			require.NoError(t, err)
 			require.Equal(t, model.ValVector, result.Type())
 			assert.Equal(t, expectedVector1, result.(model.Vector))
@@ -208,7 +208,7 @@ func testQuerierWithBlocksStorageRunningInMicroservicesMode(t *testing.T, series
 			// thanos_store_index_cache_requests_total: ExpandedPostings: 1, Postings: 1, Series: 1
 			instantQueriesCount++
 
-			result, err = c.Query(series2Name, series2Timestamp)
+			result, _, _, err = c.Query(series2Name, series2Timestamp)
 			require.NoError(t, err)
 			require.Equal(t, model.ValVector, result.Type())
 			assert.Equal(t, expectedVector2, result.(model.Vector))
@@ -216,7 +216,7 @@ func testQuerierWithBlocksStorageRunningInMicroservicesMode(t *testing.T, series
 			// thanos_store_index_cache_requests_total: ExpandedPostings: 3, Postings: 2, Series: 2
 			instantQueriesCount++
 
-			result, err = c.Query(series3Name, series3Timestamp)
+			result, _, _, err = c.Query(series3Name, series3Timestamp)
 			require.NoError(t, err)
 			require.Equal(t, model.ValVector, result.Type())
 			assert.Equal(t, expectedVector3, result.(model.Vector))
@@ -242,7 +242,7 @@ func testQuerierWithBlocksStorageRunningInMicroservicesMode(t *testing.T, series
 			}
 
 			// Query back again the 1st series from storage. This time it should use the index cache.
-			result, err = c.Query(series1Name, series1Timestamp)
+			result, _, _, err = c.Query(series1Name, series1Timestamp)
 			require.NoError(t, err)
 			require.Equal(t, model.ValVector, result.Type())
 			assert.Equal(t, expectedVector1, result.(model.Vector))
@@ -264,7 +264,7 @@ func testQuerierWithBlocksStorageRunningInMicroservicesMode(t *testing.T, series
 			const numRangeQueries = 10
 
 			for i := 0; i < numRangeQueries; i++ {
-				result, err = c.QueryRange(`count({__name__=~"series.*"})`, series3Timestamp, series3Timestamp, time.Minute)
+				result, _, _, err = c.QueryRange(`count({__name__=~"series.*"})`, series3Timestamp, series3Timestamp, time.Minute)
 				require.NoError(t, err)
 				require.Equal(t, model.ValMatrix, result.Type())
 
@@ -276,7 +276,7 @@ func testQuerierWithBlocksStorageRunningInMicroservicesMode(t *testing.T, series
 			}
 
 			// This instant query can be sharded.
-			result, err = c.Query(`count({__name__=~"series.*"})`, series3Timestamp)
+			result, _, _, err = c.Query(`count({__name__=~"series.*"})`, series3Timestamp)
 			require.NoError(t, err)
 			require.Equal(t, model.ValVector, result.Type())
 			vector := result.(model.Vector)
@@ -455,21 +455,21 @@ func TestQuerierWithBlocksStorageRunningInSingleBinaryMode(t *testing.T) {
 			//
 			// If the series does not exist in the block, then we return early after checking expanded postings and
 			// subsequently the index on disk.
-			result, err := c.Query(series1Name, series1Timestamp)
+			result, _, _, err := c.Query(series1Name, series1Timestamp)
 			require.NoError(t, err)
 			require.Equal(t, model.ValVector, result.Type())
 			assert.Equal(t, expectedVector1, result.(model.Vector))
 			expectedCacheRequests += seriesReplicationFactor * 3                                  // expanded postings, postings, series
 			expectedMemcachedOps += (seriesReplicationFactor * 3) + (seriesReplicationFactor * 3) // Same reasoning as for expectedCacheRequests, but this also includes a set for each get that is not a hit
 
-			result, err = c.Query(series2Name, series2Timestamp)
+			result, _, _, err = c.Query(series2Name, series2Timestamp)
 			require.NoError(t, err)
 			require.Equal(t, model.ValVector, result.Type())
 			assert.Equal(t, expectedVector2, result.(model.Vector))
 			expectedCacheRequests += seriesReplicationFactor*3 + seriesReplicationFactor      // expanded postings, postings, series for 1 time range; only expanded postings for another
 			expectedMemcachedOps += 2 * (seriesReplicationFactor*3 + seriesReplicationFactor) // Same reasoning as for expectedCacheRequests, but this also includes a set for each get that is not a hit
 
-			result, err = c.Query(series3Name, series3Timestamp)
+			result, _, _, err = c.Query(series3Name, series3Timestamp)
 			require.NoError(t, err)
 			require.Equal(t, model.ValVector, result.Type())
 			assert.Equal(t, expectedVector3, result.(model.Vector))
@@ -491,7 +491,7 @@ func TestQuerierWithBlocksStorageRunningInSingleBinaryMode(t *testing.T) {
 			// It should get a hit on expanded postings; this means that it will not request individual postings for matchers.
 			// It should get a hit on series.
 			// We expect 2 cache requests and 2 cache hits.
-			result, err = c.Query(series1Name, series1Timestamp)
+			result, _, _, err = c.Query(series1Name, series1Timestamp)
 			require.NoError(t, err)
 			require.Equal(t, model.ValVector, result.Type())
 			assert.Equal(t, expectedVector1, result.(model.Vector))
@@ -564,7 +564,7 @@ func testPromQLEngine(t *testing.T, engineType string) {
 	c, err := e2emimir.NewClient("", querier.HTTPEndpoint(), "", "", "user-1")
 	require.NoError(t, err)
 
-	result, err := c.Query(seriesName, seriesTimestamp)
+	result, _, _, err := c.Query(seriesName, seriesTimestamp)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, result.Type())
 	assert.Equal(t, expectedVector, result.(model.Vector))
@@ -874,12 +874,12 @@ func TestQuerierWithBlocksStorageOnMissingBlocksFromStorage(t *testing.T) {
 	c, err = e2emimir.NewClient("", querier.HTTPEndpoint(), "", "", "user-1")
 	require.NoError(t, err)
 
-	result, err := c.Query(series1Name, series1Timestamp)
+	result, _, _, err := c.Query(series1Name, series1Timestamp)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, result.Type())
 	assert.Equal(t, expectedVector1, result.(model.Vector))
 
-	result, err = c.Query(series2Name, series2Timestamp)
+	result, _, _, err = c.Query(series2Name, series2Timestamp)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, result.Type())
 	assert.Equal(t, expectedVector2, result.(model.Vector))
@@ -891,14 +891,14 @@ func TestQuerierWithBlocksStorageOnMissingBlocksFromStorage(t *testing.T) {
 
 	// Query back again the series. Now we do expect a 500 error because the blocks are
 	// missing from the storage.
-	_, err = c.Query(series1Name, series1Timestamp)
+	_, _, _, err = c.Query(series1Name, series1Timestamp)
 	require.Error(t, err)
 	var apiErr *v1.Error
 	require.ErrorAs(t, err, &apiErr)
 	assert.Contains(t, apiErr.Detail, "get range reader: The specified key does not exist")
 
 	// We expect this to still be queryable as it was not in the cleared storage
-	_, err = c.Query(series2Name, series2Timestamp)
+	_, _, _, err = c.Query(series2Name, series2Timestamp)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, result.Type())
 	assert.Equal(t, expectedVector2, result.(model.Vector))
@@ -964,7 +964,7 @@ func TestQueryLimitsWithBlocksStorageRunningInMicroServices(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 200, res.StatusCode)
 
-	result, err := c.QueryRange("{__name__=~\"series_.+\"}", series1Timestamp, series2Timestamp.Add(1*time.Hour), blockRangePeriod)
+	result, _, _, err := c.QueryRange("{__name__=~\"series_.+\"}", series1Timestamp, series2Timestamp.Add(1*time.Hour), blockRangePeriod)
 	require.NoError(t, err)
 	require.Equal(t, model.ValMatrix, result.Type())
 
@@ -975,7 +975,7 @@ func TestQueryLimitsWithBlocksStorageRunningInMicroServices(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 200, res.StatusCode)
 
-	_, err = c.QueryRange("{__name__=~\"series_.+\"}", series1Timestamp, series4Timestamp.Add(1*time.Hour), blockRangePeriod)
+	_, _, _, err = c.QueryRange("{__name__=~\"series_.+\"}", series1Timestamp, series4Timestamp.Add(1*time.Hour), blockRangePeriod)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "the query exceeded the maximum number of series")
 }
@@ -1061,7 +1061,7 @@ func TestHashCollisionHandling(t *testing.T) {
 	c, err = e2emimir.NewClient("", querier.HTTPEndpoint(), "", "", "user-0")
 	require.NoError(t, err)
 
-	result, err := c.Query("fingerprint_collision", now)
+	result, _, _, err := c.Query("fingerprint_collision", now)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, result.Type())
 	require.Equal(t, expectedVector, result.(model.Vector))

--- a/integration/query_frontend_cache_test.go
+++ b/integration/query_frontend_cache_test.go
@@ -121,7 +121,7 @@ func runTestPushSeriesAndUnalignedQuery(t *testing.T, c *e2emimir.Client, queryF
 		c, err := e2emimir.NewClient("", queryFrontendAligned.HTTPEndpoint(), "", "", user)
 		require.NoError(t, err)
 
-		res, err := c.QueryRange(seriesName, start, end, step)
+		res, _, _, err := c.QueryRange(seriesName, start, end, step)
 		require.NoError(t, err)
 
 		// Verify that returned range has sample appearing after "sampleTime", all ts are step-aligned (truncated to step).
@@ -136,7 +136,7 @@ func runTestPushSeriesAndUnalignedQuery(t *testing.T, c *e2emimir.Client, queryF
 		c, err := e2emimir.NewClient("", queryFrontendUnaligned.HTTPEndpoint(), "", "", user)
 		require.NoError(t, err)
 
-		res, err := c.QueryRange(seriesName, start, end, step)
+		res, _, _, err := c.QueryRange(seriesName, start, end, step)
 		require.NoError(t, err)
 
 		// Verify that returned result is not step-aligned ("now" is not step-aligned)

--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -396,7 +396,7 @@ func runQueryFrontendTest(t *testing.T, cfg queryFrontendTestConfig) {
 			require.NoError(t, queryFrontend.WaitSumMetrics(e2e.Equals(0), "cortex_frontend_split_queries_total"))
 			end := now
 			start := end.Add(-(30*24*time.Hour + 1*time.Hour)) // 30 days + 1 hour. Makes sure we can go above the max partial query length.
-			_, err = c.QueryRange("{instance=~\"hello.*\"}", start, end, time.Hour)
+			_, _, _, err = c.QueryRange("{instance=~\"hello.*\"}", start, end, time.Hour)
 			require.NoError(t, err)
 
 			// Depending on what time it is and how that aligns with midnight UTC, the query may be broken into 31 or 32 parts.
@@ -408,7 +408,7 @@ func runQueryFrontendTest(t *testing.T, cfg queryFrontendTestConfig) {
 			start := time.Unix(1595846748, 806*1e6)
 			end := time.Unix(1595846750, 806*1e6)
 
-			result, err := c.QueryRange("time()", start, end, time.Second)
+			result, _, _, err := c.QueryRange("time()", start, end, time.Second)
 			require.NoError(t, err)
 			require.Equal(t, model.ValMatrix, result.Type())
 
@@ -438,7 +438,7 @@ func runQueryFrontendTest(t *testing.T, cfg queryFrontendTestConfig) {
 
 		// Test that evaluating a query with a scalar result works as expected.
 		if userID == 0 {
-			result, err := c.Query("scalar(series_1)", now)
+			result, _, _, err := c.Query("scalar(series_1)", now)
 			require.NoError(t, err)
 			require.Equal(t, model.ValScalar, result.Type())
 			scalar := result.(*model.Scalar)
@@ -448,7 +448,7 @@ func runQueryFrontendTest(t *testing.T, cfg queryFrontendTestConfig) {
 
 		// Same thing, but with a range vector result.
 		if userID == 0 {
-			result, err := c.Query("series_1[5m]", now)
+			result, _, _, err := c.Query("series_1[5m]", now)
 			require.NoError(t, err)
 			require.Equal(t, model.ValMatrix, result.Type())
 			matrix := result.(model.Matrix)
@@ -462,7 +462,7 @@ func runQueryFrontendTest(t *testing.T, cfg queryFrontendTestConfig) {
 		// Test subquery spin-off.
 		if userID == 0 {
 			require.NoError(t, queryFrontend.WaitSumMetrics(e2e.Equals(0), "cortex_frontend_spun_off_subqueries_total"))
-			result, err := c.Query("sum_over_time(((count(series_1) * count(series_1)) or vector(1))[6h:15m])", now)
+			result, _, _, err := c.Query("sum_over_time(((count(series_1) * count(series_1)) or vector(1))[6h:15m])", now)
 			require.NoError(t, err)
 			require.Len(t, result, 1)
 			require.Equal(t, result.(model.Vector)[0].Metric, model.Metric{})
@@ -474,7 +474,7 @@ func runQueryFrontendTest(t *testing.T, cfg queryFrontendTestConfig) {
 			go func() {
 				defer wg.Done()
 
-				result, err := c.Query("series_1", now)
+				result, _, _, err := c.Query("series_1", now)
 				require.NoError(t, err)
 				require.Equal(t, model.ValVector, result.Type())
 				assert.Equal(t, expectedVectors[userID], result.(model.Vector))
@@ -1165,7 +1165,7 @@ func TestQueryFrontendWithExplicitLookbackDelta(t *testing.T) {
 }
 
 func queryLookbackDeltaTest(t *testing.T, client *e2emimir.Client, seriesName string, ts time.Time, expectResult bool, expectedValue float64, opts ...promv1.Option) {
-	res, err := client.Query(seriesName, ts, opts...)
+	res, _, _, err := client.Query(seriesName, ts, opts...)
 	require.NoError(t, err)
 
 	v, ok := res.(model.Vector)
@@ -1182,7 +1182,7 @@ func queryLookbackDeltaTest(t *testing.T, client *e2emimir.Client, seriesName st
 	}
 
 	step := 100 * time.Minute
-	res, err = client.QueryRange(seriesName, ts.Add(-step), ts.Add(step), step, opts...)
+	res, _, _, err = client.QueryRange(seriesName, ts.Add(-step), ts.Add(step), step, opts...)
 	require.NoError(t, err)
 
 	m, ok := res.(model.Matrix)
@@ -1269,7 +1269,7 @@ func TestQueryFrontendCardinalityEstimation(t *testing.T) {
 	}
 
 	makeRequest := func() {
-		res, err := client.Query(fmt.Sprintf("sum(%v)", metricName), sampleT)
+		res, _, _, err := client.Query(fmt.Sprintf("sum(%v)", metricName), sampleT)
 		require.NoError(t, err)
 
 		v, ok := res.(model.Vector)

--- a/integration/query_scheduler_test.go
+++ b/integration/query_scheduler_test.go
@@ -111,7 +111,7 @@ func runTestQuerySchedulerWithMaxUsedInstances(t *testing.T, seriesName string, 
 	require.Equal(t, 200, res.StatusCode)
 
 	// Query the series.
-	result, err := c.Query(seriesName, now)
+	result, _, _, err := c.Query(seriesName, now)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, result.Type())
 	assert.Equal(t, expectedVector, result.(model.Vector))
@@ -126,7 +126,7 @@ func runTestQuerySchedulerWithMaxUsedInstances(t *testing.T, seriesName string, 
 	require.NoError(t, notInUseScheduler.WaitSumMetricsWithOptions(e2e.Greater(0), []string{"cortex_query_scheduler_connected_frontend_clients"}))
 
 	// Query the series.
-	result, err = c.Query(seriesName, now)
+	result, _, _, err = c.Query(seriesName, now)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, result.Type())
 	assert.Equal(t, expectedVector, result.(model.Vector))

--- a/integration/range_vector_splitting_test.go
+++ b/integration/range_vector_splitting_test.go
@@ -22,7 +22,7 @@ func TestQuerySplittingWithRangeVectorFunction(t *testing.T) {
 	querier, now := setupRangeVectorSplittingTest(t, tenantID, nil)
 	queryClient := createQueryClient(t, querier, tenantID)
 
-	result, err := queryClient.Query("sum_over_time(test_metric[15m])", now)
+	result, _, _, err := queryClient.Query("sum_over_time(test_metric[15m])", now)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, result.Type())
 
@@ -36,7 +36,7 @@ func TestQuerySplittingWithRangeVectorFunction(t *testing.T) {
 	require.NoError(t, querier.WaitSumMetrics(e2e.Equals(1), "cortex_mimir_query_engine_range_vector_splitting_nodes_introduced_total"))
 
 	// Run the same query again to verify cached intermediate results are read back correctly.
-	result2, err := queryClient.Query("sum_over_time(test_metric[15m])", now)
+	result2, _, _, err := queryClient.Query("sum_over_time(test_metric[15m])", now)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, result2.Type())
 
@@ -56,7 +56,7 @@ func TestQuerySplittingWithRangeVectorFunctionAndLBAC(t *testing.T) {
 	queryClientWithoutLBAC := createQueryClient(t, querier, tenantID)
 
 	// Run the query without any LBAC policy to populate the cache.
-	result, err := queryClientWithoutLBAC.Query("sum_over_time(test_metric[15m])", now)
+	result, _, _, err := queryClientWithoutLBAC.Query("sum_over_time(test_metric[15m])", now)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, result.Type())
 
@@ -70,7 +70,7 @@ func TestQuerySplittingWithRangeVectorFunctionAndLBAC(t *testing.T) {
 	require.NoError(t, querier.WaitSumMetrics(e2e.Equals(1), "cortex_mimir_query_engine_range_vector_splitting_nodes_introduced_total"))
 
 	// Run the same query again to verify cached intermediate results are read back correctly.
-	result2, err := queryClientWithoutLBAC.Query("sum_over_time(test_metric[15m])", now)
+	result2, _, _, err := queryClientWithoutLBAC.Query("sum_over_time(test_metric[15m])", now)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, result2.Type())
 
@@ -84,7 +84,7 @@ func TestQuerySplittingWithRangeVectorFunctionAndLBAC(t *testing.T) {
 	policy := tenantID + ":%7B__name__!=%22test_metric%22%7D"
 	queryClientWithLBAC := createQueryClient(t, querier, tenantID, e2emimir.WithAddHeader("X-Prom-Label-Policy", policy))
 
-	resultWithLBACPolicy, err := queryClientWithLBAC.Query("sum_over_time(test_metric[15m])", now)
+	resultWithLBACPolicy, _, _, err := queryClientWithLBAC.Query("sum_over_time(test_metric[15m])", now)
 	require.NoError(t, err)
 	require.Equal(t, model.ValVector, resultWithLBACPolicy.Type())
 

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -1138,7 +1138,7 @@ func TestRulerFederatedRules(t *testing.T) {
 			// Wait until rule evaluation resulting series had been pushed
 			require.NoError(t, ingester.WaitSumMetrics(e2e.Greater(totalSeriesBeforeEval[0]), "cortex_ingester_memory_series"))
 
-			result, err := c.Query(ruleName, time.Now())
+			result, _, _, err := c.Query(ruleName, time.Now())
 			require.NoError(t, err)
 			tc.assertEvalResult(result.(model.Vector))
 		})
@@ -1306,7 +1306,7 @@ func TestRulerRemoteEvaluation(t *testing.T) {
 			))
 
 			// Assert rule evaluation result
-			result, err := c.Query(ruleName, time.Now())
+			result, _, _, err := c.Query(ruleName, time.Now())
 			require.NoError(t, err)
 			tc.assertEvalResult(result.(model.Vector))
 		})

--- a/integration/tenant_with_metadata_limits_test.go
+++ b/integration/tenant_with_metadata_limits_test.go
@@ -227,12 +227,12 @@ overrides:
 		queryClient, err := e2emimir.NewClient(distributor.HTTPEndpoint(), querier.HTTPEndpoint(), "", "", mainTenantID)
 		require.NoError(t, err)
 
-		result, err := queryClient.Query("known_test_metric_0", time.Now())
+		result, _, _, err := queryClient.Query("known_test_metric_0", time.Now())
 		require.NoError(t, err)
 		require.Equal(t, model.ValVector, result.Type())
 		require.NotEmpty(t, result.(model.Vector), "expected results for known_test_metric_0")
 
-		result, err = queryClient.Query("known_test_metric_0_bytes", time.Now())
+		result, _, _, err = queryClient.Query("known_test_metric_0_bytes", time.Now())
 		require.NoError(t, err)
 		require.Equal(t, model.ValVector, result.Type())
 		require.Empty(t, result.(model.Vector), "expected no results for known_test_metric_0_bytes (suffixes should be disabled)")

--- a/integration/zone_aware_test.go
+++ b/integration/zone_aware_test.go
@@ -92,7 +92,7 @@ func TestZoneAwareReplication(t *testing.T) {
 
 	// Query back series => all good
 	for metricName, expectedVector := range expectedVectors {
-		result, err := client.Query(metricName, now)
+		result, _, _, err := client.Query(metricName, now)
 		require.NoError(t, err)
 		require.Equal(t, model.ValVector, result.Type())
 		assert.Equal(t, expectedVector, result.(model.Vector))
@@ -113,7 +113,7 @@ func TestZoneAwareReplication(t *testing.T) {
 
 	// Query back series => all good
 	for metricName, expectedVector := range expectedVectors {
-		result, err := client.Query(metricName, now)
+		result, _, _, err := client.Query(metricName, now)
 		require.NoError(t, err)
 		require.Equal(t, model.ValVector, result.Type())
 		assert.Equal(t, expectedVector, result.(model.Vector))
@@ -134,7 +134,7 @@ func TestZoneAwareReplication(t *testing.T) {
 
 	// Query back series => all good
 	for metricName, expectedVector := range expectedVectors {
-		result, err := client.Query(metricName, now)
+		result, _, _, err := client.Query(metricName, now)
 		require.NoError(t, err)
 		require.Equal(t, model.ValVector, result.Type())
 		assert.Equal(t, expectedVector, result.(model.Vector))

--- a/pkg/continuoustest/client.go
+++ b/pkg/continuoustest/client.go
@@ -212,7 +212,7 @@ func (c *Client) QueryRange(ctx context.Context, query string, start, end time.T
 
 	ctx = querierapi.ContextWithReadConsistencyLevel(ctx, querierapi.ReadConsistencyStrong)
 
-	value, _, err := c.readClient.QueryRange(ctx, query, v1.Range{
+	value, _, _, err := c.readClient.QueryRange(ctx, query, v1.Range{
 		Start: start,
 		End:   end,
 		Step:  step,
@@ -241,7 +241,7 @@ func (c *Client) Query(ctx context.Context, query string, ts time.Time, options 
 
 	ctx = querierapi.ContextWithReadConsistencyLevel(ctx, querierapi.ReadConsistencyStrong)
 
-	value, _, err := c.readClient.Query(ctx, query, ts)
+	value, _, _, err := c.readClient.Query(ctx, query, ts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/frontend/querymiddleware/roundtrip_test.go
+++ b/pkg/frontend/querymiddleware/roundtrip_test.go
@@ -188,7 +188,7 @@ func TestTripperware_InstantQuery(t *testing.T) {
 		api := v1.NewAPI(queryClient)
 
 		ts := time.Date(2021, 1, 2, 3, 4, 5, 0, time.UTC)
-		res, _, err := api.Query(ctx, `sum(increase(we_dont_care_about_this[1h])) by (foo)`, ts)
+		res, _, _, err := api.Query(ctx, `sum(increase(we_dont_care_about_this[1h])) by (foo)`, ts)
 		require.NoError(t, err)
 		require.Equal(t, model.Vector{
 			{Metric: model.Metric{"foo": "bar"}, Timestamp: model.TimeFromUnixNano(ts.UnixNano()), Value: totalShards},
@@ -200,7 +200,7 @@ func TestTripperware_InstantQuery(t *testing.T) {
 		require.NoError(t, err)
 		api := v1.NewAPI(queryClient)
 
-		res, _, err := api.Query(ctx, `sum(increase(we_dont_care_about_this[1h])) by (foo)`, time.Time{})
+		res, _, _, err := api.Query(ctx, `sum(increase(we_dont_care_about_this[1h])) by (foo)`, time.Time{})
 		require.NoError(t, err)
 		require.IsType(t, model.Vector{}, res)
 		require.NotEmpty(t, res.(model.Vector))
@@ -223,7 +223,7 @@ func TestTripperware_InstantQuery(t *testing.T) {
 		require.NoError(t, err)
 		api := v1.NewAPI(queryClient)
 
-		res, _, err := api.Query(ctx, `sum(increase(we_dont_care_about_this[1h])) by (foo)`, postFormTimeParam)
+		res, _, _, err := api.Query(ctx, `sum(increase(we_dont_care_about_this[1h])) by (foo)`, postFormTimeParam)
 		require.NoError(t, err)
 		require.IsType(t, model.Vector{}, res)
 		require.NotEmpty(t, res.(model.Vector))

--- a/pkg/mimirtool/commands/analyse_prometheus.go
+++ b/pkg/mimirtool/commands/analyse_prometheus.go
@@ -132,7 +132,7 @@ func queryMetricNames(api v1.API, readTimeout time.Duration, logger log.Logger) 
 	var metricNames model.LabelValues
 	err := withBackoff(ctx, func() error {
 		var err error
-		metricNames, _, err = api.LabelValues(ctx, model.MetricNameLabel, nil, time.Now().Add(-10*time.Minute), time.Now())
+		metricNames, _, _, err = api.LabelValues(ctx, model.MetricNameLabel, nil, time.Now().Add(-10*time.Minute), time.Now())
 		return err
 	})
 	if err != nil {
@@ -168,7 +168,7 @@ func AnalyzePrometheus(api v1.API, metrics model.LabelValues, skip func(model.La
 		query := fmt.Sprintf(`count by (job) (%s{__ignore_usage__=""})`, metric)
 		err := withBackoff(ctx, func() error {
 			var err error
-			result, _, err = api.Query(ctx, query, time.Now())
+			result, _, _, err = api.Query(ctx, query, time.Now())
 			return err
 		})
 		if err != nil {

--- a/pkg/mimirtool/commands/loadgen.go
+++ b/pkg/mimirtool/commands/loadgen.go
@@ -263,7 +263,7 @@ func (c *LoadgenCommand) runQuery() {
 		Step:  time.Minute,
 	}
 	start := time.Now()
-	_, _, err := c.queryClient.QueryRange(ctx, c.query, r)
+	_, _, _, err := c.queryClient.QueryRange(ctx, c.query, r)
 	if err != nil {
 		c.queryRequestDuration.WithLabelValues("error").Observe(time.Since(start).Seconds())
 		stdlog.Printf("error doing query: %v", err)

--- a/vendor/github.com/prometheus/client_golang/api/prometheus/v1/api.go
+++ b/vendor/github.com/prometheus/client_golang/api/prometheus/v1/api.go
@@ -477,13 +477,13 @@ type API interface {
 	// Flags returns the flag values that Prometheus was launched with.
 	Flags(ctx context.Context) (FlagsResult, error)
 	// LabelNames returns the unique label names present in the block in sorted order by given time range and matchers.
-	LabelNames(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) (model.LabelNames, Warnings, error)
+	LabelNames(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) (model.LabelNames, Warnings, Infos, error)
 	// LabelValues performs a query for the values of the given label, time range and matchers.
-	LabelValues(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...Option) (model.LabelValues, Warnings, error)
+	LabelValues(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...Option) (model.LabelValues, Warnings, Infos, error)
 	// Query performs a query for the given time.
-	Query(ctx context.Context, query string, ts time.Time, opts ...Option) (model.Value, Warnings, error)
+	Query(ctx context.Context, query string, ts time.Time, opts ...Option) (model.Value, Warnings, Infos, error)
 	// QueryRange performs a query for the given range.
-	QueryRange(ctx context.Context, query string, r Range, opts ...Option) (model.Value, Warnings, error)
+	QueryRange(ctx context.Context, query string, r Range, opts ...Option) (model.Value, Warnings, Infos, error)
 	// QueryExemplars performs a query for exemplars by the given query and time range.
 	QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]ExemplarQueryResult, error)
 	// Buildinfo returns various build information properties about the Prometheus server
@@ -491,7 +491,7 @@ type API interface {
 	// Runtimeinfo returns the various runtime information properties about the Prometheus server.
 	Runtimeinfo(ctx context.Context) (RuntimeinfoResult, error)
 	// Series finds series by label matchers.
-	Series(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) ([]model.LabelSet, Warnings, error)
+	Series(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) ([]model.LabelSet, Warnings, Infos, error)
 	// Snapshot creates a snapshot of all current data into snapshots/<datetime>-<rand>
 	// under the TSDB's data directory and returns the directory as response.
 	Snapshot(ctx context.Context, skipHead bool) (SnapshotResult, error)
@@ -926,7 +926,7 @@ func (h *httpAPI) Alerts(ctx context.Context) (AlertsResult, error) {
 		return AlertsResult{}, err
 	}
 
-	_, body, _, err := h.client.Do(ctx, req)
+	_, body, _, _, err := h.client.Do(ctx, req)
 	if err != nil {
 		return AlertsResult{}, err
 	}
@@ -944,7 +944,7 @@ func (h *httpAPI) AlertManagers(ctx context.Context) (AlertManagersResult, error
 		return AlertManagersResult{}, err
 	}
 
-	_, body, _, err := h.client.Do(ctx, req)
+	_, body, _, _, err := h.client.Do(ctx, req)
 	if err != nil {
 		return AlertManagersResult{}, err
 	}
@@ -962,7 +962,7 @@ func (h *httpAPI) CleanTombstones(ctx context.Context) error {
 		return err
 	}
 
-	_, _, _, err = h.client.Do(ctx, req)
+	_, _, _, _, err = h.client.Do(ctx, req)
 	return err
 }
 
@@ -974,7 +974,7 @@ func (h *httpAPI) Config(ctx context.Context) (ConfigResult, error) {
 		return ConfigResult{}, err
 	}
 
-	_, body, _, err := h.client.Do(ctx, req)
+	_, body, _, _, err := h.client.Do(ctx, req)
 	if err != nil {
 		return ConfigResult{}, err
 	}
@@ -1006,7 +1006,7 @@ func (h *httpAPI) DeleteSeries(ctx context.Context, matches []string, startTime,
 		return err
 	}
 
-	_, _, _, err = h.client.Do(ctx, req)
+	_, _, _, _, err = h.client.Do(ctx, req)
 	return err
 }
 
@@ -1018,7 +1018,7 @@ func (h *httpAPI) Flags(ctx context.Context) (FlagsResult, error) {
 		return FlagsResult{}, err
 	}
 
-	_, body, _, err := h.client.Do(ctx, req)
+	_, body, _, _, err := h.client.Do(ctx, req)
 	if err != nil {
 		return FlagsResult{}, err
 	}
@@ -1036,7 +1036,7 @@ func (h *httpAPI) Buildinfo(ctx context.Context) (BuildinfoResult, error) {
 		return BuildinfoResult{}, err
 	}
 
-	_, body, _, err := h.client.Do(ctx, req)
+	_, body, _, _, err := h.client.Do(ctx, req)
 	if err != nil {
 		return BuildinfoResult{}, err
 	}
@@ -1054,7 +1054,7 @@ func (h *httpAPI) Runtimeinfo(ctx context.Context) (RuntimeinfoResult, error) {
 		return RuntimeinfoResult{}, err
 	}
 
-	_, body, _, err := h.client.Do(ctx, req)
+	_, body, _, _, err := h.client.Do(ctx, req)
 	if err != nil {
 		return RuntimeinfoResult{}, err
 	}
@@ -1064,7 +1064,7 @@ func (h *httpAPI) Runtimeinfo(ctx context.Context) (RuntimeinfoResult, error) {
 	return res, err
 }
 
-func (h *httpAPI) LabelNames(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) (model.LabelNames, Warnings, error) {
+func (h *httpAPI) LabelNames(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) (model.LabelNames, Warnings, Infos, error) {
 	u := h.client.URL(epLabels, nil)
 	q := addOptionalURLParams(u.Query(), opts)
 
@@ -1078,16 +1078,16 @@ func (h *httpAPI) LabelNames(ctx context.Context, matches []string, startTime, e
 		q.Add("match[]", m)
 	}
 
-	_, body, w, err := h.client.DoGetFallback(ctx, u, q)
+	_, body, w, i, err := h.client.DoGetFallback(ctx, u, q)
 	if err != nil {
-		return nil, w, err
+		return nil, w, i, err
 	}
 	var labelNames model.LabelNames
 	err = json.Unmarshal(body, &labelNames)
-	return labelNames, w, err
+	return labelNames, w, i, err
 }
 
-func (h *httpAPI) LabelValues(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...Option) (model.LabelValues, Warnings, error) {
+func (h *httpAPI) LabelValues(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...Option) (model.LabelValues, Warnings, Infos, error) {
 	u := h.client.URL(epLabelValues, map[string]string{"name": label})
 	q := addOptionalURLParams(u.Query(), opts)
 
@@ -1105,15 +1105,15 @@ func (h *httpAPI) LabelValues(ctx context.Context, label string, matches []strin
 
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	_, body, w, err := h.client.Do(ctx, req)
+	_, body, w, i, err := h.client.Do(ctx, req)
 	if err != nil {
-		return nil, w, err
+		return nil, w, i, err
 	}
 	var labelValues model.LabelValues
 	err = json.Unmarshal(body, &labelValues)
-	return labelValues, w, err
+	return labelValues, w, i, err
 }
 
 // StatsValue is a type for `stats` query parameter.
@@ -1192,7 +1192,7 @@ func addOptionalURLParams(q url.Values, opts []Option) url.Values {
 	return q
 }
 
-func (h *httpAPI) Query(ctx context.Context, query string, ts time.Time, opts ...Option) (model.Value, Warnings, error) {
+func (h *httpAPI) Query(ctx context.Context, query string, ts time.Time, opts ...Option) (model.Value, Warnings, Infos, error) {
 	u := h.client.URL(epQuery, nil)
 	q := addOptionalURLParams(u.Query(), opts)
 
@@ -1201,16 +1201,16 @@ func (h *httpAPI) Query(ctx context.Context, query string, ts time.Time, opts ..
 		q.Set("time", formatTime(ts))
 	}
 
-	_, body, warnings, err := h.client.DoGetFallback(ctx, u, q)
+	_, body, warnings, infos, err := h.client.DoGetFallback(ctx, u, q)
 	if err != nil {
-		return nil, warnings, err
+		return nil, warnings, infos, err
 	}
 
 	var qres queryResult
-	return qres.v, warnings, json.Unmarshal(body, &qres)
+	return qres.v, warnings, infos, json.Unmarshal(body, &qres)
 }
 
-func (h *httpAPI) QueryRange(ctx context.Context, query string, r Range, opts ...Option) (model.Value, Warnings, error) {
+func (h *httpAPI) QueryRange(ctx context.Context, query string, r Range, opts ...Option) (model.Value, Warnings, Infos, error) {
 	u := h.client.URL(epQueryRange, nil)
 	q := addOptionalURLParams(u.Query(), opts)
 
@@ -1219,16 +1219,16 @@ func (h *httpAPI) QueryRange(ctx context.Context, query string, r Range, opts ..
 	q.Set("end", formatTime(r.End))
 	q.Set("step", strconv.FormatFloat(r.Step.Seconds(), 'f', -1, 64))
 
-	_, body, warnings, err := h.client.DoGetFallback(ctx, u, q)
+	_, body, warnings, infos, err := h.client.DoGetFallback(ctx, u, q)
 	if err != nil {
-		return nil, warnings, err
+		return nil, warnings, infos, err
 	}
 
 	var qres queryResult
-	return qres.v, warnings, json.Unmarshal(body, &qres)
+	return qres.v, warnings, infos, json.Unmarshal(body, &qres)
 }
 
-func (h *httpAPI) Series(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) ([]model.LabelSet, Warnings, error) {
+func (h *httpAPI) Series(ctx context.Context, matches []string, startTime, endTime time.Time, opts ...Option) ([]model.LabelSet, Warnings, Infos, error) {
 	u := h.client.URL(epSeries, nil)
 	q := addOptionalURLParams(u.Query(), opts)
 
@@ -1243,13 +1243,13 @@ func (h *httpAPI) Series(ctx context.Context, matches []string, startTime, endTi
 		q.Set("end", formatTime(endTime))
 	}
 
-	_, body, warnings, err := h.client.DoGetFallback(ctx, u, q)
+	_, body, warnings, infos, err := h.client.DoGetFallback(ctx, u, q)
 	if err != nil {
-		return nil, warnings, err
+		return nil, warnings, infos, err
 	}
 
 	var mset []model.LabelSet
-	return mset, warnings, json.Unmarshal(body, &mset)
+	return mset, warnings, infos, json.Unmarshal(body, &mset)
 }
 
 func (h *httpAPI) Snapshot(ctx context.Context, skipHead bool) (SnapshotResult, error) {
@@ -1265,7 +1265,7 @@ func (h *httpAPI) Snapshot(ctx context.Context, skipHead bool) (SnapshotResult, 
 		return SnapshotResult{}, err
 	}
 
-	_, body, _, err := h.client.Do(ctx, req)
+	_, body, _, _, err := h.client.Do(ctx, req)
 	if err != nil {
 		return SnapshotResult{}, err
 	}
@@ -1290,7 +1290,7 @@ func (h *httpAPI) Rules(ctx context.Context, matches []string) (RulesResult, err
 		return RulesResult{}, err
 	}
 
-	_, body, _, err := h.client.Do(ctx, req)
+	_, body, _, _, err := h.client.Do(ctx, req)
 	if err != nil {
 		return RulesResult{}, err
 	}
@@ -1308,7 +1308,7 @@ func (h *httpAPI) Targets(ctx context.Context) (TargetsResult, error) {
 		return TargetsResult{}, err
 	}
 
-	_, body, _, err := h.client.Do(ctx, req)
+	_, body, _, _, err := h.client.Do(ctx, req)
 	if err != nil {
 		return TargetsResult{}, err
 	}
@@ -1333,7 +1333,7 @@ func (h *httpAPI) TargetsMetadata(ctx context.Context, matchTarget, metric, limi
 		return nil, err
 	}
 
-	_, body, _, err := h.client.Do(ctx, req)
+	_, body, _, _, err := h.client.Do(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -1357,7 +1357,7 @@ func (h *httpAPI) Metadata(ctx context.Context, metric, limit string) (map[strin
 		return nil, err
 	}
 
-	_, body, _, err := h.client.Do(ctx, req)
+	_, body, _, _, err := h.client.Do(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -1377,7 +1377,7 @@ func (h *httpAPI) TSDB(ctx context.Context, opts ...Option) (TSDBResult, error) 
 		return TSDBResult{}, err
 	}
 
-	_, body, _, err := h.client.Do(ctx, req)
+	_, body, _, _, err := h.client.Do(ctx, req)
 	if err != nil {
 		return TSDBResult{}, err
 	}
@@ -1395,7 +1395,7 @@ func (h *httpAPI) TSDBBlocks(ctx context.Context) (TSDBBlocksResult, error) {
 		return TSDBBlocksResult{}, err
 	}
 
-	_, body, _, err := h.client.Do(ctx, req)
+	_, body, _, _, err := h.client.Do(ctx, req)
 	if err != nil {
 		return TSDBBlocksResult{}, err
 	}
@@ -1413,7 +1413,7 @@ func (h *httpAPI) WalReplay(ctx context.Context) (WalReplayStatus, error) {
 		return WalReplayStatus{}, err
 	}
 
-	_, body, _, err := h.client.Do(ctx, req)
+	_, body, _, _, err := h.client.Do(ctx, req)
 	if err != nil {
 		return WalReplayStatus{}, err
 	}
@@ -1435,7 +1435,7 @@ func (h *httpAPI) QueryExemplars(ctx context.Context, query string, startTime, e
 		q.Set("end", formatTime(endTime))
 	}
 
-	_, body, _, err := h.client.DoGetFallback(ctx, u, q)
+	_, body, _, _, err := h.client.DoGetFallback(ctx, u, q)
 	if err != nil {
 		return nil, err
 	}
@@ -1450,7 +1450,7 @@ func (h *httpAPI) FormatQuery(ctx context.Context, query string) (string, error)
 	q := u.Query()
 	q.Set("query", query)
 
-	_, body, _, err := h.client.DoGetFallback(ctx, u, q)
+	_, body, _, _, err := h.client.DoGetFallback(ctx, u, q)
 	if err != nil {
 		return "", err
 	}
@@ -1458,15 +1458,18 @@ func (h *httpAPI) FormatQuery(ctx context.Context, query string) (string, error)
 	return string(body), nil
 }
 
-// Warnings is an array of non critical errors
+// Warnings is an array of non-critical errors.
 type Warnings []string
+
+// Infos is an array of informational messages.
+type Infos []string
 
 // apiClient wraps a regular client and processes successful API responses.
 // Successful also includes responses that errored at the API level.
 type apiClient interface {
 	URL(ep string, args map[string]string) *url.URL
-	Do(context.Context, *http.Request) (*http.Response, []byte, Warnings, error)
-	DoGetFallback(ctx context.Context, u *url.URL, args url.Values) (*http.Response, []byte, Warnings, error)
+	Do(context.Context, *http.Request) (*http.Response, []byte, Warnings, Infos, error)
+	DoGetFallback(ctx context.Context, u *url.URL, args url.Values) (*http.Response, []byte, Warnings, Infos, error)
 }
 
 type apiClientImpl struct {
@@ -1479,6 +1482,7 @@ type apiResponse struct {
 	ErrorType ErrorType       `json:"errorType"`
 	Error     string          `json:"error"`
 	Warnings  []string        `json:"warnings,omitempty"`
+	Infos     []string        `json:"infos,omitempty"`
 }
 
 func apiError(code int) bool {
@@ -1500,17 +1504,17 @@ func (h *apiClientImpl) URL(ep string, args map[string]string) *url.URL {
 	return h.client.URL(ep, args)
 }
 
-func (h *apiClientImpl) Do(ctx context.Context, req *http.Request) (*http.Response, []byte, Warnings, error) {
+func (h *apiClientImpl) Do(ctx context.Context, req *http.Request) (*http.Response, []byte, Warnings, Infos, error) {
 	resp, body, err := h.client.Do(ctx, req)
 	if err != nil {
-		return resp, body, nil, err
+		return resp, body, nil, nil, err
 	}
 
 	code := resp.StatusCode
 
 	if code/100 != 2 && !apiError(code) {
 		errorType, errorMsg := errorTypeAndMsgFor(resp)
-		return resp, body, nil, &Error{
+		return resp, body, nil, nil, &Error{
 			Type:   errorType,
 			Msg:    errorMsg,
 			Detail: string(body),
@@ -1521,7 +1525,7 @@ func (h *apiClientImpl) Do(ctx context.Context, req *http.Request) (*http.Respon
 
 	if http.StatusNoContent != code {
 		if jsonErr := json.Unmarshal(body, &result); jsonErr != nil {
-			return resp, body, nil, &Error{
+			return resp, body, nil, nil, &Error{
 				Type: ErrBadResponse,
 				Msg:  jsonErr.Error(),
 			}
@@ -1542,16 +1546,16 @@ func (h *apiClientImpl) Do(ctx context.Context, req *http.Request) (*http.Respon
 		}
 	}
 
-	return resp, []byte(result.Data), result.Warnings, err
+	return resp, []byte(result.Data), result.Warnings, result.Infos, err
 }
 
 // DoGetFallback will attempt to do the request as-is, and on a 403, 405, or
 // 501 it will fallback to a GET request.
-func (h *apiClientImpl) DoGetFallback(ctx context.Context, u *url.URL, args url.Values) (*http.Response, []byte, Warnings, error) {
+func (h *apiClientImpl) DoGetFallback(ctx context.Context, u *url.URL, args url.Values) (*http.Response, []byte, Warnings, Infos, error) {
 	encodedArgs := args.Encode()
 	req, err := http.NewRequest(http.MethodPost, u.String(), strings.NewReader(encodedArgs))
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	// Following comment originates from https://pkg.go.dev/net/http#Transport
@@ -1563,16 +1567,16 @@ func (h *apiClientImpl) DoGetFallback(ctx context.Context, u *url.URL, args url.
 	// the header is not sent on the wire.
 	req.Header["Idempotency-Key"] = nil
 
-	resp, body, warnings, err := h.Do(ctx, req)
+	resp, body, warnings, infos, err := h.Do(ctx, req)
 	if resp != nil && (resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusMethodNotAllowed || resp.StatusCode == http.StatusNotImplemented) {
 		u.RawQuery = encodedArgs
 		req, err = http.NewRequest(http.MethodGet, u.String(), nil)
 		if err != nil {
-			return nil, nil, warnings, err
+			return nil, nil, warnings, infos, err
 		}
 		return h.Do(ctx, req)
 	}
-	return resp, body, warnings, err
+	return resp, body, warnings, infos, err
 }
 
 func formatTime(t time.Time) string {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1127,7 +1127,7 @@ github.com/prometheus/alertmanager/template
 github.com/prometheus/alertmanager/timeinterval
 github.com/prometheus/alertmanager/tracing
 github.com/prometheus/alertmanager/types
-# github.com/prometheus/client_golang v1.24.1
+# github.com/prometheus/client_golang v1.24.2-0.20260812154952-0c5dccd910c0
 ## explicit; go 1.25.0
 github.com/prometheus/client_golang/api
 github.com/prometheus/client_golang/api/prometheus/v1


### PR DESCRIPTION
#### What this PR does

Adds an integration test to check that results with and without query sharding (within MQE with remote execution) are the same (along with the annotations).

Vendors changes from https://github.com/prometheus/client_golang/pull/1963, ~~but this is blocked now that main vendors a newer dskit which vendors a newer release of client_golang that doesn't include this change.~~

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

No changelog as it's not user-facing