### PR TITLE
fix(mixin): point runbook_url at /manage/mimir-runbooks/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,8 +175,6 @@
 * [BUGFIX] MQE: Fix issue where a sentinel value was inadvertently returned to a pool where it could be mutated by multiple threads at once. #16205
 
 ### Mixin
-* [BUGFIX] Alerts: Point `runbook_url` annotations at `/manage/mimir-runbooks/` (docs moved off `operators-guide`). #14235
-
 * [CHANGE] Dashboards: Show maximum queue length, not minimum queue length, on the "Queue length" panel in the "Query-scheduler" row of the "Reads" and "Remote ruler reads" dashboards. #15326
 * [CHANGE] Alerts: `MimirIngesterKafkaReadFailed` now fires as `warning` after 5m, and escalates to `critical` if it persists for 30m. `MimirStrongConsistencyEnforcementFailed` severity changed from `critical` to `warning`, since queriers retry on a different ingester and fire their own alerts if that retry fails. #16019
 * [CHANGE] Remove Grafana Enterprise Metrics (GEM) specific build of the mixin. #16031
@@ -194,6 +192,8 @@
 * [ENHANCEMENT] Dashboards: Add optional per-zone panels for multi-zone write path deployments to the "Writes" dashboard, enabled via the `show_multi_zone_write_path_panels` config option (disabled by default). When enabled, the gateway and distributor "Requests / sec" and "Kafka produced records / sec" panels break down the traffic by availability zone, and "Latency per zone" panels are added next to the aggregate latency panels. #16206
 * [BUGFIX] Dashboards: Fix the classic/ingest-storage split in the "Tenants", "Top tenants" and "Writes" dashboards so that selecting multiple clusters with a mix of architectures no longer drops the classic clusters' data. The `unless on (job)` filter against `cortex_partition_ring_partitions` now also matches on the cluster aggregation labels. #15400
 * [BUGFIX] Alerts: Update `MimirRulerInstanceHasNoRuleGroups` to not alert on false-positives when rulers are running in multiple zones. #16029
+
+* [BUGFIX] Alerts: Point `runbook_url` annotations at `/manage/mimir-runbooks/` (docs moved off `operators-guide`). #16329
 
 ### Jsonnet
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,7 @@
 * [BUGFIX] MQE: Fix issue where a sentinel value was inadvertently returned to a pool where it could be mutated by multiple threads at once. #16205
 
 ### Mixin
+
 * [CHANGE] Dashboards: Show maximum queue length, not minimum queue length, on the "Queue length" panel in the "Query-scheduler" row of the "Reads" and "Remote ruler reads" dashboards. #15326
 * [CHANGE] Alerts: `MimirIngesterKafkaReadFailed` now fires as `warning` after 5m, and escalates to `critical` if it persists for 30m. `MimirStrongConsistencyEnforcementFailed` severity changed from `critical` to `warning`, since queriers retry on a different ingester and fire their own alerts if that retry fails. #16019
 * [CHANGE] Remove Grafana Enterprise Metrics (GEM) specific build of the mixin. #16031
@@ -193,7 +194,6 @@
 * [ENHANCEMENT] Dashboards: Add optional per-zone panels for multi-zone write path deployments to the "Writes" dashboard, enabled via the `show_multi_zone_write_path_panels` config option (disabled by default). When enabled, the gateway and distributor "Requests / sec" and "Kafka produced records / sec" panels break down the traffic by availability zone, and "Latency per zone" panels are added next to the aggregate latency panels. #16206
 * [BUGFIX] Dashboards: Fix the classic/ingest-storage split in the "Tenants", "Top tenants" and "Writes" dashboards so that selecting multiple clusters with a mix of architectures no longer drops the classic clusters' data. The `unless on (job)` filter against `cortex_partition_ring_partitions` now also matches on the cluster aggregation labels. #15400
 * [BUGFIX] Alerts: Update `MimirRulerInstanceHasNoRuleGroups` to not alert on false-positives when rulers are running in multiple zones. #16029
-
 
 ### Jsonnet
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [ENHANCEMENT] Add the `compactor_standalone_enabled` config option (enabled by default) to hide standalone-mode compactor panels and alerts, and stop collapsing scheduler-mode dashboard rows. #16239
 * [ENHANCEMENT] Dashboards: Make the boot/root disk device regex used to filter it out of the "Disk writes" and "Disk reads" panels configurable via `_config.node_boot_disk_device_regex` (default unchanged: `.*sda.*`), so clusters where the root device isn't `sda` (e.g. `vda` on some cloud providers) don't lose data on those panels. #16235
 * [BUGFIX] Recording rules: Add the `image!=""` selector to the `cluster_namespace_deployment:container_cpu_usage_seconds_total:sum_rate` recording rule, consistently with the memory one. Where cAdvisor sandbox and parent cgroup series are not dropped at scrape time, CPU usage was counted twice, which also inflated the replica count recommended by the Scaling dashboard. #16320
+* [BUGFIX] Alerts: Point `runbook_url` annotations at `/manage/mimir-runbooks/` (docs moved off `operators-guide`). #16329
 
 ### Jsonnet
 
@@ -193,7 +194,6 @@
 * [BUGFIX] Dashboards: Fix the classic/ingest-storage split in the "Tenants", "Top tenants" and "Writes" dashboards so that selecting multiple clusters with a mix of architectures no longer drops the classic clusters' data. The `unless on (job)` filter against `cortex_partition_ring_partitions` now also matches on the cluster aggregation labels. #15400
 * [BUGFIX] Alerts: Update `MimirRulerInstanceHasNoRuleGroups` to not alert on false-positives when rulers are running in multiple zones. #16029
 
-* [BUGFIX] Alerts: Point `runbook_url` annotations at `/manage/mimir-runbooks/` (docs moved off `operators-guide`). #16329
 
 ### Jsonnet
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,7 @@
 * [BUGFIX] MQE: Fix issue where a sentinel value was inadvertently returned to a pool where it could be mutated by multiple threads at once. #16205
 
 ### Mixin
+* [BUGFIX] Alerts: Point `runbook_url` annotations at `/manage/mimir-runbooks/` (docs moved off `operators-guide`). #14235
 
 * [CHANGE] Dashboards: Show maximum queue length, not minimum queue length, on the "Queue length" panel in the "Query-scheduler" row of the "Reads" and "Remote ruler reads" dashboards. #15326
 * [CHANGE] Alerts: `MimirIngesterKafkaReadFailed` now fires as `warning` after 5m, and escalates to `critical` if it persists for 30m. `MimirStrongConsistencyEnforcementFailed` severity changed from `critical` to `warning`, since queriers retry on a different ingester and fire their own alerts if that retry fails. #16019

--- a/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
+++ b/operations/helm/tests/metamonitoring-values-generated/mimir-distributed/templates/metamonitoring/mixin-alerts.yaml
@@ -16,7 +16,7 @@ spec:
           - alert: MimirIngesterUnhealthy
             annotations:
               message: Mimir cluster {{ $labels.cluster }}/{{ $labels.namespace }} has {{ printf "%f" $value }} unhealthy ingester(s).
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterunhealthy
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterunhealthy
             expr: |
               min by (cluster, namespace) (cortex_ring_members{state="Unhealthy", name="ingester"}) > 0
             for: 15m
