### PR TITLE
Fix cardinality estimation for query containing a selector that is not used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * [CHANGE] MQE: validate that delayed name removal is only set using `-querier.enable-delayed-name-removal` or the per-tenant setting when MQE is in use. #16207
 * [ENHANCEMENT] Compactor: Add the experimental `-compactor.block-health-validation-concurrency` option to limit how many blocks are validated concurrently within a compaction job. #16269
-* [ENHANCEMENT] Query-frontend: Improve the stability of cardinality estimates and therefore sharding factors for queries when running splitting and caching inside MQE is enabled, or range vector splitting is enabled. #16274
+* [ENHANCEMENT] Query-frontend: Improve the stability of cardinality estimates and therefore sharding factors for queries when running splitting and caching inside MQE is enabled, or range vector splitting is enabled. #16274 #16301
   * When running splitting and caching inside MQE is enabled, the `cortex_query_frontend_cardinality_estimation_difference` metric will no longer be emitted.
 * [ENHANCEMENT] Distributor: Add the experimental `cortex_distributor_otlp_requests_with_job_or_instance_resource_attribute_total{user}` counter to track OTLP requests carrying `job` or `instance` as a resource attribute. #16285
 * [BUGFIX] Query-frontend: Return a HTTP 500 error rather than a HTTP 400 when a querier receives a query plan that is too new. #16233

--- a/pkg/streamingpromql/operators/selectors/instant_vector_selector.go
+++ b/pkg/streamingpromql/operators/selectors/instant_vector_selector.go
@@ -317,6 +317,7 @@ func (v *InstantVectorSelector) FinishedReading(ctx context.Context) error {
 	v.memoizedIterator = nil
 	v.chunkIterator = nil
 
+	v.Selector.FinishedReading(ctx)
 	v.Selector.Close()
 	return nil
 }

--- a/pkg/streamingpromql/operators/selectors/range_vector_selector.go
+++ b/pkg/streamingpromql/operators/selectors/range_vector_selector.go
@@ -299,6 +299,8 @@ func (m *RangeVectorSelector) FinishedReading(ctx context.Context) error {
 	m.floats.Close()
 	m.histograms.Close()
 	m.chunkIterator = nil
+
+	m.Selector.FinishedReading(ctx)
 	m.Selector.Close()
 	return nil
 }

