### PR TITLE
Add cross eviction delay to zpdb jsonnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Jsonnet
 
+* [ENHANCEMENT] Add `multi_zone_ingester_zpdb_cross_zone_eviction_delay` config option to set `crossZoneEvictionDelay` on the ingester `ZoneAwarePodDisruptionBudget`. Defaults to `20m` when `ingest_storage_enabled` is true, and to unset otherwise.
 * [BUGFIX] Add missing `-querier.mimir-query-engine.range-vector-splitting.memcached.addresses` to `multi_zone_config_validation_excluded_args`. #16237
 
 ### Documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Jsonnet
 
-* [ENHANCEMENT] Add `multi_zone_ingester_zpdb_cross_zone_eviction_delay` config option to set `crossZoneEvictionDelay` on the ingester `ZoneAwarePodDisruptionBudget`. Defaults to `20m` when `ingest_storage_enabled` is true, and to unset otherwise.
+* [ENHANCEMENT] Add `multi_zone_ingester_zpdb_cross_zone_eviction_delay` config option to set `crossZoneEvictionDelay` on the ingester `ZoneAwarePodDisruptionBudget`. Defaults to `20m` when `ingest_storage_enabled` is true, and to unset otherwise. #16271
 * [BUGFIX] Add missing `-querier.mimir-query-engine.range-vector-splitting.memcached.addresses` to `multi_zone_config_validation_excluded_args`. #16237
 
 ### Documentation

--- a/operations/mimir-tests/test-compartments-generated.yaml
+++ b/operations/mimir-tests/test-compartments-generated.yaml
@@ -8260,6 +8260,7 @@ metadata:
   name: ingester-rollout-rc-0
   namespace: default
 spec:
+  crossZoneEvictionDelay: 20m
   maxUnavailable: 1
   podNamePartitionRegex: '[a-z\-]+-zone-[a-z]-rc-[0-9]+-([0-9]+)'
   podNameRegexGroup: 1
@@ -8276,6 +8277,7 @@ metadata:
   name: ingester-rollout-rc-1
   namespace: default
 spec:
+  crossZoneEvictionDelay: 20m
   maxUnavailable: 1
   podNamePartitionRegex: '[a-z\-]+-zone-[a-z]-rc-[0-9]+-([0-9]+)'
   podNameRegexGroup: 1

--- a/operations/mimir-tests/test-ingest-storage-auto-client-rack-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-auto-client-rack-generated.yaml
@@ -3157,6 +3157,7 @@ metadata:
   name: ingester-rollout
   namespace: default
 spec:
+  crossZoneEvictionDelay: 20m
   maxUnavailable: 1
   podNamePartitionRegex: '[a-z\-]+-zone-[a-z]-([0-9]+)'
   podNameRegexGroup: 1

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-custom-stabilization-window-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-custom-stabilization-window-generated.yaml
@@ -3316,6 +3316,7 @@ metadata:
   name: ingester-rollout
   namespace: default
 spec:
+  crossZoneEvictionDelay: 20m
   maxUnavailable: 1
   podNamePartitionRegex: '[a-z\-]+-zone-[a-z]-([0-9]+)'
   podNameRegexGroup: 1

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-multiple-triggers-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-multiple-triggers-generated.yaml
@@ -3258,6 +3258,7 @@ metadata:
   name: ingester-rollout
   namespace: default
 spec:
+  crossZoneEvictionDelay: 20m
   maxUnavailable: 1
   podNamePartitionRegex: '[a-z\-]+-zone-[a-z]-([0-9]+)'
   podNameRegexGroup: 1

--- a/operations/mimir-tests/test-ingest-storage-autoscaling-one-trigger-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-autoscaling-one-trigger-generated.yaml
@@ -3240,6 +3240,7 @@ metadata:
   name: ingester-rollout
   namespace: default
 spec:
+  crossZoneEvictionDelay: 20m
   maxUnavailable: 1
   podNamePartitionRegex: '[a-z\-]+-zone-[a-z]-([0-9]+)'
   podNameRegexGroup: 1

--- a/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-10-generated.yaml
@@ -3149,6 +3149,7 @@ metadata:
   name: ingester-rollout
   namespace: default
 spec:
+  crossZoneEvictionDelay: 20m
   maxUnavailable: 1
   podNamePartitionRegex: '[a-z\-]+-zone-[a-z]-([0-9]+)'
   podNameRegexGroup: 1

--- a/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-11-generated.yaml
@@ -3153,6 +3153,7 @@ metadata:
   name: ingester-rollout
   namespace: default
 spec:
+  crossZoneEvictionDelay: 20m
   maxUnavailable: 1
   podNamePartitionRegex: '[a-z\-]+-zone-[a-z]-([0-9]+)'
   podNameRegexGroup: 1

