### PR TITLE
Jsonnet: support for custom query overrides for the compactor-scheduler HPA estimates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 ### Jsonnet
 
 * [ENHANCEMENT] Add `multi_zone_ingester_zpdb_cross_zone_eviction_delay` config option to set `crossZoneEvictionDelay` on the ingester `ZoneAwarePodDisruptionBudget`. Defaults to `20m` when `ingest_storage_enabled` is true, and to unset otherwise. #16271
+* [ENHANCEMENT] Compactor: Allow the drain autoscaler's speed estimates to be read from recording rules. #16283
 * [BUGFIX] Add missing `-querier.mimir-query-engine.range-vector-splitting.memcached.addresses` to `multi_zone_config_validation_excluded_args`. #16237
 
 ### Mixin

--- a/operations/mimir-tests/test-compactor-scheduler-autoscaling-recording-rules-generated.yaml
+++ b/operations/mimir-tests/test-compactor-scheduler-autoscaling-recording-rules-generated.yaml
@@ -1,0 +1,1525 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: compactor
+  name: compactor
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: compactor
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: compactor-scheduler
+  name: compactor-scheduler
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: compactor-scheduler
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: distributor
+  name: distributor
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: distributor
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: ingester
+  name: ingester
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: ingester
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: memcached
+  name: memcached
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: memcached
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: memcached-frontend
+  name: memcached-frontend
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: memcached-frontend
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: memcached-index-queries
+  name: memcached-index-queries
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: memcached-index-queries
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: memcached-metadata
+  name: memcached-metadata
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: memcached-metadata
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: querier
+  name: querier
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: querier
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: query-frontend
+  name: query-frontend
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: query-frontend
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: query-scheduler
+  name: query-scheduler
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: query-scheduler
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    name: store-gateway
+  name: store-gateway
+  namespace: default
+spec:
+  maxUnavailable: 2
+  selector:
+    matchLabels:
+      name: store-gateway
+---
+apiVersion: v1
+data:
+  overrides.yaml: |
+    overrides: {}
+kind: ConfigMap
+metadata:
+  name: overrides
+  namespace: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: compactor
+  name: compactor
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: compactor-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: compactor-grpc
+    port: 9095
+    targetPort: 9095
+  - name: compactor-gossip-ring
+    port: 7946
+    targetPort: 7946
+  selector:
+    name: compactor
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: compactor-scheduler
+  name: compactor-scheduler
+  namespace: default
+spec:
+  ports:
+  - name: compactor-scheduler-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: compactor-scheduler-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: compactor-scheduler
+    statefulset.kubernetes.io/pod-name: compactor-scheduler-0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: distributor
+  name: distributor
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: distributor-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: distributor-grpc
+    port: 9095
+    targetPort: 9095
+  - name: distributor-gossip-ring
+    port: 7946
+    targetPort: 7946
+  selector:
+    name: distributor
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gossip-ring
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - appProtocol: tcp
+    name: gossip-ring
+    port: 7946
+    protocol: TCP
+    targetPort: 7946
+  selector:
+    gossip_ring_member: "true"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: ingester
+  name: ingester
+  namespace: default
+spec:
+  ports:
+  - name: ingester-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: ingester-grpc
+    port: 9095
+    targetPort: 9095
+  - name: ingester-gossip-ring
+    port: 7946
+    targetPort: 7946
+  selector:
+    name: ingester
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: memcached
+  name: memcached
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: memcached-client
+    port: 11211
+    targetPort: 11211
+  - name: exporter-http-metrics
+    port: 9150
+    targetPort: 9150
+  selector:
+    name: memcached
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: memcached-frontend
+  name: memcached-frontend
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: memcached-client
+    port: 11211
+    targetPort: 11211
+  - name: exporter-http-metrics
+    port: 9150
+    targetPort: 9150
+  selector:
+    name: memcached-frontend
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: memcached-index-queries
+  name: memcached-index-queries
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: memcached-client
+    port: 11211
+    targetPort: 11211
+  - name: exporter-http-metrics
+    port: 9150
+    targetPort: 9150
+  selector:
+    name: memcached-index-queries
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: memcached-metadata
+  name: memcached-metadata
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: memcached-client
+    port: 11211
+    targetPort: 11211
+  - name: exporter-http-metrics
+    port: 9150
+    targetPort: 9150
+  selector:
+    name: memcached-metadata
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: querier
+  name: querier
+  namespace: default
+spec:
+  ports:
+  - name: querier-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: querier-grpc
+    port: 9095
+    targetPort: 9095
+  - name: querier-gossip-ring
+    port: 7946
+    targetPort: 7946
+  selector:
+    name: querier
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: query-frontend
+  name: query-frontend
+  namespace: default
+spec:
+  ports:
+  - name: query-frontend-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: query-frontend-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: query-frontend
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: query-scheduler
+  name: query-scheduler
+  namespace: default
+spec:
+  ports:
+  - name: query-scheduler-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: query-scheduler-grpc
+    port: 9095
+    targetPort: 9095
+  selector:
+    name: query-scheduler
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: query-scheduler
+  name: query-scheduler-discovery
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: query-scheduler-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: query-scheduler-grpc
+    port: 9095
+    targetPort: 9095
+  publishNotReadyAddresses: true
+  selector:
+    name: query-scheduler
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: store-gateway
+  name: store-gateway
+  namespace: default
+spec:
+  ports:
+  - name: store-gateway-http-metrics
+    port: 8080
+    targetPort: 8080
+  - name: store-gateway-grpc
+    port: 9095
+    targetPort: 9095
+  - name: store-gateway-gossip-ring
+    port: 7946
+    targetPort: 7946
+  selector:
+    name: store-gateway
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: distributor
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: distributor
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: distributor
+    spec:
+      containers:
+      - args:
+        - -distributor.ha-tracker.enable=true
+        - -distributor.ha-tracker.enable-for-all-users=true
+        - -distributor.ha-tracker.prefix=prom_ha/
+        - -distributor.ha-tracker.store=memberlist
+        - -distributor.health-check-ingesters=true
+        - -distributor.ingestion-burst-size=200000
+        - -distributor.ingestion-rate-limit=10000
+        - -distributor.ring.heartbeat-period=1m
+        - -distributor.ring.heartbeat-timeout=4m
+        - -distributor.ring.prefix=
+        - -distributor.ring.store=memberlist
+        - -ingester.ring.heartbeat-timeout=10m
+        - -ingester.ring.prefix=
+        - -ingester.ring.replication-factor=3
+        - -ingester.ring.store=memberlist
+        - -mem-ballast-size-bytes=1073741824
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc-max-concurrent-streams=1000
+        - -server.grpc.keepalive.max-connection-age=60s
+        - -server.grpc.keepalive.max-connection-age-grace=5m
+        - -server.grpc.keepalive.max-connection-idle=1m
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -shutdown-delay=90s
+        - -target=distributor
+        - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOMAXPROCS
+          value: "8"
+        image: grafana/mimir:3.1.4
+        imagePullPolicy: IfNotPresent
+        name: distributor
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 4Gi
+          requests:
+            cpu: "2"
+            ephemeral-storage: 50Mi
+            memory: 2Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      terminationGracePeriodSeconds: 100
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: distributor
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: querier
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 6
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: querier
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: querier
+    spec:
+      containers:
+      - args:
+        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
+        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
+        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
+        - -blocks-storage.bucket-store.sync-interval=15m
+        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -common.storage.backend=gcs
+        - -distributor.health-check-ingesters=true
+        - -ingester.ring.heartbeat-timeout=10m
+        - -ingester.ring.prefix=
+        - -ingester.ring.replication-factor=3
+        - -ingester.ring.store=memberlist
+        - -mem-ballast-size-bytes=268435456
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -querier.frontend-client.grpc-max-send-msg-size=419430400
+        - -querier.max-concurrent=8
+        - -querier.max-partial-query-length=768h
+        - -querier.scheduler-address=query-scheduler-discovery.default.svc.cluster.local.:9095
+        - -querier.store-gateway-client.grpc-max-recv-msg-size=209715200
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -store-gateway.sharding-ring.heartbeat-timeout=10m
+        - -store-gateway.sharding-ring.prefix=
+        - -store-gateway.sharding-ring.replication-factor=3
+        - -store-gateway.sharding-ring.store=memberlist
+        - -target=querier
+        - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOMAXPROCS
+          value: "5"
+        image: grafana/mimir:3.1.4
+        imagePullPolicy: IfNotPresent
+        name: querier
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 24Gi
+          requests:
+            cpu: "1"
+            ephemeral-storage: 50Mi
+            memory: 12Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      terminationGracePeriodSeconds: 180
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: querier
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: query-frontend
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: query-frontend
+  strategy:
+    rollingUpdate:
+      maxSurge: 15%
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        name: query-frontend
+    spec:
+      containers:
+      - args:
+        - -querier.max-query-parallelism=240
+        - -query-frontend.cache-results=true
+        - -query-frontend.max-cache-freshness=10m
+        - -query-frontend.max-total-query-length=12000h
+        - -query-frontend.parallelize-shardable-queries=true
+        - -query-frontend.query-sharding-max-sharded-queries=128
+        - -query-frontend.query-sharding-target-series-per-shard=2500
+        - -query-frontend.query-sharding-total-shards=0
+        - -query-frontend.results-cache.backend=memcached
+        - -query-frontend.results-cache.memcached.addresses=dnssrvnoa+memcached-frontend.default.svc.cluster.local.:11211
+        - -query-frontend.results-cache.memcached.max-item-size=26214400
+        - -query-frontend.results-cache.memcached.timeout=500ms
+        - -query-frontend.scheduler-address=query-scheduler-discovery.default.svc.cluster.local.:9095
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc-max-recv-msg-size-bytes=419430400
+        - -server.grpc.keepalive.max-connection-age=30s
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -shutdown-delay=90s
+        - -target=query-frontend
+        - -usage-stats.installation-mode=jsonnet
+        image: grafana/mimir:3.1.4
+        imagePullPolicy: IfNotPresent
+        name: query-frontend
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 4Gi
+          requests:
+            cpu: "2"
+            ephemeral-storage: 50Mi
+            memory: 2Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      terminationGracePeriodSeconds: 390
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            name: query-frontend
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: query-scheduler
+  namespace: default
+spec:
+  minReadySeconds: 10
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: query-scheduler
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        name: query-scheduler
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: query-scheduler
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -query-scheduler.max-outstanding-requests-per-tenant=800
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -target=query-scheduler
+        - -usage-stats.installation-mode=jsonnet
+        image: grafana/mimir:3.1.4
+        imagePullPolicy: IfNotPresent
+        name: query-scheduler
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 2Gi
+          requests:
+            cpu: "2"
+            ephemeral-storage: 50Mi
+            memory: 1Gi
+        volumeMounts:
+        - mountPath: /etc/mimir
+          name: overrides
+      terminationGracePeriodSeconds: 180
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    name: compactor
+  name: compactor
+  namespace: default
+spec:
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      name: compactor
+  serviceName: compactor
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: compactor
+    spec:
+      containers:
+      - args:
+        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -common.storage.backend=gcs
+        - -compactor.block-ranges=2h,12h,24h
+        - -compactor.blocks-retention-period=0
+        - -compactor.cleanup-interval=15m
+        - -compactor.compaction-concurrency=1
+        - -compactor.compaction-interval=30m
+        - -compactor.compactor-tenant-shard-size=1
+        - -compactor.data-dir=/data
+        - -compactor.deletion-delay=2h
+        - -compactor.first-level-compaction-wait-period=25m
+        - -compactor.max-closing-blocks-concurrency=2
+        - -compactor.max-opening-blocks-concurrency=4
+        - -compactor.ring.heartbeat-period=1m
+        - -compactor.ring.heartbeat-timeout=4m
+        - -compactor.ring.prefix=
+        - -compactor.ring.store=memberlist
+        - -compactor.ring.wait-stability-min-duration=1m
+        - -compactor.scheduler-client.enabled=true
+        - -compactor.scheduler-client.metadata-cache.backend=memcached
+        - -compactor.scheduler-client.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
+        - -compactor.scheduler-client.metadata-cache.memcached.max-async-concurrency=50
+        - -compactor.scheduler-client.metadata-cache.memcached.max-item-size=1048576
+        - -compactor.scheduler-client.scheduler-endpoint=dns:///compactor-scheduler.default.svc.cluster.local.:9095
+        - -compactor.split-and-merge-shards=0
+        - -compactor.split-groups=1
+        - -compactor.symbols-flushers-concurrency=4
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -target=compactor
+        - -usage-stats.installation-mode=jsonnet
+        image: grafana/mimir:3.1.4
+        imagePullPolicy: IfNotPresent
+        name: compactor
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 6Gi
+          requests:
+            cpu: 1
+            ephemeral-storage: 50Mi
+            memory: 6Gi
+        volumeMounts:
+        - mountPath: /data
+          name: compactor-data
+        - mountPath: /etc/mimir
+          name: overrides
+      securityContext:
+        runAsUser: 0
+      terminationGracePeriodSeconds: 900
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: compactor-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 250Gi
+      storageClassName: standard
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    name: compactor-scheduler
+  name: compactor-scheduler
+  namespace: default
+spec:
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      name: compactor-scheduler
+  serviceName: compactor-scheduler
+  template:
+    metadata:
+      labels:
+        name: compactor-scheduler
+    spec:
+      containers:
+      - args:
+        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -common.storage.backend=gcs
+        - -compactor-scheduler.bbolt.dir=/data
+        - -compactor-scheduler.persistence-type=bbolt
+        - -compactor-scheduler.planning-interval=30m
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -target=compactor-scheduler
+        image: grafana/mimir:3.1.4
+        imagePullPolicy: IfNotPresent
+        name: compactor-scheduler
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 500m
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            ephemeral-storage: 50Mi
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /data
+          name: compactor-scheduler-data
+        - mountPath: /etc/mimir
+          name: overrides
+      securityContext:
+        runAsUser: 0
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: compactor-scheduler-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi
+      storageClassName: standard
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    name: ingester
+  name: ingester
+  namespace: default
+spec:
+  podManagementPolicy: Parallel
+  replicas: 3
+  selector:
+    matchLabels:
+      name: ingester
+  serviceName: ingester
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: ingester
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: ingester
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -blocks-storage.tsdb.block-ranges-period=2h
+        - -blocks-storage.tsdb.dir=/data/tsdb
+        - -blocks-storage.tsdb.head-compaction-interval=15m
+        - -blocks-storage.tsdb.ship-interval=1m
+        - -blocks-storage.tsdb.wal-replay-concurrency=3
+        - -common.storage.backend=gcs
+        - -distributor.health-check-ingesters=true
+        - -ingester.max-global-metadata-per-metric=10
+        - -ingester.max-global-metadata-per-user=30000
+        - -ingester.max-global-series-per-user=150000
+        - -ingester.ring.heartbeat-period=2m
+        - -ingester.ring.heartbeat-timeout=10m
+        - -ingester.ring.num-tokens=512
+        - -ingester.ring.prefix=
+        - -ingester.ring.replication-factor=3
+        - -ingester.ring.store=memberlist
+        - -ingester.ring.tokens-file-path=/data/tokens
+        - -ingester.ring.unregister-on-shutdown=true
+        - -memberlist.abort-if-fast-join-fails=true
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc-max-concurrent-streams=500
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -target=ingester
+        - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOMAXPROCS
+          value: "9"
+        image: grafana/mimir:3.1.4
+        imagePullPolicy: IfNotPresent
+        name: ingester
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 25Gi
+          requests:
+            cpu: "4"
+            ephemeral-storage: 50Mi
+            memory: 15Gi
+        volumeMounts:
+        - mountPath: /data
+          name: ingester-data
+        - mountPath: /etc/mimir
+          name: overrides
+      securityContext:
+        runAsUser: 0
+      terminationGracePeriodSeconds: 1200
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: ingester-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 100Gi
+      storageClassName: fast
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: memcached
+  namespace: default
+spec:
+  minReadySeconds: 60
+  replicas: 3
+  selector:
+    matchLabels:
+      name: memcached
+  serviceName: memcached
+  template:
+    metadata:
+      labels:
+        name: memcached
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: memcached
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -m 6144
+        - -I 1m
+        - -c 16384
+        - -v
+        image: memcached:1.6.34-alpine
+        imagePullPolicy: IfNotPresent
+        name: memcached
+        ports:
+        - containerPort: 11211
+          name: client
+        resources:
+          limits:
+            memory: 9Gi
+          requests:
+            cpu: 500m
+            memory: 6552Mi
+      - args:
+        - --memcached.address=localhost:11211
+        - --web.listen-address=0.0.0.0:9150
+        image: prom/memcached-exporter:v0.15.3
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9150
+          name: http-metrics
+        resources:
+          limits:
+            memory: 250Mi
+          requests:
+            cpu: "0.05"
+            memory: 50Mi
+  updateStrategy:
+    type: RollingUpdate
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: memcached-frontend
+  namespace: default
+spec:
+  minReadySeconds: 60
+  replicas: 3
+  selector:
+    matchLabels:
+      name: memcached-frontend
+  serviceName: memcached-frontend
+  template:
+    metadata:
+      labels:
+        name: memcached-frontend
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: memcached-frontend
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -m 1024
+        - -I 25m
+        - -c 16384
+        - -v
+        image: memcached:1.6.34-alpine
+        imagePullPolicy: IfNotPresent
+        name: memcached
+        ports:
+        - containerPort: 11211
+          name: client
+        resources:
+          limits:
+            memory: 1536Mi
+          requests:
+            cpu: 500m
+            memory: 1176Mi
+      - args:
+        - --memcached.address=localhost:11211
+        - --web.listen-address=0.0.0.0:9150
+        image: prom/memcached-exporter:v0.15.3
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9150
+          name: http-metrics
+        resources:
+          limits:
+            memory: 250Mi
+          requests:
+            cpu: "0.05"
+            memory: 50Mi
+  updateStrategy:
+    type: RollingUpdate
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: memcached-index-queries
+  namespace: default
+spec:
+  minReadySeconds: 60
+  replicas: 3
+  selector:
+    matchLabels:
+      name: memcached-index-queries
+  serviceName: memcached-index-queries
+  template:
+    metadata:
+      labels:
+        name: memcached-index-queries
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: memcached-index-queries
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -m 1024
+        - -I 5m
+        - -c 16384
+        - -v
+        image: memcached:1.6.34-alpine
+        imagePullPolicy: IfNotPresent
+        name: memcached
+        ports:
+        - containerPort: 11211
+          name: client
+        resources:
+          limits:
+            memory: 1536Mi
+          requests:
+            cpu: 500m
+            memory: 1176Mi
+      - args:
+        - --memcached.address=localhost:11211
+        - --web.listen-address=0.0.0.0:9150
+        image: prom/memcached-exporter:v0.15.3
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9150
+          name: http-metrics
+        resources:
+          limits:
+            memory: 250Mi
+          requests:
+            cpu: "0.05"
+            memory: 50Mi
+  updateStrategy:
+    type: RollingUpdate
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: memcached-metadata
+  namespace: default
+spec:
+  minReadySeconds: 60
+  replicas: 3
+  selector:
+    matchLabels:
+      name: memcached-metadata
+  serviceName: memcached-metadata
+  template:
+    metadata:
+      labels:
+        name: memcached-metadata
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: memcached-metadata
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -m 512
+        - -I 1m
+        - -c 16384
+        - -v
+        image: memcached:1.6.34-alpine
+        imagePullPolicy: IfNotPresent
+        name: memcached
+        ports:
+        - containerPort: 11211
+          name: client
+        resources:
+          limits:
+            memory: 768Mi
+          requests:
+            cpu: 500m
+            memory: 638Mi
+      - args:
+        - --memcached.address=localhost:11211
+        - --web.listen-address=0.0.0.0:9150
+        image: prom/memcached-exporter:v0.15.3
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - containerPort: 9150
+          name: http-metrics
+        resources:
+          limits:
+            memory: 250Mi
+          requests:
+            cpu: "0.05"
+            memory: 50Mi
+  updateStrategy:
+    type: RollingUpdate
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    name: store-gateway
+  name: store-gateway
+  namespace: default
+spec:
+  podManagementPolicy: Parallel
+  replicas: 3
+  selector:
+    matchLabels:
+      name: store-gateway
+  serviceName: store-gateway
+  template:
+    metadata:
+      labels:
+        gossip_ring_member: "true"
+        name: store-gateway
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: store-gateway
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - args:
+        - -blocks-storage.bucket-store.chunks-cache.backend=memcached
+        - -blocks-storage.bucket-store.chunks-cache.memcached.addresses=dnssrvnoa+memcached.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-get-multi-concurrency=100
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-idle-connections=150
+        - -blocks-storage.bucket-store.chunks-cache.memcached.max-item-size=1048576
+        - -blocks-storage.bucket-store.chunks-cache.memcached.timeout=750ms
+        - -blocks-storage.bucket-store.index-cache.backend=memcached
+        - -blocks-storage.bucket-store.index-cache.memcached.addresses=dnssrvnoa+memcached-index-queries.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.index-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.index-cache.memcached.max-get-multi-concurrency=100
+        - -blocks-storage.bucket-store.index-cache.memcached.max-idle-connections=150
+        - -blocks-storage.bucket-store.index-cache.memcached.max-item-size=5242880
+        - -blocks-storage.bucket-store.index-cache.memcached.timeout=750ms
+        - -blocks-storage.bucket-store.metadata-cache.backend=memcached
+        - -blocks-storage.bucket-store.metadata-cache.memcached.addresses=dnssrvnoa+memcached-metadata.default.svc.cluster.local.:11211
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-async-concurrency=50
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-get-multi-concurrency=100
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-idle-connections=150
+        - -blocks-storage.bucket-store.metadata-cache.memcached.max-item-size=1048576
+        - -blocks-storage.bucket-store.sync-dir=/data/tsdb
+        - -blocks-storage.bucket-store.sync-interval=15m
+        - -blocks-storage.gcs.bucket-name=blocks-bucket
+        - -common.storage.backend=gcs
+        - -memberlist.bind-port=7946
+        - -memberlist.join=dns+gossip-ring.default.svc.cluster.local.:7946
+        - -runtime-config.file=/etc/mimir/overrides.yaml
+        - -server.grpc-max-send-msg-size-bytes=209715200
+        - -server.grpc.keepalive.min-time-between-pings=10s
+        - -server.grpc.keepalive.ping-without-stream-allowed=true
+        - -server.http-listen-port=8080
+        - -store-gateway.sharding-ring.heartbeat-period=1m
+        - -store-gateway.sharding-ring.heartbeat-timeout=10m
+        - -store-gateway.sharding-ring.prefix=
+        - -store-gateway.sharding-ring.replication-factor=3
+        - -store-gateway.sharding-ring.store=memberlist
+        - -store-gateway.sharding-ring.tokens-file-path=/data/tokens
+        - -store-gateway.sharding-ring.unregister-on-shutdown=false
+        - -store-gateway.sharding-ring.wait-stability-min-duration=1m
+        - -target=store-gateway
+        - -usage-stats.installation-mode=jsonnet
+        env:
+        - name: GOMAXPROCS
+          value: "5"
+        - name: GOMEMLIMIT
+          value: "12884901888"
+        image: grafana/mimir:3.1.4
+        imagePullPolicy: IfNotPresent
+        name: store-gateway
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 9095
+          name: grpc
+        - containerPort: 7946
+          name: gossip-ring
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          limits:
+            memory: 18Gi
+          requests:
+            cpu: "1"
+            ephemeral-storage: 50Mi
+            memory: 12Gi
+        volumeMounts:
+        - mountPath: /data
+          name: store-gateway-data
+        - mountPath: /etc/mimir
+          name: overrides
+      securityContext:
+        runAsUser: 0
+      terminationGracePeriodSeconds: 120
+      volumes:
+      - configMap:
+          name: overrides
+        name: overrides
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: store-gateway-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 50Gi
+      storageClassName: standard
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: compactor
+  namespace: default
+spec:
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+          - periodSeconds: 1800
+            type: Percent
+            value: 50
+          selectPolicy: Max
+          stabilizationWindowSeconds: 3600
+        scaleUp:
+          policies:
+          - periodSeconds: 600
+            type: Percent
+            value: 100
+          selectPolicy: Max
+          stabilizationWindowSeconds: 300
+  maxReplicaCount: 30
+  minReplicaCount: 2
+  pollingInterval: 10
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: compactor
+  triggers:
+  - metadata:
+      ignoreNullValues: "false"
+      metricName: cortex_compactor_drain_scheduler_hpa_default
+      query: |+
+        max_over_time(
+          (
+            (
+              # Compaction jobs: outstanding bytes * seconds/byte per compaction type
+              sum(
+                (
+                  sum by (compaction_type) (cortex_compactor_scheduler_incomplete_compaction_jobs_bytes{namespace="default", compaction_type=~"split|merge"})
+                  / (max by (compaction_type) (namespace_compaction_type:cortex_compactor_compaction_bytes_per_second:rate24h{namespace="default"}) > 0)
+                )
+                or
+                sum by (compaction_type) (cortex_compactor_scheduler_incomplete_compaction_jobs_bytes{namespace="default", compaction_type=~"split|merge"}) * 1e-07
+              )
+              +
+              # Plan jobs: pending jobs * seconds/job.
+              sum(cortex_compactor_scheduler_pending_jobs{namespace="default", job_type="plan"})
+              * (
+                max(namespace:cortex_compactor_plan_job_duration_seconds:avg24h{namespace="default"})
+                or on() vector(1)
+              )
+            )
+            / 3600
+          )[1h:5m]
+        )
+        # A [1;2] multiplier, based on the time since we last saw an empty queue.
+        # We increment 0.1 every 3600 seconds of continuous pending jobs.
+        * (
+          clamp_max(
+            1 + 0.1 * floor(
+              (time() - max(max_over_time(cortex_compactor_scheduler_pending_jobs_last_empty_timestamp_seconds{namespace="default"}[36000s]) > 0)) / 3600
+            ),
+            2
+          )
+          or on() vector(2)
+        )
+
+      serverAddress: http://prometheus.default:9090/prometheus
+      threshold: "1"
+    metricType: AverageValue
+    name: cortex_compactor_drain_scheduler_hpa_default
+    type: prometheus

