### PR TITLE
Distributor: count OTLP requests with job/instance resource attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [CHANGE] MQE: validate that delayed name removal is only set using `-querier.enable-delayed-name-removal` or the per-tenant setting when MQE is in use. #16207
 * [ENHANCEMENT] Compactor: Add the experimental `-compactor.block-health-validation-concurrency` option to limit how many blocks are validated concurrently within a compaction job. #16269
+* [ENHANCEMENT] Distributor: Add the experimental `cortex_distributor_otlp_requests_with_job_or_instance_resource_attribute_total{user}` counter to track OTLP requests carrying `job` or `instance` as a resource attribute. #16285
 * [BUGFIX] Query-frontend: Return a HTTP 500 error rather than a HTTP 400 when a querier receives a query plan that is too new. #16233
 
 ### Mixin

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -122,6 +122,7 @@ The following features are currently experimental:
     - `-distributor.otel-translation-strategy`
   - Allow controlling OTLP translation via request headers
     - `-api.otlp-translation-headers-enabled`
+  - `cortex_distributor_otlp_requests_with_job_or_instance_resource_attribute_total` metric. Counts OTLP requests, per tenant, whose payload carries `job` or `instance` as a raw resource attribute key. Temporary measurement metric to inform work on the [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/pull/4956); will be removed once we have collected enough data.
   - Configure how to handle label values over the length limit
     - `-validation.label-value-length-over-limit-strategy`
   - Enforce the out-of-order time window on the distributor when `past_grace_period` is 0

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -425,8 +425,9 @@ type PushMetrics struct {
 	influxRequestCounter       *prometheus.CounterVec
 	influxUncompressedBodySize *prometheus.HistogramVec
 	// OTLP metrics.
-	otlpRequestCounter     *prometheus.CounterVec
-	otlpContentTypeCounter *prometheus.CounterVec
+	otlpRequestCounter                             *prometheus.CounterVec
+	otlpContentTypeCounter                         *prometheus.CounterVec
+	otlpRequestsWithJobOrInstanceResourceAttribute *prometheus.CounterVec
 	// Temporary to better understand which array (ResourceMetrics/ScopeMetrics/Metrics) is usually large
 	otlpArrayLengths *prometheus.HistogramVec
 }
@@ -466,6 +467,10 @@ func newPushMetrics(reg prometheus.Registerer) *PushMetrics {
 			Name: "cortex_distributor_otlp_requests_by_content_type_total",
 			Help: "Total number of requests with a given content type.",
 		}, []string{"content_type"}),
+		otlpRequestsWithJobOrInstanceResourceAttribute: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "cortex_distributor_otlp_requests_with_job_or_instance_resource_attribute_total",
+			Help: "The total number of OTLP requests that carry at least one resource with \"job\" or \"instance\" as a resource attribute key.",
+		}, []string{"user"}),
 		otlpArrayLengths: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 			Name:                            "cortex_distributor_otlp_array_lengths",
 			Help:                            "Number of elements in the arrays of OTLP requests.",
@@ -494,6 +499,12 @@ func (m *PushMetrics) IncOTLPRequest(user string) {
 	}
 }
 
