### PR TITLE
docs: Add note to HA availability topic

### DIFF
--- a/docs/sources/mimir/configure/configure-high-availability-deduplication.md
+++ b/docs/sources/mimir/configure/configure-high-availability-deduplication.md
@@ -11,6 +11,12 @@ weight: 50
 
 # Configure Grafana Mimir high-availability deduplication
 
+{{< admonition type="note" >}}
+If you use Grafana Cloud, HA deduplication is enabled by default for your tenant, using the default label names described on this page (`cluster` and `__replica__`). You don't need to configure anything to use this feature.
+
+If you need custom cluster or replica label names for your tenant, [contact Grafana Support](/docs/grafana-cloud/account-management/support/).
+{{< /admonition >}}
+
 You can have more than one Prometheus instance that scrapes the same metrics for redundancy. Grafana Mimir already performs replication for redundancy,
 so you do not need to ingest the same data twice. In Grafana Mimir, you can deduplicate the data that you receive from HA pairs of Prometheus instances.
 


### PR DESCRIPTION
#### What this PR does
Adds a note to https://grafana.com/docs/mimir/latest/configure/configure-high-availability-deduplication/#enable-the-ha-tracker to clarify Grafana Cloud configuration.

#### Which issue(s) this PR fixes or relates to

Fixes [#<issue number>](https://github.com/grafana/support-escalations/issues/22621)

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
