### PR TITLE
Jsonnet: add per-compartment autoscaling disable knobs and expose compactor_containers 

### DIFF
--- a/operations/mimir-tests/test-compartments-config-validation.jsonnet
+++ b/operations/mimir-tests/test-compartments-config-validation.jsonnet
@@ -202,4 +202,74 @@ local err17 = validate({ gf: globalWithBucket('blocks-bucket-rc-<read-compartmen
 assert err17 == null :
        'case 17: expected no error for a parametrised blocks-storage bucket on a global deployment, got: %s' % err17;
 
+//
+// validateMimirCompartmentsAutoscalingDisabledKnobs() — the paired per-compartment autoscaling
+// disable knobs. The validator is a pure function of its arguments, so it's called directly.
+//
+
+local validateKnobs(disabledCompartments, staticReplicas, numCompartments=2, autoscalingEnabled=true) =
+  (compartmentsCommon { _config+: env._config }).validateMimirCompartmentsAutoscalingDisabledKnobs(
+    'autoscaling_foo_disabled_compartments',
+    disabledCompartments,
+    'foo_compartment_static_replicas',
+    staticReplicas,
+    numCompartments,
+    'autoscaling_foo_enabled',
+    autoscalingEnabled,
+  );
+
+// 18. A valid pair produces no error; so do the empty defaults.
+local err18a = validateKnobs([1], { compartment_1: 3 });
+assert err18a == null : 'case 18a: expected no error for a valid knob pair, got: %s' % err18a;
+local err18b = validateKnobs([], {});
+assert err18b == null : 'case 18b: expected no error for the empty defaults, got: %s' % err18b;
+
+// 19. Malformed knob shapes.
+local err19a = validateKnobs(0, {});
+assert isError(err19a, 'must be a list of compartment indexes') :
+       'case 19a: expected a shape error for a non-list disable knob, got: %s' % err19a;
+local err19b = validateKnobs([], [1]);
+assert isError(err19b, 'must be an object mapping') :
+       'case 19b: expected a shape error for a non-object static-replicas knob, got: %s' % err19b;
+
+// 20. Non-integer and out-of-range compartment indexes.
+local err20a = validateKnobs([1.5], { compartment_1: 3 });
+assert isError(err20a, 'compartment indexes must be integers') :
+       'case 20a: expected a non-integer index error, got: %s' % err20a;
+local err20b = validateKnobs(['1'], { compartment_1: 3 });
+assert isError(err20b, 'compartment indexes must be integers') :
+       'case 20b: expected a non-integer index error for a string index, got: %s' % err20b;
+local err20c = validateKnobs([2], { compartment_2: 3 });
+assert isError(err20c, 'only compartments [0, 2) exist') :
+       'case 20c: expected an out-of-range index error, got: %s' % err20c;
+
+// 21. Duplicate compartment indexes.
+local err21 = validateKnobs([1, 1], { compartment_1: 3 });
+assert isError(err21, 'duplicate compartment indexes') :
+       'case 21: expected a duplicate-index error, got: %s' % err21;
+
+// 22. A non-empty disable list has no effect while the component-level autoscaling knob is off.
+local err22 = validateKnobs([1], { compartment_1: 3 }, autoscalingEnabled=false);
+assert isError(err22, 'autoscaling_foo_enabled is false') && isError(err22, 'has no effect') :
+       'case 22: expected a component-knob pairing error, got: %s' % err22;
+
+// 23. Every disabled compartment needs a static replica count, and it must be a positive integer.
+local err23a = validateKnobs([1], {});
+assert isError(err23a, 'set an explicit count via foo_compartment_static_replicas: { compartment_1: <replicas> }') :
+       'case 23a: expected a missing static-replicas error, got: %s' % err23a;
+local err23b = validateKnobs([1], { compartment_1: 0 });
+assert isError(err23b, 'foo_compartment_static_replicas.compartment_1 must be an integer greater than 0') :
+       'case 23b: expected a non-positive replicas error, got: %s' % err23b;
+local err23c = validateKnobs([1], { compartment_1: 2.5 });
+assert isError(err23c, 'foo_compartment_static_replicas.compartment_1 must be an integer greater than 0') :
+       'case 23c: expected a non-integer replicas error, got: %s' % err23c;
+
+// 24. Stale or malformed static-replicas keys (compartment not disabled, or not a compartment key).
+local err24a = validateKnobs([1], { compartment_1: 3, compartment_0: 2 });
+assert isError(err24a, 'has entry "compartment_0"') && isError(err24a, 'not listed in autoscaling_foo_disabled_compartments') :
+       'case 24a: expected a stale static-replicas key error, got: %s' % err24a;
+local err24b = validateKnobs([1], { compartment_1: 3, foo: 2 });
+assert isError(err24b, 'has entry "foo"') :
+       'case 24b: expected a malformed static-replicas key error, got: %s' % err24b;
+
 {}

--- a/operations/mimir-tests/test-compartments.jsonnet
+++ b/operations/mimir-tests/test-compartments.jsonnet
@@ -113,4 +113,90 @@ assert compartmentSchedulerNodeSelectorTerms(0) == [{ matchExpressions: schedule
 assert compartmentSchedulerNodeSelectorTerms(1) == [{ matchExpressions: schedulerAffinityMatchers }] :
        'expected per-compartment compactor-schedulers to inherit compactor_scheduler_node_affinity_matchers';
 
+// The hidden compactor_containers map is the per-compartment patch point for downstream resource
+// overrides: patches layered onto it must propagate into the rendered StatefulSets, per compartment.
+local compactorResourcesEnv = env {
+  compactor_containers+:: {
+    compartment_1+: { resources+: { requests+: { cpu: '7' } } },
+  },
+};
+assert std.objectFields(env.compactor_containers) == ['compartment_0', 'compartment_1'] :
+       'expected one compactor_containers entry per read compartment';
+assert compactorResourcesEnv.compactor_statefulsets.compartment_1.spec.template.spec.containers[0].resources.requests.cpu == '7' :
+       'expected a compactor_containers patch to propagate into its compartment StatefulSet';
+assert compactorResourcesEnv.compactor_statefulsets.compartment_0 == env.compactor_statefulsets.compartment_0 :
+       'expected other compartments to be unaffected by a compactor_containers patch';
+
+// Per-compartment KEDA autoscaling disable: a disabled compartment loses exactly its ScaledObject
+// (and ReplicaTemplate, for the ingester), runs the explicit static replica count, and drops the
+// autoscaling annotations; sibling compartments are unaffected.
+local disabledCompartmentsEnv = env {
+  _config+:: {
+    autoscaling_compactor_disabled_compartments: [1],
+    compactor_compartment_static_replicas: { compartment_1: 3 },
+    autoscaling_distributor_disabled_compartments: [0],
+    distributor_compartment_static_replicas: { compartment_0: 2 },
+    autoscaling_store_gateway_disabled_compartments: [1],
+    store_gateway_compartment_static_replicas: { compartment_1: 4 },
+    ingest_storage_ingester_autoscaling_disabled_compartments: [1],
+    ingester_compartment_static_replicas: { compartment_1: 5 },
+  },
+};
+local annotationsOf(resource) = std.get(resource.metadata, 'annotations', {});
+local labelsOf(resource) = std.get(resource.metadata, 'labels', {});
+
+// With the knobs at their defaults, every compartment is autoscaled.
+assert std.objectFields(env.compactor_scaled_objects) == ['compartment_0', 'compartment_1'] :
+       'expected all compactor compartments to have a ScaledObject by default';
+assert std.objectFields(env.ingest_storage_ingester_primary_zone_scalings) == ['compartment_0', 'compartment_1'] :
+       'expected all ingester compartments to have a ScaledObject by default';
+
+// Exactly the disabled compartment's autoscaling objects are gone.
+assert std.objectFields(disabledCompartmentsEnv.compactor_scaled_objects) == ['compartment_0'] :
+       'expected the disabled compactor compartment to lose its ScaledObject';
+assert std.objectFields(disabledCompartmentsEnv.distributor_zone_a_scaled_objects) == ['compartment_1'] &&
+       std.objectFields(disabledCompartmentsEnv.distributor_zone_b_scaled_objects) == ['compartment_1'] :
+       'expected the disabled distributor compartment to lose its per-zone ScaledObjects';
+assert std.objectFields(disabledCompartmentsEnv.store_gateway_zone_a_scaled_objects) == ['compartment_0'] :
+       'expected the disabled store-gateway compartment to lose its leader ScaledObject';
+assert std.objectFields(disabledCompartmentsEnv.ingest_storage_ingester_primary_zone_scalings) == ['compartment_0'] &&
+       std.objectFields(disabledCompartmentsEnv.ingester_primary_zone_replica_templates) == ['compartment_0'] :
+       'expected the disabled ingester compartment to lose its ScaledObject and ReplicaTemplate';
+
+// The disabled compartment's workloads run the static replica count (per zone where zonal).
+assert disabledCompartmentsEnv.compactor_statefulsets.compartment_1.spec.replicas == 3 :
+       'expected the disabled compactor compartment to run static replicas';
+assert disabledCompartmentsEnv.distributor_zone_a_deployments.compartment_0.spec.replicas == 2 &&
+       disabledCompartmentsEnv.distributor_zone_b_deployments.compartment_0.spec.replicas == 2 :
+       'expected the disabled distributor compartment to run static replicas in every zone';
+assert disabledCompartmentsEnv.store_gateway_zone_a_statefulsets.compartment_1.spec.replicas == 4 &&
+       disabledCompartmentsEnv.store_gateway_zone_b_statefulsets.compartment_1.spec.replicas == 4 &&
+       disabledCompartmentsEnv.store_gateway_zone_c_statefulsets.compartment_1.spec.replicas == 4 :
+       'expected the disabled store-gateway compartment to run static replicas in every zone';
+assert disabledCompartmentsEnv.ingester_zone_a_statefulsets.compartment_1.spec.replicas == 5 &&
+       disabledCompartmentsEnv.ingester_zone_b_statefulsets.compartment_1.spec.replicas == 5 :
+       'expected the disabled ingester compartment to run static replicas in every zone';
+
+// The disabled compartment drops the autoscaling annotations, labels and args.
+assert !std.objectHas(annotationsOf(disabledCompartmentsEnv.store_gateway_zone_b_statefulsets.compartment_1), 'grafana.com/rollout-downscale-leader') &&
+       !std.objectHas(labelsOf(disabledCompartmentsEnv.store_gateway_zone_b_statefulsets.compartment_1), 'grafana.com/prepare-downscale') :
+       'expected the disabled store-gateway compartment to drop the autoscaling annotations and labels';
+assert !std.objectHas(disabledCompartmentsEnv.store_gateway_zone_a_compartments_args.compartment_1, 'store-gateway.sharding-ring.auto-forget-enabled') :
+       'expected the disabled store-gateway compartment to keep the default auto-forget behavior';
+assert !std.objectHas(annotationsOf(disabledCompartmentsEnv.ingester_zone_a_statefulsets.compartment_1), 'grafana.com/rollout-mirror-replicas-from-resource-name') &&
+       !std.objectHas(annotationsOf(disabledCompartmentsEnv.ingester_zone_b_statefulsets.compartment_1), 'grafana.com/rollout-downscale-leader') :
+       'expected the disabled ingester compartment to drop the leader/follower autoscaling annotations';
+
+// Sibling compartments keep the autoscaled shape: replicas stripped, annotations and args intact.
+assert !std.objectHas(disabledCompartmentsEnv.compactor_statefulsets.compartment_0.spec, 'replicas') :
+       'expected the autoscaled compactor compartment to keep its replicas stripped';
+assert !std.objectHas(disabledCompartmentsEnv.distributor_zone_a_deployments.compartment_1.spec, 'replicas') :
+       'expected the autoscaled distributor compartment to keep its replicas stripped';
+assert annotationsOf(disabledCompartmentsEnv.store_gateway_zone_b_statefulsets.compartment_0)['grafana.com/rollout-downscale-leader'] == 'store-gateway-zone-a-rc-0' :
+       'expected the autoscaled store-gateway compartment to keep following its leader';
+assert std.objectHas(annotationsOf(disabledCompartmentsEnv.ingester_zone_a_statefulsets.compartment_0), 'grafana.com/rollout-mirror-replicas-from-resource-name') :
+       'expected the autoscaled ingester compartment to keep mirroring its ReplicaTemplate';
+assert disabledCompartmentsEnv.store_gateway_zone_a_compartments_args.compartment_0['store-gateway.sharding-ring.auto-forget-enabled'] == false :
+       'expected the autoscaled store-gateway compartment to keep auto-forget disabled';
+
 env

--- a/operations/mimir/compartments-common.libsonnet
+++ b/operations/mimir/compartments-common.libsonnet
@@ -70,12 +70,78 @@ local jsonpath = import 'github.com/jsonnet-libs/xtd/jsonpath.libsonnet';
 
   // Creates a { compartment_0: …, compartment_1: … } resource map when enabled, otherwise returns {}.
   // fn is called with the compartment index (integer) for each compartment in [0, numCompartments).
+  // excludedCompartments skips the given compartment indexes from the map; it's meant only for
+  // autoscaling resources (ScaledObjects, ReplicaTemplates) — workload maps must keep every compartment.
   // Usage: foo_zone_a_deployments: $.mimirCompartmentsCreateIf(isEnabled && isZoneAEnabled, numCompartments,
   //          function(compartment) $.newFooCompartmentDeployment('a', compartment, …)),
-  mimirCompartmentsCreateIf(enabled, numCompartments, fn):: if !enabled then {} else {
+  mimirCompartmentsCreateIf(enabled, numCompartments, fn, excludedCompartments=[]):: if !enabled then {} else {
     ['compartment_%d' % compartment]: fn(compartment)
     for compartment in std.range(0, numCompartments - 1)
+    if !std.member(excludedCompartments, compartment)
   },
+
+  // Validates a component's paired per-compartment autoscaling disable knobs:
+  // disabledCompartments (compartment indexes whose ScaledObject must not render) and
+  // staticReplicas ({ compartment_<id>: <replicas> } entries for exactly those compartments).
+  // Returns a human-readable error string, or null when the configuration is valid.
+  //
+  // When a compartmentized component gains per-compartment ScaledObjects, give it the paired
+  // autoscaling_<component>_disabled_compartments / <component>_compartment_static_replicas
+  // knobs too: pass the disabled list as mimirCompartmentsCreateIf's excludedCompartments for
+  // the ScaledObject map, branch the workloads between the replica strip and an explicit
+  // static replica count (never layer one on the other — the strip hides the replicas field),
+  // and assert on this validator. See compartments-compactor.libsonnet for the simplest
+  // worked example.
+  validateMimirCompartmentsAutoscalingDisabledKnobs(disabledKnobName, disabledCompartments, staticReplicasKnobName, staticReplicas, numCompartments, autoscalingKnobName, autoscalingEnabled)::
+    local isInt(v) = std.isNumber(v) && v == std.floor(v);
+
+    local shapeError =
+      if !std.isArray(disabledCompartments) then
+        '%s must be a list of compartment indexes.' % disabledKnobName
+      else if !std.isObject(staticReplicas) then
+        '%s must be an object mapping "compartment_<id>" keys to replica counts.' % staticReplicasKnobName
+      else null;
+
+    local idError(id) =
+      if !isInt(id) then
+        '%s contains %s, but compartment indexes must be integers.' % [disabledKnobName, std.toString(id)]
+      else if id < 0 || id >= numCompartments then
+        '%s contains compartment index %d, but only compartments [0, %d) exist; remove the out-of-range index or raise the compartment count.' % [disabledKnobName, id, numCompartments]
+      else null;
+
+    local pairingError(id) =
+      local key = 'compartment_%d' % id;
+      if !std.objectHas(staticReplicas, key) then
+        'compartment %d is listed in %s, so its ScaledObject is not rendered and its replica count is no longer autoscaler-owned; set an explicit count via %s: { %s: <replicas> }.' % [id, disabledKnobName, staticReplicasKnobName, key]
+      else if !isInt(staticReplicas[key]) || staticReplicas[key] <= 0 then
+        '%s.%s must be an integer greater than 0.' % [staticReplicasKnobName, key]
+      else null;
+
+    local staleKeyError(key) =
+      if !std.member(['compartment_%d' % id for id in disabledCompartments], key) then
+        '%s has entry "%s", but that compartment is not listed in %s: static replicas apply only to compartments whose autoscaling is disabled; remove the entry or add the compartment to %s.' % [staticReplicasKnobName, key, disabledKnobName, disabledKnobName]
+      else null;
+
+    // Checked in order, first failure wins; later checks may assume earlier ones passed
+    // (e.g. the pairing and stale-key checks format ids with %d, valid only for integer ids).
+    local checks =
+      [shapeError] +
+      (
+        if shapeError != null then [] else
+          [idError(id) for id in disabledCompartments] +
+          [
+            if std.length(std.set(disabledCompartments)) != std.length(disabledCompartments) then
+              '%s contains duplicate compartment indexes.' % disabledKnobName
+            else null,
+            if std.length(disabledCompartments) > 0 && !autoscalingEnabled then
+              '%s is set but %s is false: with the component-level autoscaling switch off, no compartment renders a ScaledObject, so a per-compartment disable list has no effect; remove the entries or enable %s.' % [disabledKnobName, autoscalingKnobName, autoscalingKnobName]
+            else null,
+          ] +
+          [pairingError(id) for id in disabledCompartments] +
+          [staleKeyError(key) for key in std.objectFields(staticReplicas)]
+      );
+
+    std.foldl(function(firstError, err) if firstError != null then firstError else err, checks, null),
 
   // Base (empty) per-compartment caching config.
   blocks_chunks_zone_a_caching_configs:: $.mimirCompartmentsCreateIf(true, $._config.compartments_read_count, function(c) {}),

--- a/operations/mimir/compartments-compactor.libsonnet
+++ b/operations/mimir/compartments-compactor.libsonnet
@@ -6,6 +6,18 @@
     // Per-compartment compactor autoscaling bounds (per read compartment).
     autoscaling_compactor_min_replicas_per_compartment: 1,
     autoscaling_compactor_max_replicas_per_compartment: 10,
+
+    // Read compartment indexes whose KEDA autoscaling is disabled: the compartment's ScaledObject
+    // is not rendered and its StatefulSet runs the static replica count configured below. Only
+    // subtractive within an enabled component — it cannot re-enable single compartments when the
+    // component-level autoscaling knob is off.
+    autoscaling_compactor_disabled_compartments: [],
+
+    // Explicit replica count per disabled compartment, e.g. { compartment_0: 3 }. Required for
+    // every compartment listed above (the render fails otherwise). When first disabling a
+    // compartment, pick a count >= its current live replicas to avoid an immediate uncoordinated
+    // downscale; shrink deliberately afterwards.
+    compactor_compartment_static_replicas: {},
   },
 
   assert !$._config.compartments_compactor_enabled || $._config.compactor_scheduler_enabled
@@ -16,10 +28,13 @@
          : 'compartments_compactor_enabled requires cortex_compactor_concurrent_rollout_enabled',
 
   local container = $.core.v1.container,
+  local statefulSet = $.apps.v1.statefulSet,
 
   local isEnabled = $._config.compartments_compactor_enabled,
   local numCompartments = $._config.compartments_read_count,
   local isNoCompartmentsEnabled = $._config.no_compartments_compactor_enabled,
+  local isCompartmentAutoscalingDisabled(compartment) = std.member($._config.autoscaling_compactor_disabled_compartments, compartment),
+  local compartmentStaticReplicas(compartment) = $._config.compactor_compartment_static_replicas['compartment_%d' % compartment],
 
   local compartmentBlocksBucketArg(compartmentIdx) = {
     [$.mimirBlocksStorageBucketNameFlag]: $.mimirBlocksStorageCompartmentBucketName(compartmentIdx),
@@ -45,18 +60,28 @@
     $.compactor_container +
     container.withArgs($.util.mapToFlags($.compactor_compartments_args['compartment_%d' % compartmentIdx])),
 
+  compactor_containers:: $.mimirCompartmentsCreateIf(isEnabled, numCompartments, function(compartment) $.newCompactorCompartmentContainer(compartment)),
+
   local compartmentCompactorMaxUnavailable = std.max(std.floor($._config.autoscaling_compactor_min_replicas_per_compartment / 2), 1),
 
   newCompactorCompartmentStatefulSet(compartmentIdx)::
     $.newCompactorStatefulSet(
       'compactor-rc-%d' % compartmentIdx,
-      $.newCompactorCompartmentContainer(compartmentIdx),
+      // Referenced through the compartment map (not built inline) so per-compartment container
+      // patches layered onto compactor_containers propagate into the rendered StatefulSet.
+      $.compactor_containers['compartment_%d' % compartmentIdx],
       $.compactor_node_affinity_matchers,
       true,
       compartmentCompactorMaxUnavailable,
     ) +
-    // The per-compartment ScaledObject owns the replica count.
-    $.removeReplicasFromSpec,
+    (
+      if isCompartmentAutoscalingDisabled(compartmentIdx)
+      // Autoscaling is disabled for this compartment (no ScaledObject rendered), so the
+      // StatefulSet runs an explicit static replica count.
+      then statefulSet.mixin.spec.withReplicas(compartmentStaticReplicas(compartmentIdx))
+      // The per-compartment ScaledObject owns the replica count.
+      else $.removeReplicasFromSpec
+    ),
 
   // StatefulSets, Services and PDBs.
   compactor_statefulsets: $.mimirCompartmentsCreateIf(isEnabled, numCompartments, function(compartment) $.newCompactorCompartmentStatefulSet(compartment)),
@@ -73,7 +98,7 @@
       'pod=~"compactor-rc-%d-.*"' % compartment,
       $._config.autoscaling_compactor_min_replicas_per_compartment,
       $._config.autoscaling_compactor_max_replicas_per_compartment,
-    )),
+    ), $._config.autoscaling_compactor_disabled_compartments),
 
   // Null out the non-compartments compactor resources.
   compactor_statefulset: if !isNoCompartmentsEnabled then null else super.compactor_statefulset,
@@ -97,4 +122,15 @@
   // Config validation.
   local compactorCompartmentConfigError = $.validateMimirCompartmentsConfig(['compactor_statefulsets']),
   assert compactorCompartmentConfigError == null : compactorCompartmentConfigError,
+
+  local compactorDisabledKnobsError = if !isEnabled then null else $.validateMimirCompartmentsAutoscalingDisabledKnobs(
+    'autoscaling_compactor_disabled_compartments',
+    $._config.autoscaling_compactor_disabled_compartments,
+    'compactor_compartment_static_replicas',
+    $._config.compactor_compartment_static_replicas,
+    numCompartments,
+    'autoscaling_compactor_enabled',
+    $._config.autoscaling_compactor_enabled,
+  ),
+  assert compactorDisabledKnobsError == null : compactorDisabledKnobsError,
 }

--- a/operations/mimir/compartments-distributor.libsonnet
+++ b/operations/mimir/compartments-distributor.libsonnet
@@ -6,6 +6,18 @@
     // Controls whether the zonal distributor services route to compartment distributors.
     // This setting can be used by downstream projects during migrations.
     compartments_distributor_routing_enabled: !self.no_compartments_distributor_enabled,
+
+    // Write compartment indexes whose KEDA autoscaling is disabled: the compartment's per-zone
+    // ScaledObjects are not rendered and its Deployments run the static replica count configured
+    // below. Only subtractive within an enabled component — it cannot re-enable single
+    // compartments when the component-level autoscaling knob is off.
+    autoscaling_distributor_disabled_compartments: [],
+
+    // Explicit replica count (per zone) per disabled compartment, e.g. { compartment_0: 3 }.
+    // Required for every compartment listed above (the render fails otherwise). When first
+    // disabling a compartment, pick a count >= its current live replicas to avoid an immediate
+    // uncoordinated downscale; shrink deliberately afterwards.
+    distributor_compartment_static_replicas: {},
   },
 
   assert !$._config.compartments_distributor_enabled || $._config.multi_zone_distributor_enabled
