### PR TITLE
nautilus readcache: Stop scanning all series every 15sec.

### DIFF
--- a/pkg/mimirpb/series_sharding.go
+++ b/pkg/mimirpb/series_sharding.go
@@ -6,6 +6,7 @@
 package mimirpb
 
 import (
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 )
 
@@ -70,6 +71,16 @@ func ShardByMetricNameLocalityLabels(userID string, metricName string, ls labels
 	metricHash := ShardByMetricName(userID, metricName)
 	labelsHash := ShardByAllLabels(userID, ls)
 	return (metricHash & MetricNameMask) | (labelsHash & LabelBitsMask)
+}
+
+// ShardByMetricNameLocalityLabelsFunc returns a TSDB secondary hash
+// function for a single tenant. Series labels are immutable, so TSDB
+// can compute this hash once when a series is created and reuse it for
+// later ownership and load-stat walks.
+func ShardByMetricNameLocalityLabelsFunc(userID string) func(labels.Labels) uint32 {
+	return func(ls labels.Labels) uint32 {
+		return ShardByMetricNameLocalityLabels(userID, ls.Get(model.MetricNameLabel), ls)
+	}
 }
 
 // MetricNameHashRange returns the inclusive hash range [lo, hi] that covers all possible

--- a/pkg/mimirpb/series_sharding_test.go
+++ b/pkg/mimirpb/series_sharding_test.go
@@ -8,6 +8,7 @@ package mimirpb
 import (
 	"testing"
 
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -26,4 +27,16 @@ func TestShardByAllLabelAdaptersReturnsWrongResultsForUnsortedLabels(t *testing.
 	})
 
 	assert.NotEqual(t, val1, val2)
+}
+
+func TestShardByMetricNameLocalityLabelsFunc(t *testing.T) {
+	const userID = "user-1"
+	ls := labels.FromStrings(
+		"__name__", "http_requests_total",
+		"instance", "host-1",
+		"job", "api",
+	)
+
+	expected := ShardByMetricNameLocalityLabels(userID, "http_requests_total", ls)
+	assert.Equal(t, expected, ShardByMetricNameLocalityLabelsFunc(userID)(ls))
 }

--- a/pkg/nautilus/loadstats/hash_range_series.go
+++ b/pkg/nautilus/loadstats/hash_range_series.go
@@ -9,34 +9,26 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
-	"github.com/prometheus/prometheus/tsdb/index"
+	"github.com/prometheus/prometheus/tsdb/chunks"
 
-	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/nautilus/assignment"
 )
-
-// WalkInterval is how often a producer is expected to walk each
-// tenant's TSDB head to recount active series per owned hash range.
-const WalkInterval = 15 * time.Second
 
 // RangeSeries tracks per-hash-range active-series counts for the hash
 // ranges this instance has been told it owns (via SetRanges).
 //
 // Counts are not maintained incrementally on the write path. Instead
 // the producer periodically walks the TSDB head of each tenant,
-// computes mimirpb.ShardByMetricNameLocalityLabels for every series,
-// tallies the hits per owned range, and pushes the result via
-// SetCountsFor. This avoids the atomic-op hot path on every series
-// creation/deletion, avoids the 512 KB fixed histogram, and self-
-// corrects any accumulated drift from missed/duplicated lifecycle
+// tallies the cached secondary hashes per owned range, and pushes the
+// result via SetCountsFor. This avoids the atomic-op hot path on every
+// series creation/deletion, avoids the 512 KB fixed histogram, and
+// self-corrects any accumulated drift from missed/duplicated lifecycle
 // callbacks.
 //
 // The rebalancer fetches counts via Snapshot (through the
@@ -162,11 +154,13 @@ func (h *RangeSeries) LogSummary(logger log.Logger) {
 	)
 }
 
-// CountSeriesByHashRange walks all series in head, computes the
-// locality hash for each, looks up which of the provided sorted, non-
-// overlapping ranges (if any) contains it, and increments counts at
-// that index. counts must be the same length as ranges and is mutated
-// in place.
+// CountSeriesByHashRange walks all series in head using the secondary
+// hash cached on each TSDB series, looks up which of the provided
+// sorted, non-overlapping ranges (if any) contains it, and increments
+// counts at that index. The head must have been opened with a
+// SecondaryHashFunction that computes the metric-name-locality hash
+// for the head's tenant. counts must be the same length as ranges and
+// is mutated in place.
 //
 // If examples is non-nil it must be the same length as ranges. The
 // labels of the FIRST series found in each range are written via
