### PR TITLE
[MQE] Add ExtraQueryFrontendASTOptimizationPasses

### DIFF
--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -1005,6 +1005,12 @@ type Mimir struct {
 	// modules initialise.
 	ExtraASTOptimizationPasses       []optimize.ASTOptimizationPass
 	ExtraQueryPlanOptimizationPasses []optimize.QueryPlanOptimizationPass
+
+	// ExtraQueryFrontendASTOptimizationPasses are registered on the query-frontend planner only (not the
+	// querier planner), so they do not affect queries planned by queriers such as ruler rule evaluations.
+	// Like ExtraASTOptimizationPasses they run after the built-in passes and before sharding/subquery-spinoff,
+	// and must be set before the query planner modules initialise.
+	ExtraQueryFrontendASTOptimizationPasses []optimize.ASTOptimizationPass
 }
 
 // New makes a new Mimir.

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -999,7 +999,7 @@ type Mimir struct {
 	QuerierQueryPlanner *streamingpromql.QueryPlanner
 
 	// ExtraQueryFrontendASTOptimizationPasses are registered on the query-frontend planner only (not the
-	// querier planner), so they do not affect queries planned by queriers such as ruler rule evaluations.
+	// querier planner).
 	// They let downstream builds run query-mutating logic as MQE optimisation passes whose effect is visible
 	// via the analysis endpoint. They run after the built-in passes and before sharding/subquery-spinoff, and
 	// must be set before the query planner modules initialise.

--- a/pkg/mimir/mimir.go
+++ b/pkg/mimir/mimir.go
@@ -998,18 +998,11 @@ type Mimir struct {
 	// including when running in monolithic and read/write modes.
 	QuerierQueryPlanner *streamingpromql.QueryPlanner
 
-	// ExtraASTOptimizationPasses and ExtraQueryPlanOptimizationPasses are registered on both the querier
-	// and query-frontend planners by the planner module init (after the built-in passes, before
-	// sharding/subquery-spinoff). They let downstream builds run query-mutating logic as MQE optimisation
-	// passes whose effect is visible via the analysis endpoint. They must be set before the query planner
-	// modules initialise.
-	ExtraASTOptimizationPasses       []optimize.ASTOptimizationPass
-	ExtraQueryPlanOptimizationPasses []optimize.QueryPlanOptimizationPass
-
 	// ExtraQueryFrontendASTOptimizationPasses are registered on the query-frontend planner only (not the
 	// querier planner), so they do not affect queries planned by queriers such as ruler rule evaluations.
-	// Like ExtraASTOptimizationPasses they run after the built-in passes and before sharding/subquery-spinoff,
-	// and must be set before the query planner modules initialise.
+	// They let downstream builds run query-mutating logic as MQE optimisation passes whose effect is visible
+	// via the analysis endpoint. They run after the built-in passes and before sharding/subquery-spinoff, and
+	// must be set before the query planner modules initialise.
 	ExtraQueryFrontendASTOptimizationPasses []optimize.ASTOptimizationPass
 }
 

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -1195,6 +1195,9 @@ func (t *Mimir) createQueryFrontendQueryPlanner(opts streamingpromql.EngineOpts)
 	for _, p := range t.ExtraASTOptimizationPasses {
 		t.QueryFrontendQueryPlanner.RegisterASTOptimizationPass(p)
 	}
+	for _, p := range t.ExtraQueryFrontendASTOptimizationPasses {
+		t.QueryFrontendQueryPlanner.RegisterASTOptimizationPass(p)
+	}
 	for _, p := range t.ExtraQueryPlanOptimizationPasses {
 		t.QueryFrontendQueryPlanner.RegisterQueryPlanOptimizationPass(p)
 	}

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -1119,14 +1119,6 @@ func (t *Mimir) initQuerierQueryPlanner() (services.Service, error) {
 		return nil, err
 	}
 
-	// Register any extra passes injected from outside this package after the built-in passes registered by NewQueryPlanner.
-	for _, p := range t.ExtraASTOptimizationPasses {
-		t.QuerierQueryPlanner.RegisterASTOptimizationPass(p)
-	}
-	for _, p := range t.ExtraQueryPlanOptimizationPasses {
-		t.QuerierQueryPlanner.RegisterQueryPlanOptimizationPass(p)
-	}
-
 	// Only expose the querier's planner through the analysis endpoint if the query-frontend isn't running in this process.
 	// If the query-frontend is running in this process, it will expose its planner through the analysis endpoint.
 	if !t.Cfg.isQueryFrontendEnabled() {
@@ -1192,14 +1184,8 @@ func (t *Mimir) createQueryFrontendQueryPlanner(opts streamingpromql.EngineOpts)
 	// registered by NewQueryPlanner, but must be registered before the remote execution, subquery spin-off
 	// and sharding passes below so that query-mutating passes run before sharding, matching how the
 	// equivalent middlewares are ordered before query sharding today.
-	for _, p := range t.ExtraASTOptimizationPasses {
-		t.QueryFrontendQueryPlanner.RegisterASTOptimizationPass(p)
-	}
 	for _, p := range t.ExtraQueryFrontendASTOptimizationPasses {
 		t.QueryFrontendQueryPlanner.RegisterASTOptimizationPass(p)
-	}
-	for _, p := range t.ExtraQueryPlanOptimizationPasses {
-		t.QueryFrontendQueryPlanner.RegisterQueryPlanOptimizationPass(p)
 	}
 
 	if t.Cfg.Frontend.QueryMiddleware.EnableRemoteExecution {


### PR DESCRIPTION
#### What this PR does

Add `ExtraQueryFrontendASTOptimizationPasses` for those optimization passes that should only run on frontends and not queriers, and remove `ExtraASTOptimizationPasses` and `ExtraQueryPlanOptimizationPasses` since we have no plans to use them at the moment.

#### Which issue(s) this PR fixes or relates to

Follow up to https://github.com/grafana/mimir/pull/16248

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
