### PR TITLE
compactor: add validation concurrency limit during compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Grafana Mimir
 
 * [CHANGE] MQE: validate that delayed name removal is only set using `-querier.enable-delayed-name-removal` or the per-tenant setting when MQE is in use. #16207
+* [ENHANCEMENT] Compactor: Add the experimental `-compactor.block-health-validation-concurrency` option to limit how many blocks are validated concurrently within a compaction job. #16269
 * [BUGFIX] Query-frontend: Return a HTTP 500 error rather than a HTTP 400 when a querier receives a query plan that is too new. #16233
 
 ### Mixin

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -13205,9 +13205,9 @@
           "kind": "field",
           "name": "block_health_validation_concurrency",
           "required": false,
-          "desc": "Number of blocks whose health can be validated concurrently during compaction. Health validation reads the block index and is CPU intensive, so setting this lower than -compactor.block-sync-concurrency makes CPU usage more uniform over the course of a compaction.",
+          "desc": "Number of blocks whose health can be validated concurrently during a compaction job. A nonpositive value means no limit.",
           "fieldValue": null,
-          "fieldDefaultValue": 8,
+          "fieldDefaultValue": 0,
           "fieldFlag": "compactor.block-health-validation-concurrency",
           "fieldType": "int",
           "fieldCategory": "experimental"

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -13203,6 +13203,17 @@
         },
         {
           "kind": "field",
+          "name": "block_health_validation_concurrency",
+          "required": false,
+          "desc": "Number of blocks whose health can be validated concurrently during compaction. Health validation reads the block index and is CPU intensive, so setting this lower than -compactor.block-sync-concurrency makes CPU usage more uniform over the course of a compaction.",
+          "fieldValue": null,
+          "fieldDefaultValue": 8,
+          "fieldFlag": "compactor.block-health-validation-concurrency",
+          "fieldType": "int",
+          "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
           "name": "meta_sync_concurrency",
           "required": false,
           "desc": "Number of goroutines to use when syncing block meta files from the long term storage.",

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1134,7 +1134,7 @@ Usage of ./cmd/mimir/mimir:
   -compactor-scheduler.tenant-discovery-interval duration
     	[experimental] The duration of time between bucket listings to discover new tenants. (default 10m0s)
   -compactor.block-health-validation-concurrency int
-    	[experimental] Number of blocks whose health can be validated concurrently during compaction. Health validation reads the block index and is CPU intensive, so setting this lower than -compactor.block-sync-concurrency makes CPU usage more uniform over the course of a compaction. (default 8)
+    	[experimental] Number of blocks whose health can be validated concurrently during a compaction job. A nonpositive value means no limit.
   -compactor.block-ranges comma-separated-list-of-durations
     	List of compaction time ranges. (default 2h0m0s,12h0m0s,24h0m0s)
   -compactor.block-sync-concurrency int

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -1133,6 +1133,8 @@ Usage of ./cmd/mimir/mimir:
     	Number of times to backoff and retry before failing. (default 10)
   -compactor-scheduler.tenant-discovery-interval duration
     	[experimental] The duration of time between bucket listings to discover new tenants. (default 10m0s)
+  -compactor.block-health-validation-concurrency int
+    	[experimental] Number of blocks whose health can be validated concurrently during compaction. Health validation reads the block index and is CPU intensive, so setting this lower than -compactor.block-sync-concurrency makes CPU usage more uniform over the course of a compaction. (default 8)
   -compactor.block-ranges comma-separated-list-of-durations
     	List of compaction time ranges. (default 2h0m0s,12h0m0s,24h0m0s)
   -compactor.block-sync-concurrency int

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -66,6 +66,8 @@ The following features are currently experimental:
 - Compactor
   - Limit blocks processed in each compaction cycle. Blocks uploaded prior to the maximum lookback aren't processed.
     - `-compactor.max-lookback`
+  - Limit how many block indexes are validated for health concurrently during compaction, independently of how many blocks are downloaded and uploaded concurrently.
+    - `-compactor.block-health-validation-concurrency`
 - Compactor scheduler
   - Coordinate compactors through a shared job queue and expose additional metrics about pending and active compaction work.
     - `-compactor-scheduler.*`

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -66,7 +66,7 @@ The following features are currently experimental:
 - Compactor
   - Limit blocks processed in each compaction cycle. Blocks uploaded prior to the maximum lookback aren't processed.
     - `-compactor.max-lookback`
-  - Limit how many block indexes are validated for health concurrently during compaction, independently of how many blocks are downloaded and uploaded concurrently.
+  - Limit how many block indexes are validated for health concurrently during a compaction job.
     - `-compactor.block-health-validation-concurrency`
 - Compactor scheduler
   - Coordinate compactors through a shared job queue and expose additional metrics about pending and active compaction work.

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -6618,6 +6618,13 @@ The `compactor` block configures the compactor component.
 # CLI flag: -compactor.block-sync-concurrency
 [block_sync_concurrency: <int> | default = 8]
 
+# (experimental) Number of blocks whose health can be validated concurrently
+# during compaction. Health validation reads the block index and is CPU
+# intensive, so setting this lower than -compactor.block-sync-concurrency makes
+# CPU usage more uniform over the course of a compaction.
+# CLI flag: -compactor.block-health-validation-concurrency
+[block_health_validation_concurrency: <int> | default = 8]
+
 # (advanced) Number of goroutines to use when syncing block meta files from the
 # long term storage.
 # CLI flag: -compactor.meta-sync-concurrency

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -6619,11 +6619,9 @@ The `compactor` block configures the compactor component.
 [block_sync_concurrency: <int> | default = 8]
 
 # (experimental) Number of blocks whose health can be validated concurrently
-# during compaction. Health validation reads the block index and is CPU
-# intensive, so setting this lower than -compactor.block-sync-concurrency makes
-# CPU usage more uniform over the course of a compaction.
+# during a compaction job. A nonpositive value means no limit.
 # CLI flag: -compactor.block-health-validation-concurrency
-[block_health_validation_concurrency: <int> | default = 8]
+[block_health_validation_concurrency: <int> | default = 0]
 
 # (advanced) Number of goroutines to use when syncing block meta files from the
 # long term storage.

--- a/operations/mimir/mimir-flags-defaults.json
+++ b/operations/mimir/mimir-flags-defaults.json
@@ -930,6 +930,7 @@
   "blocks-storage.tsdb.offset-catalogue.sync-concurrency": 10,
   "compactor.block-ranges": [],
   "compactor.block-sync-concurrency": 8,
+  "compactor.block-health-validation-concurrency": 8,
   "compactor.meta-sync-concurrency": 20,
   "compactor.data-dir": "./data-compactor/",
   "compactor.compaction-interval": 3600000000000,

--- a/operations/mimir/mimir-flags-defaults.json
+++ b/operations/mimir/mimir-flags-defaults.json
@@ -930,7 +930,7 @@
   "blocks-storage.tsdb.offset-catalogue.sync-concurrency": 10,
   "compactor.block-ranges": [],
   "compactor.block-sync-concurrency": 8,
-  "compactor.block-health-validation-concurrency": 8,
+  "compactor.block-health-validation-concurrency": 0,
   "compactor.meta-sync-concurrency": 20,
   "compactor.data-dir": "./data-compactor/",
   "compactor.compaction-interval": 3600000000000,

--- a/pkg/compactor/bucket_compactor.go
+++ b/pkg/compactor/bucket_compactor.go
@@ -21,6 +21,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/cancellation"
 	"github.com/grafana/dskit/concurrency"
+	"github.com/grafana/dskit/gate"
 	"github.com/grafana/dskit/multierror"
 	"github.com/grafana/dskit/runutil"
 	"github.com/oklog/ulid/v2"
@@ -32,7 +33,6 @@ import (
 	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/objstore/providers/filesystem"
 	"go.uber.org/atomic"
-	"golang.org/x/sync/semaphore"
 
 	"github.com/grafana/mimir/pkg/storage/indexheader"
 	"github.com/grafana/mimir/pkg/storage/sharding"
@@ -316,7 +316,7 @@ func (c *BucketCompactor) runCompactionJob(ctx context.Context, job *Job) (shoul
 	// Once we have a plan we need to download the actual data.
 	downloadBegin := time.Now()
 
-	healthValidationSem := semaphore.NewWeighted(int64(c.blockHealthValidationConcurrency))
+	healthValidationGate := newBlockHealthValidationGate(c.blockHealthValidationConcurrency)
 
 	err = concurrency.ForEachJob(ctx, len(toCompact), c.blockSyncConcurrency, func(ctx context.Context, idx int) error {
 		meta := toCompact[idx]
@@ -329,7 +329,7 @@ func (c *BucketCompactor) runCompactionJob(ctx context.Context, job *Job) (shoul
 		}
 
 		// Ensure all source blocks are valid.
-		stats, err := gatherBlockHealthStats(ctx, healthValidationSem, jobLogger, bdir, meta.MinTime, meta.MaxTime)
+		stats, err := gatherBlockHealthStats(ctx, healthValidationGate, jobLogger, bdir, meta.MinTime, meta.MaxTime)
 		if err != nil {
 			return fmt.Errorf("gather index issues for block %s: %w", bdir, err)
 		}
@@ -447,7 +447,7 @@ func (c *BucketCompactor) runCompactionJob(ctx context.Context, job *Job) (shoul
 			return fmt.Errorf("remove tombstones: %w", err)
 		}
 
-		if err := verifyBlock(ctx, healthValidationSem, jobLogger, bdir, newMeta.MinTime, newMeta.MaxTime); err != nil {
+		if err := verifyBlock(ctx, healthValidationGate, jobLogger, bdir, newMeta.MinTime, newMeta.MaxTime); err != nil {
 			return fmt.Errorf("invalid result block %s: %w", bdir, err)
 		}
 		return nil
@@ -555,17 +555,25 @@ func (c *BucketCompactor) runCompactionJob(ctx context.Context, job *Job) (shoul
 	return true, compIDs, nil
 }
 
-func gatherBlockHealthStats(ctx context.Context, sem *semaphore.Weighted, logger log.Logger, bdir string, minTime, maxTime int64) (block.HealthStats, error) {
-	if err := sem.Acquire(ctx, 1); err != nil {
+func newBlockHealthValidationGate(maxConcurrency int) gate.Gate {
+	if maxConcurrency <= 0 {
+		return gate.NewNoop()
+	}
+
+	return gate.NewBlocking(maxConcurrency)
+}
+
+func gatherBlockHealthStats(ctx context.Context, g gate.Gate, logger log.Logger, bdir string, minTime, maxTime int64) (block.HealthStats, error) {
+	if err := g.Start(ctx); err != nil {
 		return block.HealthStats{}, err
 	}
-	defer sem.Release(1)
+	defer g.Done()
 
 	return block.GatherBlockHealthStats(ctx, logger, bdir, minTime, maxTime, false)
 }
 
-func verifyBlock(ctx context.Context, sem *semaphore.Weighted, logger log.Logger, bdir string, minTime, maxTime int64) error {
-	stats, err := gatherBlockHealthStats(ctx, sem, logger, bdir, minTime, maxTime)
+func verifyBlock(ctx context.Context, g gate.Gate, logger log.Logger, bdir string, minTime, maxTime int64) error {
+	stats, err := gatherBlockHealthStats(ctx, g, logger, bdir, minTime, maxTime)
 	if err != nil {
 		return err
 	}
@@ -947,10 +955,6 @@ func NewBucketCompactor(
 
 	if maxPerBlockUploadConcurrency <= 0 {
 		return nil, fmt.Errorf("invalid per block upload concurrency level (%d), concurrency must be > 0", maxPerBlockUploadConcurrency)
-	}
-
-	if blockHealthValidationConcurrency <= 0 {
-		return nil, fmt.Errorf("invalid block health validation concurrency level (%d), concurrency level must be > 0", blockHealthValidationConcurrency)
 	}
 
 	return &BucketCompactor{

--- a/pkg/compactor/bucket_compactor.go
+++ b/pkg/compactor/bucket_compactor.go
@@ -32,6 +32,7 @@ import (
 	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/objstore/providers/filesystem"
 	"go.uber.org/atomic"
+	"golang.org/x/sync/semaphore"
 
 	"github.com/grafana/mimir/pkg/storage/indexheader"
 	"github.com/grafana/mimir/pkg/storage/sharding"
@@ -315,6 +316,8 @@ func (c *BucketCompactor) runCompactionJob(ctx context.Context, job *Job) (shoul
 	// Once we have a plan we need to download the actual data.
 	downloadBegin := time.Now()
 
+	healthValidationSem := semaphore.NewWeighted(int64(c.blockHealthValidationConcurrency))
+
 	err = concurrency.ForEachJob(ctx, len(toCompact), c.blockSyncConcurrency, func(ctx context.Context, idx int) error {
 		meta := toCompact[idx]
 
@@ -326,7 +329,7 @@ func (c *BucketCompactor) runCompactionJob(ctx context.Context, job *Job) (shoul
 		}
 
 		// Ensure all source blocks are valid.
-		stats, err := block.GatherBlockHealthStats(ctx, jobLogger, bdir, meta.MinTime, meta.MaxTime, false)
+		stats, err := gatherBlockHealthStats(ctx, healthValidationSem, jobLogger, bdir, meta.MinTime, meta.MaxTime)
 		if err != nil {
 			return fmt.Errorf("gather index issues for block %s: %w", bdir, err)
 		}
@@ -444,7 +447,7 @@ func (c *BucketCompactor) runCompactionJob(ctx context.Context, job *Job) (shoul
 			return fmt.Errorf("remove tombstones: %w", err)
 		}
 
-		if err := block.VerifyBlock(ctx, jobLogger, bdir, newMeta.MinTime, newMeta.MaxTime, false); err != nil {
+		if err := verifyBlock(ctx, healthValidationSem, jobLogger, bdir, newMeta.MinTime, newMeta.MaxTime); err != nil {
 			return fmt.Errorf("invalid result block %s: %w", bdir, err)
 		}
 		return nil
@@ -550,6 +553,24 @@ func (c *BucketCompactor) runCompactionJob(ctx context.Context, job *Job) (shoul
 		}
 	}
 	return true, compIDs, nil
+}
+
+func gatherBlockHealthStats(ctx context.Context, sem *semaphore.Weighted, logger log.Logger, bdir string, minTime, maxTime int64) (block.HealthStats, error) {
+	if err := sem.Acquire(ctx, 1); err != nil {
+		return block.HealthStats{}, err
+	}
+	defer sem.Release(1)
+
+	return block.GatherBlockHealthStats(ctx, logger, bdir, minTime, maxTime, false)
+}
+
+func verifyBlock(ctx context.Context, sem *semaphore.Weighted, logger log.Logger, bdir string, minTime, maxTime int64) error {
+	stats, err := gatherBlockHealthStats(ctx, sem, logger, bdir, minTime, maxTime)
+	if err != nil {
+		return err
+	}
+
+	return stats.AnyErr()
 }
 
 func prepareSparseIndexHeader(ctx context.Context, logger log.Logger, bkt objstore.InstrumentedBucketReader, dir string, id ulid.ULID, sampling int, cfg indexheader.Config) error {
@@ -877,24 +898,25 @@ var ownAllJobs = func(*Job) (bool, error) {
 
 // BucketCompactor compacts blocks in a bucket.
 type BucketCompactor struct {
-	logger                        log.Logger
-	grouper                       Grouper
-	comp                          Compactor
-	planner                       Planner
-	compactDir                    string
-	bkt                           objstore.Bucket
-	concurrency                   int
-	skipUnhealthyBlocks           bool
-	sparseIndexHeaderSamplingRate int
-	maxPerBlockUploadConcurrency  int
-	sparseIndexHeaderconfig       indexheader.Config
-	ownJob                        ownCompactionJobFunc
-	sortJobs                      JobsOrderFunc
-	waitPeriod                    time.Duration
-	oooWaitPeriod                 time.Duration
-	skipFutureMaxTime             bool
-	blockSyncConcurrency          int
-	metrics                       *BucketCompactorMetrics
+	logger                           log.Logger
+	grouper                          Grouper
+	comp                             Compactor
+	planner                          Planner
+	compactDir                       string
+	bkt                              objstore.Bucket
+	concurrency                      int
+	skipUnhealthyBlocks              bool
+	sparseIndexHeaderSamplingRate    int
+	maxPerBlockUploadConcurrency     int
+	sparseIndexHeaderconfig          indexheader.Config
+	ownJob                           ownCompactionJobFunc
+	sortJobs                         JobsOrderFunc
+	waitPeriod                       time.Duration
+	oooWaitPeriod                    time.Duration
+	skipFutureMaxTime                bool
+	blockSyncConcurrency             int
+	blockHealthValidationConcurrency int
+	metrics                          *BucketCompactorMetrics
 }
 
 // NewBucketCompactor creates a new bucket compactor.
@@ -913,6 +935,7 @@ func NewBucketCompactor(
 	oooWaitPeriod time.Duration,
 	skipFutureMaxTime bool,
 	blockSyncConcurrency int,
+	blockHealthValidationConcurrency int,
 	metrics *BucketCompactorMetrics,
 	sparseIndexHeaderSamplingRate int,
 	sparseIndexHeaderconfig indexheader.Config,
@@ -926,25 +949,30 @@ func NewBucketCompactor(
 		return nil, fmt.Errorf("invalid per block upload concurrency level (%d), concurrency must be > 0", maxPerBlockUploadConcurrency)
 	}
 
+	if blockHealthValidationConcurrency <= 0 {
+		return nil, fmt.Errorf("invalid block health validation concurrency level (%d), concurrency level must be > 0", blockHealthValidationConcurrency)
+	}
+
 	return &BucketCompactor{
-		logger:                        logger,
-		grouper:                       grouper,
-		planner:                       planner,
-		comp:                          comp,
-		compactDir:                    compactDir,
-		bkt:                           bkt,
-		concurrency:                   concurrency,
-		skipUnhealthyBlocks:           skipUnhealthyBlocks,
-		ownJob:                        ownJob,
-		sortJobs:                      sortJobs,
-		waitPeriod:                    waitPeriod,
-		oooWaitPeriod:                 oooWaitPeriod,
-		skipFutureMaxTime:             skipFutureMaxTime,
-		blockSyncConcurrency:          blockSyncConcurrency,
-		metrics:                       metrics,
-		sparseIndexHeaderSamplingRate: sparseIndexHeaderSamplingRate,
-		sparseIndexHeaderconfig:       sparseIndexHeaderconfig,
-		maxPerBlockUploadConcurrency:  maxPerBlockUploadConcurrency,
+		logger:                           logger,
+		grouper:                          grouper,
+		planner:                          planner,
+		comp:                             comp,
+		compactDir:                       compactDir,
+		bkt:                              bkt,
+		concurrency:                      concurrency,
+		skipUnhealthyBlocks:              skipUnhealthyBlocks,
+		ownJob:                           ownJob,
+		sortJobs:                         sortJobs,
+		waitPeriod:                       waitPeriod,
+		oooWaitPeriod:                    oooWaitPeriod,
+		skipFutureMaxTime:                skipFutureMaxTime,
+		blockSyncConcurrency:             blockSyncConcurrency,
+		blockHealthValidationConcurrency: blockHealthValidationConcurrency,
+		metrics:                          metrics,
+		sparseIndexHeaderSamplingRate:    sparseIndexHeaderSamplingRate,
+		sparseIndexHeaderconfig:          sparseIndexHeaderconfig,
+		maxPerBlockUploadConcurrency:     maxPerBlockUploadConcurrency,
 	}, nil
 }
 

--- a/pkg/compactor/bucket_compactor_e2e_test.go
+++ b/pkg/compactor/bucket_compactor_e2e_test.go
@@ -244,7 +244,7 @@ func TestGroupCompactE2E(t *testing.T) {
 		metrics := NewBucketCompactorMetrics(blocksMarkedForDeletion, prometheus.NewPedanticRegistry())
 		cfg := indexheader.Config{VerifyOnLoad: true}
 		bComp, err := NewBucketCompactor(
-			logger, grouper, planner, comp, dir, bkt, 2, true, ownAllJobs, sortJobsByNewestBlocksFirst, 0, 0, false, 4, metrics, 32, cfg, 8,
+			logger, grouper, planner, comp, dir, bkt, 2, true, ownAllJobs, sortJobsByNewestBlocksFirst, 0, 0, false, 4, 2, metrics, 32, cfg, 8,
 		)
 		require.NoError(t, err)
 

--- a/pkg/compactor/bucket_compactor_test.go
+++ b/pkg/compactor/bucket_compactor_test.go
@@ -122,7 +122,7 @@ func TestBucketCompactor_FilterOwnJobs(t *testing.T) {
 	cfg := indexheader.Config{VerifyOnLoad: true}
 	for testName, testCase := range tests {
 		t.Run(testName, func(t *testing.T) {
-			bc, err := NewBucketCompactor(log.NewNopLogger(), nil, nil, nil, "", nil, 2, false, testCase.ownJob, nil, 0, 0, false, 4, m, 32, cfg, 8)
+			bc, err := NewBucketCompactor(log.NewNopLogger(), nil, nil, nil, "", nil, 2, false, testCase.ownJob, nil, 0, 0, false, 4, 4, m, 32, cfg, 8)
 			require.NoError(t, err)
 
 			res, err := bc.filterOwnJobs(jobsFn())
@@ -159,7 +159,7 @@ func TestBlockMaxTimeDeltas(t *testing.T) {
 	metrics := NewBucketCompactorMetrics(promauto.With(nil).NewCounter(prometheus.CounterOpts{}), nil)
 	cfg := indexheader.Config{VerifyOnLoad: true}
 	now := time.UnixMilli(1500002900159)
-	bc, err := NewBucketCompactor(log.NewNopLogger(), nil, nil, nil, "", nil, 2, false, nil, nil, 0, 0, false, 4, metrics, 32, cfg, 8)
+	bc, err := NewBucketCompactor(log.NewNopLogger(), nil, nil, nil, "", nil, 2, false, nil, nil, 0, 0, false, 4, 4, metrics, 32, cfg, 8)
 	require.NoError(t, err)
 
 	deltas := bc.blockMaxTimeDeltas(now, []*Job{j1, j2})

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -65,6 +65,7 @@ var (
 	errInvalidMaxClosingBlocksConcurrency         = fmt.Errorf("invalid max-closing-blocks-concurrency value, must be positive")
 	errInvalidSymbolFlushersConcurrency           = fmt.Errorf("invalid symbols-flushers-concurrency value, must be positive")
 	errInvalidMaxBlockUploadValidationConcurrency = fmt.Errorf("invalid max-block-upload-validation-concurrency value, can't be negative")
+	errInvalidBlockHealthValidationConcurrency    = fmt.Errorf("invalid block-health-validation-concurrency value, must be positive")
 	RingOp                                        = ring.NewOp([]ring.InstanceState{ring.ACTIVE}, nil)
 
 	// compactionIgnoredLabels defines the external labels that compactor will
@@ -96,21 +97,22 @@ type BlocksCompactorFactory func(
 
 // Config holds the MultitenantCompactor config.
 type Config struct {
-	BlockRanges                 mimir_tsdb.DurationList `yaml:"block_ranges" category:"advanced"`
-	BlockSyncConcurrency        int                     `yaml:"block_sync_concurrency" category:"advanced"`
-	MetaSyncConcurrency         int                     `yaml:"meta_sync_concurrency" category:"advanced"`
-	DataDir                     string                  `yaml:"data_dir"`
-	CompactionInterval          time.Duration           `yaml:"compaction_interval" category:"advanced"`
-	CompactionRetries           int                     `yaml:"compaction_retries" category:"advanced"`
-	CompactionConcurrency       int                     `yaml:"compaction_concurrency" category:"advanced"`
-	CompactionWaitPeriod        time.Duration           `yaml:"first_level_compaction_wait_period"`
-	CompactionOOOWaitPeriod     time.Duration           `yaml:"first_level_compaction_ooo_wait_period" category:"experimental"`
-	CompactionSkipFutureMaxTime bool                    `yaml:"first_level_compaction_skip_future_max_time" category:"experimental"`
-	CleanupInterval             time.Duration           `yaml:"cleanup_interval" category:"advanced"`
-	CleanupConcurrency          int                     `yaml:"cleanup_concurrency" category:"advanced"`
-	DeletionDelay               time.Duration           `yaml:"deletion_delay" category:"advanced"`
-	TenantCleanupDelay          time.Duration           `yaml:"tenant_cleanup_delay" category:"advanced"`
-	MaxCompactionTime           time.Duration           `yaml:"max_compaction_time" category:"advanced"`
+	BlockRanges                      mimir_tsdb.DurationList `yaml:"block_ranges" category:"advanced"`
+	BlockSyncConcurrency             int                     `yaml:"block_sync_concurrency" category:"advanced"`
+	BlockHealthValidationConcurrency int                     `yaml:"block_health_validation_concurrency" category:"experimental"`
+	MetaSyncConcurrency              int                     `yaml:"meta_sync_concurrency" category:"advanced"`
+	DataDir                          string                  `yaml:"data_dir"`
+	CompactionInterval               time.Duration           `yaml:"compaction_interval" category:"advanced"`
+	CompactionRetries                int                     `yaml:"compaction_retries" category:"advanced"`
+	CompactionConcurrency            int                     `yaml:"compaction_concurrency" category:"advanced"`
+	CompactionWaitPeriod             time.Duration           `yaml:"first_level_compaction_wait_period"`
+	CompactionOOOWaitPeriod          time.Duration           `yaml:"first_level_compaction_ooo_wait_period" category:"experimental"`
+	CompactionSkipFutureMaxTime      bool                    `yaml:"first_level_compaction_skip_future_max_time" category:"experimental"`
+	CleanupInterval                  time.Duration           `yaml:"cleanup_interval" category:"advanced"`
+	CleanupConcurrency               int                     `yaml:"cleanup_concurrency" category:"advanced"`
+	DeletionDelay                    time.Duration           `yaml:"deletion_delay" category:"advanced"`
+	TenantCleanupDelay               time.Duration           `yaml:"tenant_cleanup_delay" category:"advanced"`
+	MaxCompactionTime                time.Duration           `yaml:"max_compaction_time" category:"advanced"`
 
 	// Compactor concurrency options
 	MaxOpeningBlocksConcurrency         int `yaml:"max_opening_blocks_concurrency" category:"advanced"`          // Number of goroutines opening blocks before compaction.
@@ -163,6 +165,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 
 	f.Var(&cfg.BlockRanges, "compactor.block-ranges", "List of compaction time ranges.")
 	f.IntVar(&cfg.BlockSyncConcurrency, "compactor.block-sync-concurrency", 8, "Number of goroutines to use when downloading blocks for compaction and uploading resulting blocks.")
+	f.IntVar(&cfg.BlockHealthValidationConcurrency, "compactor.block-health-validation-concurrency", 8, "Number of blocks whose health can be validated concurrently during compaction. Health validation reads the block index and is CPU intensive, so setting this lower than -compactor.block-sync-concurrency makes CPU usage more uniform over the course of a compaction.")
 	f.IntVar(&cfg.MetaSyncConcurrency, "compactor.meta-sync-concurrency", 20, "Number of goroutines to use when syncing block meta files from the long term storage.")
 	f.StringVar(&cfg.DataDir, "compactor.data-dir", "./data-compactor/", "Directory to temporarily store blocks during compaction. This directory is not required to be persisted between restarts.")
 	f.DurationVar(&cfg.CompactionInterval, "compactor.compaction-interval", time.Hour, "The frequency at which the compaction runs")
@@ -220,6 +223,9 @@ func (cfg *Config) Validate(compartmentsCfg compartments.Config, logger log.Logg
 	}
 	if cfg.MaxBlockUploadValidationConcurrency < 0 {
 		return errInvalidMaxBlockUploadValidationConcurrency
+	}
+	if cfg.BlockHealthValidationConcurrency < 1 {
+		return errInvalidBlockHealthValidationConcurrency
 	}
 	if !slices.Contains(CompactionOrders, cfg.CompactionJobsOrder) {
 		return errInvalidCompactionOrder
@@ -924,6 +930,7 @@ func (c *MultitenantCompactor) newBucketCompactor(ctx context.Context, userID st
 		c.compactorCfg.CompactionOOOWaitPeriod,
 		c.compactorCfg.CompactionSkipFutureMaxTime,
 		c.compactorCfg.BlockSyncConcurrency,
+		c.compactorCfg.BlockHealthValidationConcurrency,
 		c.bucketCompactorMetrics,
 		c.compactorCfg.SparseIndexHeadersSamplingRate,
 		c.compactorCfg.SparseIndexHeadersConfig,

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -65,7 +65,6 @@ var (
 	errInvalidMaxClosingBlocksConcurrency         = fmt.Errorf("invalid max-closing-blocks-concurrency value, must be positive")
 	errInvalidSymbolFlushersConcurrency           = fmt.Errorf("invalid symbols-flushers-concurrency value, must be positive")
 	errInvalidMaxBlockUploadValidationConcurrency = fmt.Errorf("invalid max-block-upload-validation-concurrency value, can't be negative")
-	errInvalidBlockHealthValidationConcurrency    = fmt.Errorf("invalid block-health-validation-concurrency value, must be positive")
 	RingOp                                        = ring.NewOp([]ring.InstanceState{ring.ACTIVE}, nil)
 
 	// compactionIgnoredLabels defines the external labels that compactor will
@@ -165,7 +164,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 
 	f.Var(&cfg.BlockRanges, "compactor.block-ranges", "List of compaction time ranges.")
 	f.IntVar(&cfg.BlockSyncConcurrency, "compactor.block-sync-concurrency", 8, "Number of goroutines to use when downloading blocks for compaction and uploading resulting blocks.")
-	f.IntVar(&cfg.BlockHealthValidationConcurrency, "compactor.block-health-validation-concurrency", 8, "Number of blocks whose health can be validated concurrently during compaction. Health validation reads the block index and is CPU intensive, so setting this lower than -compactor.block-sync-concurrency makes CPU usage more uniform over the course of a compaction.")
+	f.IntVar(&cfg.BlockHealthValidationConcurrency, "compactor.block-health-validation-concurrency", 0, "Number of blocks whose health can be validated concurrently during a compaction job. A nonpositive value means no limit.")
 	f.IntVar(&cfg.MetaSyncConcurrency, "compactor.meta-sync-concurrency", 20, "Number of goroutines to use when syncing block meta files from the long term storage.")
 	f.StringVar(&cfg.DataDir, "compactor.data-dir", "./data-compactor/", "Directory to temporarily store blocks during compaction. This directory is not required to be persisted between restarts.")
 	f.DurationVar(&cfg.CompactionInterval, "compactor.compaction-interval", time.Hour, "The frequency at which the compaction runs")
@@ -223,9 +222,6 @@ func (cfg *Config) Validate(compartmentsCfg compartments.Config, logger log.Logg
 	}
 	if cfg.MaxBlockUploadValidationConcurrency < 0 {
 		return errInvalidMaxBlockUploadValidationConcurrency
-	}
-	if cfg.BlockHealthValidationConcurrency < 1 {
-		return errInvalidBlockHealthValidationConcurrency
 	}
 	if !slices.Contains(CompactionOrders, cfg.CompactionJobsOrder) {
 		return errInvalidCompactionOrder

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -130,10 +130,6 @@ func TestConfig_Validate(t *testing.T) {
 			setup:    func(cfg *Config) { cfg.SymbolsFlushersConcurrency = 0 },
 			expected: errInvalidSymbolFlushersConcurrency.Error(),
 		},
-		"should fail on invalid value of block-health-validation-concurrency": {
-			setup:    func(cfg *Config) { cfg.BlockHealthValidationConcurrency = 0 },
-			expected: errInvalidBlockHealthValidationConcurrency.Error(),
-		},
 		"should pass with scheduler client disabled": {
 			setup: func(cfg *Config) {
 				cfg.SchedulerClientConfig.Enabled = false

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -130,6 +130,10 @@ func TestConfig_Validate(t *testing.T) {
 			setup:    func(cfg *Config) { cfg.SymbolsFlushersConcurrency = 0 },
 			expected: errInvalidSymbolFlushersConcurrency.Error(),
 		},
+		"should fail on invalid value of block-health-validation-concurrency": {
+			setup:    func(cfg *Config) { cfg.BlockHealthValidationConcurrency = 0 },
+			expected: errInvalidBlockHealthValidationConcurrency.Error(),
+		},
 		"should pass with scheduler client disabled": {
 			setup: func(cfg *Config) {
 				cfg.SchedulerClientConfig.Enabled = false


### PR DESCRIPTION
#### What this PR does

`block.GatherBlockHealthStats` shows up in profiles prominently during compactor CPU spikes. This introduces a concurrency flag to limit concurrent calls to make CPU usage more uniform.

[block.VerifyBlock](https://github.com/grafana/mimir/blob/9f8400e81c8c2f8ebfe723797cd5bd7d21bfa3eb/pkg/storage/tsdb/block/index.go#L41) is equivalent to getting health stats and then checking for any error, so the usage is replaced here with the gate limited version.

#### Which issue(s) this PR fixes or relates to

Fixes N/A

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [x] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
