### PR TITLE
Ensure `make build-mixin` fails with error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -654,7 +654,8 @@ build-mixin: check-mixin-jb
 	@# Empty the compiled mixin directories content, without removing the directories itself,
 	@# so that Grafana can refresh re-build dashboards when using "make mixin-serve".
 	@# If any rule group has more than 20 rules, fail. 20 is our default per-tenant limit in the ruler.
-	@for suffix in $(MIXIN_OUT_PATH_SUFFIXES); do \
+	@set -e; \
+	for suffix in $(MIXIN_OUT_PATH_SUFFIXES); do \
 		mkdir -p "$(MIXIN_OUT_PATH)$$suffix"; \
 		find "$(MIXIN_OUT_PATH)$$suffix" -type f -delete; \
 		input_file="${MIXIN_PATH}/mixin-compiled$$suffix.libsonnet"; \

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/recording-rules.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/recording-rules.yaml
@@ -59,7 +59,7 @@ spec:
             record: cluster_namespace_job_route:cortex_request_duration_seconds_count:sum_rate
           - expr: sum(rate(cortex_request_duration_seconds[1m])) by (cluster, namespace, job, route)
             record: cluster_namespace_job_route:cortex_request_duration_seconds:sum_rate
-      - name: mimir_querier_api
+      - name: mimir_querier_api_1
         rules:
           - expr: histogram_quantile(0.99, sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster, job))
             record: cluster_job:cortex_querier_request_duration_seconds:99quantile
@@ -75,6 +75,8 @@ spec:
             record: cluster_job:cortex_querier_request_duration_seconds_count:sum_rate
           - expr: sum(rate(cortex_querier_request_duration_seconds[1m])) by (cluster, job)
             record: cluster_job:cortex_querier_request_duration_seconds:sum_rate
+      - name: mimir_querier_api_2
+        rules:
           - expr: histogram_quantile(0.99, sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster, job, route))
             record: cluster_job_route:cortex_querier_request_duration_seconds:99quantile
           - expr: histogram_quantile(0.50, sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster, job, route))
@@ -149,7 +151,7 @@ spec:
             record: cluster_job:cortex_query_frontend_queue_duration_seconds_count:sum_rate
           - expr: sum(rate(cortex_query_frontend_queue_duration_seconds[1m])) by (cluster, job)
             record: cluster_job:cortex_query_frontend_queue_duration_seconds:sum_rate
-      - name: mimir_ingester_queries
+      - name: mimir_ingester_queries_1
         rules:
           - expr: histogram_quantile(0.99, sum(rate(cortex_ingester_queried_series_bucket[1m])) by (le, cluster, job, stage))
             record: cluster_job_stage:cortex_ingester_queried_series:99quantile
@@ -165,6 +167,8 @@ spec:
             record: cluster_job_stage:cortex_ingester_queried_series_count:sum_rate
           - expr: sum(rate(cortex_ingester_queried_series[1m])) by (cluster, job, stage)
             record: cluster_job_stage:cortex_ingester_queried_series:sum_rate
+      - name: mimir_ingester_queries_2
+        rules:
           - expr: histogram_quantile(0.99, sum(rate(cortex_ingester_queried_samples_bucket[1m])) by (le, cluster, job))
             record: cluster_job:cortex_ingester_queried_samples:99quantile
           - expr: histogram_quantile(0.50, sum(rate(cortex_ingester_queried_samples_bucket[1m])) by (le, cluster, job))

--- a/operations/mimir-mixin-compiled-baremetal/rules.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/rules.yaml
@@ -47,7 +47,7 @@ groups:
           record: cluster_namespace_job_route:cortex_request_duration_seconds_count:sum_rate
         - expr: sum(rate(cortex_request_duration_seconds[1m])) by (cluster, namespace, job, route)
           record: cluster_namespace_job_route:cortex_request_duration_seconds:sum_rate
-    - name: mimir_querier_api
+    - name: mimir_querier_api_1
       rules:
         - expr: histogram_quantile(0.99, sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster, job))
           record: cluster_job:cortex_querier_request_duration_seconds:99quantile
@@ -63,6 +63,8 @@ groups:
           record: cluster_job:cortex_querier_request_duration_seconds_count:sum_rate
         - expr: sum(rate(cortex_querier_request_duration_seconds[1m])) by (cluster, job)
           record: cluster_job:cortex_querier_request_duration_seconds:sum_rate
+    - name: mimir_querier_api_2
+      rules:
         - expr: histogram_quantile(0.99, sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster, job, route))
           record: cluster_job_route:cortex_querier_request_duration_seconds:99quantile
         - expr: histogram_quantile(0.50, sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster, job, route))
@@ -137,7 +139,7 @@ groups:
           record: cluster_job:cortex_query_frontend_queue_duration_seconds_count:sum_rate
         - expr: sum(rate(cortex_query_frontend_queue_duration_seconds[1m])) by (cluster, job)
           record: cluster_job:cortex_query_frontend_queue_duration_seconds:sum_rate
-    - name: mimir_ingester_queries
+    - name: mimir_ingester_queries_1
       rules:
         - expr: histogram_quantile(0.99, sum(rate(cortex_ingester_queried_series_bucket[1m])) by (le, cluster, job, stage))
           record: cluster_job_stage:cortex_ingester_queried_series:99quantile
@@ -153,6 +155,8 @@ groups:
           record: cluster_job_stage:cortex_ingester_queried_series_count:sum_rate
         - expr: sum(rate(cortex_ingester_queried_series[1m])) by (cluster, job, stage)
           record: cluster_job_stage:cortex_ingester_queried_series:sum_rate
