### PR TITLE
Fix flaky TestStartTimeHandling after #16187

### DIFF
--- a/integration/otlp_ingestion_test.go
+++ b/integration/otlp_ingestion_test.go
@@ -500,6 +500,11 @@ func testStartTimeHandling(t *testing.T, enableCTzero bool) {
 	mimir := e2emimir.NewSingleBinary("mimir-1", flags, e2emimir.WithConfigFile(mimirConfigFile), e2emimir.WithPorts(9009, 9095))
 	require.NoError(t, s.StartAndWaitReady(mimir))
 
+	// Wait until the query-frontend has updated the querier ring.
+	require.NoError(t, mimir.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
+		labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
+		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
+
 	c, err := e2emimir.NewClient(mimir.HTTPEndpoint(), mimir.HTTPEndpoint(), "", "", "user-1")
 	require.NoError(t, err)
 


### PR DESCRIPTION
same fix as #16197, #16246, #16291, #16314 and #16318, applied to `TestStartTimeHandling` — it lives in the same file as the tests fixed by #16246/#16291, so my grep for the wait matched the file and skipped it. it failed on main in https://github.com/grafana/mimir/actions/runs/31110532377 with `could not get all queriers from the ring: empty ring`.