@@ -31,6 +43,8 @@
   local isAutoscalingEnabled = $._config.autoscaling_distributor_enabled,
   local isNoCompartmentsEnabled = $._config.no_compartments_distributor_enabled,
   local isRoutingEnabled = isEnabled && $._config.compartments_distributor_routing_enabled,
+  local isCompartmentAutoscalingDisabled(compartment) = std.member($._config.autoscaling_distributor_disabled_compartments, compartment),
+  local compartmentStaticReplicas(compartment) = $._config.distributor_compartment_static_replicas['compartment_%d' % compartment],
 
   newDistributorCompartmentContainer(zone, compartmentIdx, args, extraEnvVarMap={})::
     $.newDistributorZoneContainer(zone, args, extraEnvVarMap),
@@ -54,7 +68,13 @@
       ]) +
       podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecutionType.withTopologyKey('kubernetes.io/hostname'),
     ]).spec } +
-    (if !isAutoscalingEnabled then {} else $.removeReplicasFromSpec),
+    (
+      if !isAutoscalingEnabled then {}
+      // Autoscaling is disabled for this compartment (no ScaledObjects rendered), so each zone's
+      // Deployment runs an explicit static replica count.
+      else if isCompartmentAutoscalingDisabled(compartmentIdx) then deployment.mixin.spec.withReplicas(compartmentStaticReplicas(compartmentIdx))
+      else $.removeReplicasFromSpec
+    ),
 
   newDistributorCompartmentScaledObject(name, zone, numCompartments)::
     $.newDistributorScaledObject(
@@ -126,10 +146,12 @@
   distributor_zone_b_pdbs: $.mimirCompartmentsCreateIf(isEnabled && isZoneBEnabled, numCompartments, function(compartment) $.newMimirPdb('distributor-zone-b-wc-%d' % compartment)),
   distributor_zone_c_pdbs: $.mimirCompartmentsCreateIf(isEnabled && isZoneCEnabled, numCompartments, function(compartment) $.newMimirPdb('distributor-zone-c-wc-%d' % compartment)),
 
-  // Scaled objects.
-  distributor_zone_a_scaled_objects: $.mimirCompartmentsCreateIf(isEnabled && isZoneAEnabled && isAutoscalingEnabled, numCompartments, function(compartment) $.newDistributorCompartmentScaledObject('distributor-zone-a-wc-%d' % compartment, 'a', numCompartments)),
-  distributor_zone_b_scaled_objects: $.mimirCompartmentsCreateIf(isEnabled && isZoneBEnabled && isAutoscalingEnabled, numCompartments, function(compartment) $.newDistributorCompartmentScaledObject('distributor-zone-b-wc-%d' % compartment, 'b', numCompartments)),
-  distributor_zone_c_scaled_objects: $.mimirCompartmentsCreateIf(isEnabled && isZoneCEnabled && isAutoscalingEnabled, numCompartments, function(compartment) $.newDistributorCompartmentScaledObject('distributor-zone-c-wc-%d' % compartment, 'c', numCompartments)),
+  // Scaled objects. Compartments with autoscaling disabled are skipped; the remaining compartments
+  // deliberately keep weight = 1/numCompartments over the TOTAL compartment count, because write
+  // traffic still splits across every compartment regardless of how a disabled one is sized.
+  distributor_zone_a_scaled_objects: $.mimirCompartmentsCreateIf(isEnabled && isZoneAEnabled && isAutoscalingEnabled, numCompartments, function(compartment) $.newDistributorCompartmentScaledObject('distributor-zone-a-wc-%d' % compartment, 'a', numCompartments), $._config.autoscaling_distributor_disabled_compartments),
+  distributor_zone_b_scaled_objects: $.mimirCompartmentsCreateIf(isEnabled && isZoneBEnabled && isAutoscalingEnabled, numCompartments, function(compartment) $.newDistributorCompartmentScaledObject('distributor-zone-b-wc-%d' % compartment, 'b', numCompartments), $._config.autoscaling_distributor_disabled_compartments),
+  distributor_zone_c_scaled_objects: $.mimirCompartmentsCreateIf(isEnabled && isZoneCEnabled && isAutoscalingEnabled, numCompartments, function(compartment) $.newDistributorCompartmentScaledObject('distributor-zone-c-wc-%d' % compartment, 'c', numCompartments), $._config.autoscaling_distributor_disabled_compartments),
 
   // Config validation.
   local distributorCompartmentMultiZoneError = $.validateMimirMultiZoneConfig([
@@ -145,4 +167,15 @@
     'distributor_zone_c_deployments',
   ]),
   assert distributorCompartmentConfigError == null : distributorCompartmentConfigError,
+
+  local distributorDisabledKnobsError = if !isEnabled then null else $.validateMimirCompartmentsAutoscalingDisabledKnobs(
+    'autoscaling_distributor_disabled_compartments',
+    $._config.autoscaling_distributor_disabled_compartments,
+    'distributor_compartment_static_replicas',
+    $._config.distributor_compartment_static_replicas,
+    numCompartments,
+    'autoscaling_distributor_enabled',
+    $._config.autoscaling_distributor_enabled,
+  ),
+  assert distributorDisabledKnobsError == null : distributorDisabledKnobsError,
 }