+    - name: mimir_ingester_queries_2
+      rules:
         - expr: histogram_quantile(0.99, sum(rate(cortex_ingester_queried_samples_bucket[1m])) by (le, cluster, job))
           record: cluster_job:cortex_ingester_queried_samples:99quantile
         - expr: histogram_quantile(0.50, sum(rate(cortex_ingester_queried_samples_bucket[1m])) by (le, cluster, job))

--- a/operations/mimir-mixin-compiled/rules.yaml
+++ b/operations/mimir-mixin-compiled/rules.yaml
@@ -47,7 +47,7 @@ groups:
           record: cluster_namespace_job_route:cortex_request_duration_seconds_count:sum_rate
         - expr: sum(rate(cortex_request_duration_seconds[1m])) by (cluster, namespace, job, route)
           record: cluster_namespace_job_route:cortex_request_duration_seconds:sum_rate
-    - name: mimir_querier_api
+    - name: mimir_querier_api_1
       rules:
         - expr: histogram_quantile(0.99, sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster, job))
           record: cluster_job:cortex_querier_request_duration_seconds:99quantile
@@ -63,6 +63,8 @@ groups:
           record: cluster_job:cortex_querier_request_duration_seconds_count:sum_rate
         - expr: sum(rate(cortex_querier_request_duration_seconds[1m])) by (cluster, job)
           record: cluster_job:cortex_querier_request_duration_seconds:sum_rate
+    - name: mimir_querier_api_2
+      rules:
         - expr: histogram_quantile(0.99, sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster, job, route))
           record: cluster_job_route:cortex_querier_request_duration_seconds:99quantile
         - expr: histogram_quantile(0.50, sum(rate(cortex_querier_request_duration_seconds_bucket[1m])) by (le, cluster, job, route))
@@ -137,7 +139,7 @@ groups:
           record: cluster_job:cortex_query_frontend_queue_duration_seconds_count:sum_rate
         - expr: sum(rate(cortex_query_frontend_queue_duration_seconds[1m])) by (cluster, job)
           record: cluster_job:cortex_query_frontend_queue_duration_seconds:sum_rate
-    - name: mimir_ingester_queries
+    - name: mimir_ingester_queries_1
       rules:
         - expr: histogram_quantile(0.99, sum(rate(cortex_ingester_queried_series_bucket[1m])) by (le, cluster, job, stage))
           record: cluster_job_stage:cortex_ingester_queried_series:99quantile
@@ -153,6 +155,8 @@ groups:
           record: cluster_job_stage:cortex_ingester_queried_series_count:sum_rate
         - expr: sum(rate(cortex_ingester_queried_series[1m])) by (cluster, job, stage)
           record: cluster_job_stage:cortex_ingester_queried_series:sum_rate
+    - name: mimir_ingester_queries_2
+      rules:
         - expr: histogram_quantile(0.99, sum(rate(cortex_ingester_queried_samples_bucket[1m])) by (le, cluster, job))
           record: cluster_job:cortex_ingester_queried_samples:99quantile
         - expr: histogram_quantile(0.50, sum(rate(cortex_ingester_queried_samples_bucket[1m])) by (le, cluster, job))

--- a/operations/mimir-mixin/recording_rules.libsonnet
+++ b/operations/mimir-mixin/recording_rules.libsonnet
@@ -25,9 +25,13 @@ local utils = import 'mixin-utils/utils.libsonnet';
           utils.histogramRules('cortex_request_duration_seconds', $._config.job_labels + ['route'], $.rateInterval('1m'), record_native=true),
       },
       {
-        name: 'mimir_querier_api',
+        name: 'mimir_querier_api_1',
         rules:
-          utils.histogramRules('cortex_querier_request_duration_seconds', [$._config.per_cluster_label, 'job'], $.rateInterval('1m'), record_native=true) +
+          utils.histogramRules('cortex_querier_request_duration_seconds', [$._config.per_cluster_label, 'job'], $.rateInterval('1m'), record_native=true),
+      },
+      {
+        name: 'mimir_querier_api_2',
+        rules:
           utils.histogramRules('cortex_querier_request_duration_seconds', [$._config.per_cluster_label, 'job', 'route'], $.rateInterval('1m'), record_native=true) +
           utils.histogramRules('cortex_querier_request_duration_seconds', $._config.job_labels + ['route'], $.rateInterval('1m'), record_native=true),
       },
@@ -43,9 +47,13 @@ local utils = import 'mixin-utils/utils.libsonnet';
           utils.histogramRules('cortex_query_frontend_queue_duration_seconds', [$._config.per_cluster_label, 'job'], $.rateInterval('1m'), record_native=true),
       },
       {
-        name: 'mimir_ingester_queries',
+        name: 'mimir_ingester_queries_1',
         rules:
-          utils.histogramRules('cortex_ingester_queried_series', [$._config.per_cluster_label, 'job', 'stage'], $.rateInterval('1m'), record_native=true) +
+          utils.histogramRules('cortex_ingester_queried_series', [$._config.per_cluster_label, 'job', 'stage'], $.rateInterval('1m'), record_native=true),
+      },
+      {
+        name: 'mimir_ingester_queries_2',
+        rules:
           utils.histogramRules('cortex_ingester_queried_samples', [$._config.per_cluster_label, 'job'], $.rateInterval('1m'), record_native=true) +
           utils.histogramRules('cortex_ingester_queried_exemplars', [$._config.per_cluster_label, 'job'], $.rateInterval('1m'), record_native=true),
       },


### PR DESCRIPTION
#### What this PR does
 
This ensure `make build-mixin` fails with an error when a sub-command fails. Indeed, the command would succeed when `mixtool` wasn't installed, but also didn't properly check the size of the rule groups. Consequently, I splitted some rule groups.

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