--- a/pkg/streamingpromql/operators/selectors/selector.go
+++ b/pkg/streamingpromql/operators/selectors/selector.go
@@ -62,8 +62,7 @@ type Selector struct {
 
 	seriesIdx int
 
-	// The time range queried from storage, computed and used by loadSeriesSet and reused by reportCardinality.
-	queriedStartT, queriedEndT int64
+	haveReportedCardinality bool
 }
 
 type Subset struct {
@@ -133,13 +132,14 @@ func (s *Selector) SeriesMetadata(ctx context.Context, matchers types.Matchers) 
 // The matchers are taken from the original expression (Selector.Matchers and each subset's filter),
 // ignoring any additional matchers pushed down by callers of SeriesMetadata.
 func (s *Selector) reportCardinality(ctx context.Context, seriesCount int) {
+	s.haveReportedCardinality = true
+
 	queryStats := stats.FromContext(ctx)
 	if queryStats == nil {
 		return
 	}
 
-	// Use the time range computed for the Select call in loadSeriesSet, rather than recomputing it.
-	minT, maxT := s.queriedStartT, s.queriedEndT
+	minT, maxT := s.getQueriedTimeRange()
 
 	queryStats.AddSeenSelectorCardinality(stats.SelectorCardinality{
 		Matchers:    labelMatchersFromMatchers(s.Matchers, nil),
@@ -242,9 +242,7 @@ func (s *Selector) loadSeriesSet(ctx context.Context, matchers types.Matchers) e
 		return errors.New("should not call Selector.loadSeriesSet() multiple times")
 	}
 
-	startTimestamp, endTimestamp := ComputeQueriedTimeRange(s.TimeRange, s.Timestamp, s.Range, s.Offset, s.LookbackDelta, s.Anchored, s.Smoothed)
-	s.queriedStartT = startTimestamp
-	s.queriedEndT = endTimestamp
+	startTimestamp, endTimestamp := s.getQueriedTimeRange()
 
 	hints := &storage.SelectHints{
 		Start: startTimestamp,
@@ -287,6 +285,10 @@ func (s *Selector) loadSeriesSet(ctx context.Context, matchers types.Matchers) e
 	}
 
 	return nil
+}
+
+func (s *Selector) getQueriedTimeRange() (int64, int64) {
+	return ComputeQueriedTimeRange(s.TimeRange, s.Timestamp, s.Range, s.Offset, s.LookbackDelta, s.Anchored, s.Smoothed)
 }
 
 func ComputeQueriedTimeRange(timeRange types.QueryTimeRange, timestamp *int64, selectorRange time.Duration, offset int64, lookbackDelta time.Duration, anchored bool, smoothed bool) (int64, int64) {
@@ -338,6 +340,17 @@ func (s *Selector) Next(ctx context.Context, existing chunkenc.Iterator) (chunke
 func (s *Selector) updateSeriesSubsetBitmap() {
 	for subsetIdx, subset := range s.Subsets {
 		s.seriesSubsetBitmap[subsetIdx] = subset.matchingSeries[s.seriesIdx]
+	}
+}
+
+func (s *Selector) FinishedReading(ctx context.Context) {
+	if !s.haveReportedCardinality {
+		// If SeriesMetadata was never called, but FinishedReading was called, this means the query succeeded
+		// without needing to read this selector (eg. because a binary operation meant no series from this selector were needed).
+		// Report cardinality 0 so that cardinality estimates are more accurate.
+		// This also ensures a cardinality estimate can be generated next time this expression is evaluated (no estimate can be
+		// generated if any selector's cardinality is not cached).
+		s.reportCardinality(ctx, 0)
 	}
 }
 

--- a/pkg/streamingpromql/operators/selectors/selector_test.go
+++ b/pkg/streamingpromql/operators/selectors/selector_test.go
@@ -239,81 +239,143 @@ func TestSelector_ReportsCardinality(t *testing.T) {
 	baseMatchers := types.Matchers{{Type: labels.MatchEqual, Name: "__name__", Value: "foo"}}
 	expectedMinT, expectedMaxT := ComputeQueriedTimeRange(timeRange, nil, 0, 0, lookbackDelta, false, false)
 
-	t.Run("without subsets", func(t *testing.T) {
-		qs, ctx := stats.ContextWithEmptyStats(context.Background())
-		s := &Selector{
+	newSelector := func(ctx context.Context) *Selector {
+		return &Selector{
 			Queryable:                storage,
 			TimeRange:                timeRange,
 			LookbackDelta:            lookbackDelta,
 			Matchers:                 baseMatchers,
 			MemoryConsumptionTracker: limiter.NewUnlimitedMemoryConsumptionTracker(ctx),
 		}
+	}
 
-		_, err := s.SeriesMetadata(ctx, nil)
-		require.NoError(t, err)
+	t.Run("without subsets", func(t *testing.T) {
+		t.Run("SeriesMetadata() called", func(t *testing.T) {
+			qs, ctx := stats.ContextWithEmptyStats(context.Background())
+			s := newSelector(ctx)
+			defer s.Close()
 
-		require.Equal(t, []stats.SelectorCardinality{
-			{
-				Matchers:    []stats.LabelMatcher{{Type: labels.MatchEqual, Name: "__name__", Value: "foo"}},
-				MinT:        expectedMinT,
-				MaxT:        expectedMaxT,
-				SeriesCount: 3,
-			},
-		}, qs.LoadSeenSelectorCardinalities())
+			_, err := s.SeriesMetadata(ctx, nil)
+			require.NoError(t, err)
+
+			s.FinishedReading(ctx)
+
+			require.Equal(t, []stats.SelectorCardinality{
+				{
+					Matchers:    []stats.LabelMatcher{{Type: labels.MatchEqual, Name: "__name__", Value: "foo"}},
+					MinT:        expectedMinT,
+					MaxT:        expectedMaxT,
+					SeriesCount: 3,
+				},
+			}, qs.LoadSeenSelectorCardinalities())
+		})
+
+		t.Run("SeriesMetadata() not called", func(t *testing.T) {
+			qs, ctx := stats.ContextWithEmptyStats(context.Background())
+			s := newSelector(ctx)
+			defer s.Close()
+
+			s.FinishedReading(ctx)
+
+			require.Equal(t, []stats.SelectorCardinality{
+				{
+					Matchers:    []stats.LabelMatcher{{Type: labels.MatchEqual, Name: "__name__", Value: "foo"}},
+					MinT:        expectedMinT,
+					MaxT:        expectedMaxT,
+					SeriesCount: 0,
+				},
+			}, qs.LoadSeenSelectorCardinalities())
+		})
 	})
 
 	t.Run("with subsets", func(t *testing.T) {
-		qs, ctx := stats.ContextWithEmptyStats(context.Background())
-		s := &Selector{
-			Queryable:     storage,
-			TimeRange:     timeRange,
-			LookbackDelta: lookbackDelta,
-			Matchers:      baseMatchers,
-			Subsets: []Subset{
+		t.Run("SeriesMetadata() called", func(t *testing.T) {
+			qs, ctx := stats.ContextWithEmptyStats(context.Background())
+			s := newSelector(ctx)
+			s.Subsets = []Subset{
 				{Filter: []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "env", "prod")}},
 				{Filter: []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "env", "dev")}},
-			},
-			MemoryConsumptionTracker: limiter.NewUnlimitedMemoryConsumptionTracker(ctx),
-		}
-		defer s.Close()
+			}
 
-		_, err := s.SeriesMetadata(ctx, nil)
-		require.NoError(t, err)
+			defer s.Close()
 
-		require.Equal(t, []stats.SelectorCardinality{
-			{
-				Matchers:    []stats.LabelMatcher{{Type: labels.MatchEqual, Name: "__name__", Value: "foo"}},
-				MinT:        expectedMinT,
-				MaxT:        expectedMaxT,
-				SeriesCount: 3,
-			},
-			{
-				Matchers:    []stats.LabelMatcher{{Type: labels.MatchEqual, Name: "__name__", Value: "foo"}, {Type: labels.MatchEqual, Name: "env", Value: "prod"}},
-				MinT:        expectedMinT,
-				MaxT:        expectedMaxT,
-				SeriesCount: 2,
-			},
-			{
-				Matchers:    []stats.LabelMatcher{{Type: labels.MatchEqual, Name: "__name__", Value: "foo"}, {Type: labels.MatchEqual, Name: "env", Value: "dev"}},
-				MinT:        expectedMinT,
-				MaxT:        expectedMaxT,
-				SeriesCount: 1,
-			},
-		}, qs.LoadSeenSelectorCardinalities())
+			_, err := s.SeriesMetadata(ctx, nil)
+			require.NoError(t, err)
+
+			s.FinishedReading(ctx)
+
+			require.Equal(t, []stats.SelectorCardinality{
+				{
+					Matchers:    []stats.LabelMatcher{{Type: labels.MatchEqual, Name: "__name__", Value: "foo"}},
+					MinT:        expectedMinT,
+					MaxT:        expectedMaxT,
+					SeriesCount: 3,
+				},
+				{
+					Matchers:    []stats.LabelMatcher{{Type: labels.MatchEqual, Name: "__name__", Value: "foo"}, {Type: labels.MatchEqual, Name: "env", Value: "prod"}},
+					MinT:        expectedMinT,
+					MaxT:        expectedMaxT,
+					SeriesCount: 2,
+				},
+				{
+					Matchers:    []stats.LabelMatcher{{Type: labels.MatchEqual, Name: "__name__", Value: "foo"}, {Type: labels.MatchEqual, Name: "env", Value: "dev"}},
+					MinT:        expectedMinT,
+					MaxT:        expectedMaxT,
+					SeriesCount: 1,
+				},
+			}, qs.LoadSeenSelectorCardinalities())
+		})
+
+		t.Run("SeriesMetadata() not called", func(t *testing.T) {
+			qs, ctx := stats.ContextWithEmptyStats(context.Background())
+			s := newSelector(ctx)
+			s.Subsets = []Subset{
+				{Filter: []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "env", "prod")}},
+				{Filter: []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "env", "dev")}},
+			}
+
+			defer s.Close()
+
+			s.FinishedReading(ctx)
+
+			require.Equal(t, []stats.SelectorCardinality{
+				{
+					Matchers:    []stats.LabelMatcher{{Type: labels.MatchEqual, Name: "__name__", Value: "foo"}},
+					MinT:        expectedMinT,
+					MaxT:        expectedMaxT,
+					SeriesCount: 0,
+				},
+				{
+					Matchers:    []stats.LabelMatcher{{Type: labels.MatchEqual, Name: "__name__", Value: "foo"}, {Type: labels.MatchEqual, Name: "env", Value: "prod"}},
+					MinT:        expectedMinT,
+					MaxT:        expectedMaxT,
+					SeriesCount: 0,
+				},
+				{
+					Matchers:    []stats.LabelMatcher{{Type: labels.MatchEqual, Name: "__name__", Value: "foo"}, {Type: labels.MatchEqual, Name: "env", Value: "dev"}},
+					MinT:        expectedMinT,
+					MaxT:        expectedMaxT,
+					SeriesCount: 0,
+				},
+			}, qs.LoadSeenSelectorCardinalities())
+		})
 	})
 
 	t.Run("no stats in context", func(t *testing.T) {
-		s := &Selector{
-			Queryable:                storage,
-			TimeRange:                timeRange,
-			LookbackDelta:            lookbackDelta,
-			Matchers:                 baseMatchers,
-			MemoryConsumptionTracker: limiter.NewUnlimitedMemoryConsumptionTracker(context.Background()),
-		}
+		for _, callSeriesMetadata := range []bool{true, false} {
+			t.Run(fmt.Sprintf("SeriesMetadata() called = %v", callSeriesMetadata), func(t *testing.T) {
+				// Should not panic when there are no stats in the context.
+				ctx := context.Background()
+				s := newSelector(ctx)
 
-		// Should not panic when there are no stats in the context.
-		_, err := s.SeriesMetadata(context.Background(), nil)
-		require.NoError(t, err)
+				if callSeriesMetadata {
+					_, err := s.SeriesMetadata(ctx, nil)
+					require.NoError(t, err)
+				}
+
+				s.FinishedReading(ctx)
+			})
+		}
 	})
 }
 


### PR DESCRIPTION
#### What this PR does

This PR addresses a missed edge case in https://github.com/grafana/mimir/pull/16274.

If `SeriesMetadata()` is not called on a selector, then it does not report its cardinality. This can happen, for example, in expressions containing binary operations where the LHS has no series, so the RHS is never evaluated.

If a selector does not report its cardinality, then the cardinality will not be recorded in the cache, and so subsequent requests for the same expression will not generate an estimated series count. (An estimate is only generated if a cardinality has been cached for all selectors in the expression.) This would cause the expression to run with the default level of sharding, which may under- or over-shard the request.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/pull/16274

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