--- a/operations/mimir/compartments-ingester.libsonnet
+++ b/operations/mimir/compartments-ingester.libsonnet
@@ -7,6 +7,19 @@
     compartments_ingester_autoscaling_min_replicas_per_compartment_zone: 1,
     compartments_ingester_autoscaling_max_replicas_per_compartment_zone: 10,
 
+    // Read compartment indexes whose KEDA autoscaling is disabled: the compartment's ReplicaTemplate
+    // and ScaledObject are not rendered, none of its zones get the autoscaling annotations, and its
+    // StatefulSets run the static replica count configured below (per zone). Only subtractive within
+    // an enabled component — it cannot re-enable single compartments when the component-level
+    // autoscaling knob is off.
+    ingest_storage_ingester_autoscaling_disabled_compartments: [],
+
+    // Explicit replica count (per zone) per disabled compartment, e.g. { compartment_0: 3 }.
+    // Required for every compartment listed above (the render fails otherwise). When first
+    // disabling a compartment, pick a count >= its current live replicas to avoid an immediate
+    // uncoordinated downscale; shrink deliberately afterwards.
+    ingester_compartment_static_replicas: {},
+
     // The regex to extract the ingester partition identifier from a pod name.
     compartments_ingester_zpdb_partition_regex: '[a-z\\-]+-zone-[a-z]-rc-[0-9]+-([0-9]+)',
 
