### PR TITLE
fix(mixin): filter empty-image cgroup series out of the CPU scaling rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [FEATURE] Block-builder: add jsonnet for deploying the experimental block-builder and block-builder-scheduler. Enable with `block_builder.enabled: true`. #16175 #16337
 * [ENHANCEMENT] Add the `compactor_standalone_enabled` config option (enabled by default) to hide standalone-mode compactor panels and alerts, and stop collapsing scheduler-mode dashboard rows. #16239
 * [ENHANCEMENT] Dashboards: Make the boot/root disk device regex used to filter it out of the "Disk writes" and "Disk reads" panels configurable via `_config.node_boot_disk_device_regex` (default unchanged: `.*sda.*`), so clusters where the root device isn't `sda` (e.g. `vda` on some cloud providers) don't lose data on those panels. #16235
+* [BUGFIX] Recording rules: Add the `image!=""` selector to the `cluster_namespace_deployment:container_cpu_usage_seconds_total:sum_rate` recording rule, consistently with the memory one. Where cAdvisor sandbox and parent cgroup series are not dropped at scrape time, CPU usage was counted twice, which also inflated the replica count recommended by the Scaling dashboard. #16320
 
 ### Jsonnet
 

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/recording-rules.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/recording-rules.yaml
@@ -331,10 +331,13 @@ spec:
               reason: active_series
             record: cluster_namespace_deployment_reason:required_replicas:count
           - expr: |
+              # The sandbox and parent cgroup series that cAdvisor exposes next to the per-container
+              # ones have an empty "image" label and would double count CPU time, so they're filtered
+              # out, consistently with the memory_usage rule below.
               sum by (cluster, namespace, deployment) (
                 label_replace(
                   label_replace(
-                    sum by (cluster, namespace, pod)(rate(container_cpu_usage_seconds_total[4m])),
+                    sum by (cluster, namespace, pod)(rate(container_cpu_usage_seconds_total{image!=""}[4m])),
                     "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
                   ),
                   # The question mark in "(.*?)" is used to make it non-greedy, otherwise it

--- a/operations/mimir-mixin-compiled/rules.yaml
+++ b/operations/mimir-mixin-compiled/rules.yaml
@@ -319,10 +319,13 @@ groups:
             reason: active_series
           record: cluster_namespace_deployment_reason:required_replicas:count
         - expr: |
+            # The sandbox and parent cgroup series that cAdvisor exposes next to the per-container
+            # ones have an empty "image" label and would double count CPU time, so they're filtered
+            # out, consistently with the memory_usage rule below.
             sum by (cluster, namespace, deployment) (
               label_replace(
                 label_replace(
-                  sum by (cluster, namespace, pod)(rate(container_cpu_usage_seconds_total[4m])),
+                  sum by (cluster, namespace, pod)(rate(container_cpu_usage_seconds_total{image!=""}[4m])),
                   "deployment", "$1", "pod", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
                 ),
                 # The question mark in "(.*?)" is used to make it non-greedy, otherwise it

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -389,10 +389,13 @@
           |||,
         cpu_usage_seconds_total:
           |||
+            # The sandbox and parent cgroup series that cAdvisor exposes next to the per-container
+            # ones have an empty "image" label and would double count CPU time, so they're filtered
+            # out, consistently with the memory_usage rule below.
             sum by (%(alert_aggregation_labels)s, deployment) (
               label_replace(
                 label_replace(
-                  sum by (%(alert_aggregation_labels)s, %(per_instance_label)s)(rate(container_cpu_usage_seconds_total[%(rate_interval)s])),
+                  sum by (%(alert_aggregation_labels)s, %(per_instance_label)s)(rate(container_cpu_usage_seconds_total{image!=""}[%(rate_interval)s])),
                   "deployment", "$1", "%(per_instance_label)s", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
                 ),
                 # The question mark in "(.*?)" is used to make it non-greedy, otherwise it


### PR DESCRIPTION
#### What this PR does

`cluster_namespace_deployment:container_cpu_usage_seconds_total:sum_rate` sums
`container_cpu_usage_seconds_total` with no selector, while the sibling `memory_usage` rule
already reads `container_memory_usage_bytes{image!=""}`. Both come from the same cAdvisor job,
so the two are inconsistent: where the scrape keeps the sandbox and parent cgroup series next
to the per-container ones, the CPU rule counts the same CPU time twice.

This is not just a cosmetic wrong number, because `cpu_required_replicas_count` divides the
recorded CPU usage by CPU requests. A 2x inflated numerator makes the Scaling dashboard
recommend roughly double the replicas a deployment actually needs.

Measured on an affected cAdvisor scrape: 368.9 cores unfiltered versus 183.5 with `image!=""`.

This PR adds `image!=""` to the CPU selector so it matches `memory_usage`. Installations that
already drop those series at scrape time are unaffected. The compiled mixin and the helm
golden records are regenerated accordingly.

#### Which issue(s) this PR fixes or relates to

Fixes #9005

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
