### PR TITLE
mixin: add mimir_scaling_rules_selector to scope the scaling recording rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [ENHANCEMENT] Alerts: Widen the `MimirCompactorSchedulerRepeatedJobFailure` lookback window to 20m to prevent the alert from flapping, consistently with `MimirBlockBuilderPersistentJobFailure`. #16346
 * [BUGFIX] Recording rules: Add the `image!=""` selector to the `cluster_namespace_deployment:container_cpu_usage_seconds_total:sum_rate` recording rule, consistently with the memory one. Where cAdvisor sandbox and parent cgroup series are not dropped at scrape time, CPU usage was counted twice, which also inflated the replica count recommended by the Scaling dashboard. #16320
 * [BUGFIX] Alerts: Point `runbook_url` annotations at `/manage/mimir-runbooks/` (docs moved off `operators-guide`). #16329
+* [ENHANCEMENT] Recording rules: Add the `_config.mimir_scaling_rules_selector` config option (empty by default) to restrict the `mimir_scaling_rules` group to the Mimir workloads, e.g. `namespace=~"mimir.*"`. Without it, the group aggregates the kube-state-metrics and cAdvisor series of every workload the Prometheus scrapes, which produces far more output series than Mimir needs when Prometheus isn't dedicated to Mimir. #16323
 
 ### Jsonnet
 

--- a/operations/mimir-mixin-tests/test-scaling-rules-selector-asserts.sh
+++ b/operations/mimir-mixin-tests/test-scaling-rules-selector-asserts.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-only
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+RULES_FILE="${SCRIPT_DIR}"/test-scaling-rules-selector/rules.yaml
+
+# Matches mimir_scaling_rules_selector in test-scaling-rules-selector.libsonnet.
+SELECTOR='namespace=~"mimir.*"'
+
+# The series the scaling rules read from kube-state-metrics and cAdvisor. Each one must carry the
+# configured selector, otherwise the rules aggregate every workload the Prometheus scrapes.
+SELECTED_METRICS=(
+  "kube_deployment_spec_replicas"
+  "kube_statefulset_replicas"
+  "container_cpu_usage_seconds_total"
+  "container_memory_usage_bytes"
+  "kube_pod_container_resource_requests"
+  "kube_pod_container_resource_requests_cpu_cores"
+  "kube_pod_container_resource_requests_memory_bytes"
+)
+
+FAILED=0
+
+assert_failed() {
+  local msg=$1
+  echo ""
+  echo -e "$msg"
+  echo ""
+  FAILED=1
+}
+
+echo "Checking ${RULES_FILE}"
+
+# Strip PromQL comments, which mention some of these metric names, and prefix every line with a
+# space so that a metric at the beginning of a line still has a leading character to match on.
+EXPRESSIONS=$(yq eval '.groups[] | select(.name == "mimir_scaling_rules") | .rules[].expr' "${RULES_FILE}" | sed -e 's/#.*$//' -e 's/^/ /')
+
+if [ -z "$EXPRESSIONS" ]; then
+  assert_failed "No expressions found in the 'mimir_scaling_rules' group of ${RULES_FILE}."
+fi
+
+for METRIC in "${SELECTED_METRICS[@]}"; do
+  # Match the metric name only where it is a series selector: not preceded by ":", which would make
+  # it part of a recorded rule name, and not surrounded by characters that would make it part of a
+  # longer metric name. A selector is followed by "{", so anything else is an unselected reference.
+  UNSELECTED=$(echo "$EXPRESSIONS" | grep -oE "[^a-z0-9_:]${METRIC}[^a-z0-9_{]" || true)
+  if [ -n "$UNSELECTED" ]; then
+    assert_failed "The 'mimir_scaling_rules' group in ${RULES_FILE} references '${METRIC}' without any label matcher:\n$UNSELECTED"
+  fi
+
+  MATCHERS=$(echo "$EXPRESSIONS" | grep -oE "[^a-z0-9_:]${METRIC}\{[^}]*\}" || true)
+  if [ -z "$MATCHERS" ]; then
+    assert_failed "The 'mimir_scaling_rules' group in ${RULES_FILE} has no reference to '${METRIC}'. If the rules stopped using it, remove it from this test, otherwise the test silently checks nothing."
+    continue
+  fi
+
+  WITHOUT_SELECTOR=$(echo "$MATCHERS" | grep -vF "${SELECTOR}" || true)
+  if [ -n "$WITHOUT_SELECTOR" ]; then
+    assert_failed "The 'mimir_scaling_rules' group in ${RULES_FILE} references '${METRIC}' without the configured selector '${SELECTOR}':\n$WITHOUT_SELECTOR"
+  fi
+done
+
+if [[ $FAILED -ne 0 ]]; then
+  exit 1
+fi