@@ -33,6 +46,8 @@
   local isZoneAEnabled = $._config.multi_zone_ingester_enabled && std.length($._config.multi_zone_availability_zones) >= 1,
   local isZoneBEnabled = $._config.multi_zone_ingester_enabled && std.length($._config.multi_zone_availability_zones) >= 2,
   local isZoneCEnabled = $._config.multi_zone_ingester_enabled && std.length($._config.multi_zone_availability_zones) >= 3,
+  local isCompartmentAutoscalingDisabled(compartment) = std.member($._config.ingest_storage_ingester_autoscaling_disabled_compartments, compartment),
+  local compartmentStaticReplicas(compartment) = $._config.ingester_compartment_static_replicas['compartment_%d' % compartment],
 
   newIngesterCompartmentContainer(zone, compartmentIdx, args, extraEnvVarMap={})::
     $.newIngesterZoneContainer(zone, args, extraEnvVarMap),
@@ -143,7 +158,13 @@
   ingester_rollout_pdbs: $.mimirCompartmentsCreateIf(isEnabled, numCompartments, function(compartment) newIngesterRolloutCompartmentPdb(compartment)),
 
   local autoscalingEnabled = isEnabled && $._config.ingest_storage_ingester_autoscaling_enabled,
-  local autoscaledCompartments = if autoscalingEnabled then std.range(0, numCompartments - 1) else [],
+  // Compartments with autoscaling disabled are subtracted here, so both their ReplicaTemplate and the
+  // ScaledObject targeting it stop rendering together.
+  local autoscaledCompartments = if !autoscalingEnabled then [] else [
+    compartment
+    for compartment in std.range(0, numCompartments - 1)
+    if !isCompartmentAutoscalingDisabled(compartment)
+  ],
   local compartmentLeaderName(compartmentIdx) = 'ingester-zone-a-rc-%d' % compartmentIdx,
 
   ingester_primary_zone_replica_templates: {
@@ -166,7 +187,13 @@
   },
 
   local ingesterCompartmentAutoscalingStatefulSetMixin(zone, compartmentIdx) =