--- a/operations/mimir-tests/test-compactor-scheduler-autoscaling-recording-rules-generated.yaml
+++ b/operations/mimir-tests/test-compactor-scheduler-autoscaling-recording-rules-generated.yaml
@@ -1490,7 +1490,7 @@ spec:
               sum(
                 (
                   sum by (compaction_type) (cortex_compactor_scheduler_incomplete_compaction_jobs_bytes{namespace="default", compaction_type=~"split|merge"})
-                  / (max by (compaction_type) (namespace_compaction_type:cortex_compactor_compaction_bytes_per_second:rate24h{namespace="default"}) > 0)
+                  / ((max by (compaction_type) (namespace_compaction_type:cortex_compactor_compaction_bytes_per_second:rate24h{namespace="default"})) > 0)
                 )
                 or
                 sum by (compaction_type) (cortex_compactor_scheduler_incomplete_compaction_jobs_bytes{namespace="default", compaction_type=~"split|merge"}) * 1e-07
@@ -1499,7 +1499,7 @@ spec:
               # Plan jobs: pending jobs * seconds/job.
               sum(cortex_compactor_scheduler_pending_jobs{namespace="default", job_type="plan"})
               * (
-                max(namespace:cortex_compactor_plan_job_duration_seconds:avg24h{namespace="default"})
+                ((max(namespace:cortex_compactor_plan_job_duration_seconds:avg24h{namespace="default"})) > 0)
                 or on() vector(1)
               )
             )

