### PR TITLE
Docs: document focused PR and inlining conventions

### DIFF
--- a/docs/internal/contributing/README.md
+++ b/docs/internal/contributing/README.md
@@ -12,6 +12,8 @@ When you open a PR as a draft, add a short description of what you’re still wo
 
 There is an automated GitHub action which closes PRs after 180 days of inactivity to keep the PR list clean. 30 days before closing, the GitHub action will add `stale` label to the PR. If you need more time, please remove the `stale` label.
 
+Keep each pull request focused on a single coherent topic. Move independently useful changes into separate pull requests unless they are required for the primary change to work correctly.
+
 Before a piece of work is finished:
 
 - Organize it into one or more commits, and include a commit message for each that describes all of the changes that you made in that commit. It is more helpful to explain _why_ more than _what_, which are available via `git diff`.
@@ -151,6 +153,8 @@ You have to commit the changes to `go.mod` and `go.sum` before submitting the pu
 ## Design patterns and Code conventions
 
 Please see the dedicated "[Design patterns and Code conventions](design-patterns-and-conventions.md)" page.
+
+Prefer inlining unexported functions and local helpers used at only one call site. Keep a single-caller helper only when inlining would make the caller materially harder to read, such as by making it too long.
 
 For new Go code that combines multiple errors, prefer the standard library `errors.Join` over project-specific multi-error helpers unless surrounding APIs or existing local patterns require a specific error type or formatting.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

Documents two Grafana Mimir contribution conventions:

- Keep each pull request focused on one coherent topic, while retaining supporting changes required for the primary change to work correctly.
- Prefer inlining single-caller unexported functions and local helpers unless extraction materially improves readability.

The existing `AGENTS.md` and `CLAUDE.md` references make this guidance available to coding agents without duplicating it in multiple instruction files.

#### Which issue(s) this PR fixes or relates to

N/A.

#### Checklist

- [ ] Tests updated. Not applicable: this PR only updates contributor documentation.
- [x] Documentation added.
- [ ] `CHANGELOG.md` updated. Not applicable: this PR only updates contributor documentation; the `changelog-not-needed` label is applied.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features. Not applicable: this PR doesn't add or change an experimental feature.
