### PR TITLE
MQE: pass query parameters to AST optimization passes

### DIFF
--- a/pkg/streamingpromql/optimize/ast/collapse_constants.go
+++ b/pkg/streamingpromql/optimize/ast/collapse_constants.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/prometheus/prometheus/promql/parser"
 
-	"github.com/grafana/mimir/pkg/streamingpromql/types"
+	"github.com/grafana/mimir/pkg/streamingpromql/planning"
 )
 
 type CollapseConstants struct{}
@@ -18,7 +18,7 @@ func (c *CollapseConstants) Name() string {
 	return "Collapse constants"
 }
 
-func (c *CollapseConstants) Apply(_ context.Context, expr parser.Expr, _ types.QueryTimeRange) (parser.Expr, error) {
+func (c *CollapseConstants) Apply(_ context.Context, expr parser.Expr, _ *planning.QueryParameters) (parser.Expr, error) {
 	return c.apply(expr), nil
 }
 

--- a/pkg/streamingpromql/optimize/ast/insert_omitted_target_info_selector.go
+++ b/pkg/streamingpromql/optimize/ast/insert_omitted_target_info_selector.go
@@ -12,7 +12,7 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/promql/parser/posrange"
 
-	"github.com/grafana/mimir/pkg/streamingpromql/types"
+	"github.com/grafana/mimir/pkg/streamingpromql/planning"
 )
 
 const (
@@ -25,7 +25,7 @@ func (h *InsertOmittedTargetInfoSelector) Name() string {
 	return "Insert omitted target info selector"
 }
 
-func (h *InsertOmittedTargetInfoSelector) Apply(_ context.Context, root parser.Expr, _ types.QueryTimeRange) (parser.Expr, error) {
+func (h *InsertOmittedTargetInfoSelector) Apply(_ context.Context, root parser.Expr, _ *planning.QueryParameters) (parser.Expr, error) {
 	if err := parser.Walk(h, root, nil); err != nil {
 		return nil, err
 	}

--- a/pkg/streamingpromql/optimize/ast/reduce_matchers.go
+++ b/pkg/streamingpromql/optimize/ast/reduce_matchers.go
@@ -11,8 +11,8 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 
+	"github.com/grafana/mimir/pkg/streamingpromql/planning"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning/core"
-	"github.com/grafana/mimir/pkg/streamingpromql/types"
 	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/spanlogger"
 )
@@ -45,7 +45,7 @@ func (c *ReduceMatchers) Name() string {
 	return "Reduce matchers"
 }
 
-func (c *ReduceMatchers) Apply(ctx context.Context, root parser.Expr, _ types.QueryTimeRange) (parser.Expr, error) {
+func (c *ReduceMatchers) Apply(ctx context.Context, root parser.Expr, _ *planning.QueryParameters) (parser.Expr, error) {
 	spanlog := spanlogger.FromContext(ctx, c.logger)
 	c.attempts.Inc()
 

--- a/pkg/streamingpromql/optimize/ast/sharding/optimization_pass.go
+++ b/pkg/streamingpromql/optimize/ast/sharding/optimization_pass.go
@@ -17,9 +17,9 @@ import (
 	"github.com/grafana/mimir/pkg/frontend/querymiddleware"
 	"github.com/grafana/mimir/pkg/frontend/querymiddleware/astmapper"
 	"github.com/grafana/mimir/pkg/streamingpromql/optimize"
+	"github.com/grafana/mimir/pkg/streamingpromql/planning"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning/core"
 	"github.com/grafana/mimir/pkg/streamingpromql/requestoptions"
-	"github.com/grafana/mimir/pkg/streamingpromql/types"
 )
 
 type OptimizationPass struct {
@@ -36,7 +36,7 @@ func (o *OptimizationPass) Name() string {
 	return "Sharding"
 }
 
-func (o *OptimizationPass) Apply(ctx context.Context, expr parser.Expr, _ types.QueryTimeRange) (parser.Expr, error) {
+func (o *OptimizationPass) Apply(ctx context.Context, expr parser.Expr, _ *planning.QueryParameters) (parser.Expr, error) {
 	if containsSpunOffSubquery(expr) {
 		return expr, nil
 	}

--- a/pkg/streamingpromql/optimize/ast/sharding/optimization_pass_test.go
+++ b/pkg/streamingpromql/optimize/ast/sharding/optimization_pass_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/grafana/mimir/pkg/frontend/querymiddleware"
 	"github.com/grafana/mimir/pkg/frontend/querymiddleware/astmapper"
 	"github.com/grafana/mimir/pkg/streamingpromql/requestoptions"
-	"github.com/grafana/mimir/pkg/streamingpromql/types"
 	"github.com/grafana/mimir/pkg/util/promqlext"
 )
 
@@ -92,7 +91,7 @@ func TestOptimizationPass(t *testing.T) {
 
 			ctx = querymiddleware.ContextWithRequestHints(ctx, testCase.hints)
 			ctx = requestoptions.ContextWithOptions(ctx, testCase.options)
-			output, err := pass.Apply(ctx, afterRewrite, types.QueryTimeRange{})
+			output, err := pass.Apply(ctx, afterRewrite, nil)
 			require.NoError(t, err)
 			require.Equal(t, testCase.expectedOutput, output.String())
 		})
@@ -157,7 +156,7 @@ func TestOptimizationPass_EvaluationRoots(t *testing.T) {
 
 			ctx := user.InjectOrgID(context.Background(), "tenant-1")
 			ctx = requestoptions.ContextWithOptions(ctx, testCase.options)
-			output, err := pass.Apply(ctx, input, types.QueryTimeRange{})
+			output, err := pass.Apply(ctx, input, nil)
 			require.NoError(t, err)
 			require.Equal(t, testCase.expectedOutput, output.String())
 		})

--- a/pkg/streamingpromql/optimize/ast/sort_labels_and_matchers.go
+++ b/pkg/streamingpromql/optimize/ast/sort_labels_and_matchers.go
@@ -10,8 +10,8 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 
+	"github.com/grafana/mimir/pkg/streamingpromql/planning"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning/core"
-	"github.com/grafana/mimir/pkg/streamingpromql/types"
 )
 
 // SortLabelsAndMatchers is an optimization pass that ensures that all label names and matchers are sorted.
@@ -23,7 +23,7 @@ func (s *SortLabelsAndMatchers) Name() string {
 	return "Sort labels and matchers"
 }
 
-func (s *SortLabelsAndMatchers) Apply(_ context.Context, expr parser.Expr, _ types.QueryTimeRange) (parser.Expr, error) {
+func (s *SortLabelsAndMatchers) Apply(_ context.Context, expr parser.Expr, _ *planning.QueryParameters) (parser.Expr, error) {
 	parser.Inspect(expr, func(node parser.Node, _ []parser.Node) error {
 		switch expr := node.(type) {
 		case *parser.VectorSelector:

--- a/pkg/streamingpromql/optimize/ast/subqueryspinoff/optimization_pass.go
+++ b/pkg/streamingpromql/optimize/ast/subqueryspinoff/optimization_pass.go
@@ -15,7 +15,7 @@ import (
 	"github.com/grafana/mimir/pkg/frontend/querymiddleware/astmapper"
 	frontendspinoff "github.com/grafana/mimir/pkg/frontend/querymiddleware/subqueryspinoff"
 	"github.com/grafana/mimir/pkg/streamingpromql/optimize"
-	"github.com/grafana/mimir/pkg/streamingpromql/types"
+	"github.com/grafana/mimir/pkg/streamingpromql/planning"
 	"github.com/grafana/mimir/pkg/util/spanlogger"
 	"github.com/grafana/mimir/pkg/util/validation"
 )
@@ -63,9 +63,9 @@ func (o *OptimizationPass) Name() string {
 	return "Subquery spin-off"
 }
 
-func (o *OptimizationPass) Apply(ctx context.Context, expr parser.Expr, timeRange types.QueryTimeRange) (parser.Expr, error) {
+func (o *OptimizationPass) Apply(ctx context.Context, expr parser.Expr, params *planning.QueryParameters) (parser.Expr, error) {
 	// Subquery spin-off only applies to instant queries: range queries are left unchanged.
-	if !timeRange.IsInstant {
+	if !params.TimeRange.IsInstant {
 		return expr, nil
 	}
 

--- a/pkg/streamingpromql/optimize/ast/subqueryspinoff/optimization_pass_test.go
+++ b/pkg/streamingpromql/optimize/ast/subqueryspinoff/optimization_pass_test.go
@@ -19,6 +19,7 @@ import (
 	frontendspinoff "github.com/grafana/mimir/pkg/frontend/querymiddleware/subqueryspinoff"
 	"github.com/grafana/mimir/pkg/streamingpromql"
 	"github.com/grafana/mimir/pkg/streamingpromql/optimize/ast/subqueryspinoff"
+	"github.com/grafana/mimir/pkg/streamingpromql/planning"
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
 )
 
@@ -94,7 +95,11 @@ func TestOptimizationPass(t *testing.T) {
 			}
 
 			ctx := user.InjectOrgID(context.Background(), "tenant-1")
-			output, err := planner.ParseAndApplyASTOptimizationPasses(ctx, testCase.input, timeRange, streamingpromql.NoopPlanningObserver{})
+			params := &planning.QueryParameters{
+				OriginalExpression: testCase.input,
+				TimeRange:          timeRange,
+			}
+			output, err := planner.ParseAndApplyASTOptimizationPasses(ctx, params, streamingpromql.NoopPlanningObserver{})
 			require.NoError(t, err)
 
 			expectedOutput := testCase.expectedOutput

--- a/pkg/streamingpromql/optimize/ast/util_test.go
+++ b/pkg/streamingpromql/optimize/ast/util_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/grafana/mimir/pkg/streamingpromql"
 	"github.com/grafana/mimir/pkg/streamingpromql/optimize"
+	"github.com/grafana/mimir/pkg/streamingpromql/planning"
 	"github.com/grafana/mimir/pkg/streamingpromql/testutils"
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
 )
@@ -33,12 +34,15 @@ func runASTOptimizationPass(t *testing.T, ctx context.Context, input string, cre
 	reg := prometheus.NewPedanticRegistry()
 	opts.CommonOpts.Reg = reg
 	optimizer := createOptimizerFunc(opts.CommonOpts.Reg)
-	dummyTimeRange := types.NewInstantQueryTimeRange(timestamp.Time(1000))
+	params := &planning.QueryParameters{
+		OriginalExpression: input,
+		TimeRange:          types.NewInstantQueryTimeRange(timestamp.Time(1000)),
+	}
 	planner, err := streamingpromql.NewQueryPlannerWithoutOptimizationPasses(opts, streamingpromql.NewMaximumSupportedVersionQueryPlanVersionProvider())
 	require.NoError(t, err)
 	planner.RegisterASTOptimizationPass(optimizer)
 	observer := streamingpromql.NoopPlanningObserver{}
-	outputExpr, err := planner.ParseAndApplyASTOptimizationPasses(ctx, input, dummyTimeRange, observer)
+	outputExpr, err := planner.ParseAndApplyASTOptimizationPasses(ctx, params, observer)
 	require.NoError(t, err)
 	return reg, outputExpr
 }

--- a/pkg/streamingpromql/optimize/interface.go
+++ b/pkg/streamingpromql/optimize/interface.go
@@ -8,12 +8,11 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/grafana/mimir/pkg/streamingpromql/planning"
-	"github.com/grafana/mimir/pkg/streamingpromql/types"
 )
 
 type ASTOptimizationPass interface {
 	Name() string
-	Apply(ctx context.Context, expr parser.Expr, timeRange types.QueryTimeRange) (parser.Expr, error)
+	Apply(ctx context.Context, expr parser.Expr, params *planning.QueryParameters) (parser.Expr, error)
 }
 
 type QueryPlanOptimizationPass interface {

--- a/pkg/streamingpromql/planning.go
+++ b/pkg/streamingpromql/planning.go
@@ -228,27 +228,27 @@ type PlanningObserver interface {
 // ParseAndApplyASTOptimizationPasses runs the AST optimization passes on the input string and outputs
 // an expression and any error encountered. This is separated into its own method to allow testing of
 // AST optimization passes.
-func (p *QueryPlanner) ParseAndApplyASTOptimizationPasses(ctx context.Context, qs string, timeRange types.QueryTimeRange, observer PlanningObserver) (parser.Expr, error) {
-	expr, err := p.runASTStage("Parsing", observer, func() (parser.Expr, error) { return p.parser.ParseExpr(qs) })
+func (p *QueryPlanner) ParseAndApplyASTOptimizationPasses(ctx context.Context, params *planning.QueryParameters, observer PlanningObserver) (parser.Expr, error) {
+	expr, err := p.runASTStage("Parsing", observer, func() (parser.Expr, error) { return p.parser.ParseExpr(params.OriginalExpression) })
 	if err != nil {
 		return nil, err
 	}
 
-	if !timeRange.IsInstant {
+	if !params.TimeRange.IsInstant {
 		if expr.Type() != parser.ValueTypeVector && expr.Type() != parser.ValueTypeScalar {
 			return nil, apierror.Newf(apierror.TypeBadData, "query expression produces a %s, but expression for range queries must produce an instant vector or scalar", parser.DocumentedType(expr.Type()))
 		}
 	}
 
 	expr, err = p.runASTStage("Pre-processing", observer, func() (parser.Expr, error) {
-		step := time.Duration(timeRange.IntervalMilliseconds) * time.Millisecond
+		step := time.Duration(params.TimeRange.IntervalMilliseconds) * time.Millisecond
 
-		if timeRange.IsInstant {
-			// timeRange.IntervalMilliseconds is 1 for instant queries, but we need to pass 0 for instant queries to PreprocessExpr.
+		if params.TimeRange.IsInstant {
+			// params.TimeRange.IntervalMilliseconds is 1 for instant queries, but we need to pass 0 for instant queries to PreprocessExpr.
 			step = 0
 		}
 
-		return promql.PreprocessExpr(expr, timestamp.Time(timeRange.StartT), timestamp.Time(timeRange.EndT), step)
+		return promql.PreprocessExpr(expr, timestamp.Time(params.TimeRange.StartT), timestamp.Time(params.TimeRange.EndT), step)
 	})
 
 	if err != nil {
@@ -256,7 +256,7 @@ func (p *QueryPlanner) ParseAndApplyASTOptimizationPasses(ctx context.Context, q
 	}
 
 	for _, o := range p.astOptimizationPasses {
-		expr, err = p.runASTStage(o.Name(), observer, func() (parser.Expr, error) { return o.Apply(ctx, expr, timeRange) })
+		expr, err = p.runASTStage(o.Name(), observer, func() (parser.Expr, error) { return o.Apply(ctx, expr, params) })
 
 		if err != nil {
 			return nil, err
@@ -288,8 +288,14 @@ func (p *QueryPlanner) NewQueryPlan(ctx context.Context, qs string, timeRange ty
 	}
 
 	spanLogger.DebugLog("msg", "starting planning", "expression", qs, "maximum_supported_query_plan_version", maximumSupportedQueryPlanVersion)
+	params := &planning.QueryParameters{
+		TimeRange:                timeRange,
+		OriginalExpression:       qs,
+		EnableDelayedNameRemoval: enableDelayedNameRemoval,
+		LookbackDelta:            lookbackDelta,
+	}
 
-	expr, err := p.ParseAndApplyASTOptimizationPasses(ctx, qs, timeRange, observer)
+	expr, err := p.ParseAndApplyASTOptimizationPasses(ctx, params, observer)
 	if err != nil {
 		return nil, err
 	}
@@ -311,13 +317,8 @@ func (p *QueryPlanner) NewQueryPlan(ctx context.Context, qs string, timeRange ty
 		}
 
 		plan := &planning.QueryPlan{
-			Root: root,
-			Parameters: &planning.QueryParameters{
-				TimeRange:                timeRange,
-				OriginalExpression:       qs,
-				EnableDelayedNameRemoval: enableDelayedNameRemoval,
-				LookbackDelta:            lookbackDelta,
-			},
+			Root:       root,
+			Parameters: params,
 		}
 
 		return plan, nil


### PR DESCRIPTION
#### What this PR does

This PR refactors the `ASTOptimizationPass` interface to pass the full set of query parameters to AST optimization passes, rather than just the time range.

This allows them to access values such as the lookback delta.

This has no user-facing impact, so I haven't added a changelog entry.

#### Which issue(s) this PR fixes or relates to

(none)

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [n/a] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
