### PR TITLE
mimirpb: fix RW2 write request splitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   * When running splitting and caching inside MQE is enabled, the `cortex_query_frontend_cardinality_estimation_difference` metric will no longer be emitted.
 * [ENHANCEMENT] Distributor: Add the experimental `cortex_distributor_otlp_requests_with_job_or_instance_resource_attribute_total{user}` counter to track OTLP requests carrying `job` or `instance` as a resource attribute. #16285
 * [ENHANCEMENT] Ruler: Split oversized remote distributor writes to keep resulting calls within the configured gRPC maximum send size, and expose the number of generated requests in `cortex_ruler_remote_distributor_requests_per_write_request`. #16160
+* [BUGFIX] Ingest storage: Keep split Remote Write 2.0 Kafka records within the configured producer record size when multiple series fit near the limit, and preserve write-request settings across splits. #16295
 * [BUGFIX] Query-frontend: Return a HTTP 500 error rather than a HTTP 400 when a querier receives a query plan that is too new. #16233
 * [BUGFIX] Compactor, Store-gateway: Fix the store-gateway always logging `num_series=0` in its `loaded new block` message. #16276
 * [BUGFIX] Ingest storage: Account for protobuf framing when splitting Remote Write 1.0 requests so generated Kafka record data stays within `-ingest-storage.kafka.producer-max-record-size-bytes` when individual series and metadata entries fit. #16160

