### PR TITLE
MQE: fix issue where a lower-than-expected cardinality estimate can be cached, improve tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * [CHANGE] MQE: validate that delayed name removal is only set using `-querier.enable-delayed-name-removal` or the per-tenant setting when MQE is in use. #16207
 * [ENHANCEMENT] Compactor: Add the experimental `-compactor.block-health-validation-concurrency` option to limit how many blocks are validated concurrently within a compaction job. #16269
-* [ENHANCEMENT] Query-frontend: Improve the stability of cardinality estimates and therefore sharding factors for queries when running splitting and caching inside MQE is enabled, or range vector splitting is enabled. #16274 #16301
+* [ENHANCEMENT] Query-frontend: Improve the stability of cardinality estimates and therefore sharding factors for queries when running splitting and caching inside MQE is enabled, or range vector splitting is enabled. #16274 #16301 #16305
   * When running splitting and caching inside MQE is enabled, the `cortex_query_frontend_cardinality_estimation_difference` metric will no longer be emitted.
 * [ENHANCEMENT] Distributor: Add the experimental `cortex_distributor_otlp_requests_with_job_or_instance_resource_attribute_total{user}` counter to track OTLP requests carrying `job` or `instance` as a resource attribute. #16285
 * [ENHANCEMENT] Ruler: Split oversized remote distributor writes to keep resulting calls within the configured gRPC maximum send size, and expose the number of generated requests in `cortex_ruler_remote_distributor_requests_per_write_request`. #16160

--- a/pkg/streamingpromql/optimize/ast/sharding/cardinality_estimation.go
+++ b/pkg/streamingpromql/optimize/ast/sharding/cardinality_estimation.go
@@ -324,91 +324,102 @@ func (p *cardinalityStoringPostProcessor) PostProcess(ctx context.Context, origi
 		return nil
 	}
 
-	// Group the reported cardinalities by selector (ignoring the query-shard matcher) and time range,
-	// then aggregate within each group. Different shards of the same logical selector each report a
-	// disjoint subset of the series, so their cardinalities are summed. A selector that is reported
-	// more than once with the same shard (for example the same selector appearing twice in a query
-	// without common-subexpression elimination) is counted once, using the maximum reported value.
+	// Group the reported cardinalities by selector (ignoring the query-shard matcher) and bucket time range,
+	// then aggregate within each group.
+	//
+	// Different shards of the same logical selector each report a disjoint subset of the series, so their cardinalities are
+	// summed.
+	//
+	// A selector that is reported more than once with the same shard (for example the same selector appearing twice in a
+	// query without common-subexpression elimination) is counted once, using the maximum reported value.
+	//
+	// Multiple instances of the same selector that contribute to the same bucket (eg. in a split range query where the
+	// split time ranges don't align with bucket boundaries) are counted once, using the maximum reported value.
 	type groupKey struct {
-		selector   string
-		minT, maxT int64
+		selector               string
+		bucketMinT, bucketMaxT int64
 	}
