### PR TITLE
Fix store-gateway reporting num_series=0 from the bucket index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,7 +152,7 @@
 * [BUGFIX] Packaging: Fix the DEB/RPM packages shipping the `mimir`, `mimirtool`, `metaconvert`, and `query-tee` binaries without the executable bit set, which caused `mimir.service` to fail to start. #16166
 * [BUGFIX] Query-frontend: Fix a goroutine leak when a querier's streaming response arrives just as the query is cancelled: the goroutine handling the response could stay blocked forever writing a response body that would never be read. #16151
 * [BUGFIX] MQE: Fix issue where a sentinel value was inadvertently returned to a pool where it could be mutated by multiple threads at once. #16205
-* [BUGFIX] Compactor, Store-gateway: Fix the store-gateway reporting `num_series=0` in its `loaded new block` log message and in the blocks web UI when the bucket index is enabled, by tracking the number of series per block in the bucket index. Blocks already present in the bucket index are not backfilled, so they continue to report 0 until they are compacted into new blocks. #16275
+* [BUGFIX] Compactor, Store-gateway: Fix the store-gateway reporting `num_series=0` in its `loaded new block` log message and in the blocks web UI when the bucket index is enabled, by tracking the number of series per block in the bucket index. Blocks already present in the bucket index are not backfilled, so they continue to report 0 until they are compacted into new blocks. #16276
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [CHANGE] MQE: validate that delayed name removal is only set using `-querier.enable-delayed-name-removal` or the per-tenant setting when MQE is in use. #16207
 * [BUGFIX] Query-frontend: Return a HTTP 500 error rather than a HTTP 400 when a querier receives a query plan that is too new. #16233
+* [BUGFIX] Compactor, Store-gateway: Fix the store-gateway always logging `num_series=0` in its `loaded new block` message. #16276
 
 ### Mixin
 
@@ -152,7 +153,6 @@
 * [BUGFIX] Packaging: Fix the DEB/RPM packages shipping the `mimir`, `mimirtool`, `metaconvert`, and `query-tee` binaries without the executable bit set, which caused `mimir.service` to fail to start. #16166
 * [BUGFIX] Query-frontend: Fix a goroutine leak when a querier's streaming response arrives just as the query is cancelled: the goroutine handling the response could stay blocked forever writing a response body that would never be read. #16151
 * [BUGFIX] MQE: Fix issue where a sentinel value was inadvertently returned to a pool where it could be mutated by multiple threads at once. #16205
-* [BUGFIX] Compactor, Store-gateway: Fix the store-gateway reporting `num_series=0` in its `loaded new block` log message and in the blocks web UI when the bucket index is enabled, by tracking the number of series per block in the bucket index. Blocks already present in the bucket index are not backfilled, so they continue to report 0 until they are compacted into new blocks. #16276
 
 ### Mixin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,7 @@
 * [BUGFIX] Packaging: Fix the DEB/RPM packages shipping the `mimir`, `mimirtool`, `metaconvert`, and `query-tee` binaries without the executable bit set, which caused `mimir.service` to fail to start. #16166
 * [BUGFIX] Query-frontend: Fix a goroutine leak when a querier's streaming response arrives just as the query is cancelled: the goroutine handling the response could stay blocked forever writing a response body that would never be read. #16151
 * [BUGFIX] MQE: Fix issue where a sentinel value was inadvertently returned to a pool where it could be mutated by multiple threads at once. #16205
+* [BUGFIX] Compactor, Store-gateway: Fix the store-gateway reporting `num_series=0` in its `loaded new block` log message and in the blocks web UI when the bucket index is enabled, by tracking the number of series per block in the bucket index. Blocks already present in the bucket index are not backfilled, so they continue to report 0 until they are compacted into new blocks. #16275
 
 ### Mixin
 

--- a/pkg/storage/tsdb/bucketindex/index.go
+++ b/pkg/storage/tsdb/bucketindex/index.go
@@ -113,6 +113,9 @@ type Block struct {
 	// Whether the block was from out of order samples
 	OutOfOrder bool `json:"out_of_order,omitempty"`
 
+	// NumSeries is the number of series in the block.
+	NumSeries uint64 `json:"num_series,omitempty"`
+
 	// Labels contains the external labels from the block's metadata.
 	Labels map[string]string `json:"labels,omitempty"`
 }