--- a/operations/mimir-tests/test-compactor-scheduler-autoscaling-recording-rules.jsonnet
+++ b/operations/mimir-tests/test-compactor-scheduler-autoscaling-recording-rules.jsonnet
@@ -1,0 +1,9 @@
+// Based on test-compactor-scheduler-autoscaling.jsonnet.
+(import 'test-compactor-scheduler-autoscaling.jsonnet') {
+  _config+:: {
+    autoscaling_compactor_scheduler_compaction_bytes_per_second_query:
+      'max by (compaction_type) (namespace_compaction_type:cortex_compactor_compaction_bytes_per_second:rate24h{namespace="default"})',
+    autoscaling_compactor_scheduler_plan_job_seconds_query:
+      'max(namespace:cortex_compactor_plan_job_duration_seconds:avg24h{namespace="default"})',
+  },
+}

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -966,29 +966,35 @@
     local promql_scheduler_matchers = if scheduler_matchers == '' then '' else ', %s' % scheduler_matchers;
     local promql_compactor_matchers = if compactor_matchers == '' then '' else ', %s' % compactor_matchers;
 
-    local estimate(override, default) =
-      if override != '' then override
-      else default % {
-        namespace: $._config.namespace,
-        promql_compactor_matchers: promql_compactor_matchers,
-        lookback: lookback,
-        min_duration_samples: min_duration_samples,
-      };
+    local estimation_vars = {
+      namespace: $._config.namespace,
+      promql_compactor_matchers: promql_compactor_matchers,
+      lookback: lookback,
+      min_duration_samples: min_duration_samples,
+    };
 