-	seenGroups := make(map[groupKey]map[string]uint64)
+	type selectorInfo struct {
+		cardinalityByShard map[string]uint64
+		cacheKey           cacheKey
+	}
+	seenGroups := make(map[groupKey]selectorInfo)
 
 	for _, c := range seenCardinalities {
 		selector, shard := selectorStringWithoutShardingMatcher(c.Matchers)
-		gk := groupKey{selector: selector, minT: c.MinT, maxT: c.MaxT}
 
-		byShard := seenGroups[gk]
-		if byShard == nil {
-			byShard = make(map[string]uint64)
-			seenGroups[gk] = byShard
+		// Get all the cache keys (ie. buckets) that this seen selector maps to.
+		keys, err := selectorCardinalityCacheKeys(ctx, p.cfg, originalExpression, selector, c.MinT, c.MaxT, false, spanLogger)
+		if err != nil {
+			return err
 		}
-		byShard[shard] = max(byShard[shard], c.SeriesCount)
+
+		for _, k := range keys {
+			gk := groupKey{selector: selector, bucketMinT: k.bucketMinT, bucketMaxT: k.bucketMaxT}
+
+			if _, ok := seenGroups[gk]; !ok {
+				seenGroups[gk] = selectorInfo{
+					cacheKey:           k,
+					cardinalityByShard: make(map[string]uint64),
+				}
+			}
+
+			seenGroups[gk].cardinalityByShard[shard] = max(seenGroups[gk].cardinalityByShard[shard], c.SeriesCount)
+		}
 	}
 
 	estimatedGroups := make(map[groupKey]uint64)
 	estimatedCardinalities := queryStats.LoadEstimatedSelectorCardinalities()
 	for _, c := range estimatedCardinalities {
 		selector, _ := selectorStringWithoutShardingMatcher(c.Matchers) // Estimated cardinalities should have no shard matcher.
-		gk := groupKey{selector: selector, minT: c.MinT, maxT: c.MaxT}
+		gk := groupKey{selector: selector, bucketMinT: c.MinT, bucketMaxT: c.MaxT}
 		estimatedGroups[gk] = c.SeriesCount
 	}
 
 	entries := make(map[string][]byte)
 	ignoredUpdates := 0
 
-	for gk, byShard := range seenGroups {
+	for gk, group := range seenGroups {
 		var seenCardinality uint64
-		for _, count := range byShard {
+		for _, count := range group.cardinalityByShard {
 			seenCardinality += count
 		}
 
-		// Get all the cache keys (ie. buckets) that this seen selector maps to.
-		// We don't need to do the same thing below for the estimates, because they're read and stored in the stats exactly
-		// as they were in the cache (ie. bucketed).
-		keys, err := selectorCardinalityCacheKeys(ctx, p.cfg, originalExpression, gk.selector, gk.minT, gk.maxT, false, spanLogger)
+		existingEstimate, haveExistingEstimate := estimatedGroups[groupKey{selector: gk.selector, bucketMinT: gk.bucketMinT, bucketMaxT: gk.bucketMaxT}]
+		updateThreshold := float64(existingEstimate) * (p.cfg.EstimateUpdateThreshold + 1)
+		if haveExistingEstimate && (seenCardinality == 0 || float64(seenCardinality) < updateThreshold) {
+			// The existing estimate is not above the threshold to write an updated entry,
+			// or both are 0, so leave it as-is.
+			spanLogger.DebugLog(
+				"msg", "skipping writing updated estimate to cache for selector",
+				"selector", gk.selector,
+				"bucket_min_t", gk.bucketMinT,
+				"bucket_max_t", gk.bucketMaxT,
+				"existing_estimate", existingEstimate,
+				"seen_cardinality", seenCardinality,
+			)
+
+			ignoredUpdates++
+			continue
+		}
+
+		spanLogger.DebugLog(
+			"msg", "will write updated estimate to cache for selector",
+			"selector", gk.selector,
+			"bucket_min_t", gk.bucketMinT,
+			"bucket_max_t", gk.bucketMaxT,
+			"existing_estimate", existingEstimate,
+			"have_existing_estimate", haveExistingEstimate,
+			"seen_cardinality", seenCardinality,
+		)
+
+		entry := &SelectorCardinalityStatistics{Key: group.cacheKey.plain, Cardinality: seenCardinality}
+		data, err := entry.Marshal()
 		if err != nil {
 			return err
 		}
 
-		for _, k := range keys {
-			existingEstimate, haveExistingEstimate := estimatedGroups[groupKey{selector: gk.selector, minT: k.bucketMinT, maxT: k.bucketMaxT}]
-			updateThreshold := float64(existingEstimate) * (p.cfg.EstimateUpdateThreshold + 1)
-			if haveExistingEstimate && (seenCardinality == 0 || float64(seenCardinality) < updateThreshold) {
-				// The existing estimate is not above the threshold to write an updated entry,
-				// or both are 0, so leave it as-is.
-				spanLogger.DebugLog(
-					"msg", "skipping writing updated estimate to cache for selector",
-					"selector", gk.selector,
-					"bucket_min_t", k.bucketMinT,
-					"bucket_max_t", k.bucketMaxT,
-					"existing_estimate", existingEstimate,
-					"seen_cardinality", seenCardinality,
-				)
-
-				ignoredUpdates++
-				continue
-			}
-
-			spanLogger.DebugLog(
-				"msg", "will write updated estimate to cache for selector",
-				"selector", gk.selector,
-				"bucket_min_t", k.bucketMinT,
-				"bucket_max_t", k.bucketMaxT,
-				"existing_estimate", existingEstimate,
-				"have_existing_estimate", haveExistingEstimate,
-				"seen_cardinality", seenCardinality,
-			)
-
-			entry := &SelectorCardinalityStatistics{Key: k.plain, Cardinality: seenCardinality}
-			data, err := entry.Marshal()
-			if err != nil {
-				return err
-			}
-
-			entries[k.hashed] = data
-		}
+		entries[group.cacheKey.hashed] = data
 	}
 
 	spanLogger.DebugLog(

--- a/pkg/streamingpromql/optimize/ast/sharding/cardinality_estimation.go
+++ b/pkg/streamingpromql/optimize/ast/sharding/cardinality_estimation.go
@@ -326,6 +326,39 @@ func (p *cardinalityStoringPostProcessor) PostProcess(ctx context.Context, origi
 		return nil
 	}
 
+	seenGroups, err := p.summariseSeenCardinality(ctx, seenCardinalities, originalExpression, spanLogger)
+	if err != nil {
+		return err
+	}
+
+	existingEstimates, err := p.summariseExistingEstimates(queryStats.LoadEstimatedSelectorCardinalities())
+	if err != nil {
+		return err
+	}
+
+	return p.writeUpdatedCacheEntries(ctx, seenGroups, existingEstimates, spanLogger)
+}
+
+type bucketedSelector struct {
+	selector               string
+	bucketMinT, bucketMaxT int64
+}
+
+type bucketedSelectorCardinality struct {
+	// cardinalityByShardingFactor contains one entry per sharding factor, and the value contains an element per shard.
+	// For example, if a selector was sharded into 3 shards (with 100, 200 and 300 series in each of the shards),
+	// and also sharded into 5 shards in a subquery (with 10, 20, 30, 40 and 50 series in each of the shards),
+	// then the map would contain:
+	//	3: [100, 200, 300],
+	//  5: [10, 20, 30, 40, 50]
+	cardinalityByShardingFactor map[uint64][]uint64
+
+	unshardedCardinality uint64
+	cacheKey             cacheKey
+}
+
+// summariseSeenCardinality determines the overall cardinality of a selector to store in the cache for each cache bucket.
+func (p *cardinalityStoringPostProcessor) summariseSeenCardinality(ctx context.Context, seenCardinalities []stats.SelectorCardinality, originalExpression string, spanLogger *spanlogger.SpanLogger) (map[bucketedSelector]*bucketedSelectorCardinality, error) {
 	// Group the reported cardinalities by selector (ignoring the query-shard matcher) and bucket time range,
 	// then aggregate within each group.
 	//
@@ -340,23 +373,7 @@ func (p *cardinalityStoringPostProcessor) PostProcess(ctx context.Context, origi
 	//
 	// Multiple instances of the same selector that contribute to the same bucket (eg. in a split range query where the
 	// split time ranges don't align with bucket boundaries) are counted once, using the maximum reported value.
-	type groupKey struct {
-		selector               string
-		bucketMinT, bucketMaxT int64
-	}
-	type selectorInfo struct {
-		// cardinalityByShardingFactor contains one entry per sharding factor, and the value contains an element per shard.
-		// For example, if a selector was sharded into 3 shards (with 100, 200 and 300 series in each of the shards),
-		// and also sharded into 5 shards in a subquery (with 10, 20, 30, 40 and 50 series in each of the shards),
-		// then the map would contain:
-		//	3: [100, 200, 300],
-		//  5: [10, 20, 30, 40, 50]
-		cardinalityByShardingFactor map[uint64][]uint64
-
-		unshardedCardinality uint64
-		cacheKey             cacheKey
-	}
-	seenGroups := make(map[groupKey]*selectorInfo)
+	seenGroups := make(map[bucketedSelector]*bucketedSelectorCardinality)
 
 	for _, c := range seenCardinalities {
 		selector, shard := selectorStringWithoutShardingMatcher(c.Matchers)
@@ -364,15 +381,15 @@ func (p *cardinalityStoringPostProcessor) PostProcess(ctx context.Context, origi
 		// Get all the cache keys (ie. buckets) that this seen selector maps to.
 		keys, err := selectorCardinalityCacheKeys(ctx, p.cfg, originalExpression, selector, c.MinT, c.MaxT, false, spanLogger)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		for _, k := range keys {
-			gk := groupKey{selector: selector, bucketMinT: k.bucketMinT, bucketMaxT: k.bucketMaxT}
+			gk := bucketedSelector{selector: selector, bucketMinT: k.bucketMinT, bucketMaxT: k.bucketMaxT}
 
 			group, ok := seenGroups[gk]
 			if !ok {
-				group = &selectorInfo{
+				group = &bucketedSelectorCardinality{
 					cacheKey:                    k,
 					cardinalityByShardingFactor: make(map[uint64][]uint64),
 				}
@@ -386,7 +403,7 @@ func (p *cardinalityStoringPostProcessor) PostProcess(ctx context.Context, origi
 
 			index, shardCount, err := sharding.ParseShardIDLabelValue(shard)
 			if err != nil {
-				return fmt.Errorf("failed to parse shard label value in %v: %w", c.Matchers, err)
+				return nil, fmt.Errorf("failed to parse shard label value in %v: %w", c.Matchers, err)
 			}
 
 			if _, ok := group.cardinalityByShardingFactor[shardCount]; !ok {
@@ -399,14 +416,22 @@ func (p *cardinalityStoringPostProcessor) PostProcess(ctx context.Context, origi
 		}
 	}
 
-	estimatedGroups := make(map[groupKey]uint64)
-	estimatedCardinalities := queryStats.LoadEstimatedSelectorCardinalities()
+	return seenGroups, nil
+}
+
+func (p *cardinalityStoringPostProcessor) summariseExistingEstimates(estimatedCardinalities []stats.SelectorCardinality) (map[bucketedSelector]uint64, error) {
+	existingEstimates := make(map[bucketedSelector]uint64)
+
 	for _, c := range estimatedCardinalities {
-		selector, _ := selectorStringWithoutShardingMatcher(c.Matchers) // Estimated cardinalities should have no shard matcher.
-		gk := groupKey{selector: selector, bucketMinT: c.MinT, bucketMaxT: c.MaxT}
-		estimatedGroups[gk] = c.SeriesCount
+		selector, _ := selectorStringWithoutShardingMatcher(c.Matchers) // Estimated cardinalities should have no shard matcher, and are already aligned to buckets.
+		gk := bucketedSelector{selector: selector, bucketMinT: c.MinT, bucketMaxT: c.MaxT}
+		existingEstimates[gk] = c.SeriesCount
 	}
 
+	return existingEstimates, nil
+}
+
+func (p *cardinalityStoringPostProcessor) writeUpdatedCacheEntries(ctx context.Context, seenGroups map[bucketedSelector]*bucketedSelectorCardinality, existingEstimates map[bucketedSelector]uint64, spanLogger *spanlogger.SpanLogger) error {
 	entries := make(map[string][]byte)
 	ignoredUpdates := 0
 
@@ -423,7 +448,7 @@ func (p *cardinalityStoringPostProcessor) PostProcess(ctx context.Context, origi
 			seenCardinality = max(seenCardinality, cardinalityForShardingFactor)
 		}
 
-		existingEstimate, haveExistingEstimate := estimatedGroups[groupKey{selector: gk.selector, bucketMinT: gk.bucketMinT, bucketMaxT: gk.bucketMaxT}]
+		existingEstimate, haveExistingEstimate := existingEstimates[bucketedSelector{selector: gk.selector, bucketMinT: gk.bucketMinT, bucketMaxT: gk.bucketMaxT}]
 		updateThreshold := float64(existingEstimate) * (p.cfg.EstimateUpdateThreshold + 1)
 		if haveExistingEstimate && (seenCardinality == 0 || float64(seenCardinality) < updateThreshold) {
 			// The existing estimate is not above the threshold to write an updated entry,
@@ -463,7 +488,7 @@ func (p *cardinalityStoringPostProcessor) PostProcess(ctx context.Context, origi
 	spanLogger.DebugLog(
 		"msg", "writing updated cardinality estimates (if any)",
 		"seen_selector_group_count", len(seenGroups),
-		"estimated_selector_group_count", len(estimatedGroups),
+		"estimated_selector_group_count", len(existingEstimates),
 		"new_or_updated_estimates", len(entries),
 		"ignored_updates", ignoredUpdates,
 	)

--- a/pkg/streamingpromql/optimize/ast/sharding/cardinality_estimation.go
+++ b/pkg/streamingpromql/optimize/ast/sharding/cardinality_estimation.go
@@ -86,7 +86,7 @@ func (e *cacheCardinalityEstimator) EstimateSeriesCount(ctx context.Context, ori
 		return nil, err
 	}
 	if len(keys) == 0 {
-		spanLogger.DebugLog("msg", "no selectors found in expression")
+		spanLogger.DebugLog("msg", "no selectors found in expression, returning no estimate")
 		return nil, nil
 	}
 
@@ -96,6 +96,7 @@ func (e *cacheCardinalityEstimator) EstimateSeriesCount(ctx context.Context, ori
 		return nil, err
 	}
 	if len(res) == 0 {
+		spanLogger.DebugLog("msg", "got no cache hits, returning no estimate")
 		return nil, nil
 	}
 
@@ -168,6 +169,7 @@ func (e *cacheCardinalityEstimator) EstimateSeriesCount(ctx context.Context, ori
 	}
 
 	if !sawAllSelectors {
+		spanLogger.DebugLog("msg", "could not get cached cardinality estimates for all selectors, returning no estimate")
 		return nil, nil
 	}
 

--- a/pkg/streamingpromql/optimize/ast/sharding/cardinality_estimation.go
+++ b/pkg/streamingpromql/optimize/ast/sharding/cardinality_estimation.go
@@ -335,6 +335,9 @@ func (p *cardinalityStoringPostProcessor) PostProcess(ctx context.Context, origi
 	// A selector that is reported more than once with the same shard (for example the same selector appearing twice in a
 	// query without common-subexpression elimination) is counted once, using the maximum reported value.
 	//
+	// A selector that is reported with different sharding factors (eg. due to subquery spinoff applying different sharding
+	// factors to different subqueries) is counted once, with the maximum reported value across all sharding factors.
+	//
 	// Multiple instances of the same selector that contribute to the same bucket (eg. in a split range query where the
 	// split time ranges don't align with bucket boundaries) are counted once, using the maximum reported value.
 	type groupKey struct {
@@ -342,10 +345,18 @@ func (p *cardinalityStoringPostProcessor) PostProcess(ctx context.Context, origi
 		bucketMinT, bucketMaxT int64
 	}
 	type selectorInfo struct {
-		cardinalityByShard map[string]uint64
-		cacheKey           cacheKey
+		// cardinalityByShardingFactor contains one entry per sharding factor, and the value contains an element per shard.
+		// For example, if a selector was sharded into 3 shards (with 100, 200 and 300 series in each of the shards),
+		// and also sharded into 5 shards in a subquery (with 10, 20, 30, 40 and 50 series in each of the shards),
+		// then the map would contain:
+		//	3: [100, 200, 300],
+		//  5: [10, 20, 30, 40, 50]
+		cardinalityByShardingFactor map[uint64][]uint64
+
+		unshardedCardinality uint64
+		cacheKey             cacheKey
 	}
-	seenGroups := make(map[groupKey]selectorInfo)
+	seenGroups := make(map[groupKey]*selectorInfo)
 
 	for _, c := range seenCardinalities {
 		selector, shard := selectorStringWithoutShardingMatcher(c.Matchers)
@@ -359,14 +370,32 @@ func (p *cardinalityStoringPostProcessor) PostProcess(ctx context.Context, origi
 		for _, k := range keys {
 			gk := groupKey{selector: selector, bucketMinT: k.bucketMinT, bucketMaxT: k.bucketMaxT}
 
-			if _, ok := seenGroups[gk]; !ok {
-				seenGroups[gk] = selectorInfo{
-					cacheKey:           k,
-					cardinalityByShard: make(map[string]uint64),
+			group, ok := seenGroups[gk]
+			if !ok {
+				group = &selectorInfo{
+					cacheKey:                    k,
+					cardinalityByShardingFactor: make(map[uint64][]uint64),
 				}
+				seenGroups[gk] = group
 			}
 
-			seenGroups[gk].cardinalityByShard[shard] = max(seenGroups[gk].cardinalityByShard[shard], c.SeriesCount)
+			if shard == "" {
+				group.unshardedCardinality = max(group.unshardedCardinality, c.SeriesCount)
+				continue
+			}
+
+			index, shardCount, err := sharding.ParseShardIDLabelValue(shard)
+			if err != nil {
+				return fmt.Errorf("failed to parse shard label value in %v: %w", c.Matchers, err)
+			}
+
+			if _, ok := group.cardinalityByShardingFactor[shardCount]; !ok {
+				group.cardinalityByShardingFactor[shardCount] = make([]uint64, shardCount)
+			}
+
+			// ParseShardIDFromLabelValue validates that the index is within the bounds of shardCount,
+			// so we don't need to do a bounds check here.
+			group.cardinalityByShardingFactor[shardCount][index] = max(group.cardinalityByShardingFactor[shardCount][index], c.SeriesCount)
 		}
 	}
 
@@ -382,9 +411,16 @@ func (p *cardinalityStoringPostProcessor) PostProcess(ctx context.Context, origi
 	ignoredUpdates := 0
 
 	for gk, group := range seenGroups {
-		var seenCardinality uint64
-		for _, count := range group.cardinalityByShard {
-			seenCardinality += count
+		seenCardinality := group.unshardedCardinality
+
+		for _, cardinalityPerShard := range group.cardinalityByShardingFactor {
+			var cardinalityForShardingFactor uint64
+
+			for _, count := range cardinalityPerShard {
+				cardinalityForShardingFactor += count
+			}
+
+			seenCardinality = max(seenCardinality, cardinalityForShardingFactor)
 		}
 
 		existingEstimate, haveExistingEstimate := estimatedGroups[groupKey{selector: gk.selector, bucketMinT: gk.bucketMinT, bucketMaxT: gk.bucketMaxT}]

--- a/pkg/streamingpromql/optimize/ast/sharding/cardinality_estimation.go
+++ b/pkg/streamingpromql/optimize/ast/sharding/cardinality_estimation.go
@@ -79,6 +79,7 @@ func (e *cacheCardinalityEstimator) EstimateSeriesCount(ctx context.Context, ori
 	defer spanLogger.Finish()
 	spanLogger.SetTag("timeRange", timeRange)
 	spanLogger.SetTag("lookbackDelta", lookbackDelta)
+	spanLogger.SetTag("originalExpression", originalExpression)
 
 	queryStats := stats.FromContext(ctx)
 	selectors, keys, err := e.determineSelectorsToUseForEstimation(ctx, originalExpression, expr, timeRange, lookbackDelta, spanLogger)
@@ -316,6 +317,7 @@ func NewCardinalityStoringPostProcessor(cfg streamingpromql.CardinalityEstimatio
 func (p *cardinalityStoringPostProcessor) PostProcess(ctx context.Context, originalExpression string) error {
 	spanLogger, ctx := spanlogger.New(ctx, p.logger, tracer, "cardinalityStoringPostProcessor.PostProcess")
 	defer spanLogger.Finish()
+	spanLogger.SetTag("originalExpression", originalExpression)
 
 	queryStats := stats.FromContext(ctx)
 	seenCardinalities := queryStats.LoadSeenSelectorCardinalities()

--- a/pkg/streamingpromql/optimize/ast/sharding/cardinality_estimation.go
+++ b/pkg/streamingpromql/optimize/ast/sharding/cardinality_estimation.go
@@ -359,9 +359,9 @@ func (p *cardinalityStoringPostProcessor) PostProcess(ctx context.Context, origi
 	ignoredUpdates := 0
 
 	for gk, byShard := range seenGroups {
-		var total uint64
+		var seenCardinality uint64
 		for _, count := range byShard {
-			total += count
+			seenCardinality += count
 		}
 
 		// Get all the cache keys (ie. buckets) that this seen selector maps to.
@@ -375,14 +375,33 @@ func (p *cardinalityStoringPostProcessor) PostProcess(ctx context.Context, origi
 		for _, k := range keys {
 			existingEstimate, haveExistingEstimate := estimatedGroups[groupKey{selector: gk.selector, minT: k.bucketMinT, maxT: k.bucketMaxT}]
 			updateThreshold := float64(existingEstimate) * (p.cfg.EstimateUpdateThreshold + 1)
-			if haveExistingEstimate && (total == 0 || float64(total) < updateThreshold) {
+			if haveExistingEstimate && (seenCardinality == 0 || float64(seenCardinality) < updateThreshold) {
 				// The existing estimate is not above the threshold to write an updated entry,
 				// or both are 0, so leave it as-is.
+				spanLogger.DebugLog(
+					"msg", "skipping writing updated estimate to cache for selector",
+					"selector", gk.selector,
+					"bucket_min_t", k.bucketMinT,
+					"bucket_max_t", k.bucketMaxT,
+					"existing_estimate", existingEstimate,
+					"seen_cardinality", seenCardinality,
+				)
+
 				ignoredUpdates++
 				continue
 			}
 
-			entry := &SelectorCardinalityStatistics{Key: k.plain, Cardinality: total}
+			spanLogger.DebugLog(
+				"msg", "will write updated estimate to cache for selector",
+				"selector", gk.selector,
+				"bucket_min_t", k.bucketMinT,
+				"bucket_max_t", k.bucketMaxT,
+				"existing_estimate", existingEstimate,
+				"have_existing_estimate", haveExistingEstimate,
+				"seen_cardinality", seenCardinality,
+			)
+
+			entry := &SelectorCardinalityStatistics{Key: k.plain, Cardinality: seenCardinality}
 			data, err := entry.Marshal()
 			if err != nil {
 				return err

--- a/pkg/streamingpromql/optimize/ast/sharding/cardinality_estimation_test.go
+++ b/pkg/streamingpromql/optimize/ast/sharding/cardinality_estimation_test.go
@@ -645,6 +645,29 @@ func TestCardinalityStoringPostProcessor(t *testing.T) {
 		require.ElementsMatch(t, expectedKeys, writtenKeys)
 		require.Equal(t, 2, c.SetCount)
 	})
+
+	t.Run("takes the maximum seen cardinality if selectors over different time ranges fall in the same bucket", func(t *testing.T) {
+		c, cfg := setupCardinalityEstimationTest()
+		ctx, qs := newCtxWithStats()
+
+		qs.AddSeenSelectorCardinality(stats.SelectorCardinality{Matchers: fooMatchers(), MinT: 5, MaxT: 5, SeriesCount: 1100})
+		qs.AddSeenSelectorCardinality(stats.SelectorCardinality{Matchers: fooMatchers(), MinT: 7, MaxT: 7, SeriesCount: 2200})
+
+		require.NoError(t, NewCardinalityStoringPostProcessor(cfg, log.NewNopLogger()).PostProcess(ctx, originalExpression))
+
+		writtenKeys := slices.Collect(maps.Keys(c.Entries))
+		expectedKeys, err := selectorCardinalityCacheKeys(ctx, cfg, originalExpression, `__name__="foo"`, 5, 7, false, newNoOpSpanLogger(t))
+		require.NoError(t, err)
+		require.Len(t, expectedKeys, 1, "invalid test case: expected both selectors' time range to fall into the same cache bucket")
+
+		expectedKey := expectedKeys[0].hashed
+		require.ElementsMatch(t, []string{expectedKey}, writtenKeys)
+		require.Equal(t, 1, c.SetCount)
+
+		written := SelectorCardinalityStatistics{}
+		require.NoError(t, written.Unmarshal(c.Entries[expectedKey].Value))
+		require.Equal(t, uint64(2200), written.Cardinality)
+	})
 }
 
 func setupCardinalityEstimationTest() (*caching.InMemoryCache, streamingpromql.CardinalityEstimationConfig) {

--- a/pkg/streamingpromql/optimize/ast/sharding/cardinality_estimation_test.go
+++ b/pkg/streamingpromql/optimize/ast/sharding/cardinality_estimation_test.go
@@ -668,6 +668,60 @@ func TestCardinalityStoringPostProcessor(t *testing.T) {
 		require.NoError(t, written.Unmarshal(c.Entries[expectedKey].Value))
 		require.Equal(t, uint64(2200), written.Cardinality)
 	})
+
+	t.Run("takes the maximum seen cardinality across all different sharding factors, including an unsharded selector", func(t *testing.T) {
+		c, cfg := setupCardinalityEstimationTest()
+		ctx, qs := newCtxWithStats()
+
+		qs.AddSeenSelectorCardinality(stats.SelectorCardinality{Matchers: fooMatchers(shardMatcher("1_of_2")), MinT: 5, MaxT: 5, SeriesCount: 1100})
+		qs.AddSeenSelectorCardinality(stats.SelectorCardinality{Matchers: fooMatchers(shardMatcher("2_of_2")), MinT: 5, MaxT: 5, SeriesCount: 1000})
+		qs.AddSeenSelectorCardinality(stats.SelectorCardinality{Matchers: fooMatchers(shardMatcher("1_of_3")), MinT: 5, MaxT: 5, SeriesCount: 1300})
+		qs.AddSeenSelectorCardinality(stats.SelectorCardinality{Matchers: fooMatchers(shardMatcher("2_of_3")), MinT: 5, MaxT: 5, SeriesCount: 100})
+		qs.AddSeenSelectorCardinality(stats.SelectorCardinality{Matchers: fooMatchers(shardMatcher("3_of_3")), MinT: 5, MaxT: 5, SeriesCount: 100})
+		qs.AddSeenSelectorCardinality(stats.SelectorCardinality{Matchers: fooMatchers(), MinT: 5, MaxT: 5, SeriesCount: 1200})
+
+		require.NoError(t, NewCardinalityStoringPostProcessor(cfg, log.NewNopLogger()).PostProcess(ctx, originalExpression))
+
+		writtenKeys := slices.Collect(maps.Keys(c.Entries))
+		expectedKeys, err := selectorCardinalityCacheKeys(ctx, cfg, originalExpression, `__name__="foo"`, 5, 5, false, newNoOpSpanLogger(t))
+		require.NoError(t, err)
+		require.Len(t, expectedKeys, 1, "invalid test case: expected result to fall into a single cache bucket")
+
+		expectedKey := expectedKeys[0].hashed
+		require.ElementsMatch(t, []string{expectedKey}, writtenKeys)
+		require.Equal(t, 1, c.SetCount)
+
+		written := SelectorCardinalityStatistics{}
+		require.NoError(t, written.Unmarshal(c.Entries[expectedKey].Value))
+		require.Equal(t, uint64(1100+1000), written.Cardinality)
+	})
+
+	t.Run("takes the maximum seen cardinality across all different sharding factors, and the unsharded selector has the highest cardinality", func(t *testing.T) {
+		c, cfg := setupCardinalityEstimationTest()
+		ctx, qs := newCtxWithStats()
+
+		qs.AddSeenSelectorCardinality(stats.SelectorCardinality{Matchers: fooMatchers(shardMatcher("1_of_2")), MinT: 5, MaxT: 5, SeriesCount: 1100})
+		qs.AddSeenSelectorCardinality(stats.SelectorCardinality{Matchers: fooMatchers(shardMatcher("2_of_2")), MinT: 5, MaxT: 5, SeriesCount: 1000})
+		qs.AddSeenSelectorCardinality(stats.SelectorCardinality{Matchers: fooMatchers(shardMatcher("1_of_3")), MinT: 5, MaxT: 5, SeriesCount: 1300})
+		qs.AddSeenSelectorCardinality(stats.SelectorCardinality{Matchers: fooMatchers(shardMatcher("2_of_3")), MinT: 5, MaxT: 5, SeriesCount: 100})
+		qs.AddSeenSelectorCardinality(stats.SelectorCardinality{Matchers: fooMatchers(shardMatcher("3_of_3")), MinT: 5, MaxT: 5, SeriesCount: 100})
+		qs.AddSeenSelectorCardinality(stats.SelectorCardinality{Matchers: fooMatchers(), MinT: 5, MaxT: 5, SeriesCount: 2200})
+
+		require.NoError(t, NewCardinalityStoringPostProcessor(cfg, log.NewNopLogger()).PostProcess(ctx, originalExpression))
+
+		writtenKeys := slices.Collect(maps.Keys(c.Entries))
+		expectedKeys, err := selectorCardinalityCacheKeys(ctx, cfg, originalExpression, `__name__="foo"`, 5, 5, false, newNoOpSpanLogger(t))
+		require.NoError(t, err)
+		require.Len(t, expectedKeys, 1, "invalid test case: expected result to fall into a single cache bucket")
+
+		expectedKey := expectedKeys[0].hashed
+		require.ElementsMatch(t, []string{expectedKey}, writtenKeys)
+		require.Equal(t, 1, c.SetCount)
+
+		written := SelectorCardinalityStatistics{}
+		require.NoError(t, written.Unmarshal(c.Entries[expectedKey].Value))
+		require.Equal(t, uint64(2200), written.Cardinality)
+	})
 }
 
 func setupCardinalityEstimationTest() (*caching.InMemoryCache, streamingpromql.CardinalityEstimationConfig) {


### PR DESCRIPTION
#### What this PR does

This PR improves the tracing emitted by the cardinality estimation approach introduced in https://github.com/grafana/mimir/pull/16274.

It also fixes two issues where a lower-than-expected estimate can be cached:
* if the same selector is reported for multiple time ranges that fall in the same bucket
* if the same selector is reported with different sharding factors (which can happen if the same selector appears in different subqueries)

#### Which issue(s) this PR fixes or relates to

#16274

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
