### PR TITLE
`create-draft-release-notes.sh` works on rc without draft notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Tools
 
+* [CHANGE] `create-draft-release-notes.sh` doesn't require release notes ready for release candidate. #16286
+
 ## 3.2.0-rc.0
 
 ### Grafana Mimir

--- a/tools/release/create-draft-release-notes.sh
+++ b/tools/release/create-draft-release-notes.sh
@@ -37,22 +37,23 @@ fi
 # candidates), which are the ones whose patch version is 0. Patch releases only get a CHANGELOG.
 RELEASE_PATCH=$(echo -n "${LAST_RELEASE_VERSION}" | $SED -E 's/^[0-9]+\.[0-9]+\.([0-9]+).*/\1/')
 RELEASE_MINOR=$(echo -n "${LAST_RELEASE_VERSION}" | grep -Eo '^[0-9]+\.[0-9]+')
+RELEASE_CANDIDATE=$(echo -n "${LAST_RELEASE_VERSION}" | $SED -nE 's/^[0-9]+\.[0-9]+\.[0-9]+-rc\.([0-9]+)/\1/p')
 
 if [ "${RELEASE_PATCH}" = "0" ]; then
   RELEASE_NOTES_DOC="${REPO_ROOT}/docs/sources/mimir/release-notes/v${RELEASE_MINOR}.md"
 
-  if [ ! -f "${RELEASE_NOTES_DOC}" ]; then
+  if [ -f "${RELEASE_NOTES_DOC}" ]; then
+    FIRST_HEADING_LINE=$(grep -n -m1 '^# ' "${RELEASE_NOTES_DOC}" | cut -d: -f1)
+    tail -n +"${FIRST_HEADING_LINE}" "${RELEASE_NOTES_DOC}" | # Remove everything before the first heading (the YAML front matter)
+      $SED -E '/^<!--.*-->$/d' | # Remove HTML comments (e.g. vale directives)
+      $SED -E '/^\{\{[<%].*[%>]\}\}$/d' | # Remove Hugo shortcodes, keeping inner content
+      $SED "s|<MIMIR_VERSION>|v${RELEASE_MINOR}.x|g" # Replace the docs version placeholder that the website resolves at publish time
+    printf "\n"
+  elif [ -z "${RELEASE_CANDIDATE}" ]; then
     echo "Expected release notes document '${RELEASE_NOTES_DOC}' for release ${LAST_RELEASE_VERSION}, but it was not found." > /dev/stderr
     echo "The release notes document must be committed to the release branch before tagging the release." > /dev/stderr
     exit 1
   fi
-
-  FIRST_HEADING_LINE=$(grep -n -m1 '^# ' "${RELEASE_NOTES_DOC}" | cut -d: -f1)
-  tail -n +"${FIRST_HEADING_LINE}" "${RELEASE_NOTES_DOC}" | # Remove everything before the first heading (the YAML front matter)
-    $SED -E '/^<!--.*-->$/d' | # Remove HTML comments (e.g. vale directives)
-    $SED -E '/^\{\{[<%].*[%>]\}\}$/d' | # Remove Hugo shortcodes, keeping inner content
-    $SED "s|<MIMIR_VERSION>|v${RELEASE_MINOR}.x|g" # Replace the docs version placeholder that the website resolves at publish time
-  printf "\n"
 fi
 
 #


### PR DESCRIPTION
#### What this PR does

This changes make it such that only the release `x.y.0` uses the "release notes document" instead of all the release candidate. As per the release guide, drafting the release notes shouldn't block the [publishing of a release candidate](https://github.com/grafana/mimir/blob/efcb5aef50184f84a24e0ef3fd43082d839628d3/RELEASE.md?plain=1#L69).

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