@@ -151,6 +154,7 @@ func (m *Block) ThanosMeta() *block.Meta {
 			MinTime: m.MinTime,
 			MaxTime: m.MaxTime,
 			Version: block.TSDBVersion1,
+			Stats:   tsdb.BlockStats{NumSeries: m.NumSeries},
 			Compaction: tsdb.BlockMetaCompaction{
 				Level: m.CompactionLevel,
 				Hints: compactionHints,
@@ -200,6 +204,7 @@ func BlockFromThanosMeta(meta block.Meta) *Block {
 		Source:           string(meta.Thanos.Source),
 		CompactionLevel:  meta.Compaction.Level,
 		OutOfOrder:       meta.Compaction.FromOutOfOrder(),
+		NumSeries:        meta.Stats.NumSeries,
 		Labels:           maps.Clone(meta.Thanos.Labels),
 	}
 }

--- a/pkg/storage/tsdb/bucketindex/index_test.go
+++ b/pkg/storage/tsdb/bucketindex/index_test.go
@@ -300,6 +300,34 @@ func TestBlockFromThanosMeta(t *testing.T) {
 				},
 			},
 		},
+		"meta.json with NumSeries": {
+			meta: block.Meta{
+				BlockMeta: tsdb.BlockMeta{
+					ULID:    blockID,
+					MinTime: 10,
+					MaxTime: 20,
+					Stats: tsdb.BlockStats{
+						NumSeries: 12345,
+					},
+					Compaction: tsdb.BlockMetaCompaction{
+						Level: 1,
+					},
+				},
+				Thanos: block.ThanosMeta{
+					Source: block.SourceType("test"),
+				},
+			},
+			expected: Block{
+				ID:              blockID,
+				MinTime:         10,
+				MaxTime:         20,
+				SegmentsFormat:  SegmentsFormatUnknown,
+				SegmentsNum:     0,
+				Source:          "test",
+				CompactionLevel: 1,
+				NumSeries:       12345,
+			},
+		},
 	}
 
 	for testName, testData := range tests {
@@ -433,6 +461,34 @@ func TestBlock_ThanosMeta(t *testing.T) {
 				Thanos: block.ThanosMeta{
 					Version: block.ThanosVersion1,
 					Labels:  map[string]string{"my_key": "0x8413"},
+				},
+			},
+		},
+		"block with NumSeries": {
+			block: Block{
+				ID:              blockID,
+				MinTime:         10,
+				MaxTime:         20,
+				SegmentsFormat:  SegmentsFormatUnknown,
+				SegmentsNum:     0,
+				CompactionLevel: 1,
+				NumSeries:       12345,
+			},
+			expected: &block.Meta{
+				BlockMeta: tsdb.BlockMeta{
+					ULID:    blockID,
+					MinTime: 10,
+					MaxTime: 20,
+					Version: block.TSDBVersion1,
+					Stats: tsdb.BlockStats{
+						NumSeries: 12345,
+					},
+					Compaction: tsdb.BlockMetaCompaction{
+						Level: 1,
+					},
+				},
+				Thanos: block.ThanosMeta{
+					Version: block.ThanosVersion1,
 				},
 			},
 		},


### PR DESCRIPTION
#### What this PR does

The store-gateway logs `num_series=0` in its `loaded new block` message for every block:

```
ts=2026-07-30T11:34:34.439534389Z caller=bucket.go:460 level=info user=1234 msg="loaded new block" elapsed=209.026529ms id=KYSCGN62SNSZFDPMW compaction_level=1 num_series=0 ooo=false from=1785398400000 to=1785405600000
```

The log line reads `Stats.NumSeries` off the block meta, but meta reconstructed from the bucket index never had `Stats` populated: the index didn't carry a series count, so `Block.ThanosMeta()` left it at its zero value. The store-gateway builds its metadata fetcher from the bucket index unconditionally (`bucket_stores.go`), so this affected every block on every store-gateway.

This PR persists the series count in the bucket index (`num_series`) and plumbs it through both directions of the conversion: `BlockFromThanosMeta` on the way in and `Block.ThanosMeta()` on the way out. That's the only write path into a bucket-index block entry and the only read path back out, so nothing else needs touching.

**Blocks already present in the index are not backfilled.**
Since blocks are immutable, the updater copies existing entries verbatim and only reads `meta.json` for newly discovered blocks, so pre-existing blocks keep reporting 0 until they are compacted into new blocks. In practice the reported symptom clears immediately, because `compaction_level=1` blocks are always newly discovered.

I deliberately did not bump `IndexVersion`. The field is purely additive and needs no format break. There's no read-side version validation, and older readers just ignore the unknown field. 

Deployment note: While compactors are being rolled out, an older compactor that hasn't picked up this change will unmarshal the index into a struct with no `NumSeries` field and re-marshal the copied entries, silently dropping `num_series` for those blocks. Combined with the no-backfill behaviour above it won't self-heal, so the field is only dependable once every compactor is running a build that includes this change. No correctness impact.

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