@@ -26,7 +26,7 @@ spec:
             annotations:
               message: |
                   The route {{ $labels.route }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% errors.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrequesterrors
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrequesterrors
             expr: |
               # The following 5xx errors considered as non-error:
               # - 529: used by distributor rate limiting (using 529 instead of 429 to let the client retry)
@@ -44,7 +44,7 @@ spec:
             annotations:
               message: |
                   The route {{ $labels.route }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% errors.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrequesterrors
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrequesterrors
             expr: |
               # The following 5xx errors considered as non-error:
               # - 529: used by distributor rate limiting (using 529 instead of 429 to let the client retry)
@@ -62,7 +62,7 @@ spec:
             annotations:
               message: |
                   {{ $labels.job }} {{ $labels.route }} is experiencing {{ printf "%.2f" $value }}s 99th percentile latency.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrequestlatency
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrequestlatency
             expr: |
               cluster_namespace_job_route:cortex_request_duration_seconds:99quantile{route!~"metrics|/frontend.Frontend/Process|ready|/schedulerpb.SchedulerForFrontend/FrontendLoop|/schedulerpb.SchedulerForQuerier/QuerierLoop|debug_pprof"}
                 >
@@ -75,7 +75,7 @@ spec:
             annotations:
               message: |
                   {{ $labels.job }} {{ $labels.route }} is experiencing {{ printf "%.2f" $value }}s 99th percentile latency.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrequestlatency
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrequestlatency
             expr: |
               histogram_quantile(0.99, cluster_namespace_job_route:cortex_request_duration_seconds:sum_rate{route!~"metrics|/frontend.Frontend/Process|ready|/schedulerpb.SchedulerForFrontend/FrontendLoop|/schedulerpb.SchedulerForQuerier/QuerierLoop|debug_pprof"})
                 >
@@ -88,7 +88,7 @@ spec:
             annotations:
               message: |
                   An inconsistent runtime config file is used across cluster {{ $labels.cluster }}/{{ $labels.namespace }}.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirinconsistentruntimeconfig
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirinconsistentruntimeconfig
             expr: |
               count without(sha256) (
                   count by (cluster, namespace, job, sha256) (cortex_runtime_config_hash)
@@ -110,7 +110,7 @@ spec:
             annotations:
               message: |
                   {{ $labels.job }} failed to reload runtime config.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirbadruntimeconfig
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirbadruntimeconfig
             expr: |
               # The metric value is reset to 0 on error while reloading the config at runtime.
               cortex_runtime_config_last_reload_successful == 0
@@ -121,7 +121,7 @@ spec:
             annotations:
               message: |
                   There are {{ $value }} queued up queries in {{ $labels.cluster }}/{{ $labels.namespace }} {{ $labels.job }}.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirschedulerqueriesstuck
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirschedulerqueriesstuck
             expr: |
               # There are some queries in the queue.
               (sum by (cluster, namespace, job) (cortex_query_scheduler_queue_length) > 0)
@@ -147,7 +147,7 @@ spec:
             annotations:
               message: |
                   The cache {{ $labels.name }} used by Mimir {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% errors for {{ $labels.operation }} operation.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircacherequesterrors
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircacherequesterrors
             expr: |
               (
                 sum by(cluster, namespace, name, operation) (
@@ -164,7 +164,7 @@ spec:
           - alert: MimirIngesterRestarts
             annotations:
               message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has restarted {{ printf "%.2f" $value }} times in the last 30 mins.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterrestarts
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterrestarts
             expr: |
               (
                 sum by(cluster, namespace, pod) (
@@ -182,7 +182,7 @@ spec:
             annotations:
               message: |
                   Mimir {{ $labels.pod }} in  {{ $labels.cluster }}/{{ $labels.namespace }} is failing to talk to the KV store {{ $labels.kv_name }}.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirkvstorefailure
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirkvstorefailure
             expr: |
               (
                 sum by (cluster, namespace, pod, status_code, kv_name) (rate(cortex_kv_request_duration_seconds_count{status_code!~"2.+"}[4m]))
@@ -199,7 +199,7 @@ spec:
             annotations:
               message: |
                   Mimir {{ $labels.pod }} in  {{ $labels.cluster }}/{{ $labels.namespace }} is failing to talk to the KV store {{ $labels.kv_name }}.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirkvstorefailure
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirkvstorefailure
             expr: |
               (
                 sum by (cluster, namespace, pod, status_code, kv_name) (histogram_count(rate(cortex_kv_request_duration_seconds{status_code!~"2.+"}[4m])))
@@ -215,7 +215,7 @@ spec:
           - alert: MimirMemoryMapAreasTooHigh
             annotations:
               message: '{{ $labels.job }}/{{ $labels.pod }} has a number of mmap-ed areas close to the limit.'
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirmemorymapareastoohigh
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirmemorymapareastoohigh
             expr: |
               process_memory_map_areas{job=~".*/(ingester.*|cortex|mimir|store-gateway.*|cortex|mimir)"} / process_memory_map_areas_limit{job=~".*/(ingester.*|cortex|mimir|store-gateway.*|cortex|mimir)"} > 0.8
             for: 5m
@@ -224,7 +224,7 @@ spec:
           - alert: MimirIngesterInstanceHasNoTenants
             annotations:
               message: Mimir ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has no tenants assigned.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterinstancehasnotenants
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterinstancehasnotenants
             expr: |
               (
                 (min by(cluster, namespace, pod) (cortex_ingester_memory_users) == 0)
@@ -257,7 +257,7 @@ spec:
           - alert: MimirRulerInstanceHasNoRuleGroups
             annotations:
               message: Mimir ruler {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has no rule groups assigned.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulerinstancehasnorulegroups
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrulerinstancehasnorulegroups
             expr: |
               # Alert on ruler instances in microservices mode that have no rule groups assigned,
               min by(cluster, namespace, pod) (cortex_ruler_managers_total{pod=~"(.*mimir-)?ruler.*"}) == 0
@@ -273,7 +273,7 @@ spec:
           - alert: MimirIngestedDataTooFarInTheFuture
             annotations:
               message: Mimir ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has ingested samples with timestamps more than 1h in the future.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesteddatatoofarinthefuture
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesteddatatoofarinthefuture
             expr: |
               max by(cluster, namespace, pod) (
                   cortex_ingester_tsdb_head_max_timestamp_seconds - time()
@@ -286,7 +286,7 @@ spec:
           - alert: MimirStoreGatewayTooManyFailedOperations
             annotations:
               message: Mimir store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ $value | humanizePercentage }} errors while doing {{ $labels.operation }} on the object storage.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstoregatewaytoomanyfailedoperations
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirstoregatewaytoomanyfailedoperations
             expr: |
               (
                   sum by(cluster, namespace, operation) (rate(thanos_objstore_bucket_operation_failures_total{component="store-gateway"}[4m]))
@@ -299,7 +299,7 @@ spec:
           - alert: MimirServerInvalidClusterLabelRequests
             annotations:
               message: Mimir servers in {{ $labels.cluster }}/{{ $labels.namespace }} are receiving requests with invalid cluster validation labels.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirserverinvalidclusterlabelrequests
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirserverinvalidclusterlabelrequests
             expr: |
               (sum by (cluster, namespace, protocol) (rate(cortex_server_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
               # Alert only for namespaces with Mimir clusters.
@@ -309,7 +309,7 @@ spec:
           - alert: MimirClientInvalidClusterLabelRequests
             annotations:
               message: Mimir clients in {{ $labels.cluster }}/{{ $labels.namespace }} are having requests rejected due to invalid cluster validation labels.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirclientinvalidclusterlabelrequests
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirclientinvalidclusterlabelrequests
             expr: |
               (sum by (cluster, namespace, protocol) (rate(cortex_client_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
               # Alert only for namespaces with Mimir clusters.
@@ -320,7 +320,7 @@ spec:
             annotations:
               message: |
                   Number of members in Mimir ingester hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirringmembersmismatch
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirringmembersmismatch
             expr: |
               (
                 (
@@ -346,7 +346,7 @@ spec:
             annotations:
               message: |
                   Container {{ $labels.container }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing high GRPC concurrent streams per connection.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirhighgrpcstreamsperconnection
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirhighgrpcstreamsperconnection
             expr: |
               max(avg_over_time(grpc_concurrent_streams_by_conn_max[10m])) by (cluster, namespace, container)
               /
@@ -357,7 +357,7 @@ spec:
             annotations:
               message: |
                   Queriers in the same %(product)s cluster and query path are reporting different maximum supported query plan versions.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirmixedquerierqueryplanversionsupport
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirmixedquerierqueryplanversionsupport
             expr: |
               min by (cluster, namespace, container) (cortex_querier_maximum_supported_query_plan_version)
               !=
@@ -369,7 +369,7 @@ spec:
             annotations:
               message: |
                   Query-frontends in the same Mimir cluster and query path have calculated different maximum supported query plan versions.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirmixedqueryfrontendqueryplanversionsupport
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirmixedqueryfrontendqueryplanversionsupport
             expr: |
               min by (cluster, namespace, container) (cortex_query_frontend_querier_ring_calculated_maximum_supported_query_plan_version)
               !=
@@ -381,7 +381,7 @@ spec:
             annotations:
               message: |
                   Query-frontends and queriers are reporting different maximum supported query plan versions.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirqueryfrontendsandqueriersdisagreeonsupportedqueryplanversion
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirqueryfrontendsandqueriersdisagreeonsupportedqueryplanversion
             expr: |
               # The label_replace calls below are so that we can match queriers with container labels like "ruler-querier" to
               # query-frontends with container labels like "ruler-query-frontend".
@@ -410,7 +410,7 @@ spec:
             annotations:
               message: |
                   Query-frontends are failing to compute a maximum supported query plan version.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirqueryfrontendnotcomputingsupportedqueryplanversion
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirqueryfrontendnotcomputingsupportedqueryplanversion
             expr: |
               count by (cluster, namespace, container) (cortex_query_frontend_querier_ring_calculated_maximum_supported_query_plan_version == -1) > 0
             for: 5m
@@ -422,7 +422,7 @@ spec:
             annotations:
               message: |
                   Ingester {{ $labels.job }}/{{ $labels.pod }} has reached {{ $value | humanizePercentage }} of its series limit.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterreachingserieslimit
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterreachingserieslimit
             expr: |
               (
                   (cortex_ingester_memory_series / ignoring(limit) cortex_ingester_instance_limits{limit="max_series"})
@@ -436,7 +436,7 @@ spec:
             annotations:
               message: |
                   Ingester {{ $labels.job }}/{{ $labels.pod }} has reached {{ $value | humanizePercentage }} of its series limit.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterreachingserieslimit
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterreachingserieslimit
             expr: |
               (
                   (cortex_ingester_memory_series / ignoring(limit) cortex_ingester_instance_limits{limit="max_series"})
@@ -450,7 +450,7 @@ spec:
             annotations:
               message: |
                   Ingester {{ $labels.job }}/{{ $labels.pod }} has reached {{ $value | humanizePercentage }} of its tenant limit.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterreachingtenantslimit
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterreachingtenantslimit
             expr: |
               (
                   (cortex_ingester_memory_users / ignoring(limit) cortex_ingester_instance_limits{limit="max_tenants"})
@@ -464,7 +464,7 @@ spec:
             annotations:
               message: |
                   Ingester {{ $labels.job }}/{{ $labels.pod }} has reached {{ $value | humanizePercentage }} of its tenant limit.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterreachingtenantslimit
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterreachingtenantslimit
             expr: |
               (
                   (cortex_ingester_memory_users / ignoring(limit) cortex_ingester_instance_limits{limit="max_tenants"})
@@ -478,7 +478,7 @@ spec:
             annotations:
               message: |
                   Mimir instance {{ $labels.job }}/{{ $labels.pod }} has reached {{ $value | humanizePercentage }} of its TCP connections limit for {{ $labels.protocol }} protocol.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirreachingtcpconnectionslimit
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirreachingtcpconnectionslimit
             expr: |
               cortex_tcp_connections / cortex_tcp_connections_limit > 0.8 and
               cortex_tcp_connections_limit > 0
@@ -489,7 +489,7 @@ spec:
             annotations:
               message: |
                   Distributor {{ $labels.job }}/{{ $labels.pod }} has reached {{ $value | humanizePercentage }} of its inflight push request limit.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirdistributorinflightrequestshigh
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirdistributorinflightrequestshigh
             expr: |
               (
                   (cortex_distributor_inflight_push_requests / ignoring(limit) cortex_distributor_instance_limits{limit="max_inflight_push_requests"})
@@ -505,7 +505,7 @@ spec:
             annotations:
               message: |
                   The {{ $labels.rollout_group }} rollout is stuck in {{ $labels.cluster }}/{{ $labels.namespace }}.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrolloutstuck
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrolloutstuck
             expr: |
               (
                 # Query for rollout groups in certain namespaces that are being updated, dropping the revision label.
@@ -537,7 +537,7 @@ spec:
             annotations:
               message: |
                   The {{ $labels.rollout_group }} rollout is stuck in {{ $labels.cluster }}/{{ $labels.namespace }}.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrolloutstuck
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrolloutstuck
             expr: |
               (
                 # Query for rollout groups in certain namespaces that are being updated, dropping the revision label.
@@ -569,7 +569,7 @@ spec:
             annotations:
               message: |
                   The {{ $labels.rollout_group }} rollout is stuck in {{ $labels.cluster }}/{{ $labels.namespace }}.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrolloutstuck
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrolloutstuck
             expr: |
               (
                 sum without(deployment) (label_replace(kube_deployment_spec_replicas, "rollout_group", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"))
@@ -589,7 +589,7 @@ spec:
             annotations:
               message: |
                   The {{ $labels.rollout_group }} rollout is stuck in {{ $labels.cluster }}/{{ $labels.namespace }}.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrolloutstuck
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrolloutstuck
             expr: |
               (
                 sum without(deployment) (label_replace(kube_deployment_spec_replicas, "rollout_group", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"))
@@ -609,7 +609,7 @@ spec:
             annotations:
               message: |
                   Rollout operator is not reconciling the rollout group {{ $labels.rollout_group }} in {{ $labels.cluster }}/{{ $labels.namespace }}.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#rolloutoperatornotreconciling
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#rolloutoperatornotreconciling
             expr: |
               max by(cluster, namespace, rollout_group) (time() - rollout_operator_last_successful_group_reconcile_timestamp_seconds) > 600
             for: 5m
@@ -621,7 +621,7 @@ spec:
             annotations:
               message: |
                   Instance {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is using too much memory.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirallocatingtoomuchmemory
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirallocatingtoomuchmemory
             expr: |
               (
                 # We use RSS instead of working set memory because of the ingester's extensive usage of mmap.
@@ -640,7 +640,7 @@ spec:
             annotations:
               message: |
                   Instance {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is using too much memory.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirallocatingtoomuchmemory
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirallocatingtoomuchmemory
             expr: |
               (
                 # We use RSS instead of working set memory because of the ingester's extensive usage of mmap.
@@ -661,7 +661,7 @@ spec:
             annotations:
               message: |
                   Mimir Ruler {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% write (push) errors.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulertoomanyfailedpushes
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrulertoomanyfailedpushes
             expr: |
               100 * (
               # Here it matches on empty "reason" for backwards compatibility, with when the metric didn't have this label.
@@ -676,7 +676,7 @@ spec:
             annotations:
               message: |
                   Mimir Ruler {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% errors while evaluating rules.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulertoomanyfailedqueries
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrulertoomanyfailedqueries
             expr: |
               100 * (
               # Here it matches on empty "reason" for backwards compatibility, with when the metric didn't have this label.
@@ -691,7 +691,7 @@ spec:
             annotations:
               message: |
                   Mimir Rulers in {{ $labels.cluster }}/{{ $labels.namespace }} are experiencing {{ printf "%.2f" $value }}% missed iterations.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulersmissedevaluations
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrulersmissedevaluations
             expr: |
               100 * (
               sum by (cluster, namespace) (rate(cortex_prometheus_rule_group_iterations_missed_total[4m]))
@@ -705,7 +705,7 @@ spec:
             annotations:
               message: |
                   Mimir Ruler {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% missed iterations.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulermissedevaluations
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrulermissedevaluations
             expr: |
               100 * (
               sum by (cluster, namespace, pod) (rate(cortex_prometheus_rule_group_iterations_missed_total[4m]))
@@ -719,7 +719,7 @@ spec:
             annotations:
               message: |
                   Mimir Rulers in {{ $labels.cluster }}/{{ $labels.namespace }} are experiencing errors when checking the ring for rule group ownership.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulerfailedringcheck
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrulerfailedringcheck
             expr: |
               sum by (cluster, namespace, job) (rate(cortex_ruler_ring_check_errors_total[4m]))
                  > 0
@@ -730,7 +730,7 @@ spec:
             annotations:
               message: |
                   Mimir rulers in {{ $labels.cluster }}/{{ $labels.namespace }} are failing to perform {{ printf "%.2f" $value }}% of remote evaluations through the ruler-query-frontend.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulerremoteevaluationfailing
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrulerremoteevaluationfailing
             expr: |
               (
                 sum by (cluster, namespace) (rate(cortex_request_duration_seconds_count{status_code=~"5..", route="/httpgrpc.HTTP/Handle", job=~".*/(ruler-query-frontend.*)"}[5m]))
@@ -745,7 +745,7 @@ spec:
             annotations:
               message: |
                   Mimir rulers in {{ $labels.cluster }}/{{ $labels.namespace }} are failing to perform {{ printf "%.2f" $value }}% of remote evaluations through the ruler-query-frontend.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulerremoteevaluationfailing
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrulerremoteevaluationfailing
             expr: |
               (
                 sum by (cluster, namespace) (histogram_count(rate(cortex_request_duration_seconds{status_code=~"5..", route="/httpgrpc.HTTP/Handle", job=~".*/(ruler-query-frontend.*)"}[5m])))
@@ -761,7 +761,7 @@ spec:
           - alert: MimirGossipMembersTooHigh
             annotations:
               message: One or more Mimir instances in {{ $labels.cluster }}/{{ $labels.namespace }} consistently sees a higher than expected number of gossip members.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgossipmemberstoohigh
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirgossipmemberstoohigh
             expr: |
               max by (cluster, namespace) (memberlist_client_cluster_members_count)
               >
@@ -772,7 +772,7 @@ spec:
           - alert: MimirGossipMembersTooLow
             annotations:
               message: One or more Mimir instances in {{ $labels.cluster }}/{{ $labels.namespace }} consistently sees a lower than expected number of gossip members.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgossipmemberstoolow
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirgossipmemberstoolow
             expr: |
               min by (cluster, namespace) (memberlist_client_cluster_members_count)
               <
@@ -783,7 +783,7 @@ spec:
           - alert: MimirGossipMembersEndpointsOutOfSync
             annotations:
               message: Mimir gossip-ring service endpoints list in {{ $labels.cluster }}/{{ $labels.namespace }} is out of sync.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgossipmembersendpointsoutofsync
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirgossipmembersendpointsoutofsync
             expr: |
               (
                 count by(cluster, namespace) (
@@ -805,7 +805,7 @@ spec:
           - alert: MimirGossipMembersEndpointsOutOfSync
             annotations:
               message: Mimir gossip-ring service endpoints list in {{ $labels.cluster }}/{{ $labels.namespace }} is out of sync.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgossipmembersendpointsoutofsync
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirgossipmembersendpointsoutofsync
             expr: |
               (
                 count by(cluster, namespace) (
@@ -827,7 +827,7 @@ spec:
           - alert: MimirMemberlistBridgeZoneUnavailable
             annotations:
               message: Mimir memberlist-bridge in {{ $labels.cluster }}/{{ $labels.namespace }} {{ $labels.zone }} has no available pods.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirmemberlistbridgezoneunavailable
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirmemberlistbridgezoneunavailable
             expr: |
               # Find the expected memberlist-bridge zonal deployments.
               count by (cluster, namespace, zone) (
@@ -851,7 +851,7 @@ spec:
           - alert: MimirMemberlistZoneAwareRoutingAutoFailover
             annotations:
               message: Mimir memberlist in {{ $labels.cluster }}/{{ $labels.namespace }} has automatically temporarily disabled zone-aware routing because it detected missing memberlist bridges.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirmemberlistzoneawareroutingautofailover
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirmemberlistzoneawareroutingautofailover
             expr: |
               sum by (cluster, namespace) (rate(memberlist_client_zone_aware_routing_select_nodes_skipped_total[4m])) > 0
             for: 10m
@@ -863,7 +863,7 @@ spec:
             annotations:
               message: |
                   Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is running a very high number of Go threads.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgothreadstoohigh
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirgothreadstoohigh
             expr: |
               # We filter by the namespace because go_threads can be very high cardinality in a large organization.
               max by(cluster, namespace, pod) (go_threads{job=~".*(cortex|mimir).*"} > 5000)
@@ -877,7 +877,7 @@ spec:
             annotations:
               message: |
                   Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is running a very high number of Go threads.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgothreadstoohigh
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirgothreadstoohigh
             expr: |
               # We filter by the namespace because go_threads can be very high cardinality in a large organization.
               max by(cluster, namespace, pod) (go_threads{job=~".*(cortex|mimir).*"} > 8000)
@@ -893,7 +893,7 @@ spec:
             annotations:
               message: |
                   Mimir Alertmanager {{ $labels.job }}/{{ $labels.pod }} is failing to read tenant configurations from storage.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagersyncconfigsfailing
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiralertmanagersyncconfigsfailing
             expr: |
               rate(cortex_alertmanager_sync_configs_failed_total[5m]) > 0
             for: 30m
@@ -903,7 +903,7 @@ spec:
             annotations:
               message: |
                   Mimir Alertmanager {{ $labels.job }}/{{ $labels.pod }} is unable to check tenants ownership via the ring.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagerringcheckfailing
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiralertmanagerringcheckfailing
             expr: |
               rate(cortex_alertmanager_ring_check_errors_total[4m]) > 0
             for: 10m
@@ -913,7 +913,7 @@ spec:
             annotations:
               message: |
                   Mimir Alertmanager {{ $labels.job }}/{{ $labels.pod }} is failing to merge partial state changes received from a replica.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagerstatemergefailing
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiralertmanagerstatemergefailing
             expr: |
               rate(cortex_alertmanager_partial_state_merges_failed_total[4m]) > 0
             for: 10m
@@ -923,7 +923,7 @@ spec:
             annotations:
               message: |
                   Mimir Alertmanager {{ $labels.job }}/{{ $labels.pod }} is failing to replicating partial state to its replicas.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagerreplicationfailing
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiralertmanagerreplicationfailing
             expr: |
               rate(cortex_alertmanager_state_replication_failed_total[4m]) > 0
             for: 10m
@@ -933,7 +933,7 @@ spec:
             annotations:
               message: |
                   Mimir Alertmanager {{ $labels.job }}/{{ $labels.pod }} is unable to persist full state snaphots to remote storage.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagerpersiststatefailing
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiralertmanagerpersiststatefailing
             expr: |
               rate(cortex_alertmanager_state_persist_failed_total[15m]) > 0
             for: 1h
@@ -943,7 +943,7 @@ spec:
             annotations:
               message: |
                   Mimir Alertmanager {{ $labels.job }}/{{ $labels.pod }} was unable to obtain some initial state when starting up.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagerinitialsyncfailed
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiralertmanagerinitialsyncfailed
             expr: |
               increase(cortex_alertmanager_state_initial_sync_completed_total{outcome="failed"}[4m]) > 0
             labels:
@@ -952,7 +952,7 @@ spec:
             annotations:
               message: |
                   Alertmanager {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is using too much memory.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagerallocatingtoomuchmemory
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiralertmanagerallocatingtoomuchmemory
             expr: |
               (container_memory_working_set_bytes{container="alertmanager"} / container_spec_memory_limit_bytes{container="alertmanager"}) > 0.80
               and
@@ -964,7 +964,7 @@ spec:
             annotations:
               message: |
                   Alertmanager {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is using too much memory.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagerallocatingtoomuchmemory
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiralertmanagerallocatingtoomuchmemory
             expr: |
               (container_memory_working_set_bytes{container="alertmanager"} / container_spec_memory_limit_bytes{container="alertmanager"}) > 0.90
               and
@@ -975,7 +975,7 @@ spec:
           - alert: MimirAlertmanagerInstanceHasNoTenants
             annotations:
               message: Mimir alertmanager {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} owns no tenants.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagerinstancehasnotenants
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiralertmanagerinstancehasnotenants
             expr: |
               # Alert on alertmanager instances in microservices mode that own no tenants,
               min by(cluster, namespace, pod) (cortex_alertmanager_tenants_owned{pod=~"(.*mimir-)?alertmanager.*"}) == 0
@@ -990,7 +990,7 @@ spec:
           - alert: MimirIngesterNotShippingBlocks
             annotations:
               message: Mimir Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not shipped any block in the last 4 hours.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesternotshippingblocks
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesternotshippingblocks
             expr: |
               (min by(cluster, namespace, pod) (time() - cortex_ingester_shipper_last_successful_upload_timestamp_seconds) > 60 * 60 * 4)
               and
@@ -1013,7 +1013,7 @@ spec:
           - alert: MimirIngesterNotShippingBlocksSinceStart
             annotations:
               message: Mimir Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not shipped any block in the last 4 hours.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesternotshippingblockssincestart
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesternotshippingblockssincestart
             expr: |
               (max by(cluster, namespace, pod) (cortex_ingester_shipper_last_successful_upload_timestamp_seconds) == 0)
               and
@@ -1027,7 +1027,7 @@ spec:
           - alert: MimirIngesterHasUnshippedBlocks
             annotations:
               message: Mimir Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has compacted a block {{ $value | humanizeDuration }} ago but it hasn't been successfully uploaded to the storage yet.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterhasunshippedblocks
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterhasunshippedblocks
             expr: |
               (time() - cortex_ingester_oldest_unshipped_block_timestamp_seconds > 3600)
               and
@@ -1041,7 +1041,7 @@ spec:
           - alert: MimirIngesterTSDBHeadCompactionFailed
             annotations:
               message: Mimir Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to compact TSDB head.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbheadcompactionfailed
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringestertsdbheadcompactionfailed
             expr: |
               rate(cortex_ingester_tsdb_compactions_failed_total[5m]) > 0
             for: 15m
@@ -1050,7 +1050,7 @@ spec:
           - alert: MimirIngesterTSDBHeadTruncationFailed
             annotations:
               message: Mimir Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to truncate TSDB head.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbheadtruncationfailed
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringestertsdbheadtruncationfailed
             expr: |
               rate(cortex_ingester_tsdb_head_truncations_failed_total[5m]) > 0
             labels:
@@ -1058,7 +1058,7 @@ spec:
           - alert: MimirIngesterTSDBCheckpointCreateFailed
             annotations:
               message: Mimir Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to create TSDB checkpoint.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbcheckpointcreatefailed
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringestertsdbcheckpointcreatefailed
             expr: |
               rate(cortex_ingester_tsdb_checkpoint_creations_failed_total[5m]) > 0
             labels:
@@ -1066,7 +1066,7 @@ spec:
           - alert: MimirIngesterTSDBCheckpointDeleteFailed
             annotations:
               message: Mimir Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to delete TSDB checkpoint.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbcheckpointdeletefailed
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringestertsdbcheckpointdeletefailed
             expr: |
               rate(cortex_ingester_tsdb_checkpoint_deletions_failed_total[5m]) > 0
             labels:
@@ -1074,7 +1074,7 @@ spec:
           - alert: MimirIngesterTSDBWALTruncationFailed
             annotations:
               message: Mimir Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to truncate TSDB WAL.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwaltruncationfailed
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringestertsdbwaltruncationfailed
             expr: |
               rate(cortex_ingester_tsdb_wal_truncations_failed_total[5m]) > 0
             labels:
@@ -1082,7 +1082,7 @@ spec:
           - alert: MimirIngesterTSDBWALCorrupted
             annotations:
               message: Mimir Ingester in {{ $labels.cluster }}/{{ $labels.namespace }} got a corrupted TSDB WAL.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwalcorrupted
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringestertsdbwalcorrupted
             expr: |
               # alert when there are more than one corruptions
               count by (cluster, namespace) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0) > 1
@@ -1095,7 +1095,7 @@ spec:
           - alert: MimirIngesterTSDBWALCorrupted
             annotations:
               message: Mimir Ingester in {{ $labels.cluster }}/{{ $labels.namespace }} got a corrupted TSDB WAL.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwalcorrupted
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringestertsdbwalcorrupted
             expr: |
               # alert when there are more than one corruptions
               count by (cluster, namespace) (sum by (cluster, namespace, job) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0)) > 1
@@ -1108,7 +1108,7 @@ spec:
           - alert: MimirIngesterTSDBWALWritesFailed
             annotations:
               message: Mimir Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to write to TSDB WAL.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwalwritesfailed
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringestertsdbwalwritesfailed
             expr: |
               rate(cortex_ingester_tsdb_wal_writes_failed_total[4m]) > 0
             for: 12m
@@ -1117,7 +1117,7 @@ spec:
           - alert: MimirStoreGatewayHasNotSyncTheBucket
             annotations:
               message: Mimir store-gateway {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not successfully synched the bucket since {{ $value | humanizeDuration }}.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstoregatewayhasnotsyncthebucket
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirstoregatewayhasnotsyncthebucket
             expr: |
               (time() - cortex_bucket_stores_blocks_last_successful_sync_timestamp_seconds{component="store-gateway"} > 60 * 30)
               and
@@ -1128,7 +1128,7 @@ spec:
           - alert: MimirStoreGatewayNoSyncedTenants
             annotations:
               message: Mimir store-gateway {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is not syncing any blocks for any tenant.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstoregatewaynosyncedtenants
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirstoregatewaynosyncedtenants
             expr: |
               min by(cluster, namespace, pod) (cortex_bucket_stores_tenants_synced{component="store-gateway"}) == 0
             for: 1h
@@ -1137,7 +1137,7 @@ spec:
           - alert: MimirBucketIndexNotUpdated
             annotations:
               message: Mimir bucket index for tenant {{ $labels.user }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not been updated since {{ $value | humanizeDuration }}.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirbucketindexnotupdated
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirbucketindexnotupdated
             expr: |
               min by(cluster, namespace, user) (time() - (max_over_time(cortex_bucket_index_last_successful_update_timestamp_seconds[15m]))) > 2100
             for: 2m
@@ -1146,7 +1146,7 @@ spec:
           - alert: MimirHighVolumeLevel1BlocksQueried
             annotations:
               message: Mimir store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is querying level 1 blocks, indicating the compactor may not be keeping up with compaction.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirhighvolumelevel1blocksqueried
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirhighvolumelevel1blocksqueried
             expr: |
               (
               sum by(cluster, namespace) (rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",out_of_order="false",job=~".*/(store-gateway.*|cortex|mimir)"}[10m]))
@@ -1161,7 +1161,7 @@ spec:
           - alert: MimirCompactorNotCleaningUpBlocks
             annotations:
               message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not successfully cleaned up blocks in the last 6 hours.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactornotcleaningupblocks
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactornotcleaningupblocks
             expr: |
               # The "last successful run" metric is updated even if the compactor owns no tenants,
               # so this alert correctly doesn't fire if compactor has nothing to do.
@@ -1172,7 +1172,7 @@ spec:
           - alert: MimirCompactorNotRunningCompaction
             annotations:
               message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not run compaction in the last 6 hours.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactornotrunningcompaction
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactornotrunningcompaction
             expr: |
               # The "last successful run" metric is updated even if the compactor owns no tenants,
               # so this alert correctly doesn't fire if compactor has nothing to do.
@@ -1186,7 +1186,7 @@ spec:
           - alert: MimirCompactorNotRunningCompaction
             annotations:
               message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not run compaction in the last 24 hours.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactornotrunningcompaction
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactornotrunningcompaction
             expr: |
               # The "last successful run" metric is updated even if the compactor owns no tenants,
               # so this alert correctly doesn't fire if compactor has nothing to do.
@@ -1200,7 +1200,7 @@ spec:
           - alert: MimirCompactorNotRunningCompaction
             annotations:
               message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not run compaction since startup.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactornotrunningcompaction
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactornotrunningcompaction
             expr: |
               # The "last successful run" metric is updated even if the compactor owns no tenants,
               # so this alert correctly doesn't fire if compactor has nothing to do.
@@ -1212,7 +1212,7 @@ spec:
           - alert: MimirCompactorNotRunningCompaction
             annotations:
               message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not run compaction since startup.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactornotrunningcompaction
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactornotrunningcompaction
             expr: |
               # The "last successful run" metric is updated even if the compactor owns no tenants,
               # so this alert correctly doesn't fire if compactor has nothing to do.
@@ -1224,7 +1224,7 @@ spec:
           - alert: MimirCompactorNotRunningCompaction
             annotations:
               message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} failed to run 2 consecutive compactions.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactornotrunningcompaction
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactornotrunningcompaction
             expr: |
               sum by(cluster, namespace, pod) (increase(cortex_compactor_runs_failed_total{reason!="shutdown"}[2h])) >= 2
             labels:
@@ -1233,7 +1233,7 @@ spec:
           - alert: MimirCompactorHasRunOutOfDiskSpace
             annotations:
               message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has run out of disk space.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasrunoutofdiskspace
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactorhasrunoutofdiskspace
             expr: |
               increase(cortex_compactor_disk_out_of_space_errors_total{}[24h]) >= 1
             labels:
@@ -1242,7 +1242,7 @@ spec:
           - alert: MimirCompactorHasNotUploadedBlocks
             annotations:
               message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not uploaded any block in the last 24 hours.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasnotuploadedblocks
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactorhasnotuploadedblocks
             expr: |
               (time() - (max by(cluster, namespace, pod) (thanos_objstore_bucket_last_successful_upload_time{component="compactor"})) > 60 * 60 * 24)
               and
@@ -1257,7 +1257,7 @@ spec:
           - alert: MimirCompactorHasNotUploadedBlocks
             annotations:
               message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not uploaded any block since its start.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasnotuploadedblocks
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactorhasnotuploadedblocks
             expr: |
               (max by(cluster, namespace, pod) (thanos_objstore_bucket_last_successful_upload_time{component="compactor"}) == 0)
               and
@@ -1270,7 +1270,7 @@ spec:
           - alert: MimirCompactorSkippedBlocks
             annotations:
               message: 'Mimir Compactor in {{ $labels.cluster }}/{{ $labels.namespace }} has marked {{ $value }} blocks for no-compaction (reason: {{ $labels.reason }}).'
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorskippedblocks
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactorskippedblocks
             expr: |
               sum by (cluster, namespace, reason) (
                 increase(cortex_compactor_blocks_marked_for_no_compaction_total[24h]) > 0
@@ -1281,7 +1281,7 @@ spec:
           - alert: MimirCompactorBuildingSparseIndexFailed
             annotations:
               message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to build sparse index headers
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorbuildingsparseindexfailed
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactorbuildingsparseindexfailed
             expr: |
               (sum by(cluster, namespace, pod) (increase(cortex_compactor_build_sparse_headers_failures_total[5m])) > 0)
             for: 30m
@@ -1290,7 +1290,7 @@ spec:
           - alert: MimirCompactorOOMKilled
             annotations:
               message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has been OOMKilled {{ printf "%.2f" $value }} times in the last 4h.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactoroomkilled
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactoroomkilled
             expr: |
               (
                 sum by(cluster, namespace, pod) (
@@ -1308,7 +1308,7 @@ spec:
           - alert: MimirCompactorOOMKilled
             annotations:
               message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has been OOMKilled {{ printf "%.2f" $value }} times in the last 2h.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactoroomkilled
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactoroomkilled
             expr: |
               (
                 sum by(cluster, namespace, pod) (
@@ -1328,7 +1328,7 @@ spec:
           - alert: MimirDistributorGcUsesTooMuchCpu
             annotations:
               message: Mimir distributors in {{ $labels.cluster }}/{{ $labels.namespace }} GC CPU utilization is too high.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirdistributorgcusestoomuchcpu
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirdistributorgcusestoomuchcpu
             expr: |
               (quantile by (cluster, namespace) (0.9, sum by (cluster, namespace, pod) (rate(go_cpu_classes_gc_total_cpu_seconds_total{container="distributor"}[5m]))
                 /
@@ -1349,7 +1349,7 @@ spec:
           - alert: MimirAutoscalerNotActive
             annotations:
               message: The Horizontal Pod Autoscaler (HPA) {{ $labels.horizontalpodautoscaler }} in {{ $labels.namespace }} is not active.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirautoscalernotactive
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirautoscalernotactive
             expr: |
               (
                   label_replace((
@@ -1380,7 +1380,7 @@ spec:
           - alert: MimirAutoscalerKedaFailing
             annotations:
               message: The Keda ScaledObject {{ $labels.scaledObject }} in {{ $labels.namespace }} is experiencing errors.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirautoscalerkedafailing
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirautoscalerkedafailing
             expr: |
               (
                   # Find KEDA scalers reporting errors.
@@ -1397,7 +1397,7 @@ spec:
           - alert: MimirIngesterOffsetCommitFailed
             annotations:
               message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to commit the last consumed offset.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesteroffsetcommitfailed
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesteroffsetcommitfailed
             expr: |
               sum by(cluster, namespace, pod) (rate(cortex_ingest_storage_reader_offset_commit_failures_total[5m]))
               /
@@ -1409,7 +1409,7 @@ spec:
           - alert: MimirIngesterKafkaReadFailed
             annotations:
               message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to read records from Kafka.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterkafkareadfailed
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterkafkareadfailed
             expr: |
               sum by(cluster, namespace, pod, node_id) (rate(cortex_ingest_storage_reader_read_errors_total[4m]))
               > 0
@@ -1419,7 +1419,7 @@ spec:
           - alert: MimirIngesterKafkaReadFailed
             annotations:
               message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to read records from Kafka.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterkafkareadfailed
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterkafkareadfailed
             expr: |
               sum by(cluster, namespace, pod, node_id) (rate(cortex_ingest_storage_reader_read_errors_total[4m]))
               > 0
@@ -1429,7 +1429,7 @@ spec:
           - alert: MimirIngesterKafkaFetchErrorsRateTooHigh
             annotations:
               message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is receiving fetch errors when reading records from Kafka.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterkafkafetcherrorsratetoohigh
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterkafkafetcherrorsratetoohigh
             expr: |
               sum by (cluster, namespace, pod) (rate (cortex_ingest_storage_reader_fetch_errors_total[5m]))
               /
@@ -1441,7 +1441,7 @@ spec:
           - alert: MimirStartingIngesterKafkaDelayGrowing
             annotations:
               message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} in "starting" phase is not reducing consumption lag of write requests read from Kafka.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstartingingesterkafkadelaygrowing
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirstartingingesterkafkadelaygrowing
             expr: |
               deriv((
                   sum by (cluster, namespace, pod) (rate(cortex_ingest_storage_reader_receive_delay_seconds_sum{phase="starting"}[4m]))
@@ -1455,7 +1455,7 @@ spec:
           - alert: MimirStartingIngesterKafkaDelayGrowing
             annotations:
               message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} in "starting" phase is not reducing consumption lag of write requests read from Kafka.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstartingingesterkafkadelaygrowing
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirstartingingesterkafkadelaygrowing
             expr: |
               deriv((
                   sum by (cluster, namespace, pod) (histogram_sum(rate(cortex_ingest_storage_reader_receive_delay_seconds{phase="starting"}[4m])))
@@ -1469,7 +1469,7 @@ spec:
           - alert: MimirRunningIngesterReceiveDelayTooHigh
             annotations:
               message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} in "running" phase is too far behind in its consumption of write requests from Kafka.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrunningingesterreceivedelaytoohigh
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrunningingesterreceivedelaytoohigh
             expr: |
               (
                 sum by (cluster, namespace, pod) (rate(cortex_ingest_storage_reader_receive_delay_seconds_sum{phase="running"}[4m]))
@@ -1484,7 +1484,7 @@ spec:
           - alert: MimirRunningIngesterReceiveDelayTooHigh
             annotations:
               message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} in "running" phase is too far behind in its consumption of write requests from Kafka.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrunningingesterreceivedelaytoohigh
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrunningingesterreceivedelaytoohigh
             expr: |
               (
                 sum by (cluster, namespace, pod) (histogram_sum(rate(cortex_ingest_storage_reader_receive_delay_seconds{phase="running"}[4m])))
@@ -1499,7 +1499,7 @@ spec:
           - alert: MimirRunningIngesterReceiveDelayTooHigh
             annotations:
               message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} in "running" phase is too far behind in its consumption of write requests from Kafka.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrunningingesterreceivedelaytoohigh
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrunningingesterreceivedelaytoohigh
             expr: |
               (
                 sum by (cluster, namespace, pod) (rate(cortex_ingest_storage_reader_receive_delay_seconds_sum{phase="running"}[4m]))
@@ -1514,7 +1514,7 @@ spec:
           - alert: MimirRunningIngesterReceiveDelayTooHigh
             annotations:
               message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} in "running" phase is too far behind in its consumption of write requests from Kafka.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrunningingesterreceivedelaytoohigh
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrunningingesterreceivedelaytoohigh
             expr: |
               (
                 sum by (cluster, namespace, pod) (histogram_sum(rate(cortex_ingest_storage_reader_receive_delay_seconds{phase="running"}[4m])))
@@ -1529,7 +1529,7 @@ spec:
           - alert: MimirIngesterKafkaProcessingFailed
             annotations:
               message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} fails to consume write requests read from Kafka due to internal errors.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterkafkaprocessingfailed
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterkafkaprocessingfailed
             expr: |
               (
                 sum by (cluster, namespace, pod) (
@@ -1549,7 +1549,7 @@ spec:
           - alert: MimirIngesterKafkaProcessingStuck
             annotations:
               message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is stuck processing write requests from Kafka.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterkafkaprocessingstuck
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterkafkaprocessingstuck
             expr: |
               # Alert if the reader is not processing any records, but there buffered records to process in the Kafka client.
               (sum by (cluster, namespace, pod) (
@@ -1566,7 +1566,7 @@ spec:
           - alert: MimirIngesterMissedRecordsFromKafka
             annotations:
               message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} missed processing records from Kafka. There may be data loss.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestermissedrecordsfromkafka
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringestermissedrecordsfromkafka
             expr: |
               # Alert if the ingester missed some records from Kafka.
               increase(cortex_ingest_storage_reader_missed_records_total[10m]) > 0
@@ -1575,7 +1575,7 @@ spec:
           - alert: MimirStrongConsistencyEnforcementFailed
             annotations:
               message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} fails to enforce strong-consistency on read-path.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstrongconsistencyenforcementfailed
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirstrongconsistencyenforcementfailed
             expr: |
               sum by (cluster, namespace, pod) (rate(cortex_ingest_storage_strong_consistency_failures_total[4m])) > 0
             for: 5m
@@ -1584,7 +1584,7 @@ spec:
           - alert: MimirStrongConsistencyOffsetMissing
             annotations:
               message: Mimir ingesters in {{ $labels.cluster }}/{{ $labels.namespace }} are receiving an unexpected high number of strongly consistent requests without an offset specified.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstrongconsistencyoffsetmissing
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirstrongconsistencyoffsetmissing
             expr: |
               sum by (cluster, namespace) (rate(cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", with_offset="false"}[4m]))
               /
@@ -1596,7 +1596,7 @@ spec:
           - alert: MimirKafkaClientProduceBufferHigh
             annotations:
               message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} Kafka client produce buffer utilization is {{ printf "%.2f" $value }}%.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirkafkaclientproducebufferhigh
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirkafkaclientproducebufferhigh
             expr: |
               max by(cluster, namespace, pod) (
                   # New metric.
@@ -1614,7 +1614,7 @@ spec:
           - alert: MimirBlockBuilderSchedulerPendingJobs
             annotations:
               message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} reports {{ printf "%.2f" $value }} pending jobs.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderschedulerpendingjobs
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirblockbuilderschedulerpendingjobs
             expr: |
               sum by (cluster, namespace, pod) (cortex_blockbuilder_scheduler_pending_jobs) > 0
             for: 40m
@@ -1623,7 +1623,7 @@ spec:
           - alert: MimirBlockBuilderCompactAndUploadFailed
             annotations:
               message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} fails to compact and upload blocks.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuildercompactanduploadfailed
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirblockbuildercompactanduploadfailed
             expr: |
               sum by (cluster, namespace, pod) (rate(cortex_blockbuilder_tsdb_compact_and_upload_failed_total[4m])) > 0
             labels:
@@ -1631,7 +1631,7 @@ spec:
           - alert: MimirBlockBuilderHasNotShippedBlocks
             annotations:
               message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not shipped any block in the last 4 hours.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderhasnotshippedblocks
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirblockbuilderhasnotshippedblocks
             expr: |
               (min by(cluster, namespace, pod) (time() - cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 60 * 60 * 4)
               and
@@ -1645,7 +1645,7 @@ spec:
           - alert: MimirBlockBuilderSchedulerNotRunning
             annotations:
               message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is not running.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderschedulernotrunning
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirblockbuilderschedulernotrunning
             expr: |
               max by (cluster, namespace, pod) (histogram_count(increase(cortex_blockbuilder_scheduler_schedule_update_seconds[5m])) == 0)
             for: 30m
@@ -1654,7 +1654,7 @@ spec:
           - alert: MimirBlockBuilderDataSkipped
             annotations:
               message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has detected skipped data.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderdataskipped
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirblockbuilderdataskipped
             expr: |
               sum by (cluster, namespace, pod) (
                 increase(cortex_blockbuilder_scheduler_job_gap_detected[1h])
@@ -1664,7 +1664,7 @@ spec:
           - alert: MimirBlockBuilderPersistentJobFailure
             annotations:
               message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has detected a persistently failing job.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderpersistentjobfailure
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirblockbuilderpersistentjobfailure
             expr: |
               increase(cortex_blockbuilder_scheduler_persistent_job_failures_total[20m]) > 0
             labels:
@@ -1672,7 +1672,7 @@ spec:
           - alert: MimirFewerIngestersConsumingThanActivePartitions
             annotations:
               message: Mimir ingesters in {{ $labels.cluster }}/{{ $labels.namespace }} have fewer ingesters consuming than active partitions.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirfeweringestersconsumingthanactivepartitions
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirfeweringestersconsumingthanactivepartitions
             expr: |
               max(cortex_partition_ring_partitions{name="ingester-partitions", state="Active"}) by (cluster, namespace) > count(count(cortex_ingest_storage_reader_last_consumed_offset{}) by (cluster, namespace, partition)) by (cluster, namespace)
             for: 15m
@@ -1710,7 +1710,7 @@ spec:
           - alert: MimirContinuousTestNotRunningOnWrites
             annotations:
               message: Mimir continuous test {{ $labels.test }} in {{ $labels.cluster }}/{{ $labels.namespace }} is not effectively running because writes are failing.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircontinuoustestnotrunningonwrites
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircontinuoustestnotrunningonwrites
             expr: |
               sum by(cluster, namespace, test) (rate(mimir_continuous_test_writes_failed_total[5m])) > 0
             for: 1h
@@ -1719,7 +1719,7 @@ spec:
           - alert: MimirContinuousTestNotRunningOnReads
             annotations:
               message: Mimir continuous test {{ $labels.test }} in {{ $labels.cluster }}/{{ $labels.namespace }} is not effectively running because queries are failing.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircontinuoustestnotrunningonreads
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircontinuoustestnotrunningonreads
             expr: |
               sum by(cluster, namespace, test) (rate(mimir_continuous_test_queries_failed_total[5m])) > 0
             for: 1h
@@ -1728,7 +1728,7 @@ spec:
           - alert: MimirContinuousTestFailed
             annotations:
               message: Mimir continuous test {{ $labels.test }} in {{ $labels.cluster }}/{{ $labels.namespace }} failed when asserting query results.
-              runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircontinuoustestfailed
+              runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircontinuoustestfailed
             expr: |
               sum by(cluster, namespace, test) (rate(mimir_continuous_test_query_result_checks_failed_total[10m])) > 0
             labels:

--- a/operations/mimir-mixin-compiled-baremetal/alerts.yaml
+++ b/operations/mimir-mixin-compiled-baremetal/alerts.yaml
@@ -4,7 +4,7 @@ groups:
         - alert: MimirIngesterUnhealthy
           annotations:
             message: Mimir cluster {{ $labels.cluster }}/{{ $labels.namespace }} has {{ printf "%f" $value }} unhealthy ingester(s).
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterunhealthy
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterunhealthy
           expr: |
             min by (cluster, namespace) (cortex_ring_members{state="Unhealthy", name="ingester"}) > 0
           for: 15m
@@ -14,7 +14,7 @@ groups:
           annotations:
             message: |
                 The route {{ $labels.route }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% errors.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrequesterrors
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrequesterrors
           expr: |
             # The following 5xx errors considered as non-error:
             # - 529: used by distributor rate limiting (using 529 instead of 429 to let the client retry)
@@ -32,7 +32,7 @@ groups:
           annotations:
             message: |
                 The route {{ $labels.route }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% errors.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrequesterrors
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrequesterrors
           expr: |
             # The following 5xx errors considered as non-error:
             # - 529: used by distributor rate limiting (using 529 instead of 429 to let the client retry)
@@ -50,7 +50,7 @@ groups:
           annotations:
             message: |
                 {{ $labels.job }} {{ $labels.route }} is experiencing {{ printf "%.2f" $value }}s 99th percentile latency.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrequestlatency
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrequestlatency
           expr: |
             cluster_namespace_job_route:cortex_request_duration_seconds:99quantile{route!~"metrics|/frontend.Frontend/Process|ready|/schedulerpb.SchedulerForFrontend/FrontendLoop|/schedulerpb.SchedulerForQuerier/QuerierLoop|debug_pprof"}
               >
@@ -63,7 +63,7 @@ groups:
           annotations:
             message: |
                 {{ $labels.job }} {{ $labels.route }} is experiencing {{ printf "%.2f" $value }}s 99th percentile latency.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrequestlatency
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrequestlatency
           expr: |
             histogram_quantile(0.99, cluster_namespace_job_route:cortex_request_duration_seconds:sum_rate{route!~"metrics|/frontend.Frontend/Process|ready|/schedulerpb.SchedulerForFrontend/FrontendLoop|/schedulerpb.SchedulerForQuerier/QuerierLoop|debug_pprof"})
               >
@@ -76,7 +76,7 @@ groups:
           annotations:
             message: |
                 An inconsistent runtime config file is used across cluster {{ $labels.cluster }}/{{ $labels.namespace }}.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirinconsistentruntimeconfig
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirinconsistentruntimeconfig
           expr: |
             count without(sha256) (
                 count by (cluster, namespace, job, sha256) (cortex_runtime_config_hash)
@@ -98,7 +98,7 @@ groups:
           annotations:
             message: |
                 {{ $labels.job }} failed to reload runtime config.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirbadruntimeconfig
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirbadruntimeconfig
           expr: |
             # The metric value is reset to 0 on error while reloading the config at runtime.
             cortex_runtime_config_last_reload_successful == 0
@@ -109,7 +109,7 @@ groups:
           annotations:
             message: |
                 There are {{ $value }} queued up queries in {{ $labels.cluster }}/{{ $labels.namespace }} {{ $labels.job }}.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirschedulerqueriesstuck
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirschedulerqueriesstuck
           expr: |
             # There are some queries in the queue.
             (sum by (cluster, namespace, job) (cortex_query_scheduler_queue_length) > 0)
@@ -135,7 +135,7 @@ groups:
           annotations:
             message: |
                 The cache {{ $labels.name }} used by Mimir {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% errors for {{ $labels.operation }} operation.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircacherequesterrors
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircacherequesterrors
           expr: |
             (
               sum by(cluster, namespace, name, operation) (
@@ -152,7 +152,7 @@ groups:
         - alert: MimirIngesterRestarts
           annotations:
             message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has restarted {{ printf "%.2f" $value }} times in the last 30 mins.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterrestarts
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterrestarts
           expr: |
             (
               sum by(cluster, namespace, instance) (
@@ -170,7 +170,7 @@ groups:
           annotations:
             message: |
                 Mimir {{ $labels.instance }} in  {{ $labels.cluster }}/{{ $labels.namespace }} is failing to talk to the KV store {{ $labels.kv_name }}.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirkvstorefailure
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirkvstorefailure
           expr: |
             (
               sum by (cluster, namespace, instance, status_code, kv_name) (rate(cortex_kv_request_duration_seconds_count{status_code!~"2.+"}[4m]))
@@ -187,7 +187,7 @@ groups:
           annotations:
             message: |
                 Mimir {{ $labels.instance }} in  {{ $labels.cluster }}/{{ $labels.namespace }} is failing to talk to the KV store {{ $labels.kv_name }}.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirkvstorefailure
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirkvstorefailure
           expr: |
             (
               sum by (cluster, namespace, instance, status_code, kv_name) (histogram_count(rate(cortex_kv_request_duration_seconds{status_code!~"2.+"}[4m])))
@@ -203,7 +203,7 @@ groups:
         - alert: MimirMemoryMapAreasTooHigh
           annotations:
             message: '{{ $labels.job }}/{{ $labels.instance }} has a number of mmap-ed areas close to the limit.'
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirmemorymapareastoohigh
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirmemorymapareastoohigh
           expr: |
             process_memory_map_areas{job=~".*/(ingester.*|cortex|mimir|store-gateway.*|cortex|mimir)"} / process_memory_map_areas_limit{job=~".*/(ingester.*|cortex|mimir|store-gateway.*|cortex|mimir)"} > 0.8
           for: 5m
@@ -212,7 +212,7 @@ groups:
         - alert: MimirIngesterInstanceHasNoTenants
           annotations:
             message: Mimir ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has no tenants assigned.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterinstancehasnotenants
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterinstancehasnotenants
           expr: |
             (
               (min by(cluster, namespace, instance) (cortex_ingester_memory_users) == 0)
@@ -245,7 +245,7 @@ groups:
         - alert: MimirRulerInstanceHasNoRuleGroups
           annotations:
             message: Mimir ruler {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has no rule groups assigned.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulerinstancehasnorulegroups
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrulerinstancehasnorulegroups
           expr: |
             # Alert on ruler instances in microservices mode that have no rule groups assigned,
             min by(cluster, namespace, instance) (cortex_ruler_managers_total{instance=~".*ruler.*"}) == 0
@@ -261,7 +261,7 @@ groups:
         - alert: MimirIngestedDataTooFarInTheFuture
           annotations:
             message: Mimir ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has ingested samples with timestamps more than 1h in the future.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesteddatatoofarinthefuture
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesteddatatoofarinthefuture
           expr: |
             max by(cluster, namespace, instance) (
                 cortex_ingester_tsdb_head_max_timestamp_seconds - time()
@@ -274,7 +274,7 @@ groups:
         - alert: MimirStoreGatewayTooManyFailedOperations
           annotations:
             message: Mimir store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ $value | humanizePercentage }} errors while doing {{ $labels.operation }} on the object storage.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstoregatewaytoomanyfailedoperations
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirstoregatewaytoomanyfailedoperations
           expr: |
             (
                 sum by(cluster, namespace, operation) (rate(thanos_objstore_bucket_operation_failures_total{component="store-gateway"}[4m]))
@@ -287,7 +287,7 @@ groups:
         - alert: MimirServerInvalidClusterLabelRequests
           annotations:
             message: Mimir servers in {{ $labels.cluster }}/{{ $labels.namespace }} are receiving requests with invalid cluster validation labels.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirserverinvalidclusterlabelrequests
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirserverinvalidclusterlabelrequests
           expr: |
             (sum by (cluster, namespace, protocol) (rate(cortex_server_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
             # Alert only for namespaces with Mimir clusters.
@@ -297,7 +297,7 @@ groups:
         - alert: MimirClientInvalidClusterLabelRequests
           annotations:
             message: Mimir clients in {{ $labels.cluster }}/{{ $labels.namespace }} are having requests rejected due to invalid cluster validation labels.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirclientinvalidclusterlabelrequests
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirclientinvalidclusterlabelrequests
           expr: |
             (sum by (cluster, namespace, protocol) (rate(cortex_client_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
             # Alert only for namespaces with Mimir clusters.
@@ -308,7 +308,7 @@ groups:
           annotations:
             message: |
                 Number of members in Mimir ingester hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirringmembersmismatch
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirringmembersmismatch
           expr: |
             (
               (
@@ -334,7 +334,7 @@ groups:
           annotations:
             message: |
                 Container {{ $labels.container }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing high GRPC concurrent streams per connection.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirhighgrpcstreamsperconnection
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirhighgrpcstreamsperconnection
           expr: |
             max(avg_over_time(grpc_concurrent_streams_by_conn_max[10m])) by (cluster, namespace, container)
             /
@@ -345,7 +345,7 @@ groups:
           annotations:
             message: |
                 Queriers in the same %(product)s cluster and query path are reporting different maximum supported query plan versions.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirmixedquerierqueryplanversionsupport
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirmixedquerierqueryplanversionsupport
           expr: |
             min by (cluster, namespace, container) (cortex_querier_maximum_supported_query_plan_version)
             !=
@@ -357,7 +357,7 @@ groups:
           annotations:
             message: |
                 Query-frontends in the same Mimir cluster and query path have calculated different maximum supported query plan versions.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirmixedqueryfrontendqueryplanversionsupport
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirmixedqueryfrontendqueryplanversionsupport
           expr: |
             min by (cluster, namespace, container) (cortex_query_frontend_querier_ring_calculated_maximum_supported_query_plan_version)
             !=
@@ -369,7 +369,7 @@ groups:
           annotations:
             message: |
                 Query-frontends and queriers are reporting different maximum supported query plan versions.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirqueryfrontendsandqueriersdisagreeonsupportedqueryplanversion
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirqueryfrontendsandqueriersdisagreeonsupportedqueryplanversion
           expr: |
             # The label_replace calls below are so that we can match queriers with container labels like "ruler-querier" to
             # query-frontends with container labels like "ruler-query-frontend".
@@ -398,7 +398,7 @@ groups:
           annotations:
             message: |
                 Query-frontends are failing to compute a maximum supported query plan version.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirqueryfrontendnotcomputingsupportedqueryplanversion
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirqueryfrontendnotcomputingsupportedqueryplanversion
           expr: |
             count by (cluster, namespace, container) (cortex_query_frontend_querier_ring_calculated_maximum_supported_query_plan_version == -1) > 0
           for: 5m
@@ -410,7 +410,7 @@ groups:
           annotations:
             message: |
                 Ingester {{ $labels.job }}/{{ $labels.instance }} has reached {{ $value | humanizePercentage }} of its series limit.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterreachingserieslimit
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterreachingserieslimit
           expr: |
             (
                 (cortex_ingester_memory_series / ignoring(limit) cortex_ingester_instance_limits{limit="max_series"})
@@ -424,7 +424,7 @@ groups:
           annotations:
             message: |
                 Ingester {{ $labels.job }}/{{ $labels.instance }} has reached {{ $value | humanizePercentage }} of its series limit.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterreachingserieslimit
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterreachingserieslimit
           expr: |
             (
                 (cortex_ingester_memory_series / ignoring(limit) cortex_ingester_instance_limits{limit="max_series"})
@@ -438,7 +438,7 @@ groups:
           annotations:
             message: |
                 Ingester {{ $labels.job }}/{{ $labels.instance }} has reached {{ $value | humanizePercentage }} of its tenant limit.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterreachingtenantslimit
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterreachingtenantslimit
           expr: |
             (
                 (cortex_ingester_memory_users / ignoring(limit) cortex_ingester_instance_limits{limit="max_tenants"})
@@ -452,7 +452,7 @@ groups:
           annotations:
             message: |
                 Ingester {{ $labels.job }}/{{ $labels.instance }} has reached {{ $value | humanizePercentage }} of its tenant limit.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterreachingtenantslimit
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterreachingtenantslimit
           expr: |
             (
                 (cortex_ingester_memory_users / ignoring(limit) cortex_ingester_instance_limits{limit="max_tenants"})
@@ -466,7 +466,7 @@ groups:
           annotations:
             message: |
                 Mimir instance {{ $labels.job }}/{{ $labels.instance }} has reached {{ $value | humanizePercentage }} of its TCP connections limit for {{ $labels.protocol }} protocol.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirreachingtcpconnectionslimit
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirreachingtcpconnectionslimit
           expr: |
             cortex_tcp_connections / cortex_tcp_connections_limit > 0.8 and
             cortex_tcp_connections_limit > 0
@@ -477,7 +477,7 @@ groups:
           annotations:
             message: |
                 Distributor {{ $labels.job }}/{{ $labels.instance }} has reached {{ $value | humanizePercentage }} of its inflight push request limit.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirdistributorinflightrequestshigh
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirdistributorinflightrequestshigh
           expr: |
             (
                 (cortex_distributor_inflight_push_requests / ignoring(limit) cortex_distributor_instance_limits{limit="max_inflight_push_requests"})
@@ -493,7 +493,7 @@ groups:
           annotations:
             message: |
                 The {{ $labels.rollout_group }} rollout is stuck in {{ $labels.cluster }}/{{ $labels.namespace }}.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrolloutstuck
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrolloutstuck
           expr: |
             (
               # Query for rollout groups in certain namespaces that are being updated, dropping the revision label.
@@ -525,7 +525,7 @@ groups:
           annotations:
             message: |
                 The {{ $labels.rollout_group }} rollout is stuck in {{ $labels.cluster }}/{{ $labels.namespace }}.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrolloutstuck
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrolloutstuck
           expr: |
             (
               # Query for rollout groups in certain namespaces that are being updated, dropping the revision label.
@@ -557,7 +557,7 @@ groups:
           annotations:
             message: |
                 The {{ $labels.rollout_group }} rollout is stuck in {{ $labels.cluster }}/{{ $labels.namespace }}.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrolloutstuck
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrolloutstuck
           expr: |
             (
               sum without(deployment) (label_replace(kube_deployment_spec_replicas, "rollout_group", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"))
@@ -577,7 +577,7 @@ groups:
           annotations:
             message: |
                 The {{ $labels.rollout_group }} rollout is stuck in {{ $labels.cluster }}/{{ $labels.namespace }}.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrolloutstuck
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrolloutstuck
           expr: |
             (
               sum without(deployment) (label_replace(kube_deployment_spec_replicas, "rollout_group", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"))
@@ -597,7 +597,7 @@ groups:
           annotations:
             message: |
                 Rollout operator is not reconciling the rollout group {{ $labels.rollout_group }} in {{ $labels.cluster }}/{{ $labels.namespace }}.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#rolloutoperatornotreconciling
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#rolloutoperatornotreconciling
           expr: |
             max by(cluster, namespace, rollout_group) (time() - rollout_operator_last_successful_group_reconcile_timestamp_seconds) > 600
           for: 5m
@@ -609,7 +609,7 @@ groups:
           annotations:
             message: |
                 Instance {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is using too much memory.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirallocatingtoomuchmemory
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirallocatingtoomuchmemory
           expr: |
             (
               process_resident_memory_bytes{job=~".*/(ingester)"}
@@ -623,7 +623,7 @@ groups:
           annotations:
             message: |
                 Instance {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is using too much memory.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirallocatingtoomuchmemory
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirallocatingtoomuchmemory
           expr: |
             (
               process_resident_memory_bytes{job=~".*/(ingester)"}
@@ -639,7 +639,7 @@ groups:
           annotations:
             message: |
                 Mimir Ruler {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% write (push) errors.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulertoomanyfailedpushes
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrulertoomanyfailedpushes
           expr: |
             100 * (
             # Here it matches on empty "reason" for backwards compatibility, with when the metric didn't have this label.
@@ -654,7 +654,7 @@ groups:
           annotations:
             message: |
                 Mimir Ruler {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% errors while evaluating rules.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulertoomanyfailedqueries
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrulertoomanyfailedqueries
           expr: |
             100 * (
             # Here it matches on empty "reason" for backwards compatibility, with when the metric didn't have this label.
@@ -669,7 +669,7 @@ groups:
           annotations:
             message: |
                 Mimir Rulers in {{ $labels.cluster }}/{{ $labels.namespace }} are experiencing {{ printf "%.2f" $value }}% missed iterations.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulersmissedevaluations
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrulersmissedevaluations
           expr: |
             100 * (
             sum by (cluster, namespace) (rate(cortex_prometheus_rule_group_iterations_missed_total[4m]))
@@ -683,7 +683,7 @@ groups:
           annotations:
             message: |
                 Mimir Ruler {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% missed iterations.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulermissedevaluations
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrulermissedevaluations
           expr: |
             100 * (
             sum by (cluster, namespace, instance) (rate(cortex_prometheus_rule_group_iterations_missed_total[4m]))
@@ -697,7 +697,7 @@ groups:
           annotations:
             message: |
                 Mimir Rulers in {{ $labels.cluster }}/{{ $labels.namespace }} are experiencing errors when checking the ring for rule group ownership.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulerfailedringcheck
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrulerfailedringcheck
           expr: |
             sum by (cluster, namespace, job) (rate(cortex_ruler_ring_check_errors_total[4m]))
                > 0
@@ -708,7 +708,7 @@ groups:
           annotations:
             message: |
                 Mimir rulers in {{ $labels.cluster }}/{{ $labels.namespace }} are failing to perform {{ printf "%.2f" $value }}% of remote evaluations through the ruler-query-frontend.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulerremoteevaluationfailing
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrulerremoteevaluationfailing
           expr: |
             (
               sum by (cluster, namespace) (rate(cortex_request_duration_seconds_count{status_code=~"5..", route="/httpgrpc.HTTP/Handle", job=~".*/(ruler-query-frontend.*)"}[5m]))
@@ -723,7 +723,7 @@ groups:
           annotations:
             message: |
                 Mimir rulers in {{ $labels.cluster }}/{{ $labels.namespace }} are failing to perform {{ printf "%.2f" $value }}% of remote evaluations through the ruler-query-frontend.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulerremoteevaluationfailing
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrulerremoteevaluationfailing
           expr: |
             (
               sum by (cluster, namespace) (histogram_count(rate(cortex_request_duration_seconds{status_code=~"5..", route="/httpgrpc.HTTP/Handle", job=~".*/(ruler-query-frontend.*)"}[5m])))
@@ -739,7 +739,7 @@ groups:
         - alert: MimirGossipMembersTooHigh
           annotations:
             message: One or more Mimir instances in {{ $labels.cluster }}/{{ $labels.namespace }} consistently sees a higher than expected number of gossip members.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgossipmemberstoohigh
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirgossipmemberstoohigh
           expr: |
             max by (cluster, namespace) (memberlist_client_cluster_members_count)
             >
@@ -750,7 +750,7 @@ groups:
         - alert: MimirGossipMembersTooLow
           annotations:
             message: One or more Mimir instances in {{ $labels.cluster }}/{{ $labels.namespace }} consistently sees a lower than expected number of gossip members.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgossipmemberstoolow
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirgossipmemberstoolow
           expr: |
             min by (cluster, namespace) (memberlist_client_cluster_members_count)
             <
@@ -761,7 +761,7 @@ groups:
         - alert: MimirGossipMembersEndpointsOutOfSync
           annotations:
             message: Mimir gossip-ring service endpoints list in {{ $labels.cluster }}/{{ $labels.namespace }} is out of sync.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgossipmembersendpointsoutofsync
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirgossipmembersendpointsoutofsync
           expr: |
             (
               count by(cluster, namespace) (
@@ -783,7 +783,7 @@ groups:
         - alert: MimirGossipMembersEndpointsOutOfSync
           annotations:
             message: Mimir gossip-ring service endpoints list in {{ $labels.cluster }}/{{ $labels.namespace }} is out of sync.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgossipmembersendpointsoutofsync
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirgossipmembersendpointsoutofsync
           expr: |
             (
               count by(cluster, namespace) (
@@ -805,7 +805,7 @@ groups:
         - alert: MimirMemberlistBridgeZoneUnavailable
           annotations:
             message: Mimir memberlist-bridge in {{ $labels.cluster }}/{{ $labels.namespace }} {{ $labels.zone }} has no available pods.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirmemberlistbridgezoneunavailable
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirmemberlistbridgezoneunavailable
           expr: |
             # Find the expected memberlist-bridge zonal deployments.
             count by (cluster, namespace, zone) (
@@ -829,7 +829,7 @@ groups:
         - alert: MimirMemberlistZoneAwareRoutingAutoFailover
           annotations:
             message: Mimir memberlist in {{ $labels.cluster }}/{{ $labels.namespace }} has automatically temporarily disabled zone-aware routing because it detected missing memberlist bridges.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirmemberlistzoneawareroutingautofailover
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirmemberlistzoneawareroutingautofailover
           expr: |
             sum by (cluster, namespace) (rate(memberlist_client_zone_aware_routing_select_nodes_skipped_total[4m])) > 0
           for: 10m
@@ -841,7 +841,7 @@ groups:
           annotations:
             message: |
                 Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is running a very high number of Go threads.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgothreadstoohigh
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirgothreadstoohigh
           expr: |
             # We filter by the namespace because go_threads can be very high cardinality in a large organization.
             max by(cluster, namespace, instance) (go_threads{job=~".*(cortex|mimir).*"} > 5000)
@@ -855,7 +855,7 @@ groups:
           annotations:
             message: |
                 Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is running a very high number of Go threads.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgothreadstoohigh
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirgothreadstoohigh
           expr: |
             # We filter by the namespace because go_threads can be very high cardinality in a large organization.
             max by(cluster, namespace, instance) (go_threads{job=~".*(cortex|mimir).*"} > 8000)
@@ -871,7 +871,7 @@ groups:
           annotations:
             message: |
                 Mimir Alertmanager {{ $labels.job }}/{{ $labels.instance }} is failing to read tenant configurations from storage.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagersyncconfigsfailing
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiralertmanagersyncconfigsfailing
           expr: |
             rate(cortex_alertmanager_sync_configs_failed_total[5m]) > 0
           for: 30m
@@ -881,7 +881,7 @@ groups:
           annotations:
             message: |
                 Mimir Alertmanager {{ $labels.job }}/{{ $labels.instance }} is unable to check tenants ownership via the ring.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagerringcheckfailing
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiralertmanagerringcheckfailing
           expr: |
             rate(cortex_alertmanager_ring_check_errors_total[4m]) > 0
           for: 10m
@@ -891,7 +891,7 @@ groups:
           annotations:
             message: |
                 Mimir Alertmanager {{ $labels.job }}/{{ $labels.instance }} is failing to merge partial state changes received from a replica.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagerstatemergefailing
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiralertmanagerstatemergefailing
           expr: |
             rate(cortex_alertmanager_partial_state_merges_failed_total[4m]) > 0
           for: 10m
@@ -901,7 +901,7 @@ groups:
           annotations:
             message: |
                 Mimir Alertmanager {{ $labels.job }}/{{ $labels.instance }} is failing to replicating partial state to its replicas.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagerreplicationfailing
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiralertmanagerreplicationfailing
           expr: |
             rate(cortex_alertmanager_state_replication_failed_total[4m]) > 0
           for: 10m
@@ -911,7 +911,7 @@ groups:
           annotations:
             message: |
                 Mimir Alertmanager {{ $labels.job }}/{{ $labels.instance }} is unable to persist full state snaphots to remote storage.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagerpersiststatefailing
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiralertmanagerpersiststatefailing
           expr: |
             rate(cortex_alertmanager_state_persist_failed_total[15m]) > 0
           for: 1h
@@ -921,7 +921,7 @@ groups:
           annotations:
             message: |
                 Mimir Alertmanager {{ $labels.job }}/{{ $labels.instance }} was unable to obtain some initial state when starting up.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagerinitialsyncfailed
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiralertmanagerinitialsyncfailed
           expr: |
             increase(cortex_alertmanager_state_initial_sync_completed_total{outcome="failed"}[4m]) > 0
           labels:
@@ -930,7 +930,7 @@ groups:
           annotations:
             message: |
                 Alertmanager {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is using too much memory.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagerallocatingtoomuchmemory
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiralertmanagerallocatingtoomuchmemory
           expr: |
             (process_resident_memory_bytes{job=~".*/alertmanager"} / on(instance) node_memory_MemTotal_bytes{}) > 0.80
           for: 15m
@@ -940,7 +940,7 @@ groups:
           annotations:
             message: |
                 Alertmanager {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is using too much memory.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagerallocatingtoomuchmemory
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiralertmanagerallocatingtoomuchmemory
           expr: |
             (process_resident_memory_bytes{job=~".*/alertmanager"} / on(instance) node_memory_MemTotal_bytes{}) > 0.90
           for: 15m
@@ -949,7 +949,7 @@ groups:
         - alert: MimirAlertmanagerInstanceHasNoTenants
           annotations:
             message: Mimir alertmanager {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} owns no tenants.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagerinstancehasnotenants
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiralertmanagerinstancehasnotenants
           expr: |
             # Alert on alertmanager instances in microservices mode that own no tenants,
             min by(cluster, namespace, instance) (cortex_alertmanager_tenants_owned{instance=~".*alertmanager.*"}) == 0
@@ -964,7 +964,7 @@ groups:
         - alert: MimirIngesterNotShippingBlocks
           annotations:
             message: Mimir Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not shipped any block in the last 4 hours.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesternotshippingblocks
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesternotshippingblocks
           expr: |
             (min by(cluster, namespace, instance) (time() - cortex_ingester_shipper_last_successful_upload_timestamp_seconds) > 60 * 60 * 4)
             and
@@ -987,7 +987,7 @@ groups:
         - alert: MimirIngesterNotShippingBlocksSinceStart
           annotations:
             message: Mimir Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not shipped any block in the last 4 hours.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesternotshippingblockssincestart
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesternotshippingblockssincestart
           expr: |
             (max by(cluster, namespace, instance) (cortex_ingester_shipper_last_successful_upload_timestamp_seconds) == 0)
             and
@@ -1001,7 +1001,7 @@ groups:
         - alert: MimirIngesterHasUnshippedBlocks
           annotations:
             message: Mimir Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has compacted a block {{ $value | humanizeDuration }} ago but it hasn't been successfully uploaded to the storage yet.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterhasunshippedblocks
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterhasunshippedblocks
           expr: |
             (time() - cortex_ingester_oldest_unshipped_block_timestamp_seconds > 3600)
             and
@@ -1015,7 +1015,7 @@ groups:
         - alert: MimirIngesterTSDBHeadCompactionFailed
           annotations:
             message: Mimir Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to compact TSDB head.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbheadcompactionfailed
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringestertsdbheadcompactionfailed
           expr: |
             rate(cortex_ingester_tsdb_compactions_failed_total[5m]) > 0
           for: 15m
@@ -1024,7 +1024,7 @@ groups:
         - alert: MimirIngesterTSDBHeadTruncationFailed
           annotations:
             message: Mimir Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to truncate TSDB head.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbheadtruncationfailed
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringestertsdbheadtruncationfailed
           expr: |
             rate(cortex_ingester_tsdb_head_truncations_failed_total[5m]) > 0
           labels:
@@ -1032,7 +1032,7 @@ groups:
         - alert: MimirIngesterTSDBCheckpointCreateFailed
           annotations:
             message: Mimir Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to create TSDB checkpoint.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbcheckpointcreatefailed
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringestertsdbcheckpointcreatefailed
           expr: |
             rate(cortex_ingester_tsdb_checkpoint_creations_failed_total[5m]) > 0
           labels:
@@ -1040,7 +1040,7 @@ groups:
         - alert: MimirIngesterTSDBCheckpointDeleteFailed
           annotations:
             message: Mimir Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to delete TSDB checkpoint.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbcheckpointdeletefailed
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringestertsdbcheckpointdeletefailed
           expr: |
             rate(cortex_ingester_tsdb_checkpoint_deletions_failed_total[5m]) > 0
           labels:
@@ -1048,7 +1048,7 @@ groups:
         - alert: MimirIngesterTSDBWALTruncationFailed
           annotations:
             message: Mimir Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to truncate TSDB WAL.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwaltruncationfailed
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringestertsdbwaltruncationfailed
           expr: |
             rate(cortex_ingester_tsdb_wal_truncations_failed_total[5m]) > 0
           labels:
@@ -1056,7 +1056,7 @@ groups:
         - alert: MimirIngesterTSDBWALCorrupted
           annotations:
             message: Mimir Ingester in {{ $labels.cluster }}/{{ $labels.namespace }} got a corrupted TSDB WAL.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwalcorrupted
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringestertsdbwalcorrupted
           expr: |
             # alert when there are more than one corruptions
             count by (cluster, namespace) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0) > 1
@@ -1069,7 +1069,7 @@ groups:
         - alert: MimirIngesterTSDBWALCorrupted
           annotations:
             message: Mimir Ingester in {{ $labels.cluster }}/{{ $labels.namespace }} got a corrupted TSDB WAL.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwalcorrupted
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringestertsdbwalcorrupted
           expr: |
             # alert when there are more than one corruptions
             count by (cluster, namespace) (sum by (cluster, namespace, job) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0)) > 1
@@ -1082,7 +1082,7 @@ groups:
         - alert: MimirIngesterTSDBWALWritesFailed
           annotations:
             message: Mimir Ingester {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to write to TSDB WAL.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwalwritesfailed
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringestertsdbwalwritesfailed
           expr: |
             rate(cortex_ingester_tsdb_wal_writes_failed_total[4m]) > 0
           for: 12m
@@ -1091,7 +1091,7 @@ groups:
         - alert: MimirStoreGatewayHasNotSyncTheBucket
           annotations:
             message: Mimir store-gateway {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not successfully synched the bucket since {{ $value | humanizeDuration }}.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstoregatewayhasnotsyncthebucket
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirstoregatewayhasnotsyncthebucket
           expr: |
             (time() - cortex_bucket_stores_blocks_last_successful_sync_timestamp_seconds{component="store-gateway"} > 60 * 30)
             and
@@ -1102,7 +1102,7 @@ groups:
         - alert: MimirStoreGatewayNoSyncedTenants
           annotations:
             message: Mimir store-gateway {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is not syncing any blocks for any tenant.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstoregatewaynosyncedtenants
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirstoregatewaynosyncedtenants
           expr: |
             min by(cluster, namespace, instance) (cortex_bucket_stores_tenants_synced{component="store-gateway"}) == 0
           for: 1h
@@ -1111,7 +1111,7 @@ groups:
         - alert: MimirBucketIndexNotUpdated
           annotations:
             message: Mimir bucket index for tenant {{ $labels.user }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not been updated since {{ $value | humanizeDuration }}.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirbucketindexnotupdated
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirbucketindexnotupdated
           expr: |
             min by(cluster, namespace, user) (time() - (max_over_time(cortex_bucket_index_last_successful_update_timestamp_seconds[15m]))) > 2100
           for: 2m
@@ -1120,7 +1120,7 @@ groups:
         - alert: MimirHighVolumeLevel1BlocksQueried
           annotations:
             message: Mimir store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is querying level 1 blocks, indicating the compactor may not be keeping up with compaction.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirhighvolumelevel1blocksqueried
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirhighvolumelevel1blocksqueried
           expr: |
             (
             sum by(cluster, namespace) (rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",out_of_order="false",job=~".*/(store-gateway.*|cortex|mimir)"}[10m]))
@@ -1135,7 +1135,7 @@ groups:
         - alert: MimirCompactorNotCleaningUpBlocks
           annotations:
             message: Mimir Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not successfully cleaned up blocks in the last 6 hours.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactornotcleaningupblocks
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactornotcleaningupblocks
           expr: |
             # The "last successful run" metric is updated even if the compactor owns no tenants,
             # so this alert correctly doesn't fire if compactor has nothing to do.
@@ -1146,7 +1146,7 @@ groups:
         - alert: MimirCompactorNotRunningCompaction
           annotations:
             message: Mimir Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not run compaction in the last 6 hours.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactornotrunningcompaction
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactornotrunningcompaction
           expr: |
             # The "last successful run" metric is updated even if the compactor owns no tenants,
             # so this alert correctly doesn't fire if compactor has nothing to do.
@@ -1160,7 +1160,7 @@ groups:
         - alert: MimirCompactorNotRunningCompaction
           annotations:
             message: Mimir Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not run compaction in the last 24 hours.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactornotrunningcompaction
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactornotrunningcompaction
           expr: |
             # The "last successful run" metric is updated even if the compactor owns no tenants,
             # so this alert correctly doesn't fire if compactor has nothing to do.
@@ -1174,7 +1174,7 @@ groups:
         - alert: MimirCompactorNotRunningCompaction
           annotations:
             message: Mimir Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not run compaction since startup.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactornotrunningcompaction
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactornotrunningcompaction
           expr: |
             # The "last successful run" metric is updated even if the compactor owns no tenants,
             # so this alert correctly doesn't fire if compactor has nothing to do.
@@ -1186,7 +1186,7 @@ groups:
         - alert: MimirCompactorNotRunningCompaction
           annotations:
             message: Mimir Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not run compaction since startup.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactornotrunningcompaction
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactornotrunningcompaction
           expr: |
             # The "last successful run" metric is updated even if the compactor owns no tenants,
             # so this alert correctly doesn't fire if compactor has nothing to do.
@@ -1198,7 +1198,7 @@ groups:
         - alert: MimirCompactorNotRunningCompaction
           annotations:
             message: Mimir Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} failed to run 2 consecutive compactions.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactornotrunningcompaction
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactornotrunningcompaction
           expr: |
             sum by(cluster, namespace, instance) (increase(cortex_compactor_runs_failed_total{reason!="shutdown"}[2h])) >= 2
           labels:
@@ -1207,7 +1207,7 @@ groups:
         - alert: MimirCompactorHasRunOutOfDiskSpace
           annotations:
             message: Mimir Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has run out of disk space.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasrunoutofdiskspace
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactorhasrunoutofdiskspace
           expr: |
             increase(cortex_compactor_disk_out_of_space_errors_total{}[24h]) >= 1
           labels:
@@ -1216,7 +1216,7 @@ groups:
         - alert: MimirCompactorHasNotUploadedBlocks
           annotations:
             message: Mimir Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not uploaded any block in the last 24 hours.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasnotuploadedblocks
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactorhasnotuploadedblocks
           expr: |
             (time() - (max by(cluster, namespace, instance) (thanos_objstore_bucket_last_successful_upload_time{component="compactor"})) > 60 * 60 * 24)
             and
@@ -1231,7 +1231,7 @@ groups:
         - alert: MimirCompactorHasNotUploadedBlocks
           annotations:
             message: Mimir Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not uploaded any block since its start.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasnotuploadedblocks
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactorhasnotuploadedblocks
           expr: |
             (max by(cluster, namespace, instance) (thanos_objstore_bucket_last_successful_upload_time{component="compactor"}) == 0)
             and
@@ -1244,7 +1244,7 @@ groups:
         - alert: MimirCompactorSkippedBlocks
           annotations:
             message: 'Mimir Compactor in {{ $labels.cluster }}/{{ $labels.namespace }} has marked {{ $value }} blocks for no-compaction (reason: {{ $labels.reason }}).'
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorskippedblocks
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactorskippedblocks
           expr: |
             sum by (cluster, namespace, reason) (
               increase(cortex_compactor_blocks_marked_for_no_compaction_total[24h]) > 0
@@ -1255,7 +1255,7 @@ groups:
         - alert: MimirCompactorBuildingSparseIndexFailed
           annotations:
             message: Mimir Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to build sparse index headers
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorbuildingsparseindexfailed
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactorbuildingsparseindexfailed
           expr: |
             (sum by(cluster, namespace, instance) (increase(cortex_compactor_build_sparse_headers_failures_total[5m])) > 0)
           for: 30m
@@ -1264,7 +1264,7 @@ groups:
         - alert: MimirCompactorOOMKilled
           annotations:
             message: Mimir Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has been OOMKilled {{ printf "%.2f" $value }} times in the last 4h.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactoroomkilled
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactoroomkilled
           expr: |
             (
               sum by(cluster, namespace, instance) (
@@ -1282,7 +1282,7 @@ groups:
         - alert: MimirCompactorOOMKilled
           annotations:
             message: Mimir Compactor {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has been OOMKilled {{ printf "%.2f" $value }} times in the last 2h.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactoroomkilled
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactoroomkilled
           expr: |
             (
               sum by(cluster, namespace, instance) (
@@ -1302,7 +1302,7 @@ groups:
         - alert: MimirDistributorGcUsesTooMuchCpu
           annotations:
             message: Mimir distributors in {{ $labels.cluster }}/{{ $labels.namespace }} GC CPU utilization is too high.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirdistributorgcusestoomuchcpu
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirdistributorgcusestoomuchcpu
           expr: |
             (quantile by (cluster, namespace) (0.9, sum by (cluster, namespace, instance) (rate(go_cpu_classes_gc_total_cpu_seconds_total{container="distributor"}[5m]))
               /
@@ -1323,7 +1323,7 @@ groups:
         - alert: MimirAutoscalerNotActive
           annotations:
             message: The Horizontal Pod Autoscaler (HPA) {{ $labels.horizontalpodautoscaler }} in {{ $labels.namespace }} is not active.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirautoscalernotactive
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirautoscalernotactive
           expr: |
             (
                 label_replace((
@@ -1354,7 +1354,7 @@ groups:
         - alert: MimirAutoscalerKedaFailing
           annotations:
             message: The Keda ScaledObject {{ $labels.scaledObject }} in {{ $labels.namespace }} is experiencing errors.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirautoscalerkedafailing
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirautoscalerkedafailing
           expr: |
             (
                 # Find KEDA scalers reporting errors.
@@ -1371,7 +1371,7 @@ groups:
         - alert: MimirIngesterOffsetCommitFailed
           annotations:
             message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to commit the last consumed offset.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesteroffsetcommitfailed
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesteroffsetcommitfailed
           expr: |
             sum by(cluster, namespace, instance) (rate(cortex_ingest_storage_reader_offset_commit_failures_total[5m]))
             /
@@ -1383,7 +1383,7 @@ groups:
         - alert: MimirIngesterKafkaReadFailed
           annotations:
             message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to read records from Kafka.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterkafkareadfailed
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterkafkareadfailed
           expr: |
             sum by(cluster, namespace, instance, node_id) (rate(cortex_ingest_storage_reader_read_errors_total[4m]))
             > 0
@@ -1393,7 +1393,7 @@ groups:
         - alert: MimirIngesterKafkaReadFailed
           annotations:
             message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to read records from Kafka.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterkafkareadfailed
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterkafkareadfailed
           expr: |
             sum by(cluster, namespace, instance, node_id) (rate(cortex_ingest_storage_reader_read_errors_total[4m]))
             > 0
@@ -1403,7 +1403,7 @@ groups:
         - alert: MimirIngesterKafkaFetchErrorsRateTooHigh
           annotations:
             message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is receiving fetch errors when reading records from Kafka.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterkafkafetcherrorsratetoohigh
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterkafkafetcherrorsratetoohigh
           expr: |
             sum by (cluster, namespace, instance) (rate (cortex_ingest_storage_reader_fetch_errors_total[5m]))
             /
@@ -1415,7 +1415,7 @@ groups:
         - alert: MimirStartingIngesterKafkaDelayGrowing
           annotations:
             message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} in "starting" phase is not reducing consumption lag of write requests read from Kafka.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstartingingesterkafkadelaygrowing
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirstartingingesterkafkadelaygrowing
           expr: |
             deriv((
                 sum by (cluster, namespace, instance) (rate(cortex_ingest_storage_reader_receive_delay_seconds_sum{phase="starting"}[4m]))
@@ -1429,7 +1429,7 @@ groups:
         - alert: MimirStartingIngesterKafkaDelayGrowing
           annotations:
             message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} in "starting" phase is not reducing consumption lag of write requests read from Kafka.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstartingingesterkafkadelaygrowing
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirstartingingesterkafkadelaygrowing
           expr: |
             deriv((
                 sum by (cluster, namespace, instance) (histogram_sum(rate(cortex_ingest_storage_reader_receive_delay_seconds{phase="starting"}[4m])))
@@ -1443,7 +1443,7 @@ groups:
         - alert: MimirRunningIngesterReceiveDelayTooHigh
           annotations:
             message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} in "running" phase is too far behind in its consumption of write requests from Kafka.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrunningingesterreceivedelaytoohigh
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrunningingesterreceivedelaytoohigh
           expr: |
             (
               sum by (cluster, namespace, instance) (rate(cortex_ingest_storage_reader_receive_delay_seconds_sum{phase="running"}[4m]))
@@ -1458,7 +1458,7 @@ groups:
         - alert: MimirRunningIngesterReceiveDelayTooHigh
           annotations:
             message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} in "running" phase is too far behind in its consumption of write requests from Kafka.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrunningingesterreceivedelaytoohigh
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrunningingesterreceivedelaytoohigh
           expr: |
             (
               sum by (cluster, namespace, instance) (histogram_sum(rate(cortex_ingest_storage_reader_receive_delay_seconds{phase="running"}[4m])))
@@ -1473,7 +1473,7 @@ groups:
         - alert: MimirRunningIngesterReceiveDelayTooHigh
           annotations:
             message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} in "running" phase is too far behind in its consumption of write requests from Kafka.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrunningingesterreceivedelaytoohigh
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrunningingesterreceivedelaytoohigh
           expr: |
             (
               sum by (cluster, namespace, instance) (rate(cortex_ingest_storage_reader_receive_delay_seconds_sum{phase="running"}[4m]))
@@ -1488,7 +1488,7 @@ groups:
         - alert: MimirRunningIngesterReceiveDelayTooHigh
           annotations:
             message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} in "running" phase is too far behind in its consumption of write requests from Kafka.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrunningingesterreceivedelaytoohigh
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrunningingesterreceivedelaytoohigh
           expr: |
             (
               sum by (cluster, namespace, instance) (histogram_sum(rate(cortex_ingest_storage_reader_receive_delay_seconds{phase="running"}[4m])))
@@ -1503,7 +1503,7 @@ groups:
         - alert: MimirIngesterKafkaProcessingFailed
           annotations:
             message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} fails to consume write requests read from Kafka due to internal errors.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterkafkaprocessingfailed
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterkafkaprocessingfailed
           expr: |
             (
               sum by (cluster, namespace, instance) (
@@ -1523,7 +1523,7 @@ groups:
         - alert: MimirIngesterKafkaProcessingStuck
           annotations:
             message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is stuck processing write requests from Kafka.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterkafkaprocessingstuck
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterkafkaprocessingstuck
           expr: |
             # Alert if the reader is not processing any records, but there buffered records to process in the Kafka client.
             (sum by (cluster, namespace, instance) (
@@ -1540,7 +1540,7 @@ groups:
         - alert: MimirIngesterMissedRecordsFromKafka
           annotations:
             message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} missed processing records from Kafka. There may be data loss.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestermissedrecordsfromkafka
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringestermissedrecordsfromkafka
           expr: |
             # Alert if the ingester missed some records from Kafka.
             increase(cortex_ingest_storage_reader_missed_records_total[10m]) > 0
@@ -1549,7 +1549,7 @@ groups:
         - alert: MimirStrongConsistencyEnforcementFailed
           annotations:
             message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} fails to enforce strong-consistency on read-path.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstrongconsistencyenforcementfailed
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirstrongconsistencyenforcementfailed
           expr: |
             sum by (cluster, namespace, instance) (rate(cortex_ingest_storage_strong_consistency_failures_total[4m])) > 0
           for: 5m
@@ -1558,7 +1558,7 @@ groups:
         - alert: MimirStrongConsistencyOffsetMissing
           annotations:
             message: Mimir ingesters in {{ $labels.cluster }}/{{ $labels.namespace }} are receiving an unexpected high number of strongly consistent requests without an offset specified.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstrongconsistencyoffsetmissing
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirstrongconsistencyoffsetmissing
           expr: |
             sum by (cluster, namespace) (rate(cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", with_offset="false"}[4m]))
             /
@@ -1570,7 +1570,7 @@ groups:
         - alert: MimirKafkaClientProduceBufferHigh
           annotations:
             message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} Kafka client produce buffer utilization is {{ printf "%.2f" $value }}%.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirkafkaclientproducebufferhigh
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirkafkaclientproducebufferhigh
           expr: |
             max by(cluster, namespace, instance) (
                 # New metric.
@@ -1588,7 +1588,7 @@ groups:
         - alert: MimirBlockBuilderSchedulerPendingJobs
           annotations:
             message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} reports {{ printf "%.2f" $value }} pending jobs.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderschedulerpendingjobs
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirblockbuilderschedulerpendingjobs
           expr: |
             sum by (cluster, namespace, instance) (cortex_blockbuilder_scheduler_pending_jobs) > 0
           for: 40m
@@ -1597,7 +1597,7 @@ groups:
         - alert: MimirBlockBuilderCompactAndUploadFailed
           annotations:
             message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} fails to compact and upload blocks.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuildercompactanduploadfailed
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirblockbuildercompactanduploadfailed
           expr: |
             sum by (cluster, namespace, instance) (rate(cortex_blockbuilder_tsdb_compact_and_upload_failed_total[4m])) > 0
           labels:
@@ -1605,7 +1605,7 @@ groups:
         - alert: MimirBlockBuilderHasNotShippedBlocks
           annotations:
             message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not shipped any block in the last 4 hours.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderhasnotshippedblocks
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirblockbuilderhasnotshippedblocks
           expr: |
             (min by(cluster, namespace, instance) (time() - cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 60 * 60 * 4)
             and
@@ -1619,7 +1619,7 @@ groups:
         - alert: MimirBlockBuilderSchedulerNotRunning
           annotations:
             message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} is not running.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderschedulernotrunning
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirblockbuilderschedulernotrunning
           expr: |
             max by (cluster, namespace, instance) (histogram_count(increase(cortex_blockbuilder_scheduler_schedule_update_seconds[5m])) == 0)
           for: 30m
@@ -1628,7 +1628,7 @@ groups:
         - alert: MimirBlockBuilderDataSkipped
           annotations:
             message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has detected skipped data.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderdataskipped
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirblockbuilderdataskipped
           expr: |
             sum by (cluster, namespace, instance) (
               increase(cortex_blockbuilder_scheduler_job_gap_detected[1h])
@@ -1638,7 +1638,7 @@ groups:
         - alert: MimirBlockBuilderPersistentJobFailure
           annotations:
             message: Mimir {{ $labels.instance }} in {{ $labels.cluster }}/{{ $labels.namespace }} has detected a persistently failing job.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderpersistentjobfailure
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirblockbuilderpersistentjobfailure
           expr: |
             increase(cortex_blockbuilder_scheduler_persistent_job_failures_total[20m]) > 0
           labels:
@@ -1646,7 +1646,7 @@ groups:
         - alert: MimirFewerIngestersConsumingThanActivePartitions
           annotations:
             message: Mimir ingesters in {{ $labels.cluster }}/{{ $labels.namespace }} have fewer ingesters consuming than active partitions.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirfeweringestersconsumingthanactivepartitions
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirfeweringestersconsumingthanactivepartitions
           expr: |
             max(cortex_partition_ring_partitions{name="ingester-partitions", state="Active"}) by (cluster, namespace) > count(count(cortex_ingest_storage_reader_last_consumed_offset{}) by (cluster, namespace, partition)) by (cluster, namespace)
           for: 15m
@@ -1657,7 +1657,7 @@ groups:
         - alert: MimirContinuousTestNotRunningOnWrites
           annotations:
             message: Mimir continuous test {{ $labels.test }} in {{ $labels.cluster }}/{{ $labels.namespace }} is not effectively running because writes are failing.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircontinuoustestnotrunningonwrites
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircontinuoustestnotrunningonwrites
           expr: |
             sum by(cluster, namespace, test) (rate(mimir_continuous_test_writes_failed_total[5m])) > 0
           for: 1h
@@ -1666,7 +1666,7 @@ groups:
         - alert: MimirContinuousTestNotRunningOnReads
           annotations:
             message: Mimir continuous test {{ $labels.test }} in {{ $labels.cluster }}/{{ $labels.namespace }} is not effectively running because queries are failing.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircontinuoustestnotrunningonreads
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircontinuoustestnotrunningonreads
           expr: |
             sum by(cluster, namespace, test) (rate(mimir_continuous_test_queries_failed_total[5m])) > 0
           for: 1h
@@ -1675,7 +1675,7 @@ groups:
         - alert: MimirContinuousTestFailed
           annotations:
             message: Mimir continuous test {{ $labels.test }} in {{ $labels.cluster }}/{{ $labels.namespace }} failed when asserting query results.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircontinuoustestfailed
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircontinuoustestfailed
           expr: |
             sum by(cluster, namespace, test) (rate(mimir_continuous_test_query_result_checks_failed_total[10m])) > 0
           labels:

--- a/operations/mimir-mixin-compiled/alerts.yaml
+++ b/operations/mimir-mixin-compiled/alerts.yaml
@@ -4,7 +4,7 @@ groups:
         - alert: MimirIngesterUnhealthy
           annotations:
             message: Mimir cluster {{ $labels.cluster }}/{{ $labels.namespace }} has {{ printf "%f" $value }} unhealthy ingester(s).
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterunhealthy
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterunhealthy
           expr: |
             min by (cluster, namespace) (cortex_ring_members{state="Unhealthy", name="ingester"}) > 0
           for: 15m
@@ -14,7 +14,7 @@ groups:
           annotations:
             message: |
                 The route {{ $labels.route }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% errors.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrequesterrors
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrequesterrors
           expr: |
             # The following 5xx errors considered as non-error:
             # - 529: used by distributor rate limiting (using 529 instead of 429 to let the client retry)
@@ -32,7 +32,7 @@ groups:
           annotations:
             message: |
                 The route {{ $labels.route }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% errors.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrequesterrors
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrequesterrors
           expr: |
             # The following 5xx errors considered as non-error:
             # - 529: used by distributor rate limiting (using 529 instead of 429 to let the client retry)
@@ -50,7 +50,7 @@ groups:
           annotations:
             message: |
                 {{ $labels.job }} {{ $labels.route }} is experiencing {{ printf "%.2f" $value }}s 99th percentile latency.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrequestlatency
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrequestlatency
           expr: |
             cluster_namespace_job_route:cortex_request_duration_seconds:99quantile{route!~"metrics|/frontend.Frontend/Process|ready|/schedulerpb.SchedulerForFrontend/FrontendLoop|/schedulerpb.SchedulerForQuerier/QuerierLoop|debug_pprof"}
               >
@@ -63,7 +63,7 @@ groups:
           annotations:
             message: |
                 {{ $labels.job }} {{ $labels.route }} is experiencing {{ printf "%.2f" $value }}s 99th percentile latency.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrequestlatency
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrequestlatency
           expr: |
             histogram_quantile(0.99, cluster_namespace_job_route:cortex_request_duration_seconds:sum_rate{route!~"metrics|/frontend.Frontend/Process|ready|/schedulerpb.SchedulerForFrontend/FrontendLoop|/schedulerpb.SchedulerForQuerier/QuerierLoop|debug_pprof"})
               >
@@ -76,7 +76,7 @@ groups:
           annotations:
             message: |
                 An inconsistent runtime config file is used across cluster {{ $labels.cluster }}/{{ $labels.namespace }}.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirinconsistentruntimeconfig
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirinconsistentruntimeconfig
           expr: |
             count without(sha256) (
                 count by (cluster, namespace, job, sha256) (cortex_runtime_config_hash)
@@ -98,7 +98,7 @@ groups:
           annotations:
             message: |
                 {{ $labels.job }} failed to reload runtime config.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirbadruntimeconfig
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirbadruntimeconfig
           expr: |
             # The metric value is reset to 0 on error while reloading the config at runtime.
             cortex_runtime_config_last_reload_successful == 0
@@ -109,7 +109,7 @@ groups:
           annotations:
             message: |
                 There are {{ $value }} queued up queries in {{ $labels.cluster }}/{{ $labels.namespace }} {{ $labels.job }}.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirschedulerqueriesstuck
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirschedulerqueriesstuck
           expr: |
             # There are some queries in the queue.
             (sum by (cluster, namespace, job) (cortex_query_scheduler_queue_length) > 0)
@@ -135,7 +135,7 @@ groups:
           annotations:
             message: |
                 The cache {{ $labels.name }} used by Mimir {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% errors for {{ $labels.operation }} operation.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircacherequesterrors
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircacherequesterrors
           expr: |
             (
               sum by(cluster, namespace, name, operation) (
@@ -152,7 +152,7 @@ groups:
         - alert: MimirIngesterRestarts
           annotations:
             message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has restarted {{ printf "%.2f" $value }} times in the last 30 mins.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterrestarts
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterrestarts
           expr: |
             (
               sum by(cluster, namespace, pod) (
@@ -170,7 +170,7 @@ groups:
           annotations:
             message: |
                 Mimir {{ $labels.pod }} in  {{ $labels.cluster }}/{{ $labels.namespace }} is failing to talk to the KV store {{ $labels.kv_name }}.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirkvstorefailure
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirkvstorefailure
           expr: |
             (
               sum by (cluster, namespace, pod, status_code, kv_name) (rate(cortex_kv_request_duration_seconds_count{status_code!~"2.+"}[4m]))
@@ -187,7 +187,7 @@ groups:
           annotations:
             message: |
                 Mimir {{ $labels.pod }} in  {{ $labels.cluster }}/{{ $labels.namespace }} is failing to talk to the KV store {{ $labels.kv_name }}.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirkvstorefailure
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirkvstorefailure
           expr: |
             (
               sum by (cluster, namespace, pod, status_code, kv_name) (histogram_count(rate(cortex_kv_request_duration_seconds{status_code!~"2.+"}[4m])))
@@ -203,7 +203,7 @@ groups:
         - alert: MimirMemoryMapAreasTooHigh
           annotations:
             message: '{{ $labels.job }}/{{ $labels.pod }} has a number of mmap-ed areas close to the limit.'
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirmemorymapareastoohigh
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirmemorymapareastoohigh
           expr: |
             process_memory_map_areas{job=~".*/(ingester.*|cortex|mimir|store-gateway.*|cortex|mimir)"} / process_memory_map_areas_limit{job=~".*/(ingester.*|cortex|mimir|store-gateway.*|cortex|mimir)"} > 0.8
           for: 5m
@@ -212,7 +212,7 @@ groups:
         - alert: MimirIngesterInstanceHasNoTenants
           annotations:
             message: Mimir ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has no tenants assigned.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterinstancehasnotenants
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterinstancehasnotenants
           expr: |
             (
               (min by(cluster, namespace, pod) (cortex_ingester_memory_users) == 0)
@@ -245,7 +245,7 @@ groups:
         - alert: MimirRulerInstanceHasNoRuleGroups
           annotations:
             message: Mimir ruler {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has no rule groups assigned.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulerinstancehasnorulegroups
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrulerinstancehasnorulegroups
           expr: |
             # Alert on ruler instances in microservices mode that have no rule groups assigned,
             min by(cluster, namespace, pod) (cortex_ruler_managers_total{pod=~"(.*mimir-)?ruler.*"}) == 0
@@ -261,7 +261,7 @@ groups:
         - alert: MimirIngestedDataTooFarInTheFuture
           annotations:
             message: Mimir ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has ingested samples with timestamps more than 1h in the future.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesteddatatoofarinthefuture
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesteddatatoofarinthefuture
           expr: |
             max by(cluster, namespace, pod) (
                 cortex_ingester_tsdb_head_max_timestamp_seconds - time()
@@ -274,7 +274,7 @@ groups:
         - alert: MimirStoreGatewayTooManyFailedOperations
           annotations:
             message: Mimir store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ $value | humanizePercentage }} errors while doing {{ $labels.operation }} on the object storage.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstoregatewaytoomanyfailedoperations
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirstoregatewaytoomanyfailedoperations
           expr: |
             (
                 sum by(cluster, namespace, operation) (rate(thanos_objstore_bucket_operation_failures_total{component="store-gateway"}[4m]))
@@ -287,7 +287,7 @@ groups:
         - alert: MimirServerInvalidClusterLabelRequests
           annotations:
             message: Mimir servers in {{ $labels.cluster }}/{{ $labels.namespace }} are receiving requests with invalid cluster validation labels.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirserverinvalidclusterlabelrequests
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirserverinvalidclusterlabelrequests
           expr: |
             (sum by (cluster, namespace, protocol) (rate(cortex_server_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
             # Alert only for namespaces with Mimir clusters.
@@ -297,7 +297,7 @@ groups:
         - alert: MimirClientInvalidClusterLabelRequests
           annotations:
             message: Mimir clients in {{ $labels.cluster }}/{{ $labels.namespace }} are having requests rejected due to invalid cluster validation labels.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirclientinvalidclusterlabelrequests
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirclientinvalidclusterlabelrequests
           expr: |
             (sum by (cluster, namespace, protocol) (rate(cortex_client_invalid_cluster_validation_label_requests_total{}[5m]))) > 0
             # Alert only for namespaces with Mimir clusters.
@@ -308,7 +308,7 @@ groups:
           annotations:
             message: |
                 Number of members in Mimir ingester hash ring does not match the expected number in {{ $labels.cluster }}/{{ $labels.namespace }}.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirringmembersmismatch
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirringmembersmismatch
           expr: |
             (
               (
@@ -334,7 +334,7 @@ groups:
           annotations:
             message: |
                 Container {{ $labels.container }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing high GRPC concurrent streams per connection.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirhighgrpcstreamsperconnection
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirhighgrpcstreamsperconnection
           expr: |
             max(avg_over_time(grpc_concurrent_streams_by_conn_max[10m])) by (cluster, namespace, container)
             /
@@ -345,7 +345,7 @@ groups:
           annotations:
             message: |
                 Queriers in the same %(product)s cluster and query path are reporting different maximum supported query plan versions.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirmixedquerierqueryplanversionsupport
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirmixedquerierqueryplanversionsupport
           expr: |
             min by (cluster, namespace, container) (cortex_querier_maximum_supported_query_plan_version)
             !=
@@ -357,7 +357,7 @@ groups:
           annotations:
             message: |
                 Query-frontends in the same Mimir cluster and query path have calculated different maximum supported query plan versions.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirmixedqueryfrontendqueryplanversionsupport
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirmixedqueryfrontendqueryplanversionsupport
           expr: |
             min by (cluster, namespace, container) (cortex_query_frontend_querier_ring_calculated_maximum_supported_query_plan_version)
             !=
@@ -369,7 +369,7 @@ groups:
           annotations:
             message: |
                 Query-frontends and queriers are reporting different maximum supported query plan versions.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirqueryfrontendsandqueriersdisagreeonsupportedqueryplanversion
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirqueryfrontendsandqueriersdisagreeonsupportedqueryplanversion
           expr: |
             # The label_replace calls below are so that we can match queriers with container labels like "ruler-querier" to
             # query-frontends with container labels like "ruler-query-frontend".
@@ -398,7 +398,7 @@ groups:
           annotations:
             message: |
                 Query-frontends are failing to compute a maximum supported query plan version.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirqueryfrontendnotcomputingsupportedqueryplanversion
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirqueryfrontendnotcomputingsupportedqueryplanversion
           expr: |
             count by (cluster, namespace, container) (cortex_query_frontend_querier_ring_calculated_maximum_supported_query_plan_version == -1) > 0
           for: 5m
@@ -410,7 +410,7 @@ groups:
           annotations:
             message: |
                 Ingester {{ $labels.job }}/{{ $labels.pod }} has reached {{ $value | humanizePercentage }} of its series limit.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterreachingserieslimit
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterreachingserieslimit
           expr: |
             (
                 (cortex_ingester_memory_series / ignoring(limit) cortex_ingester_instance_limits{limit="max_series"})
@@ -424,7 +424,7 @@ groups:
           annotations:
             message: |
                 Ingester {{ $labels.job }}/{{ $labels.pod }} has reached {{ $value | humanizePercentage }} of its series limit.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterreachingserieslimit
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterreachingserieslimit
           expr: |
             (
                 (cortex_ingester_memory_series / ignoring(limit) cortex_ingester_instance_limits{limit="max_series"})
@@ -438,7 +438,7 @@ groups:
           annotations:
             message: |
                 Ingester {{ $labels.job }}/{{ $labels.pod }} has reached {{ $value | humanizePercentage }} of its tenant limit.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterreachingtenantslimit
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterreachingtenantslimit
           expr: |
             (
                 (cortex_ingester_memory_users / ignoring(limit) cortex_ingester_instance_limits{limit="max_tenants"})
@@ -452,7 +452,7 @@ groups:
           annotations:
             message: |
                 Ingester {{ $labels.job }}/{{ $labels.pod }} has reached {{ $value | humanizePercentage }} of its tenant limit.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterreachingtenantslimit
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterreachingtenantslimit
           expr: |
             (
                 (cortex_ingester_memory_users / ignoring(limit) cortex_ingester_instance_limits{limit="max_tenants"})
@@ -466,7 +466,7 @@ groups:
           annotations:
             message: |
                 Mimir instance {{ $labels.job }}/{{ $labels.pod }} has reached {{ $value | humanizePercentage }} of its TCP connections limit for {{ $labels.protocol }} protocol.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirreachingtcpconnectionslimit
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirreachingtcpconnectionslimit
           expr: |
             cortex_tcp_connections / cortex_tcp_connections_limit > 0.8 and
             cortex_tcp_connections_limit > 0
@@ -477,7 +477,7 @@ groups:
           annotations:
             message: |
                 Distributor {{ $labels.job }}/{{ $labels.pod }} has reached {{ $value | humanizePercentage }} of its inflight push request limit.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirdistributorinflightrequestshigh
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirdistributorinflightrequestshigh
           expr: |
             (
                 (cortex_distributor_inflight_push_requests / ignoring(limit) cortex_distributor_instance_limits{limit="max_inflight_push_requests"})
@@ -493,7 +493,7 @@ groups:
           annotations:
             message: |
                 The {{ $labels.rollout_group }} rollout is stuck in {{ $labels.cluster }}/{{ $labels.namespace }}.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrolloutstuck
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrolloutstuck
           expr: |
             (
               # Query for rollout groups in certain namespaces that are being updated, dropping the revision label.
@@ -525,7 +525,7 @@ groups:
           annotations:
             message: |
                 The {{ $labels.rollout_group }} rollout is stuck in {{ $labels.cluster }}/{{ $labels.namespace }}.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrolloutstuck
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrolloutstuck
           expr: |
             (
               # Query for rollout groups in certain namespaces that are being updated, dropping the revision label.
@@ -557,7 +557,7 @@ groups:
           annotations:
             message: |
                 The {{ $labels.rollout_group }} rollout is stuck in {{ $labels.cluster }}/{{ $labels.namespace }}.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrolloutstuck
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrolloutstuck
           expr: |
             (
               sum without(deployment) (label_replace(kube_deployment_spec_replicas, "rollout_group", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"))
@@ -577,7 +577,7 @@ groups:
           annotations:
             message: |
                 The {{ $labels.rollout_group }} rollout is stuck in {{ $labels.cluster }}/{{ $labels.namespace }}.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrolloutstuck
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrolloutstuck
           expr: |
             (
               sum without(deployment) (label_replace(kube_deployment_spec_replicas, "rollout_group", "$1", "deployment", "(.*?)(?:-zone-[a-z])?"))
@@ -597,7 +597,7 @@ groups:
           annotations:
             message: |
                 Rollout operator is not reconciling the rollout group {{ $labels.rollout_group }} in {{ $labels.cluster }}/{{ $labels.namespace }}.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#rolloutoperatornotreconciling
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#rolloutoperatornotreconciling
           expr: |
             max by(cluster, namespace, rollout_group) (time() - rollout_operator_last_successful_group_reconcile_timestamp_seconds) > 600
           for: 5m
@@ -609,7 +609,7 @@ groups:
           annotations:
             message: |
                 Instance {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is using too much memory.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirallocatingtoomuchmemory
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirallocatingtoomuchmemory
           expr: |
             (
               # We use RSS instead of working set memory because of the ingester's extensive usage of mmap.
@@ -628,7 +628,7 @@ groups:
           annotations:
             message: |
                 Instance {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is using too much memory.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirallocatingtoomuchmemory
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirallocatingtoomuchmemory
           expr: |
             (
               # We use RSS instead of working set memory because of the ingester's extensive usage of mmap.
@@ -649,7 +649,7 @@ groups:
           annotations:
             message: |
                 Mimir Ruler {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% write (push) errors.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulertoomanyfailedpushes
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrulertoomanyfailedpushes
           expr: |
             100 * (
             # Here it matches on empty "reason" for backwards compatibility, with when the metric didn't have this label.
@@ -664,7 +664,7 @@ groups:
           annotations:
             message: |
                 Mimir Ruler {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% errors while evaluating rules.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulertoomanyfailedqueries
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrulertoomanyfailedqueries
           expr: |
             100 * (
             # Here it matches on empty "reason" for backwards compatibility, with when the metric didn't have this label.
@@ -679,7 +679,7 @@ groups:
           annotations:
             message: |
                 Mimir Rulers in {{ $labels.cluster }}/{{ $labels.namespace }} are experiencing {{ printf "%.2f" $value }}% missed iterations.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulersmissedevaluations
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrulersmissedevaluations
           expr: |
             100 * (
             sum by (cluster, namespace) (rate(cortex_prometheus_rule_group_iterations_missed_total[4m]))
@@ -693,7 +693,7 @@ groups:
           annotations:
             message: |
                 Mimir Ruler {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is experiencing {{ printf "%.2f" $value }}% missed iterations.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulermissedevaluations
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrulermissedevaluations
           expr: |
             100 * (
             sum by (cluster, namespace, pod) (rate(cortex_prometheus_rule_group_iterations_missed_total[4m]))
@@ -707,7 +707,7 @@ groups:
           annotations:
             message: |
                 Mimir Rulers in {{ $labels.cluster }}/{{ $labels.namespace }} are experiencing errors when checking the ring for rule group ownership.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulerfailedringcheck
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrulerfailedringcheck
           expr: |
             sum by (cluster, namespace, job) (rate(cortex_ruler_ring_check_errors_total[4m]))
                > 0
@@ -718,7 +718,7 @@ groups:
           annotations:
             message: |
                 Mimir rulers in {{ $labels.cluster }}/{{ $labels.namespace }} are failing to perform {{ printf "%.2f" $value }}% of remote evaluations through the ruler-query-frontend.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulerremoteevaluationfailing
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrulerremoteevaluationfailing
           expr: |
             (
               sum by (cluster, namespace) (rate(cortex_request_duration_seconds_count{status_code=~"5..", route="/httpgrpc.HTTP/Handle", job=~".*/(ruler-query-frontend.*)"}[5m]))
@@ -733,7 +733,7 @@ groups:
           annotations:
             message: |
                 Mimir rulers in {{ $labels.cluster }}/{{ $labels.namespace }} are failing to perform {{ printf "%.2f" $value }}% of remote evaluations through the ruler-query-frontend.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrulerremoteevaluationfailing
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrulerremoteevaluationfailing
           expr: |
             (
               sum by (cluster, namespace) (histogram_count(rate(cortex_request_duration_seconds{status_code=~"5..", route="/httpgrpc.HTTP/Handle", job=~".*/(ruler-query-frontend.*)"}[5m])))
@@ -749,7 +749,7 @@ groups:
         - alert: MimirGossipMembersTooHigh
           annotations:
             message: One or more Mimir instances in {{ $labels.cluster }}/{{ $labels.namespace }} consistently sees a higher than expected number of gossip members.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgossipmemberstoohigh
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirgossipmemberstoohigh
           expr: |
             max by (cluster, namespace) (memberlist_client_cluster_members_count)
             >
@@ -760,7 +760,7 @@ groups:
         - alert: MimirGossipMembersTooLow
           annotations:
             message: One or more Mimir instances in {{ $labels.cluster }}/{{ $labels.namespace }} consistently sees a lower than expected number of gossip members.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgossipmemberstoolow
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirgossipmemberstoolow
           expr: |
             min by (cluster, namespace) (memberlist_client_cluster_members_count)
             <
@@ -771,7 +771,7 @@ groups:
         - alert: MimirGossipMembersEndpointsOutOfSync
           annotations:
             message: Mimir gossip-ring service endpoints list in {{ $labels.cluster }}/{{ $labels.namespace }} is out of sync.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgossipmembersendpointsoutofsync
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirgossipmembersendpointsoutofsync
           expr: |
             (
               count by(cluster, namespace) (
@@ -793,7 +793,7 @@ groups:
         - alert: MimirGossipMembersEndpointsOutOfSync
           annotations:
             message: Mimir gossip-ring service endpoints list in {{ $labels.cluster }}/{{ $labels.namespace }} is out of sync.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgossipmembersendpointsoutofsync
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirgossipmembersendpointsoutofsync
           expr: |
             (
               count by(cluster, namespace) (
@@ -815,7 +815,7 @@ groups:
         - alert: MimirMemberlistBridgeZoneUnavailable
           annotations:
             message: Mimir memberlist-bridge in {{ $labels.cluster }}/{{ $labels.namespace }} {{ $labels.zone }} has no available pods.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirmemberlistbridgezoneunavailable
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirmemberlistbridgezoneunavailable
           expr: |
             # Find the expected memberlist-bridge zonal deployments.
             count by (cluster, namespace, zone) (
@@ -839,7 +839,7 @@ groups:
         - alert: MimirMemberlistZoneAwareRoutingAutoFailover
           annotations:
             message: Mimir memberlist in {{ $labels.cluster }}/{{ $labels.namespace }} has automatically temporarily disabled zone-aware routing because it detected missing memberlist bridges.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirmemberlistzoneawareroutingautofailover
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirmemberlistzoneawareroutingautofailover
           expr: |
             sum by (cluster, namespace) (rate(memberlist_client_zone_aware_routing_select_nodes_skipped_total[4m])) > 0
           for: 10m
@@ -851,7 +851,7 @@ groups:
           annotations:
             message: |
                 Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is running a very high number of Go threads.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgothreadstoohigh
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirgothreadstoohigh
           expr: |
             # We filter by the namespace because go_threads can be very high cardinality in a large organization.
             max by(cluster, namespace, pod) (go_threads{job=~".*(cortex|mimir).*"} > 5000)
@@ -865,7 +865,7 @@ groups:
           annotations:
             message: |
                 Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is running a very high number of Go threads.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirgothreadstoohigh
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirgothreadstoohigh
           expr: |
             # We filter by the namespace because go_threads can be very high cardinality in a large organization.
             max by(cluster, namespace, pod) (go_threads{job=~".*(cortex|mimir).*"} > 8000)
@@ -881,7 +881,7 @@ groups:
           annotations:
             message: |
                 Mimir Alertmanager {{ $labels.job }}/{{ $labels.pod }} is failing to read tenant configurations from storage.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagersyncconfigsfailing
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiralertmanagersyncconfigsfailing
           expr: |
             rate(cortex_alertmanager_sync_configs_failed_total[5m]) > 0
           for: 30m
@@ -891,7 +891,7 @@ groups:
           annotations:
             message: |
                 Mimir Alertmanager {{ $labels.job }}/{{ $labels.pod }} is unable to check tenants ownership via the ring.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagerringcheckfailing
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiralertmanagerringcheckfailing
           expr: |
             rate(cortex_alertmanager_ring_check_errors_total[4m]) > 0
           for: 10m
@@ -901,7 +901,7 @@ groups:
           annotations:
             message: |
                 Mimir Alertmanager {{ $labels.job }}/{{ $labels.pod }} is failing to merge partial state changes received from a replica.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagerstatemergefailing
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiralertmanagerstatemergefailing
           expr: |
             rate(cortex_alertmanager_partial_state_merges_failed_total[4m]) > 0
           for: 10m
@@ -911,7 +911,7 @@ groups:
           annotations:
             message: |
                 Mimir Alertmanager {{ $labels.job }}/{{ $labels.pod }} is failing to replicating partial state to its replicas.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagerreplicationfailing
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiralertmanagerreplicationfailing
           expr: |
             rate(cortex_alertmanager_state_replication_failed_total[4m]) > 0
           for: 10m
@@ -921,7 +921,7 @@ groups:
           annotations:
             message: |
                 Mimir Alertmanager {{ $labels.job }}/{{ $labels.pod }} is unable to persist full state snaphots to remote storage.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagerpersiststatefailing
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiralertmanagerpersiststatefailing
           expr: |
             rate(cortex_alertmanager_state_persist_failed_total[15m]) > 0
           for: 1h
@@ -931,7 +931,7 @@ groups:
           annotations:
             message: |
                 Mimir Alertmanager {{ $labels.job }}/{{ $labels.pod }} was unable to obtain some initial state when starting up.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagerinitialsyncfailed
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiralertmanagerinitialsyncfailed
           expr: |
             increase(cortex_alertmanager_state_initial_sync_completed_total{outcome="failed"}[4m]) > 0
           labels:
@@ -940,7 +940,7 @@ groups:
           annotations:
             message: |
                 Alertmanager {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is using too much memory.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagerallocatingtoomuchmemory
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiralertmanagerallocatingtoomuchmemory
           expr: |
             (container_memory_working_set_bytes{container="alertmanager"} / container_spec_memory_limit_bytes{container="alertmanager"}) > 0.80
             and
@@ -952,7 +952,7 @@ groups:
           annotations:
             message: |
                 Alertmanager {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is using too much memory.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagerallocatingtoomuchmemory
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiralertmanagerallocatingtoomuchmemory
           expr: |
             (container_memory_working_set_bytes{container="alertmanager"} / container_spec_memory_limit_bytes{container="alertmanager"}) > 0.90
             and
@@ -963,7 +963,7 @@ groups:
         - alert: MimirAlertmanagerInstanceHasNoTenants
           annotations:
             message: Mimir alertmanager {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} owns no tenants.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiralertmanagerinstancehasnotenants
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiralertmanagerinstancehasnotenants
           expr: |
             # Alert on alertmanager instances in microservices mode that own no tenants,
             min by(cluster, namespace, pod) (cortex_alertmanager_tenants_owned{pod=~"(.*mimir-)?alertmanager.*"}) == 0
@@ -978,7 +978,7 @@ groups:
         - alert: MimirIngesterNotShippingBlocks
           annotations:
             message: Mimir Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not shipped any block in the last 4 hours.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesternotshippingblocks
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesternotshippingblocks
           expr: |
             (min by(cluster, namespace, pod) (time() - cortex_ingester_shipper_last_successful_upload_timestamp_seconds) > 60 * 60 * 4)
             and
@@ -1001,7 +1001,7 @@ groups:
         - alert: MimirIngesterNotShippingBlocksSinceStart
           annotations:
             message: Mimir Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not shipped any block in the last 4 hours.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesternotshippingblockssincestart
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesternotshippingblockssincestart
           expr: |
             (max by(cluster, namespace, pod) (cortex_ingester_shipper_last_successful_upload_timestamp_seconds) == 0)
             and
@@ -1015,7 +1015,7 @@ groups:
         - alert: MimirIngesterHasUnshippedBlocks
           annotations:
             message: Mimir Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has compacted a block {{ $value | humanizeDuration }} ago but it hasn't been successfully uploaded to the storage yet.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterhasunshippedblocks
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterhasunshippedblocks
           expr: |
             (time() - cortex_ingester_oldest_unshipped_block_timestamp_seconds > 3600)
             and
@@ -1029,7 +1029,7 @@ groups:
         - alert: MimirIngesterTSDBHeadCompactionFailed
           annotations:
             message: Mimir Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to compact TSDB head.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbheadcompactionfailed
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringestertsdbheadcompactionfailed
           expr: |
             rate(cortex_ingester_tsdb_compactions_failed_total[5m]) > 0
           for: 15m
@@ -1038,7 +1038,7 @@ groups:
         - alert: MimirIngesterTSDBHeadTruncationFailed
           annotations:
             message: Mimir Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to truncate TSDB head.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbheadtruncationfailed
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringestertsdbheadtruncationfailed
           expr: |
             rate(cortex_ingester_tsdb_head_truncations_failed_total[5m]) > 0
           labels:
@@ -1046,7 +1046,7 @@ groups:
         - alert: MimirIngesterTSDBCheckpointCreateFailed
           annotations:
             message: Mimir Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to create TSDB checkpoint.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbcheckpointcreatefailed
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringestertsdbcheckpointcreatefailed
           expr: |
             rate(cortex_ingester_tsdb_checkpoint_creations_failed_total[5m]) > 0
           labels:
@@ -1054,7 +1054,7 @@ groups:
         - alert: MimirIngesterTSDBCheckpointDeleteFailed
           annotations:
             message: Mimir Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to delete TSDB checkpoint.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbcheckpointdeletefailed
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringestertsdbcheckpointdeletefailed
           expr: |
             rate(cortex_ingester_tsdb_checkpoint_deletions_failed_total[5m]) > 0
           labels:
@@ -1062,7 +1062,7 @@ groups:
         - alert: MimirIngesterTSDBWALTruncationFailed
           annotations:
             message: Mimir Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to truncate TSDB WAL.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwaltruncationfailed
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringestertsdbwaltruncationfailed
           expr: |
             rate(cortex_ingester_tsdb_wal_truncations_failed_total[5m]) > 0
           labels:
@@ -1070,7 +1070,7 @@ groups:
         - alert: MimirIngesterTSDBWALCorrupted
           annotations:
             message: Mimir Ingester in {{ $labels.cluster }}/{{ $labels.namespace }} got a corrupted TSDB WAL.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwalcorrupted
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringestertsdbwalcorrupted
           expr: |
             # alert when there are more than one corruptions
             count by (cluster, namespace) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0) > 1
@@ -1083,7 +1083,7 @@ groups:
         - alert: MimirIngesterTSDBWALCorrupted
           annotations:
             message: Mimir Ingester in {{ $labels.cluster }}/{{ $labels.namespace }} got a corrupted TSDB WAL.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwalcorrupted
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringestertsdbwalcorrupted
           expr: |
             # alert when there are more than one corruptions
             count by (cluster, namespace) (sum by (cluster, namespace, job) (rate(cortex_ingester_tsdb_wal_corruptions_total[5m]) > 0)) > 1
@@ -1096,7 +1096,7 @@ groups:
         - alert: MimirIngesterTSDBWALWritesFailed
           annotations:
             message: Mimir Ingester {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to write to TSDB WAL.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestertsdbwalwritesfailed
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringestertsdbwalwritesfailed
           expr: |
             rate(cortex_ingester_tsdb_wal_writes_failed_total[4m]) > 0
           for: 12m
@@ -1105,7 +1105,7 @@ groups:
         - alert: MimirStoreGatewayHasNotSyncTheBucket
           annotations:
             message: Mimir store-gateway {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not successfully synched the bucket since {{ $value | humanizeDuration }}.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstoregatewayhasnotsyncthebucket
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirstoregatewayhasnotsyncthebucket
           expr: |
             (time() - cortex_bucket_stores_blocks_last_successful_sync_timestamp_seconds{component="store-gateway"} > 60 * 30)
             and
@@ -1116,7 +1116,7 @@ groups:
         - alert: MimirStoreGatewayNoSyncedTenants
           annotations:
             message: Mimir store-gateway {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is not syncing any blocks for any tenant.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstoregatewaynosyncedtenants
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirstoregatewaynosyncedtenants
           expr: |
             min by(cluster, namespace, pod) (cortex_bucket_stores_tenants_synced{component="store-gateway"}) == 0
           for: 1h
@@ -1125,7 +1125,7 @@ groups:
         - alert: MimirBucketIndexNotUpdated
           annotations:
             message: Mimir bucket index for tenant {{ $labels.user }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not been updated since {{ $value | humanizeDuration }}.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirbucketindexnotupdated
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirbucketindexnotupdated
           expr: |
             min by(cluster, namespace, user) (time() - (max_over_time(cortex_bucket_index_last_successful_update_timestamp_seconds[15m]))) > 2100
           for: 2m
@@ -1134,7 +1134,7 @@ groups:
         - alert: MimirHighVolumeLevel1BlocksQueried
           annotations:
             message: Mimir store-gateway in {{ $labels.cluster }}/{{ $labels.namespace }} is querying level 1 blocks, indicating the compactor may not be keeping up with compaction.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirhighvolumelevel1blocksqueried
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirhighvolumelevel1blocksqueried
           expr: |
             (
             sum by(cluster, namespace) (rate(cortex_bucket_store_series_blocks_queried_sum{component="store-gateway",level="1",out_of_order="false",job=~".*/(store-gateway.*|cortex|mimir)"}[10m]))
@@ -1149,7 +1149,7 @@ groups:
         - alert: MimirCompactorNotCleaningUpBlocks
           annotations:
             message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not successfully cleaned up blocks in the last 6 hours.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactornotcleaningupblocks
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactornotcleaningupblocks
           expr: |
             # The "last successful run" metric is updated even if the compactor owns no tenants,
             # so this alert correctly doesn't fire if compactor has nothing to do.
@@ -1160,7 +1160,7 @@ groups:
         - alert: MimirCompactorNotRunningCompaction
           annotations:
             message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not run compaction in the last 6 hours.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactornotrunningcompaction
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactornotrunningcompaction
           expr: |
             # The "last successful run" metric is updated even if the compactor owns no tenants,
             # so this alert correctly doesn't fire if compactor has nothing to do.
@@ -1174,7 +1174,7 @@ groups:
         - alert: MimirCompactorNotRunningCompaction
           annotations:
             message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not run compaction in the last 24 hours.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactornotrunningcompaction
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactornotrunningcompaction
           expr: |
             # The "last successful run" metric is updated even if the compactor owns no tenants,
             # so this alert correctly doesn't fire if compactor has nothing to do.
@@ -1188,7 +1188,7 @@ groups:
         - alert: MimirCompactorNotRunningCompaction
           annotations:
             message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not run compaction since startup.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactornotrunningcompaction
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactornotrunningcompaction
           expr: |
             # The "last successful run" metric is updated even if the compactor owns no tenants,
             # so this alert correctly doesn't fire if compactor has nothing to do.
@@ -1200,7 +1200,7 @@ groups:
         - alert: MimirCompactorNotRunningCompaction
           annotations:
             message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not run compaction since startup.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactornotrunningcompaction
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactornotrunningcompaction
           expr: |
             # The "last successful run" metric is updated even if the compactor owns no tenants,
             # so this alert correctly doesn't fire if compactor has nothing to do.
@@ -1212,7 +1212,7 @@ groups:
         - alert: MimirCompactorNotRunningCompaction
           annotations:
             message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} failed to run 2 consecutive compactions.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactornotrunningcompaction
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactornotrunningcompaction
           expr: |
             sum by(cluster, namespace, pod) (increase(cortex_compactor_runs_failed_total{reason!="shutdown"}[2h])) >= 2
           labels:
@@ -1221,7 +1221,7 @@ groups:
         - alert: MimirCompactorHasRunOutOfDiskSpace
           annotations:
             message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has run out of disk space.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasrunoutofdiskspace
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactorhasrunoutofdiskspace
           expr: |
             increase(cortex_compactor_disk_out_of_space_errors_total{}[24h]) >= 1
           labels:
@@ -1230,7 +1230,7 @@ groups:
         - alert: MimirCompactorHasNotUploadedBlocks
           annotations:
             message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not uploaded any block in the last 24 hours.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasnotuploadedblocks
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactorhasnotuploadedblocks
           expr: |
             (time() - (max by(cluster, namespace, pod) (thanos_objstore_bucket_last_successful_upload_time{component="compactor"})) > 60 * 60 * 24)
             and
@@ -1245,7 +1245,7 @@ groups:
         - alert: MimirCompactorHasNotUploadedBlocks
           annotations:
             message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not uploaded any block since its start.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorhasnotuploadedblocks
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactorhasnotuploadedblocks
           expr: |
             (max by(cluster, namespace, pod) (thanos_objstore_bucket_last_successful_upload_time{component="compactor"}) == 0)
             and
@@ -1258,7 +1258,7 @@ groups:
         - alert: MimirCompactorSkippedBlocks
           annotations:
             message: 'Mimir Compactor in {{ $labels.cluster }}/{{ $labels.namespace }} has marked {{ $value }} blocks for no-compaction (reason: {{ $labels.reason }}).'
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorskippedblocks
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactorskippedblocks
           expr: |
             sum by (cluster, namespace, reason) (
               increase(cortex_compactor_blocks_marked_for_no_compaction_total[24h]) > 0
@@ -1269,7 +1269,7 @@ groups:
         - alert: MimirCompactorBuildingSparseIndexFailed
           annotations:
             message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to build sparse index headers
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactorbuildingsparseindexfailed
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactorbuildingsparseindexfailed
           expr: |
             (sum by(cluster, namespace, pod) (increase(cortex_compactor_build_sparse_headers_failures_total[5m])) > 0)
           for: 30m
@@ -1278,7 +1278,7 @@ groups:
         - alert: MimirCompactorOOMKilled
           annotations:
             message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has been OOMKilled {{ printf "%.2f" $value }} times in the last 4h.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactoroomkilled
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactoroomkilled
           expr: |
             (
               sum by(cluster, namespace, pod) (
@@ -1296,7 +1296,7 @@ groups:
         - alert: MimirCompactorOOMKilled
           annotations:
             message: Mimir Compactor {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has been OOMKilled {{ printf "%.2f" $value }} times in the last 2h.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircompactoroomkilled
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircompactoroomkilled
           expr: |
             (
               sum by(cluster, namespace, pod) (
@@ -1316,7 +1316,7 @@ groups:
         - alert: MimirDistributorGcUsesTooMuchCpu
           annotations:
             message: Mimir distributors in {{ $labels.cluster }}/{{ $labels.namespace }} GC CPU utilization is too high.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirdistributorgcusestoomuchcpu
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirdistributorgcusestoomuchcpu
           expr: |
             (quantile by (cluster, namespace) (0.9, sum by (cluster, namespace, pod) (rate(go_cpu_classes_gc_total_cpu_seconds_total{container="distributor"}[5m]))
               /
@@ -1337,7 +1337,7 @@ groups:
         - alert: MimirAutoscalerNotActive
           annotations:
             message: The Horizontal Pod Autoscaler (HPA) {{ $labels.horizontalpodautoscaler }} in {{ $labels.namespace }} is not active.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirautoscalernotactive
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirautoscalernotactive
           expr: |
             (
                 label_replace((
@@ -1368,7 +1368,7 @@ groups:
         - alert: MimirAutoscalerKedaFailing
           annotations:
             message: The Keda ScaledObject {{ $labels.scaledObject }} in {{ $labels.namespace }} is experiencing errors.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirautoscalerkedafailing
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirautoscalerkedafailing
           expr: |
             (
                 # Find KEDA scalers reporting errors.
@@ -1385,7 +1385,7 @@ groups:
         - alert: MimirIngesterOffsetCommitFailed
           annotations:
             message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to commit the last consumed offset.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesteroffsetcommitfailed
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesteroffsetcommitfailed
           expr: |
             sum by(cluster, namespace, pod) (rate(cortex_ingest_storage_reader_offset_commit_failures_total[5m]))
             /
@@ -1397,7 +1397,7 @@ groups:
         - alert: MimirIngesterKafkaReadFailed
           annotations:
             message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to read records from Kafka.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterkafkareadfailed
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterkafkareadfailed
           expr: |
             sum by(cluster, namespace, pod, node_id) (rate(cortex_ingest_storage_reader_read_errors_total[4m]))
             > 0
@@ -1407,7 +1407,7 @@ groups:
         - alert: MimirIngesterKafkaReadFailed
           annotations:
             message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is failing to read records from Kafka.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterkafkareadfailed
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterkafkareadfailed
           expr: |
             sum by(cluster, namespace, pod, node_id) (rate(cortex_ingest_storage_reader_read_errors_total[4m]))
             > 0
@@ -1417,7 +1417,7 @@ groups:
         - alert: MimirIngesterKafkaFetchErrorsRateTooHigh
           annotations:
             message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is receiving fetch errors when reading records from Kafka.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterkafkafetcherrorsratetoohigh
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterkafkafetcherrorsratetoohigh
           expr: |
             sum by (cluster, namespace, pod) (rate (cortex_ingest_storage_reader_fetch_errors_total[5m]))
             /
@@ -1429,7 +1429,7 @@ groups:
         - alert: MimirStartingIngesterKafkaDelayGrowing
           annotations:
             message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} in "starting" phase is not reducing consumption lag of write requests read from Kafka.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstartingingesterkafkadelaygrowing
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirstartingingesterkafkadelaygrowing
           expr: |
             deriv((
                 sum by (cluster, namespace, pod) (rate(cortex_ingest_storage_reader_receive_delay_seconds_sum{phase="starting"}[4m]))
@@ -1443,7 +1443,7 @@ groups:
         - alert: MimirStartingIngesterKafkaDelayGrowing
           annotations:
             message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} in "starting" phase is not reducing consumption lag of write requests read from Kafka.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstartingingesterkafkadelaygrowing
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirstartingingesterkafkadelaygrowing
           expr: |
             deriv((
                 sum by (cluster, namespace, pod) (histogram_sum(rate(cortex_ingest_storage_reader_receive_delay_seconds{phase="starting"}[4m])))
@@ -1457,7 +1457,7 @@ groups:
         - alert: MimirRunningIngesterReceiveDelayTooHigh
           annotations:
             message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} in "running" phase is too far behind in its consumption of write requests from Kafka.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrunningingesterreceivedelaytoohigh
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrunningingesterreceivedelaytoohigh
           expr: |
             (
               sum by (cluster, namespace, pod) (rate(cortex_ingest_storage_reader_receive_delay_seconds_sum{phase="running"}[4m]))
@@ -1472,7 +1472,7 @@ groups:
         - alert: MimirRunningIngesterReceiveDelayTooHigh
           annotations:
             message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} in "running" phase is too far behind in its consumption of write requests from Kafka.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrunningingesterreceivedelaytoohigh
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrunningingesterreceivedelaytoohigh
           expr: |
             (
               sum by (cluster, namespace, pod) (histogram_sum(rate(cortex_ingest_storage_reader_receive_delay_seconds{phase="running"}[4m])))
@@ -1487,7 +1487,7 @@ groups:
         - alert: MimirRunningIngesterReceiveDelayTooHigh
           annotations:
             message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} in "running" phase is too far behind in its consumption of write requests from Kafka.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrunningingesterreceivedelaytoohigh
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrunningingesterreceivedelaytoohigh
           expr: |
             (
               sum by (cluster, namespace, pod) (rate(cortex_ingest_storage_reader_receive_delay_seconds_sum{phase="running"}[4m]))
@@ -1502,7 +1502,7 @@ groups:
         - alert: MimirRunningIngesterReceiveDelayTooHigh
           annotations:
             message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} in "running" phase is too far behind in its consumption of write requests from Kafka.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirrunningingesterreceivedelaytoohigh
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirrunningingesterreceivedelaytoohigh
           expr: |
             (
               sum by (cluster, namespace, pod) (histogram_sum(rate(cortex_ingest_storage_reader_receive_delay_seconds{phase="running"}[4m])))
@@ -1517,7 +1517,7 @@ groups:
         - alert: MimirIngesterKafkaProcessingFailed
           annotations:
             message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} fails to consume write requests read from Kafka due to internal errors.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterkafkaprocessingfailed
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterkafkaprocessingfailed
           expr: |
             (
               sum by (cluster, namespace, pod) (
@@ -1537,7 +1537,7 @@ groups:
         - alert: MimirIngesterKafkaProcessingStuck
           annotations:
             message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is stuck processing write requests from Kafka.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringesterkafkaprocessingstuck
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringesterkafkaprocessingstuck
           expr: |
             # Alert if the reader is not processing any records, but there buffered records to process in the Kafka client.
             (sum by (cluster, namespace, pod) (
@@ -1554,7 +1554,7 @@ groups:
         - alert: MimirIngesterMissedRecordsFromKafka
           annotations:
             message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} missed processing records from Kafka. There may be data loss.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimiringestermissedrecordsfromkafka
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimiringestermissedrecordsfromkafka
           expr: |
             # Alert if the ingester missed some records from Kafka.
             increase(cortex_ingest_storage_reader_missed_records_total[10m]) > 0
@@ -1563,7 +1563,7 @@ groups:
         - alert: MimirStrongConsistencyEnforcementFailed
           annotations:
             message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} fails to enforce strong-consistency on read-path.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstrongconsistencyenforcementfailed
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirstrongconsistencyenforcementfailed
           expr: |
             sum by (cluster, namespace, pod) (rate(cortex_ingest_storage_strong_consistency_failures_total[4m])) > 0
           for: 5m
@@ -1572,7 +1572,7 @@ groups:
         - alert: MimirStrongConsistencyOffsetMissing
           annotations:
             message: Mimir ingesters in {{ $labels.cluster }}/{{ $labels.namespace }} are receiving an unexpected high number of strongly consistent requests without an offset specified.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirstrongconsistencyoffsetmissing
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirstrongconsistencyoffsetmissing
           expr: |
             sum by (cluster, namespace) (rate(cortex_ingest_storage_strong_consistency_requests_total{component="partition-reader", with_offset="false"}[4m]))
             /
@@ -1584,7 +1584,7 @@ groups:
         - alert: MimirKafkaClientProduceBufferHigh
           annotations:
             message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} Kafka client produce buffer utilization is {{ printf "%.2f" $value }}%.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirkafkaclientproducebufferhigh
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirkafkaclientproducebufferhigh
           expr: |
             max by(cluster, namespace, pod) (
                 # New metric.
@@ -1602,7 +1602,7 @@ groups:
         - alert: MimirBlockBuilderSchedulerPendingJobs
           annotations:
             message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} reports {{ printf "%.2f" $value }} pending jobs.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderschedulerpendingjobs
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirblockbuilderschedulerpendingjobs
           expr: |
             sum by (cluster, namespace, pod) (cortex_blockbuilder_scheduler_pending_jobs) > 0
           for: 40m
@@ -1611,7 +1611,7 @@ groups:
         - alert: MimirBlockBuilderCompactAndUploadFailed
           annotations:
             message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} fails to compact and upload blocks.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuildercompactanduploadfailed
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirblockbuildercompactanduploadfailed
           expr: |
             sum by (cluster, namespace, pod) (rate(cortex_blockbuilder_tsdb_compact_and_upload_failed_total[4m])) > 0
           labels:
@@ -1619,7 +1619,7 @@ groups:
         - alert: MimirBlockBuilderHasNotShippedBlocks
           annotations:
             message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has not shipped any block in the last 4 hours.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderhasnotshippedblocks
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirblockbuilderhasnotshippedblocks
           expr: |
             (min by(cluster, namespace, pod) (time() - cortex_blockbuilder_tsdb_last_successful_compact_and_upload_timestamp_seconds) > 60 * 60 * 4)
             and
@@ -1633,7 +1633,7 @@ groups:
         - alert: MimirBlockBuilderSchedulerNotRunning
           annotations:
             message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} is not running.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderschedulernotrunning
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirblockbuilderschedulernotrunning
           expr: |
             max by (cluster, namespace, pod) (histogram_count(increase(cortex_blockbuilder_scheduler_schedule_update_seconds[5m])) == 0)
           for: 30m
@@ -1642,7 +1642,7 @@ groups:
         - alert: MimirBlockBuilderDataSkipped
           annotations:
             message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has detected skipped data.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderdataskipped
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirblockbuilderdataskipped
           expr: |
             sum by (cluster, namespace, pod) (
               increase(cortex_blockbuilder_scheduler_job_gap_detected[1h])
@@ -1652,7 +1652,7 @@ groups:
         - alert: MimirBlockBuilderPersistentJobFailure
           annotations:
             message: Mimir {{ $labels.pod }} in {{ $labels.cluster }}/{{ $labels.namespace }} has detected a persistently failing job.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirblockbuilderpersistentjobfailure
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirblockbuilderpersistentjobfailure
           expr: |
             increase(cortex_blockbuilder_scheduler_persistent_job_failures_total[20m]) > 0
           labels:
@@ -1660,7 +1660,7 @@ groups:
         - alert: MimirFewerIngestersConsumingThanActivePartitions
           annotations:
             message: Mimir ingesters in {{ $labels.cluster }}/{{ $labels.namespace }} have fewer ingesters consuming than active partitions.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimirfeweringestersconsumingthanactivepartitions
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimirfeweringestersconsumingthanactivepartitions
           expr: |
             max(cortex_partition_ring_partitions{name="ingester-partitions", state="Active"}) by (cluster, namespace) > count(count(cortex_ingest_storage_reader_last_consumed_offset{}) by (cluster, namespace, partition)) by (cluster, namespace)
           for: 15m
@@ -1698,7 +1698,7 @@ groups:
         - alert: MimirContinuousTestNotRunningOnWrites
           annotations:
             message: Mimir continuous test {{ $labels.test }} in {{ $labels.cluster }}/{{ $labels.namespace }} is not effectively running because writes are failing.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircontinuoustestnotrunningonwrites
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircontinuoustestnotrunningonwrites
           expr: |
             sum by(cluster, namespace, test) (rate(mimir_continuous_test_writes_failed_total[5m])) > 0
           for: 1h
@@ -1707,7 +1707,7 @@ groups:
         - alert: MimirContinuousTestNotRunningOnReads
           annotations:
             message: Mimir continuous test {{ $labels.test }} in {{ $labels.cluster }}/{{ $labels.namespace }} is not effectively running because queries are failing.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircontinuoustestnotrunningonreads
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircontinuoustestnotrunningonreads
           expr: |
             sum by(cluster, namespace, test) (rate(mimir_continuous_test_queries_failed_total[5m])) > 0
           for: 1h
@@ -1716,7 +1716,7 @@ groups:
         - alert: MimirContinuousTestFailed
           annotations:
             message: Mimir continuous test {{ $labels.test }} in {{ $labels.cluster }}/{{ $labels.namespace }} failed when asserting query results.
-            runbook_url: https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#mimircontinuoustestfailed
+            runbook_url: https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#mimircontinuoustestfailed
           expr: |
             sum by(cluster, namespace, test) (rate(mimir_continuous_test_query_result_checks_failed_total[10m])) > 0
           labels:

--- a/operations/mimir-mixin/alerts/alertmanager.libsonnet
+++ b/operations/mimir-mixin/alerts/alertmanager.libsonnet
@@ -145,7 +145,7 @@
 
   groups+:
     $.withRunbookURL(
-      'https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#%s',
+      'https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#%s',
       $.withDashboardURL(
         'mimir-alertmanager.json',
         $.withExtraLabelsAnnotations(alertGroups)

--- a/operations/mimir-mixin/alerts/alerts.libsonnet
+++ b/operations/mimir-mixin/alerts/alerts.libsonnet
@@ -1203,5 +1203,5 @@ local utils = import 'mixin-utils/utils.libsonnet';
     },
   ],
 
-  groups+: $.withRunbookURL('https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#%s', $.withExtraLabelsAnnotations(alertGroups)),
+  groups+: $.withRunbookURL('https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#%s', $.withExtraLabelsAnnotations(alertGroups)),
 }

--- a/operations/mimir-mixin/alerts/autoscaling.libsonnet
+++ b/operations/mimir-mixin/alerts/autoscaling.libsonnet
@@ -67,5 +67,5 @@
     },
   ],
 
-  groups+: $.withRunbookURL('https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#%s', $.withExtraLabelsAnnotations(alertGroups)),
+  groups+: $.withRunbookURL('https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#%s', $.withExtraLabelsAnnotations(alertGroups)),
 }

--- a/operations/mimir-mixin/alerts/blocks.libsonnet
+++ b/operations/mimir-mixin/alerts/blocks.libsonnet
@@ -278,5 +278,5 @@
     },
   ],
 
-  groups+: $.withRunbookURL('https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#%s', $.withExtraLabelsAnnotations(alertGroups)),
+  groups+: $.withRunbookURL('https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#%s', $.withExtraLabelsAnnotations(alertGroups)),
 }

--- a/operations/mimir-mixin/alerts/compactor-scheduler.libsonnet
+++ b/operations/mimir-mixin/alerts/compactor-scheduler.libsonnet
@@ -76,7 +76,7 @@
 
   groups+:
     $.withRunbookURL(
-      'https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#%s',
+      'https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#%s',
       $.withDashboardURL(
         'mimir-compactor.json',
         $.withExtraLabelsAnnotations(alertGroups)

--- a/operations/mimir-mixin/alerts/compactor.libsonnet
+++ b/operations/mimir-mixin/alerts/compactor.libsonnet
@@ -203,7 +203,7 @@
 
   groups+:
     $.withRunbookURL(
-      'https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#%s',
+      'https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#%s',
       $.withDashboardURL(
         'mimir-compactor.json',
         $.withExtraLabelsAnnotations(alertGroups)

--- a/operations/mimir-mixin/alerts/continuous-test.libsonnet
+++ b/operations/mimir-mixin/alerts/continuous-test.libsonnet
@@ -57,5 +57,5 @@
     },
   ],
 
-  groups+: $.withRunbookURL('https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#%s', $.withExtraLabelsAnnotations(alertGroups)),
+  groups+: $.withRunbookURL('https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#%s', $.withExtraLabelsAnnotations(alertGroups)),
 }

--- a/operations/mimir-mixin/alerts/distributor.libsonnet
+++ b/operations/mimir-mixin/alerts/distributor.libsonnet
@@ -33,5 +33,5 @@
     },
   ],
 
-  groups+: $.withRunbookURL('https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#%s', $.withExtraLabelsAnnotations(alertGroups)),
+  groups+: $.withRunbookURL('https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#%s', $.withExtraLabelsAnnotations(alertGroups)),
 }

--- a/operations/mimir-mixin/alerts/ingest-storage.libsonnet
+++ b/operations/mimir-mixin/alerts/ingest-storage.libsonnet
@@ -408,5 +408,5 @@ local utils = import 'mixin-utils/utils.libsonnet';
     },
   ],
 
-  groups+: $.withRunbookURL('https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#%s', $.withExtraLabelsAnnotations(alertGroups)),
+  groups+: $.withRunbookURL('https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#%s', $.withExtraLabelsAnnotations(alertGroups)),
 }

--- a/operations/mimir-mixin/alerts/usage-tracker.libsonnet
+++ b/operations/mimir-mixin/alerts/usage-tracker.libsonnet
@@ -53,7 +53,7 @@
 
   groups+:
     $.withRunbookURL(
-      'https://grafana.com/docs/mimir/latest/operators-guide/mimir-runbooks/#%s',
+      'https://grafana.com/docs/mimir/latest/manage/mimir-runbooks/#%s',
       $.withExtraLabelsAnnotations(alertGroups)
     ),
 }


### PR DESCRIPTION
Runbooks live under `/manage/mimir-runbooks/` now. Alert `runbook_url` annotations still pointed at `operators-guide`, which only 301s and makes the anchors easy to miss.

Updated the libsonnet sources and the compiled mixin YAML.

Fixes #14235