-    if !autoscalingEnabled then {} else
+    if !autoscalingEnabled then {}
+    // Autoscaling is disabled for this compartment: there is no ReplicaTemplate to mirror and no
+    // prepare-downscale coordination, so each zone's StatefulSet runs an explicit static replica
+    // count (overriding the min-replicas default set by newIngesterCompartmentStatefulSet).
+    else if isCompartmentAutoscalingDisabled(compartmentIdx) then
+      statefulSet.mixin.spec.withReplicas(compartmentStaticReplicas(compartmentIdx))
+    else
       $.ingesterPartitionAutoscalingStatefulSetMixin(compartmentLeaderName(compartmentIdx), zone == 'a', $.ingester_primary_zone_replica_templates['compartment_%d' % compartmentIdx]),
 
   // Governing headless services (required by Kubernetes for StatefulSet pod DNS).
@@ -188,4 +215,15 @@
     'ingester_zone_c_statefulsets',
   ]),
   assert ingesterCompartmentConfigError == null : ingesterCompartmentConfigError,
+
+  local ingesterDisabledKnobsError = if !isEnabled then null else $.validateMimirCompartmentsAutoscalingDisabledKnobs(
+    'ingest_storage_ingester_autoscaling_disabled_compartments',
+    $._config.ingest_storage_ingester_autoscaling_disabled_compartments,
+    'ingester_compartment_static_replicas',
+    $._config.ingester_compartment_static_replicas,
+    numCompartments,
+    'ingest_storage_ingester_autoscaling_enabled',
+    $._config.ingest_storage_ingester_autoscaling_enabled,
+  ),
+  assert ingesterDisabledKnobsError == null : ingesterDisabledKnobsError,
 }