--- a/operations/mimir-tests/test-ingest-storage-migration-step-12-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-12-generated.yaml
@@ -3151,6 +3151,7 @@ metadata:
   name: ingester-rollout
   namespace: default
 spec:
+  crossZoneEvictionDelay: 20m
   maxUnavailable: 1
   podNamePartitionRegex: '[a-z\-]+-zone-[a-z]-([0-9]+)'
   podNameRegexGroup: 1

--- a/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-7-generated.yaml
@@ -3206,6 +3206,7 @@ metadata:
   name: ingester-rollout
   namespace: default
 spec:
+  crossZoneEvictionDelay: 20m
   maxUnavailable: 1
   podNamePartitionRegex: '[a-z\-]+-zone-[a-z]-([0-9]+)'
   podNameRegexGroup: 1

--- a/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-8-generated.yaml
@@ -3206,6 +3206,7 @@ metadata:
   name: ingester-rollout
   namespace: default
 spec:
+  crossZoneEvictionDelay: 20m
   maxUnavailable: 1
   podNamePartitionRegex: '[a-z\-]+-zone-[a-z]-([0-9]+)'
   podNameRegexGroup: 1

--- a/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-9-generated.yaml
@@ -3031,6 +3031,7 @@ metadata:
   name: ingester-rollout
   namespace: default
 spec:
+  crossZoneEvictionDelay: 20m
   maxUnavailable: 1
   podNamePartitionRegex: '[a-z\-]+-zone-[a-z]-([0-9]+)'
   podNameRegexGroup: 1

--- a/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
+++ b/operations/mimir-tests/test-ingest-storage-migration-step-final-generated.yaml
@@ -3316,6 +3316,7 @@ metadata:
   name: ingester-rollout
   namespace: default
 spec:
+  crossZoneEvictionDelay: 20m
   maxUnavailable: 1
   podNamePartitionRegex: '[a-z\-]+-zone-[a-z]-([0-9]+)'
   podNameRegexGroup: 1

--- a/operations/mimir/compartments-ingester.libsonnet
+++ b/operations/mimir/compartments-ingester.libsonnet
@@ -129,6 +129,7 @@
           $._config.multi_zone_ingester_zpdb_max_unavailable,
           $._config.compartments_ingester_zpdb_partition_regex,
           $._config.compartments_ingester_zpdb_partition_group,
+          $._config.multi_zone_ingester_zpdb_cross_zone_eviction_delay,
         )
       else
         podDisruptionBudget.new(name) +

--- a/operations/mimir/multi-zone-ingester.libsonnet
+++ b/operations/mimir/multi-zone-ingester.libsonnet
@@ -17,6 +17,10 @@
     // the regex subexpression group number - only required if the above regular expression has more then 1 grouping
     multi_zone_ingester_zpdb_partition_group: 1,
 
+    // the minimum time that must elapse after a pod becomes ready before a pod in another zone
+    // for the same partition can be evicted - only applicable when a partition regex is set
+    multi_zone_ingester_zpdb_cross_zone_eviction_delay: if $._config.ingest_storage_enabled then '20m' else '',
+
     // Controls whether the multi (virtual) zone ingester should also be deployed multi-AZ.
     multi_zone_ingester_multi_az_enabled: $._config.multi_zone_read_path_multi_az_enabled,
     multi_zone_ingester_zone_a_multi_az_enabled: self.multi_zone_ingester_multi_az_enabled,
@@ -147,7 +151,7 @@
   ingester_rollout_pdb: if !$._config.multi_zone_ingester_enabled then null else
     (
       if $._config.multi_zone_ingester_zpdb_enabled then
-        $.newZPDB('ingester-rollout', 'ingester', $._config.multi_zone_ingester_zpdb_max_unavailable, $._config.multi_zone_ingester_zpdb_partition_regex, $._config.multi_zone_ingester_zpdb_partition_group)
+        $.newZPDB('ingester-rollout', 'ingester', $._config.multi_zone_ingester_zpdb_max_unavailable, $._config.multi_zone_ingester_zpdb_partition_regex, $._config.multi_zone_ingester_zpdb_partition_group, $._config.multi_zone_ingester_zpdb_cross_zone_eviction_delay)
       else
         podDisruptionBudget.new('ingester-rollout') +
         podDisruptionBudget.mixin.spec.withMaxUnavailable(1)


### PR DESCRIPTION
#### What this PR does

This PR introduces a jsonnet variable to set the crossZoneEvictionDelay in zpdb configurations. 

#### Which issue(s) this PR fixes or relates to

Fixes #<issue number>

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