+func (m *PushMetrics) IncOTLPRequestWithJobOrInstanceResourceAttribute(user string) {
+	if m != nil {
+		m.otlpRequestsWithJobOrInstanceResourceAttribute.WithLabelValues(user).Inc()
+	}
+}
+
 func (m *PushMetrics) ObserveRequestBodySize(user, handler string, uncompressedSize, compressedSize int64) {
 	if m != nil {
 		if compressedSize > 0 {
@@ -519,6 +530,7 @@ func (m *PushMetrics) deleteUserMetrics(user string) {
 	m.influxRequestCounter.DeleteLabelValues(user)
 	m.influxUncompressedBodySize.DeleteLabelValues(user)
 	m.otlpRequestCounter.DeleteLabelValues(user)
+	m.otlpRequestsWithJobOrInstanceResourceAttribute.DeleteLabelValues(user)
 	m.uncompressedBodySize.DeleteLabelValues(user)
 }
 

--- a/pkg/distributor/otel.go
+++ b/pkg/distributor/otel.go
@@ -234,11 +234,22 @@ func handlePartialOTLPPush(pushErr error, w http.ResponseWriter, r *http.Request
 	writeOTLPResponse(r, w, http.StatusOK, &expResp, logger)
 }
 
-func observeOTLPFieldsCount(pushMetrics *PushMetrics, req pmetricotlp.ExportRequest) {
+// inspectOTLPResourceMetrics observes ResourceMetrics/ScopeMetrics/Metrics
+// array lengths and reports whether any ResourceMetrics carries "job" or
+// "instance" as a resource attribute key.
+func inspectOTLPResourceMetrics(pushMetrics *PushMetrics, req pmetricotlp.ExportRequest) (hasJobOrInstanceResourceAttr bool) {
 	resourceMetricsSlice := req.Metrics().ResourceMetrics()
 	pushMetrics.ObserveOTLPArrayLengths("resource_metrics", resourceMetricsSlice.Len())
 	for i := 0; i < resourceMetricsSlice.Len(); i++ {
 		resourceMetrics := resourceMetricsSlice.At(i)
+		if !hasJobOrInstanceResourceAttr {
+			attrs := resourceMetrics.Resource().Attributes()
+			if _, ok := attrs.Get("job"); ok {
+				hasJobOrInstanceResourceAttr = true
+			} else if _, ok := attrs.Get("instance"); ok {
+				hasJobOrInstanceResourceAttr = true
+			}
+		}
 		scopeMetricsSlice := resourceMetrics.ScopeMetrics()
 		pushMetrics.ObserveOTLPArrayLengths("scope_metrics", scopeMetricsSlice.Len())
 		for j := 0; j < scopeMetricsSlice.Len(); j++ {
@@ -247,6 +258,7 @@ func observeOTLPFieldsCount(pushMetrics *PushMetrics, req pmetricotlp.ExportRequ
 			pushMetrics.ObserveOTLPArrayLengths("metrics", metricSlice.Len())
 		}
 	}
+	return hasJobOrInstanceResourceAttr
 }
 
 func newOTLPParser(
@@ -420,7 +432,9 @@ func newOTLPParser(
 		pushMetrics.IncOTLPRequest(tenantID)
 		pushMetrics.ObserveRequestBodySize(tenantID, "otlp", int64(uncompressedBodySize), r.ContentLength)
 		pushMetrics.IncOTLPContentType(contentType)
-		observeOTLPFieldsCount(pushMetrics, otlpReq)
+		if inspectOTLPResourceMetrics(pushMetrics, otlpReq) {
+			pushMetrics.IncOTLPRequestWithJobOrInstanceResourceAttribute(tenantID)
+		}
 
 		convOpts := conversionOptions{
 			addSuffixes:                       translationStrategy.ShouldAddSuffixes(),

--- a/pkg/distributor/otel_test.go
+++ b/pkg/distributor/otel_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/klauspost/compress/zstd"
 	"github.com/pierrec/lz4/v4"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/otlptranslator"
 	"github.com/prometheus/prometheus/model/labels"
@@ -2821,6 +2822,64 @@ func TestOTLPJSONEnumEncoding(t *testing.T) {
 	data, err := json.Marshal(st)
 	require.NoError(t, err)
 	assert.Contains(t, string(data), `"code":13`, "code field must be encoded as integer (13), not string")
+}
+
+func TestInspectOTLPResourceMetrics(t *testing.T) {
+	tests := map[string]struct {
+		attrsPerResource []map[string]string
+		expected         bool
+	}{
+		"empty request": {
+			attrsPerResource: nil,
+			expected:         false,
+		},
+		"no matching attributes": {
+			attrsPerResource: []map[string]string{
+				{"service.name": "s1", "service.instance.id": "i1"},
+			},
+			expected: false,
+		},
+		"job resource attribute set": {
+			attrsPerResource: []map[string]string{
+				{"job": "s1"},
+			},
+			expected: true,
+		},
+		"instance resource attribute set": {
+			attrsPerResource: []map[string]string{
+				{"instance": "i1"},
+			},
+			expected: true,
+		},
+		"both job and instance set": {
+			attrsPerResource: []map[string]string{
+				{"job": "s1", "instance": "i1"},
+			},
+			expected: true,
+		},
+		"match on later resource": {
+			attrsPerResource: []map[string]string{
+				{"service.name": "s1"},
+				{"instance": "i2"},
+			},
+			expected: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			req := pmetricotlp.NewExportRequest()
+			metrics := req.Metrics()
+			for _, attrs := range tc.attrsPerResource {
+				rm := metrics.ResourceMetrics().AppendEmpty()
+				for k, v := range attrs {
+					rm.Resource().Attributes().PutStr(k, v)
+				}
+			}
+			pushMetrics := newPushMetrics(prometheus.NewRegistry())
+			require.Equal(t, tc.expected, inspectOTLPResourceMetrics(pushMetrics, req))
+		})
+	}
 }
 
 type fakeResourceAttributePromotionConfig struct {


### PR DESCRIPTION
## Summary

Adds a per-tenant counter `cortex_distributor_otlp_requests_with_job_or_instance_resource_attribute_total{user}` in the distributor. It increments once for each OTLP request whose payload contains at least one `ResourceMetrics` carrying `job` or `instance` as a raw resource attribute key.

The detection is folded into the existing ResourceMetrics pass (`inspectOTLPResourceMetrics`, renamed from `observeOTLPFieldsCount`) and short-circuits after the first match, so the overhead is two `pcommon.Map` lookups per resource until a hit — negligible.

⚠️ This is **experimental** and expected to be short-lived. It exists to gather production data for the OpenTelemetry specification PR https://github.com/open-telemetry/opentelemetry-specification/pull/4956, which is deciding how OTel senders should convey `job` and `instance` identity. Once we have enough signal on how prevalent this pattern is across tenants, the metric will most likely be removed.

Because it's short-lived and diagnostic in nature, expect it to disappear in a future release; please do not build long-lived dashboards or alerts on it.

## Test plan

- [x] `go test ./pkg/distributor/ -run TestInspectOTLPResourceMetrics` — new table-driven test covering no-match, job-only, instance-only, both, and match-on-later-resource cases
- [x] `go test ./pkg/distributor/ -run TestHandlerOTLPPush` — existing OTLP handler tests still pass
- [x] `go build ./pkg/distributor/... && go vet ./pkg/distributor/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)