--- a/operations/mimir/store-gateway-autoscaling.libsonnet
+++ b/operations/mimir/store-gateway-autoscaling.libsonnet
@@ -27,6 +27,19 @@
     autoscaling_store_gateway_min_replicas_per_compartment_zone: 3,
     autoscaling_store_gateway_max_replicas_per_compartment_zone: 10,
 
+    // Read compartment indexes whose KEDA autoscaling is disabled: the compartment's zone-a leader
+    // ScaledObject is not rendered, none of its zones get the autoscaling annotations, and its
+    // primary-zone StatefulSets run the static replica count configured below (backup zones keep
+    // their base 0 replicas). Only subtractive within an enabled component — it cannot re-enable
+    // single compartments when autoscaling_store_gateway_enabled is false.
+    autoscaling_store_gateway_disabled_compartments: [],
+
+    // Explicit replica count (per primary zone) per disabled compartment, e.g. { compartment_0: 3 }.
+    // Required for every compartment listed above (the render fails otherwise). When first
+    // disabling a compartment, pick a count >= its current live replicas to avoid an immediate
+    // uncoordinated downscale; shrink deliberately afterwards.
+    store_gateway_compartment_static_replicas: {},
+
     // Give more time if lazy-loading is disabled.
     store_gateway_automated_downscale_min_time_between_zones: if $._config.store_gateway_lazy_loading_enabled then '15m' else '60m',
   },
@@ -204,19 +217,30 @@
   //
 
   local compartmentsStoreGatewayAutoscalingEnabled = $._config.compartments_store_gateway_enabled && $._config.autoscaling_store_gateway_enabled,
+  local isCompartmentAutoscalingDisabled(compartment) = std.member($._config.autoscaling_store_gateway_disabled_compartments, compartment),
+  local compartmentStaticReplicas(compartment) = $._config.store_gateway_compartment_static_replicas['compartment_%d' % compartment],
 
   // Applied to every per-compartment StatefulSet: the autoscaler owns the replicas and the rollout-operator
   // drives safe downscales via the prepare-shutdown endpoint (zones follow their leader per compartment).
   local storeGatewayCompartmentAutoscaleMixin(zone) = function(compartmentIdx)
