### PR TITLE
Query-frontend: Enable sharding info() queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [ENHANCEMENT] Distributor: Add the experimental `cortex_distributor_otlp_requests_with_job_or_instance_resource_attribute_total{user}` counter to track OTLP requests carrying `job` or `instance` as a resource attribute. #16285
 * [ENHANCEMENT] Ruler: Split oversized remote distributor writes to keep resulting calls within the configured gRPC maximum send size, and expose the number of generated requests in `cortex_ruler_remote_distributor_requests_per_write_request`. #16160
 * [ENHANCEMENT] Alerts: Don't fire `MimirMemberlistZoneAwareRoutingAutoFailover` while the node is still joining the cluster. #16315
+* [ENHANCEMENT] Query-frontend: Queries using the `info()` function are now shardable. #16255
 * [FEATURE] Querier: Add experimental per-tenant limit `-querier.max-blocks-per-store-request` to cap the number of blocks a single store-gateway request may reference. Disabled by default. #16292
 * [BUGFIX] Query-frontend: Wait for the querier ring to be populated during startup, up to 30 seconds, before reporting the query-frontend as ready. Previously a query-frontend could become ready before it had seen any querier in the ring and fail every query it received until the ring was populated. Only applies when remote execution is enabled, and can be disabled with the experimental `-query-frontend.wait-for-querier-ring-on-startup=false`. #16333
 * [BUGFIX] Query-frontend: Fail queries with a clear error, rather than planning them against an invalid maximum supported query plan version, when the querier ring contains only unhealthy queriers. #16333

--- a/pkg/frontend/querymiddleware/astmapper/parallel.go
+++ b/pkg/frontend/querymiddleware/astmapper/parallel.go
@@ -27,7 +27,6 @@ var NonParallelFuncs = []string{
 	// The following functions are not safe to parallelize.
 	"absent",
 	"absent_over_time",
-	"info", // TODO: Find out whether can be parallelizable.
 	"histogram_quantile",
 	"histogram_quantiles",
 	"limitk",

--- a/pkg/frontend/querymiddleware/astmapper/sharding.go
+++ b/pkg/frontend/querymiddleware/astmapper/sharding.go
@@ -139,6 +139,21 @@ func (summer *shardSummer) MapExpr(ctx context.Context, expr parser.Expr) (mappe
 			return e, !analysis.WillShardAllSelectors, nil
 		}
 
+		// info() performs a many-to-one join between its first argument (the vector to
+		// enrich) and the target_info series. When sharding, we shard only the first
+		// argument: each shard must see the full set of target_info series to correctly
+		// enrich its subset of the inner series, so the target_info (data label) selector
+		// must not be sharded. For the single-argument form of info(), the target_info
+		// selector is injected later by the query engine and is likewise never sharded.
+		if isInfoCall(e) && len(e.Args) > 0 {
+			mappedArg, err := NewASTExprMapper(summer).Map(ctx, e.Args[0])
+			if err != nil {
+				return nil, true, err
+			}
+			e.Args[0] = mappedArg
+			return e, true, nil
+		}
+
 		return e, false, nil
 
 	case *parser.BinaryExpr:
@@ -727,6 +742,11 @@ func (summer *shardSummer) shardVectorSelector(selector *parser.VectorSelector) 
 	)
 
 	return shardedSelector, nil
+}
+
+// isInfoCall returns true if the given function call expression is a call to info().
+func isInfoCall(n *parser.Call) bool {
+	return n.Func != nil && n.Func.Name == "info"
 }
 
 // isSubqueryCall returns true if the given function call expression is a subquery,