-    local compaction_bytes_per_second_query = $._config.autoscaling_compactor_scheduler_compaction_bytes_per_second_query;
+    local compaction_query = $._config.autoscaling_compactor_scheduler_compaction_bytes_per_second_query;
+    local plan_query = $._config.autoscaling_compactor_scheduler_plan_job_seconds_query;
 
-    local compaction_speed = estimate(if compaction_bytes_per_second_query == '' then '' else '/ (%s > 0)' % compaction_bytes_per_second_query, |||
-      * (
-        sum by (compaction_type) (histogram_sum(rate(cortex_compactor_job_duration_seconds{namespace="%(namespace)s", job_type="compaction", compaction_type=~"split|merge"%(promql_compactor_matchers)s}[%(lookback)s] @ end())))
-        / sum by (compaction_type) (histogram_sum(rate(cortex_compactor_compaction_job_bytes{namespace="%(namespace)s", compaction_type=~"split|merge"%(promql_compactor_matchers)s}[%(lookback)s] @ end())))
-        and sum by (compaction_type) (histogram_count(increase(cortex_compactor_job_duration_seconds{namespace="%(namespace)s", job_type="compaction", compaction_type=~"split|merge"%(promql_compactor_matchers)s}[%(lookback)s] @ end()))) >= %(min_duration_samples)d
-      )
-    |||);
+    // Turns outstanding bytes into seconds of work: divide by a configured throughput, or multiply by the seconds/byte we measure ourselves.
+    local bytes_to_seconds =
+      if compaction_query != '' then
+        '/ (%s > 0)' % compaction_query
+      else |||
+        * (
+          sum by (compaction_type) (histogram_sum(rate(cortex_compactor_job_duration_seconds{namespace="%(namespace)s", job_type="compaction", compaction_type=~"split|merge"%(promql_compactor_matchers)s}[%(lookback)s] @ end())))
+          / sum by (compaction_type) (histogram_sum(rate(cortex_compactor_compaction_job_bytes{namespace="%(namespace)s", compaction_type=~"split|merge"%(promql_compactor_matchers)s}[%(lookback)s] @ end())))
+          and sum by (compaction_type) (histogram_count(increase(cortex_compactor_job_duration_seconds{namespace="%(namespace)s", job_type="compaction", compaction_type=~"split|merge"%(promql_compactor_matchers)s}[%(lookback)s] @ end()))) >= %(min_duration_samples)d
+        )
+      ||| % estimation_vars;
 