-    $.removeReplicasFromSpec +
-    prepareDownscaleLabelsAnnotations +
-    storeGatewayDownscaleLeaderMixin(zone, compartmentIdx),
+    if isCompartmentAutoscalingDisabled(compartmentIdx) then
+      // Autoscaling is disabled for this compartment: mirror the component-level disable — no
+      // replica strip and no rollout-operator annotations. Primary zones run an explicit static
+      // replica count; backup zones keep their base 0 replicas (they exist to follow an autoscaled
+      // leader on spot nodes, which this compartment no longer has).
+      (if zone == 'a-backup' || zone == 'b-backup' then {} else statefulSet.mixin.spec.withReplicas(compartmentStaticReplicas(compartmentIdx)))
+    else
+      $.removeReplicasFromSpec +
+      prepareDownscaleLabelsAnnotations +
+      storeGatewayDownscaleLeaderMixin(zone, compartmentIdx),
 
   // Per-compartment store-gateways always use prepare-downscale when autoscaled (the shutdown endpoint removes
-  // them from the ring), so disable auto-forget.
-  local storeGatewayCompartmentAutoForgetArgs = if !compartmentsStoreGatewayAutoscalingEnabled then {} else {
-    'store-gateway.sharding-ring.auto-forget-enabled': false,
-  },
+  // them from the ring), so disable auto-forget. Compartments with autoscaling disabled keep the default
+  // auto-forget behavior, exactly like the component-level disable.
+  local storeGatewayCompartmentAutoForgetArgs = function(compartmentIdx)
+    if !compartmentsStoreGatewayAutoscalingEnabled || isCompartmentAutoscalingDisabled(compartmentIdx) then {} else {
+      'store-gateway.sharding-ring.auto-forget-enabled': false,
+    },
 
   store_gateway_zone_a_compartments_args+:: $.mimirCompartmentsOverrides(super.store_gateway_zone_a_compartments_args, storeGatewayCompartmentAutoForgetArgs),
   store_gateway_zone_b_compartments_args+:: $.mimirCompartmentsOverrides(super.store_gateway_zone_b_compartments_args, storeGatewayCompartmentAutoForgetArgs),
@@ -238,5 +262,17 @@
       $._config.autoscaling_store_gateway_max_replicas_per_compartment_zone,
       $._config.autoscaling_store_gateway_disk_usage_threshold,
       'store-gateway-data-store-gateway-zone-.*-rc-%d-.*' % c,
-    )),
+    ), $._config.autoscaling_store_gateway_disabled_compartments),
+
+  // Config validation.
+  local storeGatewayDisabledKnobsError = if !$._config.compartments_store_gateway_enabled then null else $.validateMimirCompartmentsAutoscalingDisabledKnobs(
+    'autoscaling_store_gateway_disabled_compartments',
+    $._config.autoscaling_store_gateway_disabled_compartments,
+    'store_gateway_compartment_static_replicas',
+    $._config.store_gateway_compartment_static_replicas,
+    $._config.compartments_read_count,
+    'autoscaling_store_gateway_enabled',
+    $._config.autoscaling_store_gateway_enabled,
+  ),
+  assert storeGatewayDisabledKnobsError == null : storeGatewayDisabledKnobsError,
 }


### PR DESCRIPTION
#### What this PR does

Two additions to the experimental compartments jsonnet in `operations/mimir`. Both are inert
by default: with the new options at their defaults, no generated manifest in
`operations/mimir-tests` changes.

Mimir's experimental compartments architecture splits a component into independent
"compartments": instead of one compactor StatefulSet, a cell runs `compactor-rc-0`,
`compactor-rc-1`, and so on. Each compartment gets its own workloads and its own KEDA
ScaledObject — the object that tells the autoscaler how to scale it. Two things you can do
with a normal (non-compartmentized) component are not possible per compartment today, and
this PR closes both gaps with two independent changes: customizing one compartment's
*containers* (resources, arguments), and turning one compartment's *autoscaling* off.

##### 1. Expose a per-compartment `compactor_containers` map

This first change is independent of the per-compartment autoscaling disable below: it adds a
patch point for the containers themselves (resources, arguments, environment) and does not
itself change replica management. Every other compartmentized component (store-gateway,
ingester, distributor) exposes a hidden per-compartment container map that downstream
projects patch to customize individual compartments — for example, to give one compartment
more memory. The compactor built its container inline, leaving nothing to patch. This PR adds
the map and routes the per-compartment StatefulSet through it, so a patch like

```jsonnet
compactor_containers+:: { compartment_1+: { resources+: { requests+: { memory: '12Gi' } } } }
```

lands in the rendered `compactor-rc-1` StatefulSet, and only there. The StatefulSet builder
keeps its signature; rendered output is identical until someone actually patches the map.

##### 2. Per-compartment autoscaling disable

Autoscaling can only be switched off component-wide today; there is no way to take one
compartment off KEDA and run it at a fixed size — useful for isolating, debugging, or pinning
a single compartment without touching its siblings. Each compartmentized component that
autoscales (compactor, distributor, store-gateway, ingester) gets a pair of options.
Disabling one compartment of a cell that runs three compactor compartments:

```jsonnet
_config+:: {
  // Take compartment 1 off KEDA autoscaling…
  autoscaling_compactor_disabled_compartments: [1],
  // …and run it at a fixed 3 replicas instead.
  compactor_compartment_static_replicas: { compartment_1: 3 },
},
```

renders to:

```
ScaledObjects:  compactor-rc-0, compactor-rc-2              (none for compactor-rc-1)
StatefulSets:   compactor-rc-0   spec.replicas: <absent>    # autoscaler-owned
                compactor-rc-1   spec.replicas: 3           # fixed
                compactor-rc-2   spec.replicas: <absent>    # autoscaler-owned
```

<details>
<summary><b>Knob naming, index semantics, and what happens to a disabled compartment</b></summary>

The other components follow the same pattern (`autoscaling_store_gateway_disabled_compartments`
/ `store_gateway_compartment_static_replicas`, etc.). The one naming exception is the
ingester's disable list, `ingest_storage_ingester_autoscaling_disabled_compartments`, which
matches its master knob's prefix; its replica option is plain
`ingester_compartment_static_replicas`. The indexes refer to the compartment kind the
component is split by: write compartments for the distributor (`distributor-zone-a-wc-0`, …),
read compartments for compactor, store-gateway, and ingester (`compactor-rc-0`, …). The
replica count is per zone for zonal components and a total for the zone-less compactor. The
compactor-scheduler is not covered because it has no ScaledObjects.