--- a/operations/mimir-mixin-tests/test-scaling-rules-selector.libsonnet
+++ b/operations/mimir-mixin-tests/test-scaling-rules-selector.libsonnet
@@ -1,0 +1,5 @@
+(import 'mixin-compiled.libsonnet') + {
+  _config+:: {
+    mimir_scaling_rules_selector: 'namespace=~"mimir.*"',
+  },
+}

--- a/operations/mimir-mixin/config.libsonnet
+++ b/operations/mimir-mixin/config.libsonnet
@@ -358,6 +358,22 @@
         |||,
       },
     },
+    // Optional label matchers restricting the scaling recording rules (the "mimir_scaling_rules"
+    // group) to the Mimir workloads. The mixin assumes a Prometheus dedicated to Mimir, so by
+    // default these rules aggregate the kube-state-metrics and cAdvisor series of every workload
+    // the Prometheus scrapes. On a Prometheus shared with other workloads, set this to a matcher
+    // selecting the namespaces Mimir runs in, e.g. 'namespace=~"mimir.*"'.
+    //
+    // Empty by default, which keeps the previous behaviour. Only applies to the "kubernetes"
+    // deployment type, because the "baremetal" rules are already scoped by their job and
+    // namespace matchers.
+    mimir_scaling_rules_selector: '',
+
+    // Computed from mimir_scaling_rules_selector, don't set these directly. The first is used on
+    // series which have no other label matcher, the second on series which already have one.
+    mimir_scaling_rules_matcher: if self.mimir_scaling_rules_selector == '' then '' else '{%s}' % self.mimir_scaling_rules_selector,
+    mimir_scaling_rules_extra_matcher: if self.mimir_scaling_rules_selector == '' then '' else ',%s' % self.mimir_scaling_rules_selector,
+
     mimir_scaling_rules: {
       kubernetes: {
         actual_replicas_count:
@@ -373,7 +389,7 @@
               label_replace(
                 sum by (%(alert_aggregation_labels)s, deployment_without_zone) (
                   label_replace(
-                    kube_deployment_spec_replicas,
+                    kube_deployment_spec_replicas%(mimir_scaling_rules_matcher)s,
                     # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
                     # always matches everything and the (optional) zone is not removed.
                     "deployment_without_zone", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"
@@ -381,7 +397,7 @@
                 )
                 or
                 sum by (%(alert_aggregation_labels)s, deployment_without_zone) (
-                  label_replace(kube_statefulset_replicas, "deployment_without_zone", "$1", "statefulset", "(.*?)(?:-zone-[a-z])?")
+                  label_replace(kube_statefulset_replicas%(mimir_scaling_rules_matcher)s, "deployment_without_zone", "$1", "statefulset", "(.*?)(?:-zone-[a-z])?")
                 ),
                 "deployment", "$1", "deployment_without_zone", "(.*)"
               )
@@ -395,7 +411,7 @@
             sum by (%(alert_aggregation_labels)s, deployment) (
               label_replace(
                 label_replace(
-                  sum by (%(alert_aggregation_labels)s, %(per_instance_label)s)(rate(container_cpu_usage_seconds_total{image!=""}[%(rate_interval)s])),
+                  sum by (%(alert_aggregation_labels)s, %(per_instance_label)s)(rate(container_cpu_usage_seconds_total{image!=""%(mimir_scaling_rules_extra_matcher)s}[%(rate_interval)s])),
                   "deployment", "$1", "%(per_instance_label)s", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
                 ),
                 # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
@@ -419,7 +435,7 @@
               sum by (%(alert_aggregation_labels)s, deployment) (
                 label_replace(
                   label_replace(
-                    kube_pod_container_resource_requests_cpu_cores,
+                    kube_pod_container_resource_requests_cpu_cores%(mimir_scaling_rules_matcher)s,
                     "deployment", "$1", "%(per_instance_label)s", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
                   ),
                   # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
@@ -435,7 +451,7 @@
               sum by (%(alert_aggregation_labels)s, deployment) (
                 label_replace(
                   label_replace(
-                    kube_pod_container_resource_requests{resource="cpu"},
+                    kube_pod_container_resource_requests{resource="cpu"%(mimir_scaling_rules_extra_matcher)s},
                     "deployment", "$1", "%(per_instance_label)s", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
                   ),
                   # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
@@ -465,7 +481,7 @@
             sum by (%(alert_aggregation_labels)s, deployment) (
               label_replace(
                 label_replace(
-                  container_memory_usage_bytes{image!=""},
+                  container_memory_usage_bytes{image!=""%(mimir_scaling_rules_extra_matcher)s},
                   "deployment", "$1", "%(per_instance_label)s", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
                 ),
                 # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
@@ -489,7 +505,7 @@
               sum by (%(alert_aggregation_labels)s, deployment) (
                 label_replace(
                   label_replace(
-                    kube_pod_container_resource_requests_memory_bytes,
+                    kube_pod_container_resource_requests_memory_bytes%(mimir_scaling_rules_matcher)s,
                     "deployment", "$1", "%(per_instance_label)s", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
                   ),
                   # The question mark in "(.*?)" is used to make it non-greedy, otherwise it
@@ -505,7 +521,7 @@
               sum by (%(alert_aggregation_labels)s, deployment) (
                 label_replace(
                   label_replace(
-                    kube_pod_container_resource_requests{resource="memory"},
+                    kube_pod_container_resource_requests{resource="memory"%(mimir_scaling_rules_extra_matcher)s},
                     "deployment", "$1", "%(per_instance_label)s", "(.*)-(?:([0-9]+)|([a-z0-9]+)-([a-z0-9]+))"
                   ),
                   # The question mark in "(.*?)" is used to make it non-greedy, otherwise it


### PR DESCRIPTION
#### What this PR does

The `mimir_scaling_rules` group selects `kube_deployment_spec_replicas`,
`kube_statefulset_replicas`, `container_cpu_usage_seconds_total`, `container_memory_usage_bytes`
and `kube_pod_container_resource_requests*` with no namespace or cluster matcher, because the
mixin assumes a Prometheus dedicated to Mimir. On a Prometheus shared with other workloads the
group aggregates every workload it can see, so it records far more output series than Mimir's own
workloads justify.

This PR adds `_config.mimir_scaling_rules_selector`, appended to those selectors:

```jsonnet
_config+:: {
  mimir_scaling_rules_selector: 'namespace=~"mimir.*"',
}
```

which renders as:

```
kube_deployment_spec_replicas{namespace=~"mimir.*"}
container_cpu_usage_seconds_total{namespace=~"mimir.*"}
kube_pod_container_resource_requests{resource="cpu",namespace=~"mimir.*"}
```

It is empty by default, so the compiled mixin is byte for byte unchanged and nobody's recorded
rules move. Only the `kubernetes` deployment type is affected, since the `baremetal` rules are
already scoped by their job and namespace matchers.

The issue suggested a label join as a possible mechanism. I went with an explicit selector
because it is opt-in and costs nothing to evaluate, whereas a join on `cortex_build_info`
(the mechanism `MimirAllocatingTooMuchMemory` already uses) would change the recorded output for
every user and would still only narrow to Mimir namespaces rather than Mimir workloads. Happy to
switch if maintainers prefer that shape.

#### Which issue(s) this PR fixes or relates to

Fixes #4731

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`. If changelog entry is not needed, please add the `changelog-not-needed` label to the PR.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
