### PR TITLE
query-frontend: wait for the querier ring before serving queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [ENHANCEMENT] Distributor: Add the experimental `cortex_distributor_otlp_requests_with_job_or_instance_resource_attribute_total{user}` counter to track OTLP requests carrying `job` or `instance` as a resource attribute. #16285
 * [ENHANCEMENT] Ruler: Split oversized remote distributor writes to keep resulting calls within the configured gRPC maximum send size, and expose the number of generated requests in `cortex_ruler_remote_distributor_requests_per_write_request`. #16160
 * [ENHANCEMENT] Alerts: Don't fire `MimirMemberlistZoneAwareRoutingAutoFailover` while the node is still joining the cluster. #16315
+* [BUGFIX] Query-frontend: Fail queries with a clear error, rather than planning them against an invalid maximum supported query plan version, when the querier ring contains only unhealthy queriers. #16333
 * [BUGFIX] Query-frontend: Return a HTTP 500 error rather than a HTTP 400 when a querier receives a query plan that is too new. #16233
 * [BUGFIX] Compactor, Store-gateway: Fix the store-gateway always logging `num_series=0` in its `loaded new block` message. #16276
 * [BUGFIX] Ingest storage: Account for protobuf framing when splitting Remote Write 1.0 requests so generated Kafka record data stays within `-ingest-storage.kafka.producer-max-record-size-bytes` when individual series and metadata entries fit. #16160

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [ENHANCEMENT] Distributor: Add the experimental `cortex_distributor_otlp_requests_with_job_or_instance_resource_attribute_total{user}` counter to track OTLP requests carrying `job` or `instance` as a resource attribute. #16285
 * [ENHANCEMENT] Ruler: Split oversized remote distributor writes to keep resulting calls within the configured gRPC maximum send size, and expose the number of generated requests in `cortex_ruler_remote_distributor_requests_per_write_request`. #16160
 * [ENHANCEMENT] Alerts: Don't fire `MimirMemberlistZoneAwareRoutingAutoFailover` while the node is still joining the cluster. #16315
+* [BUGFIX] Query-frontend: Wait for the querier ring to be populated during startup, up to 30 seconds, before reporting the query-frontend as ready. Previously a query-frontend could become ready before it had seen any querier in the ring and fail every query it received until the ring was populated. Only applies when remote execution is enabled, and can be disabled with the experimental `-query-frontend.wait-for-querier-ring-on-startup=false`. #16333
 * [BUGFIX] Query-frontend: Fail queries with a clear error, rather than planning them against an invalid maximum supported query plan version, when the querier ring contains only unhealthy queriers. #16333
 * [BUGFIX] Query-frontend: Return a HTTP 500 error rather than a HTTP 400 when a querier receives a query plan that is too new. #16233
 * [BUGFIX] Compactor, Store-gateway: Fix the store-gateway always logging `num_series=0` in its `loaded new block` message. #16276

--- a/cmd/mimir/config-descriptor.json
+++ b/cmd/mimir/config-descriptor.json
@@ -9237,6 +9237,17 @@
           "fieldFlag": "query-frontend.enable-query-engine-fallback",
           "fieldType": "boolean",
           "fieldCategory": "experimental"
+        },
+        {
+          "kind": "field",
+          "name": "wait_for_querier_ring_on_startup",
+          "required": false,
+          "desc": "If set to true and remote execution is enabled, don't report the query-frontend as ready during startup until it has seen at least one querier in the querier ring, or 30s elapses. Queries fail while the ring is empty, so starting to serve before then means failing queries.",
+          "fieldValue": null,
+          "fieldDefaultValue": true,
+          "fieldFlag": "query-frontend.wait-for-querier-ring-on-startup",
+          "fieldType": "boolean",
+          "fieldCategory": "experimental"
         }
       ],
       "fieldValue": null,

--- a/cmd/mimir/help-all.txt.tmpl
+++ b/cmd/mimir/help-all.txt.tmpl
@@ -2975,6 +2975,8 @@ Usage of ./cmd/mimir/mimir:
     	[experimental] Set to true to enable performing query sharding inside the Mimir query engine (MQE). Requires remote execution and MQE to be enabled. Has no effect if sharding is not enabled with -query-frontend.parallelize-shardable-queries=true (default true)
   -query-frontend.use-mimir-query-engine-for-splitting-and-caching-results
     	[experimental] Set to true to enable performing splitting range queries by interval and caching inside the Mimir query engine (MQE), and spinning off subqueries from instant queries inside MQE. This only has an effect if the corresponding feature is enabled (with -query-frontend.split-queries-by-interval=true, -query-frontend.cache-results=true or -query-frontend.subquery-spin-off-enabled=true, respectively). Requires MQE, remote execution and sharding inside MQE to be enabled.
+  -query-frontend.wait-for-querier-ring-on-startup
+    	[experimental] If set to true and remote execution is enabled, don't report the query-frontend as ready during startup until it has seen at least one querier in the querier ring, or 30s elapses. Queries fail while the ring is empty, so starting to serve before then means failing queries. (default true)
   -query-scheduler.grpc-client-config.backoff-max-period duration
     	Maximum delay when backing off. (default 10s)
   -query-scheduler.grpc-client-config.backoff-min-period duration

