### PR TITLE
Fix remaining flaky integration tests after #16187

### DIFF
--- a/integration/getting_started_with_gossiped_ring_test.go
+++ b/integration/getting_started_with_gossiped_ring_test.go
@@ -96,6 +96,13 @@ func TestGettingStartedWithGossipedRing(t *testing.T) {
 		labels.MustNewMatcher(labels.MatchEqual, "name", "ruler"),
 		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
 
+	// Wait until the query-frontends have updated the querier ring.
+	for _, instance := range []*e2emimir.MimirService{mimir1, mimir2} {
+		require.NoError(t, instance.WaitSumMetricsWithOptions(e2e.Equals(2), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+			labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
+			labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+	}
+
 	runTestGettingStartedWithGossipedRing(t, mimir1, mimir2, "series_1", generateFloatSeries, 0)
 	runTestGettingStartedWithGossipedRing(t, mimir1, mimir2, "hseries_1", generateHistogramSeries, 1)
 }

--- a/integration/getting_started_with_grafana_mimir_test.go
+++ b/integration/getting_started_with_grafana_mimir_test.go
@@ -75,6 +75,11 @@ func TestPlayWithGrafanaMimirTutorial(t *testing.T) {
 }
 
 func runTestPushSeriesAndQueryBack(t *testing.T, mimir *e2emimir.MimirService, seriesName string, genSeries generateSeriesFunc) {
+	// Wait until the query-frontend has updated the querier ring.
+	require.NoError(t, mimir.WaitSumMetricsWithOptions(e2e.GreaterOrEqual(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
+		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+
 	c, err := e2emimir.NewClient(mimir.HTTPEndpoint(), mimir.HTTPEndpoint(), "", "", "user-1")
 	require.NoError(t, err)
 

--- a/integration/ooo_ingestion_test.go
+++ b/integration/ooo_ingestion_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/e2e"
 	e2edb "github.com/grafana/e2e/db"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/integration/e2ehistograms"
@@ -45,6 +46,11 @@ func TestOOOIngestion(t *testing.T) {
 
 	mimir := e2emimir.NewSingleBinary("mimir-1", flags, e2emimir.WithConfigFile(mimirConfigFile), e2emimir.WithPorts(9009, 9095))
 	require.NoError(t, s.StartAndWaitReady(mimir))
+
+	// Wait until the query-frontend has updated the querier ring.
+	require.NoError(t, mimir.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
+		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
 
 	c, err := e2emimir.NewClient(mimir.HTTPEndpoint(), mimir.HTTPEndpoint(), "", "", "user-1")
 	require.NoError(t, err)


### PR DESCRIPTION
same fix as #16197, #16246, #16291 and #16314, applied to the remaining tests that query through a query-frontend without waiting for it to observe the querier ring: `TestOOOIngestion` (which failed twice in a row in https://github.com/grafana/mimir/actions/runs/31099284996), `TestGettingStartedWithGrafanaMimir`, `TestPlayWithGrafanaMimirTutorial` and `TestGettingStartedWithGossipedRing`.