-    local plan_job_seconds = estimate($._config.autoscaling_compactor_scheduler_plan_job_seconds_query, |||
-      histogram_avg(sum(rate(cortex_compactor_job_duration_seconds{namespace="%(namespace)s", job_type="plan"%(promql_compactor_matchers)s}[%(lookback)s] @ end())))
-      and on() (sum(histogram_count(increase(cortex_compactor_job_duration_seconds{namespace="%(namespace)s", job_type="plan"%(promql_compactor_matchers)s}[%(lookback)s] @ end()))) >= %(min_duration_samples)d)
-    |||);
+    local plan_job_seconds =
+      if plan_query != '' then
+        plan_query
+      else |||
+        histogram_avg(sum(rate(cortex_compactor_job_duration_seconds{namespace="%(namespace)s", job_type="plan"%(promql_compactor_matchers)s}[%(lookback)s] @ end())))
+        and on() (sum(histogram_count(increase(cortex_compactor_job_duration_seconds{namespace="%(namespace)s", job_type="plan"%(promql_compactor_matchers)s}[%(lookback)s] @ end()))) >= %(min_duration_samples)d)
+      ||| % estimation_vars;
 
     local indented(expr, spaces) = std.strReplace(std.rstripChars(expr, '\n'), '\n', '\n' + std.repeat(' ', spaces));
 