--- a/pkg/frontend/querymiddleware/astmapper/sharding_test.go
+++ b/pkg/frontend/querymiddleware/astmapper/sharding_test.go
@@ -58,6 +58,28 @@ func TestSharding(t *testing.T) {
 			expectedShardableQueries: 0,
 		},
 		{
+			// A bare info() call is not sharded, just like a bare vector selector: there's no aggregation to parallelize.
+			in:                       `info(rate(foo[1m]))`,
+			out:                      `info(rate(foo[1m]))`,
+			expectedShardableQueries: 0,
+		},
+		{
+			// info() is a many-to-one join, so its inner (enriched) vector can be sharded.
+			// For the single-argument form the target_info selector is injected later by the query engine.
+			in:                       `sum(info(rate(foo[1m])))`,
+			out:                      `sum(` + concatShards(t, shardCount, `sum(info(rate(foo{__query_shard__="x_of_y"}[1m])))`) + `)`,
+			expectedShardableQueries: 1,
+		},
+		{
+			// For the two-argument form, only the inner vector is sharded: the target_info (data label)
+			// selector must not be sharded, as each shard needs to see the full set of target_info series.
+			in: `sum by (job) (info(rate(foo[1m]), {namespace=~".+"}))`,
+			out: `sum by (job) (` +
+				concatShards(t, shardCount, `sum by (job) (info(rate(foo{__query_shard__="x_of_y"}[1m]), {namespace=~".+"}))`) +
+				`)`,
+			expectedShardableQueries: 1,
+		},
+		{
 			in:                       `sum by (foo) (histogram_quantile(0.9, rate(http_request_duration_seconds_bucket[10m])))`,
 			out:                      `sum by (foo) (histogram_quantile(0.9, rate(http_request_duration_seconds_bucket[10m])))`,
 			expectedShardableQueries: 0,

--- a/pkg/frontend/querymiddleware/shardingtest/correctness.go
+++ b/pkg/frontend/querymiddleware/shardingtest/correctness.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -539,6 +540,22 @@ func RunCorrectnessTests(t *testing.T, runTestCase func(t *testing.T, testCase C
 			Query:                  `histogram_stddev(sum(metric_native_histogram))`,
 			ExpectedShardedQueries: 1,
 		},
+		// info() is a many-to-one join between the enriched metric and target_info. The inner
+		// metric is sharded while the target_info selector is not, so every shard sees the full
+		// set of target_info series to enrich its subset of the metric correctly.
+		`sum by on info(metric)`: {
+			Query:                  `sum by (data_center) (info(metric_with_info))`,
+			ExpectedShardedQueries: 1,
+		},
+		`sum by on rate(info(metric))`: {
+			Query:                  `sum by (data_center) (info(rate(metric_with_info[1m])))`,
+			ExpectedShardedQueries: 1,
+		},
+		// Two-argument form: only the inner metric is sharded, the data label selector is not.
+		`sum by on info(metric, data label selector)`: {
+			Query:                  `sum by (data_center) (info(metric_with_info, {data_center=~".+"}))`,
+			ExpectedShardedQueries: 1,
+		},
 	}
 
 	series := make([]storage.Series, 0, numSeries+(numConvHistograms*len(histogramBuckets))+numNativeHistograms)
@@ -600,6 +617,33 @@ func RunCorrectnessTests(t *testing.T, runTestCase func(t *testing.T, testCase C
 		}
 
 		series = append(series, testdatagen.NewNativeHistogramSeries(testdatagen.NewTestNativeHistogramLabels(seriesID), Start.Add(-lookbackDelta), End, Step, gen))
+		seriesID++
+	}
+
+	// Add series with identifying labels (instance, job) alongside matching target_info series.
+	// These are used to test sharding of the info() function, which is a many-to-one join between
+	// the enriched metric and target_info. Multiple instances ensure the metric series are spread
+	// across shards, while each shard must still see the full set of target_info series to enrich
+	// its subset of the metric correctly.
+	const numInfoInstances = 20
+	for i := range numInfoInstances {
+		instance := strconv.Itoa(i)
+
+		series = append(series, testdatagen.NewSeries(labels.FromStrings(
+			"__name__", "metric_with_info",
+			"instance", instance,
+			"job", "test",
+			"group_1", strconv.Itoa(i%3),
+		), Start.Add(-lookbackDelta), End, Step, testdatagen.Factor(float64(i+1)*0.1)))
+		seriesID++
+
+		// The matching target_info series enriches the metric above with a data_center data label.
+		series = append(series, testdatagen.NewSeries(labels.FromStrings(
+			"__name__", "target_info",
+			"instance", instance,
+			"job", "test",
+			"data_center", "dc_"+strconv.Itoa(i%4),
+		), Start.Add(-lookbackDelta), End, Step, testdatagen.Factor(1)))
 		seriesID++
 	}
 
@@ -679,6 +723,7 @@ func RunFunctionCorrectnessTests(t *testing.T, runTestCase functionCorrectnessTe
 		{fn: "label_join", args: []string{`"fuzz"`, `","`, `"foo"`, `"bar"`}},
 		{fn: "ts_of_first_over_time", rangeQuery: true},
 		{fn: "ts_of_last_over_time", rangeQuery: true},
+		{fn: "info"},
 	}
 	testsForFloatsOnly := []queryShardingFunctionCorrectnessTest{
 		{fn: "abs"},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Enable query sharding for queries using `info()`.  
This simply shards the inner query and leaves `info()` as is.

This came to my attention when debugging otel metrics performance.
Tested with a local mimir instance.

Note: the commit in this PR was made with AI assistance, and I am far from an expert on the query sharder semantics.

I guess we could theoretically also optimize the "legacy" `* on(job, instance) group_left(label) target_info`, but that seems a lot more involved.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
