### PR TITLE
Allow optional write amplification factor

### DIFF
--- a/tools/read-tee/README.md
+++ b/tools/read-tee/README.md
@@ -99,6 +99,7 @@ Copies flow through the full read path (query-frontend → querier → ingesters
 ```
 -backend.endpoint             The query-frontend endpoint to forward reads to. Required.
 -backend.amplification-factor Factor N (default 1 = passthrough). Integer part = original + (N-1) copies.
+-backend.write-amplification-factor  Write-tee factor W (default 0 = disabled). When set, copy k targets variant k mod W (0 = base series), so N may exceed W by wrapping around the variants that exist.
 -backend.negative-matchers-exclude-all-amp-values  Default true. Negative matchers (!=, !~) exclude the value in all forms (base + every _amp{N}); != becomes a regex-quoted !~. Set false to suffix negative matchers with _amp{k} like positive matchers.
 -backend.amplify-all-replicas-fraction  Fraction (0.0-1.0, default 0) of reads sent as a single heavy copy matching base + all replicas instead of N-1 per-replica copies. Requires amplification-factor > 1.
 -backend.strong-consistency-instant-fraction  Fraction (0.0-1.0, default 0) of instant-query copies sent with X-Read-Consistency: strong (per-copy, copies only). Mirrors the ruler.
@@ -111,4 +112,6 @@ Copies flow through the full read path (query-frontend → querier → ingesters
 
 ## Coordinating With Write-Tee
 
-Amplified copies only do real work if the `_amp{k}` series exist. Read-tee at factor `R` queries `_amp1`..`_amp{R-1}`; write-tee at factor `W` creates `_amp1`..`_amp{W-1}`. **Keep `R ≤ W`** — otherwise copies hit `_amp` series that were never written and return empty results (wasted load). The ksonnet library enforces this with an assertion.
+Amplified copies only do real work if the `_amp{k}` series exist. Read-tee at factor `R` queries `_amp1`..`_amp{R-1}`; write-tee at factor `W` creates `_amp1`..`_amp{W-1}`. By default, **keep `R ≤ W`** — otherwise copies hit `_amp` series that were never written and return empty results (wasted load). The ksonnet library enforces this with an assertion.
+
+To scale read load beyond write load, set `-backend.write-amplification-factor` to `W`. Copy `k` then wraps around the variants that actually exist (`k mod W`): variant 0 is the base series (the copy is sent with the original, unrewritten query) and variants 1..`W-1` are the written replicas. Every copy reads real data, so `R` may exceed `W` freely — the extra copies re-read the same series in distinct queries, which is representative read load (production queries re-read the same series constantly). One caveat: repeated identical *range* queries can partially collapse into the query-frontend results cache; *instant* queries (the ruler-shaped load) are not results-cached and do full work per copy.

--- a/tools/read-tee/proxy.go
+++ b/tools/read-tee/proxy.go
@@ -35,6 +35,7 @@ type ProxyConfig struct {
 
 	BackendEndpoint                     string
 	AmplificationFactor                 float64
+	WriteAmplificationFactor            int
 	NegativeMatchersExcludeAllAmpValues bool
 	AmplifyAllReplicasFraction          float64
 	StrongConsistencyInstantFraction    float64
@@ -91,6 +92,12 @@ func (cfg *ProxyConfig) RegisterFlags(f *flag.FlagSet) {
 			"each with all label-value matchers (except __name__) suffixed with _amp{k}. "+
 			"A value of 1 disables amplification (only the original request is sent). "+
 			"Fractional values are not supported in v1 (truncated to the integer part).",
+	)
+	f.IntVar(&cfg.WriteAmplificationFactor, "backend.write-amplification-factor", 0,
+		"The write-tee amplification factor W: the number of write copies that exist per series (the base series plus replicas _amp1.._amp{W-1}). "+
+			"When set (>= 1), the read amplification factor may exceed W: read copy k wraps around the existing variants (k mod W), where variant 0 is the base series (the copy is sent with the original, unrewritten query). "+
+			"This lets read load scale beyond write load by re-reading the same series in distinct queries, instead of querying _amp variants that were never written. "+
+			"0 (default) disables wrapping: copy k always targets _amp{k}, so the read factor must not exceed the write factor.",
 	)
 	f.BoolVar(&cfg.NegativeMatchersExcludeAllAmpValues, "backend.negative-matchers-exclude-all-amp-values", true,
 		"When rewriting a query copy, make negative matchers (!=, !~) exclude the value in all its forms - the base value and every _amp{N} variant (value plus the optional _amp{N} suffix) - instead of only the single _amp{replica} form. A != becomes a !~ with its value regex-quoted, since a single != can only exclude one exact string. "+
@@ -156,6 +163,11 @@ func NewProxy(cfg ProxyConfig, logger log.Logger, routes []Route, registerer pro
 	// The amplification factor must be >= 1 so the endpoint always receives the full original request.
 	if cfg.AmplificationFactor < 1.0 {
 		return nil, errors.New("amplification-factor must be >= 1")
+	}
+
+	// Validate the write amplification factor (0 = wrapping disabled).
+	if cfg.WriteAmplificationFactor < 0 {
+		return nil, errors.New("backend.write-amplification-factor must be >= 0")
 	}
 
 	// Validate async max in-flight.
@@ -238,7 +250,7 @@ func (p *Proxy) Start() error {
 
 	// register fan-out routes (explicit endpoints we want to amplify)
 	for _, route := range p.routes {
-		endpoint := NewProxyEndpoint(p.backend, route, p.metrics, p.logger, p.cfg.AmplificationFactor, rewriteOpts, p.cfg.AmplifyAllReplicasFraction, p.cfg.StrongConsistencyInstantFraction, p.asyncDispatcher)
+		endpoint := NewProxyEndpoint(p.backend, route, p.metrics, p.logger, p.cfg.AmplificationFactor, p.cfg.WriteAmplificationFactor, rewriteOpts, p.cfg.AmplifyAllReplicasFraction, p.cfg.StrongConsistencyInstantFraction, p.asyncDispatcher)
 		router.Path(route.Path).Methods(route.Methods...).Handler(endpoint)
 	}
 
@@ -249,7 +261,7 @@ func (p *Proxy) Start() error {
 		RouteName: "passthrough",
 		Methods:   []string{"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"},
 	}
-	passthroughEndpoint := NewProxyEndpoint(p.backend, passthroughRoute, p.metrics, p.logger, p.cfg.AmplificationFactor, rewriteOpts, p.cfg.AmplifyAllReplicasFraction, p.cfg.StrongConsistencyInstantFraction, p.asyncDispatcher)
+	passthroughEndpoint := NewProxyEndpoint(p.backend, passthroughRoute, p.metrics, p.logger, p.cfg.AmplificationFactor, p.cfg.WriteAmplificationFactor, rewriteOpts, p.cfg.AmplifyAllReplicasFraction, p.cfg.StrongConsistencyInstantFraction, p.asyncDispatcher)
 	router.PathPrefix("/").Handler(http.HandlerFunc(passthroughEndpoint.ServeHTTPPassthrough))
 
 	// Create HTTP connection TTL middleware if enabled.

--- a/tools/read-tee/proxy_endpoint.go
+++ b/tools/read-tee/proxy_endpoint.go
@@ -46,6 +46,7 @@ type ProxyEndpoint struct {
 	metrics                   *ProxyMetrics
 	logger                    log.Logger
 	amplificationFactor       float64
+	writeAmplificationFactor  int
 	rewriteOpts               rewriteOptions
 	ampAllReplicasFraction    float64
 	strongConsistencyFraction float64
@@ -54,13 +55,14 @@ type ProxyEndpoint struct {
 	route Route
 }
 
-func NewProxyEndpoint(backend ProxyBackend, route Route, metrics *ProxyMetrics, logger log.Logger, amplificationFactor float64, rewriteOpts rewriteOptions, ampAllReplicasFraction, strongConsistencyFraction float64, asyncDispatcher *AsyncBackendDispatcher) *ProxyEndpoint {
+func NewProxyEndpoint(backend ProxyBackend, route Route, metrics *ProxyMetrics, logger log.Logger, amplificationFactor float64, writeAmplificationFactor int, rewriteOpts rewriteOptions, ampAllReplicasFraction, strongConsistencyFraction float64, asyncDispatcher *AsyncBackendDispatcher) *ProxyEndpoint {
 	return &ProxyEndpoint{
 		backend:                   backend,
 		route:                     route,
 		metrics:                   metrics,
 		logger:                    logger,
 		amplificationFactor:       amplificationFactor,
+		writeAmplificationFactor:  writeAmplificationFactor,
 		rewriteOpts:               rewriteOpts,
 		ampAllReplicasFraction:    ampAllReplicasFraction,
 		strongConsistencyFraction: strongConsistencyFraction,
@@ -191,10 +193,13 @@ type amplifiedRequestSource struct {
 
 // prepareAmplifiedRequests builds the rewritten copies of the original read request. Normally it
 // builds N-1 per-replica copies (amplified replicas _amp1.._amp{N-1}, where N is the integer part
-// of the amplification factor), each with its query and match[] parameters suffixed _amp{k}. For a
-// sampled fraction of queries (amplify-all-replicas-fraction) it instead builds a single heavy copy
-// whose matchers target the base series plus every replica at once. Copies that fail to rewrite are
-// skipped and counted. Returns nil when amplification is disabled (factor <= 1).
+// of the amplification factor), each with its query and match[] parameters suffixed _amp{k}. When
+// the write amplification factor W is set, copy k instead targets variant k mod W so N may exceed
+// W: the copies wrap around the base series (variant 0, sent with the original unrewritten params)
+// and the W-1 replicas write-tee actually created. For a sampled fraction of queries
+// (amplify-all-replicas-fraction) it instead builds a single heavy copy whose matchers target the
+// base series plus every replica at once. Copies that fail to rewrite are skipped and counted.
+// Returns nil when amplification is disabled (factor <= 1).
 func (p *ProxyEndpoint) prepareAmplifiedRequests(ctx context.Context, orig *http.Request, origBody []byte, logger *spanlogger.SpanLogger) []amplifiedRequest {
 	// Integer factors only for v1; the fractional part is ignored.
 	n := int(p.amplificationFactor)
@@ -244,7 +249,14 @@ func (p *ProxyEndpoint) prepareAmplifiedRequests(ctx context.Context, orig *http
 
 	result := make([]amplifiedRequest, 0, n-1)
 	for k := 1; k <= n-1; k++ {
-		a, ok := p.buildCopy(ctx, src, k, p.rewriteOpts, logger)
+		// With the write amplification factor set, wrap copies around the variants that actually
+		// exist: the base series (0) and replicas _amp1.._amp{W-1}. Without it, copy k targets
+		// _amp{k} unconditionally (the caller must keep N <= W).
+		variant := k
+		if p.writeAmplificationFactor > 0 {
+			variant = k % p.writeAmplificationFactor
+		}
+		a, ok := p.buildCopy(ctx, src, variant, p.rewriteOpts, logger)
 		if !ok {
 			continue
 		}
@@ -309,7 +321,13 @@ func (p *ProxyEndpoint) rewriteFailed(replica int, logger *spanlogger.SpanLogger
 // rewriteParams returns a copy of values with the "query" and "match[]" parameters rewritten for
 // the given replica. All other parameters are copied unchanged. Returns an error if any value
 // fails to rewrite (invalid PromQL), so the caller can skip that copy.
+//
+// Replica 0 is the base series (used by write-amplification-factor wrapping): the params are
+// returned verbatim, so the copy re-reads exactly what the original request read.
 func rewriteParams(values url.Values, replica int, opts rewriteOptions) (url.Values, error) {
+	if replica == 0 && !opts.matchAllReplicas {
+		return values, nil
+	}
 	out := make(url.Values, len(values))
 	for key, vs := range values {
 		switch key {

--- a/tools/read-tee/proxy_test.go
+++ b/tools/read-tee/proxy_test.go
@@ -189,7 +189,7 @@ func TestProxyEndpoint_Response(t *testing.T) {
 			asyncDispatcher := NewAsyncBackendDispatcher(1000, metrics, logger)
 			defer asyncDispatcher.Stop()
 
-			endpoint := NewProxyEndpoint(backend, route, metrics, logger, 1.0, rewriteOptions{}, 0.0, 0.0, asyncDispatcher)
+			endpoint := NewProxyEndpoint(backend, route, metrics, logger, 1.0, 0, rewriteOptions{}, 0.0, 0.0, asyncDispatcher)
 
 			req := httptest.NewRequest("GET", `/api/v1/query?query=up`, nil)
 			rec := httptest.NewRecorder()
@@ -258,7 +258,7 @@ func TestProxyEndpoint_Amplification(t *testing.T) {
 
 			asyncDispatcher := NewAsyncBackendDispatcher(1000, metrics, logger)
 
-			endpoint := NewProxyEndpoint(backend, route, metrics, logger, tt.factor, rewriteOptions{}, 0.0, 0.0, asyncDispatcher)
+			endpoint := NewProxyEndpoint(backend, route, metrics, logger, tt.factor, 0, rewriteOptions{}, 0.0, 0.0, asyncDispatcher)
 
 			req := httptest.NewRequest("GET", "/api/v1/query?query="+url.QueryEscape(originalQuery), nil)
 			rec := httptest.NewRecorder()
@@ -298,6 +298,105 @@ func TestProxyEndpoint_Amplification(t *testing.T) {
 	}
 }
 
+// TestProxyEndpoint_AmplificationWrapsAroundWriteFactor verifies that when the write amplification
+// factor W is set, read copies wrap around the W existing variants (k mod W, where variant 0 is the
+// base series sent with the original query) so the read factor may exceed the write factor without
+// referencing series that were never written.
+func TestProxyEndpoint_AmplificationWrapsAroundWriteFactor(t *testing.T) {
+	logger := log.NewNopLogger()
+
+	const originalQuery = `up{job="api"}`
+
+	tests := []struct {
+		name        string
+		factor      float64
+		writeFactor int
+		// expectedQueries maps each expected query string to the number of times it must be seen,
+		// including the synchronously-sent original.
+		expectedQueries map[string]int
+	}{
+		{
+			// N=5, W=2: copies k=1..4 -> variants 1,0,1,0.
+			name:        "read factor exceeds write factor",
+			factor:      5.0,
+			writeFactor: 2,
+			expectedQueries: map[string]int{
+				originalQuery:       3, // original + copies k=2, k=4 (variant 0 = base series)
+				`up{job="api_amp1"}`: 2, // copies k=1, k=3
+			},
+		},
+		{
+			// N=3, W=3: wrapping enabled but not needed; behavior identical to strict mode.
+			name:        "read factor within write factor",
+			factor:      3.0,
+			writeFactor: 3,
+			expectedQueries: map[string]int{
+				originalQuery:       1,
+				`up{job="api_amp1"}`: 1,
+				`up{job="api_amp2"}`: 1,
+			},
+		},
+		{
+			// N=4, W=1: only the base series exists; all copies are duplicates of the original.
+			name:        "write factor of one duplicates the original",
+			factor:      4.0,
+			writeFactor: 1,
+			expectedQueries: map[string]int{
+				originalQuery: 4,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry := prometheus.NewRegistry()
+			metrics := NewProxyMetrics(registry)
+
+			var mu sync.Mutex
+			queries := map[string]int{}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				queries[r.URL.Query().Get("query")]++
+				mu.Unlock()
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("ok"))
+			}))
+			defer server.Close()
+
+			backend := NewHTTPProxyBackend("backend1", mustParseURL(t, server.URL), 5*time.Second, false)
+
+			route := Route{
+				Path:      "/api/v1/query",
+				RouteName: "api_v1_query",
+				Methods:   []string{"GET"},
+			}
+
+			asyncDispatcher := NewAsyncBackendDispatcher(1000, metrics, logger)
+
+			endpoint := NewProxyEndpoint(backend, route, metrics, logger, tt.factor, tt.writeFactor, rewriteOptions{}, 0.0, 0.0, asyncDispatcher)
+
+			req := httptest.NewRequest("GET", "/api/v1/query?query="+url.QueryEscape(originalQuery), nil)
+			rec := httptest.NewRecorder()
+
+			endpoint.ServeHTTP(rec, req)
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			// Drain async (fire-and-forget) amplified copies before asserting counts.
+			asyncDispatcher.Stop()
+			asyncDispatcher.Await()
+
+			mu.Lock()
+			got := map[string]int{}
+			for q, c := range queries {
+				got[q] = c
+			}
+			mu.Unlock()
+
+			require.Equal(t, tt.expectedQueries, got)
+		})
+	}
+}
+
 // TestProxyEndpoint_AmplifyAllReplicas verifies that with amplify-all-replicas-fraction=1 a single
 // heavy copy (matching the base value plus all replicas) is sent instead of the N-1 per-replica
 // copies, regardless of the amplification factor.
@@ -325,7 +424,7 @@ func TestProxyEndpoint_AmplifyAllReplicas(t *testing.T) {
 	asyncDispatcher := NewAsyncBackendDispatcher(1000, metrics, logger)
 
 	// Factor 3 would normally send 2 per-replica copies; with fraction 1.0 we expect a single copy.
-	endpoint := NewProxyEndpoint(backend, route, metrics, logger, 3.0, rewriteOptions{}, 1.0, 0.0, asyncDispatcher)
+	endpoint := NewProxyEndpoint(backend, route, metrics, logger, 3.0, 0, rewriteOptions{}, 1.0, 0.0, asyncDispatcher)
 
 	req := httptest.NewRequest("GET", "/api/v1/query?query="+url.QueryEscape(originalQuery), nil)
 	rec := httptest.NewRecorder()
@@ -392,7 +491,7 @@ func TestProxyEndpoint_StrongConsistency(t *testing.T) {
 			asyncDispatcher := NewAsyncBackendDispatcher(1000, metrics, logger)
 
 			// factor 3 -> 2 copies; strong-consistency-instant-fraction 1.0 -> every copy sampled.
-			endpoint := NewProxyEndpoint(backend, tt.route, metrics, logger, 3.0, rewriteOptions{}, 0.0, 1.0, asyncDispatcher)
+			endpoint := NewProxyEndpoint(backend, tt.route, metrics, logger, 3.0, 0, rewriteOptions{}, 0.0, 1.0, asyncDispatcher)
 
 			req := httptest.NewRequest("GET", tt.route.Path+"?query="+url.QueryEscape(originalQuery), nil)
 			rec := httptest.NewRecorder()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Adds optional write-amplification-factor. This allows the read-tee's amplification factor to safely exceed write amplification, in which case amplified requests will repeat/wrap back around, to avoid referencing series that don't exist.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
