### PR TITLE
docs: clarify Alertmanager /api/v1/alerts is tenant config API

### DIFF
--- a/docs/sources/mimir/references/http-api/_index.md
+++ b/docs/sources/mimir/references/http-api/_index.md
@@ -1286,7 +1286,7 @@ Requires [authentication](#authentication).
 GET /api/v1/alerts
 ```
 
-Get the current **tenant Alertmanager YAML configuration** for the authenticated
+Get the current tenant Alertmanager YAML configuration for the authenticated
 tenant from the configured object storage. This is Mimir's multi-tenant config
 API (enabled with `-alertmanager.enable-api`), not the Alertmanager "list
 firing alerts" API.

--- a/docs/sources/mimir/references/http-api/_index.md
+++ b/docs/sources/mimir/references/http-api/_index.md
@@ -1286,7 +1286,19 @@ Requires [authentication](#authentication).
 GET /api/v1/alerts
 ```
 
-Get the current Alertmanager configuration for the authenticated tenant, reading it from the configured object storage.
+Get the current **tenant Alertmanager YAML configuration** for the authenticated
+tenant from the configured object storage. This is Mimir's multi-tenant config
+API (enabled with `-alertmanager.enable-api`), not the Alertmanager "list
+firing alerts" API.
+
+{{< admonition type="caution" >}}
+Do not confuse this path with Alertmanager's own HTTP API under
+`<alertmanager-http-prefix>` (default `/alertmanager`). Paths such as
+`/alertmanager/api/v1/alerts` are the upstream Alertmanager API; v1 was removed
+and returns HTTP 410. For live alerts and silences, use the Alertmanager **v2**
+routes under that prefix, or the Ruler's
+`<prometheus-http-prefix>/api/v1/alerts` for Prometheus-format alerts.
+{{< /admonition >}}
 
 This endpoint doesn't accept any URL query parameter and returns `200` on success.
 
@@ -1303,6 +1315,11 @@ To retrieve a tenant's Alertmanager configuration from Mimir, use [`mimirtool al
 ```
 POST /api/v1/alerts
 ```
+
+This is the multi-tenant configuration endpoint (same path family as
+[Get Alertmanager configuration](#get-alertmanager-configuration)), not the
+Alertmanager UI/API under `<alertmanager-http-prefix>`.
+
 
 Stores or updates the Alertmanager configuration for the authenticated tenant. The Alertmanager configuration is stored in the configured backend object storage.
 
@@ -1350,6 +1367,11 @@ alertmanager_config: |
 ```
 DELETE /api/v1/alerts
 ```
+
+This is the multi-tenant configuration endpoint (same path family as
+[Get Alertmanager configuration](#get-alertmanager-configuration)), not the
+Alertmanager UI/API under `<alertmanager-http-prefix>`.
+
 
 Deletes the Alertmanager configuration for the authenticated tenant.
 

--- a/docs/sources/mimir/references/http-api/_index.md
+++ b/docs/sources/mimir/references/http-api/_index.md
@@ -1320,7 +1320,6 @@ This is the multi-tenant configuration endpoint (same path family as
 [Get Alertmanager configuration](#get-alertmanager-configuration)), not the
 Alertmanager UI/API under `<alertmanager-http-prefix>`.
 
-
 Stores or updates the Alertmanager configuration for the authenticated tenant. The Alertmanager configuration is stored in the configured backend object storage.
 
 This endpoint expects the Alertmanager **YAML** configuration in the request body and returns `201` on success.
@@ -1371,7 +1370,6 @@ DELETE /api/v1/alerts
 This is the multi-tenant configuration endpoint (same path family as
 [Get Alertmanager configuration](#get-alertmanager-configuration)), not the
 Alertmanager UI/API under `<alertmanager-http-prefix>`.
-
 
 Deletes the Alertmanager configuration for the authenticated tenant.
 


### PR DESCRIPTION
Easy to hit `/alertmanager/api/v1/alerts` and get HTTP 410 after Alertmanager dropped v1. The Mimir docs' `GET/POST/DELETE /api/v1/alerts` are the multi-tenant **config** endpoints (YAML in object storage), not the live alerts API. Spelled that out with a pointer to v2 / Ruler paths.

Fixes #14695