What happens to a disabled compartment:

- Its ScaledObject is no longer rendered, so KEDA/HPA stops managing it. For the ingester,
  the ReplicaTemplate the ScaledObject targets disappears with it — both come from one
  filtered list, so one can't be left pointing at the other.
- Its workloads stop carrying the autoscaling machinery. For every component the replicas
  field is no longer stripped. Store-gateway and ingester additionally drop their
  rollout-operator annotations (prepare-downscale, leader/follower coordination); compactor
  and distributor never had such coordination — they simply switch from autoscaler-owned to
  fixed replicas. The store-gateway's "disable auto-forget" argument reverts too — it was
  only set because autoscaled downscales replaced it.
- Its workloads get the fixed `spec.replicas` you configured, in every primary zone.
  Store-gateway backup zones are the exception: they only ever get replicas by mirroring
  their autoscaled leader (via the rollout-operator), so a disabled compartment's backups
  scale down to their rendered 0 — the same state a component-wide disable leaves them in.
  Account for that lost backup capacity when choosing the fixed count, or size the backups
  explicitly by patching the per-compartment backup StatefulSet maps.
- Everything else keeps rendering exactly as before. In particular the per-compartment
  container maps (including the new `compactor_containers`) are unaffected, so you can still
  size a compartment's containers individually while its replica count is fixed.

</details>

<details>
<summary><b>Interaction with the component-wide knobs (100% backward compatible), and validation</b></summary>

Listing every compartment takes the whole component off KEDA. For compactor, distributor,
and ingester this is also the *only* way to run the whole component static, because their
component-wide autoscaling knob must stay enabled while compartmentized (turning it off has
always failed the render there); store-gateway can alternatively use its component-wide
switch. That render failure is deliberate, pre-existing behavior, not a gap this PR leaves
open: without an autoscaler those components' compartments had no defined sizing (every
compartment would fall back to one shared default), so the render fails loudly instead. This
PR deliberately keeps the component-wide knobs 100% backward compatible and adds the safe
expression of that state instead — the disable list requires an explicit replica count for
every compartment. If relaxing the component-wide knob is ever wanted, it can be its own
follow-up change. The component-wide knobs are otherwise untouched: the new list only
subtracts from an autoscaling-enabled component and cannot re-enable a compartment under a
disabled one. Listing compartments while a master switch is off fails the render on purpose —
the list would do nothing, and a forgotten one would spring back to life when someone later
flips the switch back on.

Mistakes fail at render time with a message that says what to fix: every disabled compartment
must have a replica count (and a replica count for a compartment that isn't disabled is
rejected as stale); compartment indexes must be integers that actually exist, without
duplicates; replica counts must be whole numbers greater than zero. The checks live in one
shared validator in `compartments-common.libsonnet` that returns the error text, so the tests
exercise every message.

</details>

<details>
<summary><b>Two implementation details reviewers should check, and one operational note</b></summary>

- The existing replica-strip helper (`removeReplicasFromSpec`) doesn't just delete the
  replicas field — it marks it *hidden*, and a value set on top of a hidden field silently
  doesn't render. So the code always picks one branch — fixed replicas OR the strip — and
  never stacks one on the other.
- Distributor compartments are sized off the whole zone's write traffic: incoming writes are
  split evenly across all N compartments, so each compartment's ScaledObject targets 1/N of
  the zone's total load. Disabling one compartment does not change how traffic is split — the
  disabled compartment keeps receiving its ~1/N share, and the autoscaled ones keep serving
  ~1/N each. Two consequences, both deliberate and commented in code: the remaining
  ScaledObjects keep the 1/N weight (recomputing it as 1/(N-1) would over-provision them for
  traffic they don't serve), and the disabled compartment's fixed replica count must be large
  enough for the ~1/N share it still receives.

One operational note, also written on the option comments: when first disabling a
compartment, set the fixed count to at least its current live replica count — a lower number
takes effect immediately, and for store-gateway and ingester without the
coordinated-downscale protection autoscaling used to provide. Shrink deliberately afterwards.

</details>

<details>
<summary><b>Verification performed</b></summary>

- `make build-jsonnet-tests` regenerates the YAML for all ~100 test environments; not a
  single generated file changed (re-checked after adding the tests and after formatting) —
  the defaults are proven inert.
- New tests in `test-compartments.jsonnet` (21 assertions) cover: a `compactor_containers`
  patch landing in the right compartment's StatefulSet while its sibling stays
  byte-identical; and, per component, that disabling one compartment removes exactly its
  ScaledObject (plus the ingester's ReplicaTemplate), sets the fixed replica count in every
  rendered zone, drops the autoscaling annotations and arguments, and leaves the sibling
  compartments alone. (The store-gateway backup-zone branch — disabled compartments keep the
  base 0 replicas — is a two-line branch verified by review, not by these tests: the test
  environment renders no backup zones.)
- `test-compartments-config-validation.jsonnet` exercises every validator error message plus
  the valid and empty-default cases.
- `make jsonnet-conftest-quick-test`: all 100 generated manifests pass the policy checks;
  `jsonnetfmt` clean.

</details>

<details>
<summary><b>Not in this PR (possible follow-ups)</b></summary>

- The ingester compartment ScaledObjects hardcode their trigger list instead of honoring the
  `_config.ingest_storage_ingester_autoscaling_triggers` customization the non-compartment
  path supports. Pre-existing and independent — better fixed in its own small PR.
- A few container arguments are derived from the *shared base* container's resources (for
  example `GOMAXPROCS` and the WAL-replay concurrency come from the ingester base CPU
  request, `GOMEMLIMIT` from the store-gateway base memory), so patching one compartment's
  resources does not update those derived values for that compartment. Deriving them per
  compartment is a candidate improvement, out of scope here.

</details>


#### Which issue(s) this PR fixes or relates to

N/A — experimental compartments architecture.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added. Not applicable: experimental and disabled by default; the option
      comments carry the operator-facing documentation.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`,
      `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the
      `changelog-not-needed` label to the PR. Not needed (experimental, disabled by default,
      consistent with the rest of the compartments work) — adding the `changelog-not-needed`
      label.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md)
      updated with experimental features. Not applicable: no new Mimir configuration flags;
      jsonnet-only change.