@@ -179,59 +173,79 @@ func (h *RangeSeries) LogSummary(logger log.Logger) {
 //
 // Returns the number of series it observed (regardless of whether they
 // landed in an owned range).
-func CountSeriesByHashRange(ctx context.Context, userID string, head *tsdb.Head, ranges []assignment.HashRange, counts []int64, examples []string) (int64, error) {
+func CountSeriesByHashRange(ctx context.Context, head *tsdb.Head, ranges []assignment.HashRange, counts []int64, examples []string) (int64, error) {
+	wantExamples := examples != nil && len(examples) == len(ranges)
+	exampleRefs := make([]chunks.HeadSeriesRef, len(ranges))
+	exampleRefsSet := make([]bool, len(ranges))
+	var walked int64
+	var walkErr error
+
+	head.ForEachSecondaryHash(func(refs []chunks.HeadSeriesRef, hashes []uint32) {
+		if walkErr != nil {
+			return
+		}
+		if err := ctx.Err(); err != nil {
+			walkErr = err
+			return
+		}
+		for i, hash := range hashes {
+			walked++
+
+			// Binary search: find largest i such that ranges[i].Lo <= hash.
+			ri := sort.Search(len(ranges), func(i int) bool {
+				return ranges[i].Lo > hash
+			}) - 1
+			if ri >= 0 && ranges[ri].Contains(hash) {
+				counts[ri]++
+				if wantExamples && examples[ri] == "" && !exampleRefsSet[ri] {
+					exampleRefs[ri] = refs[i]
+					exampleRefsSet[ri] = true
+				}
+			}
+		}
+	})
+	if walkErr != nil {
+		return walked, walkErr
+	}
+
+	if !wantExamples {
+		return walked, nil
+	}
+
+	if err := loadSeriesExamples(ctx, head, exampleRefs, exampleRefsSet, examples); err != nil {
+		return walked, err
+	}
+	return walked, nil
+}
+
+func loadSeriesExamples(ctx context.Context, head *tsdb.Head, exampleRefs []chunks.HeadSeriesRef, exampleRefsSet []bool, examples []string) error {
 	idx, err := head.Index()
 	if err != nil {
-		return 0, err
+		return err
 	}
 	defer idx.Close()
 
-	name, value := index.AllPostingsKey()
-	postings, err := idx.Postings(ctx, name, value)
-	if err != nil {
-		return 0, err
-	}
-
-	wantExamples := examples != nil && len(examples) == len(ranges)
 	builder := labels.NewScratchBuilder(16)
-	var walked int64
-
-	for postings.Next() {
-		if walked&0xffff == 0 && ctx.Err() != nil {
-			return walked, ctx.Err()
+	for i, ref := range exampleRefs {
+		if !exampleRefsSet[i] || examples[i] != "" {
+			continue
 		}
-
-		ref := postings.At()
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		builder.Reset()
-		if err := idx.Series(ref, &builder, nil); err != nil {
-			// Series may be deleted between Postings() and Series();
-			// treat as absent.
+		if err := idx.Series(storage.SeriesRef(ref), &builder, nil); err != nil {
+			// Series may be deleted between the secondary-hash walk and
+			// this bounded example lookup; treat it as absent.
 			if errors.Is(err, storage.ErrNotFound) {
 				continue
 			}
-			return walked, err
+			return err
 		}
-		walked++
-
-		lset := builder.Labels()
-		metricName := lset.Get(model.MetricNameLabel)
-		hash := mimirpb.ShardByMetricNameLocalityLabels(userID, metricName, lset)
-
-		// Binary search: find largest i such that ranges[i].Lo <= hash.
-		ri := sort.Search(len(ranges), func(i int) bool {
-			return ranges[i].Lo > hash
-		}) - 1
-		if ri >= 0 && ranges[ri].Contains(hash) {
-			counts[ri]++
-			if wantExamples && examples[ri] == "" {
-				// labels.Labels.String() allocates a fresh Go string,
-				// detaching us from the TSDB intern pool. Capturing
-				// once per range bounds the allocation to one per
-				// owned range per walk, even on heads with millions
-				// of series.
-				examples[ri] = lset.String()
-			}
-		}
+		// labels.Labels.String() allocates a fresh Go string, detaching
+		// the example from the TSDB intern pool. At most one lookup and
+		// allocation is performed per range.
+		examples[i] = builder.Labels().String()
 	}
-	return walked, postings.Err()
+	return nil
 }

--- a/pkg/nautilus/loadstats/hash_range_series_test.go
+++ b/pkg/nautilus/loadstats/hash_range_series_test.go
@@ -4,8 +4,10 @@ package loadstats
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -13,7 +15,10 @@ import (
 	"github.com/go-kit/log"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -21,11 +26,12 @@ import (
 	"github.com/grafana/mimir/pkg/nautilus/assignment"
 )
 
-func newTestHead(t *testing.T) *tsdb.Head {
+func newTestHead(t testing.TB) *tsdb.Head {
 	t.Helper()
 	opts := tsdb.DefaultHeadOptions()
 	opts.ChunkDirRoot = t.TempDir()
 	opts.IsolationDisabled = true
+	opts.SecondaryHashFunction = mimirpb.ShardByMetricNameLocalityLabelsFunc("user-1")
 	head, err := tsdb.NewHead(nil, nil, nil, nil, opts, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = head.Close() })
@@ -216,7 +222,7 @@ func TestCountSeriesByHashRange_EmptyRanges(t *testing.T) {
 	head := newTestHead(t)
 
 	counts := []int64{}
-	n, err := CountSeriesByHashRange(context.Background(), "user-1", head, nil, counts, nil)
+	n, err := CountSeriesByHashRange(context.Background(), head, nil, counts, nil)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), n)
 }
@@ -226,7 +232,7 @@ func TestCountSeriesByHashRange_EmptyHead(t *testing.T) {
 
 	ranges := []assignment.HashRange{{Lo: 0, Hi: math.MaxUint32}}
 	counts := make([]int64, len(ranges))
-	n, err := CountSeriesByHashRange(context.Background(), "user-1", head, ranges, counts, nil)
+	n, err := CountSeriesByHashRange(context.Background(), head, ranges, counts, nil)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), n)
 	assert.Equal(t, int64(0), counts[0])
@@ -268,7 +274,7 @@ func TestCountSeriesByHashRange_AppendsAndAttributesSeries(t *testing.T) {
 		}
 		counts := make([]int64, len(ranges))
 		examples := make([]string, len(ranges))
-		n, err := CountSeriesByHashRange(context.Background(), userID, head, ranges, counts, examples)
+		n, err := CountSeriesByHashRange(context.Background(), head, ranges, counts, examples)
 		require.NoError(t, err)
 		assert.Equal(t, int64(totalSeries), n)
 		assert.Equal(t, int64(totalSeries), counts[0]+counts[1])
@@ -319,7 +325,7 @@ func TestCountSeriesByHashRange_AppendsAndAttributesSeries(t *testing.T) {
 
 		ranges := []assignment.HashRange{{Lo: lo, Hi: hi}}
 		counts := make([]int64, len(ranges))
-		n, err := CountSeriesByHashRange(context.Background(), userID, head, ranges, counts, nil)
+		n, err := CountSeriesByHashRange(context.Background(), head, ranges, counts, nil)
 		require.NoError(t, err)
 		assert.Equal(t, int64(totalSeries), n)
 		assert.Equal(t, want, counts[0])
@@ -340,8 +346,116 @@ func TestCountSeriesByHashRange_ContextCancellation(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, app.Commit())
 
-	_, err = CountSeriesByHashRange(ctx, "user-1", head, ranges, counts, nil)
-	if err != nil {
-		assert.ErrorIs(t, err, context.Canceled)
+	_, err = CountSeriesByHashRange(ctx, head, ranges, counts, nil)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestLoadSeriesExamples_ToleratesDeletedSeries(t *testing.T) {
+	head := newTestHead(t)
+	examples := []string{""}
+
+	err := loadSeriesExamples(
+		t.Context(),
+		head,
+		[]chunks.HeadSeriesRef{chunks.HeadSeriesRef(math.MaxUint64)},
+		[]bool{true},
+		examples,
+	)
+	require.NoError(t, err)
+	assert.Empty(t, examples[0])
+}
+
+func BenchmarkCountSeriesByHashRange(b *testing.B) {
+	const (
+		userID     = "user-1"
+		numSeries  = 100_000
+		numRanges  = 128
+		numMetrics = 1_000
+	)
+
+	head := newTestHead(b)
+	app := head.Appender(context.Background())
+	for i := 0; i < numSeries; i++ {
+		ls := labels.FromStrings(
+			model.MetricNameLabel, fmt.Sprintf("metric_%d", i%numMetrics),
+			"instance", fmt.Sprintf("host-%d", i),
+			"job", "benchmark",
+		)
+		_, err := app.Append(0, ls, int64(i), float64(i))
+		require.NoError(b, err)
 	}
+	require.NoError(b, app.Commit())
+
+	ranges := make([]assignment.HashRange, numRanges)
+	rangeWidth := (uint64(math.MaxUint32) + 1) / numRanges
+	for i := range ranges {
+		lo := uint64(i) * rangeWidth
+		hi := lo + rangeWidth - 1
+		if i == len(ranges)-1 {
+			hi = math.MaxUint32
+		}
+		ranges[i] = assignment.HashRange{Lo: uint32(lo), Hi: uint32(hi)}
+	}
+
+	b.Run("postings-and-rehash", func(b *testing.B) {
+		counts := make([]int64, len(ranges))
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			clear(counts)
+			_, err := countSeriesByHashRangeWithRehash(context.Background(), userID, head, ranges, counts)
+			require.NoError(b, err)
+		}
+	})
+
+	b.Run("secondary-hash", func(b *testing.B) {
+		counts := make([]int64, len(ranges))
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			clear(counts)
+			_, err := CountSeriesByHashRange(context.Background(), head, ranges, counts, nil)
+			require.NoError(b, err)
+		}
+	})
+}
+
+// countSeriesByHashRangeWithRehash preserves the pre-optimization
+// algorithm as a benchmark baseline.
+func countSeriesByHashRangeWithRehash(ctx context.Context, userID string, head *tsdb.Head, ranges []assignment.HashRange, counts []int64) (int64, error) {
+	idx, err := head.Index()
+	if err != nil {
+		return 0, err
+	}
+	defer idx.Close()
+
+	name, value := index.AllPostingsKey()
+	postings, err := idx.Postings(ctx, name, value)
+	if err != nil {
+		return 0, err
+	}
+
+	builder := labels.NewScratchBuilder(16)
+	var walked int64
+	for postings.Next() {
+		ref := postings.At()
+		builder.Reset()
+		if err := idx.Series(ref, &builder, nil); err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				continue
+			}
+			return walked, err
+		}
+		walked++
+
+		lset := builder.Labels()
+		hash := mimirpb.ShardByMetricNameLocalityLabels(userID, lset.Get(model.MetricNameLabel), lset)
+		ri := sort.Search(len(ranges), func(i int) bool {
+			return ranges[i].Lo > hash
+		}) - 1
+		if ri >= 0 && ranges[ri].Contains(hash) {
+			counts[ri]++
+		}
+	}
+	return walked, postings.Err()
 }

--- a/pkg/nautilus/loadstats/query_load_tracker.go
+++ b/pkg/nautilus/loadstats/query_load_tracker.go
@@ -15,9 +15,7 @@ import (
 )
 
 // TickInterval is how often the per-partition and unnamed EWMA rates
-// are advanced from accumulated counts to per-second rates. Aligned
-// with WalkInterval so the two background signals progress on the same
-// cadence.
+// are advanced from accumulated counts to per-second rates.
 const TickInterval = 15 * time.Second
 
 // Alpha is the smoothing factor applied at each tick.

--- a/pkg/readcache/handlers.go
+++ b/pkg/readcache/handlers.go
@@ -859,10 +859,13 @@ func (r *Readcache) setHashRanges(_ context.Context, req *client.SetHashRangesRe
 	owned := make(map[int32]struct{}, len(parts))
 	var updatedPartitions, clearedPartitions []int32
 	var ignoredUnowned []int32
+	rangesChanged := false
 	for _, p := range parts {
 		owned[p.partitionID] = struct{}{}
 		ranges := byPartition[p.partitionID]
-		p.ranges.setRanges(ranges)
+		if p.ranges.setRanges(ranges) {
+			rangesChanged = true
+		}
 		if len(ranges) > 0 {
 			updatedPartitions = append(updatedPartitions, p.partitionID)
 		} else {
@@ -897,6 +900,9 @@ func (r *Readcache) setHashRanges(_ context.Context, req *client.SetHashRangesRe
 		"cleared_partition_ids", formatPartitionIDs(clearedPartitions, 20),
 		"ignored_unowned_ids", formatPartitionIDs(ignoredUnowned, 20),
 	)
+	if rangesChanged {
+		r.requestSeriesStatsRefresh()
+	}
 	return &client.SetHashRangesResponse{}, nil
 }
 

--- a/pkg/readcache/partition_ranges.go
+++ b/pkg/readcache/partition_ranges.go
@@ -3,6 +3,7 @@
 package readcache
 
 import (
+	"slices"
 	"sort"
 	"sync"
 
@@ -106,12 +107,15 @@ func newPartitionRangeEWMA() *util_math.EwmaRate {
 // range splits across rounds, both halves appear separately so the
 // rebalancer can score each independently. Counts for ranges still in
 // the working set (current ∪ historical) are retained; counts for
-// ranges that fell out of both sets are discarded.
-func (pr *partitionRanges) setRanges(newRanges []assignment.HashRange) {
+// ranges that fell out of both sets are discarded. It returns true
+// when the current range assignment materially changed.
+func (pr *partitionRanges) setRanges(newRanges []assignment.HashRange) bool {
 	sortedNew := sortedNonOverlappingCopy(newRanges)
 
 	pr.mu.Lock()
 	defer pr.mu.Unlock()
+
+	changed := !slices.Equal(pr.currentRanges, sortedNew)
 
 	// Hash space that this partition just lost.
 	removed := rangeDiff(pr.currentRanges, sortedNew)
@@ -160,6 +164,7 @@ func (pr *partitionRanges) setRanges(newRanges []assignment.HashRange) {
 			}
 		}
 	}
+	return changed
 }
 
 // rangesSnapshot returns the current working set of ranges (current ∪

--- a/pkg/readcache/partition_ranges_test.go
+++ b/pkg/readcache/partition_ranges_test.go
@@ -131,6 +131,14 @@ func TestRangeDiff(t *testing.T) {
 }
 
 func TestPartitionRangesSetRanges_TransitionsTracked(t *testing.T) {
+	t.Run("reports only material assignment changes", func(t *testing.T) {
+		pr := newPartitionRanges()
+		require.True(t, pr.setRanges([]assignment.HashRange{hr(200, 299), hr(0, 99)}))
+		assert.False(t, pr.setRanges([]assignment.HashRange{hr(0, 99), hr(200, 299)}),
+			"the same canonical assignment should not request another series walk")
+		assert.True(t, pr.setRanges([]assignment.HashRange{hr(0, 49), hr(50, 99), hr(200, 299)}))
+	})
+
 	t.Run("initial assignment populates current with no historical", func(t *testing.T) {
 		pr := newPartitionRanges()
 		pr.setRanges([]assignment.HashRange{hr(0, 99), hr(200, 299)})

--- a/pkg/readcache/partition_tsdb.go
+++ b/pkg/readcache/partition_tsdb.go
@@ -20,6 +20,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/hashcache"
 
 	"github.com/grafana/mimir/pkg/ingester/lookupplan"
+	"github.com/grafana/mimir/pkg/mimirpb"
 	mimir_tsdb "github.com/grafana/mimir/pkg/storage/tsdb"
 	util_log "github.com/grafana/mimir/pkg/util/log"
 	"github.com/grafana/mimir/pkg/util/validation"
@@ -146,6 +147,7 @@ func openPartitionTSDB(
 		HeadPostingsForMatchersCacheFactory:  headPostingsForMatchersCacheFactory,
 		BlockPostingsForMatchersCacheFactory: blockPostingsForMatchersCacheFactory,
 		PostingsClonerFactory:                lookupplan.ActualSelectedPostingsClonerFactory{},
+		SecondaryHashFunction:                mimirpb.ShardByMetricNameLocalityLabelsFunc(tenantID),
 	}
 
 	db, err := tsdb.Open(dir, util_log.SlogFromGoKit(userLogger), tsdbPromReg, opts, nil)

--- a/pkg/readcache/readcache.go
+++ b/pkg/readcache/readcache.go
@@ -123,9 +123,18 @@ type Readcache struct {
 	// the two histograms compare directly.
 	queriedSamples prometheus.Histogram
 
-	// seriesWalkMu prevents overlapping background series walks when a
-	// single tick takes longer than loadstats.TickInterval.
+	// seriesWalkMu prevents overlapping background series walks. The
+	// refresh worker is single-threaded, but the mutex also protects
+	// direct test/debug invocations.
 	seriesWalkMu sync.Mutex
+	// seriesStatsRefreshRequested coalesces event-driven requests while
+	// a series walk is already running. The worker consumes at most one
+	// pending request after the current walk finishes.
+	seriesStatsRefreshRequested chan struct{}
+	// seriesStatsRefreshInterval is the fallback cadence for a full
+	// per-range series walk. It is a field so scheduling tests can use a
+	// short duration without changing production configuration.
+	seriesStatsRefreshInterval time.Duration
 
 	// seriesHashCache and postings-for-matchers cache factories mirror
 	// the ingester: shared across partition TSDBs on this process.
@@ -280,17 +289,19 @@ func New(
 
 	tsdbCfg := cfg.BlocksStorage.TSDB
 	r := &Readcache{
-		cfg:                cfg,
-		limits:             limits,
-		logger:             logger,
-		reg:                reg,
-		partitions:         make(map[int32]*partitionState),
-		frozen:             make(map[int32][]*frozenEpoch),
-		epochSeq:           make(map[int32]int),
-		instanceLifecycler: instanceLifecycler,
-		queryLoad:          loadstats.NewTracker("cortex_readcache"),
-		partitionSeries:    loadstats.NewPartitionSeries(),
-		spotlights:         newReadcacheSpotlightTracker(),
+		cfg:                         cfg,
+		limits:                      limits,
+		logger:                      logger,
+		reg:                         reg,
+		partitions:                  make(map[int32]*partitionState),
+		frozen:                      make(map[int32][]*frozenEpoch),
+		epochSeq:                    make(map[int32]int),
+		instanceLifecycler:          instanceLifecycler,
+		queryLoad:                   loadstats.NewTracker("cortex_readcache"),
+		partitionSeries:             loadstats.NewPartitionSeries(),
+		spotlights:                  newReadcacheSpotlightTracker(),
+		seriesStatsRefreshRequested: make(chan struct{}, 1),
+		seriesStatsRefreshInterval:  seriesStatsRefreshInterval,
 	}
 
 	r.seriesHashCache = hashcache.NewSeriesHashCache(tsdbCfg.SeriesHashCacheMaxBytes)
@@ -484,9 +495,10 @@ func (r *Readcache) running(ctx context.Context) error {
 		go r.runSpotlightLoop(ctx)
 	}
 
-	// Prime partition/hash-range snapshots so the first HashRangeStats
-	// RPC does not return zeros while waiting for the first tick.
-	go r.refreshSeriesStats(ctx)
+	// Prime the cheap partition totals immediately and run the slower
+	// per-range refresh in its coalescing worker.
+	r.refreshPartitionSeriesCounts()
+	go r.runSeriesStatsRefreshLoop(ctx)
 
 	for {
 		select {
@@ -499,10 +511,58 @@ func (r *Readcache) running(ctx context.Context) error {
 		case <-loadStatsTickT.C:
 			r.queryLoad.Tick()
 			r.tickSampleRates()
-			go r.refreshSeriesStats(ctx)
+			r.refreshPartitionSeriesCounts()
 		case <-reapT.C:
 			r.reapFrozenEpochs(time.Now())
 		}
+	}
+}
+
+const seriesStatsRefreshInterval = 5 * time.Minute
+
+// requestSeriesStatsRefresh schedules a per-range series walk without
+// blocking the caller. Multiple requests coalesce while a walk is in
+// progress.
+func (r *Readcache) requestSeriesStatsRefresh() {
+	select {
+	case r.seriesStatsRefreshRequested <- struct{}{}:
+	default:
+	}
+}
+
+// runSeriesStatsRefreshLoop runs one full per-range walk at startup,
+// after each coalesced event request, and as a five-minute fallback.
+// The fallback timer is reset after every attempted walk so an
+// event-driven refresh doesn't get followed immediately by a periodic
+// duplicate.
+func (r *Readcache) runSeriesStatsRefreshLoop(ctx context.Context) {
+	// A request queued before the worker starts is already represented
+	// in the startup walk's snapshot.
+	select {
+	case <-r.seriesStatsRefreshRequested:
+	default:
+	}
+	r.refreshSeriesStats(ctx)
+	if ctx.Err() != nil {
+		return
+	}
+
+	timer := time.NewTimer(r.seriesStatsRefreshInterval)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+		case <-r.seriesStatsRefreshRequested:
+		}
+
+		r.refreshSeriesStats(ctx)
+		if ctx.Err() != nil {
+			return
+		}
+		timer.Reset(r.seriesStatsRefreshInterval)
 	}
 }
 
@@ -928,6 +988,7 @@ func (r *Readcache) compactHeads() {
 			}
 		}
 	}
+	r.requestSeriesStatsRefresh()
 }
 
 // OwnedPartitions returns a snapshot of currently-owned partition IDs.

--- a/pkg/readcache/readcache_test.go
+++ b/pkg/readcache/readcache_test.go
@@ -15,10 +15,13 @@ import (
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	ingester_client "github.com/grafana/mimir/pkg/ingester/client"
+	"github.com/grafana/mimir/pkg/mimirpb"
 	"github.com/grafana/mimir/pkg/nautilus/assignment"
 	"github.com/grafana/mimir/pkg/nautilus/readcacheassignment"
 	"github.com/grafana/mimir/pkg/storage/ingest"
@@ -299,6 +302,111 @@ func TestReadcache_SetAndGetHashRanges_PerPartition(t *testing.T) {
 	}, getResp.Ranges)
 }
 
+func TestReadcache_SetHashRangesRequestsSeriesRefreshOnlyForChanges(t *testing.T) {
+	p := newPartitionState(0)
+	r := &Readcache{
+		cfg:                         Config{InstanceID: "test"},
+		logger:                      log.NewNopLogger(),
+		partitions:                  map[int32]*partitionState{0: p},
+		seriesStatsRefreshRequested: make(chan struct{}, 1),
+	}
+	ctx := t.Context()
+
+	req := &ingester_client.SetHashRangesRequest{
+		Ranges: []ingester_client.HashRangeEntry{{Lo: 0, Hi: 99, PartitionId: 0}},
+	}
+	_, err := r.setHashRanges(ctx, req)
+	require.NoError(t, err)
+	require.Len(t, r.seriesStatsRefreshRequested, 1)
+	<-r.seriesStatsRefreshRequested
+
+	_, err = r.setHashRanges(ctx, req)
+	require.NoError(t, err)
+	assert.Empty(t, r.seriesStatsRefreshRequested, "an unchanged assignment should not request another full walk")
+
+	_, err = r.setHashRanges(ctx, &ingester_client.SetHashRangesRequest{
+		Ranges: []ingester_client.HashRangeEntry{{Lo: 100, Hi: 199, PartitionId: 0}},
+	})
+	require.NoError(t, err)
+	require.Len(t, r.seriesStatsRefreshRequested, 1)
+}
+
+func TestReadcache_SeriesStatsRefreshRequestsCoalesce(t *testing.T) {
+	r := &Readcache{seriesStatsRefreshRequested: make(chan struct{}, 1)}
+	r.requestSeriesStatsRefresh()
+	r.requestSeriesStatsRefresh()
+	r.requestSeriesStatsRefresh()
+	assert.Len(t, r.seriesStatsRefreshRequested, 1)
+}
+
+func TestReadcache_SeriesStatsRefreshLoopFallback(t *testing.T) {
+	rng := assignment.HashRange{Lo: 0, Hi: 99}
+	p := newPartitionState(0)
+	p.ranges.setRanges([]assignment.HashRange{rng})
+	r := &Readcache{
+		partitions:                  map[int32]*partitionState{0: p},
+		seriesStatsRefreshRequested: make(chan struct{}, 1),
+		seriesStatsRefreshInterval:  10 * time.Millisecond,
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	go r.runSeriesStatsRefreshLoop(ctx)
+
+	require.Eventually(t, func() bool {
+		p.ranges.mu.RLock()
+		defer p.ranges.mu.RUnlock()
+		_, ok := p.ranges.rangeCounts[rng]
+		return ok
+	}, time.Second, time.Millisecond, "startup refresh did not populate range counts")
+
+	p.ranges.mu.Lock()
+	delete(p.ranges.rangeCounts, rng)
+	p.ranges.mu.Unlock()
+
+	require.Eventually(t, func() bool {
+		p.ranges.mu.RLock()
+		defer p.ranges.mu.RUnlock()
+		_, ok := p.ranges.rangeCounts[rng]
+		return ok
+	}, time.Second, time.Millisecond, "fallback refresh did not repopulate range counts")
+}
+
+func TestReadcache_CompactHeadsRequestsSeriesRefresh(t *testing.T) {
+	r := &Readcache{
+		partitions:                  map[int32]*partitionState{},
+		seriesStatsRefreshRequested: make(chan struct{}, 1),
+	}
+	r.compactHeads()
+	assert.Len(t, r.seriesStatsRefreshRequested, 1)
+}
+
+func TestReadcache_RefreshPartitionSeriesCounts(t *testing.T) {
+	cfg := newTestConfig(t, false, 0)
+	limits := validation.NewOverrides(validation.Limits{}, nil)
+	r, err := New(cfg, limits, nil, log.NewNopLogger(), prometheus.NewRegistry())
+	require.NoError(t, err)
+	assert.Equal(t, 5*time.Minute, r.seriesStatsRefreshInterval)
+
+	r.partitions[7] = newPartitionState(7)
+	db, err := r.getOrOpenTSDB("tenant-1", 7)
+	require.NoError(t, err)
+	require.NotNil(t, db)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	app := db.Appender(t.Context())
+	_, err = app.Append(0, labels.FromStrings("__name__", "up", "instance", "host-1"), 1, 1)
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+
+	r.refreshPartitionSeriesCounts()
+	snapshot := r.partitionSeries.Snapshot()
+	require.Len(t, snapshot.Partitions, 1)
+	assert.Equal(t, int32(7), snapshot.Partitions[0].PartitionID)
+	assert.Equal(t, int64(1), snapshot.Partitions[0].ActiveSeries)
+	assert.Equal(t, int64(1), snapshot.Total)
+}
+
 // TestReadcache_HashRangeStats_ResidueOnFormerOwner verifies the
 // design goal of this commit: after a hash range moves from one
 // partition to another, the previous owner's TSDB head still has the
@@ -414,6 +522,20 @@ func TestReadcache_GetOrOpenTSDB(t *testing.T) {
 	db, err = r.getOrOpenTSDB("user-1", 0)
 	require.NoError(t, err)
 	require.NotNil(t, db)
+
+	seriesLabels := labels.FromStrings("__name__", "up", "instance", "host-1")
+	app := db.Appender(ctx)
+	_, err = app.Append(0, seriesLabels, 1, 1)
+	require.NoError(t, err)
+	require.NoError(t, app.Commit())
+
+	var secondaryHashes []uint32
+	db.Head().ForEachSecondaryHash(func(_ []chunks.HeadSeriesRef, hashes []uint32) {
+		secondaryHashes = append(secondaryHashes, hashes...)
+	})
+	require.Equal(t, []uint32{
+		mimirpb.ShardByMetricNameLocalityLabels("user-1", "up", seriesLabels),
+	}, secondaryHashes)
 
 	// Second call returns the same instance.
 	db2, err := r.getOrOpenTSDB("user-1", 0)

--- a/pkg/readcache/series_stats.go
+++ b/pkg/readcache/series_stats.go
@@ -12,9 +12,8 @@ import (
 
 // tickSampleRates advances every per-(partition, range)
 // samples-per-second EwmaRate by one tick. Must be called every
-// loadstats.TickInterval; running() drives this off the same ticker
-// that fires refreshSeriesStats so the two background signals
-// progress on the same cadence.
+// loadstats.TickInterval so the EWMA's configured half-life remains
+// accurate.
 //
 // This runs synchronously on the running() goroutine because each
 // EwmaRate.Tick is a single atomic Swap + a short mutex acquire;
@@ -34,10 +33,37 @@ func (r *Readcache) tickSampleRates() {
 	}
 }
 
+// refreshPartitionSeriesCounts updates the cheap per-partition head
+// series totals used by HashRangeStats. These totals stay on the
+// load-stats cadence because the rebalancer uses them to distinguish a
+// genuinely idle partition from a non-empty partition whose sample-rate
+// EWMA is temporarily zero.
+func (r *Readcache) refreshPartitionSeriesCounts() {
+	r.partitionMu.RLock()
+	parts := make([]*partitionState, 0, len(r.partitions))
+	for _, p := range r.partitions {
+		parts = append(parts, p)
+	}
+	r.partitionMu.RUnlock()
+
+	partitionCounts := make(map[int32]int64, len(parts))
+	for _, p := range parts {
+		var partitionTotal int64
+		p.tenantsMu.RLock()
+		for _, db := range p.tenants {
+			partitionTotal += int64(db.Head().NumSeries())
+		}
+		p.tenantsMu.RUnlock()
+		partitionCounts[p.partitionID] = partitionTotal
+	}
+	r.partitionSeries.SetCounts(partitionCounts)
+}
+
 // refreshSeriesStats walks owned partition TSDB heads and updates the
-// per-partition series and per-(partition, hash range) counts used by
-// HashRangeStats. It runs on the load-stats ticker, not on the RPC
-// path, so rebalancer polls cannot block ingest behind partitionMu.
+// per-(partition, hash range) counts used by HashRangeStats. The walk
+// runs on a slower fallback cadence and after events that can change
+// range attribution or residue; it is deliberately decoupled from the
+// 15-second EWMA tick.
 //
 // Per-partition bucketing is important for residue accounting: when a
 // hash range moves from partition P_old to partition P_new, P_old's
@@ -59,8 +85,6 @@ func (r *Readcache) refreshSeriesStats(ctx context.Context) {
 		parts = append(parts, p)
 	}
 	r.partitionMu.RUnlock()
-
-	partitionCounts := make(map[int32]int64, len(parts))
 
 	for _, p := range parts {
 		if err := ctx.Err(); err != nil {
@@ -86,24 +110,20 @@ func (r *Readcache) refreshSeriesStats(ctx context.Context) {
 			db       *partitionTSDB
 		}
 		var dbs []tenantDB
-		var partitionTotal int64
 
 		p.tenantsMu.RLock()
 		for tenantID, db := range p.tenants {
-			partitionTotal += int64(db.Head().NumSeries())
 			if len(bucketRanges) > 0 {
 				dbs = append(dbs, tenantDB{tenantID: tenantID, db: db})
 			}
 		}
 		p.tenantsMu.RUnlock()
 
-		partitionCounts[p.partitionID] = partitionTotal
-
 		for _, td := range dbs {
 			if err := ctx.Err(); err != nil {
 				return
 			}
-			if _, err := loadstats.CountSeriesByHashRange(ctx, td.tenantID, td.db.Head(), bucketRanges, counts, examples); err != nil {
+			if _, err := loadstats.CountSeriesByHashRange(ctx, td.db.Head(), bucketRanges, counts, examples); err != nil {
 				level.Warn(r.logger).Log(
 					"msg", "hash range series walk failed",
 					"partition", p.partitionID,
@@ -122,6 +142,4 @@ func (r *Readcache) refreshSeriesStats(ctx context.Context) {
 			}
 		}
 	}
-
-	r.partitionSeries.SetCounts(partitionCounts)
 }


### PR DESCRIPTION
#### What this PR does

Reduce readcache series-bookkeeping CPU (by about 30%) by decoupling expensive per-range TSDB head walks from the 15-second EWMA tick and running them on relevant events with a five-minute fallback. The remaining walks use TSDB-cached nautilus hashes instead of decoding and rehashing every series, while preserving fresh partition totals, residue tracking, and admin examples.

Ran it overnight and correctness is about the same.