### PR TITLE
perf(store-gateway): store the sparse index-header in a pointer-free columnar representation

### DIFF
--- a/pkg/blockbuilder/tsdb_test.go
+++ b/pkg/blockbuilder/tsdb_test.go
@@ -497,7 +497,7 @@ func validateSparseIndexHeadersInDir(t *testing.T, ctx context.Context, dbDir st
 			blockIDs = append(blockIDs, blockID)
 			sparseHeadersPath := path.Join(blockID.String(), block.SparseIndexHeaderFilename)
 
-			allSymbolsCount, sparseSymbolsOffsets, sparsePostingsOffsets, err := indexheader.LoadSparseIndexHeaderFromDisk(
+			sparseSymbols, sparsePostingsOffsets, err := indexheader.LoadSparseIndexHeaderFromDisk(
 				ctx, blockID, dbDir, cfg.BlocksStorage.BucketStore.PostingOffsetsInMemSampling, ll,
 			)
 
@@ -507,8 +507,8 @@ func validateSparseIndexHeadersInDir(t *testing.T, ctx context.Context, dbDir st
 			// 1. At least one symbol is sampled
 			// 2. The total symbol count recorded for the block is greater than the sampled symbols;
 			//   this is always true even with only one symbol written because the block includes the empty string symbol.
-			require.NotEmpty(t, len(sparseSymbolsOffsets))
-			require.Greater(t, allSymbolsCount, len(sparseSymbolsOffsets))
+			require.NotZero(t, sparseSymbols.NumOffsets())
+			require.Greater(t, sparseSymbols.Count(), sparseSymbols.NumOffsets())
 
 			require.NoError(t, err)
 			require.NotZero(t, len(sparsePostingsOffsets))

--- a/pkg/storage/indexheader/index/postings.go
+++ b/pkg/storage/indexheader/index/postings.go
@@ -106,19 +106,19 @@ func (t *PostingsOffsetsTableV2) PostingsOffset(ctx context.Context, name string
 		return index.Range{}, false, nil
 	}
 
-	if value < e.SparseTableOffsets[0].Value {
+	if value < e.value(0) {
 		// The desired value sorts before the first known value.
 		return index.Range{}, false, nil
 	}
 
-	i := sort.Search(len(e.SparseTableOffsets), func(i int) bool { return e.SparseTableOffsets[i].Value >= value })
+	i := sort.Search(e.numOffsets(), func(i int) bool { return e.value(i) >= value })
 
-	if i == len(e.SparseTableOffsets) {
+	if i == e.numOffsets() {
 		// The desired value sorts after the last known value.
 		return index.Range{}, false, nil
 	}
 
-	if i > 0 && e.SparseTableOffsets[i].Value != value {
+	if i > 0 && e.value(i) != value {
 		// Need to look from previous entry.
 		i--
 	}
@@ -129,18 +129,18 @@ func (t *PostingsOffsetsTableV2) PostingsOffset(ctx context.Context, name string
 		// In order to correctly set Range.End, we need to read the next entry beyond the one we are looking for.
 		// In the worst case where the value is found right before the next (i+1'th) sparse table offset,
 		// we need to read the entry that starts at the i+1'th offset. To account for this, we create the reader up to the i+2'th sparse table offset.
-		if i+2 < len(e.SparseTableOffsets) {
-			sectionEndOffset = e.SparseTableOffsets[i+2].Offset
+		if i+2 < e.numOffsets() {
+			sectionEndOffset = e.tableOffset(i + 2)
 		} else {
 			// Set this to something that will always be greater than the length of the table
 			sectionEndOffset = math.MaxInt
 		}
 		// At this point we know that our value is somewhere between the i-th offset and the next one;
 		// we shouldn't need to read/cache bucket ops beyond that.
-		d = t.decbufFactory.NewDecbufInSection(ctx, t.tableOffset, e.SparseTableOffsets[i].Offset, sectionEndOffset)
+		d = t.decbufFactory.NewDecbufInSection(ctx, t.tableOffset, e.tableOffset(i), sectionEndOffset)
 	} else {
 		d = t.decbufFactory.NewDecbufAtUnchecked(ctx, t.tableOffset)
-		d.ResetAt(e.SparseTableOffsets[i].Offset)
+		d.ResetAt(e.tableOffset(i))
 	}
 	defer runutil.CloseWithErrCapture(&err, &d, "get sparsePostingsOffsets SparseTableOffsets")
 	if err := d.Err(); err != nil {
@@ -172,9 +172,9 @@ func (t *PostingsOffsetsTableV2) PostingsOffset(ctx context.Context, name string
 		if currentValue == value {
 			rng := index.Range{Start: postingOffset + postingLengthFieldSize}
 
-			if i+1 == len(e.SparseTableOffsets) {
-				// No more SparseTableOffsets for this name.
-				rng.End = e.LastValOffset
+			if i+1 == e.numOffsets() {
+				// No more sampled offsets for this name.
+				rng.End = e.lastValOffset
 			} else {
 				// There's at least one more value for this name, use that as the end of the range.
 				skipNAndName(&d, &nAndNameSize)
@@ -204,11 +204,11 @@ func (t *PostingsOffsetsTableV2) LabelValuesOffsets(ctx context.Context, name, p
 	if !ok {
 		return nil, nil
 	}
-	if len(e.SparseTableOffsets) == 0 {
+	if e.numOffsets() == 0 {
 		return nil, nil
 	}
 
-	offsetsStart, offsetsEnd := 0, len(e.SparseTableOffsets)
+	offsetsStart, offsetsEnd := 0, e.numOffsets()
 	if prefix != "" {
 		offsetsStart, offsetsEnd, ok = e.labelValuePrefixOffsets(prefix)
 		if !ok {
@@ -220,32 +220,32 @@ func (t *PostingsOffsetsTableV2) LabelValuesOffsets(ctx context.Context, name, p
 	var d streamencoding.Decbuf
 	if t.IsRemote() {
 		var sectionEndOffset int
-		if offsetsEnd+1 < len(e.SparseTableOffsets) {
+		if offsetsEnd+1 < e.numOffsets() {
 			// We buffer the end with the distance to one more sparse offset in case the last matching entry is right at the end of the section.
-			sectionEndOffset = e.SparseTableOffsets[offsetsEnd+1].Offset
+			sectionEndOffset = e.tableOffset(offsetsEnd + 1)
 		} else {
 			sectionEndOffset = math.MaxInt
 		}
 		// For the BucketDecbufFactory, we only read the section we care about to optimize
 		// the size of cached GetRange bucket ops.
-		d = t.decbufFactory.NewDecbufInSection(ctx, t.tableOffset, e.SparseTableOffsets[offsetsStart].Offset, sectionEndOffset)
+		d = t.decbufFactory.NewDecbufInSection(ctx, t.tableOffset, e.tableOffset(offsetsStart), sectionEndOffset)
 	} else {
 		// Don't Crc32 the entire postings offset table, this is very slow
 		// so hope any issues were caught at startup.
 		d = t.decbufFactory.NewDecbufAtUnchecked(ctx, t.tableOffset)
-		d.ResetAt(e.SparseTableOffsets[offsetsStart].Offset)
+		d.ResetAt(e.tableOffset(offsetsStart))
 	}
 	defer runutil.CloseWithErrCapture(&err, &d, "get label values")
 
-	// The last value of a label gets its own offset in e.SparseTableOffsets.
-	// If that value matches, then later we should use e.LastValOffset
+	// The last value of a label gets its own sampled offset.
+	// If that value matches, then later we should use e.lastValOffset
 	// as the end offset of the value instead of reading the next value (because there will be no next value).
-	lastValMatches := offsetsEnd == len(e.SparseTableOffsets)
+	lastValMatches := offsetsEnd == e.numOffsets()
 	// noMoreMatchesMarkerVal is the value after which we know there are no more matching values.
 	// noMoreMatchesMarkerVal itself may or may not match.
-	noMoreMatchesMarkerVal := e.SparseTableOffsets[len(e.SparseTableOffsets)-1].Value
+	noMoreMatchesMarkerVal := e.value(e.numOffsets() - 1)
 	if !lastValMatches {
-		noMoreMatchesMarkerVal = e.SparseTableOffsets[offsetsEnd].Value
+		noMoreMatchesMarkerVal = e.value(offsetsEnd)
 	}
 
 	type pEntry struct {
@@ -311,7 +311,7 @@ func (t *PostingsOffsetsTableV2) LabelValuesOffsets(ctx context.Context, name, p
 		// We peek at the next list, so we can use its offset as the end offset of the current one.
 		if currEntry.LabelValue == noMoreMatchesMarkerVal && lastValMatches {
 			// There is no next value though. Since we only need the offset, we can use what we have in the sampled postings.
-			currEntry.Off.End = e.LastValOffset
+			currEntry.Off.End = e.lastValOffset
 		} else {
 			nextEntry = readNextList()
 

--- a/pkg/storage/indexheader/index/sparse_postings.go
+++ b/pkg/storage/indexheader/index/sparse_postings.go
@@ -47,14 +47,17 @@ import (
 // the sampled entries are stored in a pointer-free, columnar layout:
 // all sampled values are concatenated into a single byte blob,
 // and per-entry data is limited to two uint32s (value end and table offset).
-// Both fit in uint32 because the postings offset table size is bounded by its 4-byte length field.
+// Both fit in uint32 because the table's content is bounded by its 4-byte length field:
+// like SparseSymbols, table offsets are stored relative to the start of the table's content
+// (after the leading length field), internally to appendOffset and tableOffset.
 type SparseTableOffsetsForLabel struct {
 	// valueBlob holds all sampled label values concatenated in sorted order.
 	valueBlob []byte
 	// valueEnds holds the end of each sampled value within valueBlob;
 	// each value starts where the previous one ends.
 	valueEnds []uint32
-	// tableOffsets holds, for each sampled entry, its offset within the postings offset table.
+	// tableOffsets holds, for each sampled entry, its offset within the postings offset table,
+	// relative to the start of the table's content.
 	tableOffsets []uint32
 
 	lastValOffset int64
@@ -76,8 +79,13 @@ func (e *SparseTableOffsetsForLabel) value(i int) string {
 }
 
 func (e *SparseTableOffsetsForLabel) tableOffset(i int) int {
-	return int(e.tableOffsets[i])
+	return int(e.tableOffsets[i]) + tableLengthFieldSize
 }
+
+// tableLengthFieldSize is the size of the length field leading each index table:
+// a 4-byte big-endian uint32 holding the byte length of the table's content.
+// In-memory table offsets are stored relative to the end of this field so that they always fit in uint32.
+const tableLengthFieldSize = 4
 
 // tableOffsetToUint32 converts a table offset to its in-memory uint32 representation.
 // Offsets are bounded by the table's 4-byte length field, so this only fails on corrupt data.
@@ -89,7 +97,7 @@ func tableOffsetToUint32(offset int64, table string) (uint32, error) {
 }
 
 func (e *SparseTableOffsetsForLabel) appendOffset(value string, tableOff int64) error {
-	off, err := tableOffsetToUint32(tableOff, "postings offset")
+	off, err := tableOffsetToUint32(tableOff-tableLengthFieldSize, "postings offset")
 	if err != nil {
 		return err
 	}
@@ -233,7 +241,8 @@ func SparseValuesFromPostingsOffsetsTable(
 				decbuf.ResetAt(lastEntryOffsetInTable)
 				decbuf.Uvarint()          // Skip the key count
 				decbuf.SkipUvarintBytes() // Skip the name
-				value := decbuf.UvarintStr()
+				// The unsafe value is only valid until the next read from decbuf; appendOffset copies it.
+				value := yoloString(decbuf.UnsafeUvarintBytes())
 				if err := sparsePostingsOffsets[lastName].appendOffset(value, int64(lastEntryOffsetInTable)); err != nil {
 					return nil, err
 				}
@@ -249,11 +258,12 @@ func SparseValuesFromPostingsOffsetsTable(
 
 		// Retain every 1-in-sparseSampleFactor entries, starting with the first one.
 		if valuesForCurrentKey%sparseSampleFactor == 0 {
-			value := decbuf.UvarintStr()
-			off := decbuf.Uvarint64()
+			// The unsafe value is only valid until the next read from decbuf; appendOffset copies it.
+			value := yoloString(decbuf.UnsafeUvarintBytes())
 			if err := sparsePostingsOffsets[currentName].appendOffset(value, int64(offsetInTable)); err != nil {
 				return nil, err
 			}
+			off := decbuf.Uvarint64()
 
 			if lastName != currentName {
 				sparsePostingsOffsets[lastName].lastValOffset = int64(off - crc32.Size)
@@ -281,7 +291,8 @@ func SparseValuesFromPostingsOffsetsTable(
 		decbuf.ResetAt(lastEntryOffsetInTable)
 		decbuf.Uvarint()          // Skip the key count
 		decbuf.SkipUvarintBytes() // Skip the key
-		value := decbuf.UvarintStr()
+		// The unsafe value is only valid until the next read from decbuf; appendOffset copies it.
+		value := yoloString(decbuf.UnsafeUvarintBytes())
 		if err := sparsePostingsOffsets[currentName].appendOffset(value, int64(lastEntryOffsetInTable)); err != nil {
 			return nil, err
 		}

--- a/pkg/storage/indexheader/index/sparse_postings.go
+++ b/pkg/storage/indexheader/index/sparse_postings.go
@@ -9,6 +9,8 @@ import (
 	"context"
 	"fmt"
 	"hash/crc32"
+	"math"
+	"slices"
 	"sort"
 	"strings"
 
@@ -40,35 +42,88 @@ import (
 // │                    . . .                   │
 // The sampled table offsets do _not_ capture the last "offset" value in the entry, which points to the Postings list.
 // They only capture an offset pointing _into_ the Postings Offsets table itself to quickly reach the table entries.
+//
+// To keep the resident memory footprint and the number of live heap objects low,
+// the sampled entries are stored in a pointer-free, columnar layout:
+// all sampled values are concatenated into a single byte blob,
+// and per-entry data is limited to two uint32s (value end and table offset).
+// Both fit in uint32 because the postings offset table size is bounded by its 4-byte length field.
 type SparseTableOffsetsForLabel struct {
-	SparseTableOffsets []tableOffsetForLabelValue
+	// valueBlob holds all sampled label values concatenated in sorted order.
+	valueBlob []byte
+	// valueEnds holds the end of each sampled value within valueBlob;
+	// each value starts where the previous one ends.
+	valueEnds []uint32
+	// tableOffsets holds, for each sampled entry, its offset within the postings offset table.
+	tableOffsets []uint32
 
 	lastValOffset int64
 }
 
-type tableOffsetForLabelValue struct {
-	// label value.
-	Value string
-	// offset of this entry in posting offset table in index-header file.
-	Offset int
-}
-
 func (e *SparseTableOffsetsForLabel) numOffsets() int {
-	return len(e.SparseTableOffsets)
+	return len(e.tableOffsets)
 }
 
 // value returns the sampled label value at index i.
+// The returned string references memory shared with valueBlob and is valid as long as e is alive:
+// it's meant for comparisons, callers should copy it (e.g. with strings.Clone) before retaining it.
 func (e *SparseTableOffsetsForLabel) value(i int) string {
-	return e.SparseTableOffsets[i].Value
+	start := uint32(0)
+	if i > 0 {
+		start = e.valueEnds[i-1]
+	}
+	return yoloString(e.valueBlob[start:e.valueEnds[i]])
 }
 
 func (e *SparseTableOffsetsForLabel) tableOffset(i int) int {
-	return e.SparseTableOffsets[i].Offset
+	return int(e.tableOffsets[i])
+}
+
+// tableOffsetToUint32 converts a table offset to its in-memory uint32 representation.
+// Offsets are bounded by the table's 4-byte length field, so this only fails on corrupt data.
+func tableOffsetToUint32(offset int64, table string) (uint32, error) {
+	if offset < 0 || offset > math.MaxUint32 {
+		return 0, fmt.Errorf("sparse index-header %s table offset %d out of bounds", table, offset)
+	}
+	return uint32(offset), nil
 }
 
 func (e *SparseTableOffsetsForLabel) appendOffset(value string, tableOff int64) error {
-	e.SparseTableOffsets = append(e.SparseTableOffsets, tableOffsetForLabelValue{Value: value, Offset: int(tableOff)})
+	off, err := tableOffsetToUint32(tableOff, "postings offset")
+	if err != nil {
+		return err
+	}
+	end := len(e.valueBlob) + len(value)
+	if end > math.MaxUint32 {
+		return fmt.Errorf("sparse index-header postings offset table values for a label exceed %d bytes", math.MaxUint32)
+	}
+	e.valueBlob = append(e.valueBlob, value...)
+	e.valueEnds = append(e.valueEnds, uint32(end))
+	e.tableOffsets = append(e.tableOffsets, off)
 	return nil
+}
+
+// grow pre-allocates space for numOffsets sampled entries totalling valueBytes of label values.
+func (e *SparseTableOffsetsForLabel) grow(numOffsets, valueBytes int) {
+	e.valueBlob = make([]byte, 0, valueBytes)
+	e.valueEnds = make([]uint32, 0, numOffsets)
+	e.tableOffsets = make([]uint32, 0, numOffsets)
+}
+
+// compact re-allocates the underlying storage to exactly fit the appended entries,
+// releasing any extra capacity accumulated while growing through appendOffset.
+func (e *SparseTableOffsetsForLabel) compact() {
+	e.valueBlob = clipExact(e.valueBlob)
+	e.valueEnds = clipExact(e.valueEnds)
+	e.tableOffsets = clipExact(e.tableOffsets)
+}
+
+// clipExact returns s re-allocated to exactly fit its elements, or s itself if it has no extra capacity.
+func clipExact[E any](s []E) []E {
+	if cap(s) == len(s) {
+		return s
+	}
+	return slices.Clone(s)
 }
 
 // labelValuePrefixOffsets returns the index of the first matching offset (start) and the index of the first non-matching (end).
@@ -243,6 +298,11 @@ func SparseValuesFromPostingsOffsetsTable(
 		sparsePostingsOffsets[currentName].lastValOffset = int64(postingsListEnd) - crc32.Size
 	}
 
+	// Trim any extra space in the slices.
+	for _, v := range sparsePostingsOffsets {
+		v.compact()
+	}
+
 	return sparsePostingsOffsets, nil
 }
 
@@ -261,7 +321,7 @@ func SparsePostingsOffsetsTableToProto(
 		postingOffsets := make([]*indexheaderpb.PostingOffset, offsets.numOffsets())
 
 		for i := range postingOffsets {
-			postingOffsets[i] = &indexheaderpb.PostingOffset{Value: offsets.value(i), TableOff: int64(offsets.tableOffset(i))}
+			postingOffsets[i] = &indexheaderpb.PostingOffset{Value: strings.Clone(offsets.value(i)), TableOff: int64(offsets.tableOffset(i))}
 		}
 		proto.Postings[labelName].Offsets = postingOffsets
 		proto.Postings[labelName].LastValOffset = offsets.lastValOffset
@@ -313,7 +373,12 @@ func SparsePostingsOffsetsTableFromProto(proto *indexheaderpb.PostingOffsetTable
 			return k * step
 		}
 
-		offsets.SparseTableOffsets = make([]tableOffsetForLabelValue, 0, downsampledLen)
+		valueBytes := 0
+		for k := 0; k < downsampledLen; k++ {
+			valueBytes += len(sOffsets.Offsets[srcIdx(k)].Value)
+		}
+		offsets.grow(downsampledLen, valueBytes)
+
 		for k := 0; k < downsampledLen; k++ {
 			sPostingOff := sOffsets.Offsets[srcIdx(k)]
 			if err := offsets.appendOffset(sPostingOff.Value, sPostingOff.TableOff); err != nil {

--- a/pkg/storage/indexheader/index/sparse_postings.go
+++ b/pkg/storage/indexheader/index/sparse_postings.go
@@ -38,11 +38,12 @@ import (
 // │ │  offset <uvarint64>                    │ │
 // │ └────────────────────────────────────────┘ │
 // │                    . . .                   │
-// SparseTableOffsets do _not_ capture the last "offset" value in the entry, which points to the Postings list.
+// The sampled table offsets do _not_ capture the last "offset" value in the entry, which points to the Postings list.
 // They only capture an offset pointing _into_ the Postings Offsets table itself to quickly reach the table entries.
 type SparseTableOffsetsForLabel struct {
 	SparseTableOffsets []tableOffsetForLabelValue
-	LastValOffset      int64
+
+	lastValOffset int64
 }
 
 type tableOffsetForLabelValue struct {
@@ -52,25 +53,43 @@ type tableOffsetForLabelValue struct {
 	Offset int
 }
 
+func (e *SparseTableOffsetsForLabel) numOffsets() int {
+	return len(e.SparseTableOffsets)
+}
+
+// value returns the sampled label value at index i.
+func (e *SparseTableOffsetsForLabel) value(i int) string {
+	return e.SparseTableOffsets[i].Value
+}
+
+func (e *SparseTableOffsetsForLabel) tableOffset(i int) int {
+	return e.SparseTableOffsets[i].Offset
+}
+
+func (e *SparseTableOffsetsForLabel) appendOffset(value string, tableOff int64) error {
+	e.SparseTableOffsets = append(e.SparseTableOffsets, tableOffsetForLabelValue{Value: value, Offset: int(tableOff)})
+	return nil
+}
+
 // labelValuePrefixOffsets returns the index of the first matching offset (start) and the index of the first non-matching (end).
-// If all SparseTableOffsets match the prefix, then end will equal the length of SparseTableOffsets.
-// labelValuePrefixOffsets returns false when no SparseTableOffsets match this prefix.
+// If all sampled offsets match the prefix, then end will equal the number of sampled offsets.
+// labelValuePrefixOffsets returns false when no sampled offsets match this prefix.
 func (e *SparseTableOffsetsForLabel) labelValuePrefixOffsets(prefix string) (start, end int, found bool) {
 	// Find the first offset that is greater or equal to the value.
-	start = sort.Search(len(e.SparseTableOffsets), func(i int) bool {
-		return prefix <= e.SparseTableOffsets[i].Value
+	start = sort.Search(e.numOffsets(), func(i int) bool {
+		return prefix <= e.value(i)
 	})
 
-	// We always include the last value in the SparseTableOffsets,
+	// We always include the last value in the sampled offsets,
 	// and given that prefix is always less or equal than the value,
 	// we can conclude that there are no values with this prefix.
-	if start == len(e.SparseTableOffsets) {
+	if start == e.numOffsets() {
 		return 0, 0, false
 	}
 
-	// Prefix is lower than the first value in the SparseTableOffsets, and that first value doesn't have this prefix.
+	// Prefix is lower than the first value in the sampled offsets, and that first value doesn't have this prefix.
 	// Next values won't have the prefix, so we can return early.
-	if start == 0 && prefix < e.SparseTableOffsets[0].Value && !strings.HasPrefix(e.SparseTableOffsets[0].Value, prefix) {
+	if first := e.value(0); start == 0 && prefix < first && !strings.HasPrefix(first, prefix) {
 		return 0, 0, false
 	}
 
@@ -78,14 +97,15 @@ func (e *SparseTableOffsetsForLabel) labelValuePrefixOffsets(prefix string) (sta
 	// But maybe the values in the previous offset also had the prefix,
 	// so we need to step back one offset to find all values with this prefix.
 	// Unless, of course, we are at the first offset.
-	if start > 0 && e.SparseTableOffsets[start].Value != prefix {
+	if start > 0 && e.value(start) != prefix {
 		start--
 	}
 
 	// Find the first offset which is larger than the prefix and doesn't have the prefix.
 	// All values at and after that offset will not match the prefix.
-	end = sort.Search(len(e.SparseTableOffsets)-start, func(i int) bool {
-		return prefix < e.SparseTableOffsets[i+start].Value && !strings.HasPrefix(e.SparseTableOffsets[i+start].Value, prefix)
+	end = sort.Search(e.numOffsets()-start, func(i int) bool {
+		v := e.value(i + start)
+		return prefix < v && !strings.HasPrefix(v, prefix)
 	})
 	end += start
 	return start, end, true
@@ -159,7 +179,9 @@ func SparseValuesFromPostingsOffsetsTable(
 				decbuf.Uvarint()          // Skip the key count
 				decbuf.SkipUvarintBytes() // Skip the name
 				value := decbuf.UvarintStr()
-				sparsePostingsOffsets[lastName].SparseTableOffsets = append(sparsePostingsOffsets[lastName].SparseTableOffsets, tableOffsetForLabelValue{Value: value, Offset: lastEntryOffsetInTable})
+				if err := sparsePostingsOffsets[lastName].appendOffset(value, int64(lastEntryOffsetInTable)); err != nil {
+					return nil, err
+				}
 
 				// Skip ahead to where we were before we called ResetAt() above.
 				decbuf.Skip(newValueOffsetInTable - decbuf.Offset())
@@ -174,13 +196,12 @@ func SparseValuesFromPostingsOffsetsTable(
 		if valuesForCurrentKey%sparseSampleFactor == 0 {
 			value := decbuf.UvarintStr()
 			off := decbuf.Uvarint64()
-			sparsePostingsOffsets[currentName].SparseTableOffsets = append(
-				sparsePostingsOffsets[currentName].SparseTableOffsets,
-				tableOffsetForLabelValue{Value: value, Offset: offsetInTable},
-			)
+			if err := sparsePostingsOffsets[currentName].appendOffset(value, int64(offsetInTable)); err != nil {
+				return nil, err
+			}
 
 			if lastName != currentName {
-				sparsePostingsOffsets[lastName].LastValOffset = int64(off - crc32.Size)
+				sparsePostingsOffsets[lastName].lastValOffset = int64(off - crc32.Size)
 			}
 
 			// If the current value is the last one for this name, we don't need to record it again.
@@ -206,7 +227,9 @@ func SparseValuesFromPostingsOffsetsTable(
 		decbuf.Uvarint()          // Skip the key count
 		decbuf.SkipUvarintBytes() // Skip the key
 		value := decbuf.UvarintStr()
-		sparsePostingsOffsets[currentName].SparseTableOffsets = append(sparsePostingsOffsets[currentName].SparseTableOffsets, tableOffsetForLabelValue{Value: value, Offset: lastEntryOffsetInTable})
+		if err := sparsePostingsOffsets[currentName].appendOffset(value, int64(lastEntryOffsetInTable)); err != nil {
+			return nil, err
+		}
 	}
 
 	if decbuf.Err() != nil {
@@ -214,21 +237,10 @@ func SparseValuesFromPostingsOffsetsTable(
 	}
 
 	if len(sparsePostingsOffsets) > 0 {
-		// In case LastValOffset is unknown as we don't have next posting anymore. Guess from the index table of contents.
+		// In case lastValOffset is unknown as we don't have next posting anymore. Guess from the index table of contents.
 		// The last posting list ends before the label offset table.
 		// In worst case we will overfetch a few bytes.
-		sparsePostingsOffsets[currentName].LastValOffset = int64(postingsListEnd) - crc32.Size
-	}
-
-	// Trim any extra space in the slices.
-	for k, v := range sparsePostingsOffsets {
-		if len(v.SparseTableOffsets) == cap(v.SparseTableOffsets) {
-			continue
-		}
-
-		l := make([]tableOffsetForLabelValue, len(v.SparseTableOffsets))
-		copy(l, v.SparseTableOffsets)
-		sparsePostingsOffsets[k].SparseTableOffsets = l
+		sparsePostingsOffsets[currentName].lastValOffset = int64(postingsListEnd) - crc32.Size
 	}
 
 	return sparsePostingsOffsets, nil
@@ -246,13 +258,13 @@ func SparsePostingsOffsetsTableToProto(
 
 	for labelName, offsets := range sparsePostingsOffsets {
 		proto.Postings[labelName] = &indexheaderpb.PostingValueOffsets{}
-		postingOffsets := make([]*indexheaderpb.PostingOffset, len(offsets.SparseTableOffsets))
+		postingOffsets := make([]*indexheaderpb.PostingOffset, offsets.numOffsets())
 
-		for i, tableOffset := range offsets.SparseTableOffsets {
-			postingOffsets[i] = &indexheaderpb.PostingOffset{Value: tableOffset.Value, TableOff: int64(tableOffset.Offset)}
+		for i := range postingOffsets {
+			postingOffsets[i] = &indexheaderpb.PostingOffset{Value: offsets.value(i), TableOff: int64(offsets.tableOffset(i))}
 		}
 		proto.Postings[labelName].Offsets = postingOffsets
-		proto.Postings[labelName].LastValOffset = offsets.LastValOffset
+		proto.Postings[labelName].LastValOffset = offsets.lastValOffset
 	}
 
 	return proto
@@ -280,30 +292,34 @@ func SparsePostingsOffsetsTableFromProto(proto *indexheaderpb.PostingOffsetTable
 
 	sparsePostingsOffsets = make(map[string]*SparseTableOffsetsForLabel, len(proto.Postings))
 	for sName, sOffsets := range proto.Postings {
-
 		olen := len(sOffsets.Offsets)
 		downsampledLen := (olen + step - 1) / step
 		if (olen > 1) && (downsampledLen == 1) {
 			downsampledLen++
 		}
 
-		sparsePostingsOffsets[sName] = &SparseTableOffsetsForLabel{
-			SparseTableOffsets: make([]tableOffsetForLabelValue, downsampledLen),
+		offsets := &SparseTableOffsetsForLabel{lastValOffset: sOffsets.LastValOffset}
+		sparsePostingsOffsets[sName] = offsets
+		if olen == 0 {
+			continue
 		}
-		for i, sPostingOff := range sOffsets.Offsets {
-			if i%step == 0 {
-				sparsePostingsOffsets[sName].SparseTableOffsets[i/step] = tableOffsetForLabelValue{
-					Value: sPostingOff.Value, Offset: int(sPostingOff.TableOff),
-				}
-			}
 
-			if i == olen-1 {
-				sparsePostingsOffsets[sName].SparseTableOffsets[downsampledLen-1] = tableOffsetForLabelValue{
-					Value: sPostingOff.Value, Offset: int(sPostingOff.TableOff),
-				}
+		// The downsampled entries are every step-th entry, except the last one,
+		// which is always the last entry of the full-resolution table.
+		srcIdx := func(k int) int {
+			if k == downsampledLen-1 {
+				return olen - 1
+			}
+			return k * step
+		}
+
+		offsets.SparseTableOffsets = make([]tableOffsetForLabelValue, 0, downsampledLen)
+		for k := 0; k < downsampledLen; k++ {
+			sPostingOff := sOffsets.Offsets[srcIdx(k)]
+			if err := offsets.appendOffset(sPostingOff.Value, sPostingOff.TableOff); err != nil {
+				return nil, err
 			}
 		}
-		sparsePostingsOffsets[sName].LastValOffset = sOffsets.LastValOffset
 	}
 	return sparsePostingsOffsets, err
 }

--- a/pkg/storage/indexheader/index/sparse_postings_test.go
+++ b/pkg/storage/indexheader/index/sparse_postings_test.go
@@ -155,7 +155,7 @@ func TestSparsePostingsOffsetsForLabelValuePrefix(t *testing.T) {
 			expectedStart:  1,
 			expectedEnd:    2,
 		},
-		"prefix matches all SparseTableOffsets": {
+		"prefix matches all sampled offsets": {
 			existingValues: []string{"010", "019", "030", "031"},
 			prefix:         "0",
 			expectedFound:  true,
@@ -169,7 +169,7 @@ func TestSparsePostingsOffsetsForLabelValuePrefix(t *testing.T) {
 			expectedStart:  3,
 			expectedEnd:    4,
 		},
-		"prefix matches multiple SparseTableOffsets": {
+		"prefix matches multiple sampled offsets": {
 			existingValues: []string{"010", "019", "020", "030", "031"},
 			prefix:         "02",
 			expectedFound:  true,

--- a/pkg/storage/indexheader/index/sparse_postings_test.go
+++ b/pkg/storage/indexheader/index/sparse_postings_test.go
@@ -129,7 +129,8 @@ func TestSparsePostingsOffsetsTableFromProto(t *testing.T) {
 func createPostingsOffsetsProto(n int) []*indexheaderpb.PostingOffset {
 	offsets := make([]*indexheaderpb.PostingOffset, n)
 	for i := 0; i < n; i++ {
-		offsets[i] = &indexheaderpb.PostingOffset{Value: fmt.Sprintf("%d", i), TableOff: int64(i)}
+		// Table offsets start after the table's length and entry count fields, like in a real file.
+		offsets[i] = &indexheaderpb.PostingOffset{Value: fmt.Sprintf("%d", i), TableOff: int64(8 + i)}
 	}
 	return offsets
 }
@@ -188,7 +189,8 @@ func TestSparsePostingsOffsetsForLabelValuePrefix(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			offsets := SparseTableOffsetsForLabel{}
 			for _, value := range testCase.existingValues {
-				require.NoError(t, offsets.appendOffset(value, 0))
+				// This test only cares about the values; any valid table offset will do.
+				require.NoError(t, offsets.appendOffset(value, 8))
 			}
 			start, end, found := offsets.labelValuePrefixOffsets(testCase.prefix)
 			assert.Equal(t, testCase.expectedStart, start)

--- a/pkg/storage/indexheader/index/sparse_postings_test.go
+++ b/pkg/storage/indexheader/index/sparse_postings_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/pkg/storage/indexheader/indexheaderpb"
 )
@@ -118,7 +119,7 @@ func TestSparsePostingsOffsetsTableFromProto(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, testCase.expectedLen, len(sparseTable["__name__"].SparseTableOffsets))
+				assert.Equal(t, testCase.expectedLen, sparseTable["__name__"].numOffsets())
 			}
 
 		})
@@ -135,89 +136,60 @@ func createPostingsOffsetsProto(n int) []*indexheaderpb.PostingOffset {
 
 func TestSparsePostingsOffsetsForLabelValuePrefix(t *testing.T) {
 	testCases := map[string]struct {
-		existingOffsets []tableOffsetForLabelValue
-		prefix          string
-		expectedFound   bool
-		expectedStart   int
-		expectedEnd     int
+		existingValues []string
+		prefix         string
+		expectedFound  bool
+		expectedStart  int
+		expectedEnd    int
 	}{
 		"prefix not found": {
-			existingOffsets: []tableOffsetForLabelValue{
-				{Value: "010"},
-				{Value: "019"},
-				{Value: "030"},
-				{Value: "031"},
-			},
-			prefix:        "a",
-			expectedFound: false,
+			existingValues: []string{"010", "019", "030", "031"},
+			prefix:         "a",
+			expectedFound:  false,
 		},
 		"prefix matches only one sampled offset": {
-			existingOffsets: []tableOffsetForLabelValue{
-				{Value: "010"},
-				{Value: "019"},
-				{Value: "030"},
-				{Value: "031"},
-			},
-			prefix:        "02",
-			expectedFound: true,
-			expectedStart: 1,
-			expectedEnd:   2,
+			existingValues: []string{"010", "019", "030", "031"},
+			prefix:         "02",
+			expectedFound:  true,
+			expectedStart:  1,
+			expectedEnd:    2,
 		},
 		"prefix matches all SparseTableOffsets": {
-			existingOffsets: []tableOffsetForLabelValue{
-				{Value: "010"},
-				{Value: "019"},
-				{Value: "030"},
-				{Value: "031"},
-			},
-			prefix:        "0",
-			expectedFound: true,
-			expectedStart: 0,
-			expectedEnd:   4,
+			existingValues: []string{"010", "019", "030", "031"},
+			prefix:         "0",
+			expectedFound:  true,
+			expectedStart:  0,
+			expectedEnd:    4,
 		},
 		"prefix matches only last offset": {
-			existingOffsets: []tableOffsetForLabelValue{
-				{Value: "010"},
-				{Value: "019"},
-				{Value: "030"},
-				{Value: "031"},
-			},
-			prefix:        "031",
-			expectedFound: true,
-			expectedStart: 3,
-			expectedEnd:   4,
+			existingValues: []string{"010", "019", "030", "031"},
+			prefix:         "031",
+			expectedFound:  true,
+			expectedStart:  3,
+			expectedEnd:    4,
 		},
 		"prefix matches multiple SparseTableOffsets": {
-			existingOffsets: []tableOffsetForLabelValue{
-				{Value: "010"},
-				{Value: "019"},
-				{Value: "020"},
-				{Value: "030"},
-				{Value: "031"},
-			},
-			prefix:        "02",
-			expectedFound: true,
-			expectedStart: 1,
-			expectedEnd:   3,
+			existingValues: []string{"010", "019", "020", "030", "031"},
+			prefix:         "02",
+			expectedFound:  true,
+			expectedStart:  1,
+			expectedEnd:    3,
 		},
 		"prefix matches only first offset": {
-			existingOffsets: []tableOffsetForLabelValue{
-				{Value: "010"},
-				{Value: "019"},
-				{Value: "020"},
-				{Value: "030"},
-				{Value: "031"},
-			},
-			prefix:        "015",
-			expectedFound: true,
-			expectedStart: 0,
-			expectedEnd:   1,
+			existingValues: []string{"010", "019", "020", "030", "031"},
+			prefix:         "015",
+			expectedFound:  true,
+			expectedStart:  0,
+			expectedEnd:    1,
 		},
 	}
 
 	for testName, testCase := range testCases {
 		t.Run(testName, func(t *testing.T) {
-			offsets := SparseTableOffsetsForLabel{SparseTableOffsets: testCase.existingOffsets}
+			offsets := SparseTableOffsetsForLabel{}
+			for _, value := range testCase.existingValues {
+				require.NoError(t, offsets.appendOffset(value, 0))
+			}
 			start, end, found := offsets.labelValuePrefixOffsets(testCase.prefix)
 			assert.Equal(t, testCase.expectedStart, start)
 			assert.Equal(t, testCase.expectedEnd, end)

--- a/pkg/storage/indexheader/index/sparse_symbols.go
+++ b/pkg/storage/indexheader/index/sparse_symbols.go
@@ -16,7 +16,7 @@ import (
 )
 
 // SparseSymbols is the sampled in-memory representation of the symbols table:
-// the total number of symbols plus the table offset of every SymbolFactor-th symbol.
+// the total number of symbols plus the table offset of every symbolFactor-th symbol.
 //
 // Offsets are stored relative to the start of the table's content (after the leading length field):
 // the index writer caps the content at 2^32-1 bytes, so content-relative offsets always fit in uint32,
@@ -90,9 +90,9 @@ func SparseValuesFromSymbolsTable(
 	sparseSymbols.count = decbuf.Be32int()
 
 	seen := 0
-	sparseSymbols.offsets = make([]uint32, 0, 1+sparseSymbols.count/SymbolFactor)
+	sparseSymbols.offsets = make([]uint32, 0, 1+sparseSymbols.count/symbolFactor)
 	for decbuf.Err() == nil && seen < sparseSymbols.count {
-		if seen%SymbolFactor == 0 {
+		if seen%symbolFactor == 0 {
 			if err := sparseSymbols.appendOffset(int64(decbuf.Offset())); err != nil {
 				return SparseSymbols{}, err
 			}

--- a/pkg/storage/indexheader/index/sparse_symbols.go
+++ b/pkg/storage/indexheader/index/sparse_symbols.go
@@ -28,6 +28,12 @@ type SparseSymbols struct {
 	offsets []uint32
 }
 
+// NumSampledSymbols returns the number of symbols the sparse representation retains in memory
+// for a symbols table holding totalSymbols symbols: every symbolFactor-th one.
+func NumSampledSymbols(totalSymbols int) int {
+	return (totalSymbols + symbolFactor - 1) / symbolFactor
+}
+
 // Count returns the total number of symbols in the table.
 func (s SparseSymbols) Count() int {
 	return s.count

--- a/pkg/storage/indexheader/index/sparse_symbols.go
+++ b/pkg/storage/indexheader/index/sparse_symbols.go
@@ -15,11 +15,8 @@ import (
 	"github.com/grafana/mimir/pkg/storage/indexheader/indexheaderpb"
 )
 
-// symbolsTableLengthFieldSize is the size of the symbols table's leading length field.
-const symbolsTableLengthFieldSize = 4
-
 // SparseSymbols is the sampled in-memory representation of the symbols table:
-// the total number of symbols plus the table offset of every symbolFactor-th symbol.
+// the total number of symbols plus the table offset of every SymbolFactor-th symbol.
 //
 // Offsets are stored relative to the start of the table's content (after the leading length field):
 // the index writer caps the content at 2^32-1 bytes, so content-relative offsets always fit in uint32,
@@ -43,12 +40,12 @@ func (s SparseSymbols) NumOffsets() int {
 
 // tableOffset returns the offset of the i-th sampled symbol, relative to the start of the symbols table.
 func (s SparseSymbols) tableOffset(i int) int {
-	return int(s.offsets[i]) + symbolsTableLengthFieldSize
+	return int(s.offsets[i]) + tableLengthFieldSize
 }
 
 // appendOffset records a sampled symbol at the given offset relative to the start of the symbols table.
 func (s *SparseSymbols) appendOffset(tableOff int64) error {
-	off, err := tableOffsetToUint32(tableOff-symbolsTableLengthFieldSize, "symbols")
+	off, err := tableOffsetToUint32(tableOff-tableLengthFieldSize, "symbols")
 	if err != nil {
 		return err
 	}
@@ -93,9 +90,9 @@ func SparseValuesFromSymbolsTable(
 	sparseSymbols.count = decbuf.Be32int()
 
 	seen := 0
-	sparseSymbols.offsets = make([]uint32, 0, 1+sparseSymbols.count/symbolFactor)
+	sparseSymbols.offsets = make([]uint32, 0, 1+sparseSymbols.count/SymbolFactor)
 	for decbuf.Err() == nil && seen < sparseSymbols.count {
-		if seen%symbolFactor == 0 {
+		if seen%SymbolFactor == 0 {
 			if err := sparseSymbols.appendOffset(int64(decbuf.Offset())); err != nil {
 				return SparseSymbols{}, err
 			}

--- a/pkg/storage/indexheader/index/sparse_symbols.go
+++ b/pkg/storage/indexheader/index/sparse_symbols.go
@@ -15,11 +15,20 @@ import (
 	"github.com/grafana/mimir/pkg/storage/indexheader/indexheaderpb"
 )
 
+// symbolsTableLengthFieldSize is the size of the symbols table's leading length field.
+const symbolsTableLengthFieldSize = 4
+
 // SparseSymbols is the sampled in-memory representation of the symbols table:
 // the total number of symbols plus the table offset of every symbolFactor-th symbol.
+//
+// Offsets are stored relative to the start of the table's content (after the leading length field):
+// the index writer caps the content at 2^32-1 bytes, so content-relative offsets always fit in uint32,
+// while offsets relative to the table start would not, because of the leading length field.
+// This is internal to SparseSymbols: offsets passed to appendOffset and returned by tableOffset
+// are relative to the table start.
 type SparseSymbols struct {
 	count   int
-	offsets []int
+	offsets []uint32
 }
 
 // Count returns the total number of symbols in the table.
@@ -34,12 +43,16 @@ func (s SparseSymbols) NumOffsets() int {
 
 // tableOffset returns the offset of the i-th sampled symbol, relative to the start of the symbols table.
 func (s SparseSymbols) tableOffset(i int) int {
-	return s.offsets[i]
+	return int(s.offsets[i]) + symbolsTableLengthFieldSize
 }
 
 // appendOffset records a sampled symbol at the given offset relative to the start of the symbols table.
 func (s *SparseSymbols) appendOffset(tableOff int64) error {
-	s.offsets = append(s.offsets, int(tableOff))
+	off, err := tableOffsetToUint32(tableOff-symbolsTableLengthFieldSize, "symbols")
+	if err != nil {
+		return err
+	}
+	s.offsets = append(s.offsets, off)
 	return nil
 }
 
@@ -80,7 +93,7 @@ func SparseValuesFromSymbolsTable(
 	sparseSymbols.count = decbuf.Be32int()
 
 	seen := 0
-	sparseSymbols.offsets = make([]int, 0, 1+sparseSymbols.count/symbolFactor)
+	sparseSymbols.offsets = make([]uint32, 0, 1+sparseSymbols.count/symbolFactor)
 	for decbuf.Err() == nil && seen < sparseSymbols.count {
 		if seen%symbolFactor == 0 {
 			if err := sparseSymbols.appendOffset(int64(decbuf.Offset())); err != nil {
@@ -119,7 +132,7 @@ func SparseSymbolsToProto(sparseSymbols SparseSymbols) *indexheaderpb.Symbols {
 func SparseSymbolsFromProto(proto *indexheaderpb.Symbols) (SparseSymbols, error) {
 	sparseSymbols := SparseSymbols{
 		count:   int(proto.SymbolsCount),
-		offsets: make([]int, 0, len(proto.Offsets)),
+		offsets: make([]uint32, 0, len(proto.Offsets)),
 	}
 
 	for _, offset := range proto.Offsets {

--- a/pkg/storage/indexheader/index/sparse_symbols.go
+++ b/pkg/storage/indexheader/index/sparse_symbols.go
@@ -15,12 +15,40 @@ import (
 	"github.com/grafana/mimir/pkg/storage/indexheader/indexheaderpb"
 )
 
+// SparseSymbols is the sampled in-memory representation of the symbols table:
+// the total number of symbols plus the table offset of every symbolFactor-th symbol.
+type SparseSymbols struct {
+	count   int
+	offsets []int
+}
+
+// Count returns the total number of symbols in the table.
+func (s SparseSymbols) Count() int {
+	return s.count
+}
+
+// NumOffsets returns the number of sampled symbols.
+func (s SparseSymbols) NumOffsets() int {
+	return len(s.offsets)
+}
+
+// tableOffset returns the offset of the i-th sampled symbol, relative to the start of the symbols table.
+func (s SparseSymbols) tableOffset(i int) int {
+	return s.offsets[i]
+}
+
+// appendOffset records a sampled symbol at the given offset relative to the start of the symbols table.
+func (s *SparseSymbols) appendOffset(tableOff int64) error {
+	s.offsets = append(s.offsets, int(tableOff))
+	return nil
+}
+
 func SparseValuesFromSymbolsTable(
 	ctx context.Context,
 	decbufFactory streamencoding.DecbufFactory,
 	tableOffset int,
 	doChecksum bool,
-) (allSymbolsCount int, sparseSymbolsOffsets []int, err error) {
+) (sparseSymbols SparseSymbols, err error) {
 	var decbuf streamencoding.Decbuf
 	if doChecksum {
 		decbuf = decbufFactory.NewDecbufAtChecked(ctx, tableOffset, castagnoliTable)
@@ -30,7 +58,7 @@ func SparseValuesFromSymbolsTable(
 
 	defer runutil.CloseWithErrCapture(&err, &decbuf, "decode symbols table")
 	if err := decbuf.Err(); err != nil {
-		return -1, nil, fmt.Errorf("init symbol table decoding buffer: %w", decbuf.Err())
+		return SparseSymbols{}, fmt.Errorf("init symbol table decoding buffer: %w", decbuf.Err())
 	}
 
 	// Symbols table format:
@@ -49,48 +77,56 @@ func SparseValuesFromSymbolsTable(
 	// └──────────────────────────────────────────┘
 
 	// Get symbols count; decbuf has already consumed the len field.
-	allSymbolsCount = decbuf.Be32int()
+	sparseSymbols.count = decbuf.Be32int()
 
 	seen := 0
-	sparseSymbolsOffsets = make([]int, 0, 1+allSymbolsCount/symbolFactor)
-	for decbuf.Err() == nil && seen < allSymbolsCount {
+	sparseSymbols.offsets = make([]int, 0, 1+sparseSymbols.count/symbolFactor)
+	for decbuf.Err() == nil && seen < sparseSymbols.count {
 		if seen%symbolFactor == 0 {
-			sparseSymbolsOffsets = append(sparseSymbolsOffsets, decbuf.Offset())
+			if err := sparseSymbols.appendOffset(int64(decbuf.Offset())); err != nil {
+				return SparseSymbols{}, err
+			}
 		}
 		decbuf.SkipUvarintBytes() // The symbol.
 		seen++
 	}
 
 	if decbuf.Err() != nil {
-		return -1, nil, decbuf.Err()
+		return SparseSymbols{}, decbuf.Err()
 	}
 
-	return allSymbolsCount, sparseSymbolsOffsets, nil
+	return sparseSymbols, nil
 }
 
-// SparseSymbolsToProto loads the in-memory sparse symbols data into the protobuf format
-func SparseSymbolsToProto(allSymbolsCount int, sparseOffsets []int) *indexheaderpb.Symbols {
+// SparseSymbolsToProto loads the in-memory sparse symbols data into the protobuf format.
+// The protobuf offsets are relative to the start of the symbols table (including its length field),
+// as written by all Mimir versions.
+func SparseSymbolsToProto(sparseSymbols SparseSymbols) *indexheaderpb.Symbols {
 	proto := &indexheaderpb.Symbols{}
 
-	offsets := make([]int64, len(sparseOffsets))
-	for i, offset := range sparseOffsets {
-		offsets[i] = int64(offset)
+	offsets := make([]int64, sparseSymbols.NumOffsets())
+	for i := range offsets {
+		offsets[i] = int64(sparseSymbols.tableOffset(i))
 	}
 
 	proto.Offsets = offsets
-	proto.SymbolsCount = int64(allSymbolsCount)
+	proto.SymbolsCount = int64(sparseSymbols.count)
 
 	return proto
 }
 
 // SparseSymbolsFromProto loads the protobuf format to in-memory sparse symbols data
-func SparseSymbolsFromProto(proto *indexheaderpb.Symbols) (allSymbolsCount int, sparseOffsets []int) {
-	allSymbolsCount = int(proto.SymbolsCount)
-	sparseOffsets = make([]int, len(proto.Offsets))
-
-	for i, offset := range proto.Offsets {
-		sparseOffsets[i] = int(offset)
+func SparseSymbolsFromProto(proto *indexheaderpb.Symbols) (SparseSymbols, error) {
+	sparseSymbols := SparseSymbols{
+		count:   int(proto.SymbolsCount),
+		offsets: make([]int, 0, len(proto.Offsets)),
 	}
 
-	return allSymbolsCount, sparseOffsets
+	for _, offset := range proto.Offsets {
+		if err := sparseSymbols.appendOffset(offset); err != nil {
+			return SparseSymbols{}, err
+		}
+	}
+
+	return sparseSymbols, nil
 }

--- a/pkg/storage/indexheader/index/symbols.go
+++ b/pkg/storage/indexheader/index/symbols.go
@@ -40,7 +40,8 @@ type SymbolsTable struct {
 	sparseSymbols SparseSymbols
 }
 
-const symbolFactor = 32
+// SymbolFactor is the sampling rate of the symbols table: every SymbolFactor-th symbol is retained in memory.
+const SymbolFactor = 32
 
 func NewSymbolsTableReader(
 	indexVersion int,
@@ -76,9 +77,9 @@ func (s *SymbolsTable) Lookup(o uint32) (sym string, err error) {
 	if int(o) >= s.sparseSymbols.Count() {
 		return "", fmt.Errorf("%w: symbol offset %d", ErrSymbolNotFound, o)
 	}
-	d.ResetAt(s.sparseSymbols.tableOffset(int(o / symbolFactor)))
+	d.ResetAt(s.sparseSymbols.tableOffset(int(o / SymbolFactor)))
 	// Walk until we find the one we want.
-	for i := o - (o / symbolFactor * symbolFactor); i > 0; i-- {
+	for i := o - (o / SymbolFactor * SymbolFactor); i > 0; i-- {
 		d.SkipUvarintBytes()
 	}
 
@@ -148,7 +149,7 @@ func (s *SymbolsTable) reverseLookup(sym string, d streamencoding.Decbuf) (uint3
 	}
 
 	d.ResetAt(s.sparseSymbols.tableOffset(i))
-	res := i * symbolFactor
+	res := i * SymbolFactor
 	var lastSymbol string
 	for d.Err() == nil && res <= s.sparseSymbols.Count() {
 		lastSymbol = yoloString(d.UnsafeUvarintBytes())
@@ -187,7 +188,6 @@ func (s *SymbolsTable) Reader() SymbolsReader {
 	return &SymbolsTableReaderV2{
 		d:             &d,
 		sparseSymbols: s.sparseSymbols,
-		lastSymbolRef: uint32(s.sparseSymbols.Count() - 1),
 	}
 }
 
@@ -197,7 +197,6 @@ type SymbolsTableReaderV2 struct {
 	d *streamencoding.Decbuf
 	// atSymbol is the index the symbol currently pointed by the Decbuf head
 	atSymbol      uint32
-	lastSymbolRef uint32
 	sparseSymbols SparseSymbols
 }
 
@@ -214,17 +213,17 @@ func (r *SymbolsTableReaderV2) Read(o uint32) (string, error) {
 	if o < r.atSymbol {
 		return "", fmt.Errorf("%w: at %d requesting %d", errReverseSymbolsReader, r.atSymbol, o)
 	}
-	if o > r.lastSymbolRef {
+	if int(o) >= r.sparseSymbols.Count() {
 		return "", fmt.Errorf("%w: %d", ErrSymbolNotFound, o)
 	}
 
-	if targetOffsetIdx, currentOffsetIdx := o/symbolFactor, r.atSymbol/symbolFactor; targetOffsetIdx > currentOffsetIdx {
+	if targetOffsetIdx, currentOffsetIdx := o/SymbolFactor, r.atSymbol/SymbolFactor; targetOffsetIdx > currentOffsetIdx {
 		// Only ResetAt a bigger offset than the current one.
 		// We don't want to ResetAt an offset we've gone past: that will reverse the file reader, and we will do unnecessary reads.
 		d.ResetAt(r.sparseSymbols.tableOffset(int(targetOffsetIdx)))
-		r.atSymbol = targetOffsetIdx * symbolFactor
+		r.atSymbol = targetOffsetIdx * SymbolFactor
 	}
-	// We've offset to the right group of symbolFactor symbols. Now skip until the requested symbol within that group.
+	// We've offset to the right group of SymbolFactor symbols. Now skip until the requested symbol within that group.
 	for i := o - r.atSymbol; i > 0; i-- {
 		d.SkipUvarintBytes()
 		r.atSymbol++

--- a/pkg/storage/indexheader/index/symbols.go
+++ b/pkg/storage/indexheader/index/symbols.go
@@ -37,8 +37,7 @@ type SymbolsTable struct {
 	tableOffset   int
 	decbufFactory streamencoding.DecbufFactory
 
-	allSymbolsCount      int
-	sparseSymbolsOffsets []int
+	sparseSymbols SparseSymbols
 }
 
 const symbolFactor = 32
@@ -47,18 +46,16 @@ func NewSymbolsTableReader(
 	indexVersion int,
 	decbufFactory streamencoding.DecbufFactory,
 	tableOffset int,
-	allSymbolsCount int,
-	sparseSymbolsOffsets []int,
+	sparseSymbols SparseSymbols,
 ) (s *SymbolsTable, err error) {
 	switch indexVersion {
 	case index.FormatV2:
 		return &SymbolsTable{
 			// Context for DecbufFactory methods is unused for symbols table and does not need to be tied to request.
-			ctx:                  context.Background(),
-			tableOffset:          tableOffset,
-			decbufFactory:        decbufFactory,
-			allSymbolsCount:      allSymbolsCount,
-			sparseSymbolsOffsets: sparseSymbolsOffsets,
+			ctx:           context.Background(),
+			tableOffset:   tableOffset,
+			decbufFactory: decbufFactory,
+			sparseSymbols: sparseSymbols,
 		}, nil
 	}
 	return nil, fmt.Errorf("unknown or unsupported index version %v", indexVersion)
@@ -76,10 +73,10 @@ func (s *SymbolsTable) Lookup(o uint32) (sym string, err error) {
 		return "", err
 	}
 
-	if int(o) >= s.allSymbolsCount {
+	if int(o) >= s.sparseSymbols.Count() {
 		return "", fmt.Errorf("%w: symbol offset %d", ErrSymbolNotFound, o)
 	}
-	d.ResetAt(s.sparseSymbolsOffsets[int(o/symbolFactor)])
+	d.ResetAt(s.sparseSymbols.tableOffset(int(o / symbolFactor)))
 	// Walk until we find the one we want.
 	for i := o - (o / symbolFactor * symbolFactor); i > 0; i-- {
 		d.SkipUvarintBytes()
@@ -94,7 +91,7 @@ func (s *SymbolsTable) Lookup(o uint32) (sym string, err error) {
 
 // ReverseLookup returns an error with cause ErrSymbolNotFound if the symbol cannot be found.
 func (s *SymbolsTable) ReverseLookup(sym string) (o uint32, err error) {
-	if len(s.sparseSymbolsOffsets) == 0 {
+	if s.sparseSymbols.NumOffsets() == 0 {
 		return 0, fmt.Errorf("unknown symbol %q - no symbols", sym)
 	}
 
@@ -115,7 +112,7 @@ func (s *SymbolsTable) ReverseLookup(sym string) (o uint32, err error) {
 // returned. If f returns an error, iteration stops immediately and the error is returned.
 // ForEachSymbol returns an error with cause ErrSymbolNotFound if any symbol cannot be found.
 func (s *SymbolsTable) ForEachSymbol(syms []string, f func(sym string, offset uint32) error) (err error) {
-	if len(s.sparseSymbolsOffsets) == 0 {
+	if s.sparseSymbols.NumOffsets() == 0 {
 		return errors.New("no symbols")
 	}
 
@@ -141,8 +138,8 @@ func (s *SymbolsTable) ForEachSymbol(syms []string, f func(sym string, offset ui
 }
 
 func (s *SymbolsTable) reverseLookup(sym string, d streamencoding.Decbuf) (uint32, error) {
-	i := sort.Search(len(s.sparseSymbolsOffsets), func(i int) bool {
-		d.ResetAt(s.sparseSymbolsOffsets[i])
+	i := sort.Search(s.sparseSymbols.NumOffsets(), func(i int) bool {
+		d.ResetAt(s.sparseSymbols.tableOffset(i))
 		return string(d.UnsafeUvarintBytes()) > sym
 	})
 
@@ -150,10 +147,10 @@ func (s *SymbolsTable) reverseLookup(sym string, d streamencoding.Decbuf) (uint3
 		i--
 	}
 
-	d.ResetAt(s.sparseSymbolsOffsets[i])
+	d.ResetAt(s.sparseSymbols.tableOffset(i))
 	res := i * symbolFactor
 	var lastSymbol string
-	for d.Err() == nil && res <= s.allSymbolsCount {
+	for d.Err() == nil && res <= s.sparseSymbols.Count() {
 		lastSymbol = yoloString(d.UnsafeUvarintBytes())
 		if lastSymbol >= sym {
 			break
@@ -185,12 +182,12 @@ type SymbolsReader interface {
 
 func (s *SymbolsTable) Reader() SymbolsReader {
 	d := s.decbufFactory.NewDecbufAtUnchecked(s.ctx, s.tableOffset)
-	d.ResetAt(s.sparseSymbolsOffsets[0])
+	d.ResetAt(s.sparseSymbols.tableOffset(0))
 
 	return &SymbolsTableReaderV2{
 		d:             &d,
-		offsets:       s.sparseSymbolsOffsets,
-		lastSymbolRef: uint32(s.allSymbolsCount - 1),
+		sparseSymbols: s.sparseSymbols,
+		lastSymbolRef: uint32(s.sparseSymbols.Count() - 1),
 	}
 }
 
@@ -201,7 +198,7 @@ type SymbolsTableReaderV2 struct {
 	// atSymbol is the index the symbol currently pointed by the Decbuf head
 	atSymbol      uint32
 	lastSymbolRef uint32
-	offsets       []int
+	sparseSymbols SparseSymbols
 }
 
 func (r *SymbolsTableReaderV2) Close() error {
@@ -224,7 +221,7 @@ func (r *SymbolsTableReaderV2) Read(o uint32) (string, error) {
 	if targetOffsetIdx, currentOffsetIdx := o/symbolFactor, r.atSymbol/symbolFactor; targetOffsetIdx > currentOffsetIdx {
 		// Only ResetAt a bigger offset than the current one.
 		// We don't want to ResetAt an offset we've gone past: that will reverse the file reader, and we will do unnecessary reads.
-		d.ResetAt(r.offsets[int(targetOffsetIdx)])
+		d.ResetAt(r.sparseSymbols.tableOffset(int(targetOffsetIdx)))
 		r.atSymbol = targetOffsetIdx * symbolFactor
 	}
 	// We've offset to the right group of symbolFactor symbols. Now skip until the requested symbol within that group.

--- a/pkg/storage/indexheader/index/symbols.go
+++ b/pkg/storage/indexheader/index/symbols.go
@@ -40,8 +40,7 @@ type SymbolsTable struct {
 	sparseSymbols SparseSymbols
 }
 
-// SymbolFactor is the sampling rate of the symbols table: every SymbolFactor-th symbol is retained in memory.
-const SymbolFactor = 32
+const symbolFactor = 32
 
 func NewSymbolsTableReader(
 	indexVersion int,
@@ -77,9 +76,9 @@ func (s *SymbolsTable) Lookup(o uint32) (sym string, err error) {
 	if int(o) >= s.sparseSymbols.Count() {
 		return "", fmt.Errorf("%w: symbol offset %d", ErrSymbolNotFound, o)
 	}
-	d.ResetAt(s.sparseSymbols.tableOffset(int(o / SymbolFactor)))
+	d.ResetAt(s.sparseSymbols.tableOffset(int(o / symbolFactor)))
 	// Walk until we find the one we want.
-	for i := o - (o / SymbolFactor * SymbolFactor); i > 0; i-- {
+	for i := o - (o / symbolFactor * symbolFactor); i > 0; i-- {
 		d.SkipUvarintBytes()
 	}
 
@@ -149,7 +148,7 @@ func (s *SymbolsTable) reverseLookup(sym string, d streamencoding.Decbuf) (uint3
 	}
 
 	d.ResetAt(s.sparseSymbols.tableOffset(i))
-	res := i * SymbolFactor
+	res := i * symbolFactor
 	var lastSymbol string
 	for d.Err() == nil && res <= s.sparseSymbols.Count() {
 		lastSymbol = yoloString(d.UnsafeUvarintBytes())
@@ -217,13 +216,13 @@ func (r *SymbolsTableReaderV2) Read(o uint32) (string, error) {
 		return "", fmt.Errorf("%w: %d", ErrSymbolNotFound, o)
 	}
 
-	if targetOffsetIdx, currentOffsetIdx := o/SymbolFactor, r.atSymbol/SymbolFactor; targetOffsetIdx > currentOffsetIdx {
+	if targetOffsetIdx, currentOffsetIdx := o/symbolFactor, r.atSymbol/symbolFactor; targetOffsetIdx > currentOffsetIdx {
 		// Only ResetAt a bigger offset than the current one.
 		// We don't want to ResetAt an offset we've gone past: that will reverse the file reader, and we will do unnecessary reads.
 		d.ResetAt(r.sparseSymbols.tableOffset(int(targetOffsetIdx)))
-		r.atSymbol = targetOffsetIdx * SymbolFactor
+		r.atSymbol = targetOffsetIdx * symbolFactor
 	}
-	// We've offset to the right group of SymbolFactor symbols. Now skip until the requested symbol within that group.
+	// We've offset to the right group of symbolFactor symbols. Now skip until the requested symbol within that group.
 	for i := o - r.atSymbol; i > 0; i-- {
 		d.SkipUvarintBytes()
 		r.atSymbol++

--- a/pkg/storage/indexheader/index/symbols_test.go
+++ b/pkg/storage/indexheader/index/symbols_test.go
@@ -66,16 +66,16 @@ func TestSymbolsV2(t *testing.T) {
 	}
 
 	for factoryName, decbufFactory := range factories {
-		allSymbolsCount, sparseOffsets, err := SparseValuesFromSymbolsTable(context.Background(), decbufFactory, symbolsStart, true)
+		sparseSymbols, err := SparseValuesFromSymbolsTable(context.Background(), decbufFactory, symbolsStart, true)
 		require.NoError(t, err)
 
 		s, err := NewSymbolsTableReader(
-			index.FormatV2, decbufFactory, symbolsStart, allSymbolsCount, sparseOffsets,
+			index.FormatV2, decbufFactory, symbolsStart, sparseSymbols,
 		)
 		require.NoError(t, err)
 
 		// We store only 4 SparseTableOffsets to symbols.
-		require.Len(t, s.sparseSymbolsOffsets, 4)
+		require.Equal(t, 4, s.sparseSymbols.NumOffsets())
 
 		t.Run(fmt.Sprintf("Lookup/DecbufFactory=%s", factoryName), func(t *testing.T) {
 			for i := 99; i >= 0; i-- {

--- a/pkg/storage/indexheader/index/symbols_test.go
+++ b/pkg/storage/indexheader/index/symbols_test.go
@@ -74,7 +74,7 @@ func TestSymbolsV2(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		// We store only 4 SparseTableOffsets to symbols.
+		// We store only 4 sampled symbols offsets.
 		require.Equal(t, 4, s.sparseSymbols.NumOffsets())
 
 		t.Run(fmt.Sprintf("Lookup/DecbufFactory=%s", factoryName), func(t *testing.T) {
@@ -99,7 +99,7 @@ func TestSymbolsV2(t *testing.T) {
 
 		t.Run(fmt.Sprintf("ForEachSymbol/DecbufFactory=%s", factoryName), func(t *testing.T) {
 			// Use ForEachSymbol to build an offset -> symbol mapping and ensure
-			// that it matches the expected SparseTableOffsets and symbols.
+			// that it matches the expected sampled offsets and symbols.
 			var symbols []string
 			expected := make(map[uint32]string)
 			for i := 99; i >= 0; i-- {

--- a/pkg/storage/indexheader/sparse_header.go
+++ b/pkg/storage/indexheader/sparse_header.go
@@ -73,8 +73,7 @@ func LoadSparseIndexHeaderFromDisk(
 	sparseSampleFactor int,
 	l log.Logger,
 ) (
-	allSymbolsCount int,
-	sparseSymbolsOffsets []int,
+	sparseSymbols streamindex.SparseSymbols,
 	sparsePostingsOffsets map[string]*streamindex.SparseTableOffsetsForLabel,
 	err error,
 ) {
@@ -90,36 +89,48 @@ func LoadSparseIndexHeaderFromDisk(
 			"msg", "sparse index-header does not exist on disk",
 			"err", err,
 		)
-		return 0, nil, nil, err
+		return streamindex.SparseSymbols{}, nil, err
+	}
+
+	sparseSymbols, sparsePostingsOffsets, err = loadSparseHeader(gzipSparseHeaderBytes, sparseSampleFactor, l)
+	if err != nil {
+		level.Error(spanLog).Log(
+			"msg", "failed to load sparse index-header from disk",
+			"err", err,
+		)
+		return streamindex.SparseSymbols{}, nil, err
+	}
+	return sparseSymbols, sparsePostingsOffsets, nil
+}
+
+// loadSparseHeader converts the gzipped protobuf encoding of the sparse index-header
+// into the in-memory representation used by index-header readers.
+func loadSparseHeader(gzipSparseHeaderBytes []byte, sparseSampleFactor int, l log.Logger) (
+	sparseSymbols streamindex.SparseSymbols,
+	sparsePostingsOffsets map[string]*streamindex.SparseTableOffsetsForLabel,
+	err error,
+) {
+	sparseHeaderBytes, err := unzipSparseHeader(gzipSparseHeaderBytes, l)
+	if err != nil {
+		return streamindex.SparseSymbols{}, nil, fmt.Errorf("failed to unzip sparse index-header file: %w", err)
 	}
 
 	sparseHeaderProto := &indexheaderpb.Sparse{}
-	if sparseHeaderBytes, err := unzipSparseHeader(gzipSparseHeaderBytes, l); err != nil {
-		level.Error(spanLog).Log(
-			"msg", "failed to unzip sparse index-header file",
-			"err", err,
-		)
-		return 0, nil, nil, err
-	} else if err := sparseHeaderProto.Unmarshal(sparseHeaderBytes); err != nil {
-		level.Error(spanLog).Log(
-			"msg", "failed to unmarshall zipped sparse index-header to proto",
-			"err", err,
-		)
-		return 0, nil, nil, err
+	if err := sparseHeaderProto.Unmarshal(sparseHeaderBytes); err != nil {
+		return streamindex.SparseSymbols{}, nil, fmt.Errorf("failed to unmarshall zipped sparse index-header to proto: %w", err)
 	}
 
-	allSymbolsCount, sparseSymbolsOffsets = streamindex.SparseSymbolsFromProto(sparseHeaderProto.Symbols)
+	sparseSymbols, err = streamindex.SparseSymbolsFromProto(sparseHeaderProto.Symbols)
+	if err != nil {
+		return streamindex.SparseSymbols{}, nil, fmt.Errorf("failed to initialize in-memory sparse symbols from proto: %w", err)
+	}
 	sparsePostingsOffsets, err = streamindex.SparsePostingsOffsetsTableFromProto(
 		sparseHeaderProto.PostingsOffsetTable, sparseSampleFactor,
 	)
 	if err != nil {
-		level.Error(spanLog).Log(
-			"msg", "failed to initialize in-memory sparse index-header from proto",
-			"err", err,
-		)
-		return 0, nil, nil, err
+		return streamindex.SparseSymbols{}, nil, fmt.Errorf("failed to initialize in-memory sparse index-header from proto: %w", err)
 	}
-	return allSymbolsCount, sparseSymbolsOffsets, sparsePostingsOffsets, nil
+	return sparseSymbols, sparsePostingsOffsets, nil
 }
 
 // DownloadAndLoadSparseHeader unmarshalls gzipped proto sparse index-header to the in-memory representation,
@@ -138,8 +149,7 @@ func DownloadAndLoadSparseHeader(
 	sparseSampleFactor int,
 	l log.Logger,
 ) (
-	allSymbolsCount int,
-	sparseSymbolsOffsets []int,
+	sparseSymbols streamindex.SparseSymbols,
 	sparsePostingsOffsets map[string]*streamindex.SparseTableOffsetsForLabel,
 	err error,
 ) {
@@ -169,7 +179,7 @@ func DownloadAndLoadSparseHeader(
 					"err", err,
 				)
 			}
-			return 0, nil, nil, err
+			return streamindex.SparseSymbols{}, nil, err
 		}
 
 		// Successfully read gzipped proto bytes from bucket; attempt to write to disk.
@@ -182,35 +192,17 @@ func DownloadAndLoadSparseHeader(
 		}
 	}
 
-	// If we reach this point, we got the zipped sparse header from disk or bucket. Unmarshall the proto.
-	sparseHeaderProto := &indexheaderpb.Sparse{}
-	if sparseHeaderBytes, err := unzipSparseHeader(gzipSparseHeaderBytes, l); err != nil {
-		level.Error(spanLog).Log(
-			"msg", "failed to unzip sparse index-header file",
-			"err", err,
-		)
-		return 0, nil, nil, err
-	} else if err := sparseHeaderProto.Unmarshal(sparseHeaderBytes); err != nil {
-		level.Error(spanLog).Log(
-			"msg", "failed to unmarshall zipped sparse index-header to proto",
-			"err", err,
-		)
-		return 0, nil, nil, err
-	}
-
-	// Finally, convert from proto to the in-memory representation used by index-header readers.
-	allSymbolsCount, sparseSymbolsOffsets = streamindex.SparseSymbolsFromProto(sparseHeaderProto.Symbols)
-	sparsePostingsOffsets, err = streamindex.SparsePostingsOffsetsTableFromProto(
-		sparseHeaderProto.PostingsOffsetTable, sparseSampleFactor,
-	)
+	// If we reach this point, we got the zipped sparse header from disk or bucket.
+	// Convert it to the in-memory representation used by index-header readers.
+	sparseSymbols, sparsePostingsOffsets, err = loadSparseHeader(gzipSparseHeaderBytes, sparseSampleFactor, l)
 	if err != nil {
 		level.Error(spanLog).Log(
-			"msg", "failed to initialize in-memory sparse index-header from proto",
+			"msg", "failed to load sparse index-header",
 			"err", err,
 		)
-		return 0, nil, nil, err
+		return streamindex.SparseSymbols{}, nil, err
 	}
-	return allSymbolsCount, sparseSymbolsOffsets, sparsePostingsOffsets, nil
+	return sparseSymbols, sparsePostingsOffsets, nil
 }
 
 // getBucketSparseHeaderBytes reads the raw sparse header bytes from object storage.
@@ -280,7 +272,7 @@ func BuildAndWriteSparseHeaderFromTSDBIndex(
 		return err
 	}
 
-	allSymbolsCount, sparseSymbolsOffsets, sparsePostingsOffsets, err := buildInMemorySparseHeaderFromIndexHeader(
+	sparseSymbols, sparsePostingsOffsets, err := buildInMemorySparseHeaderFromIndexHeader(
 		ctx, indexTOC, filePoolDecbufFactory, sparseSampleFactor, false, l,
 	)
 	if err != nil {
@@ -288,7 +280,7 @@ func BuildAndWriteSparseHeaderFromTSDBIndex(
 	}
 
 	sparseHeaderProto := &indexheaderpb.Sparse{
-		Symbols:             streamindex.SparseSymbolsToProto(allSymbolsCount, sparseSymbolsOffsets),
+		Symbols:             streamindex.SparseSymbolsToProto(sparseSymbols),
 		PostingsOffsetTable: streamindex.SparsePostingsOffsetsTableToProto(sparsePostingsOffsets, sparseSampleFactor),
 	}
 
@@ -307,8 +299,7 @@ func buildInMemorySparseHeaderFromIndexHeader(
 	doChecksum bool,
 	l log.Logger,
 ) (
-	allSymbolsCount int,
-	sparseSymbolsOffsets []int,
+	sparseSymbols streamindex.SparseSymbols,
 	sparsePostingsOffsets map[string]*streamindex.SparseTableOffsetsForLabel,
 	err error,
 ) {
@@ -320,19 +311,19 @@ func buildInMemorySparseHeaderFromIndexHeader(
 	}()
 	level.Info(l).Log("msg", "creating sparse index-header from full index-header")
 
-	allSymbolsCount, sparseSymbolsOffsets, err = streamindex.SparseValuesFromSymbolsTable(
+	sparseSymbols, err = streamindex.SparseValuesFromSymbolsTable(
 		ctx, decbufFactory, int(toc.Symbols), doChecksum,
 	)
 	if err != nil {
-		return -1, nil, nil, err
+		return streamindex.SparseSymbols{}, nil, err
 	}
 
 	sparsePostingsOffsets, err = streamindex.SparseValuesFromPostingsOffsetsTable(ctx, decbufFactory, int(toc.PostingsOffsetTable), toc.PostingsListEnd, sparseSampleFactor, doChecksum)
 	if err != nil {
-		return -1, nil, nil, err
+		return streamindex.SparseSymbols{}, nil, err
 	}
 
-	return allSymbolsCount, sparseSymbolsOffsets, sparsePostingsOffsets, nil
+	return sparseSymbols, sparsePostingsOffsets, nil
 }
 
 func writeSparseHeaderProtoToDisk(path string, sparseHeaders *indexheaderpb.Sparse, l log.Logger) (err error) {

--- a/pkg/storage/indexheader/sparse_header.go
+++ b/pkg/storage/indexheader/sparse_header.go
@@ -335,20 +335,30 @@ func writeSparseHeaderProtoToDisk(path string, sparseHeaders *indexheaderpb.Spar
 	}()
 	level.Info(l).Log("msg", "writing sparse index-header to disk in protobuf format")
 
+	gzipped, err := gzipSparseHeaderProto(sparseHeaders)
+	if err != nil {
+		return err
+	}
+
+	return atomicfs.CreateFile(path, gzipped)
+}
+
+// gzipSparseHeaderProto serializes the sparse index-header proto the way it is stored on disk.
+func gzipSparseHeaderProto(sparseHeaders *indexheaderpb.Sparse) (*bytes.Buffer, error) {
 	out, err := sparseHeaders.Marshal()
 	if err != nil {
-		return fmt.Errorf("failed to marshall sparse index-header: %w", err)
+		return nil, fmt.Errorf("failed to marshall sparse index-header: %w", err)
 	}
 
 	gzipped := &bytes.Buffer{}
 	gzipWriter := gzip.NewWriter(gzipped)
 
 	if _, err := gzipWriter.Write(out); err != nil {
-		return fmt.Errorf("failed to gzip sparse index-header: %w", err)
+		return nil, fmt.Errorf("failed to gzip sparse index-header: %w", err)
 	}
 	if err := gzipWriter.Close(); err != nil {
-		return fmt.Errorf("failed to close sparse index-header gzip writer: %w", err)
+		return nil, fmt.Errorf("failed to close sparse index-header gzip writer: %w", err)
 	}
 
-	return atomicfs.CreateFile(path, gzipped)
+	return gzipped, nil
 }

--- a/pkg/storage/indexheader/sparse_header_benchmarks_test.go
+++ b/pkg/storage/indexheader/sparse_header_benchmarks_test.go
@@ -3,8 +3,6 @@
 package indexheader
 
 import (
-	"bytes"
-	"compress/gzip"
 	"fmt"
 	"math/rand"
 	"runtime"
@@ -107,12 +105,11 @@ func buildBenchmarkGzippedSparseHeader(b *testing.B, sparseSampleFactor int) []b
 		addLabel(fmt.Sprintf("low_cardinality_%03d", i), 3)
 	}
 
-	// symbolFactor mirrors the constant of the same name in the index package.
-	const symbolFactor = 32
 	symbolsCount := totalSampledEntries * sparseSampleFactor
-	symbolsOffsets := make([]int64, 0, symbolsCount/symbolFactor+1)
-	for off := int64(8); len(symbolsOffsets)*symbolFactor < symbolsCount; off += int64(symbolFactor) * 30 {
-		symbolsOffsets = append(symbolsOffsets, off)
+	numSymbolsOffsets := (symbolsCount + streamindex.SymbolFactor - 1) / streamindex.SymbolFactor
+	symbolsOffsets := make([]int64, 0, numSymbolsOffsets)
+	for i := 0; i < numSymbolsOffsets; i++ {
+		symbolsOffsets = append(symbolsOffsets, 8+int64(i)*streamindex.SymbolFactor*30)
 	}
 
 	sparseHeaderProto := &indexheaderpb.Sparse{
@@ -126,17 +123,11 @@ func buildBenchmarkGzippedSparseHeader(b *testing.B, sparseSampleFactor int) []b
 		},
 	}
 
-	marshalled, err := sparseHeaderProto.Marshal()
+	gzipped, err := gzipSparseHeaderProto(sparseHeaderProto)
 	require.NoError(b, err)
 
-	gzipped := &bytes.Buffer{}
-	gzipWriter := gzip.NewWriter(gzipped)
-	_, err = gzipWriter.Write(marshalled)
-	require.NoError(b, err)
-	require.NoError(b, gzipWriter.Close())
-
-	b.Logf("sparse header fixture: %d labels, %d sampled entries, proto %d bytes, gzipped %d bytes",
-		len(postings), totalSampledEntries, len(marshalled), gzipped.Len())
+	b.Logf("sparse header fixture: %d labels, %d sampled entries, gzipped %d bytes",
+		len(postings), totalSampledEntries, gzipped.Len())
 
 	return gzipped.Bytes()
 }

--- a/pkg/storage/indexheader/sparse_header_benchmarks_test.go
+++ b/pkg/storage/indexheader/sparse_header_benchmarks_test.go
@@ -108,13 +108,13 @@ func buildBenchmarkGzippedSparseHeader(b *testing.B, sparseSampleFactor int) []b
 		addLabel(fmt.Sprintf("low_cardinality_%03d", i), 3)
 	}
 
-	// symbolFactor mirrors the unexported constant of the same name in the index package.
-	const symbolFactor = 32
 	symbolsCount := totalSampledEntries * sparseSampleFactor
-	numSymbolsOffsets := (symbolsCount + symbolFactor - 1) / symbolFactor
+	numSymbolsOffsets := streamindex.NumSampledSymbols(symbolsCount)
+	// Space the offsets like a table of ~30-byte symbols.
+	offsetStride := int64(symbolsCount/numSymbolsOffsets) * 30
 	symbolsOffsets := make([]int64, 0, numSymbolsOffsets)
 	for i := 0; i < numSymbolsOffsets; i++ {
-		symbolsOffsets = append(symbolsOffsets, 8+int64(i)*symbolFactor*30)
+		symbolsOffsets = append(symbolsOffsets, 8+int64(i)*offsetStride)
 	}
 
 	sparseHeaderProto := &indexheaderpb.Sparse{

--- a/pkg/storage/indexheader/sparse_header_benchmarks_test.go
+++ b/pkg/storage/indexheader/sparse_header_benchmarks_test.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package indexheader
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"math/rand"
+	"runtime"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+
+	streamindex "github.com/grafana/mimir/pkg/storage/indexheader/index"
+	"github.com/grafana/mimir/pkg/storage/indexheader/indexheaderpb"
+)
+
+// BenchmarkLoadSparseHeader isolates the sparse index-header load path:
+// gzipped proto bytes -> in-memory representation used by index-header readers.
+// It also reports the retained (live heap) bytes of the loaded representation as "live-B/op".
+func BenchmarkLoadSparseHeader(b *testing.B) {
+	const sparseSampleFactor = 32
+
+	gzBytes := buildBenchmarkGzippedSparseHeader(b, sparseSampleFactor)
+	logger := log.NewNopLogger()
+
+	liveBytes, liveObjects := measureLoadedSparseHeaderLiveMemory(b, gzBytes, sparseSampleFactor, logger)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, err := loadSparseHeader(gzBytes, sparseSampleFactor, logger)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.ReportMetric(liveBytes, "live-B/op")
+	b.ReportMetric(liveObjects, "live-objects/op")
+}
+
+type loadedSparseHeader struct {
+	sparseSymbols         streamindex.SparseSymbols
+	sparsePostingsOffsets map[string]*streamindex.SparseTableOffsetsForLabel
+}
+
+func measureLoadedSparseHeaderLiveMemory(b *testing.B, gzBytes []byte, sparseSampleFactor int, logger log.Logger) (liveBytes, liveObjects float64) {
+	const replicas = 4
+
+	retained := make([]loadedSparseHeader, 0, replicas)
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	for i := 0; i < replicas; i++ {
+		sparseSymbols, sparsePostingsOffsets, err := loadSparseHeader(gzBytes, sparseSampleFactor, logger)
+		require.NoError(b, err)
+		retained = append(retained, loadedSparseHeader{sparseSymbols, sparsePostingsOffsets})
+	}
+
+	runtime.GC()
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+	runtime.KeepAlive(retained)
+
+	return float64(after.HeapAlloc-before.HeapAlloc) / replicas,
+		float64(after.HeapObjects-before.HeapObjects) / replicas
+}
+
+// buildBenchmarkGzippedSparseHeader builds a sparse index-header proto with a realistic shape
+// (a few high-cardinality labels dominating the total number of sampled entries,
+// value strings resembling pod/instance names) and serializes it the same way it is stored on disk.
+func buildBenchmarkGzippedSparseHeader(b *testing.B, sparseSampleFactor int) []byte {
+	random := rand.New(rand.NewSource(42))
+	const suffixAlphabet = "abcdefghijklmnopqrstuvwxyz0123456789"
+	randomSuffix := func(n int) string {
+		s := make([]byte, n)
+		for i := range s {
+			s[i] = suffixAlphabet[random.Intn(len(suffixAlphabet))]
+		}
+		return string(s)
+	}
+
+	postings := make(map[string]*indexheaderpb.PostingValueOffsets)
+	tableOff := int64(8)
+	totalSampledEntries := 0
+	addLabel := func(name string, sampledOffsets int) {
+		offsets := make([]*indexheaderpb.PostingOffset, sampledOffsets)
+		for i := range offsets {
+			// Fixed-width counter keeps values sorted, like in the real postings offset table.
+			value := fmt.Sprintf("%s-%07d-%s", name, i, randomSuffix(8+random.Intn(16)))
+			offsets[i] = &indexheaderpb.PostingOffset{Value: value, TableOff: tableOff}
+			tableOff += int64(sparseSampleFactor) * int64(len(name)+len(value)+12)
+		}
+		postings[name] = &indexheaderpb.PostingValueOffsets{Offsets: offsets, LastValOffset: tableOff}
+		totalSampledEntries += sampledOffsets
+	}
+
+	for i := 0; i < 5; i++ {
+		addLabel(fmt.Sprintf("high_cardinality_%02d", i), 20_000)
+	}
+	for i := 0; i < 45; i++ {
+		addLabel(fmt.Sprintf("medium_cardinality_%02d", i), 500)
+	}
+	for i := 0; i < 100; i++ {
+		addLabel(fmt.Sprintf("low_cardinality_%03d", i), 3)
+	}
+
+	// symbolFactor mirrors the constant of the same name in the index package.
+	const symbolFactor = 32
+	symbolsCount := totalSampledEntries * sparseSampleFactor
+	symbolsOffsets := make([]int64, 0, symbolsCount/symbolFactor+1)
+	for off := int64(8); len(symbolsOffsets)*symbolFactor < symbolsCount; off += int64(symbolFactor) * 30 {
+		symbolsOffsets = append(symbolsOffsets, off)
+	}
+
+	sparseHeaderProto := &indexheaderpb.Sparse{
+		Symbols: &indexheaderpb.Symbols{
+			Offsets:      symbolsOffsets,
+			SymbolsCount: int64(symbolsCount),
+		},
+		PostingsOffsetTable: &indexheaderpb.PostingOffsetTable{
+			Postings:                      postings,
+			PostingOffsetInMemorySampling: int64(sparseSampleFactor),
+		},
+	}
+
+	marshalled, err := sparseHeaderProto.Marshal()
+	require.NoError(b, err)
+
+	gzipped := &bytes.Buffer{}
+	gzipWriter := gzip.NewWriter(gzipped)
+	_, err = gzipWriter.Write(marshalled)
+	require.NoError(b, err)
+	require.NoError(b, gzipWriter.Close())
+
+	b.Logf("sparse header fixture: %d labels, %d sampled entries, proto %d bytes, gzipped %d bytes",
+		len(postings), totalSampledEntries, len(marshalled), gzipped.Len())
+
+	return gzipped.Bytes()
+}

--- a/pkg/storage/indexheader/sparse_header_benchmarks_test.go
+++ b/pkg/storage/indexheader/sparse_header_benchmarks_test.go
@@ -62,8 +62,11 @@ func measureLoadedSparseHeaderLiveMemory(b *testing.B, gzBytes []byte, sparseSam
 	runtime.ReadMemStats(&after)
 	runtime.KeepAlive(retained)
 
-	return float64(after.HeapAlloc-before.HeapAlloc) / replicas,
-		float64(after.HeapObjects-before.HeapObjects) / replicas
+	// Subtract as signed integers: if the heap shrank between the two measurements
+	// (e.g. floating garbage collected only by the second GC), report a negative value
+	// instead of wrapping the unsigned subtraction.
+	return float64(int64(after.HeapAlloc)-int64(before.HeapAlloc)) / replicas,
+		float64(int64(after.HeapObjects)-int64(before.HeapObjects)) / replicas
 }
 
 // buildBenchmarkGzippedSparseHeader builds a sparse index-header proto with a realistic shape
@@ -105,11 +108,13 @@ func buildBenchmarkGzippedSparseHeader(b *testing.B, sparseSampleFactor int) []b
 		addLabel(fmt.Sprintf("low_cardinality_%03d", i), 3)
 	}
 
+	// symbolFactor mirrors the unexported constant of the same name in the index package.
+	const symbolFactor = 32
 	symbolsCount := totalSampledEntries * sparseSampleFactor
-	numSymbolsOffsets := (symbolsCount + streamindex.SymbolFactor - 1) / streamindex.SymbolFactor
+	numSymbolsOffsets := (symbolsCount + symbolFactor - 1) / symbolFactor
 	symbolsOffsets := make([]int64, 0, numSymbolsOffsets)
 	for i := 0; i < numSymbolsOffsets; i++ {
-		symbolsOffsets = append(symbolsOffsets, 8+int64(i)*streamindex.SymbolFactor*30)
+		symbolsOffsets = append(symbolsOffsets, 8+int64(i)*symbolFactor*30)
 	}
 
 	sparseHeaderProto := &indexheaderpb.Sparse{

--- a/pkg/storage/indexheader/stream_binary_reader.go
+++ b/pkg/storage/indexheader/stream_binary_reader.go
@@ -114,7 +114,7 @@ func NewStreamBinaryReader(
 	// we cannot necessarily rely on err != nil or the sparse values == nil,
 	// depending on what the failure mode of loading the existing sparse header was.
 	sparseHeaderLoaded := false
-	allSymbolsCount, sparseSymbolsOffsets, sparsePostingsOffsets, err := DownloadAndLoadSparseHeader(
+	sparseSymbols, sparsePostingsOffsets, err := DownloadAndLoadSparseHeader(
 		ctx, blockID, bkt, dir, sparseSampleFactor, l,
 	)
 	if err != nil {
@@ -173,7 +173,7 @@ func NewStreamBinaryReader(
 	// If we previously failed to load the sparse index-header, build it now from full header.
 	if !sparseHeaderLoaded {
 		start := time.Now()
-		allSymbolsCount, sparseSymbolsOffsets, sparsePostingsOffsets, err = buildInMemorySparseHeaderFromIndexHeader(
+		sparseSymbols, sparsePostingsOffsets, err = buildInMemorySparseHeaderFromIndexHeader(
 			ctx, indexHeaderTOC, filePoolDecbufFactory, sparseSampleFactor, cfg.VerifyOnLoad, l,
 		)
 		if err != nil {
@@ -187,7 +187,7 @@ func NewStreamBinaryReader(
 
 		// Try to write to disk so we do not have to repeat this all again.
 		sparseHeaderProto := &indexheaderpb.Sparse{
-			Symbols:             streamindex.SparseSymbolsToProto(allSymbolsCount, sparseSymbolsOffsets),
+			Symbols:             streamindex.SparseSymbolsToProto(sparseSymbols),
 			PostingsOffsetTable: streamindex.SparsePostingsOffsetsTableToProto(sparsePostingsOffsets, sparseSampleFactor),
 		}
 		if err = writeSparseHeaderProtoToDisk(localSparseHeaderPath, sparseHeaderProto, l); err != nil {
@@ -257,7 +257,7 @@ func NewStreamBinaryReader(
 		streamBinaryReader.symbolsTOC.IndexVersion,
 		streamBinaryReader.symbolsDecbufFactory,
 		int(streamBinaryReader.symbolsTOC.Symbols),
-		allSymbolsCount, sparseSymbolsOffsets,
+		sparseSymbols,
 	); err != nil {
 		return nil, fmt.Errorf("failed to initialize symbols table reader: %w", err)
 	}

--- a/pkg/storage/indexheader/stream_binary_reader_test.go
+++ b/pkg/storage/indexheader/stream_binary_reader_test.go
@@ -57,7 +57,7 @@ func TestStreamBinaryReader_ShouldBuildSparseHeadersFromFileSimple(t *testing.T)
 	require.NoError(t, err)
 
 	// Confirm sparse index headers can be read from disk on subsequent builds.
-	_, _, _, err = DownloadAndLoadSparseHeader(ctx, blockID, bkt, tmpDir, 3, log.NewNopLogger())
+	_, _, err = DownloadAndLoadSparseHeader(ctx, blockID, bkt, tmpDir, 3, log.NewNopLogger())
 	require.NoError(t, err)
 
 	// Confirm end-to-end success of second build.


### PR DESCRIPTION
#### What this PR does

Production heap profiles show the in-memory sparse index-header representation accounts for 23-86% of store-gateway heap depending on the cell, and ~66% of all live heap objects, mostly one small string allocation per sampled postings entry. In heavy cells GC takes 15-23% of used store-gateway CPU, a big part of it marking those objects over and over.

This replaces the per-entry `{string, int}` structs with a per-label columnar layout: a byte blob with all sampled values concatenated, plus two uint32 arrays (value ends and table offsets). Symbols offsets similarly become uint32 behind a new `SparseSymbols` type. Offsets are stored relative to the table's content, so they provably fit in uint32 for any file the TSDB index writer can produce; the conversions are still checked, so corrupt data fails at load time (falling back to the existing rebuild-from-index-header path) instead of silently truncating. The on-disk format is byte-identical to what all Mimir versions write.

Results from the new `BenchmarkLoadSparseHeader`:

```
                    │ before-pr.txt │            after-pr.txt            │
                    │    sec/op     │    sec/op     vs base              │
LoadSparseHeader-14    44.51m ± 11%   47.23m ± 12%  +6.12% (p=0.026 n=6)

                    │ before-pr.txt │            after-pr.txt             │
                    │   live-B/op   │  live-B/op    vs base               │
LoadSparseHeader-14    9.804Mi ± 0%   6.697Mi ± 0%  -31.69% (p=0.002 n=6)

                    │  before-pr.txt  │              after-pr.txt              │
                    │ live-objects/op │ live-objects/op  vs base               │
LoadSparseHeader-14     123254.0 ± 0%        753.9 ± 0%  -99.39% (p=0.002 n=6)

                    │ before-pr.txt │            after-pr.txt            │
                    │     B/op      │     B/op      vs base              │
LoadSparseHeader-14    33.76Mi ± 0%   36.68Mi ± 0%  +8.64% (p=0.002 n=6)

                    │ before-pr.txt │           after-pr.txt            │
                    │   allocs/op   │  allocs/op   vs base              │
LoadSparseHeader-14     255.1k ± 0%   255.4k ± 0%  +0.13% (p=0.002 n=6)
```

`live-B/op` and `live-objects/op` are the retained live heap of the loaded representation, measured with GC-fenced `MemStats` deltas over retained copies.

Query paths are unchanged (`PostingsOffset`, `LabelValuesOffsets` and `LookupSymbol` benchmarks all neutral). Loads pay ~9% extra transient bytes for the copy into the blob. I have possible patches to improve that in follow-up PRs (exact-size gzip decompression buffer, decoding straight from the proto wire bytes).

#### Which issue(s) this PR fixes or relates to

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.

