### PR TITLE
MQE: correctly cache cardinality estimates for subset regex selectors

### DIFF
--- a/pkg/streamingpromql/operators/selectors/selector.go
+++ b/pkg/streamingpromql/operators/selectors/selector.go
@@ -5,6 +5,7 @@ package selectors
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 
 	"github.com/grafana/mimir/pkg/querier/stats"
+	"github.com/grafana/mimir/pkg/streamingpromql/optimize/matchers"
 	"github.com/grafana/mimir/pkg/streamingpromql/types"
 	"github.com/grafana/mimir/pkg/util/limiter"
 )
@@ -127,7 +129,7 @@ func (s *Selector) SeriesMetadata(ctx context.Context, matchers types.Matchers) 
 }
 
 // reportCardinality records the number of series selected by this selector (and each of its subsets)
-// in the query stats, keyed by the selector's matchers and queried time range.
+// in the query stats.
 //
 // The matchers are taken from the original expression (Selector.Matchers and each subset's filter),
 // ignoring any additional matchers pushed down by callers of SeriesMetadata.
@@ -142,15 +144,30 @@ func (s *Selector) reportCardinality(ctx context.Context, seriesCount int) {
 	minT, maxT := s.getQueriedTimeRange()
 
 	queryStats.AddSeenSelectorCardinality(stats.SelectorCardinality{
-		Matchers:    labelMatchersFromMatchers(s.Matchers, nil),
+		Matchers:    labelMatchersFromMatchers(s.Matchers),
 		MinT:        minT,
 		MaxT:        maxT,
 		SeriesCount: uint64(seriesCount),
 	})
 
+	if len(s.Subsets) == 0 {
+		return
+	}
+
+	converted, err := s.Matchers.ToPrometheusType() // TODO: do this once, change mergeMatchers to work with labels.Matcher
+	if err != nil {
+		panic(fmt.Sprintf("this should never happen: could not parse matchers again: %v", err))
+	}
+
 	for _, subset := range s.Subsets {
+		combined := make([]*labels.Matcher, 0, len(s.Matchers)+len(subset.Filter))
+		combined = append(combined, converted...)
+		combined = append(combined, subset.Filter...)
+
+		reduced, _ := matchers.Reduce(combined, false)
+
 		queryStats.AddSeenSelectorCardinality(stats.SelectorCardinality{
-			Matchers:    labelMatchersFromMatchers(s.Matchers, subset.Filter),
+			Matchers:    labelMatchersFromPrometheusMatchers(reduced),
 			MinT:        minT,
 			MaxT:        maxT,
 			SeriesCount: subset.matchingSeriesCount,
@@ -158,12 +175,10 @@ func (s *Selector) reportCardinality(ctx context.Context, seriesCount int) {
 	}
 }
 
-// labelMatchersFromMatchers converts the given base matchers and optional subset filter to the
-// stats.LabelMatcher representation.
-func labelMatchersFromMatchers(base types.Matchers, filter []*labels.Matcher) []stats.LabelMatcher {
-	out := make([]stats.LabelMatcher, 0, len(base)+len(filter))
+func labelMatchersFromMatchers(matchers types.Matchers) []stats.LabelMatcher {
+	out := make([]stats.LabelMatcher, 0, len(matchers))
 
-	for _, m := range base {
+	for _, m := range matchers {
 		out = append(out, stats.LabelMatcher{
 			Type:  m.Type,
 			Name:  m.Name,
@@ -171,7 +186,13 @@ func labelMatchersFromMatchers(base types.Matchers, filter []*labels.Matcher) []
 		})
 	}
 
-	for _, m := range filter {
+	return out
+}
+
+func labelMatchersFromPrometheusMatchers(matchers []*labels.Matcher) []stats.LabelMatcher {
+	out := make([]stats.LabelMatcher, 0, len(matchers))
+
+	for _, m := range matchers {
 		out = append(out, stats.LabelMatcher{
 			Type:  m.Type,
 			Name:  m.Name,

--- a/pkg/streamingpromql/operators/selectors/selector_test.go
+++ b/pkg/streamingpromql/operators/selectors/selector_test.go
@@ -236,7 +236,10 @@ func TestSelector_ReportsCardinality(t *testing.T) {
 	timeRange := types.NewRangeQueryTimeRange(start, end, time.Minute)
 	lookbackDelta := 5 * time.Minute
 
-	baseMatchers := types.Matchers{{Type: labels.MatchEqual, Name: "__name__", Value: "foo"}}
+	baseMatchers := types.Matchers{
+		{Type: labels.MatchEqual, Name: "__name__", Value: "foo"},
+		{Type: labels.MatchRegexp, Name: "env", Value: "(prod|dev)"},
+	}
 	expectedMinT, expectedMaxT := ComputeQueriedTimeRange(timeRange, nil, 0, 0, lookbackDelta, false, false)
 
 	newSelector := func(ctx context.Context) *Selector {
@@ -262,7 +265,10 @@ func TestSelector_ReportsCardinality(t *testing.T) {
 
 			require.Equal(t, []stats.SelectorCardinality{
 				{
-					Matchers:    []stats.LabelMatcher{{Type: labels.MatchEqual, Name: "__name__", Value: "foo"}},
+					Matchers: []stats.LabelMatcher{
+						{Type: labels.MatchEqual, Name: "__name__", Value: "foo"},
+						{Type: labels.MatchRegexp, Name: "env", Value: "(prod|dev)"},
+					},
 					MinT:        expectedMinT,
 					MaxT:        expectedMaxT,
 					SeriesCount: 3,
@@ -279,7 +285,10 @@ func TestSelector_ReportsCardinality(t *testing.T) {
 
 			require.Equal(t, []stats.SelectorCardinality{
 				{
-					Matchers:    []stats.LabelMatcher{{Type: labels.MatchEqual, Name: "__name__", Value: "foo"}},
+					Matchers: []stats.LabelMatcher{
+						{Type: labels.MatchEqual, Name: "__name__", Value: "foo"},
+						{Type: labels.MatchRegexp, Name: "env", Value: "(prod|dev)"},
+					},
 					MinT:        expectedMinT,
 					MaxT:        expectedMaxT,
 					SeriesCount: 0,
@@ -294,7 +303,7 @@ func TestSelector_ReportsCardinality(t *testing.T) {
 			s := newSelector(ctx)
 			s.Subsets = []Subset{
 				{Filter: []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "env", "prod")}},
-				{Filter: []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "env", "dev")}},
+				{Filter: []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "instance", "c")}},
 			}
 
 			defer s.Close()
@@ -306,19 +315,29 @@ func TestSelector_ReportsCardinality(t *testing.T) {
 
 			require.Equal(t, []stats.SelectorCardinality{
 				{
-					Matchers:    []stats.LabelMatcher{{Type: labels.MatchEqual, Name: "__name__", Value: "foo"}},
+					Matchers: []stats.LabelMatcher{
+						{Type: labels.MatchEqual, Name: "__name__", Value: "foo"},
+						{Type: labels.MatchRegexp, Name: "env", Value: "(prod|dev)"},
+					},
 					MinT:        expectedMinT,
 					MaxT:        expectedMaxT,
 					SeriesCount: 3,
 				},
 				{
-					Matchers:    []stats.LabelMatcher{{Type: labels.MatchEqual, Name: "__name__", Value: "foo"}, {Type: labels.MatchEqual, Name: "env", Value: "prod"}},
+					Matchers: []stats.LabelMatcher{
+						{Type: labels.MatchEqual, Name: "__name__", Value: "foo"},
+						{Type: labels.MatchEqual, Name: "env", Value: "prod"}, // Matcher reduction should be applied so that this selector matches the original value in the expression.
+					},
 					MinT:        expectedMinT,
 					MaxT:        expectedMaxT,
 					SeriesCount: 2,
 				},
 				{
-					Matchers:    []stats.LabelMatcher{{Type: labels.MatchEqual, Name: "__name__", Value: "foo"}, {Type: labels.MatchEqual, Name: "env", Value: "dev"}},
+					Matchers: []stats.LabelMatcher{
+						{Type: labels.MatchEqual, Name: "__name__", Value: "foo"},
+						{Type: labels.MatchRegexp, Name: "env", Value: "(prod|dev)"},
+						{Type: labels.MatchEqual, Name: "instance", Value: "c"},
+					},
 					MinT:        expectedMinT,
 					MaxT:        expectedMaxT,
 					SeriesCount: 1,
@@ -331,7 +350,7 @@ func TestSelector_ReportsCardinality(t *testing.T) {
 			s := newSelector(ctx)
 			s.Subsets = []Subset{
 				{Filter: []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "env", "prod")}},
-				{Filter: []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "env", "dev")}},
+				{Filter: []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "instance", "c")}},
 			}
 
 			defer s.Close()
@@ -340,19 +359,29 @@ func TestSelector_ReportsCardinality(t *testing.T) {
 
 			require.Equal(t, []stats.SelectorCardinality{
 				{
-					Matchers:    []stats.LabelMatcher{{Type: labels.MatchEqual, Name: "__name__", Value: "foo"}},
+					Matchers: []stats.LabelMatcher{
+						{Type: labels.MatchEqual, Name: "__name__", Value: "foo"},
+						{Type: labels.MatchRegexp, Name: "env", Value: "(prod|dev)"},
+					},
 					MinT:        expectedMinT,
 					MaxT:        expectedMaxT,
 					SeriesCount: 0,
 				},
 				{
-					Matchers:    []stats.LabelMatcher{{Type: labels.MatchEqual, Name: "__name__", Value: "foo"}, {Type: labels.MatchEqual, Name: "env", Value: "prod"}},
+					Matchers: []stats.LabelMatcher{
+						{Type: labels.MatchEqual, Name: "__name__", Value: "foo"},
+						{Type: labels.MatchEqual, Name: "env", Value: "prod"}, // Matcher reduction should be applied so that this selector matches the original value in the expression.
+					},
 					MinT:        expectedMinT,
 					MaxT:        expectedMaxT,
 					SeriesCount: 0,
 				},
 				{
-					Matchers:    []stats.LabelMatcher{{Type: labels.MatchEqual, Name: "__name__", Value: "foo"}, {Type: labels.MatchEqual, Name: "env", Value: "dev"}},
+					Matchers: []stats.LabelMatcher{
+						{Type: labels.MatchEqual, Name: "__name__", Value: "foo"},
+						{Type: labels.MatchRegexp, Name: "env", Value: "(prod|dev)"},
+						{Type: labels.MatchEqual, Name: "instance", Value: "c"},
+					},
 					MinT:        expectedMinT,
 					MaxT:        expectedMaxT,
 					SeriesCount: 0,

--- a/pkg/streamingpromql/optimize/ast/reduce_matchers.go
+++ b/pkg/streamingpromql/optimize/ast/reduce_matchers.go
@@ -8,11 +8,10 @@ import (
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 
+	"github.com/grafana/mimir/pkg/streamingpromql/optimize/matchers"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning"
-	"github.com/grafana/mimir/pkg/streamingpromql/planning/core"
 	"github.com/grafana/mimir/pkg/util"
 	"github.com/grafana/mimir/pkg/util/spanlogger"
 )
@@ -53,7 +52,7 @@ func (c *ReduceMatchers) Apply(ctx context.Context, root parser.Expr, _ *plannin
 	c.apply(root, func(node parser.Node, keepWildcardsForInfoDataSelector bool) {
 		switch expr := node.(type) {
 		case *parser.VectorSelector:
-			retained, dropped := reduceMatchers(expr.LabelMatchers, keepWildcardsForInfoDataSelector)
+			retained, dropped := matchers.Reduce(expr.LabelMatchers, keepWildcardsForInfoDataSelector)
 
 			if len(dropped) > 0 {
 				expr.LabelMatchers = retained
@@ -65,7 +64,7 @@ func (c *ReduceMatchers) Apply(ctx context.Context, root parser.Expr, _ *plannin
 				)
 			}
 		case *parser.MatrixSelector:
-			retained, dropped := reduceMatchers(expr.VectorSelector.(*parser.VectorSelector).LabelMatchers, keepWildcardsForInfoDataSelector)
+			retained, dropped := matchers.Reduce(expr.VectorSelector.(*parser.VectorSelector).LabelMatchers, keepWildcardsForInfoDataSelector)
 
 			if len(dropped) > 0 {
 				expr.VectorSelector.(*parser.VectorSelector).LabelMatchers = retained
@@ -107,208 +106,4 @@ func (c *ReduceMatchers) apply(node parser.Node, fn func(parser.Node, bool), kee
 	for child := range parser.ChildrenIter(node) {
 		c.apply(child, fn, false)
 	}
-}
-
-func reduceMatchers(existing []*labels.Matcher, keepWildcardsForInfoDataSelector bool) (retained []*labels.Matcher, dropped []*labels.Matcher) {
-	// If there's only one matcher, we can't reduce anything.
-	if len(existing) <= 1 {
-		return existing, nil
-	}
-
-	allowedMatchers := setReduceMatchers(existing, keepWildcardsForInfoDataSelector)
-	// Rebuild a list of retained and dropped matchers. The dropped matchers are used for
-	// logging purposes to record all matchers have been removed from the query.
-	return buildOutMatchers(existing, allowedMatchers)
-}
-
-// buildOutMatchers takes a slice of matchers, and returns a slice of matchers which are included in allowedOutMatchers,
-// as well as a slice of droppedMatchers which were either duplicates or not included in allowedOutMatchers.
-func buildOutMatchers(inMatchers []*labels.Matcher, allowedOutMatchers []*labels.Matcher) ([]*labels.Matcher, []*labels.Matcher) {
-	outMatchers := make([]*labels.Matcher, 0, len(inMatchers))
-	dedupedMatchers, dropped := dedupeMatchers(inMatchers)
-
-	// allowedInResultSet maps the relevant values of matchers returned by setReduce.
-	// We use core.LabelMatcher as the key here because labels.Matcher contains a FastRegexMatcher instance
-	// which means that two otherwise identical matchers are considered different.
-	// We do it this way instead of using the matcher string via m.String()
-	// to avoid unnecessary memory allocations when building the string.
-	allowedInResultSet := make(map[core.LabelMatcher]bool, len(allowedOutMatchers))
-	for _, m := range allowedOutMatchers {
-		allowedInResultSet[core.LabelMatcherFromPrometheusType(m)] = false
-	}
-	// If we have reached the last deduped input matcher and are still not returning any matchers,
-	// we should return at least one matcher. This can happen if all input matchers are wildcard matchers.
-	for i, m := range dedupedMatchers {
-		if i == len(dedupedMatchers)-1 && len(outMatchers) == 0 {
-			outMatchers = append(outMatchers, m)
-			continue
-		}
-		// allowedOutMatchers is used to both keep track of all unique matchers (evidenced by existence in the map),
-		// and whether the matcher has already been seen and added to a set of output matchers (evidenced by the value in the map).
-		// We only want to add the matcher if it hasn't already been added to an output slice.
-		if alreadyInResultSet, allowed := allowedInResultSet[core.LabelMatcherFromPrometheusType(m)]; allowed && !alreadyInResultSet {
-			outMatchers = append(outMatchers, m)
-			allowedInResultSet[core.LabelMatcherFromPrometheusType(m)] = true
-		} else {
-			dropped = append(dropped, m)
-		}
-	}
-	return outMatchers, dropped
-}
-
-// setReduceMatchers takes a slice of matchers, and returns only those matchers which would reduce the result set size.
-// For each label name, matchers are dropped from the result set based on criteria for their type:
-//   - equals matchers are never dropped, but if there is more than one unique equals matcher,
-//     all other matchers for the label name are dropped because unique equals matchers have non-intersecting result sets.
-//   - not-equals matchers are dropped if they match any equals matcher value,
-//     or if any not-regex matchers also exclude the not-equals matcher value.
-//   - regex and not-regex matchers are dropped if they match any equals matcher value.
-func setReduceMatchers(ms []*labels.Matcher, keepWildcardsForInfoDataSelector bool) []*labels.Matcher {
-	// Group matchers by their label names so we can evaluate each label name independently
-	matchersByName := make(map[string][]*labels.Matcher)
-	for _, m := range ms {
-		if _, ok := matchersByName[m.Name]; !ok {
-			matchersByName[m.Name] = make([]*labels.Matcher, 0, 1)
-		}
-		matchersByName[m.Name] = append(matchersByName[m.Name], m)
-	}
-	outMatchers := make([]*labels.Matcher, 0, len(ms))
-	for _, matchers := range matchersByName {
-		matchersByType := groupMatchersByType(matchers)
-		equalsMatchers, _ := dedupeMatchers(matchersByType[labels.MatchEqual])
-		outMatchers = append(outMatchers, equalsMatchers...)
-		// If we have more than one unique equals matcher, we can just return those;
-		// we know we'll only return an empty set
-		if len(equalsMatchers) > 1 {
-			continue
-		}
-		outMatchers = append(outMatchers, filterRegexMatchers(matchersByType, labels.MatchRegexp, keepWildcardsForInfoDataSelector)...)
-		outMatchers = append(outMatchers, filterNotEqualsMatchers(matchersByType)...)
-		outMatchers = append(outMatchers, filterRegexMatchers(matchersByType, labels.MatchNotRegexp, false)...)
-	}
-	return outMatchers
-}
-
-// dedupeMatchers dedupes matchers based on their type, name, and value.
-func dedupeMatchers(ms []*labels.Matcher) ([]*labels.Matcher, []*labels.Matcher) {
-	deduped := make(map[core.LabelMatcher]*labels.Matcher, len(ms))
-	dropped := make([]*labels.Matcher, 0, 1)
-	for _, m := range ms {
-		key := core.LabelMatcherFromPrometheusType(m)
-		if _, ok := deduped[key]; ok {
-			dropped = append(dropped, m)
-			continue
-		}
-		deduped[key] = m
-	}
-	outMatchers := make([]*labels.Matcher, 0, len(deduped))
-	for _, ptr := range deduped {
-		outMatchers = append(outMatchers, ptr)
-	}
-	return outMatchers, dropped
-}
-
-// matcherMatchesAnyValues returns true if the given matcher matches a single value from the input matchers, and false otherwise.
-func matcherMatchesAnyValues(matcher *labels.Matcher, matchers []*labels.Matcher) bool {
-	for _, m := range matchers {
-		if matcher.Matches(m.Value) {
-			return true
-		}
-	}
-	return false
-}
-
-// filterRegexMatchers returns a subset of regex matchers which would actually reduce the result set size for either positive or negative regex matchers.
-// A regex matcher is dropped if:
-//   - it is a positive regex matcher and matches all values (foo=~".*") AND keepWildcardsForInfoDataSelector is false
-//   - it matches any equals matches, since the equals matcher will match a strict subset of values that the regex matcher would.
-//
-// Examples:
-//   - {foo=~".*bar.*", foo="bar"}, foo=~".*bar.*" is dropped because foo="bar" is a subset of foo=~".*bar.*"
-//   - {foo!~".*bar.*", foo="bar"}, foo!~".*bar.*" is not dropped because it covers a different set of values than foo="bar"
-//   - {foo!~".*baz.*", foo="bar"}, foo!~".*baz.*" is dropped because foo="bar" is a subset of foo!~".*baz.*"
-func filterRegexMatchers(mf map[labels.MatchType][]*labels.Matcher, regexType labels.MatchType, keepWildcardsForInfoDataSelector bool) []*labels.Matcher {
-	var matchers []*labels.Matcher
-	switch regexType {
-	case labels.MatchRegexp:
-		matchers = mf[labels.MatchRegexp]
-	case labels.MatchNotRegexp:
-		matchers = mf[labels.MatchNotRegexp]
-	default:
-		// Do not filter anything if passed a non-regex type.
-		panic("cannot filter unknown type regex matchers")
-	}
-	outMatchers := make([]*labels.Matcher, 0, len(matchers))
-	for _, m := range matchers {
-		// Always drop wildcard matchers if they are not in an info data selector.
-		if !keepWildcardsForInfoDataSelector && m.Type == labels.MatchRegexp && m.Value == ".*" {
-			continue
-		}
-		// If m matches any equals matcher, that equals matcher is a subset of the regex,
-		// and we should not add m to outMatchers.
-		if !matcherMatchesAnyValues(m, mf[labels.MatchEqual]) {
-			outMatchers = append(outMatchers, m)
-		}
-	}
-	return outMatchers
-}
-
-// filterNotEqualsMatchers returns a subset of not-equals matchers which should actually reduce the result set size.
-// This subset is determined by comparing each not-equals matchers against equals, regex, and not-regex matchers.
-// A not-equals matcher is dropped on any of these conditions:
-//   - there are any not-regex matchers which would also remove the not-equals matcher value from the result set
-//   - there are any regex matchers which would also remove the not-equals matcher value from the result set
-//   - any equals matcher for a value that is matched by the not-equals matcher
-//
-// Examples:
-//   - for the matcher set {foo!="bar", foo="b"}, foo!="bar" does match the value "b", so foo!="bar" is dropped.
-//   - for the matcher set {foo!="bar", foo="bar"}, foo!="bar" does not match the value "bar", so foo!="bar" is not dropped.
-//   - for the matcher set {foo!="bar", foo!~".*bar.*"}, foo!~".*bar.*" will exclude more values from the result set than foo!="bar", so foo!="bar" is dropped.
-//   - for the matcher set {foo!="bar", foo=~".*baz.*"}, foo=~".*baz.*" will already exclude the "bar" value.
-func filterNotEqualsMatchers(mf map[labels.MatchType][]*labels.Matcher) []*labels.Matcher {
-	outMatchers := make([]*labels.Matcher, 0, len(mf[labels.MatchNotEqual]))
-
-	for _, m := range mf[labels.MatchNotEqual] {
-		// If the value of a not-equals matcher is matched by the inverse of any not-regex matcher,
-		// that not-equals matcher can be dropped, because it will select a subset of the regex.
-		// Using the example of x!="a" and x!~"a.*",
-		// x!~"a.*" will exclude more values than x!="a".
-		notRegexExcludesValue := false
-		for _, nr := range mf[labels.MatchNotRegexp] {
-			if inv, err := nr.Inverse(); err == nil {
-				if inv.Matches(m.Value) {
-					notRegexExcludesValue = true
-					break
-				}
-			}
-		}
-
-		// If the value of a not-equals matcher is not matched by a positive regex matcher,
-		// that not-equals matcher can be dropped because it will already be excluded by the
-		// regex.
-		positiveRegexExcludesValue := false
-		for _, r := range mf[labels.MatchRegexp] {
-			if !r.Matches(m.Value) {
-				positiveRegexExcludesValue = true
-				break
-			}
-		}
-
-		// If the value of any equals matcher is matched by the not-equals matcher, only keep the equals matcher,
-		// because the not-equals will not "subtract" anything from the final set.
-		matchesNoEquals := !matcherMatchesAnyValues(m, mf[labels.MatchEqual])
-
-		if !notRegexExcludesValue && !positiveRegexExcludesValue && matchesNoEquals {
-			outMatchers = append(outMatchers, m)
-		}
-	}
-	return outMatchers
-}
-
-func groupMatchersByType(ms []*labels.Matcher) map[labels.MatchType][]*labels.Matcher {
-	outGroups := make(map[labels.MatchType][]*labels.Matcher)
-	for _, m := range ms {
-		outGroups[m.Type] = append(outGroups[m.Type], m)
-	}
-	return outGroups
 }

--- a/pkg/streamingpromql/optimize/ast/sort_labels_and_matchers.go
+++ b/pkg/streamingpromql/optimize/ast/sort_labels_and_matchers.go
@@ -7,11 +7,10 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 
+	"github.com/grafana/mimir/pkg/streamingpromql/optimize/matchers"
 	"github.com/grafana/mimir/pkg/streamingpromql/planning"
-	"github.com/grafana/mimir/pkg/streamingpromql/planning/core"
 )
 
 // SortLabelsAndMatchers is an optimization pass that ensures that all label names and matchers are sorted.
@@ -28,11 +27,11 @@ func (s *SortLabelsAndMatchers) Apply(_ context.Context, expr parser.Expr, _ *pl
 		switch expr := node.(type) {
 		case *parser.VectorSelector:
 			// Note that VectorSelectors sort their matchers when pretty printing, so this change may not be visible when printing as PromQL.
-			slices.SortFunc(expr.LabelMatchers, compareMatchers)
+			matchers.Sort(expr.LabelMatchers)
 
 		case *parser.MatrixSelector:
 			// Note that MatrixSelectors sort their matchers when pretty printing, so this change may not be visible when printing as PromQL.
-			slices.SortFunc(expr.VectorSelector.(*parser.VectorSelector).LabelMatchers, compareMatchers)
+			matchers.Sort(expr.VectorSelector.(*parser.VectorSelector).LabelMatchers)
 
 		case *parser.BinaryExpr:
 			if expr.VectorMatching != nil {
@@ -53,8 +52,4 @@ func (s *SortLabelsAndMatchers) Apply(_ context.Context, expr parser.Expr, _ *pl
 	})
 
 	return expr, nil
-}
-
-func compareMatchers(a, b *labels.Matcher) int {
-	return core.CompareMatchers(a.Name, b.Name, a.Type, b.Type, a.Value, b.Value)
 }

--- a/pkg/streamingpromql/optimize/matchers/reduce.go
+++ b/pkg/streamingpromql/optimize/matchers/reduce.go
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package matchers
+
+import (
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/grafana/mimir/pkg/streamingpromql/planning/core"
+)
+
+func Reduce(existing []*labels.Matcher, keepWildcardsForInfoDataSelector bool) (retained []*labels.Matcher, dropped []*labels.Matcher) {
+	// If there's only one matcher, we can't reduce anything.
+	if len(existing) <= 1 {
+		return existing, nil
+	}
+
+	allowedMatchers := setReduceMatchers(existing, keepWildcardsForInfoDataSelector)
+	// Rebuild a list of retained and dropped matchers. The dropped matchers are used for
+	// logging purposes to record all matchers have been removed from the query.
+	return buildOutMatchers(existing, allowedMatchers)
+}
+
+// buildOutMatchers takes a slice of matchers, and returns a slice of matchers which are included in allowedOutMatchers,
+// as well as a slice of droppedMatchers which were either duplicates or not included in allowedOutMatchers.
+func buildOutMatchers(inMatchers []*labels.Matcher, allowedOutMatchers []*labels.Matcher) ([]*labels.Matcher, []*labels.Matcher) {
+	outMatchers := make([]*labels.Matcher, 0, len(inMatchers))
+	dedupedMatchers, dropped := dedupeMatchers(inMatchers)
+
+	// allowedInResultSet maps the relevant values of matchers returned by setReduce.
+	// We use core.LabelMatcher as the key here because labels.Matcher contains a FastRegexMatcher instance
+	// which means that two otherwise identical matchers are considered different.
+	// We do it this way instead of using the matcher string via m.String()
+	// to avoid unnecessary memory allocations when building the string.
+	allowedInResultSet := make(map[core.LabelMatcher]bool, len(allowedOutMatchers))
+	for _, m := range allowedOutMatchers {
+		allowedInResultSet[core.LabelMatcherFromPrometheusType(m)] = false
+	}
+	// If we have reached the last deduped input matcher and are still not returning any matchers,
+	// we should return at least one matcher. This can happen if all input matchers are wildcard matchers.
+	for i, m := range dedupedMatchers {
+		if i == len(dedupedMatchers)-1 && len(outMatchers) == 0 {
+			outMatchers = append(outMatchers, m)
+			continue
+		}
+		// allowedOutMatchers is used to both keep track of all unique matchers (evidenced by existence in the map),
+		// and whether the matcher has already been seen and added to a set of output matchers (evidenced by the value in the map).
+		// We only want to add the matcher if it hasn't already been added to an output slice.
+		if alreadyInResultSet, allowed := allowedInResultSet[core.LabelMatcherFromPrometheusType(m)]; allowed && !alreadyInResultSet {
+			outMatchers = append(outMatchers, m)
+			allowedInResultSet[core.LabelMatcherFromPrometheusType(m)] = true
+		} else {
+			dropped = append(dropped, m)
+		}
+	}
+	return outMatchers, dropped
+}
+
+// setReduceMatchers takes a slice of matchers, and returns only those matchers which would reduce the result set size.
+// For each label name, matchers are dropped from the result set based on criteria for their type:
+//   - equals matchers are never dropped, but if there is more than one unique equals matcher,
+//     all other matchers for the label name are dropped because unique equals matchers have non-intersecting result sets.
+//   - not-equals matchers are dropped if they match any equals matcher value,
+//     or if any not-regex matchers also exclude the not-equals matcher value.
+//   - regex and not-regex matchers are dropped if they match any equals matcher value.
+func setReduceMatchers(ms []*labels.Matcher, keepWildcardsForInfoDataSelector bool) []*labels.Matcher {
+	// Group matchers by their label names so we can evaluate each label name independently
+	matchersByName := make(map[string][]*labels.Matcher)
+	for _, m := range ms {
+		if _, ok := matchersByName[m.Name]; !ok {
+			matchersByName[m.Name] = make([]*labels.Matcher, 0, 1)
+		}
+		matchersByName[m.Name] = append(matchersByName[m.Name], m)
+	}
+	outMatchers := make([]*labels.Matcher, 0, len(ms))
+	for _, matchers := range matchersByName {
+		matchersByType := groupMatchersByType(matchers)
+		equalsMatchers, _ := dedupeMatchers(matchersByType[labels.MatchEqual])
+		outMatchers = append(outMatchers, equalsMatchers...)
+		// If we have more than one unique equals matcher, we can just return those;
+		// we know we'll only return an empty set
+		if len(equalsMatchers) > 1 {
+			continue
+		}
+		outMatchers = append(outMatchers, filterRegexMatchers(matchersByType, labels.MatchRegexp, keepWildcardsForInfoDataSelector)...)
+		outMatchers = append(outMatchers, filterNotEqualsMatchers(matchersByType)...)
+		outMatchers = append(outMatchers, filterRegexMatchers(matchersByType, labels.MatchNotRegexp, false)...)
+	}
+	return outMatchers
+}
+
+// dedupeMatchers dedupes matchers based on their type, name, and value.
+func dedupeMatchers(ms []*labels.Matcher) ([]*labels.Matcher, []*labels.Matcher) {
+	deduped := make(map[core.LabelMatcher]*labels.Matcher, len(ms))
+	dropped := make([]*labels.Matcher, 0, 1)
+	for _, m := range ms {
+		key := core.LabelMatcherFromPrometheusType(m)
+		if _, ok := deduped[key]; ok {
+			dropped = append(dropped, m)
+			continue
+		}
+		deduped[key] = m
+	}
+	outMatchers := make([]*labels.Matcher, 0, len(deduped))
+	for _, ptr := range deduped {
+		outMatchers = append(outMatchers, ptr)
+	}
+	return outMatchers, dropped
+}
+
+// matcherMatchesAnyValues returns true if the given matcher matches a single value from the input matchers, and false otherwise.
+func matcherMatchesAnyValues(matcher *labels.Matcher, matchers []*labels.Matcher) bool {
+	for _, m := range matchers {
+		if matcher.Matches(m.Value) {
+			return true
+		}
+	}
+	return false
+}
+
+// filterRegexMatchers returns a subset of regex matchers which would actually reduce the result set size for either positive or negative regex matchers.
+// A regex matcher is dropped if:
+//   - it is a positive regex matcher and matches all values (foo=~".*") AND keepWildcardsForInfoDataSelector is false
+//   - it matches any equals matches, since the equals matcher will match a strict subset of values that the regex matcher would.
+//
+// Examples:
+//   - {foo=~".*bar.*", foo="bar"}, foo=~".*bar.*" is dropped because foo="bar" is a subset of foo=~".*bar.*"
+//   - {foo!~".*bar.*", foo="bar"}, foo!~".*bar.*" is not dropped because it covers a different set of values than foo="bar"
+//   - {foo!~".*baz.*", foo="bar"}, foo!~".*baz.*" is dropped because foo="bar" is a subset of foo!~".*baz.*"
+func filterRegexMatchers(mf map[labels.MatchType][]*labels.Matcher, regexType labels.MatchType, keepWildcardsForInfoDataSelector bool) []*labels.Matcher {
+	var matchers []*labels.Matcher
+	switch regexType {
+	case labels.MatchRegexp:
+		matchers = mf[labels.MatchRegexp]
+	case labels.MatchNotRegexp:
+		matchers = mf[labels.MatchNotRegexp]
+	default:
+		// Do not filter anything if passed a non-regex type.
+		panic("cannot filter unknown type regex matchers")
+	}
+	outMatchers := make([]*labels.Matcher, 0, len(matchers))
+	for _, m := range matchers {
+		// Always drop wildcard matchers if they are not in an info data selector.
+		if !keepWildcardsForInfoDataSelector && m.Type == labels.MatchRegexp && m.Value == ".*" {
+			continue
+		}
+		// If m matches any equals matcher, that equals matcher is a subset of the regex,
+		// and we should not add m to outMatchers.
+		if !matcherMatchesAnyValues(m, mf[labels.MatchEqual]) {
+			outMatchers = append(outMatchers, m)
+		}
+	}
+	return outMatchers
+}
+
+// filterNotEqualsMatchers returns a subset of not-equals matchers which should actually reduce the result set size.
+// This subset is determined by comparing each not-equals matchers against equals, regex, and not-regex matchers.
+// A not-equals matcher is dropped on any of these conditions:
+//   - there are any not-regex matchers which would also remove the not-equals matcher value from the result set
+//   - there are any regex matchers which would also remove the not-equals matcher value from the result set
+//   - any equals matcher for a value that is matched by the not-equals matcher
+//
+// Examples:
+//   - for the matcher set {foo!="bar", foo="b"}, foo!="bar" does match the value "b", so foo!="bar" is dropped.
+//   - for the matcher set {foo!="bar", foo="bar"}, foo!="bar" does not match the value "bar", so foo!="bar" is not dropped.
+//   - for the matcher set {foo!="bar", foo!~".*bar.*"}, foo!~".*bar.*" will exclude more values from the result set than foo!="bar", so foo!="bar" is dropped.
+//   - for the matcher set {foo!="bar", foo=~".*baz.*"}, foo=~".*baz.*" will already exclude the "bar" value.
+func filterNotEqualsMatchers(mf map[labels.MatchType][]*labels.Matcher) []*labels.Matcher {
+	outMatchers := make([]*labels.Matcher, 0, len(mf[labels.MatchNotEqual]))
+
+	for _, m := range mf[labels.MatchNotEqual] {
+		// If the value of a not-equals matcher is matched by the inverse of any not-regex matcher,
+		// that not-equals matcher can be dropped, because it will select a subset of the regex.
+		// Using the example of x!="a" and x!~"a.*",
+		// x!~"a.*" will exclude more values than x!="a".
+		notRegexExcludesValue := false
+		for _, nr := range mf[labels.MatchNotRegexp] {
+			if inv, err := nr.Inverse(); err == nil {
+				if inv.Matches(m.Value) {
+					notRegexExcludesValue = true
+					break
+				}
+			}
+		}
+
+		// If the value of a not-equals matcher is not matched by a positive regex matcher,
+		// that not-equals matcher can be dropped because it will already be excluded by the
+		// regex.
+		positiveRegexExcludesValue := false
+		for _, r := range mf[labels.MatchRegexp] {
+			if !r.Matches(m.Value) {
+				positiveRegexExcludesValue = true
+				break
+			}
+		}
+
+		// If the value of any equals matcher is matched by the not-equals matcher, only keep the equals matcher,
+		// because the not-equals will not "subtract" anything from the final set.
+		matchesNoEquals := !matcherMatchesAnyValues(m, mf[labels.MatchEqual])
+
+		if !notRegexExcludesValue && !positiveRegexExcludesValue && matchesNoEquals {
+			outMatchers = append(outMatchers, m)
+		}
+	}
+	return outMatchers
+}
+
+func groupMatchersByType(ms []*labels.Matcher) map[labels.MatchType][]*labels.Matcher {
+	outGroups := make(map[labels.MatchType][]*labels.Matcher)
+	for _, m := range ms {
+		outGroups[m.Type] = append(outGroups[m.Type], m)
+	}
+	return outGroups
+}

--- a/pkg/streamingpromql/optimize/matchers/reduce.go
+++ b/pkg/streamingpromql/optimize/matchers/reduce.go
@@ -4,8 +4,6 @@ package matchers
 
 import (
 	"github.com/prometheus/prometheus/model/labels"
-
-	"github.com/grafana/mimir/pkg/streamingpromql/planning/core"
 )
 
 func Reduce(existing []*labels.Matcher, keepWildcardsForInfoDataSelector bool) (retained []*labels.Matcher, dropped []*labels.Matcher) {
@@ -27,13 +25,13 @@ func buildOutMatchers(inMatchers []*labels.Matcher, allowedOutMatchers []*labels
 	dedupedMatchers, dropped := dedupeMatchers(inMatchers)
 
 	// allowedInResultSet maps the relevant values of matchers returned by setReduce.
-	// We use core.LabelMatcher as the key here because labels.Matcher contains a FastRegexMatcher instance
+	// We use labelMatcherKey as the key here because labels.Matcher contains a FastRegexMatcher instance
 	// which means that two otherwise identical matchers are considered different.
 	// We do it this way instead of using the matcher string via m.String()
 	// to avoid unnecessary memory allocations when building the string.
-	allowedInResultSet := make(map[core.LabelMatcher]bool, len(allowedOutMatchers))
+	allowedInResultSet := make(map[labelMatcherKey]bool, len(allowedOutMatchers))
 	for _, m := range allowedOutMatchers {
-		allowedInResultSet[core.LabelMatcherFromPrometheusType(m)] = false
+		allowedInResultSet[newLabelMatcherKey(m)] = false
 	}
 	// If we have reached the last deduped input matcher and are still not returning any matchers,
 	// we should return at least one matcher. This can happen if all input matchers are wildcard matchers.
@@ -45,9 +43,9 @@ func buildOutMatchers(inMatchers []*labels.Matcher, allowedOutMatchers []*labels
 		// allowedOutMatchers is used to both keep track of all unique matchers (evidenced by existence in the map),
 		// and whether the matcher has already been seen and added to a set of output matchers (evidenced by the value in the map).
 		// We only want to add the matcher if it hasn't already been added to an output slice.
-		if alreadyInResultSet, allowed := allowedInResultSet[core.LabelMatcherFromPrometheusType(m)]; allowed && !alreadyInResultSet {
+		if alreadyInResultSet, allowed := allowedInResultSet[newLabelMatcherKey(m)]; allowed && !alreadyInResultSet {
 			outMatchers = append(outMatchers, m)
-			allowedInResultSet[core.LabelMatcherFromPrometheusType(m)] = true
+			allowedInResultSet[newLabelMatcherKey(m)] = true
 		} else {
 			dropped = append(dropped, m)
 		}
@@ -90,10 +88,10 @@ func setReduceMatchers(ms []*labels.Matcher, keepWildcardsForInfoDataSelector bo
 
 // dedupeMatchers dedupes matchers based on their type, name, and value.
 func dedupeMatchers(ms []*labels.Matcher) ([]*labels.Matcher, []*labels.Matcher) {
-	deduped := make(map[core.LabelMatcher]*labels.Matcher, len(ms))
+	deduped := make(map[labelMatcherKey]*labels.Matcher, len(ms))
 	dropped := make([]*labels.Matcher, 0, 1)
 	for _, m := range ms {
-		key := core.LabelMatcherFromPrometheusType(m)
+		key := newLabelMatcherKey(m)
 		if _, ok := deduped[key]; ok {
 			dropped = append(dropped, m)
 			continue
@@ -210,4 +208,18 @@ func groupMatchersByType(ms []*labels.Matcher) map[labels.MatchType][]*labels.Ma
 		outGroups[m.Type] = append(outGroups[m.Type], m)
 	}
 	return outGroups
+}
+
+type labelMatcherKey struct {
+	Name  string
+	Value string
+	Type  labels.MatchType
+}
+
+func newLabelMatcherKey(m *labels.Matcher) labelMatcherKey {
+	return labelMatcherKey{
+		Name:  m.Name,
+		Value: m.Value,
+		Type:  m.Type,
+	}
 }

--- a/pkg/streamingpromql/optimize/matchers/reduce_test.go
+++ b/pkg/streamingpromql/optimize/matchers/reduce_test.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package matchers
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/mimir/pkg/util/promqlext"
+)
+
+func TestReduce(t *testing.T) {
+	tests := []struct {
+		name             string
+		input            string
+		expectedRetained string
+		expectedDropped  string
+	}{
+		{
+			name:             "only name matcher",
+			input:            `test_series`,
+			expectedRetained: `test_series`,
+		},
+		{
+			name:             "deduplicate matchers",
+			input:            `test_series{foo="bar",foo="bar",foo="bar",foo=~".*baz.*",foo=~".*baz.*"}`,
+			expectedRetained: `test_series{foo="bar",foo=~".*baz.*"}`,
+			expectedDropped:  `{foo="bar",foo="bar",foo=~".*baz.*"}`,
+		},
+		{
+			name: "multiple unique equals matchers should only return equals matchers",
+			// Even though the regex matcher matches neither equals matcher,
+			// a query with multiple equals matchers for the same label name is already guaranteed to return an empty set
+			input:            `test_series{foo="bar",foo=~".*bananas.*",foo="baz"}`,
+			expectedRetained: `test_series{foo="bar",foo="baz"}`,
+			expectedDropped:  `{foo=~".*bananas.*"}`,
+		},
+		{
+			name:             "should remove a regex matcher if it is a superset of an equals matcher",
+			input:            `test_series{foo="bar",foo=~".*bar.*"}`,
+			expectedRetained: `test_series{foo="bar"}`,
+			expectedDropped:  `{foo=~".*bar.*"}`,
+		},
+		{
+			name:             "should preserve a regex matcher if it is not a superset of an equals matcher",
+			input:            `test_series{foo="bar",foo="bar",foo=~".*baz.*"}`,
+			expectedRetained: `test_series{foo="bar",foo=~".*baz.*"}`,
+			expectedDropped:  `{foo="bar"}`,
+		},
+		{
+			name:             "do not drop wildcard negative regex matcher",
+			input:            `test_series{foo!~".*"}`,
+			expectedRetained: `test_series{foo!~".*"}`,
+		},
+		{
+			name:             "single non-wildcard matcher should not be dropped",
+			input:            `test_series{foo!=""}`,
+			expectedRetained: `test_series{foo!=""}`,
+		},
+		{
+			name:             "drop all matchers that match supersets of an equals matcher",
+			input:            `test_series{foo=~".*bar.*",foo="bar",foo!="",foo!~"",foo!="baz"}`,
+			expectedRetained: `test_series{foo="bar"}`,
+			expectedDropped:  `{foo!="",foo!="baz",foo!~"",foo=~".*bar.*"}`,
+		},
+		{
+			name:             "keep one matcher of ones that reduce the set size equivalently",
+			input:            `test_series{foo=~".*",foo!~"",foo!=""}`,
+			expectedRetained: `test_series{foo!~""}`,
+			expectedDropped:  `{foo!="",foo=~".*"}`,
+		},
+		{
+			name:             "keep at least one matcher for each label name",
+			input:            `test_series{foo=~".*",baz!="",foo!~"",foo!=""}`,
+			expectedRetained: `test_series{baz!="",foo!~""}`,
+			expectedDropped:  `{foo!="",foo=~".*"}`,
+		},
+		{
+			name:             "keep matcher that excludes empty strings if no other matcher does so",
+			input:            `test_series{foo!="",foo!="bar"}`,
+			expectedRetained: `test_series{foo!="",foo!="bar"}`,
+		},
+		{
+			name:             "not equals matcher should not be removed if it doesn't match equals matcher value",
+			input:            `test_series{foo!="bar",foo="bar"}`,
+			expectedRetained: `test_series{foo!="bar",foo="bar"}`,
+		},
+		{
+			name:             "not equals matcher should be removed if it does match equals matcher value",
+			input:            `test_series{foo!="bar",foo="baz"}`,
+			expectedRetained: `test_series{foo="baz"}`,
+			expectedDropped:  `{foo!="bar"}`,
+		},
+		{
+			name:             "not equals empty string matcher should be removed if a positive regex matcher already excludes its value",
+			input:            `test_series{foo!="",foo=~".+baz.+"}`,
+			expectedRetained: `test_series{foo=~".+baz.+"}`,
+			expectedDropped:  `{foo!=""}`,
+		},
+		{
+			name:             "not equals matcher should be removed if a positive regex matcher already excludes its value",
+			input:            `test_series{foo!="host99", foo=~"(?i:(host1|host2|host3|host4|host5))"}`,
+			expectedRetained: `test_series{foo=~"(?i:(host1|host2|host3|host4|host5))"}`,
+			expectedDropped:  `{foo!="host99"}`,
+		},
+		{
+			name:             "not equals matcher should not be removed if a positive regex matcher doesn't exclude its value",
+			input:            `test_series{foo!="bad",foo=~"b.+"}`,
+			expectedRetained: `test_series{foo!="bad",foo=~"b.+"}`,
+		},
+	}
+
+	parser := promqlext.NewPromQLParser()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matchers, err := parser.ParseMetricSelector(tt.input)
+			require.NoError(t, err)
+
+			retained, dropped := Reduce(matchers, false)
+			require.Equal(t, tt.expectedRetained, formatMatchers(retained), "retained matchers do not match expected")
+			require.Equal(t, tt.expectedDropped, formatMatchers(dropped), "dropped matchers do not match expected")
+		})
+	}
+}
+
+func formatMatchers(matchers []*labels.Matcher) string {
+	var metricName string
+	formatted := make([]string, 0, len(matchers))
+
+	for _, m := range matchers {
+		if m.Name == model.MetricNameLabel && m.Type == labels.MatchEqual {
+			metricName = m.Value
+			continue
+		}
+
+		formatted = append(formatted, m.String())
+	}
+
+	if len(formatted) > 0 {
+		slices.Sort(formatted)
+		return metricName + "{" + strings.Join(formatted, ",") + "}"
+	}
+
+	return metricName
+}

--- a/pkg/streamingpromql/optimize/matchers/sort.go
+++ b/pkg/streamingpromql/optimize/matchers/sort.go
@@ -1,0 +1,24 @@
+package matchers
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+func Sort(matchers []*labels.Matcher) {
+	slices.SortFunc(matchers, Compare)
+}
+
+func Compare(a, b *labels.Matcher) int {
+	if a.Name != b.Name {
+		return strings.Compare(a.Name, b.Name)
+	}
+
+	if a.Type != b.Type {
+		return int(a.Type - b.Type)
+	}
+
+	return strings.Compare(a.Value, b.Value)
+}


### PR DESCRIPTION
#### What this PR does

This PR fixes an issue where a repeated query like `metric_name{status="success"} / metric_name{status=~"(success|canceled)"}` never gets a cardinality estimate, because the subset's cardinality is cached for a `{__name__="metric_name", status="success", status=~"(success|canceled)"}` selector rather than `{__name__="metric_name", status="success"}`.

#### Which issue(s) this PR fixes or relates to

https://github.com/grafana/mimir/pull/16274

#### Checklist

- [x] Tests updated.
- [n/a] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [n/a] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