@@ -1065,7 +1071,7 @@
             sum(
               (
                 sum by (compaction_type) (cortex_compactor_scheduler_incomplete_compaction_jobs_bytes{namespace="%(namespace)s", compaction_type=~"split|merge"%(promql_scheduler_matchers)s})
-                %(compaction_speed)s
+                %(bytes_to_seconds)s
               )
               or
               sum by (compaction_type) (cortex_compactor_scheduler_incomplete_compaction_jobs_bytes{namespace="%(namespace)s", compaction_type=~"split|merge"%(promql_scheduler_matchers)s}) * %(default_compaction_seconds_per_byte)g
@@ -1085,7 +1091,7 @@
     ||| % {
       namespace: $._config.namespace,
       drain_target_seconds: $._config.autoscaling_compactor_scheduler_drain_target_seconds,
-      compaction_speed: indented(compaction_speed, 10),
+      bytes_to_seconds: indented(bytes_to_seconds, 10),
       plan_job_seconds: indented(plan_job_seconds, 8),
       default_compaction_seconds_per_byte: default_compaction_seconds_per_byte,
       default_plan_job_seconds: default_plan_job_seconds,

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -72,6 +72,11 @@
     autoscaling_compactor_scheduler_drain_target_seconds: 3600,
     // Lookback window for the rate-based processing-speed estimates that drive the drain-time autoscaler.
     autoscaling_compactor_scheduler_estimation_lookback: '3h',
+    // An optional PromQL term to use as a bytes/second throughput estimate for compaction jobs, to be used for autoscaling.
+    // The query must return series by compaction_type, with no other labels.
+    autoscaling_compactor_scheduler_compaction_bytes_per_second_query: '',
+    // An optional PromQL term to use as a seconds/job estimate for plan jobs. The query must return a single series with no labels.
+    autoscaling_compactor_scheduler_plan_job_seconds_query: '',
     // Lag trigger: bumps the desired replica count by +10% for every hour the pending queue stays non-empty, capped at +100%.
     autoscaling_compactor_scheduler_lag_trigger_enabled: true,
     // When enabled, the lag trigger uses the last-empty timestamp straight from the
@@ -961,6 +966,32 @@
     local promql_scheduler_matchers = if scheduler_matchers == '' then '' else ', %s' % scheduler_matchers;
     local promql_compactor_matchers = if compactor_matchers == '' then '' else ', %s' % compactor_matchers;
 
+    local estimate(override, default) =
+      if override != '' then override
+      else default % {
+        namespace: $._config.namespace,
+        promql_compactor_matchers: promql_compactor_matchers,
+        lookback: lookback,
+        min_duration_samples: min_duration_samples,
+      };
+
+    local compaction_bytes_per_second_query = $._config.autoscaling_compactor_scheduler_compaction_bytes_per_second_query;
+
+    local compaction_speed = estimate(if compaction_bytes_per_second_query == '' then '' else '/ (%s > 0)' % compaction_bytes_per_second_query, |||
+      * (
+        sum by (compaction_type) (histogram_sum(rate(cortex_compactor_job_duration_seconds{namespace="%(namespace)s", job_type="compaction", compaction_type=~"split|merge"%(promql_compactor_matchers)s}[%(lookback)s] @ end())))
+        / sum by (compaction_type) (histogram_sum(rate(cortex_compactor_compaction_job_bytes{namespace="%(namespace)s", compaction_type=~"split|merge"%(promql_compactor_matchers)s}[%(lookback)s] @ end())))
+        and sum by (compaction_type) (histogram_count(increase(cortex_compactor_job_duration_seconds{namespace="%(namespace)s", job_type="compaction", compaction_type=~"split|merge"%(promql_compactor_matchers)s}[%(lookback)s] @ end()))) >= %(min_duration_samples)d
+      )
+    |||);
+
+    local plan_job_seconds = estimate($._config.autoscaling_compactor_scheduler_plan_job_seconds_query, |||
+      histogram_avg(sum(rate(cortex_compactor_job_duration_seconds{namespace="%(namespace)s", job_type="plan"%(promql_compactor_matchers)s}[%(lookback)s] @ end())))
+      and on() (sum(histogram_count(increase(cortex_compactor_job_duration_seconds{namespace="%(namespace)s", job_type="plan"%(promql_compactor_matchers)s}[%(lookback)s] @ end()))) >= %(min_duration_samples)d)
+    |||);
+
+    local indented(expr, spaces) = std.strReplace(std.rstripChars(expr, '\n'), '\n', '\n' + std.repeat(' ', spaces));
+
     // Lag trigger: multiplies the drain-time signal by a factor that grows the longer the pending
     // queue stays non-empty. Starts at 1, grows by `lag_period_increase` per period the queue has
     // been continuously non-empty, capped at `lag_max_multiplier`.
@@ -1034,11 +1065,7 @@
             sum(
               (
                 sum by (compaction_type) (cortex_compactor_scheduler_incomplete_compaction_jobs_bytes{namespace="%(namespace)s", compaction_type=~"split|merge"%(promql_scheduler_matchers)s})
-                * (
-                  sum by (compaction_type) (histogram_sum(rate(cortex_compactor_job_duration_seconds{namespace="%(namespace)s", job_type="compaction", compaction_type=~"split|merge"%(promql_compactor_matchers)s}[%(lookback)s] @ end())))
-                  / sum by (compaction_type) (histogram_sum(rate(cortex_compactor_compaction_job_bytes{namespace="%(namespace)s", compaction_type=~"split|merge"%(promql_compactor_matchers)s}[%(lookback)s] @ end())))
-                  and sum by (compaction_type) (histogram_count(increase(cortex_compactor_job_duration_seconds{namespace="%(namespace)s", job_type="compaction", compaction_type=~"split|merge"%(promql_compactor_matchers)s}[%(lookback)s] @ end()))) >= %(min_duration_samples)d
-                )
+                %(compaction_speed)s
               )
               or
               sum by (compaction_type) (cortex_compactor_scheduler_incomplete_compaction_jobs_bytes{namespace="%(namespace)s", compaction_type=~"split|merge"%(promql_scheduler_matchers)s}) * %(default_compaction_seconds_per_byte)g
@@ -1047,8 +1074,7 @@
             # Plan jobs: pending jobs * seconds/job.
             sum(cortex_compactor_scheduler_pending_jobs{namespace="%(namespace)s", job_type="plan"%(promql_scheduler_matchers)s})
             * (
-              histogram_avg(sum(rate(cortex_compactor_job_duration_seconds{namespace="%(namespace)s", job_type="plan"%(promql_compactor_matchers)s}[%(lookback)s] @ end())))
-              and on() (sum(histogram_count(increase(cortex_compactor_job_duration_seconds{namespace="%(namespace)s", job_type="plan"%(promql_compactor_matchers)s}[%(lookback)s] @ end()))) >= %(min_duration_samples)d)
+              %(plan_job_seconds)s
               or on() vector(%(default_plan_job_seconds)d)
             )
           )
@@ -1059,13 +1085,12 @@
     ||| % {
       namespace: $._config.namespace,
       drain_target_seconds: $._config.autoscaling_compactor_scheduler_drain_target_seconds,
-      min_duration_samples: min_duration_samples,
+      compaction_speed: indented(compaction_speed, 10),
+      plan_job_seconds: indented(plan_job_seconds, 8),
       default_compaction_seconds_per_byte: default_compaction_seconds_per_byte,
       default_plan_job_seconds: default_plan_job_seconds,
-      lookback: lookback,
       peak_window: peak_window,
       promql_scheduler_matchers: promql_scheduler_matchers,
-      promql_compactor_matchers: promql_compactor_matchers,
       lag_multiplier:
         if !$._config.autoscaling_compactor_scheduler_lag_trigger_enabled then ''
         else if $._config.autoscaling_compactor_scheduler_lag_trigger_use_last_empty_metric then lag_multiplier_last_empty

--- a/operations/mimir/autoscaling.libsonnet
+++ b/operations/mimir/autoscaling.libsonnet
@@ -979,7 +979,7 @@
     // Turns outstanding bytes into seconds of work: divide by a configured throughput, or multiply by the seconds/byte we measure ourselves.
     local bytes_to_seconds =
       if compaction_query != '' then
-        '/ (%s > 0)' % compaction_query
+        '/ ((%s) > 0)' % compaction_query
       else |||
         * (
           sum by (compaction_type) (histogram_sum(rate(cortex_compactor_job_duration_seconds{namespace="%(namespace)s", job_type="compaction", compaction_type=~"split|merge"%(promql_compactor_matchers)s}[%(lookback)s] @ end())))
@@ -990,7 +990,7 @@
 
     local plan_job_seconds =
       if plan_query != '' then
-        plan_query
+        '((%s) > 0)' % plan_query
       else |||
         histogram_avg(sum(rate(cortex_compactor_job_duration_seconds{namespace="%(namespace)s", job_type="plan"%(promql_compactor_matchers)s}[%(lookback)s] @ end())))
         and on() (sum(histogram_count(increase(cortex_compactor_job_duration_seconds{namespace="%(namespace)s", job_type="plan"%(promql_compactor_matchers)s}[%(lookback)s] @ end()))) >= %(min_duration_samples)d)


### PR DESCRIPTION
#### What this PR does

The compactor-scheduler drain autoscaler uses worker throughput estimates in its query. Currently these are built in the trigger query and can be quite expensive to compute on every HPA cycle. This adds two options to configure the query terms for those estimates, particularly useful to introduce a recording rules to speed up the query, like the tests exemplify.

- `autoscaling_compactor_scheduler_compaction_bytes_per_second_query`
- `autoscaling_compactor_scheduler_plan_job_seconds_query`

Both options default to empty, which keeps the same existing estimates in the trigger query

#### Which issue(s) this PR fixes or relates to

N/A

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