--- a/docs/sources/mimir/configure/about-versioning.md
+++ b/docs/sources/mimir/configure/about-versioning.md
@@ -253,6 +253,7 @@ The following features are currently experimental:
   - Separate query sharding limit for cardinality API requests (active series and active native histogram metrics): `-query-frontend.cardinality-sharding-max-sharded-queries`
   - [Mimir query engine](https://grafana.com/docs/mimir/<MIMIR_VERSION>/references/architecture/mimir-query-engine) (`-query-frontend.query-engine` and `-query-frontend.enable-query-engine-fallback`)
   - Remote execution of queries in queriers: `-query-frontend.enable-remote-execution=true`
+  - Waiting for the querier ring to be populated during startup before reporting the query-frontend as ready: `-query-frontend.wait-for-querier-ring-on-startup` (enabled by default, and only used when remote execution is enabled)
   - Performing query sharding within MQE: `-query-frontend.use-mimir-query-engine-for-sharding=true`
   - Computing multiple aggregations over the same data without buffering: `-querier.mimir-query-engine.enable-multi-aggregation=true`
   - Subset selector elimination: `-querier.mimir-query-engine.enable-subset-selector-elimination=true`

--- a/docs/sources/mimir/configure/configuration-parameters/index.md
+++ b/docs/sources/mimir/configure/configuration-parameters/index.md
@@ -2521,6 +2521,13 @@ client_cluster_validation:
 # Mimir query engine.
 # CLI flag: -query-frontend.enable-query-engine-fallback
 [enable_query_engine_fallback: <boolean> | default = true]
+
+# (experimental) If set to true and remote execution is enabled, don't report
+# the query-frontend as ready during startup until it has seen at least one
+# querier in the querier ring, or 30s elapses. Queries fail while the ring is
+# empty, so starting to serve before then means failing queries.
+# CLI flag: -query-frontend.wait-for-querier-ring-on-startup
+[wait_for_querier_ring_on_startup: <boolean> | default = true]
 ```
 
 ### query_scheduler

--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -301,11 +301,6 @@ func checkQueries(
 				labels.MustNewMatcher(labels.MatchEqual, "name", "store-gateway-client"),
 				labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
 
-			// Wait until the query-frontend has updated the querier ring.
-			require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
-				labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
-				labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
-
 			// Wait until the store-gateway has loaded the blocks before querying.
 			//
 			// The store-gateway switches to ACTIVE in the ring only after its initial block sync completes,

--- a/integration/compartments_test.go
+++ b/integration/compartments_test.go
@@ -94,11 +94,6 @@ func TestIngesterQuerying_ShouldSupportCompartments(t *testing.T) {
 	}
 	require.NoError(t, s.StartAndWaitReady(mimirServices...))
 
-	// Wait until the query-frontend has updated the querier ring.
-	require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
-		labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
-		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
-
 	// The ingester instance ring is shared across compartments, so the distributor and querier should
 	// see every ingester ACTIVE in it.
 	for _, svc := range []*e2emimir.MimirService{distributors[0], querier} {
@@ -289,11 +284,6 @@ func TestStoreGatewayQuerying_ShouldSupportCompartments(t *testing.T) {
 		mimirServices = append(mimirServices, sg)
 	}
 	require.NoError(t, s.StartAndWaitReady(mimirServices...))
-
-	// Wait until the query-frontend has updated the querier ring.
-	require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
-		labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
-		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
 
 	// The ingester instance ring is shared across compartments, so the distributor and querier should
 	// see every ingester ACTIVE in it.

--- a/integration/distributor_test.go
+++ b/integration/distributor_test.go
@@ -1442,11 +1442,6 @@ func testDistributorNameValidation(
 		labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
 		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
 
-	// Wait until the query-frontend has updated the querier ring.
-	require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
-		labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
-		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
-
 	client, err := e2emimir.NewClient(distributor.HTTPEndpoint(), queryFrontend.HTTPEndpoint(), "", "", userID)
 	require.NoError(t, err)
 

--- a/integration/getting_started_with_grafana_mimir_test.go
+++ b/integration/getting_started_with_grafana_mimir_test.go
@@ -75,11 +75,6 @@ func TestPlayWithGrafanaMimirTutorial(t *testing.T) {
 }
 
 func runTestPushSeriesAndQueryBack(t *testing.T, mimir *e2emimir.MimirService, seriesName string, genSeries generateSeriesFunc) {
-	// Wait until the query-frontend has updated the querier ring.
-	require.NoError(t, mimir.WaitSumMetricsWithOptions(e2e.GreaterOrEqual(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
-		labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
-		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
-
 	c, err := e2emimir.NewClient(mimir.HTTPEndpoint(), mimir.HTTPEndpoint(), "", "", "user-1")
 	require.NoError(t, err)
 

--- a/integration/influx_ingestion_test.go
+++ b/integration/influx_ingestion_test.go
@@ -48,11 +48,6 @@ func TestInfluxIngestion(t *testing.T) {
 	mimir := e2emimir.NewSingleBinary("mimir-1", flags, e2emimir.WithConfigFile(mimirConfigFile), e2emimir.WithPorts(9009, 9095))
 	require.NoError(t, s.StartAndWaitReady(mimir))
 
-	// Wait until the query-frontend has updated the querier ring.
-	require.NoError(t, mimir.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
-		labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
-		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
-
 	c, err := e2emimir.NewClient(mimir.HTTPEndpoint(), mimir.HTTPEndpoint(), "", "", "user-1")
 	require.NoError(t, err)
 

--- a/integration/ooo_ingestion_test.go
+++ b/integration/ooo_ingestion_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/grafana/e2e"
 	e2edb "github.com/grafana/e2e/db"
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/mimir/integration/e2ehistograms"
@@ -46,11 +45,6 @@ func TestOOOIngestion(t *testing.T) {
 
 	mimir := e2emimir.NewSingleBinary("mimir-1", flags, e2emimir.WithConfigFile(mimirConfigFile), e2emimir.WithPorts(9009, 9095))
 	require.NoError(t, s.StartAndWaitReady(mimir))
-
-	// Wait until the query-frontend has updated the querier ring.
-	require.NoError(t, mimir.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
-		labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
-		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
 
 	c, err := e2emimir.NewClient(mimir.HTTPEndpoint(), mimir.HTTPEndpoint(), "", "", "user-1")
 	require.NoError(t, err)

--- a/integration/otlp_ingestion_test.go
+++ b/integration/otlp_ingestion_test.go
@@ -86,11 +86,6 @@ func testOTLPIngestion(t *testing.T, opts testOTLPIngestionOpts) {
 	mimir := e2emimir.NewSingleBinary("mimir-1", flags, e2emimir.WithConfigFile(mimirConfigFile), e2emimir.WithPorts(9009, 9095))
 	require.NoError(t, s.StartAndWaitReady(mimir))
 
-	// Wait until the query-frontend has updated the querier ring.
-	require.NoError(t, mimir.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
-		labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
-		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
-
 	c, err := e2emimir.NewClient(mimir.HTTPEndpoint(), mimir.HTTPEndpoint(), "", "", "user-1")
 	require.NoError(t, err)
 
@@ -278,11 +273,6 @@ func testOTLPHistogramIngestion(t *testing.T, enableExplicitHistogramToNHCB bool
 
 	mimir := e2emimir.NewSingleBinary("mimir-1", flags, e2emimir.WithConfigFile(mimirConfigFile), e2emimir.WithPorts(9009, 9095))
 	require.NoError(t, s.StartAndWaitReady(mimir))
-
-	// Wait until the query-frontend has updated the querier ring.
-	require.NoError(t, mimir.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
-		labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
-		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
 
 	c, err := e2emimir.NewClient(mimir.HTTPEndpoint(), mimir.HTTPEndpoint(), "", "", "user-1")
 	require.NoError(t, err)
@@ -499,11 +489,6 @@ func testStartTimeHandling(t *testing.T, enableCTzero bool) {
 
 	mimir := e2emimir.NewSingleBinary("mimir-1", flags, e2emimir.WithConfigFile(mimirConfigFile), e2emimir.WithPorts(9009, 9095))
 	require.NoError(t, s.StartAndWaitReady(mimir))
-
-	// Wait until the query-frontend has updated the querier ring.
-	require.NoError(t, mimir.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
-		labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
-		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
 
 	c, err := e2emimir.NewClient(mimir.HTTPEndpoint(), mimir.HTTPEndpoint(), "", "", "user-1")
 	require.NoError(t, err)

--- a/integration/querier_label_name_values_test.go
+++ b/integration/querier_label_name_values_test.go
@@ -139,11 +139,6 @@ func TestQuerierLabelNamesAndValues(t *testing.T) {
 				labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
 				labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
 
-			// Wait until the query-frontend has updated the querier ring.
-			require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
-				labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
-				labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
-
 			// Push series.
 			now := time.Now()
 
@@ -348,11 +343,6 @@ func TestQuerierLabelValuesCardinality(t *testing.T) {
 				labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
 				labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))),
 			)
-
-			// Wait until the query-frontend has updated the querier ring.
-			require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
-				labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
-				labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
 
 			// Push series.
 			now := time.Now()

--- a/integration/querier_test.go
+++ b/integration/querier_test.go
@@ -16,7 +16,6 @@ import (
 	e2edb "github.com/grafana/e2e/db"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -179,11 +178,6 @@ func testQuerierWithBlocksStorageRunningInMicroservicesMode(t *testing.T, series
 			// Wait until the querier has updated the ring. The querier will also watch
 			// the store-gateway ring if blocks sharding is enabled.
 			require.NoError(t, querier.WaitSumMetrics(e2e.Equals(float64(512+(512*storeGateways.NumInstances()))), "cortex_ring_tokens_total"))
-
-			// Wait until the query-frontend has updated the querier ring.
-			require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
-				labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
-				labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
 
 			// Wait until the store-gateway has synched the new uploaded blocks. When sharding is enabled
 			// we don't know which store-gateway instance will sync the blocks, so we need to wait on

--- a/integration/query_frontend_active_series_test.go
+++ b/integration/query_frontend_active_series_test.go
@@ -163,11 +163,6 @@ func setupComponentsForActiveSeriesTest(t *testing.T, cfg queryFrontendTestConfi
 		labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
 		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
 
-	// Wait until the query-frontend has updated the querier ring.
-	require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
-		labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
-		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
-
 	// Push series for the test user to Mimir.
 	c, err := e2emimir.NewClient(distributor.HTTPEndpoint(), queryFrontend.HTTPEndpoint(), "", "", userID)
 	require.NoError(t, err)

--- a/integration/query_frontend_labels_query_optimizer_test.go
+++ b/integration/query_frontend_labels_query_optimizer_test.go
@@ -125,11 +125,6 @@ func TestQueryFrontendLabelsQueryOptimizerIdempotency(t *testing.T) {
 			labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
 			labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
 
-		// Wait until the query-frontend has updated the querier ring.
-		require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
-			labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
-			labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
-
 		// Push series
 		client, err := e2emimir.NewClient(distributor.HTTPEndpoint(), queryFrontend.HTTPEndpoint(), "", "", userID)
 		require.NoError(t, err)

--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -349,11 +349,6 @@ func runQueryFrontendTest(t *testing.T, cfg queryFrontendTestConfig) {
 		labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
 		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
 
-	// Wait until the query-frontend has updated the querier ring.
-	require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
-		labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
-		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
-
 	// When using the ingest storage, wait until partitions are ACTIVE in the ring.
 	if flags["-ingest-storage.enabled"] == "true" {
 		for _, service := range []*e2emimir.MimirService{distributor, queryFrontend, querier} {
@@ -1033,11 +1028,6 @@ func runQueryFrontendWithQueryShardingHTTPTest(t *testing.T, cfg queryFrontendTe
 
 	require.NoError(t, querier.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
 		labels.MustNewMatcher(labels.MatchEqual, "name", "ingester"),
-		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
-
-	// Wait until the query-frontend has updated the querier ring.
-	require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
-		labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
 		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
 
 	// Push series for the test user to Mimir.

--- a/integration/query_scheduler_test.go
+++ b/integration/query_scheduler_test.go
@@ -80,11 +80,6 @@ func runTestQuerySchedulerWithMaxUsedInstances(t *testing.T, seriesName string, 
 		labels.MustNewMatcher(labels.MatchEqual, "name", "querier-query-scheduler-client"),
 		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
 
-	// Wait until the query-frontend has updated the querier ring.
-	require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
-		labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
-		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
-
 	// Compute which is the expected in-use query-scheduler.
 	schedulers := []*e2emimir.MimirService{queryScheduler1, queryScheduler2}
 	slices.SortFunc(schedulers, func(a, b *e2emimir.MimirService) int {

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -1230,11 +1230,6 @@ func TestRulerRemoteEvaluation(t *testing.T) {
 	// The distributor should have 512 tokens for the ingester ring and 1 for the distributor ring
 	require.NoError(t, distributor.WaitSumMetrics(e2e.Equals(512+1), "cortex_ring_tokens_total"))
 
-	// Wait until the query-frontend has updated the querier ring.
-	require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
-		labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
-		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
-
 	for tName, tc := range tcs {
 		t.Run(tName, func(t *testing.T) {
 			if tc.queryResultPayloadFormat == "" {
@@ -1375,11 +1370,6 @@ func TestRulerRemoteEvaluationErrorClassification(t *testing.T) {
 	require.NoError(t, distributor.WaitSumMetrics(e2e.Equals(512+1), "cortex_ring_tokens_total"))
 	// Ruler will see 512 tokens from ingester, and 128 tokens from itself.
 	require.NoError(t, ruler.WaitSumMetrics(e2e.Equals(512+128), "cortex_ring_tokens_total"))
-
-	// Wait until the query-frontend has updated the querier ring.
-	require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
-		labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
-		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
 
 	const user = "user"
 	const namespace = "test"
@@ -1574,11 +1564,6 @@ func TestRulerRemoteEvaluation_ShouldEnforceStrongReadConsistencyForDependentRul
 	// Wait until the distributor is ready.
 	// The distributor should have 512 tokens for the ingester ring and 1 for the distributor ring.
 	require.NoError(t, distributor.WaitSumMetrics(e2e.Equals(512+1), "cortex_ring_tokens_total"))
-
-	// Wait until the query-frontend has updated the querier ring.
-	require.NoError(t, queryFrontend.WaitSumMetricsWithOptions(e2e.Equals(1), []string{"cortex_ring_members"}, e2e.WithLabelMatchers(
-		labels.MustNewMatcher(labels.MatchEqual, "name", "querier"),
-		labels.MustNewMatcher(labels.MatchEqual, "state", "ACTIVE"))))
 
 	// Wait until partitions are ACTIVE in the ring.
 	for _, service := range []*e2emimir.MimirService{distributor, queryFrontend, querier} {

--- a/operations/mimir/mimir-flags-defaults.json
+++ b/operations/mimir/mimir-flags-defaults.json
@@ -625,6 +625,7 @@
   "query-frontend.client-cluster-validation.label": "",
   "query-frontend.query-engine": "mimir",
   "query-frontend.enable-query-engine-fallback": true,
+  "query-frontend.wait-for-querier-ring-on-startup": true,
   "ingest-storage.kafka.backend": "kafka",
   "ingest-storage.kafka.address": "",
   "ingest-storage.kafka.topic": "",

--- a/pkg/frontend/config.go
+++ b/pkg/frontend/config.go
@@ -36,8 +36,9 @@ type CombinedFrontendConfig struct {
 
 	ClusterValidationConfig clusterutil.ClusterValidationConfig `yaml:"client_cluster_validation" category:"experimental"`
 
-	QueryEngine               string `yaml:"query_engine" category:"experimental"`
-	EnableQueryEngineFallback bool   `yaml:"enable_query_engine_fallback" category:"experimental"`
+	QueryEngine                 string `yaml:"query_engine" category:"experimental"`
+	EnableQueryEngineFallback   bool   `yaml:"enable_query_engine_fallback" category:"experimental"`
+	WaitForQuerierRingOnStartup bool   `yaml:"wait_for_querier_ring_on_startup" category:"experimental"`
 }
 
 func (cfg *CombinedFrontendConfig) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
@@ -48,6 +49,7 @@ func (cfg *CombinedFrontendConfig) RegisterFlags(f *flag.FlagSet, logger log.Log
 
 	f.StringVar(&cfg.QueryEngine, queryEngineFlag, querier.MimirEngine, fmt.Sprintf("Query engine to use, either '%v' or '%v'", querier.PrometheusEngine, querier.MimirEngine))
 	f.BoolVar(&cfg.EnableQueryEngineFallback, "query-frontend.enable-query-engine-fallback", true, "If set to true and the Mimir query engine is in use, fall back to using the Prometheus query engine for any queries not supported by the Mimir query engine.")
+	f.BoolVar(&cfg.WaitForQuerierRingOnStartup, "query-frontend.wait-for-querier-ring-on-startup", true, fmt.Sprintf("If set to true and remote execution is enabled, don't report the query-frontend as ready during startup until it has seen at least one querier in the querier ring, or %s elapses. Queries fail while the ring is empty, so starting to serve before then means failing queries.", querier.RingStartupWaitTimeout))
 }
 
 func (cfg *CombinedFrontendConfig) Validate() error {

--- a/pkg/mimir/modules.go
+++ b/pkg/mimir/modules.go
@@ -635,7 +635,13 @@ func (t *Mimir) initQuerierRing() (services.Service, error) {
 
 	t.QuerierRing = r
 
-	return r, nil
+	// Query-frontends only consult the ring to plan queries when remote execution is enabled
+	// (see createQueryFrontendQueryPlanner), so otherwise there's nothing to wait for.
+	if !t.Cfg.Frontend.QueryMiddleware.EnableRemoteExecution || !t.Cfg.Frontend.WaitForQuerierRingOnStartup {
+		return r, nil
+	}
+
+	return querier.NewRingService(r, querier.RingStartupWaitTimeout, util_log.Logger), nil
 }
 
 // initQuerier registers an internal HTTP router with a Prometheus API backed by the

--- a/pkg/mimir/modules_test.go
+++ b/pkg/mimir/modules_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/server"
+	"github.com/grafana/dskit/services"
 	hashivault "github.com/hashicorp/vault/api"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/config"
@@ -444,4 +445,52 @@ func TestRulerDistributorClientModuleDependencies(t *testing.T) {
 
 	deps := mimir.ModuleManager.DependenciesForModule(RulerDistributorClient)
 	require.Contains(t, deps, Vault)
+}
+
+func TestMimir_InitQuerierRing(t *testing.T) {
+	tests := map[string]struct {
+		remoteExecutionEnabled bool
+		waitEnabled            bool
+		expectedWait           bool
+	}{
+		"should wait for the querier ring to be populated when remote execution is enabled": {
+			remoteExecutionEnabled: true,
+			waitEnabled:            true,
+			expectedWait:           true,
+		},
+		"should not wait for the querier ring to be populated when remote execution is disabled": {
+			remoteExecutionEnabled: false,
+			waitEnabled:            true,
+			expectedWait:           false,
+		},
+		"should not wait for the querier ring to be populated when the wait is disabled": {
+			remoteExecutionEnabled: true,
+			waitEnabled:            false,
+			expectedWait:           false,
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			cfg := newDefaultConfig()
+			cfg.Frontend.QueryMiddleware.EnableRemoteExecution = testData.remoteExecutionEnabled
+			cfg.Frontend.WaitForQuerierRingOnStartup = testData.waitEnabled
+			// The default is memberlist, which needs the MemberlistKV module to have been initialised.
+			cfg.Querier.Ring.Common.KVStore.Store = "inmemory"
+
+			mimir := &Mimir{Cfg: *cfg, Registerer: prometheus.NewPedanticRegistry()}
+
+			svc, err := mimir.initQuerierRing()
+			require.NoError(t, err)
+			require.NotNil(t, mimir.QuerierRing)
+
+			// When there's nothing to wait for, the ring client is returned directly instead of being
+			// wrapped in the service that gates the running state on the ring being populated.
+			if testData.expectedWait {
+				require.NotSame(t, services.Service(mimir.QuerierRing), svc)
+			} else {
+				require.Same(t, services.Service(mimir.QuerierRing), svc)
+			}
+		})
+	}
 }

--- a/pkg/querier/querier_ring.go
+++ b/pkg/querier/querier_ring.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/kv"
 	"github.com/grafana/dskit/ring"
+	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
@@ -127,6 +128,96 @@ func NewRing(cfg RingConfig, logger log.Logger, reg prometheus.Registerer) (*rin
 	}
 
 	return r, nil
+}
+
+// RingStartupWaitTimeout is how long processes running a query-frontend wait, during startup, for the
+// querier ring to be populated before starting to serve queries anyway.
+const RingStartupWaitTimeout = 30 * time.Second
+
+// NewRingService returns a service that runs the querier ring client r, and doesn't reach the
+// running state until the ring holds at least one querier reporting a supported query plan
+// version, or waitTimeout elapses.
+//
+// Query-frontends can't plan any query before they've seen the querier ring (see
+// RingQueryPlanVersionProvider), so a query-frontend that reaches the running state earlier
+// reports itself ready and then fails every query it receives until the ring is populated.
+func NewRingService(r *ring.Ring, waitTimeout time.Duration, logger log.Logger) services.Service {
+	watcher := services.NewFailureWatcher()
+
+	return services.NewBasicService(
+		func(ctx context.Context) error {
+			watcher.WatchService(r)
+
+			if err := services.StartAndAwaitRunning(ctx, r); err != nil {
+				return fmt.Errorf("failed to start querier ring client: %w", err)
+			}
+
+			return waitForQueriersInRing(ctx, r, waitTimeout, watcher.Chan(), logger)
+		},
+		func(ctx context.Context) error {
+			select {
+			case <-ctx.Done():
+				return nil
+			case err := <-watcher.Chan():
+				return fmt.Errorf("querier ring client failed: %w", err)
+			}
+		},
+		func(error) error {
+			return services.StopAndAwaitTerminated(context.Background(), r)
+		},
+	)
+}
+
+// waitForQueriersInRing blocks until r holds at least one querier reporting a supported query plan
+// version, the ring client fails, waitTimeout elapses or ctx is cancelled.
+//
+// ringFailures must be the channel of the failure watcher watching the ring client.
+//
+// Timing out does not an error: we prefer starting up anyway and eventually
+// fail queries over never starting up at all, for example when all queriers
+// are down.
+func waitForQueriersInRing(ctx context.Context, r ring.ReadRing, waitTimeout time.Duration, ringFailures <-chan error, logger log.Logger) error {
+	// The provider is what query-frontends use to plan queries, so it holds the exact condition we need to wait for.
+	provider := RingQueryPlanVersionProvider{ring: r, logger: logger}
+
+	waitCtx, cancel := context.WithTimeout(ctx, waitTimeout)
+	defer cancel()
+
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	var lastErr error
+
+	for {
+		version, err := provider.GetMaximumSupportedQueryPlanVersion(waitCtx)
+		if err == nil {
+			level.Info(logger).Log("msg", "querier ring is populated", "maximum_supported_query_plan_version", version)
+			return nil
+		}
+
+		lastErr = err
+
+		select {
+		case <-ticker.C:
+		case err := <-ringFailures:
+			return fmt.Errorf("querier ring client failed: %w", err)
+		case <-waitCtx.Done():
+			if ctx.Err() != nil {
+				// The service is stopping. Return nil rather than the context error: services.BasicService
+				// skips the stopping function entirely if the starting function fails, which would leave the
+				// ring client running.
+				return nil
+			}
+
+			level.Warn(logger).Log(
+				"msg", "timed out waiting for the querier ring to be populated, queries may fail until it is",
+				"timeout", waitTimeout,
+				"err", lastErr,
+			)
+
+			return nil
+		}
+	}
 }
 
 type RingQueryPlanVersionProvider struct {

--- a/pkg/querier/querier_ring.go
+++ b/pkg/querier/querier_ring.go
@@ -164,6 +164,7 @@ func NewRingQueryPlanVersionProvider(ring ring.ReadRing, reg prometheus.Register
 
 var queryPlanVersioningOp = ring.NewOp([]ring.InstanceState{ring.ACTIVE, ring.PENDING, ring.JOINING, ring.LEAVING}, nil)
 var errQuerierHasNoSupportedQueryPlanVersion = fmt.Errorf("at least one querier in the ring is not reporting a supported query plan version")
+var errNoHealthyQueriersInRing = fmt.Errorf("no healthy queriers in the ring")
 
 func (r *RingQueryPlanVersionProvider) GetMaximumSupportedQueryPlanVersion(ctx context.Context) (planning.QueryPlanVersion, error) {
 	logger := spanlogger.FromContext(ctx, r.logger)
@@ -171,6 +172,12 @@ func (r *RingQueryPlanVersionProvider) GetMaximumSupportedQueryPlanVersion(ctx c
 	instances, err := r.ring.GetAllHealthy(queryPlanVersioningOp)
 	if err != nil {
 		return 0, fmt.Errorf("could not compute maximum supported query plan version: could not get all queriers from the ring: %w", err)
+	}
+
+	// GetAllHealthy only fails if the ring is empty: a ring holding nothing but unhealthy queriers
+	// returns no instances and no error, and we can't compute a version from that.
+	if len(instances.Instances) == 0 {
+		return 0, fmt.Errorf("could not compute maximum supported query plan version: %w", errNoHealthyQueriersInRing)
 	}
 
 	lowestVersionSeen := uint64(math.MaxUint64)

--- a/pkg/querier/querier_ring_test.go
+++ b/pkg/querier/querier_ring_test.go
@@ -21,8 +21,9 @@ import (
 )
 
 type mockInstance struct {
-	state    ring.InstanceState
-	versions ring.InstanceVersions
+	state     ring.InstanceState
+	versions  ring.InstanceVersions
+	unhealthy bool
 }
 
 func TestRingQueryPlanVersionProvider(t *testing.T) {
@@ -37,6 +38,45 @@ func TestRingQueryPlanVersionProvider(t *testing.T) {
 	}{
 		"no instances in the ring": {
 			expectedError: "could not compute maximum supported query plan version: could not get all queriers from the ring: empty ring",
+		},
+		"one instance in the ring, has version but is unhealthy": {
+			instances: []mockInstance{
+				{
+					state:     ring.ACTIVE,
+					versions:  versionsMap(123),
+					unhealthy: true,
+				},
+			},
+			expectedError: "could not compute maximum supported query plan version: no healthy queriers in the ring",
+		},
+		"many instances in the ring, all have versions but all are unhealthy": {
+			instances: []mockInstance{
+				{
+					state:     ring.ACTIVE,
+					versions:  versionsMap(123),
+					unhealthy: true,
+				},
+				{
+					state:     ring.LEAVING,
+					versions:  versionsMap(124),
+					unhealthy: true,
+				},
+			},
+			expectedError: "could not compute maximum supported query plan version: no healthy queriers in the ring",
+		},
+		"many instances in the ring, only the unhealthy ones have a lower version": {
+			instances: []mockInstance{
+				{
+					state:     ring.ACTIVE,
+					versions:  versionsMap(122),
+					unhealthy: true,
+				},
+				{
+					state:    ring.ACTIVE,
+					versions: versionsMap(123),
+				},
+			},
+			expectedVersion: 123,
 		},
 		"one instance in the ring, has no version": {
 			instances: []mockInstance{
@@ -158,7 +198,14 @@ func TestRingQueryPlanVersionProvider(t *testing.T) {
 			})
 
 			for idx, instance := range testCase.instances {
-				desc.AddIngester(fmt.Sprintf("querier-%d", idx), fmt.Sprintf("127.0.0.%d", idx), "", []uint32{uint32(idx)}, instance.state, time.Now(), false, time.Time{}, instance.versions)
+				id := fmt.Sprintf("querier-%d", idx)
+				added := desc.AddIngester(id, fmt.Sprintf("127.0.0.%d", idx), "", []uint32{uint32(idx)}, instance.state, time.Now(), false, time.Time{}, instance.versions)
+
+				if instance.unhealthy {
+					// AddIngester always sets a fresh heartbeat, so backdate it beyond the ring's heartbeat timeout.
+					added.Timestamp = time.Now().Add(-time.Hour).Unix()
+					desc.Ingesters[id] = added
+				}
 			}
 
 			cfg := ring.Config{

--- a/pkg/querier/querier_ring_test.go
+++ b/pkg/querier/querier_ring_test.go
@@ -4,6 +4,7 @@ package querier
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/dskit/kv/consul"
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
@@ -282,4 +284,103 @@ func (m *mockStore) WatchKey(ctx context.Context, key string, f func(interface{}
 
 func (m *mockStore) WatchPrefix(ctx context.Context, prefix string, f func(string, interface{}) bool) {
 	panic("not supported")
+}
+
+func TestRingService_WaitsForQueriersInRing(t *testing.T) {
+	setup := func(t *testing.T, waitTimeout time.Duration) (*consul.Client, *ring.Ring, services.Service) {
+		store, closer := consul.NewInMemoryClient(ring.GetCodec(), log.NewNopLogger(), nil)
+		t.Cleanup(func() { require.NoError(t, closer.Close()) })
+
+		cfg := ring.Config{ReplicationFactor: 1, HeartbeatTimeout: time.Minute}
+		r, err := ring.NewWithStoreClientAndStrategy(cfg, "querier-test", querierRingKey, store, ring.NewDefaultReplicationStrategy(), prometheus.NewPedanticRegistry(), log.NewNopLogger())
+		require.NoError(t, err)
+
+		svc := NewRingService(r, waitTimeout, log.NewNopLogger())
+		// Stopping must outlive the test context, otherwise it returns before the service is terminated.
+		t.Cleanup(func() { require.NoError(t, services.StopAndAwaitTerminated(context.Background(), svc)) })
+
+		return store, r, svc
+	}
+
+	t.Run("doesn't become running until a querier joins the ring", func(t *testing.T) {
+		store, _, svc := setup(t, time.Minute)
+
+		require.NoError(t, svc.StartAsync(t.Context()))
+
+		// The service must stay in the starting state while the ring is empty.
+		time.Sleep(500 * time.Millisecond)
+		require.Equal(t, services.Starting, svc.State())
+
+		require.NoError(t, store.CAS(t.Context(), querierRingKey, func(interface{}) (interface{}, bool, error) {
+			desc := ring.NewDesc()
+			desc.AddIngester("querier-0", "127.0.0.1", "", []uint32{1}, ring.ACTIVE, time.Now(), false, time.Time{}, ring.InstanceVersions{MaximumSupportedQueryPlanVersion: uint64(planning.MaximumSupportedQueryPlanVersion)})
+			return desc, true, nil
+		}))
+
+		require.NoError(t, svc.AwaitRunning(t.Context()))
+	})
+
+	t.Run("doesn't become running while the ring holds only unhealthy queriers", func(t *testing.T) {
+		store, _, svc := setup(t, time.Minute)
+
+		require.NoError(t, store.CAS(t.Context(), querierRingKey, func(interface{}) (interface{}, bool, error) {
+			desc := ring.NewDesc()
+			inst := desc.AddIngester("querier-0", "127.0.0.1", "", []uint32{1}, ring.ACTIVE, time.Now(), false, time.Time{}, ring.InstanceVersions{MaximumSupportedQueryPlanVersion: uint64(planning.MaximumSupportedQueryPlanVersion)})
+			// AddIngester always sets a fresh heartbeat, so backdate it beyond the ring's heartbeat timeout.
+			inst.Timestamp = time.Now().Add(-time.Hour).Unix()
+			desc.Ingesters["querier-0"] = inst
+			return desc, true, nil
+		}))
+
+		require.NoError(t, svc.StartAsync(t.Context()))
+
+		time.Sleep(500 * time.Millisecond)
+		require.Equal(t, services.Starting, svc.State())
+	})
+
+	t.Run("becomes running once the wait times out, even if the ring is empty", func(t *testing.T) {
+		_, _, svc := setup(t, 100*time.Millisecond)
+
+		require.NoError(t, services.StartAndAwaitRunning(t.Context(), svc))
+	})
+
+	t.Run("fails immediately if the ring client fails while still waiting", func(t *testing.T) {
+		_, r, _ := setup(t, time.Minute)
+		require.NoError(t, services.StartAndAwaitRunning(t.Context(), r))
+		t.Cleanup(func() { _ = services.StopAndAwaitTerminated(context.Background(), r) })
+
+		// Send on the failure channel unbuffered, exactly like services.FailureWatcher does: if the
+		// wait doesn't drain it, this send blocks until the wait times out a minute from now.
+		ringFailures := make(chan error)
+		waitErr := make(chan error, 1)
+		go func() {
+			waitErr <- waitForQueriersInRing(t.Context(), r, time.Minute, ringFailures, log.NewNopLogger())
+		}()
+
+		select {
+		case ringFailures <- errors.New("ring client exploded"):
+		case <-time.After(time.Second):
+			t.Fatal("timed out sending the ring failure: the wait isn't draining the failure channel")
+		}
+
+		select {
+		case err := <-waitErr:
+			require.EqualError(t, err, "querier ring client failed: ring client exploded")
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for waitForQueriersInRing to return")
+		}
+	})
+
+	t.Run("terminates cleanly and stops the ring client when stopped while still waiting", func(t *testing.T) {
+		_, r, svc := setup(t, time.Minute)
+
+		require.NoError(t, svc.StartAsync(t.Context()))
+
+		time.Sleep(500 * time.Millisecond)
+		require.Equal(t, services.Starting, svc.State())
+
+		require.NoError(t, services.StopAndAwaitTerminated(context.Background(), svc))
+		require.Equal(t, services.Terminated, svc.State())
+		require.Equal(t, services.Terminated, r.State())
+	})
 }


### PR DESCRIPTION
- fail computing the max supported query plan version when the ring holds only unhealthy queriers, instead of returning `math.MaxUint64` with no error
- don't report a query-frontend ready until it's seen a querier in the ring, up to 30s — before, it went ready and failed every query until the ring showed up
  - gated behind experimental `-query-frontend.wait-for-querier-ring-on-startup`, default on
  - clean up integration tests (`cortex_ring_members` waits are no longer necessary, keeping only the four that need two queriers which looks legit)
