### PR TITLE
Scope amplified copies to one replica via amp-replica-label matcher

### DIFF
--- a/tools/read-tee/proxy.go
+++ b/tools/read-tee/proxy.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/prometheus/common/model"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/server"
@@ -36,6 +37,7 @@ type ProxyConfig struct {
 	BackendEndpoint                     string
 	AmplificationFactor                 float64
 	WriteAmplificationFactor            int
+	AmpReplicaLabel                     string
 	NegativeMatchersExcludeAllAmpValues bool
 	AmplifyAllReplicasFraction          float64
 	StrongConsistencyInstantFraction    float64
@@ -98,6 +100,11 @@ func (cfg *ProxyConfig) RegisterFlags(f *flag.FlagSet) {
 			"When set (>= 1), the read amplification factor may exceed W: read copy k wraps around the existing variants (k mod W), where variant 0 is the base series (the copy is sent with the original, unrewritten query). "+
 			"This lets read load scale beyond write load by re-reading the same series in distinct queries, instead of querying _amp variants that were never written. "+
 			"0 (default) disables wrapping: copy k always targets _amp{k}, so the read factor must not exceed the write factor.",
+	)
+	f.StringVar(&cfg.AmpReplicaLabel, "backend.amp-replica-label", "",
+		"When set (e.g. __amp__), every amplified copy additionally gets an equality matcher <name>=<replica number> appended to its selectors, and base-variant copies get <name>=\"\" (label absent). "+
+			"Requires write-tee to stamp the same label on its replicas (-backend.amp-replica-label there). "+
+			"This scopes every copy to exactly one replica's series regardless of query shape - including queries with no label matchers, which otherwise match the base plus every replica at once. Empty disables it.",
 	)
 	f.BoolVar(&cfg.NegativeMatchersExcludeAllAmpValues, "backend.negative-matchers-exclude-all-amp-values", true,
 		"When rewriting a query copy, make negative matchers (!=, !~) exclude the value in all its forms - the base value and every _amp{N} variant (value plus the optional _amp{N} suffix) - instead of only the single _amp{replica} form. A != becomes a !~ with its value regex-quoted, since a single != can only exclude one exact string. "+
@@ -168,6 +175,11 @@ func NewProxy(cfg ProxyConfig, logger log.Logger, routes []Route, registerer pro
 	// Validate the write amplification factor (0 = wrapping disabled).
 	if cfg.WriteAmplificationFactor < 0 {
 		return nil, errors.New("backend.write-amplification-factor must be >= 0")
+	}
+
+	// Validate the amp replica label (empty = disabled).
+	if cfg.AmpReplicaLabel != "" && !model.LabelName(cfg.AmpReplicaLabel).IsValid() {
+		return nil, errors.New("backend.amp-replica-label must be a valid Prometheus label name")
 	}
 
 	// Validate async max in-flight.
@@ -246,6 +258,7 @@ func (p *Proxy) Start() error {
 
 	rewriteOpts := rewriteOptions{
 		excludeAmplifiedNegative: p.cfg.NegativeMatchersExcludeAllAmpValues,
+		ampReplicaLabel:          p.cfg.AmpReplicaLabel,
 	}
 
 	// register fan-out routes (explicit endpoints we want to amplify)

--- a/tools/read-tee/proxy.go
+++ b/tools/read-tee/proxy.go
@@ -13,12 +13,12 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/prometheus/common/model"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/server"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
 	"go.opentelemetry.io/otel"
 )
 
@@ -178,7 +178,7 @@ func NewProxy(cfg ProxyConfig, logger log.Logger, routes []Route, registerer pro
 	}
 
 	// Validate the amp replica label (empty = disabled).
-	if cfg.AmpReplicaLabel != "" && !model.LabelName(cfg.AmpReplicaLabel).IsValid() {
+	if cfg.AmpReplicaLabel != "" && !model.LegacyValidation.IsValidLabelName(cfg.AmpReplicaLabel) {
 		return nil, errors.New("backend.amp-replica-label must be a valid Prometheus label name")
 	}
 

--- a/tools/read-tee/proxy_backend_http.go
+++ b/tools/read-tee/proxy_backend_http.go
@@ -37,6 +37,7 @@ func NewHTTPProxyBackend(name string, endpoint *url.URL, timeout time.Duration, 
 		Proxy: http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: skipTLSVerify, //nolint:gosec // read-tee is a load-testing tool; skipping TLS verification is an explicit operator opt-in via -backend.skip-tls-verify.
+			MinVersion:         tls.VersionTLS13,
 		},
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,

--- a/tools/read-tee/proxy_backend_http.go
+++ b/tools/read-tee/proxy_backend_http.go
@@ -36,7 +36,7 @@ func NewHTTPProxyBackend(name string, endpoint *url.URL, timeout time.Duration, 
 	innerTransport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: skipTLSVerify,
+			InsecureSkipVerify: skipTLSVerify, //nolint:gosec // read-tee is a load-testing tool; skipping TLS verification is an explicit operator opt-in via -backend.skip-tls-verify.
 		},
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,

--- a/tools/read-tee/proxy_endpoint.go
+++ b/tools/read-tee/proxy_endpoint.go
@@ -325,7 +325,7 @@ func (p *ProxyEndpoint) rewriteFailed(replica int, logger *spanlogger.SpanLogger
 // Replica 0 is the base series (used by write-amplification-factor wrapping): the params are
 // returned verbatim, so the copy re-reads exactly what the original request read.
 func rewriteParams(values url.Values, replica int, opts rewriteOptions) (url.Values, error) {
-	if replica == 0 && !opts.matchAllReplicas {
+	if replica == 0 && !opts.matchAllReplicas && opts.ampReplicaLabel == "" {
 		return values, nil
 	}
 	out := make(url.Values, len(values))

--- a/tools/read-tee/proxy_test.go
+++ b/tools/read-tee/proxy_test.go
@@ -321,7 +321,7 @@ func TestProxyEndpoint_AmplificationWrapsAroundWriteFactor(t *testing.T) {
 			factor:      5.0,
 			writeFactor: 2,
 			expectedQueries: map[string]int{
-				originalQuery:       3, // original + copies k=2, k=4 (variant 0 = base series)
+				originalQuery:        3, // original + copies k=2, k=4 (variant 0 = base series)
 				`up{job="api_amp1"}`: 2, // copies k=1, k=3
 			},
 		},
@@ -331,7 +331,7 @@ func TestProxyEndpoint_AmplificationWrapsAroundWriteFactor(t *testing.T) {
 			factor:      3.0,
 			writeFactor: 3,
 			expectedQueries: map[string]int{
-				originalQuery:       1,
+				originalQuery:        1,
 				`up{job="api_amp1"}`: 1,
 				`up{job="api_amp2"}`: 1,
 			},

--- a/tools/read-tee/query_rewrite.go
+++ b/tools/read-tee/query_rewrite.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strconv"
 
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 
@@ -90,7 +91,7 @@ func rewriteSelector(sel string, replica int, opts rewriteOptions) (string, erro
 	// printer would emit the equivalent {__name__="name",...} form.
 	vs := &parser.VectorSelector{LabelMatchers: m}
 	for _, mm := range m {
-		if mm.Name == labels.MetricName && mm.Type == labels.MatchEqual {
+		if mm.Name == model.MetricNameLabel && mm.Type == labels.MatchEqual {
 			vs.Name = mm.Value
 			break
 		}
@@ -130,7 +131,7 @@ func rewriteMatchers(ms []*labels.Matcher, replica int, opts rewriteOptions) []*
 	out := make([]*labels.Matcher, len(ms))
 	for i, mm := range ms {
 		// Never suffix metric names or empty-value (absence/presence) matchers.
-		if mm.Name == labels.MetricName || mm.Value == "" {
+		if mm.Name == model.MetricNameLabel || mm.Value == "" {
 			out[i] = mm
 			continue
 		}

--- a/tools/read-tee/query_rewrite.go
+++ b/tools/read-tee/query_rewrite.go
@@ -34,6 +34,12 @@ type rewriteOptions struct {
 	// across the base series and all _amp{N} variants at once, ignoring the replica index. Used for
 	// the amp.*-mode heavy copy that targets all replicas in a single query.
 	matchAllReplicas bool
+	// ampReplicaLabel, when non-empty, appends an equality matcher <label>=<replica> to every
+	// rewritten selector (<label>="" for the base variant, replica 0). Write-tee stamps the same
+	// label on its replicas, so this scopes every copy to exactly one replica's series regardless
+	// of query shape - including selectors with no label-value matchers, which otherwise match the
+	// base plus every replica at once.
+	ampReplicaLabel string
 }
 
 // ampSuffix returns the label-value suffix for amplification replica k. It must match exactly the
@@ -111,6 +117,15 @@ func rewriteSelector(sel string, replica int, opts rewriteOptions) (string, erro
 // mutating Matcher.Value in place would leave a stale compiled regex. For consistency we rebuild
 // every changed matcher via NewMatcher.
 func rewriteMatchers(ms []*labels.Matcher, replica int, opts rewriteOptions) []*labels.Matcher {
+	// Base variant (replica 0, produced by write-amplification-factor wrapping): the original
+	// matchers are kept verbatim; the amp replica label matcher below (value "") is what scopes
+	// the copy to the unlabeled base series.
+	if replica == 0 && !opts.matchAllReplicas {
+		out := make([]*labels.Matcher, len(ms), len(ms)+1)
+		copy(out, ms)
+		return appendAmpReplicaLabelMatcher(out, replica, opts)
+	}
+
 	suffix := ampSuffix(replica)
 	out := make([]*labels.Matcher, len(ms))
 	for i, mm := range ms {
@@ -168,5 +183,22 @@ func rewriteMatchers(ms []*labels.Matcher, replica int, opts rewriteOptions) []*
 		}
 		out[i] = nm
 	}
-	return out
+	return appendAmpReplicaLabelMatcher(out, replica, opts)
+}
+
+// appendAmpReplicaLabelMatcher appends the <ampReplicaLabel>=<replica> equality matcher when the
+// option is set. It is skipped for matchAllReplicas copies, which deliberately span every variant.
+func appendAmpReplicaLabelMatcher(ms []*labels.Matcher, replica int, opts rewriteOptions) []*labels.Matcher {
+	if opts.ampReplicaLabel == "" || opts.matchAllReplicas {
+		return ms
+	}
+	value := ""
+	if replica > 0 {
+		value = strconv.Itoa(replica)
+	}
+	nm, err := labels.NewMatcher(labels.MatchEqual, opts.ampReplicaLabel, value)
+	if err != nil {
+		return ms
+	}
+	return append(ms, nm)
 }

--- a/tools/read-tee/query_rewrite_test.go
+++ b/tools/read-tee/query_rewrite_test.go
@@ -339,3 +339,28 @@ func TestRewriteQuery_MatchAllReplicasSemantics(t *testing.T) {
 	require.False(t, m.Matches("apix"), "must not match unrelated values sharing the prefix")
 	require.False(t, m.Matches("other"))
 }
+
+// TestRewriteQuery_AmpReplicaLabel verifies the <label>=<replica> matcher is appended to every
+// copy: name-only selectors get scoped to a single replica (the class that otherwise matches the
+// base plus every replica), replica 0 selects the unlabeled base series, and matchAllReplicas
+// copies are left unscoped.
+func TestRewriteQuery_AmpReplicaLabel(t *testing.T) {
+	opts := rewriteOptions{ampReplicaLabel: "__amp__"}
+
+	got, err := rewriteQuery(`sum(rate(nodepool_node[5m]))`, 3, opts)
+	require.NoError(t, err)
+	require.Equal(t, `sum(rate(nodepool_node{__amp__="3"}[5m]))`, got)
+
+	got, err = rewriteQuery(`up{job="api"}`, 2, opts)
+	require.NoError(t, err)
+	require.Equal(t, `up{__amp__="2",job="api_amp2"}`, got)
+
+	got, err = rewriteQuery(`up{job="api"}`, 0, opts)
+	require.NoError(t, err)
+	require.Equal(t, `up{__amp__="",job="api"}`, got)
+
+	allOpts := rewriteOptions{ampReplicaLabel: "__amp__", matchAllReplicas: true}
+	got, err = rewriteQuery(`up`, 1, allOpts)
+	require.NoError(t, err)
+	require.Equal(t, `up`, got)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This scopes queries for every amplified copy using a label matcher, so queries without label matchers don't hit all replicas at once.

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