--- a/pkg/mimirpb/split.go
+++ b/pkg/mimirpb/split.go
@@ -55,6 +55,9 @@ func SplitWriteRequestByMaxMarshalSize(req *WriteRequest, reqSize, maxSize int) 
 // The request will split the RW2 symbols among the various sub-requests. The original symbols table will no longer be valid for the individual timeseries.
 // Timeseries are re-symbolized in place, so this function mutates the input.
 func SplitWriteRequestByMaxMarshalSizeRW2(req *WriteRequest, reqSize, maxSize int, offset uint32, commonSymbols *CommonSymbols) []*WriteRequest {
+	if maxSize <= 0 {
+		return []*WriteRequest{req}
+	}
 	if reqSize <= maxSize {
 		return []*WriteRequest{req}
 	}
@@ -63,20 +66,15 @@ func SplitWriteRequestByMaxMarshalSizeRW2(req *WriteRequest, reqSize, maxSize in
 	}
 
 	// Assume that the distribution of symbols usage is even across all timeseries, and that the timeseries are a roughly even size.
-	// so we preallocate the returned slice just adding 1 extra item (+2 because a +1 is to round up).
-	estimatedPartialReqs := (reqSize / maxSize) + 2
+	// so we preallocate the returned slice just adding 1 extra item (+2 because a +1 is to round up),
+	// capped at the number of timeseries.
+	estimatedPartialReqs := min((reqSize/maxSize)+2, len(req.TimeseriesRW2))
 	partialReqs := make([]*WriteRequest, 0, estimatedPartialReqs)
 	estimatedTimeseriesPerPartialReq := (len(req.TimeseriesRW2) / estimatedPartialReqs) + 1 // +1 is to round up
 
 	newPartialReq := func() (*WriteRequest, int) {
-		r := &WriteRequest{
-			Source:                          req.Source,
-			SkipLabelValidation:             req.SkipLabelValidation,
-			skipUnmarshalingExemplars:       req.skipUnmarshalingExemplars,
-			skipNormalizeMetadataMetricName: req.skipNormalizeMetadataMetricName,
-			skipDeduplicateMetadata:         req.skipDeduplicateMetadata,
-			TimeseriesRW2:                   make([]TimeSeriesRW2, 0, estimatedTimeseriesPerPartialReq),
-		}
+		r := newPartialWriteRequest(req)
+		r.TimeseriesRW2 = make([]TimeSeriesRW2, 0, estimatedTimeseriesPerPartialReq)
 
 		return r, r.Size()
 	}
@@ -92,11 +90,12 @@ func SplitWriteRequestByMaxMarshalSizeRW2(req *WriteRequest, reqSize, maxSize in
 		// Both are upper bounds. In particular symbolsSize does not have knowledge of whether symbols can be re-used.
 		// The actual growth will be less than or equal to these values.
 		seriesSize, symbolsSize := maxRW2SeriesSizeAfterResymbolization(&req.TimeseriesRW2[i], req.SymbolsRW2, offset)
+		seriesFieldSize := embeddedMessageFieldSize(seriesSize)
 
 		// Check if the next partial request is full (or close to be full), and so it's time to finalize it and create a new one.
 		// If the next partial request doesn't have any timeseries yet, we add the series anyway, in order to avoid an infinite loop
 		// if a single timeseries is bigger than the limit.
-		if nextReqSize+seriesSize+symbolsSize > maxSize && len(nextReq.TimeseriesRW2) > 0 {
+		if nextReqSize+seriesFieldSize+symbolsSize > maxSize && len(nextReq.TimeseriesRW2) > 0 {
 			// Finalize the next partial request.
 			nextReq.SymbolsRW2 = nextReqSymbols.Symbols()
 			partialReqs = append(partialReqs, nextReq)
@@ -111,7 +110,7 @@ func SplitWriteRequestByMaxMarshalSizeRW2(req *WriteRequest, reqSize, maxSize in
 		// Resymbolize the current series and add it to next partial request.
 		newTS := resymbolizeTimeSeriesRW2(&req.TimeseriesRW2[i], req.SymbolsRW2, nextReqSymbols)
 		// Add the growth in series size...
-		nextReqSize += newTS.Size() + 1 + sovMimir(uint64(seriesSize)) // Math copied from Size().
+		nextReqSize += embeddedMessageFieldSize(newTS.Size())
 		// ...and the growth in symbols size.
 		newSymbolsSize := nextReqSymbols.SymbolsSizeProto()
 		nextReqSize += newSymbolsSize - nextReqSymbolsSize

--- a/pkg/mimirpb/split_test.go
+++ b/pkg/mimirpb/split_test.go
@@ -63,6 +63,11 @@ func TestSplitWriteRequestByMaxMarshalSize(t *testing.T) {
 			partials := SplitWriteRequestByMaxMarshalSize(reqv1, reqv1.Size(), limit)
 			require.Len(t, partials, 1)
 			require.Same(t, reqv1, partials[0])
+
+			reqv2 := testReqV2Static(t)
+			partials = SplitWriteRequestByMaxMarshalSizeRW2(reqv2, reqv2.Size(), limit, 0, nil)
+			require.Len(t, partials, 1)
+			require.Same(t, reqv2, partials[0])
 		}
 	})
 
@@ -154,55 +159,21 @@ func TestSplitWriteRequestByMaxMarshalSize(t *testing.T) {
 	})
 
 	t.Run("should split the input WriteRequest into multiple requests, honoring the size limit, and bin-packing - RW2", func(t *testing.T) {
-		// 220 allows the first and second WriteRequests to fit into one request, but not the third.
 		const limit = 220
 		reqv2 := testReqV2Static(t)
+		original := testReqV2Static(t)
 
 		partials := SplitWriteRequestByMaxMarshalSizeRW2(reqv2, reqv2.Size(), limit, 0, nil)
-		assert.Equal(t, []*WriteRequest{
-			{
-				Source:              RULE,
-				SkipLabelValidation: true,
-				SymbolsRW2:          []string{"", model.MetricNameLabel, "series_1", "pod", "test-application-123456", "This is the first test metric.", "series_2", "This is the second test metric."},
-				TimeseriesRW2: []TimeSeriesRW2{
-					{
-						LabelsRefs: []uint32{1, 2, 3, 4},
-						Samples:    []Sample{{TimestampMs: 20}},
-						Exemplars:  []ExemplarRW2{{Timestamp: 30}},
-						Histograms: []Histogram{{Timestamp: 10}},
-						Metadata: MetadataRW2{
-							Type:    METRIC_TYPE_COUNTER,
-							HelpRef: 5,
-						},
-					},
-					{
-						LabelsRefs: []uint32{1, 6, 3, 4},
-						Samples:    []Sample{{TimestampMs: 30}},
-						Metadata: MetadataRW2{
-							Type:    METRIC_TYPE_COUNTER,
-							HelpRef: 7,
-						},
-					},
-				},
-			}, {
-				Source:              RULE,
-				SkipLabelValidation: true,
-				SymbolsRW2:          []string{"", model.MetricNameLabel, "series_3", "This is the third test metric."},
-				TimeseriesRW2: []TimeSeriesRW2{
-					{
-						LabelsRefs: []uint32{1, 2},
-						Metadata: MetadataRW2{
-							Type:    METRIC_TYPE_COUNTER,
-							HelpRef: 3,
-						},
-					},
-				},
-			},
-		}, partials)
-
+		require.Len(t, partials, 2)
+		require.Equal(t, 2, max(len(partials[0].TimeseriesRW2), len(partials[1].TimeseriesRW2)))
 		for _, partial := range partials {
 			assert.LessOrEqual(t, partial.Size(), limit)
 		}
+		originalData, err := original.Marshal()
+		require.NoError(t, err)
+		mergedData, err := mergeRW2s(partials).Marshal()
+		require.NoError(t, err)
+		require.Equal(t, originalData, mergedData)
 	})
 
 	t.Run("should split the input WriteRequest into multiple requests with size bigger than limit if limit < size(symbols)", func(t *testing.T) {
@@ -306,6 +277,9 @@ func TestSplitWriteRequestByMaxMarshalSize(t *testing.T) {
 		metadataPartials := SplitWriteRequestByMaxMarshalSize(metadataReq, metadataReq.Size(), limit)
 		assert.LessOrEqual(t, cap(metadataPartials), len(metadataReq.Metadata))
 
+		rw2Req := testReqV2Static(t)
+		rw2Partials := SplitWriteRequestByMaxMarshalSizeRW2(rw2Req, rw2Req.Size(), limit, 0, nil)
+		assert.LessOrEqual(t, cap(rw2Partials), len(rw2Req.TimeseriesRW2))
 	})
 
 	t.Run("should account for embedded message framing when selecting a partial request", func(t *testing.T) {
@@ -332,27 +306,21 @@ func TestSplitWriteRequestByMaxMarshalSize(t *testing.T) {
 		for _, partial := range metadataPartials {
 			require.LessOrEqual(t, partial.Size(), limit)
 		}
+
+		rw2Req := testReqV2Static(t)
+		for limit := 1; limit < rw2Req.Size(); limit++ {
+			partials := SplitWriteRequestByMaxMarshalSizeRW2(rw2Req, rw2Req.Size(), limit, 0, nil)
+			for _, partial := range partials {
+				if len(partial.TimeseriesRW2) > 1 {
+					require.LessOrEqual(t, partial.Size(), limit)
+				}
+			}
+		}
 	})
 
 	t.Run("should preserve request settings without transferring buffer ownership", func(t *testing.T) {
-		req := generateWriteRequest(2, 2, 1, 2)
-		t.Cleanup(req.FreeBuffer)
-		req.Source = RULE
-		req.SkipLabelValidation = true
-		req.SkipLabelCountValidation = true
-		req.skipUnmarshalingExemplars = true
-		req.skipNormalizeMetadataMetricName = true
-		req.skipDeduplicateMetadata = true
-		req.SetBuffer(mem.SliceBuffer([]byte("request buffer")))
-
-		source := &WriteRequest{}
-		source.SetBuffer(mem.SliceBuffer([]byte("source buffer")))
-		req.AddSourceBufferHolder(&source.BufferHolder)
-		source.FreeBuffer()
-
-		partials := SplitWriteRequestByMaxMarshalSize(req, req.Size(), 1)
-		require.Greater(t, len(partials), 1)
-		for _, partial := range partials {
+		assertSettings := func(t *testing.T, partial *WriteRequest) {
+			t.Helper()
 			require.Equal(t, RULE, partial.Source)
 			require.True(t, partial.SkipLabelValidation)
 			require.True(t, partial.SkipLabelCountValidation)
@@ -363,6 +331,40 @@ func TestSplitWriteRequestByMaxMarshalSize(t *testing.T) {
 			require.Nil(t, partial.sourceBufferHolders)
 			require.False(t, partial.unmarshalFromRW2)
 			require.Empty(t, partial.rw2symbols.pages)
+		}
+
+		setRequestSettings := func(req *WriteRequest) {
+			req.Source = RULE
+			req.SkipLabelValidation = true
+			req.SkipLabelCountValidation = true
+			req.skipUnmarshalingExemplars = true
+			req.skipNormalizeMetadataMetricName = true
+			req.skipDeduplicateMetadata = true
+			req.SetBuffer(mem.SliceBuffer([]byte("request buffer")))
+
+			source := &WriteRequest{}
+			source.SetBuffer(mem.SliceBuffer([]byte("source buffer")))
+			req.AddSourceBufferHolder(&source.BufferHolder)
+			source.FreeBuffer()
+		}
+
+		req := generateWriteRequest(2, 2, 1, 2)
+		setRequestSettings(req)
+		t.Cleanup(req.FreeBuffer)
+		partials := SplitWriteRequestByMaxMarshalSize(req, req.Size(), 1)
+		require.Greater(t, len(partials), 1)
+		for _, partial := range partials {
+			assertSettings(t, partial)
+		}
+
+		rw2Req := generateWriteRequestRW2(2, 2, 1, 0)
+		setRequestSettings(rw2Req)
+		rw2Req.unmarshalFromRW2 = true
+		t.Cleanup(rw2Req.FreeBuffer)
+		rw2Partials := SplitWriteRequestByMaxMarshalSizeRW2(rw2Req, rw2Req.Size(), 1, 0, nil)
+		require.Greater(t, len(rw2Partials), 1)
+		for _, partial := range rw2Partials {
+			assertSettings(t, partial)
 		}
 	})
 
@@ -494,6 +496,11 @@ func TestSplitWriteRequestByMaxMarshalSize_Fuzzy(t *testing.T) {
 
 			maxSize := req.Size() / (1 + rnd.Intn(10))
 			partials := SplitWriteRequestByMaxMarshalSizeRW2(req, req.Size(), maxSize, 0, nil)
+			for _, partial := range partials {
+				if partial.Size() > maxSize {
+					require.Len(t, partial.TimeseriesRW2, 1, "only an individually oversized entity may exceed the limit")
+				}
+			}
 
 			// Ensure the merge of all partial requests is equal to the original one.
 			merged := mergeRW2s(partials)


### PR DESCRIPTION
#### What this PR does

It follows the Remote Write 2.0 Kafka record-splitting pattern introduced in #12166 and fixes the split size calculation. The splitter previously counted a series' protobuf message payload but omitted the surrounding field key and length prefix when deciding whether another series fit. Requests containing multiple series near the configured producer record limit could therefore still exceed it.

The splitter now includes that embedded-message framing, preserves write-request settings across generated requests, returns the original request for non-positive limits, and caps its initial allocation at the number of series. As before, splitting is best-effort: a single series larger than the limit remains intact and may produce an oversized record.

#### Checklist

- [x] Tests updated.
- [ ] Documentation added. Not applicable: this is an internal correctness fix with no configuration or user-facing API changes.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features. Not applicable: this PR doesn't add an experimental feature or configuration surface.
